### PR TITLE
Guard remaining CodeGraph optional parser tests

### DIFF
--- a/backlog/tasks/task-66 - Guard-remaining-CodeGraph-optional-parser-tests.md
+++ b/backlog/tasks/task-66 - Guard-remaining-CodeGraph-optional-parser-tests.md
@@ -1,0 +1,53 @@
+---
+id: TASK-66
+title: Guard remaining CodeGraph optional parser tests
+status: Done
+assignee:
+  - '@Codex'
+created_date: '2026-05-05 05:25'
+updated_date: '2026-05-05 05:27'
+labels:
+  - codegraph
+  - mcp
+  - test-hardening
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Finish optional parser test hardening by adding load_parser-based skip guards for remaining parser-dependent CodeGraph positive tests covering JavaScript, TypeScript/TSX, and C# extraction, indexing, and MCP search paths.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 JavaScript extractor/indexer/MCP positive tests skip gracefully when tree-sitter-javascript cannot be loaded.
+- [x] #2 TypeScript/TSX extractor/indexer/MCP positive tests skip gracefully when tree-sitter-typescript cannot be loaded.
+- [x] #3 C# extractor/indexer/MCP positive tests skip gracefully when tree-sitter-c-sharp cannot be loaded.
+- [x] #4 Focused CodeGraph tests, Ruff, Bandit on touched test scope, and git diff --check pass before PR.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Started after PR #1295 merged. This completes the optional parser guard pattern for the remaining JS/TS and C# parser-dependent positive tests.
+
+Added load_parser-based skip guards for JavaScript, TypeScript/TSX, and C# extractor modules plus indexer and MCP positive-path tests. Verification: focused parser-dependent tests passed with 15 passed and 5 warnings; Ruff passed on touched test files; Bandit on touched test scope with B101 skipped reported errors 0 and results 0 at /tmp/bandit_codegraph_remaining_parser_guards.json; git diff --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Completed remaining optional parser guard hardening for CodeGraph tests. JavaScript, TypeScript/TSX, and C# parser-dependent extractor, indexer, and MCP positive tests now skip when their optional parser package cannot be loaded. Verification passed: focused pytest 15 passed and 5 warnings; Ruff clean; Bandit errors 0/results 0 with B101 skipped for test asserts; git diff --check clean.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-66 - Guard-remaining-CodeGraph-optional-parser-tests.md
+++ b/backlog/tasks/task-66 - Guard-remaining-CodeGraph-optional-parser-tests.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@Codex'
 created_date: '2026-05-05 05:25'
-updated_date: '2026-05-05 05:27'
+updated_date: '2026-05-05 14:07'
 labels:
   - codegraph
   - mcp
@@ -34,12 +34,18 @@ Finish optional parser test hardening by adding load_parser-based skip guards fo
 Started after PR #1295 merged. This completes the optional parser guard pattern for the remaining JS/TS and C# parser-dependent positive tests.
 
 Added load_parser-based skip guards for JavaScript, TypeScript/TSX, and C# extractor modules plus indexer and MCP positive-path tests. Verification: focused parser-dependent tests passed with 15 passed and 5 warnings; Ruff passed on touched test files; Bandit on touched test scope with B101 skipped reported errors 0 and results 0 at /tmp/bandit_codegraph_remaining_parser_guards.json; git diff --check passed.
+
+PR #1297 review-fix pass started: add guard helper docstrings, split TypeScript vs TSX extractor skips, and narrow the indexer TypeScript guard so it does not require the JavaScript parser.
+
+PR #1297 review fix completed: narrowed the indexer TypeScript guard to TS/TSX only, split TypeScript extractor module and TSX test skips, and added docstrings to parser guard helpers in indexer and MCP tests. Verification: focused pytest passed with 7 passed and 5 warnings; Ruff passed on touched test files; Bandit on touched test scope with B101 skipped reported errors 0 and results 0 at /tmp/bandit_codegraph_remaining_parser_guards_review.json; git diff --check passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Completed remaining optional parser guard hardening for CodeGraph tests. JavaScript, TypeScript/TSX, and C# parser-dependent extractor, indexer, and MCP positive tests now skip when their optional parser package cannot be loaded. Verification passed: focused pytest 15 passed and 5 warnings; Ruff clean; Bandit errors 0/results 0 with B101 skipped for test asserts; git diff --check clean.
+
+PR #1297 review follow-up addressed Qodo and CodeRabbit comments by documenting parser guard helpers, avoiding unnecessary JavaScript parser requirements for TypeScript/TSX indexer coverage, and keeping .ts tests runnable when only the TSX parser is missing.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
@@ -82,6 +82,16 @@ def _require_jvm_parsers() -> None:
         pytest.skip("tree-sitter-java/kotlin parsers are not available")
 
 
