### PR TITLE
Guard CodeGraph optional parser tests

### DIFF
--- a/backlog/tasks/task-65 - Harden-CodeGraph-optional-parser-tests.md
+++ b/backlog/tasks/task-65 - Harden-CodeGraph-optional-parser-tests.md
@@ -1,0 +1,52 @@
+---
+id: TASK-65
+title: Harden CodeGraph optional parser tests
+status: Done
+assignee:
+  - '@Codex'
+created_date: '2026-05-05 05:18'
+updated_date: '2026-05-05 05:20'
+labels:
+  - codegraph
+  - mcp
+  - test-hardening
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Make CodeGraph parser-dependent positive tests skip gracefully when optional tree-sitter language packages are unavailable, matching the optional .[codegraph] dependency contract.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Java and Kotlin extractor/indexer/MCP tests skip gracefully when their optional parsers cannot be loaded.
+- [x] #2 Tree-sitter loader parser smoke tests skip gracefully per optional parser instead of hard-failing on missing packages.
+- [x] #3 Focused CodeGraph tests, Ruff, Bandit on touched test scope, and git diff --check pass before PR.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Started after PR #1293 merged. This applies the same parser-availability guard pattern to remaining optional-parser positive tests.
+
+Implemented load_parser-based skip guards for Java/Kotlin extractor modules, Java/Kotlin indexer/MCP positive-path tests, and all Tree-sitter loader parser smoke tests. Added a regression check that the loader smoke helper raises pytest skip when an optional parser dependency is missing. Verification: focused parser tests passed with 21 passed and 5 warnings; Ruff passed on touched files; Bandit on touched test scope with B101 skipped reported errors 0 and results 0 at /tmp/bandit_codegraph_parser_test_guards.json; git diff --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Hardened CodeGraph optional parser tests after the C/C++ slice merged. Parser-dependent Java/Kotlin extractor, indexer, and MCP tests now skip when optional parser packages cannot be loaded, and loader parser smoke tests use a shared per-language skip helper. Verification passed: focused pytest 21 passed and 5 warnings; Ruff clean; Bandit errors 0/results 0 with B101 skipped for test asserts; git diff --check clean.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
@@ -77,6 +77,11 @@ def _require_c_family_parsers() -> None:
         pytest.skip("tree-sitter-c/cpp parsers are not available")
 
 
+def _require_jvm_parsers() -> None:
+    if not (load_parser("java").available and load_parser("kotlin").available):
+        pytest.skip("tree-sitter-java/kotlin parsers are not available")
+
+
 def _module(tmp_path: Path, workspace_root: Path) -> CodeGraphModule:
     """Create a CodeGraph module with default test settings."""
     return _module_with_settings(tmp_path, workspace_root, {})
@@ -276,6 +281,7 @@ async def test_codegraph_search_finds_typescript_component_after_index(tmp_path:
 
 @pytest.mark.asyncio
 async def test_codegraph_search_finds_java_kotlin_symbols_after_index(tmp_path: Path) -> None:
+    _require_jvm_parsers()
     workspace_root = tmp_path / "workspace"
     workspace_root.mkdir()
     (workspace_root / "Service.java").write_text(

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py
@@ -21,6 +21,11 @@ def _require_c_family_parsers() -> None:
         pytest.skip("tree-sitter-c/cpp parsers are not available")
 
 
+def _require_jvm_parsers() -> None:
+    if not (load_parser("java").available and load_parser("kotlin").available):
+        pytest.skip("tree-sitter-java/kotlin parsers are not available")
+
+
 def test_indexer_indexes_supported_file_inventory_and_skips_excluded_dirs(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
     workspace.mkdir()
@@ -120,6 +125,7 @@ def test_indexer_extracts_javascript_typescript_graph_rows_during_index(tmp_path
 
 
 def test_indexer_extracts_java_kotlin_graph_rows_during_index(tmp_path: Path) -> None:
+    _require_jvm_parsers()
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     (workspace / "Service.java").write_text(

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_java_extractor.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_java_extractor.py
@@ -1,7 +1,15 @@
 from __future__ import annotations
 
+import pytest
+
 from tldw_Server_API.app.core.CodeGraph.extractors.java_extractor import JavaTreeSitterExtractor
+from tldw_Server_API.app.core.CodeGraph.extractors.tree_sitter_loader import load_parser
 from tldw_Server_API.app.core.CodeGraph.models import ExtractionResult
+
+pytestmark = pytest.mark.skipif(
+    not load_parser("java").available,
+    reason="tree-sitter-java parser is not available",
+)
 
 JAVA_FIXTURE = b"""
 package com.example.app;

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_kotlin_extractor.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_kotlin_extractor.py
@@ -1,7 +1,15 @@
 from __future__ import annotations
 
+import pytest
+
 from tldw_Server_API.app.core.CodeGraph.extractors.kotlin_extractor import KotlinTreeSitterExtractor
+from tldw_Server_API.app.core.CodeGraph.extractors.tree_sitter_loader import load_parser
 from tldw_Server_API.app.core.CodeGraph.models import ExtractionResult
+
+pytestmark = pytest.mark.skipif(
+    not load_parser("kotlin").available,
+    reason="tree-sitter-kotlin parser is not available",
+)
 
 KOTLIN_FIXTURE = b"""
 package com.example.app

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_tree_sitter_loader.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_tree_sitter_loader.py
@@ -1,7 +1,32 @@
 from __future__ import annotations
 
 import importlib
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+
+def _require_parser(loader: Any, language_id: str) -> Any:
+    result = loader.load_parser(language_id)
+    if result.available:
+        return result
+    if result.missing:
+        pytest.skip(f"{language_id} parser dependencies are not available: {', '.join(result.missing)}")
+    pytest.skip(f"{language_id} parser is not available: {result.error or 'unknown error'}")
+
+
+def test_require_parser_skips_when_optional_dependency_is_missing() -> None:
+    loader = SimpleNamespace(
+        load_parser=lambda language_id: SimpleNamespace(
+            available=False,
+            missing=(f"tree_sitter_{language_id}",),
+            error=None,
+        )
+    )
+
+    with pytest.raises(pytest.skip.Exception):
+        _require_parser(loader, "java")
 
 
 def test_loader_module_imports_without_eager_parser_imports() -> None:
@@ -57,7 +82,7 @@ def test_javascript_parser_can_parse_exported_function() -> None:
         "tldw_Server_API.app.core.CodeGraph.extractors.tree_sitter_loader"
     )
 
-    result = loader.load_parser("javascript")
+    result = _require_parser(loader, "javascript")
     tree = result.parser.parse(b"export function helper() { return 1; }")
 
     assert result.missing == ()
@@ -71,7 +96,7 @@ def test_typescript_parser_can_parse_interface() -> None:
         "tldw_Server_API.app.core.CodeGraph.extractors.tree_sitter_loader"
     )
 
-    result = loader.load_parser("typescript")
+    result = _require_parser(loader, "typescript")
     tree = result.parser.parse(b"interface User { id: string }")
 
     assert result.missing == ()
@@ -85,7 +110,7 @@ def test_tsx_parser_can_parse_component() -> None:
         "tldw_Server_API.app.core.CodeGraph.extractors.tree_sitter_loader"
     )
 
-    result = loader.load_parser("tsx")
+    result = _require_parser(loader, "tsx")
     tree = result.parser.parse(b"export function Card() { return <div />; }")
 
     assert result.missing == ()
@@ -100,7 +125,7 @@ def test_java_parser_can_parse_class() -> None:
         "tldw_Server_API.app.core.CodeGraph.extractors.tree_sitter_loader"
     )
 
-    result = loader.load_parser("java")
+    result = _require_parser(loader, "java")
     tree = result.parser.parse(b"class Greeter { String greet() { return helper(); } }")
 
     assert result.missing == ()
@@ -115,7 +140,7 @@ def test_kotlin_parser_can_parse_class() -> None:
         "tldw_Server_API.app.core.CodeGraph.extractors.tree_sitter_loader"
     )
 
