### PR TITLE
Phase 2.2: defer collections reading router imports

### DIFF
--- a/backlog/tasks/task-35 - Phase-2.2-collections-reading-router-conditional-cleanup-L.md
+++ b/backlog/tasks/task-35 - Phase-2.2-collections-reading-router-conditional-cleanup-L.md
@@ -4,6 +4,7 @@ title: Phase 2.2 collections reading router conditional cleanup L
 status: Done
 assignee: []
 created_date: '2026-05-04 05:12'
+updated_date: '2026-05-04 05:31'
 labels:
   - phase-2
   - router-groups
@@ -26,6 +27,7 @@ Move only the covered collections and reading content router specs onto the shar
 - [x] #2 Router module import and router attribute lookup for moved collections/reading specs is lazy through RouterSpec resolution.
 - [x] #3 Full router group contract and adjacent main/OpenAPI contract tests pass.
 - [x] #4 Bandit touched-source scope and git diff --check pass.
+- [x] #5 WebSub callback router skip diagnostics distinguish callback_router from the management router.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -39,6 +41,27 @@ Move only the covered collections and reading content router specs onto the shar
 6. Commit the narrow tranche and update the issue.
 <!-- SECTION:PLAN:END -->
 
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Red check: `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "collections_reading_router_attr_lookup" -q` failed before implementation because collections feeds, collections WebSub, WebSub callback, and reading router attributes were resolved during spec construction.
+- Green focused check: `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "collections_reading_router_attr_lookup" -q` passed with `1 passed`.
+- Green full/adjacent checks: `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q` passed with `53 passed`; `python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q` passed with `6 passed`; `python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q` passed with `69 passed`.
+- Security and hygiene: `python -m bandit -r tldw_Server_API/app/api/v1/router_groups/content.py -f json -o /tmp/bandit_phase2_2_collections_reading_router_conditionals_l.json` reported `0 results` and `0 errors`; `git diff --check` passed.
+- Documentation: no user-facing docs required for this internal router registration refactor.
+- Known skips or blockers: none.
+- Review follow-up: PR #1260 Qodo thread reports that the collections_websub management router and callback_router use the same log_name, making skip logs ambiguous when one fails to resolve. Reopened task to add diagnostic coverage and fix the callback spec.
+- Review follow-up verification: focused red test failed on the old callback spec name, then passed after changing the callback ImportedRouterSpec to log_name=collections_websub_callback with skip_context=(callback_router). Verified focused router regression, full router group contracts, main router contract tests, OpenAPI contract tests, Bandit touched-source scope with 0 issues, and git diff --check. Ruff was also attempted on touched files; it reports existing non-blocking baseline style findings in this branch, so no broad unrelated Ruff cleanup was folded into this review fix.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Moved the covered collections feeds, collections WebSub, WebSub callback, and reading registrations to the shared lazy ImportedRouterSpec helper while preserving route prefixes, tags, route keys, and ordering. Added regression coverage proving selected collections/reading router modules and router attributes are not resolved until the selected RouterSpec objects are used, then verified the full router group contract, adjacent main/OpenAPI contract tests, Bandit touched-source scope, and whitespace checks.
+
+PR #1260 review follow-up: made the collections WebSub callback router diagnostics unambiguous by giving the callback ImportedRouterSpec a distinct internal name and callback skip context, with regression coverage that preserves public route metadata while asserting the diagnostic fields.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [x] #1 Acceptance criteria completed
@@ -48,20 +71,3 @@ Move only the covered collections and reading content router specs onto the shar
 - [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->
-
-## Notes
-
-<!-- SECTION:NOTES:BEGIN -->
-- Red check: `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "collections_reading_router_attr_lookup" -q` failed before implementation because collections feeds, collections WebSub, WebSub callback, and reading router attributes were resolved during spec construction.
-- Green focused check: `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "collections_reading_router_attr_lookup" -q` passed with `1 passed`.
-- Green full/adjacent checks: `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q` passed with `53 passed`; `python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q` passed with `6 passed`; `python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q` passed with `69 passed`.
-- Security and hygiene: `python -m bandit -r tldw_Server_API/app/api/v1/router_groups/content.py -f json -o /tmp/bandit_phase2_2_collections_reading_router_conditionals_l.json` reported `0 results` and `0 errors`; `git diff --check` passed.
-- Documentation: no user-facing docs required for this internal router registration refactor.
-- Known skips or blockers: none.
-<!-- SECTION:NOTES:END -->
-
-## Final Summary
-
-<!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Moved the covered collections feeds, collections WebSub, WebSub callback, and reading registrations to the shared lazy ImportedRouterSpec helper while preserving route prefixes, tags, route keys, and ordering. Added regression coverage proving selected collections/reading router modules and router attributes are not resolved until the selected RouterSpec objects are used, then verified the full router group contract, adjacent main/OpenAPI contract tests, Bandit touched-source scope, and whitespace checks.
-<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-35 - Phase-2.2-collections-reading-router-conditional-cleanup-L.md
+++ b/backlog/tasks/task-35 - Phase-2.2-collections-reading-router-conditional-cleanup-L.md
@@ -1,0 +1,67 @@
+---
+id: TASK-35
+title: Phase 2.2 collections reading router conditional cleanup L
+status: Done
+assignee: []
+created_date: '2026-05-04 05:12'
+labels:
+  - phase-2
+  - router-groups
+  - refactor
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Move only the covered collections and reading content router specs onto the shared lazy ImportedRouterSpec helper. Preserve public route metadata and route ordering for collections feeds, collections WebSub, WebSub callbacks, and reading.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Collections feeds, collections WebSub, WebSub callback, and reading RouterSpec metadata is preserved.
+- [x] #2 Router module import and router attribute lookup for moved collections/reading specs is lazy through RouterSpec resolution.
+- [x] #3 Full router group contract and adjacent main/OpenAPI contract tests pass.
+- [x] #4 Bandit touched-source scope and git diff --check pass.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused regression test proving collections/reading router module import and attribute lookup are deferred until RouterSpec resolution.
+2. Run the focused selection red on current code.
+3. Replace only the collections feeds, collections WebSub, WebSub callback, and reading import blocks with ImportedRouterSpec plus append_imported_router_spec while preserving metadata and ordering.
+4. Run focused and full router contract tests plus adjacent main/OpenAPI contract tests.
+5. Run Bandit on touched router source and git diff --check.
+6. Commit the narrow tranche and update the issue.
+<!-- SECTION:PLAN:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Red check: `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "collections_reading_router_attr_lookup" -q` failed before implementation because collections feeds, collections WebSub, WebSub callback, and reading router attributes were resolved during spec construction.
+- Green focused check: `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "collections_reading_router_attr_lookup" -q` passed with `1 passed`.
+- Green full/adjacent checks: `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q` passed with `53 passed`; `python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q` passed with `6 passed`; `python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q` passed with `69 passed`.
+- Security and hygiene: `python -m bandit -r tldw_Server_API/app/api/v1/router_groups/content.py -f json -o /tmp/bandit_phase2_2_collections_reading_router_conditionals_l.json` reported `0 results` and `0 errors`; `git diff --check` passed.
+- Documentation: no user-facing docs required for this internal router registration refactor.
+- Known skips or blockers: none.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Moved the covered collections feeds, collections WebSub, WebSub callback, and reading registrations to the shared lazy ImportedRouterSpec helper while preserving route prefixes, tags, route keys, and ordering. Added regression coverage proving selected collections/reading router modules and router attributes are not resolved until the selected RouterSpec objects are used, then verified the full router group contract, adjacent main/OpenAPI contract tests, Bandit touched-source scope, and whitespace checks.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/content.py
+++ b/tldw_Server_API/app/api/v1/router_groups/content.py
@@ -288,51 +288,39 @@ def iter_content_router_specs() -> Iterable[RouterSpec]:
     ):
         append_imported_router_spec(specs, integration_spec)
 
