### PR TITLE
Phase 2.2: defer audio voice router imports

### DIFF
--- a/backlog/tasks/task-42 - Phase-2.2-audio-voice-router-conditional-cleanup-Q.md
+++ b/backlog/tasks/task-42 - Phase-2.2-audio-voice-router-conditional-cleanup-Q.md
@@ -1,0 +1,64 @@
+---
+id: TASK-42
+title: Phase 2.2 audio voice router conditional cleanup Q
+status: Done
+assignee: []
+created_date: '2026-05-04 19:25'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue #1116 Phase 2.2 by deferring audiobook and voice-assistant content
+router imports from `iter_content_router_specs()` while preserving route
+metadata and optional-import behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Audiobooks, voice assistant REST, and voice assistant WebSocket router specs defer module import and router attribute lookup until registration/resolution.
+- [x] #2 Existing prefix, tags, route_key, default_stable, and `ws_router` attribute behavior remain unchanged.
+- [x] #3 Focused/full router contract tests, main router/OpenAPI contracts, Bandit touched source scan, and git diff hygiene are run before commit.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Verification
+
+<!-- SECTION:VERIFICATION:BEGIN -->
+- Red: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k audio_voice_router_attr_lookup -q`
+  - Failed before implementation because audiobook `router`, voice `router`, and voice `ws_router` were read during `iter_content_router_specs()`.
+- Green: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k audio_voice_router_attr_lookup -q`
+  - `1 passed, 57 deselected`
+- Full router group contract: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q`
+  - `58 passed`
+- Main router contract: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q`
+  - `6 passed`
+- OpenAPI contracts: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q`
+  - `69 passed`
+- Bandit: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/router_groups/content.py -f json -o /tmp/bandit_phase2_2_audio_voice_router_conditionals_q.json`
+  - `result_count: 0`
+- Diff hygiene: `git diff --check`
+  - Passed with no output.
+<!-- SECTION:VERIFICATION:END -->
+
+## Summary
+
+<!-- SECTION:SUMMARY:BEGIN -->
+Audiobook and voice-assistant content routers now use lazy `ImportedRouterSpec`
+definitions, including the voice WebSocket router's `ws_router` attribute. Route
+metadata remains unchanged while imports move to registration/resolution time.
+<!-- SECTION:SUMMARY:END -->

--- a/backlog/tasks/task-42.1 - PR-1271-review-fix-audio-voice-import-call-assertion.md
+++ b/backlog/tasks/task-42.1 - PR-1271-review-fix-audio-voice-import-call-assertion.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-42.1
 title: 'PR 1271 review fix: audio voice import call assertion'
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-05 00:15'
-updated_date: '2026-05-05 00:18'
+updated_date: '2026-05-05 00:23'
 labels: []
 dependencies: []
 references:
@@ -26,7 +26,7 @@ Address the actionable Qodo review thread on PR #1271 by making the new audio/vo
 - [x] #1 The audio/voice laziness test no longer asserts a specific import call order for behavior that is order-insensitive.
 - [x] #2 The test still verifies module import deferral before router resolution and exact lazy router attribute resolution counts after resolution.
 - [x] #3 Focused router-group contract verification passes after the review fix.
-- [ ] #4 The PR review thread is replied to or resolved with the verification summary.
+- [x] #4 The PR review thread is replied to or resolved with the verification summary.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -35,12 +35,14 @@ Address the actionable Qodo review thread on PR #1271 by making the new audio/vo
 Changed the review-fix assertion to compare the set of imported modules, preserving the pre-resolution empty import assertion and exact post-resolution attribute access counts.
 
 Verification: focused audio/voice test passed; full router group contracts passed; main router contracts passed; OpenAPI contracts passed; Bandit on test file passed with pytest assert rule B101 skipped; git diff hygiene passed.
