### PR TITLE
Add native CodeGraph Java/Kotlin extractor support

### DIFF
--- a/Docs/superpowers/plans/2026-05-05-native-codegraph-java-kotlin-extractor-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-05-native-codegraph-java-kotlin-extractor-implementation-plan.md
@@ -1,0 +1,497 @@
+# Native CodeGraph Java/Kotlin Extractor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the Stage 5 Java/Kotlin native CodeGraph extractor slice without broadening into C#, C/C++, Jobs mode, or full type/classpath resolution.
+
+**Architecture:** Keep language parsing in focused Tree-sitter extractors under `tldw_Server_API/app/core/CodeGraph/extractors/`, with shared JVM-family helpers only where they remove real duplication. Keep `CodeGraphIndexer` as the dependency-aware wiring point and `CodeGraphModule` unchanged except for search visibility through existing repository APIs.
+
+**Tech Stack:** Python 3.11, pytest, optional `tree-sitter`, `tree-sitter-java`, `tree-sitter-kotlin`, SQLite CodeGraph repository, existing Unified MCP CodeGraph module.
+
+---
+
+## Scope
+
+Included:
+
+- Java package/import/type/method/constructor extraction.
+- Kotlin package/import/class/object/interface/function extraction.
+- Conservative same-file calls resolved by simple name, with other calls/imports stored as unresolved refs.
+- Dependency-aware registry/indexer wiring and MCP search coverage through existing tools.
+- Focused verification and TASK-49 closeout.
+
+Excluded:
+
+- C#, C, and C++ extractors.
+- Full Java classpath, Gradle/Maven, Kotlin compiler, type inference, inheritance resolution, overloaded method resolution, or cross-file JVM symbol resolution.
+- New MCP tools, Jobs-backed indexing, file watching, or source-context behavior changes.
+
+## File Map
+
+- Modify: `pyproject.toml`
+  - Add optional `.[codegraph]` parser dependencies for Java/Kotlin after a local parser smoke check.
+- Modify: `tldw_Server_API/app/core/CodeGraph/extractors/tree_sitter_loader.py`
+  - Add parser module mappings for `java` and `kotlin`.
+- Create: `tldw_Server_API/app/core/CodeGraph/extractors/jvm_common.py`
+  - Shared node text, descendant traversal, qualified-name, call-site, and node/edge construction helpers for Java/Kotlin.
+- Create: `tldw_Server_API/app/core/CodeGraph/extractors/java_extractor.py`
+  - Java Tree-sitter extraction.
+- Create: `tldw_Server_API/app/core/CodeGraph/extractors/kotlin_extractor.py`
+  - Kotlin Tree-sitter extraction.
+- Modify: `tldw_Server_API/app/core/CodeGraph/extractors/__init__.py`
+  - Export Java/Kotlin extractor classes if needed by local import patterns.
+- Modify: `tldw_Server_API/app/core/CodeGraph/language_registry.py`
+  - Promote Java/Kotlin from planned metadata to foundation metadata with dependency-aware `symbol_extraction`.
+- Modify: `tldw_Server_API/app/core/CodeGraph/indexer.py`
+  - Register Java/Kotlin extractors only when their parsers are available.
+- Modify: `tldw_Server_API/tests/CodeGraph/test_codegraph_tree_sitter_loader.py`
+  - Cover parser loading and missing dependency behavior.
+- Modify: `tldw_Server_API/tests/CodeGraph/test_codegraph_language_registry.py`
+  - Cover Java/Kotlin dependency-aware metadata.
+- Create: `tldw_Server_API/tests/CodeGraph/test_codegraph_java_extractor.py`
+  - Java extractor behavior.
+- Create: `tldw_Server_API/tests/CodeGraph/test_codegraph_kotlin_extractor.py`
+  - Kotlin extractor behavior.
+- Modify: `tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py`
+  - Indexer wiring/search coverage for Java/Kotlin.
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py`
+  - Existing MCP search coverage for indexed Java/Kotlin symbols.
+- Modify: `backlog/tasks/task-49 - Implement-native-CodeGraph-Java-Kotlin-extractor-slice.md`
+  - Keep task state, verification, and final summary current.
+
+## Task 1: Dependency Gate
+
+**Files:**
+- Modify: `pyproject.toml`
+- Modify: `tldw_Server_API/app/core/CodeGraph/extractors/tree_sitter_loader.py`
+- Test: `tldw_Server_API/tests/CodeGraph/test_codegraph_tree_sitter_loader.py`
+
+- [ ] **Step 1: Install/verify candidate parser dependencies**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pip install "tree-sitter-java>=0.23,<0.24" "tree-sitter-kotlin>=1.1,<1.2"
+```
+
+Expected: packages install into the shared repo venv. If installation fails due network or wheel availability, stop and report the blocker rather than replacing this slice with regex parsing.
+
+- [ ] **Step 2: Write RED loader tests**
+
+Add tests that call `load_parser("java")` and `load_parser("kotlin")`, parse compact Java/Kotlin snippets, and assert missing-package behavior can report `tree_sitter_java` / `tree_sitter_kotlin` without raising.
+
+- [ ] **Step 3: Run RED tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_tree_sitter_loader.py -q
+```
+
+Expected before implementation: fail with unsupported Tree-sitter language for Java/Kotlin.
+
+- [ ] **Step 4: Implement parser mappings**
+
+Add:
+
+```python
+"java": ("tree_sitter_java", "language"),
+"kotlin": ("tree_sitter_kotlin", "language"),
+```
+
+to `_LANGUAGE_MODULES`.
+
+Add dependency bounds to `pyproject.toml` only after the smoke test confirms the import/function names.
+
+- [ ] **Step 5: Run GREEN loader tests**
+
+Run the same pytest command. Expected: all loader tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pyproject.toml \
+  tldw_Server_API/app/core/CodeGraph/extractors/tree_sitter_loader.py \
+  tldw_Server_API/tests/CodeGraph/test_codegraph_tree_sitter_loader.py
+git commit -m "feat: add codegraph jvm parser loading"
+```
+
+## Task 2: Shared JVM Extraction Helpers
+
+**Files:**
+- Create: `tldw_Server_API/app/core/CodeGraph/extractors/jvm_common.py`
+- Test indirectly through Java/Kotlin extractor tests in Tasks 3 and 4.
+
+- [ ] **Step 1: Add a small helper module**
+
+Include only helpers shared by both languages:
+
+- byte-backed `node_text(source, node) -> str`
+- `named_descendants_of_type(node, *types) -> iterator`
+- line/column conversion from Tree-sitter points to 1-based line and column
+- `JvmCallSite` dataclass
+- helper for creating `CodeGraphNode` with `make_node_id()`
+- helper for resolving call sites by simple local callable name
+
+- [ ] **Step 2: Keep helpers language-neutral**
+
+Do not encode Java/Kotlin grammar node-type decisions in this file unless both languages use the same Tree-sitter node type and semantics.
+
+- [ ] **Step 3: Defer commit**
+
+Commit helpers with the first extractor that uses them so the branch stays buildable.
+
+## Task 3: Java Extractor
+
+**Files:**
+- Create: `tldw_Server_API/app/core/CodeGraph/extractors/java_extractor.py`
+- Create: `tldw_Server_API/tests/CodeGraph/test_codegraph_java_extractor.py`
+- Create/modify: `tldw_Server_API/app/core/CodeGraph/extractors/jvm_common.py`
+
+- [ ] **Step 1: Write RED Java extractor test**
+
+Test source:
+
+```java
+package com.example.app;
+
+import java.util.List;
+import com.example.tools.Helper;
+
+public class Greeter {
+    public Greeter() {
+        setup();
+    }
+
+    public String greet(String name) {
+        return helper(name);
+    }
+
+    private String helper(String value) {
+        return value.toUpperCase();
+    }
+}
+```
+
+Expected nodes:
+
+- module node for `src/main/java/com/example/app/Greeter.java`
+- package node `com.example.app`
+- import nodes for `java.util.List` and `com.example.tools.Helper`
+- class node `com.example.app.Greeter`
+- constructor node `com.example.app.Greeter.Greeter`
+- method nodes `com.example.app.Greeter.greet` and `com.example.app.Greeter.helper`
+
+Expected relationships:
+
+- constructor has a resolved same-file call edge to `setup` only if `setup` exists; in this fixture it should be unresolved.
+- `greet` has a resolved same-file call edge to `helper`.
+- imports are unresolved refs unless the target file is resolved in a later slice.
+
+- [ ] **Step 2: Run RED Java test**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_java_extractor.py -q
+```
+
+Expected: fail because `JavaTreeSitterExtractor` does not exist.
+
+- [ ] **Step 3: Implement minimal Java extractor**
+
+Implement:
+
+- dependency errors through `load_parser("java")`
+- UTF-8 decode errors as `ExtractionResult(errors=(...))`
+- parse errors as `ExtractionResult(errors=("Java parse error",))`
+- package declarations from `package_declaration`
+- imports from `import_declaration`
+- classes/interfaces/enums/records from type declarations where straightforward
+- constructors and methods under classes
+- same-file simple call resolution from `method_invocation` names inside method/constructor bodies
+
+Do not attempt overload or receiver type resolution. Receiver calls such as `client.fetch()` should become unresolved refs.
+
+- [ ] **Step 4: Run GREEN Java test**
+
+Run the same pytest command. Expected: pass.
+
+- [ ] **Step 5: Add deterministic ID test**
+
+Add one test extracting the same Java source twice and assert node IDs are identical.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_Server_API/app/core/CodeGraph/extractors/jvm_common.py \
+  tldw_Server_API/app/core/CodeGraph/extractors/java_extractor.py \
+  tldw_Server_API/tests/CodeGraph/test_codegraph_java_extractor.py
+git commit -m "feat: add codegraph java extractor"
+```
+
+## Task 4: Kotlin Extractor
+
+**Files:**
+- Create: `tldw_Server_API/app/core/CodeGraph/extractors/kotlin_extractor.py`
+- Create: `tldw_Server_API/tests/CodeGraph/test_codegraph_kotlin_extractor.py`
+- Modify: `tldw_Server_API/app/core/CodeGraph/extractors/jvm_common.py` only for genuinely shared needs.
+
+- [ ] **Step 1: Write RED Kotlin extractor test**
+
+Test source:
+
+```kotlin
+package com.example.app
+
+import com.example.tools.Helper
+import kotlin.collections.List
+
+class Greeter {
+    fun greet(name: String): String {
+        return helper(name)
+    }
+
+    private fun helper(value: String): String {
+        return value.uppercase()
+    }
+}
+
+object Registry {
+    fun create(): Greeter {
+        return Greeter()
+    }
+}
+```
+
+Expected nodes:
+
+- module node for `src/main/kotlin/com/example/app/Greeter.kt`
+- package node `com.example.app`
+- import nodes for both imports
+- class node `com.example.app.Greeter`
+- function/method nodes `com.example.app.Greeter.greet`, `com.example.app.Greeter.helper`
+- object node `com.example.app.Registry`
+- function node `com.example.app.Registry.create`
+
+Expected relationships:
+
+- `greet` has a resolved same-file call edge to `helper`.
+- `create` may leave `Greeter` constructor call unresolved unless constructor nodes are explicitly modeled for Kotlin in this slice.
+
+- [ ] **Step 2: Run RED Kotlin test**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_kotlin_extractor.py -q
+```
+
+Expected: fail because `KotlinTreeSitterExtractor` does not exist.
+
+- [ ] **Step 3: Implement minimal Kotlin extractor**
+
+Implement:
+
+- dependency errors through `load_parser("kotlin")`
+- UTF-8 decode errors and parse errors
+- package/import declarations
+- class/object/interface declarations
+- named functions, including functions inside class/object bodies
+- same-file simple function call resolution
+
+Do not model Kotlin overloads, extensions, generics, delegated properties, or compiler semantics.
+
+- [ ] **Step 4: Run GREEN Kotlin test**
+
+Run the same pytest command. Expected: pass.
+
+- [ ] **Step 5: Add deterministic ID test**
+
+Add one test extracting the same Kotlin source twice and assert node IDs are identical.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_Server_API/app/core/CodeGraph/extractors/kotlin_extractor.py \
+  tldw_Server_API/app/core/CodeGraph/extractors/jvm_common.py \
+  tldw_Server_API/tests/CodeGraph/test_codegraph_kotlin_extractor.py
+git commit -m "feat: add codegraph kotlin extractor"
+```
+
+## Task 5: Registry And Indexer Wiring
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/CodeGraph/language_registry.py`
+- Modify: `tldw_Server_API/app/core/CodeGraph/indexer.py`
+- Modify: `tldw_Server_API/app/core/CodeGraph/extractors/__init__.py`
+- Modify: `tldw_Server_API/tests/CodeGraph/test_codegraph_language_registry.py`
+- Modify: `tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py`
+
+- [ ] **Step 1: Write RED registry test**
+
+Update registry tests so Java/Kotlin are foundation-stage language entries with `symbol_extraction=True` only when their parser packages are present.
+
+Expected before implementation: Java/Kotlin still report `stage == "planned"`.
+
+- [ ] **Step 2: Write RED indexer test**
+
+Add a test with `Service.java` and `Greeter.kt`, then assert:
+
+- index status is `complete`
+- both files have `node_count > 0`
+- `repo.search_nodes("Greeter", limit=10)` returns Java/Kotlin symbols as appropriate
+
+- [ ] **Step 3: Implement registry and indexer wiring**
+
+Move Java/Kotlin out of `_PLANNED_LANGUAGES` into `_foundation_languages()` with dependency-missing checks:
+
+```python
+java_missing = _missing_dependencies(missing, ("tree_sitter", "tree_sitter_java"))
+kotlin_missing = _missing_dependencies(missing, ("tree_sitter", "tree_sitter_kotlin"))
+```
+
+In `CodeGraphIndexer.__init__`, register extractors only when `load_parser("java").available` / `load_parser("kotlin").available`.
+
+In `_extract()`, pass `workspace_root` to Java/Kotlin only if extractors need it. Do not use build-system globals.
+
+- [ ] **Step 4: Run focused registry/indexer tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/CodeGraph/test_codegraph_language_registry.py \
+  tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py \
+  -q
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/CodeGraph/language_registry.py \
+  tldw_Server_API/app/core/CodeGraph/indexer.py \
+  tldw_Server_API/app/core/CodeGraph/extractors/__init__.py \
+  tldw_Server_API/tests/CodeGraph/test_codegraph_language_registry.py \
+  tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py
+git commit -m "feat: wire codegraph java kotlin extractors"
+```
+
+## Task 6: MCP Search Regression
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py`
+
+- [ ] **Step 1: Write RED MCP search test**
+
+Add a test that creates Java/Kotlin files in a temp workspace, runs `codegraph.index`, then calls existing `codegraph.search` for a Java/Kotlin symbol.
+
+Expected before wiring: search returns no Java/Kotlin symbol because files were planned-language skipped or no extractor was registered.
+
+- [ ] **Step 2: Run RED MCP test**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py::test_codegraph_search_finds_java_kotlin_symbols_after_index -q
+```
+
+Expected: fail before implementation.
+
+- [ ] **Step 3: Ensure existing MCP code needs no new tool changes**
+
+The MCP module should already surface Java/Kotlin through `status`, `index`, `files`, `search`, `node`, and context/impact tools. Only change MCP implementation if validation blocks known language IDs after registry changes.
+
+- [ ] **Step 4: Run GREEN MCP test**
+
+Run the same pytest command. Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
+git commit -m "test: cover mcp java kotlin codegraph search"
+```
+
+## Task 7: Verification And Closeout
+
+**Files:**
+- Modify: `backlog/tasks/task-49 - Implement-native-CodeGraph-Java-Kotlin-extractor-slice.md`
+
+- [ ] **Step 1: Run focused CodeGraph/MCP tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/CodeGraph \
+  tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py \
+  -q
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Run Ruff**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check \
+  tldw_Server_API/app/core/CodeGraph \
+  tldw_Server_API/app/core/DB_Management/codegraph \
+  tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py \
+  tldw_Server_API/tests/CodeGraph \
+  tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
+```
+
+Expected: `All checks passed!`
+
+- [ ] **Step 3: Run Bandit**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r \
+  tldw_Server_API/app/core/CodeGraph \
+  tldw_Server_API/app/core/DB_Management/codegraph \
+  tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py \
+  -f json -o /tmp/bandit_codegraph_java_kotlin.json
+```
+
+Expected: JSON has `errors: []` and `results: []`.
+
+- [ ] **Step 4: Run whitespace check**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output and exit 0.
+
+- [ ] **Step 5: Update TASK-49**
+
+Record:
+
+- dependency versions installed/verified
+- RED/GREEN evidence
+- verification command results
+- known limits: no classpath/type/build-system resolution
+
+- [ ] **Step 6: Commit task finalization**
+
+```bash
+git add "backlog/tasks/task-49 - Implement-native-CodeGraph-Java-Kotlin-extractor-slice.md"
+git commit -m "docs: finalize codegraph java kotlin task"
+```
+
+## Review Risks
+
+- Tree-sitter JVM package APIs may not match the JS-family `language()` shape. Verify before pinning.
+- Kotlin grammar node names may differ from expected names; inspect parsed trees in a scratch REPL if RED tests fail for grammar-shape reasons.
+- Java/Kotlin call resolution must stay conservative. Do not link receiver/member calls across objects unless the target is unambiguously same-file and simple-name local.
+- Keep Java/Kotlin dependency absence non-fatal: the module must remain importable and status should explain missing parser packages.

--- a/Docs/superpowers/plans/2026-05-05-native-codegraph-java-kotlin-extractor-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-05-native-codegraph-java-kotlin-extractor-implementation-plan.md
@@ -237,7 +237,7 @@ git commit -m "feat: add codegraph java extractor"
 - Create: `tldw_Server_API/tests/CodeGraph/test_codegraph_kotlin_extractor.py`
 - Modify: `tldw_Server_API/app/core/CodeGraph/extractors/jvm_common.py` only for genuinely shared needs.
 
-- [ ] **Step 1: Write RED Kotlin extractor test**
+- [x] **Step 1: Write RED Kotlin extractor test**
 
 Test source:
 
@@ -279,7 +279,7 @@ Expected relationships:
 - `greet` has a resolved same-file call edge to `helper`.
 - `create` may leave `Greeter` constructor call unresolved unless constructor nodes are explicitly modeled for Kotlin in this slice.
 
-- [ ] **Step 2: Run RED Kotlin test**
+- [x] **Step 2: Run RED Kotlin test**
 
 Run:
 
@@ -289,7 +289,7 @@ Run:
 
 Expected: fail because `KotlinTreeSitterExtractor` does not exist.
 
-- [ ] **Step 3: Implement minimal Kotlin extractor**
+- [x] **Step 3: Implement minimal Kotlin extractor**
 
 Implement:
 
@@ -302,15 +302,15 @@ Implement:
 
 Do not model Kotlin overloads, extensions, generics, delegated properties, or compiler semantics.
 
-- [ ] **Step 4: Run GREEN Kotlin test**
+- [x] **Step 4: Run GREEN Kotlin test**
 
 Run the same pytest command. Expected: pass.
 
-- [ ] **Step 5: Add deterministic ID test**
+- [x] **Step 5: Add deterministic ID test**
 
 Add one test extracting the same Kotlin source twice and assert node IDs are identical.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add tldw_Server_API/app/core/CodeGraph/extractors/kotlin_extractor.py \

--- a/Docs/superpowers/plans/2026-05-05-native-codegraph-java-kotlin-extractor-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-05-native-codegraph-java-kotlin-extractor-implementation-plan.md
@@ -422,7 +422,7 @@ git commit -m "test: cover mcp java kotlin codegraph search"
 **Files:**
 - Modify: `backlog/tasks/task-49 - Implement-native-CodeGraph-Java-Kotlin-extractor-slice.md`
 
-- [ ] **Step 1: Run focused CodeGraph/MCP tests**
+- [x] **Step 1: Run focused CodeGraph/MCP tests**
 
 Run:
 
@@ -436,7 +436,7 @@ Run:
 
 Expected: all pass.
 
-- [ ] **Step 2: Run Ruff**
+- [x] **Step 2: Run Ruff**
 
 Run:
 
@@ -451,7 +451,7 @@ Run:
 
 Expected: `All checks passed!`
 
-- [ ] **Step 3: Run Bandit**
+- [x] **Step 3: Run Bandit**
 
 Run:
 
@@ -465,7 +465,7 @@ Run:
 
 Expected: JSON has `errors: []` and `results: []`.
 
-- [ ] **Step 4: Run whitespace check**
+- [x] **Step 4: Run whitespace check**
 
 Run:
 
@@ -475,7 +475,7 @@ git diff --check
 
 Expected: no output and exit 0.
 
-- [ ] **Step 5: Update TASK-49**
+- [x] **Step 5: Update TASK-49**
 
 Record:
 
@@ -484,7 +484,7 @@ Record:
 - verification command results
 - known limits: no classpath/type/build-system resolution
 
-- [ ] **Step 6: Commit task finalization**
+- [x] **Step 6: Commit task finalization**
 
 ```bash
 git add "backlog/tasks/task-49 - Implement-native-CodeGraph-Java-Kotlin-extractor-slice.md"

