### PR TITLE
Phase 2.2: defer workspace character router imports

### DIFF
--- a/backlog/tasks/task-39 - Phase-2.2-workspace-character-router-conditional-cleanup-N.md
+++ b/backlog/tasks/task-39 - Phase-2.2-workspace-character-router-conditional-cleanup-N.md
@@ -1,0 +1,62 @@
+---
+id: TASK-39
+title: Phase 2.2 workspace character router conditional cleanup N
+status: Done
+assignee: []
+created_date: '2026-05-04 06:00'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue #1116 Phase 2.2 by deferring workspace and character-family content router imports from iter_content_router_specs while preserving existing route metadata and optional-import behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Workspace, character chat sessions, character memory, characters, and character messages router specs defer router attribute lookup until registration/resolution.
+- [x] #2 Existing prefix, tags, route_key, and default_stable behavior for workspace and character-family routes remain unchanged.
+- [x] #3 Focused/full router contract tests, main router/OpenAPI contracts, Bandit touched source scan, and git diff hygiene are run before commit.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Verification
+
+<!-- SECTION:VERIFICATION:BEGIN -->
+- Red: `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k workspace_character_router_attr_lookup -q`
+  - Failed before implementation because all five fake router attributes were read during `iter_content_router_specs()`.
+- Green: `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k workspace_character_router_attr_lookup -q`
+  - `1 passed, 54 deselected`
+- Full router group contract: `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q`
+  - `55 passed`
+- Main router contract: `python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q`
+  - `6 passed`
+- OpenAPI contracts: `python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q`
+  - `69 passed`
+- Bandit: `python -m bandit -r tldw_Server_API/app/api/v1/router_groups/content.py -f json -o /tmp/bandit_phase2_2_character_workspace_router_conditionals_n.json`
+  - `result_count: 0`
+- Diff hygiene: `git diff --check`
+  - Passed with no output.
+<!-- SECTION:VERIFICATION:END -->
+
+## Summary
+
+<!-- SECTION:SUMMARY:BEGIN -->
+Workspace and character-family content routers now use lazy `ImportedRouterSpec`
+definitions. This preserves the existing route metadata while deferring endpoint
+module imports and `router` attribute lookup until router registration/resolution.
+<!-- SECTION:SUMMARY:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/content.py
+++ b/tldw_Server_API/app/api/v1/router_groups/content.py
@@ -370,76 +370,45 @@ def iter_content_router_specs() -> Iterable[RouterSpec]:
     ):
         append_imported_router_spec(specs, prompt_studio_spec)
 
