### PR TITLE
Phase 2.2: defer utility router imports

### DIFF
--- a/backlog/tasks/task-32 - Phase-2.2-utility-router-conditional-cleanup-J.md
+++ b/backlog/tasks/task-32 - Phase-2.2-utility-router-conditional-cleanup-J.md
@@ -1,0 +1,67 @@
+---
+id: TASK-32
+title: Phase 2.2 utility router conditional cleanup J
+status: Done
+assignee: []
+created_date: '2026-05-04 02:51'
+labels:
+  - phase-2
+  - router-groups
+  - refactor
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Move only the covered utility/content router specs onto the shared lazy ImportedRouterSpec helper. Preserve public route metadata and route ordering for claims, Text2SQL, email, and output templates.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Claims, Text2SQL, email, and output templates RouterSpec metadata is preserved.
+- [x] #2 Router attribute lookup for moved utility/content specs is lazy through RouterSpec resolution.
+- [x] #3 Full router group contract and adjacent main/OpenAPI contract tests pass.
+- [x] #4 Bandit touched-source scope and git diff --check pass.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused regression test proving utility/content router attribute lookup is deferred until RouterSpec resolution.
+2. Run the focused selection red on current code.
+3. Replace only the utility/content import block with ImportedRouterSpec plus append_imported_router_spec while preserving metadata.
+4. Run focused and full router contract tests plus adjacent main/OpenAPI contract tests.
+5. Run Bandit on touched router source and git diff --check.
+6. Commit the narrow tranche and update the issue.
+<!-- SECTION:PLAN:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Red check: `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "utility_router_attr_lookup" -q` failed before implementation because the selected utility/content router attributes were resolved during spec construction.
+- Green focused check: `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "utility_router_attr_lookup" -q` passed with `1 passed`.
+- Green full/adjacent checks after rebasing onto #1250: `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q` passed with `50 passed`; `python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q` passed with `6 passed`; `python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q` passed with `69 passed`.
+- Security and hygiene: `python -m bandit -r tldw_Server_API/app/api/v1/router_groups/content.py -f json -o /tmp/bandit_phase2_2_utility_router_conditionals_i_rebased.json` reported `0 results` and `0 errors`; `git diff --check HEAD~1..HEAD` passed.
+- Documentation: no user-facing docs required for this internal router registration refactor.
+- Known skips or blockers: none.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Moved the covered `claims`, `text2sql`, `email`, and `outputs-templates` registrations to the shared lazy `ImportedRouterSpec` helper while preserving route prefixes, tags, route keys, and ordering. Added regression coverage proving selected utility/content router attributes are not resolved until the selected `RouterSpec` objects are used, then verified the full router group contract, adjacent main/OpenAPI contract tests, Bandit touched-source scope, and whitespace checks.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-32 - Phase-2.2-utility-router-conditional-cleanup-J.md
+++ b/backlog/tasks/task-32 - Phase-2.2-utility-router-conditional-cleanup-J.md
@@ -54,8 +54,9 @@ Move only the covered utility/content router specs onto the shared lazy Imported
 <!-- SECTION:NOTES:BEGIN -->
 - Red check: `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "utility_router_attr_lookup" -q` failed before implementation because the selected utility/content router attributes were resolved during spec construction.
 - Green focused check: `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "utility_router_attr_lookup" -q` passed with `1 passed`.
-- Green full/adjacent checks after rebasing onto #1250: `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q` passed with `50 passed`; `python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q` passed with `6 passed`; `python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q` passed with `69 passed`.
-- Security and hygiene: `python -m bandit -r tldw_Server_API/app/api/v1/router_groups/content.py -f json -o /tmp/bandit_phase2_2_utility_router_conditionals_i_rebased.json` reported `0 results` and `0 errors`; `git diff --check HEAD~1..HEAD` passed.
+- Review follow-up focused check: `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "utility_router_attr_lookup or skips_static_missing_attr or logs_missing_lazy_attr" -q` passed with `3 passed`, after strengthening the utility regression to assert module imports are deferred until selected specs are resolved. The missing-router context finding was verified against current `conditional.py` and existing tests that assert skip logs include `{module_name}.router`.
+- Green full/adjacent checks after rebasing onto #1255: `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q` passed with `50 passed`; `python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q` passed with `6 passed`; `python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q` passed with `69 passed`.
+- Security and hygiene: `python -m bandit -r tldw_Server_API/app/api/v1/router_groups/content.py -f json -o /tmp/bandit_phase2_2_utility_router_review_fix_rebased_1255.json` reported `0 results` and `0 errors`; `git diff --check origin/dev..HEAD` passed.
 - Documentation: no user-facing docs required for this internal router registration refactor.
 - Known skips or blockers: none.
 <!-- SECTION:NOTES:END -->
