### PR TITLE
Add CodeGraph context and impact tools

### DIFF
--- a/Docs/superpowers/plans/2026-05-04-native-codegraph-context-impact-tools-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-04-native-codegraph-context-impact-tools-implementation-plan.md
@@ -123,7 +123,7 @@ The initial query can be the first useful task phrase after trimming. Keep it si
 - Modify `tldw_Server_API/app/core/DB_Management/codegraph/repository.py`
 - Test `tldw_Server_API/tests/CodeGraph/test_codegraph_repository.py`
 
-- [ ] **Step 1: Write failing repository traversal tests**
+ **Step 1: Write failing repository traversal tests**
 
 Add tests that seed a graph `entry -> helper -> leaf`, plus an incoming caller to `helper`, then assert:
 
@@ -142,7 +142,7 @@ assert impact.truncated is True
 assert len(impact.relationships) == 1
 ```
 
-- [ ] **Step 2: Run RED test**
+ **Step 2: Run RED test**
 
 Run:
 
@@ -155,7 +155,7 @@ Run:
 
 Expected: fail because `traverse_impact` does not exist.
 
-- [ ] **Step 3: Implement minimal repository helper**
+ **Step 3: Implement minimal repository helper**
 
 Add a small frozen dataclass or dict return value near repository helpers:
 
@@ -179,11 +179,11 @@ Rules:
 - Stop once `limit + 1` relationships are collected so truncation can be reported
 - Reuse `_relationship_from_joined_row()` style payloads for consistency
 
-- [ ] **Step 4: Run GREEN test**
+ **Step 4: Run GREEN test**
 
 Run the two repository tests again. Expected: pass.
 
-- [ ] **Step 5: Commit**
+ **Step 5: Commit**
 
 ```bash
 git add tldw_Server_API/app/core/DB_Management/codegraph/repository.py \
@@ -198,7 +198,7 @@ git commit -m "feat: add codegraph impact traversal"
 - Create `tldw_Server_API/app/core/CodeGraph/context.py`
 - Test `tldw_Server_API/tests/CodeGraph/test_codegraph_context.py`
 
-- [ ] **Step 1: Write failing context builder tests**
+ **Step 1: Write failing context builder tests**
 
 Add tests for:
 
@@ -224,7 +224,7 @@ assert "def helper" in result["files"][0]["snippets"][0]["text"]
 assert result["truncation"]["truncated"] is False
 ```
 
-- [ ] **Step 2: Run RED test**
+ **Step 2: Run RED test**
 
 Run:
 
@@ -235,7 +235,7 @@ Run:
 
 Expected: fail because `context.py` does not exist.
 
-- [ ] **Step 3: Implement context builder**
+ **Step 3: Implement context builder**
 
 Create `CodeGraphContextBuilder` with:
 
@@ -268,11 +268,11 @@ Snippet rules:
 - Stop appending snippet text when `max_context_chars` would be exceeded.
 - Return `truncation.used_chars`, `truncation.max_context_chars`, and `truncation.truncated`.
 
-- [ ] **Step 4: Run GREEN test**
+ **Step 4: Run GREEN test**
 
 Run the context builder tests. Expected: pass.
 
-- [ ] **Step 5: Commit**
+ **Step 5: Commit**
 
 ```bash
 git add tldw_Server_API/app/core/CodeGraph/context.py \
@@ -287,7 +287,7 @@ git commit -m "feat: add codegraph context builder"
 - Modify `tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py`
 - Test `tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py`
 
-- [ ] **Step 1: Write failing MCP impact tests**
+ **Step 1: Write failing MCP impact tests**
 
 Add tests asserting:
 
@@ -298,7 +298,7 @@ Add tests asserting:
 - indexed fixture returns root, nodes, relationships, and truncation status
 - `execute_tool("codegraph.impact", ...)` uses `asyncio.to_thread`
 
-- [ ] **Step 2: Run RED test**
+ **Step 2: Run RED test**
 
 Run:
 
@@ -310,7 +310,7 @@ Run:
 
 Expected: fail because the tool is not registered.
 
-- [ ] **Step 3: Implement MCP impact wiring**
+ **Step 3: Implement MCP impact wiring**
 
 Update `CodeGraphModule`:
 
@@ -322,11 +322,11 @@ Update `CodeGraphModule`:
 - call `repository.traverse_impact(...)`
 - serialize root via `_node_to_dict`
 
-- [ ] **Step 4: Run GREEN MCP impact tests**
+ **Step 4: Run GREEN MCP impact tests**
 
 Run the impact-specific tests. Expected: pass.
 
-- [ ] **Step 5: Commit**
+ **Step 5: Commit**
 
 ```bash
 git add tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py \
@@ -342,7 +342,7 @@ git commit -m "feat: expose codegraph impact tool"
 - Modify `tldw_Server_API/app/core/CodeGraph/context.py` if integration needs small builder changes
 - Test `tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py`
 
-- [ ] **Step 1: Write failing MCP context tests**
+ **Step 1: Write failing MCP context tests**
 
 Add tests asserting:
 
@@ -353,7 +353,7 @@ Add tests asserting:
 - `include_code=False` returns file/node metadata without snippet text
 - `execute_tool("codegraph.context", ...)` uses `asyncio.to_thread`
 
-- [ ] **Step 2: Run RED test**
+ **Step 2: Run RED test**
 
 Run:
 
@@ -365,7 +365,7 @@ Run:
 
 Expected: fail because the tool is not registered.
 
-- [ ] **Step 3: Implement MCP context wiring**
+ **Step 3: Implement MCP context wiring**
 
 Update `CodeGraphModule`:
 
@@ -377,11 +377,11 @@ Update `CodeGraphModule`:
 - include bounded callers/callees for selected nodes
 - call `CodeGraphContextBuilder.build(...)`
 
-- [ ] **Step 4: Run GREEN MCP context tests**
+ **Step 4: Run GREEN MCP context tests**
 
 Run the context-specific tests. Expected: pass.
 
-- [ ] **Step 5: Commit**
+ **Step 5: Commit**
 
 ```bash
 git add tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py \
@@ -396,7 +396,7 @@ git commit -m "feat: expose codegraph context tool"
 
 - Modify `backlog/tasks/task-46 - Implement-native-CodeGraph-context-and-impact-tools.md`
 
-- [ ] **Step 1: Run focused regression suite**
+ **Step 1: Run focused regression suite**
 
 Run:
 
@@ -410,7 +410,7 @@ Run:
 
 Expected: all pass.
 
-- [ ] **Step 2: Run Ruff**
+ **Step 2: Run Ruff**
 
 Run:
 
@@ -424,7 +424,7 @@ Run:
 
 Expected: `All checks passed!`
 
-- [ ] **Step 3: Run Bandit**
+ **Step 3: Run Bandit**
 
 Run:
 
@@ -438,7 +438,7 @@ Run:
 
 Expected: JSON reports `errors: []` and no results for touched scope.
 
-- [ ] **Step 4: Run whitespace check**
+ **Step 4: Run whitespace check**
 
 Run:
 
@@ -448,7 +448,7 @@ git diff --check
 
 Expected: no output.
 
-- [ ] **Step 5: Update task and commit final verification**
+ **Step 5: Update task and commit final verification**
 
 Update TASK-46 acceptance criteria, notes, DoD, and final summary.
 

--- a/Docs/superpowers/plans/2026-05-04-native-codegraph-context-impact-tools-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-04-native-codegraph-context-impact-tools-implementation-plan.md
@@ -1,0 +1,465 @@
+# Native CodeGraph Context Impact Tools Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the Stage 4 native CodeGraph read-only `codegraph.impact` and `codegraph.context` tools.
+
+**Architecture:** Keep traversal and relationship reads in `CodeGraphRepository`, add a focused `CodeGraphContextBuilder` for bounded source snippets and task-oriented payload assembly, and keep `CodeGraphModule` as the MCP validation/offload adapter. The implementation must remain read-only, workspace-bounded, and conservative: no Jobs mode, no new language extractors, and no unbounded source output.
+
+**Tech Stack:** Python 3.11, Unified MCP `BaseModule`, SQLite, existing CodeGraph repository/model values, pytest/pytest-asyncio, Loguru, Ruff, Bandit.
+
+---
+
+## Scope
+
+Implement only:
+
+- `codegraph.impact`
+- `codegraph.context`
+- Repository read helpers needed by those tools
+- A small context builder for bounded source extraction
+- Focused tests and task documentation updates
+
+Do not implement:
+
+- File watching, background Jobs indexing, or Scheduler integration
+- New C/C++/C#/Java/Kotlin extractors
+- Whole-file source dumps
+- Cross-file semantic resolution beyond graph rows already indexed
+
+## File Structure
+
+- Modify `tldw_Server_API/app/core/DB_Management/codegraph/repository.py`
+  - Add read-only graph traversal helpers.
+  - Add node batch lookup helpers if needed.
+- Create `tldw_Server_API/app/core/CodeGraph/context.py`
+  - Add `CodeGraphContextBuilder`.
+  - Add workspace-safe source snippet extraction.
+  - Add result shaping and truncation metadata.
+- Modify `tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py`
+  - Add tool definitions, validation, and `asyncio.to_thread` execution paths.
+- Modify or add tests:
+  - `tldw_Server_API/tests/CodeGraph/test_codegraph_repository.py`
+  - `tldw_Server_API/tests/CodeGraph/test_codegraph_context.py`
+  - `tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py`
+- Modify `backlog/tasks/task-46 - Implement-native-CodeGraph-context-and-impact-tools.md`
+  - Record plan path, implementation notes, verification, and final summary.
+
+## Behavior Contract
+
+### `codegraph.impact`
+
+Arguments:
+
+- `symbol` or `node_id`: exactly one required
+- `depth`: default `2`, positive integer, bounded to `4`
+- `direction`: default `both`, one of `incoming`, `outgoing`, `both`
+- `limit`: default `10`, bounded by `settings.max_search_results`
+
+Response shape:
+
+```python
+{
+    "workspace_key": "...",
+    "index_present": True,
+    "root": {...} | None,
+    "nodes": [...],
+    "relationships": [...],
+    "depth": 2,
+    "direction": "both",
+    "truncated": False,
+}
+```
+
+Missing index returns `index_present=False` with empty nodes/relationships. A selector that does not resolve to an indexed node returns `index_present=True`, `root=None`, and empty traversal results.
+
+### `codegraph.context`
+
+Arguments:
+
+- `task`: required non-empty string
+- `max_nodes`: default `8`, positive integer, bounded by `settings.max_search_results`
+- `include_code`: default `True`
+- `max_files`: default `5`, positive integer, bounded by `settings.max_search_results`
+
+Response shape:
+
+```python
+{
+    "workspace_key": "...",
+    "index_present": True,
+    "task": "...",
+    "query": "...",
+    "nodes": [...],
+    "files": [
+        {
+            "path": "pkg/file.py",
+            "language": "python",
+            "snippets": [
+                {
+                    "start_line": 10,
+                    "end_line": 18,
+                    "text": "...",
+                    "truncated": False,
+                }
+            ],
+        }
+    ],
+    "relationships": [...],
+    "truncation": {
+        "max_context_chars": 35000,
+        "used_chars": 1234,
+        "truncated": False,
+    },
+}
+```
+
+The initial query can be the first useful task phrase after trimming. Keep it simple in this slice: search the task string through existing `search_nodes()`, use top nodes, include same-file callers/callees for those nodes, and group snippets by workspace-relative file path.
+
+## Task 1: Repository Traversal Helpers
+
+**Files:**
+
+- Modify `tldw_Server_API/app/core/DB_Management/codegraph/repository.py`
+- Test `tldw_Server_API/tests/CodeGraph/test_codegraph_repository.py`
+
+- [ ] **Step 1: Write failing repository traversal tests**
+
+Add tests that seed a graph `entry -> helper -> leaf`, plus an incoming caller to `helper`, then assert:
+
+```python
+impact = repo.traverse_impact("node_helper", depth=1, direction="both", limit=10)
+assert [node.id for node in impact.nodes] == ["node_entry", "node_helper", "node_leaf"]
+assert {edge["edge"]["id"] for edge in impact.relationships} == {"edge_entry_helper", "edge_helper_leaf"}
+assert impact.truncated is False
+```
+
+Also add a limit test:
+
+```python
+impact = repo.traverse_impact("node_helper", depth=2, direction="both", limit=1)
+assert impact.truncated is True
+assert len(impact.relationships) == 1
+```
+
+- [ ] **Step 2: Run RED test**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/CodeGraph/test_codegraph_repository.py::test_repository_traverses_bounded_impact_graph \
+  tldw_Server_API/tests/CodeGraph/test_codegraph_repository.py::test_repository_impact_traversal_reports_truncation \
+  -q
+```
+
+Expected: fail because `traverse_impact` does not exist.
+
+- [ ] **Step 3: Implement minimal repository helper**
+
+Add a small frozen dataclass or dict return value near repository helpers:
+
+```python
+@dataclass(frozen=True)
+class ImpactTraversal:
+    nodes: tuple[CodeGraphNode, ...]
+    relationships: tuple[dict[str, Any], ...]
+    truncated: bool
+```
+
+Implement `CodeGraphRepository.traverse_impact(node_id, depth, direction, limit)` using breadth-first traversal over `edges`.
+
+Rules:
+
+- Direction `incoming`: follow `target == node_id`
+- Direction `outgoing`: follow `source == node_id`
+- Direction `both`: follow both
+- Include the root node in `nodes`
+- De-duplicate nodes and relationship ids deterministically
+- Stop once `limit + 1` relationships are collected so truncation can be reported
+- Reuse `_relationship_from_joined_row()` style payloads for consistency
+
+- [ ] **Step 4: Run GREEN test**
+
+Run the two repository tests again. Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/DB_Management/codegraph/repository.py \
+  tldw_Server_API/tests/CodeGraph/test_codegraph_repository.py
+git commit -m "feat: add codegraph impact traversal"
+```
+
+## Task 2: Context Builder And Source Snippets
+
+**Files:**
+
+- Create `tldw_Server_API/app/core/CodeGraph/context.py`
+- Test `tldw_Server_API/tests/CodeGraph/test_codegraph_context.py`
+
+- [ ] **Step 1: Write failing context builder tests**
+
+Add tests for:
+
+- source snippets are read only under `workspace_root`
+- snippets include a small line window around node start/end lines
+- snippets respect `max_context_chars`
+- duplicate file snippets are grouped
+- missing source files produce metadata instead of raising
+
+Example core test:
+
+```python
+result = builder.build(
+    task="update helper",
+    nodes=(helper_node,),
+    relationships=(),
+    max_files=3,
+    include_code=True,
+)
+assert result["files"][0]["path"] == "pkg/sample.py"
+assert result["files"][0]["snippets"][0]["start_line"] == 2
+assert "def helper" in result["files"][0]["snippets"][0]["text"]
+assert result["truncation"]["truncated"] is False
+```
+
+- [ ] **Step 2: Run RED test**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/CodeGraph/test_codegraph_context.py -q
+```
+
+Expected: fail because `context.py` does not exist.
+
+- [ ] **Step 3: Implement context builder**
+
+Create `CodeGraphContextBuilder` with:
+
+```python
+class CodeGraphContextBuilder:
+    def __init__(
+        self,
+        *,
+        workspace_root: Path,
+        max_context_chars: int,
+        max_file_size_bytes: int,
+    ) -> None: ...
+    def build(
+        self,
+        *,
+        task: str,
+        nodes: tuple[CodeGraphNode, ...],
+        relationships: tuple[dict[str, Any], ...],
+        max_files: int,
+        include_code: bool,
+    ) -> dict[str, Any]: ...
+```
+
+Snippet rules:
+
+- Reject absolute node file paths and paths containing `..`.
+- Resolve each file under `workspace_root`; skip if the resolved path escapes.
+- Default snippet window: 3 lines before `start_line`, 3 lines after `end_line`.
+- Never read files larger than `max_file_size_bytes`.
+- Stop appending snippet text when `max_context_chars` would be exceeded.
+- Return `truncation.used_chars`, `truncation.max_context_chars`, and `truncation.truncated`.
+
+- [ ] **Step 4: Run GREEN test**
+
+Run the context builder tests. Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/CodeGraph/context.py \
+  tldw_Server_API/tests/CodeGraph/test_codegraph_context.py
+git commit -m "feat: add codegraph context builder"
+```
+
+## Task 3: MCP `codegraph.impact`
+
+**Files:**
+
+- Modify `tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py`
+- Test `tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py`
+
+- [ ] **Step 1: Write failing MCP impact tests**
+
+Add tests asserting:
+
+- `get_tools()` includes `codegraph.impact` with `readOnlyHint=True`
+- unknown args are rejected
+- invalid direction/depth/limit are rejected
+- missing index returns `index_present=False`
+- indexed fixture returns root, nodes, relationships, and truncation status
+- `execute_tool("codegraph.impact", ...)` uses `asyncio.to_thread`
+
+- [ ] **Step 2: Run RED test**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py::test_codegraph_impact_returns_bounded_relationship_neighborhood \
+  -q
+```
+
+Expected: fail because the tool is not registered.
+
+- [ ] **Step 3: Implement MCP impact wiring**
+
+Update `CodeGraphModule`:
+
+- add tool definition
+- add validation branch
+- add execution branch using `asyncio.to_thread`
+- add `_impact(...)` sync helper
+- resolve root node by `node_id` or `symbol`
+- call `repository.traverse_impact(...)`
+- serialize root via `_node_to_dict`
+
+- [ ] **Step 4: Run GREEN MCP impact tests**
+
+Run the impact-specific tests. Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
+git commit -m "feat: expose codegraph impact tool"
+```
+
+## Task 4: MCP `codegraph.context`
+
+**Files:**
+
+- Modify `tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py`
+- Modify `tldw_Server_API/app/core/CodeGraph/context.py` if integration needs small builder changes
+- Test `tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py`
+
+- [ ] **Step 1: Write failing MCP context tests**
+
+Add tests asserting:
+
+- `get_tools()` includes `codegraph.context` with `readOnlyHint=True`
+- invalid task/max_nodes/max_files/include_code inputs are rejected
+- missing index returns `index_present=False`
+- indexed fixture returns matching nodes and bounded snippets
+- `include_code=False` returns file/node metadata without snippet text
+- `execute_tool("codegraph.context", ...)` uses `asyncio.to_thread`
+
+- [ ] **Step 2: Run RED test**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py::test_codegraph_context_returns_bounded_source_context \
+  -q
+```
+
+Expected: fail because the tool is not registered.
+
+- [ ] **Step 3: Implement MCP context wiring**
+
+Update `CodeGraphModule`:
+
+- add tool definition with `task`, `max_nodes`, `include_code`, `max_files`
+- add validation branch
+- add execution branch using `asyncio.to_thread`
+- add `_build_context(...)` sync helper
+- search nodes with `repository.search_nodes(task, limit=max_nodes)`
+- include bounded callers/callees for selected nodes
+- call `CodeGraphContextBuilder.build(...)`
+
+- [ ] **Step 4: Run GREEN MCP context tests**
+
+Run the context-specific tests. Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py \
+  tldw_Server_API/app/core/CodeGraph/context.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
+git commit -m "feat: expose codegraph context tool"
+```
+
+## Task 5: Verification And PR Prep
+
+**Files:**
+
+- Modify `backlog/tasks/task-46 - Implement-native-CodeGraph-context-and-impact-tools.md`
+
+- [ ] **Step 1: Run focused regression suite**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/CodeGraph \
+  tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py \
+  -q
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Run Ruff**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check \
+  tldw_Server_API/app/core/CodeGraph \
+  tldw_Server_API/app/core/DB_Management/codegraph \
+  tldw_Server_API/tests/CodeGraph \
+  tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
+```
+
+Expected: `All checks passed!`
+
+- [ ] **Step 3: Run Bandit**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r \
+  tldw_Server_API/app/core/CodeGraph \
+  tldw_Server_API/app/core/DB_Management/codegraph \
+  tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py \
+  -f json -o /tmp/bandit_codegraph_context_impact.json
+```
+
+Expected: JSON reports `errors: []` and no results for touched scope.
+
+- [ ] **Step 4: Run whitespace check**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output.
+
+- [ ] **Step 5: Update task and commit final verification**
+
+Update TASK-46 acceptance criteria, notes, DoD, and final summary.
+
+```bash
+git add 'backlog/tasks/task-46 - Implement-native-CodeGraph-context-and-impact-tools.md' \
+  Docs/superpowers/plans/2026-05-04-native-codegraph-context-impact-tools-implementation-plan.md
+git commit -m "docs: record codegraph context impact verification"
+```
+
+## Open Review Points
+
+- Keep `depth` bounded to `4` unless reviewers ask for a config field.
+- Keep context query simple in this slice. If task-to-symbol matching is weak, improve later with a separate ranking task.
+- Source snippets should be helpful but small. Prefer explicit truncation metadata over trying to be clever.

