### PR TITLE
fix(sandbox): normalize runtime status reason aliases

### DIFF
--- a/Docs/Sandbox/sandbox-runtime-capability-inventory.md
+++ b/Docs/Sandbox/sandbox-runtime-capability-inventory.md
@@ -140,6 +140,12 @@ separate persisted state machine.
 | `runtime_error` | The runtime failed without a more specific normalized reason. |
 | `unknown` | Existing status data does not map to a known reason code. |
 
+The first Phase 3 taxonomy pass centralizes known runtime aliases for policy
+failures, runtime-unavailable failures, queue expiry, timeout, cancellation, and
+limit signals. Raw runner messages remain available for operator diagnostics;
+clients should group by `status_reason_code` instead of matching runtime
+message strings.
+
 ## Trust-Level Support
 
 | Runtime | `trusted` | `standard` | `untrusted` | Notes |
@@ -227,7 +233,7 @@ an equally clear ownership model.
 | --- | --- | --- |
 | Host-local runtimes need clearer docs/API warnings that they are not VM-grade. | `seatbelt`, `worktree` | Phase 2 |
 | Additional real allowlist implementations remain limited beyond Docker granular enforcement. | all except unsupported paths | Future |
-| Detailed runner-internal error strings still vary by runtime behind `runtime_error`. | all | Phase 3 |
+| Rich structured error metadata beyond the first normalized alias pass remains incomplete. | all | Phase 3 |
 | Session semantics are not normalized across warm VM, container, and host-local reuse. | all | Phase 4 |
 | Recovery/repair ownership exists only for `vz_linux`. | all except `vz_linux` | Phase 4 |
 | CI has no single cross-runtime capability gate. | all | Phase 5 |

--- a/Docs/superpowers/plans/2026-05-05-sandbox-runtime-status-taxonomy-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-05-sandbox-runtime-status-taxonomy-implementation-plan.md
@@ -1,0 +1,117 @@
+# Sandbox Runtime Status Taxonomy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Normalize known sandbox runtime status messages into stable reason codes while preserving raw runner diagnostics.
+
+**Architecture:** Keep the taxonomy centralized in `run_status_taxonomy.py`. Add explicit alias sets for known policy and runtime-unavailable messages, preserve conservative heuristics for existing compatibility, and document the remaining Phase 3 scope.
+
+**Tech Stack:** Python 3.11, pytest, existing sandbox status schemas and runtime taxonomy helpers.
+
+---
+
+### Task 1: Add Failing Taxonomy Tests
+
+**Files:**
+- Modify: `tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py`
+
+- [x] **Step 1: Add regression tests for policy aliases**
+
+Add a test that loops over:
+
+```python
+[
+    "lima_policy_failed",
+    "vz_linux_policy_failed",
+    "vz_macos_policy_failed",
+    "seatbelt_policy_failed",
+    "worktree_policy_failed",
+]
+```
+
+and expects `normalize_run_status_reason(...) == "policy_failed"`.
+
+- [x] **Step 2: Add runtime-unavailable alias tests**
+
+Add a test covering exact unavailable aliases such as `docker_unavailable`,
+`firecracker_unavailable`, `vz_linux_unavailable`, `vz_macos_unavailable`,
+`seatbelt_unavailable`, and `worktree_unavailable`.
+
+- [x] **Step 3: Verify red**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py -q
+```
+
+Expected: failure showing VZ policy aliases still normalize as `runtime_unavailable`.
+
+### Task 2: Implement Central Alias Sets
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py`
+
+- [x] **Step 1: Add `_POLICY_FAILED_MESSAGES`**
+
+Move known policy failure messages into a dedicated exact alias set.
+
+- [x] **Step 2: Remove policy failures from `_RUNTIME_UNAVAILABLE_MESSAGES`**
+
+Keep runtime-unavailable aliases limited to runtime availability and
+provisioning failures.
+
+- [x] **Step 3: Check policy aliases before runtime unavailable**
+
+In the failed-phase branch, return `policy_failed` for exact policy aliases and
+the existing conservative policy substring fallback before checking runtime
+unavailable.
+
+- [x] **Step 4: Verify green**
+
+Run the focused taxonomy tests again.
+
+### Task 3: Update Docs And Task Tracking
+
+**Files:**
+- Modify: `Docs/Sandbox/sandbox-runtime-capability-inventory.md`
+- Modify: `backlog/tasks/task-57 - Normalize-sandbox-runtime-status-reason-taxonomy.md`
+
+- [x] **Step 1: Update current gaps**
+
+Change the Phase 3 gap text to say the first alias pass is complete and richer
+structured error metadata remains future work.
+
+- [x] **Step 2: Update Backlog task**
+
+Check completed acceptance criteria and record verification.
+
+### Task 4: Verification And Commit
+
+**Files:**
+- Verify touched Python and docs.
+
+- [x] **Step 1: Run focused tests**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py -q
+```
+
+- [x] **Step 2: Run Bandit on touched Python**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py -f json -o /tmp/bandit_sandbox_runtime_taxonomy.json
+```
+
+- [x] **Step 3: Run whitespace check**
+
+```bash
+git diff --check
+```
+
+- [x] **Step 4: Commit**
+
+```bash
+git add Docs/Sandbox/sandbox-runtime-capability-inventory.md Docs/superpowers/specs/2026-05-05-sandbox-runtime-status-taxonomy-design.md Docs/superpowers/plans/2026-05-05-sandbox-runtime-status-taxonomy-implementation-plan.md "backlog/tasks/task-57 - Normalize-sandbox-runtime-status-reason-taxonomy.md" tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py
+git commit -m "fix(sandbox): normalize runtime status reason aliases"
+```

