### PR TITLE
Expose sandbox runtime session contract metadata

### DIFF
--- a/Docs/API-related/Sandbox_API.md
+++ b/Docs/API-related/Sandbox_API.md
@@ -21,8 +21,8 @@ Current runtime identities are `docker`, `firecracker`, `lima`, `vz_linux`,
 guarantee:
 - Runtime discovery includes machine-readable `boundary_class`,
   `vm_grade_isolation`, `untrusted_eligible`, `isolation_warnings`, and
-  `network_policy_contract` fields. Use those fields for client decisions
-  instead of parsing prose notes.
+  `network_policy_contract` fields, plus a `session_contract` object. Use
+  those fields for client decisions instead of parsing prose notes.
 - `isolation_warnings` are advisory metadata for client UX and operator
   context. They are not admission rejection reasons by themselves.
 - `seatbelt` is host-local. `seatbelt` is not `untrusted`-eligible.
@@ -152,6 +152,13 @@ Response (example):
           "readiness_source": "config"
         }
       },
+      "session_contract": {
+        "support_state": "supported",
+        "reuse_model": "workspace_only",
+        "requires_live_health_check": false,
+        "recovery_state": "unsupported",
+        "repair_state": "unsupported"
+      },
       "supported_spec_versions": ["1.0", "1.1"],
       "interactive_supported": false,
       "egress_allowlist_supported": false,
@@ -174,6 +181,9 @@ Runtime isolation fields mean:
   `allowlist`. It describes whether each policy is supported, unsupported,
   scaffold-only, or host-gated, whether strict enforcement is possible, and
   where current readiness should be read from.
+- `session_contract`: static runtime posture for session participation, reuse
+  model, live health check expectation, and recovery/repair maturity. It does
+  not replace `available`, runtime preflight, or admin diagnostics.
 
 Current posture mapping:
 
@@ -206,6 +216,23 @@ still reported through:
 - `strict_allowlist_supported`
 - `enforcement_ready` (object with `deny_all`/`allowlist`)
 - `host` (host capability facts for troubleshooting)
+
+Session contract mapping:
+
+| Runtime | `support_state` | `reuse_model` | Live health check | `recovery_state` | `repair_state` |
+| --- | --- | --- | --- | --- | --- |
+| `docker` | `supported` | `workspace_only` | `false` | `unsupported` | `unsupported` |
+| `firecracker` | `scaffold` | `scaffold` | `false` | `unsupported` | `unsupported` |
+| `lima` | `scaffold` | `scaffold` | `false` | `unsupported` | `unsupported` |
+| `vz_linux` | `host_gated` | `warm_vm` | `true` | `host_gated` | `host_gated` |
+| `vz_macos` | `scaffold` | `scaffold` | `false` | `scaffold` | `scaffold` |
+| `seatbelt` | `scaffold` | `workspace_only` | `false` | `unsupported` | `unsupported` |
+| `worktree` | `scaffold` | `workspace_only` | `false` | `unsupported` | `unsupported` |
+
+`session_contract` is static posture metadata. Same-session warm runtime reuse
+is currently limited to the host-gated `vz_linux` path; host-local runtimes only
+participate through workspace-oriented session inputs and do not provide warm
+runtime reuse.
 
 ## Create a session
 POST `/api/v1/sandbox/sessions`

--- a/Docs/Published/API-related/Sandbox_API.md
+++ b/Docs/Published/API-related/Sandbox_API.md
@@ -21,8 +21,8 @@ Current runtime identities are `docker`, `firecracker`, `lima`, `vz_linux`,
 guarantee:
 - Runtime discovery includes machine-readable `boundary_class`,
   `vm_grade_isolation`, `untrusted_eligible`, `isolation_warnings`, and
-  `network_policy_contract` fields. Use those fields for client decisions
-  instead of parsing prose notes.
+  `network_policy_contract` fields, plus a `session_contract` object. Use
+  those fields for client decisions instead of parsing prose notes.
 - `isolation_warnings` are advisory metadata for client UX and operator
   context. They are not admission rejection reasons by themselves.
 - `seatbelt` is host-local. `seatbelt` is not `untrusted`-eligible.
@@ -152,6 +152,13 @@ Response (example):
           "readiness_source": "config"
         }
       },
+      "session_contract": {
+        "support_state": "supported",
+        "reuse_model": "workspace_only",
+        "requires_live_health_check": false,
+        "recovery_state": "unsupported",
+        "repair_state": "unsupported"
+      },
       "supported_spec_versions": ["1.0", "1.1"],
       "interactive_supported": false,
       "egress_allowlist_supported": false,
@@ -174,6 +181,9 @@ Runtime isolation fields mean:
   `allowlist`. It describes whether each policy is supported, unsupported,
   scaffold-only, or host-gated, whether strict enforcement is possible, and
   where current readiness should be read from.
