### PR TITLE
Phase 2.2: defer minimal data router imports

### DIFF
--- a/backlog/tasks/task-69 - Phase-2.2-minimal-data-resource-router-conditional-cleanup-AE.md
+++ b/backlog/tasks/task-69 - Phase-2.2-minimal-data-resource-router-conditional-cleanup-AE.md
@@ -1,0 +1,53 @@
+---
+id: TASK-69
+title: Phase 2.2 minimal data/resource router conditional cleanup AE
+status: Done
+assignee: []
+created_date: '2026-05-05 14:00'
+updated_date: '2026-05-05 14:03'
+labels:
+  - phase2.2
+  - router-cleanup
+  - issue-1116
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+  - 'https://github.com/rmusser01/tldw_server/pull/1300'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue issue #1116 Phase 2.2 by converting the next remaining minimal-test optional router registrations from eager try/import RouterSpec blocks to ImportedRouterSpec-backed lazy router specs. Scope is limited to files, storage, data_tables, reading_highlights, items, and reminders in tldw_Server_API/app/api/v1/router_groups/minimal.py. Preserve existing prefixes, tags, route keys, skip context, and current skip-on-import-failure behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Selected data/resource minimal optional router specs defer module import and router attribute lookup until registration
+- [x] #2 Existing route metadata is preserved for files storage data-tables reading-highlights items and tasks
+- [x] #3 Focused router-group test covers the lazy behavior with red/green verification
+- [x] #4 Router-group main-router and OpenAPI contract tests pass for the touched scope
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented a narrow minimal data/resource router tranche. Added red/green router-group coverage that proves files, storage, data_tables, reading_highlights, items, and reminders defer module import and router attribute access until ImportedRouterSpec resolution. Replaced only those eager try/import RouterSpec blocks in minimal.py.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Converted the selected minimal data/resource optional router registrations to ImportedRouterSpec while preserving prefixes and tags. Verification: focused red/green test, full router_groups contract suite, main router contract suite, OpenAPI contracts, Bandit on minimal.py, and git diff --check.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-69 - Phase-2.2-minimal-data-resource-router-conditional-cleanup-AE.md
+++ b/backlog/tasks/task-69 - Phase-2.2-minimal-data-resource-router-conditional-cleanup-AE.md
@@ -4,7 +4,7 @@ title: Phase 2.2 minimal data/resource router conditional cleanup AE
 status: Done
 assignee: []
 created_date: '2026-05-05 14:00'
-updated_date: '2026-05-05 14:03'
+updated_date: '2026-05-05 14:12'
 labels:
   - phase2.2
   - router-cleanup
@@ -33,13 +33,13 @@ Continue issue #1116 Phase 2.2 by converting the next remaining minimal-test opt
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Implemented a narrow minimal data/resource router tranche. Added red/green router-group coverage that proves files, storage, data_tables, reading_highlights, items, and reminders defer module import and router attribute access until ImportedRouterSpec resolution. Replaced only those eager try/import RouterSpec blocks in minimal.py.
+Addressed PR #1301 review feedback by introducing data_resource_skip_context for the shared data/resource ImportedRouterSpec skip context.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Converted the selected minimal data/resource optional router registrations to ImportedRouterSpec while preserving prefixes and tags. Verification: focused red/green test, full router_groups contract suite, main router contract suite, OpenAPI contracts, Bandit on minimal.py, and git diff --check.
+Converted the selected minimal data/resource optional router registrations to ImportedRouterSpec while preserving prefixes and tags. Review feedback addressed by centralizing the repeated data/resource skip_context value. Verification: focused red/green test, focused review-fix rerun, full router_groups contract suite, main router contract suite, OpenAPI contracts, Bandit on minimal.py, and git diff --check.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-70 - Phase-2.2-PR-1301-router-registry-failure-handling.md
+++ b/backlog/tasks/task-70 - Phase-2.2-PR-1301-router-registry-failure-handling.md
@@ -1,0 +1,59 @@
+---
+id: TASK-70
+title: Phase 2.2 PR 1301 router registry failure handling
+status: Done
+assignee: []
+created_date: '2026-05-05 14:14'
+updated_date: '2026-05-05 14:18'
+labels:
+  - phase2.2
+  - router-cleanup
+  - issue-1116
+  - pr-1301
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+  - 'https://github.com/rmusser01/tldw_server/pull/1301'
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address PR #1301 review feedback that register_router_specs currently swallows every lazy router resolution exception. Add coverage and update the shared registry/conditional spec seam so optional missing imports or missing router attributes are skipped, while unexpected lazy factory or module import runtime errors are re-raised instead of silently omitting routers.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Optional ImportedRouterSpec ModuleNotFoundError and missing router AttributeError remain skipped with existing diagnostics
+- [x] #2 Unexpected RuntimeError from ImportedRouterSpec import resolution is re-raised
+- [x] #3 Generic RouterSpec factories can opt into skippable exceptions explicitly
+- [x] #4 Focused and full router-group contract tests pass
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing registry tests for unexpected lazy resolution failures versus configured skippable exceptions. 2. Add skip_exceptions metadata to RouterSpec/ImportedRouterSpec. 3. Update register_router_specs to skip only configured resolution exceptions and re-raise unexpected ones. 4. Rerun focused/full contract tests and Bandit.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented registry failure handling review fix. RouterSpec and ImportedRouterSpec now carry skip_exceptions metadata defaulting to ImportError and AttributeError. register_router_specs re-raises unexpected resolution failures and only skips configured exception types. Updated contract tests for imported router RuntimeError propagation, core chat-loop crash propagation, and explicit opt-in skip behavior.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed PR #1301 Qodo reliability finding by preventing unexpected lazy router resolution failures from being silently skipped. Verification: focused red run failed as expected before implementation; focused green passed; full router_groups contract suite passed; main router and OpenAPI contracts passed; Bandit on changed registry/router-group source reported 0 results and 0 errors; git diff --check clean.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/conditional.py
+++ b/tldw_Server_API/app/api/v1/router_groups/conditional.py
@@ -19,6 +19,7 @@ class ImportedRouterSpec:
     default_stable: bool = True
     attr_name: str = "router"
     skip_context: str = ""
