### PR TITLE
Add macOS sandbox recovery diagnostics summary

### DIFF
--- a/Docs/Sandbox/macos-runtime-operator-notes.md
+++ b/Docs/Sandbox/macos-runtime-operator-notes.md
@@ -251,6 +251,9 @@ It is admin-only and returns:
 - read-only observability for `vz_linux` helper stdout/stderr log pointers,
   per-VM serial log pointers, guest readiness metadata, and helper-provided
   resource counters when available
+- read-only `recovery_summary` metadata derived from reconciliation,
+  image-store, and observability blocks, including recovery posture, stable
+  issue codes, counts, and existing dry-run-first admin endpoint pointers
 - an additive image-store cleanup plan endpoint and a default-dry-run cleanup
   mutation endpoint for explicit operator action
 - additive `startup_warning_summary` showing whether current-process startup
@@ -268,6 +271,10 @@ runtime is unavailable. Use `/api/v1/sandbox/runtimes` for client-facing discove
 that payload stays summarized and does not expose helper/template internals.
 The diagnostics observability block reports log paths, existence, and byte
 sizes only; it does not read or return log contents.
+The diagnostics `recovery_summary` block is also read-only. It summarizes
+already-collected diagnostics as `healthy`, `action_recommended`, or
+`unavailable`; it does not re-query the helper, scan the image store, or perform
+repair.
 
 ACP sandbox session creation now performs runtime preflight validation before calling the sandbox service, and converts failures into `ACPResponseError` instead of leaking raw sandbox exceptions.
 
@@ -276,6 +283,9 @@ ACP sandbox session creation now performs runtime preflight validation before ca
 `/api/v1/sandbox/admin/macos-diagnostics` is read-only. Its reconciliation block
 compares persisted VZ session-control rows with helper live VM state and reports
 healthy, stale, unhealthy, active, and orphan facts without changing either side.
+Its `recovery_summary` block points operators at the existing repair and cleanup
+plan endpoints when relevant, but the actual repair endpoint remains separate,
+admin-only, explicit, and dry-run-first.
 
 `POST /api/v1/sandbox/admin/macos-reconciliation/repair` is the explicit
 admin-only repair endpoint. Repair defaults to dry-run, skips active sessions,

--- a/Docs/Sandbox/sandbox-runtime-capability-inventory.md
+++ b/Docs/Sandbox/sandbox-runtime-capability-inventory.md
@@ -243,9 +243,9 @@ VM reuse.
 | `worktree` | `supported` | `scaffold` | `unsupported` | `supported` | `supported` |
 
 `vz_linux` currently has the deepest operator path: helper diagnostics,
-image-store correlation, reconciliation, dry-run repair, and host-gated real VM
-smoke. Those details are intentionally not generalized until other runtimes have
-an equally clear ownership model.
+image-store correlation, reconciliation, read-only recovery-summary projection,
+dry-run repair, and host-gated real VM smoke. Those details are intentionally
+not generalized until other runtimes have an equally clear ownership model.
 
 ## Current Gaps
 

