### PR TITLE
Phase 2.2: defer core LLM router imports

### DIFF
--- a/backlog/tasks/task-40 - Phase-2.2-core-LLM-router-conditional-cleanup-O.md
+++ b/backlog/tasks/task-40 - Phase-2.2-core-LLM-router-conditional-cleanup-O.md
@@ -1,0 +1,51 @@
+---
+id: TASK-40
+title: Phase 2.2 core LLM router conditional cleanup O
+status: Done
+assignee: []
+created_date: '2026-05-04 06:25'
+updated_date: '2026-05-04 06:28'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+documentation:
+  - >-
+    Docs/superpowers/plans/2026-05-03-phase2-followup-stack-implementation-plan.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue #1116 Phase 2.2 by deferring core LLM/provider-tail router imports from iter_core_router_specs while preserving existing route metadata and optional-import behavior. Scope is limited to llm_providers, mlx, messages, llamacpp, vlm, and mcp_unified_endpoint in router_groups/core.py.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 llm_providers, mlx, messages, llamacpp, vlm, and mcp_unified_endpoint core router specs defer router attribute lookup until registration/resolution.
+- [x] #2 Existing prefix, tags, route_key, public_router attr_name, and default_stable behavior for the scoped core routers remain unchanged.
+- [x] #3 Focused red/green router laziness coverage, full router contract tests, main router/OpenAPI contracts, Bandit touched source scan, and git diff hygiene are run before commit.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Red: focused llm_provider_router_attr_lookup test failed before implementation because scoped core LLM/provider router attrs were touched during iter_core_router_specs(). Green: focused test passed after converting scoped routers to lazy ImportedRouterSpec entries. Full verification passed: router_groups_contract 55 passed; main_router_contract 6 passed; openapi_contracts 69 passed; Bandit core.py 0 results/0 errors; git diff --check clean.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Converted the core LLM/provider-tail router registrations for llm_providers, mlx, messages, llamacpp, vlm, and mcp_unified_endpoint to lazy ImportedRouterSpec entries. Added contract coverage proving iter_core_router_specs no longer resolves those router attributes during spec construction while preserving prefixes, tags, route keys, and public_router attr bindings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/core.py
+++ b/tldw_Server_API/app/api/v1/router_groups/core.py
@@ -294,94 +294,65 @@ def iter_core_router_specs() -> Iterable[RouterSpec]:
     ):
         append_imported_router_spec(specs, acp_spec)
 
