### PR TITLE
feat(sandbox): expose network policy metadata

### DIFF
--- a/Docs/API-related/Sandbox_API.md
+++ b/Docs/API-related/Sandbox_API.md
@@ -20,8 +20,9 @@ Current runtime identities are `docker`, `firecracker`, `lima`, `vz_linux`,
 `vz_macos`, `seatbelt`, and `worktree`. Availability does not imply a security
 guarantee:
 - Runtime discovery includes machine-readable `boundary_class`,
-  `vm_grade_isolation`, and `untrusted_eligible` fields. Use those fields for
-  client decisions instead of parsing prose notes.
+  `vm_grade_isolation`, `untrusted_eligible`, and
+  `network_policy_contract` fields. Use those fields for client decisions
+  instead of parsing prose notes.
 - `seatbelt` is host-local. `seatbelt` is not `untrusted`-eligible.
 - `worktree` is host-local. `worktree` is not `untrusted`-eligible.
 - `vz_macos` real execution is not implemented; it is a scaffold/preflight
@@ -136,6 +137,18 @@ Response (example):
       "boundary_class": "container",
       "vm_grade_isolation": false,
       "untrusted_eligible": true,
+      "network_policy_contract": {
+        "deny_all": {
+          "support_state": "supported",
+          "strict_enforcement": true,
+          "readiness_source": "config"
+        },
+        "allowlist": {
+          "support_state": "host_gated",
+          "strict_enforcement": true,
+          "readiness_source": "config"
+        }
+      },
       "supported_spec_versions": ["1.0", "1.1"],
       "interactive_supported": false,
       "egress_allowlist_supported": false,
@@ -151,6 +164,10 @@ Runtime isolation fields mean:
   claims, independent of current host availability.
 - `untrusted_eligible`: whether policy may admit this runtime for `untrusted`
   workloads when preflight and host readiness also pass.
+- `network_policy_contract`: static runtime posture for `deny_all` and
+  `allowlist`. It describes whether each policy is supported, unsupported,
+  scaffold-only, or host-gated, whether strict enforcement is possible, and
+  where current readiness should be read from.
 
 Current posture mapping:
 
@@ -164,7 +181,21 @@ Current posture mapping:
 | `seatbelt` | `host_local` | `false` | `false` |
 | `worktree` | `host_local` | `false` | `false` |
 
-For `lima`, runtime discovery also includes:
+Network policy contract mapping:
+
+| Runtime | `deny_all` | `allowlist` |
+| --- | --- | --- |
+| `docker` | `supported`, strict, `config` readiness | `host_gated`, strict, `config` readiness |
+| `firecracker` | `host_gated`, strict, `runtime_preflight` readiness | `scaffold`, not strict, `runtime_preflight` readiness |
+| `lima` | `host_gated`, strict, `runtime_preflight` readiness | `unsupported`, not strict, `not_applicable` |
+| `vz_linux` | `host_gated`, strict, `runtime_preflight` readiness | `unsupported`, not strict, `not_applicable` |
+| `vz_macos` | `scaffold`, not strict, `runtime_preflight` readiness | `unsupported`, not strict, `not_applicable` |
+| `seatbelt` | `unsupported`, not strict, `not_applicable` | `unsupported`, not strict, `not_applicable` |
+| `worktree` | `unsupported`, not strict, `not_applicable` | `unsupported`, not strict, `not_applicable` |
+
+`network_policy_contract` is static posture metadata. Current host readiness is
+still reported through:
+
 - `strict_deny_all_supported`
 - `strict_allowlist_supported`
 - `enforcement_ready` (object with `deny_all`/`allowlist`)

--- a/Docs/Published/API-related/Sandbox_API.md
+++ b/Docs/Published/API-related/Sandbox_API.md
@@ -20,8 +20,9 @@ Current runtime identities are `docker`, `firecracker`, `lima`, `vz_linux`,
 `vz_macos`, `seatbelt`, and `worktree`. Availability does not imply a security
 guarantee:
 - Runtime discovery includes machine-readable `boundary_class`,
-  `vm_grade_isolation`, and `untrusted_eligible` fields. Use those fields for
-  client decisions instead of parsing prose notes.
+  `vm_grade_isolation`, `untrusted_eligible`, and
+  `network_policy_contract` fields. Use those fields for client decisions
+  instead of parsing prose notes.
 - `seatbelt` is host-local. `seatbelt` is not `untrusted`-eligible.
 - `worktree` is host-local. `worktree` is not `untrusted`-eligible.
 - `vz_macos` real execution is not implemented; it is a scaffold/preflight
@@ -136,6 +137,18 @@ Response (example):
       "boundary_class": "container",
       "vm_grade_isolation": false,
       "untrusted_eligible": true,
+      "network_policy_contract": {
+        "deny_all": {
+          "support_state": "supported",
+          "strict_enforcement": true,
+          "readiness_source": "config"
+        },
+        "allowlist": {
+          "support_state": "host_gated",
+          "strict_enforcement": true,
+          "readiness_source": "config"
+        }
+      },
       "supported_spec_versions": ["1.0", "1.1"],
       "interactive_supported": false,
       "egress_allowlist_supported": false,
@@ -151,6 +164,10 @@ Runtime isolation fields mean:
   claims, independent of current host availability.
 - `untrusted_eligible`: whether policy may admit this runtime for `untrusted`
   workloads when preflight and host readiness also pass.
+- `network_policy_contract`: static runtime posture for `deny_all` and
+  `allowlist`. It describes whether each policy is supported, unsupported,
+  scaffold-only, or host-gated, whether strict enforcement is possible, and
+  where current readiness should be read from.
 
 Current posture mapping:
 
@@ -164,7 +181,21 @@ Current posture mapping:
 | `seatbelt` | `host_local` | `false` | `false` |
 | `worktree` | `host_local` | `false` | `false` |
 