+    skip_exceptions: tuple[type[Exception], ...] = (ImportError, AttributeError)
 
 
 def append_imported_router_spec(
@@ -42,5 +43,6 @@ def append_imported_router_spec(
             default_stable=definition.default_stable,
             name=definition.log_name,
             skip_context=definition.skip_context,
+            skip_exceptions=definition.skip_exceptions,
         )
     )

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -348,48 +348,49 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
     ):
         append_imported_router_spec(specs, collections_social_spec)
 
+    data_resource_skip_context = "in minimal test app"
     for data_resource_spec in (
         ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.files",
             log_name="files",
             prefix=f"{API_V1_PREFIX}",
             tags=("files",),
-            skip_context="in minimal test app",
+            skip_context=data_resource_skip_context,
         ),
         ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.storage",
             log_name="storage",
             prefix=f"{API_V1_PREFIX}",
             tags=("storage",),
-            skip_context="in minimal test app",
+            skip_context=data_resource_skip_context,
         ),
         ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.data_tables",
             log_name="data_tables",
             prefix=f"{API_V1_PREFIX}",
             tags=("data-tables",),
-            skip_context="in minimal test app",
+            skip_context=data_resource_skip_context,
         ),
         ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.reading_highlights",
             log_name="reading_highlights",
             prefix=f"{API_V1_PREFIX}",
             tags=("reading-highlights",),
-            skip_context="in minimal test app",
+            skip_context=data_resource_skip_context,
         ),
         ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.items",
             log_name="items",
             prefix=f"{API_V1_PREFIX}",
             tags=("items",),
-            skip_context="in minimal test app",
+            skip_context=data_resource_skip_context,
         ),
         ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.reminders",
             log_name="reminders",
             prefix=f"{API_V1_PREFIX}",
             tags=("tasks",),
