### PR TITLE
Phase 2.2: defer workspace character router imports

### DIFF
--- a/backlog/tasks/task-39 - Phase-2.2-workspace-character-router-conditional-cleanup-N.md
+++ b/backlog/tasks/task-39 - Phase-2.2-workspace-character-router-conditional-cleanup-N.md
@@ -4,7 +4,7 @@ title: Phase 2.2 workspace character router conditional cleanup N
 status: Done
 assignee: []
 created_date: '2026-05-04 06:00'
-updated_date: '2026-05-04 06:50'
+updated_date: '2026-05-04 15:38'
 labels: []
 dependencies: []
 references:
@@ -29,6 +29,8 @@ Continue #1116 Phase 2.2 by deferring workspace and character-family content rou
 
 <!-- SECTION:NOTES:BEGIN -->
 PR #1263 review follow-up: split the overlong access_count dict-comprehension in the workspace/character router laziness test. Verification rerun: focused workspace_character_router_attr_lookup 1 passed; full router_groups_contract 55 passed; git diff --check clean.
+
+PR #1265 review follow-up: Qodo flagged that the workspace/character laziness test asserts import calls in exact router-definition order. Verified this is incidental to the lazy-import contract; change the assertion to be order-insensitive while preserving duplicate detection.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done
@@ -63,6 +65,21 @@ PR #1263 review follow-up: split the overlong access_count dict-comprehension in
   - Reran focused `workspace_character_router_attr_lookup`: `1 passed, 54 deselected`.
   - Reran full router group contract: `55 passed`.
   - Reran `git diff --check`: passed with no output.
+- PR #1265 review follow-up:
+  - Replaced the ordered `import_calls` list assertion with a `Counter` comparison so duplicate or missing imports still fail without requiring router-definition order.
+  - Reran focused `workspace_character_router_attr_lookup`: `1 passed, 54 deselected`.
+  - Reran full router group contract: `55 passed`.
+  - Reran `python -m ruff check --select I001 tldw_Server_API/tests/Services/test_router_groups_contract.py`: passed.
+  - Reran Bandit on touched source: `python -m bandit -r tldw_Server_API/app/api/v1/router_groups/content.py -f json -o /tmp/bandit_pr1265_content_review.json`, `result_count: 0`.
+  - Reran `git diff --check`: passed with no output.
+  - Rebasing onto current `origin/dev` skipped the already-applied original router-import commit and left the PR with only review follow-up commits.
+  - After rebase, reran focused `workspace_character_router_attr_lookup`: `1 passed, 56 deselected`.
+  - After rebase, reran full router group contract: `57 passed`.
+  - After rebase, reran main router contract: `6 passed`.
+  - After rebase, reran OpenAPI contracts: `69 passed`.
+  - After rebase, reran `python -m ruff check --select I001 tldw_Server_API/tests/Services/test_router_groups_contract.py`: passed.
+  - After rebase, reran Bandit on touched source: `python -m bandit -r tldw_Server_API/app/api/v1/router_groups/content.py -f json -o /tmp/bandit_pr1265_content_review_rebased.json`, `result_count: 0`.
+  - After rebase, reran `git diff --check origin/dev..HEAD`: passed with no output.
 <!-- SECTION:VERIFICATION:END -->
 
 ## Summary

--- a/backlog/tasks/task-39 - Phase-2.2-workspace-character-router-conditional-cleanup-N.md
+++ b/backlog/tasks/task-39 - Phase-2.2-workspace-character-router-conditional-cleanup-N.md
@@ -4,6 +4,7 @@ title: Phase 2.2 workspace character router conditional cleanup N
 status: Done
 assignee: []
 created_date: '2026-05-04 06:00'
+updated_date: '2026-05-04 06:50'
 labels: []
 dependencies: []
 references:
