### PR TITLE
Migrate Playground recovery banners to design-system Alert

### DIFF
--- a/apps/packages/ui/src/components/Common/Playground/DocumentGeneratorDrawer.tsx
+++ b/apps/packages/ui/src/components/Common/Playground/DocumentGeneratorDrawer.tsx
@@ -529,6 +529,8 @@ export const DocumentGeneratorDrawer: React.FC<DocumentGeneratorDrawerProps> = (
       {capabilities && !capabilities.hasChatDocuments && (
         <Alert
           variant="warning"
+          role="status"
+          aria-live="polite"
           data-testid="document-generator-capability-alert"
           className="mb-4"
         >
@@ -541,6 +543,8 @@ export const DocumentGeneratorDrawer: React.FC<DocumentGeneratorDrawerProps> = (
       {!conversationId && (
         <Alert
           variant="info"
+          role="status"
+          aria-live="polite"
           data-testid="document-generator-conversation-alert"
           className="mb-4"
         >

--- a/apps/packages/ui/src/components/Common/Playground/DocumentGeneratorDrawer.tsx
+++ b/apps/packages/ui/src/components/Common/Playground/DocumentGeneratorDrawer.tsx
@@ -1,6 +1,5 @@
 import React from "react"
 import {
-  Alert,
   Button,
   Drawer,
   Form,
@@ -19,6 +18,7 @@ import { fetchChatModels } from "@/services/tldw-server"
 import { tldwClient } from "@/services/tldw/TldwApiClient"
 import { useUiModeStore } from "@/store/ui-mode"
 import { useServerCapabilities } from "@/hooks/useServerCapabilities"
+import { Alert } from "@/components/ui/primitives"
 import { RefreshCw, Trash2 } from "lucide-react"
 
 const Markdown = React.lazy(() => import("../Markdown"))
@@ -111,6 +111,16 @@ const extractDocumentList = (res: unknown): GeneratedDocument[] => {
   const list = data.documents || data.items || data.results
   return Array.isArray(list) ? (list as GeneratedDocument[]) : []
 }
+
+const getErrorMessage = (err: unknown, fallback: string) => {
+  if (err instanceof Error) return err.message
+  if (!err || typeof err !== "object" || !("message" in err)) return fallback
+  const messageValue = (err as { message?: unknown }).message
+  return typeof messageValue === "string" && messageValue ? messageValue : fallback
+}
+
+const hasValidationErrorFields = (err: unknown) =>
+  Boolean(err && typeof err === "object" && "errorFields" in err)
 
 export const DocumentGeneratorDrawer: React.FC<DocumentGeneratorDrawerProps> = ({
   open,
@@ -286,8 +296,8 @@ export const DocumentGeneratorDrawer: React.FC<DocumentGeneratorDrawerProps> = (
       })
       const list = extractDocumentList(res)
       setDocuments(list)
-    } catch (err: any) {
-      message.error(err?.message || t("common:somethingWentWrong"))
+    } catch (err: unknown) {
+      message.error(getErrorMessage(err, t("common:somethingWentWrong")))
     } finally {
       setDocsLoading(false)
     }
@@ -309,8 +319,8 @@ export const DocumentGeneratorDrawer: React.FC<DocumentGeneratorDrawerProps> = (
         temperature: res?.temperature ?? 0.7,
         max_tokens: res?.max_tokens ?? 2000
       })
-    } catch (err: any) {
-      message.error(err?.message || t("common:somethingWentWrong"))
+    } catch (err: unknown) {
+      message.error(getErrorMessage(err, t("common:somethingWentWrong")))
     } finally {
       setPromptLoading(false)
     }
@@ -425,8 +435,8 @@ export const DocumentGeneratorDrawer: React.FC<DocumentGeneratorDrawerProps> = (
         )
         void refreshDocuments()
       }
-    } catch (err: any) {
-      message.error(err?.message || t("common:somethingWentWrong"))
+    } catch (err: unknown) {
+      message.error(getErrorMessage(err, t("common:somethingWentWrong")))
     } finally {
       setIsGenerating(false)
     }
@@ -448,8 +458,8 @@ export const DocumentGeneratorDrawer: React.FC<DocumentGeneratorDrawerProps> = (
           await tldwClient.deleteChatDocument(documentId)
           setDocuments((prev) => prev.filter((doc) => doc.id !== documentId))
           message.success(t("common:deleted", "Deleted"))
-        } catch (err: any) {
-          message.error(err?.message || t("common:somethingWentWrong"))
+        } catch (err: unknown) {
+          message.error(getErrorMessage(err, t("common:somethingWentWrong")))
         }
       }
     })
