### PR TITLE
Phase 2.2: defer kanban router imports

### DIFF
--- a/backlog/tasks/task-50 - Phase-2.2-kanban-router-conditional-cleanup-S.md
+++ b/backlog/tasks/task-50 - Phase-2.2-kanban-router-conditional-cleanup-S.md
@@ -1,0 +1,53 @@
+---
+id: TASK-50
+title: Phase 2.2 kanban router conditional cleanup S
+status: Done
+assignee: []
+created_date: '2026-05-05 01:02'
+updated_date: '2026-05-05 01:08'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+  - 'https://github.com/rmusser01/tldw_server/pull/1273'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue #1116 Phase 2.2 by deferring the remaining kanban router imports in iter_content_router_specs while preserving route metadata and optional-import behavior. Scope is limited to the kanban endpoints block in tldw_Server_API/app/api/v1/router_groups/content.py; notes/study/persona, user content utilities, control-plane, VN assets, minimal router groups, and rag_unified remain outside this tranche.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Kanban router specs defer module import and router attribute lookup until registration or resolution
+- [x] #2 Existing prefix, tags, route_key, and default_stable behavior for kanban routers remain unchanged
+- [x] #3 Focused red/green router laziness coverage, full router contract tests, main router/OpenAPI contracts, Bandit touched source scan, and git diff hygiene are run before commit
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added focused router contract coverage for the nine kanban endpoint modules. The test failed red before implementation because iter_content_router_specs eagerly imported the modules and touched each router attribute during spec construction.
+
+Converted the kanban block in content.py to lazy ImportedRouterSpec entries for kanban_boards, kanban_lists, kanban_cards, kanban_labels, kanban_checklists, kanban_comments, kanban_search, kanban_links, and kanban_workflow.
+
+Verification: focused red failed as expected; focused green passed 1 selected; full router group contract passed 61; main router contract passed 6; OpenAPI contract suite passed 69; Bandit content router group source reported 0 results and 0 errors; git diff --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Deferred all kanban content router registrations to lazy ImportedRouterSpec entries while preserving the /api/v1/kanban prefix, kanban tags, route_key, and default_stable behavior. Added contract coverage proving iter_content_router_specs does not import kanban modules or touch router attributes during spec construction.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-50 - Phase-2.2-kanban-router-conditional-cleanup-S.md
+++ b/backlog/tasks/task-50 - Phase-2.2-kanban-router-conditional-cleanup-S.md
@@ -4,7 +4,7 @@ title: Phase 2.2 kanban router conditional cleanup S
 status: Done
 assignee: []
 created_date: '2026-05-05 01:02'
-updated_date: '2026-05-05 01:08'
+updated_date: '2026-05-05 01:19'
 labels: []
 dependencies: []
 references:
@@ -34,12 +34,14 @@ Added focused router contract coverage for the nine kanban endpoint modules. The
 Converted the kanban block in content.py to lazy ImportedRouterSpec entries for kanban_boards, kanban_lists, kanban_cards, kanban_labels, kanban_checklists, kanban_comments, kanban_search, kanban_links, and kanban_workflow.
 
 Verification: focused red failed as expected; focused green passed 1 selected; full router group contract passed 61; main router contract passed 6; OpenAPI contract suite passed 69; Bandit content router group source reported 0 results and 0 errors; git diff --check passed.
+
+Review follow-up: collapsed the repetitive nine-entry kanban ImportedRouterSpec block into a loop over module names after Gemini review. The existing focused kanban laziness contract still covers module names, metadata, lazy imports, and attr lookup behavior.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Deferred all kanban content router registrations to lazy ImportedRouterSpec entries while preserving the /api/v1/kanban prefix, kanban tags, route_key, and default_stable behavior. Added contract coverage proving iter_content_router_specs does not import kanban modules or touch router attributes during spec construction.
+Deferred all kanban content router registrations to lazy ImportedRouterSpec entries while preserving the /api/v1/kanban prefix, kanban tags, route_key, and default_stable behavior. Added contract coverage proving iter_content_router_specs does not import kanban modules or touch router attributes during spec construction. Addressed review feedback by using a compact loop over kanban module names.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/api/v1/router_groups/content.py
+++ b/tldw_Server_API/app/api/v1/router_groups/content.py
@@ -439,72 +439,27 @@ def iter_content_router_specs() -> Iterable[RouterSpec]:
         append_imported_router_spec(specs, audio_voice_spec)
 
     # Kanban Board endpoints
