### PR TITLE
feat(sandbox): enforce network policy contract admission

### DIFF
--- a/Docs/superpowers/plans/2026-05-05-sandbox-network-policy-admission-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-05-sandbox-network-policy-admission-implementation-plan.md
@@ -1,0 +1,137 @@
+# Sandbox Network Policy Admission Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enforce sandbox runtime `network_policy_contract` during session and run admission.
+
+**Architecture:** Add one static contract validation helper in `SandboxPolicy`, then call it from both session and run policy normalization after trust-profile defaults are applied. Keep dynamic host/runtime readiness in the existing service and runner preflight paths.
+
+**Tech Stack:** Python, pytest, Backlog.md, Bandit.
+
+---
+
+## Files
+
+- Modify: `tldw_Server_API/app/core/Sandbox/policy.py`
+- Modify: `tldw_Server_API/tests/sandbox/test_lima_strict_admission.py` or create a nearby focused policy test file
+- Create: `Docs/superpowers/specs/2026-05-05-sandbox-network-policy-admission-design.md`
+- Create: `Docs/superpowers/plans/2026-05-05-sandbox-network-policy-admission-implementation-plan.md`
+- Modify: `backlog/tasks/task-47 - Enforce-sandbox-network-policy-contract-during-admission.md`
+
+## Task 1: Add Failing Policy Tests
+
+**Files:**
+- Test: `tldw_Server_API/tests/sandbox/test_network_policy_contract_admission.py`
+
+- [x] **Step 1: Write failing tests**
+
+Cover `SandboxPolicy.apply_to_run()` and `SandboxPolicy.apply_to_session()` directly:
+
+```python
+def test_apply_to_run_rejects_worktree_deny_all_from_standard_default():
+    policy = SandboxPolicy(SandboxPolicyConfig(default_runtime=RuntimeType.worktree))
+    spec = RunSpec(session_id=None, runtime=RuntimeType.worktree, base_image=None, command=["echo", "ok"])
+
+    with pytest.raises(SandboxPolicy.PolicyUnsupported) as exc:
+        policy.apply_to_run(spec, firecracker_available=False, runtime_preflights={RuntimeType.worktree: available_worktree_preflight()})
+
+    assert exc.value.reasons == ["strict_deny_all_not_supported"]
+```
+
+Add equivalent cases for:
+
+- `seatbelt` `deny_all`
+- `worktree` `allowlist`
+- invalid policy value
+- `vz_linux` `deny_all` accepted at static contract layer
+- `vz_linux` `allowlist` rejected
+- `apply_to_session()` rejects the same host-local defaulted policy
+
+- [x] **Step 2: Run tests and verify RED**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_network_policy_contract_admission.py -q --timeout=60
+```
+
+Expected: tests fail because `SandboxPolicy` does not yet validate the static network-policy contract.
+
+## Task 2: Add Static Contract Admission Helper
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Sandbox/policy.py`
+
+- [x] **Step 1: Import runtime metadata accessor**
+
+Import `runtime_network_policy_metadata` from `runtime_capabilities.py`.
+
+- [x] **Step 2: Implement helper**
+
+Add a helper to `SandboxPolicy`:
+
+```python
+@staticmethod
+def _require_network_policy_supported(runtime: RuntimeType, network_policy: str | None) -> None:
+    requested_policy = str(network_policy or "deny_all").strip().lower() or "deny_all"
+    if requested_policy not in {"deny_all", "allowlist"}:
+        raise SandboxPolicy.PolicyUnsupported(runtime, requirement=requested_policy, reasons=["unsupported_network_policy"])
+    contract = runtime_network_policy_metadata(runtime)
+    mode = contract.deny_all if requested_policy == "deny_all" else contract.allowlist
+    if mode.support_state in {"unsupported", "not_applicable"} or not mode.strict_enforcement:
+        reason = "strict_allowlist_not_supported" if requested_policy == "allowlist" else "strict_deny_all_not_supported"
+        raise SandboxPolicy.PolicyUnsupported(runtime, requirement=requested_policy, reasons=[reason])
+```
+
+Wrap long lines to match project style.
+
+- [x] **Step 3: Call helper from admission paths**
+
+In `apply_to_session()` and `apply_to_run()`, call the helper after:
+
+- runtime selection
+- trust support validation
+- profile/default `network_policy` assignment
+
+- [x] **Step 4: Run tests and verify GREEN**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_network_policy_contract_admission.py -q --timeout=60
+```
+
+Expected: new tests pass.
+
+## Task 3: Regression Verification
+
+**Files:**
+- Existing tests under `tldw_Server_API/tests/sandbox/`
+
+- [x] **Step 1: Run related sandbox tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_network_policy_contract_admission.py tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py tldw_Server_API/tests/sandbox/test_lima_strict_admission.py -q --timeout=60
+```
+
+- [x] **Step 2: Run Bandit on touched production code**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Sandbox/policy.py -f json -o /tmp/bandit_sandbox_network_policy_admission.json
+```
+
+- [x] **Step 3: Run diff hygiene**
+
+Run:
+
+```bash
+git diff --check
+```
+
+- [x] **Step 4: Update Backlog task and commit**
+
+Record verification in `TASK-47`, then commit the complete slice.

--- a/Docs/superpowers/specs/2026-05-05-sandbox-network-policy-admission-design.md
+++ b/Docs/superpowers/specs/2026-05-05-sandbox-network-policy-admission-design.md
@@ -1,0 +1,50 @@
+# Sandbox Network Policy Admission Design
+
+## Goal
+
+Use the runtime `network_policy_contract` as the shared static admission gate for sandbox sessions and runs. Unsupported or non-strict runtime/network-policy combinations should fail before enqueue or session creation, while runtime preflight remains responsible for current host readiness.
+
+## Current State
+
+Runtime discovery now exposes `network_policy_contract` for each `RuntimeType`, but admission still relies on scattered runtime-specific checks and preflight booleans. This leaves host-local runtimes such as `seatbelt` and `worktree` available for `deny_all` requests even though their contract states strict `deny_all` is unsupported.
+
+## Design
+
+Add a single `SandboxPolicy` helper that validates the requested runtime and normalized network policy against `runtime_network_policy_metadata(runtime)`.
+
+The helper should:
+
+- Normalize empty policy through the existing trust-profile/default flow before validation.
+- Accept only `deny_all` and `allowlist`.
+- Raise `PolicyUnsupported(..., reasons=["unsupported_network_policy"])` for invalid policy values.
+- Select the requested mode metadata (`deny_all` or `allowlist`) from the static contract.
+- Raise `PolicyUnsupported(..., reasons=["strict_<mode>_not_supported"])` when `support_state` is `unsupported` or `not_applicable`.
+- Raise `PolicyUnsupported(..., reasons=["strict_<mode>_not_supported"])` when `strict_enforcement` is false.
+- Allow statically supported or host-gated strict modes to proceed to the existing dynamic runtime preflight layer.
+
+Call this helper from `apply_to_session()` and `apply_to_run()` after profile/default network policy assignment. This ensures direct runs and session creation use the same contract, including inherited trust-profile defaults.
+
+## Non-Goals
+
+- Do not remove execution-time preflights for Lima, VZ Linux, VZ macOS, Seatbelt, or Worktree.
+- Do not change Docker's dynamic config checks or egress enforcement behavior.
+- Do not implement allowlist support for runtimes whose contract says it is unsupported or scaffold-only.
+- Do not infer security guarantees from `available=True`.
+
+## Risk Review
+
+The main behavior change is intentional: `seatbelt` and `worktree` should no longer admit strict `deny_all` requests because their static contract says strict enforcement is unsupported. That can reject some previously accepted local-development paths, but it avoids representing host-local execution as a strict network sandbox.
+
+Docker `allowlist` must remain layered. The static contract can admit it only as a possible strict mode; dynamic Docker/config readiness still determines whether real enforcement is ready.
+
+Session-backed runs must validate after session values are inherited, or admission may check a placeholder request policy rather than the effective session policy.
+
+## Test Strategy
+
+Add focused policy tests that assert:
+
+- Invalid policy values fail with `unsupported_network_policy`.
+- `seatbelt` and `worktree` reject `deny_all` and `allowlist`.
+- `vz_linux` admits `deny_all` at the static contract layer and rejects `allowlist`.
+- Empty policy values are populated from trust profiles before validation.
+- Both `apply_to_session()` and `apply_to_run()` enforce the same behavior.

--- a/backlog/tasks/task-47 - Enforce-sandbox-network-policy-contract-during-admission.md
+++ b/backlog/tasks/task-47 - Enforce-sandbox-network-policy-contract-during-admission.md
@@ -4,7 +4,7 @@ title: Enforce sandbox network policy contract during admission
 status: Done
 assignee: []
 created_date: '2026-05-05 00:38'
-updated_date: '2026-05-05 00:43'
+updated_date: '2026-05-05 01:06'
 labels:
   - sandbox
   - runtime-admission
@@ -42,12 +42,16 @@ Use the sandbox runtime network_policy_contract as the shared admission source o
 Implementation complete. Added static network_policy_contract admission in SandboxPolicy after trust-profile/default network policy normalization for sessions and direct runs. RED: new admission tests failed before implementation with host-local deny_all/allowlist, invalid policy, and vz_linux allowlist admitted. GREEN: new focused tests passed after implementation.
 
 Verification: pytest test_network_policy_contract_admission.py test_runtime_inventory_contract.py test_lima_strict_admission.py => 25 passed, 2 warnings. pytest test_macos_runtime_admission.py test_macos_runtime_service_dispatch.py test_worktree_runner.py test_seatbelt_runner.py => 40 passed, 2 warnings. Bandit policy.py => 0 findings. git diff --check passed.
+
+PR review fix pass for #1275: reviewers found that SandboxPolicy validates stripped/lowercased network_policy values but does not assign the canonical value back to SessionSpec/RunSpec. This is valid because Docker/Lima downstream enforcement uses the spec value. Plan: add failing canonicalization tests for session/run and whitespace-only defaulting, update policy admission to return and assign the canonical policy, rerun focused/broader sandbox tests plus Bandit and diff checks, then push and resolve review threads.
+
+PR review fix complete. RED confirmed canonicalization bug: new tests failed with non-canonical run/session policies and whitespace-only run policy. Fixed by returning the canonical network policy from SandboxPolicy._require_network_policy_supported() and assigning it back to SessionSpec/RunSpec after whitespace-only values are treated as missing. Verification: canonicalization test file => 12 passed, broader network policy/runtime suite => 28 passed, adjacent macOS/worktree/seatbelt suite => 40 passed, Bandit policy.py => 0 findings, git diff --check passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Enforced the runtime network_policy_contract during SandboxPolicy session/run admission. Unsupported, scaffold, non-strict, and invalid network policy combinations now fail closed before enqueue/session creation while dynamic runtime preflight remains the readiness layer.
+Enforced canonical network_policy values after static runtime contract admission. SandboxPolicy now treats whitespace-only policy input as missing, applies trust-profile/default policy, validates the canonical deny_all/allowlist value, and writes that canonical value back to SessionSpec/RunSpec so downstream Docker/Lima enforcement cannot see unstripped or mixed-case strings. Added regression tests for run/session canonicalization and whitespace-only defaulting. Verification: focused sandbox admission/runtime suites passed, adjacent sandbox runtime suites passed, Bandit found 0 issues in policy.py, and git diff --check passed.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-47 - Enforce-sandbox-network-policy-contract-during-admission.md
+++ b/backlog/tasks/task-47 - Enforce-sandbox-network-policy-contract-during-admission.md
@@ -1,0 +1,61 @@
+---
+id: TASK-47
+title: Enforce sandbox network policy contract during admission
+status: Done
+assignee: []
+created_date: '2026-05-05 00:38'
+updated_date: '2026-05-05 00:43'
+labels:
+  - sandbox
+  - runtime-admission
+  - network-policy
+dependencies: []
+documentation:
+  - Docs/Sandbox/sandbox-architecture-doctrine.md
+  - Docs/Sandbox/sandbox-runtime-capability-inventory.md
+  - Docs/Sandbox/sandbox-security-policy-matrix.md
+  - Docs/superpowers/specs/2026-05-05-sandbox-network-policy-admission-design.md
+  - >-
+    Docs/superpowers/plans/2026-05-05-sandbox-network-policy-admission-implementation-plan.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Use the sandbox runtime network_policy_contract as the shared admission source of truth for session and run requests. Admission must fail closed for unsupported or non-strict runtime/network-policy combinations while keeping runtime preflight as the dynamic readiness layer.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 SandboxPolicy rejects unsupported or non-strict runtime/network-policy combinations for sessions and direct runs after trust/profile defaults are applied.
+- [x] #2 Invalid network_policy values still fail with unsupported_network_policy before runtime execution.
+- [x] #3 Host-local runtimes seatbelt and worktree are rejected for strict deny_all and allowlist admission rather than implying strict network enforcement from availability.
+- [x] #4 vz_linux deny_all remains admissible at the static contract layer while allowlist is rejected.
+- [x] #5 Focused tests cover session and run admission, default profile network_policy application, host-local negative claims, and static contract helper behavior.
+- [x] #6 Documentation or implementation notes explain that static contract admission is separate from dynamic preflight readiness.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implementation complete. Added static network_policy_contract admission in SandboxPolicy after trust-profile/default network policy normalization for sessions and direct runs. RED: new admission tests failed before implementation with host-local deny_all/allowlist, invalid policy, and vz_linux allowlist admitted. GREEN: new focused tests passed after implementation.
+
+Verification: pytest test_network_policy_contract_admission.py test_runtime_inventory_contract.py test_lima_strict_admission.py => 25 passed, 2 warnings. pytest test_macos_runtime_admission.py test_macos_runtime_service_dispatch.py test_worktree_runner.py test_seatbelt_runner.py => 40 passed, 2 warnings. Bandit policy.py => 0 findings. git diff --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Enforced the runtime network_policy_contract during SandboxPolicy session/run admission. Unsupported, scaffold, non-strict, and invalid network policy combinations now fail closed before enqueue/session creation while dynamic runtime preflight remains the readiness layer.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/Sandbox/policy.py
+++ b/tldw_Server_API/app/core/Sandbox/policy.py
@@ -249,7 +249,7 @@ class SandboxPolicy:
     def _require_network_policy_supported(
         runtime: RuntimeType,
         network_policy: str | None,
-    ) -> None:
+    ) -> str:
         requested_policy = (
             str(network_policy or "deny_all").strip().lower() or "deny_all"
         )
@@ -266,8 +266,9 @@ class SandboxPolicy:
             if requested_policy == "deny_all"
             else contract.allowlist
         )
-        if mode.support_state not in {"supported", "host_gated"} or (
-            not mode.strict_enforcement
+        if (
+            mode.support_state not in {"supported", "host_gated"}
+            or not mode.strict_enforcement
         ):
             raise SandboxPolicy.PolicyUnsupported(
                 runtime,
@@ -278,6 +279,7 @@ class SandboxPolicy:
                     )
                 ],
             )
+        return requested_policy
 
     def select_runtime(
         self,
@@ -326,9 +328,15 @@ class SandboxPolicy:
         )
         profile = TRUST_PROFILES.get(trust, TRUST_PROFILES[TrustLevel.standard])
 
-        if not spec.network_policy:
-            spec.network_policy = profile.get("network_policy", self.cfg.network_default)
-        self._require_network_policy_supported(spec.runtime, spec.network_policy)
+        if not str(spec.network_policy or "").strip():
+            spec.network_policy = profile.get(
+                "network_policy",
+                self.cfg.network_default,
+            )
+        spec.network_policy = self._require_network_policy_supported(
+            spec.runtime,
+            spec.network_policy,
+        )
 
         # Apply trust-level resource limits (more restrictive of trust profile and global policy)
         profile_max_cpu = float(profile.get("max_cpu", self.cfg.max_cpu))
@@ -386,9 +394,15 @@ class SandboxPolicy:
         )
         profile = TRUST_PROFILES.get(trust, TRUST_PROFILES[TrustLevel.standard])
 
-        if not spec.network_policy:
-            spec.network_policy = profile.get("network_policy", self.cfg.network_default)
-        self._require_network_policy_supported(spec.runtime, spec.network_policy)
+        if not str(spec.network_policy or "").strip():
+            spec.network_policy = profile.get(
+                "network_policy",
+                self.cfg.network_default,
+            )
+        spec.network_policy = self._require_network_policy_supported(
+            spec.runtime,
+            spec.network_policy,
+        )
 
         # Apply trust-level resource limits (more restrictive of trust profile and global policy)
         profile_max_cpu = float(profile.get("max_cpu", self.cfg.max_cpu))

--- a/tldw_Server_API/app/core/Sandbox/policy.py
+++ b/tldw_Server_API/app/core/Sandbox/policy.py
@@ -9,7 +9,10 @@ from tldw_Server_API.app.core.config import settings as app_settings
 from tldw_Server_API.app.core.testing import is_truthy
 
 from .models import RunSpec, RuntimeType, SessionSpec, TrustLevel
-from .runtime_capabilities import RuntimePreflightResult
+from .runtime_capabilities import (
+    RuntimePreflightResult,
+    runtime_network_policy_metadata,
+)
 
 _POLICY_NONCRITICAL_EXCEPTIONS = (
     AttributeError,
@@ -236,6 +239,46 @@ class SandboxPolicy:
                 reasons=["trust_level_not_supported"],
             )
 
+    @staticmethod
+    def _network_policy_unsupported_reason(network_policy: str) -> str:
+        if network_policy == "allowlist":
+            return "strict_allowlist_not_supported"
+        return "strict_deny_all_not_supported"
+
+    @staticmethod
+    def _require_network_policy_supported(
+        runtime: RuntimeType,
+        network_policy: str | None,
+    ) -> None:
+        requested_policy = (
+            str(network_policy or "deny_all").strip().lower() or "deny_all"
+        )
+        if requested_policy not in {"deny_all", "allowlist"}:
+            raise SandboxPolicy.PolicyUnsupported(
+                runtime,
+                requirement=requested_policy,
+                reasons=["unsupported_network_policy"],
+            )
+
+        contract = runtime_network_policy_metadata(runtime)
+        mode = (
+            contract.deny_all
+            if requested_policy == "deny_all"
+            else contract.allowlist
+        )
+        if mode.support_state not in {"supported", "host_gated"} or (
+            not mode.strict_enforcement
+        ):
+            raise SandboxPolicy.PolicyUnsupported(
+                runtime,
+                requirement=requested_policy,
+                reasons=[
+                    SandboxPolicy._network_policy_unsupported_reason(
+                        requested_policy
+                    )
+                ],
+            )
+
     def select_runtime(
         self,
         requested: RuntimeType | None,
@@ -285,6 +328,7 @@ class SandboxPolicy:
 
         if not spec.network_policy:
             spec.network_policy = profile.get("network_policy", self.cfg.network_default)
+        self._require_network_policy_supported(spec.runtime, spec.network_policy)
 
         # Apply trust-level resource limits (more restrictive of trust profile and global policy)
         profile_max_cpu = float(profile.get("max_cpu", self.cfg.max_cpu))
@@ -344,6 +388,7 @@ class SandboxPolicy:
 
         if not spec.network_policy:
             spec.network_policy = profile.get("network_policy", self.cfg.network_default)
+        self._require_network_policy_supported(spec.runtime, spec.network_policy)
 
         # Apply trust-level resource limits (more restrictive of trust profile and global policy)
         profile_max_cpu = float(profile.get("max_cpu", self.cfg.max_cpu))

--- a/tldw_Server_API/tests/sandbox/test_network_policy_contract_admission.py
+++ b/tldw_Server_API/tests/sandbox/test_network_policy_contract_admission.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.core.Sandbox.models import (
+    RunSpec,
+    RuntimeType,
+    SessionSpec,
+    TrustLevel,
+)
+from tldw_Server_API.app.core.Sandbox.policy import (
+    SandboxPolicy,
+    SandboxPolicyConfig,
+)
+from tldw_Server_API.app.core.Sandbox.runtime_capabilities import (
+    RuntimePreflightResult,
+)
+
+
+def _available_preflight(
+    runtime: RuntimeType,
+    *,
+    trust_levels: list[str] | None = None,
+) -> RuntimePreflightResult:
+    return RuntimePreflightResult(
+        runtime=runtime,
+        available=True,
+        reasons=[],
+        supported_trust_levels=trust_levels
+        or ["trusted", "standard", "untrusted"],
+        enforcement_ready={"deny_all": True, "allowlist": True},
+    )
+
+
+def _run_spec(
+    runtime: RuntimeType | None,
+    *,
+    network_policy: str | None = None,
+    trust_level: TrustLevel | None = None,
+) -> RunSpec:
+    return RunSpec(
+        session_id=None,
+        runtime=runtime,
+        base_image=None,
+        command=["echo", "ok"],
+        network_policy=network_policy,
+        trust_level=trust_level,
+    )
+
+
+def test_apply_to_run_rejects_worktree_deny_all_from_standard_default() -> None:
+    policy = SandboxPolicy()
+    spec = _run_spec(RuntimeType.worktree)
+
+    with pytest.raises(SandboxPolicy.PolicyUnsupported) as exc:
+        policy.apply_to_run(
+            spec,
+            firecracker_available=False,
+            runtime_preflights={
+                RuntimeType.worktree: _available_preflight(
+                    RuntimeType.worktree,
+                    trust_levels=["trusted", "standard"],
+                )
+            },
+        )
+
+    assert exc.value.runtime == RuntimeType.worktree
+    assert exc.value.requirement == "deny_all"
+    assert exc.value.reasons == ["strict_deny_all_not_supported"]
+
+
+def test_apply_to_session_rejects_seatbelt_deny_all_from_standard_default() -> None:
+    policy = SandboxPolicy()
+    spec = SessionSpec(
+        runtime=RuntimeType.seatbelt,
+        trust_level=TrustLevel.standard,
+        network_policy="",
+    )
+
+    with pytest.raises(SandboxPolicy.PolicyUnsupported) as exc:
+        policy.apply_to_session(
+            spec,
+            firecracker_available=False,
+            runtime_preflights={
+                RuntimeType.seatbelt: _available_preflight(
+                    RuntimeType.seatbelt,
+                    trust_levels=["trusted", "standard"],
+                )
+            },
+        )
+
+    assert exc.value.runtime == RuntimeType.seatbelt
+    assert exc.value.requirement == "deny_all"
+    assert exc.value.reasons == ["strict_deny_all_not_supported"]
+
+
+@pytest.mark.parametrize("runtime", [RuntimeType.seatbelt, RuntimeType.worktree])
+def test_apply_to_run_rejects_host_local_allowlist(runtime: RuntimeType) -> None:
+    policy = SandboxPolicy()
+    spec = _run_spec(runtime, network_policy="allowlist")
+
+    with pytest.raises(SandboxPolicy.PolicyUnsupported) as exc:
+        policy.apply_to_run(
+            spec,
+            firecracker_available=False,
+            runtime_preflights={
+                runtime: _available_preflight(
+                    runtime,
+                    trust_levels=["trusted", "standard"],
+                )
+            },
+        )
+
+    assert exc.value.runtime == runtime
+    assert exc.value.requirement == "allowlist"
+    assert exc.value.reasons == ["strict_allowlist_not_supported"]
+
+
+def test_apply_to_run_rejects_invalid_network_policy() -> None:
+    policy = SandboxPolicy()
+    spec = _run_spec(RuntimeType.docker, network_policy="allow_all")
+
+    with pytest.raises(SandboxPolicy.PolicyUnsupported) as exc:
+        policy.apply_to_run(
+            spec,
+            firecracker_available=False,
+            runtime_preflights={
+                RuntimeType.docker: _available_preflight(RuntimeType.docker)
+            },
+        )
+
+    assert exc.value.runtime == RuntimeType.docker
+    assert exc.value.requirement == "allow_all"
+    assert exc.value.reasons == ["unsupported_network_policy"]
+
+
+def test_apply_to_run_allows_vz_linux_deny_all_static_contract() -> None:
+    policy = SandboxPolicy()
+    spec = _run_spec(RuntimeType.vz_linux, network_policy="deny_all")
+
+    result = policy.apply_to_run(
+        spec,
+        firecracker_available=False,
+        runtime_preflights={
+            RuntimeType.vz_linux: _available_preflight(RuntimeType.vz_linux)
+        },
+    )
+
+    assert result.runtime == RuntimeType.vz_linux
+    assert result.network_policy == "deny_all"
+
+
+def test_apply_to_run_rejects_vz_linux_allowlist_static_contract() -> None:
+    policy = SandboxPolicy()
+    spec = _run_spec(RuntimeType.vz_linux, network_policy="allowlist")
+
+    with pytest.raises(SandboxPolicy.PolicyUnsupported) as exc:
+        policy.apply_to_run(
+            spec,
+            firecracker_available=False,
+            runtime_preflights={
+                RuntimeType.vz_linux: _available_preflight(RuntimeType.vz_linux)
+            },
+        )
+
+    assert exc.value.runtime == RuntimeType.vz_linux
+    assert exc.value.requirement == "allowlist"
+    assert exc.value.reasons == ["strict_allowlist_not_supported"]
+
+
+def test_apply_to_run_rejects_scaffold_network_policy_modes() -> None:
+    policy = SandboxPolicy()
+    spec = _run_spec(RuntimeType.firecracker, network_policy="allowlist")
+
+    with pytest.raises(SandboxPolicy.PolicyUnsupported) as exc:
+        policy.apply_to_run(
+            spec,
+            firecracker_available=True,
+            runtime_preflights={
+                RuntimeType.firecracker: _available_preflight(
+                    RuntimeType.firecracker
+                )
+            },
+        )
+
+    assert exc.value.runtime == RuntimeType.firecracker
+    assert exc.value.requirement == "allowlist"
+    assert exc.value.reasons == ["strict_allowlist_not_supported"]
+
+
+def test_apply_to_run_validates_default_runtime_after_profile_default() -> None:
+    policy = SandboxPolicy(
+        SandboxPolicyConfig(default_runtime=RuntimeType.worktree)
+    )
+    spec = _run_spec(runtime=None)
+
+    with pytest.raises(SandboxPolicy.PolicyUnsupported) as exc:
+        policy.apply_to_run(
+            spec,
+            firecracker_available=False,
+            runtime_preflights={
+                RuntimeType.worktree: _available_preflight(
+                    RuntimeType.worktree,
+                    trust_levels=["trusted", "standard"],
+                )
+            },
+        )
+
+    assert exc.value.runtime == RuntimeType.worktree
+    assert exc.value.requirement == "deny_all"
+    assert exc.value.reasons == ["strict_deny_all_not_supported"]

--- a/tldw_Server_API/tests/sandbox/test_network_policy_contract_admission.py
+++ b/tldw_Server_API/tests/sandbox/test_network_policy_contract_admission.py
@@ -134,6 +134,55 @@ def test_apply_to_run_rejects_invalid_network_policy() -> None:
     assert exc.value.reasons == ["unsupported_network_policy"]
 
 
+def test_apply_to_run_canonicalizes_admitted_network_policy() -> None:
+    policy = SandboxPolicy()
+    spec = _run_spec(RuntimeType.docker, network_policy=" DeNy_AlL ")
+
+    result = policy.apply_to_run(
+        spec,
+        firecracker_available=False,
+        runtime_preflights={
+            RuntimeType.docker: _available_preflight(RuntimeType.docker)
+        },
+    )
+
+    assert result.network_policy == "deny_all"
+
+
+def test_apply_to_session_canonicalizes_admitted_network_policy() -> None:
+    policy = SandboxPolicy()
+    spec = SessionSpec(
+        runtime=RuntimeType.docker,
+        trust_level=TrustLevel.standard,
+        network_policy=" ALLOWLIST ",
+    )
+
+    result = policy.apply_to_session(
+        spec,
+        firecracker_available=False,
+        runtime_preflights={
+            RuntimeType.docker: _available_preflight(RuntimeType.docker)
+        },
+    )
+
+    assert result.network_policy == "allowlist"
+
+
+def test_apply_to_run_treats_whitespace_only_policy_as_missing() -> None:
+    policy = SandboxPolicy()
+    spec = _run_spec(RuntimeType.docker, network_policy="   ")
+
+    result = policy.apply_to_run(
+        spec,
+        firecracker_available=False,
+        runtime_preflights={
+            RuntimeType.docker: _available_preflight(RuntimeType.docker)
+        },
+    )
+
+    assert result.network_policy == "deny_all"
+
+
 def test_apply_to_run_allows_vz_linux_deny_all_static_contract() -> None:
     policy = SandboxPolicy()
     spec = _run_spec(RuntimeType.vz_linux, network_policy="deny_all")


### PR DESCRIPTION
## Summary

- Enforce the sandbox runtime `network_policy_contract` during `SandboxPolicy` session and run admission.
- Fail closed for invalid, unsupported, scaffold, or non-strict runtime/network-policy combinations before enqueue/session creation.
- Add focused tests for host-local runtime rejection, VZ Linux allowlist rejection, scaffold mode rejection, invalid policies, and profile-defaulted policies.

## Verification

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_network_policy_contract_admission.py tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py tldw_Server_API/tests/sandbox/test_lima_strict_admission.py -q --timeout=60`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_macos_runtime_admission.py tldw_Server_API/tests/sandbox/test_macos_runtime_service_dispatch.py tldw_Server_API/tests/sandbox/test_worktree_runner.py tldw_Server_API/tests/sandbox/test_seatbelt_runner.py -q --timeout=60`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Sandbox/policy.py -f json -o /tmp/bandit_sandbox_network_policy_admission_pr.json` (`0` findings)
- `git diff --check origin/dev...HEAD`

## Merge Note

Repo policy still requires a human-authored Change summary before merge.