+def _require_typescript_parsers() -> None:
+    if not (load_parser("typescript").available and load_parser("tsx").available):
+        pytest.skip("tree-sitter-typescript parser is not available")
+
+
+def _require_csharp_parser() -> None:
+    if not load_parser("csharp").available:
+        pytest.skip("tree-sitter-c-sharp parser is not available")
+
+
 def _module(tmp_path: Path, workspace_root: Path) -> CodeGraphModule:
     """Create a CodeGraph module with default test settings."""
     return _module_with_settings(tmp_path, workspace_root, {})
@@ -255,6 +265,7 @@ def helper(value):
 
 @pytest.mark.asyncio
 async def test_codegraph_search_finds_typescript_component_after_index(tmp_path: Path) -> None:
+    _require_typescript_parsers()
     workspace_root = tmp_path / "workspace"
     workspace_root.mkdir()
     (workspace_root / "Card.tsx").write_text(
@@ -346,6 +357,7 @@ class Greeter {
 
 @pytest.mark.asyncio
 async def test_codegraph_search_finds_csharp_symbols_after_index(tmp_path: Path) -> None:
+    _require_csharp_parser()
     workspace_root = tmp_path / "workspace"
     workspace_root.mkdir()
     (workspace_root / "Greeter.cs").write_text(

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
@@ -73,21 +73,25 @@ def _context() -> RequestContext:
 
 
 def _require_c_family_parsers() -> None:
+    """Skip C/C++ MCP coverage unless both C-family parsers load."""
     if not (load_parser("c").available and load_parser("cpp").available):
         pytest.skip("tree-sitter-c/cpp parsers are not available")
 
 
 def _require_jvm_parsers() -> None:
+    """Skip JVM MCP coverage unless both Java and Kotlin parsers load."""
     if not (load_parser("java").available and load_parser("kotlin").available):
         pytest.skip("tree-sitter-java/kotlin parsers are not available")
 
 
 def _require_typescript_parsers() -> None:
+    """Skip TypeScript MCP coverage unless TS and TSX parsers load."""
     if not (load_parser("typescript").available and load_parser("tsx").available):
         pytest.skip("tree-sitter-typescript parser is not available")
 
 
 def _require_csharp_parser() -> None:
+    """Skip C# MCP coverage unless the C# parser loads."""
     if not load_parser("csharp").available:
         pytest.skip("tree-sitter-c-sharp parser is not available")
 

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_csharp_extractor.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_csharp_extractor.py
@@ -1,7 +1,15 @@
 from __future__ import annotations
 
+import pytest
+
 from tldw_Server_API.app.core.CodeGraph.extractors.csharp_extractor import CSharpTreeSitterExtractor
+from tldw_Server_API.app.core.CodeGraph.extractors.tree_sitter_loader import load_parser
 from tldw_Server_API.app.core.CodeGraph.models import ExtractionResult
+
+pytestmark = pytest.mark.skipif(
+    not load_parser("csharp").available,
+    reason="tree-sitter-c-sharp parser is not available",
+)
 
 CSHARP_FIXTURE = b"""
 using System;

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py
@@ -26,6 +26,20 @@ def _require_jvm_parsers() -> None:
         pytest.skip("tree-sitter-java/kotlin parsers are not available")
 
 
+def _require_js_ts_parsers() -> None:
+    if not (
+        load_parser("javascript").available
+        and load_parser("typescript").available
+        and load_parser("tsx").available
+    ):
+        pytest.skip("tree-sitter-javascript/typescript parsers are not available")
+
+
+def _require_csharp_parser() -> None:
+    if not load_parser("csharp").available:
+        pytest.skip("tree-sitter-c-sharp parser is not available")
+
+
 def test_indexer_indexes_supported_file_inventory_and_skips_excluded_dirs(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
     workspace.mkdir()
@@ -94,6 +108,7 @@ def helper(value):
 
 
 def test_indexer_extracts_javascript_typescript_graph_rows_during_index(tmp_path: Path) -> None:
+    _require_js_ts_parsers()
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     (workspace / "app.py").write_text("def helper():\n    return 1\n", encoding="utf-8")
@@ -182,6 +197,7 @@ class Greeter {
 
 
 def test_indexer_extracts_csharp_graph_rows_during_index(tmp_path: Path) -> None:
+    _require_csharp_parser()
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     (workspace / "Greeter.cs").write_text(

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py
@@ -17,25 +17,25 @@ from tldw_Server_API.app.core.DB_Management.codegraph.repository import CodeGrap
 
 
 def _require_c_family_parsers() -> None:
+    """Skip C/C++ indexer coverage unless both C-family parsers load."""
     if not (load_parser("c").available and load_parser("cpp").available):
         pytest.skip("tree-sitter-c/cpp parsers are not available")
 
 
 def _require_jvm_parsers() -> None:
+    """Skip JVM indexer coverage unless both Java and Kotlin parsers load."""
     if not (load_parser("java").available and load_parser("kotlin").available):
         pytest.skip("tree-sitter-java/kotlin parsers are not available")
 
 
-def _require_js_ts_parsers() -> None:
-    if not (
-        load_parser("javascript").available
-        and load_parser("typescript").available
-        and load_parser("tsx").available
-    ):
-        pytest.skip("tree-sitter-javascript/typescript parsers are not available")
+def _require_typescript_parsers() -> None:
+    """Skip TypeScript indexer coverage unless TS and TSX parsers load."""
+    if not (load_parser("typescript").available and load_parser("tsx").available):
+        pytest.skip("tree-sitter-typescript parser is not available")
 
 
 def _require_csharp_parser() -> None:
+    """Skip C# indexer coverage unless the C# parser loads."""
     if not load_parser("csharp").available:
         pytest.skip("tree-sitter-c-sharp parser is not available")
 
@@ -108,7 +108,7 @@ def helper(value):
 
 
 def test_indexer_extracts_javascript_typescript_graph_rows_during_index(tmp_path: Path) -> None:
-    _require_js_ts_parsers()
+    _require_typescript_parsers()
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     (workspace / "app.py").write_text("def helper():\n    return 1\n", encoding="utf-8")

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_javascript_extractor.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_javascript_extractor.py
@@ -2,11 +2,19 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from tldw_Server_API.app.core.CodeGraph.extractors import js_ts_imports
 from tldw_Server_API.app.core.CodeGraph.extractors.javascript_extractor import (
     JavaScriptTreeSitterExtractor,
 )
+from tldw_Server_API.app.core.CodeGraph.extractors.tree_sitter_loader import load_parser
 from tldw_Server_API.app.core.CodeGraph.models import ExtractionResult
+
+pytestmark = pytest.mark.skipif(
+    not load_parser("javascript").available,
+    reason="tree-sitter-javascript parser is not available",
+)
 
 
 def test_javascript_extractor_records_module_symbols_imports_and_calls(tmp_path: Path) -> None:

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_typescript_extractor.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_typescript_extractor.py
@@ -2,8 +2,16 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
+from tldw_Server_API.app.core.CodeGraph.extractors.tree_sitter_loader import load_parser
 from tldw_Server_API.app.core.CodeGraph.extractors.typescript_extractor import (
     TypeScriptTreeSitterExtractor,
+)
+
+pytestmark = pytest.mark.skipif(
+    not (load_parser("typescript").available and load_parser("tsx").available),
+    reason="tree-sitter-typescript parser is not available",
 )
 
 

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_typescript_extractor.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_typescript_extractor.py
@@ -10,7 +10,7 @@ from tldw_Server_API.app.core.CodeGraph.extractors.typescript_extractor import (
 )
 
 pytestmark = pytest.mark.skipif(
-    not (load_parser("typescript").available and load_parser("tsx").available),
+    not load_parser("typescript").available,
     reason="tree-sitter-typescript parser is not available",
 )
 
@@ -71,6 +71,10 @@ class Service {
     assert result.errors == ()
 
 
+@pytest.mark.skipif(
+    not load_parser("tsx").available,
+    reason="tree-sitter-typescript TSX parser is not available",
+)
 def test_tsx_extractor_records_component_function() -> None:
     result = TypeScriptTreeSitterExtractor().extract(
         workspace_key="ws",


### PR DESCRIPTION
## Change summary

Completes CodeGraph optional parser test hardening for the remaining parser-dependent positive tests. JavaScript, TypeScript/TSX, and C# extractor, indexer, and MCP search tests now check parser availability through the project `load_parser()` helper and skip when the corresponding optional Tree-sitter parser cannot be loaded.

This follows the same approach used in the recently merged Java/Kotlin and C/C++ guard slices: keep useful positive coverage when parser extras are installed, but preserve the optional `.[codegraph]` dependency contract for environments without every parser package.

## Verification

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_javascript_extractor.py tldw_Server_API/tests/CodeGraph/test_codegraph_typescript_extractor.py tldw_Server_API/tests/CodeGraph/test_codegraph_csharp_extractor.py tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py::test_indexer_extracts_javascript_typescript_graph_rows_during_index tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py::test_indexer_extracts_csharp_graph_rows_during_index tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py::test_codegraph_search_finds_typescript_component_after_index tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py::test_codegraph_search_finds_csharp_symbols_after_index -q`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check tldw_Server_API/tests/CodeGraph/test_codegraph_javascript_extractor.py tldw_Server_API/tests/CodeGraph/test_codegraph_typescript_extractor.py tldw_Server_API/tests/CodeGraph/test_codegraph_csharp_extractor.py tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/tests/CodeGraph/test_codegraph_javascript_extractor.py tldw_Server_API/tests/CodeGraph/test_codegraph_typescript_extractor.py tldw_Server_API/tests/CodeGraph/test_codegraph_csharp_extractor.py tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py -s B101 -f json -o /tmp/bandit_codegraph_remaining_parser_guards.json`
- `git diff --check`
