### PR TITLE
Fix CodeGraph Qodo follow-up review issues

### DIFF
--- a/backlog/tasks/task-34 - Address-PR-1253-Qodo-follow-up-review.md
+++ b/backlog/tasks/task-34 - Address-PR-1253-Qodo-follow-up-review.md
@@ -4,7 +4,7 @@ title: Address PR 1253 Qodo follow-up review
 status: Done
 assignee: []
 created_date: '2026-05-04 04:03'
-updated_date: '2026-05-04 04:07'
+updated_date: '2026-05-04 04:48'
 labels:
   - codegraph
   - mcp
@@ -13,6 +13,7 @@ dependencies:
   - TASK-31
 references:
   - 'https://github.com/rmusser01/tldw_server/pull/1253'
+  - 'https://github.com/rmusser01/tldw_server/pull/1258'
 priority: medium
 ---
 
@@ -39,6 +40,8 @@ Verified PR #1253 is merged. Open follow-up branch codex/codegraph-qodo-followup
 Implemented Qodo follow-up fixes: Python AST parsing catches ValueError; indexer converts extractor ValueError into per-file extraction_failed rows; codegraph.files limit is clamped by max_search_results; inventory-only files use a binary probe and streaming file hash instead of full read_bytes; extractor package now has a module docstring; test policy helpers have type hints.
 
 Verification: focused CodeGraph/MCP suite passed with 51 passed and 5 warnings; Ruff check on touched files passed; Bandit touched scope wrote /tmp/bandit_codegraph_qodo_followup.json with 0 results and 0 errors; git diff --check passed.
+
+Opened draft follow-up PR #1258 against dev for the Qodo review fixes. PR remains draft pending a human-authored Change summary.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-34 - Address-PR-1253-Qodo-follow-up-review.md
+++ b/backlog/tasks/task-34 - Address-PR-1253-Qodo-follow-up-review.md
@@ -1,0 +1,58 @@
+---
+id: TASK-34
+title: Address PR 1253 Qodo follow-up review
+status: Done
+assignee: []
+created_date: '2026-05-04 04:03'
+updated_date: '2026-05-04 04:07'
+labels:
+  - codegraph
+  - mcp
+  - review
+dependencies:
+  - TASK-31
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1253'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address post-merge Qodo review findings from PR #1253 on a follow-up branch against dev. Scope: CodeGraph extractor resilience for ast.parse ValueError, codegraph.files limit clamping, extractor package module docstring, missing test helper type hints, and indexer I/O improvements for binary and inventory-only files. Preserve merged CodeGraph behavior and add focused regression coverage.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Python extractor/indexer converts malformed source parse failures into per-file extraction_failed results without aborting the whole run.
+- [x] #2 codegraph.files clamps user limits to the configured max_search_results cap and reports truncation consistently.
+- [x] #3 Indexer avoids full-file reads for binary skips and inventory-only languages by using a small binary probe plus streaming hashing.
+- [x] #4 Qodo maintainability findings for extractor package docstring and test helper type hints are addressed.
+- [x] #5 Focused CodeGraph/MCP tests Bandit touched scope and git diff whitespace check pass.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verified PR #1253 is merged. Open follow-up branch codex/codegraph-qodo-followup from origin/dev to address Qodo findings on merged CodeGraph code.
+
+Implemented Qodo follow-up fixes: Python AST parsing catches ValueError; indexer converts extractor ValueError into per-file extraction_failed rows; codegraph.files limit is clamped by max_search_results; inventory-only files use a binary probe and streaming file hash instead of full read_bytes; extractor package now has a module docstring; test policy helpers have type hints.
+
+Verification: focused CodeGraph/MCP suite passed with 51 passed and 5 warnings; Ruff check on touched files passed; Bandit touched scope wrote /tmp/bandit_codegraph_qodo_followup.json with 0 results and 0 errors; git diff --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed post-merge Qodo review findings from PR #1253 on follow-up branch codex/codegraph-qodo-followup. The CodeGraph extractor/indexer now reports parse/extractor ValueError as per-file extraction failures, codegraph.files clamps large limits, inventory-only indexing avoids full-file reads via binary probing and streaming hashing, and the maintainability comments are fixed with a package docstring and typed test helpers.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-35 - Address-PR-1258-Qodo-second-pass-review.md
+++ b/backlog/tasks/task-35 - Address-PR-1258-Qodo-second-pass-review.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-35
 title: Address PR 1258 Qodo second-pass review
