### PR TITLE
Phase 2.2: defer content output router imports

### DIFF
--- a/backlog/tasks/task-33 - Phase-2.2-content-output-router-conditional-cleanup-J.md
+++ b/backlog/tasks/task-33 - Phase-2.2-content-output-router-conditional-cleanup-J.md
@@ -1,0 +1,57 @@
+---
+id: TASK-33
+title: Phase 2.2 content output router conditional cleanup J
+status: Done
+assignee:
+  - codex
+created_date: '2026-05-04 03:44'
+updated_date: '2026-05-04 03:47'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Defer the covered outputs_templates and outputs content router imports after PR #1255 merged, preserving existing route metadata and adding lazy router attribute coverage.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 outputs_templates and outputs router specs defer router attribute lookup until resolution
+- [x] #2 Router prefix, tags, route_key, and default_stable metadata remain unchanged
+- [x] #3 Focused router group tests, full router group tests, main router/openapi contract tests, Bandit touched source scan, and diff check are run before commit
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused router group contract test that stubs outputs_templates and outputs modules with lazy __getattr__ router access and verifies iter_content_router_specs does not touch router attributes during spec construction. 2. Run the focused test before implementation and confirm it fails against the current eager imports. 3. Convert only outputs_templates and outputs to ImportedRouterSpec via append_imported_router_spec, preserving prefix, tags, route_key, and default_stable semantics. 4. Rerun the focused test, full router group contract file, main router contract, OpenAPI contracts, Bandit on content.py, and git diff --check. 5. Update TASK-33 with verification and final summary, then commit/push/open the next PR if clean.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Red/green verified the output router laziness contract: initial focused run failed because outputs_templates and outputs resolved router attrs during iter_content_router_specs; after converting both to ImportedRouterSpec, the focused test passed.
+
+Verification: focused output_router_attr_lookup passed; full router_groups_contract passed 51 tests; main_router_contract passed 6 tests; openapi_contracts passed 69 tests; Bandit content.py JSON reported 0 results and 0 errors; git diff --check was clean.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Converted the covered outputs_templates and outputs content router registrations from eager imports to ImportedRouterSpec-based lazy registrations. This preserves the existing prefix, tags, route_key, and default_stable behavior while continuing the Phase 2.2 route-policy-friendly lazy registration pattern. Added a focused contract test that first failed against the eager imports and now proves both output router attributes are not accessed until RouterSpec resolution.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-34 - Address-PR-1256-merge-conflict.md
+++ b/backlog/tasks/task-34 - Address-PR-1256-merge-conflict.md
@@ -1,0 +1,58 @@
+---
+id: TASK-34
+title: Address PR 1256 merge conflict
+status: Done
+assignee:
+  - codex
+created_date: '2026-05-04 03:58'
+updated_date: '2026-05-04 04:07'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1256'
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Rebase PR #1256 onto latest dev and resolve any merge conflicts while preserving the narrow outputs_templates/outputs lazy router import tranche.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 PR #1256 branch rebased onto latest origin/dev
+- [x] #2 Conflict resolution preserves output router lazy registration and existing metadata
+- [x] #3 Focused router group contract test, full touched router contracts, Bandit touched source scan, and diff check are run before force-push
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Fetch latest origin/dev and inspect the delta causing PR #1256 to be dirty. 2. Rebase codex/phase2-2-content-outputs-router-conditionals-j onto origin/dev. 3. Resolve conflicts by preserving the already-merged dev changes while retaining only the outputs_templates/outputs ImportedRouterSpec conversion and its focused test. 4. Run focused output router laziness test, full router group contract test, Bandit on content.py, and git diff --check. 5. Update TASK-34, force-push with lease, and verify PR #1256 no longer reports DIRTY.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Rebased PR #1256 from dev 49f46dbc39 to 1193f296bf. The only content.py conflict was outputs_templates: latest dev already included outputs_templates in the utility_spec tuple, so the resolution kept dev's utility tuple and retained this PR's lazy outputs router registration lower in the file.
+
+Verification after rebase: focused output_router_attr_lookup passed; full router_groups_contract passed 51 tests; main_router_contract passed 6 tests; openapi_contracts passed 69 tests; Bandit content.py JSON reported 0 results and 0 errors; git diff --check was clean.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Resolved PR #1256's merge conflict by rebasing onto latest origin/dev and preserving both sides of the overlapping router-group work. The resolved content router keeps outputs_templates in dev's utility/content ImportedRouterSpec tuple while retaining this PR's lazy outputs router registration. Post-rebase focused and contract verification passed, and Bandit/diff hygiene remained clean.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/content.py
+++ b/tldw_Server_API/app/api/v1/router_groups/content.py
@@ -584,17 +584,16 @@ def iter_content_router_specs() -> Iterable[RouterSpec]:
     except Exception as e:  # noqa: BLE001
         logger.debug(f"Skipping reading_highlights router: {e}")
 
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.outputs import router as outputs_router
-
-        specs.append(RouterSpec(
-            router=outputs_router,
+    append_imported_router_spec(
+        specs,
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.outputs",
+            log_name="outputs",
             prefix=f"{API_V1_PREFIX}",
             tags=("outputs",),
             route_key="outputs",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping outputs router: {e}")
+        ),
+    )
 
     # Notes graph routes must be registered before generic notes routes so
     # /graph is not shadowed by /{note_id}.

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -1424,6 +1424,52 @@ def test_iter_content_router_specs_defers_utility_router_attr_lookup(
     }
 
 
+def test_iter_content_router_specs_defers_output_router_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify covered output specs keep router attr lookup lazy."""
+    module_paths = {
+        "tldw_Server_API.app.api.v1.endpoints.outputs_templates": "/outputs/templates",
+        "tldw_Server_API.app.api.v1.endpoints.outputs": "/outputs",
+    }
+    access_count = {module_name: 0 for module_name in module_paths}
+
+    for module_name, path in module_paths.items():
+        router = APIRouter()
+
+        @router.get(path)
+        def _endpoint() -> dict[str, str]:
+            return {"status": "ok"}
+
+        fake_module = ModuleType(module_name)
+
+        def _module_getattr(
+            name: str,
+            *,
+            module_name: str = module_name,
+            router: APIRouter = router,
+        ) -> APIRouter:
+            if name != "router":
+                raise AttributeError(name)
+            access_count[module_name] += 1
+            return router
+
+        fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    specs = list(iter_content_router_specs())
+    assert access_count == {module_name: 0 for module_name in module_paths}
+
+    by_first_path = {_first_router_path(spec.router): spec for spec in specs}
+    assert by_first_path["/outputs/templates"].prefix == "/api/v1"
+    assert by_first_path["/outputs/templates"].tags == ("outputs-templates",)
+    assert by_first_path["/outputs/templates"].route_key == "outputs-templates"
+    assert by_first_path["/outputs"].prefix == "/api/v1"
+    assert by_first_path["/outputs"].tags == ("outputs",)
+    assert by_first_path["/outputs"].route_key == "outputs"
+    assert access_count == {module_name: 1 for module_name in module_paths}
+
+
 def test_qodo_reviewed_router_policy_regressions(monkeypatch: pytest.MonkeyPatch) -> None:
     _install_fake_router_module(
         monkeypatch,


### PR DESCRIPTION
## Change summary\n\nHuman-authored summary required before merge: this PR continues Phase 2.2 by deferring the covered output router imports without changing endpoint payloads or route metadata.\n\n## What changed\n\n- Converted outputs_templates and outputs content router registrations to ImportedRouterSpec-based lazy registration.\n- Added a red/green router group contract test proving those router attributes are not accessed until RouterSpec resolution.\n- Recorded TASK-33 with plan, verification, and final summary.\n\n## Verification\n\n- Red: python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "output_router_attr_lookup" -q failed before implementation because router attrs were eagerly resolved.\n- Green: python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "output_router_attr_lookup" -q passed.\n- python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q: 51 passed.\n- python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q: 6 passed.\n- python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q: 69 passed.\n- python -m bandit -r tldw_Server_API/app/api/v1/router_groups/content.py -f json -o /tmp/bandit_phase2_2_content_outputs_router_conditionals_j.json: 0 results, 0 errors.\n- git diff --check: clean.\n\nPart of #1116.