### PR TITLE
Add native CodeGraph C# extractor

### DIFF
--- a/Docs/superpowers/plans/2026-05-05-native-codegraph-csharp-extractor-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-05-native-codegraph-csharp-extractor-implementation-plan.md
@@ -1,0 +1,298 @@
+# Native CodeGraph C# Extractor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the Stage 5 C# native CodeGraph extractor slice without broadening into C/C++, Roslyn project analysis, Jobs mode, or full type resolution.
+
+**Architecture:** Follow the Java/Kotlin slice shape: keep C# parsing in a focused Tree-sitter extractor under `tldw_Server_API/app/core/CodeGraph/extractors/`, wire optional dependency availability through the centralized parser loader and language registry, and rely on existing repository/MCP search paths. Keep the extractor truthful and conservative: symbols and same-file simple calls are indexed, while external imports and receiver calls remain unresolved references.
+
+**Tech Stack:** Python 3.11, pytest, optional `tree-sitter`, optional `tree-sitter-c-sharp>=0.23,<0.24`, SQLite CodeGraph repository, existing Unified MCP CodeGraph module.
+
+---
+
+## Scope
+
+Included:
+
+- C# `using` directive, namespace, type, constructor, method, and property extraction.
+- Types: class, interface, struct, enum, and record declarations.
+- Conservative same-file simple invocation resolution by method/constructor name.
+- Receiver/member-access calls and external imports stored as unresolved refs.
+- Dependency-aware registry/indexer wiring and MCP search coverage through existing tools.
+- Focused verification and TASK-60 closeout.
+
+Excluded:
+
+- C and C++ extractors.
+- Roslyn, `.csproj`/`.sln`, NuGet, source generators, partial type merging, overload resolution, inheritance/interface implementation resolution, cross-file semantic type resolution, or extension-method resolution.
+- New MCP tools, Jobs-backed indexing, file watching, or context/impact behavior changes.
+
+## File Map
+
+- Modify: `pyproject.toml`
+  - Add optional `.[codegraph]` parser dependency for C# after local parser smoke verification.
+- Modify: `tldw_Server_API/app/core/CodeGraph/dependencies.py`
+  - Add `tree_sitter_c_sharp` to optional language dependency probing.
+- Modify: `tldw_Server_API/app/core/CodeGraph/extractors/tree_sitter_loader.py`
+  - Add parser module mapping for `csharp`.
+- Create: `tldw_Server_API/app/core/CodeGraph/extractors/csharp_extractor.py`
+  - C# Tree-sitter extraction.
+- Modify: `tldw_Server_API/app/core/CodeGraph/extractors/__init__.py`
+  - Export `CSharpTreeSitterExtractor` if local import patterns require it.
+- Modify: `tldw_Server_API/app/core/CodeGraph/language_registry.py`
+  - Promote C# from planned metadata to foundation metadata with dependency-aware `symbol_extraction`.
+- Modify: `tldw_Server_API/app/core/CodeGraph/indexer.py`
+  - Register the C# extractor only when its parser is available.
+- Modify: `tldw_Server_API/tests/CodeGraph/test_codegraph_tree_sitter_loader.py`
+  - Cover C# parser loading and missing dependency behavior.
+- Modify: `tldw_Server_API/tests/CodeGraph/test_codegraph_language_registry.py`
+  - Cover C# dependency-aware metadata.
+- Create: `tldw_Server_API/tests/CodeGraph/test_codegraph_csharp_extractor.py`
+  - C# extractor behavior.
+- Modify: `tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py`
+  - Indexer wiring and dependency-missing coverage for C#.
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py`
+  - Existing MCP search coverage for indexed C# symbols.
+- Modify: `backlog/tasks/task-60 - Implement-native-CodeGraph-C-extractor-slice.md`
+  - Keep task state, verification, and final summary current.
+
+## Stage 1: Dependency Gate
+
+**Goal:** Verify and wire the optional C# parser package.
+**Success Criteria:** Loader can parse a compact C# fixture, missing-package behavior reports `tree_sitter_c_sharp`, and dependency bounds are recorded.
+**Tests:** `tldw_Server_API/tests/CodeGraph/test_codegraph_tree_sitter_loader.py`
+**Status:** Complete
+
+- [x] **Step 1: Verify candidate parser package**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pip index versions tree-sitter-c-sharp
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pip install "tree-sitter-c-sharp>=0.23,<0.24"
+```
+
+Observed: PyPI exposes `tree-sitter-c-sharp 0.23.5`; local package exposes `tree_sitter_c_sharp.language`.
+
+- [x] **Step 2: Write RED loader tests**
+
+Add tests that call `load_parser("csharp")`, parse a compact C# class fixture, and assert missing-package behavior can report `tree_sitter_c_sharp` without raising.
+
+- [x] **Step 3: Run RED loader tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_tree_sitter_loader.py -q
+```
+
+Expected before implementation: fail with unsupported Tree-sitter language for C#.
+
+- [x] **Step 4: Implement parser mapping and dependency probe**
+
+Add:
+
+```python
+"csharp": ("tree_sitter_c_sharp", "language"),
+```
+
+to `_LANGUAGE_MODULES`, add `tree_sitter_c_sharp` to optional dependency probing, and add `tree-sitter-c-sharp>=0.23,<0.24` to `.[codegraph]`.
+
+- [x] **Step 5: Run GREEN loader tests**
+
+Run the same pytest command. Expected: all loader tests pass.
+
+## Stage 2: C# Extractor
+
+**Goal:** Extract conservative C# symbols and same-file calls.
+**Success Criteria:** Fixture extraction captures namespace, using directives, types, constructors, methods, properties, same-file call edges, unresolved receiver calls, parse errors, and deterministic node IDs.
+**Tests:** `tldw_Server_API/tests/CodeGraph/test_codegraph_csharp_extractor.py`
+**Status:** Complete
+
+- [x] **Step 1: Write RED C# extractor tests**
+
+Test source should include:
+
+```csharp
+using System;
+using Collections = System.Collections.Generic;
+
+namespace Example.App;
+
+public class Greeter {
+    public Greeter() { Setup(); }
+    public string Name { get; set; }
+    public string Greet(string name) { return Helper(name); }
+    private string Helper(string value) { return value.ToUpperInvariant(); }
+}
+
+internal interface IMarker { void Mark(); }
+public record Person(string Name);
+public struct Point { public int X { get; set; } }
+public enum Mode { Basic, Advanced }
+```
+
+Expected nodes:
+
+- module node for `src/Example/App/Greeter.cs`
+- namespace node `Example.App`
+- import nodes for `System` and `Collections = System.Collections.Generic`
+- class/interface/record/struct/enum nodes with visibility
+- constructor, method, and property nodes under their type scopes
+
+Expected relationships:
+
+- `Greet` has a resolved same-file call edge to `Helper`
+- constructor call to missing `Setup` is unresolved
+- receiver call `value.ToUpperInvariant()` is unresolved as `value.ToUpperInvariant`
+- using directives are unresolved refs
+
+- [x] **Step 2: Run RED extractor tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_csharp_extractor.py -q
+```
+
+Expected: fail because `CSharpTreeSitterExtractor` does not exist.
+
+- [x] **Step 3: Implement minimal C# extractor**
+
+Implement:
+
+- dependency errors through `load_parser("csharp")`
+- UTF-8 decode errors as `ExtractionResult(errors=(...))`
+- parse errors as `ExtractionResult(errors=("C# parse error",))`
+- `using_directive` as import nodes preserving alias syntax
+- `namespace_declaration` and `file_scoped_namespace_declaration`
+- `class_declaration`, `interface_declaration`, `struct_declaration`, `enum_declaration`, and `record_declaration`
+- `constructor_declaration`, `method_declaration`, and `property_declaration` inside type declaration bodies
+- same-file simple invocation resolution from `invocation_expression` where the function is an `identifier`
+- unresolved call refs where the function is a `member_access_expression`
+
+Do not attempt overload, receiver type, or cross-file resolution.
+
+- [x] **Step 4: Run GREEN extractor tests**
+
+Run the same pytest command. Expected: pass.
+
+## Stage 3: Registry And Indexer Wiring
+
+**Goal:** Make C# a dependency-aware foundation language and index C# graph rows only when extractable.
+**Success Criteria:** C# appears as foundation metadata, missing parser metadata is visible, indexer persists graph rows when available, and safely skips C# when unavailable.
+**Tests:** `tldw_Server_API/tests/CodeGraph/test_codegraph_language_registry.py`, selected `test_codegraph_indexer.py`
+**Status:** Complete
+
+- [x] **Step 1: Write RED registry/indexer tests**
+
+Add assertions that:
+
+- `CodeGraphLanguageRegistry(...).language_for_path("Program.cs")` returns `csharp`
+- C# stage is `foundation` when promoted
+- `dependency_missing == ("tree_sitter_c_sharp",)` and `symbol_extraction is False` when the package is missing
+- indexer skips non-extractable C# without tripping foreground limits
+- indexer persists C# graph rows when the parser is available
+
+- [x] **Step 2: Run RED tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/CodeGraph/test_codegraph_language_registry.py \
+  tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py::test_indexer_extracts_csharp_graph_rows_during_index \
+  tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py::test_indexer_does_not_count_non_extractable_csharp_files_against_foreground_limits -q
+```
+
+Expected: fail until registry/indexer wiring exists.
+
+- [x] **Step 3: Implement registry/indexer wiring**
+
+Move C# out of `_PLANNED_LANGUAGES`, add C# foundation metadata, and register `CSharpTreeSitterExtractor` in `CodeGraphIndexer` when `load_parser("csharp").available` is true.
+
+- [x] **Step 4: Run GREEN registry/indexer tests**
+
+Run the same pytest command. Expected: pass.
+
+## Stage 4: MCP Search Coverage
+
+**Goal:** Prove existing MCP CodeGraph tools can search indexed C# symbols.
+**Success Criteria:** `codegraph.index` followed by `codegraph.search` finds C# type/member symbols in a fixture workspace.
+**Tests:** `tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py`
+**Status:** Complete
+
+- [x] **Step 1: Write RED MCP search test**
+
+Add or extend a CodeGraph MCP test fixture with `Greeter.cs`, then assert search finds `Greeter`, `Greet`, or `Name` after indexing.
+
+- [x] **Step 2: Run RED MCP test**
+
+Run the focused test. Expected: fail until indexer wiring and extractor are complete.
+
+- [x] **Step 3: Implement any missing MCP exposure**
+
+Prefer no MCP production changes if the existing module delegates correctly through registry/indexer/repository.
+
+- [x] **Step 4: Run GREEN MCP test**
+
+Run the focused test. Expected: pass.
+
+## Stage 5: Verification And Closeout
+
+**Goal:** Verify the full focused surface and record task completion.
+**Success Criteria:** Focused tests, Ruff, Bandit, and diff check pass; TASK-60 records verification and known limits.
+**Tests:** Full focused CodeGraph/MCP command below.
+**Status:** Complete
+
+- [x] **Step 1: Run focused suite**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/CodeGraph \
+  tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py -q
+```
+
+- [x] **Step 2: Run Ruff**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check \
+  tldw_Server_API/app/core/CodeGraph \
+  tldw_Server_API/app/core/DB_Management/codegraph \
+  tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py \
+  tldw_Server_API/tests/CodeGraph \
+  tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
+```
+
+- [x] **Step 3: Run Bandit**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r \
+  tldw_Server_API/app/core/CodeGraph \
+  tldw_Server_API/app/core/DB_Management/codegraph \
+  tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py \
+  -f json -o /tmp/bandit_codegraph_csharp.json
+```
+
+Inspect the JSON and record `errors` / `results`.
+
+- [x] **Step 4: Run diff check**
+
+```bash
+git diff --check
+```
+
+- [x] **Step 5: Update TASK-60**
+
+Record verification, known limits, and final summary. Check acceptance criteria and DoD only after verification passes.
+
+- [x] **Step 6: Commit**
+
+```bash
+git add pyproject.toml Docs/superpowers/plans/2026-05-05-native-codegraph-csharp-extractor-implementation-plan.md \
+  backlog/tasks/task-60\ -\ Implement-native-CodeGraph-C-extractor-slice.md \
+  tldw_Server_API/app/core/CodeGraph tldw_Server_API/tests/CodeGraph \
+  tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
+git commit -m "feat: add codegraph csharp extractor"
+```

