### PR TITLE
Migrate Chat and Playground state surfaces to design system

### DIFF
--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundEmpty.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundEmpty.tsx
@@ -15,6 +15,7 @@ import { useIsConnected } from "@/hooks/useConnectionState";
 import { useHelpModal } from "@/store/tutorials";
 import { buildResearchLaunchPath } from "@/routes/route-paths";
 import { requestQuickIngestOpen } from "@/utils/quick-ingest-open";
+import { EmptyState } from "@/components/ui/feedback";
 
 const actionButtonFocusClassName =
   "focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-bg";
@@ -131,82 +132,58 @@ export const PlaygroundEmpty = () => {
     [dispatchStarter, handleOpenDeepResearch, t],
   );
 
-  const description = demoEnabled ? (
-    t("playground:empty.demoDescription", {
-      defaultValue:
-        "You're in demo mode — try asking a question to see how the assistant responds. You can connect your own tldw server later.",
-    })
-  ) : !isConnected ? (
-    <>
-      <span>
-        {t("playground:empty.disconnectedDescription", {
+  const isDisconnected = !demoEnabled && !isConnected;
+  const description = demoEnabled
+    ? t("playground:empty.demoDescription", {
+        defaultValue:
+          "You're in demo mode — try asking a question to see how the assistant responds. You can connect your own tldw server later.",
+      })
+    : isDisconnected
+      ? t("playground:empty.disconnectedDescription", {
           defaultValue: "Connect to a tldw server to start chatting.",
-        })}
-      </span>
-      <button
-        type="button"
-        onClick={() => navigate("/settings/tldw")}
-        className={`inline-flex items-center text-sm font-medium text-primary transition hover:underline ${actionButtonFocusClassName}`}
-      >
-        {t("playground:empty.openSettings", {
-          defaultValue: "Open Settings",
-        })}
-      </button>
-    </>
-  ) : (
-    t("playground:empty.description", {
-      defaultValue:
-        "Experiment with different models, prompts, and knowledge sources here.",
-    })
-  );
+        })
+      : t("playground:empty.description", {
+          defaultValue:
+            "Experiment with different models, prompts, and knowledge sources here.",
+        });
 
   return (
     <div className="mx-auto mt-10 max-w-5xl px-4">
-      <section
+      <EmptyState
         data-testid="playground-empty-shell"
-        className="mx-auto max-w-4xl rounded-[28px] border border-border/80 bg-surface/90 p-5 text-sm text-text shadow-card backdrop-blur sm:p-7"
+        icon={MessageSquarePlus}
+        title={t("playground:empty.title", {
+          defaultValue: "Start a new chat",
+        })}
+        description={description}
+        primaryAction={{
+          label: t("playground:empty.primaryCta", {
+            defaultValue: "Start chatting",
+          }),
+          onClick: handleStartChat,
+        }}
+        secondaryAction={{
+          label: t("option:header.quickIngest", "Quick Ingest"),
+          onClick: handleOpenQuickIngest,
+        }}
+        variant="card"
+        size="lg"
+        className="max-w-4xl rounded-[28px] p-5 text-sm sm:p-7"
       >
         <div className="flex flex-col gap-6">
-          <div className="space-y-4 text-center">
+          {isDisconnected ? (
             <div className="flex justify-center">
-              <div className="rounded-full border border-border/50 bg-surface2/80 p-3 shadow-sm">
-                <MessageSquarePlus
-                  className="h-8 w-8 text-text-subtle"
-                  aria-hidden="true"
-                />
-              </div>
-            </div>
-
-            <div className="space-y-2">
-              <h2 className="text-2xl font-semibold text-text">
-                {t("playground:empty.title", {
-                  defaultValue: "Start a new chat",
-                })}
-              </h2>
-              <div className="mx-auto flex max-w-2xl flex-col items-center gap-2 text-sm text-text-muted sm:text-base">
-                {description}
-              </div>
-            </div>
-
-            <div className="flex flex-wrap items-center justify-center gap-2.5">
               <button
                 type="button"
-                onClick={handleStartChat}
-                className={`inline-flex items-center justify-center rounded-full bg-primary px-4 py-2 text-xs font-semibold uppercase tracking-[0.12em] text-primary-foreground transition hover:opacity-95 ${actionButtonFocusClassName}`}
+                onClick={() => navigate("/settings/tldw")}
+                className={`inline-flex items-center text-sm font-medium text-primary transition hover:underline ${actionButtonFocusClassName}`}
               >
-                {t("playground:empty.primaryCta", {
-                  defaultValue: "Start chatting",
+                {t("playground:empty.openSettings", {
+                  defaultValue: "Open Settings",
                 })}
               </button>
-              <button
-                type="button"
-                onClick={handleOpenQuickIngest}
-                className={`inline-flex items-center justify-center rounded-full border border-border bg-surface px-4 py-2 text-xs font-semibold uppercase tracking-[0.12em] text-text transition hover:bg-surface2 ${actionButtonFocusClassName}`}
-              >
-                {t("option:header.quickIngest", "Quick Ingest")}
-              </button>
             </div>
-          </div>
+          ) : null}
 
           <div className="border-t border-border/60 pt-5">
             <div className="flex flex-col gap-1 text-center sm:text-left">
@@ -281,7 +258,7 @@ export const PlaygroundEmpty = () => {
             </div>
           </div>
         </div>
-      </section>
+      </EmptyState>
     </div>
   );
 };

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundEmpty.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundEmpty.tsx
@@ -133,19 +133,34 @@ export const PlaygroundEmpty = () => {
   );
 
   const isDisconnected = !demoEnabled && !isConnected;
-  const description = demoEnabled
-    ? t("playground:empty.demoDescription", {
-        defaultValue:
-          "You're in demo mode — try asking a question to see how the assistant responds. You can connect your own tldw server later.",
-      })
-    : isDisconnected
-      ? t("playground:empty.disconnectedDescription", {
+  const description = demoEnabled ? (
+    t("playground:empty.demoDescription", {
+      defaultValue:
+        "You're in demo mode — try asking a question to see how the assistant responds. You can connect your own tldw server later.",
+    })
+  ) : isDisconnected ? (
+    <div className="mx-auto flex max-w-2xl flex-col items-center gap-2 sm:text-base">
+      <span>
+        {t("playground:empty.disconnectedDescription", {
           defaultValue: "Connect to a tldw server to start chatting.",
-        })
-      : t("playground:empty.description", {
-          defaultValue:
-            "Experiment with different models, prompts, and knowledge sources here.",
-        });
+        })}
+      </span>
+      <button
+        type="button"
+        onClick={() => navigate("/settings/tldw")}
+        className={`inline-flex items-center text-sm font-medium text-primary transition hover:underline ${actionButtonFocusClassName}`}
+      >
+        {t("playground:empty.openSettings", {
+          defaultValue: "Open Settings",
+        })}
+      </button>
+    </div>
+  ) : (
+    t("playground:empty.description", {
+      defaultValue:
+        "Experiment with different models, prompts, and knowledge sources here.",
+    })
+  );
 
   return (
     <div className="mx-auto mt-10 max-w-5xl px-4">
@@ -171,20 +186,6 @@ export const PlaygroundEmpty = () => {
         className="max-w-4xl rounded-[28px] p-5 text-sm sm:p-7"
       >
         <div className="flex flex-col gap-6">
-          {isDisconnected ? (
-            <div className="flex justify-center">
-              <button
-                type="button"
-                onClick={() => navigate("/settings/tldw")}
-                className={`inline-flex items-center text-sm font-medium text-primary transition hover:underline ${actionButtonFocusClassName}`}
-              >
-                {t("playground:empty.openSettings", {
-                  defaultValue: "Open Settings",
-                })}
-              </button>
-            </div>
-          ) : null}
-
           <div className="border-t border-border/60 pt-5">
             <div className="flex flex-col gap-1 text-center sm:text-left">
               <p className="text-xs font-semibold uppercase tracking-[0.16em] text-text-muted">

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundEmpty.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundEmpty.test.tsx
@@ -44,6 +44,7 @@ describe("PlaygroundEmpty", () => {
 
     const shell = screen.getByTestId("playground-empty-shell");
 
+    expect(shell).toHaveAttribute("data-ds-component", "EmptyState");
     expect(
       within(shell).getByRole("heading", { name: "Start a new chat" }),
     ).toBeInTheDocument();

--- a/apps/packages/ui/src/components/Sidepanel/Chat/ConnectionBanner.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/ConnectionBanner.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
-import { Alert, Button, Input, message } from "antd"
-import { Settings, RefreshCw, WifiOff, KeyRound, Loader2, Check } from "lucide-react"
+import { Button, Input, message } from "antd"
+import { Check } from "lucide-react"
 import {
   useConnectionState,
   useConnectionUxState,
@@ -9,6 +9,11 @@ import {
 } from "@/hooks/useConnectionState"
 import { ConnectionPhase } from "@/types/connection"
 import { tldwClient, type TldwConfig } from "@/services/tldw/TldwApiClient"
+import {
+  RecoveryCallout,
+  type RecoveryState,
+  type StateAction
+} from "@/components/ui/state"
 
 type ConnectionBannerProps = {
   className?: string
@@ -93,7 +98,7 @@ export const ConnectionBanner: React.FC<ConnectionBannerProps> = ({
       setShowApiKeyForm(false)
       setApiKeyInput("")
       void checkOnce()
-    } catch (err) {
+    } catch {
       message.error(t("sidepanel:connectionBanner.apiKeySaveError", "Failed to save API key"))
     } finally {
       setIsSaving(false)
@@ -104,8 +109,7 @@ export const ConnectionBanner: React.FC<ConnectionBannerProps> = ({
   const getBannerConfig = () => {
     if (isChecking || uxState === "testing") {
       return {
-        type: "info" as const,
-        icon: <Loader2 className="size-4 animate-spin" />,
+        state: "retrying" as RecoveryState,
         message: t(
           "sidepanel:connectionBanner.connecting",
           "Connecting to your tldw server..."
@@ -118,8 +122,7 @@ export const ConnectionBanner: React.FC<ConnectionBannerProps> = ({
 
     if (uxState === "error_auth") {
       return {
-        type: "warning" as const,
-        icon: <KeyRound className="size-4" />,
+        state: "auth_required" as RecoveryState,
         message: t(
           "sidepanel:connectionBanner.authErrorTitle",
           "API key needs attention"
@@ -135,8 +138,7 @@ export const ConnectionBanner: React.FC<ConnectionBannerProps> = ({
 
     if (uxState === "error_unreachable") {
       return {
-        type: "error" as const,
-        icon: <WifiOff className="size-4" />,
+        state: "unavailable" as RecoveryState,
         message: t(
           "sidepanel:connectionBanner.unreachableTitle",
           "Can't reach your tldw server"
@@ -157,8 +159,7 @@ export const ConnectionBanner: React.FC<ConnectionBannerProps> = ({
 
     // Default: unconfigured or unknown state
     return {
-      type: "info" as const,
-      icon: <Settings className="size-4" />,
+      state: "setup_required" as RecoveryState,
       message: hasCompletedFirstRun
         ? t(
             "sidepanel:connectionBanner.disconnectedTitle",
@@ -183,106 +184,108 @@ export const ConnectionBanner: React.FC<ConnectionBannerProps> = ({
   }
 
   const config = getBannerConfig()
+  const showInlineApiKeyForm = canInlineRepairApiKey && showApiKeyForm
+
+  const primaryAction: StateAction = (() => {
+    if (canInlineRepairApiKey && !showApiKeyForm) {
+      return {
+        label: t("sidepanel:connectionBanner.enterApiKey", "Enter API Key"),
+        onClick: () => setShowApiKeyForm(true)
+      }
+    }
+
+    if (config.showRetry) {
+      return {
+        label: t("common:retry", "Retry"),
+        onClick: handleRetry,
+        loading: isChecking
+      }
+    }
+
+    if (config.showSettings) {
+      return {
+        label: t("sidepanel:connectionBanner.openSettings", "Open Settings"),
+        onClick: openSettings
+      }
+    }
+
+    return {
+      label: t("sidepanel:connectionBanner.connectingCta", "Connecting"),
+      disabled: true
+    }
+  })()
+
+  const secondaryActionCandidates: Array<StateAction | null> = [
+    canInlineRepairApiKey && !showApiKeyForm && config.showRetry
+      ? {
+          label: t("common:retry", "Retry"),
+          onClick: handleRetry,
+          loading: isChecking
+        }
+      : null,
+    config.showSettings &&
+    !(config.showRetry === false && !canInlineRepairApiKey)
+      ? {
+          label: t("sidepanel:connectionBanner.openSettings", "Open Settings"),
+          onClick: openSettings
+        }
+      : null
+  ]
+  const secondaryActions = secondaryActionCandidates.filter(
+    (action): action is StateAction => Boolean(action)
+  )
 
   return (
     <div className={`px-3 py-2 ${className || ""}`}>
-      <Alert
-        type={config.type}
-        showIcon
-        icon={config.icon}
-        title={
-          <span className="text-sm font-medium">{config.message}</span>
-        }
-        description={
-          config.description && (
-            <div className="mt-1">
-              <p className="text-xs text-text-muted">
-                {config.description}
-              </p>
-
-              {/* Inline API key form for auth errors */}
-              {canInlineRepairApiKey && showApiKeyForm ? (
-                <div className="mt-3 space-y-2">
-                  <div className="flex items-center gap-2">
-                    <Input.Password
-                      size="small"
-                      placeholder={t("sidepanel:connectionBanner.apiKeyPlaceholder", "Enter your API key")}
-                      value={apiKeyInput}
-                      onChange={(e) => setApiKeyInput(e.target.value)}
-                      onPressEnter={handleSaveApiKey}
-                      visibilityToggle={{
-                        visible: showApiKey,
-                        onVisibleChange: setShowApiKey
-                      }}
-                      className="flex-1"
-                      autoFocus
-                    />
-                    <Button
-                      size="small"
-                      type="primary"
-                      icon={<Check className="size-3" />}
-                      onClick={handleSaveApiKey}
-                      loading={isSaving}
-                      title={t("common:save", "Save")}
-                    >
-                      {t("common:save", "Save")}
-                    </Button>
-                  </div>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setShowApiKeyForm(false)
-                      setApiKeyInput("")
-                    }}
-                    className="text-xs text-text-subtle hover:text-text underline"
-                    title={t("common:cancel", "Cancel")}
-                  >
-                    {t("common:cancel", "Cancel")}
-                  </button>
-                </div>
-              ) : (
-                <div className="mt-2 flex flex-wrap items-center gap-2">
-                  {/* Quick fix button for auth errors */}
-                  {canInlineRepairApiKey && (
-                    <Button
-                      size="small"
-                      type="primary"
-                      icon={<KeyRound className="size-3" />}
-                      onClick={() => setShowApiKeyForm(true)}
-                      title={t("sidepanel:connectionBanner.enterApiKey", "Enter API Key")}
-                    >
-                      {t("sidepanel:connectionBanner.enterApiKey", "Enter API Key")}
-                    </Button>
-                  )}
-                  {config.showRetry && (
-                    <Button
-                      size="small"
-                      icon={<RefreshCw className="size-3" />}
-                      onClick={handleRetry}
-                      loading={isChecking}
-                      title={t("common:retry", "Retry")}
-                    >
-                      {t("common:retry", "Retry")}
-                    </Button>
-                  )}
-                  {config.showSettings && (
-                    <Button
-                      size="small"
-                      type={canInlineRepairApiKey ? "default" : "primary"}
-                      icon={<Settings className="size-3" />}
-                      onClick={openSettings}
-                      title={t("sidepanel:connectionBanner.openSettings", "Open Settings")}
-                    >
-                      {t("sidepanel:connectionBanner.openSettings", "Open Settings")}
-                    </Button>
-                  )}
-                </div>
-              )}
+      <RecoveryCallout
+        state={config.state}
+        title={config.message}
+        message={config.description ?? undefined}
+        primaryAction={primaryAction}
+        secondaryActions={secondaryActions}
+        data-testid="sidepanel-connection-banner"
+      >
+        {showInlineApiKeyForm ? (
+          <div className="space-y-2">
+            <div className="flex items-center gap-2">
+              <Input.Password
+                size="small"
+                placeholder={t("sidepanel:connectionBanner.apiKeyPlaceholder", "Enter your API key")}
+                value={apiKeyInput}
+                onChange={(e) => setApiKeyInput(e.target.value)}
+                onPressEnter={handleSaveApiKey}
+                visibilityToggle={{
+                  visible: showApiKey,
+                  onVisibleChange: setShowApiKey
+                }}
+                className="flex-1"
+                autoFocus
+              />
+              <Button
+                size="small"
+                type="primary"
+                icon={<Check className="size-3" />}
+                onClick={handleSaveApiKey}
+                loading={isSaving}
+                title={t("common:save", "Save")}
+              >
+                {t("common:save", "Save")}
+              </Button>
             </div>
-          )
-        }
-        className="border-0"
-      />
+            <button
+              type="button"
+              onClick={() => {
+                setShowApiKeyForm(false)
+                setApiKeyInput("")
+              }}
+              className="text-xs text-text-subtle hover:text-text underline"
+              title={t("common:cancel", "Cancel")}
+            >
+              {t("common:cancel", "Cancel")}
+            </button>
+          </div>
+        ) : null}
+      </RecoveryCallout>
     </div>
   )
 }

--- a/apps/packages/ui/src/components/Sidepanel/Chat/ConnectionBanner.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/ConnectionBanner.tsx
@@ -1,23 +1,23 @@
-import React, { useEffect, useState } from "react"
-import { useTranslation } from "react-i18next"
-import { Button, Input, message } from "antd"
-import { Check } from "lucide-react"
+import React, { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Button, Input, message } from "antd";
+import { Check } from "lucide-react";
 import {
   useConnectionState,
   useConnectionUxState,
-  useConnectionActions
-} from "@/hooks/useConnectionState"
-import { ConnectionPhase } from "@/types/connection"
-import { tldwClient, type TldwConfig } from "@/services/tldw/TldwApiClient"
+  useConnectionActions,
+} from "@/hooks/useConnectionState";
+import { ConnectionPhase } from "@/types/connection";
+import { tldwClient, type TldwConfig } from "@/services/tldw/TldwApiClient";
 import {
   RecoveryCallout,
   type RecoveryState,
-  type StateAction
-} from "@/components/ui/state"
+  type StateAction,
+} from "@/components/ui/state";
 
 type ConnectionBannerProps = {
-  className?: string
-}
+  className?: string;
+};
 
 /**
  * Connection status banner displayed below the header when not connected.
@@ -30,80 +30,94 @@ type ConnectionBannerProps = {
  * - Unconfigured: Shows settings icon with "Set up connection" message
  */
 export const ConnectionBanner: React.FC<ConnectionBannerProps> = ({
-  className
+  className,
 }) => {
-  const { t } = useTranslation(["sidepanel", "settings", "common"])
-  const { phase, isConnected, serverUrl } = useConnectionState()
-  const { uxState, isChecking, hasCompletedFirstRun } = useConnectionUxState()
-  const { checkOnce, setConfigPartial } = useConnectionActions()
+  const { t } = useTranslation(["sidepanel", "settings", "common"]);
+  const { phase, isConnected, serverUrl } = useConnectionState();
+  const { uxState, isChecking, hasCompletedFirstRun } = useConnectionUxState();
+  const { checkOnce, setConfigPartial } = useConnectionActions();
 
   // Inline API key form state
-  const [showApiKeyForm, setShowApiKeyForm] = useState(false)
-  const [apiKeyInput, setApiKeyInput] = useState("")
-  const [showApiKey, setShowApiKey] = useState(false)
-  const [isSaving, setIsSaving] = useState(false)
-  const [authMode, setAuthMode] = useState<TldwConfig["authMode"]>("single-user")
+  const [showApiKeyForm, setShowApiKeyForm] = useState(false);
+  const [apiKeyInput, setApiKeyInput] = useState("");
+  const [showApiKey, setShowApiKey] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [authMode, setAuthMode] =
+    useState<TldwConfig["authMode"]>("single-user");
 
   useEffect(() => {
-    let cancelled = false
+    let cancelled = false;
 
     void tldwClient
       .getConfig()
       .then((config) => {
         if (!cancelled && config?.authMode) {
-          setAuthMode(config.authMode)
+          setAuthMode(config.authMode);
         }
       })
-      .catch(() => undefined)
+      .catch(() => undefined);
 
     return () => {
-      cancelled = true
-    }
-  }, [])
+      cancelled = true;
+    };
+  }, []);
 
   // Don't show banner if connected
-  const isConnectionReady = isConnected && phase === ConnectionPhase.CONNECTED
+  const isConnectionReady = isConnected && phase === ConnectionPhase.CONNECTED;
   if (isConnectionReady) {
-    return null
+    return null;
   }
 
-  const canInlineRepairApiKey = uxState === "error_auth" && authMode === "single-user"
+  const canInlineRepairApiKey =
+    uxState === "error_auth" && authMode === "single-user";
 
   const openSettings = () => {
     try {
       if (typeof chrome !== "undefined" && chrome.runtime?.openOptionsPage) {
-        chrome.runtime.openOptionsPage()
-        return
+        chrome.runtime.openOptionsPage();
+        return;
       }
     } catch {}
-    window.open("/options.html#/settings/tldw", "_blank")
-  }
+    window.open("/options.html#/settings/tldw", "_blank");
+  };
 
   const handleRetry = () => {
-    void checkOnce()
-  }
+    void checkOnce();
+  };
 
   const handleSaveApiKey = async () => {
     if (!apiKeyInput.trim()) {
-      message.error(t("sidepanel:connectionBanner.apiKeyRequired", "Please enter an API key"))
-      return
+      message.error(
+        t(
+          "sidepanel:connectionBanner.apiKeyRequired",
+          "Please enter an API key",
+        ),
+      );
+      return;
     }
 
-    setIsSaving(true)
+    setIsSaving(true);
     try {
       await setConfigPartial({
-        apiKey: apiKeyInput.trim()
-      })
-      message.success(t("sidepanel:connectionBanner.apiKeySaved", "API key saved"))
-      setShowApiKeyForm(false)
-      setApiKeyInput("")
-      void checkOnce()
+        apiKey: apiKeyInput.trim(),
+      });
+      message.success(
+        t("sidepanel:connectionBanner.apiKeySaved", "API key saved"),
+      );
+      setShowApiKeyForm(false);
+      setApiKeyInput("");
+      void checkOnce();
     } catch {
-      message.error(t("sidepanel:connectionBanner.apiKeySaveError", "Failed to save API key"))
+      message.error(
+        t(
+          "sidepanel:connectionBanner.apiKeySaveError",
+          "Failed to save API key",
+        ),
+      );
     } finally {
-      setIsSaving(false)
+      setIsSaving(false);
     }
-  }
+  };
 
   // Determine banner content based on state
   const getBannerConfig = () => {
@@ -112,12 +126,12 @@ export const ConnectionBanner: React.FC<ConnectionBannerProps> = ({
         state: "retrying" as RecoveryState,
         message: t(
           "sidepanel:connectionBanner.connecting",
-          "Connecting to your tldw server..."
+          "Connecting to your tldw server...",
         ),
         description: null,
         showRetry: false,
-        showSettings: false
-      }
+        showSettings: false,
+      };
     }
 
     if (uxState === "error_auth") {
@@ -125,15 +139,15 @@ export const ConnectionBanner: React.FC<ConnectionBannerProps> = ({
         state: "auth_required" as RecoveryState,
         message: t(
           "sidepanel:connectionBanner.authErrorTitle",
-          "API key needs attention"
+          "API key needs attention",
         ),
         description: t(
           "sidepanel:connectionBanner.authErrorBody",
-          "Your server is reachable but the API key is wrong or missing."
+          "Your server is reachable but the API key is wrong or missing.",
         ),
         showRetry: true,
-        showSettings: true
-      }
+        showSettings: true,
+      };
     }
 
     if (uxState === "error_unreachable") {
@@ -141,20 +155,20 @@ export const ConnectionBanner: React.FC<ConnectionBannerProps> = ({
         state: "unavailable" as RecoveryState,
         message: t(
           "sidepanel:connectionBanner.unreachableTitle",
-          "Can't reach your tldw server"
+          "Can't reach your tldw server",
         ),
         description: serverUrl
           ? t(
               "sidepanel:connectionBanner.unreachableBody",
-              "Check that your server is running and accessible."
+              "Check that your server is running and accessible.",
             )
           : t(
               "sidepanel:connectionBanner.noUrlBody",
-              "Add your server URL in Settings to get started."
+              "Add your server URL in Settings to get started.",
             ),
         showRetry: !!serverUrl,
-        showSettings: true
-      }
+        showSettings: true,
+      };
     }
 
     // Default: unconfigured or unknown state
@@ -163,77 +177,76 @@ export const ConnectionBanner: React.FC<ConnectionBannerProps> = ({
       message: hasCompletedFirstRun
         ? t(
             "sidepanel:connectionBanner.disconnectedTitle",
-            "Not connected to tldw server"
+            "Not connected to tldw server",
           )
         : t(
             "sidepanel:connectionBanner.setupTitle",
-            "Finish setup to start chatting"
+            "Finish setup to start chatting",
           ),
       description: hasCompletedFirstRun
         ? t(
             "sidepanel:connectionBanner.disconnectedBody",
-            "Open Settings to configure your server connection."
+            "Open Settings to configure your server connection.",
           )
         : t(
             "sidepanel:connectionBanner.setupBody",
-            "Complete the setup wizard in Settings to connect."
+            "Complete the setup wizard in Settings to connect.",
           ),
       showRetry: false,
-      showSettings: true
-    }
-  }
+      showSettings: true,
+    };
+  };
 
-  const config = getBannerConfig()
-  const showInlineApiKeyForm = canInlineRepairApiKey && showApiKeyForm
+  const config = getBannerConfig();
+  const showInlineApiKeyForm = canInlineRepairApiKey && showApiKeyForm;
 
   const primaryAction: StateAction = (() => {
     if (canInlineRepairApiKey && !showApiKeyForm) {
       return {
         label: t("sidepanel:connectionBanner.enterApiKey", "Enter API Key"),
-        onClick: () => setShowApiKeyForm(true)
-      }
+        onClick: () => setShowApiKeyForm(true),
+      };
     }
 
     if (config.showRetry) {
       return {
         label: t("common:retry", "Retry"),
         onClick: handleRetry,
-        loading: isChecking
-      }
+        loading: isChecking,
+      };
     }
 
     if (config.showSettings) {
       return {
         label: t("sidepanel:connectionBanner.openSettings", "Open Settings"),
-        onClick: openSettings
-      }
+        onClick: openSettings,
+      };
     }
 
     return {
       label: t("sidepanel:connectionBanner.connectingCta", "Connecting"),
-      disabled: true
-    }
-  })()
+      disabled: true,
+    };
+  })();
 
   const secondaryActionCandidates: Array<StateAction | null> = [
     canInlineRepairApiKey && !showApiKeyForm && config.showRetry
       ? {
           label: t("common:retry", "Retry"),
           onClick: handleRetry,
-          loading: isChecking
+          loading: isChecking,
         }
       : null,
-    config.showSettings &&
-    !(config.showRetry === false && !canInlineRepairApiKey)
+    config.showSettings && (config.showRetry || canInlineRepairApiKey)
       ? {
           label: t("sidepanel:connectionBanner.openSettings", "Open Settings"),
-          onClick: openSettings
+          onClick: openSettings,
         }
-      : null
-  ]
+      : null,
+  ];
   const secondaryActions = secondaryActionCandidates.filter(
-    (action): action is StateAction => Boolean(action)
-  )
+    (action): action is StateAction => Boolean(action),
+  );
 
   return (
     <div className={`px-3 py-2 ${className || ""}`}>
@@ -250,13 +263,16 @@ export const ConnectionBanner: React.FC<ConnectionBannerProps> = ({
             <div className="flex items-center gap-2">
               <Input.Password
                 size="small"
-                placeholder={t("sidepanel:connectionBanner.apiKeyPlaceholder", "Enter your API key")}
+                placeholder={t(
+                  "sidepanel:connectionBanner.apiKeyPlaceholder",
+                  "Enter your API key",
+                )}
                 value={apiKeyInput}
                 onChange={(e) => setApiKeyInput(e.target.value)}
                 onPressEnter={handleSaveApiKey}
                 visibilityToggle={{
                   visible: showApiKey,
-                  onVisibleChange: setShowApiKey
+                  onVisibleChange: setShowApiKey,
                 }}
                 className="flex-1"
                 autoFocus
@@ -275,8 +291,8 @@ export const ConnectionBanner: React.FC<ConnectionBannerProps> = ({
             <button
               type="button"
               onClick={() => {
-                setShowApiKeyForm(false)
-                setApiKeyInput("")
+                setShowApiKeyForm(false);
+                setApiKeyInput("");
               }}
               className="text-xs text-text-subtle hover:text-text underline"
               title={t("common:cancel", "Cancel")}
@@ -287,7 +303,7 @@ export const ConnectionBanner: React.FC<ConnectionBannerProps> = ({
         ) : null}
       </RecoveryCallout>
     </div>
-  )
-}
+  );
+};
 
-export default ConnectionBanner
+export default ConnectionBanner;

--- a/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ConnectionBanner.test.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ConnectionBanner.test.tsx
@@ -131,6 +131,11 @@ describe("ConnectionBanner", () => {
   it("repairs single-user auth through shared config instead of legacy api key storage", async () => {
     render(<ConnectionBanner />)
 
+    const banner = screen.getByTestId("sidepanel-connection-banner")
+
+    expect(banner).toHaveAttribute("data-ds-component", "RecoveryCallout")
+    expect(screen.getByText("Sign in required")).toBeInTheDocument()
+
     fireEvent.click(
       screen.getByRole("button", { name: "Enter API Key" })
     )

--- a/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/empty.test.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/empty.test.tsx
@@ -67,6 +67,10 @@ describe("EmptySidePanel", () => {
   it("frames setup around Companion Home instead of a chat-only launch", () => {
     renderPanel()
 
+    const panel = screen.getByTestId("chat-empty-connection")
+
+    expect(panel).toHaveAttribute("data-ds-component", "RecoveryCallout")
+    expect(screen.getByText("Setup required")).toBeInTheDocument()
     expect(screen.getByText("Finish setup to open Companion Home")).toBeInTheDocument()
     expect(
       screen.getByText(
@@ -86,6 +90,11 @@ describe("EmptySidePanel", () => {
 
     renderPanel()
 
+    expect(screen.getByTestId("chat-empty-connection")).toHaveAttribute(
+      "data-ds-component",
+      "RecoveryCallout"
+    )
+    expect(screen.getByText("Sign in required")).toBeInTheDocument()
     expect(screen.getByText("API key needs attention")).toBeInTheDocument()
     expect(
       screen.getByText(
@@ -110,6 +119,11 @@ describe("EmptySidePanel", () => {
 
     renderPanel()
 
+    expect(screen.getByTestId("chat-empty-connection")).toHaveAttribute(
+      "data-ds-component",
+      "RecoveryCallout"
+    )
+    expect(screen.getByText("Unavailable")).toBeInTheDocument()
     expect(screen.getByText("Can’t reach your tldw server")).toBeInTheDocument()
     expect(
       screen.getByText(/We couldn’t reach \{\{host\}\}\./)

--- a/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/empty.test.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/empty.test.tsx
@@ -1,176 +1,194 @@
-import React from "react"
-import { render, screen } from "@testing-library/react"
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { ConnectionPhase } from "@/types/connection"
-import { EmptySidePanel } from "../empty"
+import { ConnectionPhase } from "@/types/connection";
+import { EmptySidePanel } from "../empty";
 
 const connectionStateMock = vi.hoisted(() => ({
   state: {
     phase: "unconfigured",
     isConnected: false,
-    serverUrl: null
+    serverUrl: null,
   },
   uxState: {
     uxState: "unconfigured",
     mode: "normal",
     configStep: "url",
-    hasCompletedFirstRun: false
-  }
-}))
+    hasCompletedFirstRun: false,
+  },
+}));
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
-    t: (_key: string, fallback?: string) => fallback ?? _key
-  })
-}))
+    t: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}));
 
 vi.mock("wxt/browser", () => ({
   browser: {
     runtime: {
       getURL: vi.fn((path: string) => `chrome-extension://test${path}`),
-      sendMessage: vi.fn()
+      sendMessage: vi.fn(),
     },
     tabs: {
-      create: vi.fn()
-    }
-  }
-}))
+      create: vi.fn(),
+    },
+  },
+}));
 
 vi.mock("antd", () => ({
   Button: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
-  Tooltip: ({ children }: { children?: React.ReactNode }) => <>{children}</>
-}))
+  Tooltip: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
 
 vi.mock("@/hooks/useConnectionState", () => ({
   useConnectionState: () => connectionStateMock.state,
-  useConnectionUxState: () => connectionStateMock.uxState
-}))
+  useConnectionUxState: () => connectionStateMock.uxState,
+}));
 
 describe("EmptySidePanel", () => {
-  const renderPanel = () => render(<EmptySidePanel />)
+  const renderPanel = () => render(<EmptySidePanel />);
 
   beforeEach(() => {
     connectionStateMock.state = {
       phase: "unconfigured",
       isConnected: false,
-      serverUrl: null
-    }
+      serverUrl: null,
+    };
     connectionStateMock.uxState = {
       uxState: "unconfigured",
       mode: "normal",
       configStep: "url",
-      hasCompletedFirstRun: false
-    }
-  })
+      hasCompletedFirstRun: false,
+    };
+  });
 
   it("frames setup around Companion Home instead of a chat-only launch", () => {
-    renderPanel()
+    renderPanel();
 
-    const panel = screen.getByTestId("chat-empty-connection")
+    const panel = screen.getByTestId("chat-empty-connection");
 
-    expect(panel).toHaveAttribute("data-ds-component", "RecoveryCallout")
-    expect(screen.getByText("Setup required")).toBeInTheDocument()
-    expect(screen.getByText("Finish setup to open Companion Home")).toBeInTheDocument()
+    expect(panel).toHaveAttribute("data-ds-component", "RecoveryCallout");
+    expect(screen.getByText("Setup required")).toBeInTheDocument();
+    expect(
+      screen.getByText("Finish setup to open Companion Home"),
+    ).toBeInTheDocument();
     expect(
       screen.getByText(
-        "Before you can use Companion Home here, finish the short setup flow in Options to connect tldw Assistant to your tldw server or choose demo mode."
-      )
-    ).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: "Finish setup" })).toBeInTheDocument()
-  })
+        "Before you can use Companion Home here, finish the short setup flow in Options to connect tldw Assistant to your tldw server or choose demo mode.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Setup step")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Step 1 of 3 — Add your server URL in Options → tldw Server.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Finish setup" })).toHaveFocus();
+  });
 
   it("shows the auth recovery copy when credentials need attention", () => {
     connectionStateMock.uxState = {
       uxState: "error_auth",
       mode: "normal",
       configStep: "auth",
-      hasCompletedFirstRun: true
-    }
+      hasCompletedFirstRun: true,
+    };
 
-    renderPanel()
+    renderPanel();
 
     expect(screen.getByTestId("chat-empty-connection")).toHaveAttribute(
       "data-ds-component",
-      "RecoveryCallout"
-    )
-    expect(screen.getByText("Sign in required")).toBeInTheDocument()
-    expect(screen.getByText("API key needs attention")).toBeInTheDocument()
+      "RecoveryCallout",
+    );
+    expect(screen.getByText("Sign in required")).toBeInTheDocument();
+    expect(screen.getByText("API key needs attention")).toBeInTheDocument();
     expect(
       screen.getByText(
-        "Your server is up but the API key is wrong or missing. Fix the key in Settings → tldw server, then retry."
-      )
-    ).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: "Review settings" })).toBeInTheDocument()
-  })
+        "Your server is up but the API key is wrong or missing. Fix the key in Settings → tldw server, then retry.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Review settings" }),
+    ).toBeInTheDocument();
+  });
 
   it("shows the unreachable-server copy when the server cannot be reached", () => {
     connectionStateMock.state = {
       phase: "error",
       isConnected: false,
-      serverUrl: "http://localhost:8000"
-    }
+      serverUrl: "http://localhost:8000",
+    };
     connectionStateMock.uxState = {
       uxState: "error_unreachable",
       mode: "normal",
       configStep: "health",
-      hasCompletedFirstRun: true
-    }
+      hasCompletedFirstRun: true,
+    };
 
