### PR TITLE
Add native CodeGraph C and C++ extractors

### DIFF
--- a/Docs/superpowers/plans/2026-05-05-native-codegraph-c-cpp-extractor-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-05-native-codegraph-c-cpp-extractor-implementation-plan.md
@@ -1,0 +1,31 @@
+# Native CodeGraph C/C++ Extractor Implementation Plan
+
+## Stage 1: Parser and Metadata Wiring
+**Goal**: Add dependency-aware C and C++ parser support to the CodeGraph foundation language set.
+**Success Criteria**: `tree_sitter_c` and `tree_sitter_cpp` are optional dependencies, the loader supports `c` and `cpp`, and registry metadata reports C/C++ as foundation languages with `dependency_missing` when parser packages are absent.
+**Tests**: Loader parser tests, missing dependency tests, registry metadata tests.
+**Status**: Complete
+
+## Stage 2: Conservative Extractors
+**Goal**: Add Tree-sitter extraction for common C and C++ symbols without compiler-semantic claims.
+**Success Criteria**: C extraction captures includes, structs, enums, functions, and same-file simple calls. C++ extraction captures includes, namespaces, classes, structs, enums, methods, and same-file simple calls. Parse errors and deterministic IDs are covered.
+**Tests**: `test_codegraph_c_extractor.py`, `test_codegraph_cpp_extractor.py`.
+**Status**: Complete
+
+## Stage 3: Indexer Integration
+**Goal**: Register C and C++ extractors only when optional parser packages are available.
+**Success Criteria**: Indexing persists graph rows for C/C++ when dependencies exist and skips C/C++ files without consuming foreground file limits when dependencies are missing.
+**Tests**: C/C++ graph-row indexer test and dependency-missing foreground-limit test.
+**Status**: Complete
+
+## Stage 4: MCP Visibility
+**Goal**: Expose indexed C/C++ symbols through existing CodeGraph MCP search.
+**Success Criteria**: `codegraph.index` indexes C/C++ fixture files and `codegraph.search` finds C functions and C++ methods by language/kind filters.
+**Tests**: C/C++ MCP search roundtrip test.
+**Status**: Complete
+
+## Stage 5: Verification and PR
+**Goal**: Prove the slice is clean enough for review and open a PR against `dev`.
+**Success Criteria**: Focused CodeGraph/MCP suite, Ruff, Bandit on touched production scope, and `git diff --check` pass. Backlog TASK-63 records final verification and PR link.
+**Tests**: Full focused CodeGraph/MCP suite plus static and security checks.
+**Status**: In Progress

--- a/Docs/superpowers/plans/2026-05-05-native-codegraph-c-cpp-extractor-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-05-native-codegraph-c-cpp-extractor-implementation-plan.md
@@ -28,4 +28,4 @@
 **Goal**: Prove the slice is clean enough for review and open a PR against `dev`.
 **Success Criteria**: Focused CodeGraph/MCP suite, Ruff, Bandit on touched production scope, and `git diff --check` pass. Backlog TASK-63 records final verification and PR link.
 **Tests**: Full focused CodeGraph/MCP suite plus static and security checks.
-**Status**: In Progress
+**Status**: Complete

--- a/backlog/tasks/task-63 - Implement-native-CodeGraph-C-C-extractor-slice.md
+++ b/backlog/tasks/task-63 - Implement-native-CodeGraph-C-C-extractor-slice.md
@@ -1,0 +1,67 @@
+---
+id: TASK-63
+title: Implement native CodeGraph C/C++ extractor slice
+status: In Progress
+assignee:
+  - '@Codex'
+created_date: '2026-05-05 04:09'
+updated_date: '2026-05-05 04:25'
+labels:
+  - codegraph
+  - mcp
+  - c
+  - cpp
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1288'
+documentation:
+  - Docs/superpowers/specs/2026-05-03-native-codegraph-mcp-module-design.md
+  - >-
+    Docs/superpowers/plans/2026-05-05-native-codegraph-c-cpp-extractor-implementation-plan.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add the next native CodeGraph language slice for C and C++ after the merged C# work. Keep the slice conservative: optional tree-sitter-c/tree-sitter-cpp dependency awareness, parser loader wiring, foundation metadata, indexer registration, symbol extraction for common declarations, same-file simple call capture where practical, and MCP search visibility. Exclude full compiler semantics, preprocessor evaluation, include path resolution, overload resolution, templates beyond basic symbol names, and cross-file semantic resolution.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 C and C++ move from planned to dependency-aware foundation metadata with symbol_extraction tied to optional parser availability.
+- [x] #2 C/C++ extraction indexes common includes/imports, functions, methods, structs/classes/enums/unions/namespaces where supported by the grammar, with deterministic IDs and conservative unresolved refs for includes and receiver/qualified calls.
+- [x] #3 The indexer skips C/C++ files when optional parser dependencies are missing without blocking other languages or foreground limits.
+- [x] #4 MCP codegraph.search can find indexed C/C++ symbols after codegraph.index in a fixture workspace.
+- [x] #5 Focused loader, registry, extractor, indexer, and MCP tests cover C/C++ behavior plus dependency-missing paths; Ruff, Bandit on touched production scope, and git diff --check pass before PR.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Verify parser package APIs and add optional dependency metadata for tree_sitter_c and tree_sitter_cpp.
+2. Add RED loader/registry/indexer/MCP tests for C/C++ foundation behavior and missing dependency handling.
+3. Implement conservative C/C++ Tree-sitter extraction using existing CodeGraph node/edge models and shared helper patterns.
+4. Wire extractors into the indexer and MCP visibility tests.
+5. Run focused CodeGraph/MCP tests, Ruff, Bandit on touched production scope, and git diff --check before commit/PR.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Baseline in fresh worktree from origin/dev after PR #1288 merge: CodeGraph plus MCP focused suite passed with 118 passed and 5 warnings.
+
+Started implementation in /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/codegraph-c-cpp-extractor on branch codex/codegraph-c-cpp-extractor. Applying TDD for parser metadata, loader, extractor, indexer, and MCP behavior.
+
+Implemented C/C++ dependency probing, parser loader mappings, foundation language metadata, c_family extractor, indexer registration, MCP search coverage, and C/C++ regression tests. Local parser versions verified and installed in shared venv for tests: tree-sitter-c 0.24.2 and tree-sitter-cpp 0.23.4. Verification: focused C/C++ tests passed with 14 passed and 5 warnings; full CodeGraph plus MCP focused suite passed with 129 passed and 5 warnings; Ruff passed on touched CodeGraph/MCP/test scope; Bandit JSON at /tmp/bandit_codegraph_c_cpp.json reported errors 0 and results 0; git diff --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-63 - Implement-native-CodeGraph-C-C-extractor-slice.md
+++ b/backlog/tasks/task-63 - Implement-native-CodeGraph-C-C-extractor-slice.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@Codex'
 created_date: '2026-05-05 04:09'
-updated_date: '2026-05-05 04:35'
+updated_date: '2026-05-05 04:41'
 labels:
   - codegraph
   - mcp
