### PR TITLE
Phase 2.2: defer persona router imports

### DIFF
--- a/backlog/tasks/task-58 - Phase-2.2-persona-router-conditional-cleanup-X.md
+++ b/backlog/tasks/task-58 - Phase-2.2-persona-router-conditional-cleanup-X.md
@@ -1,0 +1,55 @@
+---
+id: TASK-58
+title: Phase 2.2 persona router conditional cleanup X
+status: Done
+assignee:
+  - codex
+created_date: '2026-05-05 03:08'
+updated_date: '2026-05-05 03:13'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue #1116 Phase 2.2 by deferring the adjacent persona, personalization, companion, and archetype content router imports in iter_content_router_specs while preserving route metadata and optional-import behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 persona, personalization, companion, and archetype router specs defer module import and router attribute lookup until registration or resolution
+- [x] #2 Existing prefixes, tags, route_key values, default_stable flags, and explicit pytest persona route_key behavior remain unchanged
+- [x] #3 Focused red/green router laziness coverage, full router contract tests, main router/OpenAPI contracts, Bandit touched source scan, and git diff hygiene are run before commit
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused failing laziness test for persona-family content router specs. 2. Convert persona, personalization, companion, and archetype content specs to ImportedRouterSpec. 3. Run focused/full router contract tests, main/OpenAPI contracts, Bandit, and diff hygiene.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Red test: pytest test_router_groups_contract.py -k persona_router_attr_lookup failed because all four persona-family fake modules had router attr access during iter_content_router_specs. Green verification: focused persona laziness test passed; full router group contract passed; main router contract passed; OpenAPI contracts passed; Bandit content.py results=0 errors=0; git diff --check clean. Documentation update not needed for this internal router import refactor.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Deferred persona, personalization, companion, and archetype content router imports via ImportedRouterSpec while preserving prefixes, tags, route keys, default_stable flags, and explicit pytest persona route-key behavior. Added focused contract coverage proving module import and router attr lookup stay lazy until resolution.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/content.py
+++ b/tldw_Server_API/app/api/v1/router_groups/content.py
@@ -607,57 +607,38 @@ def iter_content_router_specs() -> Iterable[RouterSpec]:
         append_imported_router_spec(specs, collaboration_spec)
 
     # Persona endpoints are force-included in explicit pytest runtime for WS/unit coverage.
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.persona import router as persona_router
-
-        specs.append(RouterSpec(
-            router=persona_router,
+    for persona_spec in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.persona",
+            log_name="persona",
             prefix=f"{API_V1_PREFIX}/persona",
             tags=("persona",),
             route_key="" if _is_explicit_pytest_runtime() else "persona",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping persona router: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.personalization import (
-            router as personalization_router,
-        )
-
-        specs.append(RouterSpec(
-            router=personalization_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.personalization",
+            log_name="personalization",
             prefix=f"{API_V1_PREFIX}/personalization",
             tags=("personalization",),
             route_key="personalization",
             default_stable=False,
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping personalization router: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.companion import router as companion_router
-
-        specs.append(RouterSpec(
-            router=companion_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.companion",
+            log_name="companion",
             prefix=f"{API_V1_PREFIX}/companion",
             tags=("companion",),
             route_key="companion",
             default_stable=False,
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping companion router: {e}")
-
-    # Archetype template endpoints are always available read-only catalog data.
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.archetype_endpoints import router as archetype_router
-
-        specs.append(RouterSpec(
-            router=archetype_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.archetype_endpoints",
+            log_name="archetype_endpoints",
             prefix=f"{API_V1_PREFIX}/persona/archetypes",
             tags=("persona-archetypes",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping archetype router: {e}")
+        ),
+    ):
+        append_imported_router_spec(specs, persona_spec)
 
     try:
         from tldw_Server_API.app.api.v1.endpoints.files import router as files_router

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -2998,7 +2998,7 @@ def test_iter_content_router_specs_defers_persona_router_attr_lookup(
             "path": "/persona",
             "prefix": "/api/v1/persona",
             "tags": ("persona",),
-            "route_key": "",
+            "route_key": "" if is_explicit_pytest_runtime() else "persona",
             "default_stable": True,
         },
         {

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -2985,6 +2985,130 @@ def test_iter_content_router_specs_defers_chatbooks_sharing_router_attr_lookup(
     }
 
 
+def test_iter_content_router_specs_defers_persona_router_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify persona-family specs keep import and attr lookup lazy."""
+    import importlib
+
+    router_definitions = [
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.persona",
+            "expected_name": "persona",
+            "path": "/persona",
+            "prefix": "/api/v1/persona",
+            "tags": ("persona",),
+            "route_key": "",
+            "default_stable": True,
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.personalization",
+            "expected_name": "personalization",
+            "path": "/personalization",
+            "prefix": "/api/v1/personalization",
+            "tags": ("personalization",),
+            "route_key": "personalization",
+            "default_stable": False,
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.companion",
+            "expected_name": "companion",
+            "path": "/companion",
+            "prefix": "/api/v1/companion",
+            "tags": ("companion",),
+            "route_key": "companion",
+            "default_stable": False,
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.archetype_endpoints",
+            "expected_name": "archetype_endpoints",
+            "path": "/archetypes",
+            "prefix": "/api/v1/persona/archetypes",
+            "tags": ("persona-archetypes",),
+            "route_key": "",
+            "default_stable": True,
+        },
+    ]
+    routers_by_module: dict[str, APIRouter] = {}
+    access_count = {
+        str(definition["module_name"]): 0 for definition in router_definitions
+    }
+    import_calls: list[str] = []
+
+    for definition in router_definitions:
+        module_name = str(definition["module_name"])
+        router = APIRouter()
+
+        @router.get(str(definition["path"]))
+        def _endpoint() -> dict[str, str]:
+            """Return a deterministic response for the fake persona router."""
+            return {"status": "ok"}
+
+        routers_by_module[module_name] = router
+        fake_module = ModuleType(module_name)
+
+        def _module_getattr(
+            name: str,
+            *,
+            module_name: str = module_name,
+            router: APIRouter = router,
+        ) -> APIRouter:
+            """Track lazy router attribute resolution for the fake module."""
+            if name != "router":
+                raise AttributeError(name)
+            access_count[module_name] += 1
+            return router
+
+        fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Track lazy module imports for selected persona-family routers."""
+        if module_name in routers_by_module:
+            import_calls.append(module_name)
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    specs = list(iter_content_router_specs())
+    assert access_count == {
+        str(definition["module_name"]): 0 for definition in router_definitions
+    }
+    assert import_calls == []
+
+    selected_specs = {
+        spec.name: spec
+        for spec in specs
+        if spec.name in {
+            str(definition["expected_name"])
+            for definition in router_definitions
+        }
+    }
+    assert set(selected_specs) == {
+        str(definition["expected_name"]) for definition in router_definitions
+    }
+
+    for definition in router_definitions:
+        spec = selected_specs[str(definition["expected_name"])]
+        assert spec.prefix == definition["prefix"]
+        assert spec.tags == definition["tags"]
+        assert spec.route_key == definition["route_key"]
+        assert spec.default_stable is definition["default_stable"]
+        assert _first_router_path(spec.router) == definition["path"]
+
+    assert import_calls == [
+        str(definition["module_name"]) for definition in router_definitions
+    ]
+    assert access_count == {
+        str(definition["module_name"]): 1 for definition in router_definitions
+    }
+
+
 def test_qodo_reviewed_router_policy_regressions(monkeypatch: pytest.MonkeyPatch) -> None:
     _install_fake_router_module(
         monkeypatch,


### PR DESCRIPTION
Change summary
- Defers persona, personalization, companion, and archetype content router imports through ImportedRouterSpec.
- Preserves prefixes, tags, route_key/default_stable settings, and explicit pytest persona route_key behavior.
- Adds focused router-group contract coverage proving module import and router attr lookup stay lazy until resolution.

Verification
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k persona_router_attr_lookup -q (red before implementation, green after)
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/router_groups/content.py -f json -o /tmp/bandit_phase2_2_persona_content_rebased.json (results=0 errors=0)
- git diff --check origin/dev..HEAD

Refs #1116