### PR TITLE
Phase 2.2: defer minimal embedding router imports

### DIFF
--- a/backlog/tasks/task-65 - Phase-2.2-minimal-embedding-router-conditional-cleanup-AB.md
+++ b/backlog/tasks/task-65 - Phase-2.2-minimal-embedding-router-conditional-cleanup-AB.md
@@ -1,0 +1,53 @@
+---
+id: TASK-65
+title: Phase 2.2 minimal embedding router conditional cleanup AB
+status: Done
+assignee: []
+created_date: '2026-05-05 05:14'
+updated_date: '2026-05-05 05:20'
+labels:
+  - phase2.2
+  - router-cleanup
+  - issue-1116
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+  - 'https://github.com/rmusser01/tldw_server/pull/1292'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue issue #1116 Phase 2.2 by converting the minimal-test app optional vector and embedding router registrations for vector_stores_openai, embeddings_v5_production_enhanced, and media_embeddings from eager try/import RouterSpec blocks to ImportedRouterSpec-backed lazy router specs. Keep the tranche narrow and preserve existing prefixes, tags, route keys, and skip behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 minimal vector and embedding optional router specs defer module import and router attribute lookup until registration
+- [x] #2 existing route metadata for vector-stores, embeddings, and media-embeddings is preserved
+- [x] #3 focused router-group tests cover the lazy behavior with red/green verification
+- [x] #4 router-group, main-router, and OpenAPI contract tests pass for the touched scope
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented a narrow lazy-router tranche for minimal vector/embedding routers. Added red/green router-group coverage that proves vector_stores_openai, embeddings_v5_production_enhanced, and media_embeddings defer module import and router attribute access until ImportedRouterSpec resolution. Updated an adjacent older test expectation so those modules are no longer treated as unrelated eager imports.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Converted minimal-test optional vector/embedding router registration to ImportedRouterSpec while preserving existing prefixes, tags, route keys, and skip behavior. Verification: focused red/green test, targeted regression pair, full router_groups contract suite, main router contract suite, OpenAPI contracts, Bandit on minimal.py, git diff --check.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -126,38 +126,30 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
     ):
         append_imported_router_spec(specs, llm_spec)
 
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.vector_stores_openai import router as vector_stores_router
-
-        specs.append(RouterSpec(
-            router=vector_stores_router,
+    for embedding_spec in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.vector_stores_openai",
+            log_name="vector-stores",
             prefix=f"{API_V1_PREFIX}",
             tags=("vector-stores",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping vector-stores router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.embeddings_v5_production_enhanced import router as embeddings_router
-
-        specs.append(RouterSpec(
-            router=embeddings_router,
+            skip_context="in minimal test app",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.embeddings_v5_production_enhanced",
+            log_name="embeddings",
             prefix=f"{API_V1_PREFIX}",
             tags=("embeddings",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping embeddings router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.media_embeddings import router as media_embeddings_router
-
-        specs.append(RouterSpec(
-            router=media_embeddings_router,
+            skip_context="in minimal test app",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.media_embeddings",
+            log_name="media_embeddings",
             prefix=f"{API_V1_PREFIX}",
             tags=("media-embeddings",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping media_embeddings router in minimal test app: {e}")
+            skip_context="in minimal test app",
+        ),
+    ):
+        append_imported_router_spec(specs, embedding_spec)
 
     if audio_imports_enabled_for_runtime():
         def _audio_router_factory():

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -3688,7 +3688,7 @@ def test_iter_minimal_optional_router_specs_defers_llamacpp_messages_attr_lookup
         "tldw_Server_API.app.api.v1.endpoints.vector_stores_openai",
         "tldw_Server_API.app.api.v1.endpoints.embeddings_v5_production_enhanced",
         "tldw_Server_API.app.api.v1.endpoints.media_embeddings",
-    }.issubset(set(fake_unrelated_eager_imports))
+    }.isdisjoint(fake_unrelated_eager_imports)
 
     selected_specs = {
         spec.name: spec
@@ -3814,6 +3814,157 @@ def test_iter_minimal_optional_router_specs_defers_rag_attr_lookup(
 
     def _import_module(module_name: str, package: str | None = None) -> ModuleType:
         """Track lazy module imports for selected minimal RAG routers."""
+        if module_name in definitions_by_module:
+            import_calls.append(module_name)
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+    fake_main = ModuleType("tldw_Server_API.app.main")
+    fake_main.app = FastAPI()  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "tldw_Server_API.app.main", fake_main)
+
+    specs = list(iter_minimal_optional_router_specs())
+    assert access_count == {
+        f"{definition['module_name']}.router": 0
+        for definition in router_definitions
+    }
+    assert import_calls == []
+
+    selected_specs = {
+        spec.name: spec
+        for spec in specs
+        if spec.name in {
+            str(definition["expected_name"])
+            for definition in router_definitions
+        }
+    }
+    assert set(selected_specs) == {
+        str(definition["expected_name"])
+        for definition in router_definitions
+    }
+
+    for definition in router_definitions:
+        spec = selected_specs[str(definition["expected_name"])]
+        assert spec.prefix == definition["prefix"]
+        assert spec.tags == definition["tags"]
+        assert spec.route_key == ""
+        assert spec.skip_context == "in minimal test app"
+        assert _first_router_path(spec.router) == definition["path"]
+
+    assert import_calls == [
+        str(definition["module_name"])
+        for definition in router_definitions
+    ]
+    assert access_count == {
+        f"{definition['module_name']}.router": 1
+        for definition in router_definitions
+    }
+
+
+def test_iter_minimal_optional_router_specs_defers_embedding_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal vector and embedding specs keep router attr lookup lazy."""
+    import builtins
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    router_definitions = (
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.vector_stores_openai",
+            "expected_name": "vector-stores",
+            "path": "/vector_stores",
+            "prefix": "/api/v1",
+            "tags": ("vector-stores",),
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.embeddings_v5_production_enhanced",
+            "expected_name": "embeddings",
+            "path": "/embeddings",
+            "prefix": "/api/v1",
+            "tags": ("embeddings",),
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.media_embeddings",
+            "expected_name": "media_embeddings",
+            "path": "/media_embeddings",
+            "prefix": "/api/v1",
+            "tags": ("media-embeddings",),
+        },
+    )
+    definitions_by_module = {
+        str(definition["module_name"]): definition
+        for definition in router_definitions
+    }
+    access_count = {
+        f"{definition['module_name']}.router": 0
+        for definition in router_definitions
+    }
+    import_calls: list[str] = []
+
+    for module_name, definition in definitions_by_module.items():
+        fake_module = ModuleType(module_name)
+        router = APIRouter()
+
+        @router.get(str(definition["path"]))
+        def _endpoint() -> dict[str, str]:
+            """Return a deterministic response for the fake minimal embedding router."""
+            return {"status": "ok"}
+
+        def _module_getattr(
+            name: str,
+            *,
+            module_name: str = module_name,
+            router: APIRouter = router,
+        ) -> APIRouter:
+            """Track lazy router attribute resolution for the fake module."""
+            if name != "router":
+                raise AttributeError(name)
+            access_count[f"{module_name}.router"] += 1
+            return router
+
+        fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    endpoints_package = "tldw_Server_API.app.api.v1.endpoints."
+    real_import = builtins.__import__
+
+    def _fake_endpoint_import(
+        name: str,
+        globals: dict[str, object] | None = None,
+        locals: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> ModuleType:
+        """Return fake routers for unrelated eager minimal optional imports."""
+        if (
+            level == 0
+            and name.startswith(endpoints_package)
+            and name not in definitions_by_module
+        ):
+            attrs = tuple(attr for attr in fromlist if attr != "*") or ("router",)
+            for attr_name in attrs:
+                _install_fake_router_module(
+                    monkeypatch,
+                    name,
+                    path="/minimal-unrelated-embedding-fake",
+                    attr_name=attr_name,
+                )
+            return sys.modules[name]
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_endpoint_import)
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Track lazy module imports for selected minimal embedding routers."""
         if module_name in definitions_by_module:
             import_calls.append(module_name)
         return real_import_module(module_name, package)


### PR DESCRIPTION
## Summary
- Convert minimal-test optional vector/embedding router registrations to ImportedRouterSpec.
- Cover vector_stores_openai, embeddings_v5_production_enhanced, and media_embeddings lazy import behavior with router-group contract tests.
- Preserve existing prefixes, tags, route keys, and skip behavior.

## Verification
- python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "minimal_optional_router_specs_defers_embedding_attr_lookup" -q (red before implementation, green after)
- python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "minimal_optional_router_specs_defers_llamacpp_messages_attr_lookup or minimal_optional_router_specs_defers_embedding_attr_lookup" -q
- python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q
- python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q
- python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q
- python -m bandit -r tldw_Server_API/app/api/v1/router_groups/minimal.py -f json -o /tmp/bandit_phase2_2_minimal_embedding_post_rebase.json (0 results, 0 errors)
- git diff --check

## Merge Gate
- Human owner still needs to provide the required AI-generated PR Change summary before merge.