@@ -470,8 +480,8 @@ export const DocumentGeneratorDrawer: React.FC<DocumentGeneratorDrawerProps> = (
           "Job cancelled."
         )
       )
-    } catch (err: any) {
-      message.error(err?.message || t("common:somethingWentWrong"))
+    } catch (err: unknown) {
+      message.error(getErrorMessage(err, t("common:somethingWentWrong")))
     }
   }
 
@@ -492,9 +502,9 @@ export const DocumentGeneratorDrawer: React.FC<DocumentGeneratorDrawerProps> = (
           "Prompt preset saved."
         )
       )
-    } catch (err: any) {
-      if (err?.errorFields) return
-      message.error(err?.message || t("common:somethingWentWrong"))
+    } catch (err: unknown) {
+      if (hasValidationErrorFields(err)) return
+      message.error(getErrorMessage(err, t("common:somethingWentWrong")))
     }
   }
 
@@ -518,25 +528,27 @@ export const DocumentGeneratorDrawer: React.FC<DocumentGeneratorDrawerProps> = (
     >
       {capabilities && !capabilities.hasChatDocuments && (
         <Alert
-          type="warning"
-          showIcon
-          title={t(
+          variant="warning"
+          data-testid="document-generator-capability-alert"
+          className="mb-4"
+        >
+          {t(
             "playground:documentGenerator.unavailable",
             "Document generation is not available on this server."
           )}
-          className="mb-4"
-        />
+        </Alert>
       )}
       {!conversationId && (
         <Alert
-          type="info"
-          showIcon
-          title={t(
+          variant="info"
+          data-testid="document-generator-conversation-alert"
+          className="mb-4"
+        >
+          {t(
             "playground:documentGenerator.noConversation",
             "Start a server-backed chat to generate documents."
           )}
-          className="mb-4"
-        />
+        </Alert>
       )}
 
       <div className="space-y-4">

--- a/apps/packages/ui/src/components/Common/Playground/__tests__/DocumentGeneratorDrawer.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Common/Playground/__tests__/DocumentGeneratorDrawer.design-system.test.tsx
@@ -128,12 +128,28 @@ describe("DocumentGeneratorDrawer design-system recovery alerts", () => {
       "data-ds-component",
       "Alert"
     )
+    expect(screen.getByTestId("document-generator-capability-alert")).toHaveAttribute(
+      "role",
+      "status"
+    )
+    expect(screen.getByTestId("document-generator-capability-alert")).toHaveAttribute(
+      "aria-live",
+      "polite"
+    )
     expect(
       screen.getByText("Document generation is not available on this server.")
     ).toBeInTheDocument()
     expect(screen.getByTestId("document-generator-conversation-alert")).toHaveAttribute(
       "data-ds-component",
       "Alert"
+    )
+    expect(screen.getByTestId("document-generator-conversation-alert")).toHaveAttribute(
+      "role",
+      "status"
+    )
+    expect(screen.getByTestId("document-generator-conversation-alert")).toHaveAttribute(
+      "aria-live",
+      "polite"
     )
     expect(
       screen.getByText("Start a server-backed chat to generate documents.")

--- a/apps/packages/ui/src/components/Common/Playground/__tests__/DocumentGeneratorDrawer.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Common/Playground/__tests__/DocumentGeneratorDrawer.design-system.test.tsx
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { DocumentGeneratorDrawer } from "../DocumentGeneratorDrawer"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string | { defaultValue?: string }) =>
+      typeof fallback === "string" ? fallback : fallback?.defaultValue ?? _key
+  })
+}))
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: () => ({ data: [] })
+}))
+
+vi.mock("@/services/tldw-server", () => ({
+  fetchChatModels: vi.fn()
+}))
+
+vi.mock("@/services/tldw/TldwApiClient", () => ({
+  tldwClient: {
+    initialize: vi.fn()
+  }
+}))
+
+vi.mock("@/store/ui-mode", () => ({
+  useUiModeStore: (selector: (state: { mode: string }) => string) =>
+    selector({ mode: "standard" })
+}))
+
+const capabilitiesState = vi.hoisted(() => ({
+  hasChatDocuments: false
+}))
+
+vi.mock("@/hooks/useServerCapabilities", () => ({
+  useServerCapabilities: () => ({
+    capabilities: capabilitiesState
+  })
+}))
+
+vi.mock("antd", () => {
+  const FormComponent: React.FC<{ children?: React.ReactNode }> & {
+    useForm: () => Array<{
+      setFieldsValue: ReturnType<typeof vi.fn>
+      validateFields: ReturnType<typeof vi.fn>
+    }>
+    Item: React.FC<{ children?: React.ReactNode }>
+  } = ({ children }) => (
+    <form>{children}</form>
+  )
+  FormComponent.useForm = () => [
+    {
+      setFieldsValue: vi.fn(),
+      validateFields: vi.fn()
+    }
+  ]
+  FormComponent.Item = ({ children }) => <div>{children}</div>
+
+  const InputComponent: React.FC<React.InputHTMLAttributes<HTMLInputElement>> & {
+    TextArea: React.FC<React.TextareaHTMLAttributes<HTMLTextAreaElement>>
+  } = (props) => <input {...props} />
+  InputComponent.TextArea = (props) => <textarea {...props} />
+
+  return {
+    Alert: ({ title }: { title?: React.ReactNode }) => <div>{title}</div>,
+    Button: ({
+      children,
+      loading: _loading,
+      ...props
+    }: React.ButtonHTMLAttributes<HTMLButtonElement> & { loading?: boolean }) => (
+      <button type="button" {...props}>
+        {children}
+      </button>
+    ),
+    Drawer: ({
+      children,
+      open
+    }: {
+      children?: React.ReactNode
+      open?: boolean
+    }) => (open ? <div>{children}</div> : null),
+    Form: FormComponent,
+    Input: InputComponent,
+    InputNumber: (props: React.InputHTMLAttributes<HTMLInputElement>) => (
+      <input {...props} />
+    ),
+    Modal: Object.assign(
+      ({
+        children,
+        open
+      }: {
+        children?: React.ReactNode
+        open?: boolean
+      }) => (open ? <div>{children}</div> : null),
+      { confirm: vi.fn() }
+    ),
+    Select: () => <select />,
+    Switch: () => <input type="checkbox" />,
+    Tag: ({ children }: { children?: React.ReactNode }) => <span>{children}</span>,
+    Tooltip: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    message: {
+      error: vi.fn(),
+      success: vi.fn()
+    }
+  }
+})
+
+vi.mock("../Markdown", () => ({
+  default: () => null
+}))
+
+describe("DocumentGeneratorDrawer design-system recovery alerts", () => {
+  it("renders availability and conversation recovery through shared alerts", () => {
+    capabilitiesState.hasChatDocuments = false
+
+    render(
+      <DocumentGeneratorDrawer
+        open
+        onClose={() => undefined}
+        conversationId={null}
+      />
+    )
+
+    expect(screen.getByTestId("document-generator-capability-alert")).toHaveAttribute(
+      "data-ds-component",
+      "Alert"
+    )
+    expect(
+      screen.getByText("Document generation is not available on this server.")
+    ).toBeInTheDocument()
+    expect(screen.getByTestId("document-generator-conversation-alert")).toHaveAttribute(
+      "data-ds-component",
+      "Alert"
+    )
+    expect(
+      screen.getByText("Start a server-backed chat to generate documents.")
+    ).toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundChatErrorBanner.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundChatErrorBanner.tsx
@@ -1,7 +1,7 @@
 import React from "react"
-import { X } from "lucide-react"
 import { Link } from "react-router-dom"
 
+import { Alert } from "@/components/ui/primitives"
 import {
   decodeChatErrorPayload,
   TLDW_ERROR_BUBBLE_PREFIX,
@@ -93,11 +93,9 @@ export const usePlaygroundChatErrorBanner = (
   messages: readonly ChatErrorMessageCandidate[]
 ) => {
   const scanSignature = getChatErrorBannerScanSignature(messages)
-  const messagesRef = React.useRef(messages)
-  messagesRef.current = messages
   const latestError = React.useMemo(
-    () => getLatestChatErrorBannerEntry(messagesRef.current),
-    [scanSignature]
+    () => (scanSignature ? getLatestChatErrorBannerEntry(messages) : null),
+    [messages, scanSignature]
   )
   const latestErrorRef = React.useRef<PlaygroundChatErrorBannerEntry | null>(
     latestError
@@ -157,32 +155,24 @@ export const PlaygroundChatErrorBanner: React.FC<
   }
 
   return (
-    <div
-      role="alert"
+    <Alert
+      variant="error"
       data-testid="playground-chat-error-banner"
-      className="mb-2 flex flex-col gap-2 rounded-xl border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-text shadow-sm sm:flex-row sm:items-start sm:justify-between"
+      title={error.summary}
+      dismissible
+      dismissLabel={dismissLabel}
+      onDismiss={() => onDismiss(error.key)}
+      className="mb-2"
     >
-      <div className="min-w-0">
-        <p className="font-medium text-destructive">{error.summary}</p>
-        <p className="mt-1 text-xs text-text-muted">{error.hint}</p>
-      </div>
-      <div className="flex shrink-0 items-center gap-2">
+      <div className="flex flex-col gap-2 text-xs text-text-muted sm:flex-row sm:items-center sm:justify-between">
+        <p>{error.hint}</p>
         <Link
           to="/settings/health"
-          className="text-xs font-medium text-destructive underline hover:text-destructive"
+          className="shrink-0 font-medium text-danger underline hover:text-danger"
         >
           {diagnosticsLabel}
         </Link>
-        <button
-          type="button"
-          onClick={() => onDismiss(error.key)}
-          className="inline-flex items-center rounded-full p-1 text-destructive hover:bg-destructive/10"
-          aria-label={dismissLabel}
-          title={dismissLabel}
-        >
-          <X className="h-3.5 w-3.5" aria-hidden="true" />
-        </button>
       </div>
-    </div>
+    </Alert>
   )
 }

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundComposerNotices.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundComposerNotices.tsx
@@ -5,10 +5,14 @@ import {
   Button
 } from "antd"
 import { Link, useNavigate } from "react-router-dom"
+import { Alert } from "@/components/ui/primitives"
 import { FirstRunBanner } from "@/components/PersonaGarden/FirstRunBanner"
 import { useFirstRunCheck } from "@/hooks/useFirstRunCheck"
 import { ModelRecommendationsPanel } from "./ModelRecommendationsPanel"
-import type { ModelRecommendationAction } from "./model-recommendations"
+import type {
+  ModelRecommendation,
+  ModelRecommendationAction
+} from "./model-recommendations"
 import { toText } from "./hooks/utils"
 import type { TFunction } from "i18next"
 
@@ -55,7 +59,7 @@ export type PlaygroundComposerNoticesProps = {
     onAction?: () => void
     actionLabel?: string
   }>
-  visibleModelRecommendations: any[]
+  visibleModelRecommendations: ModelRecommendation[]
   sessionInsightsTotalTokens: number
   jsonMode: boolean
   isConnectionReady: boolean
@@ -63,7 +67,7 @@ export type PlaygroundComposerNoticesProps = {
   isProMode: boolean
   selectedModel: string | null | undefined
   systemPrompt: string | null | undefined
-  selectedCharacter: any
+  selectedCharacter: unknown
   ragPinnedResultsLength: number
   startupTemplateDraftName: string
   setStartupTemplateDraftName: (name: string) => void
@@ -128,7 +132,6 @@ export const PlaygroundComposerNotices = React.memo(function PlaygroundComposerN
     modeAnnouncement,
     characterPendingApply,
     selectedCharacterGreeting,
-    selectedCharacterName,
     compareModeActive,
     compareSelectedModels,
     compareSelectedModelLabels,
@@ -243,7 +246,7 @@ export const PlaygroundComposerNotices = React.memo(function PlaygroundComposerN
                   "{{count}} models",
                   {
                     count: compareSelectedModels.length
-                  } as any
+                  }
                 )
               )}
             </span>
@@ -474,59 +477,71 @@ export const PlaygroundComposerNotices = React.memo(function PlaygroundComposerN
         </div>
       )}
       {!isConnectionReady && (
-        <div
+        <Alert
+          variant="info"
           role="status"
           aria-live="polite"
-          className="mt-1 flex flex-wrap items-center justify-between gap-2 rounded-md border border-text-muted/30 bg-surface2/50 px-2 py-2 text-xs text-text-muted"
+          data-testid="playground-composer-disconnected-notice"
+          className="mt-1"
         >
-          <span>
-            {t(
-              "playground:composer.disconnectedNotice",
-              "You're offline \u2014 connect to a tldw server to start chatting."
-            )}
-          </span>
-          <Link
-            to="/settings/tldw"
-            className="rounded border border-border bg-surface px-2 py-0.5 text-[11px] font-medium text-text-muted hover:bg-surface2 hover:text-text"
-          >
-            {t(
-              "playground:composer.disconnectedOpenSettings",
-              "Open settings"
-            )}
-          </Link>
-        </div>
+          <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-text-muted">
+            <span>
+              {t(
+                "playground:composer.disconnectedNotice",
+                "You're offline \u2014 connect to a tldw server to start chatting."
+              )}
+            </span>
+            <Link
+              to="/settings/tldw"
+              className="rounded border border-border bg-surface px-2 py-0.5 text-[11px] font-medium text-text-muted hover:bg-surface2 hover:text-text"
+            >
+              {t(
+                "playground:composer.disconnectedOpenSettings",
+                "Open settings"
+              )}
+            </Link>
+          </div>
+        </Alert>
       )}
       {isConnectionReady &&
         connectionUxState === "connected_degraded" && (
-          <div className="mt-1 flex flex-wrap items-center justify-between gap-2 rounded-md border border-warn/40 bg-warn/10 px-2 py-2 text-xs text-warn">
-            <span>
-              {t(
-                "playground:composer.providerDegraded",
-                "Provider connectivity is degraded. Responses may be slower or fail intermittently."
-              )}
-            </span>
-            <div className="flex items-center gap-2">
-              <button
-                type="button"
-                onClick={openModelApiSelector}
-                className="rounded border border-warn/40 bg-surface px-2 py-0.5 text-[11px] font-medium text-warn hover:bg-warn/10"
-              >
+          <Alert
+            variant="warning"
+            role="status"
+            aria-live="polite"
+            data-testid="playground-composer-degraded-notice"
+            className="mt-1"
+          >
+            <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-warn">
+              <span>
                 {t(
-                  "playground:composer.providerDegradedSwitchModel",
-                  "Switch model"
+                  "playground:composer.providerDegraded",
+                  "Provider connectivity is degraded. Responses may be slower or fail intermittently."
                 )}
-              </button>
-              <Link
-                to="/settings/health"
-                className="text-[11px] font-medium text-warn underline hover:text-warn"
-              >
-                {t(
-                  "settings:healthSummary.diagnostics",
-                  "Health & diagnostics"
-                )}
-              </Link>
+              </span>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={openModelApiSelector}
+                  className="rounded border border-warn/40 bg-surface px-2 py-0.5 text-[11px] font-medium text-warn hover:bg-warn/10"
+                >
+                  {t(
+                    "playground:composer.providerDegradedSwitchModel",
+                    "Switch model"
+                  )}
+                </button>
+                <Link
+                  to="/settings/health"
+                  className="text-[11px] font-medium text-warn underline hover:text-warn"
+                >
+                  {t(
+                    "settings:healthSummary.diagnostics",
+                    "Health & diagnostics"
+                  )}
+                </Link>
+              </div>
             </div>
-          </div>
+          </Alert>
         )}
       {isProMode && (
         <div

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundChatErrorBanner.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundChatErrorBanner.test.tsx
@@ -1,10 +1,12 @@
 // @vitest-environment jsdom
-import { act, renderHook } from "@testing-library/react"
+import { act, render, renderHook, screen } from "@testing-library/react"
 import { describe, expect, it } from "vitest"
+import { MemoryRouter } from "react-router-dom"
 
 import {
   getChatErrorBannerScanSignature,
   getLatestChatErrorBannerEntry,
+  PlaygroundChatErrorBanner,
   usePlaygroundChatErrorBanner
 } from "../PlaygroundChatErrorBanner"
 
@@ -21,6 +23,40 @@ const encodeError = (
   })
 
 describe("PlaygroundChatErrorBanner", () => {
+  it("renders chat errors through the shared alert primitive", () => {
+    const error = {
+      ...JSON.parse(
+        JSON.stringify({
+          summary: "Generation failed",
+          hint: "Open diagnostics for details",
+          detail: "server detail"
+        })
+      ),
+      key: "assistant-error-1:abc"
+    }
+
+    render(
+      <MemoryRouter>
+        <PlaygroundChatErrorBanner
+          error={error}
+          diagnosticsLabel="Health & diagnostics"
+          dismissLabel="Dismiss error"
+          onDismiss={() => undefined}
+        />
+      </MemoryRouter>
+    )
+
+    const banner = screen.getByTestId("playground-chat-error-banner")
+
+    expect(banner).toHaveAttribute("data-ds-component", "Alert")
+    expect(banner).toHaveAttribute("role", "alert")
+    expect(screen.getByRole("link", { name: "Health & diagnostics" })).toHaveAttribute(
+      "href",
+      "/settings/health"
+    )
+    expect(screen.getByRole("button", { name: "Dismiss error" })).toBeInTheDocument()
+  })
+
   it("resolves the newest encoded assistant error", () => {
     const latest = getLatestChatErrorBannerEntry([
       {

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundComposerNotices.first-run.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundComposerNotices.first-run.test.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { fireEvent, render, screen } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import { MemoryRouter } from "react-router-dom"
 
 import type { PlaygroundComposerNoticesProps } from "../PlaygroundComposerNotices"
 
@@ -143,5 +144,63 @@ describe("PlaygroundComposerNotices first-run banner", () => {
       "true"
     )
     expect(screen.queryByTestId("first-run-banner-nudge")).not.toBeInTheDocument()
+  })
+
+  it("renders disconnected composer recovery through the shared alert primitive", () => {
+    useFirstRunCheckMock.mockReturnValue({
+      shouldShowSetup: false,
+      resumeStep: null,
+      loading: false
+    })
+
+    render(
+      <MemoryRouter>
+        <PlaygroundComposerNotices
+          {...buildProps()}
+          isConnectionReady={false}
+        />
+      </MemoryRouter>
+    )
+
+    const notice = screen.getByTestId("playground-composer-disconnected-notice")
+
+    expect(notice).toHaveAttribute("data-ds-component", "Alert")
+    expect(notice).toHaveAttribute("role", "status")
+    expect(screen.getByRole("link", { name: "Open settings" })).toHaveAttribute(
+      "href",
+      "/settings/tldw"
+    )
+  })
+
+  it("renders degraded composer recovery through the shared alert primitive", () => {
+    const openModelApiSelector = vi.fn()
+
+    useFirstRunCheckMock.mockReturnValue({
+      shouldShowSetup: false,
+      resumeStep: null,
+      loading: false
+    })
+
+    render(
+      <MemoryRouter>
+        <PlaygroundComposerNotices
+          {...buildProps()}
+          isConnectionReady
+          connectionUxState="connected_degraded"
+          openModelApiSelector={openModelApiSelector}
+        />
+      </MemoryRouter>
+    )
+
+    const notice = screen.getByTestId("playground-composer-degraded-notice")
+
+    expect(notice).toHaveAttribute("data-ds-component", "Alert")
+    expect(notice).toHaveAttribute("role", "status")
+    fireEvent.click(screen.getByRole("button", { name: "Switch model" }))
+    expect(openModelApiSelector).toHaveBeenCalled()
+    expect(screen.getByRole("link", { name: "Health & diagnostics" })).toHaveAttribute(
+      "href",
+      "/settings/health"
+    )
   })
 })

--- a/apps/packages/ui/src/components/ui/primitives/Alert.tsx
+++ b/apps/packages/ui/src/components/ui/primitives/Alert.tsx
@@ -30,6 +30,12 @@ export interface AlertProps {
   dismissible?: boolean
   /** Callback when dismissed */
   onDismiss?: () => void
+  /** Accessible label for the dismiss button */
+  dismissLabel?: string
+  /** ARIA role for alert urgency */
+  role?: "alert" | "status"
+  /** Live-region politeness for status-style alerts */
+  "aria-live"?: "off" | "polite" | "assertive"
   /** Additional CSS classes */
   className?: string
   /** Test ID for testing */
@@ -91,6 +97,9 @@ export const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
       secondaryAction,
       dismissible = false,
       onDismiss,
+      dismissLabel = "Dismiss",
+      role = "alert",
+      "aria-live": ariaLive,
       className,
       "data-testid": dataTestId,
     },
@@ -107,8 +116,10 @@ export const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
           config.container,
           className
         )}
-        role="alert"
+        role={role}
+        aria-live={ariaLive}
         data-testid={dataTestId}
+        data-ds-component="Alert"
       >
         <span
           className={cn("mt-0.5 flex-shrink-0", config.text)}
@@ -162,7 +173,7 @@ export const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
               "flex-shrink-0 rounded p-1 transition-colors duration-150 hover:bg-surface2",
               config.text
             )}
-            aria-label="Dismiss"
+            aria-label={dismissLabel}
           >
             <X className="size-4" />
           </button>

--- a/backlog/tasks/task-45.5 - Migrate-Playground-error-and-recovery-banners-to-design-system-primitives.md
+++ b/backlog/tasks/task-45.5 - Migrate-Playground-error-and-recovery-banners-to-design-system-primitives.md
@@ -1,0 +1,74 @@
+---
+id: TASK-45.5
+title: Migrate Playground error and recovery banners to design-system primitives
+status: Done
+assignee:
+  - '@Codex'
+created_date: '2026-05-05 05:21'
+labels:
+  - design-system
+  - frontend
+  - playground
+dependencies: []
+documentation:
+  - Docs/Design/tldw_web_design_system_contract.md
+  - Docs/Design/tldw_web_design_system_inventory.md
+parent_task_id: TASK-45
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the next bounded Chat/Playground migration slice from the design-system inventory after TASK-45.4. Scope is limited to user-facing Playground error/recovery banners and notices: PlaygroundChatErrorBanner, PlaygroundComposerNotices recovery notices, and DocumentGeneratorDrawer availability/conversation recovery alerts. Do not migrate modal footers, product status chips, or broad AntD mechanics in this slice.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 PlaygroundChatErrorBanner uses the canonical shared Alert or state primitive for user-facing error recovery while preserving diagnostics and dismiss actions.
+- [x] #2 PlaygroundComposerNotices disconnected and degraded recovery notices use canonical design-system state language or primitives without changing composer controls or informational mode notices outside the scope.
+- [x] #3 DocumentGeneratorDrawer availability and missing-conversation recovery alerts use canonical shared Alert or state primitive while preserving the drawer workflow and AntD form/modal mechanics.
+- [x] #4 Focused tests cover migrated error/recovery states and assert accessible labels, state markers, and actions.
+- [x] #5 Verification includes focused Playground Vitest coverage, formatting/lint/diff checks, and Bandit is skipped or documented as not applicable for frontend-only changes.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing tests for design-system markers and accessible recovery actions on the target Playground banner surfaces.
+2. Migrate only user-facing error/recovery banners to shared Alert or RecoveryCallout primitives.
+3. Preserve composer controls, AntD form/drawer/modal mechanics, and informational notices that are not recovery states.
+4. Run focused Vitest, lint/format/diff checks, update this task, and commit the slice.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Started after PR #1290 merged into dev at merge commit b0db36f1074e65c2db75a548c2fbabebc5ed66b3. Work is isolated in .worktrees/tldw-playground-banner-design-system on branch codex/tldw-playground-banner-design-system from origin/dev.
+
+Verification:
+- Red tests were added first for PlaygroundChatErrorBanner, PlaygroundComposerNotices disconnected/degraded notices, and DocumentGeneratorDrawer recovery alerts; the first run failed on missing shared Alert markers.
+- `bunx vitest run ../packages/ui/src/components/Option/Playground/__tests__/PlaygroundChatErrorBanner.test.tsx ../packages/ui/src/components/Option/Playground/__tests__/PlaygroundComposerNotices.first-run.test.tsx ../packages/ui/src/components/Common/Playground/__tests__/DocumentGeneratorDrawer.design-system.test.tsx --reporter=dot` passed with 3 files and 11 tests.
+- `bunx vitest run ../packages/ui/src/components/Option/Playground/__tests__/PlaygroundEmpty.test.tsx ../packages/ui/src/components/Option/Playground/__tests__/PlaygroundEmpty.disconnected.test.tsx ../packages/ui/src/components/Option/Playground/__tests__/PlaygroundChatErrorBanner.test.tsx ../packages/ui/src/components/Option/Playground/__tests__/PlaygroundComposerNotices.first-run.test.tsx ../packages/ui/src/components/Common/Playground/__tests__/DocumentGeneratorDrawer.design-system.test.tsx ../packages/ui/src/components/Sidepanel/Chat/__tests__/ConnectionBanner.test.tsx ../packages/ui/src/components/Sidepanel/Chat/__tests__/empty.test.tsx --reporter=dot` passed with 7 files and 25 tests.
+- `apps/tldw-frontend/node_modules/.bin/eslint -c apps/tldw-frontend/eslint.config.mjs <touched files>` exited 0 with only the existing Next pages-directory notice.
+- `bunx prettier --check <touched files>` was not used as a completion gate because this package does not expose a repo-matching Prettier config for the no-semicolon style; the accidental default-format churn was reversed.
+- `bunx tsc --noEmit --pretty false -p tsconfig.json` still exits 2 on the broader frontend baseline; filtering the compiler log for the touched files produced no matches.
+- `git diff --check` passed.
+- Bandit skipped: this is a frontend-only TypeScript/React migration with no Python touched scope.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated the bounded Playground recovery-banner slice to the shared design-system Alert primitive. Chat error recovery now uses the shared Alert while preserving diagnostics and dismiss actions; disconnected/degraded composer recovery notices use shared Alert markers without touching unrelated composer notices; DocumentGeneratorDrawer availability and missing-conversation recovery alerts now use the shared Alert while preserving the AntD drawer/form/modal workflow.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.5 - Migrate-Playground-error-and-recovery-banners-to-design-system-primitives.md
+++ b/backlog/tasks/task-45.5 - Migrate-Playground-error-and-recovery-banners-to-design-system-primitives.md
@@ -55,6 +55,7 @@ Verification:
 - `bunx tsc --noEmit --pretty false -p tsconfig.json` still exits 2 on the broader frontend baseline; filtering the compiler log for the touched files produced no matches.
 - `git diff --check` passed.
 - Bandit skipped: this is a frontend-only TypeScript/React migration with no Python touched scope.
+- PR review pass: CodeRabbit and Qodo both flagged the same accessibility issue in DocumentGeneratorDrawer. Added `role="status"` and `aria-live="polite"` to the non-urgent capability and missing-conversation Alert instances, plus regression assertions for both attributes.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary


### PR DESCRIPTION
## Summary
- Migrate Playground chat error recovery to the shared design-system `Alert` while preserving diagnostics and dismiss actions.
- Migrate disconnected/degraded Playground composer recovery notices and DocumentGeneratorDrawer recovery alerts to the shared `Alert`.
- Extend the shared `Alert` primitive with `dismissLabel`, status-role support, live-region support, and a stable `data-ds-component` marker.

## Tests
- `bunx vitest run ../packages/ui/src/components/Option/Playground/__tests__/PlaygroundChatErrorBanner.test.tsx ../packages/ui/src/components/Option/Playground/__tests__/PlaygroundComposerNotices.first-run.test.tsx ../packages/ui/src/components/Common/Playground/__tests__/DocumentGeneratorDrawer.design-system.test.tsx --reporter=dot`
- `bunx vitest run ../packages/ui/src/components/Option/Playground/__tests__/PlaygroundEmpty.test.tsx ../packages/ui/src/components/Option/Playground/__tests__/PlaygroundEmpty.disconnected.test.tsx ../packages/ui/src/components/Option/Playground/__tests__/PlaygroundChatErrorBanner.test.tsx ../packages/ui/src/components/Option/Playground/__tests__/PlaygroundComposerNotices.first-run.test.tsx ../packages/ui/src/components/Common/Playground/__tests__/DocumentGeneratorDrawer.design-system.test.tsx ../packages/ui/src/components/Sidepanel/Chat/__tests__/ConnectionBanner.test.tsx ../packages/ui/src/components/Sidepanel/Chat/__tests__/empty.test.tsx --reporter=dot`
- `apps/tldw-frontend/node_modules/.bin/eslint -c apps/tldw-frontend/eslint.config.mjs <touched files>` exits 0 with the existing Next pages-directory notice.
- `bunx tsc --noEmit --pretty false -p tsconfig.json` still exits 2 on the broader frontend baseline; the touched-file filter has no matches.
- `git diff --check`
- Bandit skipped: frontend-only TypeScript/React change.

## Change summary
Needs human requester-owned summary before merge per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.