--- a/backlog/tasks/task-46 - Implement-native-CodeGraph-context-and-impact-tools.md
+++ b/backlog/tasks/task-46 - Implement-native-CodeGraph-context-and-impact-tools.md
@@ -1,0 +1,54 @@
+---
+id: TASK-46
+title: Implement native CodeGraph context and impact tools
+status: In Progress
+assignee:
+  - Codex
+created_date: '2026-05-04 19:17'
+labels:
+  - codegraph
+  - mcp
+  - context
+  - impact
+dependencies:
+  - TASK-38
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1259'
+documentation:
+  - Docs/superpowers/specs/2026-05-03-native-codegraph-mcp-module-design.md
+  - Docs/superpowers/plans/2026-05-04-native-codegraph-context-impact-tools-implementation-plan.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the next native CodeGraph Stage 4 slice after PR #1264: read-only impact traversal and bounded context assembly for indexed workspaces. Keep the slice focused on codegraph.impact and codegraph.context with safe limits, no Jobs mode, no new language extractors, and no source output beyond bounded snippets requested by the context tool.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 codegraph.impact returns bounded incoming/outgoing/both graph neighborhoods with depth and limit controls.
+- [ ] #2 codegraph.context returns task-oriented nodes, files, relationships, and bounded source snippets with truncation metadata.
+- [ ] #3 Both tools validate selectors and limits, stay read-only, and offload repository/source IO from the async MCP handler.
+- [ ] #4 Repository/core helpers have focused tests for traversal, source snippet bounds, missing index behavior, and path safety.
+- [ ] #5 Focused CodeGraph/MCP tests, Ruff, Bandit on touched production scope, and git diff --check pass before PR.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Plan document: Docs/superpowers/plans/2026-05-04-native-codegraph-context-impact-tools-implementation-plan.md
+
+Scope: implement Stage 4 read-only CodeGraph impact traversal and bounded context assembly only. The plan keeps traversal in the SQLite repository, source snippet assembly in a small CodeGraph context builder, and MCP module changes limited to tool definitions, validation, and to_thread execution.
+<!-- SECTION:PLAN:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-46 - Implement-native-CodeGraph-context-and-impact-tools.md
+++ b/backlog/tasks/task-46 - Implement-native-CodeGraph-context-and-impact-tools.md
@@ -1,10 +1,11 @@
 ---
 id: TASK-46
 title: Implement native CodeGraph context and impact tools
-status: In Progress
+status: Done
 assignee:
   - Codex
 created_date: '2026-05-04 19:17'
+updated_date: '2026-05-04 20:08'
 labels:
   - codegraph
   - mcp
@@ -16,7 +17,8 @@ references:
   - 'https://github.com/rmusser01/tldw_server/issues/1259'
 documentation:
   - Docs/superpowers/specs/2026-05-03-native-codegraph-mcp-module-design.md
-  - Docs/superpowers/plans/2026-05-04-native-codegraph-context-impact-tools-implementation-plan.md
+  - >-
+    Docs/superpowers/plans/2026-05-04-native-codegraph-context-impact-tools-implementation-plan.md
 priority: medium
 ---
 
@@ -28,11 +30,11 @@ Implement the next native CodeGraph Stage 4 slice after PR #1264: read-only impa
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 codegraph.impact returns bounded incoming/outgoing/both graph neighborhoods with depth and limit controls.
-- [ ] #2 codegraph.context returns task-oriented nodes, files, relationships, and bounded source snippets with truncation metadata.
-- [ ] #3 Both tools validate selectors and limits, stay read-only, and offload repository/source IO from the async MCP handler.
-- [ ] #4 Repository/core helpers have focused tests for traversal, source snippet bounds, missing index behavior, and path safety.
-- [ ] #5 Focused CodeGraph/MCP tests, Ruff, Bandit on touched production scope, and git diff --check pass before PR.
+- [x] #1 codegraph.impact returns bounded incoming/outgoing/both graph neighborhoods with depth and limit controls.
+- [x] #2 codegraph.context returns task-oriented nodes, files, relationships, and bounded source snippets with truncation metadata.
+- [x] #3 Both tools validate selectors and limits, stay read-only, and offload repository/source IO from the async MCP handler.
+- [x] #4 Repository/core helpers have focused tests for traversal, source snippet bounds, missing index behavior, and path safety.
+- [x] #5 Focused CodeGraph/MCP tests, Ruff, Bandit on touched production scope, and git diff --check pass before PR.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -43,12 +45,30 @@ Plan document: Docs/superpowers/plans/2026-05-04-native-codegraph-context-impact
 Scope: implement Stage 4 read-only CodeGraph impact traversal and bounded context assembly only. The plan keeps traversal in the SQLite repository, source snippet assembly in a small CodeGraph context builder, and MCP module changes limited to tool definitions, validation, and to_thread execution.
 <!-- SECTION:PLAN:END -->
 
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented repository impact traversal with deterministic bounded traversal; removed dynamic SQL construction after Bandit flagged the first implementation.
+
+Added CodeGraphContextBuilder for workspace-bounded snippets, file-size handling, path traversal protection, missing-file metadata, include_code=false metadata-only output, and truncation metadata.
+
+Exposed codegraph.impact and codegraph.context through the Unified MCP CodeGraph module with readOnlyHint metadata, strict argument validation, missing-index read-only responses, limit bounds, and asyncio.to_thread offload for repository/source IO.
+
+Verification on 2026-05-04 after rebasing onto origin/dev: pytest focused CodeGraph/MCP suite -> 92 passed, 5 warnings; Ruff touched scopes -> All checks passed; Bandit report /tmp/bandit_codegraph_context_impact.json -> zero findings; git diff --check -> clean.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the Stage 4 native CodeGraph context and impact slice. The branch adds deterministic repository graph traversal, a workspace-safe bounded context builder for source snippets, and read-only Unified MCP tools codegraph.impact and codegraph.context with validation, configured bounds, missing-index behavior, and async offload for blocking repository/source IO. Focused CodeGraph/MCP tests, Ruff, Bandit, and whitespace checks passed after rebasing onto origin/dev.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-46 - Implement-native-CodeGraph-context-and-impact-tools.md
+++ b/backlog/tasks/task-46 - Implement-native-CodeGraph-context-and-impact-tools.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - Codex
 created_date: '2026-05-04 19:17'
-updated_date: '2026-05-05 00:04'
+updated_date: '2026-05-05 00:19'
 labels:
   - codegraph
   - mcp
@@ -58,12 +58,18 @@ Exposed codegraph.impact and codegraph.context through the Unified MCP CodeGraph
 Verification on 2026-05-04 after rebasing onto origin/dev: pytest focused CodeGraph/MCP suite -> 92 passed, 5 warnings; Ruff touched scopes -> All checks passed; Bandit report /tmp/bandit_codegraph_context_impact.json -> zero findings; git diff --check -> clean.
 
 Draft PR opened: https://github.com/rmusser01/tldw_server/pull/1270
+
+PR #1270 review follow-up started: address Gemini comments about duplicated CodeGraph node serialization and relationship-neighborhood connection cycles.
+
+PR #1270 review fixes completed: centralized CodeGraphNode serialization in codegraph_node_to_dict and replaced per-node context relationship traversal with repository.traverse_impact_many batch traversal.
+
+Review-fix verification on 2026-05-05: focused CodeGraph/MCP pytest suite -> 95 passed, 5 warnings; Ruff touched scopes -> All checks passed; Bandit /tmp/bandit_codegraph_context_impact.json -> zero findings; git diff --check -> clean.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented the Stage 4 native CodeGraph context and impact slice. The branch adds deterministic repository graph traversal, a workspace-safe bounded context builder for source snippets, and read-only Unified MCP tools codegraph.impact and codegraph.context with validation, configured bounds, missing-index behavior, and async offload for blocking repository/source IO. Focused CodeGraph/MCP tests, Ruff, Bandit, and whitespace checks passed after rebasing onto origin/dev.
+Implemented the Stage 4 native CodeGraph context and impact slice. The branch adds deterministic repository graph traversal, a workspace-safe bounded context builder for source snippets, and read-only Unified MCP tools codegraph.impact and codegraph.context with validation, configured bounds, missing-index behavior, and async offload for blocking repository/source IO. Focused CodeGraph/MCP tests, Ruff, Bandit, and whitespace checks passed after rebasing onto origin/dev. PR review follow-up centralized CodeGraph node serialization in models.py and added batch impact traversal for context relationship collection, addressing Gemini review comments without changing MCP response shapes.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-46 - Implement-native-CodeGraph-context-and-impact-tools.md
+++ b/backlog/tasks/task-46 - Implement-native-CodeGraph-context-and-impact-tools.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - Codex
 created_date: '2026-05-04 19:17'
