### PR TITLE
Phase 2.2: defer minimal LLM router imports

### DIFF
--- a/backlog/tasks/task-53 - Phase-2.2-minimal-LLM-router-conditional-cleanup-U.md
+++ b/backlog/tasks/task-53 - Phase-2.2-minimal-LLM-router-conditional-cleanup-U.md
@@ -1,0 +1,56 @@
+---
+id: TASK-53
+title: Phase 2.2 minimal LLM router conditional cleanup U
+status: Done
+assignee:
+  - codex
+created_date: '2026-05-05 01:56'
+updated_date: '2026-05-05 02:03'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+  - 'https://github.com/rmusser01/tldw_server/pull/1279'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue #1116 Phase 2.2 with an independent minimal-test router tranche while PR #1279 settles. Scope is limited to the minimal optional Llama.cpp/messages try block in tldw_Server_API/app/api/v1/router_groups/minimal.py; broader minimal optional routers remain separate follow-up slices.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Minimal optional Llama.cpp and messages router specs defer module import and router/public_router attribute lookup until registration or resolution
+- [x] #2 Existing prefixes and tags for minimal Llama.cpp/messages routers remain unchanged
+- [x] #3 Focused red/green minimal-router laziness coverage, full router contract tests, main router/OpenAPI contracts, Bandit touched source scan, and git diff hygiene are run before commit
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused contract coverage showing iter_minimal_optional_router_specs does not import or touch router/public_router attrs for Llama.cpp and messages during spec construction. 2. Run the focused test red against origin/dev behavior. 3. Replace only the minimal optional Llama.cpp/messages try block with ImportedRouterSpec entries. 4. Re-run focused/full router contracts, main router contracts, OpenAPI contracts, Bandit on minimal.py, and diff hygiene. 5. Commit and decide whether to push/open a PR after checking #1279 state.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verification: focused red failed on origin/dev with eager Llama.cpp/messages attr lookup; focused green passed after patch (1 passed, 61 deselected); full router groups passed (62 passed); main router contract passed (6 passed); OpenAPI contracts passed (69 passed); Bandit on minimal.py reported 0 results and 0 errors; git diff --check clean.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Converted only the minimal optional Llama.cpp/messages grouped eager import block to four ImportedRouterSpec entries, preserving prefixes/tags while deferring module imports and router/public_router attr lookup until registration/resolution.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-55 - Address-PR-1280-review-isolate-minimal-router-laziness-test.md
+++ b/backlog/tasks/task-55 - Address-PR-1280-review-isolate-minimal-router-laziness-test.md
@@ -1,0 +1,60 @@
+---
+id: TASK-55
+title: 'Address PR #1280 review: isolate minimal router laziness test'
+status: Done
+assignee:
+  - codex
+created_date: '2026-05-05 02:25'
+updated_date: '2026-05-05 02:31'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1280'
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the Qodo PR #1280 finding that the focused minimal Llama.cpp/messages laziness test still allows unrelated eager endpoint imports from iter_minimal_optional_router_specs. Scope is test-only isolation unless verification exposes a production issue.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The focused PR #1280 laziness test installs lightweight fakes for unrelated eager-imported minimal optional endpoint modules before calling iter_minimal_optional_router_specs
+- [x] #2 The test continues to verify Llama.cpp/messages module import and router/public_router attr lookup stay deferred until resolution
+- [x] #3 Focused test, full router group tests, main router/OpenAPI contracts, Bandit touched source scope or documented test-only skip, and diff hygiene are run before commit
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce focused test and identify unrelated real endpoint imports still happening during spec construction. 2. Add lightweight fakes for the unrelated eager-imported minimal optional endpoints before the targeted Llama.cpp/messages assertion. 3. Re-run focused/full router groups, main router contracts, OpenAPI contracts, Bandit or document test-only skip, and diff hygiene. 4. Commit, push, and update PR #1280.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Addressed PR #1280 Qodo reliability finding by moving unrelated eager endpoint isolation into test_iter_minimal_optional_router_specs_defers_llamacpp_messages_attr_lookup and using a test-local __import__ shim that returns fake routers for unrelated endpoint imports while leaving the target Llama.cpp/messages importlib path tracked for laziness.
+
+Verification passed: focused Llama.cpp/messages laziness test; full router groups; main router contract; OpenAPI contracts; git diff --check.
+
+Bandit skipped for this review fix because only test code and Backlog task metadata changed; no production source scope was touched.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Resolved PR #1280 review feedback by isolating the minimal optional Llama.cpp/messages laziness regression test from unrelated eager endpoint imports. The test now dynamically fakes unrelated endpoint router imports and explicitly verifies the early vector/embedding/media embedding imports are intercepted while the target lazy import and attr lookup assertions remain intact.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -94,36 +94,37 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
         ),
     )
 
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.llamacpp import public_router as llamacpp_public_router
-        from tldw_Server_API.app.api.v1.endpoints.llamacpp import router as llamacpp_router
-        from tldw_Server_API.app.api.v1.endpoints.messages import public_router as messages_public_router
-        from tldw_Server_API.app.api.v1.endpoints.messages import router as messages_router
-
-        specs.extend([
-            RouterSpec(
-                router=llamacpp_router,
-                prefix=f"{API_V1_PREFIX}",
-                tags=("llamacpp",),
-            ),
-            RouterSpec(
-                router=llamacpp_public_router,
-                prefix="",
-                tags=("llamacpp",),
-            ),
-            RouterSpec(
-                router=messages_router,
-                prefix=f"{API_V1_PREFIX}",
-                tags=("messages",),
-            ),
-            RouterSpec(
-                router=messages_public_router,
-                prefix="",
-                tags=("messages",),
-            ),
-        ])
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping llamacpp/messages routers in minimal test app: {e}")
+    for llm_spec in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.llamacpp",
+            log_name="llamacpp",
+            prefix=f"{API_V1_PREFIX}",
+            tags=("llamacpp",),
+            skip_context="in minimal test app",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.llamacpp",
+            log_name="llamacpp_public",
+            tags=("llamacpp",),
+            attr_name="public_router",
+            skip_context="in minimal test app",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.messages",
+            log_name="messages",
+            prefix=f"{API_V1_PREFIX}",
+            tags=("messages",),
+            skip_context="in minimal test app",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.messages",
+            log_name="messages_public",
+            tags=("messages",),
+            attr_name="public_router",
+            skip_context="in minimal test app",
+        ),
+    ):
+        append_imported_router_spec(specs, llm_spec)
 
     try:
         from tldw_Server_API.app.api.v1.endpoints.vector_stores_openai import router as vector_stores_router

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -2846,6 +2846,7 @@ def test_iter_minimal_optional_router_specs_defers_llamacpp_messages_attr_lookup
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Verify minimal Llama.cpp/messages specs keep router attr lookup lazy."""
+    import builtins
     import importlib
 
     from tldw_Server_API.app.api.v1.router_groups.minimal import (
@@ -2927,6 +2928,37 @@ def test_iter_minimal_optional_router_specs_defers_llamacpp_messages_attr_lookup
         fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
         monkeypatch.setitem(sys.modules, module_name, fake_module)
 
+    endpoints_package = "tldw_Server_API.app.api.v1.endpoints."
+    fake_unrelated_eager_imports: list[str] = []
+    real_import = builtins.__import__
+
+    def _fake_endpoint_import(
+        name: str,
+        globals: dict[str, object] | None = None,
+        locals: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> ModuleType:
+        """Return fake routers for unrelated eager minimal optional imports."""
+        if (
+            level == 0
+            and name.startswith(endpoints_package)
+            and name not in definitions_by_module
+        ):
+            attrs = tuple(attr for attr in fromlist if attr != "*") or ("router",)
+            fake_unrelated_eager_imports.append(name)
+            for attr_name in attrs:
+                _install_fake_router_module(
+                    monkeypatch,
+                    name,
+                    path=f"/minimal-unrelated-fake/{len(fake_unrelated_eager_imports)}",
+                    attr_name=attr_name,
+                )
+            return sys.modules[name]
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_endpoint_import)
+
     real_import_module = importlib.import_module
 
     def _import_module(module_name: str, package: str | None = None) -> ModuleType:
@@ -2949,6 +2981,11 @@ def test_iter_minimal_optional_router_specs_defers_llamacpp_messages_attr_lookup
         for definition in router_definitions
     }
     assert import_calls == []
+    assert {
+        "tldw_Server_API.app.api.v1.endpoints.vector_stores_openai",
+        "tldw_Server_API.app.api.v1.endpoints.embeddings_v5_production_enhanced",
+        "tldw_Server_API.app.api.v1.endpoints.media_embeddings",
+    }.issubset(set(fake_unrelated_eager_imports))
 
     selected_specs = {
         spec.name: spec

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -2842,6 +2842,144 @@ def test_iter_minimal_test_router_specs_includes_health_and_auth(
     assert by_first_path["/auth/login"].route_key == ""
 
 
+def test_iter_minimal_optional_router_specs_defers_llamacpp_messages_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal Llama.cpp/messages specs keep router attr lookup lazy."""
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    router_definitions = (
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.llamacpp",
+            "attr_name": "router",
+            "expected_name": "llamacpp",
+            "path": "/llamacpp/completions",
+            "prefix": "/api/v1",
+            "tags": ("llamacpp",),
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.llamacpp",
+            "attr_name": "public_router",
+            "expected_name": "llamacpp_public",
+            "path": "/llamacpp/public/completions",
+            "prefix": "",
+            "tags": ("llamacpp",),
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.messages",
+            "attr_name": "router",
+            "expected_name": "messages",
+            "path": "/messages/send",
+            "prefix": "/api/v1",
+            "tags": ("messages",),
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.messages",
+            "attr_name": "public_router",
+            "expected_name": "messages_public",
+            "path": "/messages/public/send",
+            "prefix": "",
+            "tags": ("messages",),
+        },
+    )
+    definitions_by_module: dict[str, list[dict[str, object]]] = {}
+    for definition in router_definitions:
+        definitions_by_module.setdefault(str(definition["module_name"]), []).append(
+            definition,
+        )
+
+    access_count = {
+        f"{definition['module_name']}.{definition['attr_name']}": 0
+        for definition in router_definitions
+    }
+    import_calls: list[str] = []
+
+    for module_name, module_definitions in definitions_by_module.items():
+        routers_by_attr: dict[str, APIRouter] = {}
+        fake_module = ModuleType(module_name)
+
+        for definition in module_definitions:
+            router = APIRouter()
+
+            @router.get(str(definition["path"]))
+            def _endpoint() -> dict[str, str]:
+                """Return a deterministic response for the fake minimal router."""
+                return {"status": "ok"}
+
+            routers_by_attr[str(definition["attr_name"])] = router
+
+        def _module_getattr(
+            name: str,
+            *,
+            module_name: str = module_name,
+            routers_by_attr: dict[str, APIRouter] = routers_by_attr,
+        ) -> APIRouter:
+            """Track lazy router attribute resolution for the fake module."""
+            if name not in routers_by_attr:
+                raise AttributeError(name)
+            access_count[f"{module_name}.{name}"] += 1
+            return routers_by_attr[name]
+
+        fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Track lazy module imports for selected minimal routers."""
+        if module_name in definitions_by_module:
+            import_calls.append(module_name)
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+    fake_main = ModuleType("tldw_Server_API.app.main")
+    fake_main.app = FastAPI()  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "tldw_Server_API.app.main", fake_main)
+
+    specs = list(iter_minimal_optional_router_specs())
+    assert access_count == {
+        f"{definition['module_name']}.{definition['attr_name']}": 0
+        for definition in router_definitions
+    }
+    assert import_calls == []
+
+    selected_specs = {
+        spec.name: spec
+        for spec in specs
+        if spec.name in {
+            str(definition["expected_name"])
+            for definition in router_definitions
+        }
+    }
+    assert set(selected_specs) == {
+        str(definition["expected_name"])
+        for definition in router_definitions
+    }
+
+    for definition in router_definitions:
+        spec = selected_specs[str(definition["expected_name"])]
+        assert spec.prefix == definition["prefix"]
+        assert spec.tags == definition["tags"]
+        assert spec.route_key == ""
+        assert _first_router_path(spec.router) == definition["path"]
+
+    assert import_calls == [
+        str(definition["module_name"])
+        for definition in router_definitions
+    ]
+    assert access_count == {
+        f"{definition['module_name']}.{definition['attr_name']}": 1
+        for definition in router_definitions
+    }
+
+
 def test_iter_minimal_optional_router_specs_populates_llm_specs(monkeypatch: pytest.MonkeyPatch) -> None:
     from tldw_Server_API.app.api.v1.router_groups.minimal import iter_minimal_optional_router_specs
 


### PR DESCRIPTION
## Summary
- Defer minimal-test Llama.cpp/messages optional routers with `ImportedRouterSpec` entries instead of eager grouped imports.
- Preserve existing prefixes/tags for `llamacpp`, `llamacpp_public`, `messages`, and `messages_public`.
- Add focused contract coverage for lazy module import and router/public_router attr lookup.

## Verification
- `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k llamacpp_messages_attr_lookup -q` red on origin/dev, then green after patch
- `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q` -> 62 passed
- `python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q` -> 6 passed
- `python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q` -> 69 passed
- `python -m bandit -r tldw_Server_API/app/api/v1/router_groups/minimal.py -f json -o /tmp/bandit_phase2_2_minimal_llm_router_conditionals_u.json` -> 0 results, 0 errors
- `git diff --check`

## Change summary
TODO(user): Add the required human-written summary explaining what changed and why this implementation was chosen before merge.

Refs #1116