### PR TITLE
Add sandbox cleanup recovery contract coverage

### DIFF
--- a/Docs/superpowers/plans/2026-05-05-sandbox-cleanup-recovery-contract-tests-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-05-sandbox-cleanup-recovery-contract-tests-implementation-plan.md
@@ -1,0 +1,155 @@
+# Sandbox Cleanup And Recovery Contract Tests Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add local-first sandbox cleanup/recovery contract coverage without requiring host-gated runtimes.
+
+**Architecture:** Keep the slice test-first and portable. Use runner unit seams for process/worktree cleanup, service/orchestrator seams for durable session cleanup, and runtime capability metadata for no-warm-reuse host-local contracts. Avoid production edits unless a failing test exposes a real behavior gap.
+
+**Tech Stack:** Python 3.11, pytest, existing sandbox service/orchestrator/store helpers, git worktree runner fakes.
+
+---
+
+### Task 1: Worktree Timeout Cleanup Contract
+
+**Files:**
+- Modify: `tldw_Server_API/tests/sandbox/test_worktree_runner.py`
+
+- [x] **Step 1: Write the timeout cleanup contract test**
+
+Add a test that fakes `WorktreeRunner.create_worktree`, `destroy_worktree`,
+`tempfile.mkdtemp`, and `subprocess.Popen`. The fake process raises
+`subprocess.TimeoutExpired` from `wait()`. Assert the resulting status is
+`RunPhase.timed_out`, the created worktree is destroyed, the run directory is
+removed, and `_active_proc` / `_active_run_dir` do not retain the run id.
+
+- [x] **Step 2: Run the focused test**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_worktree_runner.py::test_start_run_timeout_cleans_worktree_run_dir_and_active_tracking -q
+```
+
+Expected: fail if timeout cleanup is incomplete, or pass immediately if the
+current implementation already satisfies the contract.
+
+- [x] **Step 3: Implement only if needed**
+
+If the test fails because cleanup is incomplete, update
+`tldw_Server_API/app/core/Sandbox/runners/worktree_runner.py` to keep cleanup in
+`finally`: destroy the worktree, clear active tracking, remove the run directory,
+and preserve the `execution_timeout` status.
+
+Outcome: no production change was needed; the contract test passed against the
+current implementation.
+
+- [x] **Step 4: Re-run worktree tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_worktree_runner.py -q
+```
+
+Expected: pass.
+
+### Task 2: Durable Session Cleanup And Stale Metadata Contracts
+
+**Files:**
+- Modify: `tldw_Server_API/tests/sandbox/test_session_store_durability.py`
+
+- [x] **Step 1: Write the durable deletion workspace cleanup test**
+
+Add a test using the SQLite sandbox store helper. Create a session in one
+service, write a marker under its workspace, instantiate a second service, and
+destroy the session through the second service. Assert the persisted session is
+gone and the original session root is removed.
+
+- [x] **Step 2: Write or preserve stale metadata rejection coverage**
+
+Confirm the existing stale cached session-backed run test rejects store lookup
+failure without enqueueing. Add only a narrow assertion if the contract is not
+explicit enough.
+
+Outcome: existing stale-cache rejection coverage already asserts the no-enqueue
+contract; this slice added the missing cross-service durable destroy cleanup
+coverage.
+
+- [x] **Step 3: Run focused session durability tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_session_store_durability.py -q
+```
+
+Expected: pass, or expose a real cleanup/recovery gap to fix in
+`SandboxService`/`SandboxOrchestrator`.
+
+### Task 3: Host-Local No Warm Reuse Contract
+
+**Files:**
+- Modify: `tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py`
+
+- [x] **Step 1: Add explicit host-local session contract test**
+
+Assert `seatbelt` and `worktree` session metadata both report
+`reuse_model="workspace_only"`, `requires_live_health_check=False`,
+`recovery_state="unsupported"`, and `repair_state="unsupported"`.
+
+- [x] **Step 2: Run runtime inventory tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py -q
+```
+
+Expected: pass.
+
+### Task 4: Verification And Closeout
+
+**Files:**
+- Modify: `backlog/tasks/task-62 - Add-sandbox-cleanup-and-recovery-contract-tests.md`
+
+- [x] **Step 1: Run all focused tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_worktree_runner.py tldw_Server_API/tests/sandbox/test_session_store_durability.py tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py -q
+```
+
+Expected: pass.
+
+- [x] **Step 2: Run diff hygiene**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output.
+
+- [x] **Step 3: Run Bandit if production code changed**
+
+If only docs/tests/backlog changed, document the skip in TASK-62. If production
+code changed, run Bandit on touched production paths.
+
+Outcome: skipped; no production code changed.
+
+- [x] **Step 4: Update TASK-62**
+
+Check completed acceptance criteria and Definition of Done items, append
+verification notes, and add a final summary.
+
+- [x] **Step 5: Commit**
+
+Run:
+
+```bash
+git add Docs/superpowers/specs/2026-05-05-sandbox-cleanup-recovery-contract-tests-design.md Docs/superpowers/plans/2026-05-05-sandbox-cleanup-recovery-contract-tests-implementation-plan.md tldw_Server_API/tests/sandbox/test_worktree_runner.py tldw_Server_API/tests/sandbox/test_session_store_durability.py tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py "backlog/tasks/task-62 - Add-sandbox-cleanup-and-recovery-contract-tests.md"
+git commit -m "test(sandbox): add cleanup recovery contract coverage"
+```

--- a/Docs/superpowers/specs/2026-05-05-sandbox-cleanup-recovery-contract-tests-design.md
+++ b/Docs/superpowers/specs/2026-05-05-sandbox-cleanup-recovery-contract-tests-design.md
@@ -1,0 +1,70 @@
+# Sandbox Cleanup And Recovery Contract Tests Design
+
+**Status:** Approved implementation design.
+**Date:** 2026-05-05.
+**Backlog:** `TASK-62`.
+**Scope:** Portable cleanup/recovery contract tests for sandbox sessions and
+host-local/runtime paths.
+
+## Related Guidance
+
+- `Docs/Sandbox/sandbox-architecture-doctrine.md`
+- `Docs/superpowers/specs/2026-05-02-sandbox-module-roadmap-design.md`
+- `Docs/Sandbox/sandbox-runtime-capability-inventory.md`
+
+## Goal
+
+Add local-first contract coverage for cleanup and recovery behaviors that should
+stay true across developer machines without requiring Apple Silicon
+Virtualization.framework, Docker, Firecracker, Lima, or another prepared host.
+
+The slice turns Phase 4 reliability doctrine into tests for portable seams:
+
+- failed run setup must not leak runtime workspaces
+- timeout/cancel paths must clear runtime tracking and temporary directories
+- session deletion must clean durable workspace state through service and
+  orchestrator seams
+- stale cached session metadata must not authorize new session-backed runs
+- host-local runtimes must continue to report workspace-only session reuse and
+  no repair/recovery contract
+
+## Non-Goals
+
+- Do not run real `vz_linux` VMs in this PR.
+- Do not expand macOS repair beyond existing `vz_linux` admin flows.
+- Do not add warm runtime reuse for `seatbelt` or `worktree`.
+- Do not introduce a new cross-runtime repair API.
+- Do not weaken fail-closed policy or runtime availability checks to make tests
+  easier.
+
+## Design Review
+
+The main risk is writing tests that overfit private implementation details while
+pretending to prove runtime behavior. This design limits private-state
+assertions to cleanup internals that are already explicit lifecycle contracts,
+such as worktree active-run maps and durable session roots. Public service and
+orchestrator seams are preferred for session recovery checks.
+
+Another risk is conflating "session participates in API workflow" with "warm
+runtime reuse". The runtime inventory says host-local runtimes are
+`workspace_only`, so tests should assert that distinction directly instead of
+adding any helper-health or repair semantics to `worktree`/`seatbelt`.
+
+The final risk is broadening the PR into runtime implementation work. The
+baseline already contains cleanup behavior for several paths. If a new contract
+test passes immediately, this PR should keep it as regression coverage and avoid
+unnecessary production edits.
+
+## Test Strategy
+
+Use focused unit/contract tests:
+
+- `test_worktree_runner.py` for portable worktree timeout cleanup with fake
+  subprocess and temporary worktree directories.
+- `test_session_store_durability.py` for durable session deletion and stale
+  metadata behavior across service/orchestrator instances.
+- `test_runtime_inventory_contract.py` for explicit host-local no-warm-reuse
+  and no-repair/no-recovery session contract metadata.
+
+The tests must not require real Docker, VZ, Firecracker, Lima, or host-gated
+network tooling. Existing real-host smoke remains under host-gated suites.

--- a/backlog/tasks/task-62 - Add-sandbox-cleanup-and-recovery-contract-tests.md
+++ b/backlog/tasks/task-62 - Add-sandbox-cleanup-and-recovery-contract-tests.md
@@ -1,0 +1,58 @@
+---
+id: TASK-62
+title: Add sandbox cleanup and recovery contract tests
+status: Done
+assignee: []
+created_date: '2026-05-05 03:58'
+labels:
+  - sandbox
+  - runtime-reliability
+  - phase-4
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add a local-first Phase 4 sandbox reliability slice that defines and tests cleanup/recovery behavior for portable runtimes and session orchestration without requiring special host-gated VM infrastructure. Scope should validate failed-start cleanup, timeout/cancel cleanup, destroyed-session workspace cleanup, stale metadata behavior, and explicit no-warm-reuse claims for host-local runtimes while keeping repair APIs ownership-checked and not generalized beyond vz_linux.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Local-first cleanup/recovery contract tests cover portable sandbox paths without requiring Apple Silicon VZ or other special host infrastructure.
+- [x] #2 Tests verify failed-start and timeout/cancel cleanup semantics for at least one portable runtime path.
+- [x] #3 Tests verify destroyed session workspace cleanup and stale metadata behavior through service/orchestrator seams.
+- [x] #4 Tests preserve the runtime session contract distinction that host-local runtimes do not provide warm runtime reuse.
+- [x] #5 Design and implementation plan reference sandbox architecture doctrine and current roadmap gaps.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Notes
+<!-- SECTION:NOTES:BEGIN -->
+Implemented local-first cleanup/recovery contract coverage in isolated worktree codex/sandbox-cleanup-recovery-contracts.
+
+Added worktree timeout cleanup test asserting timed_out status, worktree destruction, run-dir removal, SIGTERM, and active tracking cleanup.
+
+Added cross-service durable session destroy test asserting store-backed workspace root removal after service restart-style deletion.
+
+Added host-local session contract test asserting seatbelt/worktree remain workspace_only with no live-health, recovery, or repair claims.
+
+Verification: focused baseline before edits passed 64 tests; focused post-edit test set passed 67 tests; git diff --check passed.
+
+Bandit: skipped because the branch only changes tests, docs, and Backlog.md task metadata; no production Python code changed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added a local-first sandbox cleanup/recovery contract-test slice. The branch adds design and implementation-plan docs, explicit worktree timeout cleanup coverage, cross-service durable session workspace cleanup coverage, and a host-local session contract assertion that seatbelt/worktree remain workspace-only with no warm runtime reuse or repair/recovery claims. Verification passed with the focused sandbox suite: 67 tests passing; git diff --check clean. Bandit was not run because no production code changed.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-62 - Add-sandbox-cleanup-and-recovery-contract-tests.md
+++ b/backlog/tasks/task-62 - Add-sandbox-cleanup-and-recovery-contract-tests.md
@@ -50,9 +50,11 @@ Added host-local session contract test asserting seatbelt/worktree remain worksp
 Verification: focused baseline before edits passed 64 tests; focused post-edit test set passed 67 tests; git diff --check passed.
 
 Bandit: skipped because the branch only changes tests, docs, and Backlog.md task metadata; no production Python code changed.
+
+PR #1294 review-fix pass: verified and fixed Qodo/CodeRabbit feedback that the worktree timeout test cleared active-run tracking before asserting cleanup. The test now asserts `_active_proc`, `_active_run_dir`, and `_cancelled_runs` before the test-isolation cleanup block runs.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added a local-first sandbox cleanup/recovery contract-test slice. The branch adds design and implementation-plan docs, explicit worktree timeout cleanup coverage, cross-service durable session workspace cleanup coverage, and a host-local session contract assertion that seatbelt/worktree remain workspace-only with no warm runtime reuse or repair/recovery claims. Verification passed with the focused sandbox suite: 67 tests passing; git diff --check clean. Bandit was not run because no production code changed.
+Added a local-first sandbox cleanup/recovery contract-test slice. The branch adds design and implementation-plan docs, explicit worktree timeout cleanup coverage, cross-service durable session workspace cleanup coverage, and a host-local session contract assertion that seatbelt/worktree remain workspace-only with no warm runtime reuse or repair/recovery claims. PR review feedback was addressed by moving worktree active-tracking assertions before test-isolation cleanup. Verification passed with the focused sandbox suite: 67 tests passing; git diff --check clean. Bandit was not run because no production code changed.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
+++ b/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
@@ -332,6 +332,16 @@ def test_runtime_session_contract_metadata_rejects_unknown_runtime() -> None:
         runtime_caps.runtime_session_contract_metadata("future_runtime")
 
 
+def test_host_local_session_contracts_do_not_claim_warm_reuse_or_repair() -> None:
+    for runtime in (RuntimeType.seatbelt, RuntimeType.worktree):
+        contract = runtime_caps.runtime_session_contract_metadata(runtime)
+
+        assert contract.reuse_model == "workspace_only"
+        assert contract.requires_live_health_check is False
+        assert contract.recovery_state == "unsupported"
+        assert contract.repair_state == "unsupported"
+
+
 def test_runtime_info_schema_exposes_session_contract() -> None:
     schema = SandboxRuntimeInfo.model_json_schema()
 

--- a/tldw_Server_API/tests/sandbox/test_session_store_durability.py
+++ b/tldw_Server_API/tests/sandbox/test_session_store_durability.py
@@ -170,6 +170,34 @@ def test_cross_node_delete_invalidates_cached_session_state(monkeypatch, tmp_pat
         assert source.id not in orch_b._session_roots
 
 
+def test_cross_service_destroy_removes_store_backed_workspace_root(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    _configure_sqlite_store(monkeypatch, tmp_path)
+
+    creator = SandboxService()
+    session = creator.create_session(
+        user_id="user-cross-service-cleanup",
+        spec=SessionSpec(runtime=RuntimeType.docker, base_image="python:3.11-slim"),
+        spec_version="1.0",
+        idem_key=None,
+        raw_body={"spec_version": "1.0", "runtime": "docker"},
+    )
+    workspace_path = creator._orch.get_session_workspace_path(session.id)
+    assert workspace_path is not None
+    workspace = Path(str(workspace_path))
+    session_root = workspace.parent
+    (workspace / "state.txt").write_text("cleanup me", encoding="utf-8")
+
+    destroyer = SandboxService()
+
+    assert destroyer.destroy_session(session.id) is True
+    assert destroyer._orch.get_session(session.id) is None
+    assert destroyer._orch.get_session_workspace_path(session.id) is None
+    assert not session_root.exists()
+
+
 def test_destroy_session_cancels_and_drains_when_active_runs_exist(monkeypatch, tmp_path: Path) -> None:
     _configure_sqlite_store(monkeypatch, tmp_path)
 

--- a/tldw_Server_API/tests/sandbox/test_worktree_runner.py
+++ b/tldw_Server_API/tests/sandbox/test_worktree_runner.py
@@ -416,6 +416,7 @@ def test_start_run_timeout_cleans_worktree_run_dir_and_active_tracking(
         lambda pid, sig: killpg_calls.append((pid, sig)),
     )
 
+    result = None
     try:
         result = WorktreeRunner(allowed_repo_dirs=[str(tmp_path)]).start_run(
             run_id,
@@ -428,21 +429,22 @@ def test_start_run_timeout_cleans_worktree_run_dir_and_active_tracking(
             ),
             session_workspace=str(repo),
         )
+
+        assert result.phase == RunPhase.timed_out
+        assert result.message == "execution_timeout"
+        assert destroy_calls == [(str(created_worktree), str(repo))]
+        assert killpg_calls == [(9876, signal.SIGTERM)]
+        assert not created_worktree.exists()
+        assert not run_dir.exists()
+        with WorktreeRunner._active_lock:  # type: ignore[attr-defined]
+            assert run_id not in WorktreeRunner._active_proc  # type: ignore[attr-defined]
+            assert run_id not in WorktreeRunner._active_run_dir  # type: ignore[attr-defined]
+            assert run_id not in WorktreeRunner._cancelled_runs  # type: ignore[attr-defined]
     finally:
         with WorktreeRunner._active_lock:  # type: ignore[attr-defined]
             WorktreeRunner._active_proc.pop(run_id, None)  # type: ignore[attr-defined]
             WorktreeRunner._active_run_dir.pop(run_id, None)  # type: ignore[attr-defined]
             WorktreeRunner._cancelled_runs.discard(run_id)  # type: ignore[attr-defined]
-
-    assert result.phase == RunPhase.timed_out
-    assert result.message == "execution_timeout"
-    assert destroy_calls == [(str(created_worktree), str(repo))]
-    assert killpg_calls == [(9876, signal.SIGTERM)]
-    assert not created_worktree.exists()
-    assert not run_dir.exists()
-    with WorktreeRunner._active_lock:  # type: ignore[attr-defined]
-        assert run_id not in WorktreeRunner._active_proc  # type: ignore[attr-defined]
-        assert run_id not in WorktreeRunner._active_run_dir  # type: ignore[attr-defined]
 
 
 # ---------------------------------------------------------------------------

--- a/tldw_Server_API/tests/sandbox/test_worktree_runner.py
+++ b/tldw_Server_API/tests/sandbox/test_worktree_runner.py
@@ -11,6 +11,7 @@ from unittest import mock
 
 import pytest
 
+import tldw_Server_API.app.core.Sandbox.runners.worktree_runner as worktree_module
 from tldw_Server_API.app.core.Sandbox.models import RunPhase, RunSpec, RuntimeType
 from tldw_Server_API.app.core.Sandbox.runners.worktree_runner import (
     WorktreeRunner,
@@ -335,6 +336,113 @@ def test_start_run_failure_after_worktree_create_destroys_worktree(
         pytest.fail(f"unexpected destroy calls: {destroy_calls}")
     if created_worktree.exists():
         pytest.fail("created worktree should have been removed")
+
+
+def test_start_run_timeout_cleans_worktree_run_dir_and_active_tracking(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Timeout cleanup must remove runtime state before returning."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    run_dir = tmp_path / "run-dir"
+    created_worktree = tmp_path / "created-worktree"
+    run_id = "run-worktree-timeout-cleanup"
+    destroy_calls: list[tuple[str, str]] = []
+    killpg_calls: list[tuple[int, int]] = []
+
+    def _mkdtemp(prefix: str) -> str:
+        if prefix != "tldw_wt_run_":
+            pytest.fail(f"unexpected temp prefix: {prefix}")
+        run_dir.mkdir()
+        return str(run_dir)
+
+    def _create_worktree(repo_path: str, branch: str = "HEAD") -> str:
+        if repo_path != str(repo):
+            pytest.fail(f"unexpected repo path: {repo_path}")
+        if branch != "HEAD":
+            pytest.fail(f"unexpected branch: {branch}")
+        created_worktree.mkdir()
+        return str(created_worktree)
+
+    def _destroy_worktree(worktree_path: str, repo_path: str) -> None:
+        destroy_calls.append((worktree_path, repo_path))
+        shutil.rmtree(worktree_path)
+
+    class _TimeoutProc:
+        pid = 9876
+        returncode = None
+
+        def __init__(self) -> None:
+            self.wait_calls = 0
+
+        def wait(self, timeout: int | None = None) -> int:
+            self.wait_calls += 1
+            if self.wait_calls == 1:
+                raise subprocess.TimeoutExpired(cmd=["sleep"], timeout=timeout)
+            self.returncode = -signal.SIGTERM
+            return self.returncode
+
+    monkeypatch.setattr(worktree_module.tempfile, "mkdtemp", _mkdtemp)
+    monkeypatch.setattr(worktree_module.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        WorktreeRunner,
+        "_is_git_repo",
+        staticmethod(lambda path: path == str(repo)),
+    )
+    monkeypatch.setattr(
+        WorktreeRunner,
+        "create_worktree",
+        staticmethod(_create_worktree),
+    )
+    monkeypatch.setattr(
+        WorktreeRunner,
+        "destroy_worktree",
+        staticmethod(_destroy_worktree),
+    )
+    monkeypatch.setattr(
+        WorktreeRunner,
+        "_cancel_grace_seconds",
+        classmethod(lambda cls: 0),
+    )
+    monkeypatch.setattr(
+        worktree_module.subprocess,
+        "Popen",
+        lambda *args, **kwargs: _TimeoutProc(),
+    )
+    monkeypatch.setattr(
+        worktree_module.os,
+        "killpg",
+        lambda pid, sig: killpg_calls.append((pid, sig)),
+    )
+
+    try:
+        result = WorktreeRunner(allowed_repo_dirs=[str(tmp_path)]).start_run(
+            run_id,
+            RunSpec(
+                session_id=None,
+                runtime=RuntimeType.worktree,
+                base_image=None,
+                command=["/bin/sleep", "60"],
+                timeout_sec=1,
+            ),
+            session_workspace=str(repo),
+        )
+    finally:
+        with WorktreeRunner._active_lock:  # type: ignore[attr-defined]
+            WorktreeRunner._active_proc.pop(run_id, None)  # type: ignore[attr-defined]
+            WorktreeRunner._active_run_dir.pop(run_id, None)  # type: ignore[attr-defined]
+            WorktreeRunner._cancelled_runs.discard(run_id)  # type: ignore[attr-defined]
+
+    assert result.phase == RunPhase.timed_out
+    assert result.message == "execution_timeout"
+    assert destroy_calls == [(str(created_worktree), str(repo))]
+    assert killpg_calls == [(9876, signal.SIGTERM)]
+    assert not created_worktree.exists()
+    assert not run_dir.exists()
+    with WorktreeRunner._active_lock:  # type: ignore[attr-defined]
+        assert run_id not in WorktreeRunner._active_proc  # type: ignore[attr-defined]
+        assert run_id not in WorktreeRunner._active_run_dir  # type: ignore[attr-defined]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds the local-first sandbox cleanup/recovery contract-test design and implementation plan for TASK-62.
- Adds portable regression coverage for worktree timeout cleanup, including worktree removal, run-dir cleanup, SIGTERM, and active tracking cleanup.
- Adds cross-service durable session destroy cleanup coverage and an explicit host-local session contract assertion that `seatbelt`/`worktree` do not claim warm reuse, repair, or recovery.

## Test Plan
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_worktree_runner.py tldw_Server_API/tests/sandbox/test_session_store_durability.py tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py -q`
- `git diff --check`

## Change summary
Human-written change summary pending before merge.