@@ -55,12 +55,18 @@ Baseline in fresh worktree from origin/dev after PR #1288 merge: CodeGraph plus 
 Started implementation in /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/codegraph-c-cpp-extractor on branch codex/codegraph-c-cpp-extractor. Applying TDD for parser metadata, loader, extractor, indexer, and MCP behavior.
 
 Implemented C/C++ dependency probing, parser loader mappings, foundation language metadata, c_family extractor, indexer registration, MCP search coverage, and C/C++ regression tests. Local parser versions verified and installed in shared venv for tests: tree-sitter-c 0.24.2 and tree-sitter-cpp 0.23.4. Verification: focused C/C++ tests passed with 14 passed and 5 warnings; full CodeGraph plus MCP focused suite passed with 129 passed and 5 warnings; Ruff passed on touched CodeGraph/MCP/test scope; Bandit JSON at /tmp/bandit_codegraph_c_cpp.json reported errors 0 and results 0; git diff --check passed.
+
+PR #1293 review-fix pass started: Qodo requested docstrings for _node_name, _function_name, and _declarator_name in c_family_extractor.py.
+
+PR #1293 review fix: added docstrings to _node_name, _function_name, and _declarator_name. Verification: C/C++ extractor tests passed with 6 passed and 5 warnings; Ruff passed on c_family_extractor and C/C++ extractor tests; Bandit JSON at /tmp/bandit_codegraph_c_cpp_review_fixes.json reported errors 0 and results 0; git diff --check passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Implemented the native CodeGraph C/C++ extractor slice. C and C++ are now dependency-aware foundation languages backed by optional tree-sitter-c/tree-sitter-cpp packages. The slice adds conservative include/import, type, namespace, function/method, same-file simple call, indexer, and MCP search coverage while intentionally excluding compiler-semantic features such as preprocessor evaluation, include path resolution, overload resolution, and cross-file semantic resolution. Verification passed locally: focused C/C++ tests 14 passed and 5 warnings; full CodeGraph plus MCP focused suite 129 passed and 5 warnings; Ruff clean; Bandit errors 0 and results 0; git diff --check clean. PR: https://github.com/rmusser01/tldw_server/pull/1293
+
+PR #1293 review follow-up: added docstrings for the new C-family extractor helper functions requested by Qodo.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-63 - Implement-native-CodeGraph-C-C-extractor-slice.md
+++ b/backlog/tasks/task-63 - Implement-native-CodeGraph-C-C-extractor-slice.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-63
 title: Implement native CodeGraph C/C++ extractor slice
-status: In Progress
+status: Done
 assignee:
   - '@Codex'
 created_date: '2026-05-05 04:09'
-updated_date: '2026-05-05 04:25'
+updated_date: '2026-05-05 04:35'
 labels:
   - codegraph
   - mcp
@@ -14,6 +14,7 @@ labels:
 dependencies: []
 references:
   - 'https://github.com/rmusser01/tldw_server/pull/1288'
+  - 'https://github.com/rmusser01/tldw_server/pull/1293'
 documentation:
   - Docs/superpowers/specs/2026-05-03-native-codegraph-mcp-module-design.md
   - >-
@@ -56,12 +57,18 @@ Started implementation in /Users/macbook-dev/Documents/GitHub/tldw_server2/.work
 Implemented C/C++ dependency probing, parser loader mappings, foundation language metadata, c_family extractor, indexer registration, MCP search coverage, and C/C++ regression tests. Local parser versions verified and installed in shared venv for tests: tree-sitter-c 0.24.2 and tree-sitter-cpp 0.23.4. Verification: focused C/C++ tests passed with 14 passed and 5 warnings; full CodeGraph plus MCP focused suite passed with 129 passed and 5 warnings; Ruff passed on touched CodeGraph/MCP/test scope; Bandit JSON at /tmp/bandit_codegraph_c_cpp.json reported errors 0 and results 0; git diff --check passed.
 <!-- SECTION:NOTES:END -->
 
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the native CodeGraph C/C++ extractor slice. C and C++ are now dependency-aware foundation languages backed by optional tree-sitter-c/tree-sitter-cpp packages. The slice adds conservative include/import, type, namespace, function/method, same-file simple call, indexer, and MCP search coverage while intentionally excluding compiler-semantic features such as preprocessor evaluation, include path resolution, overload resolution, and cross-file semantic resolution. Verification passed locally: focused C/C++ tests 14 passed and 5 warnings; full CodeGraph plus MCP focused suite 129 passed and 5 warnings; Ruff clean; Bandit errors 0 and results 0; git diff --check clean. PR: https://github.com/rmusser01/tldw_server/pull/1293
+<!-- SECTION:FINAL_SUMMARY:END -->
+
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [x] #1 Acceptance criteria completed
 - [x] #2 Tests or verification recorded
 - [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-64 - Address-PR-1293-C-C-parser-guard-review-comments.md
+++ b/backlog/tasks/task-64 - Address-PR-1293-C-C-parser-guard-review-comments.md
@@ -1,0 +1,54 @@
+---
+id: TASK-64
+title: 'Address PR #1293 C/C++ parser guard review comments'
+status: Done
+assignee:
+  - '@Codex'
+created_date: '2026-05-05 05:12'
+updated_date: '2026-05-05 05:12'
+labels:
+  - codegraph
+  - mcp
+  - review-fix
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1293'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the remaining PR #1293 review comments by adding parser-availability skip guards for optional C/C++ positive-path tests in CodeGraph indexer, extractor, and MCP coverage.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 C and C++ extractor test modules skip gracefully when their optional parser package cannot be loaded.
+- [x] #2 Indexer and MCP positive-path C/C++ tests skip gracefully when either optional C/C++ parser is unavailable.
+- [x] #3 Focused tests and lint verification are recorded before pushing the PR update.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Review-fix pass started for CodeRabbit parser-availability comments.
+
+Added parser-availability guards using CodeGraph load_parser for C, C++, indexer, and MCP positive-path tests. Verification: focused parser guard pytest passed with 9 passed and 5 warnings; Ruff passed on touched test files; Bandit on touched test scope with B101 skipped reported errors 0 and results 0 at /tmp/bandit_codegraph_c_cpp_parser_guard_tests.json; git diff --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Resolved PR #1293 parser-availability review comments by adding load_parser-based skips to the C/C++ extractor test modules and the C/C++ indexer/MCP positive-path tests. This keeps optional tree-sitter-c/tree-sitter-cpp dependency absence as a skip instead of a failure. Verification passed: focused pytest 9 passed and 5 warnings; Ruff clean; Bandit errors 0/results 0 with B101 skipped for test asserts; git diff --check clean.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,6 +185,8 @@ codegraph = [
   "tree-sitter-java>=0.23,<0.24",
   "tree-sitter-kotlin>=1.1,<1.2",
   "tree-sitter-c-sharp>=0.23,<0.24",
+  "tree-sitter-c>=0.24,<0.25",
+  "tree-sitter-cpp>=0.23,<0.24",
 ]
 
 # Multi-User

--- a/tldw_Server_API/app/core/CodeGraph/dependencies.py
+++ b/tldw_Server_API/app/core/CodeGraph/dependencies.py
@@ -13,6 +13,8 @@ _OPTIONAL_LANGUAGE_MODULES = (
     "tree_sitter_java",
     "tree_sitter_kotlin",
     "tree_sitter_c_sharp",
+    "tree_sitter_c",
+    "tree_sitter_cpp",
 )
 _PROBED_MODULES = (*_CORE_MODULES, *_OPTIONAL_LANGUAGE_MODULES)
 