-    # Workspace endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.workspaces import router as workspaces_router
-
-        specs.append(RouterSpec(
-            router=workspaces_router,
+    # Workspace and character endpoints
+    for character_spec in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.workspaces",
+            log_name="workspaces",
             prefix=f"{API_V1_PREFIX}/workspaces",
             tags=("workspaces",),
             route_key="workspaces",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping workspaces router: {e}")
-
-    # Character chat session endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.character_chat_sessions import (
-            router as character_chat_sessions_router,
-        )
-
-        specs.append(RouterSpec(
-            router=character_chat_sessions_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.character_chat_sessions",
+            log_name="character_chat_sessions",
             prefix=f"{API_V1_PREFIX}/chats",
             tags=("character-chat-sessions",),
             route_key="character-chat-sessions",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping character_chat_sessions router: {e}")
-
-    # Character memory endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.character_memory import (
-            router as character_memory_router,
-        )
-
-        specs.append(RouterSpec(
-            router=character_memory_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.character_memory",
+            log_name="character_memory",
             prefix=f"{API_V1_PREFIX}/characters",
             tags=("character-memory",),
             route_key="character-memory",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping character_memory router: {e}")
-
-    # Character endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.characters_endpoint import (
-            router as character_router,
-        )
-
-        specs.append(RouterSpec(
-            router=character_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.characters_endpoint",
+            log_name="characters",
             prefix=f"{API_V1_PREFIX}/characters",
             tags=("characters",),
             route_key="characters",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping characters router: {e}")
-
-    # Character message endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.character_messages import router as character_messages_router
-
-        specs.append(RouterSpec(
-            router=character_messages_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.character_messages",
+            log_name="character_messages",
             prefix=f"{API_V1_PREFIX}",
             tags=("character-messages",),
             route_key="character-messages",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping character_messages router: {e}")
+        ),
+    ):
+        append_imported_router_spec(specs, character_spec)
 
     # Audiobooks endpoints
     try:

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -1824,6 +1824,133 @@ def test_iter_content_router_specs_defers_prompt_studio_router_attr_lookup(
     }
 
 
+def test_iter_content_router_specs_defers_workspace_character_router_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify workspace and character specs keep import and attr lookup lazy."""
+    import importlib
+
+    router_definitions = [
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.workspaces",
+            "expected_name": "workspaces",
+            "path": "/workspaces/list",
+            "prefix": "/api/v1/workspaces",
+            "tags": ("workspaces",),
+            "route_key": "workspaces",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.character_chat_sessions",
+            "expected_name": "character_chat_sessions",
+            "path": "/character-chat-sessions/list",
+            "prefix": "/api/v1/chats",
+            "tags": ("character-chat-sessions",),
+            "route_key": "character-chat-sessions",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.character_memory",
+            "expected_name": "character_memory",
+            "path": "/character-memory/list",
+            "prefix": "/api/v1/characters",
+            "tags": ("character-memory",),
+            "route_key": "character-memory",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.characters_endpoint",
+            "expected_name": "characters",
+            "path": "/characters/list",
+            "prefix": "/api/v1/characters",
+            "tags": ("characters",),
+            "route_key": "characters",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.character_messages",
+            "expected_name": "character_messages",
+            "path": "/character-messages/send",
+            "prefix": "/api/v1",
+            "tags": ("character-messages",),
+            "route_key": "character-messages",
+        },
+    ]
+    access_count = {str(definition["module_name"]): 0 for definition in router_definitions}
+    import_calls: list[str] = []
+
+    for definition in router_definitions:
+        module_name = str(definition["module_name"])
+        router = APIRouter()
+
+        @router.get(str(definition["path"]))
+        def _endpoint() -> dict[str, str]:
+            """Return a deterministic response for the fake character router."""
+            return {"status": "ok"}
+
+        fake_module = ModuleType(module_name)
+
+        def _module_getattr(
+            name: str,
+            *,
+            module_name: str = module_name,
+            router: APIRouter = router,
+        ) -> APIRouter:
+            """Track lazy router attribute resolution for the fake module."""
+            if name != "router":
+                raise AttributeError(name)
+            access_count[module_name] += 1
+            return router
+
+        fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Track lazy module imports for selected workspace/character routers."""
+        if module_name in access_count:
+            import_calls.append(module_name)
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    specs = list(iter_content_router_specs())
+    assert access_count == {
+        str(definition["module_name"]): 0 for definition in router_definitions
+    }
+    assert import_calls == []
+
+    selected_specs = [
+        spec
+        for spec in specs
+        if spec.route_key
+        in {
+            "workspaces",
+            "character-chat-sessions",
+            "character-memory",
+            "characters",
+            "character-messages",
+        }
+    ]
+    assert len(selected_specs) == len(router_definitions)
+
+    by_first_path = {_first_router_path(spec.router): spec for spec in selected_specs}
+    for definition in router_definitions:
+        spec = by_first_path[str(definition["path"])]
+        assert spec.prefix == definition["prefix"]
+        assert spec.tags == definition["tags"]
+        assert spec.route_key == definition["route_key"]
+        assert spec.name == definition["expected_name"]
+
+    assert import_calls == [
+        str(definition["module_name"])
+        for definition in router_definitions
+    ]
+    assert access_count == {
+        str(definition["module_name"]): 1 for definition in router_definitions
+    }
+
+
 def test_qodo_reviewed_router_policy_regressions(monkeypatch: pytest.MonkeyPatch) -> None:
     _install_fake_router_module(
         monkeypatch,


### PR DESCRIPTION
## Summary
- Defers workspace and character-family router imports in the content router group with lazy ImportedRouterSpec entries.
- Adds contract coverage proving iter_content_router_specs no longer touches those router attributes until resolution.
- Records the tranche in Backlog TASK-39.

## Change summary
Human summary required before merge: this keeps existing route prefixes, tags, route keys, and payload behavior unchanged while narrowing Phase 2.2 cleanup to workspace and character-family router imports.

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k workspace_character_router_attr_lookup -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/router_groups/content.py -f json -o /tmp/bandit_phase2_2_character_workspace_router_conditionals_n_fresh.json
- jq {results,errors}: 0/0
- git diff --check

Refs #1116