--- a/Docs/superpowers/plans/2026-05-05-sandbox-recovery-diagnostics-summary-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-05-sandbox-recovery-diagnostics-summary-implementation-plan.md
@@ -1,0 +1,166 @@
+# Sandbox Recovery Diagnostics Summary Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
+
+**Goal:** Add a read-only operator recovery summary to macOS sandbox diagnostics.
+
+**Architecture:** Implement the summary as a pure projection over existing diagnostics blocks in `macos_diagnostics.py`, then expose it through the existing admin diagnostics schema and endpoint. Do not add helper/image-store calls while building the summary, and do not add new repair behavior.
+
+**Tech Stack:** Python, FastAPI, Pydantic, pytest, existing sandbox diagnostics helpers.
+
+---
+
+### Task 1: Add Schema And Diagnostics Contract Tests
+
+**Files:**
+- Modify: `tldw_Server_API/tests/sandbox/test_macos_diagnostics.py`
+- Modify: `tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py`
+- Modify later: `tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py`
+- Modify later: `tldw_Server_API/app/core/Sandbox/macos_diagnostics.py`
+
+- [x] **Step 1: Add failing schema coverage**
+
+Add `recovery_summary` to the sample diagnostics payload and assert the schema
+accepts:
+
+- `status`
+- `severity`
+- `codes`
+- `counts`
+- `recommended_action`
+- optional `repair_endpoint`
+- optional `cleanup_plan_endpoint`
+- `notes`
+
+- [x] **Step 2: Add failing pure diagnostics coverage**
+
+Add tests for:
+
+- healthy computed reconciliation
+- helper-unavailable or uncomputed reconciliation
+- stale/unhealthy/orphaned reconciliation state
+- image-store cleanup candidates
+
+Expected: FAIL because `collect_macos_diagnostics()` does not emit
+`recovery_summary` and schema models do not define it.
+
+- [x] **Step 3: Add failing endpoint shape coverage**
+
+Update the admin diagnostics endpoint test to expect `recovery_summary` in the
+response keys.
+
+Expected: FAIL because the current response model omits the field.
+
+### Task 2: Implement Pure Recovery Summary Projection
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Sandbox/macos_diagnostics.py`
+
+- [x] **Step 1: Add constants for existing admin endpoints**
+
+Use:
+
+- `/api/v1/sandbox/admin/macos-reconciliation/repair`
+- `/api/v1/sandbox/admin/macos-image-store/cleanup-plan`
+
+- [x] **Step 2: Add a pure `summarize_recovery()` helper**
+
+Inputs:
+
+- `reconciliation: dict[str, object] | None`
+- `image_store: dict[str, object] | None`
+- `observability: dict[str, object] | None`
+
+Output:
+
+- dict matching the new schema
+
+Rules:
+
+- return `unavailable/error` when reconciliation is missing, uncomputed, or has
+  reasons
+- return `action_recommended/warning` when issue counts or GC candidates exist
+- return `healthy/ok` when computed and no issue counts exist
+- include repair endpoint only for stale, unhealthy, or owned orphan VM cases
+- include cleanup-plan endpoint only when image-store GC candidates exist
+- include unknown/foreign orphan codes as inspect-only warnings
+
+- [x] **Step 3: Wire summary into `collect_macos_diagnostics()`**
+
+Call the helper after existing diagnostics blocks are collected and include
+`recovery_summary` in the returned payload.
+
+### Task 3: Add Pydantic Response Model
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py`
+
+- [x] **Step 1: Add `SandboxAdminMacOSRecoverySummary`**
+
+Fields:
+
+- `status: Literal["healthy", "action_recommended", "unavailable"]`
+- `severity: Literal["ok", "warning", "error"]`
+- `codes: list[str]`
+- `counts: dict[str, int]`
+- `recommended_action: str | None`
+- `repair_endpoint: str | None`
+- `cleanup_plan_endpoint: str | None`
+- `notes: list[str]`
+
+- [x] **Step 2: Add the optional field to diagnostics response**
+
+Add `recovery_summary: SandboxAdminMacOSRecoverySummary | None = None` to
+`SandboxAdminMacOSDiagnosticsResponse`.
+
+### Task 4: Documentation And Verification
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Sandbox/README.md`
+- Modify: `Docs/Sandbox/sandbox-runtime-capability-inventory.md`
+- Modify: `backlog/tasks/task-70 - Add-macOS-sandbox-recovery-diagnostics-summary.md`
+
+- [x] **Step 1: Update operator docs**
+
+Document that macOS diagnostics include a read-only `recovery_summary` derived
+from reconciliation/image-store/observability state.
+
+- [x] **Step 2: Run focused tests**
+
+Run:
+
+```bash
+python -m pytest tldw_Server_API/tests/sandbox/test_macos_diagnostics.py tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py -q
+```
+
+Expected: PASS.
+
+- [x] **Step 3: Run py_compile**
+
+Run:
+
+```bash
+python -m py_compile tldw_Server_API/app/core/Sandbox/macos_diagnostics.py tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
+```
+
+Expected: PASS.
+
+- [x] **Step 4: Run Bandit on touched production code**
+
+Run:
+
+```bash
+python -m bandit -r tldw_Server_API/app/core/Sandbox/macos_diagnostics.py tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py -f json -o /tmp/bandit_sandbox_recovery_summary.json
+```
+
+Expected: zero new findings.
+
+- [x] **Step 5: Run whitespace check**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output.

--- a/Docs/superpowers/specs/2026-05-05-sandbox-recovery-diagnostics-summary-design.md
+++ b/Docs/superpowers/specs/2026-05-05-sandbox-recovery-diagnostics-summary-design.md
@@ -1,0 +1,109 @@
+# Sandbox Recovery Diagnostics Summary Design
+
+**Status:** Approved implementation design.
+**Date:** 2026-05-05.
+**Backlog:** `TASK-70`.
+**Scope:** Additive recovery summary for macOS sandbox admin diagnostics.
+
+## Related Guidance
+
+- `Docs/Sandbox/sandbox-architecture-doctrine.md`
+- `Docs/superpowers/specs/2026-05-02-sandbox-module-roadmap-design.md`
+- `Docs/Sandbox/sandbox-runtime-capability-inventory.md`
+- `Docs/superpowers/specs/2026-05-05-sandbox-cleanup-recovery-contract-tests-design.md`
+
+## Goal
+
+Add a read-only `recovery_summary` block to
+`GET /api/v1/sandbox/admin/macos-diagnostics` so operators can quickly answer:
+
+- whether recovery data is healthy, degraded, or unavailable
+- which cleanup or recovery issues are present
+- how many stale sessions, unhealthy sessions, orphan VMs, and image-store
+  cleanup candidates exist
+- which explicit next admin action is safest
+
+The summary is an operator projection over existing diagnostics. It must not
+call the helper, scan the image store, mutate state, or introduce a generic
+cross-runtime repair contract.
+
+## Design
+
+`collect_macos_diagnostics()` will continue collecting the existing blocks in
+the current order:
+
+- `reconciliation`
+- `image_store`
+- `observability`
+
+After those blocks are built, a new pure helper will derive a summary from their
+already-collected values. This keeps diagnostics truth layered and avoids a
+second source of runtime state.
+
+The summary shape is:
+
+- `status`: `healthy`, `action_recommended`, or `unavailable`
+- `severity`: `ok`, `warning`, or `error`
+- `codes`: stable issue codes for clients and dashboards
+- `counts`: stale sessions, unhealthy sessions, skipped active sessions, owned
+  orphan VMs, unknown orphan VMs, foreign orphan VMs, total orphan VMs, image
+  store GC candidates, and live VMs
+- `recommended_action`: short operator action string
+- `repair_endpoint`: existing `vz_linux` repair endpoint only when repair is a
+  relevant next action
+- `cleanup_plan_endpoint`: existing image-store cleanup-plan endpoint only when
+  image-store candidates exist
+- `notes`: bounded human-readable details for admin UX
+
+## Status Rules
+
+The summary is `unavailable` with `severity=error` when reconciliation is not
+computed or has helper/protocol/unavailable reasons. The next action should
+point operators back to helper/preflight diagnostics instead of repair.
+
+The summary is `action_recommended` with `severity=warning` when diagnostics are
+computed and any of these are non-zero:
+
+- stale session controls
+- unhealthy inactive session controls
+- owned orphan helper VMs
+- unknown or foreign orphan helper VMs
+- image-store garbage-collection candidates
+
+The summary is `healthy` with `severity=ok` when diagnostics are computed and no
+actionable issue counts are present.
+
+## Non-Goals
+
+- Do not add a new repair endpoint.
+- Do not generalize repair beyond existing `vz_linux` reconciliation repair.
+- Do not classify host-local runtime cleanup as repairable.
+- Do not read log file contents.
+- Do not re-query helper, session store, or image store while building the
+  summary.
+- Do not remove or rename existing diagnostics fields.
+
+## Risks And Mitigations
+
+- Risk: summary codes drift from underlying diagnostics.
+  Mitigation: derive codes from existing payload fields and cover representative
+  combinations with focused tests.
+- Risk: summary appears to authorize destructive repair.
+  Mitigation: expose the repair endpoint only as a next-step pointer; existing
+  repair remains explicit, admin-only, dry-run-first, and ownership-checked.
+- Risk: clients treat `healthy` as runtime availability.
+  Mitigation: keep host/runtime/template/helper availability in existing blocks;
+  this summary only describes recovery posture.
+
+## Test Strategy
+
+Add focused tests in existing sandbox diagnostics suites:
+
+- schema accepts the new `recovery_summary` block
+- healthy reconciliation produces `healthy` and no endpoints
+- helper-unavailable reconciliation produces `unavailable`
+- stale/unhealthy/orphaned VM state produces `action_recommended` and repair
+  endpoint guidance
+- image-store GC candidates produce cleanup-plan guidance without repair-only
+  claims
+- admin endpoint preserves existing fields while returning `recovery_summary`

--- a/backlog/tasks/task-70 - Add-macOS-sandbox-recovery-diagnostics-summary.md
+++ b/backlog/tasks/task-70 - Add-macOS-sandbox-recovery-diagnostics-summary.md
@@ -1,0 +1,58 @@
+---
+id: TASK-70
+title: Add macOS sandbox recovery diagnostics summary
+status: Done
+assignee: []
+created_date: '2026-05-05 14:07'
+labels:
+  - sandbox
+  - runtime-reliability
+  - diagnostics
+dependencies: []
+documentation:
+  - Docs/Sandbox/sandbox-architecture-doctrine.md
+  - Docs/superpowers/specs/2026-05-02-sandbox-module-roadmap-design.md
+  - Docs/Sandbox/sandbox-runtime-capability-inventory.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add a narrow, additive operator-facing recovery_summary block to macOS sandbox diagnostics. The summary should derive from existing reconciliation, image-store, and observability diagnostics so admins can quickly see recovery posture, issue counts, issue codes, and the next safe action without diagnostics mutating state or generalizing repair beyond vz_linux.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 /api/v1/sandbox/admin/macos-diagnostics exposes an additive recovery_summary field without removing or renaming existing diagnostics fields.
+- [x] #2 The summary is read-only and derived from existing diagnostics payloads rather than re-querying helper/image-store state.
+- [x] #3 The summary reports severity/posture, issue codes, stale/unhealthy/orphan/image-store counts, and a recommended next action for operators.
+- [x] #4 The summary keeps repair guidance vz_linux-scoped and does not introduce a generic cross-runtime repair contract.
+- [x] #5 Focused schema and diagnostics tests cover healthy, unavailable, stale/unhealthy/orphaned, and image-store cleanup candidate cases.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Added `summarize_recovery()` as a pure projection over already-collected macOS diagnostics blocks.
+- Added `SandboxAdminMacOSRecoverySummary` and wired `recovery_summary` into macOS diagnostics responses.
+- Updated sandbox README, runtime capability inventory, and macOS operator notes to document read-only recovery-summary semantics.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented an additive macOS sandbox `recovery_summary` diagnostics block for operator visibility. The summary reports healthy/action-recommended/unavailable posture, stable issue codes, counts, recommended action text, and pointers to existing dry-run-first repair or image-store cleanup-plan endpoints when relevant. It derives from existing reconciliation, image-store, and observability diagnostics without re-querying helper state or mutating data, preserving `vz_linux`-scoped repair semantics.
+
+Verification passed: focused diagnostics pytest reported 26 passed; py_compile passed for touched production Python; Ruff passed on touched source/test files; Bandit reported zero findings for touched production Python; git diff --check passed.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
@@ -11,6 +11,7 @@ except ImportError:  # pragma: no cover - pydantic v1 fallback
     from pydantic import root_validator as model_validator  # type: ignore
 
 from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
+from tldw_Server_API.app.core.Sandbox.run_status_taxonomy import RunStatusReasonCode
 from tldw_Server_API.app.core.Sandbox.runtime_capabilities import (
     RuntimeBoundaryClass,
     RuntimeImplementationState,
@@ -20,7 +21,6 @@ from tldw_Server_API.app.core.Sandbox.runtime_capabilities import (
     RuntimeReasonCode,
     RuntimeSessionReuseModel,
 )
-from tldw_Server_API.app.core.Sandbox.run_status_taxonomy import RunStatusReasonCode
 
 RuntimeType = Literal[
     "docker",
@@ -396,7 +396,7 @@ class SandboxAdminRunListResponse(BaseModel):
     items: list[SandboxAdminRunSummary]
 
     @model_validator(mode="after")
-    def default_pagination_aliases(self) -> "SandboxAdminRunListResponse":
+    def default_pagination_aliases(self) -> SandboxAdminRunListResponse:
         return _default_offset_pagination_aliases(self)
 
 
@@ -424,7 +424,7 @@ class SandboxAdminIdempotencyListResponse(BaseModel):
     items: list[SandboxAdminIdempotencyItem]
 
     @model_validator(mode="after")
-    def default_pagination_aliases(self) -> "SandboxAdminIdempotencyListResponse":
+    def default_pagination_aliases(self) -> SandboxAdminIdempotencyListResponse:
         return _default_offset_pagination_aliases(self)
 
 
@@ -446,7 +446,7 @@ class SandboxAdminUsageResponse(BaseModel):
     items: list[SandboxAdminUsageItem]
 
     @model_validator(mode="after")
-    def default_pagination_aliases(self) -> "SandboxAdminUsageResponse":
+    def default_pagination_aliases(self) -> SandboxAdminUsageResponse:
         return _default_offset_pagination_aliases(self)
 
 
@@ -631,6 +631,19 @@ class SandboxAdminStartupWarningSummary(BaseModel):
     codes: list[str] = Field(default_factory=list)
 
 
+class SandboxAdminMacOSRecoverySummary(BaseModel):
+    """Operator-facing recovery posture derived from macOS diagnostics blocks."""
+
+    status: Literal["healthy", "action_recommended", "unavailable"]
+    severity: Literal["ok", "warning", "error"]
+    codes: list[str] = Field(default_factory=list)
+    counts: dict[str, int] = Field(default_factory=dict)
+    recommended_action: str | None = None
+    repair_endpoint: str | None = None
+    cleanup_plan_endpoint: str | None = None
+    notes: list[str] = Field(default_factory=list)
+
+
 class SandboxAdminMacOSDiagnosticsResponse(BaseModel):
     """Structured admin response for macOS sandbox diagnostics."""
 
@@ -641,6 +654,7 @@ class SandboxAdminMacOSDiagnosticsResponse(BaseModel):
     reconciliation: SandboxAdminMacOSReconciliationDiagnostics | None = None
     image_store: SandboxAdminMacOSImageStoreDiagnostics | None = None
     observability: SandboxAdminMacOSObservabilityDiagnostics | None = None
+    recovery_summary: SandboxAdminMacOSRecoverySummary | None = None
     startup_warning_summary: SandboxAdminStartupWarningSummary | None = None
 
 

--- a/tldw_Server_API/app/core/Sandbox/README.md
+++ b/tldw_Server_API/app/core/Sandbox/README.md
@@ -110,6 +110,10 @@ Current limitations:
   helper stdout/stderr log pointers, per-VM serial log pointers, guest readiness
   details, and helper-provided resource counters when available. Diagnostics
   report file existence and byte sizes only; they do not read log contents.
+- `vz_linux` admin diagnostics include a read-only `recovery_summary` block
+  derived from reconciliation, image-store, and observability diagnostics. It
+  reports recovery posture, issue codes, counts, and existing dry-run-first
+  admin endpoint pointers without re-querying helper state or mutating data.
 - `vz_linux` repair is explicit and admin-only through `POST /api/v1/sandbox/admin/macos-reconciliation/repair`; diagnostics do not mutate state.
 - `vz_linux` repair defaults to dry-run, skips active sessions, can delete stale or unhealthy inactive persisted session-control rows when requested, and can terminate orphan helper VMs only when `terminate_orphaned_vms=true` is explicitly requested, helper metadata proves `owner=tldw` and `runtime=vz_linux`, and the ownership record remains eligibility-complete. Eligibility-complete means `run_id` and `created_at` are present, and `session_id` is also present when `session_mode=true`.
 - `vz_linux` orphan VM diagnostics split live unreferenced helper VMs into `owned_orphaned_vm`, `unknown_orphaned_vm`, and `foreign_orphaned_vm`. Only ownership-eligible `owned_orphaned_vm` records can be terminated automatically; unknown, foreign, and legacy generic orphan records are reported but skipped by automated repair.
@@ -189,7 +193,10 @@ included in the public discovery payload, plus reconciliation data for persisted
 correlation for persisted run manifests and dry-run GC candidates. It is
 read-only and now includes helper/serial log observability plus a compact
 `startup_warning_summary` field projected from the current-process startup
-warning registry.
+warning registry. The response also includes `recovery_summary`, a read-only
+operator projection over the already-collected reconciliation/image-store/
+observability blocks that classifies recovery posture as healthy, action
+recommended, or unavailable.
 `/api/v1/admin/startup-warnings` is the generic admin-only companion surface for
 the same startup records and returns full current-process warning items plus
 grouped counts.

--- a/tldw_Server_API/app/core/Sandbox/macos_diagnostics.py
+++ b/tldw_Server_API/app/core/Sandbox/macos_diagnostics.py
@@ -292,7 +292,6 @@ def summarize_recovery(
         if str(reason).strip()
     ]
     if observability_reasons:
-        codes.append("vz_observability_unavailable")
         notes.append(f"Observability reasons: {', '.join(observability_reasons[:3])}.")
 
     repair_needed = any(
@@ -312,8 +311,9 @@ def summarize_recovery(
             "skipped_active_session_controls",
         )
     )
+    actionable_recovery_issue = repair_needed or cleanup_needed or inspect_needed
 
-    if not codes:
+    if not actionable_recovery_issue:
         recommended_action = "No recovery action needed."
     elif repair_needed and cleanup_needed:
         recommended_action = "Run macOS reconciliation repair in dry-run mode, then inspect the image-store cleanup plan."
@@ -324,11 +324,11 @@ def summarize_recovery(
     elif inspect_needed:
         recommended_action = "Inspect orphan VM ownership before taking manual action."
     else:
-        recommended_action = "Review VZ Linux diagnostics before taking recovery action."
+        recommended_action = "Review macOS sandbox diagnostics before taking recovery action."
 
     return {
-        "status": "action_recommended" if codes else "healthy",
-        "severity": "warning" if codes else "ok",
+        "status": "action_recommended" if actionable_recovery_issue else "healthy",
+        "severity": "warning" if actionable_recovery_issue else "ok",
         "codes": codes,
         "counts": counts,
         "recommended_action": recommended_action,

--- a/tldw_Server_API/app/core/Sandbox/macos_diagnostics.py
+++ b/tldw_Server_API/app/core/Sandbox/macos_diagnostics.py
@@ -32,6 +32,8 @@ from .vz_reconciliation import (
 _VZ_LINUX_TEMPLATE_MISSING_REASON = "vz_linux_template_missing"
 _VZ_MACOS_TEMPLATE_MISSING_REASON = "macos_template_missing"
 _VZ_LINUX_OBSERVABILITY_UNAVAILABLE_REASON = "vz_linux_observability_unavailable"
+_MACOS_RECONCILIATION_REPAIR_ENDPOINT = "/api/v1/sandbox/admin/macos-reconciliation/repair"
+_MACOS_IMAGE_STORE_CLEANUP_PLAN_ENDPOINT = "/api/v1/sandbox/admin/macos-image-store/cleanup-plan"
 _HELPER_LOG_DIR_ENV = "TLDW_SANDBOX_MACOS_HELPER_LOG_DIR"
 _VZ_LINUX_SERIAL_LOG_DIR_ENV = "TLDW_SANDBOX_VZ_LINUX_SERIAL_LOG_DIR"
 _VZ_LINUX_RESOURCE_DETAIL_KEYS = (
@@ -196,6 +198,144 @@ def _resource_snapshot(details: dict[str, object]) -> dict[str, int]:
         if value is not None:
             snapshot[key] = value
     return snapshot
+
+
+def _count_list(payload: dict[str, object], key: str) -> int:
+    """Return a count for list-like diagnostics fields."""
+
+    value = payload.get(key)
+    if isinstance(value, list | tuple | set):
+        return len(value)
+    return 0
+
+
+def _count_int(payload: dict[str, object], key: str) -> int:
+    """Return a non-negative integer for diagnostics count fields."""
+
+    value = payload.get(key)
+    if isinstance(value, bool):
+        return 0
+    try:
+        return max(0, int(value or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def summarize_recovery(
+    *,
+    reconciliation: dict[str, object] | None,
+    image_store: dict[str, object] | None,
+    observability: dict[str, object] | None,
+) -> dict[str, object]:
+    """Summarize already-collected diagnostics into operator recovery posture."""
+
+    reconciliation_payload = dict(reconciliation or {})
+    image_store_payload = dict(image_store or {})
+    observability_payload = dict(observability or {})
+    reasons = [
+        str(reason).strip()
+        for reason in list(reconciliation_payload.get("reasons") or [])
+        if str(reason).strip()
+    ]
+    counts = {
+        "persisted_session_controls": _count_int(reconciliation_payload, "persisted_sessions"),
+        "healthy_session_controls": _count_list(reconciliation_payload, "healthy_session_ids"),
+        "stale_session_controls": _count_list(reconciliation_payload, "stale_session_ids"),
+        "unhealthy_session_controls": _count_list(reconciliation_payload, "unhealthy_session_ids"),
+        "skipped_active_session_controls": _count_list(reconciliation_payload, "skipped_active_session_ids"),
+        "orphaned_vms": _count_list(reconciliation_payload, "orphaned_vm_ids"),
+        "owned_orphaned_vms": _count_list(reconciliation_payload, "owned_orphaned_vm_ids"),
+        "unknown_orphaned_vms": _count_list(reconciliation_payload, "unknown_orphaned_vm_ids"),
+        "foreign_orphaned_vms": _count_list(reconciliation_payload, "foreign_orphaned_vm_ids"),
+        "image_store_gc_candidates": _count_int(image_store_payload, "gc_candidates"),
+        "live_vms": _count_int(reconciliation_payload, "live_vms"),
+    }
+    notes: list[str] = []
+    if not bool(reconciliation_payload.get("computed")) or reasons:
+        if reasons:
+            notes.append(f"Reconciliation reasons: {', '.join(reasons[:3])}.")
+        else:
+            notes.append("Reconciliation did not compute.")
+        return {
+            "status": "unavailable",
+            "severity": "error",
+            "codes": ["vz_recovery_unavailable"],
+            "counts": counts,
+            "recommended_action": "Fix helper and runtime diagnostics before running repair.",
+            "repair_endpoint": None,
+            "cleanup_plan_endpoint": None,
+            "notes": notes,
+        }
+
+    codes: list[str] = []
+    if counts["stale_session_controls"] > 0:
+        codes.append("vz_stale_session_controls")
+    if counts["unhealthy_session_controls"] > 0:
+        codes.append("vz_unhealthy_session_controls")
+    if counts["skipped_active_session_controls"] > 0:
+        codes.append("vz_active_session_controls_skipped")
+        notes.append("Active sessions were skipped by reconciliation and should not be repaired automatically.")
+    if counts["owned_orphaned_vms"] > 0:
+        codes.append("vz_owned_orphaned_vms")
+    if counts["unknown_orphaned_vms"] > 0:
+        codes.append("vz_unknown_orphaned_vms")
+        notes.append("Unknown orphan VM ownership requires manual inspection before termination.")
+    if counts["foreign_orphaned_vms"] > 0:
+        codes.append("vz_foreign_orphaned_vms")
+        notes.append("Foreign orphan VMs are reported for visibility only.")
+    if counts["image_store_gc_candidates"] > 0:
+        codes.append("vz_image_store_gc_candidates")
+
+    observability_reasons = [
+        str(reason).strip()
+        for reason in list(observability_payload.get("reasons") or [])
+        if str(reason).strip()
+    ]
+    if observability_reasons:
+        codes.append("vz_observability_unavailable")
+        notes.append(f"Observability reasons: {', '.join(observability_reasons[:3])}.")
+
+    repair_needed = any(
+        counts[key] > 0
+        for key in (
+            "stale_session_controls",
+            "unhealthy_session_controls",
+            "owned_orphaned_vms",
+        )
+    )
+    cleanup_needed = counts["image_store_gc_candidates"] > 0
+    inspect_needed = any(
+        counts[key] > 0
+        for key in (
+            "unknown_orphaned_vms",
+            "foreign_orphaned_vms",
+            "skipped_active_session_controls",
+        )
+    )
+
+    if not codes:
+        recommended_action = "No recovery action needed."
+    elif repair_needed and cleanup_needed:
+        recommended_action = "Run macOS reconciliation repair in dry-run mode, then inspect the image-store cleanup plan."
+    elif repair_needed:
+        recommended_action = "Run macOS reconciliation repair in dry-run mode and inspect planned actions."
+    elif cleanup_needed:
+        recommended_action = "Inspect the macOS image-store cleanup plan before deleting candidates."
+    elif inspect_needed:
+        recommended_action = "Inspect orphan VM ownership before taking manual action."
+    else:
+        recommended_action = "Review VZ Linux diagnostics before taking recovery action."
+
+    return {
+        "status": "action_recommended" if codes else "healthy",
+        "severity": "warning" if codes else "ok",
+        "codes": codes,
+        "counts": counts,
+        "recommended_action": recommended_action,
+        "repair_endpoint": _MACOS_RECONCILIATION_REPAIR_ENDPOINT if repair_needed else None,
+        "cleanup_plan_endpoint": _MACOS_IMAGE_STORE_CLEANUP_PLAN_ENDPOINT if cleanup_needed else None,
+        "notes": notes,
+    }
 
 
 def probe_host() -> dict[str, object]:
@@ -386,7 +526,7 @@ def _fetch_live_vms_for_diagnostics() -> tuple[Any | None, str | None, str | Non
     except MacOSVirtualizationHelperFailure as exc:
         logger.debug("VZ helper returned failure while listing VMs for diagnostics: {}", exc.error_code)
         return None, REASON_HELPER_FAILURE, REASON_HELPER_FAILURE
-    except Exception as exc:
+    except (AttributeError, OSError, RuntimeError, TypeError, ValueError) as exc:
         logger.debug("Unable to collect VZ helper VM list for diagnostics: {}", exc)
         return None, REASON_RECONCILIATION_UNAVAILABLE, _VZ_LINUX_OBSERVABILITY_UNAVAILABLE_REASON
 
@@ -667,6 +807,11 @@ def collect_macos_diagnostics(orchestrator: Any | None = None) -> dict[str, Any]
         live=live,
         live_failure_reason=observability_live_failure,
     )
+    recovery_summary = summarize_recovery(
+        reconciliation=reconciliation,
+        image_store=image_store,
+        observability=observability,
+    )
     return {
         "host": host,
         "helper": helper,
@@ -675,4 +820,5 @@ def collect_macos_diagnostics(orchestrator: Any | None = None) -> dict[str, Any]
         "reconciliation": reconciliation,
         "image_store": image_store,
         "observability": observability,
+        "recovery_summary": recovery_summary,
     }

--- a/tldw_Server_API/app/core/Sandbox/macos_diagnostics.py
+++ b/tldw_Server_API/app/core/Sandbox/macos_diagnostics.py
@@ -526,7 +526,8 @@ def _fetch_live_vms_for_diagnostics() -> tuple[Any | None, str | None, str | Non
     except MacOSVirtualizationHelperFailure as exc:
         logger.debug("VZ helper returned failure while listing VMs for diagnostics: {}", exc.error_code)
         return None, REASON_HELPER_FAILURE, REASON_HELPER_FAILURE
-    except (AttributeError, OSError, RuntimeError, TypeError, ValueError) as exc:
+    except Exception as exc:  # noqa: BLE001
+        # Diagnostics must remain best-effort when helper payload parsing changes unexpectedly.
         logger.debug("Unable to collect VZ helper VM list for diagnostics: {}", exc)
         return None, REASON_RECONCILIATION_UNAVAILABLE, _VZ_LINUX_OBSERVABILITY_UNAVAILABLE_REASON
 

--- a/tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py
+++ b/tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py
@@ -122,15 +122,37 @@ def _diagnostics_payload() -> dict:
             "items": [],
             "reasons": [],
         },
+        "recovery_summary": {
+            "status": "unavailable",
+            "severity": "error",
+            "codes": ["vz_recovery_unavailable"],
+            "counts": {
+                "persisted_session_controls": 0,
+                "healthy_session_controls": 0,
+                "stale_session_controls": 0,
+                "unhealthy_session_controls": 0,
+                "skipped_active_session_controls": 0,
+                "orphaned_vms": 0,
+                "owned_orphaned_vms": 0,
+                "unknown_orphaned_vms": 0,
+                "foreign_orphaned_vms": 0,
+                "image_store_gc_candidates": 0,
+                "live_vms": 0,
+            },
+            "recommended_action": "Fix helper and runtime diagnostics before running repair.",
+            "repair_endpoint": None,
+            "cleanup_plan_endpoint": None,
+            "notes": ["Reconciliation did not compute."],
+        },
     }
 
 
 def test_admin_macos_diagnostics_returns_structured_payload(monkeypatch) -> None:
-    from tldw_Server_API.app.services.startup_warning_registry import (
-        StartupWarningRegistry,
-    )
     from tldw_Server_API.app.services.startup_warning_models import (
         StartupWarningRecord,
+    )
+    from tldw_Server_API.app.services.startup_warning_registry import (
+        StartupWarningRegistry,
     )
 
     fake_service = SimpleNamespace(macos_diagnostics=lambda: _diagnostics_payload())
@@ -175,6 +197,7 @@ def test_admin_macos_diagnostics_returns_structured_payload(monkeypatch) -> None
         "reconciliation",
         "image_store",
         "observability",
+        "recovery_summary",
         "startup_warning_summary",
     }
     assert body["host"]["supported"] is True
@@ -188,6 +211,8 @@ def test_admin_macos_diagnostics_returns_structured_payload(monkeypatch) -> None
     assert body["image_store"]["configured"] is False
     assert body["image_store"]["items"] == []
     assert body["observability"] is None
+    assert body["recovery_summary"]["status"] == "unavailable"
+    assert body["recovery_summary"]["codes"] == ["vz_recovery_unavailable"]
     assert body["startup_warning_summary"] == {
         "present": True,
         "blocking": False,
@@ -239,6 +264,28 @@ def test_admin_macos_diagnostics_allows_real_vz_linux_execution_mode(monkeypatch
             "matched_reconciliation_status": "healthy",
         }
     ]
+    payload["recovery_summary"] = {
+        "status": "healthy",
+        "severity": "ok",
+        "codes": [],
+        "counts": {
+            "persisted_session_controls": 1,
+            "healthy_session_controls": 1,
+            "stale_session_controls": 0,
+            "unhealthy_session_controls": 0,
+            "skipped_active_session_controls": 0,
+            "orphaned_vms": 0,
+            "owned_orphaned_vms": 0,
+            "unknown_orphaned_vms": 0,
+            "foreign_orphaned_vms": 0,
+            "image_store_gc_candidates": 0,
+            "live_vms": 1,
+        },
+        "recommended_action": "No recovery action needed.",
+        "repair_endpoint": None,
+        "cleanup_plan_endpoint": None,
+        "notes": [],
+    }
 
     fake_service = SimpleNamespace(macos_diagnostics=lambda: payload)
     monkeypatch.setattr(sandbox_mod, "_service", fake_service, raising=True)
@@ -259,3 +306,4 @@ def test_admin_macos_diagnostics_allows_real_vz_linux_execution_mode(monkeypatch
     assert body["reconciliation"]["items"][0]["status"] == "healthy"
     assert body["image_store"]["configured"] is True
     assert body["image_store"]["items"][0]["matched_vm_id"] == "vm-live"
+    assert body["recovery_summary"]["status"] == "healthy"

--- a/tldw_Server_API/tests/sandbox/test_macos_diagnostics.py
+++ b/tldw_Server_API/tests/sandbox/test_macos_diagnostics.py
@@ -1025,6 +1025,44 @@ def test_probe_vz_linux_observability_handles_helper_unavailable(
     assert data["reasons"] == ["macos_virtualization_helper_unavailable"]
 
 
+def test_collect_macos_diagnostics_maps_unexpected_helper_list_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_macos_host(monkeypatch)
+
+    class _BuggyListHelper:
+        def ping(self) -> HelperPingReply:
+            return HelperPingReply(
+                protocol_version="1",
+                helper_version="0.1.0",
+                status="ok",
+                details={"transport": "unix"},
+            )
+
+        def list_vms(self) -> HelperVMListReply:
+            raise KeyError("unexpected helper payload shape")
+
+    monkeypatch.setattr(diagnostics_module, "MacOSVirtualizationHelperClient", _BuggyListHelper)
+    monkeypatch.setattr(
+        diagnostics_module,
+        "collect_runtime_preflights",
+        lambda network_policy="deny_all": {
+            RuntimeType.vz_linux: RuntimePreflightResult(
+                runtime=RuntimeType.vz_linux,
+                available=False,
+                reasons=["vz_reconciliation_unavailable"],
+                execution_mode="none",
+            ),
+        },
+    )
+
+    data = diagnostics_module.collect_macos_diagnostics()
+
+    assert data["reconciliation"]["reasons"] == ["vz_reconciliation_unavailable"]
+    assert data["observability"]["reasons"] == ["vz_linux_observability_unavailable"]
+    assert data["recovery_summary"]["status"] == "unavailable"
+
+
 def test_probe_vz_linux_observability_default_log_dir_is_not_configured(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tldw_Server_API/tests/sandbox/test_macos_diagnostics.py
+++ b/tldw_Server_API/tests/sandbox/test_macos_diagnostics.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 import pytest
+
 import tldw_Server_API.app.core.Sandbox.macos_diagnostics as diagnostics_module
 import tldw_Server_API.app.core.Sandbox.vz_reconciliation as reconciliation_module
 from tldw_Server_API.app.core.Sandbox.image_store import SandboxImageStore
@@ -164,6 +165,28 @@ def _sample_diagnostics_payload() -> dict:
                 }
             ],
             "reasons": [],
+        },
+        "recovery_summary": {
+            "status": "healthy",
+            "severity": "ok",
+            "codes": [],
+            "counts": {
+                "persisted_session_controls": 1,
+                "healthy_session_controls": 1,
+                "stale_session_controls": 0,
+                "unhealthy_session_controls": 0,
+                "skipped_active_session_controls": 0,
+                "orphaned_vms": 0,
+                "owned_orphaned_vms": 0,
+                "unknown_orphaned_vms": 0,
+                "foreign_orphaned_vms": 0,
+                "image_store_gc_candidates": 0,
+                "live_vms": 1,
+            },
+            "recommended_action": "No recovery action needed.",
+            "repair_endpoint": None,
+            "cleanup_plan_endpoint": None,
+            "notes": [],
         },
     }
 
@@ -420,6 +443,129 @@ def test_admin_schema_accepts_macos_diagnostics_payload() -> None:
     assert model.observability.vms[0].serial_log.path == "/tmp/vz-serial/vm-live.serial.log"
     assert model.observability.vms[0].guest.capabilities == ["exec", "output_cap_v1"]
     assert model.observability.vms[0].resource_snapshot == {"cpu_time_sec": 1}
+    assert model.recovery_summary is not None
+    assert model.recovery_summary.status == "healthy"
+    assert model.recovery_summary.severity == "ok"
+    assert model.recovery_summary.counts["healthy_session_controls"] == 1
+
+
+def test_recovery_summary_reports_healthy_when_no_issues() -> None:
+    summary = diagnostics_module.summarize_recovery(
+        reconciliation={
+            "computed": True,
+            "persisted_sessions": 1,
+            "live_vms": 1,
+            "healthy_session_ids": ["sess-live"],
+            "stale_session_ids": [],
+            "unhealthy_session_ids": [],
+            "skipped_active_session_ids": [],
+            "orphaned_vm_ids": [],
+            "owned_orphaned_vm_ids": [],
+            "unknown_orphaned_vm_ids": [],
+            "foreign_orphaned_vm_ids": [],
+            "items": [],
+            "reasons": [],
+        },
+        image_store={"gc_candidates": 0, "reasons": []},
+        observability={"live_vms": 1, "reasons": []},
+    )
+
+    assert summary["status"] == "healthy"
+    assert summary["severity"] == "ok"
+    assert summary["codes"] == []
+    assert summary["counts"]["healthy_session_controls"] == 1
+    assert summary["recommended_action"] == "No recovery action needed."
+    assert summary["repair_endpoint"] is None
+    assert summary["cleanup_plan_endpoint"] is None
+
+
+def test_recovery_summary_reports_unavailable_when_reconciliation_uncomputed() -> None:
+    summary = diagnostics_module.summarize_recovery(
+        reconciliation={
+            "computed": False,
+            "persisted_sessions": 0,
+            "live_vms": 0,
+            "healthy_session_ids": [],
+            "stale_session_ids": [],
+            "unhealthy_session_ids": [],
+            "skipped_active_session_ids": [],
+            "orphaned_vm_ids": [],
+            "owned_orphaned_vm_ids": [],
+            "unknown_orphaned_vm_ids": [],
+            "foreign_orphaned_vm_ids": [],
+            "items": [],
+            "reasons": ["macos_virtualization_helper_unavailable"],
+        },
+        image_store={"gc_candidates": 0, "reasons": []},
+        observability=None,
+    )
+
+    assert summary["status"] == "unavailable"
+    assert summary["severity"] == "error"
+    assert "vz_recovery_unavailable" in summary["codes"]
+    assert summary["repair_endpoint"] is None
+    assert summary["cleanup_plan_endpoint"] is None
+
+
+def test_recovery_summary_recommends_repair_for_stale_unhealthy_and_owned_orphans() -> None:
+    summary = diagnostics_module.summarize_recovery(
+        reconciliation={
+            "computed": True,
+            "persisted_sessions": 4,
+            "live_vms": 3,
+            "healthy_session_ids": ["sess-live"],
+            "stale_session_ids": ["sess-stale"],
+            "unhealthy_session_ids": ["sess-unhealthy"],
+            "skipped_active_session_ids": [],
+            "orphaned_vm_ids": ["vm-owned"],
+            "owned_orphaned_vm_ids": ["vm-owned"],
+            "unknown_orphaned_vm_ids": [],
+            "foreign_orphaned_vm_ids": [],
+            "items": [],
+            "reasons": [],
+        },
+        image_store={"gc_candidates": 0, "reasons": []},
+        observability={"live_vms": 3, "reasons": []},
+    )
+
+    assert summary["status"] == "action_recommended"
+    assert summary["severity"] == "warning"
+    assert "vz_stale_session_controls" in summary["codes"]
+    assert "vz_unhealthy_session_controls" in summary["codes"]
+    assert "vz_owned_orphaned_vms" in summary["codes"]
+    assert summary["counts"]["stale_session_controls"] == 1
+    assert summary["counts"]["unhealthy_session_controls"] == 1
+    assert summary["counts"]["owned_orphaned_vms"] == 1
+    assert summary["repair_endpoint"] == "/api/v1/sandbox/admin/macos-reconciliation/repair"
+
+
+def test_recovery_summary_recommends_cleanup_plan_for_image_store_candidates() -> None:
+    summary = diagnostics_module.summarize_recovery(
+        reconciliation={
+            "computed": True,
+            "persisted_sessions": 0,
+            "live_vms": 0,
+            "healthy_session_ids": [],
+            "stale_session_ids": [],
+            "unhealthy_session_ids": [],
+            "skipped_active_session_ids": [],
+            "orphaned_vm_ids": [],
+            "owned_orphaned_vm_ids": [],
+            "unknown_orphaned_vm_ids": [],
+            "foreign_orphaned_vm_ids": [],
+            "items": [],
+            "reasons": [],
+        },
+        image_store={"gc_candidates": 2, "reasons": []},
+        observability={"live_vms": 0, "reasons": []},
+    )
+
+    assert summary["status"] == "action_recommended"
+    assert summary["severity"] == "warning"
+    assert summary["codes"] == ["vz_image_store_gc_candidates"]
+    assert summary["counts"]["image_store_gc_candidates"] == 2
+    assert summary["repair_endpoint"] is None
+    assert summary["cleanup_plan_endpoint"] == "/api/v1/sandbox/admin/macos-image-store/cleanup-plan"
 
 
 def test_admin_schema_accepts_startup_warning_summary() -> None:

--- a/tldw_Server_API/tests/sandbox/test_macos_diagnostics.py
+++ b/tldw_Server_API/tests/sandbox/test_macos_diagnostics.py
@@ -479,6 +479,36 @@ def test_recovery_summary_reports_healthy_when_no_issues() -> None:
     assert summary["cleanup_plan_endpoint"] is None
 
 
+def test_recovery_summary_keeps_observability_only_failure_healthy() -> None:
+    summary = diagnostics_module.summarize_recovery(
+        reconciliation={
+            "computed": True,
+            "persisted_sessions": 1,
+            "live_vms": 1,
+            "healthy_session_ids": ["sess-live"],
+            "stale_session_ids": [],
+            "unhealthy_session_ids": [],
+            "skipped_active_session_ids": [],
+            "orphaned_vm_ids": [],
+            "owned_orphaned_vm_ids": [],
+            "unknown_orphaned_vm_ids": [],
+            "foreign_orphaned_vm_ids": [],
+            "items": [],
+            "reasons": [],
+        },
+        image_store={"gc_candidates": 0, "reasons": []},
+        observability={"live_vms": 1, "reasons": ["serial_log_dir_not_configured"]},
+    )
+
+    assert summary["status"] == "healthy"
+    assert summary["severity"] == "ok"
+    assert summary["codes"] == []
+    assert summary["recommended_action"] == "No recovery action needed."
+    assert summary["repair_endpoint"] is None
+    assert summary["cleanup_plan_endpoint"] is None
+    assert summary["notes"] == ["Observability reasons: serial_log_dir_not_configured."]
+
+
 def test_recovery_summary_reports_unavailable_when_reconciliation_uncomputed() -> None:
     summary = diagnostics_module.summarize_recovery(
         reconciliation={


### PR DESCRIPTION
## Summary
- Add a read-only macOS sandbox recovery_summary diagnostics block derived from existing reconciliation, image-store, and observability payloads.
- Expose additive Pydantic schema fields and focused tests for healthy, unavailable, stale/unhealthy/orphaned, and image-store cleanup candidate cases.
- Update sandbox operator docs, runtime inventory, and TASK-70 with the new operator-facing recovery posture contract.

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_macos_diagnostics.py tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile tldw_Server_API/app/core/Sandbox/macos_diagnostics.py tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check tldw_Server_API/app/core/Sandbox/macos_diagnostics.py tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py tldw_Server_API/tests/sandbox/test_macos_diagnostics.py tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Sandbox/macos_diagnostics.py tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py -f json -o /tmp/bandit_sandbox_recovery_summary.json
- git diff --check HEAD

## Human Change summary
TODO: human requester must add the merge-gate Change summary before merge.