### PR TITLE
Phase 2.2: defer core infrastructure router imports

### DIFF
--- a/backlog/tasks/task-41 - Phase-2.2-core-infrastructure-router-conditional-cleanup-P.md
+++ b/backlog/tasks/task-41 - Phase-2.2-core-infrastructure-router-conditional-cleanup-P.md
@@ -1,0 +1,51 @@
+---
+id: TASK-41
+title: Phase 2.2 core infrastructure router conditional cleanup P
+status: Done
+assignee: []
+created_date: '2026-05-04 07:01'
+updated_date: '2026-05-04 07:06'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+documentation:
+  - >-
+    Docs/superpowers/plans/2026-05-03-phase2-followup-stack-implementation-plan.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue #1116 Phase 2.2 by deferring basic core infrastructure router imports from iter_core_router_specs while preserving existing route metadata and optional-import behavior. Scope is limited to health, moderation, monitoring, metrics, audit, consent, setup, and tools in router_groups/core.py; auth/user/config/sync routes remain outside this tranche.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 health, moderation, monitoring, metrics, audit, consent, setup, and tools core router specs defer router attribute lookup until registration/resolution.
+- [x] #2 Existing prefix, tags, route_key, and tools default_stable behavior for the scoped core infrastructure routes remain unchanged.
+- [x] #3 Focused red/green router laziness coverage, full router contract tests, main router/OpenAPI contracts, Bandit touched source scan, and git diff hygiene are run before commit.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verification: red focused infrastructure laziness test failed before implementation; green focused rerun passed 1 selected; full router group contract passed 57; main router contract passed 6; OpenAPI contract suite passed 69; Bandit core router group source reported 0 results and 0 errors; git diff --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Converted health, moderation, monitoring, metrics, audit, consent, setup, and tools core router registrations to lazy ImportedRouterSpec entries while preserving prefixes, tags, route keys, and tools default_stable=false. Added contract coverage proving iter_core_router_specs does not touch those router attributes during spec construction.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/core.py
+++ b/tldw_Server_API/app/api/v1/router_groups/core.py
@@ -27,96 +27,59 @@ def iter_core_router_specs() -> Iterable[RouterSpec]:
     """
     specs: list[RouterSpec] = []
 
-    # Health endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.health import router as health_router
-
-        specs.append(RouterSpec(
-            router=health_router,
+    # Basic infrastructure endpoints
+    for infrastructure_spec in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.health",
+            log_name="health",
             prefix=f"{API_V1_PREFIX}",
             tags=("health",),
             route_key="health",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping health router: {e}")
-
-    # Moderation endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.moderation import router as moderation_router
-
-        specs.append(RouterSpec(
-            router=moderation_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.moderation",
+            log_name="moderation",
             prefix=f"{API_V1_PREFIX}",
             tags=("moderation",),
             route_key="moderation",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping moderation router: {e}")
-
-    # Monitoring endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.monitoring import router as monitoring_router
-
-        specs.append(RouterSpec(
-            router=monitoring_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.monitoring",
+            log_name="monitoring",
             prefix=f"{API_V1_PREFIX}",
             tags=("monitoring",),
             route_key="monitoring",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping monitoring router: {e}")
-
-    # Metrics endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.metrics import router as metrics_router
-
-        specs.append(RouterSpec(
-            router=metrics_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.metrics",
+            log_name="metrics",
             prefix=f"{API_V1_PREFIX}",
             tags=("metrics",),
             route_key="metrics",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping metrics router: {e}")
-
-    # Audit endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.audit import router as audit_router
-
-        specs.append(RouterSpec(
-            router=audit_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.audit",
+            log_name="audit",
             prefix=f"{API_V1_PREFIX}",
             tags=("audit",),
             route_key="audit",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping audit router: {e}")
-
-    # Consent endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.consent import router as consent_router
-
-        specs.append(RouterSpec(
-            router=consent_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.consent",
+            log_name="consent",
             prefix=f"{API_V1_PREFIX}",
             tags=("consent",),
             route_key="consent",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping consent router: {e}")
-
-    # Setup endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.setup import router as setup_router
-
-        specs.append(RouterSpec(
-            router=setup_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.setup",
+            log_name="setup",
             prefix=f"{API_V1_PREFIX}",
             tags=("setup",),
             route_key="setup",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping setup router: {e}")
+        ),
+    ):
+        append_imported_router_spec(specs, infrastructure_spec)
 
     # Authentication endpoints
     try:
@@ -235,19 +198,17 @@ def iter_core_router_specs() -> Iterable[RouterSpec]:
     ):
         append_imported_router_spec(specs, chat_spec)
 
-    # Tools endpoint
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.tools import router as tools_router
-
-        specs.append(RouterSpec(
-            router=tools_router,
+    append_imported_router_spec(
+        specs,
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.tools",
+            log_name="tools",
             prefix=f"{API_V1_PREFIX}",
             tags=("tools",),
             route_key="tools",
             default_stable=False,
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping tools router: {e}")
+        ),
+    )
 
     # Agent Client Protocol (ACP) endpoints
     for acp_spec in (

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -556,6 +556,125 @@ def test_iter_core_router_specs_defers_llm_provider_router_attr_lookup(
     }
 
 
+def test_iter_core_router_specs_defers_infrastructure_router_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify covered core infrastructure specs keep router attr lookup lazy."""
+    router_definitions = (
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.health",
+            "path": "/health",
+            "prefix": "/api/v1",
+            "tags": ("health",),
+            "route_key": "health",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.moderation",
+            "path": "/moderation/check",
+            "prefix": "/api/v1",
+            "tags": ("moderation",),
+            "route_key": "moderation",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.monitoring",
+            "path": "/monitoring/status",
+            "prefix": "/api/v1",
+            "tags": ("monitoring",),
+            "route_key": "monitoring",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.metrics",
+            "path": "/metrics/text",
+            "prefix": "/api/v1",
+            "tags": ("metrics",),
+            "route_key": "metrics",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.audit",
+            "path": "/audit/events",
+            "prefix": "/api/v1",
+            "tags": ("audit",),
+            "route_key": "audit",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.consent",
+            "path": "/consent/status",
+            "prefix": "/api/v1",
+            "tags": ("consent",),
+            "route_key": "consent",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.setup",
+            "path": "/setup/status",
+            "prefix": "/api/v1",
+            "tags": ("setup",),
+            "route_key": "setup",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.tools",
+            "path": "/tools",
+            "prefix": "/api/v1",
+            "tags": ("tools",),
+            "route_key": "tools",
+            "default_stable": False,
+        },
+    )
+    access_count = {
+        str(definition["module_name"]): 0
+        for definition in router_definitions
+    }
+
+    for definition in router_definitions:
+        module_name = str(definition["module_name"])
+        router = APIRouter()
+
+        @router.get(str(definition["path"]))
+        def _endpoint() -> dict[str, str]:
+            return {"status": "ok"}
+
+        fake_module = ModuleType(module_name)
+
+        def _module_getattr(
+            name: str,
+            *,
+            module_name: str = module_name,
+            router: APIRouter = router,
+        ) -> APIRouter:
+            if name != "router":
+                raise AttributeError(name)
+            access_count[module_name] += 1
+            return router
+
+        fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    specs = list(iter_core_router_specs())
+    assert access_count == {
+        str(definition["module_name"]): 0
+        for definition in router_definitions
+    }
+
+    selected_route_keys = {
+        str(definition["route_key"])
+        for definition in router_definitions
+    }
+    selected_specs = [
+        spec for spec in specs if spec.route_key in selected_route_keys
+    ]
+    by_first_path = {_first_router_path(spec.router): spec for spec in selected_specs}
+    for definition in router_definitions:
+        spec = by_first_path[str(definition["path"])]
+        assert spec.prefix == definition["prefix"]
+        assert spec.tags == definition["tags"]
+        assert spec.route_key == definition["route_key"]
+        assert spec.default_stable is definition.get("default_stable", True)
+
+    assert access_count == {
+        str(definition["module_name"]): 1
+        for definition in router_definitions
+    }
+
+
 def test_iter_admin_router_specs_defers_selected_router_attr_lookup(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- Defers core infrastructure router imports with lazy ImportedRouterSpec entries.
- Adds red/green contract coverage proving iter_core_router_specs no longer touches those router attributes during spec construction.
- Preserves prefixes, tags, route keys, and tools default_stable=false.

## Change summary
Human summary required before merge: this keeps existing route behavior unchanged while narrowing Phase 2.2 cleanup to basic core infrastructure routers; auth/user/config/sync remain separate.

## Verification
- Red focused test: infrastructure laziness contract failed before implementation.
- Focused green: python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k infrastructure_router_attr_lookup -q (1 passed)
- Full router group contract: python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q (57 passed)
- Main router contract: python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q (6 passed)
- OpenAPI contracts: python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q (69 passed)
- Bandit: python -m bandit -r tldw_Server_API/app/api/v1/router_groups/core.py -f json -o /tmp/bandit_phase2_2_core_infra_router_conditionals_p.json (0 results, 0 errors)
- git diff --check
- git diff --cached --check

Refs #1116