--- a/Docs/superpowers/plans/2026-05-05-native-codegraph-java-kotlin-extractor-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-05-native-codegraph-java-kotlin-extractor-implementation-plan.md
@@ -66,7 +66,7 @@ Excluded:
 - Modify: `tldw_Server_API/app/core/CodeGraph/extractors/tree_sitter_loader.py`
 - Test: `tldw_Server_API/tests/CodeGraph/test_codegraph_tree_sitter_loader.py`
 
-- [ ] **Step 1: Install/verify candidate parser dependencies**
+- [x] **Step 1: Install/verify candidate parser dependencies**
 
 Run:
 
@@ -76,11 +76,11 @@ Run:
 
 Expected: packages install into the shared repo venv. If installation fails due network or wheel availability, stop and report the blocker rather than replacing this slice with regex parsing.
 
-- [ ] **Step 2: Write RED loader tests**
+- [x] **Step 2: Write RED loader tests**
 
 Add tests that call `load_parser("java")` and `load_parser("kotlin")`, parse compact Java/Kotlin snippets, and assert missing-package behavior can report `tree_sitter_java` / `tree_sitter_kotlin` without raising.
 
-- [ ] **Step 3: Run RED tests**
+- [x] **Step 3: Run RED tests**
 
 Run:
 
@@ -90,7 +90,7 @@ Run:
 
 Expected before implementation: fail with unsupported Tree-sitter language for Java/Kotlin.
 
-- [ ] **Step 4: Implement parser mappings**
+- [x] **Step 4: Implement parser mappings**
 
 Add:
 
@@ -103,11 +103,11 @@ to `_LANGUAGE_MODULES`.
 
 Add dependency bounds to `pyproject.toml` only after the smoke test confirms the import/function names.
 
-- [ ] **Step 5: Run GREEN loader tests**
+- [x] **Step 5: Run GREEN loader tests**
 
 Run the same pytest command. Expected: all loader tests pass.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add pyproject.toml \
@@ -122,7 +122,7 @@ git commit -m "feat: add codegraph jvm parser loading"
 - Create: `tldw_Server_API/app/core/CodeGraph/extractors/jvm_common.py`
 - Test indirectly through Java/Kotlin extractor tests in Tasks 3 and 4.
 
-- [ ] **Step 1: Add a small helper module**
+- [x] **Step 1: Add a small helper module**
 
 Include only helpers shared by both languages:
 
@@ -133,11 +133,11 @@ Include only helpers shared by both languages:
 - helper for creating `CodeGraphNode` with `make_node_id()`
 - helper for resolving call sites by simple local callable name
 
-- [ ] **Step 2: Keep helpers language-neutral**
+- [x] **Step 2: Keep helpers language-neutral**
 
 Do not encode Java/Kotlin grammar node-type decisions in this file unless both languages use the same Tree-sitter node type and semantics.
 
-- [ ] **Step 3: Defer commit**
+- [x] **Step 3: Defer commit**
 
 Commit helpers with the first extractor that uses them so the branch stays buildable.
 
@@ -148,7 +148,7 @@ Commit helpers with the first extractor that uses them so the branch stays build
 - Create: `tldw_Server_API/tests/CodeGraph/test_codegraph_java_extractor.py`
 - Create/modify: `tldw_Server_API/app/core/CodeGraph/extractors/jvm_common.py`
 
-- [ ] **Step 1: Write RED Java extractor test**
+- [x] **Step 1: Write RED Java extractor test**
 
 Test source:
 
@@ -188,7 +188,7 @@ Expected relationships:
 - `greet` has a resolved same-file call edge to `helper`.
 - imports are unresolved refs unless the target file is resolved in a later slice.
 
-- [ ] **Step 2: Run RED Java test**
+- [x] **Step 2: Run RED Java test**
 
 Run:
 
@@ -198,7 +198,7 @@ Run:
 
 Expected: fail because `JavaTreeSitterExtractor` does not exist.
 
-- [ ] **Step 3: Implement minimal Java extractor**
+- [x] **Step 3: Implement minimal Java extractor**
 
 Implement:
 
@@ -213,15 +213,15 @@ Implement:
 
 Do not attempt overload or receiver type resolution. Receiver calls such as `client.fetch()` should become unresolved refs.
 
-- [ ] **Step 4: Run GREEN Java test**
+- [x] **Step 4: Run GREEN Java test**
 
 Run the same pytest command. Expected: pass.
 
-- [ ] **Step 5: Add deterministic ID test**
+- [x] **Step 5: Add deterministic ID test**
 
 Add one test extracting the same Java source twice and assert node IDs are identical.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add tldw_Server_API/app/core/CodeGraph/extractors/jvm_common.py \

--- a/Docs/superpowers/plans/2026-05-05-native-codegraph-java-kotlin-extractor-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-05-native-codegraph-java-kotlin-extractor-implementation-plan.md
@@ -328,13 +328,13 @@ git commit -m "feat: add codegraph kotlin extractor"
 - Modify: `tldw_Server_API/tests/CodeGraph/test_codegraph_language_registry.py`
 - Modify: `tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py`
 
-- [ ] **Step 1: Write RED registry test**
+- [x] **Step 1: Write RED registry test**
 
 Update registry tests so Java/Kotlin are foundation-stage language entries with `symbol_extraction=True` only when their parser packages are present.
 
 Expected before implementation: Java/Kotlin still report `stage == "planned"`.
 
-- [ ] **Step 2: Write RED indexer test**
+- [x] **Step 2: Write RED indexer test**
 
 Add a test with `Service.java` and `Greeter.kt`, then assert:
 
@@ -342,7 +342,7 @@ Add a test with `Service.java` and `Greeter.kt`, then assert:
 - both files have `node_count > 0`
 - `repo.search_nodes("Greeter", limit=10)` returns Java/Kotlin symbols as appropriate
 
-- [ ] **Step 3: Implement registry and indexer wiring**
+- [x] **Step 3: Implement registry and indexer wiring**
 
 Move Java/Kotlin out of `_PLANNED_LANGUAGES` into `_foundation_languages()` with dependency-missing checks:
 
@@ -355,7 +355,7 @@ In `CodeGraphIndexer.__init__`, register extractors only when `load_parser("java
 
 In `_extract()`, pass `workspace_root` to Java/Kotlin only if extractors need it. Do not use build-system globals.
 
-- [ ] **Step 4: Run focused registry/indexer tests**
+- [x] **Step 4: Run focused registry/indexer tests**
 
 Run:
 
@@ -368,7 +368,7 @@ Run:
 
 Expected: pass.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add tldw_Server_API/app/core/CodeGraph/language_registry.py \

--- a/Docs/superpowers/plans/2026-05-05-native-codegraph-java-kotlin-extractor-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-05-native-codegraph-java-kotlin-extractor-implementation-plan.md
@@ -384,13 +384,13 @@ git commit -m "feat: wire codegraph java kotlin extractors"
 **Files:**
 - Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py`
 
-- [ ] **Step 1: Write RED MCP search test**
+- [x] **Step 1: Write RED MCP search test**
 
 Add a test that creates Java/Kotlin files in a temp workspace, runs `codegraph.index`, then calls existing `codegraph.search` for a Java/Kotlin symbol.
 
 Expected before wiring: search returns no Java/Kotlin symbol because files were planned-language skipped or no extractor was registered.
 
-- [ ] **Step 2: Run RED MCP test**
+- [x] **Step 2: Run RED MCP test**
 
 Run:
 
@@ -400,15 +400,17 @@ Run:
 
 Expected: fail before implementation.
 
-- [ ] **Step 3: Ensure existing MCP code needs no new tool changes**
+Observed after Task 5 wiring: passed without MCP implementation changes because the existing module delegates to the newly wired registry/indexer/repository path.
+
+- [x] **Step 3: Ensure existing MCP code needs no new tool changes**
 
 The MCP module should already surface Java/Kotlin through `status`, `index`, `files`, `search`, `node`, and context/impact tools. Only change MCP implementation if validation blocks known language IDs after registry changes.
 
-- [ ] **Step 4: Run GREEN MCP test**
+- [x] **Step 4: Run GREEN MCP test**
 
 Run the same pytest command. Expected: pass.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py

--- a/backlog/tasks/task-49 - Implement-native-CodeGraph-Java-Kotlin-extractor-slice.md
+++ b/backlog/tasks/task-49 - Implement-native-CodeGraph-Java-Kotlin-extractor-slice.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@Codex'
 created_date: '2026-05-05 00:52'
