### PR TITLE
Phase 2.2: defer content ingestion router imports

### DIFF
--- a/backlog/tasks/task-43 - Phase-2.2-content-ingestion-router-conditional-cleanup-R.md
+++ b/backlog/tasks/task-43 - Phase-2.2-content-ingestion-router-conditional-cleanup-R.md
@@ -1,0 +1,57 @@
+---
+id: TASK-43
+title: Phase 2.2 content ingestion router conditional cleanup R
+status: Done
+assignee: []
+created_date: '2026-05-04 14:53'
+updated_date: '2026-05-05 00:42'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+documentation:
+  - >-
+    Docs/superpowers/plans/2026-05-03-phase2-followup-stack-implementation-plan.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue #1116 Phase 2.2 by deferring a medium conservative content ingestion/adapters tranche from iter_content_router_specs while preserving route metadata and optional-import behavior. Scope is limited to connectors, ingestion_sources, web_scraping, and reading_highlights after the audiobook router landed in PR #1271; kanban, notes/study/persona, and minimal router groups remain outside this tranche.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 connectors, ingestion_sources, web_scraping, and reading_highlights content router specs defer router attribute lookup until registration/resolution
+- [x] #2 Existing prefix, tags, route_key, and default_stable behavior for the scoped content routers remain unchanged
+- [x] #3 Focused red/green router laziness coverage, full router contract tests, main router/OpenAPI contracts, Bandit touched source scan, and git diff hygiene are run before commit
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Starting from stacked branch codex/phase2-2-content-ingestion-router-conditionals-r at local Q commit f58e634321; this branch will be rebased/PR'd after the earlier Phase 2.2 stack lands or kept stacked until then.
+
+Verification: baseline full router group contract passed 58 before edits. Red focused ingestion/adapters laziness test failed before implementation because scoped router attrs were eagerly resolved. Green focused rerun passed 1 selected; full router group contract passed 59; main router contract passed 6; OpenAPI contract suite passed 69; Bandit content router group source reported 0 results and 0 errors; git diff --check passed.
+
+After PR #1271 merged first, rebased this tranche onto origin/dev and removed the already-landed audiobook coverage from this task/test scope. The updated PR now covers connectors, ingestion_sources, web_scraping, and reading_highlights only.
+
+Post-rebase verification: focused ingestion/adapters laziness test passed 1 selected; full router group contract passed 60; main router contract passed 6; OpenAPI contract suite passed 69; Bandit content router group source reported 0 results and 0 errors; git diff --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Converted connectors, ingestion_sources, web_scraping, and reading_highlights content router registrations to lazy ImportedRouterSpec entries while preserving prefixes, tags, route keys, and default_stable behavior. Added contract coverage proving iter_content_router_specs does not touch those router attributes during spec construction.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/content.py
+++ b/tldw_Server_API/app/api/v1/router_groups/content.py
@@ -472,59 +472,40 @@ def iter_content_router_specs() -> Iterable[RouterSpec]:
     except ImportError as e:
         logger.debug(f"Kanban endpoints unavailable; skipping import: {e}")
 