--- a/Docs/superpowers/specs/2026-05-05-sandbox-runtime-status-taxonomy-design.md
+++ b/Docs/superpowers/specs/2026-05-05-sandbox-runtime-status-taxonomy-design.md
@@ -1,0 +1,67 @@
+# Sandbox Runtime Status Taxonomy Design
+
+## Goal
+
+Normalize known sandbox runner status strings into stable `status_reason_code`
+values so API clients do not need runtime-specific message matching. This is a
+narrow Phase 3 runtime parity slice: it improves the existing derived taxonomy
+without changing runner execution behavior, database shape, or raw diagnostic
+messages.
+
+## Current State
+
+`run_status_taxonomy.py` already derives a small client-facing reason vocabulary
+from `phase`, `message`, `exit_code`, and `resource_usage`. The current mapping
+handles common phases, timeout strings, queue TTL expiry, nonzero exits, limit
+signals, and some runtime-unavailable strings.
+
+The gap is that some first-class policy failure messages emitted by the service
+are currently classified inconsistently. In particular, `vz_linux_policy_failed`
+and `vz_macos_policy_failed` are listed in the runtime-unavailable alias set,
+which makes policy admission failures look like missing runtime support. Other
+policy messages depend on substring matching instead of an explicit alias set.
+
+## Design
+
+Use explicit alias sets inside `run_status_taxonomy.py` for stable categories:
+
+- Policy failures: exact aliases for `lima_policy_failed`,
+  `vz_linux_policy_failed`, `vz_macos_policy_failed`, `seatbelt_policy_failed`,
+  and `worktree_policy_failed`, plus the existing conservative substring
+  fallback for messages containing both `policy` and `failed`.
+- Runtime unavailable: exact aliases for runtime availability failures and
+  conservative heuristics for runtime/provisioning contexts with unavailable,
+  missing, or not-found signals.
+- Timeouts: preserve existing startup/execution timeout behavior and make the
+  alias intent explicit in tests.
+- Fallbacks: genuinely unknown failed messages remain `runtime_error`.
+
+Raw `message` remains unchanged for operators. Only the derived
+`status_reason_code` changes.
+
+## Risks And Mitigations
+
+- Risk: broad aliases could hide real runtime errors.
+  Mitigation: prefer exact alias sets first and keep heuristic matching narrow.
+- Risk: changing VZ policy messages from `runtime_unavailable` to
+  `policy_failed` may affect clients already compensating for the old behavior.
+  Mitigation: this is the intended taxonomy correction and is additive at the
+  schema level; raw messages remain available for compatibility and debugging.
+- Risk: adding new reason codes would expand public contract surface too early.
+  Mitigation: no new reason codes in this slice.
+
+## Tests
+
+Add focused tests in `test_run_status_reason_codes.py` that prove:
+
+- All known runtime policy failure messages normalize to `policy_failed`.
+- Runtime-unavailable aliases still normalize to `runtime_unavailable`.
+- Template/provisioning missing messages still normalize to
+  `runtime_unavailable`.
+- Unrelated missing/artifact/command errors remain `runtime_error`.
+
+## Documentation
+
+Update the sandbox runtime capability inventory to record that the first Phase 3
+taxonomy pass centralizes known aliases while leaving richer structured error
+metadata and cross-runtime session/recovery parity for later phases.