-    renderPanel()
+    renderPanel();
 
     expect(screen.getByTestId("chat-empty-connection")).toHaveAttribute(
       "data-ds-component",
-      "RecoveryCallout"
-    )
-    expect(screen.getByText("Unavailable")).toBeInTheDocument()
-    expect(screen.getByText("Can’t reach your tldw server")).toBeInTheDocument()
+      "RecoveryCallout",
+    );
+    expect(screen.getByText("Unavailable")).toBeInTheDocument();
     expect(
-      screen.getByText(/We couldn’t reach \{\{host\}\}\./)
-    ).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: "Review settings" })).toBeInTheDocument()
-  })
+      screen.getByText("Can’t reach your tldw server"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/We couldn’t reach \{\{host\}\}\./),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Review settings" }),
+    ).toBeInTheDocument();
+  });
 
   it("shows the post-onboarding connection copy when first run is complete", () => {
     connectionStateMock.uxState = {
       uxState: "unconfigured",
       mode: "normal",
       configStep: "url",
-      hasCompletedFirstRun: true
-    }
+      hasCompletedFirstRun: true,
+    };
 
-    renderPanel()
+    renderPanel();
 
-    expect(
-      screen.getByText("Connect tldw Assistant to your server to open Companion Home")
-    ).toBeInTheDocument()
     expect(
       screen.getByText(
-        "tldw_server is your private AI workspace that keeps your home dashboard, chats, notes, and media on your own machine. Add your server URL to get started."
-      )
-    ).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: "Open tldw Settings" })).toBeInTheDocument()
-  })
+        "Connect tldw Assistant to your server to open Companion Home",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "tldw_server is your private AI workspace that keeps your home dashboard, chats, notes, and media on your own machine. Add your server URL to get started.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Open tldw Settings" }),
+    ).toBeInTheDocument();
+  });
 
   it("shows suggestion cards when the sidepanel is connected", () => {
     connectionStateMock.state = {
       phase: ConnectionPhase.CONNECTED,
       isConnected: true,
-      serverUrl: "http://localhost:8000"
-    }
+      serverUrl: "http://localhost:8000",
+    };
     connectionStateMock.uxState = {
       uxState: "connected_ok",
       mode: "normal",
       configStep: "health",
-      hasCompletedFirstRun: true
-    }
+      hasCompletedFirstRun: true,
+    };
 
