### PR TITLE
feat(sandbox): expose runtime isolation metadata

### DIFF
--- a/Docs/API-related/Sandbox_API.md
+++ b/Docs/API-related/Sandbox_API.md
@@ -19,6 +19,9 @@ contract is maintained in `Docs/Sandbox/sandbox-security-policy-matrix.md`.
 Current runtime identities are `docker`, `firecracker`, `lima`, `vz_linux`,
 `vz_macos`, `seatbelt`, and `worktree`. Availability does not imply a security
 guarantee:
+- Runtime discovery includes machine-readable `boundary_class`,
+  `vm_grade_isolation`, and `untrusted_eligible` fields. Use those fields for
+  client decisions instead of parsing prose notes.
 - `seatbelt` is host-local. `seatbelt` is not `untrusted`-eligible.
 - `worktree` is host-local. `worktree` is not `untrusted`-eligible.
 - `vz_macos` real execution is not implemented; it is a scaffold/preflight
@@ -130,6 +133,9 @@ Response (example):
       "queue_ttl_sec": 120,
       "workspace_cap_mb": 256,
       "artifact_ttl_hours": 24,
+      "boundary_class": "container",
+      "vm_grade_isolation": false,
+      "untrusted_eligible": true,
       "supported_spec_versions": ["1.0", "1.1"],
       "interactive_supported": false,
       "egress_allowlist_supported": false,
@@ -138,6 +144,26 @@ Response (example):
   ]
 }
 ```
+Runtime isolation fields mean:
+- `boundary_class`: `container`, `host_local`, `vm_grade`, or
+  `vm_grade_scaffold`.
+- `vm_grade_isolation`: whether the runtime boundary is VM-grade for isolation
+  claims, independent of current host availability.
+- `untrusted_eligible`: whether policy may admit this runtime for `untrusted`
+  workloads when preflight and host readiness also pass.
+
+Current posture mapping:
+
+| Runtime | `boundary_class` | `vm_grade_isolation` | `untrusted_eligible` |
+| --- | --- | --- | --- |
+| `docker` | `container` | `false` | `true` |
+| `firecracker` | `vm_grade` | `true` | `true` |
+| `lima` | `vm_grade` | `true` | `true` |
+| `vz_linux` | `vm_grade` | `true` | `true` |
+| `vz_macos` | `vm_grade_scaffold` | `false` | `false` |
+| `seatbelt` | `host_local` | `false` | `false` |
+| `worktree` | `host_local` | `false` | `false` |
+
 For `lima`, runtime discovery also includes:
 - `strict_deny_all_supported`
 - `strict_allowlist_supported`

--- a/Docs/Published/API-related/Sandbox_API.md
+++ b/Docs/Published/API-related/Sandbox_API.md
@@ -19,6 +19,9 @@ contract is maintained in `Docs/Sandbox/sandbox-security-policy-matrix.md`.
 Current runtime identities are `docker`, `firecracker`, `lima`, `vz_linux`,
 `vz_macos`, `seatbelt`, and `worktree`. Availability does not imply a security
 guarantee:
+- Runtime discovery includes machine-readable `boundary_class`,
+  `vm_grade_isolation`, and `untrusted_eligible` fields. Use those fields for
+  client decisions instead of parsing prose notes.
 - `seatbelt` is host-local. `seatbelt` is not `untrusted`-eligible.
 - `worktree` is host-local. `worktree` is not `untrusted`-eligible.
 - `vz_macos` real execution is not implemented; it is a scaffold/preflight
@@ -130,6 +133,9 @@ Response (example):
       "queue_ttl_sec": 120,
       "workspace_cap_mb": 256,
       "artifact_ttl_hours": 24,
+      "boundary_class": "container",
+      "vm_grade_isolation": false,
+      "untrusted_eligible": true,
       "supported_spec_versions": ["1.0", "1.1"],
       "interactive_supported": false,
       "egress_allowlist_supported": false,
@@ -138,6 +144,26 @@ Response (example):
   ]
 }
 ```
+Runtime isolation fields mean:
+- `boundary_class`: `container`, `host_local`, `vm_grade`, or
+  `vm_grade_scaffold`.
+- `vm_grade_isolation`: whether the runtime boundary is VM-grade for isolation
+  claims, independent of current host availability.
+- `untrusted_eligible`: whether policy may admit this runtime for `untrusted`
+  workloads when preflight and host readiness also pass.
+
+Current posture mapping:
+
+| Runtime | `boundary_class` | `vm_grade_isolation` | `untrusted_eligible` |
+| --- | --- | --- | --- |
+| `docker` | `container` | `false` | `true` |
+| `firecracker` | `vm_grade` | `true` | `true` |
+| `lima` | `vm_grade` | `true` | `true` |
+| `vz_linux` | `vm_grade` | `true` | `true` |
+| `vz_macos` | `vm_grade_scaffold` | `false` | `false` |
+| `seatbelt` | `host_local` | `false` | `false` |
+| `worktree` | `host_local` | `false` | `false` |
+
 For `lima`, runtime discovery also includes:
 - `strict_deny_all_supported`
 - `strict_allowlist_supported`

--- a/Docs/Sandbox/sandbox-runtime-capability-inventory.md
+++ b/Docs/Sandbox/sandbox-runtime-capability-inventory.md
@@ -39,6 +39,11 @@ concepts:
 - `normalized_reasons`: stable client-facing reason codes derived from raw
   reasons so clients can group failures without runtime-specific string
   matching.