--- a/backlog/tasks/task-57 - Normalize-sandbox-runtime-status-reason-taxonomy.md
+++ b/backlog/tasks/task-57 - Normalize-sandbox-runtime-status-reason-taxonomy.md
@@ -1,0 +1,56 @@
+---
+id: TASK-57
+title: Normalize sandbox runtime status reason taxonomy
+status: In Progress
+assignee: []
+created_date: '2026-05-05 02:45'
+updated_date: '2026-05-05 02:48'
+labels:
+  - sandbox
+  - macos
+  - runtime-taxonomy
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add a narrow Phase 3 sandbox slice that centralizes known runtime status and error message aliases into the existing run status taxonomy so clients can rely on stable status_reason_code values without runtime-specific string guessing. Preserve raw runner messages for diagnostics and avoid broad runner behavior changes in this PR.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Known policy failure messages across sandbox runtimes normalize to policy_failed while preserving raw messages.
+- [x] #2 Known timeout and runtime-unavailable messages normalize through central taxonomy helpers without broadening genuinely unknown failures beyond runtime_error.
+- [x] #3 Focused tests cover added taxonomy aliases and retain runtime_error fallback coverage for unknown failures.
+- [x] #4 Sandbox runtime capability documentation is updated to reflect the Phase 3 taxonomy pass and remaining limitations.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Focused RED check failed before implementation because vz_linux_policy_failed and vz_macos_policy_failed normalized to runtime_unavailable.
+
+Verification: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py -q passed with 24 tests.
+
+Verification: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py -f json -o /tmp/bandit_sandbox_runtime_taxonomy.json reported zero findings.
+
+Verification: git diff --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Centralized known sandbox policy failure aliases in the run status taxonomy so VZ, Lima, seatbelt, and worktree policy admission failures normalize to policy_failed while raw messages remain unchanged. Added focused tests for policy/runtime-unavailable aliases, kept unknown failures falling through to runtime_error, and updated the sandbox runtime inventory to record the first Phase 3 taxonomy pass plus remaining structured error metadata work.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-57 - Normalize-sandbox-runtime-status-reason-taxonomy.md
+++ b/backlog/tasks/task-57 - Normalize-sandbox-runtime-status-reason-taxonomy.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-57
 title: Normalize sandbox runtime status reason taxonomy
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-05 02:45'
-updated_date: '2026-05-05 02:48'
+updated_date: '2026-05-05 03:09'
 labels:
   - sandbox
   - macos
@@ -25,7 +25,14 @@ Add a narrow Phase 3 sandbox slice that centralizes known runtime status and err
 - [x] #2 Known timeout and runtime-unavailable messages normalize through central taxonomy helpers without broadening genuinely unknown failures beyond runtime_error.
 - [x] #3 Focused tests cover added taxonomy aliases and retain runtime_error fallback coverage for unknown failures.
 - [x] #4 Sandbox runtime capability documentation is updated to reflect the Phase 3 taxonomy pass and remaining limitations.
+- [x] #5 Regression test covers policy_failed precedence when a failed run message also contains runtime_unavailable.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+PR #1284 review follow-up: verify current PR head and taxonomy ordering, add only a focused regression test for policy_failed precedence over runtime_unavailable if the guard is missing, avoid production-code changes unless the test exposes a real ordering bug, then run focused pytest and git diff checks. Bandit is not needed for a tests-only edit; record that skip reason.
+<!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
@@ -37,12 +44,24 @@ Verification: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python 
 Verification: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py -f json -o /tmp/bandit_sandbox_runtime_taxonomy.json reported zero findings.
 
 Verification: git diff --check passed.
+
+Review finding verification: current PR head 2067246782934a4980d00892e726985b8d2f3582 matches the local sandbox-runtime-taxonomy worktree. normalize_run_status_reason currently checks _is_policy_failed_message before _is_runtime_unavailable_message, so behavior is already correct; the still-valid issue is the missing explicit regression test for mixed policy_failed/runtime_unavailable messages.
+
+Verification: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py -q passed with 8 tests.
+
+Verification: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py -q passed with 25 tests.
+
+Verification: git diff --check passed after the review follow-up edit.
+
+Bandit: skipped for this follow-up because it only adds pytest assertions in a sandbox test file and makes no production-code changes; the PR's production taxonomy file already had zero Bandit findings in the prior verification.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Centralized known sandbox policy failure aliases in the run status taxonomy so VZ, Lima, seatbelt, and worktree policy admission failures normalize to policy_failed while raw messages remain unchanged. Added focused tests for policy/runtime-unavailable aliases, kept unknown failures falling through to runtime_error, and updated the sandbox runtime inventory to record the first Phase 3 taxonomy pass plus remaining structured error metadata work.
+
+Review follow-up on PR #1284 added an explicit regression test asserting policy_failed wins when a failed run message also contains runtime_unavailable, including mixed-case wording. Current production ordering was verified as already correct, so no runtime taxonomy code changed.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py
+++ b/tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py
@@ -51,8 +51,14 @@ _RUNTIME_UNAVAILABLE_MESSAGES = frozenset({
     "vz_macos_unavailable",
     "seatbelt_unavailable",
     "worktree_unavailable",
+})
+
+_POLICY_FAILED_MESSAGES = frozenset({
+    "lima_policy_failed",
     "vz_linux_policy_failed",
     "vz_macos_policy_failed",
+    "seatbelt_policy_failed",
+    "worktree_policy_failed",
 })
 
 _RUNTIME_CONTEXT_TERMS = ("runtime", "provision")
