### PR TITLE
Phase 2.2: defer learning writing router imports

### DIFF
--- a/backlog/tasks/task-54 - Phase-2.2-learning-writing-router-conditional-cleanup-V.md
+++ b/backlog/tasks/task-54 - Phase-2.2-learning-writing-router-conditional-cleanup-V.md
@@ -1,0 +1,57 @@
+---
+id: TASK-54
+title: Phase 2.2 learning/writing router conditional cleanup V
+status: Done
+assignee:
+  - codex
+created_date: '2026-05-05 02:11'
+updated_date: '2026-05-05 02:15'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+  - 'https://github.com/rmusser01/tldw_server/pull/1279'
+  - 'https://github.com/rmusser01/tldw_server/pull/1280'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue #1116 Phase 2.2 with a content-tail learning/writing tranche. Scope is limited to translate/slides/flashcards/quizzes/study_suggestions/writing/writing_manuscripts eager router imports in tldw_Server_API/app/api/v1/router_groups/content.py; open notes/minimal PRs remain separate.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Content translate/slides/flashcards/quizzes/study/writing router specs defer module import and router attr lookup until registration or resolution
+- [x] #2 Existing prefixes/tags/route keys/default stability for those content routers remain unchanged
+- [x] #3 Focused red/green coverage, full router group tests, main router/OpenAPI contracts, Bandit touched source scan, and git diff hygiene are run before commit
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused content-router contract coverage proving translate/slides/learning/writing modules are not imported and router attrs are not touched during iter_content_router_specs construction. 2. Run the focused test red on origin/dev behavior. 3. Replace only the selected content.py eager try blocks with ImportedRouterSpec entries. 4. Re-run focused/full router groups, main router contracts, OpenAPI contracts, Bandit on content.py, and diff hygiene. 5. Commit, push, create PR against dev, and update #1116.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verification: focused red failed on origin/dev with eager attr lookup for translate/slides/flashcards/quizzes/study_suggestions/writing/writing_manuscripts; focused green passed after patch (1 passed, 61 deselected); full router groups passed (62 passed); main router contract passed (6 passed); OpenAPI contracts passed (69 passed); Bandit on content.py reported 0 results and 0 errors; git diff --check clean.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Converted only the content-tail translate/slides/learning/writing eager try blocks to ImportedRouterSpec entries, preserving prefixes/tags/route keys/default stability while deferring imports and router attr lookup until registration or resolution.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/content.py
+++ b/tldw_Server_API/app/api/v1/router_groups/content.py
@@ -547,97 +547,58 @@ def iter_content_router_specs() -> Iterable[RouterSpec]:
     except Exception as e:  # noqa: BLE001
         logger.debug(f"Skipping web_clipper router: {e}")
 
