### PR TITLE
feat(sandbox): centralize network policy effective support

### DIFF
--- a/Docs/Sandbox/sandbox-runtime-capability-inventory.md
+++ b/Docs/Sandbox/sandbox-runtime-capability-inventory.md
@@ -160,10 +160,17 @@ It does not replace `available`, raw `reasons`, `normalized_reasons`, or
 uses the same support-state vocabulary as this inventory and records whether a
 policy can ever be strictly enforced by the runtime.
 
+Effective support is stricter than either static metadata or raw readiness by
+itself. A runtime reports `strict_deny_all_supported` or
+`strict_allowlist_supported` only when the static contract is `supported` or
+`host_gated`, `strict_enforcement=true`, and current readiness for that policy
+is true. `scaffold` and `unsupported` modes remain false even if an operator
+sets experimental flags.
+
 | Runtime | `deny_all` | `allowlist` | Notes |
 | --- | --- | --- | --- |
-| `docker` | `supported` | `host_gated` | Deny-all can use container network isolation. Allowlist depends on configured egress enforcement. |
-| `firecracker` | `host_gated` | `scaffold` | Real mode requires a prepared Linux/KVM host. Allowlist is advertised only behind explicit enforcement flags and remains planned. |
+| `docker` | `supported` | `host_gated` | Deny-all can use container network isolation. Allowlist is effective only when egress enforcement and granular enforcement are both configured; the `network=none` fallback is treated as deny-all, not allowlist. |
+| `firecracker` | `host_gated` | `scaffold` | Real mode requires a prepared Linux/KVM host. Allowlist remains planned and is not advertised as effective support. |
 | `lima` | `host_gated` | `unsupported` | Deny-all depends on the Lima enforcer preflight. Service discovery intentionally forces allowlist false for execution. |
 | `vz_linux` | `host_gated` | `unsupported` | Real helper path accepts `deny_all` only and attaches no guest network device. |
 | `vz_macos` | `scaffold` | `unsupported` | No real execution yet. |
@@ -219,7 +226,7 @@ an equally clear ownership model.
 | Gap | Runtime(s) | Follow-up phase |
 | --- | --- | --- |
 | Host-local runtimes need clearer docs/API warnings that they are not VM-grade. | `seatbelt`, `worktree` | Phase 2 |
-| Allowlist support is inconsistent and often scaffold-only. | all except host-local unsupported paths | Phase 2 |
+| Additional real allowlist implementations remain limited beyond Docker granular enforcement. | all except unsupported paths | Future |
 | Detailed runner-internal error strings still vary by runtime behind `runtime_error`. | all | Phase 3 |
 | Session semantics are not normalized across warm VM, container, and host-local reuse. | all | Phase 4 |
 | Recovery/repair ownership exists only for `vz_linux`. | all except `vz_linux` | Phase 4 |

--- a/Docs/Sandbox/sandbox-security-policy-matrix.md
+++ b/Docs/Sandbox/sandbox-security-policy-matrix.md
@@ -78,10 +78,15 @@ It records each policy's support state, whether strict enforcement is possible,
 and whether current readiness should be read from runtime preflight, operator
 configuration, or nowhere because the policy is unsupported.
 
+Effective discovery booleans such as `strict_deny_all_supported`,
+`strict_allowlist_supported`, and `egress_allowlist_supported` require both a
+strict static contract and current readiness. Scaffold or unsupported modes must
+stay false even when environment flags or test preflights report readiness.
+
 | Runtime | `deny_all` semantics | `allowlist` semantics | Operator rule |
 | --- | --- | --- | --- |
-| `docker` | Supported through container network isolation where configured. | Supported only when Docker egress enforcement is enabled and healthy. | Do not advertise allowlist unless enforcement is configured. |
-| `firecracker` | Host-gated strict deny-all when VM networking is absent or blocked. | Scaffold. | Fail closed when host enforcement cannot prove the requested policy. |
+| `docker` | Supported through container network isolation where configured. | Supported only when Docker egress enforcement and granular enforcement are enabled. | Do not advertise allowlist when execution would fall back to `network=none`; that fallback is deny-all, not allowlist. |
+| `firecracker` | Host-gated strict deny-all when VM networking is absent or blocked. | Scaffold. | Fail closed when host enforcement cannot prove the requested policy; do not advertise scaffold allowlist as effective support. |
 | `lima` | Host-gated strict deny-all through Lima enforcer readiness. | Unsupported for execution today. | `allowlist` requests must be rejected even if test overrides report readiness. |
 | `vz_linux` | Strict deny-all by Python admission plus helper rejection of non-`deny_all` VM creation; current VM config attaches no network device. | Unsupported. | Helper metadata should echo the accepted policy for diagnostics. |
 | `vz_macos` | Scaffold only. | Unsupported. | Do not claim real network enforcement until real execution exists. |