-status: In Progress
+status: Done
 assignee:
   - Codex
 created_date: '2026-05-04 05:12'
-updated_date: '2026-05-04 05:16'
+updated_date: '2026-05-04 05:24'
 labels:
   - codegraph
   - mcp
@@ -42,14 +42,22 @@ Address the new Qodo review comments on PR #1258 after the initial follow-up pus
 
 <!-- SECTION:NOTES:BEGIN -->
 Implemented second-pass Qodo fixes. Added RED tests for unreadable per-candidate file handling and single-open file processing. CodeGraphIndexer now reads each candidate from one stream, reuses the binary probe for extraction source or streaming hash, and records per-file OSError as extraction_failed without aborting the run. Verification: focused CodeGraph/MCP suite passed with 53 passed and 5 warnings; Ruff touched files passed; Bandit /tmp/bandit_codegraph_qodo_second_pass.json reported 0 results and 0 errors; git diff --check passed.
+
+No product documentation changes were needed for this PR-review-only resilience and test cleanup. Remaining external state: PR #1258 stays draft pending the required human-authored Change summary, and GitHub CI is queued after the latest push.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed PR #1258 second-pass Qodo review findings. Test helpers now use explicit type hints without ANN002 or ANN003 ignores, CodeGraphIndexer handles per-candidate file I/O OSError as extraction_failed without aborting the run, and candidate file processing now opens each file once by reusing the binary probe for extraction source or streaming hash. Verification passed locally: focused CodeGraph/MCP tests, Ruff touched files, Bandit touched scope, and git diff --check.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [x] #1 Acceptance criteria completed
 - [x] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