@@ -23,6 +24,12 @@ Continue #1116 Phase 2.2 by deferring workspace and character-family content rou
 - [x] #2 Existing prefix, tags, route_key, and default_stable behavior for workspace and character-family routes remain unchanged.
 - [x] #3 Focused/full router contract tests, main router/OpenAPI contracts, Bandit touched source scan, and git diff hygiene are run before commit.
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+PR #1263 review follow-up: split the overlong access_count dict-comprehension in the workspace/character router laziness test. Verification rerun: focused workspace_character_router_attr_lookup 1 passed; full router_groups_contract 55 passed; git diff --check clean.
+<!-- SECTION:NOTES:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
@@ -51,6 +58,11 @@ Continue #1116 Phase 2.2 by deferring workspace and character-family content rou
   - `result_count: 0`
 - Diff hygiene: `git diff --check`
   - Passed with no output.
+- PR #1263 review follow-up:
+  - Split the overlong `access_count` dict-comprehension flagged by Qodo.
+  - Reran focused `workspace_character_router_attr_lookup`: `1 passed, 54 deselected`.
+  - Reran full router group contract: `55 passed`.
+  - Reran `git diff --check`: passed with no output.
 <!-- SECTION:VERIFICATION:END -->
 
 ## Summary

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -1974,7 +1974,10 @@ def test_iter_content_router_specs_defers_prompt_studio_router_attr_lookup(
             "path": "/api/v1/prompt-studio/ws",
         },
     ]
-    access_count = {str(definition["module_name"]): 0 for definition in router_definitions}
+    access_count = {
+        str(definition["module_name"]): 0
+        for definition in router_definitions
+    }
     import_calls: list[str] = []
 
     for definition in router_definitions:

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import sys
+from collections import Counter
 from pathlib import Path
 from types import ModuleType
 from typing import Callable
-import sys
 
 import pytest
 from fastapi import APIRouter, FastAPI
@@ -13,7 +14,6 @@ from tldw_Server_API.app.api.v1.router_groups.content import iter_content_router
 from tldw_Server_API.app.api.v1.router_groups.core import iter_core_router_specs
 from tldw_Server_API.app.api.v1.router_groups.spec import RouterSpec
 from tldw_Server_API.app.api.v1.router_registry import register_router_specs
-
 
 pytestmark = pytest.mark.unit
 
@@ -162,6 +162,7 @@ def test_append_imported_router_spec_defers_module_import_until_registration(
 ) -> None:
     """Verify route policy can disable imported specs before module import."""
     import importlib
+
     from tldw_Server_API.app.api.v1.router_groups.conditional import (
         ImportedRouterSpec,
         append_imported_router_spec,
@@ -2167,10 +2168,11 @@ def test_iter_content_router_specs_defers_workspace_character_router_attr_lookup
         assert spec.route_key == definition["route_key"]
         assert spec.name == definition["expected_name"]
 
-    assert import_calls == [
+    expected_import_calls = [
         str(definition["module_name"])
         for definition in router_definitions
     ]
+    assert Counter(import_calls) == Counter(expected_import_calls)
     assert access_count == {
         str(definition["module_name"]): 1 for definition in router_definitions
     }


### PR DESCRIPTION
## Change summary

TODO: Human requester must replace this with their own merge-gate summary explaining what changed and why this implementation choice was used.

## What changed

- Converted workspace and character-family content routers to lazy ImportedRouterSpec entries.
- Added a contract test proving iter_content_router_specs does not import these endpoint modules or read router attributes during spec construction.
- Recorded the slice in backlog task 39 for issue #1116.

## Why

This continues the Phase 2.2 cleanup by reducing import-time coupling in content router grouping while preserving route metadata and optional-import behavior.

## Local verification

- Red: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k workspace_character_router_attr_lookup -q
- Green: same focused command: 1 passed, 54 deselected
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q: 55 passed
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q: 6 passed
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q: 69 passed
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/router_groups/content.py -f json -o /tmp/bandit_phase2_2_character_workspace_router_conditionals_n_postcommit.json: result_count 0
- git diff --check HEAD~1..HEAD: passed