+- `session_contract`: static runtime posture for session participation, reuse
+  model, live health check expectation, and recovery/repair maturity. It does
+  not replace `available`, runtime preflight, or admin diagnostics.
 
 Current posture mapping:
 
@@ -206,6 +216,23 @@ still reported through:
 - `strict_allowlist_supported`
 - `enforcement_ready` (object with `deny_all`/`allowlist`)
 - `host` (host capability facts for troubleshooting)
+
+Session contract mapping:
+
+| Runtime | `support_state` | `reuse_model` | Live health check | `recovery_state` | `repair_state` |
+| --- | --- | --- | --- | --- | --- |
+| `docker` | `supported` | `workspace_only` | `false` | `unsupported` | `unsupported` |
+| `firecracker` | `scaffold` | `scaffold` | `false` | `unsupported` | `unsupported` |
+| `lima` | `scaffold` | `scaffold` | `false` | `unsupported` | `unsupported` |
+| `vz_linux` | `host_gated` | `warm_vm` | `true` | `host_gated` | `host_gated` |
+| `vz_macos` | `scaffold` | `scaffold` | `false` | `scaffold` | `scaffold` |
+| `seatbelt` | `scaffold` | `workspace_only` | `false` | `unsupported` | `unsupported` |
+| `worktree` | `scaffold` | `workspace_only` | `false` | `unsupported` | `unsupported` |
+
+`session_contract` is static posture metadata. Same-session warm runtime reuse
+is currently limited to the host-gated `vz_linux` path; host-local runtimes only
+participate through workspace-oriented session inputs and do not provide warm
+runtime reuse.
 
 ## Create a session
 POST `/api/v1/sandbox/sessions`

--- a/Docs/Sandbox/sandbox-runtime-capability-inventory.md
+++ b/Docs/Sandbox/sandbox-runtime-capability-inventory.md
@@ -49,6 +49,9 @@ concepts:
   preflight, or diagnostics.
 - `network_policy_contract`: static posture for `deny_all` and `allowlist`
   support, strict enforcement, and current-readiness source.
+- `session_contract`: static posture for session participation, reuse model,
+  live-health-check expectations, and recovery/repair posture. Current host
+  truth remains in `available`, raw `reasons`, and admin diagnostics.
 
 | Runtime | `implementation_state` | Discovery source |
 | --- | --- | --- |
@@ -193,6 +196,23 @@ sets experimental flags.
 | `seatbelt` | `false` | `not_applicable` | `false` | `not_applicable` |
 | `worktree` | `false` | `not_applicable` | `false` | `not_applicable` |
 
+## Session Semantics Contract
+
+Runtime discovery exposes `session_contract` as static posture metadata. It
+does not replace session create/run APIs or runtime diagnostics. `support_state`
+describes the maturity of session participation, while `reuse_model` describes
+what can actually be reused across session-backed runs.
+
+| Runtime | `support_state` | `reuse_model` | Live health check required | `recovery_state` | `repair_state` | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| `docker` | `supported` | `workspace_only` | `false` | `unsupported` | `unsupported` | Session-backed runs share a control-plane workspace, not a warm container. |
+| `firecracker` | `scaffold` | `scaffold` | `false` | `unsupported` | `unsupported` | Session shape exists, but warm VM/session ownership is not normalized. |
+| `lima` | `scaffold` | `scaffold` | `false` | `unsupported` | `unsupported` | Session shape exists, but warm VM/session ownership is not normalized. |
+| `vz_linux` | `host_gated` | `warm_vm` | `true` | `host_gated` | `host_gated` | Same-session VM reuse requires helper VM health checks; repair is explicit/admin-only. |
+| `vz_macos` | `scaffold` | `scaffold` | `false` | `scaffold` | `scaffold` | Runtime identity exists, but real execution and session reuse are scaffolded. |
+| `seatbelt` | `scaffold` | `workspace_only` | `false` | `unsupported` | `unsupported` | Host-local workspace participation only; no warm runtime reuse. |
+| `worktree` | `scaffold` | `workspace_only` | `false` | `unsupported` | `unsupported` | Host-local workspace participation only; no warm runtime reuse. |
+
 ## Execution And Lifecycle Support
 
 | Runtime | Real execution | Interactivity | Sessions | Cancellation/timeouts | Artifacts |
@@ -234,7 +254,7 @@ an equally clear ownership model.
 | Host-local runtimes need clearer docs/API warnings that they are not VM-grade. | `seatbelt`, `worktree` | Phase 2 |
 | Additional real allowlist implementations remain limited beyond Docker granular enforcement. | all except unsupported paths | Future |
 | Rich structured error metadata beyond the first normalized alias pass remains incomplete. | all | Phase 3 |