-updated_date: '2026-05-04 20:08'
+updated_date: '2026-05-05 00:04'
 labels:
   - codegraph
   - mcp
@@ -15,6 +15,7 @@ dependencies:
   - TASK-38
 references:
   - 'https://github.com/rmusser01/tldw_server/issues/1259'
+  - 'https://github.com/rmusser01/tldw_server/pull/1270'
 documentation:
   - Docs/superpowers/specs/2026-05-03-native-codegraph-mcp-module-design.md
   - >-
@@ -55,6 +56,8 @@ Added CodeGraphContextBuilder for workspace-bounded snippets, file-size handling
 Exposed codegraph.impact and codegraph.context through the Unified MCP CodeGraph module with readOnlyHint metadata, strict argument validation, missing-index read-only responses, limit bounds, and asyncio.to_thread offload for repository/source IO.
 
 Verification on 2026-05-04 after rebasing onto origin/dev: pytest focused CodeGraph/MCP suite -> 92 passed, 5 warnings; Ruff touched scopes -> All checks passed; Bandit report /tmp/bandit_codegraph_context_impact.json -> zero findings; git diff --check -> clean.
+
+Draft PR opened: https://github.com/rmusser01/tldw_server/pull/1270
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-48 - Address-PR-1270-CodeGraph-context-impact-review-follow-ups.md
+++ b/backlog/tasks/task-48 - Address-PR-1270-CodeGraph-context-impact-review-follow-ups.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-48
 title: 'Address PR #1270 CodeGraph context/impact review follow-ups'
-status: In Progress
+status: Done
 assignee:
   - '@Codex'
 created_date: '2026-05-05 00:44'
-updated_date: '2026-05-05 00:45'
+updated_date: '2026-05-05 00:47'
 labels:
   - codegraph
   - mcp
@@ -28,7 +28,7 @@ Address the current PR #1270 review comments for the native CodeGraph context/im
 - [x] #1 Qodo SQL relationship materialization comment is addressed with a regression test and implementation bound.
 - [x] #2 Qodo include_code=null default comment is addressed with a regression test and implementation fix.
 - [x] #3 Qodo docstring comment is addressed for new PR test coverage or explicitly pushed back with repo-grounded rationale.
-- [ ] #4 CodeRabbit human-authored attestation comment is responded to without falsely claiming human authorship.
+- [x] #4 CodeRabbit human-authored attestation comment is responded to without falsely claiming human authorship.
 - [x] #5 Focused CodeGraph/MCP tests, Ruff, Bandit on touched production scope, and git diff --check are run and recorded.
 <!-- AC:END -->
 
@@ -50,14 +50,22 @@ RED verification: targeted regression tests failed before implementation because
 Implemented SQL LIMIT/max_rows for impact relationship selection, normalized codegraph.context include_code=null to the default true, and added concise docstrings to new CodeGraph test modules/helpers.
 
 Verification so far: targeted regression tests passed; focused CodeGraph/MCP pytest suite passed with 97 passed and 5 warnings; Ruff touched scopes passed; Bandit /tmp/bandit_codegraph_context_impact.json reported zero findings; git diff --check passed.
+
+PR thread updates: replied to and resolved the three Qodo review threads for docstrings, SQL row limiting, and include_code=null. Replied to the CodeRabbit human-attestation thread without adding a false human-authored attestation; the thread remains a human-owner action.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed the implementable PR #1270 review follow-ups. Added SQL-level row bounding to CodeGraph impact relationship selection, preserving truncation detection with remaining-budget-plus-one traversal queries. Normalized codegraph.context include_code=null to the documented default true and added regression coverage. Added concise docstrings to the new CodeGraph context/model/repository tests and MCP impact/context test helpers. Verification passed: targeted RED/GREEN regression tests, focused CodeGraph/MCP pytest suite (97 passed, 5 warnings), Ruff, Bandit with zero findings, and git diff --check. Qodo threads were replied to and resolved; the CodeRabbit human-attestation thread was answered but intentionally left for a human owner because Codex cannot author a human attestation.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-48 - Address-PR-1270-CodeGraph-context-impact-review-follow-ups.md
+++ b/backlog/tasks/task-48 - Address-PR-1270-CodeGraph-context-impact-review-follow-ups.md
@@ -1,0 +1,63 @@
+---
+id: TASK-48
+title: 'Address PR #1270 CodeGraph context/impact review follow-ups'
+status: In Progress
+assignee:
+  - '@Codex'
+created_date: '2026-05-05 00:44'
+updated_date: '2026-05-05 00:45'
+labels:
+  - codegraph
+  - mcp
+  - pr-review
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1270'
+  - TASK-46
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address the current PR #1270 review comments for the native CodeGraph context/impact slice: bounded impact relationship query materialization, include_code=null default behavior, test docstrings, and the human-authored attestation request.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Qodo SQL relationship materialization comment is addressed with a regression test and implementation bound.
+- [x] #2 Qodo include_code=null default comment is addressed with a regression test and implementation fix.
+- [x] #3 Qodo docstring comment is addressed for new PR test coverage or explicitly pushed back with repo-grounded rationale.
+- [ ] #4 CodeRabbit human-authored attestation comment is responded to without falsely claiming human authorship.
+- [x] #5 Focused CodeGraph/MCP tests, Ruff, Bandit on touched production scope, and git diff --check are run and recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add RED regression coverage for bounded relationship row selection and codegraph.context include_code=null defaulting.
+2. Implement SQL LIMIT/max_rows in the CodeGraph repository impact traversal and normalize include_code=None to the documented default true in the MCP module.
+3. Add concise docstrings to new PR test modules/functions touched by this slice.
+4. Run focused CodeGraph/MCP tests, Ruff, Bandit on touched production code, and git diff --check.
+5. Reply to and resolve implementable PR review threads; respond to the human-authored attestation request without generating a false human attestation.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+RED verification: targeted regression tests failed before implementation because impact traversal did not pass a max_rows selector bound and codegraph.context include_code=null returned no snippets.
+
+Implemented SQL LIMIT/max_rows for impact relationship selection, normalized codegraph.context include_code=null to the default true, and added concise docstrings to new CodeGraph test modules/helpers.
+
+Verification so far: targeted regression tests passed; focused CodeGraph/MCP pytest suite passed with 97 passed and 5 warnings; Ruff touched scopes passed; Bandit /tmp/bandit_codegraph_context_impact.json reported zero findings; git diff --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/CodeGraph/context.py
+++ b/tldw_Server_API/app/core/CodeGraph/context.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from tldw_Server_API.app.core.CodeGraph.models import CodeGraphNode
+from tldw_Server_API.app.core.CodeGraph.models import CodeGraphNode, codegraph_node_to_dict
 
 _SNIPPET_CONTEXT_LINES = 3
 
@@ -99,7 +99,7 @@ class CodeGraphContextBuilder:
 
         return {
             "task": task,
-            "nodes": [_node_to_dict(node) for node in nodes],
+            "nodes": [codegraph_node_to_dict(node) for node in nodes],
             "relationships": list(relationships),
             "files": files,
             "truncation": {
@@ -163,24 +163,4 @@ def _make_snippet(node: CodeGraphNode, lines: list[str]) -> dict[str, Any]:
         "end_line": end_line,
         "text": text,
         "truncated": False,
-    }
-
-
-def _node_to_dict(node: CodeGraphNode) -> dict[str, Any]:
-    return {
-        "id": node.id,
-        "kind": node.kind,
-        "name": node.name,
-        "qualified_name": node.qualified_name,
-        "file_path": node.file_path,
-        "language": node.language,
-        "start_line": node.start_line,
-        "end_line": node.end_line,
-        "start_column": node.start_column,
-        "end_column": node.end_column,
-        "signature": node.signature,
-        "docstring": node.docstring,
-        "visibility": node.visibility,
-        "flags": list(node.flags),
-        "metadata": dict(node.metadata),
     }

--- a/tldw_Server_API/app/core/CodeGraph/context.py
+++ b/tldw_Server_API/app/core/CodeGraph/context.py
@@ -1,0 +1,186 @@
+"""Bounded source-context assembly for native CodeGraph tools."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from tldw_Server_API.app.core.CodeGraph.models import CodeGraphNode
+
+_SNIPPET_CONTEXT_LINES = 3
+
+
+class CodeGraphContextBuilder:
+    """Build a compact, workspace-bounded source context payload."""
+
+    def __init__(
+        self,
+        *,
+        workspace_root: Path,
+        max_context_chars: int,
+        max_file_size_bytes: int,
+    ) -> None:
+        self.workspace_root = Path(workspace_root).resolve()
+        self.max_context_chars = max(0, int(max_context_chars))
+        self.max_file_size_bytes = max(0, int(max_file_size_bytes))
+
+    def build(
+        self,
+        *,
+        task: str,
+        nodes: tuple[CodeGraphNode, ...],
+        relationships: tuple[dict[str, Any], ...],
+        max_files: int,
+        include_code: bool,
+    ) -> dict[str, Any]:
+        """Return task-oriented nodes, relationships, files, and source snippets."""
+        grouped = _group_nodes_by_file(nodes, max_files=max(1, int(max_files)))
+        files: list[dict[str, Any]] = []
+        used_chars = 0
+        truncated = False
+        skipped_files = 0
+
+        for file_path, file_nodes in grouped:
+            resolved = self._resolve_workspace_file(file_path)
+            if resolved is None:
+                skipped_files += 1
+                continue
+
+            file_context = {
+                "path": file_path,
+                "language": _dominant_language(file_nodes),
+                "exists": resolved.exists(),
+                "snippets": [],
+                "errors": [],
+            }
+            if not resolved.exists():
+                file_context["errors"].append("source file not found")
+                files.append(file_context)
+                continue
+
+            if not resolved.is_file():
+                file_context["errors"].append("source path is not a file")
+                files.append(file_context)
+                continue
+
+            try:
+                size = resolved.stat().st_size
+            except OSError as exc:
+                file_context["errors"].append(f"source file stat failed: {exc.strerror or exc.__class__.__name__}")
+                files.append(file_context)
+                continue
+
+            if size > self.max_file_size_bytes:
+                file_context["errors"].append("source file exceeds max_file_size_bytes")
+                files.append(file_context)
+                continue
+
+            if include_code and not truncated:
+                try:
+                    lines = resolved.read_text(encoding="utf-8", errors="replace").splitlines()
+                except OSError as exc:
+                    file_context["errors"].append(f"source file read failed: {exc.strerror or exc.__class__.__name__}")
+                    files.append(file_context)
+                    continue
+                for node in file_nodes:
+                    snippet = _make_snippet(node, lines)
+                    remaining = self.max_context_chars - used_chars
+                    if len(snippet["text"]) > remaining:
+                        snippet["text"] = snippet["text"][: max(0, remaining)]
+                        snippet["truncated"] = True
+                        truncated = True
+                    used_chars += len(snippet["text"])
+                    file_context["snippets"].append(snippet)
+                    if truncated:
+                        break
+            files.append(file_context)
+            if truncated:
+                break
+
+        return {
+            "task": task,
+            "nodes": [_node_to_dict(node) for node in nodes],
+            "relationships": list(relationships),
+            "files": files,
+            "truncation": {
+                "max_context_chars": self.max_context_chars,
+                "used_chars": used_chars,
+                "truncated": truncated,
+                "skipped_files": skipped_files,
+            },
+        }
+
+    def _resolve_workspace_file(self, file_path: str) -> Path | None:
+        candidate = Path(file_path)
+        if candidate.is_absolute() or ".." in candidate.parts:
+            return None
+        resolved = (self.workspace_root / candidate).resolve(strict=False)
+        try:
+            resolved.relative_to(self.workspace_root)
+        except ValueError:
+            return None
+        return resolved
+
+
+def _group_nodes_by_file(
+    nodes: tuple[CodeGraphNode, ...],
+    *,
+    max_files: int,
+) -> list[tuple[str, list[CodeGraphNode]]]:
+    grouped: dict[str, list[CodeGraphNode]] = {}
+    for node in nodes:
+        if node.file_path not in grouped and len(grouped) >= max_files:
+            continue
+        grouped.setdefault(node.file_path, []).append(node)
+    return list(grouped.items())
+
+
+def _dominant_language(nodes: list[CodeGraphNode]) -> str | None:
+    for node in nodes:
+        if node.language:
+            return node.language
+    return None
+
+
+def _make_snippet(node: CodeGraphNode, lines: list[str]) -> dict[str, Any]:
+    if not lines:
+        return {
+            "node_id": node.id,
+            "start_line": 1,
+            "end_line": 0,
+            "text": "",
+            "truncated": False,
+        }
+
+    node_start = max(1, int(node.start_line or 1))
+    node_end = max(node_start, int(node.end_line or node_start))
+    start_line = max(1, node_start - _SNIPPET_CONTEXT_LINES)
+    end_line = min(len(lines), node_end + _SNIPPET_CONTEXT_LINES)
+    text = "\n".join(lines[start_line - 1 : end_line])
+    return {
+        "node_id": node.id,
+        "start_line": start_line,
+        "end_line": end_line,
+        "text": text,
+        "truncated": False,
+    }
+
+
+def _node_to_dict(node: CodeGraphNode) -> dict[str, Any]:
+    return {
+        "id": node.id,
+        "kind": node.kind,
+        "name": node.name,
+        "qualified_name": node.qualified_name,
+        "file_path": node.file_path,
+        "language": node.language,
+        "start_line": node.start_line,
+        "end_line": node.end_line,
+        "start_column": node.start_column,
+        "end_column": node.end_column,
+        "signature": node.signature,
+        "docstring": node.docstring,
+        "visibility": node.visibility,
+        "flags": list(node.flags),
+        "metadata": dict(node.metadata),
+    }

--- a/tldw_Server_API/app/core/CodeGraph/models.py
+++ b/tldw_Server_API/app/core/CodeGraph/models.py
@@ -121,6 +121,27 @@ class CodeGraphNode:
     metadata: dict[str, Any] = field(default_factory=dict)
 
 
+def codegraph_node_to_dict(node: CodeGraphNode) -> dict[str, Any]:
+    """Serialize a CodeGraphNode for API and repository relationship payloads."""
+    return {
+        "id": node.id,
+        "kind": node.kind,
+        "name": node.name,
+        "qualified_name": node.qualified_name,
+        "file_path": node.file_path,
+        "language": node.language,
+        "start_line": node.start_line,
+        "end_line": node.end_line,
+        "start_column": node.start_column,
+        "end_column": node.end_column,
+        "signature": node.signature,
+        "docstring": node.docstring,
+        "visibility": node.visibility,
+        "flags": list(node.flags),
+        "metadata": dict(node.metadata),
+    }
+
+
 @dataclass(frozen=True)
 class CodeGraphEdge:
     """Directed graph relationship between two indexed CodeGraph nodes."""

--- a/tldw_Server_API/app/core/DB_Management/codegraph/repository.py
+++ b/tldw_Server_API/app/core/DB_Management/codegraph/repository.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from contextlib import closing, contextmanager
-from dataclasses import dataclass
 import json
 import sqlite3
 import uuid
+from contextlib import closing, contextmanager
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -596,20 +596,10 @@ def _select_relationships_for_nodes(
     anchor_file_path: str,
 ) -> list[sqlite3.Row]:
     """Select joined relationships touching a set of node ids in deterministic order."""
-    placeholders = ",".join("?" for _ in node_ids)
-    ids = sorted(node_ids)
-    if direction == "incoming":
-        predicate = f"e.target IN ({placeholders})"
-        params = ids
-    elif direction == "outgoing":
-        predicate = f"e.source IN ({placeholders})"
-        params = ids
-    else:
-        predicate = f"(e.source IN ({placeholders}) OR e.target IN ({placeholders}))"
-        params = [*ids, *ids]
+    ids_json = json.dumps(sorted(node_ids))
 
     return conn.execute(
-        f"""
+        """
         SELECT
             e.id AS edge_id,
             e.kind AS edge_kind,
@@ -638,7 +628,9 @@ def _select_relationships_for_nodes(
         FROM edges e
         JOIN nodes source_node ON source_node.id = e.source
         JOIN nodes target_node ON target_node.id = e.target
-        WHERE {predicate}
+        WHERE
+            (? IN ('incoming', 'both') AND e.target IN (SELECT value FROM json_each(?)))
+            OR (? IN ('outgoing', 'both') AND e.source IN (SELECT value FROM json_each(?)))
         ORDER BY
             CASE WHEN e.file_path = ? THEN 0 ELSE 1 END,
             e.file_path,
@@ -647,7 +639,7 @@ def _select_relationships_for_nodes(
             target_node.qualified_name,
             e.id
         """,
-        [*params, anchor_file_path],
+        (direction, ids_json, direction, ids_json, anchor_file_path),
     ).fetchall()
 
 