-For `lima`, runtime discovery also includes:
+Network policy contract mapping:
+
+| Runtime | `deny_all` | `allowlist` |
+| --- | --- | --- |
+| `docker` | `supported`, strict, `config` readiness | `host_gated`, strict, `config` readiness |
+| `firecracker` | `host_gated`, strict, `runtime_preflight` readiness | `scaffold`, not strict, `runtime_preflight` readiness |
+| `lima` | `host_gated`, strict, `runtime_preflight` readiness | `unsupported`, not strict, `not_applicable` |
+| `vz_linux` | `host_gated`, strict, `runtime_preflight` readiness | `unsupported`, not strict, `not_applicable` |
+| `vz_macos` | `scaffold`, not strict, `runtime_preflight` readiness | `unsupported`, not strict, `not_applicable` |
+| `seatbelt` | `unsupported`, not strict, `not_applicable` | `unsupported`, not strict, `not_applicable` |
+| `worktree` | `unsupported`, not strict, `not_applicable` | `unsupported`, not strict, `not_applicable` |
+
+`network_policy_contract` is static posture metadata. Current host readiness is
+still reported through:
+
 - `strict_deny_all_supported`
 - `strict_allowlist_supported`
 - `enforcement_ready` (object with `deny_all`/`allowlist`)

--- a/Docs/Sandbox/sandbox-runtime-capability-inventory.md
+++ b/Docs/Sandbox/sandbox-runtime-capability-inventory.md
@@ -44,6 +44,8 @@ concepts:
   claims, independent of current host availability.
 - `untrusted_eligible`: whether policy may admit this runtime for `untrusted`
   workloads when preflight and host readiness also pass.
+- `network_policy_contract`: static posture for `deny_all` and `allowlist`
+  support, strict enforcement, and current-readiness source.
 
 | Runtime | `implementation_state` | Discovery source |
 | --- | --- | --- |
@@ -139,6 +141,12 @@ separate persisted state machine.
 
 ## Network Policy Support
 
+Runtime discovery exposes `network_policy_contract` as static posture metadata.
+It does not replace `available`, raw `reasons`, `normalized_reasons`, or
+`enforcement_ready`, which remain current host/preflight truth. The contract
+uses the same support-state vocabulary as this inventory and records whether a
+policy can ever be strictly enforced by the runtime.
+
 | Runtime | `deny_all` | `allowlist` | Notes |
 | --- | --- | --- | --- |
 | `docker` | `supported` | `host_gated` | Deny-all can use container network isolation. Allowlist depends on configured egress enforcement. |
@@ -148,6 +156,16 @@ separate persisted state machine.
 | `vz_macos` | `scaffold` | `unsupported` | No real execution yet. |
 | `seatbelt` | `unsupported` | `unsupported` | Deny-all is best effort and must not be reported as strict enforcement. |
 | `worktree` | `unsupported` | `unsupported` | Host-local process execution does not provide strict network isolation. |
+
+| Runtime | `deny_all` strict | `deny_all` readiness source | `allowlist` strict | `allowlist` readiness source |
+| --- | --- | --- | --- | --- |
+| `docker` | `true` | `config` | `true` | `config` |
+| `firecracker` | `true` | `runtime_preflight` | `false` | `runtime_preflight` |
+| `lima` | `true` | `runtime_preflight` | `false` | `not_applicable` |
+| `vz_linux` | `true` | `runtime_preflight` | `false` | `not_applicable` |
+| `vz_macos` | `false` | `runtime_preflight` | `false` | `not_applicable` |
+| `seatbelt` | `false` | `not_applicable` | `false` | `not_applicable` |
+| `worktree` | `false` | `not_applicable` | `false` | `not_applicable` |
 
 ## Execution And Lifecycle Support
 
@@ -200,6 +218,8 @@ an equally clear ownership model.
 - Keep `/api/v1/sandbox/runtimes` aligned with `RuntimeType`.
 - Do not use `available=true` as proof of a security guarantee.
 - Do not classify `seatbelt` or `worktree` as `untrusted`-eligible.
+- Add network policy metadata for every runtime and keep it separate from
+  current `enforcement_ready` host/preflight truth.
 - Prefer `unsupported` over ambiguous wording when a guarantee cannot be
   proven.
 - Update this document before expanding `vz_macos`, Apple `containerization`,

--- a/Docs/Sandbox/sandbox-security-policy-matrix.md
+++ b/Docs/Sandbox/sandbox-security-policy-matrix.md
@@ -31,10 +31,11 @@ specific runtime today.
 | `strict allowlist` | Runtime networking permits only explicitly configured destinations and blocks all others. |
 | `scaffold` | Shape exists, but the guarantee is not ready for normal operator use. |
 
-Public runtime discovery exposes these concepts through `boundary_class`,
-`vm_grade_isolation`, and `untrusted_eligible`. Those fields describe policy
-posture and boundary category; they do not replace current-host `available`,
-`reasons`, or runtime preflight checks.
+Public runtime discovery exposes isolation concepts through `boundary_class`,
+`vm_grade_isolation`, and `untrusted_eligible`. It exposes network posture
+through `network_policy_contract`. These fields describe static policy posture;
+they do not replace current-host `available`, `reasons`, `enforcement_ready`,
+or runtime preflight checks.
 
 ## Trust-Level Eligibility
 
@@ -65,6 +66,11 @@ Policy requirements:
 Network policy names are request semantics, not proof that every runtime can
 enforce them. Public discovery and diagnostics must report enforcement
 readiness separately from runtime availability.
+
+`network_policy_contract` is the static machine-readable version of this table.
+It records each policy's support state, whether strict enforcement is possible,
+and whether current readiness should be read from runtime preflight, operator
+configuration, or nowhere because the policy is unsupported.
 
 | Runtime | `deny_all` semantics | `allowlist` semantics | Operator rule |
 | --- | --- | --- | --- |
