### PR TITLE
feat(sandbox): expose host-local isolation warnings

### DIFF
--- a/Docs/API-related/Sandbox_API.md
+++ b/Docs/API-related/Sandbox_API.md
@@ -20,9 +20,11 @@ Current runtime identities are `docker`, `firecracker`, `lima`, `vz_linux`,
 `vz_macos`, `seatbelt`, and `worktree`. Availability does not imply a security
 guarantee:
 - Runtime discovery includes machine-readable `boundary_class`,
-  `vm_grade_isolation`, `untrusted_eligible`, and
+  `vm_grade_isolation`, `untrusted_eligible`, `isolation_warnings`, and
   `network_policy_contract` fields. Use those fields for client decisions
   instead of parsing prose notes.
+- `isolation_warnings` are advisory metadata for client UX and operator
+  context. They are not admission rejection reasons by themselves.
 - `seatbelt` is host-local. `seatbelt` is not `untrusted`-eligible.
 - `worktree` is host-local. `worktree` is not `untrusted`-eligible.
 - `vz_macos` real execution is not implemented; it is a scaffold/preflight
@@ -137,6 +139,7 @@ Response (example):
       "boundary_class": "container",
       "vm_grade_isolation": false,
       "untrusted_eligible": true,
+      "isolation_warnings": [],
       "network_policy_contract": {
         "deny_all": {
           "support_state": "supported",
@@ -164,6 +167,9 @@ Runtime isolation fields mean:
   claims, independent of current host availability.
 - `untrusted_eligible`: whether policy may admit this runtime for `untrusted`
   workloads when preflight and host readiness also pass.
+- `isolation_warnings`: advisory warning codes for client UX and operator
+  context. These are not rejection reasons by themselves; admission remains
+  governed by runtime preflight, policy, and request validation.
 - `network_policy_contract`: static runtime posture for `deny_all` and
   `allowlist`. It describes whether each policy is supported, unsupported,
   scaffold-only, or host-gated, whether strict enforcement is possible, and
@@ -171,15 +177,15 @@ Runtime isolation fields mean:
 
 Current posture mapping:
 
-| Runtime | `boundary_class` | `vm_grade_isolation` | `untrusted_eligible` |
-| --- | --- | --- | --- |
-| `docker` | `container` | `false` | `true` |
-| `firecracker` | `vm_grade` | `true` | `true` |
-| `lima` | `vm_grade` | `true` | `true` |
-| `vz_linux` | `vm_grade` | `true` | `true` |
-| `vz_macos` | `vm_grade_scaffold` | `false` | `false` |
-| `seatbelt` | `host_local` | `false` | `false` |
-| `worktree` | `host_local` | `false` | `false` |
+| Runtime | `boundary_class` | `vm_grade_isolation` | `untrusted_eligible` | `isolation_warnings` |
+| --- | --- | --- | --- | --- |
+| `docker` | `container` | `false` | `true` | `[]` |
+| `firecracker` | `vm_grade` | `true` | `true` | `[]` |
+| `lima` | `vm_grade` | `true` | `true` | `[]` |
+| `vz_linux` | `vm_grade` | `true` | `true` | `[]` |
+| `vz_macos` | `vm_grade_scaffold` | `false` | `false` | `[]` |
+| `seatbelt` | `host_local` | `false` | `false` | `host_local_boundary`, `not_vm_grade_isolation`, `not_untrusted_eligible` |
+| `worktree` | `host_local` | `false` | `false` | `host_local_boundary`, `not_vm_grade_isolation`, `not_untrusted_eligible` |
 
 Network policy contract mapping:
 

--- a/Docs/Published/API-related/Sandbox_API.md
+++ b/Docs/Published/API-related/Sandbox_API.md
@@ -20,9 +20,11 @@ Current runtime identities are `docker`, `firecracker`, `lima`, `vz_linux`,
 `vz_macos`, `seatbelt`, and `worktree`. Availability does not imply a security
 guarantee:
 - Runtime discovery includes machine-readable `boundary_class`,
-  `vm_grade_isolation`, `untrusted_eligible`, and
+  `vm_grade_isolation`, `untrusted_eligible`, `isolation_warnings`, and
   `network_policy_contract` fields. Use those fields for client decisions
   instead of parsing prose notes.
+- `isolation_warnings` are advisory metadata for client UX and operator
+  context. They are not admission rejection reasons by themselves.
 - `seatbelt` is host-local. `seatbelt` is not `untrusted`-eligible.
 - `worktree` is host-local. `worktree` is not `untrusted`-eligible.
 - `vz_macos` real execution is not implemented; it is a scaffold/preflight
@@ -137,6 +139,7 @@ Response (example):
       "boundary_class": "container",
       "vm_grade_isolation": false,
       "untrusted_eligible": true,
+      "isolation_warnings": [],
       "network_policy_contract": {
         "deny_all": {
           "support_state": "supported",
@@ -164,6 +167,9 @@ Runtime isolation fields mean:
   claims, independent of current host availability.
 - `untrusted_eligible`: whether policy may admit this runtime for `untrusted`
   workloads when preflight and host readiness also pass.
+- `isolation_warnings`: advisory warning codes for client UX and operator
+  context. These are not rejection reasons by themselves; admission remains
+  governed by runtime preflight, policy, and request validation.
 - `network_policy_contract`: static runtime posture for `deny_all` and
   `allowlist`. It describes whether each policy is supported, unsupported,
   scaffold-only, or host-gated, whether strict enforcement is possible, and
@@ -171,15 +177,15 @@ Runtime isolation fields mean:
 
 Current posture mapping:
 
-| Runtime | `boundary_class` | `vm_grade_isolation` | `untrusted_eligible` |
-| --- | --- | --- | --- |
-| `docker` | `container` | `false` | `true` |
-| `firecracker` | `vm_grade` | `true` | `true` |
-| `lima` | `vm_grade` | `true` | `true` |
-| `vz_linux` | `vm_grade` | `true` | `true` |
-| `vz_macos` | `vm_grade_scaffold` | `false` | `false` |
-| `seatbelt` | `host_local` | `false` | `false` |
-| `worktree` | `host_local` | `false` | `false` |
+| Runtime | `boundary_class` | `vm_grade_isolation` | `untrusted_eligible` | `isolation_warnings` |
+| --- | --- | --- | --- | --- |
+| `docker` | `container` | `false` | `true` | `[]` |
+| `firecracker` | `vm_grade` | `true` | `true` | `[]` |
+| `lima` | `vm_grade` | `true` | `true` | `[]` |
+| `vz_linux` | `vm_grade` | `true` | `true` | `[]` |
+| `vz_macos` | `vm_grade_scaffold` | `false` | `false` | `[]` |
+| `seatbelt` | `host_local` | `false` | `false` | `host_local_boundary`, `not_vm_grade_isolation`, `not_untrusted_eligible` |
+| `worktree` | `host_local` | `false` | `false` | `host_local_boundary`, `not_vm_grade_isolation`, `not_untrusted_eligible` |
 
 Network policy contract mapping:
 

--- a/Docs/Sandbox/sandbox-runtime-capability-inventory.md
+++ b/Docs/Sandbox/sandbox-runtime-capability-inventory.md
@@ -44,6 +44,9 @@ concepts:
   claims, independent of current host availability.
 - `untrusted_eligible`: whether policy may admit this runtime for `untrusted`
   workloads when preflight and host readiness also pass.
+- `isolation_warnings`: additive advisory warning codes derived from static
+  isolation metadata. These are for client UX and do not replace admission,
+  preflight, or diagnostics.
 - `network_policy_contract`: static posture for `deny_all` and `allowlist`
   support, strict enforcement, and current-readiness source.
 
@@ -77,6 +80,16 @@ healthy on the current host.
 | `vz_macos` | `vm_grade_scaffold` | `false` | `false` | Runtime identity exists, but real execution is scaffolded. |
 | `seatbelt` | `host_local` | `false` | `false` | Host-local macOS process isolation only. |
 | `worktree` | `host_local` | `false` | `false` | Host-local VCS/workspace isolation only. |
+
+Host-local runtimes also expose `isolation_warnings`:
+
+- `host_local_boundary`
+- `not_vm_grade_isolation`
+- `not_untrusted_eligible`
+
+These warnings are advisory discovery metadata. Policy admission remains the
+source of truth for whether a request is accepted, and runtime preflight/admin
+diagnostics remain the source of truth for current host readiness.
 
 ## Normalized Reason Codes
 

--- a/Docs/Sandbox/sandbox-security-policy-matrix.md
+++ b/Docs/Sandbox/sandbox-security-policy-matrix.md
@@ -32,10 +32,16 @@ specific runtime today.
 | `scaffold` | Shape exists, but the guarantee is not ready for normal operator use. |
 
 Public runtime discovery exposes isolation concepts through `boundary_class`,
-`vm_grade_isolation`, and `untrusted_eligible`. It exposes network posture
-through `network_policy_contract`. These fields describe static policy posture;
-they do not replace current-host `available`, `reasons`, `enforcement_ready`,
-or runtime preflight checks.
+`vm_grade_isolation`, `untrusted_eligible`, and advisory
+`isolation_warnings`. It exposes network posture through
+`network_policy_contract`. These fields describe static policy posture; they do
+not replace current-host `available`, `reasons`, `enforcement_ready`, or
+runtime preflight checks.
+
+`isolation_warnings` are client-facing warning codes, not rejection reasons.
+Today they flag host-local runtimes with `host_local_boundary`,
+`not_vm_grade_isolation`, and `not_untrusted_eligible` so clients can present
+the weaker boundary clearly without parsing human-readable notes.
 
 ## Trust-Level Eligibility
 

--- a/Docs/superpowers/plans/2026-05-05-sandbox-host-local-warning-metadata-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-05-sandbox-host-local-warning-metadata-implementation-plan.md
@@ -1,0 +1,137 @@
+# Sandbox Host-Local Warning Metadata Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add advisory host-local isolation warning metadata to sandbox runtime discovery.
+
+**Architecture:** Derive warning codes from existing static `RuntimeIsolationMetadata`, expose them through `SandboxService.feature_discovery()`, and type the additive response field in `SandboxRuntimeInfo`. This keeps warnings as discovery metadata and avoids new admission or execution behavior.
+
+**Tech Stack:** Python dataclasses and `Literal` types, FastAPI/Pydantic schemas, pytest, Bandit.
+
+---
+
+### Task 1: Add Failing Tests
+
+**Files:**
+- Modify: `tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py`
+- Modify: `tldw_Server_API/tests/sandbox/test_sandbox_api.py`
+
+- [ ] **Step 1: Add service discovery assertions**
+
+Add a focused test that builds `SandboxService().feature_discovery()` and
+asserts:
+
+```python
+assert discovery["seatbelt"]["isolation_warnings"] == [
+    "host_local_boundary",
+    "not_vm_grade_isolation",
+    "not_untrusted_eligible",
+]
+assert discovery["worktree"]["isolation_warnings"] == [
+    "host_local_boundary",
+    "not_vm_grade_isolation",
+    "not_untrusted_eligible",
+]
+assert "host_local_boundary" not in discovery["vz_linux"]["isolation_warnings"]
+```
+
+- [ ] **Step 2: Add API shape assertion**
+
+Extend the runtime discovery shape test to assert `isolation_warnings` is
+present and is a list.
+
+- [ ] **Step 3: Run tests and confirm RED**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py \
+  tldw_Server_API/tests/sandbox/test_sandbox_api.py::test_runtimes_discovery_shape \
+  -q --timeout=60
+```
+
+Expected: fail because `isolation_warnings` is missing.
+
+### Task 2: Implement Runtime Warning Metadata
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Sandbox/runtime_capabilities.py`
+- Modify: `tldw_Server_API/app/core/Sandbox/service.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py`
+
+- [ ] **Step 1: Add warning-code type and helper**
+
+Add `RuntimeIsolationWarningCode` with the initial host-local warning codes,
+then add `runtime_isolation_warnings(runtime)` that derives warnings from
+`runtime_isolation_metadata(runtime)`.
+
+- [ ] **Step 2: Wire discovery**
+
+Import the helper in `service.py` and include
+`"isolation_warnings": runtime_isolation_warnings(runtime)` in
+`_preflight_fields()`.
+
+- [ ] **Step 3: Type the response schema**
+
+Import `RuntimeIsolationWarningCode` in `sandbox_schemas.py` and add:
+
+```python
+isolation_warnings: list[RuntimeIsolationWarningCode] = Field(default_factory=list, ...)
+```
+
+- [ ] **Step 4: Run focused tests and confirm GREEN**
+
+Run the same focused pytest command from Task 1.
+
+### Task 3: Update Docs And Verify
+
+**Files:**
+- Modify: `Docs/Sandbox/sandbox-runtime-capability-inventory.md`
+- Modify: `Docs/Sandbox/sandbox-security-policy-matrix.md`
+- Modify: `backlog/tasks/task-51 - Expose-host-local-sandbox-runtime-warning-metadata.md`
+
+- [ ] **Step 1: Document advisory semantics**
+
+Update docs to state `isolation_warnings` is additive advisory metadata, not an
+admission decision.
+
+- [ ] **Step 2: Run full focused verification**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py \
+  tldw_Server_API/tests/sandbox/test_feature_discovery_flags.py \
+  tldw_Server_API/tests/sandbox/test_sandbox_api.py::test_runtimes_discovery_shape \
+  -q --timeout=60
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile \
+  tldw_Server_API/app/core/Sandbox/runtime_capabilities.py \
+  tldw_Server_API/app/core/Sandbox/service.py \
+  tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r \
+  tldw_Server_API/app/core/Sandbox/runtime_capabilities.py \
+  tldw_Server_API/app/core/Sandbox/service.py \
+  tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py \
+  -f json -o /tmp/bandit_sandbox_host_local_warning_metadata.json
+git diff --check
+```
+
+- [ ] **Step 3: Finalize task and commit**
+
+Update `TASK-51`, stage the touched files, and commit:
+
+```bash
+git add Docs/Sandbox/sandbox-runtime-capability-inventory.md \
+  Docs/Sandbox/sandbox-security-policy-matrix.md \
+  Docs/superpowers/specs/2026-05-05-sandbox-host-local-warning-metadata-design.md \
+  Docs/superpowers/plans/2026-05-05-sandbox-host-local-warning-metadata-implementation-plan.md \
+  "backlog/tasks/task-51 - Expose-host-local-sandbox-runtime-warning-metadata.md" \
+  tldw_Server_API/app/core/Sandbox/runtime_capabilities.py \
+  tldw_Server_API/app/core/Sandbox/service.py \
+  tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py \
+  tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py \
+  tldw_Server_API/tests/sandbox/test_sandbox_api.py
+git commit -m "feat(sandbox): expose host-local isolation warnings"
+```

--- a/Docs/superpowers/plans/2026-05-05-sandbox-host-local-warning-metadata-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-05-sandbox-host-local-warning-metadata-implementation-plan.md
@@ -45,7 +45,7 @@ present and is a list.
 Run:
 
 ```bash
-/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+python -m pytest \
   tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py \
   tldw_Server_API/tests/sandbox/test_sandbox_api.py::test_runtimes_discovery_shape \
   -q --timeout=60
@@ -101,16 +101,16 @@ admission decision.
 Run:
 
 ```bash
-/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+python -m pytest \
   tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py \
   tldw_Server_API/tests/sandbox/test_feature_discovery_flags.py \
   tldw_Server_API/tests/sandbox/test_sandbox_api.py::test_runtimes_discovery_shape \
   -q --timeout=60
-/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile \
+python -m py_compile \
   tldw_Server_API/app/core/Sandbox/runtime_capabilities.py \
   tldw_Server_API/app/core/Sandbox/service.py \
   tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
-/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r \
+python -m bandit -r \
   tldw_Server_API/app/core/Sandbox/runtime_capabilities.py \
   tldw_Server_API/app/core/Sandbox/service.py \
   tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py \

--- a/Docs/superpowers/specs/2026-05-05-sandbox-host-local-warning-metadata-design.md
+++ b/Docs/superpowers/specs/2026-05-05-sandbox-host-local-warning-metadata-design.md
@@ -1,0 +1,62 @@
+# Sandbox Host-Local Warning Metadata Design
+
+## Goal
+
+Expose additive, machine-readable runtime discovery warnings for host-local
+sandbox runtimes so clients can distinguish availability from isolation
+strength. This slice targets `seatbelt` and `worktree`.
+
+## Current Gap
+
+Runtime discovery already exposes `boundary_class`, `vm_grade_isolation`, and
+`untrusted_eligible`, and admission now enforces static network policy
+contracts. The remaining ambiguity is client UX: a runtime can be available
+while still being host-local and not VM-grade. Existing prose notes are useful
+for humans, but clients should not need to parse note strings to show safety
+warnings.
+
+## Design
+
+Add an additive `isolation_warnings: list[str]` field to each
+`/api/v1/sandbox/runtimes` item.
+
+Warning codes are static advisory discovery metadata derived from
+`RuntimeIsolationMetadata`; they do not replace admission policy, runtime
+preflight, or admin diagnostics.
+
+Initial warning codes:
+
+- `host_local_boundary`: runtime executes with a host-local boundary rather
+  than a VM boundary.
+- `not_vm_grade_isolation`: runtime must not be described as VM-grade.
+- `not_untrusted_eligible`: runtime is not eligible for untrusted workloads.
+
+Only host-local runtimes receive this initial warning set. VM-grade runtimes do
+not receive host-local warnings. `docker` remains described by its existing
+`container` boundary metadata without host-local warnings.
+
+## Non-Goals
+
+- Do not change `SandboxPolicy` admission behavior.
+- Do not change runtime preflight availability.
+- Do not introduce new runtime execution checks.
+- Do not generalize a full warning framework beyond static isolation warnings.
+
+## Risks And Mitigations
+
+- Risk: clients treat warnings as rejection reasons.
+  Mitigation: schema and docs describe warnings as advisory discovery metadata.
+- Risk: warnings drift from isolation metadata.
+  Mitigation: derive warnings from the existing `RuntimeIsolationMetadata`
+  helper instead of maintaining a parallel map.
+- Risk: over-warning non-VM runtimes like Docker.
+  Mitigation: this slice only emits host-local warnings for `seatbelt` and
+  `worktree`.
+
+## Tests
+
+- Service discovery tests assert `seatbelt` and `worktree` receive the warning
+  codes.
+- Service discovery tests assert VM-grade runtimes do not receive host-local
+  warnings.
+- API shape tests assert `/api/v1/sandbox/runtimes` includes the additive field.

--- a/backlog/tasks/task-51 - Expose-host-local-sandbox-runtime-warning-metadata.md
+++ b/backlog/tasks/task-51 - Expose-host-local-sandbox-runtime-warning-metadata.md
@@ -4,7 +4,7 @@ title: Expose host-local sandbox runtime warning metadata
 status: Done
 assignee: []
 created_date: '2026-05-05 01:14'
-updated_date: '2026-05-05 01:20'
+updated_date: '2026-05-05 02:01'
 labels:
   - sandbox
   - runtime-discovery
@@ -45,12 +45,18 @@ Add additive runtime discovery metadata that explicitly warns clients when a run
 
 <!-- SECTION:NOTES:BEGIN -->
 Implemented additive isolation_warnings discovery metadata. RED: focused service/API tests failed because isolation_warnings was absent. GREEN: 14 focused sandbox discovery/API tests passed after adding RuntimeIsolationWarningCode, runtime_isolation_warnings(), service wiring, schema field, and docs. Verification: py_compile on touched Python modules passed; Bandit on touched Python modules produced 0 findings; git diff --check passed. Broader test_feature_discovery_flags.py file was attempted but timed out in existing FastAPI lifecycle/job-worker shutdown while running unrelated lifecycle-heavy tests, so final verification used the focused service/API tests that cover this slice.
+
+PR #1278 review fix pass: Qodo identified that public Sandbox API guides still omit the new isolation_warnings response field; Gemini identified non-portable absolute local Python paths in the implementation plan. Plan: update both public guides and published guide examples/narrative, replace absolute verification commands with portable activated-environment python commands, rerun focused docs/diff checks, commit, push, and resolve review threads.
+
+PR #1278 review fixes completed: public and published Sandbox API guides now include isolation_warnings in the runtime discovery field list, example response, advisory semantics, and posture mapping. The implementation plan now uses portable python -m commands instead of local absolute venv paths. Verification: focused sandbox discovery/API pytest passed (14 tests), git diff --check passed, and the reviewed docs/plan absolute-path scan returned no hits.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Added advisory host-local isolation warning metadata to sandbox runtime discovery. The new isolation_warnings field is derived from existing RuntimeIsolationMetadata and currently flags seatbelt and worktree with host_local_boundary, not_vm_grade_isolation, and not_untrusted_eligible. This is additive discovery metadata only; admission, preflight, and runtime execution behavior are unchanged. Updated schema and sandbox docs, plus focused tests for service discovery and API response shape. Verification passed for focused pytest, py_compile, Bandit with 0 findings, and git diff --check; the broader feature_discovery_flags file timed out in unrelated lifecycle-heavy shutdown code and is documented as a known verification skip for this slice.
+
+PR review follow-up documented isolation_warnings in both public Sandbox API guides and removed local absolute Python paths from the implementation plan. Focused sandbox discovery/API pytest passed again, git diff --check passed, and the reviewed docs/plan path scan returned no hits.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-51 - Expose-host-local-sandbox-runtime-warning-metadata.md
+++ b/backlog/tasks/task-51 - Expose-host-local-sandbox-runtime-warning-metadata.md
@@ -4,7 +4,7 @@ title: Expose host-local sandbox runtime warning metadata
 status: Done
 assignee: []
 created_date: '2026-05-05 01:14'
-updated_date: '2026-05-05 02:01'
+updated_date: '2026-05-05 02:03'
 labels:
   - sandbox
   - runtime-discovery
@@ -49,6 +49,10 @@ Implemented additive isolation_warnings discovery metadata. RED: focused service
 PR #1278 review fix pass: Qodo identified that public Sandbox API guides still omit the new isolation_warnings response field; Gemini identified non-portable absolute local Python paths in the implementation plan. Plan: update both public guides and published guide examples/narrative, replace absolute verification commands with portable activated-environment python commands, rerun focused docs/diff checks, commit, push, and resolve review threads.
 
 PR #1278 review fixes completed: public and published Sandbox API guides now include isolation_warnings in the runtime discovery field list, example response, advisory semantics, and posture mapping. The implementation plan now uses portable python -m commands instead of local absolute venv paths. Verification: focused sandbox discovery/API pytest passed (14 tests), git diff --check passed, and the reviewed docs/plan absolute-path scan returned no hits.
+
+Additional PR #1278 review pass: CodeRabbit requested test hardening so non-host-local warning assertions cover every discovered runtime and API response shape checks validate every runtime entry rather than only the first. Verified current tests still have those narrower assertions; updating tests only.
+
+Additional CodeRabbit review hardening completed: service discovery warning test now verifies every discovered non-host-local runtime lacks host_local_boundary, and the API shape test verifies required fields plus list-typed isolation_warnings for every runtime entry. Verification: focused sandbox discovery/API pytest passed (14 tests) and git diff --check passed. Bandit was not rerun for this final test/docs-only hardening slice; prior production-code Bandit run for the feature had 0 findings.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
@@ -57,6 +61,8 @@ PR #1278 review fixes completed: public and published Sandbox API guides now inc
 Added advisory host-local isolation warning metadata to sandbox runtime discovery. The new isolation_warnings field is derived from existing RuntimeIsolationMetadata and currently flags seatbelt and worktree with host_local_boundary, not_vm_grade_isolation, and not_untrusted_eligible. This is additive discovery metadata only; admission, preflight, and runtime execution behavior are unchanged. Updated schema and sandbox docs, plus focused tests for service discovery and API response shape. Verification passed for focused pytest, py_compile, Bandit with 0 findings, and git diff --check; the broader feature_discovery_flags file timed out in unrelated lifecycle-heavy shutdown code and is documented as a known verification skip for this slice.
 
 PR review follow-up documented isolation_warnings in both public Sandbox API guides and removed local absolute Python paths from the implementation plan. Focused sandbox discovery/API pytest passed again, git diff --check passed, and the reviewed docs/plan path scan returned no hits.
+
+Final PR review hardening expanded test coverage so runtime warning absence and API response shape are checked across all discovered runtimes, not only selected entries. Focused sandbox discovery/API pytest passed and git diff --check passed.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-51 - Expose-host-local-sandbox-runtime-warning-metadata.md
+++ b/backlog/tasks/task-51 - Expose-host-local-sandbox-runtime-warning-metadata.md
@@ -1,0 +1,64 @@
+---
+id: TASK-51
+title: Expose host-local sandbox runtime warning metadata
+status: Done
+assignee: []
+created_date: '2026-05-05 01:14'
+updated_date: '2026-05-05 01:20'
+labels:
+  - sandbox
+  - runtime-discovery
+  - security-contract
+dependencies: []
+documentation:
+  - Docs/Sandbox/sandbox-runtime-capability-inventory.md
+  - Docs/Sandbox/sandbox-security-policy-matrix.md
+  - Docs/superpowers/specs/2026-05-02-sandbox-module-roadmap-design.md
+  - >-
+    Docs/superpowers/specs/2026-05-05-sandbox-host-local-warning-metadata-design.md
+  - >-
+    Docs/superpowers/plans/2026-05-05-sandbox-host-local-warning-metadata-implementation-plan.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add additive runtime discovery metadata that explicitly warns clients when a runtime is host-local and not VM-grade, starting with seatbelt and worktree. This follows the Phase 2 sandbox security-contract roadmap and should not change runtime admission or execution behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 /api/v1/sandbox/runtimes exposes additive machine-readable warning metadata for host-local runtimes without removing existing fields.
+- [x] #2 seatbelt and worktree advertise explicit not-VM-grade/not-untrusted-eligible warnings while VM-grade runtimes do not receive host-local warnings.
+- [x] #3 Schema/docs describe the new warning field as advisory discovery metadata rather than an admission decision.
+- [x] #4 Focused tests cover service discovery and API schema behavior for the new field.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused failing tests for additive isolation warning metadata in SandboxService.feature_discovery() and the /api/v1/sandbox/runtimes response shape. 2. Add a small warning-code type/helper in runtime_capabilities.py derived only from RuntimeIsolationMetadata. 3. Wire the helper into SandboxService._preflight_fields() and SandboxRuntimeInfo without changing admission/preflight behavior. 4. Update sandbox runtime inventory/security docs plus local design/plan docs to define warnings as advisory discovery metadata. 5. Run focused tests, py_compile/Bandit on touched Python scope, and git diff --check before committing.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented additive isolation_warnings discovery metadata. RED: focused service/API tests failed because isolation_warnings was absent. GREEN: 14 focused sandbox discovery/API tests passed after adding RuntimeIsolationWarningCode, runtime_isolation_warnings(), service wiring, schema field, and docs. Verification: py_compile on touched Python modules passed; Bandit on touched Python modules produced 0 findings; git diff --check passed. Broader test_feature_discovery_flags.py file was attempted but timed out in existing FastAPI lifecycle/job-worker shutdown while running unrelated lifecycle-heavy tests, so final verification used the focused service/API tests that cover this slice.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added advisory host-local isolation warning metadata to sandbox runtime discovery. The new isolation_warnings field is derived from existing RuntimeIsolationMetadata and currently flags seatbelt and worktree with host_local_boundary, not_vm_grade_isolation, and not_untrusted_eligible. This is additive discovery metadata only; admission, preflight, and runtime execution behavior are unchanged. Updated schema and sandbox docs, plus focused tests for service discovery and API response shape. Verification passed for focused pytest, py_compile, Bandit with 0 findings, and git diff --check; the broader feature_discovery_flags file timed out in unrelated lifecycle-heavy shutdown code and is documented as a known verification skip for this slice.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
@@ -14,6 +14,7 @@ from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
 from tldw_Server_API.app.core.Sandbox.runtime_capabilities import (
     RuntimeBoundaryClass,
     RuntimeImplementationState,
+    RuntimeIsolationWarningCode,
     RuntimeNetworkPolicyReadinessSource,
     RuntimeNetworkPolicySupportState,
     RuntimeReasonCode,
@@ -120,6 +121,13 @@ class SandboxRuntimeInfo(BaseModel):
         description=(
             "Whether policy may admit this runtime for untrusted workloads when "
             "preflight and host readiness also pass"
+        ),
+    )
+    isolation_warnings: list[RuntimeIsolationWarningCode] = Field(
+        default_factory=list,
+        description=(
+            "Advisory static isolation warning codes for client UX; these do "
+            "not replace policy admission, runtime preflight, or diagnostics"
         ),
     )
     network_policy_contract: SandboxRuntimeNetworkPolicyContract = Field(

--- a/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
+++ b/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
@@ -18,6 +18,11 @@ RuntimeBoundaryClass = Literal[
     "vm_grade",
     "vm_grade_scaffold",
 ]
+RuntimeIsolationWarningCode = Literal[
+    "host_local_boundary",
+    "not_vm_grade_isolation",
+    "not_untrusted_eligible",
+]
 RuntimeNetworkPolicySupportState = Literal[
     "supported",
     "unsupported",
@@ -301,7 +306,7 @@ def runtime_implementation_state(runtime: RuntimeType) -> RuntimeImplementationS
     return RUNTIME_IMPLEMENTATION_STATES.get(runtime, "unsupported")
 
 
-def runtime_isolation_metadata(runtime: RuntimeType) -> RuntimeIsolationMetadata:
+def runtime_isolation_metadata(runtime: RuntimeType | str) -> RuntimeIsolationMetadata:
     """Return stable isolation posture metadata, independent of host availability."""
     try:
         runtime_key = runtime if isinstance(runtime, RuntimeType) else RuntimeType(runtime)
@@ -312,6 +317,22 @@ def runtime_isolation_metadata(runtime: RuntimeType) -> RuntimeIsolationMetadata
     if metadata is None:
         raise ValueError(f"No isolation metadata configured for runtime {runtime!r}")
     return metadata
+
+
+def runtime_isolation_warnings(
+    runtime: RuntimeType | str,
+) -> list[RuntimeIsolationWarningCode]:
+    """Return advisory discovery warnings derived from static isolation posture."""
+    metadata = runtime_isolation_metadata(runtime)
+    if metadata.boundary_class != "host_local":
+        return []
+
+    warnings: list[RuntimeIsolationWarningCode] = ["host_local_boundary"]
+    if not metadata.vm_grade_isolation:
+        warnings.append("not_vm_grade_isolation")
+    if not metadata.untrusted_eligible:
+        warnings.append("not_untrusted_eligible")
+    return warnings
 
 
 def runtime_network_policy_metadata(

--- a/tldw_Server_API/app/core/Sandbox/service.py
+++ b/tldw_Server_API/app/core/Sandbox/service.py
@@ -60,6 +60,7 @@ from .runtime_capabilities import (
     collect_runtime_preflights,
     normalize_runtime_reasons,
     runtime_isolation_metadata,
+    runtime_isolation_warnings,
     runtime_implementation_state,
     runtime_network_policy_metadata,
 )
@@ -890,6 +891,7 @@ class SandboxService:
                 "boundary_class": isolation.boundary_class,
                 "vm_grade_isolation": isolation.vm_grade_isolation,
                 "untrusted_eligible": isolation.untrusted_eligible,
+                "isolation_warnings": runtime_isolation_warnings(runtime),
                 "network_policy_contract": network_contract.as_dict(),
             }
 

--- a/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
+++ b/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
@@ -77,6 +77,34 @@ def test_feature_discovery_reports_structured_isolation_metadata(
         assert discovery[host_local_runtime]["untrusted_eligible"] is False
 
 
+def test_feature_discovery_reports_host_local_isolation_warnings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SANDBOX_STORE_BACKEND", "memory")
+
+    discovery = {
+        str(item.get("name")): item
+        for item in SandboxService().feature_discovery()
+    }
+
+    expected_host_local_warnings = [
+        "host_local_boundary",
+        "not_vm_grade_isolation",
+        "not_untrusted_eligible",
+    ]
+    for host_local_runtime in ("seatbelt", "worktree"):
+        assert (
+            discovery[host_local_runtime]["isolation_warnings"]
+            == expected_host_local_warnings
+        )
+
+    for vm_runtime in ("firecracker", "lima", "vz_linux"):
+        assert (
+            "host_local_boundary"
+            not in discovery[vm_runtime]["isolation_warnings"]
+        )
+
+
 def test_runtime_isolation_metadata_contract_covers_runtime_enum() -> None:
     assert set(RUNTIME_ISOLATION_METADATA) == set(RuntimeType)
 

--- a/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
+++ b/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
@@ -98,10 +98,12 @@ def test_feature_discovery_reports_host_local_isolation_warnings(
             == expected_host_local_warnings
         )
 
-    for vm_runtime in ("firecracker", "lima", "vz_linux"):
+    for runtime_name, runtime_info in discovery.items():
+        if runtime_name in {"seatbelt", "worktree"}:
+            continue
         assert (
             "host_local_boundary"
-            not in discovery[vm_runtime]["isolation_warnings"]
+            not in runtime_info["isolation_warnings"]
         )
 
 

--- a/tldw_Server_API/tests/sandbox/test_sandbox_api.py
+++ b/tldw_Server_API/tests/sandbox/test_sandbox_api.py
@@ -29,8 +29,7 @@ def test_runtimes_discovery_shape(monkeypatch) -> None:
         data = r.json()
         assert "runtimes" in data and isinstance(data["runtimes"], list)
         assert len(data["runtimes"]) >= 1
-        first = data["runtimes"][0]
-        for key in [
+        required_keys = [
             "name",
             "available",
             "default_images",
@@ -44,9 +43,11 @@ def test_runtimes_discovery_shape(monkeypatch) -> None:
             "artifact_ttl_hours",
             "supported_spec_versions",
             "isolation_warnings",
-        ]:
-            assert key in first
-        assert isinstance(first["isolation_warnings"], list)
+        ]
+        for runtime in data["runtimes"]:
+            for key in required_keys:
+                assert key in runtime
+            assert isinstance(runtime["isolation_warnings"], list)
 
 
 def test_create_session_scaffold(monkeypatch) -> None:

--- a/tldw_Server_API/tests/sandbox/test_sandbox_api.py
+++ b/tldw_Server_API/tests/sandbox/test_sandbox_api.py
@@ -43,8 +43,10 @@ def test_runtimes_discovery_shape(monkeypatch) -> None:
             "workspace_cap_mb",
             "artifact_ttl_hours",
             "supported_spec_versions",
+            "isolation_warnings",
         ]:
             assert key in first
+        assert isinstance(first["isolation_warnings"], list)
 
 
 def test_create_session_scaffold(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Adds additive `isolation_warnings` metadata to sandbox runtime discovery.
- Derives warning codes from existing static isolation metadata, currently flagging `seatbelt` and `worktree` as host-local, not VM-grade, and not untrusted-eligible.
- Updates sandbox capability/security docs plus TASK-51; admission, preflight, and execution behavior are unchanged.

## Test Plan
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py tldw_Server_API/tests/sandbox/test_sandbox_api.py::test_runtimes_discovery_shape -q --timeout=60`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile tldw_Server_API/app/core/Sandbox/runtime_capabilities.py tldw_Server_API/app/core/Sandbox/service.py tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Sandbox/runtime_capabilities.py tldw_Server_API/app/core/Sandbox/service.py tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py -f json -o /tmp/bandit_sandbox_host_local_warning_metadata.json` (0 findings)
- [x] `git diff --check`

## Known Verification Note
- Attempted broader `test_feature_discovery_flags.py`, but it timed out in existing FastAPI lifecycle/job-worker shutdown while running unrelated lifecycle-heavy tests. Focused discovery/API coverage for this slice is passing.

## Change summary
- Human-authored change summary pending before merge.