### PR TITLE
Phase 2.2: defer integration router imports

### DIFF
--- a/backlog/tasks/task-33 - Phase-2.2-integration-router-conditional-cleanup-K.md
+++ b/backlog/tasks/task-33 - Phase-2.2-integration-router-conditional-cleanup-K.md
@@ -1,0 +1,68 @@
+---
+id: TASK-33
+title: Phase 2.2 integration router conditional cleanup K
+status: Done
+assignee: []
+created_date: '2026-05-04 04:05'
+labels:
+  - phase-2
+  - router-groups
+  - refactor
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Move only the covered integration-style content router specs onto the shared lazy ImportedRouterSpec helper. Preserve public route metadata and route ordering for Slack, Discord, Telegram, and Meetings.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Slack, Discord, Telegram, and Meetings RouterSpec metadata is preserved.
+- [x] #2 Router module import and router attribute lookup for moved integration specs is lazy through RouterSpec resolution.
+- [x] #3 Full router group contract and adjacent main/OpenAPI contract tests pass.
+- [x] #4 Bandit touched-source scope and git diff --check pass.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused regression test proving integration router module import and attribute lookup are deferred until RouterSpec resolution.
+2. Run the focused selection red on current code.
+3. Replace only the Slack, Discord, Telegram, and Meetings import blocks with ImportedRouterSpec plus append_imported_router_spec while preserving metadata.
+4. Run focused and full router contract tests plus adjacent main/OpenAPI contract tests.
+5. Run Bandit on touched router source and git diff --check.
+6. Commit the narrow tranche and update the issue.
+<!-- SECTION:PLAN:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Red check: `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "integration_router_attr_lookup" -q` failed before implementation because Slack, Discord, Telegram, and Meetings router attributes were resolved during spec construction.
+- Green focused check: `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "integration_router_attr_lookup" -q` passed with `1 passed`.
+- Green full/adjacent checks: `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q` passed with `51 passed`; `python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q` passed with `6 passed`; `python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q` passed with `69 passed`.
+- Security and hygiene: `python -m bandit -r tldw_Server_API/app/api/v1/router_groups/content.py -f json -o /tmp/bandit_phase2_2_integration_router_conditionals_k.json` reported `0 results` and `0 errors`; `git diff --check` passed.
+- Rebased onto `fe21a86f61` after #1256 merged; kept both the output-router lazy test from #1256 and this tranche's integration-router lazy test. Rebased verification: `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q` passed with `52 passed`; `python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q` passed with `6 passed`; `python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q` passed with `69 passed`; `python -m bandit -r tldw_Server_API/app/api/v1/router_groups/content.py -f json -o /tmp/bandit_phase2_2_integration_router_conditionals_k_rebased.json` reported `0 results` and `0 errors`; `git diff --check HEAD` passed.
+- Documentation: no user-facing docs required for this internal router registration refactor.
+- Known skips or blockers: none.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Moved the covered Slack, Discord, Telegram, and Meetings registrations to the shared lazy ImportedRouterSpec helper while preserving route prefixes, tags, route keys, default-stable policy, and ordering. Added regression coverage proving selected integration router modules and router attributes are not resolved until the selected RouterSpec objects are used, then verified the full router group contract, adjacent main/OpenAPI contract tests, Bandit touched-source scope, and whitespace checks.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/content.py
+++ b/tldw_Server_API/app/api/v1/router_groups/content.py
@@ -251,61 +251,42 @@ def iter_content_router_specs() -> Iterable[RouterSpec]:
     ):
         append_imported_router_spec(specs, utility_spec)
 
