### PR TITLE
Phase 2.2: defer content knowledge router imports

### DIFF
--- a/backlog/tasks/task-30 - Phase-2.2-content-knowledge-router-conditional-cleanup-I.md
+++ b/backlog/tasks/task-30 - Phase-2.2-content-knowledge-router-conditional-cleanup-I.md
@@ -1,0 +1,57 @@
+---
+id: TASK-30
+title: Phase 2.2 content knowledge router conditional cleanup I
+status: Done
+assignee:
+  - codex
+created_date: '2026-05-04 03:01'
+updated_date: '2026-05-04 03:05'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Defer content knowledge/query router imports for claims, text2sql, and email after PR #1250 merged, preserving existing route metadata while adding coverage for lazy router attr lookup.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 claims, text2sql, and email router specs defer router attribute lookup until resolution
+- [x] #2 Router prefix, tags, route_key, and default_stable metadata remain unchanged
+- [x] #3 Focused router group tests, full router group tests, main router/openapi contract tests, Bandit touched source scan, and diff check are run before commit
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused router group contract test that stubs claims, text2sql, and email modules with lazy __getattr__ router access and verifies iter_content_router_specs does not touch router attributes during spec construction. 2. Run the focused test before implementation and confirm it fails because the current content group eagerly resolves those routers. 3. Convert only claims, text2sql, and email to ImportedRouterSpec via append_imported_router_spec, preserving prefix, tags, route_key, and default_stable semantics. 4. Rerun the focused test, touched router group contracts, main router contract, OpenAPI contracts, Bandit on content.py, and git diff --check. 5. Update TASK-30 with verification and final summary, then commit/push/open the next PR if the tranche is clean.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Red/green verified the new knowledge router laziness contract: initial focused run failed because claims, text2sql, and email resolved router attrs during iter_content_router_specs; after converting those three to ImportedRouterSpec, the focused test passed.
+
+Verification: focused knowledge_router_attr_lookup passed; full router_groups_contract passed 50 tests; main_router_contract passed 6 tests; openapi_contracts passed 69 tests; Bandit content.py JSON reported 0 results and 0 errors; git diff --check was clean.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Converted the covered claims, text2sql, and email content router registrations from eager imports to ImportedRouterSpec-based lazy registrations. This preserves the existing route prefix, tags, route_key, and default_stable behavior while allowing route policy and registration to defer router module/attribute resolution consistently with the prior Phase 2.2 tranches. Added a focused contract test that first failed against the eager imports and now proves those router attributes are not accessed until RouterSpec resolution.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/content.py
+++ b/tldw_Server_API/app/api/v1/router_groups/content.py
@@ -218,44 +218,31 @@ def iter_content_router_specs() -> Iterable[RouterSpec]:
     ):
         append_imported_router_spec(specs, workflow_spec)
 
-    # Claims
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.claims import router as claims_router
-
-        specs.append(RouterSpec(
-            router=claims_router,
+    # Claims, Text2SQL, and email search routers
+    for knowledge_spec in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.claims",
+            log_name="claims",
             prefix=f"{API_V1_PREFIX}",
             tags=("claims",),
             route_key="claims",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping claims router: {e}")
-
-    # Text2SQL
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.text2sql import router as text2sql_router
-
-        specs.append(RouterSpec(
-            router=text2sql_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.text2sql",
+            log_name="text2sql",
             prefix=f"{API_V1_PREFIX}",
             tags=("text2sql",),
             route_key="text2sql",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping text2sql router: {e}")
-
-    # Email search
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.email import router as email_router
-
-        specs.append(RouterSpec(
-            router=email_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.email",
+            log_name="email",
             prefix=f"{API_V1_PREFIX}/email",
             tags=("email",),
             route_key="email",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping email router: {e}")
+        ),
+    ):
+        append_imported_router_spec(specs, knowledge_spec)
 
     # Outputs and output templates
     try:

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -1317,6 +1317,56 @@ def test_iter_content_router_specs_defers_embedding_router_attr_lookup(
     }
 
 
+def test_iter_content_router_specs_defers_knowledge_router_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify covered knowledge/query specs keep router attr lookup lazy."""
+    module_paths = {
+        "tldw_Server_API.app.api.v1.endpoints.claims": "/claims",
+        "tldw_Server_API.app.api.v1.endpoints.text2sql": "/text2sql",
+        "tldw_Server_API.app.api.v1.endpoints.email": "/email/search",
+    }
+    access_count = {module_name: 0 for module_name in module_paths}
+
+    for module_name, path in module_paths.items():
+        router = APIRouter()
+
+        @router.get(path)
+        def _endpoint() -> dict[str, str]:
+            return {"status": "ok"}
+
+        fake_module = ModuleType(module_name)
+
+        def _module_getattr(
+            name: str,
+            *,
+            module_name: str = module_name,
+            router: APIRouter = router,
+        ) -> APIRouter:
+            if name != "router":
+                raise AttributeError(name)
+            access_count[module_name] += 1
+            return router
+
+        fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    specs = list(iter_content_router_specs())
+    assert access_count == {module_name: 0 for module_name in module_paths}
+
+    by_first_path = {_first_router_path(spec.router): spec for spec in specs}
+    assert by_first_path["/claims"].prefix == "/api/v1"
+    assert by_first_path["/claims"].tags == ("claims",)
+    assert by_first_path["/claims"].route_key == "claims"
+    assert by_first_path["/text2sql"].prefix == "/api/v1"
+    assert by_first_path["/text2sql"].tags == ("text2sql",)
+    assert by_first_path["/text2sql"].route_key == "text2sql"
+    assert by_first_path["/email/search"].prefix == "/api/v1/email"
+    assert by_first_path["/email/search"].tags == ("email",)
+    assert by_first_path["/email/search"].route_key == "email"
+    assert access_count == {module_name: 1 for module_name in module_paths}
+
+
 def test_qodo_reviewed_router_policy_regressions(monkeypatch: pytest.MonkeyPatch) -> None:
     _install_fake_router_module(
         monkeypatch,


### PR DESCRIPTION
## Change summary\n\nHuman-authored summary required before merge: this PR continues Phase 2.2 by deferring the covered claims, text2sql, and email content router imports without changing endpoint payloads or route metadata.\n\n## What changed\n\n- Converted claims, text2sql, and email content router registrations to ImportedRouterSpec-based lazy registration.\n- Added a red/green router group contract test proving those router attributes are not accessed until RouterSpec resolution.\n- Recorded TASK-30 with plan, verification, and final summary.\n\n## Verification\n\n- Red: python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "knowledge_router_attr_lookup" -q failed before implementation because router attrs were eagerly resolved.\n- Green: python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "knowledge_router_attr_lookup" -q passed.\n- python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q: 50 passed.\n- python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q: 6 passed.\n- python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q: 69 passed.\n- python -m bandit -r tldw_Server_API/app/api/v1/router_groups/content.py -f json -o /tmp/bandit_phase2_2_content_knowledge_router_conditionals_i.json: 0 results, 0 errors.\n- git diff --check: clean.\n\nPart of #1116.