### PR TITLE
Phase 2.2: defer minimal collections router imports

### DIFF
--- a/backlog/tasks/task-68 - Phase-2.2-minimal-collections-social-router-conditional-cleanup-AD.md
+++ b/backlog/tasks/task-68 - Phase-2.2-minimal-collections-social-router-conditional-cleanup-AD.md
@@ -1,0 +1,53 @@
+---
+id: TASK-68
+title: Phase 2.2 minimal collections/social router conditional cleanup AD
+status: Done
+assignee: []
+created_date: '2026-05-05 05:45'
+updated_date: '2026-05-05 05:47'
+labels:
+  - phase2.2
+  - router-cleanup
+  - issue-1116
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+  - 'https://github.com/rmusser01/tldw_server/pull/1298'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue issue #1116 Phase 2.2 by converting the next remaining minimal-test optional router registrations from eager try/import RouterSpec blocks to ImportedRouterSpec-backed lazy router specs. Scope is limited to collections_feeds, collections_websub router and callback_router, slack, discord, and telegram in tldw_Server_API/app/api/v1/router_groups/minimal.py. Preserve existing prefixes, tags, route keys, skip context, and current skip-on-import-failure behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Selected collections and social minimal optional router specs defer module import and router attribute lookup until registration
+- [x] #2 Existing route metadata is preserved for collections-feeds collections-websub slack discord and telegram
+- [x] #3 Focused router-group test covers the lazy behavior with red/green verification
+- [x] #4 Router-group main-router and OpenAPI contract tests pass for the touched scope
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented a narrow minimal collections/social router tranche. Added red/green router-group coverage that proves collections_feeds, collections_websub router, collections_websub callback_router, slack, discord, and telegram defer module import and router attribute access until ImportedRouterSpec resolution. Replaced only those eager try/import RouterSpec blocks in minimal.py.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Converted the selected minimal collections/social optional router registrations to ImportedRouterSpec while preserving prefixes and tags. Verification: focused red/green test, full router_groups contract suite, main router contract suite, OpenAPI contracts, Bandit on minimal.py, and git diff --check.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -301,72 +301,52 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
     ):
         append_imported_router_spec(specs, auxiliary_spec)
 
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.collections_feeds import router as collections_feeds_router
-
-        specs.append(RouterSpec(
-            router=collections_feeds_router,
+    for collections_social_spec in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.collections_feeds",
+            log_name="collections_feeds",
             prefix=f"{API_V1_PREFIX}",
             tags=("collections-feeds",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping collections_feeds router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.collections_websub import (
-            callback_router as websub_callback_router,
-        )
-        from tldw_Server_API.app.api.v1.endpoints.collections_websub import (
-            router as collections_websub_router,
-        )
-
-        specs.extend([
-            RouterSpec(
-                router=collections_websub_router,
-                prefix=f"{API_V1_PREFIX}",
-                tags=("collections-websub",),
-            ),
-            RouterSpec(
-                router=websub_callback_router,
-                prefix=f"{API_V1_PREFIX}",
-                tags=("collections-websub",),
-            ),
-        ])
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping collections_websub router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.slack import router as slack_router
-
-        specs.append(RouterSpec(
-            router=slack_router,
+            skip_context="in minimal test app",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.collections_websub",
+            log_name="collections_websub",
+            prefix=f"{API_V1_PREFIX}",
+            tags=("collections-websub",),
+            skip_context="in minimal test app",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.collections_websub",
+            log_name="collections_websub_callback",
+            prefix=f"{API_V1_PREFIX}",
+            tags=("collections-websub",),
+            attr_name="callback_router",
+            skip_context="in minimal test app",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.slack",
+            log_name="slack",
             prefix=f"{API_V1_PREFIX}",
             tags=("slack",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping slack router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.discord import router as discord_router
-
-        specs.append(RouterSpec(
-            router=discord_router,
+            skip_context="in minimal test app",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.discord",
+            log_name="discord",
             prefix=f"{API_V1_PREFIX}",
             tags=("discord",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping discord router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.telegram import router as telegram_router
-
-        specs.append(RouterSpec(
-            router=telegram_router,
+            skip_context="in minimal test app",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.telegram",
+            log_name="telegram",
             prefix=f"{API_V1_PREFIX}",
             tags=("telegram",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping telegram router in minimal test app: {e}")
+            skip_context="in minimal test app",
+        ),
+    ):
+        append_imported_router_spec(specs, collections_social_spec)
 
     try:
         from tldw_Server_API.app.api.v1.endpoints.files import router as files_router

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -4208,6 +4208,191 @@ def test_iter_minimal_optional_router_specs_defers_auxiliary_attr_lookup(
     }
 
 
+def test_iter_minimal_optional_router_specs_defers_collections_social_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal collections/social specs keep router attr lookup lazy."""
+    import builtins
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    router_definitions = (
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.collections_feeds",
+            "attr_name": "router",
+            "expected_name": "collections_feeds",
+            "path": "/collections/feeds",
+            "prefix": "/api/v1",
+            "tags": ("collections-feeds",),
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.collections_websub",
+            "attr_name": "router",
+            "expected_name": "collections_websub",
+            "path": "/collections/websub",
+            "prefix": "/api/v1",
+            "tags": ("collections-websub",),
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.collections_websub",
+            "attr_name": "callback_router",
+            "expected_name": "collections_websub_callback",
+            "path": "/websub/callback",
+            "prefix": "/api/v1",
+            "tags": ("collections-websub",),
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.slack",
+            "attr_name": "router",
+            "expected_name": "slack",
+            "path": "/slack/events",
+            "prefix": "/api/v1",
+            "tags": ("slack",),
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.discord",
+            "attr_name": "router",
+            "expected_name": "discord",
+            "path": "/discord/events",
+            "prefix": "/api/v1",
+            "tags": ("discord",),
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.telegram",
+            "attr_name": "router",
+            "expected_name": "telegram",
+            "path": "/telegram/events",
+            "prefix": "/api/v1",
+            "tags": ("telegram",),
+        },
+    )
+    definitions_by_module: dict[str, list[dict[str, object]]] = {}
+    for definition in router_definitions:
+        definitions_by_module.setdefault(str(definition["module_name"]), []).append(
+            definition,
+        )
+
+    access_count = {
+        f"{definition['module_name']}.{definition['attr_name']}": 0
+        for definition in router_definitions
+    }
+    import_calls: list[str] = []
+
+    for module_name, module_definitions in definitions_by_module.items():
+        routers_by_attr: dict[str, APIRouter] = {}
+        fake_module = ModuleType(module_name)
+
+        for definition in module_definitions:
+            router = APIRouter()
+
+            @router.get(str(definition["path"]))
+            def _endpoint() -> dict[str, str]:
+                """Return a deterministic response for the fake minimal router."""
+                return {"status": "ok"}
+
+            routers_by_attr[str(definition["attr_name"])] = router
+
+        def _module_getattr(
+            name: str,
+            *,
+            module_name: str = module_name,
+            routers_by_attr: dict[str, APIRouter] = routers_by_attr,
+        ) -> APIRouter:
+            """Track lazy router attribute resolution for the fake module."""
+            if name not in routers_by_attr:
+                raise AttributeError(name)
+            access_count[f"{module_name}.{name}"] += 1
+            return routers_by_attr[name]
+
+        fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    endpoints_package = "tldw_Server_API.app.api.v1.endpoints."
+    real_import = builtins.__import__
+
+    def _fake_endpoint_import(
+        name: str,
+        globals: dict[str, object] | None = None,
+        locals: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> ModuleType:
+        """Return fake routers for unrelated eager minimal optional imports."""
+        if (
+            level == 0
+            and name.startswith(endpoints_package)
+            and name not in definitions_by_module
+        ):
+            attrs = tuple(attr for attr in fromlist if attr != "*") or ("router",)
+            for attr_name in attrs:
+                _install_fake_router_module(
+                    monkeypatch,
+                    name,
+                    path="/minimal-unrelated-collections-social-fake",
+                    attr_name=attr_name,
+                )
+            return sys.modules[name]
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_endpoint_import)
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Track lazy module imports for selected minimal collections/social routers."""
+        if module_name in definitions_by_module:
+            import_calls.append(module_name)
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+    fake_main = ModuleType("tldw_Server_API.app.main")
+    fake_main.app = FastAPI()  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "tldw_Server_API.app.main", fake_main)
+
+    specs = list(iter_minimal_optional_router_specs())
+    assert access_count == {
+        f"{definition['module_name']}.{definition['attr_name']}": 0
+        for definition in router_definitions
+    }
+    assert import_calls == []
+
+    selected_specs = {
+        spec.name: spec
+        for spec in specs
+        if spec.name in {
+            str(definition["expected_name"])
+            for definition in router_definitions
+        }
+    }
+    assert set(selected_specs) == {
+        str(definition["expected_name"])
+        for definition in router_definitions
+    }
+
+    for definition in router_definitions:
+        spec = selected_specs[str(definition["expected_name"])]
+        assert spec.prefix == definition["prefix"]
+        assert spec.tags == definition["tags"]
+        assert spec.route_key == ""
+        assert spec.skip_context == "in minimal test app"
+        assert _first_router_path(spec.router) == definition["path"]
+
+    assert import_calls == [
+        str(definition["module_name"])
+        for definition in router_definitions
+    ]
+    assert access_count == {
+        f"{definition['module_name']}.{definition['attr_name']}": 1
+        for definition in router_definitions
+    }
+
+
 def test_iter_minimal_optional_router_specs_populates_llm_specs(monkeypatch: pytest.MonkeyPatch) -> None:
     from tldw_Server_API.app.api.v1.router_groups.minimal import iter_minimal_optional_router_specs
 


### PR DESCRIPTION
## Summary
- Convert the next minimal-test optional router cluster to ImportedRouterSpec.
- Cover collections_feeds, collections_websub router and callback_router, slack, discord, and telegram lazy import behavior with router-group contract coverage.
- Preserve existing prefixes, tags, route keys, and skip behavior through registration-time resolution.

## Verification
- python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k minimal_optional_router_specs_defers_collections_social_attr_lookup -q (red before implementation, green after)
- python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q
- python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q
- python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q
- python -m bandit -r tldw_Server_API/app/api/v1/router_groups/minimal.py -f json -o /tmp/bandit_phase2_2_minimal_collections_social.json (0 results, 0 errors)
- git diff --check

## Merge Gate
- Human owner still needs to provide the required AI-generated PR Change summary before merge.