@@ -156,5 +162,7 @@ diagnostic paths.
 - Keep `sandbox-runtime-capability-inventory.md` as the current support-state
   inventory and this document as the security contract.
 - Add focused tests when a row describes a fail-closed admission rule.
+- Keep `network_policy_contract` aligned with the Network Semantics table, and
+  do not use current `enforcement_ready` values as static security claims.
 - Prefer explicit `unsupported` reasons over ambiguous best-effort language.
 - Do not use `available=true` as proof of a security guarantee.

--- a/Docs/superpowers/plans/2026-05-04-sandbox-network-policy-metadata-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-04-sandbox-network-policy-metadata-implementation-plan.md
@@ -1,0 +1,164 @@
+# Sandbox Network Policy Metadata Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add structured sandbox runtime network policy metadata to runtime discovery.
+
+**Architecture:** Reuse the existing runtime-capability metadata pattern. Add a static metadata map in `runtime_capabilities.py`, project it through `SandboxService.feature_discovery()`, type it in `SandboxRuntimeInfo`, and update docs/tests to keep the contract synchronized.
+
+**Tech Stack:** Python 3.11, FastAPI/Pydantic, pytest, Backlog.md.
+
+---
+
+## Files
+
+- Modify: `tldw_Server_API/app/core/Sandbox/runtime_capabilities.py`
+- Modify: `tldw_Server_API/app/core/Sandbox/service.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py`
+- Modify: `tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py`
+- Modify: `tldw_Server_API/tests/Docs/test_sandbox_public_docs_contract.py`
+- Modify: `Docs/API-related/Sandbox_API.md`
+- Modify: `Docs/Published/API-related/Sandbox_API.md`
+- Modify: `Docs/Sandbox/sandbox-runtime-capability-inventory.md`
+- Modify: `Docs/Sandbox/sandbox-security-policy-matrix.md`
+- Modify: `backlog/tasks/task-44 - Expose-sandbox-runtime-network-policy-metadata.md`
+
+## Task 1: Contract Tests
+
+**Files:**
+- Modify: `tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py`
+- Modify: `tldw_Server_API/tests/Docs/test_sandbox_public_docs_contract.py`
+
+- [ ] **Step 1: Add failing runtime metadata tests**
+
+Add tests that import `RUNTIME_NETWORK_POLICY_METADATA` and
+`runtime_network_policy_metadata`, then assert:
+
+- `set(RUNTIME_NETWORK_POLICY_METADATA) == set(RuntimeType)`
+- `runtime_network_policy_metadata("future_runtime")` raises `ValueError`
+- discovery includes `network_policy_contract` for every runtime
+- `seatbelt` and `worktree` report both policies as unsupported
+- `vz_linux` reports host-gated strict `deny_all` and unsupported `allowlist`
+
+- [ ] **Step 2: Add failing schema contract test**
+
+Assert `SandboxRuntimeInfo.model_json_schema()` requires
+`network_policy_contract` and the field is not nullable.
+
+- [ ] **Step 3: Run focused tests and confirm RED**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py \
+  tldw_Server_API/tests/Docs/test_sandbox_public_docs_contract.py \
+  -q --timeout=60
+```
+
+Expected: fail because the metadata map and schema field do not exist.
+
+## Task 2: Runtime Metadata And Discovery
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Sandbox/runtime_capabilities.py`
+- Modify: `tldw_Server_API/app/core/Sandbox/service.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py`
+
+- [ ] **Step 1: Add metadata types and map**
+
+Add `RuntimeNetworkPolicySupportState`, `RuntimeNetworkPolicyReadinessSource`,
+`RuntimeNetworkPolicyModeMetadata`, and `RuntimeNetworkPolicyMetadata`.
+
+- [ ] **Step 2: Add complete metadata map**
+
+Add `RUNTIME_NETWORK_POLICY_METADATA` for every `RuntimeType` using the design
+table from `2026-05-04-sandbox-network-policy-metadata-design.md`.
+
+- [ ] **Step 3: Add import-time completeness validation**
+
+Mirror the isolation metadata validation pattern and raise `RuntimeError` with
+missing/extra runtime keys.
+
+- [ ] **Step 4: Add safe accessor**
+
+Add `runtime_network_policy_metadata(runtime)` that coerces string inputs and
+raises `ValueError` for unknown or missing runtime metadata.
+
+- [ ] **Step 5: Wire discovery**
+
+In `SandboxService.feature_discovery()`, add `network_policy_contract` to
+`_preflight_fields()` from the static accessor. Do not remove existing
+readiness booleans.
+
+- [ ] **Step 6: Type schema**
+
+Add Pydantic models for policy mode metadata and the contract field. Mark
+`network_policy_contract` required on `SandboxRuntimeInfo`.
+
+- [ ] **Step 7: Run focused tests and confirm GREEN**
+
+Run the same focused pytest command. Expected: pass.
+
+## Task 3: Documentation And Verification
+
+**Files:**
+- Modify: `Docs/API-related/Sandbox_API.md`
+- Modify: `Docs/Published/API-related/Sandbox_API.md`
+- Modify: `Docs/Sandbox/sandbox-runtime-capability-inventory.md`
+- Modify: `Docs/Sandbox/sandbox-security-policy-matrix.md`
+- Modify: `backlog/tasks/task-44 - Expose-sandbox-runtime-network-policy-metadata.md`
+
+- [ ] **Step 1: Update public API docs**
+
+Document `network_policy_contract` as static security posture metadata and
+state that `enforcement_ready` remains current host readiness.
+
+- [ ] **Step 2: Update inventory and security matrix**
+
+Add maintenance text requiring updates when runtime/network policy contracts
+change. Ensure host-local negative claims are explicit.
+
+- [ ] **Step 3: Run focused tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py \
+  tldw_Server_API/tests/Docs/test_sandbox_public_docs_contract.py \
+  -q --timeout=60
+```
+
+- [ ] **Step 4: Run Bandit on touched Python files**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit \
+  -r tldw_Server_API/app/core/Sandbox/runtime_capabilities.py \
+     tldw_Server_API/app/core/Sandbox/service.py \
+     tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py \
+  -f json -o /tmp/bandit_sandbox_network_policy_metadata.json
+```
+
+- [ ] **Step 5: Run whitespace check**
+
+Run:
+
+```bash
+git diff --check
+```
+
+- [ ] **Step 6: Finalize Backlog task**
+
+Check acceptance criteria, record verification, and add final summary.
+
+- [ ] **Step 7: Commit**
+
+Commit all changes with:
+
+```bash
+git add Docs tldw_Server_API backlog
+git commit -m "feat(sandbox): expose network policy metadata"
+```

