### PR TITLE
Phase 2.2: defer chatbooks sharing router imports

### DIFF
--- a/backlog/tasks/task-57 - Phase-2.2-chatbooks-sharing-router-conditional-cleanup-W.md
+++ b/backlog/tasks/task-57 - Phase-2.2-chatbooks-sharing-router-conditional-cleanup-W.md
@@ -1,0 +1,53 @@
+---
+id: TASK-57
+title: Phase 2.2 chatbooks sharing router conditional cleanup W
+status: Done
+assignee:
+  - codex
+created_date: '2026-05-05 02:49'
+updated_date: '2026-05-05 02:52'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue #1116 Phase 2.2 by deferring the adjacent chatbooks and sharing content router imports in iter_content_router_specs while preserving route metadata and optional-import behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 chatbooks and sharing router specs defer module import and router attribute lookup until registration or resolution
+- [x] #2 Existing prefixes, tags, route_key values, and default_stable behavior for chatbooks and sharing remain unchanged
+- [x] #3 Focused red/green router laziness coverage, full router contract tests, main router/OpenAPI contracts, Bandit touched source scan, and git diff hygiene are run before commit
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added focused red/green coverage for chatbooks and sharing router specs. Red failed on origin/dev because both fake router attrs were touched during iter_content_router_specs construction.
+
+Converted only chatbooks and sharing from eager try/import blocks to ImportedRouterSpec entries via append_imported_router_spec, preserving prefix /api/v1, tags, route_key values, and default_stable=True behavior.
+
+Verification passed: focused chatbooks/sharing laziness test; full router group contracts 65 passed; main router contracts 6 passed; OpenAPI contracts 69 passed; Bandit content.py 0 results and 0 errors; git diff --check.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Deferred chatbooks and sharing content router registrations to lazy ImportedRouterSpec entries while preserving route metadata and optional resolution behavior. Added contract coverage proving iter_content_router_specs does not resolve those router attrs during spec construction.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/content.py
+++ b/tldw_Server_API/app/api/v1/router_groups/content.py
@@ -588,29 +588,23 @@ def iter_content_router_specs() -> Iterable[RouterSpec]:
         append_imported_router_spec(specs, learning_spec)
 
     # Chatbooks and sharing endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.chatbooks import router as chatbooks_router
-
-        specs.append(RouterSpec(
-            router=chatbooks_router,
+    for collaboration_spec in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.chatbooks",
+            log_name="chatbooks",
             prefix=f"{API_V1_PREFIX}",
             tags=("chatbooks",),
             route_key="chatbooks",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping chatbooks router: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.sharing import router as sharing_router
-
-        specs.append(RouterSpec(
-            router=sharing_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.sharing",
+            log_name="sharing",
             prefix=f"{API_V1_PREFIX}",
             tags=("sharing",),
             route_key="sharing",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping sharing router: {e}")
+        ),
+    ):
+        append_imported_router_spec(specs, collaboration_spec)
 
     # Persona endpoints are force-included in explicit pytest runtime for WS/unit coverage.
     try:

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -2884,6 +2884,107 @@ def test_iter_content_router_specs_defers_learning_writing_router_attr_lookup(
     }
 
 
+def test_iter_content_router_specs_defers_chatbooks_sharing_router_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify chatbooks/sharing specs keep import and attr lookup lazy."""
+    import importlib
+
+    router_definitions = [
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.chatbooks",
+            "path": "/chatbooks",
+            "prefix": "/api/v1",
+            "tags": ("chatbooks",),
+            "route_key": "chatbooks",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.sharing",
+            "path": "/sharing",
+            "prefix": "/api/v1",
+            "tags": ("sharing",),
+            "route_key": "sharing",
+        },
+    ]
+    routers_by_module: dict[str, APIRouter] = {}
+    access_count = {
+        str(definition["module_name"]): 0 for definition in router_definitions
+    }
+    import_calls: list[str] = []
+
+    for definition in router_definitions:
+        module_name = str(definition["module_name"])
+        router = APIRouter()
+
+        @router.get(str(definition["path"]))
+        def _endpoint() -> dict[str, str]:
+            """Return a deterministic response for the fake sharing router."""
+            return {"status": "ok"}
+
+        routers_by_module[module_name] = router
+        fake_module = ModuleType(module_name)
+
+        def _module_getattr(
+            name: str,
+            *,
+            module_name: str = module_name,
+            router: APIRouter = router,
+        ) -> APIRouter:
+            """Track lazy router attribute resolution for the fake module."""
+            if name != "router":
+                raise AttributeError(name)
+            access_count[module_name] += 1
+            return router
+
+        fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Track lazy module imports for selected chatbooks/sharing routers."""
+        if module_name in routers_by_module:
+            import_calls.append(module_name)
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    specs = list(iter_content_router_specs())
+    assert access_count == {
+        str(definition["module_name"]): 0 for definition in router_definitions
+    }
+    assert import_calls == []
+
+    selected_specs = {
+        spec.route_key: spec
+        for spec in specs
+        if spec.route_key in {
+            str(definition["route_key"])
+            for definition in router_definitions
+        }
+    }
+    assert set(selected_specs) == {
+        str(definition["route_key"]) for definition in router_definitions
+    }
+
+    for definition in router_definitions:
+        spec = selected_specs[str(definition["route_key"])]
+        assert spec.prefix == definition["prefix"]
+        assert spec.tags == definition["tags"]
+        assert spec.default_stable is True
+        assert _first_router_path(spec.router) == definition["path"]
+
+    assert import_calls == [
+        str(definition["module_name"]) for definition in router_definitions
+    ]
+    assert access_count == {
+        str(definition["module_name"]): 1 for definition in router_definitions
+    }
+
+
 def test_qodo_reviewed_router_policy_regressions(monkeypatch: pytest.MonkeyPatch) -> None:
     _install_fake_router_module(
         monkeypatch,


### PR DESCRIPTION
## Change summary\n- Converts the adjacent chatbooks and sharing content router registrations from eager try/import blocks to lazy ImportedRouterSpec entries.\n- Preserves existing /api/v1 prefixes, tags, route keys, and default_stable behavior.\n- Adds focused red/green contract coverage proving iter_content_router_specs does not import or touch those router attributes during spec construction.\n\n## Verification\n- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k chatbooks_sharing_router_attr_lookup -q\n- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q\n- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q\n- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q\n- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/router_groups/content.py -f json -o /tmp/bandit_phase2_2_chatbooks_sharing_content.json (0 results, 0 errors)\n- git diff --check\n\nRefs #1116