-updated_date: '2026-05-05 01:04'
+updated_date: '2026-05-05 01:06'
 labels:
   - codegraph
   - mcp
@@ -55,6 +55,8 @@ Created focused Stage 5 implementation plan at Docs/superpowers/plans/2026-05-05
 Task 1 dependency gate complete: installed tree-sitter-java 0.23.5 and tree-sitter-kotlin 1.1.0 into the shared venv, verified both expose language(), added loader mappings and optional dependency bounds, and loader tests pass with 9 passed.
 
 Task 3 Java extractor complete: added shared JVM helpers plus Java Tree-sitter extraction for package/import/type/method/constructor nodes, same-file bare method call resolution, unresolved imports/receiver calls, parse errors, and deterministic node IDs. Verified with python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_java_extractor.py -q (3 passed).
+
+Task 4 Kotlin extractor complete: added Kotlin Tree-sitter extraction for package/import/class/object/interface/function nodes, same-file simple function call resolution, unresolved imports/receiver calls, parse errors, and deterministic node IDs. Verified with python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_kotlin_extractor.py -q (3 passed).
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-49 - Implement-native-CodeGraph-Java-Kotlin-extractor-slice.md
+++ b/backlog/tasks/task-49 - Implement-native-CodeGraph-Java-Kotlin-extractor-slice.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@Codex'
 created_date: '2026-05-05 00:52'
-updated_date: '2026-05-05 01:13'
+updated_date: '2026-05-05 03:20'
 labels:
   - codegraph
   - mcp
@@ -64,6 +64,12 @@ Task 5 registry/indexer wiring complete: promoted Java/Kotlin to foundation meta
 Task 6 MCP regression complete: added codegraph.index plus codegraph.search coverage for Java method and Kotlin function symbols. No MCP implementation changes were needed because the existing module delegates through the registry/indexer/repository path. Verified with python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py::test_codegraph_search_finds_java_kotlin_symbols_after_index -q (1 passed).
 
 Final verification: python -m pytest tldw_Server_API/tests/CodeGraph tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py -q passed with 108 passed and 5 warnings. Ruff passed on touched CodeGraph/MCP scope. Bandit JSON at /tmp/bandit_codegraph_java_kotlin.json reported errors [] and results []. git diff --check exited 0 with no output. Dependency versions verified in the shared venv: tree-sitter-java 0.23.5 and tree-sitter-kotlin 1.1.0. Known limits remain intentional: no classpath, build-system, overload, inheritance, or full type-resolution semantics in this slice.
+
+PR #1277 review-fix pass started. Active actionable items: avoid counting non-extractable optional JVM files in foreground size guards, keep dependency_available tied to core availability rather than all optional parser packages, preserve Java/Kotlin import syntax more faithfully, add type visibility for Java/Kotlin declarations, and harden Kotlin interface/navigation parsing.
+
+PR #1277 review-fix pass completed. Addressed active review issues: core dependency health no longer fails when optional Java/Kotlin parsers are missing; non-extractable JVM files are skipped before foreground file/byte guards with dependency_missing_language_skipped; Java imports preserve static and wildcard syntax and type declarations record visibility; Kotlin imports preserve alias and wildcard syntax, type declarations record visibility, interface detection no longer depends on source-text prefix, and nested navigation call refs preserve the full expression.
+
+Review-fix verification: focused review regressions passed (4 passed); focused config/indexer/Java/Kotlin extractor suite passed (31 passed); full CodeGraph plus MCP module/dynamic catalog suite passed (110 passed); Ruff passed on touched CodeGraph/MCP/test scope; Bandit on touched production scope reported 0 results and 0 errors in /tmp/bandit_codegraph_java_kotlin_review_fixes.json; git diff --check passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
@@ -72,6 +78,8 @@ Final verification: python -m pytest tldw_Server_API/tests/CodeGraph tldw_Server
 Implemented the native CodeGraph Java/Kotlin extractor slice. Added optional parser dependency pins and loader support, shared JVM Tree-sitter helpers, Java and Kotlin extractors, dependency-aware language registry/indexer wiring, and MCP search regression coverage. The implementation stays conservative: it extracts package/import/type/function or method symbols and same-file simple call edges while leaving imports, receiver calls, constructor calls without modeled targets, and build-system/type-resolution cases unresolved for later slices.
 
 PR: https://github.com/rmusser01/tldw_server/pull/1277
+
+PR #1277 review follow-up: fixed optional dependency health semantics, skipped unavailable JVM language files before foreground guard accounting, and tightened Java/Kotlin extraction to preserve import syntax, declaration visibility, Kotlin interface detection, and nested navigation call references.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-49 - Implement-native-CodeGraph-Java-Kotlin-extractor-slice.md
+++ b/backlog/tasks/task-49 - Implement-native-CodeGraph-Java-Kotlin-extractor-slice.md
@@ -1,0 +1,64 @@
+---
+id: TASK-49
+title: Implement native CodeGraph Java/Kotlin extractor slice
+status: In Progress
+assignee:
+  - '@Codex'
+created_date: '2026-05-05 00:52'
+updated_date: '2026-05-05 00:54'
+labels:
+  - codegraph
+  - mcp
+  - java
+  - kotlin
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1270'
+  - Docs/superpowers/specs/2026-05-03-native-codegraph-mcp-module-design.md
+documentation:
+  - Docs/superpowers/specs/2026-05-03-native-codegraph-mcp-module-design.md
+  - >-
+    Docs/superpowers/plans/2026-05-05-native-codegraph-java-kotlin-extractor-implementation-plan.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add the next Stage 5 native CodeGraph language slice after the merged context/impact tools: Java and Kotlin extractor support with conservative package/class/function/method/import symbols, same-file call edges, dependency-aware registry/indexer wiring, and focused MCP search coverage. Keep the slice narrow: no C#, no C/C++, no Jobs mode, no full type resolution or build-system-aware classpath analysis.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Java files index package, class/interface, method/constructor, and import nodes with deterministic IDs and conservative same-file call or unresolved references.
+- [ ] #2 Kotlin files index package, class/object/interface, function, and import nodes with deterministic IDs and conservative same-file call or unresolved references.
+- [ ] #3 Language registry and indexer expose Java/Kotlin as symbol-extraction capable only when optional Tree-sitter dependencies are available; otherwise they remain visible with dependency_missing metadata and safe skip/failure behavior.
+- [ ] #4 Focused extractor, loader, registry, indexer, and MCP search tests cover Java/Kotlin behavior and dependency-missing paths.
+- [ ] #5 Focused CodeGraph/MCP tests, Ruff, Bandit on touched production scope, and git diff --check pass before PR.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Write a focused Java/Kotlin implementation plan under Docs/superpowers/plans and verify current parser dependency state.
+2. Add RED loader/registry tests for Java/Kotlin optional parser support and dependency-missing metadata.
+3. Add RED extractor tests for conservative Java and Kotlin symbols/imports/calls.
+4. Implement shared JVM-family helper code plus Java/Kotlin extractors using Tree-sitter when dependencies are present.
+5. Wire registry/indexer/MCP search behavior and run focused verification before PR.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Created focused Stage 5 implementation plan at Docs/superpowers/plans/2026-05-05-native-codegraph-java-kotlin-extractor-implementation-plan.md. Local venv currently has tree_sitter but not tree_sitter_java/tree_sitter_kotlin; dependency install/verification is the first implementation gate.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-49 - Implement-native-CodeGraph-Java-Kotlin-extractor-slice.md
+++ b/backlog/tasks/task-49 - Implement-native-CodeGraph-Java-Kotlin-extractor-slice.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@Codex'
 created_date: '2026-05-05 00:52'
-updated_date: '2026-05-05 01:06'
+updated_date: '2026-05-05 01:09'
 labels:
   - codegraph
   - mcp
@@ -57,6 +57,8 @@ Task 1 dependency gate complete: installed tree-sitter-java 0.23.5 and tree-sitt
 Task 3 Java extractor complete: added shared JVM helpers plus Java Tree-sitter extraction for package/import/type/method/constructor nodes, same-file bare method call resolution, unresolved imports/receiver calls, parse errors, and deterministic node IDs. Verified with python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_java_extractor.py -q (3 passed).
 
 Task 4 Kotlin extractor complete: added Kotlin Tree-sitter extraction for package/import/class/object/interface/function nodes, same-file simple function call resolution, unresolved imports/receiver calls, parse errors, and deterministic node IDs. Verified with python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_kotlin_extractor.py -q (3 passed).
+
+Task 5 registry/indexer wiring complete: promoted Java/Kotlin to foundation metadata with dependency_missing tracking, added dependency probe coverage, exported/register Java/Kotlin extractors when parsers are available, and added indexer coverage for persisted Java/Kotlin graph rows. Verified with python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_language_registry.py tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py::test_indexer_extracts_java_kotlin_graph_rows_during_index -q (7 passed) and python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py -q (18 passed).
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-49 - Implement-native-CodeGraph-Java-Kotlin-extractor-slice.md
+++ b/backlog/tasks/task-49 - Implement-native-CodeGraph-Java-Kotlin-extractor-slice.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@Codex'
 created_date: '2026-05-05 00:52'
-updated_date: '2026-05-05 01:11'
+updated_date: '2026-05-05 01:13'
 labels:
   - codegraph
   - mcp
@@ -15,6 +15,7 @@ dependencies: []
 references:
   - 'https://github.com/rmusser01/tldw_server/pull/1270'
   - Docs/superpowers/specs/2026-05-03-native-codegraph-mcp-module-design.md
+  - 'https://github.com/rmusser01/tldw_server/pull/1277'
 documentation:
   - Docs/superpowers/specs/2026-05-03-native-codegraph-mcp-module-design.md
   - >-
@@ -69,6 +70,8 @@ Final verification: python -m pytest tldw_Server_API/tests/CodeGraph tldw_Server
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Implemented the native CodeGraph Java/Kotlin extractor slice. Added optional parser dependency pins and loader support, shared JVM Tree-sitter helpers, Java and Kotlin extractors, dependency-aware language registry/indexer wiring, and MCP search regression coverage. The implementation stays conservative: it extracts package/import/type/function or method symbols and same-file simple call edges while leaving imports, receiver calls, constructor calls without modeled targets, and build-system/type-resolution cases unresolved for later slices.
+
+PR: https://github.com/rmusser01/tldw_server/pull/1277
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-49 - Implement-native-CodeGraph-Java-Kotlin-extractor-slice.md
+++ b/backlog/tasks/task-49 - Implement-native-CodeGraph-Java-Kotlin-extractor-slice.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@Codex'
 created_date: '2026-05-05 00:52'
-updated_date: '2026-05-05 01:09'
+updated_date: '2026-05-05 01:10'
 labels:
   - codegraph
   - mcp
@@ -59,6 +59,8 @@ Task 3 Java extractor complete: added shared JVM helpers plus Java Tree-sitter e
 Task 4 Kotlin extractor complete: added Kotlin Tree-sitter extraction for package/import/class/object/interface/function nodes, same-file simple function call resolution, unresolved imports/receiver calls, parse errors, and deterministic node IDs. Verified with python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_kotlin_extractor.py -q (3 passed).
 
 Task 5 registry/indexer wiring complete: promoted Java/Kotlin to foundation metadata with dependency_missing tracking, added dependency probe coverage, exported/register Java/Kotlin extractors when parsers are available, and added indexer coverage for persisted Java/Kotlin graph rows. Verified with python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_language_registry.py tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py::test_indexer_extracts_java_kotlin_graph_rows_during_index -q (7 passed) and python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py -q (18 passed).
+
+Task 6 MCP regression complete: added codegraph.index plus codegraph.search coverage for Java method and Kotlin function symbols. No MCP implementation changes were needed because the existing module delegates through the registry/indexer/repository path. Verified with python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py::test_codegraph_search_finds_java_kotlin_symbols_after_index -q (1 passed).
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-49 - Implement-native-CodeGraph-Java-Kotlin-extractor-slice.md
+++ b/backlog/tasks/task-49 - Implement-native-CodeGraph-Java-Kotlin-extractor-slice.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-49
 title: Implement native CodeGraph Java/Kotlin extractor slice
-status: In Progress
+status: Done
 assignee:
   - '@Codex'
 created_date: '2026-05-05 00:52'
-updated_date: '2026-05-05 01:10'
+updated_date: '2026-05-05 01:11'
 labels:
   - codegraph
   - mcp
@@ -30,11 +30,11 @@ Add the next Stage 5 native CodeGraph language slice after the merged context/im
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Java files index package, class/interface, method/constructor, and import nodes with deterministic IDs and conservative same-file call or unresolved references.
-- [ ] #2 Kotlin files index package, class/object/interface, function, and import nodes with deterministic IDs and conservative same-file call or unresolved references.
-- [ ] #3 Language registry and indexer expose Java/Kotlin as symbol-extraction capable only when optional Tree-sitter dependencies are available; otherwise they remain visible with dependency_missing metadata and safe skip/failure behavior.
-- [ ] #4 Focused extractor, loader, registry, indexer, and MCP search tests cover Java/Kotlin behavior and dependency-missing paths.
-- [ ] #5 Focused CodeGraph/MCP tests, Ruff, Bandit on touched production scope, and git diff --check pass before PR.
+- [x] #1 Java files index package, class/interface, method/constructor, and import nodes with deterministic IDs and conservative same-file call or unresolved references.
+- [x] #2 Kotlin files index package, class/object/interface, function, and import nodes with deterministic IDs and conservative same-file call or unresolved references.
+- [x] #3 Language registry and indexer expose Java/Kotlin as symbol-extraction capable only when optional Tree-sitter dependencies are available; otherwise they remain visible with dependency_missing metadata and safe skip/failure behavior.
+- [x] #4 Focused extractor, loader, registry, indexer, and MCP search tests cover Java/Kotlin behavior and dependency-missing paths.
+- [x] #5 Focused CodeGraph/MCP tests, Ruff, Bandit on touched production scope, and git diff --check pass before PR.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -61,14 +61,22 @@ Task 4 Kotlin extractor complete: added Kotlin Tree-sitter extraction for packag
 Task 5 registry/indexer wiring complete: promoted Java/Kotlin to foundation metadata with dependency_missing tracking, added dependency probe coverage, exported/register Java/Kotlin extractors when parsers are available, and added indexer coverage for persisted Java/Kotlin graph rows. Verified with python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_language_registry.py tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py::test_indexer_extracts_java_kotlin_graph_rows_during_index -q (7 passed) and python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py -q (18 passed).
 
 Task 6 MCP regression complete: added codegraph.index plus codegraph.search coverage for Java method and Kotlin function symbols. No MCP implementation changes were needed because the existing module delegates through the registry/indexer/repository path. Verified with python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py::test_codegraph_search_finds_java_kotlin_symbols_after_index -q (1 passed).