-    renderPanel()
+    renderPanel();
 
-    expect(screen.getByTestId("chat-empty-connected")).toBeInTheDocument()
-    expect(screen.getByText("Try asking")).toBeInTheDocument()
-    expect(screen.getByTestId("chat-suggestion-1")).toBeInTheDocument()
-    expect(screen.getByTestId("chat-suggestion-2")).toBeInTheDocument()
-    expect(screen.getByTestId("chat-suggestion-3")).toBeInTheDocument()
-  })
-})
+    expect(screen.getByTestId("chat-empty-connected")).toBeInTheDocument();
+    expect(screen.getByText("Try asking")).toBeInTheDocument();
+    expect(screen.getByTestId("chat-suggestion-1")).toBeInTheDocument();
+    expect(screen.getByTestId("chat-suggestion-2")).toBeInTheDocument();
+    expect(screen.getByTestId("chat-suggestion-3")).toBeInTheDocument();
+  });
+});

--- a/apps/packages/ui/src/components/Sidepanel/Chat/empty.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/empty.tsx
@@ -1,6 +1,5 @@
 import React from "react"
 import { useTranslation } from "react-i18next"
-import { Button, Tooltip } from "antd"
 import { browser } from "wxt/browser"
 import {
   useConnectionState,
@@ -10,15 +9,13 @@ import { ConnectionPhase } from "@/types/connection"
 import { cleanUrl } from "@/libs/clean-url"
 import {
   MessageSquare,
-  Settings,
-  KeyRound,
   Wifi,
-  WifiOff,
   Sparkles,
   FileText,
   Search,
   BookOpen
 } from "lucide-react"
+import { RecoveryCallout, type RecoveryState } from "@/components/ui/state"
 
 type EmptySidePanelProps = {
   inputRef?: React.RefObject<HTMLTextAreaElement>
@@ -31,7 +28,6 @@ export const EmptySidePanel = ({ inputRef }: EmptySidePanelProps) => {
     useConnectionUxState()
   const isConnectionReady =
     isConnected && phase === ConnectionPhase.CONNECTED
-  const primaryButtonRef = React.useRef<HTMLButtonElement | null>(null)
 
   const openExtensionUrl = (
     path: `/options.html${string}` | `/sidepanel.html${string}`
@@ -186,96 +182,53 @@ export const EmptySidePanel = ({ inputRef }: EmptySidePanelProps) => {
 
   React.useEffect(() => {
     if (!showConnectionCard) return
-    if (!primaryButtonRef.current) return
     if (hasCompletedFirstRun) return
     try {
-      primaryButtonRef.current.focus()
+      document
+        .querySelector<HTMLButtonElement>('[data-testid="chat-connection-cta"]')
+        ?.focus()
     } catch {
       // ignore focus failures
     }
   }, [showConnectionCard, hasCompletedFirstRun])
 
   if (showConnectionCard) {
-    // Determine the icon based on error state
-    const StatusIcon = uxState === "error_auth"
-      ? KeyRound
-      : uxState === "error_unreachable"
-        ? WifiOff
-        : Settings
-
-    const iconColorClass = uxState === "error_auth" || uxState === "error_unreachable"
-      ? "text-warn"
-      : "text-primary"
+    const recoveryState: RecoveryState =
+      uxState === "error_auth"
+        ? "auth_required"
+        : uxState === "error_unreachable"
+          ? "unavailable"
+          : "setup_required"
+    const primaryLabel = !hasCompletedFirstRun
+      ? t("sidepanel:firstRun.finishSetup", "Finish setup")
+      : uxState === "error_auth" || uxState === "error_unreachable"
+        ? t("sidepanel:firstRun.reviewSettings", "Review settings")
+        : t("sidepanel:firstRun.openOptionsPrimary", "Open tldw Settings")
 
     return (
       <div
         className="mt-5 flex w-full flex-col items-stretch gap-3 px-4"
-        data-testid="chat-empty-connection"
       >
-        {/* Main card with icon */}
-        <div className="overflow-hidden rounded-2xl border border-border/70 bg-surface/95 shadow-sm">
-          {/* Header with icon */}
-          <div className="flex items-center gap-3 border-b border-border/70 px-4 py-4">
-            <div className={`flex-shrink-0 rounded-2xl p-2 ${
-              uxState === "error_auth" || uxState === "error_unreachable"
-                ? "bg-warn/10"
-                : "bg-primary/10"
-            }`}>
-              <StatusIcon className={`size-5 ${iconColorClass}`} />
-            </div>
-            <div className="flex-1 min-w-0">
-              <p className="text-sm font-semibold text-text">
-                {bannerHeading}
-              </p>
-            </div>
-          </div>
-
-          {/* Body */}
-          <div className="space-y-3 px-4 py-4">
-            <p className="text-xs text-text-muted leading-relaxed">
-              {bannerBody}
-            </p>
-
-            {/* Action button */}
-            <button
-              type="button"
-              onClick={openOnboarding}
-              ref={primaryButtonRef}
-              data-testid="chat-connection-cta"
-              className={`flex w-full items-center justify-center gap-2 rounded-full px-4 py-2.5 text-xs font-medium transition-colors ${
-                uxState === "error_auth" || uxState === "error_unreachable"
-                  ? "bg-warn hover:bg-warn/90 text-white"
-                  : "bg-primary hover:bg-primaryStrong text-white"
-              }`}
-              title={
-                !hasCompletedFirstRun
-                  ? t("sidepanel:firstRun.finishSetup", "Finish setup")
-                  : uxState === "error_auth" || uxState === "error_unreachable"
-                    ? t("sidepanel:firstRun.reviewSettings", "Review settings")
-                    : t(
-                        "sidepanel:firstRun.openOptionsPrimary",
-                        "Open tldw Settings"
-                      )
-              }
-            >
-              <Settings className="size-3.5" />
-              {!hasCompletedFirstRun
-                ? t("sidepanel:firstRun.finishSetup", "Finish setup")
-                : uxState === "error_auth" || uxState === "error_unreachable"
-                  ? t("sidepanel:firstRun.reviewSettings", "Review settings")
-                  : t("sidepanel:firstRun.openOptionsPrimary", "Open tldw Settings")}
-            </button>
-          </div>
-
-          {/* Step indicator for first-run */}
+        <RecoveryCallout
+          state={recoveryState}
+          title={bannerHeading}
+          message={bannerBody}
+          primaryAction={{
+            label: primaryLabel,
+            onClick: openOnboarding,
+            "data-testid": "chat-connection-cta"
+          }}
+          data-testid="chat-empty-connection"
+          className="rounded-2xl border-border/70 bg-surface/95"
+        >
           {stepSummary && (
-            <div className="border-t border-border/70 bg-surface2/70 px-4 py-2">
+            <div className="rounded-md border border-border bg-surface2 px-3 py-2">
               <p className="text-label text-text-subtle">
                 {stepSummary}
               </p>
             </div>
           )}
-        </div>
+        </RecoveryCallout>
 
         {/* Quick tips for first-time users */}
         {!hasCompletedFirstRun && (

--- a/apps/packages/ui/src/components/Sidepanel/Chat/empty.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/empty.tsx
@@ -1,86 +1,97 @@
-import React from "react"
-import { useTranslation } from "react-i18next"
-import { browser } from "wxt/browser"
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { browser } from "wxt/browser";
 import {
   useConnectionState,
-  useConnectionUxState
-} from "@/hooks/useConnectionState"
-import { ConnectionPhase } from "@/types/connection"
-import { cleanUrl } from "@/libs/clean-url"
+  useConnectionUxState,
+} from "@/hooks/useConnectionState";
+import { ConnectionPhase } from "@/types/connection";
+import { cleanUrl } from "@/libs/clean-url";
 import {
   MessageSquare,
   Wifi,
   Sparkles,
   FileText,
   Search,
-  BookOpen
-} from "lucide-react"
-import { RecoveryCallout, type RecoveryState } from "@/components/ui/state"
+  BookOpen,
+} from "lucide-react";
+import { RecoveryCallout, type RecoveryState } from "@/components/ui/state";
 
 type EmptySidePanelProps = {
-  inputRef?: React.RefObject<HTMLTextAreaElement>
-}
+  inputRef?: React.RefObject<HTMLTextAreaElement>;
+};
 
 export const EmptySidePanel = ({ inputRef }: EmptySidePanelProps) => {
-  const { t } = useTranslation(["sidepanel", "settings", "option", "playground"])
-  const { phase, isConnected, serverUrl } = useConnectionState()
+  const { t } = useTranslation([
+    "sidepanel",
+    "settings",
+    "option",
+    "playground",
+  ]);
+  const { phase, isConnected, serverUrl } = useConnectionState();
   const { uxState, mode, configStep, hasCompletedFirstRun } =
-    useConnectionUxState()
-  const isConnectionReady =
-    isConnected && phase === ConnectionPhase.CONNECTED
+    useConnectionUxState();
+  const isConnectionReady = isConnected && phase === ConnectionPhase.CONNECTED;
+  const primaryButtonRef = React.useRef<HTMLButtonElement | null>(null);
 
   const openExtensionUrl = (
-    path: `/options.html${string}` | `/sidepanel.html${string}`
+    path: `/options.html${string}` | `/sidepanel.html${string}`,
   ) => {
     try {
       // Prefer opening the extension's options.html directly so users land
       // on the tldw settings page instead of the generic extensions manager.
       // `browser` is provided by the WebExtension polyfill in WXT.
       if (browser?.runtime?.getURL) {
-        const url = browser.runtime.getURL(path)
+        const url = browser.runtime.getURL(path);
         if (browser.tabs?.create) {
-          browser.tabs.create({ url })
+          browser.tabs.create({ url });
         } else {
-          window.open(url, "_blank")
+          window.open(url, "_blank");
         }
-        return
+        return;
       }
     } catch (err) {
       // Fall through to chrome.* / window.open below.
-      console.debug("[EmptySidePanel] openExtensionUrl browser API unavailable:", err)
+      console.debug(
+        "[EmptySidePanel] openExtensionUrl browser API unavailable:",
+        err,
+      );
     }
 
     try {
       if (typeof chrome !== "undefined" && chrome.runtime?.getURL) {
-        const url = chrome.runtime.getURL(path)
-        window.open(url, "_blank")
-        return
+        const url = chrome.runtime.getURL(path);
+        window.open(url, "_blank");
+        return;
       }
       if (
         typeof chrome !== "undefined" &&
         chrome.runtime?.openOptionsPage &&
         path.includes("/options.html")
       ) {
-        chrome.runtime.openOptionsPage()
-        return
+        chrome.runtime.openOptionsPage();
+        return;
       }
     } catch (err) {
       // ignore and fall back to plain window.open
-      console.debug("[EmptySidePanel] openExtensionUrl chrome API unavailable:", err)
+      console.debug(
+        "[EmptySidePanel] openExtensionUrl chrome API unavailable:",
+        err,
+      );
     }
 
-    window.open(path, "_blank")
-  }
+    window.open(path, "_blank");
+  };
 
-  const showConnectionCard = !isConnectionReady
-  const host = serverUrl ? cleanUrl(serverUrl) : "tldw_server"
+  const showConnectionCard = !isConnectionReady;
+  const host = serverUrl ? cleanUrl(serverUrl) : "tldw_server";
 
   const activeStep = (() => {
-    if (configStep === "url") return 1
-    if (configStep === "auth") return 2
-    if (configStep === "health") return 3
-    if (uxState === "configuring_url" || uxState === "unconfigured") return 1
-    if (uxState === "configuring_auth") return 2
+    if (configStep === "url") return 1;
+    if (configStep === "auth") return 2;
+    if (configStep === "health") return 3;
+    if (uxState === "configuring_url" || uxState === "unconfigured") return 1;
+    if (uxState === "configuring_auth") return 2;
     if (
       uxState === "testing" ||
       uxState === "connected_ok" ||
@@ -88,109 +99,104 @@ export const EmptySidePanel = ({ inputRef }: EmptySidePanelProps) => {
       uxState === "error_auth" ||
       uxState === "error_unreachable"
     ) {
-      return 3
+      return 3;
     }
-    return 1
-  })()
+    return 1;
+  })();
 
   const stepSummary = (() => {
-    if (hasCompletedFirstRun) return null
+    if (hasCompletedFirstRun) return null;
     if (activeStep === 1) {
       return t(
         "sidepanel:firstRun.step1",
-        "Step 1 of 3 — Add your server URL in Options → tldw Server."
-      )
+        "Step 1 of 3 — Add your server URL in Options → tldw Server.",
+      );
     }
     if (activeStep === 2) {
       return t(
         "sidepanel:firstRun.step2",
-        "Step 2 of 3 — Add your API key or log in on the tldw Server settings page."
-      )
+        "Step 2 of 3 — Add your API key or log in on the tldw Server settings page.",
+      );
     }
     return t(
       "sidepanel:firstRun.step3",
-      "Step 3 of 3 — Check connection & Knowledge in Health & diagnostics."
-    )
-  })()
+      "Step 3 of 3 — Check connection & Knowledge in Health & diagnostics.",
+    );
+  })();
 
   const openOnboarding = () => {
-    openExtensionUrl("/options.html#/")
-  }
+    openExtensionUrl("/options.html#/");
+  };
 
   const bannerHeading = (() => {
     if (uxState === "error_auth") {
       return t(
         "option:connectionCard.headlineErrorAuth",
-        "API key needs attention"
-      )
+        "API key needs attention",
+      );
     }
     if (uxState === "error_unreachable") {
       return t(
         "option:connectionCard.headlineError",
-        "Can’t reach your tldw server"
-      )
+        "Can’t reach your tldw server",
+      );
     }
     // First-run emphasis: make it clear that setup must be finished
     // before chat is available from the sidepanel.
     return hasCompletedFirstRun
       ? t(
           "option:connectionCard.headlineMissing",
-          "Connect tldw Assistant to your server to open Companion Home"
+          "Connect tldw Assistant to your server to open Companion Home",
         )