-    # Connectors endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.connectors import router as connectors_router
-
-        specs.append(RouterSpec(
-            router=connectors_router,
+    # Ingestion and adapter endpoints
+    for adapter_spec in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.connectors",
+            log_name="connectors",
             prefix=f"{API_V1_PREFIX}",
             tags=("connectors",),
             route_key="connectors",
             default_stable=False,
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping connectors router: {e}")
-
-    # Ingestion sources endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.ingestion_sources import router as ingestion_sources_router
-
-        specs.append(RouterSpec(
-            router=ingestion_sources_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.ingestion_sources",
+            log_name="ingestion_sources",
             prefix=f"{API_V1_PREFIX}",
             tags=("ingestion-sources",),
             route_key="ingestion-sources",
             default_stable=False,
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping ingestion_sources router: {e}")
-
-    # Web scraping endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.web_scraping import router as web_scraping_router
-
-        specs.append(RouterSpec(
-            router=web_scraping_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.web_scraping",
+            log_name="web_scraping",
             prefix=f"{API_V1_PREFIX}",
             tags=("web-scraping",),
             route_key="web-scraping",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping web_scraping router: {e}")
-
-    # Reading highlights endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.reading_highlights import router as reading_highlights_router
-
-        specs.append(RouterSpec(
-            router=reading_highlights_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.reading_highlights",
+            log_name="reading_highlights",
             prefix=f"{API_V1_PREFIX}",
             tags=("reading-highlights",),
             route_key="reading-highlights",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping reading_highlights router: {e}")
+        ),
+    ):
+        append_imported_router_spec(specs, adapter_spec)
 
     append_imported_router_spec(
         specs,

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -1458,6 +1458,98 @@ def test_iter_content_router_specs_defers_media_audio_router_attr_lookup(
     }
 
 
+def test_iter_content_router_specs_defers_ingestion_adapter_router_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify covered ingestion/adapters specs keep router attr lookup lazy."""
+    router_definitions = (
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.connectors",
+            "path": "/connectors/status",
+            "prefix": "/api/v1",
+            "tags": ("connectors",),
+            "route_key": "connectors",
+            "default_stable": False,
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.ingestion_sources",
+            "path": "/ingestion-sources/status",
+            "prefix": "/api/v1",
+            "tags": ("ingestion-sources",),
+            "route_key": "ingestion-sources",
+            "default_stable": False,
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.web_scraping",
+            "path": "/web-scraping/status",
+            "prefix": "/api/v1",
+            "tags": ("web-scraping",),
+            "route_key": "web-scraping",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.reading_highlights",
+            "path": "/reading-highlights/status",
+            "prefix": "/api/v1",
+            "tags": ("reading-highlights",),
+            "route_key": "reading-highlights",
+        },
+    )
+    access_count = {
+        str(definition["module_name"]): 0
+        for definition in router_definitions
+    }
+
+    for definition in router_definitions:
+        module_name = str(definition["module_name"])
+        router = APIRouter()
+
+        @router.get(str(definition["path"]))
+        def _endpoint() -> dict[str, str]:
+            return {"status": "ok"}
+
+        fake_module = ModuleType(module_name)
+
+        def _module_getattr(
+            name: str,
+            *,
+            module_name: str = module_name,
+            router: APIRouter = router,
+        ) -> APIRouter:
+            if name != "router":
+                raise AttributeError(name)
+            access_count[module_name] += 1
+            return router
+
+        fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    specs = list(iter_content_router_specs())
+    assert access_count == {
+        str(definition["module_name"]): 0
+        for definition in router_definitions
+    }
+
+    selected_route_keys = {
+        str(definition["route_key"])
+        for definition in router_definitions
+    }
+    selected_specs = [
+        spec for spec in specs if spec.route_key in selected_route_keys
+    ]
+    by_first_path = {_first_router_path(spec.router): spec for spec in selected_specs}
+    for definition in router_definitions:
+        spec = by_first_path[str(definition["path"])]
+        assert spec.prefix == definition["prefix"]
+        assert spec.tags == definition["tags"]
+        assert spec.route_key == definition["route_key"]
+        assert spec.default_stable is definition.get("default_stable", True)
+
+    assert access_count == {
+        str(definition["module_name"]): 1
+        for definition in router_definitions
+    }
+
+
 def test_iter_content_router_specs_defers_workflow_router_attr_lookup(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- Defers content ingestion/adapters router imports with lazy ImportedRouterSpec entries.
- Adds contract coverage proving iter_content_router_specs no longer touches those router attributes during spec construction.
- Preserves prefixes, tags, route keys, and default_stable behavior for connectors, ingestion_sources, web_scraping, and reading_highlights.
- Audiobooks landed separately in PR #1271, so this rebased PR no longer carries audiobook changes.

## Change summary
Human summary required before merge: this keeps existing route behavior unchanged while narrowing Phase 2.2 cleanup to a conservative content ingestion/adapters tranche; kanban, notes/study/persona, and minimal groups remain separate.

## Verification
- Rebased onto origin/dev after #1271 merged; branch is one commit ahead of dev.
- Focused: python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k ingestion_adapter_router_attr_lookup -q (1 passed, 59 deselected)
- Full router group contract: python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q (60 passed)
- Main router contract: python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q (6 passed)
- OpenAPI contracts: python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q (69 passed)
- Bandit: python -m bandit -r tldw_Server_API/app/api/v1/router_groups/content.py -f json -o /tmp/bandit_phase2_2_content_ingestion_rebase_r.json (0 results, 0 errors)
- git diff --check

Refs #1116