+
+Replied to Qodo review thread with fix commit and verification summary, then resolved thread `PRRT_kwDOL1aGf85_gbK5`.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Resolved the Qodo PR #1271 maintainability finding by removing order-sensitive import call list equality from the audio/voice laziness test. The test now verifies selected modules were imported by resolution time without depending on spec ordering or duplicate import counts, while retaining exact lazy attribute resolution checks.
+Resolved the Qodo PR #1271 maintainability finding by removing order-sensitive import call list equality from the audio/voice laziness test. The test now verifies selected modules were imported by resolution time without depending on spec ordering or duplicate import counts, while retaining exact lazy attribute resolution checks. Replied to and resolved the Qodo review thread after pushing the fix.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-42.1 - PR-1271-review-fix-audio-voice-import-call-assertion.md
+++ b/backlog/tasks/task-42.1 - PR-1271-review-fix-audio-voice-import-call-assertion.md
@@ -1,0 +1,54 @@
+---
+id: TASK-42.1
+title: 'PR 1271 review fix: audio voice import call assertion'
+status: In Progress
+assignee: []
+created_date: '2026-05-05 00:15'
+updated_date: '2026-05-05 00:18'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1271'
+  - 'https://github.com/rmusser01/tldw_server/pull/1271#discussion_r3185257968'
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+parent_task_id: TASK-42
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address the actionable Qodo review thread on PR #1271 by making the new audio/voice router laziness test verify deferred imports without depending on router spec ordering. This is a follow-up to TASK-42 and should keep the production router change untouched unless verification shows otherwise.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The audio/voice laziness test no longer asserts a specific import call order for behavior that is order-insensitive.
+- [x] #2 The test still verifies module import deferral before router resolution and exact lazy router attribute resolution counts after resolution.
+- [x] #3 Focused router-group contract verification passes after the review fix.
+- [ ] #4 The PR review thread is replied to or resolved with the verification summary.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Changed the review-fix assertion to compare the set of imported modules, preserving the pre-resolution empty import assertion and exact post-resolution attribute access counts.
+
+Verification: focused audio/voice test passed; full router group contracts passed; main router contracts passed; OpenAPI contracts passed; Bandit on test file passed with pytest assert rule B101 skipped; git diff hygiene passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Resolved the Qodo PR #1271 maintainability finding by removing order-sensitive import call list equality from the audio/voice laziness test. The test now verifies selected modules were imported by resolution time without depending on spec ordering or duplicate import counts, while retaining exact lazy attribute resolution checks.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/content.py
+++ b/tldw_Server_API/app/api/v1/router_groups/content.py
@@ -410,43 +410,33 @@ def iter_content_router_specs() -> Iterable[RouterSpec]:
     ):
         append_imported_router_spec(specs, character_spec)
 
-    # Audiobooks endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.audio.audiobooks import router as audiobooks_router
-
-        specs.append(RouterSpec(
-            router=audiobooks_router,
+    # Audiobooks and Voice Assistant endpoints
+    for audio_voice_spec in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.audio.audiobooks",
+            log_name="audiobooks",
             prefix=f"{API_V1_PREFIX}",
             tags=("audiobooks",),
             route_key="audiobooks",
             default_stable=False,
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping audiobooks router: {e}")
-
-    # Voice Assistant endpoints (REST + WebSocket)
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.voice_assistant import (
-            router as voice_assistant_router,
-        )
-        from tldw_Server_API.app.api.v1.endpoints.voice_assistant import (
-            ws_router as voice_assistant_ws_router,
-        )
-
-        specs.append(RouterSpec(
-            router=voice_assistant_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.voice_assistant",
+            log_name="voice_assistant",
             prefix=f"{API_V1_PREFIX}/voice",
             tags=("voice-assistant",),
             route_key="voice-assistant",
-        ))
-        specs.append(RouterSpec(
-            router=voice_assistant_ws_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.voice_assistant",
+            log_name="voice_assistant_ws",
             prefix=f"{API_V1_PREFIX}/voice",
             tags=("voice-assistant-ws",),
             route_key="voice-assistant-ws",
-        ))
-    except ImportError as e:
-        logger.debug(f"Voice assistant endpoints not available: {e}")
+            attr_name="ws_router",
+        ),
+    ):
+        append_imported_router_spec(specs, audio_voice_spec)
 
     # Kanban Board endpoints
     try:

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -2178,6 +2178,132 @@ def test_iter_content_router_specs_defers_workspace_character_router_attr_lookup
     }
 
 