--- a/tldw_Server_API/app/core/CodeGraph/extractors/__init__.py
+++ b/tldw_Server_API/app/core/CodeGraph/extractors/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from .c_family_extractor import CppTreeSitterExtractor, CTreeSitterExtractor
 from .csharp_extractor import CSharpTreeSitterExtractor
 from .java_extractor import JavaTreeSitterExtractor
 from .javascript_extractor import JavaScriptTreeSitterExtractor
@@ -10,7 +11,9 @@ from .python_extractor import PythonAstExtractor
 from .typescript_extractor import TypeScriptTreeSitterExtractor
 
 __all__ = [
+    "CppTreeSitterExtractor",
     "CSharpTreeSitterExtractor",
+    "CTreeSitterExtractor",
     "JavaScriptTreeSitterExtractor",
     "JavaTreeSitterExtractor",
     "KotlinTreeSitterExtractor",

--- a/tldw_Server_API/app/core/CodeGraph/extractors/c_family_extractor.py
+++ b/tldw_Server_API/app/core/CodeGraph/extractors/c_family_extractor.py
@@ -346,6 +346,7 @@ class _CFamilyGraphBuilder:
 
 
 def _node_name(source: bytes, node: Any) -> str:
+    """Return the declared name for a C-family type or namespace node."""
     name_node = node.child_by_field_name("name")
     if name_node is not None:
         return node_text(source, name_node)
@@ -356,6 +357,7 @@ def _node_name(source: bytes, node: Any) -> str:
 
 
 def _function_name(source: bytes, node: Any) -> str:
+    """Return the declared function name from a C-family function definition."""
     declarator = node.child_by_field_name("declarator")
     if declarator is None:
         return ""
@@ -363,6 +365,7 @@ def _function_name(source: bytes, node: Any) -> str:
 
 
 def _declarator_name(source: bytes, node: Any) -> str:
+    """Walk nested declarator nodes to find the identifier that names a callable."""
     name_node = node.child_by_field_name("name")
     if name_node is not None:
         return node_text(source, name_node)

--- a/tldw_Server_API/app/core/CodeGraph/extractors/c_family_extractor.py
+++ b/tldw_Server_API/app/core/CodeGraph/extractors/c_family_extractor.py
@@ -1,0 +1,381 @@
+"""Tree-sitter C and C++ extraction for native CodeGraph."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tldw_Server_API.app.core.CodeGraph.extractors.jvm_common import (
+    JvmCallSite,
+    column,
+    first_named_child_of_type,
+    line,
+    make_jvm_node,
+    module_qualified_name,
+    node_text,
+    qualified_name,
+    remember_callable,
+    resolve_call_sites,
+)
+from tldw_Server_API.app.core.CodeGraph.extractors.tree_sitter_loader import load_parser
+from tldw_Server_API.app.core.CodeGraph.models import (
+    CodeGraphNode,
+    CodeGraphUnresolvedRef,
+    ExtractionResult,
+)
+
+_TYPE_KINDS = {
+    "class_specifier": "class",
+    "struct_specifier": "struct",
+    "enum_specifier": "enum",
+    "union_specifier": "union",
+}
+_DECLARATION_CONTAINERS = {
+    "declaration",
+    "declaration_list",
+    "field_declaration",
+    "field_declaration_list",
+    "type_definition",
+}
+_NAME_NODE_TYPES = {
+    "identifier",
+    "field_identifier",
+    "namespace_identifier",
+    "type_identifier",
+}
+
+
+class CTreeSitterExtractor:
+    """Extract conservative C symbols and same-file calls with Tree-sitter."""
+
+    language_id = "c"
+    display_name = "C"
+    provenance = "tree_sitter_c"
+
+    def extract(self, *, workspace_key: str, file_path: str, source: bytes) -> ExtractionResult:
+        """Parse one C file and return symbols, calls, unresolved refs, and errors."""
+        return _extract_c_family(
+            language_id=self.language_id,
+            display_name=self.display_name,
+            provenance=self.provenance,
+            workspace_key=workspace_key,
+            file_path=file_path,
+            source=source,
+        )
+
+
+class CppTreeSitterExtractor:
+    """Extract conservative C++ symbols and same-file calls with Tree-sitter."""
+
+    language_id = "cpp"
+    display_name = "C++"
+    provenance = "tree_sitter_cpp"
+
+    def extract(self, *, workspace_key: str, file_path: str, source: bytes) -> ExtractionResult:
+        """Parse one C++ file and return symbols, calls, unresolved refs, and errors."""
+        return _extract_c_family(
+            language_id=self.language_id,
+            display_name=self.display_name,
+            provenance=self.provenance,
+            workspace_key=workspace_key,
+            file_path=file_path,
+            source=source,
+        )
+
+
+def _extract_c_family(
+    *,
+    language_id: str,
+    display_name: str,
+    provenance: str,
+    workspace_key: str,
+    file_path: str,
+    source: bytes,
+) -> ExtractionResult:
+    parser_result = load_parser(language_id)
+    if parser_result.missing:
+        return ExtractionResult(errors=(f"Missing Tree-sitter dependencies: {', '.join(parser_result.missing)}",))
+    if parser_result.error or parser_result.parser is None:
+        return ExtractionResult(errors=(parser_result.error or f"{display_name} parser unavailable",))
+
+    try:
+        text = source.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        return ExtractionResult(errors=(str(exc),))
+
+    tree = parser_result.parser.parse(source)
+    if tree.root_node.has_error:
+        return ExtractionResult(errors=(f"{display_name} parse error",))
+
+    builder = _CFamilyGraphBuilder(
+        language_id=language_id,
+        provenance=provenance,
+        workspace_key=workspace_key,
+        file_path=file_path,
+        source=source,
+        source_text=text,
+    )
+    return builder.build(tree.root_node)
+
+
+class _CFamilyGraphBuilder:
+    """Stateful Tree-sitter visitor for one C-family source file."""
+
+    def __init__(
+        self,
+        *,
+        language_id: str,
+        provenance: str,
+        workspace_key: str,
+        file_path: str,
+        source: bytes,
+        source_text: str,
+    ) -> None:
+        self.language_id = language_id
+        self.provenance = provenance
+        self.workspace_key = workspace_key
+        self.file_path = file_path
+        self.source = source
+        self.source_text = source_text
+        self.nodes: list[CodeGraphNode] = []
+        self.unresolved_refs: list[CodeGraphUnresolvedRef] = []
+        self._namespace_name = ""
+        self._scope_stack: list[CodeGraphNode] = []
+        self._type_stack: list[str] = []
+        self._call_sites: list[JvmCallSite] = []
+        self._callable_by_name: dict[str, CodeGraphNode | None] = {}
+
+    def build(self, root_node: Any) -> ExtractionResult:
+        """Visit a parsed C-family translation unit and resolve same-file calls."""
+        module_node = self._make_node(
+            kind="module",
+            name=module_qualified_name(self.file_path).rsplit(".", 1)[-1],
+            qualified_name_value=module_qualified_name(self.file_path),
+            node=root_node,
+            start_line=1,
+            end_line=max(1, len(self.source_text.splitlines())),
+        )
+        self.nodes.append(module_node)
+        self._scope_stack.append(module_node)
+        self._visit_declaration_children(root_node.named_children)
+        self._scope_stack.pop()
+
+        call_edges, call_unresolved_refs = resolve_call_sites(
+            call_sites=tuple(self._call_sites),
+            callable_by_name=self._callable_by_name,
+            file_path=self.file_path,
+            language_id=self.language_id,
+            provenance=self.provenance,
+        )
+        return ExtractionResult(
+            nodes=tuple(self.nodes),
+            edges=call_edges,
+            unresolved_refs=(*self.unresolved_refs, *call_unresolved_refs),
+        )
+
+    def _visit_declaration_children(self, children: list[Any] | tuple[Any, ...]) -> None:
+        for child in children:
+            self._visit_declaration_child(child)
+
+    def _visit_declaration_child(self, node: Any) -> None:
+        if node.type == "preproc_include":
+            self._visit_include(node)
+            return
+        if node.type == "namespace_definition":
+            self._visit_namespace_definition(node)
+            return
+        if node.type == "function_definition":
+            self._visit_function_definition(node)
+            return
+        if node.type in _TYPE_KINDS:
+            self._visit_type_specifier(node)
+            return
+        if node.type in _DECLARATION_CONTAINERS:
+            self._visit_declaration_children(node.named_children)
+
+    def _visit_include(self, node: Any) -> None:
+        include_path = node_text(self.source, node.child_by_field_name("path")).strip()
+        if not include_path:
+            return
+        import_node = self._make_node(
+            kind="import",
+            name=include_path,
+            qualified_name_value=include_path,
+            node=node,
+            metadata={"imported": include_path, "source": include_path},
+        )
+        self.nodes.append(import_node)
+        self.unresolved_refs.append(
+            CodeGraphUnresolvedRef(
+                from_node_id=import_node.id,
+                reference_name=include_path,
+                reference_kind="import",
+                file_path=self.file_path,
+                line=line(node),
+                column=column(node),
+                language=self.language_id,
+            )
+        )
+
+    def _visit_namespace_definition(self, node: Any) -> None:
+        local_name = node_text(self.source, node.child_by_field_name("name"))
+        if not local_name:
+            return
+        previous_namespace = self._namespace_name
+        namespace_name = qualified_name(previous_namespace, local_name)
+        self._namespace_name = namespace_name
+        self.nodes.append(
+            self._make_node(
+                kind="namespace",
+                name=local_name,
+                qualified_name_value=namespace_name,
+                node=node,
+            )
+        )
+
+        body = first_named_child_of_type(node, "declaration_list")
+        if body is not None:
+            self._visit_declaration_children(body.named_children)
+        self._namespace_name = previous_namespace
+
+    def _visit_type_specifier(self, node: Any) -> None:
+        name = _node_name(self.source, node)
+        if not name:
+            return
+        type_node = self._make_node(
+            kind=_TYPE_KINDS[node.type],
+            name=name,
+            qualified_name_value=qualified_name(self._namespace_name, *self._type_stack, name),
+            node=node,
+        )
+        self.nodes.append(type_node)
+
+        body = first_named_child_of_type(node, "field_declaration_list", "declaration_list")
+        if body is None:
+            return
+        self._scope_stack.append(type_node)
+        self._type_stack.append(name)
+        self._visit_declaration_children(body.named_children)
+        self._type_stack.pop()
+        self._scope_stack.pop()
+
+    def _visit_function_definition(self, node: Any) -> None:
+        name = _function_name(self.source, node)
+        if not name:
+            return
+        function_node = self._make_node(
+            kind="method" if self._type_stack else "function",
+            name=name,
+            qualified_name_value=qualified_name(self._namespace_name, *self._type_stack, name),
+            node=node,
+        )
+        self.nodes.append(function_node)
+        remember_callable(self._callable_by_name, function_node)
+
+        body = first_named_child_of_type(node, "compound_statement")
+        if body is None:
+            return
+        self._scope_stack.append(function_node)
+        self._visit_executable(body)
+        self._scope_stack.pop()
+
+    def _visit_executable(self, node: Any) -> None:
+        if node.type == "call_expression":
+            self._visit_call_expression(node)
+        for child in node.named_children:
+            self._visit_executable(child)
+
+    def _visit_call_expression(self, node: Any) -> None:
+        current_scope = self._scope_stack[-1] if self._scope_stack else None
+        if current_scope is None or current_scope.kind not in {"function", "method"}:
+            return
+
+        function_node = node.child_by_field_name("function")
+        if function_node is None:
+            return
+
+        if function_node.type in {"identifier", "field_identifier"}:
+            reference_name = node_text(self.source, function_node)
+            if reference_name:
+                self._call_sites.append(
+                    JvmCallSite(
+                        source_node_id=current_scope.id,
+                        reference_name=reference_name,
+                        line=line(node),
+                        column=column(node),
+                    )
+                )
+            return
+
+        reference_name = node_text(self.source, function_node)
+        if reference_name:
+            self.unresolved_refs.append(
+                CodeGraphUnresolvedRef(
+                    from_node_id=current_scope.id,
+                    reference_name=reference_name,
+                    reference_kind="call",
+                    file_path=self.file_path,
+                    line=line(node),
+                    column=column(node),
+                    language=self.language_id,
+                )
+            )
+
+    def _make_node(
+        self,
+        *,
+        kind: str,
+        name: str,
+        qualified_name_value: str,
+        node: Any,
+        start_line: int | None = None,
+        end_line: int | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> CodeGraphNode:
+        return make_jvm_node(
+            workspace_key=self.workspace_key,
+            language_id=self.language_id,
+            file_path=self.file_path,
+            kind=kind,
+            name=name,
+            qualified_name_value=qualified_name_value,
+            node=node,
+            start_line=start_line,
+            end_line=end_line,
+            metadata=metadata,
+        )
+
+
+def _node_name(source: bytes, node: Any) -> str:
+    name_node = node.child_by_field_name("name")
+    if name_node is not None:
+        return node_text(source, name_node)
+    for child in node.named_children:
+        if child.type in _NAME_NODE_TYPES:
+            return node_text(source, child)
+    return ""
+
+
+def _function_name(source: bytes, node: Any) -> str:
+    declarator = node.child_by_field_name("declarator")
+    if declarator is None:
+        return ""
+    return _declarator_name(source, declarator)
+
+
+def _declarator_name(source: bytes, node: Any) -> str:
+    name_node = node.child_by_field_name("name")
+    if name_node is not None:
+        return node_text(source, name_node)
+    nested = node.child_by_field_name("declarator")
+    if nested is not None:
+        return _declarator_name(source, nested)
+    if node.type in _NAME_NODE_TYPES:
+        return node_text(source, node)
+    for child in node.named_children:
+        name = _declarator_name(source, child)
+        if name:
+            return name
+    return ""
+
+
+__all__ = ["CTreeSitterExtractor", "CppTreeSitterExtractor"]

--- a/tldw_Server_API/app/core/CodeGraph/extractors/tree_sitter_loader.py
+++ b/tldw_Server_API/app/core/CodeGraph/extractors/tree_sitter_loader.py
@@ -29,6 +29,8 @@ _LANGUAGE_MODULES: dict[str, tuple[str, str]] = {
     "java": ("tree_sitter_java", "language"),
     "kotlin": ("tree_sitter_kotlin", "language"),
     "csharp": ("tree_sitter_c_sharp", "language"),
+    "c": ("tree_sitter_c", "language"),
+    "cpp": ("tree_sitter_cpp", "language"),
 }
 
 

--- a/tldw_Server_API/app/core/CodeGraph/indexer.py
+++ b/tldw_Server_API/app/core/CodeGraph/indexer.py
@@ -14,6 +14,7 @@ from loguru import logger
 from tldw_Server_API.app.core.DB_Management.codegraph.repository import CodeGraphRepository
 
 from .config import CodeGraphSettings
+from .extractors.c_family_extractor import CppTreeSitterExtractor, CTreeSitterExtractor
 from .extractors.csharp_extractor import CSharpTreeSitterExtractor
 from .extractors.java_extractor import JavaTreeSitterExtractor
 from .extractors.javascript_extractor import JavaScriptTreeSitterExtractor
@@ -89,6 +90,10 @@ class CodeGraphIndexer:
             self._extractors["kotlin"] = KotlinTreeSitterExtractor()
         if load_parser("csharp").available:
             self._extractors["csharp"] = CSharpTreeSitterExtractor()
+        if load_parser("c").available:
+            self._extractors["c"] = CTreeSitterExtractor()
+        if load_parser("cpp").available:
+            self._extractors["cpp"] = CppTreeSitterExtractor()
 
     def index_workspace(
         self,

--- a/tldw_Server_API/app/core/CodeGraph/language_registry.py
+++ b/tldw_Server_API/app/core/CodeGraph/language_registry.py
@@ -5,28 +5,13 @@ from pathlib import Path
 from .dependencies import DependencyHealth, probe_codegraph_dependencies
 from .models import LanguageInfo
 
-_PLANNED_LANGUAGES = (
-    LanguageInfo(
-        language_id="c",
-        display_name="C",
-        extensions=(".c", ".h"),
-        stage="planned",
-    ),
-    LanguageInfo(
-        language_id="cpp",
-        display_name="C++",
-        extensions=(".cc", ".cpp", ".cxx", ".hpp", ".hh", ".hxx"),
-        stage="planned",
-    ),
-)
-
 
 class CodeGraphLanguageRegistry:
     """Language metadata and extension lookup for the foundation indexer."""
 
     def __init__(self, dependency_health: DependencyHealth | None = None) -> None:
         self.dependency_health = dependency_health or probe_codegraph_dependencies()
-        self._languages = (*_foundation_languages(self.dependency_health), *_PLANNED_LANGUAGES)
+        self._languages = _foundation_languages(self.dependency_health)
         self._by_extension = {
             extension: language
             for language in self._languages
@@ -58,6 +43,8 @@ def _foundation_languages(dependency_health: DependencyHealth) -> tuple[Language
     java_missing = _missing_dependencies(missing, ("tree_sitter", "tree_sitter_java"))
     kotlin_missing = _missing_dependencies(missing, ("tree_sitter", "tree_sitter_kotlin"))
     csharp_missing = _missing_dependencies(missing, ("tree_sitter", "tree_sitter_c_sharp"))
+    c_missing = _missing_dependencies(missing, ("tree_sitter", "tree_sitter_c"))
+    cpp_missing = _missing_dependencies(missing, ("tree_sitter", "tree_sitter_cpp"))
     return (
         LanguageInfo(
             language_id="python",
@@ -105,6 +92,22 @@ def _foundation_languages(dependency_health: DependencyHealth) -> tuple[Language
             stage="foundation",
             dependency_missing=csharp_missing,
             symbol_extraction=not csharp_missing,
+        ),
+        LanguageInfo(
+            language_id="c",
+            display_name="C",
+            extensions=(".c", ".h"),
+            stage="foundation",
+            dependency_missing=c_missing,
+            symbol_extraction=not c_missing,
+        ),
+        LanguageInfo(
+            language_id="cpp",
+            display_name="C++",
+            extensions=(".cc", ".cpp", ".cxx", ".hpp", ".hh", ".hxx"),
+            stage="foundation",
+            dependency_missing=cpp_missing,
+            symbol_extraction=not cpp_missing,
         ),
     )
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import pytest
 
+from tldw_Server_API.app.core.CodeGraph.extractors.tree_sitter_loader import load_parser
 from tldw_Server_API.app.core.CodeGraph.models import CodeGraphNode
 from tldw_Server_API.app.core.MCP_unified.modules.base import ModuleConfig
 from tldw_Server_API.app.core.MCP_unified.modules.implementations.codegraph_module import (
@@ -69,6 +70,11 @@ def _context() -> RequestContext:
         session_id="sess-1",
         metadata={"workspace_id": "workspace-1"},
     )
+
+
+def _require_c_family_parsers() -> None:
+    if not (load_parser("c").available and load_parser("cpp").available):
+        pytest.skip("tree-sitter-c/cpp parsers are not available")
 
 
 def _module(tmp_path: Path, workspace_root: Path) -> CodeGraphModule:
@@ -376,6 +382,7 @@ public class Greeter {
 
 @pytest.mark.asyncio
 async def test_codegraph_search_finds_c_cpp_symbols_after_index(tmp_path: Path) -> None:
+    _require_c_family_parsers()
     workspace_root = tmp_path / "workspace"
     workspace_root.mkdir()
     (workspace_root / "greeter.c").write_text(

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
@@ -374,6 +374,68 @@ public class Greeter {
     ]
 
 
+@pytest.mark.asyncio
+async def test_codegraph_search_finds_c_cpp_symbols_after_index(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    (workspace_root / "greeter.c").write_text(
+        """
+#include <stdio.h>
+
+int helper(int value) {
+    return value + 1;
+}
+
+int greet(int name) {
+    return helper(name);
+}
+""",
+        encoding="utf-8",
+    )
+    (workspace_root / "Greeter.cpp").write_text(
+        """
+#include <string>
+
+namespace demo {
+class Greeter {
+public:
+    std::string greet(std::string name) {
+        return helper(name);
+    }
+
+private:
+    std::string helper(std::string value) {
+        return value;
+    }
+};
+}
+""",
+        encoding="utf-8",
+    )
+    module = _module(tmp_path, workspace_root)
+
+    index_result = await module.execute_tool(
+        "codegraph.index",
+        {"mode": "foreground", "force": True, "max_files": 10},
+        context=_context(),
+    )
+    c_search = await module.execute_tool(
+        "codegraph.search",
+        {"query": "helper", "kind": "function", "language": "c", "limit": 10},
+        context=_context(),
+    )
+    cpp_search = await module.execute_tool(
+        "codegraph.search",
+        {"query": "helper", "kind": "method", "language": "cpp", "limit": 10},
+        context=_context(),
+    )
+
+    assert index_result["status"] == "complete"  # nosec B101
+    assert index_result["counters"]["files_indexed"] == 2  # nosec B101
+    assert [item["qualified_name"] for item in c_search["results"]] == ["helper"]  # nosec B101
+    assert [item["qualified_name"] for item in cpp_search["results"]] == ["demo.Greeter.helper"]  # nosec B101
+
+
 def test_codegraph_rejects_ambiguous_node_selectors(tmp_path: Path) -> None:
     workspace_root = tmp_path / "workspace"
     workspace_root.mkdir()

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_c_extractor.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_c_extractor.py
@@ -1,7 +1,15 @@
 from __future__ import annotations
 
+import pytest
+
 from tldw_Server_API.app.core.CodeGraph.extractors.c_family_extractor import CTreeSitterExtractor
+from tldw_Server_API.app.core.CodeGraph.extractors.tree_sitter_loader import load_parser
 from tldw_Server_API.app.core.CodeGraph.models import ExtractionResult
+
+pytestmark = pytest.mark.skipif(
+    not load_parser("c").available,
+    reason="tree-sitter-c parser is not available",
+)
 
 C_FIXTURE = b"""
 #include <stdio.h>

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_c_extractor.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_c_extractor.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from tldw_Server_API.app.core.CodeGraph.extractors.c_family_extractor import CTreeSitterExtractor
+from tldw_Server_API.app.core.CodeGraph.models import ExtractionResult
+
+C_FIXTURE = b"""
+#include <stdio.h>
+
+struct Greeter {
+    int value;
+};
+
+enum Mode {
+    MODE_BASIC,
+    MODE_ADVANCED
+};
+
+static int helper(int value) {
+    return value + 1;
+}
+
+int greet(int name) {
+    return helper(name);
+}
+"""
+
+
+def test_c_extractor_records_includes_types_functions_and_calls() -> None:
+    """Extract conservative C symbols and same-file function calls."""
+    result = CTreeSitterExtractor().extract(
+        workspace_key="ws",
+        file_path="src/greeter.c",
+        source=C_FIXTURE,
+    )
+
+    nodes_by_kind_name = {(node.kind, node.name): node for node in result.nodes}
+
+    assert ("module", "greeter") in nodes_by_kind_name
+    assert ("import", "<stdio.h>") in nodes_by_kind_name
+    assert ("struct", "Greeter") in nodes_by_kind_name
+    assert ("enum", "Mode") in nodes_by_kind_name
+    assert ("function", "helper") in nodes_by_kind_name
+    assert ("function", "greet") in nodes_by_kind_name
+
+    helper = nodes_by_kind_name[("function", "helper")]
+    greet = nodes_by_kind_name[("function", "greet")]
+    include = nodes_by_kind_name[("import", "<stdio.h>")]
+
+    assert helper.qualified_name == "helper"
+    assert greet.qualified_name == "greet"
+    assert (greet.id, helper.id) in {(edge.source, edge.target) for edge in result.edges}
+    assert any(
+        ref.reference_kind == "import" and ref.reference_name == "<stdio.h>" and ref.from_node_id == include.id
+        for ref in result.unresolved_refs
+    )
+    assert result.errors == ()
+
+
+def test_c_extractor_marks_parse_errors() -> None:
+    """Return extraction errors for invalid C syntax."""
+    result = CTreeSitterExtractor().extract(
+        workspace_key="ws",
+        file_path="src/broken.c",
+        source=b"int broken(",
+    )
+
+    assert result == ExtractionResult(errors=("C parse error",))
+
+
+def test_c_extractor_uses_deterministic_node_ids() -> None:
+    """Use stable node IDs across repeated C extraction."""
+    first = CTreeSitterExtractor().extract(
+        workspace_key="ws",
+        file_path="src/greeter.c",
+        source=C_FIXTURE,
+    )
+    second = CTreeSitterExtractor().extract(
+        workspace_key="ws",
+        file_path="src/greeter.c",
+        source=C_FIXTURE,
+    )
+
+    assert [node.id for node in first.nodes] == [node.id for node in second.nodes]

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_cpp_extractor.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_cpp_extractor.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from tldw_Server_API.app.core.CodeGraph.extractors.c_family_extractor import CppTreeSitterExtractor
+from tldw_Server_API.app.core.CodeGraph.models import ExtractionResult
+
+CPP_FIXTURE = b"""
+#include <string>
+
+namespace demo {
+class Greeter {
+public:
+    std::string greet(std::string name) {
+        return helper(name);
+    }
+
+private:
+    std::string helper(std::string value) {
+        return value;
+    }
+};
+
+struct Point {
+    int x;
+};
+
+enum Mode {
+    Basic,
+    Advanced
+};
+}
+"""
+
+
+def test_cpp_extractor_records_includes_namespaces_types_methods_and_calls() -> None:
+    """Extract conservative C++ symbols and same-file method calls."""
+    result = CppTreeSitterExtractor().extract(
+        workspace_key="ws",
+        file_path="src/demo/greeter.cpp",
+        source=CPP_FIXTURE,
+    )
+
+    nodes_by_kind_name = {(node.kind, node.name): node for node in result.nodes}
+
+    assert ("module", "greeter") in nodes_by_kind_name
+    assert ("import", "<string>") in nodes_by_kind_name
+    assert ("namespace", "demo") in nodes_by_kind_name
+    assert ("class", "Greeter") in nodes_by_kind_name
+    assert ("method", "greet") in nodes_by_kind_name
+    assert ("method", "helper") in nodes_by_kind_name
+    assert ("struct", "Point") in nodes_by_kind_name
+    assert ("enum", "Mode") in nodes_by_kind_name
+
+    namespace = nodes_by_kind_name[("namespace", "demo")]
+    greeter = nodes_by_kind_name[("class", "Greeter")]
+    greet = nodes_by_kind_name[("method", "greet")]
+    helper = nodes_by_kind_name[("method", "helper")]
+    include = nodes_by_kind_name[("import", "<string>")]
+    point = nodes_by_kind_name[("struct", "Point")]
+
+    assert namespace.qualified_name == "demo"
+    assert greeter.qualified_name == "demo.Greeter"
+    assert greet.qualified_name == "demo.Greeter.greet"
+    assert helper.qualified_name == "demo.Greeter.helper"
+    assert point.qualified_name == "demo.Point"
+    assert (greet.id, helper.id) in {(edge.source, edge.target) for edge in result.edges}
+    assert any(
+        ref.reference_kind == "import" and ref.reference_name == "<string>" and ref.from_node_id == include.id
+        for ref in result.unresolved_refs
+    )
+    assert result.errors == ()
+
+
+def test_cpp_extractor_marks_parse_errors() -> None:
+    """Return extraction errors for invalid C++ syntax."""
+    result = CppTreeSitterExtractor().extract(
+        workspace_key="ws",
+        file_path="src/broken.cpp",
+        source=b"class Broken {",
+    )
+
+    assert result == ExtractionResult(errors=("C++ parse error",))
+
+
+def test_cpp_extractor_uses_deterministic_node_ids() -> None:
+    """Use stable node IDs across repeated C++ extraction."""
+    first = CppTreeSitterExtractor().extract(
+        workspace_key="ws",
+        file_path="src/greeter.cpp",
+        source=CPP_FIXTURE,
+    )
+    second = CppTreeSitterExtractor().extract(
+        workspace_key="ws",
+        file_path="src/greeter.cpp",
+        source=CPP_FIXTURE,
+    )
+
+    assert [node.id for node in first.nodes] == [node.id for node in second.nodes]

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_cpp_extractor.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_cpp_extractor.py
@@ -1,7 +1,15 @@
 from __future__ import annotations
 
+import pytest
+
 from tldw_Server_API.app.core.CodeGraph.extractors.c_family_extractor import CppTreeSitterExtractor
+from tldw_Server_API.app.core.CodeGraph.extractors.tree_sitter_loader import load_parser
 from tldw_Server_API.app.core.CodeGraph.models import ExtractionResult
+
+pytestmark = pytest.mark.skipif(
+    not load_parser("cpp").available,
+    reason="tree-sitter-cpp parser is not available",
+)
 
 CPP_FIXTURE = b"""
 #include <string>

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py
@@ -210,6 +210,66 @@ public class Greeter {
     assert helper_paths == ["Greeter.cs"]
 
 
+def test_indexer_extracts_c_cpp_graph_rows_during_index(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "greeter.c").write_text(
+        """
+#include <stdio.h>
+
+int helper(int value) {
+    return value + 1;
+}
+
+int greet(int name) {
+    return helper(name);
+}
+""",
+        encoding="utf-8",
+    )
+    (workspace / "Greeter.cpp").write_text(
+        """
+#include <string>
+
+namespace demo {
+class Greeter {
+public:
+    std::string greet(std::string name) {
+        return helper(name);
+    }
+
+private:
+    std::string helper(std::string value) {
+        return value;
+    }
+};
+}
+""",
+        encoding="utf-8",
+    )
+    repo = CodeGraphRepository(tmp_path / "codegraph.db")
+    indexer = CodeGraphIndexer(settings=CodeGraphSettings.from_mapping({}), registry=CodeGraphLanguageRegistry())
+
+    result = indexer.index_workspace(
+        workspace_root=workspace,
+        workspace_key="ws_test",
+        repository=repo,
+        force=True,
+        languages=None,
+        max_files=10,
+    )
+
+    files = {item.path: item for item in repo.list_files(limit=10)}
+    c_helpers = [node.qualified_name for node in repo.search_nodes("helper", language="c", limit=10)]
+    cpp_helpers = [node.qualified_name for node in repo.search_nodes("helper", language="cpp", limit=10)]
+
+    assert result.status == "complete"
+    assert files["greeter.c"].node_count > 0
+    assert files["Greeter.cpp"].node_count > 0
+    assert c_helpers == ["helper"]
+    assert cpp_helpers == ["demo.Greeter.helper"]
+
+
 def test_indexer_does_not_count_non_extractable_jvm_files_against_foreground_limits(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -271,6 +331,50 @@ def test_indexer_does_not_count_non_extractable_csharp_files_against_foreground_
                 "tree_sitter_typescript",
                 "tree_sitter_java",
                 "tree_sitter_kotlin",
+            ),
+        )
+    )
+    indexer = CodeGraphIndexer(settings=CodeGraphSettings.from_mapping({}), registry=registry)
+
+    result = indexer.index_workspace(
+        workspace_root=workspace,
+        workspace_key="ws_test",
+        repository=repo,
+        force=True,
+        languages=None,
+        max_files=1,
+    )
+
+    assert result.status == "complete"
+    assert result.counters["dependency_missing_language_skipped"] == 2
+    assert [item.path for item in repo.list_files(limit=10)] == ["app.py"]
+
+
+def test_indexer_does_not_count_non_extractable_c_cpp_files_against_foreground_limits(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_load_parser(language_id: str) -> SimpleNamespace:
+        return SimpleNamespace(available=language_id not in {"c", "cpp"})
+
+    monkeypatch.setattr(indexer_module, "load_parser", fake_load_parser)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "A.c").write_text("int a() { return 1; }\n", encoding="utf-8")
+    (workspace / "B.cpp").write_text("int b() { return 1; }\n", encoding="utf-8")
+    (workspace / "app.py").write_text("def helper():\n    return 1\n", encoding="utf-8")
+    repo = CodeGraphRepository(tmp_path / "codegraph.db")
+    registry = CodeGraphLanguageRegistry(
+        dependency_health=DependencyHealth(
+            available=True,
+            missing=("tree_sitter_c", "tree_sitter_cpp"),
+            present=(
+                "tree_sitter",
+                "tree_sitter_javascript",
+                "tree_sitter_typescript",
+                "tree_sitter_java",
+                "tree_sitter_kotlin",
+                "tree_sitter_c_sharp",
             ),
         )
     )
@@ -657,7 +761,7 @@ def test_indexer_stops_when_foreground_time_budget_expires(tmp_path: Path) -> No
     assert result.counters["files_indexed"] == 1
 
 
-def test_indexer_skips_planned_language_files_until_extractors_exist(tmp_path: Path) -> None:
+def test_indexer_extracts_former_planned_cpp_extension_when_parser_exists(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     (workspace / "main.cc").write_text("int main() { return 0; }\n", encoding="utf-8")
@@ -674,8 +778,11 @@ def test_indexer_skips_planned_language_files_until_extractors_exist(tmp_path: P
     )
 
     assert result.status == "complete"
-    assert result.counters["planned_language_skipped"] == 1
-    assert repo.counts()["files"] == 0
+    assert result.counters["files_indexed"] == 1
+    assert repo.list_files(limit=10)[0].path == "main.cc"
+    assert [node.qualified_name for node in repo.search_nodes("main", kind="function", language="cpp", limit=10)] == [
+        "main"
+    ]
 
 
 def test_sync_removes_deleted_files(tmp_path: Path) -> None:

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py
@@ -9,10 +9,16 @@ import pytest
 import tldw_Server_API.app.core.CodeGraph.indexer as indexer_module
 from tldw_Server_API.app.core.CodeGraph.config import CodeGraphSettings
 from tldw_Server_API.app.core.CodeGraph.dependencies import DependencyHealth
+from tldw_Server_API.app.core.CodeGraph.extractors.tree_sitter_loader import load_parser
 from tldw_Server_API.app.core.CodeGraph.indexer import CodeGraphIndexer, _Candidate, _DiscoveryResult
 from tldw_Server_API.app.core.CodeGraph.language_registry import CodeGraphLanguageRegistry
 from tldw_Server_API.app.core.CodeGraph.models import ExtractionResult, LanguageInfo
 from tldw_Server_API.app.core.DB_Management.codegraph.repository import CodeGraphRepository
+
+
+def _require_c_family_parsers() -> None:
+    if not (load_parser("c").available and load_parser("cpp").available):
+        pytest.skip("tree-sitter-c/cpp parsers are not available")
 
 
 def test_indexer_indexes_supported_file_inventory_and_skips_excluded_dirs(tmp_path: Path) -> None:
@@ -211,6 +217,7 @@ public class Greeter {
 
 
 def test_indexer_extracts_c_cpp_graph_rows_during_index(tmp_path: Path) -> None:
+    _require_c_family_parsers()
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     (workspace / "greeter.c").write_text(
@@ -762,6 +769,7 @@ def test_indexer_stops_when_foreground_time_budget_expires(tmp_path: Path) -> No
 
 
 def test_indexer_extracts_former_planned_cpp_extension_when_parser_exists(tmp_path: Path) -> None:
+    _require_c_family_parsers()
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     (workspace / "main.cc").write_text("int main() { return 0; }\n", encoding="utf-8")

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_language_registry.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_language_registry.py
@@ -40,8 +40,8 @@ def test_registry_reports_foundation_languages_and_planned_languages() -> None:
     assert by_id["java"].stage == "foundation"
     assert by_id["kotlin"].stage == "foundation"
     assert by_id["csharp"].stage == "foundation"
-    assert by_id["c"].stage == "planned"
-    assert by_id["cpp"].stage == "planned"
+    assert by_id["c"].stage == "foundation"
+    assert by_id["cpp"].stage == "foundation"
 
 
 def test_registry_maps_extensions_and_reports_symbol_extraction_support() -> None:
@@ -57,6 +57,8 @@ def test_registry_maps_extensions_and_reports_symbol_extraction_support() -> Non
                 "tree_sitter_java",
                 "tree_sitter_kotlin",
                 "tree_sitter_c_sharp",
+                "tree_sitter_c",
+                "tree_sitter_cpp",
             ),
         )
     )
@@ -67,7 +69,9 @@ def test_registry_maps_extensions_and_reports_symbol_extraction_support() -> Non
     assert registry.language_for_path("src/main/java/com/example/App.java").language_id == "java"
     assert registry.language_for_path("src/main/kotlin/com/example/App.kt").language_id == "kotlin"
     assert registry.language_for_path("src/main/csharp/Example/App.cs").language_id == "csharp"
-    assert registry.language_for_path("src/main.cc").stage == "planned"
+    assert registry.language_for_path("src/main.c").language_id == "c"
+    assert registry.language_for_path("src/main.cc").language_id == "cpp"
+    assert registry.language_for_path("include/main.hpp").language_id == "cpp"
     assert registry.language_for_path("README.md") is None
 
     by_id = {language.language_id: language for language in registry.list_languages()}
@@ -78,6 +82,8 @@ def test_registry_maps_extensions_and_reports_symbol_extraction_support() -> Non
     assert by_id["java"].symbol_extraction is True
     assert by_id["kotlin"].symbol_extraction is True
     assert by_id["csharp"].symbol_extraction is True
+    assert by_id["c"].symbol_extraction is True
+    assert by_id["cpp"].symbol_extraction is True
 
 
 def test_registry_reports_missing_parser_dependencies_per_language() -> None:
@@ -89,6 +95,8 @@ def test_registry_reports_missing_parser_dependencies_per_language() -> None:
                 "tree_sitter_java",
                 "tree_sitter_kotlin",
                 "tree_sitter_c_sharp",
+                "tree_sitter_c",
+                "tree_sitter_cpp",
             ),
             present=("tree_sitter", "tree_sitter_typescript"),
         )
@@ -107,3 +115,7 @@ def test_registry_reports_missing_parser_dependencies_per_language() -> None:
     assert by_id["kotlin"].dependency_missing == ("tree_sitter_kotlin",)
     assert by_id["csharp"].symbol_extraction is False
     assert by_id["csharp"].dependency_missing == ("tree_sitter_c_sharp",)
+    assert by_id["c"].symbol_extraction is False
+    assert by_id["c"].dependency_missing == ("tree_sitter_c",)
+    assert by_id["cpp"].symbol_extraction is False
+    assert by_id["cpp"].dependency_missing == ("tree_sitter_cpp",)

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_tree_sitter_loader.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_tree_sitter_loader.py
@@ -139,15 +139,51 @@ def test_csharp_parser_can_parse_class() -> None:
     assert not tree.root_node.has_error
 
 
-def test_load_parser_reports_missing_java_kotlin_csharp_optional_dependencies(monkeypatch) -> None:
-    """Report missing JVM/.NET parser packages without raising import errors."""
+def test_c_parser_can_parse_function() -> None:
+    """Load the optional C parser and parse a compact function fixture."""
+    loader = importlib.import_module(
+        "tldw_Server_API.app.core.CodeGraph.extractors.tree_sitter_loader"
+    )
+
+    result = loader.load_parser("c")
+    tree = result.parser.parse(b"int helper(int value) { return value + 1; }")
+
+    assert result.missing == ()
+    assert result.error is None
+    assert tree.root_node.type == "translation_unit"
+    assert not tree.root_node.has_error
+
+
+def test_cpp_parser_can_parse_class() -> None:
+    """Load the optional C++ parser and parse a compact class fixture."""
+    loader = importlib.import_module(
+        "tldw_Server_API.app.core.CodeGraph.extractors.tree_sitter_loader"
+    )
+
+    result = loader.load_parser("cpp")
+    tree = result.parser.parse(b"class Greeter { int helper() { return 1; } };")
+
+    assert result.missing == ()
+    assert result.error is None
+    assert tree.root_node.type == "translation_unit"
+    assert not tree.root_node.has_error
+
+
+def test_load_parser_reports_missing_java_kotlin_csharp_c_cpp_optional_dependencies(monkeypatch) -> None:
+    """Report missing JVM/.NET/C-family parser packages without raising import errors."""
     loader = importlib.import_module(
         "tldw_Server_API.app.core.CodeGraph.extractors.tree_sitter_loader"
     )
     real_import_module = loader.importlib.import_module
 
     def fake_import_module(name: str) -> ModuleType:
-        if name in {"tree_sitter_java", "tree_sitter_kotlin", "tree_sitter_c_sharp"}:
+        if name in {
+            "tree_sitter_java",
+            "tree_sitter_kotlin",
+            "tree_sitter_c_sharp",
+            "tree_sitter_c",
+            "tree_sitter_cpp",
+        }:
             raise ModuleNotFoundError(f"No module named '{name}'")
         return real_import_module(name)
 
@@ -156,6 +192,8 @@ def test_load_parser_reports_missing_java_kotlin_csharp_optional_dependencies(mo
     java = loader.load_parser("java")
     kotlin = loader.load_parser("kotlin")
     csharp = loader.load_parser("csharp")
+    c = loader.load_parser("c")
+    cpp = loader.load_parser("cpp")
 
     assert java.parser is None
     assert java.missing == ("tree_sitter_java",)
@@ -166,3 +204,9 @@ def test_load_parser_reports_missing_java_kotlin_csharp_optional_dependencies(mo
     assert csharp.parser is None
     assert csharp.missing == ("tree_sitter_c_sharp",)
     assert csharp.error is None
+    assert c.parser is None
+    assert c.missing == ("tree_sitter_c",)
+    assert c.error is None
+    assert cpp.parser is None
+    assert cpp.missing == ("tree_sitter_cpp",)
+    assert cpp.error is None


### PR DESCRIPTION
## Summary
- promote C and C++ to dependency-aware CodeGraph foundation languages
- add optional tree-sitter-c/tree-sitter-cpp loader wiring and conservative C-family extraction
- cover C/C++ indexing, missing dependency skips, and MCP search visibility

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/CodeGraph tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check tldw_Server_API/app/core/CodeGraph tldw_Server_API/app/core/DB_Management/codegraph tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py tldw_Server_API/tests/CodeGraph tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/CodeGraph tldw_Server_API/app/core/DB_Management/codegraph tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py -f json -o /tmp/bandit_codegraph_c_cpp.json
- git diff --check

## Backlog
- TASK-63

## Merge note
- Per the AI-generated PR policy, the human requester still needs to add the required human-written Change summary before merge.