@@ -658,12 +650,11 @@ def _select_nodes_by_ids(
     anchor_file_path: str,
 ) -> list[sqlite3.Row]:
     """Select nodes by id in stable source-location order."""
-    placeholders = ",".join("?" for _ in node_ids)
     return conn.execute(
-        f"""
+        """
         SELECT *
         FROM nodes
-        WHERE id IN ({placeholders})
+        WHERE id IN (SELECT value FROM json_each(?))
         ORDER BY
             CASE WHEN file_path = ? THEN 0 ELSE 1 END,
             file_path,
@@ -671,7 +662,7 @@ def _select_nodes_by_ids(
             qualified_name,
             id
         """,
-        [*sorted(node_ids), anchor_file_path],
+        (json.dumps(sorted(node_ids)), anchor_file_path),
     ).fetchall()
 
 

--- a/tldw_Server_API/app/core/DB_Management/codegraph/repository.py
+++ b/tldw_Server_API/app/core/DB_Management/codegraph/repository.py
@@ -475,7 +475,17 @@ class CodeGraphRepository:
             for _level in range(effective_depth):
                 if not frontier or truncated:
                     break
-                rows = _select_relationships_for_nodes(conn, frontier, direction, anchor_file_path=anchor_file_path)
+                remaining_rows = (effective_limit - len(relationships)) + 1
+                if remaining_rows <= 0:
+                    truncated = True
+                    break
+                rows = _select_relationships_for_nodes(
+                    conn,
+                    frontier,
+                    direction,
+                    anchor_file_path=anchor_file_path,
+                    max_rows=remaining_rows,
+                )
                 next_frontier: set[str] = set()
                 for row in rows:
                     edge_id = str(row["edge_id"])
@@ -612,6 +622,7 @@ def _select_relationships_for_nodes(
     direction: str,
     *,
     anchor_file_path: str,
+    max_rows: int,
 ) -> list[sqlite3.Row]:
     """Select joined relationships touching a set of node ids in deterministic order."""
     ids_json = json.dumps(sorted(node_ids))
@@ -656,8 +667,9 @@ def _select_relationships_for_nodes(
             source_node.qualified_name,
             target_node.qualified_name,
             e.id
+        LIMIT ?
         """,
-        (direction, ids_json, direction, ids_json, anchor_file_path),
+        (direction, ids_json, direction, ids_json, anchor_file_path, max(1, int(max_rows))),
     ).fetchall()
 
 

--- a/tldw_Server_API/app/core/DB_Management/codegraph/repository.py
+++ b/tldw_Server_API/app/core/DB_Management/codegraph/repository.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from contextlib import closing, contextmanager
+from dataclasses import dataclass
 import json
 import sqlite3
 import uuid
@@ -20,6 +21,15 @@ from tldw_Server_API.app.core.CodeGraph.models import (
     IndexRunSummary,
 )
 from tldw_Server_API.app.core.DB_Management.sqlite_policy import configure_sqlite_connection
+
+
+@dataclass(frozen=True)
+class ImpactTraversal:
+    """Bounded graph traversal result for CodeGraph impact queries."""
+
+    nodes: tuple[CodeGraphNode, ...]
+    relationships: tuple[dict[str, Any], ...]
+    truncated: bool
 
 
 class CodeGraphRepository:
@@ -418,6 +428,62 @@ class CodeGraphRepository:
             ).fetchall()
         return [_relationship_from_joined_row(row) for row in rows]
 
