### PR TITLE
Phase 2.2: defer core identity router imports

### DIFF
--- a/backlog/tasks/task-42 - Phase-2.2-core-identity-router-conditional-cleanup-Q.md
+++ b/backlog/tasks/task-42 - Phase-2.2-core-identity-router-conditional-cleanup-Q.md
@@ -1,0 +1,53 @@
+---
+id: TASK-42
+title: Phase 2.2 core identity router conditional cleanup Q
+status: Done
+assignee: []
+created_date: '2026-05-04 14:46'
+updated_date: '2026-05-04 14:51'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+documentation:
+  - >-
+    Docs/superpowers/plans/2026-05-03-phase2-followup-stack-implementation-plan.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue #1116 Phase 2.2 by deferring remaining small core identity/config/sync router imports from iter_core_router_specs while preserving route metadata and optional-import behavior. Scope is limited to auth, authnz_debug, users, user_keys, feedback, config_info, and sync; larger/minimal/content groups remain outside this tranche.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 auth, authnz_debug, users, user_keys, feedback, config_info, and sync core router specs defer router attribute lookup until registration/resolution
+- [x] #2 Existing prefix, tags, route_key, and authnz_debug default_stable behavior remain unchanged
+- [x] #3 Focused red/green router laziness coverage, full router contract tests, main router/OpenAPI contracts, Bandit touched source scan, and git diff hygiene are run before commit
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Starting from stacked branch codex/phase2-2-core-auth-router-conditionals-q at PR #1267 commit 4e5d09361f; this branch will be rebased/PR'd after #1267 lands or kept stacked until then.
+
+Verification: baseline full router group contract passed 57 before edits. Red focused identity/config/sync laziness test failed before implementation because scoped router attrs were eagerly resolved. Green focused rerun passed 1 selected; full router group contract passed 58; main router contract passed 6; OpenAPI contract suite passed 69; Bandit core router group source reported 0 results and 0 errors; git diff --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Converted auth, authnz_debug, users, user_keys, feedback, config_info, and sync core router registrations to lazy ImportedRouterSpec entries while preserving prefixes, tags, route keys, and authnz_debug default_stable behavior. Added contract coverage proving iter_core_router_specs does not touch those router attributes during spec construction.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/core.py
+++ b/tldw_Server_API/app/api/v1/router_groups/core.py
@@ -7,8 +7,6 @@ from __future__ import annotations
 
 from typing import Iterable
 
-from loguru import logger
-
 from tldw_Server_API.app.api.v1.router_groups.conditional import (
     ImportedRouterSpec,
     append_imported_router_spec,
@@ -81,97 +79,60 @@ def iter_core_router_specs() -> Iterable[RouterSpec]:
     ):
         append_imported_router_spec(specs, infrastructure_spec)
 