+
+Final verification: python -m pytest tldw_Server_API/tests/CodeGraph tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py -q passed with 108 passed and 5 warnings. Ruff passed on touched CodeGraph/MCP scope. Bandit JSON at /tmp/bandit_codegraph_java_kotlin.json reported errors [] and results []. git diff --check exited 0 with no output. Dependency versions verified in the shared venv: tree-sitter-java 0.23.5 and tree-sitter-kotlin 1.1.0. Known limits remain intentional: no classpath, build-system, overload, inheritance, or full type-resolution semantics in this slice.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the native CodeGraph Java/Kotlin extractor slice. Added optional parser dependency pins and loader support, shared JVM Tree-sitter helpers, Java and Kotlin extractors, dependency-aware language registry/indexer wiring, and MCP search regression coverage. The implementation stays conservative: it extracts package/import/type/function or method symbols and same-file simple call edges while leaving imports, receiver calls, constructor calls without modeled targets, and build-system/type-resolution cases unresolved for later slices.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-49 - Implement-native-CodeGraph-Java-Kotlin-extractor-slice.md
+++ b/backlog/tasks/task-49 - Implement-native-CodeGraph-Java-Kotlin-extractor-slice.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@Codex'
 created_date: '2026-05-05 00:52'
-updated_date: '2026-05-05 00:59'
+updated_date: '2026-05-05 01:04'
 labels:
   - codegraph
   - mcp
@@ -53,6 +53,8 @@ Add the next Stage 5 native CodeGraph language slice after the merged context/im
 Created focused Stage 5 implementation plan at Docs/superpowers/plans/2026-05-05-native-codegraph-java-kotlin-extractor-implementation-plan.md. Local venv currently has tree_sitter but not tree_sitter_java/tree_sitter_kotlin; dependency install/verification is the first implementation gate.
 
 Task 1 dependency gate complete: installed tree-sitter-java 0.23.5 and tree-sitter-kotlin 1.1.0 into the shared venv, verified both expose language(), added loader mappings and optional dependency bounds, and loader tests pass with 9 passed.
+
+Task 3 Java extractor complete: added shared JVM helpers plus Java Tree-sitter extraction for package/import/type/method/constructor nodes, same-file bare method call resolution, unresolved imports/receiver calls, parse errors, and deterministic node IDs. Verified with python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_java_extractor.py -q (3 passed).
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-49 - Implement-native-CodeGraph-Java-Kotlin-extractor-slice.md
+++ b/backlog/tasks/task-49 - Implement-native-CodeGraph-Java-Kotlin-extractor-slice.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@Codex'
 created_date: '2026-05-05 00:52'
-updated_date: '2026-05-05 00:54'
+updated_date: '2026-05-05 00:59'
 labels:
   - codegraph
   - mcp
@@ -51,6 +51,8 @@ Add the next Stage 5 native CodeGraph language slice after the merged context/im
 
 <!-- SECTION:NOTES:BEGIN -->
 Created focused Stage 5 implementation plan at Docs/superpowers/plans/2026-05-05-native-codegraph-java-kotlin-extractor-implementation-plan.md. Local venv currently has tree_sitter but not tree_sitter_java/tree_sitter_kotlin; dependency install/verification is the first implementation gate.
+
+Task 1 dependency gate complete: installed tree-sitter-java 0.23.5 and tree-sitter-kotlin 1.1.0 into the shared venv, verified both expose language(), added loader mappings and optional dependency bounds, and loader tests pass with 9 passed.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,6 +182,8 @@ codegraph = [
   "tree-sitter-python>=0.25,<0.26",
   "tree-sitter-javascript>=0.25,<0.26",
   "tree-sitter-typescript>=0.23,<0.24",
+  "tree-sitter-java>=0.23,<0.24",
+  "tree-sitter-kotlin>=1.1,<1.2",
 ]
 
 # Multi-User

--- a/tldw_Server_API/app/core/CodeGraph/dependencies.py
+++ b/tldw_Server_API/app/core/CodeGraph/dependencies.py
@@ -8,6 +8,8 @@ _REQUIRED_MODULES = (
     "tree_sitter_python",
     "tree_sitter_javascript",
     "tree_sitter_typescript",
+    "tree_sitter_java",
+    "tree_sitter_kotlin",
 )
 
 

--- a/tldw_Server_API/app/core/CodeGraph/dependencies.py
+++ b/tldw_Server_API/app/core/CodeGraph/dependencies.py
@@ -3,14 +3,17 @@ from __future__ import annotations
 import importlib.util
 from dataclasses import dataclass
 
