### PR TITLE
Add native CodeGraph JS/TS extractor slice

### DIFF
--- a/Docs/superpowers/plans/2026-05-04-native-codegraph-js-ts-extractor-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-04-native-codegraph-js-ts-extractor-implementation-plan.md
@@ -234,7 +234,7 @@ git commit -m "feat: add codegraph javascript extractor"
 - Create: `tldw_Server_API/app/core/CodeGraph/extractors/typescript_extractor.py`
 - Test: `tldw_Server_API/tests/CodeGraph/test_codegraph_typescript_extractor.py`
 
-- [ ] **Step 1: Write RED TypeScript tests**
+- [x] **Step 1: Write RED TypeScript tests**
 
 Cover:
 
@@ -244,17 +244,17 @@ Cover:
 - Import/export capture.
 - Deterministic IDs.
 
-- [ ] **Step 2: Run tests and verify RED**
+- [x] **Step 2: Run tests and verify RED**
 
 ```bash
 python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_typescript_extractor.py -q
 ```
 
-- [ ] **Step 3: Implement TypeScript extractor**
+- [x] **Step 3: Implement TypeScript extractor**
 
 Reuse JavaScript traversal where possible. Keep TS-specific declarations small and explicit. Do not attempt type resolution.
 
-- [ ] **Step 4: Run tests and commit**
+- [x] **Step 4: Run tests and commit**
 
 ```bash
 python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_typescript_extractor.py -q

--- a/Docs/superpowers/plans/2026-05-04-native-codegraph-js-ts-extractor-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-04-native-codegraph-js-ts-extractor-implementation-plan.md
@@ -1,0 +1,362 @@
+# Native CodeGraph JS/TS Extractor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the Stage 3 native CodeGraph JavaScript/TypeScript extractor slice with conservative symbols, imports/exports, same-file calls, and trusted-workspace path-alias resolution.
+
+**Architecture:** Keep extraction in focused core modules under `tldw_Server_API/app/core/CodeGraph/extractors/`, keeping the MCP module thin. JS/TS parsing should use the optional `.[codegraph]` Tree-sitter dependency set when available, while the module remains importable when those dependencies are missing. Import resolution should be workspace-root bounded and conservative: resolve relative and configured path-alias targets under the trusted workspace, record external/unresolved imports, and avoid TypeScript compiler/type-check requirements.
+
+**Tech Stack:** Python 3.11, pytest, SQLite repository helpers, optional `tree-sitter`, `tree-sitter-javascript`, `tree-sitter-typescript`, Unified MCP CodeGraph module.
+
+---
+
+## Scope
+
+Implement this slice only:
+
+- JavaScript/TypeScript/TSX/JSX extractor modules.
+- A small Tree-sitter loader/helper scoped to CodeGraph.
+- Relative import and `tsconfig.json` / `jsconfig.json` path-alias resolution.
+- Indexer wiring and focused MCP/search regression coverage.
+
+Do not implement:
+
+- `codegraph.context` or `codegraph.impact`.
+- Jobs/background indexing.
+- C, C++, C#, Java, or Kotlin extractors.
+- Full TypeScript compiler integration or project type checking.
+- `node_modules` indexing.
+
+## File Structure
+
+- Create: `tldw_Server_API/app/core/CodeGraph/extractors/tree_sitter_loader.py`
+  - Optional dependency import boundary and parser construction helpers.
+- Create: `tldw_Server_API/app/core/CodeGraph/extractors/js_ts_imports.py`
+  - Workspace-bounded relative import and path-alias resolution helpers.
+- Create: `tldw_Server_API/app/core/CodeGraph/extractors/javascript_extractor.py`
+  - JavaScript/JSX extraction plus shared JS-family graph builder if practical.
+- Create: `tldw_Server_API/app/core/CodeGraph/extractors/typescript_extractor.py`
+  - TypeScript/TSX parser selection and TS-specific declarations.
+- Create: `tldw_Server_API/tests/CodeGraph/test_codegraph_js_ts_imports.py`
+  - Relative and alias resolver tests.
+- Create: `tldw_Server_API/tests/CodeGraph/test_codegraph_javascript_extractor.py`
+  - JS/JSX extractor tests.
+- Create: `tldw_Server_API/tests/CodeGraph/test_codegraph_typescript_extractor.py`
+  - TS/TSX extractor tests.
+- Modify: `tldw_Server_API/app/core/CodeGraph/indexer.py`
+  - Register JS/TS extractors when optional dependencies are available and pass workspace context needed for import resolution.
+- Modify: `tldw_Server_API/app/core/CodeGraph/language_registry.py`
+  - Mark JS/TS symbol extraction truthfully when dependencies are available.
+- Modify: `tldw_Server_API/app/core/CodeGraph/extractors/__init__.py`
+  - Export extractor classes if local pattern requires it.
+- Modify: `tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py`
+  - Replace the inventory-only JS/TS expectation with graph extraction behavior under injected extractors/dependencies.
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py`
+  - Add one MCP-level smoke proving JS/TS symbols are searchable after indexing.
+- Modify: `backlog/tasks/task-38 - Implement-native-CodeGraph-JS-TS-extractor-slice.md`
+  - Keep notes, acceptance criteria, verification, and final summary current.
+
+## Dependency Gate
+
+The current shared venv does not have `tree_sitter`, `tree_sitter_javascript`, or `tree_sitter_typescript` installed. Before implementing parser-dependent production code, run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python - <<'PY'
+import importlib.util
+for name in ["tree_sitter", "tree_sitter_javascript", "tree_sitter_typescript"]:
+    print(name, bool(importlib.util.find_spec(name)))
+PY
+```
+
+If missing, install or verify the optional extra:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pip install -e ".[codegraph]"
+```
+
+Expected parser matrix after install:
+
+- `tree-sitter>=0.25,<0.26`
+- `tree-sitter-javascript>=0.25,<0.26`
+- `tree-sitter-typescript>=0.23,<0.24`
+
+If installation is unavailable in the environment, stop and report the blocker rather than replacing this slice with regex parsing.
+
+## Task 1: Parser Loader And Smoke Tests
+
+**Files:**
+- Create: `tldw_Server_API/app/core/CodeGraph/extractors/tree_sitter_loader.py`
+- Test: `tldw_Server_API/tests/CodeGraph/test_codegraph_tree_sitter_loader.py`
+
+- [ ] **Step 1: Write RED tests for dependency-aware parser loading**
+
+Test cases:
+
+- Missing modules return an unavailable result without raising at module import time.
+- JavaScript parser can parse `export function helper() { return 1; }`.
+- TypeScript parser can parse `interface User { id: string }`.
+- TSX parser can parse `export function Card() { return <div />; }`.
+
+- [ ] **Step 2: Run tests and verify RED**
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_tree_sitter_loader.py -q
+```
+
+Expected: fails because `tree_sitter_loader.py` does not exist.
+
+- [ ] **Step 3: Implement loader**
+
+Create small value objects such as:
+
+```python
+@dataclass(frozen=True)
+class ParserLoadResult:
+    parser: Any | None = None
+    missing: tuple[str, ...] = ()
+    error: str | None = None
+```
+
+Use dynamic imports inside functions so normal CodeGraph imports work without `.[codegraph]`.
+
+- [ ] **Step 4: Run loader tests and commit**
+
+```bash
+python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_tree_sitter_loader.py -q
+git add tldw_Server_API/app/core/CodeGraph/extractors/tree_sitter_loader.py \
+  tldw_Server_API/tests/CodeGraph/test_codegraph_tree_sitter_loader.py
+git commit -m "test: add codegraph tree-sitter loader"
+```
+
+## Task 2: Import Resolver
+
+**Files:**
+- Create: `tldw_Server_API/app/core/CodeGraph/extractors/js_ts_imports.py`
+- Test: `tldw_Server_API/tests/CodeGraph/test_codegraph_js_ts_imports.py`
+
+- [ ] **Step 1: Write RED resolver tests**
+
+Cover:
+
+- `./utils` resolves to `src/utils.ts` when imported from `src/app.ts`.
+- `../shared/button` resolves with `.tsx` extension.
+- `@/components/Button` resolves through `tsconfig.json` paths.
+- `~/*`, `@web/*`, and `@tldw/ui/*` style aliases resolve when targets stay under the workspace root.
+- Alias targets that escape the workspace root are ignored and reported as unresolved.
+- External packages like `react` are classified as external/unresolved, not resolved into `node_modules`.
+
+- [ ] **Step 2: Run tests and verify RED**
+
+```bash
+python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_js_ts_imports.py -q
+```
+
+- [ ] **Step 3: Implement resolver**
+
+Implement focused helpers:
+
+- `load_js_ts_project_config(workspace_root: Path, source_path: str)`.
+- `resolve_js_ts_import(workspace_root: Path, source_path: str, specifier: str)`.
+- `resolve_relative_import(...)`.
+- `resolve_path_alias_import(...)`.
+
+Use JSON parsing only. Strip JSONC comments only if tests require real repo config parsing; otherwise start with valid JSON fixtures and document JSONC as follow-up if needed.
+
+- [ ] **Step 4: Run resolver tests and commit**
+
+```bash
+python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_js_ts_imports.py -q
+git add tldw_Server_API/app/core/CodeGraph/extractors/js_ts_imports.py \
+  tldw_Server_API/tests/CodeGraph/test_codegraph_js_ts_imports.py
+git commit -m "feat: add codegraph js ts import resolver"
+```
+
+## Task 3: JavaScript Extractor
+
+**Files:**
+- Create: `tldw_Server_API/app/core/CodeGraph/extractors/javascript_extractor.py`
+- Test: `tldw_Server_API/tests/CodeGraph/test_codegraph_javascript_extractor.py`
+
+- [ ] **Step 1: Write RED extractor tests**
+
+Cover:
+
+- Module node for `src/app.js`.
+- Function declaration node.
+- Arrow-function variable node.
+- Class and method nodes.
+- React-like component node for PascalCase function returning JSX.
+- Import and re-export nodes.
+- Same-file call edge for direct identifier calls.
+- Member expression call unresolved ref, not false-linked to a same-file symbol.
+- Parse errors return `ExtractionResult(errors=...)`.
+
+- [ ] **Step 2: Run tests and verify RED**
+
+```bash
+python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_javascript_extractor.py -q
+```
+
+- [ ] **Step 3: Implement conservative graph builder**
+
+Use Tree-sitter named nodes and a small traversal wrapper. Prefer node type checks over broad text regex. Use stable IDs with `make_node_id()` and `make_edge_id()`, matching Python extractor conventions.
+
+Minimum node kinds:
+
+- `module`
+- `function`
+- `component`
+- `class`
+- `method`
+- `import`
+
+Minimum edge/ref kinds:
+
+- `calls`
+- unresolved `call`
+- unresolved `import`
+
+- [ ] **Step 4: Run tests and commit**
+
+```bash
+python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_javascript_extractor.py -q
+git add tldw_Server_API/app/core/CodeGraph/extractors/javascript_extractor.py \
+  tldw_Server_API/tests/CodeGraph/test_codegraph_javascript_extractor.py
+git commit -m "feat: add codegraph javascript extractor"
+```
+
+## Task 4: TypeScript And TSX Extractor
+
+**Files:**
+- Create: `tldw_Server_API/app/core/CodeGraph/extractors/typescript_extractor.py`
+- Test: `tldw_Server_API/tests/CodeGraph/test_codegraph_typescript_extractor.py`
+
+- [ ] **Step 1: Write RED TypeScript tests**
+
+Cover:
+
+- Function, class, method.
+- Interface, type alias, enum.
+- TSX component function.
+- Import/export capture.
+- Deterministic IDs.
+
+- [ ] **Step 2: Run tests and verify RED**
+
+```bash
+python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_typescript_extractor.py -q
+```
+
+- [ ] **Step 3: Implement TypeScript extractor**
+
+Reuse JavaScript traversal where possible. Keep TS-specific declarations small and explicit. Do not attempt type resolution.
+
+- [ ] **Step 4: Run tests and commit**
+
+```bash
+python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_typescript_extractor.py -q
+git add tldw_Server_API/app/core/CodeGraph/extractors/typescript_extractor.py \
+  tldw_Server_API/tests/CodeGraph/test_codegraph_typescript_extractor.py
+git commit -m "feat: add codegraph typescript extractor"
+```
+
+## Task 5: Indexer Wiring And Search Regression
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/CodeGraph/indexer.py`
+- Modify: `tldw_Server_API/app/core/CodeGraph/language_registry.py`
+- Modify: `tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py`
+
+- [ ] **Step 1: Write RED indexer tests**
+
+Cover:
+
+- `.ts` files now produce graph nodes when dependencies are available.
+- `.tsx` component is searchable through repository search.
+- JS/TS extraction failure becomes `extraction_failed` without aborting indexing.
+- Missing parser dependencies keep module importable and status truthful.
+
+- [ ] **Step 2: Run tests and verify RED**
+
+```bash
+python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py -q
+```
+
+- [ ] **Step 3: Wire extractors**
+
+Instantiate JS/TS extractors in `CodeGraphIndexer.__init__` only when loader health says the parser is available. Pass workspace root to the extractor or resolver through an explicit extraction context rather than global state.
+
+- [ ] **Step 4: Run focused tests and commit**
+
+```bash
+python -m pytest tldw_Server_API/tests/CodeGraph \
+  tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py -q
+git add tldw_Server_API/app/core/CodeGraph/indexer.py \
+  tldw_Server_API/app/core/CodeGraph/language_registry.py \
+  tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
+git commit -m "feat: wire codegraph js ts extractors"
+```
+
+## Task 6: Final Verification And Backlog Closeout
+
+**Files:**
+- Modify: `backlog/tasks/task-38 - Implement-native-CodeGraph-JS-TS-extractor-slice.md`
+
+- [ ] **Step 1: Run focused regression tests**
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/CodeGraph \
+  tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py -q
+```
+
+- [ ] **Step 2: Run Ruff on touched files**
+
+```bash
+python -m ruff check tldw_Server_API/app/core/CodeGraph \
+  tldw_Server_API/tests/CodeGraph \
+  tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
+```
+
+- [ ] **Step 3: Run Bandit on touched production scope**
+
+```bash
+python -m bandit -r tldw_Server_API/app/core/CodeGraph \
+  tldw_Server_API/app/core/DB_Management/codegraph \
+  tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py \
+  -f json -o /tmp/bandit_codegraph_js_ts_extractor.json
+```
+
+Expected: `results 0`, `errors 0`, or documented pre-existing/non-actionable findings outside touched code.
+
+- [ ] **Step 4: Run whitespace check**
+
+```bash
+git diff --check
+```
+
+- [ ] **Step 5: Update Backlog task**
+
+Mark acceptance criteria and Definition of Done items complete, record verification output, and add a final summary.
+
+- [ ] **Step 6: Commit closeout**
+
+```bash
+git add backlog/tasks/task-38\ -\ Implement-native-CodeGraph-JS-TS-extractor-slice.md
+git commit -m "docs: finalize codegraph js ts extractor task"
+```
+
+## Known Risks
+
+- Tree-sitter package APIs can differ across minor versions. Keep the loader small and verify against the pinned optional-extra matrix before production wiring.
+- `tsconfig.json` commonly contains JSONC comments. If real repo configs require JSONC parsing, add a tiny comment stripper with tests or defer with a documented unresolved reason; do not add a large config parser dependency in this slice.
+- Cross-file import resolution should not imply symbol-level target accuracy yet. Store import nodes and unresolved refs with candidate file paths rather than claiming fully resolved imported symbols.
+- React component detection should be conservative. PascalCase plus JSX return is enough; avoid overclassifying ordinary PascalCase functions without JSX evidence.

--- a/Docs/superpowers/plans/2026-05-04-native-codegraph-js-ts-extractor-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-04-native-codegraph-js-ts-extractor-implementation-plan.md
@@ -180,7 +180,7 @@ git commit -m "feat: add codegraph js ts import resolver"
 - Create: `tldw_Server_API/app/core/CodeGraph/extractors/javascript_extractor.py`
 - Test: `tldw_Server_API/tests/CodeGraph/test_codegraph_javascript_extractor.py`
 
-- [ ] **Step 1: Write RED extractor tests**
+- [x] **Step 1: Write RED extractor tests**
 
 Cover:
 
@@ -194,13 +194,13 @@ Cover:
 - Member expression call unresolved ref, not false-linked to a same-file symbol.
 - Parse errors return `ExtractionResult(errors=...)`.
 
-- [ ] **Step 2: Run tests and verify RED**
+- [x] **Step 2: Run tests and verify RED**
 
 ```bash
 python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_javascript_extractor.py -q
 ```
 
-- [ ] **Step 3: Implement conservative graph builder**
+- [x] **Step 3: Implement conservative graph builder**
 
 Use Tree-sitter named nodes and a small traversal wrapper. Prefer node type checks over broad text regex. Use stable IDs with `make_node_id()` and `make_edge_id()`, matching Python extractor conventions.
 
@@ -219,7 +219,7 @@ Minimum edge/ref kinds:
 - unresolved `call`
 - unresolved `import`
 
-- [ ] **Step 4: Run tests and commit**
+- [x] **Step 4: Run tests and commit**
 
 ```bash
 python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_javascript_extractor.py -q

--- a/Docs/superpowers/plans/2026-05-04-native-codegraph-js-ts-extractor-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-04-native-codegraph-js-ts-extractor-implementation-plan.md
@@ -137,7 +137,7 @@ git commit -m "test: add codegraph tree-sitter loader"
 - Create: `tldw_Server_API/app/core/CodeGraph/extractors/js_ts_imports.py`
 - Test: `tldw_Server_API/tests/CodeGraph/test_codegraph_js_ts_imports.py`
 
-- [ ] **Step 1: Write RED resolver tests**
+- [x] **Step 1: Write RED resolver tests**
 
 Cover:
 
@@ -148,13 +148,13 @@ Cover:
 - Alias targets that escape the workspace root are ignored and reported as unresolved.
 - External packages like `react` are classified as external/unresolved, not resolved into `node_modules`.
 
-- [ ] **Step 2: Run tests and verify RED**
+- [x] **Step 2: Run tests and verify RED**
 
 ```bash
 python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_js_ts_imports.py -q
 ```
 
-- [ ] **Step 3: Implement resolver**
+- [x] **Step 3: Implement resolver**
 
 Implement focused helpers:
 
@@ -165,7 +165,7 @@ Implement focused helpers:
 
 Use JSON parsing only. Strip JSONC comments only if tests require real repo config parsing; otherwise start with valid JSON fixtures and document JSONC as follow-up if needed.
 
-- [ ] **Step 4: Run resolver tests and commit**
+- [x] **Step 4: Run resolver tests and commit**
 
 ```bash
 python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_js_ts_imports.py -q

--- a/Docs/superpowers/plans/2026-05-04-native-codegraph-js-ts-extractor-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-04-native-codegraph-js-ts-extractor-implementation-plan.md
@@ -309,7 +309,7 @@ git commit -m "feat: wire codegraph js ts extractors"
 **Files:**
 - Modify: `backlog/tasks/task-38 - Implement-native-CodeGraph-JS-TS-extractor-slice.md`
 
-- [ ] **Step 1: Run focused regression tests**
+- [x] **Step 1: Run focused regression tests**
 
 ```bash
 source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
@@ -318,7 +318,7 @@ python -m pytest tldw_Server_API/tests/CodeGraph \
   tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py -q
 ```
 
-- [ ] **Step 2: Run Ruff on touched files**
+- [x] **Step 2: Run Ruff on touched files**
 
 ```bash
 python -m ruff check tldw_Server_API/app/core/CodeGraph \
@@ -326,7 +326,7 @@ python -m ruff check tldw_Server_API/app/core/CodeGraph \
   tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
 ```
 
-- [ ] **Step 3: Run Bandit on touched production scope**
+- [x] **Step 3: Run Bandit on touched production scope**
 
 ```bash
 python -m bandit -r tldw_Server_API/app/core/CodeGraph \
@@ -337,17 +337,17 @@ python -m bandit -r tldw_Server_API/app/core/CodeGraph \
 
 Expected: `results 0`, `errors 0`, or documented pre-existing/non-actionable findings outside touched code.
 
-- [ ] **Step 4: Run whitespace check**
+- [x] **Step 4: Run whitespace check**
 
 ```bash
 git diff --check
 ```
 
-- [ ] **Step 5: Update Backlog task**
+- [x] **Step 5: Update Backlog task**
 
 Mark acceptance criteria and Definition of Done items complete, record verification output, and add a final summary.
 
-- [ ] **Step 6: Commit closeout**
+- [x] **Step 6: Commit closeout**
 
 ```bash
 git add backlog/tasks/task-38\ -\ Implement-native-CodeGraph-JS-TS-extractor-slice.md

--- a/Docs/superpowers/plans/2026-05-04-native-codegraph-js-ts-extractor-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-04-native-codegraph-js-ts-extractor-implementation-plan.md
@@ -271,7 +271,7 @@ git commit -m "feat: add codegraph typescript extractor"
 - Modify: `tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py`
 - Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py`
 
-- [ ] **Step 1: Write RED indexer tests**
+- [x] **Step 1: Write RED indexer tests**
 
 Cover:
 
@@ -280,18 +280,18 @@ Cover:
 - JS/TS extraction failure becomes `extraction_failed` without aborting indexing.
 - Missing parser dependencies keep module importable and status truthful.
 
-- [ ] **Step 2: Run tests and verify RED**
+- [x] **Step 2: Run tests and verify RED**
 
 ```bash
 python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py \
   tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py -q
 ```
 
-- [ ] **Step 3: Wire extractors**
+- [x] **Step 3: Wire extractors**
 
 Instantiate JS/TS extractors in `CodeGraphIndexer.__init__` only when loader health says the parser is available. Pass workspace root to the extractor or resolver through an explicit extraction context rather than global state.
 
-- [ ] **Step 4: Run focused tests and commit**
+- [x] **Step 4: Run focused tests and commit**
 
 ```bash
 python -m pytest tldw_Server_API/tests/CodeGraph \

--- a/Docs/superpowers/plans/2026-05-04-native-codegraph-js-ts-extractor-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-04-native-codegraph-js-ts-extractor-implementation-plan.md
@@ -90,7 +90,7 @@ If installation is unavailable in the environment, stop and report the blocker r
 - Create: `tldw_Server_API/app/core/CodeGraph/extractors/tree_sitter_loader.py`
 - Test: `tldw_Server_API/tests/CodeGraph/test_codegraph_tree_sitter_loader.py`
 
-- [ ] **Step 1: Write RED tests for dependency-aware parser loading**
+- [x] **Step 1: Write RED tests for dependency-aware parser loading**
 
 Test cases:
 
@@ -99,7 +99,7 @@ Test cases:
 - TypeScript parser can parse `interface User { id: string }`.
 - TSX parser can parse `export function Card() { return <div />; }`.
 
-- [ ] **Step 2: Run tests and verify RED**
+- [x] **Step 2: Run tests and verify RED**
 
 ```bash
 source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
@@ -108,7 +108,7 @@ python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_tree_sitter_load
 
 Expected: fails because `tree_sitter_loader.py` does not exist.
 
-- [ ] **Step 3: Implement loader**
+- [x] **Step 3: Implement loader**
 
 Create small value objects such as:
 
@@ -122,7 +122,7 @@ class ParserLoadResult:
 
 Use dynamic imports inside functions so normal CodeGraph imports work without `.[codegraph]`.
 
-- [ ] **Step 4: Run loader tests and commit**
+- [x] **Step 4: Run loader tests and commit**
 
 ```bash
 python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_tree_sitter_loader.py -q

--- a/backlog/tasks/task-38 - Implement-native-CodeGraph-JS-TS-extractor-slice.md
+++ b/backlog/tasks/task-38 - Implement-native-CodeGraph-JS-TS-extractor-slice.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - Codex
 created_date: '2026-05-04 05:48'
-updated_date: '2026-05-04 06:06'
+updated_date: '2026-05-04 06:08'
 labels:
   - codegraph
   - mcp
@@ -55,6 +55,8 @@ Task 1 red-green complete: added tree_sitter_loader tests, confirmed ModuleNotFo
 Task 2 red-green complete: added resolver tests for relative imports, nearest config loading, frontend-style aliases, escaping aliases, and external package classification; verified 6 passed.
 
 Task 3 red-green complete: added JavaScript extractor tests for modules, imports, re-exports, functions, arrow functions, classes, methods, JSX components, same-file calls, member-call unresolved refs, parse errors, and deterministic IDs; verified 3 passed.
+
+Task 4 red-green complete: added TypeScript/TSX extractor tests for interface, type alias, enum, imports, function/class/method calls, TSX component detection, and deterministic IDs; verified 3 passed.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-38 - Implement-native-CodeGraph-JS-TS-extractor-slice.md
+++ b/backlog/tasks/task-38 - Implement-native-CodeGraph-JS-TS-extractor-slice.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - Codex
 created_date: '2026-05-04 05:48'
-updated_date: '2026-05-04 06:02'
+updated_date: '2026-05-04 06:06'
 labels:
   - codegraph
   - mcp
@@ -53,6 +53,8 @@ Installed pinned CodeGraph parser dependency set directly after .[codegraph] res
 Task 1 red-green complete: added tree_sitter_loader tests, confirmed ModuleNotFoundError RED, implemented dynamic optional parser loader, and verified 5 passed.
 
 Task 2 red-green complete: added resolver tests for relative imports, nearest config loading, frontend-style aliases, escaping aliases, and external package classification; verified 6 passed.
+
+Task 3 red-green complete: added JavaScript extractor tests for modules, imports, re-exports, functions, arrow functions, classes, methods, JSX components, same-file calls, member-call unresolved refs, parse errors, and deterministic IDs; verified 3 passed.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-38 - Implement-native-CodeGraph-JS-TS-extractor-slice.md
+++ b/backlog/tasks/task-38 - Implement-native-CodeGraph-JS-TS-extractor-slice.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-38
 title: Implement native CodeGraph JS/TS extractor slice
-status: In Progress
+status: Done
 assignee:
   - Codex
 created_date: '2026-05-04 05:48'
-updated_date: '2026-05-04 06:12'
+updated_date: '2026-05-04 06:15'
 labels:
   - codegraph
   - mcp
@@ -29,12 +29,12 @@ Implement the next native CodeGraph epic slice after PR #1258: JavaScript/TypeSc
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 JavaScript and TypeScript files index symbol nodes for functions, arrow-function variables, classes, methods, React-like components, interfaces, type aliases, and enums where supported by the parser.
-- [ ] #2 JS/TS import and re-export declarations create import nodes and unresolved refs for external package imports.
-- [ ] #3 Same-file calls by identifier or member expression are resolved conservatively or recorded as unresolved refs without false cross-file claims.
-- [ ] #4 Relative import targets and trusted tsconfig/jsconfig path aliases are resolved under the workspace root; escaping aliases are ignored with a clear unresolved reason.
-- [ ] #5 Indexer wires JS/TS extractors so TS/TSX/JS/JSX files no longer remain inventory-only when parser dependencies are available.
-- [ ] #6 Focused extractor, indexer, repository/MCP regression tests plus Ruff, Bandit, and git diff checks pass.
+- [x] #1 JavaScript and TypeScript files index symbol nodes for functions, arrow-function variables, classes, methods, React-like components, interfaces, type aliases, and enums where supported by the parser.
+- [x] #2 JS/TS import and re-export declarations create import nodes and unresolved refs for external package imports.
+- [x] #3 Same-file calls by identifier or member expression are resolved conservatively or recorded as unresolved refs without false cross-file claims.
+- [x] #4 Relative import targets and trusted tsconfig/jsconfig path aliases are resolved under the workspace root; escaping aliases are ignored with a clear unresolved reason.
+- [x] #5 Indexer wires JS/TS extractors so TS/TSX/JS/JSX files no longer remain inventory-only when parser dependencies are available.
+- [x] #6 Focused extractor, indexer, repository/MCP regression tests plus Ruff, Bandit, and git diff checks pass.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -59,14 +59,22 @@ Task 3 red-green complete: added JavaScript extractor tests for modules, imports
 Task 4 red-green complete: added TypeScript/TSX extractor tests for interface, type alias, enum, imports, function/class/method calls, TSX component detection, and deterministic IDs; verified 3 passed.
 
 Task 5 red-green complete: indexer now wires optional JS/TS extractors, registry reports dependency-aware symbol extraction, MCP search finds indexed TSX components, and focused CodeGraph/MCP tests verified 72 passed.
+
+Final verification: focused CodeGraph/MCP regression suite passed with 72 passed and 5 warnings; Ruff passed; Bandit JSON reported errors 0 and results 0; git diff --check passed.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the native CodeGraph JavaScript/TypeScript extractor slice. Added optional Tree-sitter loader, JS/TS import resolver with workspace-bounded path alias handling, JavaScript and TypeScript/TSX extractors, dependency-aware language metadata, and indexer/MCP wiring so JS/TS symbols are searchable. Verification: focused CodeGraph/MCP tests 72 passed, Ruff passed, Bandit reported errors 0/results 0, and git diff --check passed.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-38 - Implement-native-CodeGraph-JS-TS-extractor-slice.md
+++ b/backlog/tasks/task-38 - Implement-native-CodeGraph-JS-TS-extractor-slice.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - Codex
 created_date: '2026-05-04 05:48'
-updated_date: '2026-05-04 05:50'
+updated_date: '2026-05-04 05:59'
 labels:
   - codegraph
   - mcp
@@ -47,6 +47,10 @@ Implement the next native CodeGraph epic slice after PR #1258: JavaScript/TypeSc
 
 <!-- SECTION:NOTES:BEGIN -->
 Created implementation plan at Docs/superpowers/plans/2026-05-04-native-codegraph-js-ts-extractor-implementation-plan.md. Baseline focused CodeGraph/MCP tests passed with 53 passed and 5 warnings before Stage 3 work. Current shared venv is missing optional tree-sitter parser packages, so the plan explicitly gates implementation on installing/verifying .[codegraph] parser dependencies.
+
+Installed pinned CodeGraph parser dependency set directly after .[codegraph] resolver conflict blocked full extra installation.
+
+Task 1 red-green complete: added tree_sitter_loader tests, confirmed ModuleNotFoundError RED, implemented dynamic optional parser loader, and verified 5 passed.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-38 - Implement-native-CodeGraph-JS-TS-extractor-slice.md
+++ b/backlog/tasks/task-38 - Implement-native-CodeGraph-JS-TS-extractor-slice.md
@@ -1,0 +1,60 @@
+---
+id: TASK-38
+title: Implement native CodeGraph JS/TS extractor slice
+status: In Progress
+assignee:
+  - Codex
+created_date: '2026-05-04 05:48'
+updated_date: '2026-05-04 05:50'
+labels:
+  - codegraph
+  - mcp
+  - javascript
+  - typescript
+dependencies:
+  - TASK-35
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1259'
+documentation:
+  - >-
+    Docs/superpowers/plans/2026-05-04-native-codegraph-js-ts-extractor-implementation-plan.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the next native CodeGraph epic slice after PR #1258: JavaScript/TypeScript/TSX extraction with conservative symbols, imports, exports, same-file calls, and trusted-workspace tsconfig/jsconfig path-alias resolution. Keep the slice focused: no context/impact tools, no Jobs mode, no C/C++/C#/Java/Kotlin extractors, and no full TypeScript compiler/type-check dependency.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 JavaScript and TypeScript files index symbol nodes for functions, arrow-function variables, classes, methods, React-like components, interfaces, type aliases, and enums where supported by the parser.
+- [ ] #2 JS/TS import and re-export declarations create import nodes and unresolved refs for external package imports.
+- [ ] #3 Same-file calls by identifier or member expression are resolved conservatively or recorded as unresolved refs without false cross-file claims.
+- [ ] #4 Relative import targets and trusted tsconfig/jsconfig path aliases are resolved under the workspace root; escaping aliases are ignored with a clear unresolved reason.
+- [ ] #5 Indexer wires JS/TS extractors so TS/TSX/JS/JSX files no longer remain inventory-only when parser dependencies are available.
+- [ ] #6 Focused extractor, indexer, repository/MCP regression tests plus Ruff, Bandit, and git diff checks pass.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Confirm current Stage 3 requirements from the approved CodeGraph design and baseline tests. 2. Add RED extractor tests for JS, TS, TSX components, imports/exports, same-file calls, and parse failures. 3. Add RED resolver tests for relative imports and trusted/escaping tsconfig/jsconfig path aliases. 4. Implement a small parser loader plus JS/TS extractor modules using optional Tree-sitter dependencies with dependency-aware skip/error behavior. 5. Wire extractors into CodeGraphIndexer only when dependencies are available. 6. Add indexer/MCP regression coverage proving JS/TS files produce graph nodes/search results. 7. Run focused CodeGraph/MCP tests, Ruff touched files, Bandit touched CodeGraph/MCP scope, and git diff --check.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Created implementation plan at Docs/superpowers/plans/2026-05-04-native-codegraph-js-ts-extractor-implementation-plan.md. Baseline focused CodeGraph/MCP tests passed with 53 passed and 5 warnings before Stage 3 work. Current shared venv is missing optional tree-sitter parser packages, so the plan explicitly gates implementation on installing/verifying .[codegraph] parser dependencies.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-38 - Implement-native-CodeGraph-JS-TS-extractor-slice.md
+++ b/backlog/tasks/task-38 - Implement-native-CodeGraph-JS-TS-extractor-slice.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - Codex
 created_date: '2026-05-04 05:48'
-updated_date: '2026-05-04 06:08'
+updated_date: '2026-05-04 06:12'
 labels:
   - codegraph
   - mcp
@@ -57,6 +57,8 @@ Task 2 red-green complete: added resolver tests for relative imports, nearest co
 Task 3 red-green complete: added JavaScript extractor tests for modules, imports, re-exports, functions, arrow functions, classes, methods, JSX components, same-file calls, member-call unresolved refs, parse errors, and deterministic IDs; verified 3 passed.
 
 Task 4 red-green complete: added TypeScript/TSX extractor tests for interface, type alias, enum, imports, function/class/method calls, TSX component detection, and deterministic IDs; verified 3 passed.
+
+Task 5 red-green complete: indexer now wires optional JS/TS extractors, registry reports dependency-aware symbol extraction, MCP search finds indexed TSX components, and focused CodeGraph/MCP tests verified 72 passed.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-38 - Implement-native-CodeGraph-JS-TS-extractor-slice.md
+++ b/backlog/tasks/task-38 - Implement-native-CodeGraph-JS-TS-extractor-slice.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - Codex
 created_date: '2026-05-04 05:48'
-updated_date: '2026-05-04 05:59'
+updated_date: '2026-05-04 06:02'
 labels:
   - codegraph
   - mcp
@@ -51,6 +51,8 @@ Created implementation plan at Docs/superpowers/plans/2026-05-04-native-codegrap
 Installed pinned CodeGraph parser dependency set directly after .[codegraph] resolver conflict blocked full extra installation.
 
 Task 1 red-green complete: added tree_sitter_loader tests, confirmed ModuleNotFoundError RED, implemented dynamic optional parser loader, and verified 5 passed.
+
+Task 2 red-green complete: added resolver tests for relative imports, nearest config loading, frontend-style aliases, escaping aliases, and external package classification; verified 6 passed.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-44 - Address-PR-1264-CodeGraph-JS-TS-review-comments.md
+++ b/backlog/tasks/task-44 - Address-PR-1264-CodeGraph-JS-TS-review-comments.md
@@ -1,0 +1,57 @@
+---
+id: TASK-44
+title: 'Address PR #1264 CodeGraph JS/TS review comments'
+status: Done
+assignee:
+  - Codex
+created_date: '2026-05-04 15:01'
+updated_date: '2026-05-04 15:08'
+labels:
+  - codegraph
+  - mcp
+  - review-fix
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1264'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve actionable review feedback on PR #1264 for the native CodeGraph JavaScript/TypeScript extractor slice. Scope includes keeping optional parser and extractor failures contained, simplifying shared JS/TS helpers, handling invalid JSONC config gracefully, avoiding unnecessary TypeScript gating on TSX availability, and recording focused verification before updating the PR.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Invalid tsconfig/jsconfig content does not abort JS/TS extraction or indexing.
+- [x] #2 Optional Tree-sitter import-time failures are reported as unavailable parser results instead of raising during availability checks.
+- [x] #3 TypeScript extraction is registered when the TypeScript parser is available even if TSX parser availability is false.
+- [x] #4 Shared JS/TS extractor helpers no longer require cross-module imports of underscore-prefixed symbols.
+- [x] #5 New review-fix behavior has focused regression tests and the CodeGraph test subset passes.
+- [x] #6 Ruff, Bandit on touched production scope, and git diff whitespace checks pass before pushing the PR update.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Resolved PR #1264 review feedback by adding regression coverage for invalid JSONC config fallback, optional parser import errors, non-ValueError extractor failures, TypeScript registration without TSX parser availability, and one-config-load-per-JS-file behavior. Implementation updates keep optional parser/import failures structured, cache project config per JS/TS extracted file, publicize the JS graph builder helpers consumed by the TypeScript extractor, and keep index runs alive when one extractor raises an expected boundary exception.
+
+Verification: focused red tests failed before implementation and passed after; CodeGraph/MCP subset passed with 77 passed and 5 warnings; Ruff passed; Bandit JSON reported errors 0 and results 0; git diff --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed all actionable PR #1264 review items for the CodeGraph JS/TS extractor slice. The PR now handles invalid JS/TS project config and optional native parser failures gracefully, registers TypeScript extraction without requiring TSX availability, avoids repeated config parsing per import, removes cross-module private helper imports, and records the review-fix verification.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/CodeGraph/config.py
+++ b/tldw_Server_API/app/core/CodeGraph/config.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Mapping
-
+from typing import Any
 
 DEFAULT_EXCLUDE_DIRS = (
     ".git",
@@ -36,7 +36,7 @@ class CodeGraphSettings:
     exclude_dirs: tuple[str, ...] = DEFAULT_EXCLUDE_DIRS
 
     @classmethod
-    def from_mapping(cls, values: Mapping[str, Any] | None) -> "CodeGraphSettings":
+    def from_mapping(cls, values: Mapping[str, Any] | None) -> CodeGraphSettings:
         raw = dict(values or {})
         defaults = cls()
 

--- a/tldw_Server_API/app/core/CodeGraph/dependencies.py
+++ b/tldw_Server_API/app/core/CodeGraph/dependencies.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import importlib.util
 from dataclasses import dataclass
 
-
 _REQUIRED_MODULES = (
     "tree_sitter",
     "tree_sitter_python",

--- a/tldw_Server_API/app/core/CodeGraph/extractors/__init__.py
+++ b/tldw_Server_API/app/core/CodeGraph/extractors/__init__.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from .javascript_extractor import JavaScriptTreeSitterExtractor
 from .python_extractor import PythonAstExtractor
+from .typescript_extractor import TypeScriptTreeSitterExtractor
 
-__all__ = ["PythonAstExtractor"]
+__all__ = ["JavaScriptTreeSitterExtractor", "PythonAstExtractor", "TypeScriptTreeSitterExtractor"]

--- a/tldw_Server_API/app/core/CodeGraph/extractors/javascript_extractor.py
+++ b/tldw_Server_API/app/core/CodeGraph/extractors/javascript_extractor.py
@@ -1,0 +1,583 @@
+"""Tree-sitter JavaScript extraction for native CodeGraph."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from tldw_Server_API.app.core.CodeGraph.extractors.js_ts_imports import resolve_js_ts_import
+from tldw_Server_API.app.core.CodeGraph.extractors.tree_sitter_loader import load_parser
+from tldw_Server_API.app.core.CodeGraph.models import (
+    CodeGraphEdge,
+    CodeGraphNode,
+    CodeGraphUnresolvedRef,
+    ExtractionResult,
+    make_edge_id,
+    make_node_id,
+)
+
+
+@dataclass(frozen=True)
+class _CallSite:
+    """Deferred same-file JS call reference captured while walking a callable body."""
+
+    source_node_id: str
+    reference_name: str
+    line: int
+    column: int
+
+
+class JavaScriptTreeSitterExtractor:
+    """Extract conservative JavaScript and JSX symbols with Tree-sitter."""
+
+    language_id = "javascript"
+
+    def __init__(self, *, workspace_root: Path | None = None) -> None:
+        self.workspace_root = workspace_root
+
+    def extract(self, *, workspace_key: str, file_path: str, source: bytes) -> ExtractionResult:
+        """Parse one JavaScript/JSX file and return symbols, calls, unresolved refs, and errors."""
+        parser_result = load_parser("javascript")
+        if parser_result.missing:
+            return ExtractionResult(errors=(f"Missing Tree-sitter dependencies: {', '.join(parser_result.missing)}",))
+        if parser_result.error or parser_result.parser is None:
+            return ExtractionResult(errors=(parser_result.error or "JavaScript parser unavailable",))
+
+        try:
+            text = source.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            return ExtractionResult(errors=(str(exc),))
+
+        tree = parser_result.parser.parse(source)
+        if tree.root_node.has_error:
+            return ExtractionResult(errors=("JavaScript parse error",))
+
+        builder = _JavaScriptGraphBuilder(
+            workspace_key=workspace_key,
+            workspace_root=self.workspace_root,
+            file_path=file_path,
+            source=source,
+            source_text=text,
+            language_id=self.language_id,
+        )
+        return builder.build(tree.root_node)
+
+
+class _JavaScriptGraphBuilder:
+    """Stateful Tree-sitter visitor for one JS-family source file."""
+
+    def __init__(
+        self,
+        *,
+        workspace_key: str,
+        workspace_root: Path | None,
+        file_path: str,
+        source: bytes,
+        source_text: str,
+        language_id: str,
+    ) -> None:
+        self.workspace_key = workspace_key
+        self.workspace_root = workspace_root
+        self.file_path = file_path
+        self.source = source
+        self.source_text = source_text
+        self.language_id = language_id
+        self.nodes: list[CodeGraphNode] = []
+        self.edges: list[CodeGraphEdge] = []
+        self.unresolved_refs: list[CodeGraphUnresolvedRef] = []
+        self._scope_stack: list[CodeGraphNode] = []
+        self._class_stack: list[str] = []
+        self._call_sites: list[_CallSite] = []
+        self._callable_by_name: dict[str, CodeGraphNode | None] = {}
+
+    def build(self, root_node: Any) -> ExtractionResult:
+        """Visit a parsed JS-family program and resolve same-file call references."""
+        module_name = Path(self.file_path).stem
+        module_node = self._make_node(
+            kind="module",
+            name=module_name,
+            qualified_name=_module_qualified_name(self.file_path),
+            node=root_node,
+            start_line=1,
+            end_line=max(1, len(self.source_text.splitlines())),
+        )
+        self.nodes.append(module_node)
+        self._scope_stack.append(module_node)
+        for child in root_node.named_children:
+            self._visit(child)
+        self._scope_stack.pop()
+        self._resolve_calls()
+        return ExtractionResult(
+            nodes=tuple(self.nodes),
+            edges=tuple(self.edges),
+            unresolved_refs=tuple(self.unresolved_refs),
+        )
+
+    def _visit(self, node: Any, *, exported: bool = False) -> None:
+        if node.type == "import_statement":
+            self._visit_import_statement(node)
+            return
+        if node.type == "export_statement":
+            self._visit_export_statement(node)
+            return
+        if node.type in {"function_declaration", "generator_function_declaration"}:
+            self._visit_function_declaration(node, exported=exported)
+            return
+        if node.type in {"lexical_declaration", "variable_declaration"}:
+            for child in node.named_children:
+                self._visit(child, exported=exported)
+            return
+        if node.type == "variable_declarator":
+            self._visit_variable_declarator(node, exported=exported)
+            return
+        if node.type == "class_declaration":
+            self._visit_class_declaration(node, exported=exported)
+            return
+        if node.type == "method_definition":
+            self._visit_method_definition(node)
+            return
+        if node.type == "call_expression":
+            self._visit_call_expression(node)
+            return
+
+        for child in node.named_children:
+            self._visit(child, exported=exported)
+
+    def _visit_export_statement(self, node: Any) -> None:
+        declaration = node.child_by_field_name("declaration")
+        if declaration is not None:
+            self._visit(declaration, exported=True)
+            return
+
+        source_node = node.child_by_field_name("source")
+        source_specifier = _string_literal_value(self.source, source_node)
+        export_clause = _first_named_child_of_type(node, "export_clause")
+        if source_specifier and export_clause is not None:
+            for specifier_node in _named_descendants_of_type(export_clause, "export_specifier"):
+                imported = _node_text(self.source, specifier_node.child_by_field_name("name"))
+                local = _node_text(self.source, specifier_node.child_by_field_name("alias")) or imported
+                self._add_import_node(
+                    node=specifier_node,
+                    name=local,
+                    source_specifier=source_specifier,
+                    imported=imported,
+                    alias=local if local != imported else None,
+                    is_re_export=True,
+                )
+
+    def _visit_import_statement(self, node: Any) -> None:
+        source_node = node.child_by_field_name("source")
+        source_specifier = _string_literal_value(self.source, source_node)
+        if not source_specifier:
+            return
+
+        import_clause = _first_named_child_of_type(node, "import_clause")
+        if import_clause is None:
+            self._add_import_node(
+                node=node,
+                name=Path(source_specifier).name or source_specifier,
+                source_specifier=source_specifier,
+                imported="side_effect",
+                alias=None,
+                is_re_export=False,
+            )
+            return
+
+        default_name = _direct_named_child_of_type(import_clause, "identifier")
+        if default_name is not None:
+            self._add_import_node(
+                node=default_name,
+                name=_node_text(self.source, default_name),
+                source_specifier=source_specifier,
+                imported="default",
+                alias=None,
+                is_re_export=False,
+            )
+
+        for specifier_node in _named_descendants_of_type(import_clause, "import_specifier"):
+            imported = _node_text(self.source, specifier_node.child_by_field_name("name"))
+            local = _node_text(self.source, specifier_node.child_by_field_name("alias")) or imported
+            self._add_import_node(
+                node=specifier_node,
+                name=local,
+                source_specifier=source_specifier,
+                imported=imported,
+                alias=local if local != imported else None,
+                is_re_export=False,
+            )
+
+        namespace_import = _first_named_child_of_type(import_clause, "namespace_import")
+        if namespace_import is not None:
+            local_name = _last_identifier_text(namespace_import)
+            if local_name:
+                self._add_import_node(
+                    node=namespace_import,
+                    name=local_name,
+                    source_specifier=source_specifier,
+                    imported="namespace",
+                    alias=local_name,
+                    is_re_export=False,
+                )
+
+    def _visit_function_declaration(self, node: Any, *, exported: bool = False) -> None:
+        name_node = node.child_by_field_name("name") or _direct_named_child_of_type(node, "identifier")
+        name = _node_text(self.source, name_node)
+        if not name:
+            return
+        kind = "component" if _is_component_name(name) and _contains_jsx(node) else "function"
+        function_node = self._make_node(
+            kind=kind,
+            name=name,
+            qualified_name=_qualified_name((*self._class_stack, name)),
+            node=node,
+            flags=("exported",) if exported else (),
+        )
+        self.nodes.append(function_node)
+        self._remember_callable(function_node)
+
+        self._scope_stack.append(function_node)
+        body = node.child_by_field_name("body")
+        if body is not None:
+            self._visit(body)
+        self._scope_stack.pop()
+
+    def _visit_variable_declarator(self, node: Any, *, exported: bool = False) -> None:
+        name_node = node.child_by_field_name("name")
+        value_node = node.child_by_field_name("value")
+        if value_node is None or value_node.type not in {"arrow_function", "function_expression"}:
+            for child in node.named_children:
+                self._visit(child, exported=exported)
+            return
+
+        name = _node_text(self.source, name_node)
+        if not name:
+            return
+        kind = "component" if _is_component_name(name) and _contains_jsx(value_node) else "function"
+        function_node = self._make_node(
+            kind=kind,
+            name=name,
+            qualified_name=_qualified_name((*self._class_stack, name)),
+            node=node,
+            flags=("exported", "arrow") if exported else ("arrow",),
+        )
+        self.nodes.append(function_node)
+        self._remember_callable(function_node)
+
+        self._scope_stack.append(function_node)
+        self._visit(value_node)
+        self._scope_stack.pop()
+
+    def _visit_class_declaration(self, node: Any, *, exported: bool = False) -> None:
+        name_node = node.child_by_field_name("name") or _direct_named_child_of_type(node, "identifier")
+        name = _node_text(self.source, name_node)
+        if not name:
+            return
+        class_node = self._make_node(
+            kind="class",
+            name=name,
+            qualified_name=_qualified_name((*self._class_stack, name)),
+            node=node,
+            flags=("exported",) if exported else (),
+        )
+        self.nodes.append(class_node)
+        self._remember_callable(class_node)
+
+        self._scope_stack.append(class_node)
+        self._class_stack.append(name)
+        body = node.child_by_field_name("body") or _first_named_child_of_type(node, "class_body")
+        if body is not None:
+            for child in body.named_children:
+                self._visit(child)
+        self._class_stack.pop()
+        self._scope_stack.pop()
+
+    def _visit_method_definition(self, node: Any) -> None:
+        name_node = node.child_by_field_name("name")
+        name = _node_text(self.source, name_node)
+        if not name:
+            return
+        method_node = self._make_node(
+            kind="method",
+            name=name,
+            qualified_name=_qualified_name((*self._class_stack, name)),
+            node=node,
+        )
+        self.nodes.append(method_node)
+        self._remember_callable(method_node)
+
+        self._scope_stack.append(method_node)
+        body = node.child_by_field_name("body")
+        if body is not None:
+            self._visit(body)
+        self._scope_stack.pop()
+
+    def _visit_call_expression(self, node: Any) -> None:
+        current_scope = self._scope_stack[-1] if self._scope_stack else None
+        function_node = node.child_by_field_name("function")
+        if current_scope is not None and current_scope.kind in {"function", "method", "component"}:
+            if function_node is not None and function_node.type == "identifier":
+                self._call_sites.append(
+                    _CallSite(
+                        source_node_id=current_scope.id,
+                        reference_name=_node_text(self.source, function_node),
+                        line=_line(node),
+                        column=_column(node),
+                    )
+                )
+            elif function_node is not None and function_node.type == "member_expression":
+                reference_name = _member_reference_name(self.source, function_node)
+                if reference_name:
+                    self.unresolved_refs.append(
+                        CodeGraphUnresolvedRef(
+                            from_node_id=current_scope.id,
+                            reference_name=reference_name,
+                            reference_kind="call",
+                            file_path=self.file_path,
+                            line=_line(node),
+                            column=_column(node),
+                            language=self.language_id,
+                        )
+                    )
+
+        for child in node.named_children:
+            self._visit(child)
+
+    def _add_import_node(
+        self,
+        *,
+        node: Any,
+        name: str,
+        source_specifier: str,
+        imported: str,
+        alias: str | None,
+        is_re_export: bool,
+    ) -> None:
+        resolution = (
+            resolve_js_ts_import(self.workspace_root, self.file_path, source_specifier)
+            if self.workspace_root is not None
+            else None
+        )
+        metadata: dict[str, Any] = {
+            "source": source_specifier,
+            "imported": imported,
+            "alias": alias,
+            "re_export": is_re_export,
+        }
+        if resolution is not None:
+            metadata.update(
+                {
+                    "resolution_kind": resolution.resolution_kind,
+                    "resolved_path": resolution.resolved_path,
+                    "resolution_reason": resolution.reason,
+                }
+            )
+
+        import_node = self._make_node(
+            kind="import",
+            name=name,
+            qualified_name=f"{source_specifier}:{imported}:{name}",
+            node=node,
+            metadata=metadata,
+        )
+        self.nodes.append(import_node)
+
+        if resolution is not None and resolution.resolution_kind == "external":
+            self.unresolved_refs.append(
+                CodeGraphUnresolvedRef(
+                    from_node_id=import_node.id,
+                    reference_name=source_specifier,
+                    reference_kind="import",
+                    file_path=self.file_path,
+                    line=_line(node),
+                    column=_column(node),
+                    language=self.language_id,
+                )
+            )
+        elif resolution is not None and resolution.resolution_kind == "unresolved":
+            self.unresolved_refs.append(
+                CodeGraphUnresolvedRef(
+                    from_node_id=import_node.id,
+                    reference_name=source_specifier,
+                    reference_kind="import",
+                    file_path=self.file_path,
+                    line=_line(node),
+                    column=_column(node),
+                    candidates=resolution.candidates,
+                    language=self.language_id,
+                )
+            )
+
+    def _make_node(
+        self,
+        *,
+        kind: str,
+        name: str,
+        qualified_name: str,
+        node: Any,
+        start_line: int | None = None,
+        end_line: int | None = None,
+        flags: tuple[str, ...] = (),
+        metadata: dict[str, Any] | None = None,
+    ) -> CodeGraphNode:
+        resolved_start = start_line or _line(node)
+        identity_key = (
+            f"{self.workspace_key}:{self.language_id}:{self.file_path}:{kind}:{qualified_name}:{resolved_start}"
+        )
+        return CodeGraphNode(
+            id=make_node_id(self.workspace_key, self.language_id, self.file_path, kind, qualified_name, resolved_start),
+            identity_key=identity_key,
+            kind=kind,
+            name=name,
+            qualified_name=qualified_name,
+            file_path=self.file_path,
+            language=self.language_id,
+            start_line=resolved_start,
+            end_line=end_line or _end_line(node),
+            start_column=_column(node),
+            end_column=_end_column(node),
+            flags=flags,
+            metadata=dict(metadata or {}),
+        )
+
+    def _remember_callable(self, node: CodeGraphNode) -> None:
+        for key in {node.name, node.qualified_name}:
+            existing = self._callable_by_name.get(key)
+            if existing is None and key in self._callable_by_name:
+                continue
+            if existing is not None and existing.id != node.id:
+                self._callable_by_name[key] = None
+                continue
+            self._callable_by_name[key] = node
+
+    def _resolve_calls(self) -> None:
+        for call in self._call_sites:
+            target = self._callable_by_name.get(call.reference_name)
+            if target is None:
+                self.unresolved_refs.append(
+                    CodeGraphUnresolvedRef(
+                        from_node_id=call.source_node_id,
+                        reference_name=call.reference_name,
+                        reference_kind="call",
+                        file_path=self.file_path,
+                        line=call.line,
+                        column=call.column,
+                        language=self.language_id,
+                    )
+                )
+                continue
+            self.edges.append(
+                CodeGraphEdge(
+                    id=make_edge_id(
+                        call.source_node_id,
+                        "calls",
+                        target.id,
+                        self.file_path,
+                        call.line,
+                        call.column,
+                    ),
+                    source=call.source_node_id,
+                    target=target.id,
+                    kind="calls",
+                    file_path=self.file_path,
+                    line=call.line,
+                    column=call.column,
+                    provenance="tree_sitter",
+                )
+            )
+
+
+def _node_text(source: bytes, node: Any | None) -> str:
+    if node is None:
+        return ""
+    return source[node.start_byte : node.end_byte].decode("utf-8")
+
+
+def _string_literal_value(source: bytes, node: Any | None) -> str:
+    if node is None:
+        return ""
+    for child in node.named_children:
+        if child.type == "string_fragment":
+            return _node_text(source, child)
+    value = _node_text(source, node)
+    return value[1:-1] if len(value) >= 2 and value[0] in {'"', "'"} else value
+
+
+def _first_named_child_of_type(node: Any, node_type: str) -> Any | None:
+    for child in node.named_children:
+        if child.type == node_type:
+            return child
+    return None
+
+
+def _direct_named_child_of_type(node: Any, node_type: str) -> Any | None:
+    for child in node.named_children:
+        if child.type == node_type:
+            return child
+    return None
+
+
+def _named_descendants_of_type(node: Any, node_type: str) -> tuple[Any, ...]:
+    matches: list[Any] = []
+    stack = list(reversed(node.named_children))
+    while stack:
+        current = stack.pop()
+        if current.type == node_type:
+            matches.append(current)
+        stack.extend(reversed(current.named_children))
+    return tuple(matches)
+
+
+def _last_identifier_text(node: Any) -> str:
+    identifiers = list(_named_descendants_of_type(node, "identifier"))
+    if not identifiers:
+        return ""
+    return identifiers[-1].text.decode("utf-8")
+
+
+def _member_reference_name(source: bytes, node: Any) -> str:
+    object_node = node.child_by_field_name("object")
+    property_node = node.child_by_field_name("property")
+    object_name = _member_reference_name(source, object_node) if object_node and object_node.type == "member_expression" else _node_text(source, object_node)
+    property_name = _node_text(source, property_node)
+    if object_name and property_name:
+        return f"{object_name}.{property_name}"
+    return _node_text(source, node)
+
+
+def _contains_jsx(node: Any) -> bool:
+    if node.type.startswith("jsx_"):
+        return True
+    return any(_contains_jsx(child) for child in node.named_children)
+
+
+def _is_component_name(name: str) -> bool:
+    return bool(name) and name[0].isupper()
+
+
+def _qualified_name(parts: tuple[str, ...]) -> str:
+    return ".".join(part for part in parts if part)
+
+
+def _module_qualified_name(file_path: str) -> str:
+    path = Path(file_path)
+    return ".".join((*path.with_suffix("").parts,))
+
+
+def _line(node: Any) -> int:
+    return int(node.start_point.row) + 1
+
+
+def _column(node: Any) -> int:
+    return int(node.start_point.column) + 1
+
+
+def _end_line(node: Any) -> int:
+    return int(node.end_point.row) + 1
+
+
+def _end_column(node: Any) -> int:
+    return int(node.end_point.column) + 1
+
+
+__all__ = ["JavaScriptTreeSitterExtractor"]

--- a/tldw_Server_API/app/core/CodeGraph/extractors/javascript_extractor.py
+++ b/tldw_Server_API/app/core/CodeGraph/extractors/javascript_extractor.py
@@ -36,7 +36,14 @@ class JavaScriptTreeSitterExtractor:
     def __init__(self, *, workspace_root: Path | None = None) -> None:
         self.workspace_root = workspace_root
 
-    def extract(self, *, workspace_key: str, file_path: str, source: bytes) -> ExtractionResult:
+    def extract(
+        self,
+        *,
+        workspace_key: str,
+        file_path: str,
+        source: bytes,
+        workspace_root: Path | None = None,
+    ) -> ExtractionResult:
         """Parse one JavaScript/JSX file and return symbols, calls, unresolved refs, and errors."""
         parser_result = load_parser("javascript")
         if parser_result.missing:
@@ -55,7 +62,7 @@ class JavaScriptTreeSitterExtractor:
 
         builder = _JavaScriptGraphBuilder(
             workspace_key=workspace_key,
-            workspace_root=self.workspace_root,
+            workspace_root=workspace_root or self.workspace_root,
             file_path=file_path,
             source=source,
             source_text=text,

--- a/tldw_Server_API/app/core/CodeGraph/extractors/javascript_extractor.py
+++ b/tldw_Server_API/app/core/CodeGraph/extractors/javascript_extractor.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from tldw_Server_API.app.core.CodeGraph.extractors.js_ts_imports import resolve_js_ts_import
+import tldw_Server_API.app.core.CodeGraph.extractors.js_ts_imports as js_ts_imports
 from tldw_Server_API.app.core.CodeGraph.extractors.tree_sitter_loader import load_parser
 from tldw_Server_API.app.core.CodeGraph.models import (
     CodeGraphEdge,
@@ -60,7 +60,7 @@ class JavaScriptTreeSitterExtractor:
         if tree.root_node.has_error:
             return ExtractionResult(errors=("JavaScript parse error",))
 
-        builder = _JavaScriptGraphBuilder(
+        builder = JavaScriptGraphBuilder(
             workspace_key=workspace_key,
             workspace_root=workspace_root or self.workspace_root,
             file_path=file_path,
@@ -71,7 +71,7 @@ class JavaScriptTreeSitterExtractor:
         return builder.build(tree.root_node)
 
 
-class _JavaScriptGraphBuilder:
+class JavaScriptGraphBuilder:
     """Stateful Tree-sitter visitor for one JS-family source file."""
 
     def __init__(
@@ -85,11 +85,16 @@ class _JavaScriptGraphBuilder:
         language_id: str,
     ) -> None:
         self.workspace_key = workspace_key
-        self.workspace_root = workspace_root
+        self.workspace_root = workspace_root.resolve() if workspace_root is not None else None
         self.file_path = file_path
         self.source = source
         self.source_text = source_text
         self.language_id = language_id
+        self.project_config = (
+            js_ts_imports.load_js_ts_project_config(self.workspace_root, self.file_path)
+            if self.workspace_root is not None
+            else None
+        )
         self.nodes: list[CodeGraphNode] = []
         self.edges: list[CodeGraphEdge] = []
         self.unresolved_refs: list[CodeGraphUnresolvedRef] = []
@@ -159,11 +164,11 @@ class _JavaScriptGraphBuilder:
 
         source_node = node.child_by_field_name("source")
         source_specifier = _string_literal_value(self.source, source_node)
-        export_clause = _first_named_child_of_type(node, "export_clause")
+        export_clause = first_named_child_of_type(node, "export_clause")
         if source_specifier and export_clause is not None:
             for specifier_node in _named_descendants_of_type(export_clause, "export_specifier"):
-                imported = _node_text(self.source, specifier_node.child_by_field_name("name"))
-                local = _node_text(self.source, specifier_node.child_by_field_name("alias")) or imported
+                imported = node_text(self.source, specifier_node.child_by_field_name("name"))
+                local = node_text(self.source, specifier_node.child_by_field_name("alias")) or imported
                 self._add_import_node(
                     node=specifier_node,
                     name=local,
@@ -179,7 +184,7 @@ class _JavaScriptGraphBuilder:
         if not source_specifier:
             return
 
-        import_clause = _first_named_child_of_type(node, "import_clause")
+        import_clause = first_named_child_of_type(node, "import_clause")
         if import_clause is None:
             self._add_import_node(
                 node=node,
@@ -191,11 +196,11 @@ class _JavaScriptGraphBuilder:
             )
             return
 
-        default_name = _direct_named_child_of_type(import_clause, "identifier")
+        default_name = first_named_child_of_type(import_clause, "identifier")
         if default_name is not None:
             self._add_import_node(
                 node=default_name,
-                name=_node_text(self.source, default_name),
+                name=node_text(self.source, default_name),
                 source_specifier=source_specifier,
                 imported="default",
                 alias=None,
@@ -203,8 +208,8 @@ class _JavaScriptGraphBuilder:
             )
 
         for specifier_node in _named_descendants_of_type(import_clause, "import_specifier"):
-            imported = _node_text(self.source, specifier_node.child_by_field_name("name"))
-            local = _node_text(self.source, specifier_node.child_by_field_name("alias")) or imported
+            imported = node_text(self.source, specifier_node.child_by_field_name("name"))
+            local = node_text(self.source, specifier_node.child_by_field_name("alias")) or imported
             self._add_import_node(
                 node=specifier_node,
                 name=local,
@@ -214,7 +219,7 @@ class _JavaScriptGraphBuilder:
                 is_re_export=False,
             )
 
-        namespace_import = _first_named_child_of_type(import_clause, "namespace_import")
+        namespace_import = first_named_child_of_type(import_clause, "namespace_import")
         if namespace_import is not None:
             local_name = _last_identifier_text(namespace_import)
             if local_name:
@@ -228,15 +233,15 @@ class _JavaScriptGraphBuilder:
                 )
 
     def _visit_function_declaration(self, node: Any, *, exported: bool = False) -> None:
-        name_node = node.child_by_field_name("name") or _direct_named_child_of_type(node, "identifier")
-        name = _node_text(self.source, name_node)
+        name_node = node.child_by_field_name("name") or first_named_child_of_type(node, "identifier")
+        name = node_text(self.source, name_node)
         if not name:
             return
         kind = "component" if _is_component_name(name) and _contains_jsx(node) else "function"
         function_node = self._make_node(
             kind=kind,
             name=name,
-            qualified_name=_qualified_name((*self._class_stack, name)),
+            qualified_name=qualified_name((*self._class_stack, name)),
             node=node,
             flags=("exported",) if exported else (),
         )
@@ -257,14 +262,14 @@ class _JavaScriptGraphBuilder:
                 self._visit(child, exported=exported)
             return
 
-        name = _node_text(self.source, name_node)
+        name = node_text(self.source, name_node)
         if not name:
             return
         kind = "component" if _is_component_name(name) and _contains_jsx(value_node) else "function"
         function_node = self._make_node(
             kind=kind,
             name=name,
-            qualified_name=_qualified_name((*self._class_stack, name)),
+            qualified_name=qualified_name((*self._class_stack, name)),
             node=node,
             flags=("exported", "arrow") if exported else ("arrow",),
         )
@@ -276,14 +281,14 @@ class _JavaScriptGraphBuilder:
         self._scope_stack.pop()
 
     def _visit_class_declaration(self, node: Any, *, exported: bool = False) -> None:
-        name_node = node.child_by_field_name("name") or _direct_named_child_of_type(node, "identifier")
-        name = _node_text(self.source, name_node)
+        name_node = node.child_by_field_name("name") or first_named_child_of_type(node, "identifier")
+        name = node_text(self.source, name_node)
         if not name:
             return
         class_node = self._make_node(
             kind="class",
             name=name,
-            qualified_name=_qualified_name((*self._class_stack, name)),
+            qualified_name=qualified_name((*self._class_stack, name)),
             node=node,
             flags=("exported",) if exported else (),
         )
@@ -292,7 +297,7 @@ class _JavaScriptGraphBuilder:
 
         self._scope_stack.append(class_node)
         self._class_stack.append(name)
-        body = node.child_by_field_name("body") or _first_named_child_of_type(node, "class_body")
+        body = node.child_by_field_name("body") or first_named_child_of_type(node, "class_body")
         if body is not None:
             for child in body.named_children:
                 self._visit(child)
@@ -301,13 +306,13 @@ class _JavaScriptGraphBuilder:
 
     def _visit_method_definition(self, node: Any) -> None:
         name_node = node.child_by_field_name("name")
-        name = _node_text(self.source, name_node)
+        name = node_text(self.source, name_node)
         if not name:
             return
         method_node = self._make_node(
             kind="method",
             name=name,
-            qualified_name=_qualified_name((*self._class_stack, name)),
+            qualified_name=qualified_name((*self._class_stack, name)),
             node=node,
         )
         self.nodes.append(method_node)
@@ -327,7 +332,7 @@ class _JavaScriptGraphBuilder:
                 self._call_sites.append(
                     _CallSite(
                         source_node_id=current_scope.id,
-                        reference_name=_node_text(self.source, function_node),
+                        reference_name=node_text(self.source, function_node),
                         line=_line(node),
                         column=_column(node),
                     )
@@ -361,7 +366,12 @@ class _JavaScriptGraphBuilder:
         is_re_export: bool,
     ) -> None:
         resolution = (
-            resolve_js_ts_import(self.workspace_root, self.file_path, source_specifier)
+            js_ts_imports.resolve_js_ts_import_with_config(
+                self.workspace_root,
+                self.file_path,
+                source_specifier,
+                self.project_config,
+            )
             if self.workspace_root is not None
             else None
         )
@@ -494,7 +504,8 @@ class _JavaScriptGraphBuilder:
             )
 
 
-def _node_text(source: bytes, node: Any | None) -> str:
+def node_text(source: bytes, node: Any | None) -> str:
+    """Return a node's UTF-8 source slice, or an empty string for missing nodes."""
     if node is None:
         return ""
     return source[node.start_byte : node.end_byte].decode("utf-8")
@@ -505,19 +516,13 @@ def _string_literal_value(source: bytes, node: Any | None) -> str:
         return ""
     for child in node.named_children:
         if child.type == "string_fragment":
-            return _node_text(source, child)
-    value = _node_text(source, node)
+            return node_text(source, child)
+    value = node_text(source, node)
     return value[1:-1] if len(value) >= 2 and value[0] in {'"', "'"} else value
 
 
-def _first_named_child_of_type(node: Any, node_type: str) -> Any | None:
-    for child in node.named_children:
-        if child.type == node_type:
-            return child
-    return None
-
-
-def _direct_named_child_of_type(node: Any, node_type: str) -> Any | None:
+def first_named_child_of_type(node: Any, node_type: str) -> Any | None:
+    """Return the first direct named child with the requested Tree-sitter node type."""
     for child in node.named_children:
         if child.type == node_type:
             return child
@@ -545,11 +550,14 @@ def _last_identifier_text(node: Any) -> str:
 def _member_reference_name(source: bytes, node: Any) -> str:
     object_node = node.child_by_field_name("object")
     property_node = node.child_by_field_name("property")
-    object_name = _member_reference_name(source, object_node) if object_node and object_node.type == "member_expression" else _node_text(source, object_node)
-    property_name = _node_text(source, property_node)
+    if object_node is not None and object_node.type == "member_expression":
+        object_name = _member_reference_name(source, object_node)
+    else:
+        object_name = node_text(source, object_node)
+    property_name = node_text(source, property_node)
     if object_name and property_name:
         return f"{object_name}.{property_name}"
-    return _node_text(source, node)
+    return node_text(source, node)
 
 
 def _contains_jsx(node: Any) -> bool:
@@ -562,7 +570,8 @@ def _is_component_name(name: str) -> bool:
     return bool(name) and name[0].isupper()
 
 
-def _qualified_name(parts: tuple[str, ...]) -> str:
+def qualified_name(parts: tuple[str, ...]) -> str:
+    """Join qualified-name parts while dropping empty segments."""
     return ".".join(part for part in parts if part)
 
 
@@ -587,4 +596,10 @@ def _end_column(node: Any) -> int:
     return int(node.end_point.column) + 1
 
 
-__all__ = ["JavaScriptTreeSitterExtractor"]
+__all__ = [
+    "JavaScriptGraphBuilder",
+    "JavaScriptTreeSitterExtractor",
+    "first_named_child_of_type",
+    "node_text",
+    "qualified_name",
+]

--- a/tldw_Server_API/app/core/CodeGraph/extractors/js_ts_imports.py
+++ b/tldw_Server_API/app/core/CodeGraph/extractors/js_ts_imports.py
@@ -1,0 +1,299 @@
+"""JavaScript and TypeScript import resolution helpers for CodeGraph."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+_SOURCE_EXTENSIONS = (
+    ".ts",
+    ".tsx",
+    ".js",
+    ".jsx",
+    ".mts",
+    ".cts",
+    ".mjs",
+    ".cjs",
+    ".json",
+)
+
+
+@dataclass(frozen=True)
+class JsTsProjectConfig:
+    """Nearest JS/TS project config relevant to a source file."""
+
+    config_path: str
+    base_url: str
+    paths: dict[str, tuple[str, ...]]
+
+
+@dataclass(frozen=True)
+class ImportResolution:
+    """Resolved or classified JS/TS import specifier."""
+
+    specifier: str
+    resolution_kind: str
+    resolved_path: str | None = None
+    reason: str | None = None
+    candidates: tuple[str, ...] = ()
+
+
+def load_js_ts_project_config(workspace_root: Path, source_path: str | Path) -> JsTsProjectConfig | None:
+    """Load the nearest tsconfig.json or jsconfig.json for a workspace-relative file."""
+    workspace = workspace_root.resolve()
+    source_abs = _resolve_under_workspace(workspace, source_path)
+    if source_abs is None:
+        return None
+
+    current = source_abs.parent
+    while current == workspace or workspace in current.parents:
+        for config_name in ("tsconfig.json", "jsconfig.json"):
+            config_path = current / config_name
+            if config_path.is_file():
+                return _read_project_config(workspace, config_path)
+        if current == workspace:
+            break
+        current = current.parent
+    return None
+
+
+def resolve_js_ts_import(workspace_root: Path, source_path: str | Path, specifier: str) -> ImportResolution:
+    """Resolve a JS/TS import specifier without following dependencies outside the workspace."""
+    workspace = workspace_root.resolve()
+    source_abs = _resolve_under_workspace(workspace, source_path)
+    if source_abs is None:
+        return ImportResolution(specifier=specifier, resolution_kind="unresolved", reason="source_outside_workspace")
+
+    if specifier.startswith(("./", "../")):
+        return resolve_relative_import(workspace, source_abs, specifier)
+
+    config = load_js_ts_project_config(workspace, source_path)
+    if config is not None:
+        alias_result = resolve_path_alias_import(workspace, config, specifier)
+        if alias_result is not None:
+            return alias_result
+
+    return ImportResolution(specifier=specifier, resolution_kind="external", reason="external_package")
+
+
+def resolve_relative_import(workspace_root: Path, source_abs: Path, specifier: str) -> ImportResolution:
+    """Resolve a relative import from one source file."""
+    candidate_base = (source_abs.parent / specifier).resolve()
+    if not _is_under_workspace(workspace_root, candidate_base):
+        return ImportResolution(specifier=specifier, resolution_kind="unresolved", reason="relative_target_escapes_workspace")
+
+    resolved = _resolve_source_candidate(workspace_root, candidate_base)
+    if resolved is not None:
+        return ImportResolution(
+            specifier=specifier,
+            resolution_kind="relative",
+            resolved_path=_workspace_relative(workspace_root, resolved),
+        )
+
+    return ImportResolution(
+        specifier=specifier,
+        resolution_kind="unresolved",
+        reason="not_found",
+        candidates=_candidate_strings(workspace_root, candidate_base),
+    )
+
+
+def resolve_path_alias_import(
+    workspace_root: Path,
+    config: JsTsProjectConfig,
+    specifier: str,
+) -> ImportResolution | None:
+    """Resolve a specifier through tsconfig/jsconfig paths, if it matches one."""
+    matches = list(_matching_path_aliases(config.paths, specifier))
+    if not matches:
+        return None
+
+    base_abs = (workspace_root / config.base_url).resolve()
+    attempted: list[str] = []
+    saw_escape = False
+    for target_pattern, wildcard_value in matches:
+        target = target_pattern.replace("*", wildcard_value) if wildcard_value is not None else target_pattern
+        candidate_base = (base_abs / target).resolve()
+        if not _is_under_workspace(workspace_root, candidate_base):
+            saw_escape = True
+            continue
+        resolved = _resolve_source_candidate(workspace_root, candidate_base)
+        if resolved is not None:
+            return ImportResolution(
+                specifier=specifier,
+                resolution_kind="alias",
+                resolved_path=_workspace_relative(workspace_root, resolved),
+            )
+        attempted.extend(_candidate_strings(workspace_root, candidate_base))
+
+    if saw_escape and not attempted:
+        return ImportResolution(
+            specifier=specifier,
+            resolution_kind="unresolved",
+            reason="alias_target_escapes_workspace",
+        )
+
+    return ImportResolution(
+        specifier=specifier,
+        resolution_kind="unresolved",
+        reason="not_found",
+        candidates=tuple(dict.fromkeys(attempted)),
+    )
+
+
+def _read_project_config(workspace_root: Path, config_path: Path) -> JsTsProjectConfig:
+    raw = config_path.read_text(encoding="utf-8")
+    try:
+        parsed: dict[str, Any] = json.loads(raw)
+    except json.JSONDecodeError:
+        parsed = json.loads(_strip_jsonc_comments(raw))
+
+    compiler_options = parsed.get("compilerOptions", {})
+    if not isinstance(compiler_options, dict):
+        compiler_options = {}
+
+    config_dir = config_path.parent
+    base_url_value = compiler_options.get("baseUrl", ".")
+    base_url = str(base_url_value) if isinstance(base_url_value, str) else "."
+    base_abs = (config_dir / base_url).resolve()
+    if not _is_under_workspace(workspace_root, base_abs):
+        base_abs = config_dir.resolve()
+
+    paths_value = compiler_options.get("paths", {})
+    paths: dict[str, tuple[str, ...]] = {}
+    if isinstance(paths_value, dict):
+        for pattern, targets in paths_value.items():
+            if not isinstance(pattern, str):
+                continue
+            if isinstance(targets, str):
+                paths[pattern] = (targets,)
+            elif isinstance(targets, list):
+                paths[pattern] = tuple(target for target in targets if isinstance(target, str))
+
+    return JsTsProjectConfig(
+        config_path=_workspace_relative(workspace_root, config_path.resolve()),
+        base_url=_workspace_relative(workspace_root, base_abs),
+        paths=paths,
+    )
+
+
+def _matching_path_aliases(
+    paths: dict[str, tuple[str, ...]],
+    specifier: str,
+) -> tuple[tuple[str, str | None], ...]:
+    matches: list[tuple[int, tuple[str, str | None]]] = []
+    for pattern, targets in paths.items():
+        wildcard_value = _match_alias_pattern(pattern, specifier)
+        if wildcard_value is None and pattern != specifier:
+            continue
+        static_prefix = pattern.split("*", 1)[0]
+        for target in targets:
+            matches.append((len(static_prefix), (target, wildcard_value)))
+    return tuple(item for _, item in sorted(matches, key=lambda entry: entry[0], reverse=True))
+
+
+def _match_alias_pattern(pattern: str, specifier: str) -> str | None:
+    if "*" not in pattern:
+        return "" if pattern == specifier else None
+    prefix, suffix = pattern.split("*", 1)
+    if not specifier.startswith(prefix) or (suffix and not specifier.endswith(suffix)):
+        return None
+    end = len(specifier) - len(suffix) if suffix else len(specifier)
+    return specifier[len(prefix) : end]
+
+
+def _resolve_source_candidate(workspace_root: Path, candidate_base: Path) -> Path | None:
+    candidates: list[Path]
+    if candidate_base.suffix:
+        candidates = [candidate_base]
+    else:
+        candidates = [candidate_base.with_suffix(extension) for extension in _SOURCE_EXTENSIONS]
+        candidates.extend(candidate_base / f"index{extension}" for extension in _SOURCE_EXTENSIONS)
+
+    for candidate in candidates:
+        resolved = candidate.resolve()
+        if _is_under_workspace(workspace_root, resolved) and resolved.is_file():
+            return resolved
+    return None
+
+
+def _candidate_strings(workspace_root: Path, candidate_base: Path) -> tuple[str, ...]:
+    if not _is_under_workspace(workspace_root, candidate_base):
+        return ()
+    if candidate_base.suffix:
+        return (_workspace_relative(workspace_root, candidate_base),)
+    candidates = [candidate_base.with_suffix(extension) for extension in _SOURCE_EXTENSIONS]
+    candidates.extend(candidate_base / f"index{extension}" for extension in _SOURCE_EXTENSIONS)
+    return tuple(_workspace_relative(workspace_root, candidate.resolve()) for candidate in candidates)
+
+
+def _resolve_under_workspace(workspace_root: Path, path: str | Path) -> Path | None:
+    candidate = Path(path)
+    if not candidate.is_absolute():
+        candidate = workspace_root / candidate
+    resolved = candidate.resolve()
+    if not _is_under_workspace(workspace_root, resolved):
+        return None
+    return resolved
+
+
+def _is_under_workspace(workspace_root: Path, path: Path) -> bool:
+    resolved_workspace = workspace_root.resolve()
+    resolved_path = path.resolve()
+    return resolved_path == resolved_workspace or resolved_workspace in resolved_path.parents
+
+
+def _workspace_relative(workspace_root: Path, path: Path) -> str:
+    return path.resolve().relative_to(workspace_root.resolve()).as_posix()
+
+
+def _strip_jsonc_comments(text: str) -> str:
+    result: list[str] = []
+    in_string = False
+    escape = False
+    index = 0
+    while index < len(text):
+        char = text[index]
+        next_char = text[index + 1] if index + 1 < len(text) else ""
+        if in_string:
+            result.append(char)
+            if escape:
+                escape = False
+            elif char == "\\":
+                escape = True
+            elif char == '"':
+                in_string = False
+            index += 1
+            continue
+        if char == '"':
+            in_string = True
+            result.append(char)
+            index += 1
+            continue
+        if char == "/" and next_char == "/":
+            index = text.find("\n", index)
+            if index == -1:
+                break
+            result.append("\n")
+            index += 1
+            continue
+        if char == "/" and next_char == "*":
+            end = text.find("*/", index + 2)
+            index = len(text) if end == -1 else end + 2
+            continue
+        result.append(char)
+        index += 1
+    return "".join(result)
+
+
+__all__ = [
+    "ImportResolution",
+    "JsTsProjectConfig",
+    "load_js_ts_project_config",
+    "resolve_js_ts_import",
+    "resolve_path_alias_import",
+    "resolve_relative_import",
+]