+- [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-35 - Address-PR-1258-Qodo-second-pass-review.md
+++ b/backlog/tasks/task-35 - Address-PR-1258-Qodo-second-pass-review.md
@@ -1,0 +1,55 @@
+---
+id: TASK-35
+title: Address PR 1258 Qodo second-pass review
+status: In Progress
+assignee:
+  - Codex
+created_date: '2026-05-04 05:12'
+updated_date: '2026-05-04 05:16'
+labels:
+  - codegraph
+  - mcp
+  - review
+dependencies:
+  - TASK-34
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1258'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address the new Qodo review comments on PR #1258 after the initial follow-up push. Scope is limited to typed test helpers in test_codegraph_indexer.py, per-candidate OSError resilience in CodeGraphIndexer indexing, and avoiding duplicate file opens in the indexer hot loop. Preserve existing CodeGraph behavior and keep PR #1258 focused on review remediation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 New test helpers in test_codegraph_indexer.py use explicit type hints without ANN002 or ANN003 ignores.
+- [x] #2 A per-file OSError during binary probe or content read or hashing is recorded as a per-file skipped or failed item and does not abort the whole indexing run.
+- [x] #3 Indexer file processing avoids duplicate opens by reusing the binary probe bytes for extraction source or streaming hash.
+- [x] #4 Focused CodeGraph and MCP tests pass after the review fixes.
+- [x] #5 Ruff Bandit and git diff whitespace checks pass on touched scope.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Verify Qodo findings against current code and existing tests. 2. Add RED tests for per-candidate OSError handling and single-open indexing behavior. 3. Update test helper type hints to remove ANN002 and ANN003 ignores. 4. Refactor CodeGraphIndexer per-file I/O so each candidate is opened once and probe bytes are reused for binary detection plus extraction or streaming hash. 5. Run focused CodeGraph/MCP tests, Ruff, Bandit, and git diff --check before updating PR #1258.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented second-pass Qodo fixes. Added RED tests for unreadable per-candidate file handling and single-open file processing. CodeGraphIndexer now reads each candidate from one stream, reuses the binary probe for extraction source or streaming hash, and records per-file OSError as extraction_failed without aborting the run. Verification: focused CodeGraph/MCP suite passed with 53 passed and 5 warnings; Ruff touched files passed; Bandit /tmp/bandit_codegraph_qodo_second_pass.json reported 0 results and 0 errors; git diff --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/CodeGraph/extractors/__init__.py
+++ b/tldw_Server_API/app/core/CodeGraph/extractors/__init__.py
@@ -1,3 +1,5 @@
+"""Extractor implementations exported for native CodeGraph indexing."""
+
 from __future__ import annotations
 
 from .python_extractor import PythonAstExtractor

--- a/tldw_Server_API/app/core/CodeGraph/extractors/python_extractor.py
+++ b/tldw_Server_API/app/core/CodeGraph/extractors/python_extractor.py
@@ -36,7 +36,7 @@ class PythonAstExtractor:
         try:
             text = source.decode("utf-8")
             tree = ast.parse(text, filename=file_path)
-        except (SyntaxError, UnicodeDecodeError) as exc:
+        except (SyntaxError, UnicodeDecodeError, ValueError) as exc:
             return ExtractionResult(errors=(str(exc),))
 
         builder = _PythonGraphBuilder(workspace_key=workspace_key, file_path=file_path, source=text)

--- a/tldw_Server_API/app/core/CodeGraph/indexer.py
+++ b/tldw_Server_API/app/core/CodeGraph/indexer.py
@@ -48,6 +48,15 @@ class _DiscoveryResult:
     status: str | None = None
 
 
+@dataclass(frozen=True)
+class _CandidateContent:
+    """Opened file content or hash derived from a single file stream."""
+
+    content_hash: str
+    source: bytes | None = None
+    is_binary: bool = False
+
+
 class CodeGraphIndexer:
     """Bounded foreground file-inventory indexer."""
 
@@ -167,16 +176,38 @@ class CodeGraphIndexer:
                     counters["files_too_large"] += 1
                     counters["files_skipped"] += 1
                     continue
-                if self._is_binary_path(candidate.path):
+
+                has_extractor = candidate.language_id in self._extractors
+                try:
+                    content = self._read_candidate_content(candidate, needs_source=has_extractor)
+                except OSError as exc:
+                    message = str(exc)
+                    logger.warning(f"CodeGraph skipped unreadable path during indexing: {candidate.path} ({message})")
+                    counters["errors"] += 1
+                    counters["files_skipped"] += 1
+                    errors.append(f"{candidate.relative_path}: {message}")
+                    repository.upsert_file_and_replace_graph(
+                        path=candidate.relative_path,
+                        language=candidate.language_id,
+                        size=candidate.size,
+                        content_hash="",
+                        modified_at=candidate.modified_at,
+                        status="extraction_failed",
+                        errors=(message,),
+                        node_count=0,
+                        nodes=(),
+                        edges=(),
+                        unresolved_refs=(),
+                    )
+                    continue
+
+                if content.is_binary:
                     counters["files_skipped"] += 1
                     continue
 
-                if candidate.language_id in self._extractors:
-                    source = candidate.path.read_bytes()
-                    content_hash = self._hash_bytes(source)
-                    extraction = self._extract(candidate, workspace_key, source)
+                if has_extractor:
+                    extraction = self._extract(candidate, workspace_key, content.source or b"")
                 else:
-                    content_hash = self._hash_file(candidate.path)
                     extraction = ExtractionResult()
                 file_status = "indexed"
                 if extraction.errors:
@@ -187,7 +218,7 @@ class CodeGraphIndexer:
                     path=candidate.relative_path,
                     language=candidate.language_id,
                     size=candidate.size,
-                    content_hash=content_hash,
+                    content_hash=content.content_hash,
                     modified_at=candidate.modified_at,
                     status=file_status,
                     errors=extraction.errors,
@@ -306,24 +337,30 @@ class CodeGraphIndexer:
             return ExtractionResult(errors=(str(exc),))
 
     @staticmethod
-    def _hash_file(path: Path) -> str:
-        """Return a streaming SHA-256 content hash for a file path."""
+    def _read_candidate_content(candidate: _Candidate, *, needs_source: bool) -> _CandidateContent:
+        """Read or hash one candidate from a single open stream."""
         digest = hashlib.sha256()
-        with path.open("rb") as handle:
+        with candidate.path.open("rb") as handle:
+            probe = handle.read(4096)
+            if CodeGraphIndexer._is_binary(probe):
+                return _CandidateContent(content_hash="", is_binary=True)
+
+            if needs_source:
+                source = probe + handle.read()
+                return _CandidateContent(
+                    content_hash=CodeGraphIndexer._hash_bytes(source),
+                    source=source,
+                )
+
+            digest.update(probe)
             for chunk in iter(lambda: handle.read(1024 * 1024), b""):
                 digest.update(chunk)
-        return digest.hexdigest()
+            return _CandidateContent(content_hash=digest.hexdigest())
 
     @staticmethod
     def _hash_bytes(source: bytes) -> str:
         """Return a SHA-256 content hash for indexed file bytes."""
         return hashlib.sha256(source).hexdigest()
-
-    @staticmethod
-    def _is_binary_path(path: Path) -> bool:
-        """Detect obvious binary files from a small leading byte probe."""
-        with path.open("rb") as handle:
-            return CodeGraphIndexer._is_binary(handle.read(4096))
 
     @staticmethod
     def _is_binary(source: bytes) -> bool:

--- a/tldw_Server_API/app/core/CodeGraph/indexer.py
+++ b/tldw_Server_API/app/core/CodeGraph/indexer.py
@@ -167,13 +167,17 @@ class CodeGraphIndexer:
                     counters["files_too_large"] += 1
                     counters["files_skipped"] += 1
                     continue
-                source = candidate.path.read_bytes()
-                if self._is_binary(source):
+                if self._is_binary_path(candidate.path):
                     counters["files_skipped"] += 1
                     continue
 
-                content_hash = self._hash_bytes(source)
-                extraction = self._extract(candidate, workspace_key, source)
+                if candidate.language_id in self._extractors:
+                    source = candidate.path.read_bytes()
+                    content_hash = self._hash_bytes(source)
+                    extraction = self._extract(candidate, workspace_key, source)
+                else:
+                    content_hash = self._hash_file(candidate.path)
+                    extraction = ExtractionResult()
                 file_status = "indexed"
                 if extraction.errors:
                     counters["errors"] += len(extraction.errors)
@@ -291,16 +295,35 @@ class CodeGraphIndexer:
         extractor = self._extractors.get(candidate.language_id)
         if extractor is None:
             return ExtractionResult()
-        return extractor.extract(
-            workspace_key=workspace_key,
-            file_path=candidate.relative_path,
-            source=source,
-        )
+        try:
+            return extractor.extract(
+                workspace_key=workspace_key,
+                file_path=candidate.relative_path,
+                source=source,
+            )
+        except ValueError as exc:
+            logger.warning(f"CodeGraph extractor failed for {candidate.relative_path}: {exc}")
+            return ExtractionResult(errors=(str(exc),))
+
+    @staticmethod
+    def _hash_file(path: Path) -> str:
+        """Return a streaming SHA-256 content hash for a file path."""
+        digest = hashlib.sha256()
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
 
     @staticmethod
     def _hash_bytes(source: bytes) -> str:
         """Return a SHA-256 content hash for indexed file bytes."""
         return hashlib.sha256(source).hexdigest()
+
+    @staticmethod
+    def _is_binary_path(path: Path) -> bool:
+        """Detect obvious binary files from a small leading byte probe."""
+        with path.open("rb") as handle:
+            return CodeGraphIndexer._is_binary(handle.read(4096))
 
     @staticmethod
     def _is_binary(source: bytes) -> bool:

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py
@@ -24,7 +24,6 @@ from tldw_Server_API.app.core.DB_Management.codegraph.repository import CodeGrap
 
 from ..base import BaseModule, ModuleConfig, create_tool_definition
 
-
 _EMPTY_COUNTS = {"files": 0, "nodes": 0, "edges": 0, "unresolved_refs": 0}
 _FOREGROUND_MODE = "foreground"
 
@@ -469,7 +468,7 @@ class CodeGraphModule(BaseModule):
             }
 
         repository = CodeGraphRepository(resolution.index_db_path)