--- a/Docs/superpowers/specs/2026-05-04-sandbox-network-policy-metadata-design.md
+++ b/Docs/superpowers/specs/2026-05-04-sandbox-network-policy-metadata-design.md
@@ -1,0 +1,110 @@
+# Sandbox Network Policy Metadata Design
+
+**Status:** Approved implementation design.
+**Date:** 2026-05-04.
+**Task:** TASK-44.
+
+## Goal
+
+Expose a structured, machine-readable network policy contract in sandbox runtime
+discovery so clients can distinguish static runtime guarantees from current host
+readiness.
+
+This is an additive follow-up to runtime implementation state, normalized reason
+codes, and runtime isolation metadata. It should not change admission behavior
+or remove existing discovery fields.
+
+## Current Problem
+
+`/api/v1/sandbox/runtimes` already exposes compatibility/readiness booleans:
+
+- `strict_deny_all_supported`
+- `strict_allowlist_supported`
+- `enforcement_ready`
+- `egress_allowlist_supported`
+
+Those fields are useful, but they mix static security posture, current host
+preflight, and runtime-specific implementation details. That makes it hard for
+clients and ACP callers to know whether a runtime is fundamentally capable of a
+policy, merely host-gated, scaffold-only, or explicitly unsupported.
+
+## Design
+
+Add static network policy metadata to `runtime_capabilities.py`, keyed by
+`RuntimeType`, with import-time completeness validation.
+
+Each runtime exposes `network_policy_contract` in discovery:
+
+```json
+{
+  "deny_all": {
+    "support_state": "host_gated",
+    "strict_enforcement": true,
+    "readiness_source": "runtime_preflight"
+  },
+  "allowlist": {
+    "support_state": "unsupported",
+    "strict_enforcement": false,
+    "readiness_source": "not_applicable"
+  }
+}
+```
+
+The support-state vocabulary reuses the roadmap maturity vocabulary:
+`supported`, `unsupported`, `scaffold`, `host_gated`, and `not_applicable`.
+
+The readiness-source vocabulary is intentionally small:
+
+- `runtime_preflight`: current readiness comes from runtime preflight truth
+- `config`: readiness depends primarily on server/operator configuration
+- `not_applicable`: no runtime readiness is meaningful because unsupported
+
+Existing booleans remain for compatibility. The new contract is the stable,
+static policy posture. Existing fields continue to summarize current readiness
+or legacy client expectations.
+
+## Runtime Contract
+
+| Runtime | `deny_all` | `allowlist` |
+| --- | --- | --- |
+| `docker` | `supported`, strict, config/preflight summarized by existing fields | `host_gated`, strict, config |
+| `firecracker` | `host_gated`, strict, runtime preflight | `scaffold`, not strict, runtime preflight |
+| `lima` | `host_gated`, strict, runtime preflight | `unsupported`, not strict, not applicable |
+| `vz_linux` | `host_gated`, strict, runtime preflight | `unsupported`, not strict, not applicable |
+| `vz_macos` | `scaffold`, not strict, runtime preflight | `unsupported`, not strict, not applicable |
+| `seatbelt` | `unsupported`, not strict, not applicable | `unsupported`, not strict, not applicable |
+| `worktree` | `unsupported`, not strict, not applicable | `unsupported`, not strict, not applicable |
+
+## Guardrails
+
+- Do not use `available=true` as proof of a network security guarantee.
+- Do not imply `seatbelt` or `worktree` provide strict egress isolation.
+- Do not imply `vz_macos` has real strict enforcement before real execution
+  exists.
+- Do not make Docker look VM-grade; this metadata only describes network
+  policy semantics.
+- Treat the map like isolation metadata: adding a `RuntimeType` without
+  metadata should fail fast at import time.
+
+## Testing
+
+Add focused tests for:
+
+- map completeness against `RuntimeType`
+- unknown runtime rejection
+- discovery payload includes `network_policy_contract` for every runtime
+- host-local runtimes report unsupported strict network policy contracts
+- `vz_linux` reports host-gated strict `deny_all` and unsupported `allowlist`
+- schema marks the new field required and non-nullable
+
+## Documentation
+
+Update:
+
+- `Docs/API-related/Sandbox_API.md`
+- `Docs/Published/API-related/Sandbox_API.md`
+- `Docs/Sandbox/sandbox-runtime-capability-inventory.md`
+- `Docs/Sandbox/sandbox-security-policy-matrix.md`
+
+The docs should state that the contract is static posture metadata, while
+runtime preflight remains the source of current host readiness.

--- a/backlog/tasks/task-44 - Expose-sandbox-runtime-network-policy-metadata.md
+++ b/backlog/tasks/task-44 - Expose-sandbox-runtime-network-policy-metadata.md
@@ -4,7 +4,7 @@ title: Expose sandbox runtime network policy metadata
 status: Done
 assignee: []
 created_date: '2026-05-04 14:58'