-      : t(
-          "sidepanel:firstRun.headline",
-          "Finish setup to open Companion Home"
-        )
-  })()
+      : t("sidepanel:firstRun.headline", "Finish setup to open Companion Home");
+  })();
 
   const bannerBody = (() => {
     if (uxState === "error_auth") {
       return t(
         "option:connectionCard.descriptionErrorAuth",
-        "Your server is up but the API key is wrong or missing. Fix the key in Settings → tldw server, then retry."
-      )
+        "Your server is up but the API key is wrong or missing. Fix the key in Settings → tldw server, then retry.",
+      );
     }
     if (uxState === "error_unreachable") {
       return t(
         "option:connectionCard.descriptionError",
         "We couldn’t reach {{host}}. Check that your tldw_server is running and that your browser can reach it, then open diagnostics or update the URL.",
-        { host }
-      )
+        { host },
+      );
     }
     if (!hasCompletedFirstRun) {
       return t(
         "sidepanel:firstRun.description",
-        "Before you can use Companion Home here, finish the short setup flow in Options to connect tldw Assistant to your tldw server or choose demo mode."
-      )
+        "Before you can use Companion Home here, finish the short setup flow in Options to connect tldw Assistant to your tldw server or choose demo mode.",
+      );
     }
     return t(
       "option:connectionCard.descriptionMissing",
-      "tldw_server is your private AI workspace that keeps your home dashboard, chats, notes, and media on your own machine. Add your server URL to get started."
-    )
-  })()
+      "tldw_server is your private AI workspace that keeps your home dashboard, chats, notes, and media on your own machine. Add your server URL to get started.",
+    );
+  })();
 
   const insertPrompt = (text: string) => {
     const input =
       inputRef?.current ??
-      document.querySelector<HTMLTextAreaElement>('[data-testid="chat-input"]')
+      document.querySelector<HTMLTextAreaElement>('[data-testid="chat-input"]');
     if (input) {
-      input.value = text
-      input.focus()
-      input.dispatchEvent(new Event("input", { bubbles: true }))
+      input.value = text;
+      input.focus();
+      input.dispatchEvent(new Event("input", { bubbles: true }));
     }
-  }
+  };
 
   React.useEffect(() => {
-    if (!showConnectionCard) return
-    if (hasCompletedFirstRun) return
+    if (!showConnectionCard) return;
+    if (hasCompletedFirstRun) return;
     try {
-      document
-        .querySelector<HTMLButtonElement>('[data-testid="chat-connection-cta"]')
-        ?.focus()
+      primaryButtonRef.current?.focus();
     } catch {
       // ignore focus failures
     }
-  }, [showConnectionCard, hasCompletedFirstRun])
+  }, [showConnectionCard, hasCompletedFirstRun]);
 
   if (showConnectionCard) {
     const recoveryState: RecoveryState =
@@ -198,46 +204,49 @@ export const EmptySidePanel = ({ inputRef }: EmptySidePanelProps) => {
         ? "auth_required"
         : uxState === "error_unreachable"
           ? "unavailable"
-          : "setup_required"
+          : "setup_required";
     const primaryLabel = !hasCompletedFirstRun
       ? t("sidepanel:firstRun.finishSetup", "Finish setup")
       : uxState === "error_auth" || uxState === "error_unreachable"
         ? t("sidepanel:firstRun.reviewSettings", "Review settings")
-        : t("sidepanel:firstRun.openOptionsPrimary", "Open tldw Settings")
+        : t("sidepanel:firstRun.openOptionsPrimary", "Open tldw Settings");
+    const stepDiagnostics = stepSummary
+      ? [
+          {
+            label: t("sidepanel:firstRun.stepLabel", "Setup step"),
+            value: stepSummary,
+          },
+        ]
+      : undefined;
 
     return (
-      <div
-        className="mt-5 flex w-full flex-col items-stretch gap-3 px-4"
-      >
+      <div className="mt-5 flex w-full flex-col items-stretch gap-3 px-4">
         <RecoveryCallout
           state={recoveryState}
           title={bannerHeading}
           message={bannerBody}
+          diagnostics={stepDiagnostics}
           primaryAction={{
             label: primaryLabel,
             onClick: openOnboarding,
-            "data-testid": "chat-connection-cta"
+            ref: primaryButtonRef,
+            "data-testid": "chat-connection-cta",
           }}
           data-testid="chat-empty-connection"
           className="rounded-2xl border-border/70 bg-surface/95"
-        >
-          {stepSummary && (
-            <div className="rounded-md border border-border bg-surface2 px-3 py-2">
-              <p className="text-label text-text-subtle">
-                {stepSummary}
-              </p>
-            </div>
-          )}
-        </RecoveryCallout>
+        />
 
         {/* Quick tips for first-time users */}
         {!hasCompletedFirstRun && (
           <div className="text-center text-label text-text-muted">
-            {t("sidepanel:firstRun.quickTip", "Need help? Check our docs or try demo mode.")}
+            {t(
+              "sidepanel:firstRun.quickTip",
+              "Need help? Check our docs or try demo mode.",
+            )}
           </div>
         )}
       </div>
-    )
+    );
   }
 
   // Connected state: show welcoming empty chat guidance