+    def traverse_impact(
+        self,
+        node_id: str,
+        *,
+        depth: int = 2,
+        direction: str = "both",
+        limit: int = 10,
+    ) -> ImpactTraversal:
+        """Traverse a bounded incoming/outgoing relationship neighborhood."""
+        if direction not in {"incoming", "outgoing", "both"}:
+            raise ValueError("direction must be incoming, outgoing, or both")
+
+        effective_depth = max(1, int(depth))
+        effective_limit = max(1, int(limit))
+        with self._connection() as conn:
+            root = conn.execute("SELECT * FROM nodes WHERE id = ?", (node_id,)).fetchone()
+            if root is None:
+                return ImpactTraversal(nodes=(), relationships=(), truncated=False)
+            anchor_file_path = str(root["file_path"])
+
+            seen_node_ids = {node_id}
+            frontier = {node_id}
+            relationships: list[dict[str, Any]] = []
+            seen_relationship_ids: set[str] = set()
+            truncated = False
+
+            for _level in range(effective_depth):
+                if not frontier or truncated:
+                    break
+                rows = _select_relationships_for_nodes(conn, frontier, direction, anchor_file_path=anchor_file_path)
+                next_frontier: set[str] = set()
+                for row in rows:
+                    edge_id = str(row["edge_id"])
+                    if edge_id in seen_relationship_ids:
+                        continue
+                    if len(relationships) >= effective_limit:
+                        truncated = True
+                        break
+                    relationship = _relationship_from_joined_row(row)
+                    relationships.append(relationship)
+                    seen_relationship_ids.add(edge_id)
+                    for endpoint in (relationship["source"], relationship["target"]):
+                        endpoint_id = str(endpoint["id"])
+                        if endpoint_id not in seen_node_ids:
+                            seen_node_ids.add(endpoint_id)
+                            next_frontier.add(endpoint_id)
+                frontier = next_frontier
+
+            node_rows = _select_nodes_by_ids(conn, seen_node_ids, anchor_file_path=anchor_file_path)
+
+        return ImpactTraversal(
+            nodes=tuple(_node_from_row(row) for row in node_rows),
+            relationships=tuple(relationships),
+            truncated=truncated,
+        )
+
     def seed_graph_rows_for_test(
         self,
         *,
@@ -520,6 +586,93 @@ def _delete_file_rows(conn: sqlite3.Connection, paths: list[str]) -> None:
     conn.executemany("DELETE FROM nodes WHERE file_path = ?", params)
     conn.executemany("DELETE FROM files WHERE path = ?", params)
     _delete_dangling_edges(conn)
+
+
+def _select_relationships_for_nodes(
+    conn: sqlite3.Connection,
+    node_ids: set[str],
+    direction: str,
+    *,
+    anchor_file_path: str,
+) -> list[sqlite3.Row]:
+    """Select joined relationships touching a set of node ids in deterministic order."""
+    placeholders = ",".join("?" for _ in node_ids)
+    ids = sorted(node_ids)
+    if direction == "incoming":
+        predicate = f"e.target IN ({placeholders})"
+        params = ids
+    elif direction == "outgoing":
+        predicate = f"e.source IN ({placeholders})"
+        params = ids
+    else:
+        predicate = f"(e.source IN ({placeholders}) OR e.target IN ({placeholders}))"
+        params = [*ids, *ids]
+
+    return conn.execute(
+        f"""
+        SELECT
+            e.id AS edge_id,
+            e.kind AS edge_kind,
+            e.file_path AS edge_file_path,
+            e.line AS edge_line,
+            e.column AS edge_column,
+            e.metadata AS edge_metadata,
+            e.provenance AS edge_provenance,
+            source_node.*,
+            target_node.id AS target_id,
+            target_node.identity_key AS target_identity_key,
+            target_node.kind AS target_kind,
+            target_node.name AS target_name,
+            target_node.qualified_name AS target_qualified_name,
+            target_node.file_path AS target_file_path,
+            target_node.language AS target_language,
+            target_node.start_line AS target_start_line,
+            target_node.end_line AS target_end_line,
+            target_node.start_column AS target_start_column,
+            target_node.end_column AS target_end_column,
+            target_node.signature AS target_signature,
+            target_node.docstring AS target_docstring,
+            target_node.visibility AS target_visibility,
+            target_node.flags AS target_flags,
+            target_node.metadata AS target_metadata
+        FROM edges e
+        JOIN nodes source_node ON source_node.id = e.source
+        JOIN nodes target_node ON target_node.id = e.target
+        WHERE {predicate}
+        ORDER BY
+            CASE WHEN e.file_path = ? THEN 0 ELSE 1 END,
+            e.file_path,
+            COALESCE(e.line, 0),
+            source_node.qualified_name,
+            target_node.qualified_name,
+            e.id
+        """,
+        [*params, anchor_file_path],
+    ).fetchall()
+
+
+def _select_nodes_by_ids(
+    conn: sqlite3.Connection,
+    node_ids: set[str],
+    *,
+    anchor_file_path: str,
+) -> list[sqlite3.Row]:
+    """Select nodes by id in stable source-location order."""
+    placeholders = ",".join("?" for _ in node_ids)
+    return conn.execute(
+        f"""
+        SELECT *
+        FROM nodes
+        WHERE id IN ({placeholders})
+        ORDER BY
+            CASE WHEN file_path = ? THEN 0 ELSE 1 END,
+            file_path,
+            COALESCE(start_line, 0),
+            qualified_name,
+            id
+        """,
+        [*sorted(node_ids), anchor_file_path],
+    ).fetchall()
 
 
 def _upsert_file(

--- a/tldw_Server_API/app/core/DB_Management/codegraph/repository.py
+++ b/tldw_Server_API/app/core/DB_Management/codegraph/repository.py
@@ -19,6 +19,7 @@ from tldw_Server_API.app.core.CodeGraph.models import (
     CodeGraphUnresolvedRef,
     IndexedFile,
     IndexRunSummary,
+    codegraph_node_to_dict,
 )
 from tldw_Server_API.app.core.DB_Management.sqlite_policy import configure_sqlite_connection
 
@@ -437,19 +438,36 @@ class CodeGraphRepository:
         limit: int = 10,
     ) -> ImpactTraversal:
         """Traverse a bounded incoming/outgoing relationship neighborhood."""
+        return self.traverse_impact_many((node_id,), depth=depth, direction=direction, limit=limit)
+
+    def traverse_impact_many(
+        self,
+        node_ids: tuple[str, ...],
+        *,
+        depth: int = 2,
+        direction: str = "both",
+        limit: int = 10,
+    ) -> ImpactTraversal:
+        """Traverse a bounded relationship neighborhood from multiple root nodes."""
         if direction not in {"incoming", "outgoing", "both"}:
             raise ValueError("direction must be incoming, outgoing, or both")
+
+        root_ids = tuple(dict.fromkeys(str(node_id) for node_id in node_ids if str(node_id)))
+        if not root_ids:
+            return ImpactTraversal(nodes=(), relationships=(), truncated=False)
 
         effective_depth = max(1, int(depth))
         effective_limit = max(1, int(limit))
         with self._connection() as conn:
-            root = conn.execute("SELECT * FROM nodes WHERE id = ?", (node_id,)).fetchone()
-            if root is None:
+            root_rows = _select_nodes_by_ids_without_anchor(conn, set(root_ids))
+            if not root_rows:
                 return ImpactTraversal(nodes=(), relationships=(), truncated=False)
-            anchor_file_path = str(root["file_path"])
+            roots_by_id = {str(row["id"]): row for row in root_rows}
+            first_root = next((roots_by_id[root_id] for root_id in root_ids if root_id in roots_by_id), root_rows[0])
+            anchor_file_path = str(first_root["file_path"])
 
-            seen_node_ids = {node_id}
-            frontier = {node_id}
+            seen_node_ids = set(roots_by_id)
+            frontier = set(roots_by_id)
             relationships: list[dict[str, Any]] = []
             seen_relationship_ids: set[str] = set()
             truncated = False
@@ -663,6 +681,22 @@ def _select_nodes_by_ids(
             id
         """,
         (json.dumps(sorted(node_ids)), anchor_file_path),
+    ).fetchall()
+
+
+def _select_nodes_by_ids_without_anchor(
+    conn: sqlite3.Connection,
+    node_ids: set[str],
+) -> list[sqlite3.Row]:
+    """Select nodes by id before an anchor file is known."""
+    return conn.execute(
+        """
+        SELECT *
+        FROM nodes
+        WHERE id IN (SELECT value FROM json_each(?))
+        ORDER BY file_path, COALESCE(start_line, 0), qualified_name, id
+        """,
+        (json.dumps(sorted(node_ids)),),
     ).fetchall()
 
 
@@ -883,27 +917,6 @@ def _node_from_row(row: sqlite3.Row) -> CodeGraphNode:
     )
 
 
-def _node_to_dict(node: CodeGraphNode) -> dict[str, Any]:
-    """Serialize a CodeGraphNode for relationship payloads."""
-    return {
-        "id": node.id,
-        "kind": node.kind,
-        "name": node.name,
-        "qualified_name": node.qualified_name,
-        "file_path": node.file_path,
-        "language": node.language,
-        "start_line": node.start_line,
-        "end_line": node.end_line,
-        "start_column": node.start_column,
-        "end_column": node.end_column,
-        "signature": node.signature,
-        "docstring": node.docstring,
-        "visibility": node.visibility,
-        "flags": list(node.flags),
-        "metadata": dict(node.metadata),
-    }
-
-
 def _target_node_from_joined_row(row: sqlite3.Row) -> CodeGraphNode:
     """Convert target-node aliases from a relationship join row."""
     return CodeGraphNode(
@@ -938,8 +951,8 @@ def _relationship_from_joined_row(row: sqlite3.Row) -> dict[str, Any]:
         "column": int(row["edge_column"]) if row["edge_column"] is not None else None,
         "metadata": dict(json.loads(row["edge_metadata"] or "{}")),
         "provenance": str(row["edge_provenance"]) if row["edge_provenance"] else None,
-        "source": _node_to_dict(source),
-        "target": _node_to_dict(target),
+        "source": codegraph_node_to_dict(source),
+        "target": codegraph_node_to_dict(target),
     }
 
 

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py
@@ -223,7 +223,38 @@ class CodeGraphModule(BaseModule):
         )
         callees_tool["inputSchema"]["additionalProperties"] = False
 
-        return [status_tool, index_tool, sync_tool, files_tool, search_tool, node_tool, callers_tool, callees_tool]
+        impact_tool = create_tool_definition(
+            name="codegraph.impact",
+            description="Traverse a bounded incoming or outgoing CodeGraph relationship neighborhood.",
+            parameters={
+                "properties": {
+                    "node_id": {"type": "string"},
+                    "symbol": {"type": "string"},
+                    "depth": {"type": "integer"},
+                    "direction": {"type": "string", "description": "incoming, outgoing, or both"},
+                    "limit": {"type": "integer"},
+                },
+            },
+            metadata={
+                "category": "retrieval",
+                "readOnlyHint": True,
+                "capabilities": ["codegraph.read"],
+                **workspace_metadata,
+            },
+        )
+        impact_tool["inputSchema"]["additionalProperties"] = False
+
+        return [
+            status_tool,
+            index_tool,
+            sync_tool,
+            files_tool,
+            search_tool,
+            node_tool,
+            callers_tool,
+            callees_tool,
+            impact_tool,
+        ]
 
     async def execute_tool(self, tool_name: str, arguments: dict[str, Any], context: Any | None = None) -> Any:
         """Validate and dispatch one CodeGraph MCP tool invocation."""
@@ -302,6 +333,17 @@ class CodeGraphModule(BaseModule):
                 args.get("limit"),
             )
 
+        if tool_name == "codegraph.impact":
+            return await asyncio.to_thread(
+                self._impact,
+                resolution,
+                args.get("node_id"),
+                args.get("symbol"),
+                str(args.get("direction") or "both"),
+                args.get("depth"),
+                args.get("limit"),
+            )
+
         raise ValueError(f"Unknown tool: {tool_name}")
 
     def validate_tool_arguments(self, tool_name: str, arguments: dict[str, Any]) -> None:
@@ -373,6 +415,18 @@ class CodeGraphModule(BaseModule):
         if tool_name in {"codegraph.callers", "codegraph.callees"}:
             self._reject_unknown(arguments, allowed={"node_id", "symbol", "limit"})
             self._validate_node_selector(arguments)
+            self._validate_positive_int(arguments.get("limit"), "limit")
+            return
+
+        if tool_name == "codegraph.impact":
+            self._reject_unknown(arguments, allowed={"node_id", "symbol", "depth", "direction", "limit"})
+            self._validate_node_selector(arguments)
+            direction = arguments.get("direction")
+            if direction is not None and direction not in {"incoming", "outgoing", "both"}:
+                raise ValueError("direction must be incoming, outgoing, or both")
+            self._validate_positive_int(arguments.get("depth"), "depth")
+            if arguments.get("depth") is not None and int(arguments["depth"]) > 4:
+                raise ValueError("depth must be between 1 and 4")
             self._validate_positive_int(arguments.get("limit"), "limit")
             return
 
@@ -574,6 +628,61 @@ class CodeGraphModule(BaseModule):
             "node": _node_to_dict(node),
             "relationships": rows[:effective_limit],
             "truncated": truncated,
+        }
+
+    def _impact(
+        self,
+        resolution: WorkspaceResolution,
+        node_id: str | None,
+        symbol: str | None,
+        direction: str,
+        depth: int | None,
+        limit: int | None,
+    ) -> dict[str, Any]:
+        """Traverse an indexed graph neighborhood for a node selector."""
+        effective_depth = min(max(1, int(depth or 2)), 4)
+        effective_limit = self._bounded_limit(limit)
+        if not resolution.index_db_path.exists():
+            return {
+                "workspace_key": resolution.workspace_key,
+                "index_present": False,
+                "root": None,
+                "nodes": [],
+                "relationships": [],
+                "depth": effective_depth,
+                "direction": direction,
+                "truncated": False,
+            }
+
+        repository = CodeGraphRepository(resolution.index_db_path)
+        node = repository.get_node(node_id) if node_id else repository.find_node_by_symbol(str(symbol))
+        if node is None:
+            return {
+                "workspace_key": resolution.workspace_key,
+                "index_present": True,
+                "root": None,
+                "nodes": [],
+                "relationships": [],
+                "depth": effective_depth,
+                "direction": direction,
+                "truncated": False,
+            }
+
+        impact = repository.traverse_impact(
+            node.id,
+            depth=effective_depth,
+            direction=direction,
+            limit=effective_limit,
+        )
+        return {
+            "workspace_key": resolution.workspace_key,
+            "index_present": True,
+            "root": _node_to_dict(node),
+            "nodes": [_node_to_dict(item) for item in impact.nodes],
+            "relationships": list(impact.relationships),
+            "depth": effective_depth,
+            "direction": direction,
+            "truncated": impact.truncated,
         }
 
     def _new_indexer(self) -> CodeGraphIndexer:

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py
@@ -19,7 +19,13 @@ from tldw_Server_API.app.core.CodeGraph.context import CodeGraphContextBuilder
 from tldw_Server_API.app.core.CodeGraph.dependencies import probe_codegraph_dependencies
 from tldw_Server_API.app.core.CodeGraph.indexer import CodeGraphIndexer
 from tldw_Server_API.app.core.CodeGraph.language_registry import CodeGraphLanguageRegistry
-from tldw_Server_API.app.core.CodeGraph.models import CodeGraphNode, IndexedFile, IndexRunSummary, WorkspaceResolution
+from tldw_Server_API.app.core.CodeGraph.models import (
+    CodeGraphNode,
+    IndexedFile,
+    IndexRunSummary,
+    WorkspaceResolution,
+    codegraph_node_to_dict,
+)
 from tldw_Server_API.app.core.CodeGraph.workspace import CodeGraphWorkspaceResolver, WorkspaceRootResolver
 from tldw_Server_API.app.core.DB_Management.codegraph.repository import CodeGraphRepository
 
@@ -610,7 +616,7 @@ class CodeGraphModule(BaseModule):
             "workspace_key": resolution.workspace_key,
             "index_present": True,
             "query": query,
-            "results": [_node_to_dict(row) for row in rows[:effective_limit]],
+            "results": [codegraph_node_to_dict(row) for row in rows[:effective_limit]],
             "truncated": truncated,
         }
 
@@ -626,7 +632,7 @@ class CodeGraphModule(BaseModule):
             return {"workspace_key": resolution.workspace_key, "index_present": False, "node": None}
         repository = CodeGraphRepository(resolution.index_db_path)
         node = repository.get_node(node_id) if node_id else repository.find_node_by_symbol(str(symbol))
-        node_dict = _node_to_dict(node) if node is not None else None
+        node_dict = codegraph_node_to_dict(node) if node is not None else None
         if node_dict is not None and include_code:
             node_dict["code_available"] = False
         return {
@@ -671,7 +677,7 @@ class CodeGraphModule(BaseModule):
         return {
             "workspace_key": resolution.workspace_key,
             "index_present": True,
-            "node": _node_to_dict(node),
+            "node": codegraph_node_to_dict(node),
             "relationships": rows[:effective_limit],
             "truncated": truncated,
         }
@@ -723,8 +729,8 @@ class CodeGraphModule(BaseModule):
         return {
             "workspace_key": resolution.workspace_key,
             "index_present": True,
-            "root": _node_to_dict(node),
-            "nodes": [_node_to_dict(item) for item in impact.nodes],
+            "root": codegraph_node_to_dict(node),
+            "nodes": [codegraph_node_to_dict(item) for item in impact.nodes],
             "relationships": list(impact.relationships),
             "depth": effective_depth,
             "direction": direction,
@@ -867,18 +873,22 @@ def _relationship_neighborhood(
     limit: int,
 ) -> list[dict[str, Any]]:
     """Collect a deduplicated one-hop relationship neighborhood for selected nodes."""
+    impact = repository.traverse_impact_many(
+        tuple(node.id for node in nodes),
+        depth=1,
+        direction="both",
+        limit=limit,
+    )
     relationships: list[dict[str, Any]] = []
     seen: set[str] = set()
-    for node in nodes:
-        impact = repository.traverse_impact(node.id, depth=1, direction="both", limit=limit)
-        for relationship in impact.relationships:
-            relationship_id = str(relationship["id"])
-            if relationship_id in seen:
-                continue
-            relationships.append(relationship)
-            seen.add(relationship_id)
-            if len(relationships) >= limit:
-                return relationships
+    for relationship in impact.relationships:
+        relationship_id = str(relationship["id"])
+        if relationship_id in seen:
+            continue
+        relationships.append(relationship)
+        seen.add(relationship_id)
+        if len(relationships) >= limit:
+            return relationships
     return relationships
 
 
@@ -901,27 +911,6 @@ def _indexed_file_to_dict(file: IndexedFile, *, include_metadata: bool) -> dict[
             }
         )
     return result
-
-
-def _node_to_dict(node: CodeGraphNode) -> dict[str, Any]:
-    """Serialize a graph node for MCP responses."""
-    return {
-        "id": node.id,
-        "kind": node.kind,
-        "name": node.name,
-        "qualified_name": node.qualified_name,
-        "file_path": node.file_path,
-        "language": node.language,
-        "start_line": node.start_line,
-        "end_line": node.end_line,
-        "start_column": node.start_column,
-        "end_column": node.end_column,
-        "signature": node.signature,
-        "docstring": node.docstring,
-        "visibility": node.visibility,
-        "flags": list(node.flags),
-        "metadata": dict(node.metadata),
-    }
 
 
 def _index_run_to_dict(run: IndexRunSummary | None) -> dict[str, Any] | None:

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py
@@ -15,6 +15,7 @@ from typing import Any
 from loguru import logger
 
 from tldw_Server_API.app.core.CodeGraph.config import CodeGraphSettings
+from tldw_Server_API.app.core.CodeGraph.context import CodeGraphContextBuilder
 from tldw_Server_API.app.core.CodeGraph.dependencies import probe_codegraph_dependencies
 from tldw_Server_API.app.core.CodeGraph.indexer import CodeGraphIndexer
 from tldw_Server_API.app.core.CodeGraph.language_registry import CodeGraphLanguageRegistry
@@ -244,6 +245,27 @@ class CodeGraphModule(BaseModule):
         )
         impact_tool["inputSchema"]["additionalProperties"] = False
 
+        context_tool = create_tool_definition(
+            name="codegraph.context",
+            description="Build bounded task-oriented CodeGraph context with related source snippets.",
+            parameters={
+                "properties": {
+                    "task": {"type": "string"},
+                    "max_nodes": {"type": "integer"},
+                    "include_code": {"type": "boolean"},
+                    "max_files": {"type": "integer"},
+                },
+                "required": ["task"],
+            },
+            metadata={
+                "category": "retrieval",
+                "readOnlyHint": True,
+                "capabilities": ["codegraph.read"],
+                **workspace_metadata,
+            },
+        )
+        context_tool["inputSchema"]["additionalProperties"] = False
+
         return [
             status_tool,
             index_tool,
@@ -254,6 +276,7 @@ class CodeGraphModule(BaseModule):
             callers_tool,
             callees_tool,
             impact_tool,
+            context_tool,
         ]
 
     async def execute_tool(self, tool_name: str, arguments: dict[str, Any], context: Any | None = None) -> Any:
@@ -344,6 +367,16 @@ class CodeGraphModule(BaseModule):
                 args.get("limit"),
             )
 
+        if tool_name == "codegraph.context":
+            return await asyncio.to_thread(
+                self._build_context,
+                resolution,
+                str(args["task"]),
+                args.get("max_nodes"),
+                bool(args.get("include_code", True)),
+                args.get("max_files"),
+            )
+
         raise ValueError(f"Unknown tool: {tool_name}")
 
     def validate_tool_arguments(self, tool_name: str, arguments: dict[str, Any]) -> None:
@@ -428,6 +461,19 @@ class CodeGraphModule(BaseModule):
             if arguments.get("depth") is not None and int(arguments["depth"]) > 4:
                 raise ValueError("depth must be between 1 and 4")
             self._validate_positive_int(arguments.get("limit"), "limit")
+            return
+
+        if tool_name == "codegraph.context":
+            self._reject_unknown(arguments, allowed={"task", "max_nodes", "include_code", "max_files"})
+            task = arguments.get("task")
+            if not isinstance(task, str) or not task.strip():
+                raise ValueError("task must be a non-empty string")
+            arguments["task"] = task.strip()
+            self._validate_positive_int(arguments.get("max_nodes"), "max_nodes")
+            self._validate_positive_int(arguments.get("max_files"), "max_files")
+            include_code = arguments.get("include_code")
+            if include_code is not None and not isinstance(include_code, bool):
+                raise ValueError("include_code must be a boolean")
             return
 
         raise ValueError(f"Unknown tool: {tool_name}")
@@ -685,6 +731,52 @@ class CodeGraphModule(BaseModule):
             "truncated": impact.truncated,
         }
 
+    def _build_context(
+        self,
+        resolution: WorkspaceResolution,
+        task: str,
+        max_nodes: int | None,
+        include_code: bool,
+        max_files: int | None,
+    ) -> dict[str, Any]:
+        """Build bounded source context for a task string."""
+        query = _context_query(task)
+        effective_max_nodes = self._bounded_limit(max_nodes, default=8)
+        effective_max_files = self._bounded_limit(max_files, default=5)
+        if not resolution.index_db_path.exists():
+            return {
+                "workspace_key": resolution.workspace_key,
+                "index_present": False,
+                "task": task,
+                "query": query,
+                "nodes": [],
+                "files": [],
+                "relationships": [],
+                "truncation": _empty_truncation(self._settings.max_context_chars),
+            }
+
+        repository = CodeGraphRepository(resolution.index_db_path)
+        nodes = tuple(repository.search_nodes(query, limit=effective_max_nodes + 1)[:effective_max_nodes])
+        relationships = tuple(_relationship_neighborhood(repository, nodes, limit=self._settings.max_search_results))
+        builder = CodeGraphContextBuilder(
+            workspace_root=resolution.workspace_root,
+            max_context_chars=self._settings.max_context_chars,
+            max_file_size_bytes=self._settings.max_file_size_bytes,
+        )
+        result = builder.build(
+            task=task,
+            nodes=nodes,
+            relationships=relationships,
+            max_files=effective_max_files,
+            include_code=include_code,
+        )
+        return {
+            "workspace_key": resolution.workspace_key,
+            "index_present": True,
+            "query": query,
+            **result,
+        }
+
     def _new_indexer(self) -> CodeGraphIndexer:
         """Create a fresh indexer for a blocking foreground operation."""
         return CodeGraphIndexer(settings=self._settings, registry=self._language_registry)
@@ -751,6 +843,43 @@ def _normalize_path_prefix(path: str | None) -> str | None:
     if raw.is_absolute() or ".." in raw.parts:
         raise PermissionError("path is outside workspace scope")
     return raw.as_posix().strip("/") or None
+
+
+def _context_query(task: str) -> str:
+    """Derive the first-pass symbol search query from a task description."""
+    return task.strip()
+
+
+def _empty_truncation(max_context_chars: int) -> dict[str, Any]:
+    """Build empty source-context truncation metadata."""
+    return {
+        "max_context_chars": max_context_chars,
+        "used_chars": 0,
+        "truncated": False,
+        "skipped_files": 0,
+    }
+
+
+def _relationship_neighborhood(
+    repository: CodeGraphRepository,
+    nodes: tuple[CodeGraphNode, ...],
+    *,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Collect a deduplicated one-hop relationship neighborhood for selected nodes."""
+    relationships: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for node in nodes:
+        impact = repository.traverse_impact(node.id, depth=1, direction="both", limit=limit)
+        for relationship in impact.relationships:
+            relationship_id = str(relationship["id"])
+            if relationship_id in seen:
+                continue
+            relationships.append(relationship)
+            seen.add(relationship_id)
+            if len(relationships) >= limit:
+                return relationships
+    return relationships
 
 
 def _indexed_file_to_dict(file: IndexedFile, *, include_metadata: bool) -> dict[str, Any]:

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py
@@ -379,7 +379,7 @@ class CodeGraphModule(BaseModule):
                 resolution,
                 str(args["task"]),
                 args.get("max_nodes"),
-                bool(args.get("include_code", True)),
+                args.get("include_code", True),
                 args.get("max_files"),
             )
 
@@ -480,6 +480,7 @@ class CodeGraphModule(BaseModule):
             include_code = arguments.get("include_code")
             if include_code is not None and not isinstance(include_code, bool):
                 raise ValueError("include_code must be a boolean")
+            arguments["include_code"] = True if include_code is None else include_code
             return
 
         raise ValueError(f"Unknown tool: {tool_name}")

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
@@ -36,6 +36,7 @@ class _CodeGraphRegistry:
             "codegraph.callers",
             "codegraph.callees",
             "codegraph.impact",
+            "codegraph.context",
         }
 
     async def find_module_for_tool(self, tool_name: str):  # noqa: ANN001