-updated_date: '2026-05-04 15:06'
+updated_date: '2026-05-05 00:16'
 labels:
   - sandbox
   - runtime-discovery
@@ -48,6 +48,10 @@ Add a structured, machine-readable network policy contract to sandbox runtime di
 Approved design reviewed for risk before implementation. Main adjustments: use network_policy_contract with support_state, strict_enforcement, and readiness_source; keep existing readiness booleans for compatibility; avoid implying availability is a security guarantee.
 
 Verification: focused runtime inventory/docs tests passed: 19 passed, 2 warnings. Bandit on touched Python sandbox/schema files reported 0 findings. git diff --check passed.
+
+PR review pass: Qodo opened four active threads on PR #1269. Verified against current branch: missing class docstrings, two PEP8 wrapping issues, and runtime_network_policy_metadata signature mismatch all apply and will be fixed in this branch.
+
+PR review fixes applied: added class docstrings for the new Pydantic models, wrapped the long metadata declaration and ValueError line, changed runtime_network_policy_metadata to accept RuntimeType | str, and removed the now-unneeded test type ignore. Verification after fixes: focused tests 19 passed, 2 warnings; Bandit 0 findings; git diff --check passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-44 - Expose-sandbox-runtime-network-policy-metadata.md
+++ b/backlog/tasks/task-44 - Expose-sandbox-runtime-network-policy-metadata.md
@@ -1,0 +1,67 @@
+---
+id: TASK-44
+title: Expose sandbox runtime network policy metadata
+status: Done
+assignee: []
+created_date: '2026-05-04 14:58'
+updated_date: '2026-05-04 15:06'
+labels:
+  - sandbox
+  - runtime-discovery
+  - network-policy
+dependencies: []
+documentation:
+  - Docs/Sandbox/sandbox-architecture-doctrine.md
+  - Docs/Sandbox/sandbox-runtime-capability-inventory.md
+  - Docs/Sandbox/sandbox-security-policy-matrix.md
+  - Docs/superpowers/specs/2026-05-04-sandbox-network-policy-metadata-design.md
+  - >-
+    Docs/superpowers/plans/2026-05-04-sandbox-network-policy-metadata-implementation-plan.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add a structured, machine-readable network policy contract to sandbox runtime discovery. The contract must separate static security guarantees from current host readiness, preserve existing compatibility booleans, and align with the sandbox architecture doctrine, runtime capability inventory, and security policy matrix.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Each RuntimeType has static network policy metadata with import-time completeness validation.
+- [x] #2 Runtime discovery includes required network_policy_contract fields for deny_all and allowlist without removing existing compatibility fields.
+- [x] #3 Host-local runtimes seatbelt and worktree machine-report strict deny_all and allowlist as unsupported.
+- [x] #4 vz_linux reports deny_all as host-gated strict and allowlist as unsupported without implying network readiness from availability.
+- [x] #5 Public API docs, published API docs, runtime capability inventory, and security policy matrix describe the new contract and warn that availability is not a security guarantee.
+- [x] #6 Focused tests cover metadata completeness, discovery payload shape, host-local negative claims, and schema requirements.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing contract/schema tests for network policy metadata. 2. Add runtime metadata map, validation, safe accessor, discovery projection, and schema models. 3. Update public docs and sandbox contract docs. 4. Run focused pytest, Bandit, and git diff --check before finalizing.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Approved design reviewed for risk before implementation. Main adjustments: use network_policy_contract with support_state, strict_enforcement, and readiness_source; keep existing readiness booleans for compatibility; avoid implying availability is a security guarantee.
+
+Verification: focused runtime inventory/docs tests passed: 19 passed, 2 warnings. Bandit on touched Python sandbox/schema files reported 0 findings. git diff --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added a structured sandbox runtime network_policy_contract to runtime discovery, with complete runtime metadata, schema coverage, focused tests, and public/operator documentation. The contract separates static runtime network-policy posture from current host readiness while preserving existing compatibility booleans.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
@@ -14,6 +14,8 @@ from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
 from tldw_Server_API.app.core.Sandbox.runtime_capabilities import (
     RuntimeBoundaryClass,
     RuntimeImplementationState,
+    RuntimeNetworkPolicyReadinessSource,
+    RuntimeNetworkPolicySupportState,
     RuntimeReasonCode,
 )
 from tldw_Server_API.app.core.Sandbox.run_status_taxonomy import RunStatusReasonCode
@@ -28,6 +30,35 @@ RuntimeType = Literal[
     "worktree",
 ]
 TrustLevelType = Literal["trusted", "standard", "untrusted"]
+
+
+class SandboxRuntimeNetworkPolicyModeInfo(BaseModel):
+    support_state: RuntimeNetworkPolicySupportState = Field(
+        ...,
+        description=(
+            "Static support state for this runtime/network-policy pair: "
+            "supported, unsupported, scaffold, host_gated, or not_applicable"
+        ),
+    )
+    strict_enforcement: bool = Field(
+        ...,
+        description=(
+            "Whether the runtime can provide strict enforcement for this policy "
+            "when its support and readiness requirements are satisfied"
+        ),
+    )
+    readiness_source: RuntimeNetworkPolicyReadinessSource = Field(
+        ...,
+        description=(
+            "Where current readiness should be read from: runtime_preflight, "
+            "config, or not_applicable"
+        ),
+    )
+
+
+class SandboxRuntimeNetworkPolicyContract(BaseModel):
+    deny_all: SandboxRuntimeNetworkPolicyModeInfo
+    allowlist: SandboxRuntimeNetworkPolicyModeInfo
 
 
 def _default_offset_pagination_aliases(response):