-    # Translation
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.translate import router as translate_router
-
-        specs.append(RouterSpec(
-            router=translate_router,
+    for learning_spec in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.translate",
+            log_name="translate",
             prefix=f"{API_V1_PREFIX}",
             tags=("translation",),
             route_key="translation",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping translate router: {e}")
-
-    # Slides
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.slides import router as slides_router
-
-        specs.append(RouterSpec(
-            router=slides_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.slides",
+            log_name="slides",
             prefix=f"{API_V1_PREFIX}",
             tags=("slides",),
             route_key="slides",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping slides router: {e}")
-
-    # Study content endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.flashcards import router as flashcards_router
-
-        specs.append(RouterSpec(
-            router=flashcards_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.flashcards",
+            log_name="flashcards",
             prefix=f"{API_V1_PREFIX}",
             tags=("flashcards",),
             route_key="flashcards",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping flashcards router: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.quizzes import router as quizzes_router
-
-        specs.append(RouterSpec(
-            router=quizzes_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.quizzes",
+            log_name="quizzes",
             prefix=f"{API_V1_PREFIX}",
             tags=("quizzes",),
             route_key="quizzes",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping quizzes router: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.study_suggestions import (
-            router as study_suggestions_router,
-        )
-
-        specs.append(RouterSpec(
-            router=study_suggestions_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.study_suggestions",
+            log_name="study_suggestions",
             prefix=f"{API_V1_PREFIX}",
             tags=("study-suggestions",),
             route_key="study-suggestions",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping study_suggestions router: {e}")
-
-    # Writing playground endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.writing import router as writing_router
-
-        specs.append(RouterSpec(
-            router=writing_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.writing",
+            log_name="writing",
             prefix=f"{API_V1_PREFIX}/writing",
             tags=("writing",),
             route_key="writing",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping writing router: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.writing_manuscripts import (
-            router as manuscripts_router,
-        )
-
-        specs.append(RouterSpec(
-            router=manuscripts_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.writing_manuscripts",
+            log_name="writing_manuscripts",
             prefix=f"{API_V1_PREFIX}/writing/manuscripts",
             tags=("manuscripts",),
             route_key="manuscripts",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping writing_manuscripts router: {e}")
+        ),
+    ):
+        append_imported_router_spec(specs, learning_spec)
 
     # Chatbooks and sharing endpoints
     try:

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -2635,6 +2635,142 @@ def test_iter_content_router_specs_defers_kanban_router_attr_lookup(
     }
 
 
+def test_iter_content_router_specs_defers_learning_writing_router_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify learning/writing specs keep import and attr lookup lazy."""
+    import importlib
+
+    router_definitions = [
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.translate",
+            "path": "/translate",
+            "prefix": "/api/v1",
+            "tags": ("translation",),
+            "route_key": "translation",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.slides",
+            "path": "/slides",
+            "prefix": "/api/v1",
+            "tags": ("slides",),
+            "route_key": "slides",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.flashcards",
+            "path": "/flashcards",
+            "prefix": "/api/v1",
+            "tags": ("flashcards",),
+            "route_key": "flashcards",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.quizzes",
+            "path": "/quizzes",
+            "prefix": "/api/v1",
+            "tags": ("quizzes",),
+            "route_key": "quizzes",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.study_suggestions",
+            "path": "/study/suggestions",
+            "prefix": "/api/v1",
+            "tags": ("study-suggestions",),
+            "route_key": "study-suggestions",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.writing",
+            "path": "/writing",
+            "prefix": "/api/v1/writing",
+            "tags": ("writing",),
+            "route_key": "writing",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.writing_manuscripts",
+            "path": "/writing/manuscripts",
+            "prefix": "/api/v1/writing/manuscripts",
+            "tags": ("manuscripts",),
+            "route_key": "manuscripts",
+        },
+    ]
+    routers_by_module: dict[str, APIRouter] = {}
+    access_count = {
+        str(definition["module_name"]): 0 for definition in router_definitions
+    }
+    import_calls: list[str] = []
+
+    for definition in router_definitions:
+        module_name = str(definition["module_name"])
+        router = APIRouter()
+
+        @router.get(str(definition["path"]))
+        def _endpoint() -> dict[str, str]:
+            """Return a deterministic response for the fake learning router."""
+            return {"status": "ok"}
+
+        routers_by_module[module_name] = router
+        fake_module = ModuleType(module_name)
+
+        def _module_getattr(
+            name: str,
+            *,
+            module_name: str = module_name,
+            router: APIRouter = router,
+        ) -> APIRouter:
+            """Track lazy router attribute resolution for the fake module."""
+            if name != "router":
+                raise AttributeError(name)
+            access_count[module_name] += 1
+            return router
+
+        fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Track lazy module imports for selected learning/writing routers."""
+        if module_name in routers_by_module:
+            import_calls.append(module_name)
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    specs = list(iter_content_router_specs())
+    assert access_count == {
+        str(definition["module_name"]): 0 for definition in router_definitions
+    }
+    assert import_calls == []
+
+    selected_specs = {
+        spec.route_key: spec
+        for spec in specs
+        if spec.route_key in {
+            str(definition["route_key"])
+            for definition in router_definitions
+        }
+    }
+    assert set(selected_specs) == {
+        str(definition["route_key"]) for definition in router_definitions
+    }
+
+    for definition in router_definitions:
+        spec = selected_specs[str(definition["route_key"])]
+        assert spec.prefix == definition["prefix"]
+        assert spec.tags == definition["tags"]
+        assert spec.default_stable is True
+        assert _first_router_path(spec.router) == definition["path"]
+
+    assert import_calls == [
+        str(definition["module_name"]) for definition in router_definitions
+    ]
+    assert access_count == {
+        str(definition["module_name"]): 1 for definition in router_definitions
+    }
+
+
 def test_qodo_reviewed_router_policy_regressions(monkeypatch: pytest.MonkeyPatch) -> None:
     _install_fake_router_module(
         monkeypatch,


### PR DESCRIPTION
## Summary
- Defer content-tail translate/slides/learning/writing router imports with `ImportedRouterSpec`.
- Preserve prefixes, tags, route keys, and default stability for translation, slides, flashcards, quizzes, study suggestions, writing, and writing manuscripts.
- Add focused contract coverage for lazy module import and router attr lookup.

## Verification
- `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k learning_writing_router_attr_lookup -q` red on origin/dev, then green after patch
- `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q` -> 62 passed
- `python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q` -> 6 passed
- `python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q` -> 69 passed
- `python -m bandit -r tldw_Server_API/app/api/v1/router_groups/content.py -f json -o /tmp/bandit_phase2_2_learning_writing_router_conditionals_v.json` -> 0 results, 0 errors
- `git diff --check`

## Change summary
TODO(user): Add the required human-written summary explaining what changed and why this implementation was chosen before merge.

Refs #1116