--- a/Docs/superpowers/plans/2026-05-05-sandbox-network-effective-support-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-05-sandbox-network-effective-support-implementation-plan.md
@@ -1,0 +1,155 @@
+# Sandbox Network Effective Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make sandbox network policy discovery and admission derive effective support from static policy contracts plus current readiness.
+
+**Architecture:** Add one effective-support helper in `runtime_capabilities.py`, feed Docker/Firecracker readiness into shared preflight collection, and make policy admission plus discovery consume the helper. Keep unsupported/scaffold allowlist paths fail-closed and avoid adding new runtime allowlist implementations.
+
+**Tech Stack:** Python dataclasses/helpers, pytest, existing SandboxService/SandboxPolicy contracts, Bandit.
+
+---
+
+### Task 1: Add Failing Coverage For Effective Network Support
+
+**Files:**
+- Modify: `tldw_Server_API/tests/sandbox/test_network_policy_contract_admission.py`
+- Modify: `tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py`
+
+- [ ] **Step 1: Extend admission helper test setup**
+
+Allow `_available_preflight()` in
+`test_network_policy_contract_admission.py` to accept an `enforcement_ready`
+override so tests can model ready and not-ready policy modes.
+
+- [ ] **Step 2: Add Docker not-ready rejection test**
+
+Add a test asserting Docker `allowlist` is rejected when the Docker preflight
+has `{"deny_all": True, "allowlist": False}`.
+
+- [ ] **Step 3: Preserve Docker ready admission**
+
+Keep or add a test asserting Docker `allowlist` is admitted when the preflight
+has `{"deny_all": True, "allowlist": True}`.
+
+- [ ] **Step 4: Add discovery consistency tests**
+
+In `test_runtime_inventory_contract.py`, assert each runtime's
+`strict_deny_all_supported` and `strict_allowlist_supported` values match
+`runtime_network_policy_effective_support(runtime, enforcement_ready)`.
+
+- [ ] **Step 5: Confirm RED**
+
+Run:
+
+```bash
+python -m pytest \
+  tldw_Server_API/tests/sandbox/test_network_policy_contract_admission.py \
+  tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py \
+  -q --timeout=60
+```
+
+Expected: fail because admission still checks static support only and discovery
+does not use the shared effective-support helper.
+
+### Task 2: Implement Effective Support Helper And Admission
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Sandbox/runtime_capabilities.py`
+- Modify: `tldw_Server_API/app/core/Sandbox/policy.py`
+
+- [ ] **Step 1: Add readiness helpers**
+
+Add Docker config readiness helpers to `runtime_capabilities.py` so
+`collect_runtime_preflights()` can set Docker `enforcement_ready` for `deny_all`
+and `allowlist`.
+
+- [ ] **Step 2: Add effective-support helper**
+
+Add `runtime_network_policy_effective_support(runtime, enforcement_ready)`.
+Return false unless the static contract is `supported` or `host_gated`, strict
+enforcement is possible, and current readiness is true.
+
+- [ ] **Step 3: Wire preflight readiness**
+
+Set Docker readiness to `deny_all=docker_available` and
+`allowlist=docker_available and egress_enforcement and granular_enforcement`.
+Set Firecracker readiness to `deny_all=firecracker_available` and
+`allowlist=False`.
+
+- [ ] **Step 4: Wire policy admission**
+
+Update `_require_network_policy_supported()` to accept the selected runtime
+preflight and use `runtime_network_policy_effective_support()`. Pass the
+selected preflight from `apply_to_session()` and `apply_to_run()`.
+
+- [ ] **Step 5: Confirm GREEN for admission tests**
+
+Run the focused command from Task 1.
+
+### Task 3: Align Discovery And Docs
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Sandbox/service.py`
+- Modify: `Docs/Sandbox/sandbox-runtime-capability-inventory.md`
+- Modify: `Docs/Sandbox/sandbox-security-policy-matrix.md`
+- Modify: `backlog/tasks/task-54 - Stabilize-sandbox-network-policy-effective-support-reporting.md`
+
+- [ ] **Step 1: Derive discovery booleans from the helper**
+
+Use `runtime_network_policy_effective_support()` inside
+`SandboxService.feature_discovery()` so `strict_deny_all_supported`,
+`strict_allowlist_supported`, and `egress_allowlist_supported` are effective
+support signals, not raw preflight/config echoes.
+
+- [ ] **Step 2: Update Firecracker notes**
+
+Ensure Firecracker discovery notes do not imply allowlist is usable today when
+it remains scaffold/non-strict.
+
+- [ ] **Step 3: Update docs**
+
+Document that effective support requires the static contract and current
+readiness to agree. Clarify that Docker's coarse `network=none` fallback is not
+advertised as allowlist support.
+
+- [ ] **Step 4: Run verification**
+
+Run:
+
+```bash
+python -m pytest \
+  tldw_Server_API/tests/sandbox/test_network_policy_contract_admission.py \
+  tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py \
+  tldw_Server_API/tests/sandbox/test_lima_strict_admission.py \
+  -q --timeout=60
+python -m py_compile \
+  tldw_Server_API/app/core/Sandbox/runtime_capabilities.py \
+  tldw_Server_API/app/core/Sandbox/policy.py \
+  tldw_Server_API/app/core/Sandbox/service.py
+python -m bandit -r \
+  tldw_Server_API/app/core/Sandbox/runtime_capabilities.py \
+  tldw_Server_API/app/core/Sandbox/policy.py \
+  tldw_Server_API/app/core/Sandbox/service.py \
+  -f json -o /tmp/bandit_sandbox_network_effective_support.json
+git diff --check
+```
+
+- [ ] **Step 5: Finalize task and commit**
+
+Update `TASK-54`, stage all touched files, and commit:
+
+```bash
+git add \
+  Docs/Sandbox/sandbox-runtime-capability-inventory.md \
+  Docs/Sandbox/sandbox-security-policy-matrix.md \
+  Docs/superpowers/specs/2026-05-05-sandbox-network-effective-support-design.md \
+  Docs/superpowers/plans/2026-05-05-sandbox-network-effective-support-implementation-plan.md \
+  "backlog/tasks/task-54 - Stabilize-sandbox-network-policy-effective-support-reporting.md" \
+  tldw_Server_API/app/core/Sandbox/runtime_capabilities.py \
+  tldw_Server_API/app/core/Sandbox/policy.py \
+  tldw_Server_API/app/core/Sandbox/service.py \
+  tldw_Server_API/tests/sandbox/test_network_policy_contract_admission.py \
+  tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
+git commit -m "feat(sandbox): centralize network policy effective support"
+```

--- a/Docs/superpowers/specs/2026-05-05-sandbox-network-effective-support-design.md
+++ b/Docs/superpowers/specs/2026-05-05-sandbox-network-effective-support-design.md
@@ -1,0 +1,102 @@
+# Sandbox Network Effective Support Design
+
+## Goal
+
+Stabilize sandbox network policy discovery and admission so `allowlist` is only
+reported or admitted when a runtime can strictly enforce that policy right now.
+
+## Context
+
+The sandbox runtime inventory already exposes a static `network_policy_contract`
+for `deny_all` and `allowlist`. The contract records whether a policy is
+supported, host-gated, scaffold-only, or unsupported, and whether strict
+enforcement is possible.
+
+The remaining Phase 2 gap is effective support drift:
+
+- Policy admission uses the static contract but does not check current
+  readiness for host-gated/config-gated policies.
+- Docker discovery can report allowlist support through older
+  `egress_allowlist_supported` wording even when the execution path would fall
+  back to `network=none`.
+- Firecracker allowlist is scaffold/planned and must not be advertised as
+  currently usable, even if operator flags are set.
+
+## Design
+
+Add a single effective-support helper in
+`tldw_Server_API/app/core/Sandbox/runtime_capabilities.py`:
+
+```python
+runtime_network_policy_effective_support(
+    runtime: RuntimeType | str,
+    enforcement_ready: Mapping[str, bool] | None,
+) -> dict[str, bool]
+```
+
+The helper evaluates each policy mode with the same rules:
+
+1. Static contract must be `supported` or `host_gated`.
+2. Static contract must have `strict_enforcement=True`.
+3. Current readiness for that policy must be true.
+
+This deliberately treats `scaffold`, `unsupported`, and non-strict modes as
+false even when raw runtime preflight or environment flags claim readiness.
+
+## Runtime Readiness Inputs
+
+`collect_runtime_preflights()` should provide useful readiness facts for
+runtimes that do not have a dedicated preflight object today:
+
+- Docker: `deny_all=True` when Docker is available; `allowlist=True` only when
+  Docker is available and both egress enforcement and granular enforcement are
+  enabled.
+- Firecracker: `deny_all=True` when Firecracker is available; `allowlist=False`
+  because the static contract remains scaffold/non-strict.
+- Lima, VZ, seatbelt, and worktree continue to use their existing runner
+  preflights.
+
+## Admission
+
+`SandboxPolicy._require_network_policy_supported()` should use the effective
+support helper and the runtime's current preflight result. A requested policy is
+admitted only when the helper returns true.
+
+This preserves existing fail-closed reasons:
+
+- invalid policy -> `unsupported_network_policy`
+- unsupported `allowlist` -> `strict_allowlist_not_supported`
+- unsupported `deny_all` -> `strict_deny_all_not_supported`
+
+## Discovery
+
+`SandboxService.feature_discovery()` should derive legacy discovery booleans
+from the same effective-support helper:
+
+- `strict_deny_all_supported`
+- `strict_allowlist_supported`
+- runtime-specific `egress_allowlist_supported`
+
+The raw `enforcement_ready` object remains visible for diagnostics, but clients
+should treat the strict support booleans as the effective admission signal.
+
+## Non-Goals
+
+- Do not implement granular allowlist support for Firecracker, Lima, VZ, or
+  host-local runtimes.
+- Do not change the static `network_policy_contract` vocabulary.
+- Do not add a new public API field unless tests show existing fields cannot
+  express the contract clearly.
+- Do not treat Docker's `network=none` fallback as a valid `allowlist`.
+
+## Testing
+
+Add focused tests for:
+
+- Docker allowlist admission fails when granular enforcement is not ready.
+- Docker allowlist admission succeeds when granular enforcement readiness is
+  explicitly true.
+- Firecracker allowlist remains rejected even if raw readiness is true.
+- Discovery strict support booleans match effective support for every runtime.
+- Docker discovery reports allowlist support only when granular enforcement is
+  enabled.

--- a/backlog/tasks/task-54 - Stabilize-sandbox-network-policy-effective-support-reporting.md
+++ b/backlog/tasks/task-54 - Stabilize-sandbox-network-policy-effective-support-reporting.md
@@ -4,7 +4,7 @@ title: Stabilize sandbox network policy effective support reporting
 status: Done
 assignee: []
 created_date: '2026-05-05 02:11'
