### PR TITLE
Phase 2.2: defer Prompt Studio router imports

### DIFF
--- a/backlog/tasks/task-37 - Phase-2.2-prompt-studio-router-conditional-cleanup-M.md
+++ b/backlog/tasks/task-37 - Phase-2.2-prompt-studio-router-conditional-cleanup-M.md
@@ -1,0 +1,50 @@
+---
+id: TASK-37
+title: Phase 2.2 prompt studio router conditional cleanup M
+status: Done
+assignee: []
+created_date: '2026-05-04 05:40'
+updated_date: '2026-05-04 05:44'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue #1116 Phase 2.2 by deferring the remaining Prompt Studio content router imports from iter_content_router_specs while preserving existing route metadata and optional-import behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Prompt Studio projects, prompts, test cases, optimization, status, evaluations, and websocket router specs defer router attribute lookup until registration/resolution.
+- [x] #2 Existing prefix, tags, route_key, and default_stable behavior for Prompt Studio routes remain unchanged.
+- [x] #3 Focused/full router contract tests, main router/OpenAPI contracts, Bandit touched source scan, and git diff hygiene are run before commit.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Red/green focused test: python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "prompt_studio_router_attr_lookup" -q failed before implementation on eager router attr lookup, then passed after converting Prompt Studio specs to lazy imported specs.
+
+Verification: router group contract 54 passed; main router contract 6 passed; OpenAPI contracts 69 passed; Bandit source scan content.py returned 0 results/0 errors; git diff --check clean.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Converted the Prompt Studio content router block to lazy ImportedRouterSpec entries and added covered contract coverage proving router attribute lookup is deferred until resolution while preserving existing route metadata.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-37 - Phase-2.2-prompt-studio-router-conditional-cleanup-M.md
+++ b/backlog/tasks/task-37 - Phase-2.2-prompt-studio-router-conditional-cleanup-M.md
@@ -4,7 +4,7 @@ title: Phase 2.2 prompt studio router conditional cleanup M
 status: Done
 assignee: []
 created_date: '2026-05-04 05:40'
-updated_date: '2026-05-04 05:44'
+updated_date: '2026-05-04 05:47'
 labels: []
 dependencies: []
 references:
@@ -37,6 +37,8 @@ Verification: router group contract 54 passed; main router contract 6 passed; Op
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Converted the Prompt Studio content router block to lazy ImportedRouterSpec entries and added covered contract coverage proving router attribute lookup is deferred until resolution while preserving existing route metadata.
+
+PR: https://github.com/rmusser01/tldw_server/pull/1262
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/api/v1/router_groups/content.py
+++ b/tldw_Server_API/app/api/v1/router_groups/content.py
@@ -324,38 +324,51 @@ def iter_content_router_specs() -> Iterable[RouterSpec]:
         append_imported_router_spec(specs, collections_spec)
 
     # Prompt Studio endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.prompt_studio.prompt_studio_evaluations import (
-            router as prompt_studio_evaluations_router,
-        )
-        from tldw_Server_API.app.api.v1.endpoints.prompt_studio.prompt_studio_optimization import (
-            router as prompt_studio_optimization_router,
-        )
-        from tldw_Server_API.app.api.v1.endpoints.prompt_studio.prompt_studio_projects import (
-            router as prompt_studio_projects_router,
-        )
-        from tldw_Server_API.app.api.v1.endpoints.prompt_studio.prompt_studio_prompts import (
-            router as prompt_studio_prompts_router,
-        )
-        from tldw_Server_API.app.api.v1.endpoints.prompt_studio.prompt_studio_status import (
-            router as prompt_studio_status_router,
-        )
-        from tldw_Server_API.app.api.v1.endpoints.prompt_studio.prompt_studio_test_cases import (
-            router as prompt_studio_test_cases_router,
-        )
-        from tldw_Server_API.app.api.v1.endpoints.prompt_studio.prompt_studio_websocket import (
-            router as prompt_studio_websocket_router,
-        )
-
-        specs.append(RouterSpec(router=prompt_studio_projects_router, tags=("prompt-studio",), route_key="prompt-studio"))
-        specs.append(RouterSpec(router=prompt_studio_prompts_router, tags=("prompt-studio",), route_key="prompt-studio"))
-        specs.append(RouterSpec(router=prompt_studio_test_cases_router, tags=("prompt-studio",), route_key="prompt-studio"))
-        specs.append(RouterSpec(router=prompt_studio_optimization_router, tags=("prompt-studio",), route_key="prompt-studio"))
-        specs.append(RouterSpec(router=prompt_studio_status_router, tags=("prompt-studio",), route_key="prompt-studio"))
-        specs.append(RouterSpec(router=prompt_studio_evaluations_router, tags=("prompt-studio",), route_key="prompt-studio"))
-        specs.append(RouterSpec(router=prompt_studio_websocket_router, tags=("prompt-studio",), route_key="prompt-studio"))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping prompt_studio routers: {e}")
+    for prompt_studio_spec in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.prompt_studio.prompt_studio_projects",
+            log_name="prompt_studio_projects",
+            tags=("prompt-studio",),
+            route_key="prompt-studio",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.prompt_studio.prompt_studio_prompts",
+            log_name="prompt_studio_prompts",
+            tags=("prompt-studio",),
+            route_key="prompt-studio",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.prompt_studio.prompt_studio_test_cases",
+            log_name="prompt_studio_test_cases",
+            tags=("prompt-studio",),
+            route_key="prompt-studio",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.prompt_studio.prompt_studio_optimization",
+            log_name="prompt_studio_optimization",
+            tags=("prompt-studio",),
+            route_key="prompt-studio",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.prompt_studio.prompt_studio_status",
+            log_name="prompt_studio_status",
+            tags=("prompt-studio",),
+            route_key="prompt-studio",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.prompt_studio.prompt_studio_evaluations",
+            log_name="prompt_studio_evaluations",
+            tags=("prompt-studio",),
+            route_key="prompt-studio",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.prompt_studio.prompt_studio_websocket",
+            log_name="prompt_studio_websocket",
+            tags=("prompt-studio",),
+            route_key="prompt-studio",
+        ),
+    ):
+        append_imported_router_spec(specs, prompt_studio_spec)
 
     # Workspace endpoints
     try:

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -1709,6 +1709,121 @@ def test_iter_content_router_specs_defers_collections_reading_router_attr_lookup
     }
 
 
