### PR TITLE
Phase 2.2: defer notes router imports

### DIFF
--- a/backlog/tasks/task-52 - Phase-2.2-notes-router-conditional-cleanup-T.md
+++ b/backlog/tasks/task-52 - Phase-2.2-notes-router-conditional-cleanup-T.md
@@ -1,0 +1,56 @@
+---
+id: TASK-52
+title: Phase 2.2 notes router conditional cleanup T
+status: Done
+assignee:
+  - codex
+created_date: '2026-05-05 01:39'
+updated_date: '2026-05-05 01:43'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+  - 'https://github.com/rmusser01/tldw_server/pull/1276'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue #1116 Phase 2.2 after PR #1276 by deferring the notes-focused content router imports in iter_content_router_specs while preserving route metadata and optional-import behavior. Scope is limited to notes_graph, notes, and web_clipper in tldw_Server_API/app/api/v1/router_groups/content.py.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 notes_graph, notes, and web_clipper router specs defer module import and router attribute lookup until registration or resolution
+- [x] #2 Existing prefixes, tags, route_key values, and default_stable behavior for the notes tranche remain unchanged
+- [x] #3 Focused red/green router laziness coverage, full router contract tests, main router/OpenAPI contracts, Bandit touched source scan, and git diff hygiene are run before commit
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused router contract coverage showing iter_content_router_specs does not import or touch router attrs for notes_graph, notes, and web_clipper during spec construction. 2. Run the focused test red against origin/dev behavior. 3. Replace only the notes-focused try/except blocks with ImportedRouterSpec entries via append_imported_router_spec. 4. Re-run focused/full router contracts, main router contracts, OpenAPI contracts, Bandit on content.py, and diff hygiene. 5. Commit and open/update the next PR against dev.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added focused red/green router contract coverage for notes_graph, notes, and web_clipper. Red failed on origin/dev because iter_content_router_specs eagerly resolved all three router attributes during spec construction. Replaced only the notes-focused try/except blocks in content.py with ImportedRouterSpec entries while preserving notes_graph ordering before generic notes and keeping prefixes, tags, route keys, and default_stable behavior unchanged. Verification: focused notes laziness test red then green; router group contracts 62 passed; main router contract 6 passed; OpenAPI contracts 69 passed; Bandit touched source reported 0 results and 0 errors; git diff --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Deferred notes_graph, notes, and web_clipper content router registrations to lazy ImportedRouterSpec entries while preserving route metadata and optional-import behavior. Added contract coverage proving iter_content_router_specs does not resolve those router attrs during spec construction.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-56 - Address-PR-1279-review-isolate-notes-router-laziness-test.md
+++ b/backlog/tasks/task-56 - Address-PR-1279-review-isolate-notes-router-laziness-test.md
@@ -1,0 +1,54 @@
+---
+id: TASK-56
+title: 'Address PR #1279 review: isolate notes router laziness test'
+status: Done
+assignee:
+  - codex
+created_date: '2026-05-05 02:38'
+updated_date: '2026-05-05 02:43'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1279'
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve Qodo PR #1279 reliability finding that the notes laziness contract test resolves every content RouterSpec instead of only the targeted notes_graph, notes, and web_clipper specs.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Notes laziness test filters selected specs before resolving router factories
+- [x] #2 Test still verifies notes_graph, notes, and web_clipper metadata plus lazy attr lookup behavior
+- [x] #3 Focused/full router group, main router/OpenAPI contracts, Bandit or documented test-only skip, and diff hygiene are run before commit
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Addressed PR #1279 Qodo reliability finding after rebasing the branch onto origin/dev. The notes laziness test now selects only notes_graph, notes, and web_clipper specs by ImportedRouterSpec log_name before resolving router factories, so unrelated content routers are not imported by this focused test.
+
+Added importlib tracking for the three targeted notes modules. list(iter_content_router_specs()) leaves import_calls and router attr access at zero; resolving the selected specs imports and resolves only those three routers once.
+
+Verification passed post-rebase: focused notes laziness test; full router groups; main router contract; OpenAPI contracts; Bandit content.py 0 results and 0 errors; git diff --check.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Resolved PR #1279 review feedback by isolating the notes laziness test to the targeted notes_graph, notes, and web_clipper specs before router factory resolution. Rebased the PR branch onto latest origin/dev and verified focused/full router contracts, main router contracts, OpenAPI contracts, Bandit, and diff hygiene.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/content.py
+++ b/tldw_Server_API/app/api/v1/router_groups/content.py
@@ -509,43 +509,30 @@ def iter_content_router_specs() -> Iterable[RouterSpec]:
 
     # Notes graph routes must be registered before generic notes routes so
     # /graph is not shadowed by /{note_id}.
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.notes_graph import router as notes_graph_router
-
-        specs.append(RouterSpec(
-            router=notes_graph_router,
+    for notes_spec in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.notes_graph",
+            log_name="notes_graph",
             prefix=f"{API_V1_PREFIX}/notes",
             tags=("notes",),
             route_key="notes",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping notes_graph router: {e}")
-
-    # Notes
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.notes import router as notes_router
-
-        specs.append(RouterSpec(
-            router=notes_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.notes",
+            log_name="notes",
             prefix=f"{API_V1_PREFIX}/notes",
             tags=("notes",),
             route_key="notes",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping notes router: {e}")
-
-    # Web clipper
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.web_clipper import router as web_clipper_router
-
-        specs.append(RouterSpec(
-            router=web_clipper_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.web_clipper",
+            log_name="web_clipper",
             prefix=f"{API_V1_PREFIX}/web-clipper",
             tags=("web-clipper",),
             route_key="web-clipper",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping web_clipper router: {e}")
+        ),
+    ):
+        append_imported_router_spec(specs, notes_spec)
 
     for learning_spec in (
         ImportedRouterSpec(

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -1898,6 +1898,84 @@ def test_iter_content_router_specs_defers_output_router_attr_lookup(
     assert access_count == {module_name: 1 for module_name in module_paths}
 
 
+def test_iter_content_router_specs_defers_notes_router_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify notes and clipper specs keep router attr lookup lazy."""
+    router_definitions = (
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.notes_graph",
+            "path": "/graph",
+            "prefix": "/api/v1/notes",
+            "tags": ("notes",),
+            "route_key": "notes",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.notes",
+            "path": "/{note_id}",
+            "prefix": "/api/v1/notes",
+            "tags": ("notes",),
+            "route_key": "notes",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.web_clipper",
+            "path": "/clip",
+            "prefix": "/api/v1/web-clipper",
+            "tags": ("web-clipper",),
+            "route_key": "web-clipper",
+        },
+    )
+    access_count = {
+        str(definition["module_name"]): 0
+        for definition in router_definitions
+    }
+
+    for definition in router_definitions:
+        module_name = str(definition["module_name"])
+        router = APIRouter()
+
+        @router.get(str(definition["path"]))
+        def _endpoint() -> dict[str, str]:
+            """Return a deterministic response for the fake notes router."""
+            return {"status": "ok"}
+
+        fake_module = ModuleType(module_name)
+
+        def _module_getattr(
+            name: str,
+            *,
+            module_name: str = module_name,
+            router: APIRouter = router,
+        ) -> APIRouter:
+            """Track lazy router attribute resolution for the fake module."""
+            if name != "router":
+                raise AttributeError(name)
+            access_count[module_name] += 1
+            return router
+
+        fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    specs = list(iter_content_router_specs())
+    assert access_count == {
+        str(definition["module_name"]): 0
+        for definition in router_definitions
+    }
+
+    by_first_path = {_first_router_path(spec.router): spec for spec in specs}
+    for definition in router_definitions:
+        spec = by_first_path[str(definition["path"])]
+        assert spec.prefix == definition["prefix"]
+        assert spec.tags == definition["tags"]
+        assert spec.route_key == definition["route_key"]
+        assert spec.default_stable is True
+
+    assert access_count == {
+        str(definition["module_name"]): 1
+        for definition in router_definitions
+    }
+
+
 def test_iter_content_router_specs_defers_integration_router_attr_lookup(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -1902,9 +1902,12 @@ def test_iter_content_router_specs_defers_notes_router_attr_lookup(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Verify notes and clipper specs keep router attr lookup lazy."""
+    import importlib
+
     router_definitions = (
         {
             "module_name": "tldw_Server_API.app.api.v1.endpoints.notes_graph",
+            "expected_name": "notes_graph",
             "path": "/graph",
             "prefix": "/api/v1/notes",
             "tags": ("notes",),
@@ -1912,6 +1915,7 @@ def test_iter_content_router_specs_defers_notes_router_attr_lookup(
         },
         {
             "module_name": "tldw_Server_API.app.api.v1.endpoints.notes",
+            "expected_name": "notes",
             "path": "/{note_id}",
             "prefix": "/api/v1/notes",
             "tags": ("notes",),
@@ -1919,6 +1923,7 @@ def test_iter_content_router_specs_defers_notes_router_attr_lookup(
         },
         {
             "module_name": "tldw_Server_API.app.api.v1.endpoints.web_clipper",
+            "expected_name": "web_clipper",
             "path": "/clip",
             "prefix": "/api/v1/web-clipper",
             "tags": ("web-clipper",),
@@ -1956,24 +1961,54 @@ def test_iter_content_router_specs_defers_notes_router_attr_lookup(
         fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
         monkeypatch.setitem(sys.modules, module_name, fake_module)
 
+    real_import_module = importlib.import_module
+    target_modules = set(access_count)
+    import_calls: list[str] = []
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Track lazy module imports for selected notes router modules."""
+        if module_name in target_modules:
+            import_calls.append(module_name)
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
     specs = list(iter_content_router_specs())
     assert access_count == {
         str(definition["module_name"]): 0
         for definition in router_definitions
     }
+    assert import_calls == []
 
-    by_first_path = {_first_router_path(spec.router): spec for spec in specs}
+    selected_specs = {
+        spec.name: spec
+        for spec in specs
+        if spec.name in {str(definition["expected_name"]) for definition in router_definitions}
+    }
+    assert set(selected_specs) == {
+        str(definition["expected_name"])
+        for definition in router_definitions
+    }
+
     for definition in router_definitions:
-        spec = by_first_path[str(definition["path"])]
+        spec = selected_specs[str(definition["expected_name"])]
         assert spec.prefix == definition["prefix"]
         assert spec.tags == definition["tags"]
         assert spec.route_key == definition["route_key"]
         assert spec.default_stable is True
+        assert _first_router_path(spec.router) == definition["path"]
 
     assert access_count == {
         str(definition["module_name"]): 1
         for definition in router_definitions
     }
+    assert import_calls == [
+        str(definition["module_name"])
+        for definition in router_definitions
+    ]
 
 
 def test_iter_content_router_specs_defers_integration_router_attr_lookup(


### PR DESCRIPTION
## Summary
- Defer notes_graph, notes, and web_clipper content-router imports through lazy ImportedRouterSpec entries.
- Preserve notes_graph ordering before generic notes so /graph is not shadowed by /{note_id}.
- Add red/green router contract coverage for notes/clipper attr lookup laziness.

## Verification
- Red: python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k notes_router_attr_lookup -q failed before implementation because notes router attrs were eagerly accessed.
- Green: python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k notes_router_attr_lookup -q -> 1 passed.
- python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q -> 62 passed.
- python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q -> 6 passed.
- python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q -> 69 passed.
- python -m bandit -r tldw_Server_API/app/api/v1/router_groups/content.py -f json -o /tmp/bandit_phase2_2_notes_router_conditionals_t.json -> 0 results, 0 errors.
- git diff --check and git diff --check HEAD~1..HEAD -> clean.

## Change summary
TODO(user): Human-authored rationale required before merge per AI-generated PR policy.

Refs #1116