-| Session semantics are not normalized across warm VM, container, and host-local reuse. | all | Phase 4 |
+| Cross-runtime session behavior contract tests and recovery flows remain incomplete beyond the discovery-level `session_contract`. | all | Phase 4 |
 | Recovery/repair ownership exists only for `vz_linux`. | all except `vz_linux` | Phase 4 |
 | CI has no single cross-runtime capability gate. | all | Phase 5 |
 
@@ -246,6 +266,8 @@ an equally clear ownership model.
 - Do not classify `seatbelt` or `worktree` as `untrusted`-eligible.
 - Add network policy metadata for every runtime and keep it separate from
   current `enforcement_ready` host/preflight truth.
+- Add session contract metadata for every runtime and keep it separate from
+  current host availability and admin diagnostics.
 - Prefer `unsupported` over ambiguous wording when a guarantee cannot be
   proven.
 - Update this document before expanding `vz_macos`, Apple `containerization`,

--- a/Docs/superpowers/plans/2026-05-05-sandbox-session-semantics-contract-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-05-sandbox-session-semantics-contract-implementation-plan.md
@@ -134,7 +134,7 @@ active. This slice added direct `SandboxRuntimesResponse` validation around
 `SandboxService.feature_discovery()` to cover the endpoint response model
 without starting the full app lifespan.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add Docs/API-related/Sandbox_API.md Docs/Published/API-related/Sandbox_API.md Docs/Sandbox/sandbox-runtime-capability-inventory.md Docs/superpowers/specs/2026-05-05-sandbox-session-semantics-contract-design.md Docs/superpowers/plans/2026-05-05-sandbox-session-semantics-contract-implementation-plan.md "backlog/tasks/task-59 - Add-sandbox-runtime-session-semantics-discovery-contract.md" tldw_Server_API/app/core/Sandbox/runtime_capabilities.py tldw_Server_API/app/core/Sandbox/service.py tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py tldw_Server_API/tests/Docs/test_sandbox_public_docs_contract.py tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py