-    # Authentication endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.auth import router as auth_router
-
-        specs.append(RouterSpec(
-            router=auth_router,
+    # Identity, config, and sync endpoints
+    for identity_spec in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.auth",
+            log_name="auth",
             prefix=f"{API_V1_PREFIX}",
             tags=("authentication",),
             route_key="auth",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping auth router: {e}")
-
-    # AuthNZ debug endpoints are enabled by default only in explicit pytest runtime.
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.authnz_debug import router as authnz_debug_router
-
-        specs.append(RouterSpec(
-            router=authnz_debug_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.authnz_debug",
+            log_name="authnz_debug",
             prefix=f"{API_V1_PREFIX}",
             tags=("authnz-debug",),
             route_key="authnz-debug",
             default_stable=_is_explicit_pytest_runtime(),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping authnz_debug router: {e}")
-
-    # User management endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.users import router as users_router
-
-        specs.append(RouterSpec(
-            router=users_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.users",
+            log_name="users",
             prefix=f"{API_V1_PREFIX}",
             tags=("users",),
             route_key="users",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping users router: {e}")
-
-    # User key management endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.user_keys import router as user_keys_router
-
-        specs.append(RouterSpec(
-            router=user_keys_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.user_keys",
+            log_name="user_keys",
             prefix=f"{API_V1_PREFIX}",
             tags=("users",),
             route_key="users",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping user_keys router: {e}")
-
-    # Feedback endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.feedback import router as feedback_router
-
-        specs.append(RouterSpec(
-            router=feedback_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.feedback",
+            log_name="feedback",
             prefix=f"{API_V1_PREFIX}/feedback",
             tags=("feedback",),
             route_key="feedback",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping feedback router: {e}")
-
-    # Config info endpoint
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.config_info import router as config_info_router
-
-        specs.append(RouterSpec(
-            router=config_info_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.config_info",
+            log_name="config_info",
             prefix=f"{API_V1_PREFIX}",
             tags=("config",),
             route_key="config",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping config_info router: {e}")
-
-    # Sync endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.sync import router as sync_router
-
-        specs.append(RouterSpec(
-            router=sync_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.sync",
+            log_name="sync",
             prefix=f"{API_V1_PREFIX}/sync",
             tags=("sync",),
             route_key="sync",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping sync router: {e}")
+        ),
+    ):
+        append_imported_router_spec(specs, identity_spec)
 
     # Chat endpoints
     for chat_spec in (

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -13,6 +13,7 @@ from tldw_Server_API.app.api.v1.router_groups.content import iter_content_router
 from tldw_Server_API.app.api.v1.router_groups.core import iter_core_router_specs
 from tldw_Server_API.app.api.v1.router_groups.spec import RouterSpec
 from tldw_Server_API.app.api.v1.router_registry import register_router_specs
+from tldw_Server_API.app.core.testing import is_explicit_pytest_runtime
 
 
 pytestmark = pytest.mark.unit
@@ -617,6 +618,118 @@ def test_iter_core_router_specs_defers_infrastructure_router_attr_lookup(
             "tags": ("tools",),
             "route_key": "tools",
             "default_stable": False,
+        },
+    )
+    access_count = {
+        str(definition["module_name"]): 0
+        for definition in router_definitions
+    }
+
+    for definition in router_definitions:
+        module_name = str(definition["module_name"])
+        router = APIRouter()
+
+        @router.get(str(definition["path"]))
+        def _endpoint() -> dict[str, str]:
+            return {"status": "ok"}
+
+        fake_module = ModuleType(module_name)
+
+        def _module_getattr(
+            name: str,
+            *,
+            module_name: str = module_name,
+            router: APIRouter = router,
+        ) -> APIRouter:
+            if name != "router":
+                raise AttributeError(name)
+            access_count[module_name] += 1
+            return router
+
+        fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    specs = list(iter_core_router_specs())
+    assert access_count == {
+        str(definition["module_name"]): 0
+        for definition in router_definitions
+    }
+
+    selected_route_keys = {
+        str(definition["route_key"])
+        for definition in router_definitions
+    }
+    selected_specs = [
+        spec for spec in specs if spec.route_key in selected_route_keys
+    ]
+    by_first_path = {_first_router_path(spec.router): spec for spec in selected_specs}
+    for definition in router_definitions:
+        spec = by_first_path[str(definition["path"])]
+        assert spec.prefix == definition["prefix"]
+        assert spec.tags == definition["tags"]
+        assert spec.route_key == definition["route_key"]
+        assert spec.default_stable is definition.get("default_stable", True)
+
+    assert access_count == {
+        str(definition["module_name"]): 1
+        for definition in router_definitions
+    }
+
+
+def test_iter_core_router_specs_defers_identity_config_sync_router_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify covered identity/config/sync specs keep router attr lookup lazy."""
+    router_definitions = (
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.auth",
+            "path": "/auth/login",
+            "prefix": "/api/v1",
+            "tags": ("authentication",),
+            "route_key": "auth",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.authnz_debug",
+            "path": "/authnz/debug",
+            "prefix": "/api/v1",
+            "tags": ("authnz-debug",),
+            "route_key": "authnz-debug",
+            "default_stable": is_explicit_pytest_runtime(),
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.users",
+            "path": "/users",
+            "prefix": "/api/v1",
+            "tags": ("users",),
+            "route_key": "users",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.user_keys",
+            "path": "/users/keys",
+            "prefix": "/api/v1",
+            "tags": ("users",),
+            "route_key": "users",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.feedback",
+            "path": "/feedback/submit",
+            "prefix": "/api/v1/feedback",
+            "tags": ("feedback",),
+            "route_key": "feedback",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.config_info",
+            "path": "/config",
+            "prefix": "/api/v1",
+            "tags": ("config",),
+            "route_key": "config",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.sync",
+            "path": "/sync/status",
+            "prefix": "/api/v1/sync",
+            "tags": ("sync",),
+            "route_key": "sync",
         },
     )
     access_count = {


### PR DESCRIPTION
## Summary
- Defers core identity/config/sync router imports with lazy ImportedRouterSpec entries.
- Adds red/green contract coverage proving iter_core_router_specs no longer touches those router attributes during spec construction.
- Preserves prefixes, tags, route keys, and authnz_debug default_stable behavior.

## Change summary
Human summary required before merge: this keeps existing route behavior unchanged while narrowing Phase 2.2 cleanup to the remaining small core identity/config/sync routers; larger content/minimal groups remain separate.

## Verification
- Rebasing: rebased onto origin/dev after #1267 merged; branch is one commit ahead of dev.
- Focused green: python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k identity_config_sync_router_attr_lookup -q (1 passed)
- Full router group contract: python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q (58 passed)
- Main router contract: python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q (6 passed)
- OpenAPI contracts: python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q (69 passed)
- Bandit: python -m bandit -r tldw_Server_API/app/api/v1/router_groups/core.py -f json -o /tmp/bandit_phase2_2_core_identity_router_conditionals_q_rebased.json (0 results, 0 errors)
- git diff --check

Refs #1116