--- a/backlog/tasks/task-60 - Implement-native-CodeGraph-C-extractor-slice.md
+++ b/backlog/tasks/task-60 - Implement-native-CodeGraph-C-extractor-slice.md
@@ -1,0 +1,61 @@
+---
+id: TASK-60
+title: Implement native CodeGraph C# extractor slice
+status: Done
+assignee:
+  - '@Codex'
+created_date: '2026-05-05 03:25'
+updated_date: '2026-05-05 03:35'
+labels:
+  - codegraph
+  - mcp
+  - csharp
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1277'
+  - Docs/superpowers/specs/2026-05-03-native-codegraph-mcp-module-design.md
+documentation:
+  - Docs/superpowers/specs/2026-05-03-native-codegraph-mcp-module-design.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add the next Stage 5 native CodeGraph language slice after the merged Java/Kotlin work: conservative C# extractor support with namespace, using directive, type, constructor, method, property, and same-file simple call capture where practical. Keep the slice narrow: no C/C++, no Roslyn semantic model, no project/solution analysis, no full overload/type resolution, and no Jobs/file-watcher changes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 C# files are promoted from planned metadata to foundation metadata with dependency_missing and symbol_extraction reflecting optional parser availability.
+- [x] #2 C# extraction indexes namespace, using/import, class/interface/struct/enum/record, constructor, method, and property symbols with deterministic IDs and conservative unresolved references for external imports and receiver calls.
+- [x] #3 The indexer safely skips C# files when the optional C# parser is unavailable without blocking other extractable languages or foreground limits.
+- [x] #4 MCP search can find indexed C# type and member symbols after codegraph.index in a fixture workspace.
+- [x] #5 Focused loader, registry, extractor, indexer, and MCP tests cover C# behavior plus dependency-missing paths, with Ruff, Bandit on touched production scope, and git diff --check passing before PR.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented focused C# CodeGraph slice. Verified tree-sitter-c-sharp 0.23.5 exposes tree_sitter_c_sharp.language and installed tree-sitter-c-sharp>=0.23,<0.24 into the shared venv for local tests.
+
+Added optional dependency probing, parser loader mapping, csharp foundation metadata, CodeGraphIndexer registration, CSharpTreeSitterExtractor, extractor/indexer/registry/loader/MCP search tests, and implementation plan Docs/superpowers/plans/2026-05-05-native-codegraph-csharp-extractor-implementation-plan.md.
+
+Verification: focused RED tests failed for unsupported csharp or missing extractor before implementation; focused C# regression set passed with 9 passed; full CodeGraph plus MCP focused suite passed with 117 passed and 5 warnings; Ruff passed on touched CodeGraph/MCP/test scope; Bandit JSON at /tmp/bandit_codegraph_csharp.json reported results 0 and errors 0; git diff --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the native CodeGraph C# extractor slice. C# is now a dependency-aware foundation language backed by optional tree-sitter-c-sharp, with conservative extraction for using directives, namespaces, classes, interfaces, structs, records, enums, constructors, methods, properties, same-file simple calls, and unresolved external/receiver references. Known limits remain intentional: no Roslyn project model, project/solution analysis, partial type merging, overload/type inference, inheritance, extension-method, or cross-file semantic resolution.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-60 - Implement-native-CodeGraph-C-extractor-slice.md
+++ b/backlog/tasks/task-60 - Implement-native-CodeGraph-C-extractor-slice.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@Codex'
 created_date: '2026-05-05 03:25'