--- a/Docs/superpowers/plans/2026-05-05-sandbox-session-semantics-contract-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-05-sandbox-session-semantics-contract-implementation-plan.md
@@ -1,0 +1,142 @@
+# Sandbox Session Semantics Contract Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a structured `session_contract` to sandbox runtime discovery so clients can distinguish workspace-only sessions, warm VM reuse, scaffolded session shapes, and recovery/repair posture.
+
+**Architecture:** Follow the existing static metadata pattern in `runtime_capabilities.py`, expose the metadata through `SandboxService.feature_discovery()`, type it in `sandbox_schemas.py`, and document the inventory contract. No runtime execution behavior changes.
+
+**Tech Stack:** Python 3.11, FastAPI/Pydantic schemas, pytest, existing sandbox runtime capability helpers.
+
+---
+
+### Task 1: Add Failing Discovery Contract Tests
+
+**Files:**
+- Modify: `tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py`
+
+- [x] **Step 1: Import session metadata helper names**
+
+Add imports for the new helper after implementation names are selected:
+`RUNTIME_SESSION_CONTRACT_METADATA` and `runtime_session_contract_metadata`.
+
+- [x] **Step 2: Add discovery assertion test**
+
+Assert every runtime row includes a `session_contract` object with fields:
+`support_state`, `reuse_model`, `requires_live_health_check`,
+`recovery_state`, and `repair_state`.
+
+- [x] **Step 3: Add classification assertions**
+
+Assert:
+
+```python
+discovery["docker"]["session_contract"]["reuse_model"] == "workspace_only"
+discovery["vz_linux"]["session_contract"]["reuse_model"] == "warm_vm"
+discovery["vz_linux"]["session_contract"]["requires_live_health_check"] is True
+discovery["seatbelt"]["session_contract"]["support_state"] == "scaffold"
+discovery["worktree"]["session_contract"]["support_state"] == "scaffold"
+```
+
+- [x] **Step 4: Verify RED**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py -q
+```
+
+Expected: failure because `session_contract` does not exist yet.
+
+### Task 2: Implement Session Metadata
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Sandbox/runtime_capabilities.py`
+- Modify: `tldw_Server_API/app/core/Sandbox/service.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py`
+
+- [x] **Step 1: Add typed metadata classes**
+
+Add `RuntimeSessionReuseModel` and `RuntimeSessionContractMetadata` in
+`runtime_capabilities.py`.
+
+- [x] **Step 2: Add `RUNTIME_SESSION_CONTRACT_METADATA`**
+
+Create a complete map for every `RuntimeType`.
+
+- [x] **Step 3: Add completeness validation and accessor**
+
+Validate the map at import time and add `runtime_session_contract_metadata()`
+that rejects unknown runtimes with `ValueError`.
+
+- [x] **Step 4: Add schema object**
+
+Create `SandboxRuntimeSessionContract` in `sandbox_schemas.py` and add
+`session_contract` to `SandboxRuntimeInfo`.
+
+- [x] **Step 5: Wire discovery**
+
+In `SandboxService.feature_discovery()` add `session_contract` to `_preflight_fields()`.
+
+- [x] **Step 6: Verify GREEN**
+
+Run the focused runtime inventory test file again.
+
+### Task 3: Update Documentation And Tracking
+
+**Files:**
+- Modify: `Docs/Sandbox/sandbox-runtime-capability-inventory.md`
+- Modify: `backlog/tasks/task-59 - Add-sandbox-runtime-session-semantics-discovery-contract.md`
+
+- [x] **Step 1: Document the new discovery field**
+
+Add `session_contract` to the discovery contract list.
+
+- [x] **Step 2: Add session contract table**
+
+Document support state, reuse model, live health check requirement, recovery
+state, and repair state for each runtime.
+
+- [x] **Step 3: Narrow the current gap**
+
+Replace the broad session-semantics gap with remaining cross-runtime behavior
+contract tests/recovery work.
+
+### Task 4: Verification And Commit
+
+**Files:**
+- Verify touched code/docs.
+
+- [x] **Step 1: Run focused tests**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py tldw_Server_API/tests/Docs/test_sandbox_public_docs_contract.py -q
+```
+
+- [x] **Step 2: Run Bandit on touched Python**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Sandbox/runtime_capabilities.py tldw_Server_API/app/core/Sandbox/service.py tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py -f json -o /tmp/bandit_sandbox_session_contract.json
+```
+
+- [x] **Step 3: Run whitespace check**
+
+```bash
+git diff --check
+```
+
+- [x] **Step 4: Record broader API TestClient limitation**
+
+The broader `test_feature_discovery_flags.py` and
+`test_sandbox_api.py::test_runtimes_discovery_shape` TestClient run timed out
+in unrelated full-app lifespan teardown while background workers/schedulers were
+active. This slice added direct `SandboxRuntimesResponse` validation around
+`SandboxService.feature_discovery()` to cover the endpoint response model
+without starting the full app lifespan.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Docs/API-related/Sandbox_API.md Docs/Published/API-related/Sandbox_API.md Docs/Sandbox/sandbox-runtime-capability-inventory.md Docs/superpowers/specs/2026-05-05-sandbox-session-semantics-contract-design.md Docs/superpowers/plans/2026-05-05-sandbox-session-semantics-contract-implementation-plan.md "backlog/tasks/task-59 - Add-sandbox-runtime-session-semantics-discovery-contract.md" tldw_Server_API/app/core/Sandbox/runtime_capabilities.py tldw_Server_API/app/core/Sandbox/service.py tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py tldw_Server_API/tests/Docs/test_sandbox_public_docs_contract.py tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
+git commit -m "feat(sandbox): expose runtime session contract metadata"
+```

--- a/Docs/superpowers/specs/2026-05-05-sandbox-session-semantics-contract-design.md
+++ b/Docs/superpowers/specs/2026-05-05-sandbox-session-semantics-contract-design.md
@@ -1,0 +1,76 @@
+# Sandbox Session Semantics Contract Design
+
+## Goal
+
+Expose stable session semantics metadata through runtime discovery so clients can
+distinguish shared-workspace sessions, warm VM reuse, scaffolded session shapes,
+and unsupported recovery/repair posture without parsing runtime notes. This is a
+narrow Phase 4 contract slice and does not change session creation, dispatch,
+VM reuse, cleanup, or repair behavior.
+
+## Current State
+
+`/api/v1/sandbox/runtimes` already exposes static isolation and network policy
+contracts from `runtime_capabilities.py`. The inventory documents session
+support in a table, but clients still cannot tell from discovery whether
+`Sessions=supported` means a persistent workspace only or actual warm runtime
+reuse. Today `vz_linux` is the only runtime with real same-session VM reuse and
+helper health validation.
+
+## Design
+
+Add a `session_contract` object to every runtime discovery row. Keep the
+contract static and roadmap-oriented, like isolation and network policy
+metadata. Current host truth remains in `available`, `reasons`, and runtime
+diagnostics.
+
+The contract fields are:
+
+- `support_state`: `supported`, `unsupported`, `scaffold`, `host_gated`, or
+  `not_applicable`.
+- `reuse_model`: `none`, `workspace_only`, `warm_vm`, or `scaffold`.
+- `requires_live_health_check`: whether safe reuse depends on checking live
+  runtime state before reuse.
+- `recovery_state`: support state for cross-restart recovery semantics.
+- `repair_state`: support state for operator/admin repair semantics.
+
+Runtime classification:
+
+- Docker: supported sessions with `workspace_only`; no runtime-owned warm
+  container reuse or repair contract in this slice.
+- Firecracker and Lima: scaffolded sessions.
+- `vz_linux`: host-gated `warm_vm` sessions requiring live helper VM health
+  checks, with host-gated recovery/repair posture.
+- `vz_macos`: scaffolded sessions.
+- `seatbelt` and `worktree`: scaffolded host-local workspace participation,
+  not warm runtime reuse and no repair contract.
+
+## Risks And Mitigations
+
+- Risk: clients may treat `session_contract.support_state=supported` as proof
+  of current host availability.
+  Mitigation: document that `available` and preflight reasons remain host truth.
+- Risk: contract could overclaim host-local session guarantees.
+  Mitigation: mark host-local runtimes as scaffolded with workspace-only reuse,
+  leaving policy/isolation warnings unchanged.
+- Risk: fields may become too behavior-specific before all runtimes implement
+  parity.
+  Mitigation: keep the field set small and descriptive; do not add repair
+  endpoints or runtime behavior in this PR.
+
+## Tests
+
+Add focused runtime inventory tests that fail before implementation:
+
+- every runtime discovery row includes `session_contract`;
+- `vz_linux` advertises host-gated `warm_vm` semantics and requires live health
+  checks;
+- Docker advertises workspace-only semantics;
+- scaffold and host-local runtimes do not claim warm reuse or repair support;
+- the metadata map covers all `RuntimeType` values and rejects unknown runtimes.
+
+## Documentation
+
+Update `Docs/Sandbox/sandbox-runtime-capability-inventory.md` to document the
+new discovery field and replace the broad "session semantics are not
+normalized" gap with narrower remaining behavior/recovery contract-test work.

--- a/backlog/tasks/task-59 - Add-sandbox-runtime-session-semantics-discovery-contract.md
+++ b/backlog/tasks/task-59 - Add-sandbox-runtime-session-semantics-discovery-contract.md
@@ -1,0 +1,53 @@
+---
+id: TASK-59
+title: Add sandbox runtime session semantics discovery contract
+status: Done
+assignee: []
+created_date: '2026-05-05 03:15'
+labels:
+  - sandbox
+  - runtime-discovery
+  - phase-4
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add a narrow Phase 4 sandbox runtime parity slice that exposes stable session semantics metadata in runtime discovery. This should let clients distinguish real warm reuse from scaffold or host-local session support without runtime-specific notes parsing, while avoiding behavior changes to session execution or repair.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Runtime discovery exposes a structured session contract for every RuntimeType without changing session execution behavior.
+- [x] #2 Session contract metadata distinguishes support state, reuse model, health check expectation, and recovery/repair posture for Docker, Firecracker, Lima, vz_linux, vz_macos, seatbelt, and worktree.
+- [x] #3 Focused tests verify all runtimes include session contract metadata and the current vz_linux warm VM reuse/health semantics remain distinct from scaffold and host-local runtimes.
+- [x] #4 Sandbox runtime inventory documentation is updated to replace or narrow the current session-semantics gap.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Added a narrow discovery-only `session_contract` metadata layer for every sandbox runtime. This keeps runtime behavior unchanged while making workspace-only, warm VM, and scaffolded session semantics machine-readable.
+- Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py tldw_Server_API/tests/Docs/test_sandbox_public_docs_contract.py -q` passed with 30 tests.
+- Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Sandbox/runtime_capabilities.py tldw_Server_API/app/core/Sandbox/service.py tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py -f json -o /tmp/bandit_sandbox_session_contract.json` completed with no findings.
+- Verification: `git diff --check` passed.
+- Known limitation: the broader TestClient feature-discovery suite timed out in unrelated full-app lifespan teardown while background workers/schedulers were active. The branch adds direct `SandboxRuntimesResponse` validation of `SandboxService.feature_discovery()` to cover the endpoint response schema without starting full app lifespan.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Exposed static sandbox runtime session semantics through discovery using a complete metadata map, schema model, and service wiring. Updated sandbox runtime inventory and public API docs so clients can distinguish workspace-only sessions, scaffolded session shapes, and `vz_linux` warm VM reuse/recovery posture without parsing runtime notes.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
@@ -18,6 +18,7 @@ from tldw_Server_API.app.core.Sandbox.runtime_capabilities import (
     RuntimeNetworkPolicyReadinessSource,
     RuntimeNetworkPolicySupportState,
     RuntimeReasonCode,
+    RuntimeSessionReuseModel,
 )
 from tldw_Server_API.app.core.Sandbox.run_status_taxonomy import RunStatusReasonCode
 
@@ -64,6 +65,40 @@ class SandboxRuntimeNetworkPolicyContract(BaseModel):
 
     deny_all: SandboxRuntimeNetworkPolicyModeInfo
     allowlist: SandboxRuntimeNetworkPolicyModeInfo
+
+
+class SandboxRuntimeSessionContract(BaseModel):
+    """Static session semantics for a runtime."""
+
+    support_state: RuntimeImplementationState = Field(
+        ...,
+        description=(
+            "Static support state for session participation: supported, "
+            "unsupported, scaffold, host_gated, or not_applicable"
+        ),
+    )
+    reuse_model: RuntimeSessionReuseModel = Field(
+        ...,
+        description=(
+            "Runtime reuse model for session-backed runs: none, workspace_only, "
+            "warm_vm, or scaffold"
+        ),
+    )
+    requires_live_health_check: bool = Field(
+        ...,
+        description=(
+            "Whether safe session reuse depends on checking live runtime state "
+            "before reusing the session runtime"
+        ),
+    )
+    recovery_state: RuntimeImplementationState = Field(
+        ...,
+        description="Static support state for cross-restart session recovery semantics",
+    )
+    repair_state: RuntimeImplementationState = Field(
+        ...,
+        description="Static support state for explicit operator/admin session repair semantics",
+    )
 
 
 def _default_offset_pagination_aliases(response):
@@ -135,6 +170,13 @@ class SandboxRuntimeInfo(BaseModel):
         description=(
             "Static runtime network policy posture; current host readiness remains "
             "in enforcement_ready and runtime preflight reasons"
+        ),
+    )
+    session_contract: SandboxRuntimeSessionContract = Field(
+        ...,
+        description=(
+            "Static runtime session semantics; current host readiness remains "
+            "in available, reasons, and admin diagnostics"
         ),
     )
     supported_spec_versions: list[str] = Field(default_factory=lambda: ["1.0"], description="Supported spec versions (e.g., ['1.0','1.1'] when 1.1 features are enabled)")

--- a/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
+++ b/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
@@ -42,6 +42,12 @@ RuntimeNetworkPolicyReadinessSource = Literal[
     "config",
     "not_applicable",
 ]
+RuntimeSessionReuseModel = Literal[
+    "none",
+    "workspace_only",
+    "warm_vm",
+    "scaffold",
+]
 RuntimeReasonCode = Literal[
     "runtime_unavailable",
     "unsupported_os",
@@ -110,6 +116,26 @@ class RuntimeNetworkPolicyMetadata:
         }
 
 
+@dataclass(frozen=True)
+class RuntimeSessionContractMetadata:
+    """Machine-readable session semantics for runtime discovery."""
+
+    support_state: RuntimeImplementationState
+    reuse_model: RuntimeSessionReuseModel
+    requires_live_health_check: bool
+    recovery_state: RuntimeImplementationState
+    repair_state: RuntimeImplementationState
+
+    def as_dict(self) -> dict[str, str | bool]:
+        return {
+            "support_state": self.support_state,
+            "reuse_model": self.reuse_model,
+            "requires_live_health_check": self.requires_live_health_check,
+            "recovery_state": self.recovery_state,
+            "repair_state": self.repair_state,
+        }
+
+
 RUNTIME_ISOLATION_METADATA: Mapping[RuntimeType, RuntimeIsolationMetadata] = {
     RuntimeType.docker: RuntimeIsolationMetadata(
         boundary_class="container",
@@ -145,6 +171,62 @@ RUNTIME_ISOLATION_METADATA: Mapping[RuntimeType, RuntimeIsolationMetadata] = {
         boundary_class="host_local",
         vm_grade_isolation=False,
         untrusted_eligible=False,
+    ),
+}
+
+
+RUNTIME_SESSION_CONTRACT_METADATA: Mapping[
+    RuntimeType,
+    RuntimeSessionContractMetadata,
+] = {
+    RuntimeType.docker: RuntimeSessionContractMetadata(
+        support_state="supported",
+        reuse_model="workspace_only",
+        requires_live_health_check=False,
+        recovery_state="unsupported",
+        repair_state="unsupported",
+    ),
+    RuntimeType.firecracker: RuntimeSessionContractMetadata(
+        support_state="scaffold",
+        reuse_model="scaffold",
+        requires_live_health_check=False,
+        recovery_state="unsupported",
+        repair_state="unsupported",
+    ),
+    RuntimeType.lima: RuntimeSessionContractMetadata(
+        support_state="scaffold",
+        reuse_model="scaffold",
+        requires_live_health_check=False,
+        recovery_state="unsupported",
+        repair_state="unsupported",
+    ),
+    RuntimeType.vz_linux: RuntimeSessionContractMetadata(
+        support_state="host_gated",
+        reuse_model="warm_vm",
+        requires_live_health_check=True,
+        recovery_state="host_gated",
+        repair_state="host_gated",
+    ),
+    RuntimeType.vz_macos: RuntimeSessionContractMetadata(
+        support_state="scaffold",
+        reuse_model="scaffold",
+        requires_live_health_check=False,
+        recovery_state="scaffold",
+        repair_state="scaffold",
+    ),
+    RuntimeType.seatbelt: RuntimeSessionContractMetadata(
+        support_state="scaffold",
+        reuse_model="workspace_only",
+        requires_live_health_check=False,
+        recovery_state="unsupported",
+        repair_state="unsupported",
+    ),
+    RuntimeType.worktree: RuntimeSessionContractMetadata(
+        support_state="scaffold",
+        reuse_model="workspace_only",
+        requires_live_health_check=False,
+        recovery_state="unsupported",
+        repair_state="unsupported",
     ),
 }
 
@@ -264,7 +346,20 @@ def _validate_runtime_network_policy_metadata_map() -> None:
         )
 
 
+def _validate_runtime_session_contract_metadata_map() -> None:
+    expected = set(RuntimeType)
+    actual = set(RUNTIME_SESSION_CONTRACT_METADATA)
+    missing = sorted(runtime.value for runtime in expected - actual)
+    extra = sorted(str(runtime) for runtime in actual - expected)
+    if missing or extra:
+        raise RuntimeError(
+            "Runtime session contract metadata map is incomplete: "
+            f"missing={missing}, extra={extra}"
+        )
+
+
 _validate_runtime_isolation_metadata_map()
+_validate_runtime_session_contract_metadata_map()
 _validate_runtime_network_policy_metadata_map()
 
 
@@ -356,6 +451,25 @@ def runtime_network_policy_metadata(
     metadata = RUNTIME_NETWORK_POLICY_METADATA.get(runtime_key)
     if metadata is None:
         raise ValueError(f"No network policy metadata configured for runtime {runtime!r}")
+    return metadata
+
+
+def runtime_session_contract_metadata(
+    runtime: RuntimeType | str,
+) -> RuntimeSessionContractMetadata:
+    """Return stable session semantics metadata, independent of host availability."""
+    try:
+        runtime_key = runtime if isinstance(runtime, RuntimeType) else RuntimeType(runtime)
+    except ValueError as exc:
+        raise ValueError(
+            f"No session contract metadata configured for runtime {runtime!r}"
+        ) from exc
+
+    metadata = RUNTIME_SESSION_CONTRACT_METADATA.get(runtime_key)
+    if metadata is None:
+        raise ValueError(
+            f"No session contract metadata configured for runtime {runtime!r}"
+        )
     return metadata
 
 

--- a/tldw_Server_API/app/core/Sandbox/service.py
+++ b/tldw_Server_API/app/core/Sandbox/service.py
@@ -64,6 +64,7 @@ from .runtime_capabilities import (
     runtime_implementation_state,
     runtime_network_policy_effective_support,
     runtime_network_policy_metadata,
+    runtime_session_contract_metadata,
 )
 from .snapshots import SnapshotManager
 from .store import get_store_mode
@@ -891,6 +892,7 @@ class SandboxService:
             reasons = list((preflight.reasons if preflight else []) or [])
             isolation = runtime_isolation_metadata(runtime)
             network_contract = runtime_network_policy_metadata(runtime)
+            session_contract = runtime_session_contract_metadata(runtime)
             effective_network_support = runtime_network_policy_effective_support(
                 runtime,
                 enforcement_ready,
@@ -909,6 +911,7 @@ class SandboxService:
                 "untrusted_eligible": isolation.untrusted_eligible,
                 "isolation_warnings": runtime_isolation_warnings(runtime),
                 "network_policy_contract": network_contract.as_dict(),
+                "session_contract": session_contract.as_dict(),
             }
 
         docker_fields = _preflight_fields(RuntimeType.docker, docker_preflight)

--- a/tldw_Server_API/tests/Docs/test_sandbox_public_docs_contract.py
+++ b/tldw_Server_API/tests/Docs/test_sandbox_public_docs_contract.py
@@ -64,6 +64,7 @@ def test_public_sandbox_api_docs_do_not_overclaim_runtime_support(doc_path: Path
         "vm_grade_isolation",
         "untrusted_eligible",
         "network_policy_contract",
+        "session_contract",
     ):
         _require(
             field_name in text,
@@ -137,4 +138,20 @@ def test_sandbox_runtime_network_policy_schema_field_is_required() -> None:
     _require(
         "'type': 'null'" not in serialized,
         "SandboxRuntimeInfo field network_policy_contract should not be nullable",
+    )
+
+
+def test_sandbox_runtime_session_contract_schema_field_is_required() -> None:
+    schema = SandboxRuntimeInfo.model_json_schema()
+    required = set(schema.get("required", []))
+
+    _require(
+        "session_contract" in required,
+        "SandboxRuntimeInfo should require session_contract",
+    )
+    field_schema = schema["properties"]["session_contract"]
+    serialized = str(field_schema)
+    _require(
+        "'type': 'null'" not in serialized,
+        "SandboxRuntimeInfo field session_contract should not be nullable",
     )

--- a/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
+++ b/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 import pytest
 
-from tldw_Server_API.app.core.Sandbox.models import RuntimeType
+from tldw_Server_API.app.api.v1.schemas.sandbox_schemas import (
+    SandboxRuntimeInfo,
+    SandboxRuntimesResponse,
+)
 from tldw_Server_API.app.core.Sandbox import runtime_capabilities as runtime_caps
+from tldw_Server_API.app.core.Sandbox.models import RuntimeType
 from tldw_Server_API.app.core.Sandbox.runtime_capabilities import (
     RUNTIME_ISOLATION_METADATA,
     RuntimePreflightResult,
@@ -263,6 +267,88 @@ def test_runtime_network_policy_metadata_rejects_unknown_runtime() -> None:
     assert hasattr(runtime_caps, "runtime_network_policy_metadata")
     with pytest.raises(ValueError, match="No network policy metadata configured"):
         runtime_caps.runtime_network_policy_metadata("future_runtime")
+
+
+def test_feature_discovery_reports_structured_session_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SANDBOX_STORE_BACKEND", "memory")
+
+    discovery = {
+        str(item.get("name")): item
+        for item in SandboxService().feature_discovery()
+    }
+
+    assert set(discovery) == {runtime.value for runtime in RuntimeType}
+    for runtime in RuntimeType:
+        contract = discovery[runtime.value]["session_contract"]
+        assert set(contract) == {
+            "support_state",
+            "reuse_model",
+            "requires_live_health_check",
+            "recovery_state",
+            "repair_state",
+        }
+
+    assert discovery["docker"]["session_contract"] == {
+        "support_state": "supported",
+        "reuse_model": "workspace_only",
+        "requires_live_health_check": False,
+        "recovery_state": "unsupported",
+        "repair_state": "unsupported",
+    }
+    assert discovery["vz_linux"]["session_contract"] == {
+        "support_state": "host_gated",
+        "reuse_model": "warm_vm",
+        "requires_live_health_check": True,
+        "recovery_state": "host_gated",
+        "repair_state": "host_gated",
+    }
+
+    for runtime_name in ("firecracker", "lima", "vz_macos"):
+        assert discovery[runtime_name]["session_contract"]["support_state"] == "scaffold"
+        assert discovery[runtime_name]["session_contract"]["reuse_model"] == "scaffold"
+        assert (
+            discovery[runtime_name]["session_contract"]["requires_live_health_check"]
+            is False
+        )
+
+    for runtime_name in ("seatbelt", "worktree"):
+        assert discovery[runtime_name]["session_contract"] == {
+            "support_state": "scaffold",
+            "reuse_model": "workspace_only",
+            "requires_live_health_check": False,
+            "recovery_state": "unsupported",
+            "repair_state": "unsupported",
+        }
+
+
+def test_runtime_session_contract_metadata_contract_covers_runtime_enum() -> None:
+    assert set(runtime_caps.RUNTIME_SESSION_CONTRACT_METADATA) == set(RuntimeType)
+
+
+def test_runtime_session_contract_metadata_rejects_unknown_runtime() -> None:
+    with pytest.raises(ValueError, match="No session contract metadata configured"):
+        runtime_caps.runtime_session_contract_metadata("future_runtime")
+
+
+def test_runtime_info_schema_exposes_session_contract() -> None:
+    schema = SandboxRuntimeInfo.model_json_schema()
+
+    assert "session_contract" in schema["properties"]
+
+
+def test_feature_discovery_validates_against_runtime_response_schema(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SANDBOX_STORE_BACKEND", "memory")
+
+    response = SandboxRuntimesResponse(
+        runtimes=SandboxService().feature_discovery(),
+    )
+
+    assert response.runtimes
+    assert response.runtimes[0].session_contract is not None
 
 
 def test_runtime_reason_normalization_maps_raw_runtime_reasons() -> None:


### PR DESCRIPTION
## Summary
- Adds a static `session_contract` discovery object for every sandbox runtime.
- Distinguishes workspace-only sessions, scaffolded session shapes, and `vz_linux` warm VM reuse/recovery posture without changing execution behavior.
- Updates runtime inventory and public Sandbox API docs, plus contract tests for schema/docs/discovery coverage.

## Test Plan
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py tldw_Server_API/tests/Docs/test_sandbox_public_docs_contract.py -q`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Sandbox/runtime_capabilities.py tldw_Server_API/app/core/Sandbox/service.py tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py -f json -o /tmp/bandit_sandbox_session_contract.json`
- [x] `git diff --check origin/dev..HEAD`

## Known Limitation
- Broader TestClient feature-discovery tests timed out in unrelated full-app lifespan teardown while background workers/schedulers were active. This PR adds direct `SandboxRuntimesResponse` validation around `SandboxService.feature_discovery()` to cover the endpoint response model without starting full app lifespan.

## Change Summary
Human-authored change summary to be added before merge.