@@ -261,7 +270,10 @@ export const EmptySidePanel = ({ inputRef }: EmptySidePanelProps) => {
       </div>
       <p className="mb-4 text-sm font-medium text-text">
         {mode === "demo"
-          ? t("sidepanel:emptyChat.demoHint", "Demo mode — try sending a message")
+          ? t(
+              "sidepanel:emptyChat.demoHint",
+              "Demo mode — try sending a message",
+            )
           : t("sidepanel:emptyChat.hint", "Start a conversation below")}
       </p>
 
@@ -274,57 +286,72 @@ export const EmptySidePanel = ({ inputRef }: EmptySidePanelProps) => {
           type="button"
           data-testid="chat-suggestion-1"
           className="group flex w-full items-center gap-3 rounded-2xl border border-border/70 bg-surface px-3 py-2 text-left transition-colors hover:border-primary/40 hover:bg-surface2"
-          title={t("sidepanel:emptyChat.examplePrompt1", "\"Summarize this page\"")}
+          title={t(
+            "sidepanel:emptyChat.examplePrompt1",
+            '"Summarize this page"',
+          )}
           onClick={() =>
             insertPrompt(
               t(
                 "sidepanel:emptyChat.examplePrompt1Text",
-                "Summarize this page"
-              )
+                "Summarize this page",
+              ),
             )
           }
         >
           <FileText className="size-4 text-text-subtle group-hover:text-primary flex-shrink-0" />
           <span className="text-xs text-text-muted">
-            {t("sidepanel:emptyChat.examplePrompt1", "\"Summarize this page\"")}
+            {t("sidepanel:emptyChat.examplePrompt1", '"Summarize this page"')}
           </span>
         </button>
         <button
           type="button"
           data-testid="chat-suggestion-2"
           className="group flex w-full items-center gap-3 rounded-2xl border border-border/70 bg-surface px-3 py-2 text-left transition-colors hover:border-primary/40 hover:bg-surface2"
-          title={t("sidepanel:emptyChat.examplePrompt2", "\"What are the key points?\"")}
+          title={t(
+            "sidepanel:emptyChat.examplePrompt2",
+            '"What are the key points?"',
+          )}
           onClick={() =>
             insertPrompt(
               t(
                 "sidepanel:emptyChat.examplePrompt2Text",
-                "What are the key points?"
-              )
+                "What are the key points?",
+              ),
             )
           }
         >
           <Search className="size-4 text-text-subtle group-hover:text-primary flex-shrink-0" />
           <span className="text-xs text-text-muted">