-    result = loader.load_parser("kotlin")
+    result = _require_parser(loader, "kotlin")
     tree = result.parser.parse(b"class Greeter {\n fun greet(): String { return helper() }\n}")
 
     assert result.missing == ()
@@ -130,7 +155,7 @@ def test_csharp_parser_can_parse_class() -> None:
         "tldw_Server_API.app.core.CodeGraph.extractors.tree_sitter_loader"
     )
 
-    result = loader.load_parser("csharp")
+    result = _require_parser(loader, "csharp")
     tree = result.parser.parse(b"class Greeter { string Greet() { return Helper(); } }")
 
     assert result.missing == ()
@@ -145,7 +170,7 @@ def test_c_parser_can_parse_function() -> None:
         "tldw_Server_API.app.core.CodeGraph.extractors.tree_sitter_loader"
     )
 
-    result = loader.load_parser("c")
+    result = _require_parser(loader, "c")
     tree = result.parser.parse(b"int helper(int value) { return value + 1; }")
 
     assert result.missing == ()
@@ -160,7 +185,7 @@ def test_cpp_parser_can_parse_class() -> None:
         "tldw_Server_API.app.core.CodeGraph.extractors.tree_sitter_loader"
     )
 
-    result = loader.load_parser("cpp")
+    result = _require_parser(loader, "cpp")
     tree = result.parser.parse(b"class Greeter { int helper() { return 1; } };")
 
     assert result.missing == ()


### PR DESCRIPTION
## Change summary

Hardens CodeGraph parser-dependent tests so optional Tree-sitter language packages remain optional in test environments. The change applies the same `load_parser()` availability guard pattern used for the C/C++ review fix to Java/Kotlin extractor tests, Java/Kotlin indexer/MCP positive-path tests, and the Tree-sitter loader parser smoke tests.

This keeps positive parser coverage when packages are installed while turning missing optional parser packages into explicit pytest skips instead of import/parser failures.

## Verification

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_java_extractor.py tldw_Server_API/tests/CodeGraph/test_codegraph_kotlin_extractor.py tldw_Server_API/tests/CodeGraph/test_codegraph_tree_sitter_loader.py tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py::test_indexer_extracts_java_kotlin_graph_rows_during_index tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py::test_codegraph_search_finds_java_kotlin_symbols_after_index -q`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check tldw_Server_API/tests/CodeGraph/test_codegraph_java_extractor.py tldw_Server_API/tests/CodeGraph/test_codegraph_kotlin_extractor.py tldw_Server_API/tests/CodeGraph/test_codegraph_tree_sitter_loader.py tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/tests/CodeGraph/test_codegraph_java_extractor.py tldw_Server_API/tests/CodeGraph/test_codegraph_kotlin_extractor.py tldw_Server_API/tests/CodeGraph/test_codegraph_tree_sitter_loader.py tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py -s B101 -f json -o /tmp/bandit_codegraph_parser_test_guards.json`
- `git diff --check HEAD~1..HEAD`
