### PR TITLE
Phase 2.2: defer minimal auxiliary router imports

### DIFF
--- a/backlog/tasks/task-67 - Phase-2.2-minimal-auxiliary-router-conditional-cleanup-AC.md
+++ b/backlog/tasks/task-67 - Phase-2.2-minimal-auxiliary-router-conditional-cleanup-AC.md
@@ -1,0 +1,53 @@
+---
+id: TASK-67
+title: Phase 2.2 minimal auxiliary router conditional cleanup AC
+status: Done
+assignee: []
+created_date: '2026-05-05 05:33'
+updated_date: '2026-05-05 05:36'
+labels:
+  - phase2.2
+  - router-cleanup
+  - issue-1116
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+  - 'https://github.com/rmusser01/tldw_server/pull/1296'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue issue #1116 Phase 2.2 by converting the first remaining auxiliary minimal-test optional router registrations from eager try/import RouterSpec blocks to ImportedRouterSpec-backed lazy router specs. Scope is limited to chunking_templates, prompts, claims, text2sql, feedback, vlm, consent, outputs_templates, and outputs in tldw_Server_API/app/api/v1/router_groups/minimal.py. Preserve existing prefixes, tags, route keys, skip context, and current skip-on-import-failure behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Selected auxiliary minimal optional router specs defer module import and router attribute lookup until registration
+- [x] #2 Existing route metadata is preserved for chunking-templates prompts claims text2sql feedback vlm consent outputs-templates and outputs
+- [x] #3 Focused router-group test covers the lazy behavior with red/green verification
+- [x] #4 Router-group main-router and OpenAPI contract tests pass for the touched scope
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented a narrow minimal auxiliary router tranche. Added red/green router-group coverage that proves chunking_templates, prompts, claims, text2sql, feedback, vlm, consent, outputs_templates, and outputs defer module import and router attribute access until ImportedRouterSpec resolution. Replaced only those eager try/import RouterSpec blocks in minimal.py.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Converted the selected minimal auxiliary optional router registrations to ImportedRouterSpec while preserving prefixes and tags. Verification: focused red/green test, full router_groups contract suite, main router contract suite, OpenAPI contracts, Bandit on minimal.py, and git diff --check.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -206,38 +206,30 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
     else:
         logger.info("Skipping audio-jobs router in minimal test app (set MINIMAL_TEST_INCLUDE_AUDIO_JOBS=1 to enable)")
 
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.chunking_templates import router as chunking_templates_router
-
-        specs.append(RouterSpec(
-            router=chunking_templates_router,
+    for auxiliary_spec in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.chunking_templates",
+            log_name="chunking templates",
             prefix=f"{API_V1_PREFIX}",
             tags=("chunking-templates",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping chunking templates router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.prompts import router as prompt_router
-
-        specs.append(RouterSpec(
-            router=prompt_router,
+            skip_context="in minimal test app",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.prompts",
+            log_name="prompts",
             prefix=f"{API_V1_PREFIX}/prompts",
             tags=("prompts",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping prompts router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.claims import router as claims_router
-
-        specs.append(RouterSpec(
-            router=claims_router,
+            skip_context="in minimal test app",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.claims",
+            log_name="claims",
             prefix=f"{API_V1_PREFIX}",
             tags=("claims",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping claims router in minimal test app: {e}")
+            skip_context="in minimal test app",
+        ),
+    ):
+        append_imported_router_spec(specs, auxiliary_spec)
 
     append_imported_router_spec(
         specs,
@@ -249,38 +241,30 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
         ),
     )
 
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.text2sql import router as text2sql_router
-
-        specs.append(RouterSpec(
-            router=text2sql_router,
+    for auxiliary_spec in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.text2sql",
+            log_name="text2sql",
             prefix=f"{API_V1_PREFIX}",
             tags=("text2sql",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping text2sql router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.feedback import router as feedback_router
-
-        specs.append(RouterSpec(
-            router=feedback_router,
+            skip_context="in minimal test app",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.feedback",
+            log_name="feedback",
             prefix=f"{API_V1_PREFIX}/feedback",
             tags=("feedback",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping feedback router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.vlm import router as vlm_router
-
-        specs.append(RouterSpec(
-            router=vlm_router,
+            skip_context="in minimal test app",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.vlm",
+            log_name="vlm",
             prefix=f"{API_V1_PREFIX}",
             tags=("vlm",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping vlm router in minimal test app: {e}")
+            skip_context="in minimal test app",
+        ),
+    ):
+        append_imported_router_spec(specs, auxiliary_spec)
 
     append_imported_router_spec(
         specs,
@@ -292,38 +276,30 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
         ),
     )
 
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.consent import router as consent_router
-
-        specs.append(RouterSpec(
-            router=consent_router,
+    for auxiliary_spec in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.consent",
+            log_name="consent",
             prefix=f"{API_V1_PREFIX}",
             tags=("consent",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping consent router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.outputs_templates import router as outputs_templates_router
-
-        specs.append(RouterSpec(
-            router=outputs_templates_router,
+            skip_context="in minimal test app",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.outputs_templates",
+            log_name="outputs_templates",
             prefix=f"{API_V1_PREFIX}",
             tags=("outputs-templates",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping outputs_templates router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.outputs import router as outputs_router
-
-        specs.append(RouterSpec(
-            router=outputs_router,
+            skip_context="in minimal test app",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.outputs",
+            log_name="outputs",
             prefix=f"{API_V1_PREFIX}",
             tags=("outputs",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping outputs router in minimal test app: {e}")
+            skip_context="in minimal test app",
+        ),
+    ):
+        append_imported_router_spec(specs, auxiliary_spec)
 
     try:
         from tldw_Server_API.app.api.v1.endpoints.collections_feeds import router as collections_feeds_router

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -4015,6 +4015,199 @@ def test_iter_minimal_optional_router_specs_defers_embedding_attr_lookup(
     }
 
 
+def test_iter_minimal_optional_router_specs_defers_auxiliary_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal auxiliary specs keep router attr lookup lazy."""
+    import builtins
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    router_definitions = (
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.chunking_templates",
+            "expected_name": "chunking templates",
+            "path": "/chunking-templates",
+            "prefix": "/api/v1",
+            "tags": ("chunking-templates",),
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.prompts",
+            "expected_name": "prompts",
+            "path": "/prompts",
+            "prefix": "/api/v1/prompts",
+            "tags": ("prompts",),
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.claims",
+            "expected_name": "claims",
+            "path": "/claims",
+            "prefix": "/api/v1",
+            "tags": ("claims",),
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.text2sql",
+            "expected_name": "text2sql",
+            "path": "/text2sql",
+            "prefix": "/api/v1",
+            "tags": ("text2sql",),
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.feedback",
+            "expected_name": "feedback",
+            "path": "/feedback",
+            "prefix": "/api/v1/feedback",
+            "tags": ("feedback",),
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.vlm",
+            "expected_name": "vlm",
+            "path": "/vlm",
+            "prefix": "/api/v1",
+            "tags": ("vlm",),
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.consent",
+            "expected_name": "consent",
+            "path": "/consent",
+            "prefix": "/api/v1",
+            "tags": ("consent",),
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.outputs_templates",
+            "expected_name": "outputs_templates",
+            "path": "/outputs/templates",
+            "prefix": "/api/v1",
+            "tags": ("outputs-templates",),
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.outputs",
+            "expected_name": "outputs",
+            "path": "/outputs",
+            "prefix": "/api/v1",
+            "tags": ("outputs",),
+        },
+    )
+    definitions_by_module = {
+        str(definition["module_name"]): definition
+        for definition in router_definitions
+    }
+    access_count = {
+        f"{definition['module_name']}.router": 0
+        for definition in router_definitions
+    }
+    import_calls: list[str] = []
+
+    for module_name, definition in definitions_by_module.items():
+        fake_module = ModuleType(module_name)
+        router = APIRouter()
+
+        @router.get(str(definition["path"]))
+        def _endpoint() -> dict[str, str]:
+            """Return a deterministic response for the fake minimal auxiliary router."""
+            return {"status": "ok"}
+
+        def _module_getattr(
+            name: str,
+            *,
+            module_name: str = module_name,
+            router: APIRouter = router,
+        ) -> APIRouter:
+            """Track lazy router attribute resolution for the fake module."""
+            if name != "router":
+                raise AttributeError(name)
+            access_count[f"{module_name}.router"] += 1
+            return router
+
+        fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    endpoints_package = "tldw_Server_API.app.api.v1.endpoints."
+    real_import = builtins.__import__
+
+    def _fake_endpoint_import(
+        name: str,
+        globals: dict[str, object] | None = None,
+        locals: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> ModuleType:
+        """Return fake routers for unrelated eager minimal optional imports."""
+        if (
+            level == 0
+            and name.startswith(endpoints_package)
+            and name not in definitions_by_module
+        ):
+            attrs = tuple(attr for attr in fromlist if attr != "*") or ("router",)
+            for attr_name in attrs:
+                _install_fake_router_module(
+                    monkeypatch,
+                    name,
+                    path="/minimal-unrelated-auxiliary-fake",
+                    attr_name=attr_name,
+                )
+            return sys.modules[name]
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_endpoint_import)
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Track lazy module imports for selected minimal auxiliary routers."""
+        if module_name in definitions_by_module:
+            import_calls.append(module_name)
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+    fake_main = ModuleType("tldw_Server_API.app.main")
+    fake_main.app = FastAPI()  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "tldw_Server_API.app.main", fake_main)
+
+    specs = list(iter_minimal_optional_router_specs())
+    assert access_count == {
+        f"{definition['module_name']}.router": 0
+        for definition in router_definitions
+    }
+    assert import_calls == []
+
+    selected_specs = {
+        spec.name: spec
+        for spec in specs
+        if spec.name in {
+            str(definition["expected_name"])
+            for definition in router_definitions
+        }
+    }
+    assert set(selected_specs) == {
+        str(definition["expected_name"])
+        for definition in router_definitions
+    }
+
+    for definition in router_definitions:
+        spec = selected_specs[str(definition["expected_name"])]
+        assert spec.prefix == definition["prefix"]
+        assert spec.tags == definition["tags"]
+        assert spec.route_key == ""
+        assert spec.skip_context == "in minimal test app"
+        assert _first_router_path(spec.router) == definition["path"]
+
+    assert import_calls == [
+        str(definition["module_name"])
+        for definition in router_definitions
+    ]
+    assert access_count == {
+        f"{definition['module_name']}.router": 1
+        for definition in router_definitions
+    }
+
+
 def test_iter_minimal_optional_router_specs_populates_llm_specs(monkeypatch: pytest.MonkeyPatch) -> None:
     from tldw_Server_API.app.api.v1.router_groups.minimal import iter_minimal_optional_router_specs
 


### PR DESCRIPTION
## Summary
- Convert the first remaining auxiliary minimal-test optional routers to ImportedRouterSpec.
- Cover chunking_templates, prompts, claims, text2sql, feedback, vlm, consent, outputs_templates, and outputs lazy import behavior with router-group contract coverage.
- Preserve existing prefixes, tags, route keys, and skip behavior through registration-time resolution.

## Verification
- python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k minimal_optional_router_specs_defers_auxiliary_attr_lookup -q (red before implementation, green after)
- python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q
- python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q
- python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q
- python -m bandit -r tldw_Server_API/app/api/v1/router_groups/minimal.py -f json -o /tmp/bandit_phase2_2_minimal_aux.json (0 results, 0 errors)
- git diff --check

## Merge Gate
- Human owner still needs to provide the required AI-generated PR Change summary before merge.