-    # LLM Providers listing
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.llm_providers import router as llm_providers_router
-
-        specs.append(RouterSpec(
-            router=llm_providers_router,
+    # LLM/provider endpoints
+    for provider_spec in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.llm_providers",
+            log_name="llm_providers",
             prefix=f"{API_V1_PREFIX}",
             tags=("llm",),
             route_key="llm",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping llm_providers router: {e}")
-
-    # MLX endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.mlx import router as mlx_router
-
-        specs.append(RouterSpec(
-            router=mlx_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.mlx",
+            log_name="mlx",
             prefix=f"{API_V1_PREFIX}",
             tags=("llm",),
             route_key="llm",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping mlx router: {e}")
-
-    # Message endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.messages import public_router as messages_public_router
-        from tldw_Server_API.app.api.v1.endpoints.messages import router as messages_router
-
-        specs.append(RouterSpec(
-            router=messages_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.messages",
+            log_name="messages",
             prefix=f"{API_V1_PREFIX}",
             tags=("messages",),
             route_key="llm",
-        ))
-        specs.append(RouterSpec(
-            router=messages_public_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.messages",
+            log_name="messages_public",
             tags=("messages",),
             route_key="llm",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping messages routers: {e}")
-
-    # llama.cpp endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.llamacpp import public_router as llamacpp_public_router
-        from tldw_Server_API.app.api.v1.endpoints.llamacpp import router as llamacpp_router
-
-        specs.append(RouterSpec(
-            router=llamacpp_router,
+            attr_name="public_router",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.llamacpp",
+            log_name="llamacpp",
             prefix=f"{API_V1_PREFIX}",
             tags=("llamacpp",),
             route_key="llamacpp",
-        ))
-        specs.append(RouterSpec(
-            router=llamacpp_public_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.llamacpp",
+            log_name="llamacpp_public",
             tags=("llamacpp",),
             route_key="llamacpp",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping llamacpp routers: {e}")
-
-    # VLM backends listing
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.vlm import router as vlm_router
-
-        specs.append(RouterSpec(
-            router=vlm_router,
+            attr_name="public_router",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.vlm",
+            log_name="vlm",
             prefix=f"{API_V1_PREFIX}",
             tags=("vlm",),
             route_key="vlm",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping vlm router: {e}")
-
-    # MCP unified endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.mcp_unified_endpoint import router as mcp_unified_router
-
-        specs.append(RouterSpec(
-            router=mcp_unified_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.mcp_unified_endpoint",
+            log_name="mcp_unified",
             prefix=f"{API_V1_PREFIX}",
             tags=("mcp-unified",),
             route_key="mcp-unified",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping mcp_unified router: {e}")
+        ),
+    ):
+        append_imported_router_spec(specs, provider_spec)
 
     return specs

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -453,6 +453,109 @@ def test_iter_core_router_specs_defers_chat_router_attr_lookup(
     }
 
 
+def test_iter_core_router_specs_defers_llm_provider_router_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify covered core LLM/provider specs keep router attr lookup lazy."""
+    module_paths = {
+        "tldw_Server_API.app.api.v1.endpoints.llm_providers": {
+            "router": "/llm/providers",
+        },
+        "tldw_Server_API.app.api.v1.endpoints.mlx": {
+            "router": "/mlx/health",
+        },
+        "tldw_Server_API.app.api.v1.endpoints.messages": {
+            "router": "/messages/send",
+            "public_router": "/messages/public/send",
+        },
+        "tldw_Server_API.app.api.v1.endpoints.llamacpp": {
+            "router": "/llamacpp/completions",
+            "public_router": "/llamacpp/public/completions",
+        },
+        "tldw_Server_API.app.api.v1.endpoints.vlm": {
+            "router": "/vlm/models",
+        },
+        "tldw_Server_API.app.api.v1.endpoints.mcp_unified_endpoint": {
+            "router": "/mcp/status",
+        },
+    }
+    access_count = {
+        f"{module_name}.{attr_name}": 0
+        for module_name, attrs in module_paths.items()
+        for attr_name in attrs
+    }
+
+    for module_name, attr_paths in module_paths.items():
+        fake_module = ModuleType(module_name)
+        routers: dict[str, APIRouter] = {}
+        for attr_name, path in attr_paths.items():
+            router = APIRouter()
+
+            @router.get(path)
+            def _endpoint() -> dict[str, str]:
+                return {"status": "ok"}
+
+            routers[attr_name] = router
+
+        def _module_getattr(
+            name: str,
+            *,
+            module_name: str = module_name,
+            routers: dict[str, APIRouter] = routers,
+        ) -> APIRouter:
+            if name not in routers:
+                raise AttributeError(name)
+            access_count[f"{module_name}.{name}"] += 1
+            return routers[name]
+
+        fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    specs = list(iter_core_router_specs())
+    assert access_count == {
+        f"{module_name}.{attr_name}": 0
+        for module_name, attrs in module_paths.items()
+        for attr_name in attrs
+    }
+
+    selected_specs = [
+        spec
+        for spec in specs
+        if spec.route_key in {"llm", "llamacpp", "vlm", "mcp-unified"}
+    ]
+    by_first_path = {_first_router_path(spec.router): spec for spec in selected_specs}
+
+    assert by_first_path["/llm/providers"].prefix == "/api/v1"
+    assert by_first_path["/llm/providers"].tags == ("llm",)
+    assert by_first_path["/llm/providers"].route_key == "llm"
+    assert by_first_path["/mlx/health"].prefix == "/api/v1"
+    assert by_first_path["/mlx/health"].tags == ("llm",)
+    assert by_first_path["/mlx/health"].route_key == "llm"
+    assert by_first_path["/messages/send"].prefix == "/api/v1"
+    assert by_first_path["/messages/send"].tags == ("messages",)
+    assert by_first_path["/messages/send"].route_key == "llm"
+    assert by_first_path["/messages/public/send"].prefix == ""
+    assert by_first_path["/messages/public/send"].tags == ("messages",)
+    assert by_first_path["/messages/public/send"].route_key == "llm"
+    assert by_first_path["/llamacpp/completions"].prefix == "/api/v1"
+    assert by_first_path["/llamacpp/completions"].tags == ("llamacpp",)
+    assert by_first_path["/llamacpp/completions"].route_key == "llamacpp"
+    assert by_first_path["/llamacpp/public/completions"].prefix == ""
+    assert by_first_path["/llamacpp/public/completions"].tags == ("llamacpp",)
+    assert by_first_path["/llamacpp/public/completions"].route_key == "llamacpp"
+    assert by_first_path["/vlm/models"].prefix == "/api/v1"
+    assert by_first_path["/vlm/models"].tags == ("vlm",)
+    assert by_first_path["/vlm/models"].route_key == "vlm"
+    assert by_first_path["/mcp/status"].prefix == "/api/v1"
+    assert by_first_path["/mcp/status"].tags == ("mcp-unified",)
+    assert by_first_path["/mcp/status"].route_key == "mcp-unified"
+    assert access_count == {
+        f"{module_name}.{attr_name}": 1
+        for module_name, attrs in module_paths.items()
+        for attr_name in attrs
+    }
+
+
 def test_iter_admin_router_specs_defers_selected_router_attr_lookup(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- Defers core LLM/provider-tail router imports with lazy ImportedRouterSpec entries.
- Adds red/green contract coverage proving iter_core_router_specs no longer touches those router attributes during spec construction.
- Preserves prefixes, tags, route keys, default_stable defaults, and public_router attr bindings.

## Change summary
Human summary required before merge: this keeps existing route behavior unchanged while narrowing Phase 2.2 cleanup to the independent core LLM/provider-tail router block.

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k llm_provider_router_attr_lookup -q (red before implementation, green after)
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/router_groups/core.py -f json -o /tmp/bandit_phase2_2_core_llm_router_conditionals_o.json
- jq {results,errors}: 0/0
- git diff --cached --check

Refs #1116