-            {t("sidepanel:emptyChat.examplePrompt2", "\"What are the key points?\"")}
+            {t(
+              "sidepanel:emptyChat.examplePrompt2",
+              '"What are the key points?"',
+            )}
           </span>
         </button>
         <button
           type="button"
           data-testid="chat-suggestion-3"
           className="group flex w-full items-center gap-3 rounded-2xl border border-border/70 bg-surface px-3 py-2 text-left transition-colors hover:border-primary/40 hover:bg-surface2"
-          title={t("sidepanel:emptyChat.examplePrompt3", "\"Explain this in simple terms\"")}
+          title={t(
+            "sidepanel:emptyChat.examplePrompt3",
+            '"Explain this in simple terms"',
+          )}
           onClick={() =>
             insertPrompt(
               t(
                 "sidepanel:emptyChat.examplePrompt3Text",
-                "Explain this in simple terms"
-              )
+                "Explain this in simple terms",
+              ),
             )
           }
         >
           <BookOpen className="size-4 text-text-subtle group-hover:text-primary flex-shrink-0" />
           <span className="text-xs text-text-muted">
-            {t("sidepanel:emptyChat.examplePrompt3", "\"Explain this in simple terms\"")}
+            {t(
+              "sidepanel:emptyChat.examplePrompt3",
+              '"Explain this in simple terms"',
+            )}
           </span>
         </button>
       </div>