@@ -63,5 +64,5 @@ Move only the covered utility/content router specs onto the shared lazy Imported
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Moved the covered `claims`, `text2sql`, `email`, and `outputs-templates` registrations to the shared lazy `ImportedRouterSpec` helper while preserving route prefixes, tags, route keys, and ordering. Added regression coverage proving selected utility/content router attributes are not resolved until the selected `RouterSpec` objects are used, then verified the full router group contract, adjacent main/OpenAPI contract tests, Bandit touched-source scope, and whitespace checks.
+Moved the covered `claims`, `text2sql`, `email`, and `outputs-templates` registrations to the shared lazy `ImportedRouterSpec` helper while preserving route prefixes, tags, route keys, and ordering. Added regression coverage proving selected utility/content router modules and router attributes are not resolved until the selected `RouterSpec` objects are used, then verified the full router group contract, adjacent main/OpenAPI contract tests, Bandit touched-source scope, and whitespace checks. Review follow-up confirmed missing-router skip logs already retain module context through the current shared helper.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/content.py
+++ b/tldw_Server_API/app/api/v1/router_groups/content.py
@@ -218,8 +218,8 @@ def iter_content_router_specs() -> Iterable[RouterSpec]:
     ):
         append_imported_router_spec(specs, workflow_spec)
 