+def test_iter_content_router_specs_defers_audio_voice_router_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify audiobook and voice specs keep import and attr lookup lazy."""
+    import importlib
+
+    router_definitions = [
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.audio.audiobooks",
+            "expected_name": "audiobooks",
+            "attr_name": "router",
+            "path": "/audiobooks/create",
+            "prefix": "/api/v1",
+            "tags": ("audiobooks",),
+            "route_key": "audiobooks",
+            "default_stable": False,
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.voice_assistant",
+            "expected_name": "voice_assistant",
+            "attr_name": "router",
+            "path": "/sessions",
+            "prefix": "/api/v1/voice",
+            "tags": ("voice-assistant",),
+            "route_key": "voice-assistant",
+            "default_stable": True,
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.voice_assistant",
+            "expected_name": "voice_assistant_ws",
+            "attr_name": "ws_router",
+            "path": "/ws",
+            "prefix": "/api/v1/voice",
+            "tags": ("voice-assistant-ws",),
+            "route_key": "voice-assistant-ws",
+            "default_stable": True,
+        },
+    ]
+    routers_by_module: dict[str, dict[str, APIRouter]] = {}
+    access_count = {
+        f"{definition['module_name']}.{definition['attr_name']}": 0
+        for definition in router_definitions
+    }
+    import_calls: list[str] = []
+
+    for definition in router_definitions:
+        module_name = str(definition["module_name"])
+        attr_name = str(definition["attr_name"])
+        router = APIRouter()
+
+        @router.get(str(definition["path"]))
+        def _endpoint() -> dict[str, str]:
+            """Return a deterministic response for the fake audio/voice router."""
+            return {"status": "ok"}
+
+        routers_by_module.setdefault(module_name, {})[attr_name] = router
+
+    for module_name, routers in routers_by_module.items():
+        fake_module = ModuleType(module_name)
+
+        def _module_getattr(
+            name: str,
+            *,
+            module_name: str = module_name,
+            routers: dict[str, APIRouter] = routers,
+        ) -> APIRouter:
+            """Track lazy router attribute resolution for the fake module."""
+            if name not in routers:
+                raise AttributeError(name)
+            access_count[f"{module_name}.{name}"] += 1
+            return routers[name]
+
+        fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Track lazy module imports for selected audio/voice routers."""
+        if module_name in routers_by_module:
+            import_calls.append(module_name)
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    specs = list(iter_content_router_specs())
+    assert access_count == {
+        f"{definition['module_name']}.{definition['attr_name']}": 0
+        for definition in router_definitions
+    }
+    assert import_calls == []
+
+    selected_specs = [
+        spec
+        for spec in specs
+        if spec.route_key
+        in {
+            "audiobooks",
+            "voice-assistant",
+            "voice-assistant-ws",
+        }
+    ]
+    assert len(selected_specs) == len(router_definitions)
+
+    by_first_path = {_first_router_path(spec.router): spec for spec in selected_specs}
+    for definition in router_definitions:
+        spec = by_first_path[str(definition["path"])]
+        assert spec.prefix == definition["prefix"]
+        assert spec.tags == definition["tags"]
+        assert spec.route_key == definition["route_key"]
+        assert spec.name == definition["expected_name"]
+        assert spec.default_stable is definition["default_stable"]
+
+    assert import_calls == [
+        str(definition["module_name"])
+        for definition in router_definitions
+    ]
+    assert access_count == {
+        f"{definition['module_name']}.{definition['attr_name']}": 1
+        for definition in router_definitions
+    }
+
+
 def test_qodo_reviewed_router_policy_regressions(monkeypatch: pytest.MonkeyPatch) -> None:
     _install_fake_router_module(
         monkeypatch,

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -2294,10 +2294,11 @@ def test_iter_content_router_specs_defers_audio_voice_router_attr_lookup(
         assert spec.name == definition["expected_name"]
         assert spec.default_stable is definition["default_stable"]
 
-    assert import_calls == [
+    expected_import_modules = {
         str(definition["module_name"])
         for definition in router_definitions
-    ]
+    }
+    assert set(import_calls) == expected_import_modules
     assert access_count == {
         f"{definition['module_name']}.{definition['attr_name']}": 1
         for definition in router_definitions


### PR DESCRIPTION
## Change summary

TODO before merge: requester must replace this with a human-written Change summary explaining what changed and why these implementation choices were made.

This PR continues issue #1116 Phase 2.2 by converting the audiobook and voice-assistant content router registrations from eager imports to lazy ImportedRouterSpec definitions. The audiobook REST router, voice assistant REST router, and voice assistant WebSocket router keep their existing prefixes, tags, route keys, default stability, and ws_router attribute mapping while deferring import and router attribute lookup until registration/resolution time.

## Why

The router-group cleanup is removing eager optional imports from main/router assembly in small, reviewable batches. This slice targets one audio/voice cluster after PR #1265 was merged, keeping the phase semantics proven before moving to another router family.

## Verification

- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q
  - 58 passed, 30 warnings
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q
  - 6 passed, 5 warnings
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q
  - 69 passed, 24 warnings
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/router_groups/content.py -f json -o /tmp/bandit_phase2_2_audio_voice_router_conditionals_q_postcommit.json
  - result_count: 0, errors: []
- git diff --check HEAD~1..HEAD
  - passed with no output