### PR TITLE
Phase 2.2: defer RAG router import

### DIFF
--- a/backlog/tasks/task-61 - Phase-2.2-RAG-router-conditional-cleanup-Z.md
+++ b/backlog/tasks/task-61 - Phase-2.2-RAG-router-conditional-cleanup-Z.md
@@ -1,0 +1,55 @@
+---
+id: TASK-61
+title: Phase 2.2 RAG router conditional cleanup Z
+status: Done
+assignee:
+  - codex
+created_date: '2026-05-05 03:50'
+updated_date: '2026-05-05 03:53'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Complete #1116 Phase 2.2 content router cleanup by deferring the remaining rag_unified content router import while preserving route metadata and optional-import behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 rag_unified content router spec defers module import and router attribute lookup until registration or resolution
+- [x] #2 Existing tags, route_key, prefix, and default_stable behavior remain unchanged for the rag-unified router
+- [x] #3 Focused red/green router laziness coverage, full router contract tests, main router/OpenAPI contracts, Bandit touched source scan, and git diff hygiene are run before commit
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused failing laziness test for rag_unified. 2. Convert rag_unified to ImportedRouterSpec. 3. Run focused/full router contract tests, main/OpenAPI contracts, Bandit, and diff hygiene.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Red test: pytest test_router_groups_contract.py -k rag_unified_router_attr_lookup failed because rag_unified fake module had router attr access during iter_content_router_specs. Green verification: focused RAG laziness test passed; full router group contract passed; main router contract passed; OpenAPI contracts passed; Bandit content.py results=0 errors=0; git diff --check clean. Documentation update not needed for this internal router import refactor.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Deferred the remaining rag_unified content router import via ImportedRouterSpec while preserving tags, route_key, prefix, and default_stable behavior. Added focused contract coverage proving module import and router attr lookup stay lazy until resolution.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/content.py
+++ b/tldw_Server_API/app/api/v1/router_groups/content.py
@@ -26,18 +26,15 @@ def iter_content_router_specs() -> Iterable[RouterSpec]:
     specs: list[RouterSpec] = []
 
     # RAG unified endpoints (router has its own /api/v1/rag prefix)
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.rag_unified import (
-            router as rag_unified_router,
-        )
-
-        specs.append(RouterSpec(
-            router=rag_unified_router,
+    append_imported_router_spec(
+        specs,
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.rag_unified",
+            log_name="rag_unified",
             tags=("rag-unified",),
             route_key="rag-unified",
-        ))
-    except ImportError as e:
-        logger.debug(f"Skipping rag_unified router: {e}")
+        ),
+    )
 
     # RAG health and research discovery endpoints
     for discovery_spec in (

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -1340,6 +1340,66 @@ def test_iter_content_router_specs_uses_canonical_rag_key_and_single_web_scrapin
     assert web_scraping_specs[0].prefix == "/api/v1"
 
 
+def test_iter_content_router_specs_defers_rag_unified_router_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify rag_unified keeps import and router attr lookup lazy."""
+    import importlib
+
+    module_name = "tldw_Server_API.app.api.v1.endpoints.rag_unified"
+    access_count = 0
+    import_calls: list[str] = []
+    router = APIRouter()
+
+    @router.get("/api/v1/rag/search")
+    def _endpoint() -> dict[str, str]:
+        """Return a deterministic response for the fake rag router."""
+        return {"status": "ok"}
+
+    fake_module = ModuleType(module_name)
+
+    def _module_getattr(name: str) -> APIRouter:
+        """Track lazy router attribute resolution for the fake module."""
+        nonlocal access_count
+        if name != "router":
+            raise AttributeError(name)
+        access_count += 1
+        return router
+
+    fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    real_import_module = importlib.import_module
+
+    def _import_module(import_path: str, package: str | None = None) -> ModuleType:
+        """Track lazy module imports for the selected RAG router."""
+        if import_path == module_name:
+            import_calls.append(import_path)
+        return real_import_module(import_path, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    specs = list(iter_content_router_specs())
+    assert access_count == 0
+    assert import_calls == []
+
+    selected_specs = [spec for spec in specs if spec.name == "rag_unified"]
+    assert len(selected_specs) == 1
+
+    spec = selected_specs[0]
+    assert spec.prefix == ""
+    assert spec.tags == ("rag-unified",)
+    assert spec.route_key == "rag-unified"
+    assert spec.default_stable is True
+    assert _first_router_path(spec.router) == "/api/v1/rag/search"
+
+    assert import_calls == [module_name]
+    assert access_count == 1
+
+
 def test_iter_content_router_specs_defers_discovery_router_attr_lookup(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Change summary
- Defers the remaining rag_unified content router import through ImportedRouterSpec.
- Preserves tags, route_key/default_stable settings, and the router-owned /api/v1/rag prefix behavior.
- Adds focused router-group contract coverage proving module import and router attr lookup stay lazy until resolution.

Verification
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k rag_unified_router_attr_lookup -q (red before implementation, green after, green after rebase check)
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/router_groups/content.py -f json -o /tmp/bandit_phase2_2_rag_content.json (results=0 errors=0)
- git diff --check
- git diff --check origin/dev..HEAD
- rg -n "try:" tldw_Server_API/app/api/v1/router_groups/content.py (no matches)

Refs #1116