-    # Collections feeds endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.collections_feeds import router as collections_feeds_router
-
-        specs.append(RouterSpec(
-            router=collections_feeds_router,
+    # Collections and reading endpoints
+    for collections_spec in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.collections_feeds",
+            log_name="collections_feeds",
             prefix=f"{API_V1_PREFIX}",
             tags=("collections-feeds",),
             route_key="collections-feeds",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping collections_feeds router: {e}")
-
-    # Collections WebSub endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.collections_websub import callback_router as websub_callback_router
-        from tldw_Server_API.app.api.v1.endpoints.collections_websub import router as collections_websub_router
-
-        specs.append(RouterSpec(
-            router=collections_websub_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.collections_websub",
+            log_name="collections_websub",
             prefix=f"{API_V1_PREFIX}",
             tags=("collections-websub",),
             route_key="collections-websub",
-        ))
-        specs.append(RouterSpec(
-            router=websub_callback_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.collections_websub",
+            log_name="collections_websub",
             prefix=f"{API_V1_PREFIX}",
             tags=("collections-websub",),
             route_key="collections-websub",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping collections_websub router: {e}")
-
-    # Reading endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.reading import router as reading_router
-
-        specs.append(RouterSpec(
-            router=reading_router,
+            attr_name="callback_router",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.reading",
+            log_name="reading",
             prefix=f"{API_V1_PREFIX}",
             tags=("reading",),
             route_key="reading",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping reading router: {e}")
+        ),
+    ):
+        append_imported_router_spec(specs, collections_spec)
 
     # Prompt Studio endpoints
     try:

--- a/tldw_Server_API/app/api/v1/router_groups/content.py
+++ b/tldw_Server_API/app/api/v1/router_groups/content.py
@@ -306,11 +306,12 @@ def iter_content_router_specs() -> Iterable[RouterSpec]:
         ),
         ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.collections_websub",
-            log_name="collections_websub",
+            log_name="collections_websub_callback",
             prefix=f"{API_V1_PREFIX}",
             tags=("collections-websub",),
             route_key="collections-websub",
             attr_name="callback_router",
+            skip_context="(callback_router)",
         ),
         ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.reading",

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -1588,6 +1588,8 @@ def test_iter_content_router_specs_defers_collections_reading_router_attr_lookup
         {
             "module_name": "tldw_Server_API.app.api.v1.endpoints.collections_feeds",
             "attr_name": "router",
+            "expected_name": "collections_feeds",
+            "expected_skip_context": "",
             "path": "/collections/feeds",
             "prefix": "/api/v1",
             "tags": ("collections-feeds",),
@@ -1596,6 +1598,8 @@ def test_iter_content_router_specs_defers_collections_reading_router_attr_lookup
         {
             "module_name": "tldw_Server_API.app.api.v1.endpoints.collections_websub",
             "attr_name": "router",
+            "expected_name": "collections_websub",
+            "expected_skip_context": "",
             "path": "/collections/feeds/{feed_id}/websub/subscribe",
             "prefix": "/api/v1",
             "tags": ("collections-websub",),
@@ -1604,6 +1608,8 @@ def test_iter_content_router_specs_defers_collections_reading_router_attr_lookup
         {
             "module_name": "tldw_Server_API.app.api.v1.endpoints.collections_websub",
             "attr_name": "callback_router",
+            "expected_name": "collections_websub_callback",
+            "expected_skip_context": "(callback_router)",
             "path": "/websub/callback/{user_id}/{callback_token}",
             "prefix": "/api/v1",
             "tags": ("collections-websub",),
@@ -1612,6 +1618,8 @@ def test_iter_content_router_specs_defers_collections_reading_router_attr_lookup
         {
             "module_name": "tldw_Server_API.app.api.v1.endpoints.reading",
             "attr_name": "router",
+            "expected_name": "reading",
+            "expected_skip_context": "",
             "path": "/reading/items",
             "prefix": "/api/v1",
             "tags": ("reading",),
@@ -1688,6 +1696,8 @@ def test_iter_content_router_specs_defers_collections_reading_router_attr_lookup
         assert spec.prefix == definition["prefix"]
         assert spec.tags == definition["tags"]
         assert spec.route_key == definition["route_key"]
+        assert spec.name == definition["expected_name"]
+        assert spec.skip_context == definition["expected_skip_context"]
 
     assert import_calls == [
         str(definition["module_name"])

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -1578,6 +1578,127 @@ def test_iter_content_router_specs_defers_integration_router_attr_lookup(
     }
 
 
+def test_iter_content_router_specs_defers_collections_reading_router_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify collections and reading specs keep import and attr lookup lazy."""
+    import importlib
+
+    router_definitions = [
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.collections_feeds",
+            "attr_name": "router",
+            "path": "/collections/feeds",
+            "prefix": "/api/v1",
+            "tags": ("collections-feeds",),
+            "route_key": "collections-feeds",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.collections_websub",
+            "attr_name": "router",
+            "path": "/collections/feeds/{feed_id}/websub/subscribe",
+            "prefix": "/api/v1",
+            "tags": ("collections-websub",),
+            "route_key": "collections-websub",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.collections_websub",
+            "attr_name": "callback_router",
+            "path": "/websub/callback/{user_id}/{callback_token}",
+            "prefix": "/api/v1",
+            "tags": ("collections-websub",),
+            "route_key": "collections-websub",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.reading",
+            "attr_name": "router",
+            "path": "/reading/items",
+            "prefix": "/api/v1",
+            "tags": ("reading",),
+            "route_key": "reading",
+        },
+    ]
+    access_count = {
+        f"{definition['module_name']}.{definition['attr_name']}": 0
+        for definition in router_definitions
+    }
+    routers_by_module: dict[str, dict[str, APIRouter]] = {}
+    import_calls: list[str] = []
+
+    for definition in router_definitions:
+        module_name = str(definition["module_name"])
+        attr_name = str(definition["attr_name"])
+        router = APIRouter()
+
+        @router.get(str(definition["path"]))
+        def _endpoint() -> dict[str, str]:
+            """Return a deterministic response for the fake collections router."""
+            return {"status": "ok"}
+
+        routers_by_module.setdefault(module_name, {})[attr_name] = router
+
+    for module_name, routers in routers_by_module.items():
+        fake_module = ModuleType(module_name)
+
+        def _module_getattr(
+            name: str,
+            *,
+            module_name: str = module_name,
+            routers: dict[str, APIRouter] = routers,
+        ) -> APIRouter:
+            """Track lazy router attribute resolution for the fake module."""
+            if name not in routers:
+                raise AttributeError(name)
+            access_count[f"{module_name}.{name}"] += 1
+            return routers[name]
+
+        fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Track lazy module imports for selected collections router modules."""
+        if module_name in routers_by_module:
+            import_calls.append(module_name)
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    specs = list(iter_content_router_specs())
+    assert access_count == {
+        f"{definition['module_name']}.{definition['attr_name']}": 0
+        for definition in router_definitions
+    }
+    assert import_calls == []
+
+    selected_specs = [
+        spec
+        for spec in specs
+        if spec.route_key in {"collections-feeds", "collections-websub", "reading"}
+    ]
+    assert len(selected_specs) == len(router_definitions)
+
+    by_first_path = {_first_router_path(spec.router): spec for spec in selected_specs}
+    for definition in router_definitions:
+        spec = by_first_path[str(definition["path"])]
+        assert spec.prefix == definition["prefix"]
+        assert spec.tags == definition["tags"]
+        assert spec.route_key == definition["route_key"]
+
+    assert import_calls == [
+        str(definition["module_name"])
+        for definition in router_definitions
+    ]
+    assert access_count == {
+        f"{definition['module_name']}.{definition['attr_name']}": 1
+        for definition in router_definitions
+    }
+
+
 def test_qodo_reviewed_router_policy_regressions(monkeypatch: pytest.MonkeyPatch) -> None:
     _install_fake_router_module(
         monkeypatch,


### PR DESCRIPTION
## Summary
- Move collections feeds, collections WebSub, WebSub callback, and reading content router registrations to the shared lazy ImportedRouterSpec helper.
- Preserve route prefixes, tags, route keys, and ordering, including both WebSub router attrs from the same endpoint module.
- Add a focused regression proving selected collections/reading router imports and router attr lookup stay deferred until RouterSpec resolution.

## Change summary
TODO: human-authored summary required before merge. Explain what changed and why these implementation choices were made.

## Test Plan
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k collections_reading_router_attr_lookup -q (red before implementation; green after)
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q -> 53 passed
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q -> 6 passed
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q -> 69 passed
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/router_groups/content.py -f json -o /tmp/bandit_phase2_2_collections_reading_router_conditionals_l_postcommit.json -> 0 results, 0 errors
- git diff --check HEAD -> passed