-updated_date: '2026-05-05 02:30'
+updated_date: '2026-05-05 02:34'
 labels:
   - sandbox
   - network-policy
@@ -49,6 +49,10 @@ Implemented network policy effective support gating. RED: Docker allowlist admis
 PR review follow-up: verifying and fixing Qodo findings for _settings_flag() observability and missing-preflight SandboxPolicy admission compatibility.
 
 PR review fixes completed. Added regression coverage for missing-preflight Docker deny_all admission and _settings_flag() observability. Implemented static supported-only fallback for direct SandboxPolicy callers without preflights and warning logging for readiness flag read failures. Verification: 44 sandbox policy/discovery tests passed, py_compile passed, Bandit reported 0 findings for touched Sandbox modules, and git diff --check passed.
+
+Additional PR review follow-up: verifying Gemini cleanup suggestions for shared noncritical exceptions, _settings_flag() signature redundancy, and redundant service effective-support calculations.
+
+Additional Gemini review fixes completed. Centralized the shared config noncritical exception tuple for policy/runtime capability config parsing, simplified _settings_flag() to a single setting name, and reused _preflight_fields() results for Docker/Firecracker/Lima effective support in feature discovery. Verification rerun: 44 sandbox policy/discovery tests passed, py_compile passed, Bandit reported 0 findings for touched Sandbox modules, and git diff --check passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
@@ -57,6 +61,8 @@ PR review fixes completed. Added regression coverage for missing-preflight Docke
 Centralized sandbox network-policy effective support so discovery and admission use the same static contract plus current readiness calculation. Docker allowlist now requires granular egress enforcement readiness; scaffold/unsupported allowlist paths remain fail-closed and cannot be over-advertised through legacy discovery booleans. Updated network-policy docs and focused tests.
 
 PR review follow-up: fixed Qodo findings by adding operator-visible logging for readiness flag read failures and preserving no-preflight direct SandboxPolicy callers for statically supported Docker deny_all while keeping host-gated/scaffold policies fail-closed.
+
+Additional PR review follow-up: addressed Gemini cleanup comments by centralizing shared config exception handling, simplifying readiness flag lookup, and removing redundant service effective-support calculations.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-54 - Stabilize-sandbox-network-policy-effective-support-reporting.md
+++ b/backlog/tasks/task-54 - Stabilize-sandbox-network-policy-effective-support-reporting.md
@@ -4,7 +4,7 @@ title: Stabilize sandbox network policy effective support reporting
 status: Done
 assignee: []
 created_date: '2026-05-05 02:11'
-updated_date: '2026-05-05 02:15'
+updated_date: '2026-05-05 02:30'
 labels:
   - sandbox
   - network-policy
@@ -45,12 +45,18 @@ Make sandbox runtime discovery and admission report effective network policy sup
 
 <!-- SECTION:NOTES:BEGIN -->
 Implemented network policy effective support gating. RED: Docker allowlist admission with allowlist readiness false did not raise, and discovery tests failed because runtime_network_policy_effective_support() did not exist. GREEN: added the helper, Docker/Firecracker readiness facts, policy admission wiring, and discovery wiring. Docker allowlist is now effectively supported only with Docker available plus egress enforcement plus granular enforcement; Docker network=none fallback is treated as deny_all, not allowlist. Firecracker allowlist remains scaffold and is never advertised as effective support. Verification: focused sandbox admission/discovery/Lima tests passed (33 tests), py_compile passed for touched production modules, Bandit reported 0 findings for touched production modules, and git diff --check passed.
+
+PR review follow-up: verifying and fixing Qodo findings for _settings_flag() observability and missing-preflight SandboxPolicy admission compatibility.
+
+PR review fixes completed. Added regression coverage for missing-preflight Docker deny_all admission and _settings_flag() observability. Implemented static supported-only fallback for direct SandboxPolicy callers without preflights and warning logging for readiness flag read failures. Verification: 44 sandbox policy/discovery tests passed, py_compile passed, Bandit reported 0 findings for touched Sandbox modules, and git diff --check passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Centralized sandbox network-policy effective support so discovery and admission use the same static contract plus current readiness calculation. Docker allowlist now requires granular egress enforcement readiness; scaffold/unsupported allowlist paths remain fail-closed and cannot be over-advertised through legacy discovery booleans. Updated network-policy docs and focused tests.
+
+PR review follow-up: fixed Qodo findings by adding operator-visible logging for readiness flag read failures and preserving no-preflight direct SandboxPolicy callers for statically supported Docker deny_all while keeping host-gated/scaffold policies fail-closed.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-54 - Stabilize-sandbox-network-policy-effective-support-reporting.md
+++ b/backlog/tasks/task-54 - Stabilize-sandbox-network-policy-effective-support-reporting.md
@@ -1,0 +1,64 @@
+---
+id: TASK-54
+title: Stabilize sandbox network policy effective support reporting
+status: Done
+assignee: []
+created_date: '2026-05-05 02:11'
+updated_date: '2026-05-05 02:15'
+labels:
+  - sandbox
+  - network-policy
+  - runtime-discovery
+  - security-contract
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1278'
+documentation:
+  - Docs/Sandbox/sandbox-runtime-capability-inventory.md
+  - Docs/Sandbox/sandbox-security-policy-matrix.md
+  - Docs/Sandbox/sandbox-architecture-doctrine.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Make sandbox runtime discovery and admission report effective network policy support consistently so scaffold or unsupported allowlist paths cannot be advertised as currently usable. Scope is the Phase 2 sandbox gap for inconsistent allowlist support: centralize effective support from static network_policy_contract plus current readiness/config, keep unsupported and scaffold policies fail-closed, and preserve existing runtime execution behavior unless the contract already admits it.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Runtime discovery exposes consistent effective network policy support for deny_all and allowlist without over-claiming scaffold or unsupported policies.
+- [x] #2 Sandbox admission accepts allowlist only when the runtime contract supports strict enforcement and the configured or preflight readiness source is ready.
+- [x] #3 Docker allowlist discovery reflects configured enforcement readiness and does not treat deny-all fallback as true allowlist support.
+- [x] #4 Firecracker scaffold allowlist, Lima allowlist, VZ allowlist, seatbelt allowlist, and worktree allowlist remain rejected with stable normalized reasons.
+- [x] #5 Focused tests cover discovery consistency and admission behavior for the affected runtimes, and sandbox network policy docs are updated.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add RED tests for effective network-policy support and Docker readiness-gated allowlist admission. 2. Add a shared runtime_network_policy_effective_support() helper derived from network_policy_contract plus preflight readiness. 3. Feed Docker and Firecracker readiness into collect_runtime_preflights(). 4. Use effective support for SandboxPolicy admission and SandboxService discovery booleans. 5. Update sandbox network-policy docs and run focused tests, py_compile, Bandit, and git diff --check.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented network policy effective support gating. RED: Docker allowlist admission with allowlist readiness false did not raise, and discovery tests failed because runtime_network_policy_effective_support() did not exist. GREEN: added the helper, Docker/Firecracker readiness facts, policy admission wiring, and discovery wiring. Docker allowlist is now effectively supported only with Docker available plus egress enforcement plus granular enforcement; Docker network=none fallback is treated as deny_all, not allowlist. Firecracker allowlist remains scaffold and is never advertised as effective support. Verification: focused sandbox admission/discovery/Lima tests passed (33 tests), py_compile passed for touched production modules, Bandit reported 0 findings for touched production modules, and git diff --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Centralized sandbox network-policy effective support so discovery and admission use the same static contract plus current readiness calculation. Docker allowlist now requires granular egress enforcement readiness; scaffold/unsupported allowlist paths remain fail-closed and cannot be over-advertised through legacy discovery booleans. Updated network-policy docs and focused tests.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/Sandbox/exceptions.py
+++ b/tldw_Server_API/app/core/Sandbox/exceptions.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+SANDBOX_CONFIG_NONCRITICAL_EXCEPTIONS: tuple[type[Exception], ...] = (
+    AttributeError,
+    OSError,
+    RuntimeError,
+    TypeError,
+    ValueError,
+)
+