-            skip_context="in minimal test app",
+            skip_context=data_resource_skip_context,
         ),
     ):
         append_imported_router_spec(specs, data_resource_spec)

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -348,71 +348,51 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
     ):
         append_imported_router_spec(specs, collections_social_spec)
 
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.files import router as files_router
-
-        specs.append(RouterSpec(
-            router=files_router,
+    for data_resource_spec in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.files",
+            log_name="files",
             prefix=f"{API_V1_PREFIX}",
             tags=("files",),
-        ))
-    except ImportError as e:
-        logger.debug(f"Skipping files router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.storage import router as storage_router
-
-        specs.append(RouterSpec(
-            router=storage_router,
+            skip_context="in minimal test app",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.storage",
+            log_name="storage",
             prefix=f"{API_V1_PREFIX}",
             tags=("storage",),
-        ))
-    except ImportError as e:
-        logger.debug(f"Skipping storage router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.data_tables import router as data_tables_router
-
-        specs.append(RouterSpec(
-            router=data_tables_router,
+            skip_context="in minimal test app",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.data_tables",
+            log_name="data_tables",
             prefix=f"{API_V1_PREFIX}",
             tags=("data-tables",),
-        ))
-    except ImportError as e:
-        logger.debug(f"Skipping data_tables router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.reading_highlights import router as reading_highlights_router
-
-        specs.append(RouterSpec(
-            router=reading_highlights_router,
+            skip_context="in minimal test app",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.reading_highlights",
+            log_name="reading_highlights",
             prefix=f"{API_V1_PREFIX}",
             tags=("reading-highlights",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping reading_highlights router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.items import router as items_router
-
-        specs.append(RouterSpec(
-            router=items_router,
+            skip_context="in minimal test app",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.items",
+            log_name="items",
             prefix=f"{API_V1_PREFIX}",
             tags=("items",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping items router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.reminders import router as reminders_router
-
-        specs.append(RouterSpec(
-            router=reminders_router,
+            skip_context="in minimal test app",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.reminders",
+            log_name="reminders",
             prefix=f"{API_V1_PREFIX}",
             tags=("tasks",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping reminders router in minimal test app: {e}")
+            skip_context="in minimal test app",
+        ),
+    ):
+        append_imported_router_spec(specs, data_resource_spec)
 
     try:
         from tldw_Server_API.app.api.v1.endpoints.integrations_control_plane import (

--- a/tldw_Server_API/app/api/v1/router_groups/spec.py
+++ b/tldw_Server_API/app/api/v1/router_groups/spec.py
@@ -20,6 +20,7 @@ class RouterSpec:
         default_stable: Passed to route_enabled() as default_stable kwarg.
         name: Optional display name for diagnostics; falls back to route_key.
         skip_context: Optional extra diagnostic context for skip logs.
+        skip_exceptions: Resolution exceptions that should skip registration.
     """
     router: APIRouter | RouterFactory
     prefix: str = ""
@@ -28,6 +29,7 @@ class RouterSpec:
     default_stable: bool = True
     name: str = ""
     skip_context: str = ""
+    skip_exceptions: tuple[type[Exception], ...] = (ImportError, AttributeError)
     _resolved_router: APIRouter | None = field(default=None, init=False, repr=False, compare=False)
 
     def resolve_router(self) -> APIRouter:

--- a/tldw_Server_API/app/api/v1/router_registry.py
+++ b/tldw_Server_API/app/api/v1/router_registry.py
@@ -54,6 +54,8 @@ def register_router_specs(app: FastAPI, specs: Iterable[RouterSpec]) -> int:
         try:
             router = spec.resolve_router()
         except Exception as e:  # noqa: BLE001
+            if not isinstance(e, spec.skip_exceptions):
+                raise
             spec_name = spec.name or spec.route_key or "unnamed"
             context = f" {spec.skip_context}" if spec.skip_context else ""
             logger.debug(f"Skipping {spec_name} router{context}: {e}")

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -4393,6 +4393,178 @@ def test_iter_minimal_optional_router_specs_defers_collections_social_attr_looku
     }
 
 
+def test_iter_minimal_optional_router_specs_defers_data_resource_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal data/resource specs keep router attr lookup lazy."""
+    import builtins
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    router_definitions = (
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.files",
+            "expected_name": "files",
+            "path": "/files",
+            "prefix": "/api/v1",
+            "tags": ("files",),
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.storage",
+            "expected_name": "storage",
+            "path": "/storage",
+            "prefix": "/api/v1",
+            "tags": ("storage",),
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.data_tables",
+            "expected_name": "data_tables",
+            "path": "/data-tables",
+            "prefix": "/api/v1",
+            "tags": ("data-tables",),
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.reading_highlights",
+            "expected_name": "reading_highlights",
+            "path": "/reading-highlights",
+            "prefix": "/api/v1",
+            "tags": ("reading-highlights",),
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.items",
+            "expected_name": "items",
+            "path": "/items",
+            "prefix": "/api/v1",
+            "tags": ("items",),
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.reminders",
+            "expected_name": "reminders",
+            "path": "/reminders",
+            "prefix": "/api/v1",
+            "tags": ("tasks",),
+        },
+    )
+    definitions_by_module = {
+        str(definition["module_name"]): definition
+        for definition in router_definitions
+    }
+    access_count = {
+        f"{definition['module_name']}.router": 0
+        for definition in router_definitions
+    }
+    import_calls: list[str] = []
+
+    for module_name, definition in definitions_by_module.items():
+        fake_module = ModuleType(module_name)
+        router = APIRouter()
+
+        @router.get(str(definition["path"]))
+        def _endpoint() -> dict[str, str]:
+            """Return a deterministic response for the fake minimal router."""
+            return {"status": "ok"}
+
+        def _module_getattr(
+            name: str,
+            *,
+            module_name: str = module_name,
+            router: APIRouter = router,
+        ) -> APIRouter:
+            """Track lazy router attribute resolution for the fake module."""
+            if name != "router":
+                raise AttributeError(name)
+            access_count[f"{module_name}.router"] += 1
+            return router
+
+        fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    endpoints_package = "tldw_Server_API.app.api.v1.endpoints."
+    real_import = builtins.__import__
+
+    def _fake_endpoint_import(
+        name: str,
+        globals: dict[str, object] | None = None,
+        locals: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> ModuleType:
+        """Return fake routers for unrelated eager minimal optional imports."""
+        if (
+            level == 0
+            and name.startswith(endpoints_package)
+            and name not in definitions_by_module
+        ):
+            attrs = tuple(attr for attr in fromlist if attr != "*") or ("router",)
+            for attr_name in attrs:
+                _install_fake_router_module(
+                    monkeypatch,
+                    name,
+                    path="/minimal-unrelated-data-resource-fake",
+                    attr_name=attr_name,
+                )
+            return sys.modules[name]
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_endpoint_import)
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Track lazy module imports for selected minimal data/resource routers."""
+        if module_name in definitions_by_module:
+            import_calls.append(module_name)
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+    fake_main = ModuleType("tldw_Server_API.app.main")
+    fake_main.app = FastAPI()  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "tldw_Server_API.app.main", fake_main)
+
+    specs = list(iter_minimal_optional_router_specs())
+    assert access_count == {
+        f"{definition['module_name']}.router": 0
+        for definition in router_definitions
+    }
+    assert import_calls == []
+
+    selected_specs = {
+        spec.name: spec
+        for spec in specs
+        if spec.name in {
+            str(definition["expected_name"])
+            for definition in router_definitions
+        }
+    }
+    assert set(selected_specs) == {
+        str(definition["expected_name"])
+        for definition in router_definitions
+    }
+
+    for definition in router_definitions:
+        spec = selected_specs[str(definition["expected_name"])]
+        assert spec.prefix == definition["prefix"]
+        assert spec.tags == definition["tags"]
+        assert spec.route_key == ""
+        assert spec.skip_context == "in minimal test app"
+        assert _first_router_path(spec.router) == definition["path"]
+
+    assert import_calls == [
+        str(definition["module_name"])
+        for definition in router_definitions
+    ]
+    assert access_count == {
+        f"{definition['module_name']}.router": 1
+        for definition in router_definitions
+    }
+
+
 def test_iter_minimal_optional_router_specs_populates_llm_specs(monkeypatch: pytest.MonkeyPatch) -> None:
     from tldw_Server_API.app.api.v1.router_groups.minimal import iter_minimal_optional_router_specs
 

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -112,6 +112,7 @@ def test_append_imported_router_spec_preserves_metadata(
     assert specs[0].tags == ("acp-schedules",)
     assert specs[0].route_key == "acp"
     assert specs[0].default_stable is False
+    assert specs[0].skip_exceptions == (ImportError, AttributeError)
 
 
 def test_append_imported_router_spec_defers_router_attr_lookup_until_resolution(
@@ -266,10 +267,10 @@ def test_append_imported_router_spec_skips_optional_import_error_at_registration
     ]
 
 
-def test_append_imported_router_spec_logs_unexpected_import_error_at_registration(
+def test_append_imported_router_spec_raises_unexpected_import_error_at_registration(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Verify unexpected import-time failures are logged by registration."""
+    """Verify unexpected import-time failures are not silently skipped."""
     from tldw_Server_API.app.api.v1.router_groups.conditional import (
         ImportedRouterSpec,
         append_imported_router_spec,
@@ -296,8 +297,9 @@ def test_append_imported_router_spec_logs_unexpected_import_error_at_registratio
     monkeypatch.setattr("loguru.logger.debug", debug_messages.append)
 
     assert len(specs) == 1
-    assert register_router_specs(FastAPI(), specs) == 0
-    assert debug_messages == ["Skipping crashing-router router: router module crashed during import"]
+    with pytest.raises(RuntimeError, match="router module crashed during import"):
+        register_router_specs(FastAPI(), specs)
+    assert debug_messages == []
 
 
 def test_append_imported_router_spec_skips_static_missing_attr_at_registration(
@@ -855,10 +857,10 @@ def test_iter_admin_router_specs_defers_selected_router_attr_lookup(
     assert access_count == {module_name: 1 for module_name in router_definitions}
 
 
-def test_iter_core_router_specs_skips_crashing_chat_import(
+def test_iter_core_router_specs_raises_crashing_chat_import(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Verify chat import crashes skip only the affected router at registration."""
+    """Verify unexpected chat import crashes are not silently skipped."""
     import importlib
 
     app = FastAPI()
@@ -907,14 +909,15 @@ def test_iter_core_router_specs_skips_crashing_chat_import(
         for spec in specs
         if spec.route_key == "chat"
     ]
-    count = register_router_specs(app, chat_specs)
+    with pytest.raises(RuntimeError, match="chat loop crashed during import"):
+        register_router_specs(app, chat_specs)
+
     chat_paths = {route.path for route in app.routes}
 
-    assert count == 2
     assert "/api/v1/chat/chat/completions" in chat_paths
-    assert "/api/v1/chats/conversations" in chat_paths
+    assert "/api/v1/chats/conversations" not in chat_paths
     assert "/api/v1/chat/loop/start" not in chat_paths
-    assert "Skipping chat_loop router: chat loop crashed during import" in debug_messages
+    assert debug_messages == []
 
 
 def test_register_router_specs_respects_route_policy(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -981,14 +984,48 @@ def test_register_router_specs_resolves_lazy_router_after_route_policy(
     assert "/api/v1/lazy" in {route.path for route in app.routes}
 
 
-def test_register_router_specs_logs_spec_name_for_resolution_failures(
+def test_register_router_specs_raises_unexpected_resolution_failures(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Verify unexpected lazy router failures fail closed."""
     app = FastAPI()
     debug_messages: list[str] = []
 
     def router_factory() -> APIRouter:
         raise RuntimeError("lazy router failed")
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.config.route_enabled",
+        lambda *_args, **_kwargs: True,
+    )
+    monkeypatch.setattr("loguru.logger.debug", debug_messages.append)
+
+    with pytest.raises(RuntimeError, match="lazy router failed"):
+        register_router_specs(
+            app,
+            [
+                RouterSpec(
+                    router=router_factory,
+                    prefix="/api/v1",
+                    tags=("lazy",),
+                    route_key="chat",
+                    name="chat_loop",
+                ),
+            ],
+        )
+
+    assert debug_messages == []
+
+
+def test_register_router_specs_skips_configured_resolution_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify router specs can explicitly opt into skippable failures."""
+    app = FastAPI()
+    debug_messages: list[str] = []
+
+    def router_factory() -> APIRouter:
+        raise RuntimeError("lazy optional router failed")
 
     monkeypatch.setattr(
         "tldw_Server_API.app.core.config.route_enabled",
@@ -1005,12 +1042,13 @@ def test_register_router_specs_logs_spec_name_for_resolution_failures(
                 tags=("lazy",),
                 route_key="chat",
                 name="chat_loop",
+                skip_exceptions=(RuntimeError,),
             ),
         ],
     )
 
     assert count == 0
-    assert debug_messages == ["Skipping chat_loop router: lazy router failed"]
+    assert debug_messages == ["Skipping chat_loop router: lazy optional router failed"]
 
 
 def test_register_router_specs_fails_closed_when_route_policy_errors(


### PR DESCRIPTION
## Summary
- Convert the next minimal-test optional data/resource router cluster to ImportedRouterSpec.
- Cover files, storage, data_tables, reading_highlights, items, and reminders lazy import behavior with router-group contract coverage.
- Preserve existing prefixes, tags, route keys, and skip behavior through registration-time resolution.

## Verification
- python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k minimal_optional_router_specs_defers_data_resource_attr_lookup -q (red before implementation, green after)
- python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q
- python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q
- python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q
- python -m bandit -r tldw_Server_API/app/api/v1/router_groups/minimal.py -f json -o /tmp/bandit_phase2_2_minimal_data_resource.json (0 results, 0 errors)
- git diff --check

## Merge Gate
- Human owner still needs to provide the required AI-generated PR Change summary before merge.