-_REQUIRED_MODULES = (
+_CORE_MODULES = (
     "tree_sitter",
+)
+_OPTIONAL_LANGUAGE_MODULES = (
     "tree_sitter_python",
     "tree_sitter_javascript",
     "tree_sitter_typescript",
     "tree_sitter_java",
     "tree_sitter_kotlin",
 )
+_PROBED_MODULES = (*_CORE_MODULES, *_OPTIONAL_LANGUAGE_MODULES)
 
 
 @dataclass(frozen=True)
@@ -21,20 +24,25 @@ class DependencyHealth:
     missing: tuple[str, ...]
     present: tuple[str, ...]
 
+    @property
+    def all_optional_available(self) -> bool:
+        """Return whether every optional language parser package is installed."""
+        return not any(module_name in self.missing for module_name in _OPTIONAL_LANGUAGE_MODULES)
+
 
 def probe_codegraph_dependencies() -> DependencyHealth:
     """Probe optional parser packages without importing them."""
 
     present: list[str] = []
     missing: list[str] = []
-    for module_name in _REQUIRED_MODULES:
+    for module_name in _PROBED_MODULES:
         if importlib.util.find_spec(module_name) is None:
             missing.append(module_name)
         else:
             present.append(module_name)
 
     return DependencyHealth(
-        available=not missing,
+        available=not any(module_name in missing for module_name in _CORE_MODULES),
         missing=tuple(missing),
         present=tuple(present),
     )

--- a/tldw_Server_API/app/core/CodeGraph/extractors/__init__.py
+++ b/tldw_Server_API/app/core/CodeGraph/extractors/__init__.py
@@ -2,8 +2,16 @@
 
 from __future__ import annotations
 
+from .java_extractor import JavaTreeSitterExtractor
 from .javascript_extractor import JavaScriptTreeSitterExtractor
+from .kotlin_extractor import KotlinTreeSitterExtractor
 from .python_extractor import PythonAstExtractor
 from .typescript_extractor import TypeScriptTreeSitterExtractor
 
-__all__ = ["JavaScriptTreeSitterExtractor", "PythonAstExtractor", "TypeScriptTreeSitterExtractor"]
+__all__ = [
+    "JavaScriptTreeSitterExtractor",
+    "JavaTreeSitterExtractor",
+    "KotlinTreeSitterExtractor",
+    "PythonAstExtractor",
+    "TypeScriptTreeSitterExtractor",
+]

--- a/tldw_Server_API/app/core/CodeGraph/extractors/java_extractor.py
+++ b/tldw_Server_API/app/core/CodeGraph/extractors/java_extractor.py
@@ -23,7 +23,6 @@ from tldw_Server_API.app.core.CodeGraph.models import (
     ExtractionResult,
 )
 
-
 _TYPE_KINDS = {
     "class_declaration": "class",
     "enum_declaration": "enum",
@@ -100,7 +99,7 @@ class _JavaGraphBuilder:
         return ExtractionResult(
             nodes=tuple(self.nodes),
             edges=call_edges,
-            unresolved_refs=tuple([*self.unresolved_refs, *call_unresolved_refs]),
+            unresolved_refs=(*self.unresolved_refs, *call_unresolved_refs),
         )
 
     def _visit_top_level(self, node: Any) -> None:

--- a/tldw_Server_API/app/core/CodeGraph/extractors/java_extractor.py
+++ b/tldw_Server_API/app/core/CodeGraph/extractors/java_extractor.py
@@ -1,0 +1,303 @@
+"""Tree-sitter Java extraction for native CodeGraph."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tldw_Server_API.app.core.CodeGraph.extractors.jvm_common import (
+    JvmCallSite,
+    column,
+    first_named_child_of_type,
+    line,
+    make_jvm_node,
+    module_qualified_name,
+    node_text,
+    qualified_name,
+    remember_callable,
+    resolve_call_sites,
+)
+from tldw_Server_API.app.core.CodeGraph.extractors.tree_sitter_loader import load_parser
+from tldw_Server_API.app.core.CodeGraph.models import (
+    CodeGraphNode,
+    CodeGraphUnresolvedRef,
+    ExtractionResult,
+)
+
+
+_TYPE_KINDS = {
+    "class_declaration": "class",
+    "enum_declaration": "enum",
+    "interface_declaration": "interface",
+    "record_declaration": "record",
+}
+
+
+class JavaTreeSitterExtractor:
+    """Extract conservative Java symbols and same-file calls with Tree-sitter."""
+
+    language_id = "java"
+
+    def extract(self, *, workspace_key: str, file_path: str, source: bytes) -> ExtractionResult:
+        """Parse one Java file and return symbols, calls, unresolved refs, and errors."""
+        parser_result = load_parser("java")
+        if parser_result.missing:
+            return ExtractionResult(errors=(f"Missing Tree-sitter dependencies: {', '.join(parser_result.missing)}",))
+        if parser_result.error or parser_result.parser is None:
+            return ExtractionResult(errors=(parser_result.error or "Java parser unavailable",))
+
+        try:
+            text = source.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            return ExtractionResult(errors=(str(exc),))
+
+        tree = parser_result.parser.parse(source)
+        if tree.root_node.has_error:
+            return ExtractionResult(errors=("Java parse error",))
+
+        builder = _JavaGraphBuilder(workspace_key=workspace_key, file_path=file_path, source=source, source_text=text)
+        return builder.build(tree.root_node)
+
+
+class _JavaGraphBuilder:
+    """Stateful Tree-sitter visitor for one Java source file."""
+
+    def __init__(self, *, workspace_key: str, file_path: str, source: bytes, source_text: str) -> None:
+        self.workspace_key = workspace_key
+        self.file_path = file_path
+        self.source = source
+        self.source_text = source_text
+        self.nodes: list[CodeGraphNode] = []
+        self.unresolved_refs: list[CodeGraphUnresolvedRef] = []
+        self._package_name = ""
+        self._scope_stack: list[CodeGraphNode] = []
+        self._type_stack: list[str] = []
+        self._call_sites: list[JvmCallSite] = []
+        self._callable_by_name: dict[str, CodeGraphNode | None] = {}
+
+    def build(self, root_node: Any) -> ExtractionResult:
+        """Visit a parsed Java program and resolve captured same-file call references."""
+        module_node = self._make_node(
+            kind="module",
+            name=module_qualified_name(self.file_path).rsplit(".", 1)[-1],
+            qualified_name_value=module_qualified_name(self.file_path),
+            node=root_node,
+            start_line=1,
+            end_line=max(1, len(self.source_text.splitlines())),
+        )
+        self.nodes.append(module_node)
+        self._scope_stack.append(module_node)
+        for child in root_node.named_children:
+            self._visit_top_level(child)
+        self._scope_stack.pop()
+
+        call_edges, call_unresolved_refs = resolve_call_sites(
+            call_sites=tuple(self._call_sites),
+            callable_by_name=self._callable_by_name,
+            file_path=self.file_path,
+            language_id=JavaTreeSitterExtractor.language_id,
+            provenance="tree_sitter_java",
+        )
+        return ExtractionResult(
+            nodes=tuple(self.nodes),
+            edges=call_edges,
+            unresolved_refs=tuple([*self.unresolved_refs, *call_unresolved_refs]),
+        )
+
+    def _visit_top_level(self, node: Any) -> None:
+        if node.type == "package_declaration":
+            self._visit_package_declaration(node)
+            return
+        if node.type == "import_declaration":
+            self._visit_import_declaration(node)
+            return
+        if node.type in _TYPE_KINDS:
+            self._visit_type_declaration(node)
+
+    def _visit_package_declaration(self, node: Any) -> None:
+        package_name = _java_qualified_child_text(self.source, node)
+        if not package_name:
+            return
+        self._package_name = package_name
+        self.nodes.append(
+            self._make_node(
+                kind="package",
+                name=package_name,
+                qualified_name_value=package_name,
+                node=node,
+            )
+        )
+
+    def _visit_import_declaration(self, node: Any) -> None:
+        imported = _java_qualified_child_text(self.source, node)
+        if not imported:
+            return
+        import_node = self._make_node(
+            kind="import",
+            name=imported,
+            qualified_name_value=imported,
+            node=node,
+            metadata={"imported": imported, "source": imported},
+        )
+        self.nodes.append(import_node)
+        self.unresolved_refs.append(
+            CodeGraphUnresolvedRef(
+                from_node_id=import_node.id,
+                reference_name=imported,
+                reference_kind="import",
+                file_path=self.file_path,
+                line=line(node),
+                column=column(node),
+                language=JavaTreeSitterExtractor.language_id,
+            )
+        )
+
+    def _visit_type_declaration(self, node: Any) -> None:
+        name_node = node.child_by_field_name("name")
+        name = node_text(self.source, name_node)
+        if not name:
+            return
+        type_node = self._make_node(
+            kind=_TYPE_KINDS[node.type],
+            name=name,
+            qualified_name_value=qualified_name(self._package_name, *self._type_stack, name),
+            node=node,
+        )
+        self.nodes.append(type_node)
+
+        self._scope_stack.append(type_node)
+        self._type_stack.append(name)
+        body = node.child_by_field_name("body")
+        if body is not None:
+            for child in body.named_children:
+                if child.type in _TYPE_KINDS:
+                    self._visit_type_declaration(child)
+                elif child.type == "constructor_declaration":
+                    self._visit_constructor_declaration(child)
+                elif child.type == "method_declaration":
+                    self._visit_method_declaration(child)
+        self._type_stack.pop()
+        self._scope_stack.pop()
+
+    def _visit_constructor_declaration(self, node: Any) -> None:
+        name_node = node.child_by_field_name("name")
+        name = node_text(self.source, name_node)
+        if not name:
+            return
+        constructor_node = self._make_node(
+            kind="constructor",
+            name=name,
+            qualified_name_value=qualified_name(self._package_name, *self._type_stack, name),
+            node=node,
+            visibility=_visibility(node),
+        )
+        self.nodes.append(constructor_node)
+        remember_callable(self._callable_by_name, constructor_node)
+        self._visit_callable_body(node, constructor_node, "body")
+
+    def _visit_method_declaration(self, node: Any) -> None:
+        name_node = node.child_by_field_name("name")
+        name = node_text(self.source, name_node)
+        if not name:
+            return
+        method_node = self._make_node(
+            kind="method",
+            name=name,
+            qualified_name_value=qualified_name(self._package_name, *self._type_stack, name),
+            node=node,
+            visibility=_visibility(node),
+        )
+        self.nodes.append(method_node)
+        remember_callable(self._callable_by_name, method_node)
+        self._visit_callable_body(node, method_node, "body")
+
+    def _visit_callable_body(self, node: Any, callable_node: CodeGraphNode, body_field: str) -> None:
+        body = node.child_by_field_name(body_field)
+        if body is None:
+            return
+        self._scope_stack.append(callable_node)
+        self._visit_executable(body)
+        self._scope_stack.pop()
+
+    def _visit_executable(self, node: Any) -> None:
+        if node.type == "method_invocation":
+            self._visit_method_invocation(node)
+        for child in node.named_children:
+            self._visit_executable(child)
+
+    def _visit_method_invocation(self, node: Any) -> None:
+        current_scope = self._scope_stack[-1] if self._scope_stack else None
+        if current_scope is None or current_scope.kind not in {"constructor", "method"}:
+            return
+
+        name_node = node.child_by_field_name("name")
+        name = node_text(self.source, name_node)
+        if not name:
+            return
+
+        object_node = node.child_by_field_name("object")
+        if object_node is None:
+            self._call_sites.append(
+                JvmCallSite(
+                    source_node_id=current_scope.id,
+                    reference_name=name,
+                    line=line(node),
+                    column=column(node),
+                )
+            )
+            return
+
+        self.unresolved_refs.append(
+            CodeGraphUnresolvedRef(
+                from_node_id=current_scope.id,
+                reference_name=f"{node_text(self.source, object_node)}.{name}",
+                reference_kind="call",
+                file_path=self.file_path,
+                line=line(node),
+                column=column(node),
+                language=JavaTreeSitterExtractor.language_id,
+            )
+        )
+
+    def _make_node(
+        self,
+        *,
+        kind: str,
+        name: str,
+        qualified_name_value: str,
+        node: Any,
+        start_line: int | None = None,
+        end_line: int | None = None,
+        visibility: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> CodeGraphNode:
+        return make_jvm_node(
+            workspace_key=self.workspace_key,
+            language_id=JavaTreeSitterExtractor.language_id,
+            file_path=self.file_path,
+            kind=kind,
+            name=name,
+            qualified_name_value=qualified_name_value,
+            node=node,
+            start_line=start_line,
+            end_line=end_line,
+            visibility=visibility,
+            metadata=metadata,
+        )
+
+
+def _java_qualified_child_text(source: bytes, node: Any) -> str:
+    qualified_child = first_named_child_of_type(node, "scoped_identifier", "identifier")
+    return node_text(source, qualified_child)
+
+
+def _visibility(node: Any) -> str | None:
+    modifiers = first_named_child_of_type(node, "modifiers")
+    if modifiers is None:
+        return None
+    for child in modifiers.children:
+        if child.type in {"public", "protected", "private"}:
+            return child.type
+    return None
+
+
+__all__ = ["JavaTreeSitterExtractor"]

--- a/tldw_Server_API/app/core/CodeGraph/extractors/java_extractor.py
+++ b/tldw_Server_API/app/core/CodeGraph/extractors/java_extractor.py
@@ -7,6 +7,7 @@ from typing import Any
 from tldw_Server_API.app.core.CodeGraph.extractors.jvm_common import (
     JvmCallSite,
     column,
+    declaration_payload_text,
     first_named_child_of_type,
     line,
     make_jvm_node,
@@ -113,7 +114,7 @@ class _JavaGraphBuilder:
             self._visit_type_declaration(node)
 
     def _visit_package_declaration(self, node: Any) -> None:
-        package_name = _java_qualified_child_text(self.source, node)
+        package_name = declaration_payload_text(self.source, node, "package")
         if not package_name:
             return
         self._package_name = package_name
@@ -127,7 +128,7 @@ class _JavaGraphBuilder:
         )
 
     def _visit_import_declaration(self, node: Any) -> None:
-        imported = _java_qualified_child_text(self.source, node)
+        imported = declaration_payload_text(self.source, node, "import")
         if not imported:
             return
         import_node = self._make_node(
@@ -160,6 +161,7 @@ class _JavaGraphBuilder:
             name=name,
             qualified_name_value=qualified_name(self._package_name, *self._type_stack, name),
             node=node,
+            visibility=_visibility(node),
         )
         self.nodes.append(type_node)
 
@@ -282,11 +284,6 @@ class _JavaGraphBuilder:
             visibility=visibility,
             metadata=metadata,
         )
-
-
-def _java_qualified_child_text(source: bytes, node: Any) -> str:
-    qualified_child = first_named_child_of_type(node, "scoped_identifier", "identifier")
-    return node_text(source, qualified_child)
 
 
 def _visibility(node: Any) -> str | None:

--- a/tldw_Server_API/app/core/CodeGraph/extractors/jvm_common.py
+++ b/tldw_Server_API/app/core/CodeGraph/extractors/jvm_common.py
@@ -32,6 +32,16 @@ def node_text(source: bytes, node: Any | None) -> str:
     return source[node.start_byte : node.end_byte].decode("utf-8")
 
 
+def declaration_payload_text(source: bytes, node: Any, keyword: str) -> str:
+    """Return declaration text after a leading keyword while preserving syntax."""
+    text = node_text(source, node).strip()
+    if text.startswith(keyword):
+        text = text[len(keyword) :].strip()
+    if text.endswith(";"):
+        text = text[:-1].strip()
+    return " ".join(text.split())
+
+
 def named_descendants_of_type(node: Any, *node_types: str) -> tuple[Any, ...]:
     """Return named descendants matching any requested Tree-sitter node type."""
     matches: list[Any] = []
@@ -181,6 +191,7 @@ def end_column(node: Any) -> int:
 __all__ = [
     "JvmCallSite",
     "column",
+    "declaration_payload_text",
     "end_column",
     "end_line_number",
     "first_named_child_of_type",

--- a/tldw_Server_API/app/core/CodeGraph/extractors/jvm_common.py
+++ b/tldw_Server_API/app/core/CodeGraph/extractors/jvm_common.py
@@ -1,0 +1,195 @@
+"""Shared Tree-sitter helpers for JVM-family CodeGraph extractors."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from tldw_Server_API.app.core.CodeGraph.models import (
+    CodeGraphEdge,
+    CodeGraphNode,
+    CodeGraphUnresolvedRef,
+    make_edge_id,
+    make_node_id,
+)
+
+
+@dataclass(frozen=True)
+class JvmCallSite:
+    """Deferred same-file call reference captured inside a callable body."""
+
+    source_node_id: str
+    reference_name: str
+    line: int
+    column: int
+
+
+def node_text(source: bytes, node: Any | None) -> str:
+    """Return a node's UTF-8 source slice, or an empty string for missing nodes."""
+    if node is None:
+        return ""
+    return source[node.start_byte : node.end_byte].decode("utf-8")
+
+
+def named_descendants_of_type(node: Any, *node_types: str) -> tuple[Any, ...]:
+    """Return named descendants matching any requested Tree-sitter node type."""
+    matches: list[Any] = []
+    requested = set(node_types)
+    stack = list(reversed(node.named_children))
+    while stack:
+        current = stack.pop()
+        if current.type in requested:
+            matches.append(current)
+        stack.extend(reversed(current.named_children))
+    return tuple(matches)
+
+
+def first_named_child_of_type(node: Any, *node_types: str) -> Any | None:
+    """Return the first direct named child with a requested Tree-sitter node type."""
+    requested = set(node_types)
+    for child in node.named_children:
+        if child.type in requested:
+            return child
+    return None
+
+
+def module_qualified_name(file_path: str) -> str:
+    """Return a dotted module identity from a workspace-relative path."""
+    path = Path(file_path)
+    return ".".join((*path.with_suffix("").parts,))
+
+
+def qualified_name(*parts: str) -> str:
+    """Join qualified-name parts while dropping empty segments."""
+    return ".".join(part for part in parts if part)
+
+
+def make_jvm_node(
+    *,
+    workspace_key: str,
+    language_id: str,
+    file_path: str,
+    kind: str,
+    name: str,
+    qualified_name_value: str,
+    node: Any,
+    start_line: int | None = None,
+    end_line: int | None = None,
+    signature: str | None = None,
+    visibility: str | None = None,
+    flags: tuple[str, ...] = (),
+    metadata: dict[str, Any] | None = None,
+) -> CodeGraphNode:
+    """Create a stable CodeGraph node for a JVM Tree-sitter node."""
+    resolved_start = start_line or line(node)
+    identity_key = (
+        f"{workspace_key}:{language_id}:{file_path}:{kind}:{qualified_name_value}:{resolved_start}"
+    )
+    return CodeGraphNode(
+        id=make_node_id(workspace_key, language_id, file_path, kind, qualified_name_value, resolved_start),
+        identity_key=identity_key,
+        kind=kind,
+        name=name,
+        qualified_name=qualified_name_value,
+        file_path=file_path,
+        language=language_id,
+        start_line=resolved_start,
+        end_line=end_line or end_line_number(node),
+        start_column=column(node),
+        end_column=end_column(node),
+        signature=signature,
+        visibility=visibility,
+        flags=flags,
+        metadata=dict(metadata or {}),
+    )
+
+
+def remember_callable(callable_by_name: dict[str, CodeGraphNode | None], node: CodeGraphNode) -> None:
+    """Register a callable by simple and qualified names unless ambiguous."""
+    for key in {node.name, node.qualified_name}:
+        existing = callable_by_name.get(key)
+        if existing is None and key in callable_by_name:
+            continue
+        if existing is not None and existing.id != node.id:
+            callable_by_name[key] = None
+            continue
+        callable_by_name[key] = node
+
+
+def resolve_call_sites(
+    *,
+    call_sites: tuple[JvmCallSite, ...],
+    callable_by_name: dict[str, CodeGraphNode | None],
+    file_path: str,
+    language_id: str,
+    provenance: str,
+) -> tuple[tuple[CodeGraphEdge, ...], tuple[CodeGraphUnresolvedRef, ...]]:
+    """Resolve deferred same-file calls into edges or unresolved references."""
+    edges: list[CodeGraphEdge] = []
+    unresolved_refs: list[CodeGraphUnresolvedRef] = []
+    for call in call_sites:
+        target = callable_by_name.get(call.reference_name)
+        if target is None:
+            unresolved_refs.append(
+                CodeGraphUnresolvedRef(
+                    from_node_id=call.source_node_id,
+                    reference_name=call.reference_name,
+                    reference_kind="call",
+                    file_path=file_path,
+                    line=call.line,
+                    column=call.column,
+                    language=language_id,
+                )
+            )
+            continue
+        edges.append(
+            CodeGraphEdge(
+                id=make_edge_id(call.source_node_id, "calls", target.id, file_path, call.line, call.column),
+                source=call.source_node_id,
+                target=target.id,
+                kind="calls",
+                file_path=file_path,
+                line=call.line,
+                column=call.column,
+                provenance=provenance,
+            )
+        )
+    return tuple(edges), tuple(unresolved_refs)
+
+
+def line(node: Any) -> int:
+    """Return a Tree-sitter start line using 1-based coordinates."""
+    return int(node.start_point.row) + 1
+
+
+def column(node: Any) -> int:
+    """Return a Tree-sitter start column using 1-based coordinates."""
+    return int(node.start_point.column) + 1
+
+
+def end_line_number(node: Any) -> int:
+    """Return a Tree-sitter end line using 1-based coordinates."""
+    return int(node.end_point.row) + 1
+
+
+def end_column(node: Any) -> int:
+    """Return a Tree-sitter end column using 1-based coordinates."""
+    return int(node.end_point.column) + 1
+
+
+__all__ = [
+    "JvmCallSite",
+    "column",
+    "end_column",
+    "end_line_number",
+    "first_named_child_of_type",
+    "line",
+    "make_jvm_node",
+    "module_qualified_name",
+    "named_descendants_of_type",
+    "node_text",
+    "qualified_name",
+    "remember_callable",
+    "resolve_call_sites",
+]

--- a/tldw_Server_API/app/core/CodeGraph/extractors/kotlin_extractor.py
+++ b/tldw_Server_API/app/core/CodeGraph/extractors/kotlin_extractor.py
@@ -97,7 +97,7 @@ class _KotlinGraphBuilder:
         return ExtractionResult(
             nodes=tuple(self.nodes),
             edges=call_edges,
-            unresolved_refs=tuple([*self.unresolved_refs, *call_unresolved_refs]),
+            unresolved_refs=(*self.unresolved_refs, *call_unresolved_refs),
         )
 
     def _visit_top_level(self, node: Any) -> None:

--- a/tldw_Server_API/app/core/CodeGraph/extractors/kotlin_extractor.py
+++ b/tldw_Server_API/app/core/CodeGraph/extractors/kotlin_extractor.py
@@ -7,6 +7,7 @@ from typing import Any
 from tldw_Server_API.app.core.CodeGraph.extractors.jvm_common import (
     JvmCallSite,
     column,
+    declaration_payload_text,
     first_named_child_of_type,
     line,
     make_jvm_node,
@@ -114,7 +115,7 @@ class _KotlinGraphBuilder:
             self._visit_function_declaration(node)
 
     def _visit_package_header(self, node: Any) -> None:
-        package_name = _kotlin_qualified_child_text(self.source, node)
+        package_name = declaration_payload_text(self.source, node, "package")
         if not package_name:
             return
         self._package_name = package_name
@@ -128,7 +129,7 @@ class _KotlinGraphBuilder:
         )
 
     def _visit_import(self, node: Any) -> None:
-        imported = _kotlin_qualified_child_text(self.source, node)
+        imported = declaration_payload_text(self.source, node, "import")
         if not imported:
             return
         import_node = self._make_node(
@@ -161,6 +162,7 @@ class _KotlinGraphBuilder:
             name=name,
             qualified_name_value=qualified_name(self._package_name, *self._type_stack, name),
             node=node,
+            visibility=_visibility(self.source, node),
         )
         self.nodes.append(type_node)
 
@@ -266,16 +268,11 @@ class _KotlinGraphBuilder:
         )
 
 
-def _kotlin_qualified_child_text(source: bytes, node: Any) -> str:
-    qualified_child = first_named_child_of_type(node, "qualified_identifier", "identifier")
-    return node_text(source, qualified_child)
-
-
 def _kotlin_type_kind(source: bytes, node: Any) -> str:
     if node.type == "object_declaration":
         return "object"
-    source_text = node_text(source, node).lstrip()
-    if source_text.startswith("interface "):
+    del source
+    if any(child.type == "interface" for child in node.children):
         return "interface"
     return "class"
 
@@ -289,8 +286,7 @@ def _visibility(source: bytes, node: Any) -> str | None:
 
 
 def _navigation_reference_name(source: bytes, node: Any) -> str:
-    parts = [node_text(source, child) for child in node.named_children if child.type == "identifier"]
-    return ".".join(part for part in parts if part)
+    return node_text(source, node)
 
 
 __all__ = ["KotlinTreeSitterExtractor"]

--- a/tldw_Server_API/app/core/CodeGraph/extractors/kotlin_extractor.py
+++ b/tldw_Server_API/app/core/CodeGraph/extractors/kotlin_extractor.py
@@ -1,0 +1,296 @@
+"""Tree-sitter Kotlin extraction for native CodeGraph."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tldw_Server_API.app.core.CodeGraph.extractors.jvm_common import (
+    JvmCallSite,
+    column,
+    first_named_child_of_type,
+    line,
+    make_jvm_node,
+    module_qualified_name,
+    node_text,
+    qualified_name,
+    remember_callable,
+    resolve_call_sites,
+)
+from tldw_Server_API.app.core.CodeGraph.extractors.tree_sitter_loader import load_parser
+from tldw_Server_API.app.core.CodeGraph.models import (
+    CodeGraphNode,
+    CodeGraphUnresolvedRef,
+    ExtractionResult,
+)
+
+
+class KotlinTreeSitterExtractor:
+    """Extract conservative Kotlin symbols and same-file calls with Tree-sitter."""
+
+    language_id = "kotlin"
+
+    def extract(self, *, workspace_key: str, file_path: str, source: bytes) -> ExtractionResult:
+        """Parse one Kotlin file and return symbols, calls, unresolved refs, and errors."""
+        parser_result = load_parser("kotlin")
+        if parser_result.missing:
+            return ExtractionResult(errors=(f"Missing Tree-sitter dependencies: {', '.join(parser_result.missing)}",))
+        if parser_result.error or parser_result.parser is None:
+            return ExtractionResult(errors=(parser_result.error or "Kotlin parser unavailable",))
+
+        try:
+            text = source.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            return ExtractionResult(errors=(str(exc),))
+
+        tree = parser_result.parser.parse(source)
+        if tree.root_node.has_error:
+            return ExtractionResult(errors=("Kotlin parse error",))
+
+        builder = _KotlinGraphBuilder(
+            workspace_key=workspace_key,
+            file_path=file_path,
+            source=source,
+            source_text=text,
+        )
+        return builder.build(tree.root_node)
+
+
+class _KotlinGraphBuilder:
+    """Stateful Tree-sitter visitor for one Kotlin source file."""
+
+    def __init__(self, *, workspace_key: str, file_path: str, source: bytes, source_text: str) -> None:
+        self.workspace_key = workspace_key
+        self.file_path = file_path
+        self.source = source
+        self.source_text = source_text
+        self.nodes: list[CodeGraphNode] = []
+        self.unresolved_refs: list[CodeGraphUnresolvedRef] = []
+        self._package_name = ""
+        self._scope_stack: list[CodeGraphNode] = []
+        self._type_stack: list[str] = []
+        self._call_sites: list[JvmCallSite] = []
+        self._callable_by_name: dict[str, CodeGraphNode | None] = {}
+
+    def build(self, root_node: Any) -> ExtractionResult:
+        """Visit a parsed Kotlin source file and resolve same-file calls."""
+        module_node = self._make_node(
+            kind="module",
+            name=module_qualified_name(self.file_path).rsplit(".", 1)[-1],
+            qualified_name_value=module_qualified_name(self.file_path),
+            node=root_node,
+            start_line=1,
+            end_line=max(1, len(self.source_text.splitlines())),
+        )
+        self.nodes.append(module_node)
+        self._scope_stack.append(module_node)
+        for child in root_node.named_children:
+            self._visit_top_level(child)
+        self._scope_stack.pop()
+
+        call_edges, call_unresolved_refs = resolve_call_sites(
+            call_sites=tuple(self._call_sites),
+            callable_by_name=self._callable_by_name,
+            file_path=self.file_path,
+            language_id=KotlinTreeSitterExtractor.language_id,
+            provenance="tree_sitter_kotlin",
+        )
+        return ExtractionResult(
+            nodes=tuple(self.nodes),
+            edges=call_edges,
+            unresolved_refs=tuple([*self.unresolved_refs, *call_unresolved_refs]),
+        )
+
+    def _visit_top_level(self, node: Any) -> None:
+        if node.type == "package_header":
+            self._visit_package_header(node)
+            return
+        if node.type == "import":
+            self._visit_import(node)
+            return
+        if node.type in {"class_declaration", "object_declaration"}:
+            self._visit_type_declaration(node)
+            return
+        if node.type == "function_declaration":
+            self._visit_function_declaration(node)
+
+    def _visit_package_header(self, node: Any) -> None:
+        package_name = _kotlin_qualified_child_text(self.source, node)
+        if not package_name:
+            return
+        self._package_name = package_name
+        self.nodes.append(
+            self._make_node(
+                kind="package",
+                name=package_name,
+                qualified_name_value=package_name,
+                node=node,
+            )
+        )
+
+    def _visit_import(self, node: Any) -> None:
+        imported = _kotlin_qualified_child_text(self.source, node)
+        if not imported:
+            return
+        import_node = self._make_node(
+            kind="import",
+            name=imported,
+            qualified_name_value=imported,
+            node=node,
+            metadata={"imported": imported, "source": imported},
+        )
+        self.nodes.append(import_node)
+        self.unresolved_refs.append(
+            CodeGraphUnresolvedRef(
+                from_node_id=import_node.id,
+                reference_name=imported,
+                reference_kind="import",
+                file_path=self.file_path,
+                line=line(node),
+                column=column(node),
+                language=KotlinTreeSitterExtractor.language_id,
+            )
+        )
+
+    def _visit_type_declaration(self, node: Any) -> None:
+        name_node = node.child_by_field_name("name")
+        name = node_text(self.source, name_node)
+        if not name:
+            return
+        type_node = self._make_node(
+            kind=_kotlin_type_kind(self.source, node),
+            name=name,
+            qualified_name_value=qualified_name(self._package_name, *self._type_stack, name),
+            node=node,
+        )
+        self.nodes.append(type_node)
+
+        self._scope_stack.append(type_node)
+        self._type_stack.append(name)
+        body = first_named_child_of_type(node, "class_body")
+        if body is not None:
+            for child in body.named_children:
+                if child.type in {"class_declaration", "object_declaration"}:
+                    self._visit_type_declaration(child)
+                elif child.type == "function_declaration":
+                    self._visit_function_declaration(child)
+        self._type_stack.pop()
+        self._scope_stack.pop()
+
+    def _visit_function_declaration(self, node: Any) -> None:
+        name_node = node.child_by_field_name("name")
+        name = node_text(self.source, name_node)
+        if not name:
+            return
+        function_node = self._make_node(
+            kind="function",
+            name=name,
+            qualified_name_value=qualified_name(self._package_name, *self._type_stack, name),
+            node=node,
+            visibility=_visibility(self.source, node),
+        )
+        self.nodes.append(function_node)
+        remember_callable(self._callable_by_name, function_node)
+
+        body = first_named_child_of_type(node, "function_body")
+        if body is None:
+            return
+        self._scope_stack.append(function_node)
+        self._visit_executable(body)
+        self._scope_stack.pop()
+
+    def _visit_executable(self, node: Any) -> None:
+        if node.type == "call_expression":
+            self._visit_call_expression(node)
+        for child in node.named_children:
+            self._visit_executable(child)
+
+    def _visit_call_expression(self, node: Any) -> None:
+        current_scope = self._scope_stack[-1] if self._scope_stack else None
+        if current_scope is None or current_scope.kind != "function":
+            return
+
+        callee_node = node.named_children[0] if node.named_children else None
+        if callee_node is None:
+            return
+
+        if callee_node.type == "identifier":
+            self._call_sites.append(
+                JvmCallSite(
+                    source_node_id=current_scope.id,
+                    reference_name=node_text(self.source, callee_node),
+                    line=line(node),
+                    column=column(node),
+                )
+            )
+            return
+
+        if callee_node.type == "navigation_expression":
+            reference_name = _navigation_reference_name(self.source, callee_node)
+            if reference_name:
+                self.unresolved_refs.append(
+                    CodeGraphUnresolvedRef(
+                        from_node_id=current_scope.id,
+                        reference_name=reference_name,
+                        reference_kind="call",
+                        file_path=self.file_path,
+                        line=line(node),
+                        column=column(node),
+                        language=KotlinTreeSitterExtractor.language_id,
+                    )
+                )
+
+    def _make_node(
+        self,
+        *,
+        kind: str,
+        name: str,
+        qualified_name_value: str,
+        node: Any,
+        start_line: int | None = None,
+        end_line: int | None = None,
+        visibility: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> CodeGraphNode:
+        return make_jvm_node(
+            workspace_key=self.workspace_key,
+            language_id=KotlinTreeSitterExtractor.language_id,
+            file_path=self.file_path,
+            kind=kind,
+            name=name,
+            qualified_name_value=qualified_name_value,
+            node=node,
+            start_line=start_line,
+            end_line=end_line,
+            visibility=visibility,
+            metadata=metadata,
+        )
+
+
+def _kotlin_qualified_child_text(source: bytes, node: Any) -> str:
+    qualified_child = first_named_child_of_type(node, "qualified_identifier", "identifier")
+    return node_text(source, qualified_child)
+
+
+def _kotlin_type_kind(source: bytes, node: Any) -> str:
+    if node.type == "object_declaration":
+        return "object"
+    source_text = node_text(source, node).lstrip()
+    if source_text.startswith("interface "):
+        return "interface"
+    return "class"
+
+
+def _visibility(source: bytes, node: Any) -> str | None:
+    modifiers = first_named_child_of_type(node, "modifiers")
+    if modifiers is None:
+        return None
+    visibility = first_named_child_of_type(modifiers, "visibility_modifier")
+    return node_text(source, visibility) or None
+
+
+def _navigation_reference_name(source: bytes, node: Any) -> str:
+    parts = [node_text(source, child) for child in node.named_children if child.type == "identifier"]
+    return ".".join(part for part in parts if part)
+
+
+__all__ = ["KotlinTreeSitterExtractor"]

--- a/tldw_Server_API/app/core/CodeGraph/extractors/tree_sitter_loader.py
+++ b/tldw_Server_API/app/core/CodeGraph/extractors/tree_sitter_loader.py
@@ -26,6 +26,8 @@ _LANGUAGE_MODULES: dict[str, tuple[str, str]] = {
     "jsx": ("tree_sitter_javascript", "language"),
     "typescript": ("tree_sitter_typescript", "language_typescript"),
     "tsx": ("tree_sitter_typescript", "language_tsx"),
+    "java": ("tree_sitter_java", "language"),
+    "kotlin": ("tree_sitter_kotlin", "language"),
 }
 
 

--- a/tldw_Server_API/app/core/CodeGraph/indexer.py
+++ b/tldw_Server_API/app/core/CodeGraph/indexer.py
@@ -14,7 +14,9 @@ from loguru import logger
 from tldw_Server_API.app.core.DB_Management.codegraph.repository import CodeGraphRepository
 
 from .config import CodeGraphSettings
+from .extractors.java_extractor import JavaTreeSitterExtractor
 from .extractors.javascript_extractor import JavaScriptTreeSitterExtractor
+from .extractors.kotlin_extractor import KotlinTreeSitterExtractor
 from .extractors.python_extractor import PythonAstExtractor
 from .extractors.tree_sitter_loader import load_parser
 from .extractors.typescript_extractor import TypeScriptTreeSitterExtractor
@@ -79,6 +81,10 @@ class CodeGraphIndexer:
             self._extractors["javascript"] = JavaScriptTreeSitterExtractor()
         if load_parser("typescript").available:
             self._extractors["typescript"] = TypeScriptTreeSitterExtractor()
+        if load_parser("java").available:
+            self._extractors["java"] = JavaTreeSitterExtractor()
+        if load_parser("kotlin").available:
+            self._extractors["kotlin"] = KotlinTreeSitterExtractor()
 
     def index_workspace(
         self,

--- a/tldw_Server_API/app/core/CodeGraph/indexer.py
+++ b/tldw_Server_API/app/core/CodeGraph/indexer.py
@@ -41,6 +41,7 @@ class _Candidate:
     relative_path: str
     language_id: str
     stage: str
+    symbol_extraction: bool
     size: int
     modified_at: float
 
@@ -163,7 +164,11 @@ class CodeGraphIndexer:
                 return IndexingResult(status=discovery.status, counters=counters, errors=tuple(errors))
 
             candidates = discovery.candidates
-            foundation_candidates = [candidate for candidate in candidates if candidate.stage == "foundation"]
+            foundation_candidates = [
+                candidate
+                for candidate in candidates
+                if candidate.stage == "foundation" and candidate.symbol_extraction
+            ]
             total_bytes = sum(candidate.size for candidate in foundation_candidates)
 
             if len(foundation_candidates) > limit or total_bytes > self._settings.foreground_max_bytes:
@@ -317,11 +322,20 @@ class CodeGraphIndexer:
                 if language.stage == "planned":
                     counters["planned_language_skipped"] += 1
                     counters["files_skipped"] += 1
+                    continue
+
+                has_extractor = language.language_id in self._extractors
+                if language.stage == "foundation" and (not language.symbol_extraction or not has_extractor):
+                    counters["dependency_missing_language_skipped"] += 1
+                    counters["files_skipped"] += 1
+                    continue
+
                 candidate = _Candidate(
                     path=resolved,
                     relative_path=relative_path,
                     language_id=language.language_id,
                     stage=language.stage,
+                    symbol_extraction=language.symbol_extraction,
                     size=int(stat_result.st_size),
                     modified_at=float(stat_result.st_mtime),
                 )
@@ -392,6 +406,7 @@ def _empty_counters() -> dict[str, int]:
         "files_skipped": 0,
         "files_too_large": 0,
         "planned_language_skipped": 0,
+        "dependency_missing_language_skipped": 0,
         "unsupported_language": 0,
         "errors": 0,
     }

--- a/tldw_Server_API/app/core/CodeGraph/language_registry.py
+++ b/tldw_Server_API/app/core/CodeGraph/language_registry.py
@@ -24,18 +24,6 @@ _PLANNED_LANGUAGES = (
         extensions=(".cs",),
         stage="planned",
     ),
-    LanguageInfo(
-        language_id="java",
-        display_name="Java",
-        extensions=(".java",),
-        stage="planned",
-    ),
-    LanguageInfo(
-        language_id="kotlin",
-        display_name="Kotlin",
-        extensions=(".kt", ".kts"),
-        stage="planned",
-    ),
 )
 
 
@@ -73,6 +61,8 @@ def _foundation_languages(dependency_health: DependencyHealth) -> tuple[Language
     missing = set(dependency_health.missing)
     javascript_missing = _missing_dependencies(missing, ("tree_sitter", "tree_sitter_javascript"))
     typescript_missing = _missing_dependencies(missing, ("tree_sitter", "tree_sitter_typescript"))
+    java_missing = _missing_dependencies(missing, ("tree_sitter", "tree_sitter_java"))
+    kotlin_missing = _missing_dependencies(missing, ("tree_sitter", "tree_sitter_kotlin"))
     return (
         LanguageInfo(
             language_id="python",
@@ -96,6 +86,22 @@ def _foundation_languages(dependency_health: DependencyHealth) -> tuple[Language
             stage="foundation",
             dependency_missing=typescript_missing,
             symbol_extraction=not typescript_missing,
+        ),
+        LanguageInfo(
+            language_id="java",
+            display_name="Java",
+            extensions=(".java",),
+            stage="foundation",
+            dependency_missing=java_missing,
+            symbol_extraction=not java_missing,
+        ),
+        LanguageInfo(
+            language_id="kotlin",
+            display_name="Kotlin",
+            extensions=(".kt", ".kts"),
+            stage="foundation",
+            dependency_missing=kotlin_missing,
+            symbol_extraction=not kotlin_missing,
         ),
     )
 

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py
@@ -64,6 +64,7 @@ class CodeGraphModule(BaseModule):
             "initialized": True,
             "workspace_root_resolver": self._workspace is not None,
             "dependencies_available": self._dependency_health.available,
+            "dependencies_all_optional_available": self._dependency_health.all_optional_available,
         }
 
     async def get_tools(self) -> list[dict[str, Any]]:
@@ -497,6 +498,8 @@ class CodeGraphModule(BaseModule):
 
         return {
             "dependency_available": self._dependency_health.available,
+            "dependency_available_core": self._dependency_health.available,
+            "dependency_available_all_optional": self._dependency_health.all_optional_available,
             "dependency_missing": list(self._dependency_health.missing),
             "dependency_present": list(self._dependency_health.present),
             "languages": [asdict(language) for language in self._language_registry.list_languages()],

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
@@ -268,6 +268,70 @@ async def test_codegraph_search_finds_typescript_component_after_index(tmp_path:
     assert [item["file_path"] for item in search["results"]] == ["Card.tsx"]  # nosec B101
 
 
+@pytest.mark.asyncio
+async def test_codegraph_search_finds_java_kotlin_symbols_after_index(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    (workspace_root / "Service.java").write_text(
+        """
+package com.example.app;
+
+public class Service {
+    public String greet(String name) {
+        return helper(name);
+    }
+
+    private String helper(String value) {
+        return value.trim();
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    (workspace_root / "Greeter.kt").write_text(
+        """
+package com.example.app
+
+class Greeter {
+    fun greet(name: String): String {
+        return helper(name)
+    }
+
+    private fun helper(value: String): String {
+        return value.trim()
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    module = _module(tmp_path, workspace_root)
+
+    index_result = await module.execute_tool(
+        "codegraph.index",
+        {"mode": "foreground", "force": True, "max_files": 10},
+        context=_context(),
+    )
+    java_search = await module.execute_tool(
+        "codegraph.search",
+        {"query": "helper", "kind": "method", "language": "java", "limit": 10},
+        context=_context(),
+    )
+    kotlin_search = await module.execute_tool(
+        "codegraph.search",
+        {"query": "helper", "kind": "function", "language": "kotlin", "limit": 10},
+        context=_context(),
+    )
+
+    assert index_result["status"] == "complete"  # nosec B101
+    assert index_result["counters"]["files_indexed"] == 2  # nosec B101
+    assert [item["qualified_name"] for item in java_search["results"]] == [  # nosec B101
+        "com.example.app.Service.helper"
+    ]
+    assert [item["qualified_name"] for item in kotlin_search["results"]] == [  # nosec B101
+        "com.example.app.Greeter.helper"
+    ]
+
+
 def test_codegraph_rejects_ambiguous_node_selectors(tmp_path: Path) -> None:
     workspace_root = tmp_path / "workspace"
     workspace_root.mkdir()

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_config.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_config.py
@@ -45,3 +45,20 @@ def test_dependency_probe_reports_missing_without_importing_tree_sitter(monkeypa
 
     assert health.available is False
     assert "tree_sitter" in health.missing
+
+
+def test_dependency_probe_keeps_core_available_when_optional_jvm_parsers_are_missing(monkeypatch) -> None:
+    present_modules = {
+        "tree_sitter",
+        "tree_sitter_javascript",
+        "tree_sitter_typescript",
+    }
+
+    monkeypatch.setattr("importlib.util.find_spec", lambda name: object() if name in present_modules else None)
+
+    health = probe_codegraph_dependencies()
+
+    assert health.available is True
+    assert health.all_optional_available is False
+    assert "tree_sitter_java" in health.missing
+    assert "tree_sitter_kotlin" in health.missing

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py
@@ -110,6 +110,62 @@ def test_indexer_extracts_javascript_typescript_graph_rows_during_index(tmp_path
     assert [node.file_path for node in repo.search_nodes("Card", kind="component", limit=10)] == ["Card.tsx"]
 
 
+def test_indexer_extracts_java_kotlin_graph_rows_during_index(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "Service.java").write_text(
+        """
+package com.example.app;
+
+public class Service {
+    public String greet(String name) {
+        return helper(name);
+    }
+
+    private String helper(String value) {
+        return value.trim();
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    (workspace / "Greeter.kt").write_text(
+        """
+package com.example.app
+
+class Greeter {
+    fun greet(name: String): String {
+        return helper(name)
+    }
+
+    private fun helper(value: String): String {
+        return value.trim()
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    repo = CodeGraphRepository(tmp_path / "codegraph.db")
+    indexer = CodeGraphIndexer(settings=CodeGraphSettings.from_mapping({}), registry=CodeGraphLanguageRegistry())
+
+    result = indexer.index_workspace(
+        workspace_root=workspace,
+        workspace_key="ws_test",
+        repository=repo,
+        force=True,
+        languages=None,
+        max_files=10,
+    )
+
+    files = {item.path: item for item in repo.list_files(limit=10)}
+    helper_paths = sorted(node.file_path for node in repo.search_nodes("helper", limit=10))
+
+    assert result.status == "complete"
+    assert files["Service.java"].node_count > 0
+    assert files["Greeter.kt"].node_count > 0
+    assert helper_paths == ["Greeter.kt", "Service.java"]
+
+
 def test_indexer_marks_python_extraction_errors_without_claiming_indexed_status(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
     workspace.mkdir()

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import tldw_Server_API.app.core.CodeGraph.indexer as indexer_module
 from tldw_Server_API.app.core.CodeGraph.config import CodeGraphSettings
+from tldw_Server_API.app.core.CodeGraph.dependencies import DependencyHealth
 from tldw_Server_API.app.core.CodeGraph.indexer import CodeGraphIndexer, _Candidate, _DiscoveryResult
 from tldw_Server_API.app.core.CodeGraph.language_registry import CodeGraphLanguageRegistry
 from tldw_Server_API.app.core.CodeGraph.models import ExtractionResult, LanguageInfo
@@ -166,6 +167,43 @@ class Greeter {
     assert helper_paths == ["Greeter.kt", "Service.java"]
 
 
+def test_indexer_does_not_count_non_extractable_jvm_files_against_foreground_limits(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    def fake_load_parser(language_id: str) -> SimpleNamespace:
+        return SimpleNamespace(available=language_id not in {"java", "kotlin"})
+
+    monkeypatch.setattr(indexer_module, "load_parser", fake_load_parser)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "A.java").write_text("class A {}\n", encoding="utf-8")
+    (workspace / "B.java").write_text("class B {}\n", encoding="utf-8")
+    (workspace / "app.py").write_text("def helper():\n    return 1\n", encoding="utf-8")
+    repo = CodeGraphRepository(tmp_path / "codegraph.db")
+    registry = CodeGraphLanguageRegistry(
+        dependency_health=DependencyHealth(
+            available=True,
+            missing=("tree_sitter_java", "tree_sitter_kotlin"),
+            present=("tree_sitter", "tree_sitter_javascript", "tree_sitter_typescript"),
+        )
+    )
+    indexer = CodeGraphIndexer(settings=CodeGraphSettings.from_mapping({}), registry=registry)
+
+    result = indexer.index_workspace(
+        workspace_root=workspace,
+        workspace_key="ws_test",
+        repository=repo,
+        force=True,
+        languages=None,
+        max_files=1,
+    )
+
+    assert result.status == "complete"
+    assert result.counters["dependency_missing_language_skipped"] == 2
+    assert [item.path for item in repo.list_files(limit=10)] == ["app.py"]
+
+
 def test_indexer_marks_python_extraction_errors_without_claiming_indexed_status(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
     workspace.mkdir()
@@ -301,6 +339,7 @@ def test_indexer_does_not_read_full_inventory_only_file_into_memory(tmp_path: Pa
             relative_path=result.candidates[0].relative_path,
             language_id=result.candidates[0].language_id,
             stage=result.candidates[0].stage,
+            symbol_extraction=result.candidates[0].symbol_extraction,
             size=result.candidates[0].size,
             modified_at=result.candidates[0].modified_at,
         )
@@ -360,6 +399,7 @@ def test_indexer_records_unreadable_files_without_aborting_run(tmp_path: Path) -
                 relative_path=candidate.relative_path,
                 language_id=candidate.language_id,
                 stage=candidate.stage,
+                symbol_extraction=candidate.symbol_extraction,
                 size=candidate.size,
                 modified_at=candidate.modified_at,
             )
@@ -436,6 +476,7 @@ def test_indexer_opens_each_candidate_once_for_probe_and_content(tmp_path: Path)
                     relative_path=candidate.relative_path,
                     language_id=candidate.language_id,
                     stage=candidate.stage,
+                    symbol_extraction=candidate.symbol_extraction,
                     size=candidate.size,
                     modified_at=candidate.modified_at,
                 )
@@ -599,6 +640,7 @@ def test_indexer_stops_discovery_once_file_limit_is_exceeded(tmp_path: Path) -> 
                 display_name="Python",
                 extensions=(".py",),
                 stage="foundation",
+                symbol_extraction=True,
             )
 
     registry = _CountingRegistry()

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_java_extractor.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_java_extractor.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from tldw_Server_API.app.core.CodeGraph.extractors.java_extractor import JavaTreeSitterExtractor
+from tldw_Server_API.app.core.CodeGraph.models import ExtractionResult
+
+
+JAVA_FIXTURE = b"""
+package com.example.app;
+
+import java.util.List;
+import com.example.tools.Helper;
+
+public class Greeter {
+    public Greeter() {
+        setup();
+    }
+
+    public String greet(String name) {
+        return helper(name);
+    }
+
+    private String helper(String value) {
+        return value.toUpperCase();
+    }
+}
+"""
+
+
+def test_java_extractor_records_package_imports_types_methods_and_calls() -> None:
+    """Extract conservative Java symbols and same-file method calls."""
+    result = JavaTreeSitterExtractor().extract(
+        workspace_key="ws",
+        file_path="src/main/java/com/example/app/Greeter.java",
+        source=JAVA_FIXTURE,
+    )
+
+    nodes_by_kind_name = {(node.kind, node.name): node for node in result.nodes}
+
+    assert ("module", "Greeter") in nodes_by_kind_name
+    assert ("package", "com.example.app") in nodes_by_kind_name
+    assert ("import", "java.util.List") in nodes_by_kind_name
+    assert ("import", "com.example.tools.Helper") in nodes_by_kind_name
+    assert ("class", "Greeter") in nodes_by_kind_name
+    assert ("constructor", "Greeter") in nodes_by_kind_name
+    assert ("method", "greet") in nodes_by_kind_name
+    assert ("method", "helper") in nodes_by_kind_name
+
+    greeter = nodes_by_kind_name[("class", "Greeter")]
+    constructor = nodes_by_kind_name[("constructor", "Greeter")]
+    greet = nodes_by_kind_name[("method", "greet")]
+    helper = nodes_by_kind_name[("method", "helper")]
+
+    assert greeter.qualified_name == "com.example.app.Greeter"
+    assert constructor.qualified_name == "com.example.app.Greeter.Greeter"
+    assert greet.qualified_name == "com.example.app.Greeter.greet"
+    assert helper.qualified_name == "com.example.app.Greeter.helper"
+    assert (greet.id, helper.id) in {(edge.source, edge.target) for edge in result.edges}
+    assert any(
+        ref.reference_kind == "call" and ref.reference_name == "setup" and ref.from_node_id == constructor.id
+        for ref in result.unresolved_refs
+    )
+    assert any(
+        ref.reference_kind == "import" and ref.reference_name == "java.util.List"
+        for ref in result.unresolved_refs
+    )
+    assert result.errors == ()
+
+
+def test_java_extractor_marks_parse_errors() -> None:
+    """Return extraction errors for invalid Java syntax."""
+    result = JavaTreeSitterExtractor().extract(
+        workspace_key="ws",
+        file_path="src/Broken.java",
+        source=b"class Broken {",
+    )
+
+    assert result == ExtractionResult(errors=("Java parse error",))
+
+
+def test_java_extractor_uses_deterministic_node_ids() -> None:
+    """Use stable node IDs across repeated Java extraction."""
+    first = JavaTreeSitterExtractor().extract(
+        workspace_key="ws",
+        file_path="src/Greeter.java",
+        source=JAVA_FIXTURE,
+    )
+    second = JavaTreeSitterExtractor().extract(
+        workspace_key="ws",
+        file_path="src/Greeter.java",
+        source=JAVA_FIXTURE,
+    )
+
+    assert [node.id for node in first.nodes] == [node.id for node in second.nodes]

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_java_extractor.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_java_extractor.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from tldw_Server_API.app.core.CodeGraph.extractors.java_extractor import JavaTreeSitterExtractor
 from tldw_Server_API.app.core.CodeGraph.models import ExtractionResult
 
-
 JAVA_FIXTURE = b"""
 package com.example.app;
 

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_java_extractor.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_java_extractor.py
@@ -7,6 +7,8 @@ JAVA_FIXTURE = b"""
 package com.example.app;
 
 import java.util.List;
+import static java.util.Collections.emptyList;
+import java.util.*;
 import com.example.tools.Helper;
 
 public class Greeter {
@@ -38,6 +40,8 @@ def test_java_extractor_records_package_imports_types_methods_and_calls() -> Non
     assert ("module", "Greeter") in nodes_by_kind_name
     assert ("package", "com.example.app") in nodes_by_kind_name
     assert ("import", "java.util.List") in nodes_by_kind_name
+    assert ("import", "static java.util.Collections.emptyList") in nodes_by_kind_name
+    assert ("import", "java.util.*") in nodes_by_kind_name
     assert ("import", "com.example.tools.Helper") in nodes_by_kind_name
     assert ("class", "Greeter") in nodes_by_kind_name
     assert ("constructor", "Greeter") in nodes_by_kind_name
@@ -50,6 +54,7 @@ def test_java_extractor_records_package_imports_types_methods_and_calls() -> Non
     helper = nodes_by_kind_name[("method", "helper")]
 
     assert greeter.qualified_name == "com.example.app.Greeter"
+    assert greeter.visibility == "public"
     assert constructor.qualified_name == "com.example.app.Greeter.Greeter"
     assert greet.qualified_name == "com.example.app.Greeter.greet"
     assert helper.qualified_name == "com.example.app.Greeter.helper"
@@ -60,6 +65,14 @@ def test_java_extractor_records_package_imports_types_methods_and_calls() -> Non
     )
     assert any(
         ref.reference_kind == "import" and ref.reference_name == "java.util.List"
+        for ref in result.unresolved_refs
+    )
+    assert any(
+        ref.reference_kind == "import" and ref.reference_name == "static java.util.Collections.emptyList"
+        for ref in result.unresolved_refs
+    )
+    assert any(
+        ref.reference_kind == "import" and ref.reference_name == "java.util.*"
         for ref in result.unresolved_refs
     )
     assert result.errors == ()

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_kotlin_extractor.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_kotlin_extractor.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from tldw_Server_API.app.core.CodeGraph.extractors.kotlin_extractor import KotlinTreeSitterExtractor
 from tldw_Server_API.app.core.CodeGraph.models import ExtractionResult
 
-
 KOTLIN_FIXTURE = b"""
 package com.example.app
 

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_kotlin_extractor.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_kotlin_extractor.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from tldw_Server_API.app.core.CodeGraph.extractors.kotlin_extractor import KotlinTreeSitterExtractor
+from tldw_Server_API.app.core.CodeGraph.models import ExtractionResult
+
+
+KOTLIN_FIXTURE = b"""
+package com.example.app
+
+import com.example.tools.Helper
+import kotlin.collections.List
+
+class Greeter {
+    fun greet(name: String): String {
+        return helper(name)
+    }
+
+    private fun helper(value: String): String {
+        return value.uppercase()
+    }
+}
+
+object Registry {
+    fun create(): Greeter {
+        return Greeter()
+    }
+}
+"""
+
+
+def test_kotlin_extractor_records_package_imports_types_functions_and_calls() -> None:
+    """Extract conservative Kotlin symbols and same-file function calls."""
+    result = KotlinTreeSitterExtractor().extract(
+        workspace_key="ws",
+        file_path="src/main/kotlin/com/example/app/Greeter.kt",
+        source=KOTLIN_FIXTURE,
+    )
+
+    nodes_by_kind_name = {(node.kind, node.name): node for node in result.nodes}
+
+    assert ("module", "Greeter") in nodes_by_kind_name
+    assert ("package", "com.example.app") in nodes_by_kind_name
+    assert ("import", "com.example.tools.Helper") in nodes_by_kind_name
+    assert ("import", "kotlin.collections.List") in nodes_by_kind_name
+    assert ("class", "Greeter") in nodes_by_kind_name
+    assert ("function", "greet") in nodes_by_kind_name
+    assert ("function", "helper") in nodes_by_kind_name
+    assert ("object", "Registry") in nodes_by_kind_name
+    assert ("function", "create") in nodes_by_kind_name
+
+    greeter = nodes_by_kind_name[("class", "Greeter")]
+    registry = nodes_by_kind_name[("object", "Registry")]
+    greet = nodes_by_kind_name[("function", "greet")]
+    helper = nodes_by_kind_name[("function", "helper")]
+    create = nodes_by_kind_name[("function", "create")]
+
+    assert greeter.qualified_name == "com.example.app.Greeter"
+    assert registry.qualified_name == "com.example.app.Registry"
+    assert greet.qualified_name == "com.example.app.Greeter.greet"
+    assert helper.qualified_name == "com.example.app.Greeter.helper"
+    assert create.qualified_name == "com.example.app.Registry.create"
+    assert (greet.id, helper.id) in {(edge.source, edge.target) for edge in result.edges}
+    assert any(
+        ref.reference_kind == "call" and ref.reference_name == "Greeter" and ref.from_node_id == create.id
+        for ref in result.unresolved_refs
+    )
+    assert any(
+        ref.reference_kind == "import" and ref.reference_name == "com.example.tools.Helper"
+        for ref in result.unresolved_refs
+    )
+    assert result.errors == ()
+
+
+def test_kotlin_extractor_marks_parse_errors() -> None:
+    """Return extraction errors for invalid Kotlin syntax."""
+    result = KotlinTreeSitterExtractor().extract(
+        workspace_key="ws",
+        file_path="src/Broken.kt",
+        source=b"class Broken {",
+    )
+
+    assert result == ExtractionResult(errors=("Kotlin parse error",))
+
+
+def test_kotlin_extractor_uses_deterministic_node_ids() -> None:
+    """Use stable node IDs across repeated Kotlin extraction."""
+    first = KotlinTreeSitterExtractor().extract(
+        workspace_key="ws",
+        file_path="src/Greeter.kt",
+        source=KOTLIN_FIXTURE,
+    )
+    second = KotlinTreeSitterExtractor().extract(
+        workspace_key="ws",
+        file_path="src/Greeter.kt",
+        source=KOTLIN_FIXTURE,
+    )
+
+    assert [node.id for node in first.nodes] == [node.id for node in second.nodes]

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_kotlin_extractor.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_kotlin_extractor.py
@@ -7,9 +7,11 @@ KOTLIN_FIXTURE = b"""
 package com.example.app
 
 import com.example.tools.Helper
+import com.example.tools.Helper as ToolHelper
+import kotlin.collections.*
 import kotlin.collections.List
 
-class Greeter {
+internal class Greeter {
     fun greet(name: String): String {
         return helper(name)
     }
@@ -21,8 +23,14 @@ class Greeter {
 
 object Registry {
     fun create(): Greeter {
+        com.example.factories.GreeterFactory.create()
         return Greeter()
     }
+}
+
+@Deprecated("use NewMarker")
+internal interface Marker {
+    fun mark()
 }
 """
 
@@ -40,20 +48,27 @@ def test_kotlin_extractor_records_package_imports_types_functions_and_calls() ->
     assert ("module", "Greeter") in nodes_by_kind_name
     assert ("package", "com.example.app") in nodes_by_kind_name
     assert ("import", "com.example.tools.Helper") in nodes_by_kind_name
+    assert ("import", "com.example.tools.Helper as ToolHelper") in nodes_by_kind_name
+    assert ("import", "kotlin.collections.*") in nodes_by_kind_name
     assert ("import", "kotlin.collections.List") in nodes_by_kind_name
     assert ("class", "Greeter") in nodes_by_kind_name
     assert ("function", "greet") in nodes_by_kind_name
     assert ("function", "helper") in nodes_by_kind_name
     assert ("object", "Registry") in nodes_by_kind_name
     assert ("function", "create") in nodes_by_kind_name
+    assert ("interface", "Marker") in nodes_by_kind_name
 
     greeter = nodes_by_kind_name[("class", "Greeter")]
+    marker = nodes_by_kind_name[("interface", "Marker")]
     registry = nodes_by_kind_name[("object", "Registry")]
     greet = nodes_by_kind_name[("function", "greet")]
     helper = nodes_by_kind_name[("function", "helper")]
     create = nodes_by_kind_name[("function", "create")]
 
     assert greeter.qualified_name == "com.example.app.Greeter"
+    assert greeter.visibility == "internal"
+    assert marker.qualified_name == "com.example.app.Marker"
+    assert marker.visibility == "internal"
     assert registry.qualified_name == "com.example.app.Registry"
     assert greet.qualified_name == "com.example.app.Greeter.greet"
     assert helper.qualified_name == "com.example.app.Greeter.helper"
@@ -65,6 +80,18 @@ def test_kotlin_extractor_records_package_imports_types_functions_and_calls() ->
     )
     assert any(
         ref.reference_kind == "import" and ref.reference_name == "com.example.tools.Helper"
+        for ref in result.unresolved_refs
+    )
+    assert any(
+        ref.reference_kind == "import" and ref.reference_name == "com.example.tools.Helper as ToolHelper"
+        for ref in result.unresolved_refs
+    )
+    assert any(
+        ref.reference_kind == "import" and ref.reference_name == "kotlin.collections.*"
+        for ref in result.unresolved_refs
+    )
+    assert any(
+        ref.reference_kind == "call" and ref.reference_name == "com.example.factories.GreeterFactory.create"
         for ref in result.unresolved_refs
     )
     assert result.errors == ()

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_language_registry.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_language_registry.py
@@ -37,11 +37,11 @@ def test_registry_reports_foundation_languages_and_planned_languages() -> None:
     assert by_id["python"].stage == "foundation"
     assert by_id["javascript"].stage == "foundation"
     assert by_id["typescript"].stage == "foundation"
+    assert by_id["java"].stage == "foundation"
+    assert by_id["kotlin"].stage == "foundation"
     assert by_id["c"].stage == "planned"
     assert by_id["cpp"].stage == "planned"
     assert by_id["csharp"].stage == "planned"
-    assert by_id["java"].stage == "planned"
-    assert by_id["kotlin"].stage == "planned"
 
 
 def test_registry_maps_extensions_and_reports_symbol_extraction_support() -> None:
@@ -54,6 +54,8 @@ def test_registry_maps_extensions_and_reports_symbol_extraction_support() -> Non
                 "tree_sitter_python",
                 "tree_sitter_javascript",
                 "tree_sitter_typescript",
+                "tree_sitter_java",
+                "tree_sitter_kotlin",
             ),
         )
     )
@@ -61,6 +63,8 @@ def test_registry_maps_extensions_and_reports_symbol_extraction_support() -> Non
     assert registry.language_for_path("api/server.py").language_id == "python"
     assert registry.language_for_path("apps/ui/page.tsx").language_id == "typescript"
     assert registry.language_for_path("apps/ui/component.jsx").language_id == "javascript"
+    assert registry.language_for_path("src/main/java/com/example/App.java").language_id == "java"
+    assert registry.language_for_path("src/main/kotlin/com/example/App.kt").language_id == "kotlin"
     assert registry.language_for_path("src/main.cc").stage == "planned"
     assert registry.language_for_path("README.md") is None
 
@@ -69,13 +73,15 @@ def test_registry_maps_extensions_and_reports_symbol_extraction_support() -> Non
     assert by_id["python"].symbol_extraction is True
     assert by_id["javascript"].symbol_extraction is True
     assert by_id["typescript"].symbol_extraction is True
+    assert by_id["java"].symbol_extraction is True
+    assert by_id["kotlin"].symbol_extraction is True
 
 
 def test_registry_reports_missing_parser_dependencies_per_language() -> None:
     registry = CodeGraphLanguageRegistry(
         dependency_health=DependencyHealth(
             available=False,
-            missing=("tree_sitter_javascript",),
+            missing=("tree_sitter_javascript", "tree_sitter_java", "tree_sitter_kotlin"),
             present=("tree_sitter", "tree_sitter_typescript"),
         )
     )
@@ -87,3 +93,7 @@ def test_registry_reports_missing_parser_dependencies_per_language() -> None:
     assert by_id["javascript"].dependency_missing == ("tree_sitter_javascript",)
     assert by_id["typescript"].symbol_extraction is True
     assert by_id["typescript"].dependency_missing == ()
+    assert by_id["java"].symbol_extraction is False
+    assert by_id["java"].dependency_missing == ("tree_sitter_java",)
+    assert by_id["kotlin"].symbol_extraction is False
+    assert by_id["kotlin"].dependency_missing == ("tree_sitter_kotlin",)

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_tree_sitter_loader.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_tree_sitter_loader.py
@@ -92,3 +92,58 @@ def test_tsx_parser_can_parse_component() -> None:
     assert result.error is None
     assert tree.root_node.type == "program"
     assert not tree.root_node.has_error
+
+
+def test_java_parser_can_parse_class() -> None:
+    """Load the optional Java parser and parse a compact class fixture."""
+    loader = importlib.import_module(
+        "tldw_Server_API.app.core.CodeGraph.extractors.tree_sitter_loader"
+    )
+
+    result = loader.load_parser("java")
+    tree = result.parser.parse(b"class Greeter { String greet() { return helper(); } }")
+
+    assert result.missing == ()
+    assert result.error is None
+    assert tree.root_node.type == "program"
+    assert not tree.root_node.has_error
+
+
+def test_kotlin_parser_can_parse_class() -> None:
+    """Load the optional Kotlin parser and parse a compact class fixture."""
+    loader = importlib.import_module(
+        "tldw_Server_API.app.core.CodeGraph.extractors.tree_sitter_loader"
+    )
+
+    result = loader.load_parser("kotlin")
+    tree = result.parser.parse(b"class Greeter {\n fun greet(): String { return helper() }\n}")
+
+    assert result.missing == ()
+    assert result.error is None
+    assert tree.root_node.type == "source_file"
+    assert not tree.root_node.has_error
+
+
+def test_load_parser_reports_missing_java_kotlin_optional_dependencies(monkeypatch) -> None:
+    """Report missing JVM parser packages without raising import errors."""
+    loader = importlib.import_module(
+        "tldw_Server_API.app.core.CodeGraph.extractors.tree_sitter_loader"
+    )
+    real_import_module = loader.importlib.import_module
+
+    def fake_import_module(name: str) -> ModuleType:
+        if name in {"tree_sitter_java", "tree_sitter_kotlin"}:
+            raise ModuleNotFoundError(f"No module named '{name}'")
+        return real_import_module(name)
+
+    monkeypatch.setattr(loader.importlib, "import_module", fake_import_module)
+
+    java = loader.load_parser("java")
+    kotlin = loader.load_parser("kotlin")
+
+    assert java.parser is None
+    assert java.missing == ("tree_sitter_java",)
+    assert java.error is None
+    assert kotlin.parser is None
+    assert kotlin.missing == ("tree_sitter_kotlin",)
+    assert kotlin.error is None


### PR DESCRIPTION
## Summary
- Add optional Tree-sitter Java/Kotlin parser dependencies and loader support for native CodeGraph.
- Add conservative Java/Kotlin extractors, shared JVM helpers, dependency-aware registry/indexer wiring, and MCP search regression coverage.
- Mark TASK-49 complete with verification evidence and known limits.

## Test Plan
- [x] `python -m pytest tldw_Server_API/tests/CodeGraph tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py -q`
- [x] `python -m ruff check tldw_Server_API/app/core/CodeGraph tldw_Server_API/app/core/DB_Management/codegraph tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py tldw_Server_API/tests/CodeGraph tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py`
- [x] `python -m bandit -r tldw_Server_API/app/core/CodeGraph tldw_Server_API/app/core/DB_Management/codegraph tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py -f json -o /tmp/bandit_codegraph_java_kotlin.json`
- [x] `git diff --check`

## Merge Gate
- Human-authored Change summary still required before this AI-authored PR is merge-ready.