@@ -339,11 +366,11 @@ export const EmptySidePanel = ({ inputRef }: EmptySidePanelProps) => {
           <p className="mt-1 text-[10px] text-purple-600 dark:text-purple-400">
             {t(
               "sidepanel:emptyChat.demoLimitations",
-              "Some features are limited. Connect to tldw_server for full functionality."
+              "Some features are limited. Connect to tldw_server for full functionality.",
             )}
           </p>
         </div>
       )}
     </div>
-  )
-}
+  );
+};

--- a/apps/packages/ui/src/components/ui/feedback/EmptyState.tsx
+++ b/apps/packages/ui/src/components/ui/feedback/EmptyState.tsx
@@ -1,67 +1,67 @@
-import React from "react"
-import type { LucideIcon } from "lucide-react"
-import { cn } from "@/libs/utils"
-import { Button } from "@/components/Common/Button"
+import React from "react";
+import type { LucideIcon } from "lucide-react";
+import { cn } from "@/libs/utils";
+import { Button } from "@/components/Common/Button";
 
-export type EmptyStateVariant = "card" | "inline" | "fullPage"
-export type EmptyStateSize = "sm" | "md" | "lg"
+export type EmptyStateVariant = "card" | "inline" | "fullPage";
+export type EmptyStateSize = "sm" | "md" | "lg";
 
 export interface EmptyStateAction {
   /** Button label */
-  label: React.ReactNode
+  label: React.ReactNode;
   /** Click handler */
-  onClick?: () => void
+  onClick?: () => void;
   /** Show loading spinner */
-  loading?: boolean
+  loading?: boolean;
   /** Disable the button */
-  disabled?: boolean
+  disabled?: boolean;
 }
 
 export interface EmptyStateStep {
   /** Step icon */
-  icon: LucideIcon
+  icon: LucideIcon;
   /** Step text */
-  text: string
+  text: string;
 }
 
 export interface EmptyStateSuggestion {
   /** Suggestion icon */
-  icon: LucideIcon
+  icon: LucideIcon;
   /** Suggestion label */
-  label: string
+  label: string;
   /** Click handler */
-  onClick: () => void
+  onClick: () => void;
 }
 
 export interface EmptyStateProps {
   /** Main title */
-  title: React.ReactNode
+  title: React.ReactNode;
   /** Description text */
-  description?: React.ReactNode
+  description?: React.ReactNode;
   /** Icon to display above title */
-  icon?: LucideIcon
+  icon?: LucideIcon;
   /** Icon color class */
-  iconClassName?: string
+  iconClassName?: string;
   /** Example items to display as bullets */
-  examples?: React.ReactNode[]
+  examples?: React.ReactNode[];
   /** Steps to display */
-  steps?: EmptyStateStep[]
+  steps?: EmptyStateStep[];
   /** Quick action suggestions */
-  suggestions?: EmptyStateSuggestion[]
+  suggestions?: EmptyStateSuggestion[];
   /** Primary action button */
-  primaryAction?: EmptyStateAction
+  primaryAction?: EmptyStateAction;
   /** Secondary action button */
-  secondaryAction?: EmptyStateAction
+  secondaryAction?: EmptyStateAction;
   /** Layout variant */
-  variant?: EmptyStateVariant
+  variant?: EmptyStateVariant;
   /** Size variant */
-  size?: EmptyStateSize
+  size?: EmptyStateSize;
   /** Additional CSS classes */
-  className?: string
+  className?: string;
   /** Test ID */
-  "data-testid"?: string
+  "data-testid"?: string;
   /** Additional content after the standard empty-state header and actions */
-  children?: React.ReactNode
+  children?: React.ReactNode;
 }
 
 const sizeConfig = {
@@ -86,13 +86,13 @@ const sizeConfig = {
     title: "text-lg",
     description: "text-sm",
   },
-} as const
+} as const;
 
 const variantConfig = {
   card: "rounded-2xl border border-border/80 bg-surface/90 shadow-card backdrop-blur",
   inline: "bg-transparent",
   fullPage: "min-h-[400px] flex items-center justify-center",
-} as const
+} as const;
 
 /**
  * EmptyState component for displaying when there's no content.
@@ -141,10 +141,20 @@ export const EmptyState = React.forwardRef<HTMLDivElement, EmptyStateProps>(
       "data-testid": dataTestId,
       children,
     },
-    ref
+    ref,
   ) => {
-    const sizeStyles = sizeConfig[size]
-    const variantStyles = variantConfig[variant]
+    const sizeStyles = sizeConfig[size];
+    const variantStyles = variantConfig[variant];
+    const descriptionNode =
+      typeof description === "string" || typeof description === "number" ? (
+        <p className={cn("text-text-muted", sizeStyles.description)}>
+          {description}
+        </p>
+      ) : description ? (
+        <div className={cn("text-text-muted", sizeStyles.description)}>
+          {description}
+        </div>
+      ) : null;
 
     return (
       <div
@@ -153,7 +163,7 @@ export const EmptyState = React.forwardRef<HTMLDivElement, EmptyStateProps>(
           "mx-auto text-center",
           sizeStyles.container,
           variantStyles,
-          className
+          className,
         )}
         data-testid={dataTestId}
         data-ds-component="EmptyState"
@@ -164,13 +174,13 @@ export const EmptyState = React.forwardRef<HTMLDivElement, EmptyStateProps>(
               <div
                 className={cn(
                   "rounded-full bg-surface2/80",
-                  sizeStyles.iconWrapper
+                  sizeStyles.iconWrapper,
                 )}
               >
                 <Icon
                   className={cn(
                     sizeStyles.icon,
-                    iconClassName || "text-text-subtle"
+                    iconClassName || "text-text-subtle",
                   )}
                   aria-hidden="true"
                 />
@@ -182,24 +192,20 @@ export const EmptyState = React.forwardRef<HTMLDivElement, EmptyStateProps>(
             className={cn(
               "font-semibold text-text",
               sizeStyles.title,
-              Icon && "text-center"
+              Icon && "text-center",
             )}
           >
             {title}
           </h2>
 
-          {description && (
-            <p className={cn("text-text-muted", sizeStyles.description)}>
-              {description}
-            </p>
-          )}
+          {descriptionNode}
 
           {examples && examples.length > 0 && (
             <div className="text-left">
               <ul
                 className={cn(
                   "list-disc space-y-1 pl-4 text-text-muted",
-                  sizeStyles.description
+                  sizeStyles.description,
                 )}
               >
                 {examples.map((example, index) => (
@@ -269,10 +275,10 @@ export const EmptyState = React.forwardRef<HTMLDivElement, EmptyStateProps>(
           {children}
         </div>
       </div>
-    )
-  }
-)
+    );
+  },
+);
 
-EmptyState.displayName = "EmptyState"
+EmptyState.displayName = "EmptyState";
 
-export default EmptyState
+export default EmptyState;

--- a/apps/packages/ui/src/components/ui/feedback/EmptyState.tsx
+++ b/apps/packages/ui/src/components/ui/feedback/EmptyState.tsx
@@ -60,6 +60,8 @@ export interface EmptyStateProps {
   className?: string
   /** Test ID */
   "data-testid"?: string
+  /** Additional content after the standard empty-state header and actions */
+  children?: React.ReactNode
 }
 
 const sizeConfig = {
@@ -137,6 +139,7 @@ export const EmptyState = React.forwardRef<HTMLDivElement, EmptyStateProps>(
       size = "md",
       className,
       "data-testid": dataTestId,
+      children,
     },
     ref
   ) => {
@@ -153,6 +156,7 @@ export const EmptyState = React.forwardRef<HTMLDivElement, EmptyStateProps>(
           className
         )}
         data-testid={dataTestId}
+        data-ds-component="EmptyState"
       >
         <div className="space-y-3">
           {Icon && (
@@ -261,6 +265,8 @@ export const EmptyState = React.forwardRef<HTMLDivElement, EmptyStateProps>(
               )}
             </div>
           )}
+
+          {children}
         </div>
       </div>
     )