-    # Claims, Text2SQL, and email search routers
-    for knowledge_spec in (
+    # Utility/content routers
+    for utility_spec in (
         ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.claims",
             log_name="claims",
@@ -241,21 +241,15 @@ def iter_content_router_specs() -> Iterable[RouterSpec]:
             tags=("email",),
             route_key="email",
         ),
-    ):
-        append_imported_router_spec(specs, knowledge_spec)
-
-    # Outputs and output templates
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.outputs_templates import router as outputs_templates_router
-
-        specs.append(RouterSpec(
-            router=outputs_templates_router,
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.outputs_templates",
+            log_name="outputs_templates",
             prefix=f"{API_V1_PREFIX}",
             tags=("outputs-templates",),
             route_key="outputs-templates",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping outputs_templates router: {e}")
+        ),
+    ):
+        append_imported_router_spec(specs, utility_spec)
 
     # Slack integration endpoints
     try:

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -1361,6 +1361,7 @@ def test_iter_content_router_specs_defers_utility_router_attr_lookup(
 
         @router.get(str(definition["path"]))
         def _endpoint() -> dict[str, str]:
+            """Return a deterministic response for the fake utility router."""
             return {"status": "ok"}
 
         fake_module = ModuleType(module_name)
@@ -1371,6 +1372,7 @@ def test_iter_content_router_specs_defers_utility_router_attr_lookup(
             module_name: str = module_name,
             router: APIRouter = router,
         ) -> APIRouter:
+            """Track lazy router attribute resolution for the fake module."""
             if name != "router":
                 raise AttributeError(name)
             access_count[module_name] += 1
@@ -1382,6 +1384,7 @@ def test_iter_content_router_specs_defers_utility_router_attr_lookup(
     real_import_module = importlib.import_module
 
     def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Track lazy module imports for selected utility router modules."""
         if module_name in access_count:
             import_calls.append(module_name)
         return real_import_module(module_name, package)

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -1317,21 +1317,49 @@ def test_iter_content_router_specs_defers_embedding_router_attr_lookup(
     }
 
 
-def test_iter_content_router_specs_defers_knowledge_router_attr_lookup(
+def test_iter_content_router_specs_defers_utility_router_attr_lookup(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Verify covered knowledge/query specs keep router attr lookup lazy."""
-    module_paths = {
-        "tldw_Server_API.app.api.v1.endpoints.claims": "/claims",
-        "tldw_Server_API.app.api.v1.endpoints.text2sql": "/text2sql",
-        "tldw_Server_API.app.api.v1.endpoints.email": "/email/search",
-    }
-    access_count = {module_name: 0 for module_name in module_paths}
+    """Verify covered utility content specs keep import and attr lookup lazy."""
+    import importlib
 
-    for module_name, path in module_paths.items():
+    router_definitions = {
+        "claims": {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.claims",
+            "path": "/claims",
+            "prefix": "/api/v1",
+            "tags": ("claims",),
+        },
+        "text2sql": {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.text2sql",
+            "path": "/text2sql/query",
+            "prefix": "/api/v1",
+            "tags": ("text2sql",),
+        },
+        "email": {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.email",
+            "path": "/email/search",
+            "prefix": "/api/v1/email",
+            "tags": ("email",),
+        },
+        "outputs-templates": {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.outputs_templates",
+            "path": "/outputs/templates",
+            "prefix": "/api/v1",
+            "tags": ("outputs-templates",),
+        },
+    }
+    access_count = {
+        str(definition["module_name"]): 0
+        for definition in router_definitions.values()
+    }
+    import_calls: list[str] = []
+
+    for definition in router_definitions.values():
+        module_name = str(definition["module_name"])
         router = APIRouter()
 
-        @router.get(path)
+        @router.get(str(definition["path"]))
         def _endpoint() -> dict[str, str]:
             return {"status": "ok"}
 
@@ -1351,20 +1379,46 @@ def test_iter_content_router_specs_defers_knowledge_router_attr_lookup(
         fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
         monkeypatch.setitem(sys.modules, module_name, fake_module)
 
-    specs = list(iter_content_router_specs())
-    assert access_count == {module_name: 0 for module_name in module_paths}
+    real_import_module = importlib.import_module
 
-    by_first_path = {_first_router_path(spec.router): spec for spec in specs}
-    assert by_first_path["/claims"].prefix == "/api/v1"
-    assert by_first_path["/claims"].tags == ("claims",)
-    assert by_first_path["/claims"].route_key == "claims"
-    assert by_first_path["/text2sql"].prefix == "/api/v1"
-    assert by_first_path["/text2sql"].tags == ("text2sql",)
-    assert by_first_path["/text2sql"].route_key == "text2sql"
-    assert by_first_path["/email/search"].prefix == "/api/v1/email"
-    assert by_first_path["/email/search"].tags == ("email",)
-    assert by_first_path["/email/search"].route_key == "email"
-    assert access_count == {module_name: 1 for module_name in module_paths}
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        if module_name in access_count:
+            import_calls.append(module_name)
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    specs = list(iter_content_router_specs())
+    assert access_count == {
+        str(definition["module_name"]): 0
+        for definition in router_definitions.values()
+    }
+    assert import_calls == []
+
+    utility_specs = {
+        spec.route_key: spec
+        for spec in specs
+        if spec.route_key in router_definitions
+    }
+    assert set(utility_specs) == set(router_definitions)
+
+    for route_key, spec in utility_specs.items():
+        definition = router_definitions[route_key]
+        assert spec.prefix == definition["prefix"]
+        assert spec.tags == definition["tags"]
+        assert _first_router_path(spec.router) == definition["path"]
+
+    assert import_calls == [
+        str(router_definitions[route_key]["module_name"])
+        for route_key in utility_specs
+    ]
+    assert access_count == {
+        str(definition["module_name"]): 1
+        for definition in router_definitions.values()
+    }
 
 
 def test_qodo_reviewed_router_policy_regressions(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- Moves claims, text2sql, email, and outputs templates router registrations onto the shared lazy ImportedRouterSpec helper.
- Preserves prefixes, tags, route keys, and ordering for the moved content/utility routers after rebasing onto the merged content-knowledge cleanup.
- Adds regression coverage proving selected utility router modules and attrs are not resolved during spec construction.
- Addresses review feedback by verifying missing-attribute skip logs retain module context via existing shared-helper coverage.
- Adds short docstrings to the new nested test helpers to satisfy the docstring coverage warning.

## Change summary
TODO: human-authored summary required before merge under Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md.

## Test Plan
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "utility_router_attr_lookup" -q (red before implementation, green after)
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "utility_router_attr_lookup or skips_static_missing_attr or logs_missing_lazy_attr" -q (3 passed)
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q (50 passed)
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q (6 passed)
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q (69 passed)
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/router_groups/content.py -f json -o /tmp/bandit_phase2_2_utility_router_review_fix_rebased_1255.json (0 results, 0 errors)
- [x] git diff --check origin/dev..HEAD