--- a/tldw_Server_API/app/core/Sandbox/policy.py
+++ b/tldw_Server_API/app/core/Sandbox/policy.py
@@ -12,6 +12,7 @@ from .models import RunSpec, RuntimeType, SessionSpec, TrustLevel
 from .runtime_capabilities import (
     RuntimePreflightResult,
     runtime_network_policy_effective_support,
+    runtime_network_policy_metadata,
 )
 
 _POLICY_NONCRITICAL_EXCEPTIONS = (
@@ -246,6 +247,19 @@ class SandboxPolicy:
         return "strict_deny_all_not_supported"
 
     @staticmethod
+    def _network_policy_static_support(
+        runtime: RuntimeType,
+        network_policy: str,
+    ) -> bool:
+        contract = runtime_network_policy_metadata(runtime)
+        mode = (
+            contract.deny_all
+            if network_policy == "deny_all"
+            else contract.allowlist
+        )
+        return mode.support_state == "supported" and mode.strict_enforcement
+
+    @staticmethod
     def _require_network_policy_supported(
         runtime: RuntimeType,
         network_policy: str | None,
@@ -261,11 +275,19 @@ class SandboxPolicy:
                 reasons=["unsupported_network_policy"],
             )
 
-        effective_support = runtime_network_policy_effective_support(
-            runtime,
-            runtime_preflight.enforcement_ready if runtime_preflight else None,
-        )
-        if not effective_support.get(requested_policy, False):
+        if runtime_preflight is None:
+            supported = SandboxPolicy._network_policy_static_support(
+                runtime,
+                requested_policy,
+            )
+        else:
+            effective_support = runtime_network_policy_effective_support(
+                runtime,
+                runtime_preflight.enforcement_ready,
+            )
+            supported = effective_support.get(requested_policy, False)
+
+        if not supported:
             raise SandboxPolicy.PolicyUnsupported(
                 runtime,
                 requirement=requested_policy,

--- a/tldw_Server_API/app/core/Sandbox/policy.py
+++ b/tldw_Server_API/app/core/Sandbox/policy.py
@@ -11,7 +11,7 @@ from tldw_Server_API.app.core.testing import is_truthy
 from .models import RunSpec, RuntimeType, SessionSpec, TrustLevel
 from .runtime_capabilities import (
     RuntimePreflightResult,
-    runtime_network_policy_metadata,
+    runtime_network_policy_effective_support,
 )
 
 _POLICY_NONCRITICAL_EXCEPTIONS = (
@@ -249,6 +249,7 @@ class SandboxPolicy:
     def _require_network_policy_supported(
         runtime: RuntimeType,
         network_policy: str | None,
+        runtime_preflight: RuntimePreflightResult | None = None,
     ) -> str:
         requested_policy = (
             str(network_policy or "deny_all").strip().lower() or "deny_all"
@@ -260,16 +261,11 @@ class SandboxPolicy:
                 reasons=["unsupported_network_policy"],
             )
 
-        contract = runtime_network_policy_metadata(runtime)
-        mode = (
-            contract.deny_all
-            if requested_policy == "deny_all"
-            else contract.allowlist
+        effective_support = runtime_network_policy_effective_support(
+            runtime,
+            runtime_preflight.enforcement_ready if runtime_preflight else None,
         )
-        if (
-            mode.support_state not in {"supported", "host_gated"}
-            or not mode.strict_enforcement
-        ):
+        if not effective_support.get(requested_policy, False):
             raise SandboxPolicy.PolicyUnsupported(
                 runtime,
                 requirement=requested_policy,
@@ -336,6 +332,11 @@ class SandboxPolicy:
         spec.network_policy = self._require_network_policy_supported(
             spec.runtime,
             spec.network_policy,
+            runtime_preflight=(
+                runtime_preflights.get(spec.runtime)
+                if runtime_preflights is not None
+                else None
+            ),
         )
 
         # Apply trust-level resource limits (more restrictive of trust profile and global policy)
@@ -402,6 +403,11 @@ class SandboxPolicy:
         spec.network_policy = self._require_network_policy_supported(
             spec.runtime,
             spec.network_policy,
+            runtime_preflight=(
+                runtime_preflights.get(spec.runtime)
+                if runtime_preflights is not None
+                else None
+            ),
         )
 
         # Apply trust-level resource limits (more restrictive of trust profile and global policy)

--- a/tldw_Server_API/app/core/Sandbox/policy.py
+++ b/tldw_Server_API/app/core/Sandbox/policy.py
@@ -8,19 +8,12 @@ from typing import Mapping
 from tldw_Server_API.app.core.config import settings as app_settings
 from tldw_Server_API.app.core.testing import is_truthy
 
+from .exceptions import SANDBOX_CONFIG_NONCRITICAL_EXCEPTIONS
 from .models import RunSpec, RuntimeType, SessionSpec, TrustLevel
 from .runtime_capabilities import (
     RuntimePreflightResult,
     runtime_network_policy_effective_support,
     runtime_network_policy_metadata,
-)
-
-_POLICY_NONCRITICAL_EXCEPTIONS = (
-    AttributeError,
-    OSError,
-    RuntimeError,
-    TypeError,
-    ValueError,
 )
 
 # Trust-level presets define resource limits and security constraints
@@ -82,20 +75,20 @@ class SandboxPolicyConfig:
     def from_settings(cls) -> SandboxPolicyConfig:
         try:
             rt_raw = str(getattr(app_settings, "SANDBOX_DEFAULT_RUNTIME", "docker")).strip().lower()
-        except _POLICY_NONCRITICAL_EXCEPTIONS:
+        except SANDBOX_CONFIG_NONCRITICAL_EXCEPTIONS:
             rt_raw = "docker"
         try:
             runtime = RuntimeType(rt_raw)
-        except _POLICY_NONCRITICAL_EXCEPTIONS:
+        except SANDBOX_CONFIG_NONCRITICAL_EXCEPTIONS:
             runtime = RuntimeType.docker
         try:
             network_default = str(getattr(app_settings, "SANDBOX_NETWORK_DEFAULT", "deny_all")).strip().lower()
-        except _POLICY_NONCRITICAL_EXCEPTIONS:
+        except SANDBOX_CONFIG_NONCRITICAL_EXCEPTIONS:
             network_default = "deny_all"
         def _get_int(key: str, dv: int) -> int:
             try:
                 return int(getattr(app_settings, key))  # type: ignore[arg-type]
-            except _POLICY_NONCRITICAL_EXCEPTIONS:
+            except SANDBOX_CONFIG_NONCRITICAL_EXCEPTIONS:
                 return dv
         def _get_positive_int(key: str, dv: int) -> int:
             value = _get_int(key, dv)
@@ -103,7 +96,7 @@ class SandboxPolicyConfig:
         def _get_float(key: str, dv: float) -> float:
             try:
                 return float(getattr(app_settings, key))  # type: ignore[arg-type]
-            except _POLICY_NONCRITICAL_EXCEPTIONS:
+            except SANDBOX_CONFIG_NONCRITICAL_EXCEPTIONS:
                 return dv
         def _get_list(key: str, dv: list[str]) -> list[str]:
             try:
@@ -112,7 +105,7 @@ class SandboxPolicyConfig:
                     return [str(x) for x in v]
                 s = str(v)
                 return [t.strip() for t in s.split(',') if t.strip()]
-            except _POLICY_NONCRITICAL_EXCEPTIONS:
+            except SANDBOX_CONFIG_NONCRITICAL_EXCEPTIONS:
                 return dv
         def _get_bool(key: str, dv: bool) -> bool:
             try:
@@ -121,7 +114,7 @@ class SandboxPolicyConfig:
                     return v
                 s = str(v).strip().lower()
                 return is_truthy(s)
-            except _POLICY_NONCRITICAL_EXCEPTIONS:
+            except SANDBOX_CONFIG_NONCRITICAL_EXCEPTIONS:
                 return dv
         return cls(
             default_runtime=runtime,
@@ -376,19 +369,19 @@ class SandboxPolicy:
                 spec.cpu_limit = effective_max_cpu
             elif spec.cpu_limit > effective_max_cpu:
                 spec.cpu_limit = float(effective_max_cpu)
-        except _POLICY_NONCRITICAL_EXCEPTIONS:
+        except SANDBOX_CONFIG_NONCRITICAL_EXCEPTIONS:
             pass
         try:
             if spec.memory_mb is None:
                 spec.memory_mb = effective_max_mem
             elif spec.memory_mb > effective_max_mem:
                 spec.memory_mb = int(effective_max_mem)
-        except _POLICY_NONCRITICAL_EXCEPTIONS:
+        except SANDBOX_CONFIG_NONCRITICAL_EXCEPTIONS:
             pass
         try:
             if spec.timeout_sec > profile_max_timeout:
                 spec.timeout_sec = profile_max_timeout
-        except _POLICY_NONCRITICAL_EXCEPTIONS:
+        except SANDBOX_CONFIG_NONCRITICAL_EXCEPTIONS:
             pass
 
         return spec
@@ -447,19 +440,19 @@ class SandboxPolicy:
                 spec.cpu = effective_max_cpu
             elif spec.cpu > effective_max_cpu:
                 spec.cpu = float(effective_max_cpu)
-        except _POLICY_NONCRITICAL_EXCEPTIONS:
+        except SANDBOX_CONFIG_NONCRITICAL_EXCEPTIONS:
             pass
         try:
             if spec.memory_mb is None:
                 spec.memory_mb = effective_max_mem
             elif spec.memory_mb > effective_max_mem:
                 spec.memory_mb = int(effective_max_mem)
-        except _POLICY_NONCRITICAL_EXCEPTIONS:
+        except SANDBOX_CONFIG_NONCRITICAL_EXCEPTIONS:
             pass
         try:
             if spec.timeout_sec > profile_max_timeout:
                 spec.timeout_sec = profile_max_timeout
-        except _POLICY_NONCRITICAL_EXCEPTIONS:
+        except SANDBOX_CONFIG_NONCRITICAL_EXCEPTIONS:
             pass
 
         return spec
@@ -474,19 +467,19 @@ def _canonical_policy_dict(cfg: SandboxPolicyConfig) -> dict:
     try:
         # Runner security toggles (booleans for determinism)
         docker_seccomp_enabled = bool(getattr(app_settings, "SANDBOX_DOCKER_SECCOMP", None))
-    except _POLICY_NONCRITICAL_EXCEPTIONS:
+    except SANDBOX_CONFIG_NONCRITICAL_EXCEPTIONS:
         docker_seccomp_enabled = False
     try:
         docker_apparmor_enabled = bool(getattr(app_settings, "SANDBOX_DOCKER_APPARMOR_PROFILE", None))
-    except _POLICY_NONCRITICAL_EXCEPTIONS:
+    except SANDBOX_CONFIG_NONCRITICAL_EXCEPTIONS:
         docker_apparmor_enabled = False
     try:
         ul_nofile = int(getattr(app_settings, "SANDBOX_ULIMIT_NOFILE", 1024))
-    except _POLICY_NONCRITICAL_EXCEPTIONS:
+    except SANDBOX_CONFIG_NONCRITICAL_EXCEPTIONS:
         ul_nofile = 1024
     try:
         ul_nproc = int(getattr(app_settings, "SANDBOX_ULIMIT_NPROC", 512))
-    except _POLICY_NONCRITICAL_EXCEPTIONS:
+    except SANDBOX_CONFIG_NONCRITICAL_EXCEPTIONS:
         ul_nproc = 512
 
     # Normalize supported spec versions list

--- a/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
+++ b/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
@@ -4,6 +4,8 @@ import os
 from dataclasses import dataclass, field
 from typing import Any, Literal, Mapping
 
+from loguru import logger
+
 from tldw_Server_API.app.core.config import settings as app_settings
 from tldw_Server_API.app.core.testing import is_truthy
 
@@ -365,12 +367,20 @@ def runtime_network_policy_metadata(
 
 
 def _settings_flag(env_name: str, setting_name: str) -> bool:
+    """Read a boolean readiness flag, failing closed with operator-visible logs."""
+
     try:
         raw = os.getenv(env_name)
         if raw is None:
             raw = getattr(app_settings, setting_name, "")
         return is_truthy(str(raw).strip().lower())
-    except _RUNTIME_CAPABILITIES_NONCRITICAL_EXCEPTIONS:
+    except _RUNTIME_CAPABILITIES_NONCRITICAL_EXCEPTIONS as exc:
+        logger.warning(
+            "Failed to read sandbox readiness flag env={} setting={}: {}",
+            env_name,
+            setting_name,
+            exc,
+        )
         return False
 
 

--- a/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
+++ b/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
@@ -9,15 +9,8 @@ from loguru import logger
 from tldw_Server_API.app.core.config import settings as app_settings
 from tldw_Server_API.app.core.testing import is_truthy
 
+from .exceptions import SANDBOX_CONFIG_NONCRITICAL_EXCEPTIONS
 from .models import RuntimeType
-
-_RUNTIME_CAPABILITIES_NONCRITICAL_EXCEPTIONS = (
-    AttributeError,
-    OSError,
-    RuntimeError,
-    TypeError,
-    ValueError,
-)
 
 RuntimeImplementationState = Literal[
     "supported",
@@ -366,19 +359,18 @@ def runtime_network_policy_metadata(
     return metadata
 
 
-def _settings_flag(env_name: str, setting_name: str) -> bool:
+def _settings_flag(name: str) -> bool:
     """Read a boolean readiness flag, failing closed with operator-visible logs."""
 
     try:
-        raw = os.getenv(env_name)
+        raw = os.getenv(name)
         if raw is None:
-            raw = getattr(app_settings, setting_name, "")
+            raw = getattr(app_settings, name, "")
         return is_truthy(str(raw).strip().lower())
-    except _RUNTIME_CAPABILITIES_NONCRITICAL_EXCEPTIONS as exc:
+    except SANDBOX_CONFIG_NONCRITICAL_EXCEPTIONS as exc:
         logger.warning(
-            "Failed to read sandbox readiness flag env={} setting={}: {}",
-            env_name,
-            setting_name,
+            "Failed to read sandbox readiness flag {}: {}",
+            name,
             exc,
         )
         return False
@@ -387,14 +379,8 @@ def _settings_flag(env_name: str, setting_name: str) -> bool:
 def docker_network_policy_readiness(docker_available: bool) -> dict[str, bool]:
     """Return Docker network readiness facts used by discovery and admission."""
 
-    egress_enforced = _settings_flag(
-        "SANDBOX_EGRESS_ENFORCEMENT",
-        "SANDBOX_EGRESS_ENFORCEMENT",
-    )
-    granular_enforced = _settings_flag(
-        "SANDBOX_EGRESS_GRANULAR_ENFORCEMENT",
-        "SANDBOX_EGRESS_GRANULAR_ENFORCEMENT",
-    )
+    egress_enforced = _settings_flag("SANDBOX_EGRESS_ENFORCEMENT")
+    granular_enforced = _settings_flag("SANDBOX_EGRESS_GRANULAR_ENFORCEMENT")
     return {
         "deny_all": bool(docker_available),
         "allowlist": bool(docker_available and egress_enforced and granular_enforced),

--- a/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
+++ b/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
@@ -1,9 +1,21 @@
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
 from typing import Any, Literal, Mapping
 
+from tldw_Server_API.app.core.config import settings as app_settings
+from tldw_Server_API.app.core.testing import is_truthy
+
 from .models import RuntimeType
+
+_RUNTIME_CAPABILITIES_NONCRITICAL_EXCEPTIONS = (
+    AttributeError,
+    OSError,
+    RuntimeError,
+    TypeError,
+    ValueError,
+)
 
 RuntimeImplementationState = Literal[
     "supported",
@@ -352,6 +364,55 @@ def runtime_network_policy_metadata(
     return metadata
 
 
+def _settings_flag(env_name: str, setting_name: str) -> bool:
+    try:
+        raw = os.getenv(env_name)
+        if raw is None:
+            raw = getattr(app_settings, setting_name, "")
+        return is_truthy(str(raw).strip().lower())
+    except _RUNTIME_CAPABILITIES_NONCRITICAL_EXCEPTIONS:
+        return False
+
+
+def docker_network_policy_readiness(docker_available: bool) -> dict[str, bool]:
+    """Return Docker network readiness facts used by discovery and admission."""
+
+    egress_enforced = _settings_flag(
+        "SANDBOX_EGRESS_ENFORCEMENT",
+        "SANDBOX_EGRESS_ENFORCEMENT",
+    )
+    granular_enforced = _settings_flag(
+        "SANDBOX_EGRESS_GRANULAR_ENFORCEMENT",
+        "SANDBOX_EGRESS_GRANULAR_ENFORCEMENT",
+    )
+    return {
+        "deny_all": bool(docker_available),
+        "allowlist": bool(docker_available and egress_enforced and granular_enforced),
+    }
+
+
+def runtime_network_policy_effective_support(
+    runtime: RuntimeType | str,
+    enforcement_ready: Mapping[str, bool] | None = None,
+) -> dict[str, bool]:
+    """Return currently usable strict network policy support for a runtime."""
+
+    contract = runtime_network_policy_metadata(runtime)
+    ready = dict(enforcement_ready or {})
+
+    def _supported(mode: RuntimeNetworkPolicyModeMetadata, key: str) -> bool:
+        if mode.support_state not in {"supported", "host_gated"}:
+            return False
+        if not mode.strict_enforcement:
+            return False
+        return bool(ready.get(key))
+
+    return {
+        "deny_all": _supported(contract.deny_all, "deny_all"),
+        "allowlist": _supported(contract.allowlist, "allowlist"),
+    }
+
+
 def normalize_runtime_reason(reason: str) -> RuntimeReasonCode:
     """Return a stable client-facing code for a raw runtime preflight reason."""
 
@@ -441,11 +502,13 @@ def collect_runtime_preflights(
             runtime=RuntimeType.docker,
             available=docker_ok,
             reasons=[] if docker_ok else ["docker_unavailable"],
+            enforcement_ready=docker_network_policy_readiness(docker_ok),
         ),
         RuntimeType.firecracker: RuntimePreflightResult(
             runtime=RuntimeType.firecracker,
             available=firecracker_ok,
             reasons=[] if firecracker_ok else ["firecracker_unavailable"],
+            enforcement_ready={"deny_all": firecracker_ok, "allowlist": False},
         ),
         RuntimeType.lima: LimaRunner().preflight(network_policy=requested_policy),
         RuntimeType.seatbelt: SeatbeltRunner().preflight(network_policy=requested_policy),

--- a/tldw_Server_API/app/core/Sandbox/service.py
+++ b/tldw_Server_API/app/core/Sandbox/service.py
@@ -870,7 +870,18 @@ class SandboxService:
         lima_enforcement_ready = dict((lima_preflight.enforcement_ready if lima_preflight else {}) or {})
         # Allowlist enforcement is not implemented for Lima runtime execution.
         lima_enforcement_ready["allowlist"] = False
-        lima_host = dict((lima_preflight.host if lima_preflight else {}) or {})
+        if lima_preflight is not None:
+            lima_preflight = RuntimePreflightResult(
+                runtime=lima_preflight.runtime,
+                available=lima_preflight.available,
+                reasons=list(lima_preflight.reasons or []),
+                execution_mode=lima_preflight.execution_mode,
+                supported_trust_levels=list(
+                    lima_preflight.supported_trust_levels or []
+                ),
+                host=dict(lima_preflight.host or {}),
+                enforcement_ready=lima_enforcement_ready,
+            )
 
         def _preflight_fields(
             runtime: RuntimeType,
@@ -900,24 +911,18 @@ class SandboxService:
                 "network_policy_contract": network_contract.as_dict(),
             }
 
-        docker_effective_network_support = runtime_network_policy_effective_support(
-            RuntimeType.docker,
-            docker_preflight.enforcement_ready if docker_preflight else None,
-        )
-        firecracker_effective_network_support = runtime_network_policy_effective_support(
+        docker_fields = _preflight_fields(RuntimeType.docker, docker_preflight)
+        firecracker_fields = _preflight_fields(
             RuntimeType.firecracker,
-            firecracker_preflight.enforcement_ready if firecracker_preflight else None,
+            firecracker_preflight,
         )
-        lima_effective_network_support = runtime_network_policy_effective_support(
-            RuntimeType.lima,
-            lima_enforcement_ready,
-        )
+        lima_fields = _preflight_fields(RuntimeType.lima, lima_preflight)
 
         return [
             {
                 "name": "docker",
                 "implementation_state": runtime_implementation_state(RuntimeType.docker),
-                **_preflight_fields(RuntimeType.docker, docker_preflight),
+                **docker_fields,
                 "available": bool(docker_preflight.available) if docker_preflight is not None else bool(docker_available()),
                 "default_images": images,
                 "max_cpu": max_cpu,
@@ -940,11 +945,11 @@ class SandboxService:
                         else bool(docker_available())
                     )
                 ),
-                "egress_allowlist_supported": bool(docker_effective_network_support["allowlist"]),
+                "egress_allowlist_supported": bool(docker_fields["strict_allowlist_supported"]),
                 "store_mode": store_mode,
                 "notes": (
                     "Granular egress allowlist (CIDR, hostname) enforced via host iptables (DOCKER-USER) with DNS pinning"
-                    if bool(docker_effective_network_support["allowlist"] and granular)
+                    if bool(docker_fields["strict_allowlist_supported"] and granular)
                     else (
                         "Docker allowlist enforcement is configured without granular enforcement; "
                         "allowlist is not advertised because execution would fall back to deny-all"
@@ -956,7 +961,7 @@ class SandboxService:
             {
                 "name": "firecracker",
                 "implementation_state": runtime_implementation_state(RuntimeType.firecracker),
-                **_preflight_fields(RuntimeType.firecracker, firecracker_preflight),
+                **firecracker_fields,
                 "available": bool(firecracker_preflight.available) if firecracker_preflight is not None else bool(firecracker_available()),
                 "default_images": images,  # firecracker images will differ; placeholder for UX
                 "max_cpu": max_cpu,
@@ -971,14 +976,14 @@ class SandboxService:
                 "artifact_ttl_hours": artifact_ttl_hours,
                 "supported_spec_versions": supported_spec_versions,
                 "interactive_supported": False,
-                "egress_allowlist_supported": bool(firecracker_effective_network_support["allowlist"]),
+                "egress_allowlist_supported": bool(firecracker_fields["strict_allowlist_supported"]),
                 "store_mode": store_mode,
                 "notes": "Allowlist enforcement is scaffold/planned and is not advertised as effective support",
             },
             {
                 "name": "lima",
                 "implementation_state": runtime_implementation_state(RuntimeType.lima),
-                **_preflight_fields(RuntimeType.lima, lima_preflight),
+                **lima_fields,
                 "available": bool(lima_preflight.available) if lima_preflight is not None else bool(lima_available()),
                 "default_images": ["ubuntu:24.04"],  # Lima uses distro images
                 "max_cpu": max_cpu,
@@ -993,11 +998,7 @@ class SandboxService:
                 "artifact_ttl_hours": artifact_ttl_hours,
                 "supported_spec_versions": supported_spec_versions,
                 "interactive_supported": False,  # Not implemented for Lima yet
-                "egress_allowlist_supported": bool(lima_effective_network_support["allowlist"]),
-                "strict_deny_all_supported": bool(lima_effective_network_support["deny_all"]),
-                "strict_allowlist_supported": bool(lima_effective_network_support["allowlist"]),
-                "enforcement_ready": lima_enforcement_ready,
-                "host": lima_host,
+                "egress_allowlist_supported": bool(lima_fields["strict_allowlist_supported"]),
                 "store_mode": store_mode,
                 "notes": "Full VM isolation via Lima; recommended for macOS",
             },

--- a/tldw_Server_API/app/core/Sandbox/service.py
+++ b/tldw_Server_API/app/core/Sandbox/service.py
@@ -62,6 +62,7 @@ from .runtime_capabilities import (
     runtime_isolation_metadata,
     runtime_isolation_warnings,
     runtime_implementation_state,
+    runtime_network_policy_effective_support,
     runtime_network_policy_metadata,
 )
 from .snapshots import SnapshotManager
@@ -879,13 +880,17 @@ class SandboxService:
             reasons = list((preflight.reasons if preflight else []) or [])
             isolation = runtime_isolation_metadata(runtime)
             network_contract = runtime_network_policy_metadata(runtime)
+            effective_network_support = runtime_network_policy_effective_support(
+                runtime,
+                enforcement_ready,
+            )
             return {
                 "available": bool(preflight.available) if preflight is not None else False,
                 "reasons": reasons,
                 "normalized_reasons": normalize_runtime_reasons(reasons),
                 "supported_trust_levels": list((preflight.supported_trust_levels if preflight else []) or []),
-                "strict_deny_all_supported": bool(enforcement_ready.get("deny_all")),
-                "strict_allowlist_supported": bool(enforcement_ready.get("allowlist")),
+                "strict_deny_all_supported": effective_network_support["deny_all"],
+                "strict_allowlist_supported": effective_network_support["allowlist"],
                 "enforcement_ready": enforcement_ready,
                 "host": dict((preflight.host if preflight else {}) or {}),
                 "boundary_class": isolation.boundary_class,
@@ -894,6 +899,19 @@ class SandboxService:
                 "isolation_warnings": runtime_isolation_warnings(runtime),
                 "network_policy_contract": network_contract.as_dict(),
             }
+
+        docker_effective_network_support = runtime_network_policy_effective_support(
+            RuntimeType.docker,
+            docker_preflight.enforcement_ready if docker_preflight else None,
+        )
+        firecracker_effective_network_support = runtime_network_policy_effective_support(
+            RuntimeType.firecracker,
+            firecracker_preflight.enforcement_ready if firecracker_preflight else None,
+        )
+        lima_effective_network_support = runtime_network_policy_effective_support(
+            RuntimeType.lima,
+            lima_enforcement_ready,
+        )
 
         return [
             {
@@ -922,12 +940,17 @@ class SandboxService:
                         else bool(docker_available())
                     )
                 ),
-                "egress_allowlist_supported": bool(egress_supported),
+                "egress_allowlist_supported": bool(docker_effective_network_support["allowlist"]),
                 "store_mode": store_mode,
                 "notes": (
                     "Granular egress allowlist (CIDR, hostname) enforced via host iptables (DOCKER-USER) with DNS pinning"
-                    if bool(egress_supported and granular)
-                    else ("Egress allowlist enforced as deny-all (network=none)" if bool(egress_supported) else None)
+                    if bool(docker_effective_network_support["allowlist"] and granular)
+                    else (
+                        "Docker allowlist enforcement is configured without granular enforcement; "
+                        "allowlist is not advertised because execution would fall back to deny-all"
+                        if bool(egress_supported)
+                        else None
+                    )
                 ),
             },
             {
@@ -948,28 +971,9 @@ class SandboxService:
                 "artifact_ttl_hours": artifact_ttl_hours,
                 "supported_spec_versions": supported_spec_versions,
                 "interactive_supported": False,
-                # Only advertise allowlist support when explicit Firecracker enforcement is enabled
-                "egress_allowlist_supported": bool(
-                    is_truthy(
-                        str(
-                            os.getenv("SANDBOX_FIRECRACKER_EGRESS_ENFORCEMENT")
-                            or getattr(app_settings, "SANDBOX_FIRECRACKER_EGRESS_ENFORCEMENT", "")
-                        ).strip().lower()
-                    )
-                ),
+                "egress_allowlist_supported": bool(firecracker_effective_network_support["allowlist"]),
                 "store_mode": store_mode,
-                "notes": (
-                    "Granular egress allowlist enforced via VM tap/bridge + host firewall (planned)"
-                    if bool(
-                        is_truthy(
-                            str(
-                                os.getenv("SANDBOX_FIRECRACKER_EGRESS_GRANULAR_ENFORCEMENT")
-                                or getattr(app_settings, "SANDBOX_FIRECRACKER_EGRESS_GRANULAR_ENFORCEMENT", "")
-                            ).strip().lower()
-                        )
-                    )
-                    else "Allowlist enforcement uses deny-all fallback currently; granular Firecracker egress isolation planned"
-                ),
+                "notes": "Allowlist enforcement is scaffold/planned and is not advertised as effective support",
             },
             {
                 "name": "lima",
@@ -989,9 +993,9 @@ class SandboxService:
                 "artifact_ttl_hours": artifact_ttl_hours,
                 "supported_spec_versions": supported_spec_versions,
                 "interactive_supported": False,  # Not implemented for Lima yet
-                "egress_allowlist_supported": bool(lima_enforcement_ready.get("allowlist")),
-                "strict_deny_all_supported": bool(lima_enforcement_ready.get("deny_all")),
-                "strict_allowlist_supported": bool(lima_enforcement_ready.get("allowlist")),
+                "egress_allowlist_supported": bool(lima_effective_network_support["allowlist"]),
+                "strict_deny_all_supported": bool(lima_effective_network_support["deny_all"]),
+                "strict_allowlist_supported": bool(lima_effective_network_support["allowlist"]),
                 "enforcement_ready": lima_enforcement_ready,
                 "host": lima_host,
                 "store_mode": store_mode,

--- a/tldw_Server_API/tests/sandbox/test_network_policy_contract_admission.py
+++ b/tldw_Server_API/tests/sandbox/test_network_policy_contract_admission.py
@@ -170,6 +170,16 @@ def test_apply_to_session_canonicalizes_admitted_network_policy() -> None:
     assert result.network_policy == "allowlist"
 
 
+def test_apply_to_run_allows_default_docker_deny_all_without_preflights() -> None:
+    policy = SandboxPolicy()
+    spec = _run_spec(None)
+
+    result = policy.apply_to_run(spec, firecracker_available=False)
+
+    assert result.runtime == RuntimeType.docker
+    assert result.network_policy == "deny_all"
+
+
 def test_apply_to_run_rejects_docker_allowlist_when_not_effectively_ready() -> None:
     policy = SandboxPolicy()
     spec = _run_spec(RuntimeType.docker, network_policy="allowlist")

--- a/tldw_Server_API/tests/sandbox/test_network_policy_contract_admission.py
+++ b/tldw_Server_API/tests/sandbox/test_network_policy_contract_admission.py
@@ -21,6 +21,7 @@ def _available_preflight(
     runtime: RuntimeType,
     *,
     trust_levels: list[str] | None = None,
+    enforcement_ready: dict[str, bool] | None = None,
 ) -> RuntimePreflightResult:
     return RuntimePreflightResult(
         runtime=runtime,
@@ -28,7 +29,8 @@ def _available_preflight(
         reasons=[],
         supported_trust_levels=trust_levels
         or ["trusted", "standard", "untrusted"],
-        enforcement_ready={"deny_all": True, "allowlist": True},
+        enforcement_ready=enforcement_ready
+        or {"deny_all": True, "allowlist": True},
     )
 
 
@@ -166,6 +168,27 @@ def test_apply_to_session_canonicalizes_admitted_network_policy() -> None:
     )
 
     assert result.network_policy == "allowlist"
+
+
+def test_apply_to_run_rejects_docker_allowlist_when_not_effectively_ready() -> None:
+    policy = SandboxPolicy()
+    spec = _run_spec(RuntimeType.docker, network_policy="allowlist")
+
+    with pytest.raises(SandboxPolicy.PolicyUnsupported) as exc:
+        policy.apply_to_run(
+            spec,
+            firecracker_available=False,
+            runtime_preflights={
+                RuntimeType.docker: _available_preflight(
+                    RuntimeType.docker,
+                    enforcement_ready={"deny_all": True, "allowlist": False},
+                )
+            },
+        )
+
+    assert exc.value.runtime == RuntimeType.docker
+    assert exc.value.requirement == "allowlist"
+    assert exc.value.reasons == ["strict_allowlist_not_supported"]
 
 
 def test_apply_to_run_treats_whitespace_only_policy_as_missing() -> None:

--- a/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
+++ b/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
@@ -163,6 +163,70 @@ def test_feature_discovery_reports_structured_network_policy_contract(
     }
 
 
+def test_feature_discovery_reports_effective_network_policy_support(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SANDBOX_STORE_BACKEND", "memory")
+
+    discovery = {
+        str(item.get("name")): item
+        for item in SandboxService().feature_discovery()
+    }
+
+    for runtime in RuntimeType:
+        info = discovery[runtime.value]
+        effective_support = runtime_caps.runtime_network_policy_effective_support(
+            runtime,
+            info["enforcement_ready"],
+        )
+        assert info["strict_deny_all_supported"] is effective_support["deny_all"]
+        assert info["strict_allowlist_supported"] is effective_support["allowlist"]
+        assert info["egress_allowlist_supported"] is effective_support["allowlist"]
+
+
+def test_docker_discovery_does_not_advertise_allowlist_for_coarse_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SANDBOX_STORE_BACKEND", "memory")
+    monkeypatch.setenv("TLDW_SANDBOX_DOCKER_AVAILABLE", "1")
+    monkeypatch.setenv("SANDBOX_EGRESS_ENFORCEMENT", "1")
+    monkeypatch.setenv("SANDBOX_EGRESS_GRANULAR_ENFORCEMENT", "0")
+
+    discovery = {
+        str(item.get("name")): item
+        for item in SandboxService().feature_discovery()
+    }
+    docker = discovery["docker"]
+
+    assert docker["enforcement_ready"] == {"deny_all": True, "allowlist": False}
+    assert docker["strict_allowlist_supported"] is False
+    assert docker["egress_allowlist_supported"] is False
+    assert "fall back to deny-all" in str(docker["notes"])
+
+
+def test_firecracker_discovery_does_not_advertise_scaffold_allowlist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SANDBOX_STORE_BACKEND", "memory")
+    monkeypatch.setenv("TLDW_SANDBOX_FIRECRACKER_AVAILABLE", "1")
+    monkeypatch.setenv("SANDBOX_FIRECRACKER_EGRESS_ENFORCEMENT", "1")
+    monkeypatch.setenv("SANDBOX_FIRECRACKER_EGRESS_GRANULAR_ENFORCEMENT", "1")
+
+    discovery = {
+        str(item.get("name")): item
+        for item in SandboxService().feature_discovery()
+    }
+    firecracker = discovery["firecracker"]
+
+    assert firecracker["enforcement_ready"] == {
+        "deny_all": True,
+        "allowlist": False,
+    }
+    assert firecracker["strict_allowlist_supported"] is False
+    assert firecracker["egress_allowlist_supported"] is False
+    assert "scaffold/planned" in str(firecracker["notes"])
+
+
 def test_runtime_network_policy_metadata_contract_covers_runtime_enum() -> None:
     assert hasattr(runtime_caps, "RUNTIME_NETWORK_POLICY_METADATA")
     assert set(runtime_caps.RUNTIME_NETWORK_POLICY_METADATA) == set(RuntimeType)

--- a/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
+++ b/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
@@ -227,6 +227,34 @@ def test_firecracker_discovery_does_not_advertise_scaffold_allowlist(
     assert "scaffold/planned" in str(firecracker["notes"])
 
 
+def test_settings_flag_logs_read_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class BrokenSettings:
+        @property
+        def SANDBOX_EGRESS_ENFORCEMENT(self) -> str:
+            raise RuntimeError("settings unavailable")
+
+    class CapturingLogger:
+        def __init__(self) -> None:
+            self.warnings: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+        def warning(self, *args: object, **kwargs: object) -> None:
+            self.warnings.append((args, kwargs))
+
+    logger = CapturingLogger()
+    monkeypatch.delenv("SANDBOX_EGRESS_ENFORCEMENT", raising=False)
+    monkeypatch.setattr(runtime_caps, "app_settings", BrokenSettings())
+    monkeypatch.setattr(runtime_caps, "logger", logger, raising=False)
+
+    assert runtime_caps._settings_flag(  # noqa: SLF001
+        "SANDBOX_EGRESS_ENFORCEMENT",
+        "SANDBOX_EGRESS_ENFORCEMENT",
+    ) is False
+    assert logger.warnings
+    assert "Failed to read sandbox readiness flag" in str(logger.warnings[0][0][0])
+
+
 def test_runtime_network_policy_metadata_contract_covers_runtime_enum() -> None:
     assert hasattr(runtime_caps, "RUNTIME_NETWORK_POLICY_METADATA")
     assert set(runtime_caps.RUNTIME_NETWORK_POLICY_METADATA) == set(RuntimeType)

--- a/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
+++ b/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
@@ -247,10 +247,9 @@ def test_settings_flag_logs_read_failures(
     monkeypatch.setattr(runtime_caps, "app_settings", BrokenSettings())
     monkeypatch.setattr(runtime_caps, "logger", logger, raising=False)
 
-    assert runtime_caps._settings_flag(  # noqa: SLF001
-        "SANDBOX_EGRESS_ENFORCEMENT",
-        "SANDBOX_EGRESS_ENFORCEMENT",
-    ) is False
+    assert (  # noqa: SLF001
+        runtime_caps._settings_flag("SANDBOX_EGRESS_ENFORCEMENT") is False
+    )
     assert logger.warnings
     assert "Failed to read sandbox readiness flag" in str(logger.warnings[0][0][0])
 


### PR DESCRIPTION
## Summary
- Centralizes effective network-policy support by combining static runtime contracts with current runtime readiness.
- Makes network-policy admission fail closed when the requested policy is not effectively ready for the selected runtime.
- Updates discovery, docs, and tests so Docker only advertises allowlist with granular enforcement and Firecracker scaffold allowlist remains planned.

## Test Plan
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_network_policy_contract_admission.py tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py tldw_Server_API/tests/sandbox/test_lima_strict_admission.py -q --timeout=60
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile tldw_Server_API/app/core/Sandbox/runtime_capabilities.py tldw_Server_API/app/core/Sandbox/policy.py tldw_Server_API/app/core/Sandbox/service.py
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Sandbox/runtime_capabilities.py tldw_Server_API/app/core/Sandbox/policy.py tldw_Server_API/app/core/Sandbox/service.py -f json -o /tmp/bandit_sandbox_network_effective_support.json
- [x] git diff --check

## Human Change summary
Pending human-authored summary before merge, per repo policy.