-updated_date: '2026-05-05 03:35'
+updated_date: '2026-05-05 03:38'
 labels:
   - codegraph
   - mcp
@@ -14,6 +14,7 @@ dependencies: []
 references:
   - 'https://github.com/rmusser01/tldw_server/pull/1277'
   - Docs/superpowers/specs/2026-05-03-native-codegraph-mcp-module-design.md
+  - 'https://github.com/rmusser01/tldw_server/pull/1288'
 documentation:
   - Docs/superpowers/specs/2026-05-03-native-codegraph-mcp-module-design.md
 priority: medium
@@ -48,6 +49,8 @@ Verification: focused RED tests failed for unsupported csharp or missing extract
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Implemented the native CodeGraph C# extractor slice. C# is now a dependency-aware foundation language backed by optional tree-sitter-c-sharp, with conservative extraction for using directives, namespaces, classes, interfaces, structs, records, enums, constructors, methods, properties, same-file simple calls, and unresolved external/receiver references. Known limits remain intentional: no Roslyn project model, project/solution analysis, partial type merging, overload/type inference, inheritance, extension-method, or cross-file semantic resolution.
+
+PR: https://github.com/rmusser01/tldw_server/pull/1288
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-60 - Implement-native-CodeGraph-C-extractor-slice.md
+++ b/backlog/tasks/task-60 - Implement-native-CodeGraph-C-extractor-slice.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@Codex'
 created_date: '2026-05-05 03:25'
-updated_date: '2026-05-05 03:38'
+updated_date: '2026-05-05 04:00'
 labels:
   - codegraph
   - mcp
@@ -35,6 +35,12 @@ Add the next Stage 5 native CodeGraph language slice after the merged Java/Kotli
 - [x] #5 Focused loader, registry, extractor, indexer, and MCP tests cover C# behavior plus dependency-missing paths, with Ruff, Bandit on touched production scope, and git diff --check passing before PR.
 <!-- AC:END -->
 
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+PR #1288 review-fix pass: add extractor regression coverage for nested block namespaces, namespace-scoped using directives, and generic method invocations; annotate the new C# indexer monkeypatch fixture; update C# namespace/call visitor behavior narrowly; rerun focused CodeGraph tests plus Ruff, Bandit, and git diff --check; then push and resolve the addressed review threads.
+<!-- SECTION:PLAN:END -->
+
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
@@ -43,6 +49,10 @@ Implemented focused C# CodeGraph slice. Verified tree-sitter-c-sharp 0.23.5 expo
 Added optional dependency probing, parser loader mapping, csharp foundation metadata, CodeGraphIndexer registration, CSharpTreeSitterExtractor, extractor/indexer/registry/loader/MCP search tests, and implementation plan Docs/superpowers/plans/2026-05-05-native-codegraph-csharp-extractor-implementation-plan.md.
 
 Verification: focused RED tests failed for unsupported csharp or missing extractor before implementation; focused C# regression set passed with 9 passed; full CodeGraph plus MCP focused suite passed with 117 passed and 5 warnings; Ruff passed on touched CodeGraph/MCP/test scope; Bandit JSON at /tmp/bandit_codegraph_csharp.json reported results 0 and errors 0; git diff --check passed.
+
+Reopened for PR #1288 review comments from Gemini and Qodo: nested namespace qualification, generic method invocations, namespace-scoped using extraction, and monkeypatch typing.
+
+PR #1288 review-fix verification: focused review tests passed for block namespaces/usings/generic calls and C# dependency-missing indexer path; full CodeGraph plus MCP focused suite passed with 118 passed and 5 warnings; Ruff passed on touched CodeGraph/MCP/test scope; Bandit JSON at /tmp/bandit_codegraph_csharp_review_fixes.json reported errors 0 and results 0; git diff --check passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
@@ -51,6 +61,8 @@ Verification: focused RED tests failed for unsupported csharp or missing extract
 Implemented the native CodeGraph C# extractor slice. C# is now a dependency-aware foundation language backed by optional tree-sitter-c-sharp, with conservative extraction for using directives, namespaces, classes, interfaces, structs, records, enums, constructors, methods, properties, same-file simple calls, and unresolved external/receiver references. Known limits remain intentional: no Roslyn project model, project/solution analysis, partial type merging, overload/type inference, inheritance, extension-method, or cross-file semantic resolution.
 
 PR: https://github.com/rmusser01/tldw_server/pull/1288
+
+PR #1288 review follow-up: fixed nested block-scoped namespace qualification, namespace-scoped using extraction, generic same-file method invocation resolution, and pytest MonkeyPatch typing in the touched indexer tests.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,6 +184,7 @@ codegraph = [
   "tree-sitter-typescript>=0.23,<0.24",
   "tree-sitter-java>=0.23,<0.24",
   "tree-sitter-kotlin>=1.1,<1.2",
+  "tree-sitter-c-sharp>=0.23,<0.24",
 ]
 
 # Multi-User

--- a/tldw_Server_API/app/core/CodeGraph/dependencies.py
+++ b/tldw_Server_API/app/core/CodeGraph/dependencies.py
@@ -12,6 +12,7 @@ _OPTIONAL_LANGUAGE_MODULES = (
     "tree_sitter_typescript",
     "tree_sitter_java",
     "tree_sitter_kotlin",
+    "tree_sitter_c_sharp",
 )
 _PROBED_MODULES = (*_CORE_MODULES, *_OPTIONAL_LANGUAGE_MODULES)
 

--- a/tldw_Server_API/app/core/CodeGraph/extractors/__init__.py
+++ b/tldw_Server_API/app/core/CodeGraph/extractors/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from .csharp_extractor import CSharpTreeSitterExtractor
 from .java_extractor import JavaTreeSitterExtractor
 from .javascript_extractor import JavaScriptTreeSitterExtractor
 from .kotlin_extractor import KotlinTreeSitterExtractor
@@ -9,6 +10,7 @@ from .python_extractor import PythonAstExtractor
 from .typescript_extractor import TypeScriptTreeSitterExtractor
 
 __all__ = [
+    "CSharpTreeSitterExtractor",
     "JavaScriptTreeSitterExtractor",
     "JavaTreeSitterExtractor",
     "KotlinTreeSitterExtractor",

--- a/tldw_Server_API/app/core/CodeGraph/extractors/csharp_extractor.py
+++ b/tldw_Server_API/app/core/CodeGraph/extractors/csharp_extractor.py
@@ -139,16 +139,17 @@ class _CSharpGraphBuilder:
         )
 
     def _visit_namespace_declaration(self, node: Any) -> None:
-        name = node_text(self.source, node.child_by_field_name("name"))
-        if not name:
+        local_name = node_text(self.source, node.child_by_field_name("name"))
+        if not local_name:
             return
         previous_namespace = self._namespace_name
-        self._namespace_name = name
+        namespace_name = qualified_name(previous_namespace, local_name)
+        self._namespace_name = namespace_name
         self.nodes.append(
             self._make_node(
                 kind="namespace",
-                name=name,
-                qualified_name_value=name,
+                name=local_name,
+                qualified_name_value=namespace_name,
                 node=node,
             )
         )
@@ -156,11 +157,13 @@ class _CSharpGraphBuilder:
         body = first_named_child_of_type(node, "declaration_list")
         if body is not None:
             for child in body.named_children:
-                if child.type in _TYPE_KINDS:
+                if child.type == "using_directive":
+                    self._visit_using_directive(child)
+                elif child.type in _TYPE_KINDS:
                     self._visit_type_declaration(child)
                 elif child.type in {"file_scoped_namespace_declaration", "namespace_declaration"}:
                     self._visit_namespace_declaration(child)
-        self._namespace_name = previous_namespace if node.type == "namespace_declaration" else name
+        self._namespace_name = previous_namespace if node.type == "namespace_declaration" else namespace_name
 
     def _visit_type_declaration(self, node: Any) -> None:
         name_node = node.child_by_field_name("name")
@@ -259,11 +262,20 @@ class _CSharpGraphBuilder:
         if function_node is None:
             return
 
