### PR TITLE
Add native CodeGraph Python search slice

### DIFF
--- a/Docs/superpowers/plans/2026-05-04-native-codegraph-python-search-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-04-native-codegraph-python-search-implementation-plan.md
@@ -1,0 +1,104 @@
+# Native CodeGraph Python Extractor And Search Implementation Plan
+
+Goal: add the Stage 2 Python-only CodeGraph slice on top of the merged foundation. The slice should turn indexed Python files into deterministic symbol nodes, same-file call edges or unresolved references, repository search/query results, and Unified MCP read tools.
+
+Scope boundaries:
+
+- Include Python extraction via the standard library `ast` module.
+- Include repository graph persistence and query helpers needed by Stage 2 tools.
+- Include MCP tools: `codegraph.search`, `codegraph.node`, `codegraph.callers`, and `codegraph.callees`.
+- Preserve Stage 1 tools and bounded foreground behavior.
+- Exclude JavaScript/TypeScript extraction, TypeScript path aliases, Jobs mode, `impact`, `context`, and planned-language extractors.
+
+## Stage 1: Extractor And Graph Models
+
+**Goal**: Define the data passed from extractors to storage and prove Python AST extraction behavior with focused tests.
+
+**Success Criteria**:
+
+- Module, class, function, method, and import nodes get deterministic IDs.
+- Same-file direct calls resolve to `calls` edges where possible.
+- Ambiguous or unresolved calls become unresolved refs rather than noisy edges.
+- Optional Tree-sitter packages are not imported for Python extraction.
+
+**Tests**:
+
+- `tldw_Server_API/tests/CodeGraph/test_codegraph_python_extractor.py`
+
+**Status**: Complete
+
+## Stage 2: Repository Graph Persistence And Search
+
+**Goal**: Persist graph rows safely and expose node/search/call relationship query helpers.
+
+**Success Criteria**:
+
+- Replacing a file deletes owned graph rows and dangling edges before inserting new graph rows.
+- Search returns deterministic bounded symbol matches from indexed graph rows.
+- Node lookup can resolve by `node_id` and by exact/qualified symbol name.
+- Caller/callee queries do not return dangling relationships.
+
+**Tests**:
+
+- `tldw_Server_API/tests/CodeGraph/test_codegraph_repository.py`
+
+**Status**: Complete
+
+## Stage 3: Bounded Indexer Integration
+
+**Goal**: Use the Python extractor during indexing while keeping existing foreground limits and Stage 1 inventory behavior intact.
+
+**Success Criteria**:
+
+- Python files record node counts and graph rows during index/sync.
+- JS/TS foundation inventory remains file-only until its extractor slice.
+- Planned-language files are still skipped.
+- Existing file, byte, and wall-clock bounds still prevent partial over-limit indexing.
+
+**Tests**:
+
+- `tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py`
+
+**Status**: Complete
+
+## Stage 4: MCP Stage 2 Read Tools
+
+**Goal**: Expose Python graph search and relationship reads through `CodeGraphModule`.
+
+**Success Criteria**:
+
+- `get_tools()` includes Stage 1 tools plus `search`, `node`, `callers`, and `callees`.
+- All Stage 2 tools are read-only and offload blocking repository work via `asyncio.to_thread`.
+- Argument validation rejects unknown parameters and unsafe limits.
+- Protocol tests cover at least one Stage 2 validation path.
+
+**Tests**:
+
+- `tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py`
+
+**Status**: Complete
+
+## Stage 5: Verification And Task Closeout
+
+**Goal**: Verify the slice and record results in Backlog.
+
+**Success Criteria**:
+
+- Focused CodeGraph and adjacent MCP tests pass.
+- Bandit reports no new actionable findings in touched CodeGraph/MCP code.
+- `git diff --check` passes.
+- TASK-27 includes verification notes and a final summary.
+
+**Tests**:
+
+- `python -m pytest tldw_Server_API/tests/CodeGraph tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py -q`
+- `python -m bandit -r tldw_Server_API/app/core/CodeGraph tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py -f json -o /tmp/bandit_codegraph_python_search.json`
+- `git diff --check`
+
+**Status**: Complete
+
+## Local Review Notes
+
+- Python extraction should use `ast` for this slice. It is stable, available by default, and avoids coupling the Python extractor to optional Tree-sitter package availability.
+- Keep search truthful: same-file direct calls can become resolved `calls` edges; anything uncertain should remain unresolved.
+- Avoid expanding the module into source excerpt tooling. `include_code` may remain false or unsupported in this slice unless tests justify a bounded implementation.

--- a/backlog/tasks/task-27 - Implement-native-CodeGraph-Python-extractor-and-search-slice.md
+++ b/backlog/tasks/task-27 - Implement-native-CodeGraph-Python-extractor-and-search-slice.md
@@ -1,0 +1,79 @@
+---
+id: TASK-27
+title: Implement native CodeGraph Python extractor and search slice
+status: Done
+assignee: []
+created_date: '2026-05-04 02:38'
+updated_date: '2026-05-04 02:49'
+labels:
+  - codegraph
+  - mcp
+  - python
+dependencies:
+  - TASK-16
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1244'
+documentation:
+  - Docs/superpowers/specs/2026-05-03-native-codegraph-mcp-module-design.md
+  - >-
+    Docs/superpowers/plans/2026-05-03-native-codegraph-foundation-implementation-plan.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add the next native CodeGraph slice after the merged foundation: index Python symbols into the existing graph tables, expose searchable symbol/node/caller/callee read tools through Unified MCP, and keep behavior bounded and truthful. This task builds on the Stage 1 foundation from PR #1244 and should not add JavaScript/TypeScript extraction, path-alias resolution, Jobs mode, impact/context tools, or planned-language extractors.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Python files are parsed into deterministic module, class, function, method, import, and same-file call graph nodes or references without requiring optional tree-sitter dependencies at import time.
+- [x] #2 The repository can persist, replace, search, and fetch graph nodes and edges without returning dangling relationships after re-index or sync.
+- [x] #3 Unified MCP exposes Stage 2 read tools for symbol search, node lookup, callers, and callees while preserving Stage 1 status, index, sync, and files behavior.
+- [x] #4 Indexing remains bounded by existing foreground file, byte, and wall-clock limits and does not write graph storage inside the source workspace.
+- [x] #5 Focused CodeGraph and MCP tests cover the new Python extractor, repository query behavior, MCP tools, and Stage 1 regressions.
+- [x] #6 Bandit on touched CodeGraph/MCP code and git diff whitespace checks are run before completion.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Plan: Docs/superpowers/plans/2026-05-04-native-codegraph-python-search-implementation-plan.md
+
+1. Add RED tests for Python AST extraction and repository graph persistence/search.
+2. Implement deterministic CodeGraph node/edge/ref models, repository insert/query methods, and a stdlib-`ast` Python extractor.
+3. Wire Python extraction into the bounded indexer while preserving Stage 1 inventory behavior for JS/TS and planned languages.
+4. Add RED/GREEN MCP coverage for `codegraph.search`, `codegraph.node`, `codegraph.callers`, and `codegraph.callees`.
+5. Run focused CodeGraph/MCP regression tests, Bandit on touched CodeGraph/MCP code, and `git diff --check`; then update this task and prepare the PR.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+RED/GREEN evidence: extractor/repository tests first failed on missing CodeGraphNode/CodeGraphEdge/CodeGraphUnresolvedRef and missing PythonAstExtractor, then passed after implementation. Indexer tests first failed because Python files still had 0 graph nodes, then passed after wiring Python AST extraction. MCP tests first failed on missing Stage 2 tools, then passed after adding read tools and validation.
+
+Verification: python -m pytest tldw_Server_API/tests/CodeGraph tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py -q passed with 43 passed, 5 warnings. Bandit touched scope wrote /tmp/bandit_codegraph_python_search.json with 0 results and 0 errors. git diff --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the native CodeGraph Python extractor/search slice: Python files now index deterministic module/class/function/method/import nodes plus conservative same-file call edges or unresolved refs; repository graph persistence and query helpers support search, node lookup, callers, and callees without dangling relationship results; Unified MCP exposes the Stage 2 read tools while preserving bounded foreground indexing and Stage 1 inventory behavior for JS/TS/planned languages. Added the branch implementation plan and focused tests for extractor, repository, indexer, MCP tools, and protocol validation.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Baseline before Stage 2 edits: `python -m pytest tldw_Server_API/tests/CodeGraph tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py -q` passed with `31 passed`.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-27 - Implement-native-CodeGraph-Python-extractor-and-search-slice.md
+++ b/backlog/tasks/task-27 - Implement-native-CodeGraph-Python-extractor-and-search-slice.md
@@ -50,11 +50,11 @@ Plan: Docs/superpowers/plans/2026-05-04-native-codegraph-python-search-implement
 
 ## Implementation Notes
 
-<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 RED/GREEN evidence: extractor/repository tests first failed on missing CodeGraphNode/CodeGraphEdge/CodeGraphUnresolvedRef and missing PythonAstExtractor, then passed after implementation. Indexer tests first failed because Python files still had 0 graph nodes, then passed after wiring Python AST extraction. MCP tests first failed on missing Stage 2 tools, then passed after adding read tools and validation.
 
 Verification: python -m pytest tldw_Server_API/tests/CodeGraph tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py -q passed with 43 passed, 5 warnings. Bandit touched scope wrote /tmp/bandit_codegraph_python_search.json with 0 results and 0 errors. git diff --check passed.
-<!-- SECTION:NOTES:END -->
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
@@ -74,6 +74,6 @@ Implemented the native CodeGraph Python extractor/search slice: Python files now
 
 ## Notes
 
-<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:BASELINE_NOTES:BEGIN -->
 - Baseline before Stage 2 edits: `python -m pytest tldw_Server_API/tests/CodeGraph tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py -q` passed with `31 passed`.
-<!-- SECTION:NOTES:END -->
+<!-- SECTION:BASELINE_NOTES:END -->

--- a/backlog/tasks/task-31 - Address-PR-1253-CodeRabbit-docstring-review.md
+++ b/backlog/tasks/task-31 - Address-PR-1253-CodeRabbit-docstring-review.md
@@ -1,0 +1,59 @@
+---
+id: TASK-31
+title: Address PR 1253 CodeRabbit docstring review
+status: Done
+assignee: []
+created_date: '2026-05-04 03:06'
+updated_date: '2026-05-04 03:16'
+labels:
+  - codegraph
+  - mcp
+  - review
+dependencies:
+  - TASK-27
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1253'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address actionable PR #1253 review feedback from CodeRabbit. The review covered duplicate Backlog section markers, Python attribute-call false edges, atomic file plus graph persistence, extraction failure status reporting, MCP search normalization, ambiguous node selector validation, and docstring coverage. The PR description Change summary gate is intentionally left for the human requester because repository policy requires a human-written summary.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 All six actionable CodeRabbit inline comments on PR 1253 are addressed in code tests or Backlog task metadata.
+- [x] #2 Changed CodeGraph production code has focused docstrings and local AST docstring coverage remains above the reviewer threshold.
+- [x] #3 Python attribute calls do not create false same-file call edges and are represented conservatively as unresolved refs.
+- [x] #4 Indexer file inventory and graph replacement happen in one repository transaction and extraction failures persist a non-indexed status with run errors.
+- [x] #5 MCP search and node selector validation normalizes whitespace and rejects ambiguous node_id plus symbol selectors.
+- [x] #6 Focused CodeGraph/MCP tests Bandit touched scope and git diff whitespace check pass after the review fixes.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Addressed PR #1253 review threads: renamed duplicate TASK-27 section markers; kept Python attribute calls unresolved instead of resolving by bare attribute name; added atomic file plus graph repository persistence; persisted extraction_failed file status and run error summaries; normalized MCP search and selector inputs; rejected node_id plus symbol ambiguity; added focused docstrings for changed production code.
+
+Verification: focused CodeGraph/MCP pytest suite passed with 47 passed and 5 warnings; AST docstring inspection reported 111 definitions with 0 missing docstrings; Bandit touched scope reported 0 results and 0 errors; git diff --check origin/dev...HEAD passed.
+
+Known non-code blocker: PR description Change summary still requires a human-written summary per repository policy.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed all actionable PR #1253 CodeRabbit inline comments with focused CodeGraph fixes and tests. Attribute calls now remain unresolved instead of false-linking to same-file functions; file inventory and graph replacement persist in one repository transaction; extraction failures are reported as extraction_failed with run errors; MCP search and node selectors normalize/reject ambiguous inputs; duplicate Backlog markers were made unique; changed production definitions have docstrings. Verification passed locally.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/tldw_Server_API/app/core/CodeGraph/extractors/__init__.py
+++ b/tldw_Server_API/app/core/CodeGraph/extractors/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from .python_extractor import PythonAstExtractor
+
+__all__ = ["PythonAstExtractor"]

--- a/tldw_Server_API/app/core/CodeGraph/extractors/python_extractor.py
+++ b/tldw_Server_API/app/core/CodeGraph/extractors/python_extractor.py
@@ -1,3 +1,5 @@
+"""Python AST extraction for the first native CodeGraph symbol slice."""
+
 from __future__ import annotations
 
 import ast