@@ -85,6 +116,13 @@ class SandboxRuntimeInfo(BaseModel):
         description=(
             "Whether policy may admit this runtime for untrusted workloads when "
             "preflight and host readiness also pass"
+        ),
+    )
+    network_policy_contract: SandboxRuntimeNetworkPolicyContract = Field(
+        ...,
+        description=(
+            "Static runtime network policy posture; current host readiness remains "
+            "in enforcement_ready and runtime preflight reasons"
         ),
     )
     supported_spec_versions: list[str] = Field(default_factory=lambda: ["1.0"], description="Supported spec versions (e.g., ['1.0','1.1'] when 1.1 features are enabled)")

--- a/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
@@ -33,6 +33,8 @@ TrustLevelType = Literal["trusted", "standard", "untrusted"]
 
 
 class SandboxRuntimeNetworkPolicyModeInfo(BaseModel):
+    """Static network policy posture for one runtime policy mode."""
+
     support_state: RuntimeNetworkPolicySupportState = Field(
         ...,
         description=(
@@ -57,6 +59,8 @@ class SandboxRuntimeNetworkPolicyModeInfo(BaseModel):
 
 
 class SandboxRuntimeNetworkPolicyContract(BaseModel):
+    """Static deny-all and allowlist network policy posture for a runtime."""
+
     deny_all: SandboxRuntimeNetworkPolicyModeInfo
     allowlist: SandboxRuntimeNetworkPolicyModeInfo
 

--- a/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
+++ b/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
@@ -18,6 +18,18 @@ RuntimeBoundaryClass = Literal[
     "vm_grade",
     "vm_grade_scaffold",
 ]
+RuntimeNetworkPolicySupportState = Literal[
+    "supported",
+    "unsupported",
+    "scaffold",
+    "host_gated",
+    "not_applicable",
+]
+RuntimeNetworkPolicyReadinessSource = Literal[
+    "runtime_preflight",
+    "config",
+    "not_applicable",
+]
 RuntimeReasonCode = Literal[
     "runtime_unavailable",
     "unsupported_os",
@@ -54,6 +66,36 @@ class RuntimeIsolationMetadata:
     boundary_class: RuntimeBoundaryClass
     vm_grade_isolation: bool
     untrusted_eligible: bool
+
+
+@dataclass(frozen=True)
+class RuntimeNetworkPolicyModeMetadata:
+    """Static network policy posture for one runtime policy mode."""
+
+    support_state: RuntimeNetworkPolicySupportState
+    strict_enforcement: bool
+    readiness_source: RuntimeNetworkPolicyReadinessSource
+
+    def as_dict(self) -> dict[str, str | bool]:
+        return {
+            "support_state": self.support_state,
+            "strict_enforcement": self.strict_enforcement,
+            "readiness_source": self.readiness_source,
+        }
+
+
+@dataclass(frozen=True)
+class RuntimeNetworkPolicyMetadata:
+    """Machine-readable network policy contract for runtime discovery."""
+
+    deny_all: RuntimeNetworkPolicyModeMetadata
+    allowlist: RuntimeNetworkPolicyModeMetadata
+
+    def as_dict(self) -> dict[str, dict[str, str | bool]]:
+        return {
+            "deny_all": self.deny_all.as_dict(),
+            "allowlist": self.allowlist.as_dict(),
+        }
 
 
 RUNTIME_ISOLATION_METADATA: Mapping[RuntimeType, RuntimeIsolationMetadata] = {
@@ -95,6 +137,94 @@ RUNTIME_ISOLATION_METADATA: Mapping[RuntimeType, RuntimeIsolationMetadata] = {
 }
 
 
+RUNTIME_NETWORK_POLICY_METADATA: Mapping[RuntimeType, RuntimeNetworkPolicyMetadata] = {
+    RuntimeType.docker: RuntimeNetworkPolicyMetadata(
+        deny_all=RuntimeNetworkPolicyModeMetadata(
+            support_state="supported",
+            strict_enforcement=True,
+            readiness_source="config",
+        ),
+        allowlist=RuntimeNetworkPolicyModeMetadata(
+            support_state="host_gated",
+            strict_enforcement=True,
+            readiness_source="config",
+        ),
+    ),
+    RuntimeType.firecracker: RuntimeNetworkPolicyMetadata(
+        deny_all=RuntimeNetworkPolicyModeMetadata(
+            support_state="host_gated",
+            strict_enforcement=True,
+            readiness_source="runtime_preflight",
+        ),
+        allowlist=RuntimeNetworkPolicyModeMetadata(
+            support_state="scaffold",
+            strict_enforcement=False,
+            readiness_source="runtime_preflight",
+        ),
+    ),
+    RuntimeType.lima: RuntimeNetworkPolicyMetadata(
+        deny_all=RuntimeNetworkPolicyModeMetadata(
+            support_state="host_gated",
+            strict_enforcement=True,
+            readiness_source="runtime_preflight",
+        ),
+        allowlist=RuntimeNetworkPolicyModeMetadata(
+            support_state="unsupported",
+            strict_enforcement=False,
+            readiness_source="not_applicable",
+        ),
+    ),
+    RuntimeType.vz_linux: RuntimeNetworkPolicyMetadata(
+        deny_all=RuntimeNetworkPolicyModeMetadata(
+            support_state="host_gated",
+            strict_enforcement=True,
+            readiness_source="runtime_preflight",
+        ),
+        allowlist=RuntimeNetworkPolicyModeMetadata(
+            support_state="unsupported",
+            strict_enforcement=False,
+            readiness_source="not_applicable",
+        ),
+    ),
+    RuntimeType.vz_macos: RuntimeNetworkPolicyMetadata(
+        deny_all=RuntimeNetworkPolicyModeMetadata(
+            support_state="scaffold",
+            strict_enforcement=False,
+            readiness_source="runtime_preflight",
+        ),
+        allowlist=RuntimeNetworkPolicyModeMetadata(
+            support_state="unsupported",
+            strict_enforcement=False,
+            readiness_source="not_applicable",
+        ),
+    ),
+    RuntimeType.seatbelt: RuntimeNetworkPolicyMetadata(
+        deny_all=RuntimeNetworkPolicyModeMetadata(
+            support_state="unsupported",
+            strict_enforcement=False,
+            readiness_source="not_applicable",
+        ),
+        allowlist=RuntimeNetworkPolicyModeMetadata(
+            support_state="unsupported",
+            strict_enforcement=False,
+            readiness_source="not_applicable",
+        ),
+    ),
+    RuntimeType.worktree: RuntimeNetworkPolicyMetadata(
+        deny_all=RuntimeNetworkPolicyModeMetadata(
+            support_state="unsupported",
+            strict_enforcement=False,
+            readiness_source="not_applicable",
+        ),
+        allowlist=RuntimeNetworkPolicyModeMetadata(
+            support_state="unsupported",
+            strict_enforcement=False,
+            readiness_source="not_applicable",
+        ),
+    ),
+}
+
+
 def _validate_runtime_isolation_metadata_map() -> None:
     expected = set(RuntimeType)
     actual = set(RUNTIME_ISOLATION_METADATA)
@@ -107,7 +237,20 @@ def _validate_runtime_isolation_metadata_map() -> None:
         )
 
 
+def _validate_runtime_network_policy_metadata_map() -> None:
+    expected = set(RuntimeType)
+    actual = set(RUNTIME_NETWORK_POLICY_METADATA)
+    missing = sorted(runtime.value for runtime in expected - actual)
+    extra = sorted(str(runtime) for runtime in actual - expected)
+    if missing or extra:
+        raise RuntimeError(
+            "Runtime network policy metadata map is incomplete: "
+            f"missing={missing}, extra={extra}"
+        )
+
+
 _validate_runtime_isolation_metadata_map()
+_validate_runtime_network_policy_metadata_map()
 
 
 _RUNTIME_REASON_CODE_MAP: Mapping[str, RuntimeReasonCode] = {
@@ -165,6 +308,19 @@ def runtime_isolation_metadata(runtime: RuntimeType) -> RuntimeIsolationMetadata
     metadata = RUNTIME_ISOLATION_METADATA.get(runtime_key)
     if metadata is None:
         raise ValueError(f"No isolation metadata configured for runtime {runtime!r}")
+    return metadata
+
+
+def runtime_network_policy_metadata(runtime: RuntimeType) -> RuntimeNetworkPolicyMetadata:
+    """Return stable network policy posture metadata, independent of host availability."""
+    try:
+        runtime_key = runtime if isinstance(runtime, RuntimeType) else RuntimeType(runtime)
+    except ValueError as exc:
+        raise ValueError(f"No network policy metadata configured for runtime {runtime!r}") from exc
+
+    metadata = RUNTIME_NETWORK_POLICY_METADATA.get(runtime_key)
+    if metadata is None:
+        raise ValueError(f"No network policy metadata configured for runtime {runtime!r}")
     return metadata
 
 

--- a/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
+++ b/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
@@ -137,7 +137,10 @@ RUNTIME_ISOLATION_METADATA: Mapping[RuntimeType, RuntimeIsolationMetadata] = {
 }
 
 
-RUNTIME_NETWORK_POLICY_METADATA: Mapping[RuntimeType, RuntimeNetworkPolicyMetadata] = {
+RUNTIME_NETWORK_POLICY_METADATA: Mapping[
+    RuntimeType,
+    RuntimeNetworkPolicyMetadata,
+] = {
     RuntimeType.docker: RuntimeNetworkPolicyMetadata(
         deny_all=RuntimeNetworkPolicyModeMetadata(
             support_state="supported",
@@ -311,12 +314,16 @@ def runtime_isolation_metadata(runtime: RuntimeType) -> RuntimeIsolationMetadata
     return metadata
 
 
-def runtime_network_policy_metadata(runtime: RuntimeType) -> RuntimeNetworkPolicyMetadata:
+def runtime_network_policy_metadata(
+    runtime: RuntimeType | str,
+) -> RuntimeNetworkPolicyMetadata:
     """Return stable network policy posture metadata, independent of host availability."""
     try:
         runtime_key = runtime if isinstance(runtime, RuntimeType) else RuntimeType(runtime)
     except ValueError as exc:
-        raise ValueError(f"No network policy metadata configured for runtime {runtime!r}") from exc
+        raise ValueError(
+            f"No network policy metadata configured for runtime {runtime!r}"
+        ) from exc
 
     metadata = RUNTIME_NETWORK_POLICY_METADATA.get(runtime_key)
     if metadata is None:

--- a/tldw_Server_API/app/core/Sandbox/service.py
+++ b/tldw_Server_API/app/core/Sandbox/service.py
@@ -61,6 +61,7 @@ from .runtime_capabilities import (
     normalize_runtime_reasons,
     runtime_isolation_metadata,
     runtime_implementation_state,
+    runtime_network_policy_metadata,
 )
 from .snapshots import SnapshotManager
 from .store import get_store_mode
@@ -876,6 +877,7 @@ class SandboxService:
             enforcement_ready = dict((preflight.enforcement_ready if preflight else {}) or {})
             reasons = list((preflight.reasons if preflight else []) or [])
             isolation = runtime_isolation_metadata(runtime)
+            network_contract = runtime_network_policy_metadata(runtime)
             return {
                 "available": bool(preflight.available) if preflight is not None else False,
                 "reasons": reasons,
@@ -888,6 +890,7 @@ class SandboxService:
                 "boundary_class": isolation.boundary_class,
                 "vm_grade_isolation": isolation.vm_grade_isolation,
                 "untrusted_eligible": isolation.untrusted_eligible,
+                "network_policy_contract": network_contract.as_dict(),
             }
 
         return [

--- a/tldw_Server_API/tests/Docs/test_sandbox_public_docs_contract.py
+++ b/tldw_Server_API/tests/Docs/test_sandbox_public_docs_contract.py
@@ -63,6 +63,7 @@ def test_public_sandbox_api_docs_do_not_overclaim_runtime_support(doc_path: Path
         "boundary_class",
         "vm_grade_isolation",
         "untrusted_eligible",
+        "network_policy_contract",
     ):
         _require(
             field_name in text,
@@ -121,3 +122,19 @@ def test_sandbox_runtime_isolation_schema_fields_are_required() -> None:
             "'type': 'null'" not in serialized,
             f"SandboxRuntimeInfo field {field_name} should not be nullable",
         )
+
+
+def test_sandbox_runtime_network_policy_schema_field_is_required() -> None:
+    schema = SandboxRuntimeInfo.model_json_schema()
+    required = set(schema.get("required", []))
+
+    _require(
+        "network_policy_contract" in required,
+        "SandboxRuntimeInfo should require network_policy_contract",
+    )
+    field_schema = schema["properties"]["network_policy_contract"]
+    serialized = str(field_schema)
+    _require(
+        "'type': 'null'" not in serialized,
+        "SandboxRuntimeInfo field network_policy_contract should not be nullable",
+    )

--- a/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
+++ b/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from tldw_Server_API.app.core.Sandbox.models import RuntimeType
+from tldw_Server_API.app.core.Sandbox import runtime_capabilities as runtime_caps
 from tldw_Server_API.app.core.Sandbox.runtime_capabilities import (
     RUNTIME_ISOLATION_METADATA,
     RuntimePreflightResult,
@@ -83,6 +84,64 @@ def test_runtime_isolation_metadata_contract_covers_runtime_enum() -> None:
 def test_runtime_isolation_metadata_rejects_unknown_runtime() -> None:
     with pytest.raises(ValueError, match="No isolation metadata configured"):
         runtime_isolation_metadata("future_runtime")  # type: ignore[arg-type]
+
+
+def test_feature_discovery_reports_structured_network_policy_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SANDBOX_STORE_BACKEND", "memory")
+
+    discovery = {
+        str(item.get("name")): item
+        for item in SandboxService().feature_discovery()
+    }
+
+    assert set(discovery) == {runtime.value for runtime in RuntimeType}
+    for runtime in RuntimeType:
+        contract = discovery[runtime.value]["network_policy_contract"]
+        assert set(contract) == {"deny_all", "allowlist"}
+        for mode in ("deny_all", "allowlist"):
+            assert set(contract[mode]) == {
+                "support_state",
+                "strict_enforcement",
+                "readiness_source",
+            }
+
+    for host_local_runtime in ("seatbelt", "worktree"):
+        contract = discovery[host_local_runtime]["network_policy_contract"]
+        assert contract["deny_all"] == {
+            "support_state": "unsupported",
+            "strict_enforcement": False,
+            "readiness_source": "not_applicable",
+        }
+        assert contract["allowlist"] == {
+            "support_state": "unsupported",
+            "strict_enforcement": False,
+            "readiness_source": "not_applicable",
+        }
+
+    vz_linux_contract = discovery["vz_linux"]["network_policy_contract"]
+    assert vz_linux_contract["deny_all"] == {
+        "support_state": "host_gated",
+        "strict_enforcement": True,
+        "readiness_source": "runtime_preflight",
+    }
+    assert vz_linux_contract["allowlist"] == {
+        "support_state": "unsupported",
+        "strict_enforcement": False,
+        "readiness_source": "not_applicable",
+    }
+
+
+def test_runtime_network_policy_metadata_contract_covers_runtime_enum() -> None:
+    assert hasattr(runtime_caps, "RUNTIME_NETWORK_POLICY_METADATA")
+    assert set(runtime_caps.RUNTIME_NETWORK_POLICY_METADATA) == set(RuntimeType)
+
+
+def test_runtime_network_policy_metadata_rejects_unknown_runtime() -> None:
+    assert hasattr(runtime_caps, "runtime_network_policy_metadata")
+    with pytest.raises(ValueError, match="No network policy metadata configured"):
+        runtime_caps.runtime_network_policy_metadata("future_runtime")  # type: ignore[attr-defined]
 
 
 def test_runtime_reason_normalization_maps_raw_runtime_reasons() -> None:

--- a/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
+++ b/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
@@ -141,7 +141,7 @@ def test_runtime_network_policy_metadata_contract_covers_runtime_enum() -> None:
 def test_runtime_network_policy_metadata_rejects_unknown_runtime() -> None:
     assert hasattr(runtime_caps, "runtime_network_policy_metadata")
     with pytest.raises(ValueError, match="No network policy metadata configured"):
-        runtime_caps.runtime_network_policy_metadata("future_runtime")  # type: ignore[attr-defined]
+        runtime_caps.runtime_network_policy_metadata("future_runtime")
 
 
 def test_runtime_reason_normalization_maps_raw_runtime_reasons() -> None:


### PR DESCRIPTION
## Summary

- Add a machine-readable `network_policy_contract` to sandbox runtime discovery and API schema.
- Cover `deny_all` and `allowlist` posture with `support_state`, `strict_enforcement`, and `readiness_source` for every `RuntimeType`.
- Keep existing readiness/compatibility booleans intact while documenting that `available` is not a security guarantee.
- Update sandbox API docs, runtime capability inventory, security policy matrix, design plan, and Backlog task.

## Verification

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py tldw_Server_API/tests/Docs/test_sandbox_public_docs_contract.py -q --timeout=60`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Sandbox/runtime_capabilities.py tldw_Server_API/app/core/Sandbox/service.py tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py -f json -o /tmp/bandit_sandbox_network_policy_metadata_rebased.json` (`0` findings)
- `git diff --check origin/dev...HEAD`

## Merge Note

Repo policy still requires a human-authored Change summary before merge.