+- `boundary_class`: machine-readable isolation boundary category.
+- `vm_grade_isolation`: whether the runtime boundary is VM-grade for isolation
+  claims, independent of current host availability.
+- `untrusted_eligible`: whether policy may admit this runtime for `untrusted`
+  workloads when preflight and host readiness also pass.
 
 | Runtime | `implementation_state` | Discovery source |
 | --- | --- | --- |
@@ -53,6 +58,23 @@ concepts:
 Discovery is intentionally summarized. Admin/operator diagnostics can expose
 helper, template, reconciliation, and image-store details that should not be
 duplicated into the public discovery payload.
+
+## Runtime Isolation Metadata
+
+Isolation posture is exposed as structured discovery metadata so clients do not
+parse human-readable notes for security decisions. `untrusted_eligible` is a
+policy eligibility signal, not a statement that the runtime is available or
+healthy on the current host.
+
+| Runtime | `boundary_class` | `vm_grade_isolation` | `untrusted_eligible` | Notes |
+| --- | --- | --- | --- | --- |
+| `docker` | `container` | `false` | `true` | Compatibility path; not VM-grade. |
+| `firecracker` | `vm_grade` | `true` | `true` | Linux/KVM host-gated VM runtime. |
+| `lima` | `vm_grade` | `true` | `true` | macOS/Linux VM runtime when host preflight passes. |
+| `vz_linux` | `vm_grade` | `true` | `true` | Primary Apple silicon Linux VM path. |
+| `vz_macos` | `vm_grade_scaffold` | `false` | `false` | Runtime identity exists, but real execution is scaffolded. |
+| `seatbelt` | `host_local` | `false` | `false` | Host-local macOS process isolation only. |
+| `worktree` | `host_local` | `false` | `false` | Host-local VCS/workspace isolation only. |
 
 ## Normalized Reason Codes
 

--- a/Docs/Sandbox/sandbox-security-policy-matrix.md
+++ b/Docs/Sandbox/sandbox-security-policy-matrix.md
@@ -31,6 +31,11 @@ specific runtime today.
 | `strict allowlist` | Runtime networking permits only explicitly configured destinations and blocks all others. |
 | `scaffold` | Shape exists, but the guarantee is not ready for normal operator use. |
 
+Public runtime discovery exposes these concepts through `boundary_class`,
+`vm_grade_isolation`, and `untrusted_eligible`. Those fields describe policy
+posture and boundary category; they do not replace current-host `available`,
+`reasons`, or runtime preflight checks.
+
 ## Trust-Level Eligibility
 
 `trusted` and `standard` workloads may use VM-backed or host-local runtimes