+def test_iter_content_router_specs_defers_prompt_studio_router_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify Prompt Studio specs keep import and attr lookup lazy."""
+    import importlib
+
+    router_definitions = [
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.prompt_studio.prompt_studio_projects",
+            "expected_name": "prompt_studio_projects",
+            "path": "/api/v1/prompt-studio/projects",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.prompt_studio.prompt_studio_prompts",
+            "expected_name": "prompt_studio_prompts",
+            "path": "/api/v1/prompt-studio/prompts",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.prompt_studio.prompt_studio_test_cases",
+            "expected_name": "prompt_studio_test_cases",
+            "path": "/api/v1/prompt-studio/test-cases",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.prompt_studio.prompt_studio_optimization",
+            "expected_name": "prompt_studio_optimization",
+            "path": "/api/v1/prompt-studio/optimizations",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.prompt_studio.prompt_studio_status",
+            "expected_name": "prompt_studio_status",
+            "path": "/api/v1/prompt-studio/status",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.prompt_studio.prompt_studio_evaluations",
+            "expected_name": "prompt_studio_evaluations",
+            "path": "/api/v1/prompt-studio/evaluations",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.prompt_studio.prompt_studio_websocket",
+            "expected_name": "prompt_studio_websocket",
+            "path": "/api/v1/prompt-studio/ws",
+        },
+    ]
+    access_count = {str(definition["module_name"]): 0 for definition in router_definitions}
+    import_calls: list[str] = []
+
+    for definition in router_definitions:
+        module_name = str(definition["module_name"])
+        router = APIRouter()
+
+        @router.get(str(definition["path"]))
+        def _endpoint() -> dict[str, str]:
+            """Return a deterministic response for the fake Prompt Studio router."""
+            return {"status": "ok"}
+
+        fake_module = ModuleType(module_name)
+
+        def _module_getattr(
+            name: str,
+            *,
+            module_name: str = module_name,
+            router: APIRouter = router,
+        ) -> APIRouter:
+            """Track lazy router attribute resolution for the fake module."""
+            if name != "router":
+                raise AttributeError(name)
+            access_count[module_name] += 1
+            return router
+
+        fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Track lazy module imports for selected Prompt Studio router modules."""
+        if module_name in access_count:
+            import_calls.append(module_name)
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    specs = list(iter_content_router_specs())
+    assert access_count == {
+        str(definition["module_name"]): 0 for definition in router_definitions
+    }
+    assert import_calls == []
+
+    selected_specs = [
+        spec
+        for spec in specs
+        if spec.name and spec.name.startswith("prompt_studio_")
+    ]
+    assert len(selected_specs) == len(router_definitions)
+
+    by_first_path = {_first_router_path(spec.router): spec for spec in selected_specs}
+    for definition in router_definitions:
+        spec = by_first_path[str(definition["path"])]
+        assert spec.prefix == ""
+        assert spec.tags == ("prompt-studio",)
+        assert spec.route_key == "prompt-studio"
+        assert spec.name == definition["expected_name"]
+
+    assert import_calls == [
+        str(definition["module_name"])
+        for definition in router_definitions
+    ]
+    assert access_count == {
+        str(definition["module_name"]): 1 for definition in router_definitions
+    }
+
+
 def test_qodo_reviewed_router_policy_regressions(monkeypatch: pytest.MonkeyPatch) -> None:
     _install_fake_router_module(
         monkeypatch,


### PR DESCRIPTION
## Summary
- Convert the Prompt Studio content router block to lazy imported router specs.
- Add contract coverage proving Prompt Studio router attributes are not resolved during spec iteration.
- Track the tranche in Backlog task TASK-37.

## Change summary
Human-written change summary required before merge: please replace this with your own explanation of what changed and why this implementation choice was made.

## Verification
- `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "prompt_studio_router_attr_lookup" -q` (red before implementation, green after)
- `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q` (54 passed)
- `python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q` (6 passed)
- `python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q` (69 passed)
- `python -m bandit -r tldw_Server_API/app/api/v1/router_groups/content.py -f json -o /tmp/bandit_phase2_2_prompt_studio_content.json` (0 results, 0 errors)
- `git diff --check`

Refs #1116