-    for kanban_spec in (
-        ImportedRouterSpec(
-            import_path="tldw_Server_API.app.api.v1.endpoints.kanban.kanban_boards",
-            log_name="kanban_boards",
-            prefix=f"{API_V1_PREFIX}/kanban",
-            tags=("kanban",),
-            route_key="kanban",
-        ),
-        ImportedRouterSpec(
-            import_path="tldw_Server_API.app.api.v1.endpoints.kanban.kanban_lists",
-            log_name="kanban_lists",
-            prefix=f"{API_V1_PREFIX}/kanban",
-            tags=("kanban",),
-            route_key="kanban",
-        ),
-        ImportedRouterSpec(
-            import_path="tldw_Server_API.app.api.v1.endpoints.kanban.kanban_cards",
-            log_name="kanban_cards",
-            prefix=f"{API_V1_PREFIX}/kanban",
-            tags=("kanban",),
-            route_key="kanban",
-        ),
-        ImportedRouterSpec(
-            import_path="tldw_Server_API.app.api.v1.endpoints.kanban.kanban_labels",
-            log_name="kanban_labels",
-            prefix=f"{API_V1_PREFIX}/kanban",
-            tags=("kanban",),
-            route_key="kanban",
-        ),
-        ImportedRouterSpec(
-            import_path="tldw_Server_API.app.api.v1.endpoints.kanban.kanban_checklists",
-            log_name="kanban_checklists",
-            prefix=f"{API_V1_PREFIX}/kanban",
-            tags=("kanban",),
-            route_key="kanban",
-        ),
-        ImportedRouterSpec(
-            import_path="tldw_Server_API.app.api.v1.endpoints.kanban.kanban_comments",
-            log_name="kanban_comments",
-            prefix=f"{API_V1_PREFIX}/kanban",
-            tags=("kanban",),
-            route_key="kanban",
-        ),
-        ImportedRouterSpec(
-            import_path="tldw_Server_API.app.api.v1.endpoints.kanban.kanban_search",
-            log_name="kanban_search",
-            prefix=f"{API_V1_PREFIX}/kanban",
-            tags=("kanban",),
-            route_key="kanban",
-        ),
-        ImportedRouterSpec(
-            import_path="tldw_Server_API.app.api.v1.endpoints.kanban.kanban_links",
-            log_name="kanban_links",
-            prefix=f"{API_V1_PREFIX}/kanban",
-            tags=("kanban",),
-            route_key="kanban",
-        ),
-        ImportedRouterSpec(
-            import_path="tldw_Server_API.app.api.v1.endpoints.kanban.kanban_workflow",
-            log_name="kanban_workflow",
-            prefix=f"{API_V1_PREFIX}/kanban",
-            tags=("kanban",),
-            route_key="kanban",
-        ),
+    for kanban_module in (
+        "kanban_boards",
+        "kanban_lists",
+        "kanban_cards",
+        "kanban_labels",
+        "kanban_checklists",
+        "kanban_comments",
+        "kanban_search",
+        "kanban_links",
+        "kanban_workflow",
     ):
-        append_imported_router_spec(specs, kanban_spec)
+        append_imported_router_spec(
+            specs,
+            ImportedRouterSpec(
+                import_path=f"tldw_Server_API.app.api.v1.endpoints.kanban.{kanban_module}",
+                log_name=kanban_module,
+                prefix=f"{API_V1_PREFIX}/kanban",
+                tags=("kanban",),
+                route_key="kanban",
+            ),
+        )
 
     # Ingestion and adapter endpoints
     for adapter_spec in (

--- a/tldw_Server_API/app/api/v1/router_groups/content.py
+++ b/tldw_Server_API/app/api/v1/router_groups/content.py
@@ -439,38 +439,72 @@ def iter_content_router_specs() -> Iterable[RouterSpec]:
         append_imported_router_spec(specs, audio_voice_spec)
 
     # Kanban Board endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.kanban.kanban_boards import router as kanban_boards_router
-        from tldw_Server_API.app.api.v1.endpoints.kanban.kanban_cards import router as kanban_cards_router
-        from tldw_Server_API.app.api.v1.endpoints.kanban.kanban_checklists import router as kanban_checklists_router
-        from tldw_Server_API.app.api.v1.endpoints.kanban.kanban_comments import router as kanban_comments_router
-        from tldw_Server_API.app.api.v1.endpoints.kanban.kanban_labels import router as kanban_labels_router
-        from tldw_Server_API.app.api.v1.endpoints.kanban.kanban_links import router as kanban_links_router
-        from tldw_Server_API.app.api.v1.endpoints.kanban.kanban_lists import router as kanban_lists_router
-        from tldw_Server_API.app.api.v1.endpoints.kanban.kanban_search import router as kanban_search_router
-        from tldw_Server_API.app.api.v1.endpoints.kanban.kanban_workflow import router as kanban_workflow_router
-
-        specs.extend([
-            RouterSpec(
-                router=kanban_router,
-                prefix=f"{API_V1_PREFIX}/kanban",
-                tags=("kanban",),
-                route_key="kanban",
-            )
-            for kanban_router in (
-                kanban_boards_router,
-                kanban_lists_router,
-                kanban_cards_router,
-                kanban_labels_router,
-                kanban_checklists_router,
-                kanban_comments_router,
-                kanban_search_router,
-                kanban_links_router,
-                kanban_workflow_router,
-            )
-        ])
-    except ImportError as e:
-        logger.debug(f"Kanban endpoints unavailable; skipping import: {e}")
+    for kanban_spec in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.kanban.kanban_boards",
+            log_name="kanban_boards",
+            prefix=f"{API_V1_PREFIX}/kanban",
+            tags=("kanban",),
+            route_key="kanban",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.kanban.kanban_lists",
+            log_name="kanban_lists",
+            prefix=f"{API_V1_PREFIX}/kanban",
+            tags=("kanban",),
+            route_key="kanban",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.kanban.kanban_cards",
+            log_name="kanban_cards",
+            prefix=f"{API_V1_PREFIX}/kanban",
+            tags=("kanban",),
+            route_key="kanban",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.kanban.kanban_labels",
+            log_name="kanban_labels",
+            prefix=f"{API_V1_PREFIX}/kanban",
+            tags=("kanban",),
+            route_key="kanban",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.kanban.kanban_checklists",
+            log_name="kanban_checklists",
+            prefix=f"{API_V1_PREFIX}/kanban",
+            tags=("kanban",),
+            route_key="kanban",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.kanban.kanban_comments",
+            log_name="kanban_comments",
+            prefix=f"{API_V1_PREFIX}/kanban",
+            tags=("kanban",),
+            route_key="kanban",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.kanban.kanban_search",
+            log_name="kanban_search",
+            prefix=f"{API_V1_PREFIX}/kanban",
+            tags=("kanban",),
+            route_key="kanban",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.kanban.kanban_links",
+            log_name="kanban_links",
+            prefix=f"{API_V1_PREFIX}/kanban",
+            tags=("kanban",),
+            route_key="kanban",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.kanban.kanban_workflow",
+            log_name="kanban_workflow",
+            prefix=f"{API_V1_PREFIX}/kanban",
+            tags=("kanban",),
+            route_key="kanban",
+        ),
+    ):
+        append_imported_router_spec(specs, kanban_spec)
 
     # Ingestion and adapter endpoints
     for adapter_spec in (

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -2510,6 +2510,131 @@ def test_iter_content_router_specs_defers_audio_voice_router_attr_lookup(
     }
 
 
+def test_iter_content_router_specs_defers_kanban_router_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify kanban specs keep import and attr lookup lazy."""
+    import importlib
+
+    router_definitions = [
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_boards",
+            "expected_name": "kanban_boards",
+            "path": "/boards",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_lists",
+            "expected_name": "kanban_lists",
+            "path": "/lists",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_cards",
+            "expected_name": "kanban_cards",
+            "path": "/cards",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_labels",
+            "expected_name": "kanban_labels",
+            "path": "/labels",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_checklists",
+            "expected_name": "kanban_checklists",
+            "path": "/checklists",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_comments",
+            "expected_name": "kanban_comments",
+            "path": "/comments",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_search",
+            "expected_name": "kanban_search",
+            "path": "/search",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_links",
+            "expected_name": "kanban_links",
+            "path": "/links",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_workflow",
+            "expected_name": "kanban_workflow",
+            "path": "/workflow",
+        },
+    ]
+    routers_by_module: dict[str, APIRouter] = {}
+    access_count = {
+        str(definition["module_name"]): 0 for definition in router_definitions
+    }
+    import_calls: list[str] = []
+
+    for definition in router_definitions:
+        module_name = str(definition["module_name"])
+        router = APIRouter()
+
+        @router.get(str(definition["path"]))
+        def _endpoint() -> dict[str, str]:
+            """Return a deterministic response for the fake kanban router."""
+            return {"status": "ok"}
+
+        routers_by_module[module_name] = router
+        fake_module = ModuleType(module_name)
+
+        def _module_getattr(
+            name: str,
+            *,
+            module_name: str = module_name,
+            router: APIRouter = router,
+        ) -> APIRouter:
+            """Track lazy router attribute resolution for the fake module."""
+            if name != "router":
+                raise AttributeError(name)
+            access_count[module_name] += 1
+            return router
+
+        fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Track lazy module imports for selected kanban routers."""
+        if module_name in routers_by_module:
+            import_calls.append(module_name)
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    specs = list(iter_content_router_specs())
+    assert access_count == {
+        str(definition["module_name"]): 0 for definition in router_definitions
+    }
+    assert import_calls == []
+
+    kanban_specs = [spec for spec in specs if spec.route_key == "kanban"]
+    assert len(kanban_specs) == len(router_definitions)
+
+    by_first_path = {_first_router_path(spec.router): spec for spec in kanban_specs}
+    for definition in router_definitions:
+        spec = by_first_path[str(definition["path"])]
+        assert spec.prefix == "/api/v1/kanban"
+        assert spec.tags == ("kanban",)
+        assert spec.route_key == "kanban"
+        assert spec.name == definition["expected_name"]
+        assert spec.default_stable is True
+
+    assert set(import_calls) == {
+        str(definition["module_name"]) for definition in router_definitions
+    }
+    assert access_count == {
+        str(definition["module_name"]): 1 for definition in router_definitions
+    }
+
+
 def test_qodo_reviewed_router_policy_regressions(monkeypatch: pytest.MonkeyPatch) -> None:
     _install_fake_router_module(
         monkeypatch,


### PR DESCRIPTION
## Summary
- Defers the remaining kanban router imports in content.py with lazy ImportedRouterSpec entries.
- Adds red/green contract coverage proving iter_content_router_specs no longer imports kanban modules or touches router attributes during spec construction.
- Preserves the /api/v1/kanban prefix, kanban tags, route_key, and default_stable behavior for all nine kanban routers.

## Change summary
Human summary required before merge: this keeps existing kanban route behavior unchanged while continuing Phase 2.2 router conditional cleanup as a narrow self-contained content.py tranche after #1273 merged.

## Verification
- Red: python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k kanban_router_attr_lookup -q (failed before implementation because kanban router attrs were eagerly accessed)
- Focused green: python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k kanban_router_attr_lookup -q (1 passed)
- Full router group contract: python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q (61 passed)
- Main router contract: python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q (6 passed)
- OpenAPI contracts: python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q (69 passed)
- Bandit: python -m bandit -r tldw_Server_API/app/api/v1/router_groups/content.py -f json -o /tmp/bandit_phase2_2_kanban_router_conditionals_s.json (0 results, 0 errors)
- git diff --check
- git diff --cached --check

Refs #1116