@@ -102,6 +108,14 @@ def _is_runtime_unavailable_message(message_value: str) -> bool:
     return has_runtime_context and has_unavailable_signal
 
 
+def _is_policy_failed_message(message_value: str) -> bool:
+    if message_value in _POLICY_FAILED_MESSAGES:
+        return True
+    return "policy_failed" in message_value or (
+        "policy" in message_value and "failed" in message_value
+    )
+
+
 def normalize_run_status_reason(
     *,
     phase: RunPhase | str | None,
@@ -138,12 +152,10 @@ def normalize_run_status_reason(
     if phase_value == "failed":
         if message_value == "queue_ttl_expired":
             return "queue_ttl_expired"
+        if _is_policy_failed_message(message_value):
+            return "policy_failed"
         if _is_runtime_unavailable_message(message_value):
             return "runtime_unavailable"
-        if "policy_failed" in message_value or (
-            "policy" in message_value and "failed" in message_value
-        ):
-            return "policy_failed"
         if "startup_timeout" in message_value:
             return "startup_timeout"
         if "execution_timeout" in message_value or message_value == "timeout":

--- a/tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py
+++ b/tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py
@@ -107,6 +107,19 @@ def test_run_status_reason_taxonomy_maps_known_policy_failures() -> None:
         ) == "policy_failed"
 
 
+def test_run_status_reason_taxonomy_prefers_policy_failed_over_runtime_unavailable() -> None:
+    for message in (
+        "lima_policy_failed runtime_unavailable",
+        "Runtime unavailable after VZ_MACOS_POLICY_FAILED",
+    ):
+        assert normalize_run_status_reason(
+            phase=RunPhase.failed,
+            message=message,
+            exit_code=None,
+            resource_usage=None,
+        ) == "policy_failed"
+
+
 def test_run_status_reason_taxonomy_distinguishes_runtime_unavailable() -> None:
     for message in (
         "runtime_unavailable",

--- a/tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py
+++ b/tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py
@@ -91,19 +91,39 @@ def test_run_status_reason_taxonomy_reports_limit_signals() -> None:
     ) == "limits_applied"
 
 
+def test_run_status_reason_taxonomy_maps_known_policy_failures() -> None:
+    for message in (
+        "lima_policy_failed",
+        "vz_linux_policy_failed",
+        "vz_macos_policy_failed",
+        "seatbelt_policy_failed",
+        "worktree_policy_failed",
+    ):
+        assert normalize_run_status_reason(
+            phase=RunPhase.failed,
+            message=message,
+            exit_code=None,
+            resource_usage=None,
+        ) == "policy_failed"
+
+
 def test_run_status_reason_taxonomy_distinguishes_runtime_unavailable() -> None:
-    assert normalize_run_status_reason(
-        phase=RunPhase.failed,
-        message="vz_linux_policy_failed",
-        exit_code=None,
-        resource_usage=None,
-    ) == "runtime_unavailable"
-    assert normalize_run_status_reason(
-        phase=RunPhase.failed,
-        message="vz_macos_policy_failed",
-        exit_code=None,
-        resource_usage=None,
-    ) == "runtime_unavailable"
+    for message in (
+        "runtime_unavailable",
+        "runtime unavailable",
+        "docker_unavailable",
+        "firecracker_unavailable",
+        "vz_linux_unavailable",
+        "vz_macos_unavailable",
+        "seatbelt_unavailable",
+        "worktree_unavailable",
+    ):
+        assert normalize_run_status_reason(
+            phase=RunPhase.failed,
+            message=message,
+            exit_code=None,
+            resource_usage=None,
+        ) == "runtime_unavailable"
     assert normalize_run_status_reason(
         phase=RunPhase.failed,
         message="runtime provisioning template missing",


### PR DESCRIPTION
## Summary
- Centralize known sandbox policy failure aliases so VZ, Lima, seatbelt, and worktree policy admission failures normalize to `policy_failed`.
- Keep runtime-unavailable aliases distinct and preserve raw runner messages for operator diagnostics.
- Add focused taxonomy tests plus sandbox inventory/docs and Backlog tracking for the Phase 3 slice.

## Test Plan
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py -q`
- [x] `git diff --check origin/dev...HEAD`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py -f json -o /tmp/bandit_sandbox_runtime_taxonomy.json`

## Change summary
Human-authored change summary required before merge.