### PR TITLE
Phase 2.2: defer content tail router imports

### DIFF
--- a/backlog/tasks/task-59 - Phase-2.2-content-tail-router-conditional-cleanup-Y.md
+++ b/backlog/tasks/task-59 - Phase-2.2-content-tail-router-conditional-cleanup-Y.md
@@ -1,0 +1,55 @@
+---
+id: TASK-59
+title: Phase 2.2 content tail router conditional cleanup Y
+status: Done
+assignee:
+  - codex
+created_date: '2026-05-05 03:28'
+updated_date: '2026-05-05 03:31'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue #1116 Phase 2.2 by deferring the adjacent tail content router imports for files, data tables, items, tasks, notifications, watchlists, integrations, scheduled tasks, and VN assets while preserving route metadata and optional-import behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 tail content router specs defer module import and router attribute lookup until registration or resolution
+- [x] #2 Existing prefixes, tags, route_key values, and default_stable flags remain unchanged for files, data-tables, items, tasks, notifications, watchlists, integrations, scheduled-tasks, and vn-assets
+- [x] #3 Focused red/green router laziness coverage, full router contract tests, main router/OpenAPI contracts, Bandit touched source scan, and git diff hygiene are run before commit
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused failing laziness test for tail content router specs. 2. Convert files, data-tables, items, tasks, notifications, watchlists, integrations, scheduled-tasks, and vn-assets specs to ImportedRouterSpec. 3. Run focused/full router contract tests, main/OpenAPI contracts, Bandit, and diff hygiene.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Red test: pytest test_router_groups_contract.py -k tail_router_attr_lookup failed because tail fake modules had router attr access during iter_content_router_specs. Green verification: focused tail laziness test passed; full router group contract passed; main router contract passed; OpenAPI contracts passed; Bandit content.py results=0 errors=0; git diff --check clean. Documentation update not needed for this internal router import refactor.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Deferred files, data-tables, items, tasks, notifications, watchlists, integrations, scheduled-tasks, and vn-assets content router imports via ImportedRouterSpec while preserving prefixes, tags, route keys, and default_stable flags. Added focused contract coverage proving module import and router attr lookup stay lazy until resolution.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/content.py
+++ b/tldw_Server_API/app/api/v1/router_groups/content.py
@@ -640,120 +640,73 @@ def iter_content_router_specs() -> Iterable[RouterSpec]:
     ):
         append_imported_router_spec(specs, persona_spec)
 
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.files import router as files_router
-
-        specs.append(RouterSpec(
-            router=files_router,
+    for tail_spec in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.files",
+            log_name="files",
             prefix=f"{API_V1_PREFIX}",
             tags=("files",),
             route_key="files",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping files router: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.data_tables import router as data_tables_router
-
-        specs.append(RouterSpec(
-            router=data_tables_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.data_tables",
+            log_name="data_tables",
             prefix=f"{API_V1_PREFIX}",
             tags=("data-tables",),
             route_key="data-tables",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping data_tables router: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.items import router as items_router
-
-        specs.append(RouterSpec(
-            router=items_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.items",
+            log_name="items",
             prefix=f"{API_V1_PREFIX}",
             tags=("items",),
             route_key="items",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping items router: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.reminders import router as reminders_router
-
-        specs.append(RouterSpec(
-            router=reminders_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.reminders",
+            log_name="reminders",
             prefix=f"{API_V1_PREFIX}",
             tags=("tasks",),
             route_key="tasks",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping reminders router: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.notifications import (
-            router as notifications_router,
-        )
-
-        specs.append(RouterSpec(
-            router=notifications_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.notifications",
+            log_name="notifications",
             prefix=f"{API_V1_PREFIX}",
             tags=("notifications",),
             route_key="notifications",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping notifications router: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.watchlists import router as watchlists_router
-
-        specs.append(RouterSpec(
-            router=watchlists_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.watchlists",
+            log_name="watchlists",
             prefix=f"{API_V1_PREFIX}",
             tags=("watchlists",),
             route_key="watchlists",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping watchlists router: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.integrations_control_plane import (
-            router as integrations_control_plane_router,
-        )
-
-        specs.append(RouterSpec(
-            router=integrations_control_plane_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.integrations_control_plane",
+            log_name="integrations_control_plane",
             prefix=f"{API_V1_PREFIX}",
             tags=("integrations",),
             route_key="integrations",
             default_stable=False,
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping integrations_control_plane router: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.scheduled_tasks_control_plane import (
-            router as scheduled_tasks_control_plane_router,
-        )
-
-        specs.append(RouterSpec(
-            router=scheduled_tasks_control_plane_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.scheduled_tasks_control_plane",
+            log_name="scheduled_tasks_control_plane",
             prefix=f"{API_V1_PREFIX}",
             tags=("scheduled-tasks",),
             route_key="scheduled-tasks",
             default_stable=False,
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping scheduled_tasks_control_plane router: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.vn_assets import router as vn_assets_router
-
-        specs.append(RouterSpec(
-            router=vn_assets_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.vn_assets",
+            log_name="vn_assets",
             prefix=f"{API_V1_PREFIX}",
             tags=("vn-assets",),
             route_key="vn-assets",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping VN assets router: {e}")
+        ),
+    ):
+        append_imported_router_spec(specs, tail_spec)
 
     return specs

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -3109,6 +3109,175 @@ def test_iter_content_router_specs_defers_persona_router_attr_lookup(
     }
 
 
+def test_iter_content_router_specs_defers_tail_router_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify tail content specs keep import and attr lookup lazy."""
+    import importlib
+
+    router_definitions = [
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.files",
+            "expected_name": "files",
+            "path": "/files",
+            "prefix": "/api/v1",
+            "tags": ("files",),
+            "route_key": "files",
+            "default_stable": True,
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.data_tables",
+            "expected_name": "data_tables",
+            "path": "/data-tables",
+            "prefix": "/api/v1",
+            "tags": ("data-tables",),
+            "route_key": "data-tables",
+            "default_stable": True,
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.items",
+            "expected_name": "items",
+            "path": "/items",
+            "prefix": "/api/v1",
+            "tags": ("items",),
+            "route_key": "items",
+            "default_stable": True,
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.reminders",
+            "expected_name": "reminders",
+            "path": "/tasks",
+            "prefix": "/api/v1",
+            "tags": ("tasks",),
+            "route_key": "tasks",
+            "default_stable": True,
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.notifications",
+            "expected_name": "notifications",
+            "path": "/notifications",
+            "prefix": "/api/v1",
+            "tags": ("notifications",),
+            "route_key": "notifications",
+            "default_stable": True,
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.watchlists",
+            "expected_name": "watchlists",
+            "path": "/watchlists",
+            "prefix": "/api/v1",
+            "tags": ("watchlists",),
+            "route_key": "watchlists",
+            "default_stable": True,
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.integrations_control_plane",
+            "expected_name": "integrations_control_plane",
+            "path": "/integrations",
+            "prefix": "/api/v1",
+            "tags": ("integrations",),
+            "route_key": "integrations",
+            "default_stable": False,
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.scheduled_tasks_control_plane",
+            "expected_name": "scheduled_tasks_control_plane",
+            "path": "/scheduled-tasks",
+            "prefix": "/api/v1",
+            "tags": ("scheduled-tasks",),
+            "route_key": "scheduled-tasks",
+            "default_stable": False,
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.vn_assets",
+            "expected_name": "vn_assets",
+            "path": "/vn-assets",
+            "prefix": "/api/v1",
+            "tags": ("vn-assets",),
+            "route_key": "vn-assets",
+            "default_stable": True,
+        },
+    ]
+    routers_by_module: dict[str, APIRouter] = {}
+    access_count = {
+        str(definition["module_name"]): 0 for definition in router_definitions
+    }
+    import_calls: list[str] = []
+
+    for definition in router_definitions:
+        module_name = str(definition["module_name"])
+        router = APIRouter()
+
+        @router.get(str(definition["path"]))
+        def _endpoint() -> dict[str, str]:
+            """Return a deterministic response for the fake tail router."""
+            return {"status": "ok"}
+
+        routers_by_module[module_name] = router
+        fake_module = ModuleType(module_name)
+
+        def _module_getattr(
+            name: str,
+            *,
+            module_name: str = module_name,
+            router: APIRouter = router,
+        ) -> APIRouter:
+            """Track lazy router attribute resolution for the fake module."""
+            if name != "router":
+                raise AttributeError(name)
+            access_count[module_name] += 1
+            return router
+
+        fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Track lazy module imports for selected tail routers."""
+        if module_name in routers_by_module:
+            import_calls.append(module_name)
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    specs = list(iter_content_router_specs())
+    assert access_count == {
+        str(definition["module_name"]): 0 for definition in router_definitions
+    }
+    assert import_calls == []
+
+    selected_specs = {
+        spec.name: spec
+        for spec in specs
+        if spec.name in {
+            str(definition["expected_name"])
+            for definition in router_definitions
+        }
+    }
+    assert set(selected_specs) == {
+        str(definition["expected_name"]) for definition in router_definitions
+    }
+
+    for definition in router_definitions:
+        spec = selected_specs[str(definition["expected_name"])]
+        assert spec.prefix == definition["prefix"]
+        assert spec.tags == definition["tags"]
+        assert spec.route_key == definition["route_key"]
+        assert spec.default_stable is definition["default_stable"]
+        assert _first_router_path(spec.router) == definition["path"]
+
+    assert import_calls == [
+        str(definition["module_name"]) for definition in router_definitions
+    ]
+    assert access_count == {
+        str(definition["module_name"]): 1 for definition in router_definitions
+    }
+
+
 def test_qodo_reviewed_router_policy_regressions(monkeypatch: pytest.MonkeyPatch) -> None:
     _install_fake_router_module(
         monkeypatch,


### PR DESCRIPTION
Change summary
- Defers files, data-tables, items, tasks, notifications, watchlists, integrations, scheduled-tasks, and vn-assets content router imports through ImportedRouterSpec.
- Preserves prefixes, tags, route_key/default_stable settings, and router registration order for this tail family.
- Adds focused router-group contract coverage proving module import and router attr lookup stay lazy until resolution.

Verification
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k tail_router_attr_lookup -q (red before implementation, green after)
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/router_groups/content.py -f json -o /tmp/bandit_phase2_2_content_tail.json (results=0 errors=0)
- git diff --check
- git diff --check origin/dev..HEAD

Refs #1116