--- a/tldw_Server_API/app/core/CodeGraph/extractors/js_ts_imports.py
+++ b/tldw_Server_API/app/core/CodeGraph/extractors/js_ts_imports.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-
 _SOURCE_EXTENSIONS = (
     ".ts",
     ".tsx",

--- a/tldw_Server_API/app/core/CodeGraph/extractors/js_ts_imports.py
+++ b/tldw_Server_API/app/core/CodeGraph/extractors/js_ts_imports.py
@@ -66,10 +66,25 @@ def resolve_js_ts_import(workspace_root: Path, source_path: str | Path, specifie
     if source_abs is None:
         return ImportResolution(specifier=specifier, resolution_kind="unresolved", reason="source_outside_workspace")
 
+    config = load_js_ts_project_config(workspace, source_abs)
+    return resolve_js_ts_import_with_config(workspace, source_abs, specifier, config)
+
+
+def resolve_js_ts_import_with_config(
+    workspace_root: Path,
+    source_path: str | Path,
+    specifier: str,
+    config: JsTsProjectConfig | None,
+) -> ImportResolution:
+    """Resolve an import using a caller-supplied project config cache entry."""
+    workspace = workspace_root.resolve()
+    source_abs = _resolve_under_workspace(workspace, source_path)
+    if source_abs is None:
+        return ImportResolution(specifier=specifier, resolution_kind="unresolved", reason="source_outside_workspace")
+
     if specifier.startswith(("./", "../")):
         return resolve_relative_import(workspace, source_abs, specifier)
 
-    config = load_js_ts_project_config(workspace, source_path)
     if config is not None:
         alias_result = resolve_path_alias_import(workspace, config, specifier)
         if alias_result is not None:
@@ -144,11 +159,17 @@ def resolve_path_alias_import(
 
 
 def _read_project_config(workspace_root: Path, config_path: Path) -> JsTsProjectConfig:
+    """Read a tsconfig/jsconfig file and normalize the subset needed for import aliases."""
     raw = config_path.read_text(encoding="utf-8")
     try:
         parsed: dict[str, Any] = json.loads(raw)
     except json.JSONDecodeError:
-        parsed = json.loads(_strip_jsonc_comments(raw))
+        try:
+            parsed = json.loads(_strip_jsonc_comments(raw))
+        except json.JSONDecodeError:
+            parsed = {}
+    if not isinstance(parsed, dict):
+        parsed = {}
 
     compiler_options = parsed.get("compilerOptions", {})
     if not isinstance(compiler_options, dict):
@@ -183,6 +204,7 @@ def _matching_path_aliases(
     paths: dict[str, tuple[str, ...]],
     specifier: str,
 ) -> tuple[tuple[str, str | None], ...]:
+    """Return alias targets whose pattern matches a specifier, longest prefix first."""
     matches: list[tuple[int, tuple[str, str | None]]] = []
     for pattern, targets in paths.items():
         wildcard_value = _match_alias_pattern(pattern, specifier)
@@ -195,6 +217,7 @@ def _matching_path_aliases(
 
 
 def _match_alias_pattern(pattern: str, specifier: str) -> str | None:
+    """Return the wildcard text for a matching paths pattern, or None when unmatched."""
     if "*" not in pattern:
         return "" if pattern == specifier else None
     prefix, suffix = pattern.split("*", 1)
@@ -205,6 +228,7 @@ def _match_alias_pattern(pattern: str, specifier: str) -> str | None:
 
 
 def _resolve_source_candidate(workspace_root: Path, candidate_base: Path) -> Path | None:
+    """Resolve a file or index-file candidate under the workspace, if it exists."""
     candidates: list[Path]
     if candidate_base.suffix:
         candidates = [candidate_base]
@@ -220,6 +244,7 @@ def _resolve_source_candidate(workspace_root: Path, candidate_base: Path) -> Pat
 
 
 def _candidate_strings(workspace_root: Path, candidate_base: Path) -> tuple[str, ...]:
+    """Return workspace-relative candidate paths considered for a missing import."""
     if not _is_under_workspace(workspace_root, candidate_base):
         return ()
     if candidate_base.suffix:
@@ -230,6 +255,7 @@ def _candidate_strings(workspace_root: Path, candidate_base: Path) -> tuple[str,
 
 
 def _resolve_under_workspace(workspace_root: Path, path: str | Path) -> Path | None:
+    """Resolve a path only when the result remains inside the workspace root."""
     candidate = Path(path)
     if not candidate.is_absolute():
         candidate = workspace_root / candidate
@@ -240,16 +266,19 @@ def _resolve_under_workspace(workspace_root: Path, path: str | Path) -> Path | N
 
 
 def _is_under_workspace(workspace_root: Path, path: Path) -> bool:
+    """Return whether path is the workspace root or a descendant of it."""
     resolved_workspace = workspace_root.resolve()
     resolved_path = path.resolve()
     return resolved_path == resolved_workspace or resolved_workspace in resolved_path.parents
 
 
 def _workspace_relative(workspace_root: Path, path: Path) -> str:
+    """Render a resolved path as a POSIX workspace-relative path."""
     return path.resolve().relative_to(workspace_root.resolve()).as_posix()
 
 
 def _strip_jsonc_comments(text: str) -> str:
+    """Remove JSONC line and block comments while preserving string literal contents."""
     result: list[str] = []
     in_string = False
     escape = False
@@ -293,6 +322,7 @@ __all__ = [
     "JsTsProjectConfig",
     "load_js_ts_project_config",
     "resolve_js_ts_import",
+    "resolve_js_ts_import_with_config",
     "resolve_path_alias_import",
     "resolve_relative_import",
 ]

--- a/tldw_Server_API/app/core/CodeGraph/extractors/tree_sitter_loader.py
+++ b/tldw_Server_API/app/core/CodeGraph/extractors/tree_sitter_loader.py
@@ -38,11 +38,15 @@ def load_parser(language_id: str) -> ParserLoadResult:
     tree_sitter = _import_optional("tree_sitter")
     if tree_sitter.missing:
         return ParserLoadResult(missing=tree_sitter.missing)
+    if tree_sitter.error:
+        return ParserLoadResult(error=tree_sitter.error)
 
     module_name, language_function = parser_package
     language_module = _import_optional(module_name)
     if language_module.missing:
         return ParserLoadResult(missing=language_module.missing)
+    if language_module.error:
+        return ParserLoadResult(error=language_module.error)
 
     try:
         language = tree_sitter.module.Language(getattr(language_module.module, language_function)())
@@ -59,14 +63,19 @@ class _ImportResult:
 
     module: Any | None = None
     missing: tuple[str, ...] = ()
+    error: str | None = None
 
 
 def _import_optional(module_name: str) -> _ImportResult:
-    """Import an optional module and report missing modules without raising."""
+    """Import an optional module and report optional dependency failures without raising."""
     try:
         return _ImportResult(module=importlib.import_module(module_name))
-    except ModuleNotFoundError:
-        return _ImportResult(missing=(module_name,))
+    except ModuleNotFoundError as exc:
+        if exc.name in {None, module_name}:
+            return _ImportResult(missing=(module_name,))
+        return _ImportResult(error=f"Failed to import {module_name}: {exc}")
+    except (ImportError, OSError) as exc:
+        return _ImportResult(error=f"Failed to import {module_name}: {exc}")
 
 
 __all__ = ["ParserLoadResult", "load_parser"]

--- a/tldw_Server_API/app/core/CodeGraph/extractors/tree_sitter_loader.py
+++ b/tldw_Server_API/app/core/CodeGraph/extractors/tree_sitter_loader.py
@@ -1,0 +1,72 @@
+"""Optional Tree-sitter parser loading for CodeGraph JS-family extractors."""
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ParserLoadResult:
+    """Result of loading an optional Tree-sitter parser."""
+
+    parser: Any | None = None
+    missing: tuple[str, ...] = ()
+    error: str | None = None
+
+    @property
+    def available(self) -> bool:
+        """Return whether a parser was built successfully."""
+        return self.parser is not None and not self.missing and self.error is None
+
+
+_LANGUAGE_MODULES: dict[str, tuple[str, str]] = {
+    "javascript": ("tree_sitter_javascript", "language"),
+    "jsx": ("tree_sitter_javascript", "language"),
+    "typescript": ("tree_sitter_typescript", "language_typescript"),
+    "tsx": ("tree_sitter_typescript", "language_tsx"),
+}
+
+
+def load_parser(language_id: str) -> ParserLoadResult:
+    """Dynamically load a Tree-sitter parser for a supported JS-family language."""
+    parser_package = _LANGUAGE_MODULES.get(language_id)
+    if parser_package is None:
+        return ParserLoadResult(error=f"Unsupported Tree-sitter language: {language_id}")
+
+    tree_sitter = _import_optional("tree_sitter")
+    if tree_sitter.missing:
+        return ParserLoadResult(missing=tree_sitter.missing)
+
+    module_name, language_function = parser_package
+    language_module = _import_optional(module_name)
+    if language_module.missing:
+        return ParserLoadResult(missing=language_module.missing)
+
+    try:
+        language = tree_sitter.module.Language(getattr(language_module.module, language_function)())
+        parser = tree_sitter.module.Parser(language)
+    except Exception as exc:  # pragma: no cover - defensive boundary for optional native packages.
+        return ParserLoadResult(error=str(exc))
+
+    return ParserLoadResult(parser=parser)
+
+
+@dataclass(frozen=True)
+class _ImportResult:
+    """Internal dynamic import result."""
+
+    module: Any | None = None
+    missing: tuple[str, ...] = ()
+
+
+def _import_optional(module_name: str) -> _ImportResult:
+    """Import an optional module and report missing modules without raising."""
+    try:
+        return _ImportResult(module=importlib.import_module(module_name))
+    except ModuleNotFoundError:
+        return _ImportResult(missing=(module_name,))
+
+
+__all__ = ["ParserLoadResult", "load_parser"]

--- a/tldw_Server_API/app/core/CodeGraph/extractors/tree_sitter_loader.py
+++ b/tldw_Server_API/app/core/CodeGraph/extractors/tree_sitter_loader.py
@@ -47,7 +47,7 @@ def load_parser(language_id: str) -> ParserLoadResult:
     try:
         language = tree_sitter.module.Language(getattr(language_module.module, language_function)())
         parser = tree_sitter.module.Parser(language)
-    except Exception as exc:  # pragma: no cover - defensive boundary for optional native packages.
+    except (AttributeError, TypeError, ValueError) as exc:  # pragma: no cover - optional native package boundary.
         return ParserLoadResult(error=str(exc))
 
     return ParserLoadResult(parser=parser)

--- a/tldw_Server_API/app/core/CodeGraph/extractors/typescript_extractor.py
+++ b/tldw_Server_API/app/core/CodeGraph/extractors/typescript_extractor.py
@@ -23,7 +23,14 @@ class TypeScriptTreeSitterExtractor:
     def __init__(self, *, workspace_root: Path | None = None) -> None:
         self.workspace_root = workspace_root
 
-    def extract(self, *, workspace_key: str, file_path: str, source: bytes) -> ExtractionResult:
+    def extract(
+        self,
+        *,
+        workspace_key: str,
+        file_path: str,
+        source: bytes,
+        workspace_root: Path | None = None,
+    ) -> ExtractionResult:
         """Parse one TypeScript/TSX file and return symbols, calls, unresolved refs, and errors."""
         parser_language = "tsx" if file_path.endswith(".tsx") else "typescript"
         parser_result = load_parser(parser_language)
@@ -43,7 +50,7 @@ class TypeScriptTreeSitterExtractor:
 
         builder = _TypeScriptGraphBuilder(
             workspace_key=workspace_key,
-            workspace_root=self.workspace_root,
+            workspace_root=workspace_root or self.workspace_root,
             file_path=file_path,
             source=source,
             source_text=text,

--- a/tldw_Server_API/app/core/CodeGraph/extractors/typescript_extractor.py
+++ b/tldw_Server_API/app/core/CodeGraph/extractors/typescript_extractor.py
@@ -1,0 +1,91 @@
+"""Tree-sitter TypeScript and TSX extraction for native CodeGraph."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from tldw_Server_API.app.core.CodeGraph.extractors.javascript_extractor import (
+    _JavaScriptGraphBuilder,
+    _direct_named_child_of_type,
+    _node_text,
+    _qualified_name,
+)
+from tldw_Server_API.app.core.CodeGraph.extractors.tree_sitter_loader import load_parser
+from tldw_Server_API.app.core.CodeGraph.models import ExtractionResult
+
+
+class TypeScriptTreeSitterExtractor:
+    """Extract conservative TypeScript and TSX symbols with Tree-sitter."""
+
+    language_id = "typescript"
+
+    def __init__(self, *, workspace_root: Path | None = None) -> None:
+        self.workspace_root = workspace_root
+
+    def extract(self, *, workspace_key: str, file_path: str, source: bytes) -> ExtractionResult:
+        """Parse one TypeScript/TSX file and return symbols, calls, unresolved refs, and errors."""
+        parser_language = "tsx" if file_path.endswith(".tsx") else "typescript"
+        parser_result = load_parser(parser_language)
+        if parser_result.missing:
+            return ExtractionResult(errors=(f"Missing Tree-sitter dependencies: {', '.join(parser_result.missing)}",))
+        if parser_result.error or parser_result.parser is None:
+            return ExtractionResult(errors=(parser_result.error or "TypeScript parser unavailable",))
+
+        try:
+            text = source.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            return ExtractionResult(errors=(str(exc),))
+
+        tree = parser_result.parser.parse(source)
+        if tree.root_node.has_error:
+            return ExtractionResult(errors=("TypeScript parse error",))
+
+        builder = _TypeScriptGraphBuilder(
+            workspace_key=workspace_key,
+            workspace_root=self.workspace_root,
+            file_path=file_path,
+            source=source,
+            source_text=text,
+            language_id=self.language_id,
+        )
+        return builder.build(tree.root_node)
+
+
+class _TypeScriptGraphBuilder(_JavaScriptGraphBuilder):
+    """JS-family graph builder with TypeScript declaration support."""
+
+    _TYPE_DECLARATION_KINDS = {
+        "interface_declaration": "interface",
+        "type_alias_declaration": "type_alias",
+        "enum_declaration": "enum",
+    }
+
+    def _visit(self, node: Any, *, exported: bool = False) -> None:
+        kind = self._TYPE_DECLARATION_KINDS.get(node.type)
+        if kind is not None:
+            self._visit_type_declaration(node, kind=kind, exported=exported)
+            return
+        super()._visit(node, exported=exported)
+
+    def _visit_type_declaration(self, node: Any, *, kind: str, exported: bool) -> None:
+        name_node = (
+            node.child_by_field_name("name")
+            or _direct_named_child_of_type(node, "type_identifier")
+            or _direct_named_child_of_type(node, "identifier")
+        )
+        name = _node_text(self.source, name_node)
+        if not name:
+            return
+        self.nodes.append(
+            self._make_node(
+                kind=kind,
+                name=name,
+                qualified_name=_qualified_name((*self._class_stack, name)),
+                node=node,
+                flags=("exported",) if exported else (),
+            )
+        )
+
+
+__all__ = ["TypeScriptTreeSitterExtractor"]

--- a/tldw_Server_API/app/core/CodeGraph/extractors/typescript_extractor.py
+++ b/tldw_Server_API/app/core/CodeGraph/extractors/typescript_extractor.py
@@ -6,10 +6,10 @@ from pathlib import Path
 from typing import Any
 
 from tldw_Server_API.app.core.CodeGraph.extractors.javascript_extractor import (
-    _direct_named_child_of_type,
-    _JavaScriptGraphBuilder,
-    _node_text,
-    _qualified_name,
+    JavaScriptGraphBuilder,
+    first_named_child_of_type,
+    node_text,
+    qualified_name,
 )
 from tldw_Server_API.app.core.CodeGraph.extractors.tree_sitter_loader import load_parser
 from tldw_Server_API.app.core.CodeGraph.models import ExtractionResult
@@ -59,7 +59,7 @@ class TypeScriptTreeSitterExtractor:
         return builder.build(tree.root_node)
 
 
-class _TypeScriptGraphBuilder(_JavaScriptGraphBuilder):
+class _TypeScriptGraphBuilder(JavaScriptGraphBuilder):
     """JS-family graph builder with TypeScript declaration support."""
 
     _TYPE_DECLARATION_KINDS = {
@@ -78,17 +78,17 @@ class _TypeScriptGraphBuilder(_JavaScriptGraphBuilder):
     def _visit_type_declaration(self, node: Any, *, kind: str, exported: bool) -> None:
         name_node = (
             node.child_by_field_name("name")
-            or _direct_named_child_of_type(node, "type_identifier")
-            or _direct_named_child_of_type(node, "identifier")
+            or first_named_child_of_type(node, "type_identifier")
+            or first_named_child_of_type(node, "identifier")
         )
-        name = _node_text(self.source, name_node)
+        name = node_text(self.source, name_node)
         if not name:
             return
         self.nodes.append(
             self._make_node(
                 kind=kind,
                 name=name,
-                qualified_name=_qualified_name((*self._class_stack, name)),
+                qualified_name=qualified_name((*self._class_stack, name)),
                 node=node,
                 flags=("exported",) if exported else (),
             )

--- a/tldw_Server_API/app/core/CodeGraph/extractors/typescript_extractor.py
+++ b/tldw_Server_API/app/core/CodeGraph/extractors/typescript_extractor.py
@@ -6,8 +6,8 @@ from pathlib import Path
 from typing import Any
 
 from tldw_Server_API.app.core.CodeGraph.extractors.javascript_extractor import (
-    _JavaScriptGraphBuilder,
     _direct_named_child_of_type,
+    _JavaScriptGraphBuilder,
     _node_text,
     _qualified_name,
 )

--- a/tldw_Server_API/app/core/CodeGraph/indexer.py
+++ b/tldw_Server_API/app/core/CodeGraph/indexer.py
@@ -77,7 +77,7 @@ class CodeGraphIndexer:
         self._extractors = {"python": PythonAstExtractor()}
         if load_parser("javascript").available:
             self._extractors["javascript"] = JavaScriptTreeSitterExtractor()
-        if load_parser("typescript").available and load_parser("tsx").available:
+        if load_parser("typescript").available:
             self._extractors["typescript"] = TypeScriptTreeSitterExtractor()
 
     def index_workspace(
@@ -342,8 +342,8 @@ class CodeGraphIndexer:
             if candidate.language_id in {"javascript", "typescript"}:
                 kwargs["workspace_root"] = workspace_root
             return extractor.extract(**kwargs)
-        except ValueError as exc:
-            logger.warning(f"CodeGraph extractor failed for {candidate.relative_path}: {exc}")
+        except (ValueError, OSError, ImportError, AttributeError, TypeError, RuntimeError) as exc:
+            logger.opt(exception=exc).warning(f"CodeGraph extractor failed for {candidate.relative_path}: {exc}")
             return ExtractionResult(errors=(str(exc),))
 
     @staticmethod

--- a/tldw_Server_API/app/core/CodeGraph/indexer.py
+++ b/tldw_Server_API/app/core/CodeGraph/indexer.py
@@ -14,7 +14,10 @@ from loguru import logger
 from tldw_Server_API.app.core.DB_Management.codegraph.repository import CodeGraphRepository
 
 from .config import CodeGraphSettings
+from .extractors.javascript_extractor import JavaScriptTreeSitterExtractor
 from .extractors.python_extractor import PythonAstExtractor
+from .extractors.tree_sitter_loader import load_parser
+from .extractors.typescript_extractor import TypeScriptTreeSitterExtractor
 from .language_registry import CodeGraphLanguageRegistry
 from .models import ExtractionResult
 
@@ -72,6 +75,10 @@ class CodeGraphIndexer:
         self._registry = registry
         self._monotonic = monotonic or time.monotonic
         self._extractors = {"python": PythonAstExtractor()}
+        if load_parser("javascript").available:
+            self._extractors["javascript"] = JavaScriptTreeSitterExtractor()
+        if load_parser("typescript").available and load_parser("tsx").available:
+            self._extractors["typescript"] = TypeScriptTreeSitterExtractor()
 
     def index_workspace(
         self,
@@ -206,7 +213,7 @@ class CodeGraphIndexer:
                     continue
 
                 if has_extractor:
-                    extraction = self._extract(candidate, workspace_key, content.source or b"")
+                    extraction = self._extract(workspace_root, candidate, workspace_key, content.source or b"")
                 else:
                     extraction = ExtractionResult()
                 file_status = "indexed"
@@ -321,17 +328,20 @@ class CodeGraphIndexer:
                         return _DiscoveryResult(candidates=candidates, status="index_too_large_for_foreground")
         return _DiscoveryResult(candidates=candidates)
 
-    def _extract(self, candidate: _Candidate, workspace_key: str, source: bytes) -> ExtractionResult:
+    def _extract(self, workspace_root: Path, candidate: _Candidate, workspace_key: str, source: bytes) -> ExtractionResult:
         """Run the language extractor for a candidate when one is implemented."""
         extractor = self._extractors.get(candidate.language_id)
         if extractor is None:
             return ExtractionResult()
         try:
-            return extractor.extract(
-                workspace_key=workspace_key,
-                file_path=candidate.relative_path,
-                source=source,
-            )
+            kwargs = {
+                "workspace_key": workspace_key,
+                "file_path": candidate.relative_path,
+                "source": source,
+            }
+            if candidate.language_id in {"javascript", "typescript"}:
+                kwargs["workspace_root"] = workspace_root
+            return extractor.extract(**kwargs)
         except ValueError as exc:
             logger.warning(f"CodeGraph extractor failed for {candidate.relative_path}: {exc}")
             return ExtractionResult(errors=(str(exc),))

--- a/tldw_Server_API/app/core/CodeGraph/language_registry.py
+++ b/tldw_Server_API/app/core/CodeGraph/language_registry.py
@@ -6,27 +6,6 @@ from .dependencies import DependencyHealth, probe_codegraph_dependencies
 from .models import LanguageInfo
 
 
-_FOUNDATION_LANGUAGES = (
-    LanguageInfo(
-        language_id="python",
-        display_name="Python",
-        extensions=(".py", ".pyi"),
-        stage="foundation",
-    ),
-    LanguageInfo(
-        language_id="javascript",
-        display_name="JavaScript",
-        extensions=(".js", ".jsx", ".mjs", ".cjs"),
-        stage="foundation",
-    ),
-    LanguageInfo(
-        language_id="typescript",
-        display_name="TypeScript",
-        extensions=(".ts", ".tsx"),
-        stage="foundation",
-    ),
-)
-
 _PLANNED_LANGUAGES = (
     LanguageInfo(
         language_id="c",
@@ -66,7 +45,7 @@ class CodeGraphLanguageRegistry:
 
     def __init__(self, dependency_health: DependencyHealth | None = None) -> None:
         self.dependency_health = dependency_health or probe_codegraph_dependencies()
-        self._languages = (*_FOUNDATION_LANGUAGES, *_PLANNED_LANGUAGES)
+        self._languages = (*_foundation_languages(self.dependency_health), *_PLANNED_LANGUAGES)
         self._by_extension = {
             extension: language
             for language in self._languages
@@ -89,3 +68,38 @@ class CodeGraphLanguageRegistry:
             for language in self._languages
             if language.stage == "foundation"
         }
+
+
+def _foundation_languages(dependency_health: DependencyHealth) -> tuple[LanguageInfo, ...]:
+    missing = set(dependency_health.missing)
+    javascript_missing = _missing_dependencies(missing, ("tree_sitter", "tree_sitter_javascript"))
+    typescript_missing = _missing_dependencies(missing, ("tree_sitter", "tree_sitter_typescript"))
+    return (
+        LanguageInfo(
+            language_id="python",
+            display_name="Python",
+            extensions=(".py", ".pyi"),
+            stage="foundation",
+            symbol_extraction=True,
+        ),
+        LanguageInfo(
+            language_id="javascript",
+            display_name="JavaScript",
+            extensions=(".js", ".jsx", ".mjs", ".cjs"),
+            stage="foundation",
+            dependency_missing=javascript_missing,
+            symbol_extraction=not javascript_missing,
+        ),
+        LanguageInfo(
+            language_id="typescript",
+            display_name="TypeScript",
+            extensions=(".ts", ".tsx"),
+            stage="foundation",
+            dependency_missing=typescript_missing,
+            symbol_extraction=not typescript_missing,
+        ),
+    )
+
+
+def _missing_dependencies(missing: set[str], dependencies: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(dependency for dependency in dependencies if dependency in missing)

--- a/tldw_Server_API/app/core/CodeGraph/language_registry.py
+++ b/tldw_Server_API/app/core/CodeGraph/language_registry.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from .dependencies import DependencyHealth, probe_codegraph_dependencies
 from .models import LanguageInfo
 
-
 _PLANNED_LANGUAGES = (
     LanguageInfo(
         language_id="c",

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
@@ -220,6 +220,32 @@ def helper(value):
     assert [item["target"]["qualified_name"] for item in callees["relationships"]] == ["helper"]  # nosec B101
 
 
+@pytest.mark.asyncio
+async def test_codegraph_search_finds_typescript_component_after_index(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    (workspace_root / "Card.tsx").write_text(
+        "export function Card() { return <div />; }\n",
+        encoding="utf-8",
+    )
+    module = _module(tmp_path, workspace_root)
+
+    index_result = await module.execute_tool(
+        "codegraph.index",
+        {"mode": "foreground", "force": True, "max_files": 10},
+        context=_context(),
+    )
+    search = await module.execute_tool(
+        "codegraph.search",
+        {"query": "Card", "kind": "component", "language": "typescript", "limit": 10},
+        context=_context(),
+    )
+
+    assert index_result["status"] == "complete"  # nosec B101
+    assert [item["qualified_name"] for item in search["results"]] == ["Card"]  # nosec B101
+    assert [item["file_path"] for item in search["results"]] == ["Card.tsx"]  # nosec B101
+
+
 def test_codegraph_rejects_ambiguous_node_selectors(tmp_path: Path) -> None:
     workspace_root = tmp_path / "workspace"
     workspace_root.mkdir()

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py
@@ -77,11 +77,15 @@ def helper(value):
     ]
 
 
-def test_indexer_keeps_javascript_typescript_as_inventory_only_until_extractor_slice(tmp_path: Path) -> None:
+def test_indexer_extracts_javascript_typescript_graph_rows_during_index(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     (workspace / "app.py").write_text("def helper():\n    return 1\n", encoding="utf-8")
     (workspace / "ui.ts").write_text("export function helper() { return 1; }\n", encoding="utf-8")
+    (workspace / "Card.tsx").write_text(
+        "export function Card() { return <div />; }\n",
+        encoding="utf-8",
+    )
     repo = CodeGraphRepository(tmp_path / "codegraph.db")
     indexer = CodeGraphIndexer(settings=CodeGraphSettings.from_mapping({}), registry=CodeGraphLanguageRegistry())
 
@@ -98,8 +102,10 @@ def test_indexer_keeps_javascript_typescript_as_inventory_only_until_extractor_s
 
     assert result.status == "complete"
     assert files["app.py"].node_count > 0
-    assert files["ui.ts"].node_count == 0
-    assert [node.file_path for node in repo.search_nodes("helper", limit=10)] == ["app.py"]
+    assert files["ui.ts"].node_count > 0
+    assert files["Card.tsx"].node_count > 0
+    assert sorted(node.file_path for node in repo.search_nodes("helper", limit=10)) == ["app.py", "ui.ts"]
+    assert [node.file_path for node in repo.search_nodes("Card", kind="component", limit=10)] == ["Card.tsx"]
 
 
 def test_indexer_marks_python_extraction_errors_without_claiming_indexed_status(tmp_path: Path) -> None:

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
+import tldw_Server_API.app.core.CodeGraph.indexer as indexer_module
 from tldw_Server_API.app.core.CodeGraph.config import CodeGraphSettings
 from tldw_Server_API.app.core.CodeGraph.indexer import CodeGraphIndexer, _Candidate, _DiscoveryResult
 from tldw_Server_API.app.core.CodeGraph.language_registry import CodeGraphLanguageRegistry
@@ -160,6 +162,50 @@ def test_indexer_converts_extractor_exceptions_to_file_errors(tmp_path: Path) ->
     assert result.counters["errors"] == 1
     assert file_row.status == "extraction_failed"
     assert file_row.errors == ("source code string cannot contain null bytes",)
+
+
+def test_indexer_converts_non_value_extractor_exceptions_to_file_errors(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "broken.py").write_text("x = 1\n", encoding="utf-8")
+    (workspace / "healthy.py").write_text("y = 2\n", encoding="utf-8")
+    repo = CodeGraphRepository(tmp_path / "codegraph.db")
+    indexer = CodeGraphIndexer(settings=CodeGraphSettings.from_mapping({}), registry=CodeGraphLanguageRegistry())
+
+    class _RaisingExtractor:
+        def extract(self, *, workspace_key: str, file_path: str, source: bytes) -> ExtractionResult:
+            if file_path == "broken.py":
+                raise OSError("bad tsconfig")
+            return ExtractionResult()
+
+    indexer._extractors["python"] = _RaisingExtractor()  # noqa: SLF001
+
+    result = indexer.index_workspace(
+        workspace_root=workspace,
+        workspace_key="ws_test",
+        repository=repo,
+        force=True,
+        languages=None,
+        max_files=10,
+    )
+    files = {item.path: item for item in repo.list_files(limit=10)}
+
+    assert result.status == "complete"
+    assert result.counters["errors"] == 1
+    assert files["broken.py"].status == "extraction_failed"
+    assert files["broken.py"].errors == ("bad tsconfig",)
+    assert files["healthy.py"].status == "indexed"
+
+
+def test_indexer_registers_typescript_extractor_when_ts_parser_exists_without_tsx(monkeypatch) -> None:
+    def fake_load_parser(language_id: str) -> SimpleNamespace:
+        return SimpleNamespace(available=language_id == "typescript")
+
+    monkeypatch.setattr(indexer_module, "load_parser", fake_load_parser)
+
+    indexer = CodeGraphIndexer(settings=CodeGraphSettings.from_mapping({}), registry=CodeGraphLanguageRegistry())
+
+    assert "typescript" in indexer._extractors  # noqa: SLF001
 
 
 def test_indexer_does_not_read_full_inventory_only_file_into_memory(tmp_path: Path) -> None:

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_javascript_extractor.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_javascript_extractor.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tldw_Server_API.app.core.CodeGraph.extractors.javascript_extractor import (
+    JavaScriptTreeSitterExtractor,
+)
+from tldw_Server_API.app.core.CodeGraph.models import ExtractionResult
+
+
+def test_javascript_extractor_records_module_symbols_imports_and_calls(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    (workspace / "src" / "lib").mkdir(parents=True)
+    (workspace / "src" / "lib" / "api.js").write_text("export const apiClient = {};\n", encoding="utf-8")
+    (workspace / "src" / "shared.js").write_text("export function helper() {}\n", encoding="utf-8")
+
+    result = _extract(
+        workspace,
+        """
+import React from "react";
+import { apiClient as client } from "./lib/api";
+export { helper as sharedHelper } from "./shared";
+
+export function Helper(value) {
+  return value + 1;
+}
+
+const loadData = () => {
+  return Helper(1);
+};
+
+class Widget {
+  render() {
+    client.fetch();
+    return Helper(2);
+  }
+}
+
+export function Card() {
+  return <div>{loadData()}</div>;
+}
+""",
+    )
+
+    nodes_by_kind_name = {(node.kind, node.name): node for node in result.nodes}
+    imports = [node for node in result.nodes if node.kind == "import"]
+
+    assert ("module", "app") in nodes_by_kind_name
+    assert ("function", "Helper") in nodes_by_kind_name
+    assert ("function", "loadData") in nodes_by_kind_name
+    assert ("class", "Widget") in nodes_by_kind_name
+    assert ("method", "render") in nodes_by_kind_name
+    assert ("component", "Card") in nodes_by_kind_name
+    assert [(node.name, node.metadata["source"], node.metadata["imported"]) for node in imports] == [
+        ("React", "react", "default"),
+        ("client", "./lib/api", "apiClient"),
+        ("sharedHelper", "./shared", "helper"),
+    ]
+
+    helper = nodes_by_kind_name[("function", "Helper")]
+    load_data = nodes_by_kind_name[("function", "loadData")]
+    render = nodes_by_kind_name[("method", "render")]
+    card = nodes_by_kind_name[("component", "Card")]
+
+    assert (load_data.id, helper.id) in {(edge.source, edge.target) for edge in result.edges}
+    assert (render.id, helper.id) in {(edge.source, edge.target) for edge in result.edges}
+    assert (card.id, load_data.id) in {(edge.source, edge.target) for edge in result.edges}
+    assert any(
+        ref.reference_kind == "call" and ref.reference_name == "client.fetch" and ref.from_node_id == render.id
+        for ref in result.unresolved_refs
+    )
+    assert any(
+        ref.reference_kind == "import" and ref.reference_name == "react"
+        for ref in result.unresolved_refs
+    )
+    assert result.errors == ()
+
+
+def test_javascript_extractor_marks_parse_errors() -> None:
+    result = JavaScriptTreeSitterExtractor().extract(
+        workspace_key="ws",
+        file_path="src/broken.js",
+        source=b"function broken(",
+    )
+
+    assert result == ExtractionResult(errors=("JavaScript parse error",))
+
+
+def test_javascript_extractor_uses_deterministic_node_ids() -> None:
+    first = JavaScriptTreeSitterExtractor().extract(
+        workspace_key="ws",
+        file_path="src/app.js",
+        source=b"export function helper() { return 1; }\n",
+    )
+    second = JavaScriptTreeSitterExtractor().extract(
+        workspace_key="ws",
+        file_path="src/app.js",
+        source=b"export function helper() { return 1; }\n",
+    )
+
+    assert [node.id for node in first.nodes] == [node.id for node in second.nodes]
+
+
+def _extract(workspace: Path, source: str) -> ExtractionResult:
+    return JavaScriptTreeSitterExtractor(workspace_root=workspace).extract(
+        workspace_key="ws",
+        file_path="src/app.jsx",
+        source=source.encode("utf-8"),
+    )

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_javascript_extractor.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_javascript_extractor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from tldw_Server_API.app.core.CodeGraph.extractors import js_ts_imports
 from tldw_Server_API.app.core.CodeGraph.extractors.javascript_extractor import (
     JavaScriptTreeSitterExtractor,
 )
@@ -84,6 +85,34 @@ def test_javascript_extractor_marks_parse_errors() -> None:
     )
 
     assert result == ExtractionResult(errors=("JavaScript parse error",))
+
+
+def test_javascript_extractor_loads_project_config_once_per_file(tmp_path: Path, monkeypatch) -> None:
+    workspace = tmp_path / "workspace"
+    (workspace / "src").mkdir(parents=True)
+    calls: list[tuple[Path, str | Path]] = []
+
+    def fake_load_js_ts_project_config(
+        workspace_root: Path,
+        source_path: str | Path,
+    ) -> js_ts_imports.JsTsProjectConfig | None:
+        calls.append((workspace_root, source_path))
+        return None
+
+    monkeypatch.setattr(js_ts_imports, "load_js_ts_project_config", fake_load_js_ts_project_config)
+
+    result = JavaScriptTreeSitterExtractor(workspace_root=workspace).extract(
+        workspace_key="ws",
+        file_path="src/app.jsx",
+        source=b"""
+import React from "react";
+import { helper } from "@web/helper";
+export { Card } from "@tldw/ui/Card";
+""",
+    )
+
+    assert result.errors == ()
+    assert calls == [(workspace.resolve(), "src/app.jsx")]
 
 
 def test_javascript_extractor_uses_deterministic_node_ids() -> None:

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_js_ts_imports.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_js_ts_imports.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tldw_Server_API.app.core.CodeGraph.extractors.js_ts_imports import (
+    load_js_ts_project_config,
+    resolve_js_ts_import,
+)
+
+
+def test_relative_import_resolves_extensionless_typescript_file(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    (workspace / "src").mkdir(parents=True)
+    (workspace / "src" / "app.ts").write_text("import { helper } from './utils';\n", encoding="utf-8")
+    (workspace / "src" / "utils.ts").write_text("export const helper = 1;\n", encoding="utf-8")
+
+    result = resolve_js_ts_import(workspace, "src/app.ts", "./utils")
+
+    assert result.resolution_kind == "relative"
+    assert result.resolved_path == "src/utils.ts"
+    assert result.reason is None
+
+
+def test_parent_relative_import_resolves_tsx_file(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    (workspace / "src" / "pages").mkdir(parents=True)
+    (workspace / "src" / "shared").mkdir(parents=True)
+    (workspace / "src" / "pages" / "app.ts").write_text(
+        "import { Button } from '../shared/button';\n",
+        encoding="utf-8",
+    )
+    (workspace / "src" / "shared" / "button.tsx").write_text(
+        "export function Button() { return <button />; }\n",
+        encoding="utf-8",
+    )
+
+    result = resolve_js_ts_import(workspace, "src/pages/app.ts", "../shared/button")
+
+    assert result.resolution_kind == "relative"
+    assert result.resolved_path == "src/shared/button.tsx"
+
+
+def test_tsconfig_paths_resolve_common_frontend_aliases(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    _write_json(
+        workspace / "apps" / "tldw-frontend" / "tsconfig.json",
+        {
+            "compilerOptions": {
+                "baseUrl": ".",
+                "paths": {
+                    "@/*": ["../packages/ui/src/*"],
+                    "~/*": ["../packages/ui/src/*"],
+                    "@web/*": ["./*"],
+                    "@tldw/ui/*": ["../packages/ui/src/*"],
+                },
+            }
+        },
+    )
+    (workspace / "apps" / "tldw-frontend" / "pages").mkdir(parents=True)
+    (workspace / "apps" / "packages" / "ui" / "src" / "components").mkdir(parents=True)
+    (workspace / "apps" / "tldw-frontend" / "lib").mkdir(parents=True)
+    (workspace / "apps" / "packages" / "ui" / "src" / "components" / "Button.tsx").write_text(
+        "export function Button() { return <button />; }\n",
+        encoding="utf-8",
+    )
+    (workspace / "apps" / "tldw-frontend" / "lib" / "routes.ts").write_text(
+        "export const routes = [];\n",
+        encoding="utf-8",
+    )
+
+    assert (
+        resolve_js_ts_import(
+            workspace,
+            "apps/tldw-frontend/pages/index.tsx",
+            "@/components/Button",
+        ).resolved_path
+        == "apps/packages/ui/src/components/Button.tsx"
+    )
+    assert (
+        resolve_js_ts_import(
+            workspace,
+            "apps/tldw-frontend/pages/index.tsx",
+            "~/components/Button",
+        ).resolved_path
+        == "apps/packages/ui/src/components/Button.tsx"
+    )
+    assert (
+        resolve_js_ts_import(
+            workspace,
+            "apps/tldw-frontend/pages/index.tsx",
+            "@tldw/ui/components/Button",
+        ).resolved_path
+        == "apps/packages/ui/src/components/Button.tsx"
+    )
+    assert (
+        resolve_js_ts_import(
+            workspace,
+            "apps/tldw-frontend/pages/index.tsx",
+            "@web/lib/routes",
+        ).resolved_path
+        == "apps/tldw-frontend/lib/routes.ts"
+    )
+
+
+def test_project_config_loads_nearest_tsconfig(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    _write_json(workspace / "tsconfig.json", {"compilerOptions": {"baseUrl": "src"}})
+    _write_json(
+        workspace / "packages" / "web" / "tsconfig.json",
+        {"compilerOptions": {"baseUrl": ".", "paths": {"@web/*": ["src/*"]}}},
+    )
+
+    config = load_js_ts_project_config(workspace, "packages/web/src/app.ts")
+
+    assert config is not None
+    assert config.config_path == "packages/web/tsconfig.json"
+    assert config.base_url == "packages/web"
+    assert config.paths == {"@web/*": ("src/*",)}
+
+
+def test_alias_targets_escaping_workspace_are_not_resolved(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    _write_json(
+        workspace / "tsconfig.json",
+        {"compilerOptions": {"baseUrl": ".", "paths": {"@bad/*": ["../outside/*"]}}},
+    )
+    (tmp_path / "outside").mkdir()
+    (tmp_path / "outside" / "secret.ts").write_text("export const secret = 1;\n", encoding="utf-8")
+
+    result = resolve_js_ts_import(workspace, "src/app.ts", "@bad/secret")
+
+    assert result.resolved_path is None
+    assert result.resolution_kind == "unresolved"
+    assert result.reason == "alias_target_escapes_workspace"
+    assert result.candidates == ()
+
+
+def test_external_package_import_is_not_resolved_into_node_modules(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    (workspace / "node_modules" / "react").mkdir(parents=True)
+    (workspace / "node_modules" / "react" / "index.js").write_text(
+        "module.exports = {};\n",
+        encoding="utf-8",
+    )
+
+    result = resolve_js_ts_import(workspace, "src/app.ts", "react")
+
+    assert result.resolved_path is None
+    assert result.resolution_kind == "external"
+    assert result.reason == "external_package"
+    assert result.candidates == ()
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value), encoding="utf-8")

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_js_ts_imports.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_js_ts_imports.py
@@ -119,6 +119,30 @@ def test_project_config_loads_nearest_tsconfig(tmp_path: Path) -> None:
     assert config.paths == {"@web/*": ("src/*",)}
 
 
+def test_invalid_jsonc_project_config_does_not_abort_resolution(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    (workspace / "src").mkdir(parents=True)
+    (workspace / "src" / "app.ts").write_text("import Button from '@/Button';\n", encoding="utf-8")
+    (workspace / "tsconfig.json").write_text(
+        """
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"],
+    },
+  },
+}
+""",
+        encoding="utf-8",
+    )
+
+    result = resolve_js_ts_import(workspace, "src/app.ts", "@/Button")
+
+    assert result.resolution_kind == "external"
+    assert result.reason == "external_package"
+
+
 def test_alias_targets_escaping_workspace_are_not_resolved(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
     _write_json(

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_language_registry.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_language_registry.py
@@ -44,11 +44,46 @@ def test_registry_reports_foundation_languages_and_planned_languages() -> None:
     assert by_id["kotlin"].stage == "planned"
 
 
-def test_registry_maps_extensions_without_claiming_symbol_extraction() -> None:
-    registry = CodeGraphLanguageRegistry()
+def test_registry_maps_extensions_and_reports_symbol_extraction_support() -> None:
+    registry = CodeGraphLanguageRegistry(
+        dependency_health=DependencyHealth(
+            available=True,
+            missing=(),
+            present=(
+                "tree_sitter",
+                "tree_sitter_python",
+                "tree_sitter_javascript",
+                "tree_sitter_typescript",
+            ),
+        )
+    )
 
     assert registry.language_for_path("api/server.py").language_id == "python"
     assert registry.language_for_path("apps/ui/page.tsx").language_id == "typescript"
     assert registry.language_for_path("apps/ui/component.jsx").language_id == "javascript"
     assert registry.language_for_path("src/main.cc").stage == "planned"
     assert registry.language_for_path("README.md") is None
+
+    by_id = {language.language_id: language for language in registry.list_languages()}
+
+    assert by_id["python"].symbol_extraction is True
+    assert by_id["javascript"].symbol_extraction is True
+    assert by_id["typescript"].symbol_extraction is True
+
+
+def test_registry_reports_missing_parser_dependencies_per_language() -> None:
+    registry = CodeGraphLanguageRegistry(
+        dependency_health=DependencyHealth(
+            available=False,
+            missing=("tree_sitter_javascript",),
+            present=("tree_sitter", "tree_sitter_typescript"),
+        )
+    )
+
+    by_id = {language.language_id: language for language in registry.list_languages()}
+
+    assert by_id["python"].symbol_extraction is True
+    assert by_id["javascript"].symbol_extraction is False
+    assert by_id["javascript"].dependency_missing == ("tree_sitter_javascript",)
+    assert by_id["typescript"].symbol_extraction is True
+    assert by_id["typescript"].dependency_missing == ()

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_tree_sitter_loader.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_tree_sitter_loader.py
@@ -18,7 +18,7 @@ def test_load_parser_reports_missing_optional_dependency(monkeypatch) -> None:
     )
     real_import_module = loader.importlib.import_module
 
-    def fake_import_module(name: str):
+    def fake_import_module(name: str) -> ModuleType:
         if name == "tree_sitter_javascript":
             raise ModuleNotFoundError("No module named 'tree_sitter_javascript'")
         return real_import_module(name)
@@ -30,6 +30,26 @@ def test_load_parser_reports_missing_optional_dependency(monkeypatch) -> None:
     assert result.parser is None
     assert result.missing == ("tree_sitter_javascript",)
     assert result.error is None
+
+
+def test_load_parser_reports_optional_import_errors(monkeypatch) -> None:
+    loader = importlib.import_module(
+        "tldw_Server_API.app.core.CodeGraph.extractors.tree_sitter_loader"
+    )
+    real_import_module = loader.importlib.import_module
+
+    def fake_import_module(name: str) -> ModuleType:
+        if name == "tree_sitter_javascript":
+            raise OSError("bad native extension")
+        return real_import_module(name)
+
+    monkeypatch.setattr(loader.importlib, "import_module", fake_import_module)
+
+    result = loader.load_parser("javascript")
+
+    assert result.parser is None
+    assert result.missing == ()
+    assert result.error == "Failed to import tree_sitter_javascript: bad native extension"
 
 
 def test_javascript_parser_can_parse_exported_function() -> None:

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_tree_sitter_loader.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_tree_sitter_loader.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import importlib
+from types import ModuleType
+
+
+def test_loader_module_imports_without_eager_parser_imports() -> None:
+    loader = importlib.import_module(
+        "tldw_Server_API.app.core.CodeGraph.extractors.tree_sitter_loader"
+    )
+
+    assert isinstance(loader, ModuleType)
+
+
+def test_load_parser_reports_missing_optional_dependency(monkeypatch) -> None:
+    loader = importlib.import_module(
+        "tldw_Server_API.app.core.CodeGraph.extractors.tree_sitter_loader"
+    )
+    real_import_module = loader.importlib.import_module
+
+    def fake_import_module(name: str):
+        if name == "tree_sitter_javascript":
+            raise ModuleNotFoundError("No module named 'tree_sitter_javascript'")
+        return real_import_module(name)
+
+    monkeypatch.setattr(loader.importlib, "import_module", fake_import_module)
+
+    result = loader.load_parser("javascript")
+
+    assert result.parser is None
+    assert result.missing == ("tree_sitter_javascript",)
+    assert result.error is None
+
+
+def test_javascript_parser_can_parse_exported_function() -> None:
+    loader = importlib.import_module(
+        "tldw_Server_API.app.core.CodeGraph.extractors.tree_sitter_loader"
+    )
+
+    result = loader.load_parser("javascript")
+    tree = result.parser.parse(b"export function helper() { return 1; }")
+
+    assert result.missing == ()
+    assert result.error is None
+    assert tree.root_node.type == "program"
+    assert not tree.root_node.has_error
+
+
+def test_typescript_parser_can_parse_interface() -> None:
+    loader = importlib.import_module(
+        "tldw_Server_API.app.core.CodeGraph.extractors.tree_sitter_loader"
+    )
+
+    result = loader.load_parser("typescript")
+    tree = result.parser.parse(b"interface User { id: string }")
+
+    assert result.missing == ()
+    assert result.error is None
+    assert tree.root_node.type == "program"
+    assert not tree.root_node.has_error
+
+
+def test_tsx_parser_can_parse_component() -> None:
+    loader = importlib.import_module(
+        "tldw_Server_API.app.core.CodeGraph.extractors.tree_sitter_loader"
+    )
+
+    result = loader.load_parser("tsx")
+    tree = result.parser.parse(b"export function Card() { return <div />; }")
+
+    assert result.missing == ()
+    assert result.error is None
+    assert tree.root_node.type == "program"
+    assert not tree.root_node.has_error

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_typescript_extractor.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_typescript_extractor.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tldw_Server_API.app.core.CodeGraph.extractors.typescript_extractor import (
+    TypeScriptTreeSitterExtractor,
+)
+
+
+def test_typescript_extractor_records_ts_symbols_imports_and_calls(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    (workspace / "src").mkdir(parents=True)
+    (workspace / "src" / "types.ts").write_text("export interface User { id: string }\n", encoding="utf-8")
+
+    result = TypeScriptTreeSitterExtractor(workspace_root=workspace).extract(
+        workspace_key="ws",
+        file_path="src/service.ts",
+        source=b"""
+import type { User } from "./types";
+import { z } from "zod";
+
+export interface Account { id: string }
+type Result<T> = T | null;
+export enum Mode { Read, Write }
+
+export function makeAccount(id: string): Account {
+  return { id };
+}
+
+class Service {
+  run(): Result<Account> {
+    return makeAccount("1");
+  }
+}
+""",
+    )
+
+    nodes_by_kind_name = {(node.kind, node.name): node for node in result.nodes}
+
+    assert ("interface", "Account") in nodes_by_kind_name
+    assert ("type_alias", "Result") in nodes_by_kind_name
+    assert ("enum", "Mode") in nodes_by_kind_name
+    assert ("function", "makeAccount") in nodes_by_kind_name
+    assert ("class", "Service") in nodes_by_kind_name
+    assert ("method", "run") in nodes_by_kind_name
+    assert [
+        (node.name, node.metadata["source"], node.metadata["imported"])
+        for node in result.nodes
+        if node.kind == "import"
+    ] == [
+        ("User", "./types", "User"),
+        ("z", "zod", "z"),
+    ]
+
+    make_account = nodes_by_kind_name[("function", "makeAccount")]
+    run = nodes_by_kind_name[("method", "run")]
+
+    assert (run.id, make_account.id) in {(edge.source, edge.target) for edge in result.edges}
+    assert any(
+        ref.reference_kind == "import" and ref.reference_name == "zod"
+        for ref in result.unresolved_refs
+    )
+    assert result.errors == ()
+
+
+def test_tsx_extractor_records_component_function() -> None:
+    result = TypeScriptTreeSitterExtractor().extract(
+        workspace_key="ws",
+        file_path="src/Card.tsx",
+        source=b"export function Card(props: { title: string }) { return <div>{props.title}</div>; }\n",
+    )
+
+    nodes_by_kind_name = {(node.kind, node.name): node for node in result.nodes}
+
+    assert ("component", "Card") in nodes_by_kind_name
+    assert result.errors == ()
+
+
+def test_typescript_extractor_uses_deterministic_node_ids() -> None:
+    source = b"export interface Account { id: string }\nexport enum Mode { Read }\n"
+    first = TypeScriptTreeSitterExtractor().extract(
+        workspace_key="ws",
+        file_path="src/types.ts",
+        source=source,
+    )
+    second = TypeScriptTreeSitterExtractor().extract(
+        workspace_key="ws",
+        file_path="src/types.ts",
+        source=source,
+    )
+
+    assert [node.id for node in first.nodes] == [node.id for node in second.nodes]


### PR DESCRIPTION
## Summary
- Adds optional Tree-sitter loader and pinned-parser-compatible JS/TS parser boundary for CodeGraph.
- Adds workspace-bounded JS/TS import resolution for relative imports and trusted tsconfig/jsconfig path aliases.
- Adds JavaScript and TypeScript/TSX extractors plus indexer/MCP wiring so JS/TS symbols and TSX components are searchable.

## Test Plan
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/CodeGraph tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py -q
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check tldw_Server_API/app/core/CodeGraph tldw_Server_API/tests/CodeGraph tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/CodeGraph tldw_Server_API/app/core/DB_Management/codegraph tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py -f json -o /tmp/bandit_codegraph_js_ts_extractor.json
- [x] git diff --check

## Change summary
Pending human-authored summary before merge, per AI-generated PR policy.