### PR TITLE
Phase 2.2: defer minimal RAG router imports

### DIFF
--- a/backlog/tasks/task-63 - Phase-2.2-minimal-RAG-router-conditional-cleanup-AA.md
+++ b/backlog/tasks/task-63 - Phase-2.2-minimal-RAG-router-conditional-cleanup-AA.md
@@ -1,0 +1,59 @@
+---
+id: TASK-63
+title: Phase 2.2 minimal RAG router conditional cleanup AA
+status: Done
+assignee: []
+created_date: '2026-05-05 04:09'
+updated_date: '2026-05-05 04:12'
+labels:
+  - phase2.2
+  - router-cleanup
+  - issue-1116
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+  - 'https://github.com/rmusser01/tldw_server/pull/1291'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue issue #1116 Phase 2.2 by converting the minimal-test app RAG optional router registrations for rag_unified and rag_health from eager try/import RouterSpec blocks to ImportedRouterSpec-backed lazy router specs. Keep this tranche intentionally narrow and preserve existing prefixes, tags, route keys, and skip behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 minimal rag_unified and rag_health optional router specs defer module import and router attribute lookup until registration
+- [x] #2 existing route metadata for rag_unified and rag_health is preserved
+- [x] #3 focused router-group tests cover the lazy behavior with red/green verification
+- [x] #4 router-group, main-router, and OpenAPI contract tests pass for the touched scope
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused red test for minimal RAG optional router laziness. 2. Convert only rag_unified and rag_health minimal optional router blocks to ImportedRouterSpec. 3. Run focused, router-group, main-router, OpenAPI, Bandit, and diff hygiene checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Red: pytest test_router_groups_contract.py -k minimal_optional_router_specs_defers_rag_attr_lookup failed because rag_unified.router and rag_health.router were resolved during iter_minimal_optional_router_specs(). Green: focused test passed after converting those two specs. Full touched gates passed: router_groups_contract 69 passed; main_router_contract 6 passed; openapi_contracts 69 passed; Bandit minimal.py results=0 errors=0; git diff --check clean.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Converted the minimal-test app rag_unified and rag_health optional router registrations to ImportedRouterSpec-backed lazy specs while preserving empty prefixes, tags, route keys, and minimal skip context. Added focused contract coverage proving module import and router attr lookup stay deferred until spec resolution.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -247,15 +247,15 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
     except Exception as e:  # noqa: BLE001
         logger.debug(f"Skipping claims router in minimal test app: {e}")
 
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.rag_unified import router as rag_unified_router
-
-        specs.append(RouterSpec(
-            router=rag_unified_router,
+    append_imported_router_spec(
+        specs,
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.rag_unified",
+            log_name="rag_unified",
             tags=("rag-unified",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping rag_unified router in minimal test app: {e}")
+            skip_context="in minimal test app",
+        ),
+    )
 
     try:
         from tldw_Server_API.app.api.v1.endpoints.text2sql import router as text2sql_router
@@ -290,15 +290,15 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
     except Exception as e:  # noqa: BLE001
         logger.debug(f"Skipping vlm router in minimal test app: {e}")
 
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.rag_health import router as rag_health_router
-
-        specs.append(RouterSpec(
-            router=rag_health_router,
+    append_imported_router_spec(
+        specs,
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.rag_health",
+            log_name="rag_health",
             tags=("rag-health",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping rag_health router in minimal test app: {e}")
+            skip_context="in minimal test app",
+        ),
+    )
 
     try:
         from tldw_Server_API.app.api.v1.endpoints.consent import router as consent_router

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -3720,6 +3720,150 @@ def test_iter_minimal_optional_router_specs_defers_llamacpp_messages_attr_lookup
     }
 
 
+def test_iter_minimal_optional_router_specs_defers_rag_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal RAG specs keep router attr lookup lazy."""
+    import builtins
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    router_definitions = (
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.rag_unified",
+            "expected_name": "rag_unified",
+            "path": "/api/v1/rag/search",
+            "prefix": "",
+            "tags": ("rag-unified",),
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.rag_health",
+            "expected_name": "rag_health",
+            "path": "/api/v1/rag/health",
+            "prefix": "",
+            "tags": ("rag-health",),
+        },
+    )
+    definitions_by_module = {
+        str(definition["module_name"]): definition
+        for definition in router_definitions
+    }
+    access_count = {
+        f"{definition['module_name']}.router": 0
+        for definition in router_definitions
+    }
+    import_calls: list[str] = []
+
+    for module_name, definition in definitions_by_module.items():
+        fake_module = ModuleType(module_name)
+        router = APIRouter()
+
+        @router.get(str(definition["path"]))
+        def _endpoint() -> dict[str, str]:
+            """Return a deterministic response for the fake minimal RAG router."""
+            return {"status": "ok"}
+
+        def _module_getattr(
+            name: str,
+            *,
+            module_name: str = module_name,
+            router: APIRouter = router,
+        ) -> APIRouter:
+            """Track lazy router attribute resolution for the fake module."""
+            if name != "router":
+                raise AttributeError(name)
+            access_count[f"{module_name}.router"] += 1
+            return router
+
+        fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    endpoints_package = "tldw_Server_API.app.api.v1.endpoints."
+    real_import = builtins.__import__
+
+    def _fake_endpoint_import(
+        name: str,
+        globals: dict[str, object] | None = None,
+        locals: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> ModuleType:
+        """Return fake routers for unrelated eager minimal optional imports."""
+        if (
+            level == 0
+            and name.startswith(endpoints_package)
+            and name not in definitions_by_module
+        ):
+            attrs = tuple(attr for attr in fromlist if attr != "*") or ("router",)
+            for attr_name in attrs:
+                _install_fake_router_module(
+                    monkeypatch,
+                    name,
+                    path="/minimal-unrelated-rag-fake",
+                    attr_name=attr_name,
+                )
+            return sys.modules[name]
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_endpoint_import)
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Track lazy module imports for selected minimal RAG routers."""
+        if module_name in definitions_by_module:
+            import_calls.append(module_name)
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+    fake_main = ModuleType("tldw_Server_API.app.main")
+    fake_main.app = FastAPI()  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "tldw_Server_API.app.main", fake_main)
+
+    specs = list(iter_minimal_optional_router_specs())
+    assert access_count == {
+        f"{definition['module_name']}.router": 0
+        for definition in router_definitions
+    }
+    assert import_calls == []
+
+    selected_specs = {
+        spec.name: spec
+        for spec in specs
+        if spec.name in {
+            str(definition["expected_name"])
+            for definition in router_definitions
+        }
+    }
+    assert set(selected_specs) == {
+        str(definition["expected_name"])
+        for definition in router_definitions
+    }
+
+    for definition in router_definitions:
+        spec = selected_specs[str(definition["expected_name"])]
+        assert spec.prefix == definition["prefix"]
+        assert spec.tags == definition["tags"]
+        assert spec.route_key == ""
+        assert spec.skip_context == "in minimal test app"
+        assert _first_router_path(spec.router) == definition["path"]
+
+    assert import_calls == [
+        str(definition["module_name"])
+        for definition in router_definitions
+    ]
+    assert access_count == {
+        f"{definition['module_name']}.router": 1
+        for definition in router_definitions
+    }
+
+
 def test_iter_minimal_optional_router_specs_populates_llm_specs(monkeypatch: pytest.MonkeyPatch) -> None:
     from tldw_Server_API.app.api.v1.router_groups.minimal import iter_minimal_optional_router_specs
 


### PR DESCRIPTION
## Summary
- Convert minimal-test app rag_unified and rag_health optional router blocks to ImportedRouterSpec-backed lazy specs.
- Preserve existing empty prefixes, tags, route keys, and minimal skip context.
- Add focused red/green coverage proving module import and router attr lookup are deferred until spec resolution.

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k minimal_optional_router_specs_defers_rag_attr_lookup -q (red before implementation, green after)
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/router_groups/minimal.py -f json -o /tmp/bandit_phase2_2_minimal_rag.json (results=0, errors=0)
- git diff --check

## Human Change Summary Required
Per repo policy, the human owner should add or replace the final Change summary before merge.