@@ -16,6 +18,8 @@ from tldw_Server_API.app.core.CodeGraph.models import (
 
 @dataclass(frozen=True)
 class _CallSite:
+    """Deferred same-file call reference captured while walking a function body."""
+
     source_node_id: str
     reference_name: str
     line: int
@@ -28,6 +32,7 @@ class PythonAstExtractor:
     language_id = "python"
 
     def extract(self, *, workspace_key: str, file_path: str, source: bytes) -> ExtractionResult:
+        """Parse one Python file and return symbols, calls, unresolved refs, and errors."""
         try:
             text = source.decode("utf-8")
             tree = ast.parse(text, filename=file_path)
@@ -39,7 +44,10 @@ class PythonAstExtractor:
 
 
 class _PythonGraphBuilder(ast.NodeVisitor):
+    """Stateful AST visitor that emits CodeGraph rows for one Python module."""
+
     def __init__(self, *, workspace_key: str, file_path: str, source: str) -> None:
+        """Initialize per-file extraction state."""
         self.workspace_key = workspace_key
         self.file_path = file_path
         self.source = source
@@ -52,6 +60,7 @@ class _PythonGraphBuilder(ast.NodeVisitor):
         self._callable_by_name: dict[str, CodeGraphNode | None] = {}
 
     def build(self, tree: ast.Module) -> ExtractionResult:
+        """Visit a parsed module and resolve captured same-file call references."""
         module_name = _module_name_for_path(self.file_path)
         module_node = self._make_node(
             kind="module",
@@ -73,6 +82,7 @@ class _PythonGraphBuilder(ast.NodeVisitor):
         )
 
     def visit_Import(self, node: ast.Import) -> None:  # noqa: N802
+        """Record import statements as graph nodes without following them."""
         for alias in node.names:
             self.nodes.append(
                 self._make_node(
@@ -85,6 +95,7 @@ class _PythonGraphBuilder(ast.NodeVisitor):
             )
 
     def visit_ImportFrom(self, node: ast.ImportFrom) -> None:  # noqa: N802
+        """Record from-import statements as graph nodes without following them."""
         module = "." * int(node.level) + (node.module or "")
         for alias in node.names:
             imported = f"{module}.{alias.name}" if module else alias.name
@@ -99,6 +110,7 @@ class _PythonGraphBuilder(ast.NodeVisitor):
             )
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:  # noqa: N802
+        """Record a class and visit its body in class-qualified scope."""
         qualified_name = ".".join([*self._class_stack, node.name])
         class_node = self._make_node(
             kind="class",
@@ -118,9 +130,11 @@ class _PythonGraphBuilder(ast.NodeVisitor):
         self._scope_stack.pop()
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:  # noqa: N802
+        """Record a synchronous function or method definition."""
         self._visit_function(node)
 
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:  # noqa: N802
+        """Record an asynchronous function or method definition."""
         self._visit_function(node, is_async=True)
 
     def _visit_function(
@@ -129,6 +143,7 @@ class _PythonGraphBuilder(ast.NodeVisitor):
         *,
         is_async: bool = False,
     ) -> None:
+        """Record a function-like node and visit nested executable statements."""
         container = ".".join(self._class_stack)
         qualified_name = f"{container}.{node.name}" if container else node.name
         function_node = self._make_node(
@@ -148,6 +163,7 @@ class _PythonGraphBuilder(ast.NodeVisitor):
         self._scope_stack.pop()
 
     def visit_Call(self, node: ast.Call) -> None:  # noqa: N802
+        """Capture call expressions that originate inside functions or methods."""
         if self._scope_stack:
             reference_name = _call_reference_name(node.func)
             current_scope = self._scope_stack[-1]
@@ -160,6 +176,20 @@ class _PythonGraphBuilder(ast.NodeVisitor):
                         column=int(getattr(node, "col_offset", 0) or 0) + 1,
                     )
                 )
+            elif current_scope.kind in {"function", "method"}:
+                unresolved_name = _attribute_reference_name(node.func)
+                if unresolved_name:
+                    self.unresolved_refs.append(
+                        CodeGraphUnresolvedRef(
+                            from_node_id=current_scope.id,
+                            reference_name=unresolved_name,
+                            reference_kind="call",
+                            file_path=self.file_path,
+                            line=int(getattr(node, "lineno", 0) or 0),
+                            column=int(getattr(node, "col_offset", 0) or 0) + 1,
+                            language="python",
+                        )
+                    )
         self.generic_visit(node)
 
     def _make_node(
@@ -175,6 +205,7 @@ class _PythonGraphBuilder(ast.NodeVisitor):
         flags: tuple[str, ...] = (),
         metadata: dict[str, str | None] | None = None,
     ) -> CodeGraphNode:
+        """Create a stable CodeGraph node from an AST node and qualified name."""
         resolved_start = start_line or int(getattr(node, "lineno", 1) or 1)
         identity_key = f"{self.workspace_key}:python:{self.file_path}:{kind}:{qualified_name}:{resolved_start}"
         return CodeGraphNode(
@@ -199,6 +230,7 @@ class _PythonGraphBuilder(ast.NodeVisitor):
         )
 
     def _remember_callable(self, node: CodeGraphNode) -> None:
+        """Register a callable by simple and qualified names unless ambiguous."""
         for key in {node.name, node.qualified_name}:
             existing = self._callable_by_name.get(key)
             if existing is None and key in self._callable_by_name:
@@ -209,6 +241,7 @@ class _PythonGraphBuilder(ast.NodeVisitor):
             self._callable_by_name[key] = node
 
     def _resolve_calls(self) -> None:
+        """Convert captured call sites into resolved edges or unresolved references."""
         for call in self._call_sites:
             target = self._callable_by_name.get(call.reference_name)
             if target is None:
@@ -246,6 +279,7 @@ class _PythonGraphBuilder(ast.NodeVisitor):
 
 
 def _module_name_for_path(file_path: str) -> str:
+    """Return a dotted module name from a workspace-relative Python path."""
     path = Path(file_path)
     parts = list(path.with_suffix("").parts)
     if parts and parts[-1] == "__init__":
@@ -254,8 +288,22 @@ def _module_name_for_path(file_path: str) -> str:
 
 
 def _call_reference_name(node: ast.AST) -> str | None:
+    """Return the comparable callable name for bare-name calls only."""
     if isinstance(node, ast.Name):
         return node.id
-    if isinstance(node, ast.Attribute):
-        return node.attr
     return None
+
+
+def _attribute_reference_name(node: ast.AST) -> str | None:
+    """Return a dotted best-effort name for attribute calls that stay unresolved."""
+    if not isinstance(node, ast.Attribute):
+        return None
+
+    parts: list[str] = []
+    current: ast.AST = node
+    while isinstance(current, ast.Attribute):
+        parts.append(current.attr)
+        current = current.value
+    if isinstance(current, ast.Name):
+        parts.append(current.id)
+    return ".".join(reversed(parts)) if parts else None

--- a/tldw_Server_API/app/core/CodeGraph/extractors/python_extractor.py
+++ b/tldw_Server_API/app/core/CodeGraph/extractors/python_extractor.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+
+from tldw_Server_API.app.core.CodeGraph.models import (
+    CodeGraphEdge,
+    CodeGraphNode,
+    CodeGraphUnresolvedRef,
+    ExtractionResult,
+    make_edge_id,
+    make_node_id,
+)
+
+
+@dataclass(frozen=True)
+class _CallSite:
+    source_node_id: str
+    reference_name: str
+    line: int
+    column: int
+
+
+class PythonAstExtractor:
+    """Extract conservative Python symbols and same-file calls with stdlib ast."""
+
+    language_id = "python"
+
+    def extract(self, *, workspace_key: str, file_path: str, source: bytes) -> ExtractionResult:
+        try:
+            text = source.decode("utf-8")
+            tree = ast.parse(text, filename=file_path)
+        except (SyntaxError, UnicodeDecodeError) as exc:
+            return ExtractionResult(errors=(str(exc),))
+
+        builder = _PythonGraphBuilder(workspace_key=workspace_key, file_path=file_path, source=text)
+        return builder.build(tree)
+
+
+class _PythonGraphBuilder(ast.NodeVisitor):
+    def __init__(self, *, workspace_key: str, file_path: str, source: str) -> None:
+        self.workspace_key = workspace_key
+        self.file_path = file_path
+        self.source = source
+        self.nodes: list[CodeGraphNode] = []
+        self.edges: list[CodeGraphEdge] = []
+        self.unresolved_refs: list[CodeGraphUnresolvedRef] = []
+        self._scope_stack: list[CodeGraphNode] = []
+        self._class_stack: list[str] = []
+        self._call_sites: list[_CallSite] = []
+        self._callable_by_name: dict[str, CodeGraphNode | None] = {}
+
+    def build(self, tree: ast.Module) -> ExtractionResult:
+        module_name = _module_name_for_path(self.file_path)
+        module_node = self._make_node(
+            kind="module",
+            name=module_name.rsplit(".", 1)[-1],
+            qualified_name=module_name,
+            node=tree,
+            start_line=1,
+            end_line=max(1, len(self.source.splitlines())),
+        )
+        self.nodes.append(module_node)
+        self._scope_stack.append(module_node)
+        self.visit(tree)
+        self._scope_stack.pop()
+        self._resolve_calls()
+        return ExtractionResult(
+            nodes=tuple(self.nodes),
+            edges=tuple(self.edges),
+            unresolved_refs=tuple(self.unresolved_refs),
+        )
+
+    def visit_Import(self, node: ast.Import) -> None:  # noqa: N802
+        for alias in node.names:
+            self.nodes.append(
+                self._make_node(
+                    kind="import",
+                    name=alias.asname or alias.name.split(".")[-1],
+                    qualified_name=alias.name,
+                    node=node,
+                    metadata={"imported": alias.name, "alias": alias.asname},
+                )
+            )
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:  # noqa: N802
+        module = "." * int(node.level) + (node.module or "")
+        for alias in node.names:
+            imported = f"{module}.{alias.name}" if module else alias.name
+            self.nodes.append(
+                self._make_node(
+                    kind="import",
+                    name=alias.asname or alias.name,
+                    qualified_name=imported,
+                    node=node,
+                    metadata={"imported": imported, "alias": alias.asname},
+                )
+            )
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:  # noqa: N802
+        qualified_name = ".".join([*self._class_stack, node.name])
+        class_node = self._make_node(
+            kind="class",
+            name=node.name,
+            qualified_name=qualified_name,
+            node=node,
+            docstring=ast.get_docstring(node),
+        )
+        self.nodes.append(class_node)
+        self._remember_callable(class_node)
+
+        self._scope_stack.append(class_node)
+        self._class_stack.append(node.name)
+        for item in node.body:
+            self.visit(item)
+        self._class_stack.pop()
+        self._scope_stack.pop()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:  # noqa: N802
+        self._visit_function(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:  # noqa: N802
+        self._visit_function(node, is_async=True)
+
+    def _visit_function(
+        self,
+        node: ast.FunctionDef | ast.AsyncFunctionDef,
+        *,
+        is_async: bool = False,
+    ) -> None:
+        container = ".".join(self._class_stack)
+        qualified_name = f"{container}.{node.name}" if container else node.name
+        function_node = self._make_node(
+            kind="method" if self._class_stack else "function",
+            name=node.name,
+            qualified_name=qualified_name,
+            node=node,
+            docstring=ast.get_docstring(node),
+            flags=("async",) if is_async else (),
+        )
+        self.nodes.append(function_node)
+        self._remember_callable(function_node)
+
+        self._scope_stack.append(function_node)
+        for item in node.body:
+            self.visit(item)
+        self._scope_stack.pop()
+
+    def visit_Call(self, node: ast.Call) -> None:  # noqa: N802
+        if self._scope_stack:
+            reference_name = _call_reference_name(node.func)
+            current_scope = self._scope_stack[-1]
+            if reference_name and current_scope.kind in {"function", "method"}:
+                self._call_sites.append(
+                    _CallSite(
+                        source_node_id=current_scope.id,
+                        reference_name=reference_name,
+                        line=int(getattr(node, "lineno", 0) or 0),
+                        column=int(getattr(node, "col_offset", 0) or 0) + 1,
+                    )
+                )
+        self.generic_visit(node)
+
+    def _make_node(
+        self,
+        *,
+        kind: str,
+        name: str,
+        qualified_name: str,
+        node: ast.AST,
+        start_line: int | None = None,
+        end_line: int | None = None,
+        docstring: str | None = None,
+        flags: tuple[str, ...] = (),
+        metadata: dict[str, str | None] | None = None,
+    ) -> CodeGraphNode:
+        resolved_start = start_line or int(getattr(node, "lineno", 1) or 1)
+        identity_key = f"{self.workspace_key}:python:{self.file_path}:{kind}:{qualified_name}:{resolved_start}"
+        return CodeGraphNode(
+            id=make_node_id(self.workspace_key, "python", self.file_path, kind, qualified_name, resolved_start),
+            identity_key=identity_key,
+            kind=kind,
+            name=name,
+            qualified_name=qualified_name,
+            file_path=self.file_path,
+            language="python",
+            start_line=resolved_start,
+            end_line=end_line or int(getattr(node, "end_lineno", resolved_start) or resolved_start),
+            start_column=int(getattr(node, "col_offset", 0) or 0) + 1,
+            end_column=(
+                int(getattr(node, "end_col_offset", 0)) + 1
+                if getattr(node, "end_col_offset", None) is not None
+                else None
+            ),
+            docstring=docstring,
+            flags=flags,
+            metadata=dict(metadata or {}),
+        )
+
+    def _remember_callable(self, node: CodeGraphNode) -> None:
+        for key in {node.name, node.qualified_name}:
+            existing = self._callable_by_name.get(key)
+            if existing is None and key in self._callable_by_name:
+                continue
+            if existing is not None and existing.id != node.id:
+                self._callable_by_name[key] = None
+                continue
+            self._callable_by_name[key] = node
+
+    def _resolve_calls(self) -> None:
+        for call in self._call_sites:
+            target = self._callable_by_name.get(call.reference_name)
+            if target is None:
+                self.unresolved_refs.append(
+                    CodeGraphUnresolvedRef(
+                        from_node_id=call.source_node_id,
+                        reference_name=call.reference_name,
+                        reference_kind="call",
+                        file_path=self.file_path,
+                        line=call.line,
+                        column=call.column,
+                        language="python",
+                    )
+                )
+                continue
+            self.edges.append(
+                CodeGraphEdge(
+                    id=make_edge_id(
+                        call.source_node_id,
+                        "calls",
+                        target.id,
+                        self.file_path,
+                        call.line,
+                        call.column,
+                    ),
+                    source=call.source_node_id,
+                    target=target.id,
+                    kind="calls",
+                    file_path=self.file_path,
+                    line=call.line,
+                    column=call.column,
+                    provenance="python_ast",
+                )
+            )
+
+
+def _module_name_for_path(file_path: str) -> str:
+    path = Path(file_path)
+    parts = list(path.with_suffix("").parts)
+    if parts and parts[-1] == "__init__":
+        parts = parts[:-1]
+    return ".".join(parts) if parts else path.stem
+
+
+def _call_reference_name(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None

--- a/tldw_Server_API/app/core/CodeGraph/indexer.py
+++ b/tldw_Server_API/app/core/CodeGraph/indexer.py
@@ -1,3 +1,5 @@
+"""Bounded foreground indexing orchestration for native CodeGraph."""
+
 from __future__ import annotations
 
 import hashlib
@@ -19,6 +21,8 @@ from .models import ExtractionResult
 
 @dataclass(frozen=True)
 class IndexingResult:
+    """Result returned by foreground index and sync operations."""
+
     status: str
     counters: dict[str, int] = field(default_factory=dict)
     errors: tuple[str, ...] = ()
@@ -26,6 +30,8 @@ class IndexingResult:
 
 @dataclass(frozen=True)
 class _Candidate:
+    """Discovered workspace-relative file with language and size metadata."""
+
     path: Path
     relative_path: str
     language_id: str
@@ -36,6 +42,8 @@ class _Candidate:
 
 @dataclass(frozen=True)
 class _DiscoveryResult:
+    """Candidate discovery output with an optional early terminal status."""
+
     candidates: list[_Candidate]
     status: str | None = None
 
@@ -50,6 +58,7 @@ class CodeGraphIndexer:
         registry: CodeGraphLanguageRegistry,
         monotonic: Callable[[], float] | None = None,
     ) -> None:
+        """Create an indexer using settings, language metadata, and time source."""
         self._settings = settings
         self._registry = registry
         self._monotonic = monotonic or time.monotonic
@@ -65,6 +74,7 @@ class CodeGraphIndexer:
         languages: list[str] | tuple[str, ...] | None,
         max_files: int | None,
     ) -> IndexingResult:
+        """Run a bounded foreground full workspace index."""
         return self._run(
             workspace_root,
             workspace_key,
@@ -84,6 +94,7 @@ class CodeGraphIndexer:
         languages: list[str] | tuple[str, ...] | None,
         max_files: int | None,
     ) -> IndexingResult:
+        """Run a bounded foreground sync for the current workspace state."""
         return self._run(
             workspace_root,
             workspace_key,
@@ -105,6 +116,7 @@ class CodeGraphIndexer:
         languages: list[str] | tuple[str, ...] | None,
         max_files: int | None,
     ) -> IndexingResult:
+        """Execute shared index or sync flow with size and wall-clock safeguards."""
         del force  # Stage 1 records file inventory only; extraction cache comes later.
         repository.initialize()
         run_id = repository.record_index_run_start(workspace_key=workspace_key, mode=mode)
@@ -162,20 +174,20 @@ class CodeGraphIndexer:
 
                 content_hash = self._hash_bytes(source)
                 extraction = self._extract(candidate, workspace_key, source)
+                file_status = "indexed"
                 if extraction.errors:
                     counters["errors"] += len(extraction.errors)
-                repository.upsert_file(
+                    file_status = "extraction_failed"
+                    errors.append(f"{candidate.relative_path}: {'; '.join(extraction.errors[:3])}")
+                repository.upsert_file_and_replace_graph(
                     path=candidate.relative_path,
                     language=candidate.language_id,
                     size=candidate.size,
                     content_hash=content_hash,
                     modified_at=candidate.modified_at,
-                    status="indexed",
+                    status=file_status,
                     errors=extraction.errors,
                     node_count=len(extraction.nodes),
-                )
-                repository.replace_file_graph(
-                    path=candidate.relative_path,
                     nodes=extraction.nodes,
                     edges=extraction.edges,
                     unresolved_refs=extraction.unresolved_refs,
@@ -212,6 +224,7 @@ class CodeGraphIndexer:
         counters: dict[str, int],
         max_files: int,
     ) -> _DiscoveryResult:
+        """Walk the workspace and collect supported-language candidate files."""
         root = workspace_root.expanduser().resolve(strict=False)
         selected_languages = set(languages or [])
         candidates: list[_Candidate] = []
@@ -274,6 +287,7 @@ class CodeGraphIndexer:
         return _DiscoveryResult(candidates=candidates)
 
     def _extract(self, candidate: _Candidate, workspace_key: str, source: bytes) -> ExtractionResult:
+        """Run the language extractor for a candidate when one is implemented."""
         extractor = self._extractors.get(candidate.language_id)
         if extractor is None:
             return ExtractionResult()
@@ -285,14 +299,17 @@ class CodeGraphIndexer:
 
     @staticmethod
     def _hash_bytes(source: bytes) -> str:
+        """Return a SHA-256 content hash for indexed file bytes."""
         return hashlib.sha256(source).hexdigest()
 
     @staticmethod
     def _is_binary(source: bytes) -> bool:
+        """Detect obvious binary files from the leading byte window."""
         return b"\x00" in source[:4096]
 
 
 def _empty_counters() -> dict[str, int]:
+    """Return a fresh counter map for a single index run."""
     return {
         "files_seen": 0,
         "files_indexed": 0,

--- a/tldw_Server_API/app/core/CodeGraph/indexer.py
+++ b/tldw_Server_API/app/core/CodeGraph/indexer.py
@@ -12,7 +12,9 @@ from loguru import logger
 from tldw_Server_API.app.core.DB_Management.codegraph.repository import CodeGraphRepository
 
 from .config import CodeGraphSettings
+from .extractors.python_extractor import PythonAstExtractor
 from .language_registry import CodeGraphLanguageRegistry
+from .models import ExtractionResult
 
 
 @dataclass(frozen=True)
@@ -51,6 +53,7 @@ class CodeGraphIndexer:
         self._settings = settings
         self._registry = registry
         self._monotonic = monotonic or time.monotonic
+        self._extractors = {"python": PythonAstExtractor()}
 
     def index_workspace(
         self,
@@ -152,12 +155,15 @@ class CodeGraphIndexer:
                     counters["files_too_large"] += 1
                     counters["files_skipped"] += 1
                     continue
-                if self._is_binary(candidate.path):
+                source = candidate.path.read_bytes()
+                if self._is_binary(source):
                     counters["files_skipped"] += 1
                     continue
 
-                content_hash = self._hash_file(candidate.path)
-                repository.prepare_file_replacement(candidate.relative_path)
+                content_hash = self._hash_bytes(source)
+                extraction = self._extract(candidate, workspace_key, source)
+                if extraction.errors:
+                    counters["errors"] += len(extraction.errors)
                 repository.upsert_file(
                     path=candidate.relative_path,
                     language=candidate.language_id,
@@ -165,7 +171,14 @@ class CodeGraphIndexer:
                     content_hash=content_hash,
                     modified_at=candidate.modified_at,
                     status="indexed",
-                    errors=[],
+                    errors=extraction.errors,
+                    node_count=len(extraction.nodes),
+                )
+                repository.replace_file_graph(
+                    path=candidate.relative_path,
+                    nodes=extraction.nodes,
+                    edges=extraction.edges,
+                    unresolved_refs=extraction.unresolved_refs,
                 )
                 indexed_paths.add(candidate.relative_path)
                 counters["files_indexed"] += 1
@@ -260,18 +273,23 @@ class CodeGraphIndexer:
                         return _DiscoveryResult(candidates=candidates, status="index_too_large_for_foreground")
         return _DiscoveryResult(candidates=candidates)
 
-    @staticmethod
-    def _hash_file(path: Path) -> str:
-        digest = hashlib.sha256()
-        with path.open("rb") as handle:
-            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-                digest.update(chunk)
-        return digest.hexdigest()
+    def _extract(self, candidate: _Candidate, workspace_key: str, source: bytes) -> ExtractionResult:
+        extractor = self._extractors.get(candidate.language_id)
+        if extractor is None:
+            return ExtractionResult()
+        return extractor.extract(
+            workspace_key=workspace_key,
+            file_path=candidate.relative_path,
+            source=source,
+        )
 
     @staticmethod
-    def _is_binary(path: Path) -> bool:
-        with path.open("rb") as handle:
-            return b"\x00" in handle.read(4096)
+    def _hash_bytes(source: bytes) -> str:
+        return hashlib.sha256(source).hexdigest()
+
+    @staticmethod
+    def _is_binary(source: bytes) -> bool:
+        return b"\x00" in source[:4096]
 
 
 def _empty_counters() -> dict[str, int]:

--- a/tldw_Server_API/app/core/CodeGraph/models.py
+++ b/tldw_Server_API/app/core/CodeGraph/models.py
@@ -89,6 +89,59 @@ class IndexedFile:
 
 
 @dataclass(frozen=True)
+class CodeGraphNode:
+    id: str
+    identity_key: str
+    kind: str
+    name: str
+    qualified_name: str
+    file_path: str
+    language: str
+    start_line: int | None = None
+    end_line: int | None = None
+    start_column: int | None = None
+    end_column: int | None = None
+    signature: str | None = None
+    docstring: str | None = None
+    visibility: str | None = None
+    flags: tuple[str, ...] = ()
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class CodeGraphEdge:
+    id: str
+    source: str
+    target: str | None
+    kind: str
+    file_path: str
+    line: int | None = None
+    column: int | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    provenance: str | None = None
+
+
+@dataclass(frozen=True)
+class CodeGraphUnresolvedRef:
+    from_node_id: str
+    reference_name: str
+    reference_kind: str
+    file_path: str
+    line: int | None = None
+    column: int | None = None
+    candidates: tuple[str, ...] = ()
+    language: str | None = None
+
+
+@dataclass(frozen=True)
+class ExtractionResult:
+    nodes: tuple[CodeGraphNode, ...] = ()
+    edges: tuple[CodeGraphEdge, ...] = ()
+    unresolved_refs: tuple[CodeGraphUnresolvedRef, ...] = ()
+    errors: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
 class IndexRunSummary:
     run_id: str
     workspace_key: str

--- a/tldw_Server_API/app/core/CodeGraph/models.py
+++ b/tldw_Server_API/app/core/CodeGraph/models.py
@@ -1,3 +1,5 @@
+"""Shared value objects and stable ID helpers for native CodeGraph indexes."""
+
 from __future__ import annotations
 
 import hashlib
@@ -8,6 +10,7 @@ from typing import Any
 
 
 def stable_hash_id(prefix: str, identity: str) -> str:
+    """Return a deterministic prefixed identifier for a logical graph identity."""
     digest = hashlib.sha256(identity.encode("utf-8")).hexdigest()[:32]
     return f"{prefix}_{digest}"
 
@@ -20,6 +23,7 @@ def make_node_id(
     qualified_name: str,
     start_line: int,
 ) -> str:
+    """Build the stable node identifier used across repeated workspace indexes."""
     identity = json.dumps(
         [
             workspace_key,
@@ -42,6 +46,7 @@ def make_edge_id(
     line: int,
     column: int,
 ) -> str:
+    """Build a stable edge identifier from source, relation, target, and location."""
     identity = json.dumps(
         [
             source_node_id,
@@ -58,6 +63,8 @@ def make_edge_id(
 
 @dataclass(frozen=True)
 class LanguageInfo:
+    """Language support metadata exposed through CodeGraph status and validation."""
+
     language_id: str
     display_name: str
     extensions: tuple[str, ...]
@@ -68,6 +75,8 @@ class LanguageInfo:
 
 @dataclass(frozen=True)
 class WorkspaceResolution:
+    """Resolved workspace root and database location for one MCP request context."""
+
     workspace_root: Path
     workspace_key: str
     index_db_path: Path
@@ -77,6 +86,8 @@ class WorkspaceResolution:
 
 @dataclass(frozen=True)
 class IndexedFile:
+    """Persisted file inventory row for a workspace-relative source file."""
+
     path: str
     language: str
     size: int
@@ -90,6 +101,8 @@ class IndexedFile:
 
 @dataclass(frozen=True)
 class CodeGraphNode:
+    """Symbol, import, or module node extracted from an indexed source file."""
+
     id: str
     identity_key: str
     kind: str
@@ -110,6 +123,8 @@ class CodeGraphNode:
 
 @dataclass(frozen=True)
 class CodeGraphEdge:
+    """Directed graph relationship between two indexed CodeGraph nodes."""
+
     id: str
     source: str
     target: str | None
@@ -123,6 +138,8 @@ class CodeGraphEdge:
 
 @dataclass(frozen=True)
 class CodeGraphUnresolvedRef:
+    """Reference that could not be resolved to a concrete node during extraction."""
+
     from_node_id: str
     reference_name: str
     reference_kind: str
@@ -135,6 +152,8 @@ class CodeGraphUnresolvedRef:
 
 @dataclass(frozen=True)
 class ExtractionResult:
+    """Extractor output for one file, including graph rows and parse errors."""
+
     nodes: tuple[CodeGraphNode, ...] = ()
     edges: tuple[CodeGraphEdge, ...] = ()
     unresolved_refs: tuple[CodeGraphUnresolvedRef, ...] = ()
@@ -143,6 +162,8 @@ class ExtractionResult:
 
 @dataclass(frozen=True)
 class IndexRunSummary:
+    """Stored summary for a completed or running CodeGraph index operation."""
+
     run_id: str
     workspace_key: str
     mode: str
@@ -155,6 +176,8 @@ class IndexRunSummary:
 
 @dataclass(frozen=True)
 class CodeGraphStatus:
+    """Read-only status payload describing dependencies, languages, and index state."""
+
     dependency_available: bool
     languages: tuple[LanguageInfo, ...]
     workspace_key: str

--- a/tldw_Server_API/app/core/DB_Management/codegraph/repository.py
+++ b/tldw_Server_API/app/core/DB_Management/codegraph/repository.py
@@ -10,7 +10,13 @@ from typing import Any
 
 from loguru import logger
 
-from tldw_Server_API.app.core.CodeGraph.models import IndexedFile, IndexRunSummary
+from tldw_Server_API.app.core.CodeGraph.models import (
+    CodeGraphEdge,
+    CodeGraphNode,
+    CodeGraphUnresolvedRef,
+    IndexedFile,
+    IndexRunSummary,
+)
 from tldw_Server_API.app.core.DB_Management.sqlite_policy import configure_sqlite_connection
 
 
@@ -186,6 +192,185 @@ class CodeGraphRepository:
             self._prepare_file_replacement(conn, path)
             conn.commit()
 
+    def replace_file_graph(
+        self,
+        *,
+        path: str,
+        nodes: list[CodeGraphNode] | tuple[CodeGraphNode, ...],
+        edges: list[CodeGraphEdge] | tuple[CodeGraphEdge, ...],
+        unresolved_refs: list[CodeGraphUnresolvedRef] | tuple[CodeGraphUnresolvedRef, ...],
+    ) -> None:
+        if Path(path).is_absolute():
+            raise ValueError("file path must be workspace-relative")
+        with self._connection() as conn:
+            self._prepare_file_replacement(conn, path)
+            _insert_nodes(conn, nodes)
+            _insert_edges(conn, edges)
+            _insert_unresolved_refs(conn, unresolved_refs)
+            _delete_dangling_edges(conn)
+            conn.commit()
+
+    def search_nodes(
+        self,
+        query: str,
+        *,
+        limit: int = 10,
+        kind: str | None = None,
+        language: str | None = None,
+    ) -> list[CodeGraphNode]:
+        text = query.strip()
+        if not text:
+            return []
+
+        filters = [
+            """
+            (
+                lower(name) = lower(?)
+                OR lower(qualified_name) = lower(?)
+                OR name LIKE ? ESCAPE '\\'
+                OR qualified_name LIKE ? ESCAPE '\\'
+                OR signature LIKE ? ESCAPE '\\'
+                OR docstring LIKE ? ESCAPE '\\'
+            )
+            """
+        ]
+        like = f"%{_escape_like_literal(text)}%"
+        params: list[Any] = [text, text, like, like, like, like]
+        if kind:
+            filters.append("kind = ?")
+            params.append(kind)
+        if language:
+            filters.append("language = ?")
+            params.append(language)
+
+        params.extend([text, text, f"{_escape_like_literal(text)}%", max(1, int(limit))])
+        with self._connection() as conn:
+            rows = conn.execute(
+                f"""
+                SELECT *
+                FROM nodes
+                WHERE {' AND '.join(filters)}
+                ORDER BY
+                    CASE
+                        WHEN lower(qualified_name) = lower(?) THEN 0
+                        WHEN lower(name) = lower(?) THEN 1
+                        WHEN name LIKE ? ESCAPE '\\' THEN 2
+                        ELSE 3
+                    END,
+                    file_path,
+                    COALESCE(start_line, 0),
+                    qualified_name
+                LIMIT ?
+                """,
+                params,
+            ).fetchall()
+        return [_node_from_row(row) for row in rows]
+
+    def get_node(self, node_id: str) -> CodeGraphNode | None:
+        with self._connection() as conn:
+            row = conn.execute("SELECT * FROM nodes WHERE id = ?", (node_id,)).fetchone()
+        return _node_from_row(row) if row else None
+
+    def find_node_by_symbol(self, symbol: str) -> CodeGraphNode | None:
+        text = symbol.strip()
+        if not text:
+            return None
+        with self._connection() as conn:
+            row = conn.execute(
+                """
+                SELECT *
+                FROM nodes
+                WHERE lower(qualified_name) = lower(?) OR lower(name) = lower(?)
+                ORDER BY
+                    CASE WHEN lower(qualified_name) = lower(?) THEN 0 ELSE 1 END,
+                    file_path,
+                    COALESCE(start_line, 0)
+                LIMIT 1
+                """,
+                (text, text, text),
+            ).fetchone()
+        return _node_from_row(row) if row else None
+
+    def list_callers(self, node_id: str, *, limit: int = 10) -> list[dict[str, Any]]:
+        with self._connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT
+                    e.id AS edge_id,
+                    e.kind AS edge_kind,
+                    e.file_path AS edge_file_path,
+                    e.line AS edge_line,
+                    e.column AS edge_column,
+                    e.metadata AS edge_metadata,
+                    e.provenance AS edge_provenance,
+                    source_node.*,
+                    target_node.id AS target_id,
+                    target_node.identity_key AS target_identity_key,
+                    target_node.kind AS target_kind,
+                    target_node.name AS target_name,
+                    target_node.qualified_name AS target_qualified_name,
+                    target_node.file_path AS target_file_path,
+                    target_node.language AS target_language,
+                    target_node.start_line AS target_start_line,
+                    target_node.end_line AS target_end_line,
+                    target_node.start_column AS target_start_column,
+                    target_node.end_column AS target_end_column,
+                    target_node.signature AS target_signature,
+                    target_node.docstring AS target_docstring,
+                    target_node.visibility AS target_visibility,
+                    target_node.flags AS target_flags,
+                    target_node.metadata AS target_metadata
+                FROM edges e
+                JOIN nodes source_node ON source_node.id = e.source
+                JOIN nodes target_node ON target_node.id = e.target
+                WHERE e.target = ?
+                ORDER BY e.file_path, COALESCE(e.line, 0), source_node.qualified_name
+                LIMIT ?
+                """,
+                (node_id, max(1, int(limit))),
+            ).fetchall()
+        return [_relationship_from_joined_row(row) for row in rows]
+
+    def list_callees(self, node_id: str, *, limit: int = 10) -> list[dict[str, Any]]:
+        with self._connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT
+                    e.id AS edge_id,
+                    e.kind AS edge_kind,
+                    e.file_path AS edge_file_path,
+                    e.line AS edge_line,
+                    e.column AS edge_column,
+                    e.metadata AS edge_metadata,
+                    e.provenance AS edge_provenance,
+                    source_node.*,
+                    target_node.id AS target_id,
+                    target_node.identity_key AS target_identity_key,
+                    target_node.kind AS target_kind,
+                    target_node.name AS target_name,
+                    target_node.qualified_name AS target_qualified_name,
+                    target_node.file_path AS target_file_path,
+                    target_node.language AS target_language,
+                    target_node.start_line AS target_start_line,
+                    target_node.end_line AS target_end_line,
+                    target_node.start_column AS target_start_column,
+                    target_node.end_column AS target_end_column,
+                    target_node.signature AS target_signature,
+                    target_node.docstring AS target_docstring,
+                    target_node.visibility AS target_visibility,
+                    target_node.flags AS target_flags,
+                    target_node.metadata AS target_metadata
+                FROM edges e
+                JOIN nodes source_node ON source_node.id = e.source
+                JOIN nodes target_node ON target_node.id = e.target
+                WHERE e.source = ?
+                ORDER BY e.file_path, COALESCE(e.line, 0), target_node.qualified_name
+                LIMIT ?
+                """,
+                (node_id, max(1, int(limit))),
+            ).fetchall()
+        return [_relationship_from_joined_row(row) for row in rows]
+
     def seed_graph_rows_for_test(
         self,
         *,
@@ -284,6 +469,96 @@ def _delete_file_rows(conn: sqlite3.Connection, paths: list[str]) -> None:
     _delete_dangling_edges(conn)
 
 
+def _insert_nodes(
+    conn: sqlite3.Connection,
+    nodes: list[CodeGraphNode] | tuple[CodeGraphNode, ...],
+) -> None:
+    conn.executemany(
+        """
+        INSERT INTO nodes(
+            id, identity_key, kind, name, qualified_name, file_path, language,
+            start_line, end_line, start_column, end_column, signature, docstring,
+            visibility, flags, metadata
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        [
+            (
+                node.id,
+                node.identity_key,
+                node.kind,
+                node.name,
+                node.qualified_name,
+                node.file_path,
+                node.language,
+                node.start_line,
+                node.end_line,
+                node.start_column,
+                node.end_column,
+                node.signature,
+                node.docstring,
+                node.visibility,
+                json.dumps(list(node.flags)),
+                json.dumps(node.metadata, sort_keys=True),
+            )
+            for node in nodes
+        ],
+    )
+
+
+def _insert_edges(
+    conn: sqlite3.Connection,
+    edges: list[CodeGraphEdge] | tuple[CodeGraphEdge, ...],
+) -> None:
+    conn.executemany(
+        """
+        INSERT INTO edges(id, source, target, kind, file_path, line, column, metadata, provenance)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        [
+            (
+                edge.id,
+                edge.source,
+                edge.target,
+                edge.kind,
+                edge.file_path,
+                edge.line,
+                edge.column,
+                json.dumps(edge.metadata, sort_keys=True),
+                edge.provenance,
+            )
+            for edge in edges
+        ],
+    )
+
+
+def _insert_unresolved_refs(
+    conn: sqlite3.Connection,
+    unresolved_refs: list[CodeGraphUnresolvedRef] | tuple[CodeGraphUnresolvedRef, ...],
+) -> None:
+    conn.executemany(
+        """
+        INSERT INTO unresolved_refs(
+            from_node_id, reference_name, reference_kind, file_path, line, column, candidates, language
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        [
+            (
+                ref.from_node_id,
+                ref.reference_name,
+                ref.reference_kind,
+                ref.file_path,
+                ref.line,
+                ref.column,
+                json.dumps(list(ref.candidates)),
+                ref.language,
+            )
+            for ref in unresolved_refs
+        ],
+    )
+
+
 def _escape_like_literal(value: str) -> str:
     return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
@@ -338,6 +613,84 @@ def _indexed_file_from_row(row: sqlite3.Row) -> IndexedFile:
         status=str(row["status"]),
         errors=tuple(json.loads(row["errors"] or "[]")),
     )
+
+
+def _node_from_row(row: sqlite3.Row) -> CodeGraphNode:
+    return CodeGraphNode(
+        id=str(row["id"]),
+        identity_key=str(row["identity_key"]),
+        kind=str(row["kind"]),
+        name=str(row["name"]),
+        qualified_name=str(row["qualified_name"] or row["name"]),
+        file_path=str(row["file_path"]),
+        language=str(row["language"] or ""),
+        start_line=int(row["start_line"]) if row["start_line"] is not None else None,
+        end_line=int(row["end_line"]) if row["end_line"] is not None else None,
+        start_column=int(row["start_column"]) if row["start_column"] is not None else None,
+        end_column=int(row["end_column"]) if row["end_column"] is not None else None,
+        signature=str(row["signature"]) if row["signature"] is not None else None,
+        docstring=str(row["docstring"]) if row["docstring"] is not None else None,
+        visibility=str(row["visibility"]) if row["visibility"] is not None else None,
+        flags=tuple(json.loads(row["flags"] or "[]")),
+        metadata=dict(json.loads(row["metadata"] or "{}")),
+    )
+
+
+def _node_to_dict(node: CodeGraphNode) -> dict[str, Any]:
+    return {
+        "id": node.id,
+        "kind": node.kind,
+        "name": node.name,
+        "qualified_name": node.qualified_name,
+        "file_path": node.file_path,
+        "language": node.language,
+        "start_line": node.start_line,
+        "end_line": node.end_line,
+        "start_column": node.start_column,
+        "end_column": node.end_column,
+        "signature": node.signature,
+        "docstring": node.docstring,
+        "visibility": node.visibility,
+        "flags": list(node.flags),
+        "metadata": dict(node.metadata),
+    }
+
+
+def _target_node_from_joined_row(row: sqlite3.Row) -> CodeGraphNode:
+    return CodeGraphNode(
+        id=str(row["target_id"]),
+        identity_key=str(row["target_identity_key"]),
+        kind=str(row["target_kind"]),
+        name=str(row["target_name"]),
+        qualified_name=str(row["target_qualified_name"] or row["target_name"]),
+        file_path=str(row["target_file_path"]),
+        language=str(row["target_language"] or ""),
+        start_line=int(row["target_start_line"]) if row["target_start_line"] is not None else None,
+        end_line=int(row["target_end_line"]) if row["target_end_line"] is not None else None,
+        start_column=int(row["target_start_column"]) if row["target_start_column"] is not None else None,
+        end_column=int(row["target_end_column"]) if row["target_end_column"] is not None else None,
+        signature=str(row["target_signature"]) if row["target_signature"] is not None else None,
+        docstring=str(row["target_docstring"]) if row["target_docstring"] is not None else None,
+        visibility=str(row["target_visibility"]) if row["target_visibility"] is not None else None,
+        flags=tuple(json.loads(row["target_flags"] or "[]")),
+        metadata=dict(json.loads(row["target_metadata"] or "{}")),
+    )
+
+
+def _relationship_from_joined_row(row: sqlite3.Row) -> dict[str, Any]:
+    source = _node_from_row(row)
+    target = _target_node_from_joined_row(row)
+    return {
+        "id": str(row["edge_id"]),
+        "kind": str(row["edge_kind"]),
+        "file_path": str(row["edge_file_path"]),
+        "line": int(row["edge_line"]) if row["edge_line"] is not None else None,
+        "column": int(row["edge_column"]) if row["edge_column"] is not None else None,
+        "metadata": dict(json.loads(row["edge_metadata"] or "{}")),
+        "provenance": str(row["edge_provenance"]) if row["edge_provenance"] else None,
+        "source": _node_to_dict(source),
+        "target": _node_to_dict(target),
+    }
 
 
 def _index_run_from_row(row: sqlite3.Row) -> IndexRunSummary:

--- a/tldw_Server_API/app/core/DB_Management/codegraph/repository.py
+++ b/tldw_Server_API/app/core/DB_Management/codegraph/repository.py
@@ -1,3 +1,5 @@
+"""SQLite persistence helpers for native CodeGraph indexes."""
+
 from __future__ import annotations
 
 from contextlib import closing, contextmanager
@@ -24,9 +26,11 @@ class CodeGraphRepository:
     """SQLite repository for the native CodeGraph index."""
 
     def __init__(self, db_path: str | Path) -> None:
+        """Store the target SQLite database path without creating it."""
         self.db_path = Path(db_path)
 
     def initialize(self) -> None:
+        """Create parent directories, schema tables, and optional FTS structures."""
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         schema = Path(__file__).with_name("schema.sql").read_text(encoding="utf-8")
         with self._connection() as conn:
@@ -35,6 +39,7 @@ class CodeGraphRepository:
             conn.commit()
 
     def counts(self) -> dict[str, int]:
+        """Return row counts for graph inventory tables."""
         with self._connection() as conn:
             return {
                 "files": self._count(conn, "files"),
@@ -44,6 +49,7 @@ class CodeGraphRepository:
             }
 
     def record_index_run_start(self, *, workspace_key: str, mode: str) -> str:
+        """Insert a running index-run row and return its generated run id."""
         run_id = f"run_{uuid.uuid4().hex}"
         with self._connection() as conn:
             conn.execute(
@@ -72,6 +78,7 @@ class CodeGraphRepository:
         counters: dict[str, int],
         error_summary: list[str] | tuple[str, ...],
     ) -> None:
+        """Mark an index run complete with counters and error summary."""
         with self._connection() as conn:
             conn.execute(
                 """
@@ -101,34 +108,20 @@ class CodeGraphRepository:
         errors: list[str] | tuple[str, ...],
         node_count: int = 0,
     ) -> None:
+        """Insert or update a workspace-relative file inventory row."""
         if Path(path).is_absolute():
             raise ValueError("file path must be workspace-relative")
         with self._connection() as conn:
-            conn.execute(
-                """
-                INSERT INTO files(path, language, size, content_hash, modified_at, indexed_at, node_count, status, errors)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(path) DO UPDATE SET
-                    language = excluded.language,
-                    size = excluded.size,
-                    content_hash = excluded.content_hash,
-                    modified_at = excluded.modified_at,
-                    indexed_at = excluded.indexed_at,
-                    node_count = excluded.node_count,
-                    status = excluded.status,
-                    errors = excluded.errors
-                """,
-                (
-                    path,
-                    language,
-                    int(size),
-                    content_hash,
-                    float(modified_at),
-                    _utc_now(),
-                    int(node_count),
-                    status,
-                    json.dumps(list(errors)),
-                ),
+            _upsert_file(
+                conn,
+                path=path,
+                language=language,
+                size=size,
+                content_hash=content_hash,
+                modified_at=modified_at,
+                status=status,
+                errors=errors,
+                node_count=node_count,
             )
             conn.commit()
 
@@ -139,6 +132,7 @@ class CodeGraphRepository:
         path_prefix: str | None = None,
         path_pattern: str | None = None,
     ) -> list[IndexedFile]:
+        """List indexed files with optional path prefix and glob filtering."""
         sql = """
             SELECT path, language, size, content_hash, modified_at, indexed_at, node_count, status, errors
             FROM files
@@ -161,6 +155,7 @@ class CodeGraphRepository:
         return [_indexed_file_from_row(row) for row in rows]
 
     def last_index_run(self) -> IndexRunSummary | None:
+        """Return the most recent index run if the database has any run history."""
         with self._connection() as conn:
             row = conn.execute(
                 """
@@ -173,6 +168,7 @@ class CodeGraphRepository:
         return _index_run_from_row(row) if row else None
 
     def delete_missing_files(self, current_paths: set[str]) -> int:
+        """Remove files and graph rows not present in the current discovery set."""
         existing = {item.path for item in self.list_files(limit=1_000_000)}
         removed = sorted(existing - set(current_paths))
         if not removed:
@@ -183,11 +179,13 @@ class CodeGraphRepository:
         return len(removed)
 
     def delete_file(self, path: str) -> None:
+        """Delete one file inventory row and its dependent graph rows."""
         with self._connection() as conn:
             _delete_file_rows(conn, [path])
             conn.commit()
 
     def prepare_file_replacement(self, path: str) -> None:
+        """Clear graph rows for a file before writing a replacement graph."""
         with self._connection() as conn:
             self._prepare_file_replacement(conn, path)
             conn.commit()
@@ -200,9 +198,47 @@ class CodeGraphRepository:
         edges: list[CodeGraphEdge] | tuple[CodeGraphEdge, ...],
         unresolved_refs: list[CodeGraphUnresolvedRef] | tuple[CodeGraphUnresolvedRef, ...],
     ) -> None:
+        """Replace all graph rows for one workspace-relative file atomically."""
         if Path(path).is_absolute():
             raise ValueError("file path must be workspace-relative")
         with self._connection() as conn:
+            self._prepare_file_replacement(conn, path)
+            _insert_nodes(conn, nodes)
+            _insert_edges(conn, edges)
+            _insert_unresolved_refs(conn, unresolved_refs)
+            _delete_dangling_edges(conn)
+            conn.commit()
+
+    def upsert_file_and_replace_graph(
+        self,
+        *,
+        path: str,
+        language: str,
+        size: int,
+        content_hash: str,
+        modified_at: float,
+        status: str,
+        errors: list[str] | tuple[str, ...],
+        node_count: int,
+        nodes: list[CodeGraphNode] | tuple[CodeGraphNode, ...],
+        edges: list[CodeGraphEdge] | tuple[CodeGraphEdge, ...],
+        unresolved_refs: list[CodeGraphUnresolvedRef] | tuple[CodeGraphUnresolvedRef, ...],
+    ) -> None:
+        """Persist file inventory and replacement graph rows in one transaction."""
+        if Path(path).is_absolute():
+            raise ValueError("file path must be workspace-relative")
+        with self._connection() as conn:
+            _upsert_file(
+                conn,
+                path=path,
+                language=language,
+                size=size,
+                content_hash=content_hash,
+                modified_at=modified_at,
+                status=status,
+                errors=errors,
+                node_count=node_count,
+            )
             self._prepare_file_replacement(conn, path)
             _insert_nodes(conn, nodes)
             _insert_edges(conn, edges)
@@ -218,38 +254,45 @@ class CodeGraphRepository:
         kind: str | None = None,
         language: str | None = None,
     ) -> list[CodeGraphNode]:
+        """Search indexed nodes by exact or fuzzy symbol text with optional filters."""
         text = query.strip()
         if not text:
             return []
 
-        filters = [
-            """
-            (
-                lower(name) = lower(?)
-                OR lower(qualified_name) = lower(?)
-                OR name LIKE ? ESCAPE '\\'
-                OR qualified_name LIKE ? ESCAPE '\\'
-                OR signature LIKE ? ESCAPE '\\'
-                OR docstring LIKE ? ESCAPE '\\'
-            )
-            """
-        ]
         like = f"%{_escape_like_literal(text)}%"
-        params: list[Any] = [text, text, like, like, like, like]
-        if kind:
-            filters.append("kind = ?")
-            params.append(kind)
-        if language:
-            filters.append("language = ?")
-            params.append(language)
-
-        params.extend([text, text, f"{_escape_like_literal(text)}%", max(1, int(limit))])
+        prefix_like = f"{_escape_like_literal(text)}%"
+        params: list[Any] = [
+            text,
+            text,
+            like,
+            like,
+            like,
+            like,
+            kind,
+            kind,
+            language,
+            language,
+            text,
+            text,
+            prefix_like,
+            max(1, int(limit)),
+        ]
         with self._connection() as conn:
             rows = conn.execute(
-                f"""
+                """
                 SELECT *
                 FROM nodes
-                WHERE {' AND '.join(filters)}
+                WHERE
+                    (
+                        lower(name) = lower(?)
+                        OR lower(qualified_name) = lower(?)
+                        OR name LIKE ? ESCAPE '\\'
+                        OR qualified_name LIKE ? ESCAPE '\\'
+                        OR signature LIKE ? ESCAPE '\\'
+                        OR docstring LIKE ? ESCAPE '\\'
+                    )
+                    AND (? IS NULL OR kind = ?)
+                    AND (? IS NULL OR language = ?)
                 ORDER BY
                     CASE
                         WHEN lower(qualified_name) = lower(?) THEN 0
@@ -267,11 +310,13 @@ class CodeGraphRepository:
         return [_node_from_row(row) for row in rows]
 
     def get_node(self, node_id: str) -> CodeGraphNode | None:
+        """Fetch one graph node by stable node id."""
         with self._connection() as conn:
             row = conn.execute("SELECT * FROM nodes WHERE id = ?", (node_id,)).fetchone()
         return _node_from_row(row) if row else None
 
     def find_node_by_symbol(self, symbol: str) -> CodeGraphNode | None:
+        """Resolve a symbol name or qualified name to the best matching node."""
         text = symbol.strip()
         if not text:
             return None
@@ -292,6 +337,7 @@ class CodeGraphRepository:
         return _node_from_row(row) if row else None
 
     def list_callers(self, node_id: str, *, limit: int = 10) -> list[dict[str, Any]]:
+        """List call edges whose target is the requested node."""
         with self._connection() as conn:
             rows = conn.execute(
                 """
@@ -332,6 +378,7 @@ class CodeGraphRepository:
         return [_relationship_from_joined_row(row) for row in rows]
 
     def list_callees(self, node_id: str, *, limit: int = 10) -> list[dict[str, Any]]:
+        """List call edges whose source is the requested node."""
         with self._connection() as conn:
             rows = conn.execute(
                 """
@@ -378,6 +425,7 @@ class CodeGraphRepository:
         edges: list[dict[str, Any]],
         unresolved_refs: list[dict[str, Any]],
     ) -> None:
+        """Insert raw graph rows for repository regression tests."""
         with self._connection() as conn:
             for node in nodes:
                 conn.execute(
@@ -432,10 +480,12 @@ class CodeGraphRepository:
 
     @contextmanager
     def _connection(self):  # type: ignore[no-untyped-def]
+        """Yield a managed SQLite connection for one repository operation."""
         with closing(self._connect()) as conn:
             yield conn
 
     def _connect(self) -> sqlite3.Connection:
+        """Open a SQLite connection using the shared project SQLite policy."""
         conn = sqlite3.connect(self.db_path)
         conn.row_factory = sqlite3.Row
         configure_sqlite_connection(conn)
@@ -443,6 +493,7 @@ class CodeGraphRepository:
 
     @staticmethod
     def _count(conn: sqlite3.Connection, table: str) -> int:
+        """Return the count for a whitelisted repository table."""
         count_sql = {
             "files": "SELECT COUNT(*) AS count FROM files",
             "nodes": "SELECT COUNT(*) AS count FROM nodes",
@@ -454,6 +505,7 @@ class CodeGraphRepository:
 
     @staticmethod
     def _prepare_file_replacement(conn: sqlite3.Connection, path: str) -> None:
+        """Delete graph rows for a file and clear edges left without endpoints."""
         conn.execute("DELETE FROM unresolved_refs WHERE file_path = ?", (path,))
         conn.execute("DELETE FROM edges WHERE file_path = ?", (path,))
         conn.execute("DELETE FROM nodes WHERE file_path = ?", (path,))
@@ -461,6 +513,7 @@ class CodeGraphRepository:
 
 
 def _delete_file_rows(conn: sqlite3.Connection, paths: list[str]) -> None:
+    """Delete files and all graph rows that belong to the provided paths."""
     params = [(path,) for path in paths]
     conn.executemany("DELETE FROM unresolved_refs WHERE file_path = ?", params)
     conn.executemany("DELETE FROM edges WHERE file_path = ?", params)
@@ -469,10 +522,52 @@ def _delete_file_rows(conn: sqlite3.Connection, paths: list[str]) -> None:
     _delete_dangling_edges(conn)
 
 
+def _upsert_file(
+    conn: sqlite3.Connection,
+    *,
+    path: str,
+    language: str,
+    size: int,
+    content_hash: str,
+    modified_at: float,
+    status: str,
+    errors: list[str] | tuple[str, ...],
+    node_count: int = 0,
+) -> None:
+    """Insert or update a file row using an existing transaction."""
+    conn.execute(
+        """
+        INSERT INTO files(path, language, size, content_hash, modified_at, indexed_at, node_count, status, errors)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(path) DO UPDATE SET
+            language = excluded.language,
+            size = excluded.size,
+            content_hash = excluded.content_hash,
+            modified_at = excluded.modified_at,
+            indexed_at = excluded.indexed_at,
+            node_count = excluded.node_count,
+            status = excluded.status,
+            errors = excluded.errors
+        """,
+        (
+            path,
+            language,
+            int(size),
+            content_hash,
+            float(modified_at),
+            _utc_now(),
+            int(node_count),
+            status,
+            json.dumps(list(errors)),
+        ),
+    )
+
+
 def _insert_nodes(
     conn: sqlite3.Connection,
     nodes: list[CodeGraphNode] | tuple[CodeGraphNode, ...],
 ) -> None:
+    """Bulk insert extracted graph nodes."""
     conn.executemany(
         """
         INSERT INTO nodes(
@@ -510,6 +605,7 @@ def _insert_edges(
     conn: sqlite3.Connection,
     edges: list[CodeGraphEdge] | tuple[CodeGraphEdge, ...],
 ) -> None:
+    """Bulk insert extracted graph edges."""
     conn.executemany(
         """
         INSERT INTO edges(id, source, target, kind, file_path, line, column, metadata, provenance)
@@ -536,6 +632,7 @@ def _insert_unresolved_refs(
     conn: sqlite3.Connection,
     unresolved_refs: list[CodeGraphUnresolvedRef] | tuple[CodeGraphUnresolvedRef, ...],
 ) -> None:
+    """Bulk insert unresolved references captured by extractors."""
     conn.executemany(
         """
         INSERT INTO unresolved_refs(
@@ -560,10 +657,12 @@ def _insert_unresolved_refs(
 
 
 def _escape_like_literal(value: str) -> str:
+    """Escape user text before using it inside a SQLite LIKE pattern."""
     return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
 
 def _delete_dangling_edges(conn: sqlite3.Connection) -> None:
+    """Remove edges whose source or target node no longer exists."""
     # Stage 1 only stores bounded foreground inventories, so this cleanup favors
     # straightforward correctness; if graph volume grows, switch to a join/exists
     # form or staged node-id table to avoid repeated full-node scans.
@@ -577,6 +676,7 @@ def _delete_dangling_edges(conn: sqlite3.Connection) -> None:
 
 
 def _create_optional_fts(conn: sqlite3.Connection) -> None:
+    """Create the optional nodes FTS table when SQLite was built with FTS5."""
     try:
         conn.execute(
             """
@@ -598,10 +698,12 @@ def _create_optional_fts(conn: sqlite3.Connection) -> None:
 
 
 def _utc_now() -> str:
+    """Return the current UTC timestamp in the repository's stored format."""
     return datetime.now(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")
 
 
 def _indexed_file_from_row(row: sqlite3.Row) -> IndexedFile:
+    """Convert a files table row to an IndexedFile value object."""
     return IndexedFile(
         path=str(row["path"]),
         language=str(row["language"]),
@@ -616,6 +718,7 @@ def _indexed_file_from_row(row: sqlite3.Row) -> IndexedFile:
 
 
 def _node_from_row(row: sqlite3.Row) -> CodeGraphNode:
+    """Convert a nodes table row to a CodeGraphNode value object."""
     return CodeGraphNode(
         id=str(row["id"]),
         identity_key=str(row["identity_key"]),
@@ -637,6 +740,7 @@ def _node_from_row(row: sqlite3.Row) -> CodeGraphNode:
 
 
 def _node_to_dict(node: CodeGraphNode) -> dict[str, Any]:
+    """Serialize a CodeGraphNode for relationship payloads."""
     return {
         "id": node.id,
         "kind": node.kind,
@@ -657,6 +761,7 @@ def _node_to_dict(node: CodeGraphNode) -> dict[str, Any]:
 
 
 def _target_node_from_joined_row(row: sqlite3.Row) -> CodeGraphNode:
+    """Convert target-node aliases from a relationship join row."""
     return CodeGraphNode(
         id=str(row["target_id"]),
         identity_key=str(row["target_identity_key"]),
@@ -678,6 +783,7 @@ def _target_node_from_joined_row(row: sqlite3.Row) -> CodeGraphNode:
 
 
 def _relationship_from_joined_row(row: sqlite3.Row) -> dict[str, Any]:
+    """Serialize a joined edge/source/target row into API-ready shape."""
     source = _node_from_row(row)
     target = _target_node_from_joined_row(row)
     return {
@@ -694,6 +800,7 @@ def _relationship_from_joined_row(row: sqlite3.Row) -> dict[str, Any]:
 
 
 def _index_run_from_row(row: sqlite3.Row) -> IndexRunSummary:
+    """Convert an index_runs table row to an IndexRunSummary."""
     return IndexRunSummary(
         run_id=str(row["run_id"]),
         workspace_key=str(row["workspace_key"]),

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py
@@ -18,7 +18,7 @@ from tldw_Server_API.app.core.CodeGraph.config import CodeGraphSettings
 from tldw_Server_API.app.core.CodeGraph.dependencies import probe_codegraph_dependencies
 from tldw_Server_API.app.core.CodeGraph.indexer import CodeGraphIndexer
 from tldw_Server_API.app.core.CodeGraph.language_registry import CodeGraphLanguageRegistry
-from tldw_Server_API.app.core.CodeGraph.models import IndexedFile, IndexRunSummary, WorkspaceResolution
+from tldw_Server_API.app.core.CodeGraph.models import CodeGraphNode, IndexedFile, IndexRunSummary, WorkspaceResolution
 from tldw_Server_API.app.core.CodeGraph.workspace import CodeGraphWorkspaceResolver, WorkspaceRootResolver
 from tldw_Server_API.app.core.DB_Management.codegraph.repository import CodeGraphRepository
 
@@ -141,7 +141,85 @@ class CodeGraphModule(BaseModule):
         )
         files_tool["inputSchema"]["additionalProperties"] = False
 
-        return [status_tool, index_tool, sync_tool, files_tool]
+        search_tool = create_tool_definition(
+            name="codegraph.search",
+            description="Search indexed CodeGraph symbols for the active workspace.",
+            parameters={
+                "properties": {
+                    "query": {"type": "string"},
+                    "kind": {"type": "string"},
+                    "language": {"type": "string"},
+                    "limit": {"type": "integer"},
+                },
+                "required": ["query"],
+            },
+            metadata={
+                "category": "retrieval",
+                "readOnlyHint": True,
+                "capabilities": ["codegraph.read"],
+                **workspace_metadata,
+            },
+        )
+        search_tool["inputSchema"]["additionalProperties"] = False
+
+        node_tool = create_tool_definition(
+            name="codegraph.node",
+            description="Fetch one indexed CodeGraph symbol by node id or exact symbol name.",
+            parameters={
+                "properties": {
+                    "node_id": {"type": "string"},
+                    "symbol": {"type": "string"},
+                    "include_code": {"type": "boolean"},
+                },
+            },
+            metadata={
+                "category": "retrieval",
+                "readOnlyHint": True,
+                "capabilities": ["codegraph.read"],
+                **workspace_metadata,
+            },
+        )
+        node_tool["inputSchema"]["additionalProperties"] = False
+
+        callers_tool = create_tool_definition(
+            name="codegraph.callers",
+            description="List indexed call relationships that target a symbol.",
+            parameters={
+                "properties": {
+                    "node_id": {"type": "string"},
+                    "symbol": {"type": "string"},
+                    "limit": {"type": "integer"},
+                },
+            },
+            metadata={
+                "category": "retrieval",
+                "readOnlyHint": True,
+                "capabilities": ["codegraph.read"],
+                **workspace_metadata,
+            },
+        )
+        callers_tool["inputSchema"]["additionalProperties"] = False
+
+        callees_tool = create_tool_definition(
+            name="codegraph.callees",
+            description="List indexed call relationships emitted by a symbol.",
+            parameters={
+                "properties": {
+                    "node_id": {"type": "string"},
+                    "symbol": {"type": "string"},
+                    "limit": {"type": "integer"},
+                },
+            },
+            metadata={
+                "category": "retrieval",
+                "readOnlyHint": True,
+                "capabilities": ["codegraph.read"],
+                **workspace_metadata,
+            },
+        )
+        callees_tool["inputSchema"]["additionalProperties"] = False
+
+        return [status_tool, index_tool, sync_tool, files_tool, search_tool, node_tool, callers_tool, callees_tool]
 
     async def execute_tool(self, tool_name: str, arguments: dict[str, Any], context: Any | None = None) -> Any:
         args = self.sanitize_input(arguments or {})
@@ -177,6 +255,45 @@ class CodeGraphModule(BaseModule):
                 args.get("pattern"),
                 str(args.get("format") or "flat"),
                 bool(args.get("include_metadata", True)),
+                args.get("limit"),
+            )
+
+        if tool_name == "codegraph.search":
+            return await asyncio.to_thread(
+                self._search_nodes,
+                resolution,
+                str(args["query"]),
+                args.get("kind"),
+                args.get("language"),
+                args.get("limit"),
+            )
+
+        if tool_name == "codegraph.node":
+            return await asyncio.to_thread(
+                self._get_node,
+                resolution,
+                args.get("node_id"),
+                args.get("symbol"),
+                bool(args.get("include_code", False)),
+            )
+
+        if tool_name == "codegraph.callers":
+            return await asyncio.to_thread(
+                self._list_relationships,
+                resolution,
+                "callers",
+                args.get("node_id"),
+                args.get("symbol"),
+                args.get("limit"),
+            )
+
+        if tool_name == "codegraph.callees":
+            return await asyncio.to_thread(
+                self._list_relationships,
+                resolution,
+                "callees",
+                args.get("node_id"),
+                args.get("symbol"),
                 args.get("limit"),
             )
 
@@ -218,6 +335,35 @@ class CodeGraphModule(BaseModule):
                 raise ValueError("format must be flat, tree, or grouped")
             if include_metadata is not None and not isinstance(include_metadata, bool):
                 raise ValueError("include_metadata must be a boolean")
+            self._validate_positive_int(arguments.get("limit"), "limit")
+            return
+
+        if tool_name == "codegraph.search":
+            self._reject_unknown(arguments, allowed={"query", "kind", "language", "limit"})
+            query = arguments.get("query")
+            if not isinstance(query, str) or not query.strip():
+                raise ValueError("query must be a non-empty string")
+            kind = arguments.get("kind")
+            language = arguments.get("language")
+            if kind is not None and (not isinstance(kind, str) or not kind.strip()):
+                raise ValueError("kind must be a non-empty string")
+            if language is not None:
+                if not isinstance(language, str) or language not in self._language_registry.known_language_ids():
+                    raise ValueError("language must be a known language id")
+            self._validate_positive_int(arguments.get("limit"), "limit")
+            return
+
+        if tool_name == "codegraph.node":
+            self._reject_unknown(arguments, allowed={"node_id", "symbol", "include_code"})
+            self._validate_node_selector(arguments)
+            include_code = arguments.get("include_code")
+            if include_code is not None and not isinstance(include_code, bool):
+                raise ValueError("include_code must be a boolean")
+            return
+
+        if tool_name in {"codegraph.callers", "codegraph.callees"}:
+            self._reject_unknown(arguments, allowed={"node_id", "symbol", "limit"})
+            self._validate_node_selector(arguments)
             self._validate_positive_int(arguments.get("limit"), "limit")
             return
 
@@ -326,6 +472,93 @@ class CodeGraphModule(BaseModule):
             "truncated": truncated,
         }
 
+    def _search_nodes(
+        self,
+        resolution: WorkspaceResolution,
+        query: str,
+        kind: str | None,
+        language: str | None,
+        limit: int | None,
+    ) -> dict[str, Any]:
+        effective_limit = self._bounded_limit(limit)
+        if not resolution.index_db_path.exists():
+            return {
+                "workspace_key": resolution.workspace_key,
+                "index_present": False,
+                "results": [],
+                "truncated": False,
+            }
+        repository = CodeGraphRepository(resolution.index_db_path)
+        rows = repository.search_nodes(query, limit=effective_limit + 1, kind=kind, language=language)
+        truncated = len(rows) > effective_limit
+        return {
+            "workspace_key": resolution.workspace_key,
+            "index_present": True,
+            "query": query,
+            "results": [_node_to_dict(row) for row in rows[:effective_limit]],
+            "truncated": truncated,
+        }
+
+    def _get_node(
+        self,
+        resolution: WorkspaceResolution,
+        node_id: str | None,
+        symbol: str | None,
+        include_code: bool,
+    ) -> dict[str, Any]:
+        if not resolution.index_db_path.exists():
+            return {"workspace_key": resolution.workspace_key, "index_present": False, "node": None}
+        repository = CodeGraphRepository(resolution.index_db_path)
+        node = repository.get_node(node_id) if node_id else repository.find_node_by_symbol(str(symbol))
+        node_dict = _node_to_dict(node) if node is not None else None
+        if node_dict is not None and include_code:
+            node_dict["code_available"] = False
+        return {
+            "workspace_key": resolution.workspace_key,
+            "index_present": True,
+            "node": node_dict,
+        }
+
+    def _list_relationships(
+        self,
+        resolution: WorkspaceResolution,
+        direction: str,
+        node_id: str | None,
+        symbol: str | None,
+        limit: int | None,
+    ) -> dict[str, Any]:
+        effective_limit = self._bounded_limit(limit)
+        if not resolution.index_db_path.exists():
+            return {
+                "workspace_key": resolution.workspace_key,
+                "index_present": False,
+                "node": None,
+                "relationships": [],
+                "truncated": False,
+            }
+        repository = CodeGraphRepository(resolution.index_db_path)
+        node = repository.get_node(node_id) if node_id else repository.find_node_by_symbol(str(symbol))
+        if node is None:
+            return {
+                "workspace_key": resolution.workspace_key,
+                "index_present": True,
+                "node": None,
+                "relationships": [],
+                "truncated": False,
+            }
+        if direction == "callers":
+            rows = repository.list_callers(node.id, limit=effective_limit + 1)
+        else:
+            rows = repository.list_callees(node.id, limit=effective_limit + 1)
+        truncated = len(rows) > effective_limit
+        return {
+            "workspace_key": resolution.workspace_key,
+            "index_present": True,
+            "node": _node_to_dict(node),
+            "relationships": rows[:effective_limit],
+            "truncated": truncated,
+        }
+
     def _new_indexer(self) -> CodeGraphIndexer:
         return CodeGraphIndexer(settings=self._settings, registry=self._language_registry)
 
@@ -356,6 +589,20 @@ class CodeGraphModule(BaseModule):
         if not isinstance(value, int) or isinstance(value, bool) or value < 1:
             raise ValueError(f"{field_name} must be a positive integer")
 
+    @staticmethod
+    def _validate_node_selector(arguments: dict[str, Any]) -> None:
+        node_id = arguments.get("node_id")
+        symbol = arguments.get("symbol")
+        if node_id is None and symbol is None:
+            raise ValueError("node_id or symbol is required")
+        if node_id is not None and (not isinstance(node_id, str) or not node_id.strip()):
+            raise ValueError("node_id must be a non-empty string")
+        if symbol is not None and (not isinstance(symbol, str) or not symbol.strip()):
+            raise ValueError("symbol must be a non-empty string")
+
+    def _bounded_limit(self, limit: int | None) -> int:
+        return min(max(1, int(limit or 10)), self._settings.max_search_results)
+
 
 def _normalize_path_prefix(path: str | None) -> str | None:
     if path is None or not path.strip() or path.strip() == ".":
@@ -384,6 +631,26 @@ def _indexed_file_to_dict(file: IndexedFile, *, include_metadata: bool) -> dict[
             }
         )
     return result
+
+
+def _node_to_dict(node: CodeGraphNode) -> dict[str, Any]:
+    return {
+        "id": node.id,
+        "kind": node.kind,
+        "name": node.name,
+        "qualified_name": node.qualified_name,
+        "file_path": node.file_path,
+        "language": node.language,
+        "start_line": node.start_line,
+        "end_line": node.end_line,
+        "start_column": node.start_column,
+        "end_column": node.end_column,
+        "signature": node.signature,
+        "docstring": node.docstring,
+        "visibility": node.visibility,
+        "flags": list(node.flags),
+        "metadata": dict(node.metadata),
+    }
 
 
 def _index_run_to_dict(run: IndexRunSummary | None) -> dict[str, Any] | None:

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py
@@ -1,8 +1,8 @@
 """
 Workspace-bounded native CodeGraph MCP module.
 
-Stage 1 exposes bounded foreground indexing and file inventory only. Symbol
-extraction and graph queries are intentionally deferred.
+This module exposes bounded foreground indexing, file inventory, Python symbol
+search, and same-file call relationship queries for trusted workspace roots.
 """
 
 from __future__ import annotations
@@ -37,6 +37,7 @@ class CodeGraphModule(BaseModule):
         config: ModuleConfig,
         workspace_root_resolver: WorkspaceRootResolver | None = None,
     ) -> None:
+        """Create module-scoped settings, dependency probes, and workspace resolver."""
         super().__init__(config)
         self._settings = CodeGraphSettings.from_mapping(config.settings)
         self._dependency_health = probe_codegraph_dependencies()
@@ -44,12 +45,15 @@ class CodeGraphModule(BaseModule):
         self._workspace = CodeGraphWorkspaceResolver(workspace_root_resolver, self._settings)
 
     async def on_initialize(self) -> None:
+        """Log CodeGraph module initialization."""
         logger.info(f"Initializing CodeGraph module: {self.name}")
 
     async def on_shutdown(self) -> None:
+        """Log CodeGraph module shutdown."""
         logger.info(f"Shutting down CodeGraph module: {self.name}")
 
     async def check_health(self) -> dict[str, bool]:
+        """Return lightweight module health flags for MCP status reporting."""
         return {
             "initialized": True,
             "workspace_root_resolver": self._workspace is not None,
@@ -57,6 +61,7 @@ class CodeGraphModule(BaseModule):
         }
 
     async def get_tools(self) -> list[dict[str, Any]]:
+        """Return MCP tool definitions for native CodeGraph operations."""
         shared_metadata = {
             "uses_filesystem": True,
             "path_boundable": True,
@@ -222,6 +227,7 @@ class CodeGraphModule(BaseModule):
         return [status_tool, index_tool, sync_tool, files_tool, search_tool, node_tool, callers_tool, callees_tool]
 
     async def execute_tool(self, tool_name: str, arguments: dict[str, Any], context: Any | None = None) -> Any:
+        """Validate and dispatch one CodeGraph MCP tool invocation."""
         args = self.sanitize_input(arguments or {})
         self.validate_tool_arguments(tool_name, args)
 
@@ -300,6 +306,7 @@ class CodeGraphModule(BaseModule):
         raise ValueError(f"Unknown tool: {tool_name}")
 
     def validate_tool_arguments(self, tool_name: str, arguments: dict[str, Any]) -> None:
+        """Validate the input shape for a supported CodeGraph tool."""
         if tool_name == "codegraph.status":
             self._reject_unknown(arguments, allowed=set())
             return
@@ -343,10 +350,13 @@ class CodeGraphModule(BaseModule):
             query = arguments.get("query")
             if not isinstance(query, str) or not query.strip():
                 raise ValueError("query must be a non-empty string")
+            arguments["query"] = query.strip()
             kind = arguments.get("kind")
             language = arguments.get("language")
             if kind is not None and (not isinstance(kind, str) or not kind.strip()):
                 raise ValueError("kind must be a non-empty string")
+            if isinstance(kind, str):
+                arguments["kind"] = kind.strip()
             if language is not None:
                 if not isinstance(language, str) or language not in self._language_registry.known_language_ids():
                     raise ValueError("language must be a known language id")
@@ -370,6 +380,7 @@ class CodeGraphModule(BaseModule):
         raise ValueError(f"Unknown tool: {tool_name}")
 
     async def _status(self, resolution: WorkspaceResolution) -> dict[str, Any]:
+        """Build a read-only status payload without creating the index database."""
         if resolution.index_db_path.exists():
             counts, last_run = await asyncio.to_thread(self._read_status_from_repository, resolution)
             index_present = True
@@ -396,6 +407,7 @@ class CodeGraphModule(BaseModule):
         self,
         resolution: WorkspaceResolution,
     ) -> tuple[dict[str, int], IndexRunSummary | None]:
+        """Read status details from an existing index repository."""
         repository = CodeGraphRepository(resolution.index_db_path)
         return repository.counts(), repository.last_index_run()
 
@@ -406,6 +418,7 @@ class CodeGraphModule(BaseModule):
         languages: list[str] | None,
         max_files: int | None,
     ) -> dict[str, Any]:
+        """Run foreground indexing and serialize the result."""
         repository = CodeGraphRepository(resolution.index_db_path)
         indexer = self._new_indexer()
         result = indexer.index_workspace(
@@ -424,6 +437,7 @@ class CodeGraphModule(BaseModule):
         languages: list[str] | None,
         max_files: int | None,
     ) -> dict[str, Any]:
+        """Run foreground sync and serialize the result."""
         repository = CodeGraphRepository(resolution.index_db_path)
         indexer = self._new_indexer()
         result = indexer.sync_workspace(
@@ -444,6 +458,7 @@ class CodeGraphModule(BaseModule):
         include_metadata: bool,
         limit: int | None,
     ) -> dict[str, Any]:
+        """List indexed files without mutating absent index storage."""
         if not resolution.index_db_path.exists():
             return {
                 "workspace_key": resolution.workspace_key,
@@ -480,6 +495,7 @@ class CodeGraphModule(BaseModule):
         language: str | None,
         limit: int | None,
     ) -> dict[str, Any]:
+        """Search indexed graph nodes for one workspace."""
         effective_limit = self._bounded_limit(limit)
         if not resolution.index_db_path.exists():
             return {
@@ -506,6 +522,7 @@ class CodeGraphModule(BaseModule):
         symbol: str | None,
         include_code: bool,
     ) -> dict[str, Any]:
+        """Fetch one indexed graph node by id or symbol selector."""
         if not resolution.index_db_path.exists():
             return {"workspace_key": resolution.workspace_key, "index_present": False, "node": None}
         repository = CodeGraphRepository(resolution.index_db_path)
@@ -527,6 +544,7 @@ class CodeGraphModule(BaseModule):
         symbol: str | None,
         limit: int | None,
     ) -> dict[str, Any]:
+        """List callers or callees for one indexed graph node selector."""
         effective_limit = self._bounded_limit(limit)
         if not resolution.index_db_path.exists():
             return {
@@ -560,15 +578,18 @@ class CodeGraphModule(BaseModule):
         }
 
     def _new_indexer(self) -> CodeGraphIndexer:
+        """Create a fresh indexer for a blocking foreground operation."""
         return CodeGraphIndexer(settings=self._settings, registry=self._language_registry)
 
     @staticmethod
     def _reject_unknown(arguments: dict[str, Any], *, allowed: set[str]) -> None:
+        """Reject argument names outside a tool-specific allowlist."""
         unknown = sorted(set(arguments) - allowed)
         if unknown:
             raise ValueError(f"unknown arguments: {', '.join(unknown)}")
 
     def _validate_languages(self, languages: Any) -> None:
+        """Validate optional language filters against the registry."""
         if languages is None:
             return
         if not isinstance(languages, list) or not all(isinstance(item, str) for item in languages):
@@ -579,11 +600,13 @@ class CodeGraphModule(BaseModule):
 
     @staticmethod
     def _validate_foreground_mode(mode: Any) -> None:
+        """Ensure Stage 1 callers only request foreground execution."""
         if mode is not None and mode != _FOREGROUND_MODE:
             raise ValueError("only foreground mode is supported")
 
     @staticmethod
     def _validate_positive_int(value: Any, field_name: str) -> None:
+        """Validate optional positive integer tool arguments."""
         if value is None:
             return
         if not isinstance(value, int) or isinstance(value, bool) or value < 1:
@@ -591,6 +614,7 @@ class CodeGraphModule(BaseModule):
 
     @staticmethod
     def _validate_node_selector(arguments: dict[str, Any]) -> None:
+        """Require a non-empty node id or symbol selector."""
         node_id = arguments.get("node_id")
         symbol = arguments.get("symbol")
         if node_id is None and symbol is None:
@@ -599,12 +623,20 @@ class CodeGraphModule(BaseModule):
             raise ValueError("node_id must be a non-empty string")
         if symbol is not None and (not isinstance(symbol, str) or not symbol.strip()):
             raise ValueError("symbol must be a non-empty string")
+        if node_id is not None and symbol is not None:
+            raise ValueError("node_id and symbol are mutually exclusive")
+        if isinstance(node_id, str):
+            arguments["node_id"] = node_id.strip()
+        if isinstance(symbol, str):
+            arguments["symbol"] = symbol.strip()
 
     def _bounded_limit(self, limit: int | None) -> int:
+        """Clamp user-provided result limits to configured maximums."""
         return min(max(1, int(limit or 10)), self._settings.max_search_results)
 
 
 def _normalize_path_prefix(path: str | None) -> str | None:
+    """Normalize an optional workspace-relative path prefix."""
     if path is None or not path.strip() or path.strip() == ".":
         return None
     raw = Path(path)
@@ -614,6 +646,7 @@ def _normalize_path_prefix(path: str | None) -> str | None:
 
 
 def _indexed_file_to_dict(file: IndexedFile, *, include_metadata: bool) -> dict[str, Any]:
+    """Serialize an indexed file row for MCP responses."""
     result: dict[str, Any] = {
         "path": file.path,
         "language": file.language,
@@ -634,6 +667,7 @@ def _indexed_file_to_dict(file: IndexedFile, *, include_metadata: bool) -> dict[
 
 
 def _node_to_dict(node: CodeGraphNode) -> dict[str, Any]:
+    """Serialize a graph node for MCP responses."""
     return {
         "id": node.id,
         "kind": node.kind,
@@ -654,6 +688,7 @@ def _node_to_dict(node: CodeGraphNode) -> dict[str, Any]:
 
 
 def _index_run_to_dict(run: IndexRunSummary | None) -> dict[str, Any] | None:
+    """Serialize an index run summary or preserve a missing run as None."""
     if run is None:
         return None
     return {
@@ -669,6 +704,7 @@ def _index_run_to_dict(run: IndexRunSummary | None) -> dict[str, Any] | None:
 
 
 def _index_result_to_dict(result: Any, resolution: WorkspaceResolution) -> dict[str, Any]:
+    """Serialize an indexer result with workspace identity and database path."""
     return {
         "workspace_key": resolution.workspace_key,
         "index_db_path": str(resolution.index_db_path),

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
@@ -28,7 +28,16 @@ class _FakeWorkspaceRootResolver:
 class _CodeGraphRegistry:
     def __init__(self, module: CodeGraphModule) -> None:
         self.module = module
-        self._tool_names = {"codegraph.status", "codegraph.index", "codegraph.sync", "codegraph.files"}
+        self._tool_names = {
+            "codegraph.status",
+            "codegraph.index",
+            "codegraph.sync",
+            "codegraph.files",
+            "codegraph.search",
+            "codegraph.node",
+            "codegraph.callers",
+            "codegraph.callees",
+        }
 
     async def find_module_for_tool(self, tool_name: str):  # noqa: ANN001
         if tool_name in self._tool_names:
@@ -66,7 +75,7 @@ def _module(tmp_path: Path, workspace_root: Path) -> CodeGraphModule:
 
 
 @pytest.mark.asyncio
-async def test_codegraph_exposes_stage1_tools_only(tmp_path: Path) -> None:
+async def test_codegraph_exposes_stage2_tools(tmp_path: Path) -> None:
     workspace_root = tmp_path / "workspace"
     workspace_root.mkdir()
     module = _module(tmp_path, workspace_root)
@@ -74,9 +83,22 @@ async def test_codegraph_exposes_stage1_tools_only(tmp_path: Path) -> None:
     tools = await module.get_tools()
     by_name = {tool["name"]: tool for tool in tools}
 
-    assert set(by_name) == {"codegraph.status", "codegraph.index", "codegraph.sync", "codegraph.files"}  # nosec B101
+    assert set(by_name) == {  # nosec B101
+        "codegraph.status",
+        "codegraph.index",
+        "codegraph.sync",
+        "codegraph.files",
+        "codegraph.search",
+        "codegraph.node",
+        "codegraph.callers",
+        "codegraph.callees",
+    }
     assert by_name["codegraph.status"]["metadata"]["readOnlyHint"] is True  # nosec B101
     assert by_name["codegraph.files"]["metadata"]["readOnlyHint"] is True  # nosec B101
+    assert by_name["codegraph.search"]["metadata"]["readOnlyHint"] is True  # nosec B101
+    assert by_name["codegraph.node"]["metadata"]["readOnlyHint"] is True  # nosec B101
+    assert by_name["codegraph.callers"]["metadata"]["readOnlyHint"] is True  # nosec B101
+    assert by_name["codegraph.callees"]["metadata"]["readOnlyHint"] is True  # nosec B101
     assert by_name["codegraph.index"]["metadata"]["category"] == "management"  # nosec B101
     assert by_name["codegraph.sync"]["metadata"]["category"] == "management"  # nosec B101
 
@@ -89,6 +111,7 @@ async def test_codegraph_exposes_stage1_tools_only(tmp_path: Path) -> None:
     assert by_name["codegraph.index"]["metadata"]["path_argument_hints"] == []  # nosec B101
     assert by_name["codegraph.sync"]["metadata"]["path_argument_hints"] == []  # nosec B101
     assert by_name["codegraph.files"]["metadata"]["path_argument_hints"] == ["path"]  # nosec B101
+    assert by_name["codegraph.search"]["metadata"]["path_argument_hints"] == []  # nosec B101
 
 
 @pytest.mark.asyncio
@@ -134,6 +157,40 @@ async def test_codegraph_index_and_files_roundtrip(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_codegraph_search_node_callers_and_callees_roundtrip(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    (workspace_root / "app.py").write_text(
+        """
+class Greeter:
+    def greet(self, name):
+        return helper(name)
+
+
+def helper(value):
+    return value.upper()
+""",
+        encoding="utf-8",
+    )
+    module = _module(tmp_path, workspace_root)
+
+    await module.execute_tool(
+        "codegraph.index",
+        {"mode": "foreground", "force": True, "max_files": 10},
+        context=_context(),
+    )
+    search = await module.execute_tool("codegraph.search", {"query": "helper", "limit": 10}, context=_context())
+    node = await module.execute_tool("codegraph.node", {"symbol": "helper"}, context=_context())
+    callers = await module.execute_tool("codegraph.callers", {"symbol": "helper"}, context=_context())
+    callees = await module.execute_tool("codegraph.callees", {"symbol": "Greeter.greet"}, context=_context())
+
+    assert [item["qualified_name"] for item in search["results"]] == ["helper"]  # nosec B101
+    assert node["node"]["qualified_name"] == "helper"  # nosec B101
+    assert [item["source"]["qualified_name"] for item in callers["relationships"]] == ["Greeter.greet"]  # nosec B101
+    assert [item["target"]["qualified_name"] for item in callees["relationships"]] == ["helper"]  # nosec B101
+
+
+@pytest.mark.asyncio
 async def test_codegraph_offloads_blocking_repository_work(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -152,9 +209,10 @@ async def test_codegraph_offloads_blocking_repository_work(
 
     await module.execute_tool("codegraph.index", {"mode": "foreground"}, context=_context())
     await module.execute_tool("codegraph.files", {}, context=_context())
+    await module.execute_tool("codegraph.search", {"query": "app"}, context=_context())
     await module.execute_tool("codegraph.sync", {"mode": "foreground"}, context=_context())
 
-    assert len(offloaded) >= 3  # nosec B101
+    assert len(offloaded) >= 4  # nosec B101
 
 
 @pytest.mark.asyncio
@@ -180,5 +238,32 @@ async def test_protocol_rejects_unknown_codegraph_index_arguments(tmp_path: Path
     with pytest.raises(InvalidParamsException, match="Unknown parameters"):
         await protocol._handle_tools_call(
             {"name": "codegraph.index", "arguments": {"mode": "foreground", "unknown": "boom"}},
+            _context(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_protocol_rejects_unknown_codegraph_search_arguments(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    module = _module(tmp_path, workspace_root)
+
+    protocol = MCPProtocol()
+    protocol.module_registry = _CodeGraphRegistry(module)
+
+    async def _resolve_effective_policy(_context):
+        return {"enabled": True, "allowed_tools": ["codegraph.search"], "policy_document": {"path_scope_mode": "none"}}
+
+    async def _allow(*_args, **_kwargs) -> bool:
+        return True
+
+    protocol._resolve_effective_tool_policy = _resolve_effective_policy  # type: ignore[method-assign]
+    protocol._has_module_permission = _allow  # type: ignore[method-assign]
+    protocol._has_tool_permission = _allow  # type: ignore[method-assign]
+    protocol._is_tool_allowed_by_context = lambda *_args, **_kwargs: True  # type: ignore[method-assign]
+
+    with pytest.raises(InvalidParamsException, match="Unknown parameters"):
+        await protocol._handle_tools_call(
+            {"name": "codegraph.search", "arguments": {"query": "helper", "unknown": "boom"}},
             _context(),
         )

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
@@ -179,15 +179,31 @@ def helper(value):
         {"mode": "foreground", "force": True, "max_files": 10},
         context=_context(),
     )
-    search = await module.execute_tool("codegraph.search", {"query": "helper", "limit": 10}, context=_context())
-    node = await module.execute_tool("codegraph.node", {"symbol": "helper"}, context=_context())
-    callers = await module.execute_tool("codegraph.callers", {"symbol": "helper"}, context=_context())
-    callees = await module.execute_tool("codegraph.callees", {"symbol": "Greeter.greet"}, context=_context())
+    search = await module.execute_tool(
+        "codegraph.search",
+        {"query": " helper ", "kind": " function ", "limit": 10},
+        context=_context(),
+    )
+    node = await module.execute_tool("codegraph.node", {"symbol": " helper "}, context=_context())
+    callers = await module.execute_tool("codegraph.callers", {"symbol": " helper "}, context=_context())
+    callees = await module.execute_tool("codegraph.callees", {"symbol": " Greeter.greet "}, context=_context())
 
     assert [item["qualified_name"] for item in search["results"]] == ["helper"]  # nosec B101
     assert node["node"]["qualified_name"] == "helper"  # nosec B101
     assert [item["source"]["qualified_name"] for item in callers["relationships"]] == ["Greeter.greet"]  # nosec B101
     assert [item["target"]["qualified_name"] for item in callees["relationships"]] == ["helper"]  # nosec B101
+
+
+def test_codegraph_rejects_ambiguous_node_selectors(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    module = _module(tmp_path, workspace_root)
+
+    with pytest.raises(ValueError, match="node_id and symbol are mutually exclusive"):
+        module.validate_tool_arguments(
+            "codegraph.node",
+            {"node_id": "node_helper", "symbol": "helper"},
+        )
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py
@@ -37,6 +37,70 @@ def test_indexer_indexes_supported_file_inventory_and_skips_excluded_dirs(tmp_pa
     assert repo.list_files(limit=10)[0].path == "app.py"
 
 
+def test_indexer_extracts_python_graph_rows_during_index(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "app.py").write_text(
+        """
+class Greeter:
+    def greet(self, name):
+        return helper(name)
+
+
+def helper(value):
+    return value.upper()
+""",
+        encoding="utf-8",
+    )
+    repo = CodeGraphRepository(tmp_path / "codegraph.db")
+    indexer = CodeGraphIndexer(settings=CodeGraphSettings.from_mapping({}), registry=CodeGraphLanguageRegistry())
+
+    result = indexer.index_workspace(
+        workspace_root=workspace,
+        workspace_key="ws_test",
+        repository=repo,
+        force=True,
+        languages=None,
+        max_files=10,
+    )
+
+    helper = repo.find_node_by_symbol("helper")
+
+    assert result.status == "complete"
+    assert repo.counts()["nodes"] >= 4
+    assert repo.counts()["edges"] == 1
+    assert repo.list_files(limit=10)[0].node_count >= 4
+    assert helper is not None
+    assert [relationship["source"]["qualified_name"] for relationship in repo.list_callers(helper.id, limit=10)] == [
+        "Greeter.greet"
+    ]
+
+
+def test_indexer_keeps_javascript_typescript_as_inventory_only_until_extractor_slice(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "app.py").write_text("def helper():\n    return 1\n", encoding="utf-8")
+    (workspace / "ui.ts").write_text("export function helper() { return 1; }\n", encoding="utf-8")
+    repo = CodeGraphRepository(tmp_path / "codegraph.db")
+    indexer = CodeGraphIndexer(settings=CodeGraphSettings.from_mapping({}), registry=CodeGraphLanguageRegistry())
+
+    result = indexer.index_workspace(
+        workspace_root=workspace,
+        workspace_key="ws_test",
+        repository=repo,
+        force=True,
+        languages=None,
+        max_files=10,
+    )
+
+    files = {item.path: item for item in repo.list_files(limit=10)}
+
+    assert result.status == "complete"
+    assert files["app.py"].node_count > 0
+    assert files["ui.ts"].node_count == 0
+    assert [node.file_path for node in repo.search_nodes("helper", limit=10)] == ["app.py"]
+
+
 def test_indexer_rejects_over_limit_foreground_workspace(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
     workspace.mkdir()

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py
@@ -101,6 +101,31 @@ def test_indexer_keeps_javascript_typescript_as_inventory_only_until_extractor_s
     assert [node.file_path for node in repo.search_nodes("helper", limit=10)] == ["app.py"]
 
 
+def test_indexer_marks_python_extraction_errors_without_claiming_indexed_status(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "broken.py").write_text("def broken(:\n    pass\n", encoding="utf-8")
+    repo = CodeGraphRepository(tmp_path / "codegraph.db")
+    indexer = CodeGraphIndexer(settings=CodeGraphSettings.from_mapping({}), registry=CodeGraphLanguageRegistry())
+
+    result = indexer.index_workspace(
+        workspace_root=workspace,
+        workspace_key="ws_test",
+        repository=repo,
+        force=True,
+        languages=None,
+        max_files=10,
+    )
+    file_row = repo.list_files(limit=10)[0]
+
+    assert result.status == "complete"
+    assert result.counters["errors"] > 0
+    assert any(error.startswith("broken.py:") for error in result.errors)
+    assert file_row.status == "extraction_failed"
+    assert file_row.node_count == 0
+    assert file_row.errors
+
+
 def test_indexer_rejects_over_limit_foreground_workspace(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
     workspace.mkdir()

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_python_extractor.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_python_extractor.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from tldw_Server_API.app.core.CodeGraph.extractors.python_extractor import PythonAstExtractor
+
+
+def test_python_extractor_captures_symbols_imports_and_same_file_calls() -> None:
+    source = b"""
+import os
+from app.tools import external_call
+
+
+class Greeter:
+    def greet(self, name):
+        return helper(name)
+
+
+def helper(value):
+    external_call(value)
+    return value.upper()
+"""
+    extractor = PythonAstExtractor()
+
+    result = extractor.extract(workspace_key="ws_test", file_path="pkg/sample.py", source=source)
+
+    by_qualified = {node.qualified_name: node for node in result.nodes}
+
+    assert by_qualified["pkg.sample"].kind == "module"
+    assert by_qualified["os"].kind == "import"
+    assert by_qualified["app.tools.external_call"].kind == "import"
+    assert by_qualified["Greeter"].kind == "class"
+    assert by_qualified["Greeter.greet"].kind == "method"
+    assert by_qualified["helper"].kind == "function"
+
+    greet = by_qualified["Greeter.greet"]
+    helper = by_qualified["helper"]
+
+    assert any(
+        edge.kind == "calls" and edge.source == greet.id and edge.target == helper.id
+        for edge in result.edges
+    )
+    assert any(
+        ref.from_node_id == helper.id
+        and ref.reference_name == "external_call"
+        and ref.reference_kind == "call"
+        for ref in result.unresolved_refs
+    )
+
+
+def test_python_extractor_uses_deterministic_node_ids() -> None:
+    source = b"def helper():\n    return 1\n"
+    extractor = PythonAstExtractor()
+
+    first = extractor.extract(workspace_key="ws_test", file_path="pkg/sample.py", source=source)
+    second = extractor.extract(workspace_key="ws_test", file_path="pkg/sample.py", source=source)
+
+    assert [node.id for node in first.nodes] == [node.id for node in second.nodes]
+    assert [edge.id for edge in first.edges] == [edge.id for edge in second.edges]

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_python_extractor.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_python_extractor.py
@@ -55,3 +55,32 @@ def test_python_extractor_uses_deterministic_node_ids() -> None:
 
     assert [node.id for node in first.nodes] == [node.id for node in second.nodes]
     assert [edge.id for edge in first.edges] == [edge.id for edge in second.edges]
+
+
+def test_python_extractor_does_not_link_external_attribute_calls_to_same_file_symbols() -> None:
+    source = b"""
+def save():
+    return True
+
+
+def persist(external_client):
+    external_client.save()
+"""
+    extractor = PythonAstExtractor()
+
+    result = extractor.extract(workspace_key="ws_test", file_path="pkg/sample.py", source=source)
+
+    by_qualified = {node.qualified_name: node for node in result.nodes}
+    save = by_qualified["save"]
+    persist = by_qualified["persist"]
+
+    assert not any(
+        edge.kind == "calls" and edge.source == persist.id and edge.target == save.id
+        for edge in result.edges
+    )
+    assert any(
+        ref.from_node_id == persist.id
+        and ref.reference_name == "external_client.save"
+        and ref.reference_kind == "call"
+        for ref in result.unresolved_refs
+    )

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_repository.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_repository.py
@@ -270,3 +270,78 @@ def test_repository_replacement_removes_stale_symbols_from_search(tmp_path: Path
 
     assert repo.search_nodes("old_helper", limit=10) == []
     assert [node.id for node in repo.search_nodes("new_helper", limit=10)] == ["node_new"]
+
+
+def test_repository_atomic_file_and_graph_replacement_rolls_back_on_graph_error(tmp_path: Path) -> None:
+    repo = CodeGraphRepository(tmp_path / "codegraph.db")
+    repo.initialize()
+    repo.upsert_file(
+        path="pkg/sample.py",
+        language="python",
+        size=128,
+        content_hash="old_hash",
+        modified_at=1.0,
+        status="indexed",
+        errors=[],
+        node_count=1,
+    )
+    repo.replace_file_graph(
+        path="pkg/sample.py",
+        nodes=[
+            CodeGraphNode(
+                id="node_old",
+                identity_key="old",
+                kind="function",
+                name="old_helper",
+                qualified_name="old_helper",
+                file_path="pkg/sample.py",
+                language="python",
+            )
+        ],
+        edges=[],
+        unresolved_refs=[],
+    )
+    repo.seed_graph_rows_for_test(
+        nodes=[
+            {
+                "id": "node_conflict",
+                "identity_key": "conflict",
+                "kind": "function",
+                "name": "other_helper",
+                "file_path": "pkg/other.py",
+            }
+        ],
+        edges=[],
+        unresolved_refs=[],
+    )
+
+    with pytest.raises(sqlite3.IntegrityError):
+        repo.upsert_file_and_replace_graph(
+            path="pkg/sample.py",
+            language="python",
+            size=256,
+            content_hash="new_hash",
+            modified_at=2.0,
+            status="indexed",
+            errors=[],
+            node_count=1,
+            nodes=[
+                CodeGraphNode(
+                    id="node_conflict",
+                    identity_key="new",
+                    kind="function",
+                    name="new_helper",
+                    qualified_name="new_helper",
+                    file_path="pkg/sample.py",
+                    language="python",
+                )
+            ],
+            edges=[],
+            unresolved_refs=[],
+        )
+
+    file_row = repo.list_files(limit=10)[0]
+
+    assert file_row.content_hash == "old_hash"
+    assert repo.get_node("node_old") is not None
+    assert repo.search_nodes("new_helper", limit=10) == []

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_repository.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_repository.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+from tldw_Server_API.app.core.CodeGraph.models import CodeGraphEdge, CodeGraphNode, CodeGraphUnresolvedRef
 from tldw_Server_API.app.core.DB_Management.codegraph.repository import CodeGraphRepository, _create_optional_fts
 
 
@@ -133,3 +134,139 @@ def test_repository_replacing_file_removes_owned_graph_rows_and_dangling_edges(t
     assert repo.counts()["nodes"] == 1
     assert repo.counts()["edges"] == 0
     assert repo.counts()["unresolved_refs"] == 0
+
+
+def test_repository_persists_searches_and_fetches_graph_relationships(tmp_path: Path) -> None:
+    repo = CodeGraphRepository(tmp_path / "codegraph.db")
+    repo.initialize()
+    repo.upsert_file(
+        path="pkg/sample.py",
+        language="python",
+        size=128,
+        content_hash="hash",
+        modified_at=1.0,
+        status="indexed",
+        errors=[],
+        node_count=3,
+    )
+    module = CodeGraphNode(
+        id="node_module",
+        identity_key="module",
+        kind="module",
+        name="sample",
+        qualified_name="pkg.sample",
+        file_path="pkg/sample.py",
+        language="python",
+        start_line=1,
+        end_line=12,
+    )
+    caller = CodeGraphNode(
+        id="node_caller",
+        identity_key="caller",
+        kind="method",
+        name="greet",
+        qualified_name="Greeter.greet",
+        file_path="pkg/sample.py",
+        language="python",
+        start_line=6,
+        end_line=7,
+    )
+    callee = CodeGraphNode(
+        id="node_callee",
+        identity_key="callee",
+        kind="function",
+        name="helper",
+        qualified_name="helper",
+        file_path="pkg/sample.py",
+        language="python",
+        start_line=10,
+        end_line=12,
+    )
+    edge = CodeGraphEdge(
+        id="edge_call",
+        source="node_caller",
+        target="node_callee",
+        kind="calls",
+        file_path="pkg/sample.py",
+        line=7,
+        column=15,
+    )
+    unresolved = CodeGraphUnresolvedRef(
+        from_node_id="node_callee",
+        reference_name="external_call",
+        reference_kind="call",
+        file_path="pkg/sample.py",
+        line=11,
+        column=4,
+        language="python",
+    )
+
+    repo.replace_file_graph(
+        path="pkg/sample.py",
+        nodes=[module, caller, callee],
+        edges=[edge],
+        unresolved_refs=[unresolved],
+    )
+
+    search_results = repo.search_nodes("helper", limit=10)
+    fetched = repo.get_node("node_callee")
+    callers = repo.list_callers("node_callee", limit=10)
+    callees = repo.list_callees("node_caller", limit=10)
+
+    assert [node.id for node in search_results] == ["node_callee"]
+    assert fetched is not None
+    assert fetched.qualified_name == "helper"
+    assert [relationship["source"]["id"] for relationship in callers] == ["node_caller"]
+    assert [relationship["target"]["id"] for relationship in callees] == ["node_callee"]
+    assert callees[0]["kind"] == "calls"
+
+
+def test_repository_replacement_removes_stale_symbols_from_search(tmp_path: Path) -> None:
+    repo = CodeGraphRepository(tmp_path / "codegraph.db")
+    repo.initialize()
+    repo.upsert_file(
+        path="pkg/sample.py",
+        language="python",
+        size=128,
+        content_hash="hash",
+        modified_at=1.0,
+        status="indexed",
+        errors=[],
+        node_count=1,
+    )
+    repo.replace_file_graph(
+        path="pkg/sample.py",
+        nodes=[
+            CodeGraphNode(
+                id="node_old",
+                identity_key="old",
+                kind="function",
+                name="old_helper",
+                qualified_name="old_helper",
+                file_path="pkg/sample.py",
+                language="python",
+            )
+        ],
+        edges=[],
+        unresolved_refs=[],
+    )
+
+    repo.replace_file_graph(
+        path="pkg/sample.py",
+        nodes=[
+            CodeGraphNode(
+                id="node_new",
+                identity_key="new",
+                kind="function",
+                name="new_helper",
+                qualified_name="new_helper",
+                file_path="pkg/sample.py",
+                language="python",
+            )
+        ],
+        edges=[],
+        unresolved_refs=[],
+    )
+
+    assert repo.search_nodes("old_helper", limit=10) == []
+    assert [node.id for node in repo.search_nodes("new_helper", limit=10)] == ["node_new"]


### PR DESCRIPTION
## Summary

- What changed:
  - Added a stdlib `ast` Python extractor for native CodeGraph indexing.
  - Persisted deterministic Python module/class/function/method/import nodes plus conservative same-file call edges or unresolved refs.
  - Added repository query helpers and Unified MCP read tools for `codegraph.search`, `codegraph.node`, `codegraph.callers`, and `codegraph.callees`.
  - Added TASK-27 and a branch implementation plan for the Stage 2 slice.
- Why:
  - This is the next reviewable slice after the merged CodeGraph foundation, giving the MCP module useful Python symbol/search behavior without expanding into JS/TS extraction, Jobs mode, or impact/context tooling yet.

## Validation

- [x] Tests added/updated for behavior changes
- [x] Relevant unit/integration tests pass locally
- [x] Docs updated (if behavior, routes, or config changed)

Commands run:

- `python -m pytest tldw_Server_API/tests/CodeGraph tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py -q` -> 43 passed
- `python -m bandit -r tldw_Server_API/app/core/CodeGraph tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py -f json -o /tmp/bandit_codegraph_python_search.json` -> 0 results, 0 errors
- `git diff --check origin/dev...HEAD` -> passed

## UX Audit Checklist (v2 Stage 5)

- [ ] `npm run e2e:smoke:stage5` passes
- [ ] `npx playwright test e2e/smoke/all-pages.spec.ts --reporter=line` passes (or failures documented)
- [ ] No listed AntD deprecations in console output: `Drawer.width`, `Space.direction`, `Alert.message`, `List`
- [ ] No `Maximum update depth exceeded` warnings on audited routes
- [ ] No unresolved `{{...}}` placeholders on audited routes
- [ ] WebUI/extension parity validated for shared UI fixes
- [ ] For Flashcards UI changes: tabs remain `Study` / `Manage` / `Transfer` and secondary create CTAs route through manager create-entry path
- [ ] For Flashcards drawer changes: use `FLASHCARDS_DRAWER_WIDTH_PX` and keep footer action order `Cancel -> secondary -> primary`
- [ ] For Flashcards help/copy/import UX changes: update `Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md` and keep in-app help links pointed at guide section anchors

Not applicable: no WebUI, extension, Watchlists, or Flashcards UI behavior changed.

## Watchlists Accessibility Checklist (Group 09 Stage 5)

- [ ] If Watchlists UI behavior changed: `cd apps/packages/ui && bun run test:watchlists:a11y` passes locally
- [ ] If Watchlists UI behavior changed: keyboard-only path still works for Overview -> Feeds -> Monitors -> Activity -> Articles -> Reports
- [ ] If Watchlists UI behavior changed: list/table labels and live-region copy remain localized (no new hardcoded assistive text)
- [ ] If Watchlists UI behavior changed: monitor/feed active state is not color-only (explicit text or icon signal is present)
- [ ] If Watchlists UI behavior changed: known assistive-tech constraints reviewed in `Docs/Plans/WATCHLISTS_ASSISTIVE_TECH_AUDIT_2026_02_24.md`

Not applicable: no Watchlists UI behavior changed.

## Watchlists Scale Checklist (Group 10 Stage 5)

- [ ] If Watchlists UI behavior changed: `cd apps/packages/ui && bun run test:watchlists:scale` passes locally
- [ ] If Watchlists polling/notifications behavior changed: no duplicate terminal notifications during in-flight polling overlap
- [ ] If Watchlists Activity polling changed: auto-refresh is gated to active + visible Activity context (no background tab polling churn)
- [ ] If Watchlists batch triage behavior changed: partial-failure retry path remains available and updates only failed IDs
- [ ] If Watchlists scale behavior changed: constraints/mitigations reviewed in `Docs/Plans/WATCHLISTS_SCALE_READINESS_RUNBOOK_2026_02_24.md`

Not applicable: no Watchlists polling, notifications, or scale behavior changed.

## Risk & Rollback

- Risk level: Medium
- Rollback plan: Revert this PR; the Stage 1 CodeGraph foundation remains intact because this slice adds the Python extractor/query layer and Stage 2 MCP read tools on top of existing storage/index contracts.

## Change summary

Draft PR note: per repo policy, this AI-authored PR needs a human-written Change summary before it is merge-ready.