@@ -101,6 +102,7 @@ async def test_codegraph_exposes_stage2_tools(tmp_path: Path) -> None:
         "codegraph.callers",
         "codegraph.callees",
         "codegraph.impact",
+        "codegraph.context",
     }
     assert by_name["codegraph.status"]["metadata"]["readOnlyHint"] is True  # nosec B101
     assert by_name["codegraph.files"]["metadata"]["readOnlyHint"] is True  # nosec B101
@@ -109,6 +111,7 @@ async def test_codegraph_exposes_stage2_tools(tmp_path: Path) -> None:
     assert by_name["codegraph.callers"]["metadata"]["readOnlyHint"] is True  # nosec B101
     assert by_name["codegraph.callees"]["metadata"]["readOnlyHint"] is True  # nosec B101
     assert by_name["codegraph.impact"]["metadata"]["readOnlyHint"] is True  # nosec B101
+    assert by_name["codegraph.context"]["metadata"]["readOnlyHint"] is True  # nosec B101
     assert by_name["codegraph.index"]["metadata"]["category"] == "management"  # nosec B101
     assert by_name["codegraph.sync"]["metadata"]["category"] == "management"  # nosec B101
 
@@ -123,6 +126,7 @@ async def test_codegraph_exposes_stage2_tools(tmp_path: Path) -> None:
     assert by_name["codegraph.files"]["metadata"]["path_argument_hints"] == ["path"]  # nosec B101
     assert by_name["codegraph.search"]["metadata"]["path_argument_hints"] == []  # nosec B101
     assert by_name["codegraph.impact"]["metadata"]["path_argument_hints"] == []  # nosec B101
+    assert by_name["codegraph.context"]["metadata"]["path_argument_hints"] == []  # nosec B101
 
 
 @pytest.mark.asyncio
@@ -333,6 +337,103 @@ def helper(value):
     assert result["truncated"] is False  # nosec B101
 
 