--- a/Docs/superpowers/plans/2026-05-04-sandbox-runtime-isolation-metadata-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-04-sandbox-runtime-isolation-metadata-implementation-plan.md
@@ -1,0 +1,149 @@
+# Sandbox Runtime Isolation Metadata Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add structured isolation posture metadata to sandbox runtime discovery so API clients do not infer security guarantees from prose.
+
+**Architecture:** Define a small runtime-to-isolation metadata map in `runtime_capabilities.py`, expose it through `SandboxService.feature_discovery()`, and document the additive schema fields in API/runtime contract docs. The implementation must not change runtime admission or execution behavior.
+
+**Tech Stack:** FastAPI/Pydantic schemas, Python sandbox service code, pytest contract tests, Markdown docs.
+
+---
+
+### Task 1: Add Failing Runtime Discovery Contract Tests
+
+**Files:**
+- Modify: `tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py`
+
+- [x] **Step 1: Add a focused test for isolation metadata**
+
+Add a test that builds `SandboxService().feature_discovery()` with `SANDBOX_STORE_BACKEND=memory` and asserts each runtime has `boundary_class`, `vm_grade_isolation`, and `untrusted_eligible`.
+
+- [x] **Step 2: Add host-local and non-overclaim assertions**
+
+Assert:
+
+```python
+assert discovery["seatbelt"]["boundary_class"] == "host_local"
+assert discovery["seatbelt"]["vm_grade_isolation"] is False
+assert discovery["seatbelt"]["untrusted_eligible"] is False
+assert discovery["worktree"]["boundary_class"] == "host_local"
+assert discovery["worktree"]["vm_grade_isolation"] is False
+assert discovery["worktree"]["untrusted_eligible"] is False
+assert discovery["docker"]["boundary_class"] == "container"
+assert discovery["docker"]["vm_grade_isolation"] is False
+assert discovery["docker"]["untrusted_eligible"] is True
+assert discovery["vz_macos"]["boundary_class"] == "vm_grade_scaffold"
+assert discovery["vz_macos"]["vm_grade_isolation"] is False
+assert discovery["vz_macos"]["untrusted_eligible"] is False
+```
+
+- [x] **Step 3: Run the test and verify it fails**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py -q --timeout=60
+```
+
+Expected: fail because the new fields are missing.
+
+### Task 2: Implement Runtime Isolation Metadata
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Sandbox/runtime_capabilities.py`
+- Modify: `tldw_Server_API/app/core/Sandbox/service.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py`
+
+- [x] **Step 1: Define isolation metadata types and map**
+
+Add a `RuntimeBoundaryClass` literal, an immutable `RuntimeIsolationMetadata` dataclass, and a `runtime_isolation_metadata(runtime)` helper in `runtime_capabilities.py`.
+
+- [x] **Step 2: Expose metadata through discovery**
+
+Import `runtime_isolation_metadata` in `service.py` and merge the metadata into each runtime row through the existing shared helper path.
+
+- [x] **Step 3: Update the Pydantic response schema**
+
+Add `boundary_class`, `vm_grade_isolation`, and `untrusted_eligible` fields to `SandboxRuntimeInfo` with descriptions that distinguish policy eligibility from current availability.
+
+- [x] **Step 4: Run focused tests**
+
+Run the runtime inventory test again. Expected: pass.
+
+### Task 3: Update Runtime Contract Documentation
+
+**Files:**
+- Modify: `Docs/Sandbox/sandbox-runtime-capability-inventory.md`
+- Modify: `Docs/Sandbox/sandbox-security-policy-matrix.md`
+- Modify: `Docs/API-related/Sandbox_API.md`
+- Modify: `Docs/Published/API-related/Sandbox_API.md`
+
+- [x] **Step 1: Document the new discovery fields**
+
+Describe the new machine-readable fields near the existing `/api/v1/sandbox/runtimes` explanation.
+
+- [x] **Step 2: Add the runtime posture table**
+
+Document the runtime mapping and the fact that `untrusted_eligible` is policy eligibility, not availability.
+
+- [x] **Step 3: Run public docs contract tests**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/Docs/test_sandbox_public_docs_contract.py -q --timeout=60
+```
+
+Expected: pass.
+
+### Task 4: Verify, Update Task, Commit, And Open PR
+
+**Files:**
+- Modify: `backlog/tasks/task-36 - Add-structured-sandbox-runtime-isolation-metadata.md`
+
+- [x] **Step 1: Run focused sandbox verification**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py tldw_Server_API/tests/sandbox/test_feature_discovery_flags.py tldw_Server_API/tests/Docs/test_sandbox_public_docs_contract.py -q --timeout=60
+```
+
+Expected: pass for direct runtime/docs contract tests. During execution,
+`test_feature_discovery_flags.py` timed out in existing FastAPI `TestClient`
+teardown/background worker shutdown both alone and in the combined suite, so
+TASK-36 records that as a known verification note rather than a metadata
+regression.
+
+- [x] **Step 2: Run Bandit on touched Python code**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m bandit -r tldw_Server_API/app/core/Sandbox/runtime_capabilities.py tldw_Server_API/app/core/Sandbox/service.py tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py -f json -o /tmp/bandit_sandbox_runtime_isolation_metadata.json
+```
+
+Expected: no new findings in touched code.
+
+- [x] **Step 3: Run whitespace check**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output.
+
+- [x] **Step 4: Update TASK-36**
+
+Check completed acceptance criteria, add verification notes, and add a final summary.
+
+- [ ] **Step 5: Commit and open PR**
+
+Commit the branch and open a pull request against `dev`.

--- a/Docs/superpowers/specs/2026-05-04-sandbox-runtime-isolation-metadata-design.md
+++ b/Docs/superpowers/specs/2026-05-04-sandbox-runtime-isolation-metadata-design.md
@@ -1,0 +1,58 @@
+# Sandbox Runtime Isolation Metadata Design
+
+**Status:** Approved for TASK-36 implementation.
+**Date:** 2026-05-04.
+**Scope:** `/api/v1/sandbox/runtimes` discovery metadata for all sandbox runtimes.
+
+## Problem
+
+Sandbox runtime discovery already exposes availability, trust levels, network enforcement flags, implementation state, and human-readable notes. That is enough for operators, but clients still have to infer core security posture from prose. This is especially risky for host-local runtimes such as `seatbelt` and `worktree`, which may be available for trusted or standard workflows but must never be represented as VM-grade isolation or `untrusted`-eligible.
+
+## Goals
+
+- Add machine-readable isolation posture fields to every runtime discovery row.
+- Keep the change additive and backward compatible with existing clients.
+- Align the fields with `Docs/Sandbox/sandbox-security-policy-matrix.md`.
+- Avoid treating host availability as proof of security readiness.
+
+## Non-Goals
+
+- No runtime admission behavior changes.
+- No changes to runner execution, network enforcement, or helper protocols.
+- No attempt to make Docker VM-grade or to make `vz_macos` production-ready.
+
+## Proposed Contract
+
+Each `SandboxRuntimeInfo` row gains:
+
+- `boundary_class`: stable runtime boundary category.
+- `vm_grade_isolation`: whether the runtime boundary is VM-grade for policy and UX purposes.
+- `untrusted_eligible`: whether the runtime may be admitted for `untrusted` workloads when preflight and policy allow it.
+
+Boundary values:
+
+| Runtime | `boundary_class` | `vm_grade_isolation` | `untrusted_eligible` |
+| --- | --- | --- | --- |
+| `docker` | `container` | `false` | `true` |
+| `firecracker` | `vm_grade` | `true` | `true` |
+| `lima` | `vm_grade` | `true` | `true` |
+| `vz_linux` | `vm_grade` | `true` | `true` |
+| `vz_macos` | `vm_grade_scaffold` | `false` | `false` |
+| `seatbelt` | `host_local` | `false` | `false` |
+| `worktree` | `host_local` | `false` | `false` |
+
+`untrusted_eligible` describes policy eligibility, not current availability. A runtime can be eligible but unavailable on the current host.
+
+## Design Review Notes
+
+- Docker remains `container`, not `vm_grade`, even though the current policy can admit it for `untrusted`; this avoids overstating macOS isolation guarantees.
+- `vz_macos` is not marked VM-grade-ready because real execution is scaffolded. Its identity remains separate from its current readiness.
+- The fields duplicate information available in docs and policy code intentionally, so API clients do not parse notes or trust-level arrays to decide safety.
+- The runtime-specific values should be centralized in `runtime_capabilities.py` rather than embedded ad hoc in `SandboxService.feature_discovery()`.
+
+## Testing
+
+- Add a focused discovery contract test asserting all runtimes expose the three fields.
+- Add host-local assertions for `seatbelt` and `worktree`.
+- Add VM/container/scaffold assertions to prevent overclaiming Docker and `vz_macos`.
+- Keep existing discovery shape tests passing.

--- a/backlog/tasks/task-36 - Add-structured-sandbox-runtime-isolation-metadata.md
+++ b/backlog/tasks/task-36 - Add-structured-sandbox-runtime-isolation-metadata.md
@@ -4,7 +4,7 @@ title: Add structured sandbox runtime isolation metadata
 status: Done
 assignee: []
 created_date: '2026-05-04 05:19'
-updated_date: '2026-05-04 06:01'
+updated_date: '2026-05-04 06:07'
 labels:
   - sandbox
   - runtime-discovery
@@ -46,6 +46,8 @@ PR #1261 review follow-up: Qodo identified two valid contract issues. The runtim
 PR #1261 review fixes applied: runtime_isolation_metadata() now validates the metadata map at import time and raises a clear ValueError for unknown runtimes instead of leaking KeyError. SandboxRuntimeInfo now makes boundary_class, vm_grade_isolation, and untrusted_eligible required/non-nullable to match the implementation contract.
 
 Review-fix verification passed: python -m pytest tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py tldw_Server_API/tests/Docs/test_sandbox_public_docs_contract.py -q --timeout=60 -> 15 passed; Bandit on touched Python files -> 0 results; git diff --check -> no output.
+
+Follow-up after refreshed Qodo state: runtime_isolation_metadata() now avoids direct dictionary indexing entirely by using .get(...) plus an explicit missing-metadata ValueError after runtime coercion.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-36 - Add-structured-sandbox-runtime-isolation-metadata.md
+++ b/backlog/tasks/task-36 - Add-structured-sandbox-runtime-isolation-metadata.md
@@ -4,7 +4,7 @@ title: Add structured sandbox runtime isolation metadata
 status: Done
 assignee: []
 created_date: '2026-05-04 05:19'
-updated_date: '2026-05-04 05:33'
+updated_date: '2026-05-04 06:01'
 labels:
   - sandbox
   - runtime-discovery
@@ -40,12 +40,20 @@ Implementation added structured runtime isolation metadata fields to sandbox run
 Verification passed: python -m pytest tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py tldw_Server_API/tests/Docs/test_sandbox_public_docs_contract.py -q --timeout=60; Bandit on touched Python files reported 0 findings; git diff --check produced no output.
 
 Known verification note: tldw_Server_API/tests/sandbox/test_feature_discovery_flags.py timed out in existing FastAPI TestClient teardown / background worker shutdown when run alone and in the combined suite. The timeout occurred in TestClient context manager exit after startup/background jobs, not in the new metadata assertions; no pytest process remained afterward.
+
+PR #1261 review follow-up: Qodo identified two valid contract issues. The runtime isolation metadata helper should fail clearly if the map is incomplete or called with an unknown runtime, and the new schema fields should be required/non-nullable because feature_discovery always emits them.
+
+PR #1261 review fixes applied: runtime_isolation_metadata() now validates the metadata map at import time and raises a clear ValueError for unknown runtimes instead of leaking KeyError. SandboxRuntimeInfo now makes boundary_class, vm_grade_isolation, and untrusted_eligible required/non-nullable to match the implementation contract.
+
+Review-fix verification passed: python -m pytest tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py tldw_Server_API/tests/Docs/test_sandbox_public_docs_contract.py -q --timeout=60 -> 15 passed; Bandit on touched Python files -> 0 results; git diff --check -> no output.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Added additive, machine-readable sandbox runtime isolation posture metadata so clients can distinguish container, VM-grade, scaffold, and host-local runtimes without parsing prose notes. Updated public and internal sandbox docs, schema, focused contract tests, and the Backlog task record.
+
+PR review follow-up tightened the runtime metadata contract by adding explicit map completeness/unknown-runtime handling and making the new response fields required in OpenAPI/schema output.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-36 - Add-structured-sandbox-runtime-isolation-metadata.md
+++ b/backlog/tasks/task-36 - Add-structured-sandbox-runtime-isolation-metadata.md
@@ -1,0 +1,59 @@
+---
+id: TASK-36
+title: Add structured sandbox runtime isolation metadata
+status: Done
+assignee: []
+created_date: '2026-05-04 05:19'
+updated_date: '2026-05-04 05:33'
+labels:
+  - sandbox
+  - runtime-discovery
+  - security
+dependencies: []
+documentation:
+  - Docs/Sandbox/sandbox-architecture-doctrine.md
+  - Docs/Sandbox/sandbox-runtime-capability-inventory.md
+  - Docs/Sandbox/sandbox-security-policy-matrix.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Expose machine-readable isolation posture in sandbox runtime discovery so clients and operators do not infer security guarantees from prose notes. The slice should stay additive and align with the sandbox architecture doctrine and security policy matrix: VM-backed runtimes can advertise VM-grade posture, host-local runtimes must be explicit as not VM-grade and not untrusted-eligible, and scaffold runtimes must not overclaim readiness.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Sandbox runtime discovery includes explicit structured isolation fields for every RuntimeType without removing existing fields.
+- [x] #2 seatbelt and worktree discovery report host-local isolation, not VM-grade isolation, and not untrusted-eligible in machine-readable fields.
+- [x] #3 VM-backed runtimes report their boundary class and untrusted eligibility consistently with the security policy matrix without treating availability as proof of readiness.
+- [x] #4 API schema, focused tests, and public/runtime contract docs are updated to cover the new metadata.
+- [x] #5 Focused sandbox tests and diff whitespace checks pass.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implementation added structured runtime isolation metadata fields to sandbox runtime discovery: boundary_class, vm_grade_isolation, and untrusted_eligible. Metadata is centralized in runtime_capabilities.py and wired through SandboxService.feature_discovery() plus the Pydantic response schema.
+
+Verification passed: python -m pytest tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py tldw_Server_API/tests/Docs/test_sandbox_public_docs_contract.py -q --timeout=60; Bandit on touched Python files reported 0 findings; git diff --check produced no output.
+
+Known verification note: tldw_Server_API/tests/sandbox/test_feature_discovery_flags.py timed out in existing FastAPI TestClient teardown / background worker shutdown when run alone and in the combined suite. The timeout occurred in TestClient context manager exit after startup/background jobs, not in the new metadata assertions; no pytest process remained afterward.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added additive, machine-readable sandbox runtime isolation posture metadata so clients can distinguish container, VM-grade, scaffold, and host-local runtimes without parsing prose notes. Updated public and internal sandbox docs, schema, focused contract tests, and the Backlog task record.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
@@ -12,6 +12,7 @@ except ImportError:  # pragma: no cover - pydantic v1 fallback
 
 from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
 from tldw_Server_API.app.core.Sandbox.runtime_capabilities import (
+    RuntimeBoundaryClass,
     RuntimeImplementationState,
     RuntimeReasonCode,
 )
@@ -65,6 +66,27 @@ class SandboxRuntimeInfo(BaseModel):
     queue_ttl_sec: int | None = Field(default=None, description="Maximum time a run may remain queued before being dropped")
     workspace_cap_mb: int | None = Field(default=None, description="Default workspace size cap (MB)")
     artifact_ttl_hours: int | None = Field(default=None, description="Default artifact retention (hours)")
+    boundary_class: RuntimeBoundaryClass | None = Field(
+        default=None,
+        description=(
+            "Machine-readable runtime boundary category: container, host_local, "
+            "vm_grade, or vm_grade_scaffold"
+        ),
+    )
+    vm_grade_isolation: bool | None = Field(
+        default=None,
+        description=(
+            "Whether the runtime boundary is VM-grade for isolation claims; "
+            "independent of current host availability"
+        ),
+    )
+    untrusted_eligible: bool | None = Field(
+        default=None,
+        description=(
+            "Whether policy may admit this runtime for untrusted workloads when "
+            "preflight and host readiness also pass"
+        ),
+    )
     supported_spec_versions: list[str] = Field(default_factory=lambda: ["1.0"], description="Supported spec versions (e.g., ['1.0','1.1'] when 1.1 features are enabled)")
     interactive_supported: bool | None = Field(default=None, description="Whether stdin-over-WS interactive runs are supported")
     egress_allowlist_supported: bool | None = Field(default=None, description="Whether egress allowlisting is supported by the runtime")

--- a/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
@@ -66,22 +66,22 @@ class SandboxRuntimeInfo(BaseModel):
     queue_ttl_sec: int | None = Field(default=None, description="Maximum time a run may remain queued before being dropped")
     workspace_cap_mb: int | None = Field(default=None, description="Default workspace size cap (MB)")
     artifact_ttl_hours: int | None = Field(default=None, description="Default artifact retention (hours)")
-    boundary_class: RuntimeBoundaryClass | None = Field(
-        default=None,
+    boundary_class: RuntimeBoundaryClass = Field(
+        ...,
         description=(
             "Machine-readable runtime boundary category: container, host_local, "
             "vm_grade, or vm_grade_scaffold"
         ),
     )
-    vm_grade_isolation: bool | None = Field(
-        default=None,
+    vm_grade_isolation: bool = Field(
+        ...,
         description=(
             "Whether the runtime boundary is VM-grade for isolation claims; "
             "independent of current host availability"
         ),
     )
-    untrusted_eligible: bool | None = Field(
-        default=None,
+    untrusted_eligible: bool = Field(
+        ...,
         description=(
             "Whether policy may admit this runtime for untrusted workloads when "
             "preflight and host readiness also pass"

--- a/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
+++ b/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
@@ -12,6 +12,12 @@ RuntimeImplementationState = Literal[
     "host_gated",
     "not_applicable",
 ]
+RuntimeBoundaryClass = Literal[
+    "container",
+    "host_local",
+    "vm_grade",
+    "vm_grade_scaffold",
+]
 RuntimeReasonCode = Literal[
     "runtime_unavailable",
     "unsupported_os",
@@ -38,6 +44,54 @@ RUNTIME_IMPLEMENTATION_STATES: Mapping[RuntimeType, RuntimeImplementationState] 
     RuntimeType.vz_macos: "scaffold",
     RuntimeType.seatbelt: "host_gated",
     RuntimeType.worktree: "supported",
+}
+
+
+@dataclass(frozen=True)
+class RuntimeIsolationMetadata:
+    """Machine-readable isolation posture for runtime discovery."""
+
+    boundary_class: RuntimeBoundaryClass
+    vm_grade_isolation: bool
+    untrusted_eligible: bool
+
+
+RUNTIME_ISOLATION_METADATA: Mapping[RuntimeType, RuntimeIsolationMetadata] = {
+    RuntimeType.docker: RuntimeIsolationMetadata(
+        boundary_class="container",
+        vm_grade_isolation=False,
+        untrusted_eligible=True,
+    ),
+    RuntimeType.firecracker: RuntimeIsolationMetadata(
+        boundary_class="vm_grade",
+        vm_grade_isolation=True,
+        untrusted_eligible=True,
+    ),
+    RuntimeType.lima: RuntimeIsolationMetadata(
+        boundary_class="vm_grade",
+        vm_grade_isolation=True,
+        untrusted_eligible=True,
+    ),
+    RuntimeType.vz_linux: RuntimeIsolationMetadata(
+        boundary_class="vm_grade",
+        vm_grade_isolation=True,
+        untrusted_eligible=True,
+    ),
+    RuntimeType.vz_macos: RuntimeIsolationMetadata(
+        boundary_class="vm_grade_scaffold",
+        vm_grade_isolation=False,
+        untrusted_eligible=False,
+    ),
+    RuntimeType.seatbelt: RuntimeIsolationMetadata(
+        boundary_class="host_local",
+        vm_grade_isolation=False,
+        untrusted_eligible=False,
+    ),
+    RuntimeType.worktree: RuntimeIsolationMetadata(
+        boundary_class="host_local",
+        vm_grade_isolation=False,
+        untrusted_eligible=False,
+    ),
 }
 
 _RUNTIME_REASON_CODE_MAP: Mapping[str, RuntimeReasonCode] = {
@@ -83,6 +137,11 @@ _RUNTIME_REASON_CODE_MAP: Mapping[str, RuntimeReasonCode] = {
 def runtime_implementation_state(runtime: RuntimeType) -> RuntimeImplementationState:
     """Return the roadmap maturity label for a runtime, independent of host availability."""
     return RUNTIME_IMPLEMENTATION_STATES.get(runtime, "unsupported")
+
+
+def runtime_isolation_metadata(runtime: RuntimeType) -> RuntimeIsolationMetadata:
+    """Return stable isolation posture metadata, independent of host availability."""
+    return RUNTIME_ISOLATION_METADATA[runtime]
 
 
 def normalize_runtime_reason(reason: str) -> RuntimeReasonCode:

--- a/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
+++ b/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
@@ -159,9 +159,13 @@ def runtime_isolation_metadata(runtime: RuntimeType) -> RuntimeIsolationMetadata
     """Return stable isolation posture metadata, independent of host availability."""
     try:
         runtime_key = runtime if isinstance(runtime, RuntimeType) else RuntimeType(runtime)
-        return RUNTIME_ISOLATION_METADATA[runtime_key]
-    except (KeyError, ValueError) as exc:
+    except ValueError as exc:
         raise ValueError(f"No isolation metadata configured for runtime {runtime!r}") from exc
+
+    metadata = RUNTIME_ISOLATION_METADATA.get(runtime_key)
+    if metadata is None:
+        raise ValueError(f"No isolation metadata configured for runtime {runtime!r}")
+    return metadata
 
 
 def normalize_runtime_reason(reason: str) -> RuntimeReasonCode:

--- a/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
+++ b/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
@@ -94,6 +94,22 @@ RUNTIME_ISOLATION_METADATA: Mapping[RuntimeType, RuntimeIsolationMetadata] = {
     ),
 }
 
+
+def _validate_runtime_isolation_metadata_map() -> None:
+    expected = set(RuntimeType)
+    actual = set(RUNTIME_ISOLATION_METADATA)
+    missing = sorted(runtime.value for runtime in expected - actual)
+    extra = sorted(str(runtime) for runtime in actual - expected)
+    if missing or extra:
+        raise RuntimeError(
+            "Runtime isolation metadata map is incomplete: "
+            f"missing={missing}, extra={extra}"
+        )
+
+
+_validate_runtime_isolation_metadata_map()
+
+
 _RUNTIME_REASON_CODE_MAP: Mapping[str, RuntimeReasonCode] = {
     "/dev/kvm_missing": "host_prerequisite_missing",
     "apple_silicon_required": "unsupported_arch",
@@ -141,7 +157,11 @@ def runtime_implementation_state(runtime: RuntimeType) -> RuntimeImplementationS
 
 def runtime_isolation_metadata(runtime: RuntimeType) -> RuntimeIsolationMetadata:
     """Return stable isolation posture metadata, independent of host availability."""
-    return RUNTIME_ISOLATION_METADATA[runtime]
+    try:
+        runtime_key = runtime if isinstance(runtime, RuntimeType) else RuntimeType(runtime)
+        return RUNTIME_ISOLATION_METADATA[runtime_key]
+    except (KeyError, ValueError) as exc:
+        raise ValueError(f"No isolation metadata configured for runtime {runtime!r}") from exc
 
 
 def normalize_runtime_reason(reason: str) -> RuntimeReasonCode:

--- a/tldw_Server_API/app/core/Sandbox/service.py
+++ b/tldw_Server_API/app/core/Sandbox/service.py
@@ -59,6 +59,7 @@ from .runtime_capabilities import (
     RuntimePreflightResult,
     collect_runtime_preflights,
     normalize_runtime_reasons,
+    runtime_isolation_metadata,
     runtime_implementation_state,
 )
 from .snapshots import SnapshotManager
@@ -868,9 +869,13 @@ class SandboxService:
         lima_enforcement_ready["allowlist"] = False
         lima_host = dict((lima_preflight.host if lima_preflight else {}) or {})
 
-        def _preflight_fields(preflight: RuntimePreflightResult | None) -> dict[str, object]:
+        def _preflight_fields(
+            runtime: RuntimeType,
+            preflight: RuntimePreflightResult | None,
+        ) -> dict[str, object]:
             enforcement_ready = dict((preflight.enforcement_ready if preflight else {}) or {})
             reasons = list((preflight.reasons if preflight else []) or [])
+            isolation = runtime_isolation_metadata(runtime)
             return {
                 "available": bool(preflight.available) if preflight is not None else False,
                 "reasons": reasons,
@@ -880,13 +885,16 @@ class SandboxService:
                 "strict_allowlist_supported": bool(enforcement_ready.get("allowlist")),
                 "enforcement_ready": enforcement_ready,
                 "host": dict((preflight.host if preflight else {}) or {}),
+                "boundary_class": isolation.boundary_class,
+                "vm_grade_isolation": isolation.vm_grade_isolation,
+                "untrusted_eligible": isolation.untrusted_eligible,
             }
 
         return [
             {
                 "name": "docker",
                 "implementation_state": runtime_implementation_state(RuntimeType.docker),
-                **_preflight_fields(docker_preflight),
+                **_preflight_fields(RuntimeType.docker, docker_preflight),
                 "available": bool(docker_preflight.available) if docker_preflight is not None else bool(docker_available()),
                 "default_images": images,
                 "max_cpu": max_cpu,
@@ -920,7 +928,7 @@ class SandboxService:
             {
                 "name": "firecracker",
                 "implementation_state": runtime_implementation_state(RuntimeType.firecracker),
-                **_preflight_fields(firecracker_preflight),
+                **_preflight_fields(RuntimeType.firecracker, firecracker_preflight),
                 "available": bool(firecracker_preflight.available) if firecracker_preflight is not None else bool(firecracker_available()),
                 "default_images": images,  # firecracker images will differ; placeholder for UX
                 "max_cpu": max_cpu,
@@ -961,7 +969,7 @@ class SandboxService:
             {
                 "name": "lima",
                 "implementation_state": runtime_implementation_state(RuntimeType.lima),
-                **_preflight_fields(lima_preflight),
+                **_preflight_fields(RuntimeType.lima, lima_preflight),
                 "available": bool(lima_preflight.available) if lima_preflight is not None else bool(lima_available()),
                 "default_images": ["ubuntu:24.04"],  # Lima uses distro images
                 "max_cpu": max_cpu,
@@ -1003,7 +1011,7 @@ class SandboxService:
                 "egress_allowlist_supported": False,
                 "store_mode": store_mode,
                 "notes": "Linux guest VM via Virtualization.framework on Apple silicon hosts",
-                **_preflight_fields(vz_linux_preflight),
+                **_preflight_fields(RuntimeType.vz_linux, vz_linux_preflight),
             },
             {
                 "name": "vz_macos",
@@ -1024,7 +1032,7 @@ class SandboxService:
                 "egress_allowlist_supported": False,
                 "store_mode": store_mode,
                 "notes": "macOS guest VM via Virtualization.framework on Apple silicon hosts",
-                **_preflight_fields(vz_macos_preflight),
+                **_preflight_fields(RuntimeType.vz_macos, vz_macos_preflight),
             },
             {
                 "name": "seatbelt",
@@ -1045,7 +1053,7 @@ class SandboxService:
                 "egress_allowlist_supported": False,
                 "store_mode": store_mode,
                 "notes": "Host-local seatbelt process isolation for trusted macOS workflows with best-effort deny-all networking; not VM-grade isolation",
-                **_preflight_fields(seatbelt_preflight),
+                **_preflight_fields(RuntimeType.seatbelt, seatbelt_preflight),
             },
             {
                 "name": "worktree",
@@ -1070,7 +1078,7 @@ class SandboxService:
                     "workflows; not VM-grade isolation and not suitable for "
                     "untrusted workloads"
                 ),
-                **_preflight_fields(worktree_preflight),
+                **_preflight_fields(RuntimeType.worktree, worktree_preflight),
             },
         ]
 

--- a/tldw_Server_API/tests/Docs/test_sandbox_public_docs_contract.py
+++ b/tldw_Server_API/tests/Docs/test_sandbox_public_docs_contract.py
@@ -57,6 +57,16 @@ def test_public_sandbox_api_docs_do_not_overclaim_runtime_support(doc_path: Path
     ):
         _require(runtime in text, f"{doc_path} should mention runtime {runtime}")
 
+    for field_name in (
+        "boundary_class",
+        "vm_grade_isolation",
+        "untrusted_eligible",
+    ):
+        _require(
+            field_name in text,
+            f"{doc_path} should document runtime discovery field {field_name}",
+        )
+
     for host_local_runtime in ("seatbelt", "worktree"):
         _require(
             f"`{host_local_runtime}` is host-local" in text,

--- a/tldw_Server_API/tests/Docs/test_sandbox_public_docs_contract.py
+++ b/tldw_Server_API/tests/Docs/test_sandbox_public_docs_contract.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import pytest
 
+from tldw_Server_API.app.api.v1.schemas.sandbox_schemas import SandboxRuntimeInfo
+
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
@@ -98,3 +100,24 @@ def test_code_interpreter_prd_reconciles_current_runtime_status() -> None:
         "`vz_macos` real execution is not implemented",
     ):
         _require(snippet in text, f"Sandbox PRD should include: {snippet}")
+
+
+def test_sandbox_runtime_isolation_schema_fields_are_required() -> None:
+    schema = SandboxRuntimeInfo.model_json_schema()
+    required = set(schema.get("required", []))
+
+    for field_name in (
+        "boundary_class",
+        "vm_grade_isolation",
+        "untrusted_eligible",
+    ):
+        _require(
+            field_name in required,
+            f"SandboxRuntimeInfo should require {field_name}",
+        )
+        field_schema = schema["properties"][field_name]
+        serialized = str(field_schema)
+        _require(
+            "'type': 'null'" not in serialized,
+            f"SandboxRuntimeInfo field {field_name} should not be nullable",
+        )

--- a/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
+++ b/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
@@ -4,8 +4,10 @@ import pytest
 
 from tldw_Server_API.app.core.Sandbox.models import RuntimeType
 from tldw_Server_API.app.core.Sandbox.runtime_capabilities import (
+    RUNTIME_ISOLATION_METADATA,
     RuntimePreflightResult,
     normalize_runtime_reasons,
+    runtime_isolation_metadata,
 )
 from tldw_Server_API.app.core.Sandbox.service import SandboxService
 
@@ -72,6 +74,15 @@ def test_feature_discovery_reports_structured_isolation_metadata(
         assert discovery[host_local_runtime]["boundary_class"] == "host_local"
         assert discovery[host_local_runtime]["vm_grade_isolation"] is False
         assert discovery[host_local_runtime]["untrusted_eligible"] is False
+
+
+def test_runtime_isolation_metadata_contract_covers_runtime_enum() -> None:
+    assert set(RUNTIME_ISOLATION_METADATA) == set(RuntimeType)
+
+
+def test_runtime_isolation_metadata_rejects_unknown_runtime() -> None:
+    with pytest.raises(ValueError, match="No isolation metadata configured"):
+        runtime_isolation_metadata("future_runtime")  # type: ignore[arg-type]
 
 
 def test_runtime_reason_normalization_maps_raw_runtime_reasons() -> None:

--- a/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
+++ b/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
@@ -38,6 +38,42 @@ def test_worktree_discovery_reports_host_local_limits(
     assert "not VM-grade" in str(worktree["notes"])
 
 
+def test_feature_discovery_reports_structured_isolation_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SANDBOX_STORE_BACKEND", "memory")
+
+    discovery = {
+        str(item.get("name")): item
+        for item in SandboxService().feature_discovery()
+    }
+
+    assert set(discovery) == {runtime.value for runtime in RuntimeType}
+    for runtime in RuntimeType:
+        info = discovery[runtime.value]
+        assert "boundary_class" in info
+        assert "vm_grade_isolation" in info
+        assert "untrusted_eligible" in info
+
+    assert discovery["docker"]["boundary_class"] == "container"
+    assert discovery["docker"]["vm_grade_isolation"] is False
+    assert discovery["docker"]["untrusted_eligible"] is True
+
+    for vm_runtime in ("firecracker", "lima", "vz_linux"):
+        assert discovery[vm_runtime]["boundary_class"] == "vm_grade"
+        assert discovery[vm_runtime]["vm_grade_isolation"] is True
+        assert discovery[vm_runtime]["untrusted_eligible"] is True
+
+    assert discovery["vz_macos"]["boundary_class"] == "vm_grade_scaffold"
+    assert discovery["vz_macos"]["vm_grade_isolation"] is False
+    assert discovery["vz_macos"]["untrusted_eligible"] is False
+
+    for host_local_runtime in ("seatbelt", "worktree"):
+        assert discovery[host_local_runtime]["boundary_class"] == "host_local"
+        assert discovery[host_local_runtime]["vm_grade_isolation"] is False
+        assert discovery[host_local_runtime]["untrusted_eligible"] is False
+
+
 def test_runtime_reason_normalization_maps_raw_runtime_reasons() -> None:
     """Verify raw runtime-specific reasons collapse into stable discovery codes."""
 


### PR DESCRIPTION
## Summary
- add structured runtime isolation metadata to `/api/v1/sandbox/runtimes`: `boundary_class`, `vm_grade_isolation`, and `untrusted_eligible`
- centralize runtime posture mapping in `runtime_capabilities.py` and wire it through the Pydantic runtime discovery schema
- update sandbox API/runtime/security docs plus contract tests and TASK-36

## Verification
- `python -m pytest tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py tldw_Server_API/tests/Docs/test_sandbox_public_docs_contract.py -q --timeout=60` -> 12 passed
- `python -m bandit -r tldw_Server_API/app/core/Sandbox/runtime_capabilities.py tldw_Server_API/app/core/Sandbox/service.py tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py -f json -o /tmp/bandit_sandbox_runtime_isolation_metadata.json` -> 0 results
- `git diff --check` -> no output

## Known verification note
- `tldw_Server_API/tests/sandbox/test_feature_discovery_flags.py` timed out in existing FastAPI `TestClient` teardown/background worker shutdown when run alone and in the combined suite. The timeout occurred in `TestClient` context manager exit after startup/background jobs, not in the new metadata assertions; no pytest process remained afterward.

## Change summary
Human-authored change summary still required before merge per repo policy.