--- a/apps/packages/ui/src/components/ui/state/ActionGroup.tsx
+++ b/apps/packages/ui/src/components/ui/state/ActionGroup.tsx
@@ -1,30 +1,31 @@
-import React from "react"
-import { Button } from "@/components/Common/Button"
-import { cn } from "@/libs/utils"
+import React from "react";
+import { Button } from "@/components/Common/Button";
+import { cn } from "@/libs/utils";
 
 export interface StateAction {
-  label: React.ReactNode
-  onClick?: () => void
-  loading?: boolean
-  disabled?: boolean
-  "data-testid"?: string
+  label: React.ReactNode;
+  onClick?: () => void;
+  loading?: boolean;
+  disabled?: boolean;
+  ref?: React.Ref<HTMLButtonElement>;
+  "data-testid"?: string;
 }
 
 export interface ActionGroupProps {
-  primaryAction?: StateAction
-  secondaryActions?: StateAction[]
-  className?: string
-  "data-testid"?: string
+  primaryAction?: StateAction;
+  secondaryActions?: StateAction[];
+  className?: string;
+  "data-testid"?: string;
 }
 
 export function ActionGroup({
   primaryAction,
   secondaryActions = [],
   className,
-  "data-testid": dataTestId
+  "data-testid": dataTestId,
 }: ActionGroupProps) {
   if (!primaryAction && secondaryActions.length === 0) {
-    return null
+    return null;
   }
 
   return (
@@ -34,6 +35,7 @@ export function ActionGroup({
     >
       {primaryAction ? (
         <Button
+          ref={primaryAction.ref}
           variant="primary"
           onClick={primaryAction.onClick}
           loading={primaryAction.loading}
@@ -46,6 +48,7 @@ export function ActionGroup({
       {secondaryActions.map((action, index) => (
         <Button
           key={index}
+          ref={action.ref}
           variant="outline"
           onClick={action.onClick}
           loading={action.loading}
@@ -56,5 +59,5 @@ export function ActionGroup({
         </Button>
       ))}
     </div>
-  )
+  );
 }

--- a/apps/packages/ui/src/components/ui/state/RecoveryCallout.tsx
+++ b/apps/packages/ui/src/components/ui/state/RecoveryCallout.tsx
@@ -15,5 +15,5 @@ export interface RecoveryCalloutProps extends Omit<StatePanelProps, "state"> {
 }
 
 export function RecoveryCallout(props: RecoveryCalloutProps) {
-  return <StatePanel {...props} />
+  return <StatePanel {...props} data-ds-component="RecoveryCallout" />
 }

--- a/apps/packages/ui/src/components/ui/state/StatePanel.tsx
+++ b/apps/packages/ui/src/components/ui/state/StatePanel.tsx
@@ -20,6 +20,7 @@ export interface StatePanelProps {
   className?: string
   children?: React.ReactNode
   "data-testid"?: string
+  "data-ds-component"?: string
 }
 
 const severityClasses: Record<DesignSystemSeverity, string> = {
@@ -49,7 +50,8 @@ export function StatePanel({
   secondaryActions,
   className,
   children,
-  "data-testid": dataTestId
+  "data-testid": dataTestId,
+  "data-ds-component": dataDesignSystemComponent = "StatePanel"
 }: StatePanelProps) {
   const definition = getDesignSystemState(state)
   const toneClass = stateToneClasses[state] ?? severityClasses[definition.severity]
@@ -59,6 +61,7 @@ export function StatePanel({
     <section
       className={cn("rounded-lg border bg-surface p-4 text-text shadow-sm", className)}
       data-testid={dataTestId}
+      data-ds-component={dataDesignSystemComponent}
     >
       <div className="flex flex-col gap-3">
         <div className="flex flex-col gap-2">

--- a/backlog/tasks/task-45.4 - Migrate-Chat-and-Playground-empty-and-recovery-states-to-design-system-primitives.md
+++ b/backlog/tasks/task-45.4 - Migrate-Chat-and-Playground-empty-and-recovery-states-to-design-system-primitives.md
@@ -60,12 +60,26 @@ Verification:
 - PASS: full frontend tsc output filtered for this slice's touched files shows no local type errors
 - KNOWN BASELINE: bunx tsc --noEmit --pretty false -p tsconfig.json still exits 2 on unrelated pre-existing frontend type errors across packages/ui, e2e, generated client, and Vite/Vitest config typing.
 - SKIP: Bandit is not applicable; this slice touched frontend TypeScript/TSX and Backlog docs only.
+
+PR review pass:
+- Address Gemini/Qodo feedback on first-run focus management by moving focus back to a component-scoped ref exposed through design-system action props.
+- Address Gemini feedback on disconnected Playground visual hierarchy by keeping Open Settings adjacent to the disconnected message.
+- Address Gemini feedback on ConnectionBanner secondary action readability.
+- Address Gemini feedback on Sidepanel step summary styling by using StatePanel diagnostics instead of a custom child block.
+
+PR review verification:
+- PASS: bunx vitest run ../packages/ui/src/components/Option/Playground/__tests__/PlaygroundEmpty.test.tsx ../packages/ui/src/components/Option/Playground/__tests__/PlaygroundEmpty.disconnected.test.tsx ../packages/ui/src/components/Option/Playground/__tests__/PlaygroundChatErrorBanner.test.tsx ../packages/ui/src/components/Sidepanel/Chat/__tests__/ConnectionBanner.test.tsx ../packages/ui/src/components/Sidepanel/Chat/__tests__/empty.test.tsx --reporter=dot
+- PASS: apps/tldw-frontend/node_modules/.bin/eslint -c apps/tldw-frontend/eslint.config.mjs <touched UI files> (the Next plugin still reports the existing pages-directory notice, but exits 0 with no lint warnings/errors)
+- PASS: bunx prettier --check <touched UI files>
+- PASS: git diff --check
+- PASS: full frontend tsc output filtered for this slice's touched files shows no local type errors
+- KNOWN BASELINE: bunx tsc --noEmit --pretty false -p tsconfig.json still exits 2 on unrelated pre-existing frontend type errors.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Migrated the first Chat/Playground state slice to the design-system primitives. Playground empty now renders through EmptyState, Sidepanel Chat connection empty states render through RecoveryCallout, and ConnectionBanner now uses canonical recovery states while preserving the existing user actions and inline API-key repair path.
+Migrated the first Chat/Playground state slice to the design-system primitives. Playground empty now renders through EmptyState, Sidepanel Chat connection empty states render through RecoveryCallout, and ConnectionBanner now uses canonical recovery states while preserving the existing user actions and inline API-key repair path. PR review fixes keep disconnected Settings guidance adjacent to the message, restore scoped focus management through design-system action refs, simplify secondary-action logic, and render setup progress via diagnostics.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.4 - Migrate-Chat-and-Playground-empty-and-recovery-states-to-design-system-primitives.md
+++ b/backlog/tasks/task-45.4 - Migrate-Chat-and-Playground-empty-and-recovery-states-to-design-system-primitives.md
@@ -1,0 +1,79 @@
+---
+id: TASK-45.4
+title: >-
+  Migrate Chat and Playground empty and recovery states to design-system
+  primitives
+status: Done
+assignee:
+  - '@Codex'
+created_date: '2026-05-05 03:42'
+labels:
+  - design-system
+  - frontend
+  - chat
+  - playground
+dependencies: []
+documentation:
+  - Docs/Design/tldw_web_design_system_contract.md
+  - Docs/Design/tldw_web_design_system_inventory.md
+parent_task_id: TASK-45
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the first bounded Chat/Playground migration slice from the design-system inventory. Scope is limited to empty, disconnected, loading/retrying, and recovery/error state surfaces in Playground and Sidepanel Chat. Do not migrate generic Button ownership, page shells, broad AntD usage, status chips, or modal footers in this slice unless required by the target components.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Playground empty/disconnected state uses shared design-system primitives or a thin adapter while preserving current user-facing actions and accessible labels.
+- [x] #2 Sidepanel Chat empty state uses shared design-system primitives or a thin adapter while preserving current first-use and reconnect guidance.
+- [x] #3 Sidepanel Chat connection/recovery banner uses canonical design-system state language for unavailable/degraded/retrying/error states without broad chat composer refactors.
+- [x] #4 Focused tests cover the migrated empty and connection states and continue to assert accessible labels/actions.
+- [x] #5 Verification includes the focused Chat/Playground Vitest slice from the inventory plus git diff checks; Bandit is run for touched Python only or explicitly skipped for frontend-only changes.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Inspect current Playground and Sidepanel Chat empty/recovery components and their focused tests.
+2. Add or update failing tests for the expected design-system state primitives and accessible state labels/actions.
+3. Migrate the narrow target components to shared `EmptyState`, `LoadingState`, `RecoveryCallout`, `StatePanel` or thin adapters while preserving behavior.
+4. Run focused Vitest coverage from the inventory, update task notes, and commit the slice.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Started after PR #1286 merged into dev at merge commit be9c41fa4f9a54e33ff84790125bb0ee083f7eaf. Work is isolated in .worktrees/tldw-chat-playground-design-system on branch codex/tldw-chat-playground-design-system from origin/dev.
+
+Migrated PlaygroundEmpty to the shared EmptyState primitive while preserving Start chatting, Quick Ingest, Open Settings, mode launcher, and tour actions.
+
+Migrated Sidepanel Chat setup/auth/unavailable empty state and ConnectionBanner to RecoveryCallout/StatePanel state language while preserving first-run guidance, retry/settings actions, and inline single-user API key repair.
+
+Verification:
+- PASS: bunx vitest run ../packages/ui/src/components/Option/Playground/__tests__/PlaygroundEmpty.test.tsx ../packages/ui/src/components/Option/Playground/__tests__/PlaygroundEmpty.disconnected.test.tsx ../packages/ui/src/components/Option/Playground/__tests__/PlaygroundChatErrorBanner.test.tsx ../packages/ui/src/components/Sidepanel/Chat/__tests__/ConnectionBanner.test.tsx ../packages/ui/src/components/Sidepanel/Chat/__tests__/empty.test.tsx --reporter=dot
+- PASS: apps/tldw-frontend/node_modules/.bin/eslint -c apps/tldw-frontend/eslint.config.mjs <touched UI files> (the Next plugin still reports the existing pages-directory notice, but exits 0 with no lint warnings/errors)
+- PASS: git diff --check
+- PASS: full frontend tsc output filtered for this slice's touched files shows no local type errors
+- KNOWN BASELINE: bunx tsc --noEmit --pretty false -p tsconfig.json still exits 2 on unrelated pre-existing frontend type errors across packages/ui, e2e, generated client, and Vite/Vitest config typing.
+- SKIP: Bandit is not applicable; this slice touched frontend TypeScript/TSX and Backlog docs only.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated the first Chat/Playground state slice to the design-system primitives. Playground empty now renders through EmptyState, Sidepanel Chat connection empty states render through RecoveryCallout, and ConnectionBanner now uses canonical recovery states while preserving the existing user actions and inline API-key repair path.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## What changed
- Migrates Playground empty state to the shared EmptyState primitive while preserving Start chatting, Quick Ingest, Open Settings, mode launcher, and tour actions.
- Migrates Sidepanel Chat setup/auth/unavailable empty states and ConnectionBanner to RecoveryCallout/StatePanel canonical state language.
- Adds focused assertions that the migrated surfaces render through design-system primitives and keep accessible labels/actions.
- Adds TASK-45.4 with acceptance criteria, verification notes, and final summary.

## Verification
- PASS: bunx vitest run ../packages/ui/src/components/Option/Playground/__tests__/PlaygroundEmpty.test.tsx ../packages/ui/src/components/Option/Playground/__tests__/PlaygroundEmpty.disconnected.test.tsx ../packages/ui/src/components/Option/Playground/__tests__/PlaygroundChatErrorBanner.test.tsx ../packages/ui/src/components/Sidepanel/Chat/__tests__/ConnectionBanner.test.tsx ../packages/ui/src/components/Sidepanel/Chat/__tests__/empty.test.tsx --reporter=dot
- PASS: apps/tldw-frontend/node_modules/.bin/eslint -c apps/tldw-frontend/eslint.config.mjs <touched UI files> (exits 0; existing Next pages-directory notice still prints)
- PASS: git diff --check origin/dev...HEAD
- PASS: full frontend tsc output filtered for this slice's touched files has no local type errors
- KNOWN BASELINE: bunx tsc --noEmit --pretty false -p tsconfig.json still exits 2 on unrelated pre-existing frontend type errors across packages/ui, e2e, generated client, and Vite/Vitest config typing.
- SKIP: Bandit is not applicable; this slice touched frontend TypeScript/TSX and Backlog docs only.

## Merge note
Per repo policy, this AI-authored PR still needs a human-written Change summary before merge.