-        if function_node.type == "identifier":
+        if function_node.type in {"identifier", "generic_name"}:
+            if function_node.type == "generic_name":
+                name_node = function_node.child_by_field_name("name") or first_named_child_of_type(
+                    function_node, "identifier"
+                )
+            else:
+                name_node = function_node
+            reference_name = node_text(self.source, name_node)
+            if not reference_name:
+                return
             self._call_sites.append(
                 JvmCallSite(
                     source_node_id=current_scope.id,
-                    reference_name=node_text(self.source, function_node),
+                    reference_name=reference_name,
                     line=line(node),
                     column=column(node),
                 )

--- a/tldw_Server_API/app/core/CodeGraph/extractors/csharp_extractor.py
+++ b/tldw_Server_API/app/core/CodeGraph/extractors/csharp_extractor.py
@@ -1,0 +1,325 @@
+"""Tree-sitter C# extraction for native CodeGraph."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tldw_Server_API.app.core.CodeGraph.extractors.jvm_common import (
+    JvmCallSite,
+    column,
+    declaration_payload_text,
+    first_named_child_of_type,
+    line,
+    make_jvm_node,
+    module_qualified_name,
+    node_text,
+    qualified_name,
+    remember_callable,
+    resolve_call_sites,
+)
+from tldw_Server_API.app.core.CodeGraph.extractors.tree_sitter_loader import load_parser
+from tldw_Server_API.app.core.CodeGraph.models import (
+    CodeGraphNode,
+    CodeGraphUnresolvedRef,
+    ExtractionResult,
+)
+
+_TYPE_KINDS = {
+    "class_declaration": "class",
+    "interface_declaration": "interface",
+    "struct_declaration": "struct",
+    "enum_declaration": "enum",
+    "record_declaration": "record",
+}
+
+
+class CSharpTreeSitterExtractor:
+    """Extract conservative C# symbols and same-file calls with Tree-sitter."""
+
+    language_id = "csharp"
+
+    def extract(self, *, workspace_key: str, file_path: str, source: bytes) -> ExtractionResult:
+        """Parse one C# file and return symbols, calls, unresolved refs, and errors."""
+        parser_result = load_parser("csharp")
+        if parser_result.missing:
+            return ExtractionResult(errors=(f"Missing Tree-sitter dependencies: {', '.join(parser_result.missing)}",))
+        if parser_result.error or parser_result.parser is None:
+            return ExtractionResult(errors=(parser_result.error or "C# parser unavailable",))
+
+        try:
+            text = source.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            return ExtractionResult(errors=(str(exc),))
+
+        tree = parser_result.parser.parse(source)
+        if tree.root_node.has_error:
+            return ExtractionResult(errors=("C# parse error",))
+
+        builder = _CSharpGraphBuilder(workspace_key=workspace_key, file_path=file_path, source=source, source_text=text)
+        return builder.build(tree.root_node)
+
+
+class _CSharpGraphBuilder:
+    """Stateful Tree-sitter visitor for one C# source file."""
+
+    def __init__(self, *, workspace_key: str, file_path: str, source: bytes, source_text: str) -> None:
+        self.workspace_key = workspace_key
+        self.file_path = file_path
+        self.source = source
+        self.source_text = source_text
+        self.nodes: list[CodeGraphNode] = []
+        self.unresolved_refs: list[CodeGraphUnresolvedRef] = []
+        self._namespace_name = ""
+        self._scope_stack: list[CodeGraphNode] = []
+        self._type_stack: list[str] = []
+        self._call_sites: list[JvmCallSite] = []
+        self._callable_by_name: dict[str, CodeGraphNode | None] = {}
+
+    def build(self, root_node: Any) -> ExtractionResult:
+        """Visit a parsed C# compilation unit and resolve same-file calls."""
+        module_node = self._make_node(
+            kind="module",
+            name=module_qualified_name(self.file_path).rsplit(".", 1)[-1],
+            qualified_name_value=module_qualified_name(self.file_path),
+            node=root_node,
+            start_line=1,
+            end_line=max(1, len(self.source_text.splitlines())),
+        )
+        self.nodes.append(module_node)
+        self._scope_stack.append(module_node)
+        for child in root_node.named_children:
+            self._visit_top_level(child)
+        self._scope_stack.pop()
+
+        call_edges, call_unresolved_refs = resolve_call_sites(
+            call_sites=tuple(self._call_sites),
+            callable_by_name=self._callable_by_name,
+            file_path=self.file_path,
+            language_id=CSharpTreeSitterExtractor.language_id,
+            provenance="tree_sitter_csharp",
+        )
+        return ExtractionResult(
+            nodes=tuple(self.nodes),
+            edges=call_edges,
+            unresolved_refs=(*self.unresolved_refs, *call_unresolved_refs),
+        )
+
+    def _visit_top_level(self, node: Any) -> None:
+        if node.type == "using_directive":
+            self._visit_using_directive(node)
+            return
+        if node.type in {"file_scoped_namespace_declaration", "namespace_declaration"}:
+            self._visit_namespace_declaration(node)
+            return
+        if node.type in _TYPE_KINDS:
+            self._visit_type_declaration(node)
+
+    def _visit_using_directive(self, node: Any) -> None:
+        imported = declaration_payload_text(self.source, node, "using")
+        if not imported:
+            return
+        import_node = self._make_node(
+            kind="import",
+            name=imported,
+            qualified_name_value=imported,
+            node=node,
+            metadata={"imported": imported, "source": imported},
+        )
+        self.nodes.append(import_node)
+        self.unresolved_refs.append(
+            CodeGraphUnresolvedRef(
+                from_node_id=import_node.id,
+                reference_name=imported,
+                reference_kind="import",
+                file_path=self.file_path,
+                line=line(node),
+                column=column(node),
+                language=CSharpTreeSitterExtractor.language_id,
+            )
+        )
+
+    def _visit_namespace_declaration(self, node: Any) -> None:
+        name = node_text(self.source, node.child_by_field_name("name"))
+        if not name:
+            return
+        previous_namespace = self._namespace_name
+        self._namespace_name = name
+        self.nodes.append(
+            self._make_node(
+                kind="namespace",
+                name=name,
+                qualified_name_value=name,
+                node=node,
+            )
+        )
+
+        body = first_named_child_of_type(node, "declaration_list")
+        if body is not None:
+            for child in body.named_children:
+                if child.type in _TYPE_KINDS:
+                    self._visit_type_declaration(child)
+                elif child.type in {"file_scoped_namespace_declaration", "namespace_declaration"}:
+                    self._visit_namespace_declaration(child)
+        self._namespace_name = previous_namespace if node.type == "namespace_declaration" else name
+
+    def _visit_type_declaration(self, node: Any) -> None:
+        name_node = node.child_by_field_name("name")
+        name = node_text(self.source, name_node)
+        if not name:
+            return
+        type_node = self._make_node(
+            kind=_TYPE_KINDS[node.type],
+            name=name,
+            qualified_name_value=qualified_name(self._namespace_name, *self._type_stack, name),
+            node=node,
+            visibility=_visibility(self.source, node),
+        )
+        self.nodes.append(type_node)
+
+        self._scope_stack.append(type_node)
+        self._type_stack.append(name)
+        body = first_named_child_of_type(node, "declaration_list")
+        if body is not None:
+            for child in body.named_children:
+                if child.type in _TYPE_KINDS:
+                    self._visit_type_declaration(child)
+                elif child.type == "constructor_declaration":
+                    self._visit_constructor_declaration(child)
+                elif child.type == "method_declaration":
+                    self._visit_method_declaration(child)
+                elif child.type == "property_declaration":
+                    self._visit_property_declaration(child)
+        self._type_stack.pop()
+        self._scope_stack.pop()
+
+    def _visit_constructor_declaration(self, node: Any) -> None:
+        name = node_text(self.source, node.child_by_field_name("name"))
+        if not name:
+            return
+        constructor_node = self._make_node(
+            kind="constructor",
+            name=name,
+            qualified_name_value=qualified_name(self._namespace_name, *self._type_stack, name),
+            node=node,
+            visibility=_visibility(self.source, node),
+        )
+        self.nodes.append(constructor_node)
+        remember_callable(self._callable_by_name, constructor_node)
+        self._visit_callable_body(node, constructor_node)
+
+    def _visit_method_declaration(self, node: Any) -> None:
+        name = node_text(self.source, node.child_by_field_name("name"))
+        if not name:
+            return
+        method_node = self._make_node(
+            kind="method",
+            name=name,
+            qualified_name_value=qualified_name(self._namespace_name, *self._type_stack, name),
+            node=node,
+            visibility=_visibility(self.source, node),
+        )
+        self.nodes.append(method_node)
+        remember_callable(self._callable_by_name, method_node)
+        self._visit_callable_body(node, method_node)
+
+    def _visit_property_declaration(self, node: Any) -> None:
+        name = node_text(self.source, node.child_by_field_name("name"))
+        if not name:
+            return
+        self.nodes.append(
+            self._make_node(
+                kind="property",
+                name=name,
+                qualified_name_value=qualified_name(self._namespace_name, *self._type_stack, name),
+                node=node,
+                visibility=_visibility(self.source, node),
+            )
+        )
+
+    def _visit_callable_body(self, node: Any, callable_node: CodeGraphNode) -> None:
+        body = first_named_child_of_type(node, "block")
+        if body is None:
+            return
+        self._scope_stack.append(callable_node)
+        self._visit_executable(body)
+        self._scope_stack.pop()
+
+    def _visit_executable(self, node: Any) -> None:
+        if node.type == "invocation_expression":
+            self._visit_invocation_expression(node)
+        for child in node.named_children:
+            self._visit_executable(child)
+
+    def _visit_invocation_expression(self, node: Any) -> None:
+        current_scope = self._scope_stack[-1] if self._scope_stack else None
+        if current_scope is None or current_scope.kind not in {"constructor", "method"}:
+            return
+
+        function_node = node.child_by_field_name("function")
+        if function_node is None:
+            return
+
+        if function_node.type == "identifier":
+            self._call_sites.append(
+                JvmCallSite(
+                    source_node_id=current_scope.id,
+                    reference_name=node_text(self.source, function_node),
+                    line=line(node),
+                    column=column(node),
+                )
+            )
+            return
+
+        if function_node.type == "member_access_expression":
+            reference_name = node_text(self.source, function_node)
+            if reference_name:
+                self.unresolved_refs.append(
+                    CodeGraphUnresolvedRef(
+                        from_node_id=current_scope.id,
+                        reference_name=reference_name,
+                        reference_kind="call",
+                        file_path=self.file_path,
+                        line=line(node),
+                        column=column(node),
+                        language=CSharpTreeSitterExtractor.language_id,
+                    )
+                )
+
+    def _make_node(
+        self,
+        *,
+        kind: str,
+        name: str,
+        qualified_name_value: str,
+        node: Any,
+        start_line: int | None = None,
+        end_line: int | None = None,
+        visibility: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> CodeGraphNode:
+        return make_jvm_node(
+            workspace_key=self.workspace_key,
+            language_id=CSharpTreeSitterExtractor.language_id,
+            file_path=self.file_path,
+            kind=kind,
+            name=name,
+            qualified_name_value=qualified_name_value,
+            node=node,
+            start_line=start_line,
+            end_line=end_line,
+            visibility=visibility,
+            metadata=metadata,
+        )
+
+
+def _visibility(source: bytes, node: Any) -> str | None:
+    for child in node.children:
+        if child.type != "modifier":
+            continue
+        modifier = node_text(source, child)
+        if modifier in {"public", "protected", "private", "internal"}:
+            return modifier
+    return None
+
+
+__all__ = ["CSharpTreeSitterExtractor"]

--- a/tldw_Server_API/app/core/CodeGraph/extractors/tree_sitter_loader.py
+++ b/tldw_Server_API/app/core/CodeGraph/extractors/tree_sitter_loader.py
@@ -1,4 +1,4 @@
-"""Optional Tree-sitter parser loading for CodeGraph JS-family extractors."""
+"""Optional Tree-sitter parser loading for CodeGraph extractors."""
 
 from __future__ import annotations
 
@@ -28,11 +28,12 @@ _LANGUAGE_MODULES: dict[str, tuple[str, str]] = {
     "tsx": ("tree_sitter_typescript", "language_tsx"),
     "java": ("tree_sitter_java", "language"),
     "kotlin": ("tree_sitter_kotlin", "language"),
+    "csharp": ("tree_sitter_c_sharp", "language"),
 }
 
 
 def load_parser(language_id: str) -> ParserLoadResult:
-    """Dynamically load a Tree-sitter parser for a supported JS-family language."""
+    """Dynamically load a Tree-sitter parser for a supported language."""
     parser_package = _LANGUAGE_MODULES.get(language_id)
     if parser_package is None:
         return ParserLoadResult(error=f"Unsupported Tree-sitter language: {language_id}")

--- a/tldw_Server_API/app/core/CodeGraph/indexer.py
+++ b/tldw_Server_API/app/core/CodeGraph/indexer.py
@@ -14,6 +14,7 @@ from loguru import logger
 from tldw_Server_API.app.core.DB_Management.codegraph.repository import CodeGraphRepository
 
 from .config import CodeGraphSettings
+from .extractors.csharp_extractor import CSharpTreeSitterExtractor
 from .extractors.java_extractor import JavaTreeSitterExtractor
 from .extractors.javascript_extractor import JavaScriptTreeSitterExtractor
 from .extractors.kotlin_extractor import KotlinTreeSitterExtractor
@@ -86,6 +87,8 @@ class CodeGraphIndexer:
             self._extractors["java"] = JavaTreeSitterExtractor()
         if load_parser("kotlin").available:
             self._extractors["kotlin"] = KotlinTreeSitterExtractor()
+        if load_parser("csharp").available:
+            self._extractors["csharp"] = CSharpTreeSitterExtractor()
 
     def index_workspace(
         self,

--- a/tldw_Server_API/app/core/CodeGraph/language_registry.py
+++ b/tldw_Server_API/app/core/CodeGraph/language_registry.py
@@ -18,12 +18,6 @@ _PLANNED_LANGUAGES = (
         extensions=(".cc", ".cpp", ".cxx", ".hpp", ".hh", ".hxx"),
         stage="planned",
     ),
-    LanguageInfo(
-        language_id="csharp",
-        display_name="C#",
-        extensions=(".cs",),
-        stage="planned",
-    ),
 )
 
 
@@ -63,6 +57,7 @@ def _foundation_languages(dependency_health: DependencyHealth) -> tuple[Language
     typescript_missing = _missing_dependencies(missing, ("tree_sitter", "tree_sitter_typescript"))
     java_missing = _missing_dependencies(missing, ("tree_sitter", "tree_sitter_java"))
     kotlin_missing = _missing_dependencies(missing, ("tree_sitter", "tree_sitter_kotlin"))
+    csharp_missing = _missing_dependencies(missing, ("tree_sitter", "tree_sitter_c_sharp"))
     return (
         LanguageInfo(
             language_id="python",
@@ -102,6 +97,14 @@ def _foundation_languages(dependency_health: DependencyHealth) -> tuple[Language
             stage="foundation",
             dependency_missing=kotlin_missing,
             symbol_extraction=not kotlin_missing,
+        ),
+        LanguageInfo(
+            language_id="csharp",
+            display_name="C#",
+            extensions=(".cs",),
+            stage="foundation",
+            dependency_missing=csharp_missing,
+            symbol_extraction=not csharp_missing,
         ),
     )
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
@@ -332,6 +332,48 @@ class Greeter {
     ]
 
 
+@pytest.mark.asyncio
+async def test_codegraph_search_finds_csharp_symbols_after_index(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    (workspace_root / "Greeter.cs").write_text(
+        """
+using System;
+
+namespace Example.App;
+
+public class Greeter {
+    public string Greet(string name) {
+        return Helper(name);
+    }
+
+    private string Helper(string value) {
+        return value.Trim();
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    module = _module(tmp_path, workspace_root)
+
+    index_result = await module.execute_tool(
+        "codegraph.index",
+        {"mode": "foreground", "force": True, "max_files": 10},
+        context=_context(),
+    )
+    search = await module.execute_tool(
+        "codegraph.search",
+        {"query": "Helper", "kind": "method", "language": "csharp", "limit": 10},
+        context=_context(),
+    )
+
+    assert index_result["status"] == "complete"  # nosec B101
+    assert index_result["counters"]["files_indexed"] == 1  # nosec B101
+    assert [item["qualified_name"] for item in search["results"]] == [  # nosec B101
+        "Example.App.Greeter.Helper"
+    ]
+
+
 def test_codegraph_rejects_ambiguous_node_selectors(tmp_path: Path) -> None:
     workspace_root = tmp_path / "workspace"
     workspace_root.mkdir()

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_csharp_extractor.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_csharp_extractor.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from tldw_Server_API.app.core.CodeGraph.extractors.csharp_extractor import CSharpTreeSitterExtractor
+from tldw_Server_API.app.core.CodeGraph.models import ExtractionResult
+
+CSHARP_FIXTURE = b"""
+using System;
+using Collections = System.Collections.Generic;
+
+namespace Example.App;
+
+public class Greeter {
+    public Greeter() {
+        Setup();
+    }
+
+    public string Name { get; set; }
+
+    public string Greet(string name) {
+        return Helper(name);
+    }
+
+    private string Helper(string value) {
+        return value.ToUpperInvariant();
+    }
+}
+
+internal interface IMarker {
+    void Mark();
+}
+
+public record Person(string Name);
+
+public struct Point {
+    public int X { get; set; }
+}
+
+public enum Mode {
+    Basic,
+    Advanced
+}
+"""
+
+
+def test_csharp_extractor_records_namespaces_imports_types_members_and_calls() -> None:
+    """Extract conservative C# symbols and same-file method calls."""
+    result = CSharpTreeSitterExtractor().extract(
+        workspace_key="ws",
+        file_path="src/Example/App/Greeter.cs",
+        source=CSHARP_FIXTURE,
+    )
+
+    nodes_by_kind_name = {(node.kind, node.name): node for node in result.nodes}
+
+    assert ("module", "Greeter") in nodes_by_kind_name
+    assert ("namespace", "Example.App") in nodes_by_kind_name
+    assert ("import", "System") in nodes_by_kind_name
+    assert ("import", "Collections = System.Collections.Generic") in nodes_by_kind_name
+    assert ("class", "Greeter") in nodes_by_kind_name
+    assert ("constructor", "Greeter") in nodes_by_kind_name
+    assert ("property", "Name") in nodes_by_kind_name
+    assert ("method", "Greet") in nodes_by_kind_name
+    assert ("method", "Helper") in nodes_by_kind_name
+    assert ("interface", "IMarker") in nodes_by_kind_name
+    assert ("method", "Mark") in nodes_by_kind_name
+    assert ("record", "Person") in nodes_by_kind_name
+    assert ("struct", "Point") in nodes_by_kind_name
+    assert ("property", "X") in nodes_by_kind_name
+    assert ("enum", "Mode") in nodes_by_kind_name
+
+    greeter = nodes_by_kind_name[("class", "Greeter")]
+    constructor = nodes_by_kind_name[("constructor", "Greeter")]
+    name_property = nodes_by_kind_name[("property", "Name")]
+    greet = nodes_by_kind_name[("method", "Greet")]
+    helper = nodes_by_kind_name[("method", "Helper")]
+    marker = nodes_by_kind_name[("interface", "IMarker")]
+    mark = nodes_by_kind_name[("method", "Mark")]
+    point_x = nodes_by_kind_name[("property", "X")]
+
+    assert greeter.qualified_name == "Example.App.Greeter"
+    assert greeter.visibility == "public"
+    assert constructor.qualified_name == "Example.App.Greeter.Greeter"
+    assert name_property.qualified_name == "Example.App.Greeter.Name"
+    assert greet.qualified_name == "Example.App.Greeter.Greet"
+    assert helper.qualified_name == "Example.App.Greeter.Helper"
+    assert helper.visibility == "private"
+    assert marker.qualified_name == "Example.App.IMarker"
+    assert marker.visibility == "internal"
+    assert mark.qualified_name == "Example.App.IMarker.Mark"
+    assert point_x.qualified_name == "Example.App.Point.X"
+    assert (greet.id, helper.id) in {(edge.source, edge.target) for edge in result.edges}
+    assert any(
+        ref.reference_kind == "call" and ref.reference_name == "Setup" and ref.from_node_id == constructor.id
+        for ref in result.unresolved_refs
+    )
+    assert any(
+        ref.reference_kind == "call" and ref.reference_name == "value.ToUpperInvariant"
+        for ref in result.unresolved_refs
+    )
+    assert any(
+        ref.reference_kind == "import" and ref.reference_name == "Collections = System.Collections.Generic"
+        for ref in result.unresolved_refs
+    )
+    assert result.errors == ()
+
+
+def test_csharp_extractor_marks_parse_errors() -> None:
+    """Return extraction errors for invalid C# syntax."""
+    result = CSharpTreeSitterExtractor().extract(
+        workspace_key="ws",
+        file_path="src/Broken.cs",
+        source=b"class Broken {",
+    )
+
+    assert result == ExtractionResult(errors=("C# parse error",))
+
+
+def test_csharp_extractor_uses_deterministic_node_ids() -> None:
+    """Use stable node IDs across repeated C# extraction."""
+    first = CSharpTreeSitterExtractor().extract(
+        workspace_key="ws",
+        file_path="src/Greeter.cs",
+        source=CSHARP_FIXTURE,
+    )
+    second = CSharpTreeSitterExtractor().extract(
+        workspace_key="ws",
+        file_path="src/Greeter.cs",
+        source=CSHARP_FIXTURE,
+    )
+
+    assert [node.id for node in first.nodes] == [node.id for node in second.nodes]

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_csharp_extractor.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_csharp_extractor.py
@@ -41,6 +41,24 @@ public enum Mode {
 }
 """
 
+CSHARP_BLOCK_NAMESPACE_FIXTURE = b"""
+namespace Outer {
+    using InternalThing = Example.Internal.Tooling;
+
+    namespace Inner {
+        public class GenericGreeter {
+            public string Greet(string name) {
+                return Transform<string>(name);
+            }
+
+            private string Transform<T>(string value) {
+                return value.Trim();
+            }
+        }
+    }
+}
+"""
+
 
 def test_csharp_extractor_records_namespaces_imports_types_members_and_calls() -> None:
     """Extract conservative C# symbols and same-file method calls."""
@@ -99,6 +117,42 @@ def test_csharp_extractor_records_namespaces_imports_types_members_and_calls() -
     )
     assert any(
         ref.reference_kind == "import" and ref.reference_name == "Collections = System.Collections.Generic"
+        for ref in result.unresolved_refs
+    )
+    assert result.errors == ()
+
+
+def test_csharp_extractor_handles_block_namespaces_usings_and_generic_calls() -> None:
+    """Handle common block-scoped namespace layouts without losing scope or calls."""
+    result = CSharpTreeSitterExtractor().extract(
+        workspace_key="ws",
+        file_path="src/Outer/Inner/GenericGreeter.cs",
+        source=CSHARP_BLOCK_NAMESPACE_FIXTURE,
+    )
+
+    nodes_by_kind_name = {(node.kind, node.name): node for node in result.nodes}
+
+    outer_namespace = nodes_by_kind_name[("namespace", "Outer")]
+    inner_namespace = nodes_by_kind_name[("namespace", "Inner")]
+    import_node = nodes_by_kind_name[("import", "InternalThing = Example.Internal.Tooling")]
+    greeter = nodes_by_kind_name[("class", "GenericGreeter")]
+    greet = nodes_by_kind_name[("method", "Greet")]
+    transform = nodes_by_kind_name[("method", "Transform")]
+
+    assert outer_namespace.qualified_name == "Outer"
+    assert inner_namespace.qualified_name == "Outer.Inner"
+    assert greeter.qualified_name == "Outer.Inner.GenericGreeter"
+    assert greet.qualified_name == "Outer.Inner.GenericGreeter.Greet"
+    assert transform.qualified_name == "Outer.Inner.GenericGreeter.Transform"
+    assert (greet.id, transform.id) in {(edge.source, edge.target) for edge in result.edges}
+    assert any(
+        ref.reference_kind == "import"
+        and ref.reference_name == "InternalThing = Example.Internal.Tooling"
+        and ref.from_node_id == import_node.id
+        for ref in result.unresolved_refs
+    )
+    assert any(
+        ref.reference_kind == "call" and ref.reference_name == "value.Trim" and ref.from_node_id == transform.id
         for ref in result.unresolved_refs
     )
     assert result.errors == ()

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py
@@ -167,6 +167,47 @@ class Greeter {
     assert helper_paths == ["Greeter.kt", "Service.java"]
 
 
+def test_indexer_extracts_csharp_graph_rows_during_index(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "Greeter.cs").write_text(
+        """
+using System;
+
+namespace Example.App;
+
+public class Greeter {
+    public string Greet(string name) {
+        return Helper(name);
+    }
+
+    private string Helper(string value) {
+        return value.Trim();
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    repo = CodeGraphRepository(tmp_path / "codegraph.db")
+    indexer = CodeGraphIndexer(settings=CodeGraphSettings.from_mapping({}), registry=CodeGraphLanguageRegistry())
+
+    result = indexer.index_workspace(
+        workspace_root=workspace,
+        workspace_key="ws_test",
+        repository=repo,
+        force=True,
+        languages=None,
+        max_files=10,
+    )
+
+    files = {item.path: item for item in repo.list_files(limit=10)}
+    helper_paths = sorted(node.file_path for node in repo.search_nodes("Helper", limit=10))
+
+    assert result.status == "complete"
+    assert files["Greeter.cs"].node_count > 0
+    assert helper_paths == ["Greeter.cs"]
+
+
 def test_indexer_does_not_count_non_extractable_jvm_files_against_foreground_limits(
     tmp_path: Path,
     monkeypatch,
@@ -186,6 +227,49 @@ def test_indexer_does_not_count_non_extractable_jvm_files_against_foreground_lim
             available=True,
             missing=("tree_sitter_java", "tree_sitter_kotlin"),
             present=("tree_sitter", "tree_sitter_javascript", "tree_sitter_typescript"),
+        )
+    )
+    indexer = CodeGraphIndexer(settings=CodeGraphSettings.from_mapping({}), registry=registry)
+
+    result = indexer.index_workspace(
+        workspace_root=workspace,
+        workspace_key="ws_test",
+        repository=repo,
+        force=True,
+        languages=None,
+        max_files=1,
+    )
+
+    assert result.status == "complete"
+    assert result.counters["dependency_missing_language_skipped"] == 2
+    assert [item.path for item in repo.list_files(limit=10)] == ["app.py"]
+
+
+def test_indexer_does_not_count_non_extractable_csharp_files_against_foreground_limits(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    def fake_load_parser(language_id: str) -> SimpleNamespace:
+        return SimpleNamespace(available=language_id != "csharp")
+
+    monkeypatch.setattr(indexer_module, "load_parser", fake_load_parser)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "A.cs").write_text("class A {}\n", encoding="utf-8")
+    (workspace / "B.cs").write_text("class B {}\n", encoding="utf-8")
+    (workspace / "app.py").write_text("def helper():\n    return 1\n", encoding="utf-8")
+    repo = CodeGraphRepository(tmp_path / "codegraph.db")
+    registry = CodeGraphLanguageRegistry(
+        dependency_health=DependencyHealth(
+            available=True,
+            missing=("tree_sitter_c_sharp",),
+            present=(
+                "tree_sitter",
+                "tree_sitter_javascript",
+                "tree_sitter_typescript",
+                "tree_sitter_java",
+                "tree_sitter_kotlin",
+            ),
         )
     )
     indexer = CodeGraphIndexer(settings=CodeGraphSettings.from_mapping({}), registry=registry)

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
+import pytest
+
 import tldw_Server_API.app.core.CodeGraph.indexer as indexer_module
 from tldw_Server_API.app.core.CodeGraph.config import CodeGraphSettings
 from tldw_Server_API.app.core.CodeGraph.dependencies import DependencyHealth
@@ -210,7 +212,7 @@ public class Greeter {
 
 def test_indexer_does_not_count_non_extractable_jvm_files_against_foreground_limits(
     tmp_path: Path,
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def fake_load_parser(language_id: str) -> SimpleNamespace:
         return SimpleNamespace(available=language_id not in {"java", "kotlin"})
@@ -247,7 +249,7 @@ def test_indexer_does_not_count_non_extractable_jvm_files_against_foreground_lim
 
 def test_indexer_does_not_count_non_extractable_csharp_files_against_foreground_limits(
     tmp_path: Path,
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def fake_load_parser(language_id: str) -> SimpleNamespace:
         return SimpleNamespace(available=language_id != "csharp")

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_language_registry.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_language_registry.py
@@ -39,9 +39,9 @@ def test_registry_reports_foundation_languages_and_planned_languages() -> None:
     assert by_id["typescript"].stage == "foundation"
     assert by_id["java"].stage == "foundation"
     assert by_id["kotlin"].stage == "foundation"
+    assert by_id["csharp"].stage == "foundation"
     assert by_id["c"].stage == "planned"
     assert by_id["cpp"].stage == "planned"
-    assert by_id["csharp"].stage == "planned"
 
 
 def test_registry_maps_extensions_and_reports_symbol_extraction_support() -> None:
@@ -56,6 +56,7 @@ def test_registry_maps_extensions_and_reports_symbol_extraction_support() -> Non
                 "tree_sitter_typescript",
                 "tree_sitter_java",
                 "tree_sitter_kotlin",
+                "tree_sitter_c_sharp",
             ),
         )
     )
@@ -65,6 +66,7 @@ def test_registry_maps_extensions_and_reports_symbol_extraction_support() -> Non
     assert registry.language_for_path("apps/ui/component.jsx").language_id == "javascript"
     assert registry.language_for_path("src/main/java/com/example/App.java").language_id == "java"
     assert registry.language_for_path("src/main/kotlin/com/example/App.kt").language_id == "kotlin"
+    assert registry.language_for_path("src/main/csharp/Example/App.cs").language_id == "csharp"
     assert registry.language_for_path("src/main.cc").stage == "planned"
     assert registry.language_for_path("README.md") is None
 
@@ -75,13 +77,19 @@ def test_registry_maps_extensions_and_reports_symbol_extraction_support() -> Non
     assert by_id["typescript"].symbol_extraction is True
     assert by_id["java"].symbol_extraction is True
     assert by_id["kotlin"].symbol_extraction is True
+    assert by_id["csharp"].symbol_extraction is True
 
 
 def test_registry_reports_missing_parser_dependencies_per_language() -> None:
     registry = CodeGraphLanguageRegistry(
         dependency_health=DependencyHealth(
             available=False,
-            missing=("tree_sitter_javascript", "tree_sitter_java", "tree_sitter_kotlin"),
+            missing=(
+                "tree_sitter_javascript",
+                "tree_sitter_java",
+                "tree_sitter_kotlin",
+                "tree_sitter_c_sharp",
+            ),
             present=("tree_sitter", "tree_sitter_typescript"),
         )
     )
@@ -97,3 +105,5 @@ def test_registry_reports_missing_parser_dependencies_per_language() -> None:
     assert by_id["java"].dependency_missing == ("tree_sitter_java",)
     assert by_id["kotlin"].symbol_extraction is False
     assert by_id["kotlin"].dependency_missing == ("tree_sitter_kotlin",)
+    assert by_id["csharp"].symbol_extraction is False
+    assert by_id["csharp"].dependency_missing == ("tree_sitter_c_sharp",)

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_tree_sitter_loader.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_tree_sitter_loader.py
@@ -124,15 +124,30 @@ def test_kotlin_parser_can_parse_class() -> None:
     assert not tree.root_node.has_error
 
 
-def test_load_parser_reports_missing_java_kotlin_optional_dependencies(monkeypatch) -> None:
-    """Report missing JVM parser packages without raising import errors."""
+def test_csharp_parser_can_parse_class() -> None:
+    """Load the optional C# parser and parse a compact class fixture."""
+    loader = importlib.import_module(
+        "tldw_Server_API.app.core.CodeGraph.extractors.tree_sitter_loader"
+    )
+
+    result = loader.load_parser("csharp")
+    tree = result.parser.parse(b"class Greeter { string Greet() { return Helper(); } }")
+
+    assert result.missing == ()
+    assert result.error is None
+    assert tree.root_node.type == "compilation_unit"
+    assert not tree.root_node.has_error
+
+
+def test_load_parser_reports_missing_java_kotlin_csharp_optional_dependencies(monkeypatch) -> None:
+    """Report missing JVM/.NET parser packages without raising import errors."""
     loader = importlib.import_module(
         "tldw_Server_API.app.core.CodeGraph.extractors.tree_sitter_loader"
     )
     real_import_module = loader.importlib.import_module
 
     def fake_import_module(name: str) -> ModuleType:
-        if name in {"tree_sitter_java", "tree_sitter_kotlin"}:
+        if name in {"tree_sitter_java", "tree_sitter_kotlin", "tree_sitter_c_sharp"}:
             raise ModuleNotFoundError(f"No module named '{name}'")
         return real_import_module(name)
 
@@ -140,6 +155,7 @@ def test_load_parser_reports_missing_java_kotlin_optional_dependencies(monkeypat
 
     java = loader.load_parser("java")
     kotlin = loader.load_parser("kotlin")
+    csharp = loader.load_parser("csharp")
 
     assert java.parser is None
     assert java.missing == ("tree_sitter_java",)
@@ -147,3 +163,6 @@ def test_load_parser_reports_missing_java_kotlin_optional_dependencies(monkeypat
     assert kotlin.parser is None
     assert kotlin.missing == ("tree_sitter_kotlin",)
     assert kotlin.error is None
+    assert csharp.parser is None
+    assert csharp.missing == ("tree_sitter_c_sharp",)
+    assert csharp.error is None


### PR DESCRIPTION
## Summary
- Promotes C# to a dependency-aware CodeGraph foundation language using optional tree-sitter-c-sharp.
- Adds a conservative C# Tree-sitter extractor for using directives, namespaces, types, constructors, methods, properties, same-file simple calls, and unresolved external/receiver refs.
- Adds focused loader, registry, extractor, indexer, MCP search, plan, and Backlog coverage for TASK-60.

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/CodeGraph tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check tldw_Server_API/app/core/CodeGraph tldw_Server_API/app/core/DB_Management/codegraph tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py tldw_Server_API/tests/CodeGraph tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/CodeGraph tldw_Server_API/app/core/DB_Management/codegraph tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py -f json -o /tmp/bandit_codegraph_csharp.json
- git diff --check

## Human change summary required before merge
This PR was materially authored by AI. Before merge, replace this section with a human-written Change summary explaining what changed and why these implementation choices were made.

## Known limits
No Roslyn project model, .csproj/.sln analysis, partial type merging, overload/type inference, inheritance, extension-method, or cross-file semantic resolution in this slice.