-    # Slack integration endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.slack import router as slack_router
-
-        specs.append(RouterSpec(
-            router=slack_router,
+    # Integration endpoints
+    for integration_spec in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.slack",
+            log_name="slack",
             prefix=f"{API_V1_PREFIX}",
             tags=("slack",),
             route_key="slack",
             default_stable=False,
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping slack router: {e}")
-
-    # Discord integration endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.discord import router as discord_router
-
-        specs.append(RouterSpec(
-            router=discord_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.discord",
+            log_name="discord",
             prefix=f"{API_V1_PREFIX}",
             tags=("discord",),
             route_key="discord",
             default_stable=False,
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping discord router: {e}")
-
-    # Telegram integration endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.telegram import router as telegram_router
-
-        specs.append(RouterSpec(
-            router=telegram_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.telegram",
+            log_name="telegram",
             prefix=f"{API_V1_PREFIX}",
             tags=("telegram",),
             route_key="telegram",
             default_stable=False,
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping telegram router: {e}")
-
-    # Meetings endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.meetings import router as meetings_router
-
-        specs.append(RouterSpec(
-            router=meetings_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.meetings",
+            log_name="meetings",
             prefix=f"{API_V1_PREFIX}",
             tags=("meetings",),
             route_key="meetings",
             default_stable=False,
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping meetings router: {e}")
+        ),
+    ):
+        append_imported_router_spec(specs, integration_spec)
 
     # Collections feeds endpoints
     try:

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -1470,6 +1470,114 @@ def test_iter_content_router_specs_defers_output_router_attr_lookup(
     assert access_count == {module_name: 1 for module_name in module_paths}
 
 
+def test_iter_content_router_specs_defers_integration_router_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify covered integration specs keep import and attr lookup lazy."""
+    import importlib
+
+    router_definitions = {
+        "slack": {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.slack",
+            "path": "/slack/events",
+            "prefix": "/api/v1",
+            "tags": ("slack",),
+        },
+        "discord": {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.discord",
+            "path": "/discord/events",
+            "prefix": "/api/v1",
+            "tags": ("discord",),
+        },
+        "telegram": {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.telegram",
+            "path": "/telegram/events",
+            "prefix": "/api/v1",
+            "tags": ("telegram",),
+        },
+        "meetings": {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.meetings",
+            "path": "/meetings/health",
+            "prefix": "/api/v1",
+            "tags": ("meetings",),
+        },
+    }
+    access_count = {
+        str(definition["module_name"]): 0
+        for definition in router_definitions.values()
+    }
+    import_calls: list[str] = []
+
+    for definition in router_definitions.values():
+        module_name = str(definition["module_name"])
+        router = APIRouter()
+
+        @router.get(str(definition["path"]))
+        def _endpoint() -> dict[str, str]:
+            """Return a deterministic response for the fake integration router."""
+            return {"status": "ok"}
+
+        fake_module = ModuleType(module_name)
+
+        def _module_getattr(
+            name: str,
+            *,
+            module_name: str = module_name,
+            router: APIRouter = router,
+        ) -> APIRouter:
+            """Track lazy router attribute resolution for the fake module."""
+            if name != "router":
+                raise AttributeError(name)
+            access_count[module_name] += 1
+            return router
+
+        fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Track lazy module imports for selected integration router modules."""
+        if module_name in access_count:
+            import_calls.append(module_name)
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    specs = list(iter_content_router_specs())
+    assert access_count == {
+        str(definition["module_name"]): 0
+        for definition in router_definitions.values()
+    }
+    assert import_calls == []
+
+    integration_specs = {
+        spec.route_key: spec
+        for spec in specs
+        if spec.route_key in router_definitions
+    }
+    assert set(integration_specs) == set(router_definitions)
+
+    for route_key, spec in integration_specs.items():
+        definition = router_definitions[route_key]
+        assert spec.prefix == definition["prefix"]
+        assert spec.tags == definition["tags"]
+        assert spec.default_stable is False
+        assert _first_router_path(spec.router) == definition["path"]
+
+    assert import_calls == [
+        str(router_definitions[route_key]["module_name"])
+        for route_key in integration_specs
+    ]
+    assert access_count == {
+        str(definition["module_name"]): 1
+        for definition in router_definitions.values()
+    }
+
+
 def test_qodo_reviewed_router_policy_regressions(monkeypatch: pytest.MonkeyPatch) -> None:
     _install_fake_router_module(
         monkeypatch,


### PR DESCRIPTION
## Summary
- Move Slack, Discord, Telegram, and Meetings content router registrations to the shared lazy ImportedRouterSpec helper.
- Preserve route prefixes, tags, route keys, default-stable policy, and ordering.
- Add a focused regression proving selected integration router imports and router attr lookup stay deferred until RouterSpec resolution.
- Rebased onto dev after #1256 merged; kept both the output-router lazy test from #1256 and this branch's integration-router lazy test.

## Change summary
TODO: human-authored summary required before merge. Explain what changed and why these implementation choices were made.

## Test Plan
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k integration_router_attr_lookup -q (red before implementation; green after)
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "output_router_attr_lookup or integration_router_attr_lookup" -q -> 2 passed after rebase conflict resolution
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q -> 52 passed
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q -> 6 passed
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q -> 69 passed
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/router_groups/content.py -f json -o /tmp/bandit_phase2_2_integration_router_conditionals_k_rebased.json -> 0 results, 0 errors
- git diff --check HEAD -> passed