+def test_codegraph_context_rejects_invalid_arguments(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    module = _module(tmp_path, workspace_root)
+
+    with pytest.raises(ValueError, match="unknown arguments"):
+        module.validate_tool_arguments("codegraph.context", {"task": "helper", "unknown": True})
+    with pytest.raises(ValueError, match="task"):
+        module.validate_tool_arguments("codegraph.context", {"task": " "})
+    with pytest.raises(ValueError, match="max_nodes"):
+        module.validate_tool_arguments("codegraph.context", {"task": "helper", "max_nodes": 0})
+    with pytest.raises(ValueError, match="max_files"):
+        module.validate_tool_arguments("codegraph.context", {"task": "helper", "max_files": 0})
+    with pytest.raises(ValueError, match="include_code"):
+        module.validate_tool_arguments("codegraph.context", {"task": "helper", "include_code": "yes"})
+
+
+@pytest.mark.asyncio
+async def test_codegraph_context_missing_index_is_read_only(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    index_base = tmp_path / "indexes"
+    module = _module(tmp_path, workspace_root)
+
+    result = await module.execute_tool("codegraph.context", {"task": "helper"}, context=_context())
+
+    assert result["index_present"] is False  # nosec B101
+    assert result["nodes"] == []  # nosec B101
+    assert result["files"] == []  # nosec B101
+    assert result["relationships"] == []  # nosec B101
+    assert not index_base.exists()  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_codegraph_context_returns_bounded_source_context(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    (workspace_root / "app.py").write_text(
+        """
+class Greeter:
+    def greet(self, name):
+        return helper(name)
+
+
+def helper(value):
+    return value.upper()
+""",
+        encoding="utf-8",
+    )
+    module = _module(tmp_path, workspace_root)
+
+    await module.execute_tool(
+        "codegraph.index",
+        {"mode": "foreground", "force": True, "max_files": 10},
+        context=_context(),
+    )
+    result = await module.execute_tool(
+        "codegraph.context",
+        {"task": " helper ", "max_nodes": 5, "max_files": 2, "include_code": True},
+        context=_context(),
+    )
+
+    assert result["index_present"] is True  # nosec B101
+    assert result["task"] == "helper"  # nosec B101
+    assert result["query"] == "helper"  # nosec B101
+    assert [node["qualified_name"] for node in result["nodes"]] == ["helper"]  # nosec B101
+    assert [relationship["source"]["qualified_name"] for relationship in result["relationships"]] == [
+        "Greeter.greet"
+    ]  # nosec B101
+    assert [file_context["path"] for file_context in result["files"]] == ["app.py"]  # nosec B101
+    assert "def helper" in result["files"][0]["snippets"][0]["text"]  # nosec B101
+    assert result["truncation"]["truncated"] is False  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_codegraph_context_can_return_metadata_without_source_text(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    (workspace_root / "app.py").write_text("def helper():\n    return 1\n", encoding="utf-8")
+    module = _module(tmp_path, workspace_root)
+
+    await module.execute_tool(
+        "codegraph.index",
+        {"mode": "foreground", "force": True, "max_files": 10},
+        context=_context(),
+    )
+    result = await module.execute_tool(
+        "codegraph.context",
+        {"task": "helper", "include_code": False},
+        context=_context(),
+    )
+
+    assert result["files"][0]["path"] == "app.py"  # nosec B101
+    assert result["files"][0]["snippets"] == []  # nosec B101
+    assert result["truncation"]["used_chars"] == 0  # nosec B101
+
+
 @pytest.mark.asyncio
 async def test_codegraph_offloads_blocking_repository_work(
     tmp_path: Path,
@@ -355,8 +456,10 @@ async def test_codegraph_offloads_blocking_repository_work(
     await module.execute_tool("codegraph.search", {"query": "app"}, context=_context())
     await module.execute_tool("codegraph.sync", {"mode": "foreground"}, context=_context())
     await module.execute_tool("codegraph.impact", {"symbol": "app"}, context=_context())
+    await module.execute_tool("codegraph.context", {"task": "app"}, context=_context())
 
     assert "_impact" in offloaded  # nosec B101
+    assert "_build_context" in offloaded  # nosec B101
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
@@ -35,6 +35,7 @@ class _CodeGraphRegistry:
             "codegraph.node",
             "codegraph.callers",
             "codegraph.callees",
+            "codegraph.impact",
         }
 
     async def find_module_for_tool(self, tool_name: str):  # noqa: ANN001
@@ -99,6 +100,7 @@ async def test_codegraph_exposes_stage2_tools(tmp_path: Path) -> None:
         "codegraph.node",
         "codegraph.callers",
         "codegraph.callees",
+        "codegraph.impact",
     }
     assert by_name["codegraph.status"]["metadata"]["readOnlyHint"] is True  # nosec B101
     assert by_name["codegraph.files"]["metadata"]["readOnlyHint"] is True  # nosec B101
@@ -106,6 +108,7 @@ async def test_codegraph_exposes_stage2_tools(tmp_path: Path) -> None:
     assert by_name["codegraph.node"]["metadata"]["readOnlyHint"] is True  # nosec B101
     assert by_name["codegraph.callers"]["metadata"]["readOnlyHint"] is True  # nosec B101
     assert by_name["codegraph.callees"]["metadata"]["readOnlyHint"] is True  # nosec B101
+    assert by_name["codegraph.impact"]["metadata"]["readOnlyHint"] is True  # nosec B101
     assert by_name["codegraph.index"]["metadata"]["category"] == "management"  # nosec B101
     assert by_name["codegraph.sync"]["metadata"]["category"] == "management"  # nosec B101
 
@@ -119,6 +122,7 @@ async def test_codegraph_exposes_stage2_tools(tmp_path: Path) -> None:
     assert by_name["codegraph.sync"]["metadata"]["path_argument_hints"] == []  # nosec B101
     assert by_name["codegraph.files"]["metadata"]["path_argument_hints"] == ["path"]  # nosec B101
     assert by_name["codegraph.search"]["metadata"]["path_argument_hints"] == []  # nosec B101
+    assert by_name["codegraph.impact"]["metadata"]["path_argument_hints"] == []  # nosec B101
 
 
 @pytest.mark.asyncio
@@ -258,6 +262,77 @@ def test_codegraph_rejects_ambiguous_node_selectors(tmp_path: Path) -> None:
         )
 
 
+def test_codegraph_impact_rejects_invalid_arguments(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    module = _module(tmp_path, workspace_root)
+
+    with pytest.raises(ValueError, match="unknown arguments"):
+        module.validate_tool_arguments("codegraph.impact", {"symbol": "helper", "unknown": True})
+    with pytest.raises(ValueError, match="direction"):
+        module.validate_tool_arguments("codegraph.impact", {"symbol": "helper", "direction": "sideways"})
+    with pytest.raises(ValueError, match="depth"):
+        module.validate_tool_arguments("codegraph.impact", {"symbol": "helper", "depth": 5})
+    with pytest.raises(ValueError, match="limit"):
+        module.validate_tool_arguments("codegraph.impact", {"symbol": "helper", "limit": 0})
+
+
+@pytest.mark.asyncio
+async def test_codegraph_impact_missing_index_is_read_only(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    index_base = tmp_path / "indexes"
+    module = _module(tmp_path, workspace_root)
+
+    result = await module.execute_tool("codegraph.impact", {"symbol": "helper"}, context=_context())
+
+    assert result["index_present"] is False  # nosec B101
+    assert result["root"] is None  # nosec B101
+    assert result["nodes"] == []  # nosec B101
+    assert result["relationships"] == []  # nosec B101
+    assert not index_base.exists()  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_codegraph_impact_returns_bounded_relationship_neighborhood(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    (workspace_root / "app.py").write_text(
+        """
+class Greeter:
+    def greet(self, name):
+        return helper(name)
+
+
+def helper(value):
+    return value.upper()
+""",
+        encoding="utf-8",
+    )
+    module = _module(tmp_path, workspace_root)
+
+    await module.execute_tool(
+        "codegraph.index",
+        {"mode": "foreground", "force": True, "max_files": 10},
+        context=_context(),
+    )
+    result = await module.execute_tool(
+        "codegraph.impact",
+        {"symbol": " helper ", "direction": "incoming", "depth": 1, "limit": 10},
+        context=_context(),
+    )
+
+    assert result["index_present"] is True  # nosec B101
+    assert result["root"]["qualified_name"] == "helper"  # nosec B101
+    assert result["depth"] == 1  # nosec B101
+    assert result["direction"] == "incoming"  # nosec B101
+    assert [node["qualified_name"] for node in result["nodes"]] == ["Greeter.greet", "helper"]  # nosec B101
+    assert [relationship["source"]["qualified_name"] for relationship in result["relationships"]] == [
+        "Greeter.greet"
+    ]  # nosec B101
+    assert result["truncated"] is False  # nosec B101
+
+
 @pytest.mark.asyncio
 async def test_codegraph_offloads_blocking_repository_work(
     tmp_path: Path,
@@ -279,8 +354,9 @@ async def test_codegraph_offloads_blocking_repository_work(
     await module.execute_tool("codegraph.files", {}, context=_context())
     await module.execute_tool("codegraph.search", {"query": "app"}, context=_context())
     await module.execute_tool("codegraph.sync", {"mode": "foreground"}, context=_context())
+    await module.execute_tool("codegraph.impact", {"symbol": "app"}, context=_context())
 
-    assert len(offloaded) >= 4  # nosec B101
+    assert "_impact" in offloaded  # nosec B101
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
@@ -6,9 +6,11 @@ from typing import Any
 
 import pytest
 
+from tldw_Server_API.app.core.CodeGraph.models import CodeGraphNode
 from tldw_Server_API.app.core.MCP_unified.modules.base import ModuleConfig
 from tldw_Server_API.app.core.MCP_unified.modules.implementations.codegraph_module import (
     CodeGraphModule,
+    _relationship_neighborhood,
 )
 from tldw_Server_API.app.core.MCP_unified.protocol import InvalidParamsException, MCPProtocol, RequestContext
 
@@ -352,6 +354,48 @@ def test_codegraph_context_rejects_invalid_arguments(tmp_path: Path) -> None:
         module.validate_tool_arguments("codegraph.context", {"task": "helper", "max_files": 0})
     with pytest.raises(ValueError, match="include_code"):
         module.validate_tool_arguments("codegraph.context", {"task": "helper", "include_code": "yes"})
+
+
+def test_relationship_neighborhood_uses_repository_batch_traversal() -> None:
+    node = CodeGraphNode(
+        id="node_helper",
+        identity_key="helper",
+        kind="function",
+        name="helper",
+        qualified_name="helper",
+        file_path="app.py",
+        language="python",
+    )
+    relationship = {
+        "id": "edge_call",
+        "source": {"id": "node_caller", "qualified_name": "caller"},
+        "target": {"id": "node_helper", "qualified_name": "helper"},
+    }
+
+    class _FakeRepository:
+        def __init__(self) -> None:
+            self.calls: list[tuple[tuple[str, ...], int, str, int]] = []
+
+        def traverse_impact_many(
+            self,
+            node_ids: tuple[str, ...],
+            *,
+            depth: int,
+            direction: str,
+            limit: int,
+        ):  # noqa: ANN202
+            self.calls.append((node_ids, depth, direction, limit))
+            return type("Impact", (), {"relationships": (relationship,)})()
+
+        def traverse_impact(self, *_args, **_kwargs):  # noqa: ANN202
+            raise AssertionError("relationship neighborhood should use batch traversal")
+
+    repository = _FakeRepository()
+
+    result = _relationship_neighborhood(repository, (node,), limit=10)  # type: ignore[arg-type]
+
+    assert result == [relationship]  # nosec B101
+    assert repository.calls == [(("node_helper",), 1, "both", 10)]  # nosec B101
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
@@ -1,3 +1,5 @@
+"""Tests for the Unified MCP CodeGraph module."""
+
 from __future__ import annotations
 
 import asyncio
@@ -16,16 +18,21 @@ from tldw_Server_API.app.core.MCP_unified.protocol import InvalidParamsException
 
 
 class _FakeWorkspaceRootResolver:
+    """Capture workspace resolution requests and return a fixed workspace."""
+
     def __init__(self, result: dict[str, Any]) -> None:
         self.result = dict(result)
         self.calls: list[dict[str, Any]] = []
 
     async def resolve_for_context(self, **kwargs: Any) -> dict[str, Any]:
+        """Return the configured fake workspace resolution payload."""
         self.calls.append(dict(kwargs))
         return dict(self.result)
 
 
 class _CodeGraphRegistry:
+    """Minimal registry wrapper exposing one CodeGraph module to protocol tests."""
+
     def __init__(self, module: CodeGraphModule) -> None:
         self.module = module
         self._tool_names = {
@@ -42,17 +49,20 @@ class _CodeGraphRegistry:
         }
 
     async def find_module_for_tool(self, tool_name: str):  # noqa: ANN001
+        """Return the CodeGraph module when the tool name belongs to it."""
         if tool_name in self._tool_names:
             return self.module
         return None
 
     def get_module_id_for_tool(self, tool_name: str) -> str | None:
+        """Return the CodeGraph module id for known CodeGraph tools."""
         if tool_name in self._tool_names:
             return self.module.name
         return None
 
 
 def _context() -> RequestContext:
+    """Build a request context with a workspace id for CodeGraph tests."""
     return RequestContext(
         request_id="req-codegraph",
         user_id="7",
@@ -62,6 +72,7 @@ def _context() -> RequestContext:
 
 
 def _module(tmp_path: Path, workspace_root: Path) -> CodeGraphModule:
+    """Create a CodeGraph module with default test settings."""
     return _module_with_settings(tmp_path, workspace_root, {})
 
 
@@ -70,6 +81,7 @@ def _module_with_settings(
     workspace_root: Path,
     settings: dict[str, Any],
 ) -> CodeGraphModule:
+    """Create a CodeGraph module with overridden test settings."""
     resolver = _FakeWorkspaceRootResolver(
         {
             "workspace_root": str(workspace_root),
@@ -269,6 +281,7 @@ def test_codegraph_rejects_ambiguous_node_selectors(tmp_path: Path) -> None:
 
 
 def test_codegraph_impact_rejects_invalid_arguments(tmp_path: Path) -> None:
+    """Reject invalid selectors, directions, depth, and limit arguments."""
     workspace_root = tmp_path / "workspace"
     workspace_root.mkdir()
     module = _module(tmp_path, workspace_root)
@@ -285,6 +298,7 @@ def test_codegraph_impact_rejects_invalid_arguments(tmp_path: Path) -> None:
 
 @pytest.mark.asyncio
 async def test_codegraph_impact_missing_index_is_read_only(tmp_path: Path) -> None:
+    """Return an empty read-only impact response when no index database exists."""
     workspace_root = tmp_path / "workspace"
     workspace_root.mkdir()
     index_base = tmp_path / "indexes"
@@ -301,6 +315,7 @@ async def test_codegraph_impact_missing_index_is_read_only(tmp_path: Path) -> No
 
 @pytest.mark.asyncio
 async def test_codegraph_impact_returns_bounded_relationship_neighborhood(tmp_path: Path) -> None:
+    """Return a bounded incoming impact neighborhood for an indexed symbol."""
     workspace_root = tmp_path / "workspace"
     workspace_root.mkdir()
     (workspace_root / "app.py").write_text(
@@ -340,6 +355,7 @@ def helper(value):
 
 
 def test_codegraph_context_rejects_invalid_arguments(tmp_path: Path) -> None:
+    """Reject invalid task, bounds, include_code, and unknown context arguments."""
     workspace_root = tmp_path / "workspace"
     workspace_root.mkdir()
     module = _module(tmp_path, workspace_root)
@@ -357,6 +373,7 @@ def test_codegraph_context_rejects_invalid_arguments(tmp_path: Path) -> None:
 
 
 def test_relationship_neighborhood_uses_repository_batch_traversal() -> None:
+    """Collect context relationships with one repository batch traversal call."""
     node = CodeGraphNode(
         id="node_helper",
         identity_key="helper",
@@ -373,6 +390,8 @@ def test_relationship_neighborhood_uses_repository_batch_traversal() -> None:
     }
 
     class _FakeRepository:
+        """Record impact traversal calls made by relationship-neighborhood helper."""
+
         def __init__(self) -> None:
             self.calls: list[tuple[tuple[str, ...], int, str, int]] = []
 
@@ -384,10 +403,12 @@ def test_relationship_neighborhood_uses_repository_batch_traversal() -> None:
             direction: str,
             limit: int,
         ):  # noqa: ANN202
+            """Return one fake impact relationship and record traversal arguments."""
             self.calls.append((node_ids, depth, direction, limit))
             return type("Impact", (), {"relationships": (relationship,)})()
 
         def traverse_impact(self, *_args, **_kwargs):  # noqa: ANN202
+            """Fail if legacy single-node traversal is used by context assembly."""
             raise AssertionError("relationship neighborhood should use batch traversal")
 
     repository = _FakeRepository()
@@ -400,6 +421,7 @@ def test_relationship_neighborhood_uses_repository_batch_traversal() -> None:
 
 @pytest.mark.asyncio
 async def test_codegraph_context_missing_index_is_read_only(tmp_path: Path) -> None:
+    """Return an empty read-only context response when no index database exists."""
     workspace_root = tmp_path / "workspace"
     workspace_root.mkdir()
     index_base = tmp_path / "indexes"
@@ -416,6 +438,7 @@ async def test_codegraph_context_missing_index_is_read_only(tmp_path: Path) -> N
 
 @pytest.mark.asyncio
 async def test_codegraph_context_returns_bounded_source_context(tmp_path: Path) -> None:
+    """Build bounded context with related nodes, relationships, and source snippets."""
     workspace_root = tmp_path / "workspace"
     workspace_root.mkdir()
     (workspace_root / "app.py").write_text(
@@ -456,7 +479,30 @@ def helper(value):
 
 
 @pytest.mark.asyncio
+async def test_codegraph_context_treats_null_include_code_as_default_true(tmp_path: Path) -> None:
+    """Treat JSON null include_code as the default source-including context mode."""
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    (workspace_root / "app.py").write_text("def helper():\n    return 1\n", encoding="utf-8")
+    module = _module(tmp_path, workspace_root)
+
+    await module.execute_tool(
+        "codegraph.index",
+        {"mode": "foreground", "force": True, "max_files": 10},
+        context=_context(),
+    )
+    result = await module.execute_tool(
+        "codegraph.context",
+        {"task": "helper", "include_code": None},
+        context=_context(),
+    )
+
+    assert "def helper" in result["files"][0]["snippets"][0]["text"]  # nosec B101
+
+
+@pytest.mark.asyncio
 async def test_codegraph_context_can_return_metadata_without_source_text(tmp_path: Path) -> None:
+    """Return file metadata without source snippets when include_code is false."""
     workspace_root = tmp_path / "workspace"
     workspace_root.mkdir()
     (workspace_root / "app.py").write_text("def helper():\n    return 1\n", encoding="utf-8")

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_context.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_context.py
@@ -1,3 +1,5 @@
+"""Tests for bounded workspace-safe CodeGraph context assembly."""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -7,6 +9,7 @@ from tldw_Server_API.app.core.CodeGraph.models import CodeGraphNode
 
 
 def test_context_builder_reads_bounded_source_snippet(tmp_path: Path) -> None:
+    """Read a source snippet around the indexed node with surrounding context."""
     source = tmp_path / "pkg" / "sample.py"
     source.parent.mkdir()
     source.write_text(
@@ -49,6 +52,7 @@ def test_context_builder_reads_bounded_source_snippet(tmp_path: Path) -> None:
 
 
 def test_context_builder_groups_duplicate_file_snippets(tmp_path: Path) -> None:
+    """Group multiple node snippets from the same file under one file entry."""
     source = tmp_path / "pkg" / "sample.py"
     source.parent.mkdir()
     source.write_text(
@@ -88,6 +92,7 @@ def test_context_builder_groups_duplicate_file_snippets(tmp_path: Path) -> None:
 
 
 def test_context_builder_respects_context_character_budget(tmp_path: Path) -> None:
+    """Truncate snippet text when the context character budget is exhausted."""
     source = tmp_path / "pkg" / "large.py"
     source.parent.mkdir()
     source.write_text(
@@ -127,6 +132,7 @@ def test_context_builder_respects_context_character_budget(tmp_path: Path) -> No
 
 
 def test_context_builder_skips_unsafe_paths(tmp_path: Path) -> None:
+    """Skip absolute and parent-traversal file paths instead of reading them."""
     builder = CodeGraphContextBuilder(
         workspace_root=tmp_path,
         max_context_chars=500,
@@ -149,6 +155,7 @@ def test_context_builder_skips_unsafe_paths(tmp_path: Path) -> None:
 
 
 def test_context_builder_reports_missing_files_without_raising(tmp_path: Path) -> None:
+    """Represent missing source files as file-context errors without raising."""
     builder = CodeGraphContextBuilder(
         workspace_root=tmp_path,
         max_context_chars=500,
@@ -175,6 +182,7 @@ def test_context_builder_reports_missing_files_without_raising(tmp_path: Path) -
 
 
 def test_context_builder_can_exclude_source_text(tmp_path: Path) -> None:
+    """Return metadata-only file context when source snippets are disabled."""
     source = tmp_path / "pkg" / "sample.py"
     source.parent.mkdir()
     source.write_text("def helper():\n    return 1\n", encoding="utf-8")
@@ -211,6 +219,7 @@ def _node(
     start_line: int | None = 1,
     end_line: int | None = 1,
 ) -> CodeGraphNode:
+    """Build a minimal CodeGraph node for context builder tests."""
     return CodeGraphNode(
         id=node_id,
         identity_key=node_id,

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_context.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_context.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tldw_Server_API.app.core.CodeGraph.context import CodeGraphContextBuilder
+from tldw_Server_API.app.core.CodeGraph.models import CodeGraphNode
+
+
+def test_context_builder_reads_bounded_source_snippet(tmp_path: Path) -> None:
+    source = tmp_path / "pkg" / "sample.py"
+    source.parent.mkdir()
+    source.write_text(
+        "\n".join(
+            [
+                "import os",
+                "",
+                "def entry():",
+                "    helper()",
+                "",
+                "def helper(value):",
+                "    return value + 1",
+                "",
+                "def leaf():",
+                "    return helper(1)",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    builder = CodeGraphContextBuilder(
+        workspace_root=tmp_path,
+        max_context_chars=500,
+        max_file_size_bytes=10_000,
+    )
+
+    result = builder.build(
+        task="update helper",
+        nodes=(_node("node_helper", "pkg/sample.py", start_line=6, end_line=7),),
+        relationships=(),
+        max_files=3,
+        include_code=True,
+    )
+
+    assert result["files"][0]["path"] == "pkg/sample.py"
+    snippet = result["files"][0]["snippets"][0]
+    assert snippet["start_line"] == 3
+    assert snippet["end_line"] == 10
+    assert "def helper" in snippet["text"]
+    assert result["truncation"]["truncated"] is False
+
+
+def test_context_builder_groups_duplicate_file_snippets(tmp_path: Path) -> None:
+    source = tmp_path / "pkg" / "sample.py"
+    source.parent.mkdir()
+    source.write_text(
+        "\n".join(
+            [
+                "def entry():",
+                "    helper()",
+                "",
+                "def helper():",
+                "    return leaf()",
+                "",
+                "def leaf():",
+                "    return 1",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    builder = CodeGraphContextBuilder(
+        workspace_root=tmp_path,
+        max_context_chars=1_000,
+        max_file_size_bytes=10_000,
+    )
+
+    result = builder.build(
+        task="inspect helper",
+        nodes=(
+            _node("node_helper", "pkg/sample.py", start_line=4, end_line=5),
+            _node("node_leaf", "pkg/sample.py", start_line=7, end_line=8),
+        ),
+        relationships=(),
+        max_files=3,
+        include_code=True,
+    )
+
+    assert [file_context["path"] for file_context in result["files"]] == ["pkg/sample.py"]
+    assert len(result["files"][0]["snippets"]) == 2
+
+
+def test_context_builder_respects_context_character_budget(tmp_path: Path) -> None:
+    source = tmp_path / "pkg" / "large.py"
+    source.parent.mkdir()
+    source.write_text(
+        "\n".join(
+            [
+                "def before():",
+                "    return 'before'",
+                "",
+                "def helper():",
+                "    return 'this snippet is intentionally too long for the budget'",
+                "",
+                "def after():",
+                "    return 'after'",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    builder = CodeGraphContextBuilder(
+        workspace_root=tmp_path,
+        max_context_chars=48,
+        max_file_size_bytes=10_000,
+    )
+
+    result = builder.build(
+        task="short budget",
+        nodes=(_node("node_helper", "pkg/large.py", start_line=4, end_line=5),),
+        relationships=(),
+        max_files=3,
+        include_code=True,
+    )
+
+    snippet = result["files"][0]["snippets"][0]
+    assert len(snippet["text"]) <= 48
+    assert snippet["truncated"] is True
+    assert result["truncation"]["used_chars"] <= 48
+    assert result["truncation"]["truncated"] is True
+
+
+def test_context_builder_skips_unsafe_paths(tmp_path: Path) -> None:
+    builder = CodeGraphContextBuilder(
+        workspace_root=tmp_path,
+        max_context_chars=500,
+        max_file_size_bytes=10_000,
+    )
+
+    result = builder.build(
+        task="path safety",
+        nodes=(
+            _node("node_parent", "../outside.py"),
+            _node("node_absolute", str(tmp_path / "absolute.py")),
+        ),
+        relationships=(),
+        max_files=3,
+        include_code=True,
+    )
+
+    assert result["files"] == []
+    assert result["truncation"]["skipped_files"] == 2
+
+
+def test_context_builder_reports_missing_files_without_raising(tmp_path: Path) -> None:
+    builder = CodeGraphContextBuilder(
+        workspace_root=tmp_path,
+        max_context_chars=500,
+        max_file_size_bytes=10_000,
+    )
+
+    result = builder.build(
+        task="missing source",
+        nodes=(_node("node_missing", "pkg/missing.py"),),
+        relationships=(),
+        max_files=3,
+        include_code=True,
+    )
+
+    assert result["files"] == [
+        {
+            "path": "pkg/missing.py",
+            "language": "python",
+            "exists": False,
+            "snippets": [],
+            "errors": ["source file not found"],
+        }
+    ]
+
+
+def test_context_builder_can_exclude_source_text(tmp_path: Path) -> None:
+    source = tmp_path / "pkg" / "sample.py"
+    source.parent.mkdir()
+    source.write_text("def helper():\n    return 1\n", encoding="utf-8")
+    builder = CodeGraphContextBuilder(
+        workspace_root=tmp_path,
+        max_context_chars=500,
+        max_file_size_bytes=10_000,
+    )
+
+    result = builder.build(
+        task="metadata only",
+        nodes=(_node("node_helper", "pkg/sample.py", start_line=1, end_line=2),),
+        relationships=(),
+        max_files=3,
+        include_code=False,
+    )
+
+    assert result["files"] == [
+        {
+            "path": "pkg/sample.py",
+            "language": "python",
+            "exists": True,
+            "snippets": [],
+            "errors": [],
+        }
+    ]
+    assert result["truncation"]["used_chars"] == 0
+
+
+def _node(
+    node_id: str,
+    file_path: str,
+    *,
+    start_line: int | None = 1,
+    end_line: int | None = 1,
+) -> CodeGraphNode:
+    return CodeGraphNode(
+        id=node_id,
+        identity_key=node_id,
+        kind="function",
+        name=node_id.removeprefix("node_"),
+        qualified_name=node_id.removeprefix("node_"),
+        file_path=file_path,
+        language="python",
+        start_line=start_line,
+        end_line=end_line,
+    )

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_models.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_models.py
@@ -1,9 +1,12 @@
+"""Tests for shared CodeGraph model serialization helpers."""
+
 from __future__ import annotations
 
 from tldw_Server_API.app.core.CodeGraph.models import CodeGraphNode, codegraph_node_to_dict
 
 
 def test_codegraph_node_to_dict_serializes_public_fields() -> None:
+    """Serialize CodeGraph nodes into stable public MCP payload fields."""
     node = CodeGraphNode(
         id="node_helper",
         identity_key="helper-key",

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_models.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_models.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from tldw_Server_API.app.core.CodeGraph.models import CodeGraphNode, codegraph_node_to_dict
+
+
+def test_codegraph_node_to_dict_serializes_public_fields() -> None:
+    node = CodeGraphNode(
+        id="node_helper",
+        identity_key="helper-key",
+        kind="function",
+        name="helper",
+        qualified_name="pkg.helper",
+        file_path="pkg/sample.py",
+        language="python",
+        start_line=4,
+        end_line=8,
+        start_column=1,
+        end_column=12,
+        signature="helper(value)",
+        docstring="Help.",
+        visibility="public",
+        flags=("async",),
+        metadata={"decorators": ["cached"]},
+    )
+
+    assert codegraph_node_to_dict(node) == {
+        "id": "node_helper",
+        "kind": "function",
+        "name": "helper",
+        "qualified_name": "pkg.helper",
+        "file_path": "pkg/sample.py",
+        "language": "python",
+        "start_line": 4,
+        "end_line": 8,
+        "start_column": 1,
+        "end_column": 12,
+        "signature": "helper(value)",
+        "docstring": "Help.",
+        "visibility": "public",
+        "flags": ["async"],
+        "metadata": {"decorators": ["cached"]},
+    }

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_repository.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_repository.py
@@ -1,11 +1,15 @@
+"""Tests for the native CodeGraph SQLite repository."""
+
 from __future__ import annotations
 
+import inspect
 import sqlite3
 from pathlib import Path
 
 import pytest
 
 from tldw_Server_API.app.core.CodeGraph.models import CodeGraphEdge, CodeGraphNode, CodeGraphUnresolvedRef
+from tldw_Server_API.app.core.DB_Management.codegraph import repository as repository_module
 from tldw_Server_API.app.core.DB_Management.codegraph.repository import CodeGraphRepository, _create_optional_fts
 
 
@@ -348,6 +352,7 @@ def test_repository_atomic_file_and_graph_replacement_rolls_back_on_graph_error(
 
 
 def test_repository_traverses_bounded_impact_graph(tmp_path: Path) -> None:
+    """Return a deterministic bounded impact neighborhood around a node."""
     repo = CodeGraphRepository(tmp_path / "codegraph.db")
     repo.initialize()
     _seed_impact_graph(repo)
@@ -369,6 +374,7 @@ def test_repository_traverses_bounded_impact_graph(tmp_path: Path) -> None:
 
 
 def test_repository_impact_traversal_reports_truncation(tmp_path: Path) -> None:
+    """Report truncation when relationship traversal reaches the result cap."""
     repo = CodeGraphRepository(tmp_path / "codegraph.db")
     repo.initialize()
     _seed_impact_graph(repo)
@@ -380,6 +386,7 @@ def test_repository_impact_traversal_reports_truncation(tmp_path: Path) -> None:
 
 
 def test_repository_batch_impact_traversal_uses_one_neighborhood(tmp_path: Path) -> None:
+    """Traverse one shared impact neighborhood for multiple starting nodes."""
     repo = CodeGraphRepository(tmp_path / "codegraph.db")
     repo.initialize()
     _seed_impact_graph(repo)
@@ -400,7 +407,40 @@ def test_repository_batch_impact_traversal_uses_one_neighborhood(tmp_path: Path)
     assert impact.truncated is False
 
 
+def test_repository_impact_traversal_passes_remaining_row_bound(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bound each relationship query to the remaining result budget plus one row."""
+    assert "max_rows" in inspect.signature(repository_module._select_relationships_for_nodes).parameters
+    repo = CodeGraphRepository(tmp_path / "codegraph.db")
+    repo.initialize()
+    _seed_impact_graph(repo)
+    requested_row_limits: list[int | None] = []
+    original_select = repository_module._select_relationships_for_nodes
+
+    def _spy_select_relationships_for_nodes(
+        conn: sqlite3.Connection,
+        node_ids: set[str],
+        direction: str,
+        *,
+        anchor_file_path: str,
+        max_rows: int | None = None,
+    ) -> list[sqlite3.Row]:
+        requested_row_limits.append(max_rows)
+        return original_select(conn, node_ids, direction, anchor_file_path=anchor_file_path, max_rows=max_rows)
+
+    monkeypatch.setattr(repository_module, "_select_relationships_for_nodes", _spy_select_relationships_for_nodes)
+
+    impact = repo.traverse_impact("node_helper", depth=2, direction="both", limit=1)
+
+    assert requested_row_limits == [2]
+    assert [relationship["id"] for relationship in impact.relationships] == ["edge_entry_helper"]
+    assert impact.truncated is True
+
+
 def _seed_impact_graph(repo: CodeGraphRepository) -> None:
+    """Seed a compact graph for impact traversal tests."""
     repo.seed_graph_rows_for_test(
         nodes=[
             {

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_repository.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_repository.py
@@ -345,3 +345,97 @@ def test_repository_atomic_file_and_graph_replacement_rolls_back_on_graph_error(
     assert file_row.content_hash == "old_hash"
     assert repo.get_node("node_old") is not None
     assert repo.search_nodes("new_helper", limit=10) == []
+
+
+def test_repository_traverses_bounded_impact_graph(tmp_path: Path) -> None:
+    repo = CodeGraphRepository(tmp_path / "codegraph.db")
+    repo.initialize()
+    _seed_impact_graph(repo)
+
+    impact = repo.traverse_impact("node_helper", depth=1, direction="both", limit=10)
+
+    assert [node.id for node in impact.nodes] == [
+        "node_entry",
+        "node_helper",
+        "node_leaf",
+        "node_other",
+    ]
+    assert [relationship["id"] for relationship in impact.relationships] == [
+        "edge_entry_helper",
+        "edge_helper_leaf",
+        "edge_other_helper",
+    ]
+    assert impact.truncated is False
+
+
+def test_repository_impact_traversal_reports_truncation(tmp_path: Path) -> None:
+    repo = CodeGraphRepository(tmp_path / "codegraph.db")
+    repo.initialize()
+    _seed_impact_graph(repo)
+
+    impact = repo.traverse_impact("node_helper", depth=2, direction="both", limit=1)
+
+    assert [relationship["id"] for relationship in impact.relationships] == ["edge_entry_helper"]
+    assert impact.truncated is True
+
+
+def _seed_impact_graph(repo: CodeGraphRepository) -> None:
+    repo.seed_graph_rows_for_test(
+        nodes=[
+            {
+                "id": "node_entry",
+                "identity_key": "entry",
+                "kind": "function",
+                "name": "entry",
+                "file_path": "pkg/sample.py",
+            },
+            {
+                "id": "node_helper",
+                "identity_key": "helper",
+                "kind": "function",
+                "name": "helper",
+                "file_path": "pkg/sample.py",
+            },
+            {
+                "id": "node_leaf",
+                "identity_key": "leaf",
+                "kind": "function",
+                "name": "leaf",
+                "file_path": "pkg/sample.py",
+            },
+            {
+                "id": "node_other",
+                "identity_key": "other",
+                "kind": "function",
+                "name": "other",
+                "file_path": "pkg/other.py",
+            },
+        ],
+        edges=[
+            {
+                "id": "edge_entry_helper",
+                "source": "node_entry",
+                "target": "node_helper",
+                "kind": "calls",
+                "file_path": "pkg/sample.py",
+                "line": 2,
+            },
+            {
+                "id": "edge_helper_leaf",
+                "source": "node_helper",
+                "target": "node_leaf",
+                "kind": "calls",
+                "file_path": "pkg/sample.py",
+                "line": 6,
+            },
+            {
+                "id": "edge_other_helper",
+                "source": "node_other",
+                "target": "node_helper",
+                "kind": "calls",
+                "file_path": "pkg/other.py",
+                "line": 3,
+            },
+        ],
+        unresolved_refs=[],
+    )

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_repository.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_repository.py
@@ -379,6 +379,27 @@ def test_repository_impact_traversal_reports_truncation(tmp_path: Path) -> None:
     assert impact.truncated is True
 
 
+def test_repository_batch_impact_traversal_uses_one_neighborhood(tmp_path: Path) -> None:
+    repo = CodeGraphRepository(tmp_path / "codegraph.db")
+    repo.initialize()
+    _seed_impact_graph(repo)
+
+    impact = repo.traverse_impact_many(("node_entry", "node_helper"), depth=1, direction="both", limit=10)
+
+    assert [node.id for node in impact.nodes] == [
+        "node_entry",
+        "node_helper",
+        "node_leaf",
+        "node_other",
+    ]
+    assert [relationship["id"] for relationship in impact.relationships] == [
+        "edge_entry_helper",
+        "edge_helper_leaf",
+        "edge_other_helper",
+    ]
+    assert impact.truncated is False
+
+
 def _seed_impact_graph(repo: CodeGraphRepository) -> None:
     repo.seed_graph_rows_for_test(
         nodes=[


### PR DESCRIPTION
## Change summary
Human-authored change summary required before merge per project policy. Implementation summary below is AI-generated.

## Summary
- Add deterministic repository impact traversal for bounded incoming, outgoing, and bidirectional graph neighborhoods.
- Add a workspace-safe CodeGraph context builder for bounded source snippets, missing-file metadata, path safety, file-size checks, and truncation metadata.
- Expose read-only Unified MCP tools codegraph.impact and codegraph.context with strict validation, missing-index read-only responses, configured bounds, and asyncio.to_thread offload.

## Backlog
- TASK-46: Implement native CodeGraph context and impact tools
- Epic: #1259

## Test plan
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/CodeGraph tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py -q
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check tldw_Server_API/app/core/CodeGraph tldw_Server_API/app/core/DB_Management/codegraph tldw_Server_API/tests/CodeGraph tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/CodeGraph tldw_Server_API/app/core/DB_Management/codegraph tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py -f json -o /tmp/bandit_codegraph_context_impact.json
- [x] git diff --check