-        effective_limit = max(1, int(limit or 100))
+        effective_limit = self._bounded_limit(limit, default=100)
         path_prefix = _normalize_path_prefix(path)
         rows = repository.list_files(
             limit=effective_limit + 1,
@@ -630,9 +629,9 @@ class CodeGraphModule(BaseModule):
         if isinstance(symbol, str):
             arguments["symbol"] = symbol.strip()
 
-    def _bounded_limit(self, limit: int | None) -> int:
+    def _bounded_limit(self, limit: int | None, *, default: int = 10) -> int:
         """Clamp user-provided result limits to configured maximums."""
-        return min(max(1, int(limit or 10)), self._settings.max_search_results)
+        return min(max(1, int(limit or default)), self._settings.max_search_results)
 
 
 def _normalize_path_prefix(path: str | None) -> str | None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
@@ -10,9 +10,7 @@ from tldw_Server_API.app.core.MCP_unified.modules.base import ModuleConfig
 from tldw_Server_API.app.core.MCP_unified.modules.implementations.codegraph_module import (
     CodeGraphModule,
 )
-from tldw_Server_API.app.core.MCP_unified.protocol import InvalidParamsException
-from tldw_Server_API.app.core.MCP_unified.protocol import MCPProtocol
-from tldw_Server_API.app.core.MCP_unified.protocol import RequestContext
+from tldw_Server_API.app.core.MCP_unified.protocol import InvalidParamsException, MCPProtocol, RequestContext
 
 
 class _FakeWorkspaceRootResolver:
@@ -60,6 +58,14 @@ def _context() -> RequestContext:
 
 
 def _module(tmp_path: Path, workspace_root: Path) -> CodeGraphModule:
+    return _module_with_settings(tmp_path, workspace_root, {})
+
+
+def _module_with_settings(
+    tmp_path: Path,
+    workspace_root: Path,
+    settings: dict[str, Any],
+) -> CodeGraphModule:
     resolver = _FakeWorkspaceRootResolver(
         {
             "workspace_root": str(workspace_root),
@@ -68,8 +74,9 @@ def _module(tmp_path: Path, workspace_root: Path) -> CodeGraphModule:
             "reason": None,
         }
     )
+    module_settings = {"index_base_dir": str(tmp_path / "indexes"), **settings}
     return CodeGraphModule(
-        ModuleConfig(name="CodeGraph", settings={"index_base_dir": str(tmp_path / "indexes")}),
+        ModuleConfig(name="CodeGraph", settings=module_settings),
         workspace_root_resolver=resolver,
     )
 
@@ -157,6 +164,25 @@ async def test_codegraph_index_and_files_roundtrip(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_codegraph_files_clamps_large_limits_to_configured_max(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    for index in range(3):
+        (workspace_root / f"file_{index}.py").write_text("x = 1\n", encoding="utf-8")
+    module = _module_with_settings(tmp_path, workspace_root, {"max_search_results": 2})
+
+    await module.execute_tool(
+        "codegraph.index",
+        {"mode": "foreground", "force": True, "max_files": 10},
+        context=_context(),
+    )
+    files_result = await module.execute_tool("codegraph.files", {"limit": 999}, context=_context())
+
+    assert len(files_result["files"]) == 2  # nosec B101
+    assert files_result["truncated"] is True  # nosec B101
+
+
+@pytest.mark.asyncio
 async def test_codegraph_search_node_callers_and_callees_roundtrip(tmp_path: Path) -> None:
     workspace_root = tmp_path / "workspace"
     workspace_root.mkdir()
@@ -240,7 +266,7 @@ async def test_protocol_rejects_unknown_codegraph_index_arguments(tmp_path: Path
     protocol = MCPProtocol()
     protocol.module_registry = _CodeGraphRegistry(module)
 
-    async def _resolve_effective_policy(_context):
+    async def _resolve_effective_policy(_context: RequestContext) -> dict[str, Any]:
         return {"enabled": True, "allowed_tools": ["codegraph.index"], "policy_document": {"path_scope_mode": "none"}}
 
     async def _allow(*_args, **_kwargs) -> bool:
@@ -267,7 +293,7 @@ async def test_protocol_rejects_unknown_codegraph_search_arguments(tmp_path: Pat
     protocol = MCPProtocol()
     protocol.module_registry = _CodeGraphRegistry(module)
 
-    async def _resolve_effective_policy(_context):
+    async def _resolve_effective_policy(_context: RequestContext) -> dict[str, Any]:
         return {"enabled": True, "allowed_tools": ["codegraph.search"], "policy_document": {"path_scope_mode": "none"}}
 
     async def _allow(*_args, **_kwargs) -> bool:

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py
@@ -4,8 +4,8 @@ from pathlib import Path
 
 from tldw_Server_API.app.core.CodeGraph.config import CodeGraphSettings
 from tldw_Server_API.app.core.CodeGraph.indexer import CodeGraphIndexer
-from tldw_Server_API.app.core.CodeGraph.models import LanguageInfo
 from tldw_Server_API.app.core.CodeGraph.language_registry import CodeGraphLanguageRegistry
+from tldw_Server_API.app.core.CodeGraph.models import ExtractionResult, LanguageInfo
 from tldw_Server_API.app.core.DB_Management.codegraph.repository import CodeGraphRepository
 
 
@@ -124,6 +124,81 @@ def test_indexer_marks_python_extraction_errors_without_claiming_indexed_status(
     assert file_row.status == "extraction_failed"
     assert file_row.node_count == 0
     assert file_row.errors
+
+
+def test_indexer_converts_extractor_exceptions_to_file_errors(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "broken.py").write_text("x = 1\n", encoding="utf-8")
+    repo = CodeGraphRepository(tmp_path / "codegraph.db")
+    indexer = CodeGraphIndexer(settings=CodeGraphSettings.from_mapping({}), registry=CodeGraphLanguageRegistry())
+
+    class _RaisingExtractor:
+        def extract(self, *, workspace_key: str, file_path: str, source: bytes) -> ExtractionResult:
+            raise ValueError("source code string cannot contain null bytes")
+
+    indexer._extractors["python"] = _RaisingExtractor()  # noqa: SLF001
+
+    result = indexer.index_workspace(
+        workspace_root=workspace,
+        workspace_key="ws_test",
+        repository=repo,
+        force=True,
+        languages=None,
+        max_files=10,
+    )
+    file_row = repo.list_files(limit=10)[0]
+
+    assert result.status == "complete"
+    assert result.counters["errors"] == 1
+    assert file_row.status == "extraction_failed"
+    assert file_row.errors == ("source code string cannot contain null bytes",)
+
+
+def test_indexer_does_not_read_full_inventory_only_file_into_memory(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "ui.ts").write_text("export const value = 1;\n", encoding="utf-8")
+    repo = CodeGraphRepository(tmp_path / "codegraph.db")
+    indexer = CodeGraphIndexer(settings=CodeGraphSettings.from_mapping({}), registry=CodeGraphLanguageRegistry())
+
+    class _NoReadBytesPath:
+        def __init__(self, path: Path) -> None:
+            self._path = path
+
+        def open(self, *args, **kwargs):  # noqa: ANN002, ANN003
+            return self._path.open(*args, **kwargs)
+
+        def read_bytes(self) -> bytes:
+            raise AssertionError("inventory-only files should not be loaded fully")
+
+    original_discover = indexer._discover_candidates  # noqa: SLF001
+
+    def _discover_with_wrapped_paths(*args, **kwargs):  # noqa: ANN002, ANN003
+        result = original_discover(*args, **kwargs)
+        result.candidates[0] = result.candidates[0].__class__(
+            path=_NoReadBytesPath(result.candidates[0].path),  # type: ignore[arg-type]
+            relative_path=result.candidates[0].relative_path,
+            language_id=result.candidates[0].language_id,
+            stage=result.candidates[0].stage,
+            size=result.candidates[0].size,
+            modified_at=result.candidates[0].modified_at,
+        )
+        return result
+
+    indexer._discover_candidates = _discover_with_wrapped_paths  # type: ignore[method-assign]  # noqa: SLF001
+
+    result = indexer.index_workspace(
+        workspace_root=workspace,
+        workspace_key="ws_test",
+        repository=repo,
+        force=True,
+        languages=None,
+        max_files=10,
+    )
+
+    assert result.status == "complete"
+    assert repo.list_files(limit=10)[0].path == "ui.ts"
 
 
 def test_indexer_rejects_over_limit_foreground_workspace(tmp_path: Path) -> None:

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 from tldw_Server_API.app.core.CodeGraph.config import CodeGraphSettings
-from tldw_Server_API.app.core.CodeGraph.indexer import CodeGraphIndexer
+from tldw_Server_API.app.core.CodeGraph.indexer import CodeGraphIndexer, _Candidate, _DiscoveryResult
 from tldw_Server_API.app.core.CodeGraph.language_registry import CodeGraphLanguageRegistry
 from tldw_Server_API.app.core.CodeGraph.models import ExtractionResult, LanguageInfo
 from tldw_Server_API.app.core.DB_Management.codegraph.repository import CodeGraphRepository
@@ -166,7 +167,7 @@ def test_indexer_does_not_read_full_inventory_only_file_into_memory(tmp_path: Pa
         def __init__(self, path: Path) -> None:
             self._path = path
 
-        def open(self, *args, **kwargs):  # noqa: ANN002, ANN003
+        def open(self, *args: Any, **kwargs: Any) -> Any:
             return self._path.open(*args, **kwargs)
 
         def read_bytes(self) -> bytes:
@@ -174,8 +175,19 @@ def test_indexer_does_not_read_full_inventory_only_file_into_memory(tmp_path: Pa
 
     original_discover = indexer._discover_candidates  # noqa: SLF001
 
-    def _discover_with_wrapped_paths(*args, **kwargs):  # noqa: ANN002, ANN003
-        result = original_discover(*args, **kwargs)
+    def _discover_with_wrapped_paths(
+        workspace_root: Path,
+        *,
+        languages: list[str] | tuple[str, ...] | None,
+        counters: dict[str, int],
+        max_files: int,
+    ) -> _DiscoveryResult:
+        result = original_discover(
+            workspace_root,
+            languages=languages,
+            counters=counters,
+            max_files=max_files,
+        )
         result.candidates[0] = result.candidates[0].__class__(
             path=_NoReadBytesPath(result.candidates[0].path),  # type: ignore[arg-type]
             relative_path=result.candidates[0].relative_path,
@@ -199,6 +211,143 @@ def test_indexer_does_not_read_full_inventory_only_file_into_memory(tmp_path: Pa
 
     assert result.status == "complete"
     assert repo.list_files(limit=10)[0].path == "ui.ts"
+
+
+def test_indexer_records_unreadable_files_without_aborting_run(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "broken.py").write_text("x = 1\n", encoding="utf-8")
+    (workspace / "healthy.py").write_text("y = 2\n", encoding="utf-8")
+    repo = CodeGraphRepository(tmp_path / "codegraph.db")
+    indexer = CodeGraphIndexer(settings=CodeGraphSettings.from_mapping({}), registry=CodeGraphLanguageRegistry())
+
+    class _UnreadablePath:
+        def __init__(self, path: Path) -> None:
+            self._path = path
+
+        def open(self, *args: Any, **kwargs: Any) -> Any:
+            raise OSError("permission denied")
+
+        def read_bytes(self) -> bytes:
+            raise OSError("permission denied")
+
+    original_discover = indexer._discover_candidates  # noqa: SLF001
+
+    def _discover_with_unreadable_path(
+        workspace_root: Path,
+        *,
+        languages: list[str] | tuple[str, ...] | None,
+        counters: dict[str, int],
+        max_files: int,
+    ) -> _DiscoveryResult:
+        result = original_discover(
+            workspace_root,
+            languages=languages,
+            counters=counters,
+            max_files=max_files,
+        )
+        candidates = [
+            _Candidate(
+                path=_UnreadablePath(candidate.path),  # type: ignore[arg-type]
+                relative_path=candidate.relative_path,
+                language_id=candidate.language_id,
+                stage=candidate.stage,
+                size=candidate.size,
+                modified_at=candidate.modified_at,
+            )
+            if candidate.relative_path == "broken.py"
+            else candidate
+            for candidate in result.candidates
+        ]
+        return _DiscoveryResult(candidates=candidates, status=result.status)
+
+    indexer._discover_candidates = _discover_with_unreadable_path  # type: ignore[method-assign]  # noqa: SLF001
+
+    result = indexer.index_workspace(
+        workspace_root=workspace,
+        workspace_key="ws_test",
+        repository=repo,
+        force=True,
+        languages=None,
+        max_files=10,
+    )
+    files = {item.path: item for item in repo.list_files(limit=10)}
+
+    assert result.status == "complete"
+    assert result.counters["errors"] == 1
+    assert result.counters["files_skipped"] == 1
+    assert result.counters["files_indexed"] == 1
+    assert files["broken.py"].status == "extraction_failed"
+    assert files["broken.py"].errors == ("permission denied",)
+    assert files["healthy.py"].status == "indexed"
+
+
+def test_indexer_opens_each_candidate_once_for_probe_and_content(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "app.py").write_text("x = 1\n", encoding="utf-8")
+    (workspace / "ui.ts").write_text("export const y = 2;\n", encoding="utf-8")
+    repo = CodeGraphRepository(tmp_path / "codegraph.db")
+    indexer = CodeGraphIndexer(settings=CodeGraphSettings.from_mapping({}), registry=CodeGraphLanguageRegistry())
+    wrapped_paths: dict[str, _OpenCountingPath] = {}
+
+    class _OpenCountingPath:
+        def __init__(self, path: Path) -> None:
+            self._path = path
+            self.open_calls = 0
+
+        def open(self, *args: Any, **kwargs: Any) -> Any:
+            self.open_calls += 1
+            return self._path.open(*args, **kwargs)
+
+        def read_bytes(self) -> bytes:
+            raise AssertionError("indexer should reuse the open stream instead of read_bytes")
+
+    original_discover = indexer._discover_candidates  # noqa: SLF001
+
+    def _discover_with_counting_paths(
+        workspace_root: Path,
+        *,
+        languages: list[str] | tuple[str, ...] | None,
+        counters: dict[str, int],
+        max_files: int,
+    ) -> _DiscoveryResult:
+        result = original_discover(
+            workspace_root,
+            languages=languages,
+            counters=counters,
+            max_files=max_files,
+        )
+        candidates: list[_Candidate] = []
+        for candidate in result.candidates:
+            wrapped = _OpenCountingPath(candidate.path)
+            wrapped_paths[candidate.relative_path] = wrapped
+            candidates.append(
+                _Candidate(
+                    path=wrapped,  # type: ignore[arg-type]
+                    relative_path=candidate.relative_path,
+                    language_id=candidate.language_id,
+                    stage=candidate.stage,
+                    size=candidate.size,
+                    modified_at=candidate.modified_at,
+                )
+            )
+        return _DiscoveryResult(candidates=candidates, status=result.status)
+
+    indexer._discover_candidates = _discover_with_counting_paths  # type: ignore[method-assign]  # noqa: SLF001
+
+    result = indexer.index_workspace(
+        workspace_root=workspace,
+        workspace_key="ws_test",
+        repository=repo,
+        force=True,
+        languages=None,
+        max_files=10,
+    )
+
+    assert result.status == "complete"
+    assert wrapped_paths["app.py"].open_calls == 1
+    assert wrapped_paths["ui.ts"].open_calls == 1
 
 
 def test_indexer_rejects_over_limit_foreground_workspace(tmp_path: Path) -> None:

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_python_extractor.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_python_extractor.py
@@ -84,3 +84,12 @@ def persist(external_client):
         and ref.reference_kind == "call"
         for ref in result.unresolved_refs
     )
+
+
+def test_python_extractor_reports_value_error_parse_failures() -> None:
+    extractor = PythonAstExtractor()
+
+    result = extractor.extract(workspace_key="ws_test", file_path="pkg/broken.py", source=b"def broken():\n\x00\n")
+
+    assert result.nodes == ()
+    assert result.errors


### PR DESCRIPTION
## Change summary

TODO: human-authored summary required before this AI-authored PR is merge-ready.

## What changed

- Convert Python parse/extractor ValueError into per-file CodeGraph extraction failures instead of aborting an index run.
- Clamp codegraph.files limits to the configured CodeGraph max_search_results cap.
- Avoid full-file reads for binary skips and inventory-only CodeGraph languages by using a small binary probe and streaming file hashes.
- Refactor the indexer hot loop so each candidate is opened once, reusing the binary probe bytes for either extraction source or streaming hash.
- Convert per-candidate file I/O OSError into a per-file `extraction_failed` row with skipped/error counters instead of aborting the whole run.
- Add the extractor package docstring and explicit type annotations for review-introduced test helpers.
- Add `TASK-35` to track the PR #1258 second-pass Qodo review remediation.

## Verification

- python -m pytest tldw_Server_API/tests/CodeGraph tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py -q
- python -m ruff check tldw_Server_API/app/core/CodeGraph/indexer.py tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py
- python -m bandit -r tldw_Server_API/app/core/CodeGraph tldw_Server_API/app/core/DB_Management/codegraph tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py -f json -o /tmp/bandit_codegraph_qodo_second_pass.json
- git diff --check
