### PR TITLE
Add CodeGraph Jobs indexing mode

### DIFF
--- a/Docs/superpowers/plans/2026-05-05-native-codegraph-jobs-indexing-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-05-native-codegraph-jobs-indexing-implementation-plan.md
@@ -1,0 +1,228 @@
+# Native CodeGraph Jobs Indexing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the deferred Jobs-backed execution path for native CodeGraph index and sync work.
+
+**Architecture:** Keep foreground CodeGraph behavior unchanged. Add small job payload helpers under `app/core/CodeGraph/`, a worker entrypoint that delegates to the existing `CodeGraphIndexer`, and thin MCP enqueue handling in `CodeGraphModule`. The first Jobs slice should not add file watching, Scheduler integration, automatic in-process startup, or new graph semantics.
+
+**Tech Stack:** Python 3.11, Unified MCP `BaseModule`, core Jobs `JobManager`/`WorkerSDK`, SQLite-backed CodeGraph repository, pytest/pytest-asyncio, Ruff, Bandit.
+
+---
+
+## Scope
+
+Implement only:
+
+- `mode="job"` and `mode="background"` for `codegraph.index` and `codegraph.sync`.
+- Core Jobs payload helpers for CodeGraph index and sync work.
+- A CodeGraph Jobs worker handler and `run_codegraph_jobs_worker()` entrypoint.
+- Focused tests for helper payloads, worker validation/execution, MCP enqueue responses, and existing foreground behavior.
+
+Do not implement:
+
+- File watchers or Scheduler-triggered recurring sync.
+- Automatic worker startup in FastAPI lifespan.
+- Jobs-specific progress callbacks beyond returning the serialized index result.
+- Full cancellation checkpoints inside `CodeGraphIndexer`.
+- Any new language extractor or semantic-resolution behavior.
+
+## File Structure
+
+- Create `tldw_Server_API/app/core/CodeGraph/jobs.py`
+  - Constants for Jobs domain, queue, and job types.
+  - JSON-safe payload builder from `WorkspaceResolution`, `CodeGraphSettings`, and tool arguments.
+  - `enqueue_codegraph_index_job(...)` helper that accepts an optional `JobManager`.
+- Create `tldw_Server_API/app/core/CodeGraph/jobs_worker.py`
+  - `handle_codegraph_index_job(job)` worker handler.
+  - Safe payload validation and path-bounding for `workspace_root` and `index_db_path`.
+  - `run_codegraph_jobs_worker(stop_event=None)` WorkerSDK entrypoint.
+- Modify `tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py`
+  - Accept optional `job_manager_factory` for tests.
+  - Add job/background mode validation.
+  - Enqueue Jobs entries for index/sync job mode via `asyncio.to_thread`.
+- Add `tldw_Server_API/tests/CodeGraph/test_codegraph_jobs.py`
+  - Payload/enqueue helper tests.
+- Add `tldw_Server_API/tests/CodeGraph/test_codegraph_jobs_worker.py`
+  - Worker handler success and validation tests.
+- Modify `tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py`
+  - MCP job-mode enqueue tests and foreground regression.
+- Modify `backlog/tasks/task-70 - Add-CodeGraph-Jobs-backed-indexing-mode.md`
+  - Record plan, implementation notes, verification, and final summary.
+
+## Task 1: Job Payload Helpers
+
+**Files:**
+
+- Create `tldw_Server_API/app/core/CodeGraph/jobs.py`
+- Test `tldw_Server_API/tests/CodeGraph/test_codegraph_jobs.py`
+
+- [x] **Step 1: Write failing payload/enqueue tests**
+
+Add tests proving:
+
+- `build_codegraph_index_job_payload(...)` returns JSON-safe strings for paths, settings, languages, `force`, and operation.
+- `enqueue_codegraph_index_job(...)` creates a Jobs row with domain `codegraph`, queue from `CODEGRAPH_JOBS_QUEUE` or `default`, job type `codegraph_index`, owner id, and payload.
+
+Run:
+
+```bash
+python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_jobs.py -q
+```
+
+Expected: fail because `tldw_Server_API.app.core.CodeGraph.jobs` does not exist.
+
+- [x] **Step 2: Implement minimal helpers**
+
+Create constants:
+
+- `CODEGRAPH_JOBS_DOMAIN = "codegraph"`
+- `CODEGRAPH_INDEX_JOB_TYPE = "codegraph_index"`
+
+Implement queue resolution, settings serialization, payload building, and enqueueing through `JobManager.create_job(...)`.
+
+- [x] **Step 3: Verify helper tests pass**
+
+Run:
+
+```bash
+python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_jobs.py -q
+```
+
+Expected: pass.
+
+## Task 2: Jobs Worker Handler
+
+**Files:**
+
+- Create `tldw_Server_API/app/core/CodeGraph/jobs_worker.py`
+- Test `tldw_Server_API/tests/CodeGraph/test_codegraph_jobs_worker.py`
+
+- [x] **Step 1: Write failing worker tests**
+
+Add tests proving:
+
+- A valid index job indexes a Python fixture and returns serialized CodeGraph result data.
+- A valid sync job delegates to sync and returns serialized result data.
+- Unsupported job types, missing operation, unsupported operation, missing paths, and unsafe index paths fail with non-retryable errors.
+
+Run:
+
+```bash
+python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_jobs_worker.py -q
+```
+
+Expected: fail because the worker module does not exist.
+
+- [x] **Step 2: Implement worker handler and entrypoint**
+
+Use `CodeGraphSettings.from_mapping(...)`, `CodeGraphLanguageRegistry`, `CodeGraphRepository`, and `CodeGraphIndexer`. Validate that `index_db_path` is below `settings.index_base_dir`; reject unsafe payloads before opening SQLite. Add `run_codegraph_jobs_worker(stop_event=None)` using `WorkerSDK`.
+
+- [x] **Step 3: Verify worker tests pass**
+
+Run:
+
+```bash
+python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_jobs_worker.py -q
+```
+
+Expected: pass.
+
+## Task 3: MCP Job Mode
+
+**Files:**
+
+- Modify `tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py`
+- Modify `tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py`
+
+- [x] **Step 1: Write failing MCP tests**
+
+Add tests proving:
+
+- `codegraph.index` with `mode="job"` returns `status="queued"`, job identifiers, workspace metadata, and does not initialize the CodeGraph index DB.
+- `codegraph.sync` with `mode="background"` enqueues the sync operation.
+- Existing `mode="foreground"` behavior still indexes immediately.
+- Unknown modes are still rejected.
+
+Run:
+
+```bash
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py -q
+```
+
+Expected: fail because only foreground mode is supported.
+
+- [x] **Step 2: Implement MCP enqueue path**
+
+Preserve foreground dispatch. For job/background mode, call `enqueue_codegraph_index_job(...)` through `asyncio.to_thread` with `owner_user_id` derived from the request context. Return a compact MCP response with `status`, `job_id`, `job_uuid`, `job_status`, `workspace_key`, and `mode`.
+
+- [x] **Step 3: Verify MCP tests pass**
+
+Run:
+
+```bash
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py -q
+```
+
+Expected: pass.
+
+## Task 4: Final Verification And Task Closeout
+
+**Files:**
+
+- Modify `backlog/tasks/task-70 - Add-CodeGraph-Jobs-backed-indexing-mode.md`
+
+- [x] **Step 1: Run focused tests**
+
+```bash
+python -m pytest \
+  tldw_Server_API/tests/CodeGraph/test_codegraph_jobs.py \
+  tldw_Server_API/tests/CodeGraph/test_codegraph_jobs_worker.py \
+  tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py \
+  -q
+```
+
+- [x] **Step 2: Run Ruff**
+
+```bash
+python -m ruff check \
+  tldw_Server_API/app/core/CodeGraph/jobs.py \
+  tldw_Server_API/app/core/CodeGraph/jobs_worker.py \
+  tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py \
+  tldw_Server_API/tests/CodeGraph/test_codegraph_jobs.py \
+  tldw_Server_API/tests/CodeGraph/test_codegraph_jobs_worker.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
+```
+
+- [x] **Step 3: Run Bandit**
+
+```bash
+python -m bandit -r \
+  tldw_Server_API/app/core/CodeGraph/jobs.py \
+  tldw_Server_API/app/core/CodeGraph/jobs_worker.py \
+  tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py \
+  -f json -o /tmp/bandit_codegraph_jobs_indexing.json
+```
+
+- [x] **Step 4: Run whitespace check**
+
+```bash
+git diff --check
+```
+
+- [x] **Step 5: Update TASK-70 and commit**
+
+Record verification, mark acceptance criteria and DoD complete, then commit with:
+
+```bash
+git add Docs/superpowers/plans/2026-05-05-native-codegraph-jobs-indexing-implementation-plan.md \
+  'backlog/tasks/task-70 - Add-CodeGraph-Jobs-backed-indexing-mode.md' \
+  tldw_Server_API/app/core/CodeGraph/jobs.py \
+  tldw_Server_API/app/core/CodeGraph/jobs_worker.py \
+  tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py \
+  tldw_Server_API/tests/CodeGraph/test_codegraph_jobs.py \
+  tldw_Server_API/tests/CodeGraph/test_codegraph_jobs_worker.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
+git commit -m "feat: add codegraph jobs indexing mode"
+```

--- a/backlog/tasks/task-70 - Add-CodeGraph-Jobs-backed-indexing-mode.md
+++ b/backlog/tasks/task-70 - Add-CodeGraph-Jobs-backed-indexing-mode.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@Codex'
 created_date: '2026-05-05 14:15'
-updated_date: '2026-05-05 14:41'
+updated_date: '2026-05-05 14:44'
 labels:
   - codegraph
   - mcp
@@ -58,6 +58,14 @@ PR review fixes implemented:
 - Jobs payloads now serialize workspace_root, index_db_path, and settings.index_base_dir as absolute paths.
 - CodeGraphJobError now lives in tldw_Server_API.app.core.exceptions.
 - MCP index/sync write dispatch now uses a shared helper for foreground and queued modes.
+- CodeRabbit follow-up: wrap repository/indexer execution failures as non-retryable CodeGraphJobError values so WorkerSDK retry semantics stay stable.
+
+Final review-fix verification passed:
+
+- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_jobs.py tldw_Server_API/tests/CodeGraph/test_codegraph_jobs_worker.py tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py -q (61 passed)
+- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check tldw_Server_API/app/core/exceptions.py tldw_Server_API/app/core/CodeGraph/jobs.py tldw_Server_API/app/core/CodeGraph/jobs_worker.py tldw_Server_API/app/core/CodeGraph/workspace.py tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py tldw_Server_API/tests/CodeGraph/test_codegraph_jobs.py tldw_Server_API/tests/CodeGraph/test_codegraph_jobs_worker.py tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
+- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/exceptions.py tldw_Server_API/app/core/CodeGraph/jobs.py tldw_Server_API/app/core/CodeGraph/jobs_worker.py tldw_Server_API/app/core/CodeGraph/workspace.py tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py -f json -o /tmp/bandit_codegraph_jobs_review_fixes.json (0 findings)
+- git diff --check
 
 Review-fix verification passed:
 
@@ -85,4 +93,6 @@ Added a Jobs-backed execution path for native CodeGraph index and sync work whil
 No known blockers. Automatic worker deployment/startup remains intentionally out of scope for this task.
 
 Review follow-up addressed Qodo and Gemini comments on PR #1304. The worker now uses a local index-base boundary, payload paths are absolute across process boundaries, CodeGraphJobError is centralized, and duplicate MCP write-mode dispatch is factored through a helper.
+
+Additional CodeRabbit follow-up wraps repository and indexer execution failures into non-retryable CodeGraphJobError values while preserving the original exception as the cause.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-70 - Add-CodeGraph-Jobs-backed-indexing-mode.md
+++ b/backlog/tasks/task-70 - Add-CodeGraph-Jobs-backed-indexing-mode.md
@@ -1,0 +1,63 @@
+---
+id: TASK-70
+title: Add CodeGraph Jobs-backed indexing mode
+status: Done
+assignee:
+  - '@Codex'
+created_date: '2026-05-05 14:15'
+updated_date: '2026-05-05 14:24'
+labels:
+  - codegraph
+  - mcp
+  - jobs
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add the deferred Jobs-backed execution path for native CodeGraph indexing so large workspaces can enqueue index/sync work instead of relying only on bounded foreground MCP calls. Scope this first Jobs slice to job payload helpers, MCP job-mode enqueue responses, a CodeGraph Jobs worker entrypoint that runs the existing indexer against trusted workspace/index paths, and focused tests. Exclude file watching, Scheduler integration, automatic in-process startup, and changing existing foreground behavior unless explicitly covered by tests.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 codegraph.index and codegraph.sync accept a job/background mode that creates a core Jobs entry with domain, queue, job_type, owner, and JSON-safe workspace/index payload
+- [x] #2 Foreground mode keeps the current synchronous behavior and existing CodeGraph tests continue to pass
+- [x] #3 A CodeGraph Jobs worker handler validates job payloads, runs index or sync through the existing CodeGraphIndexer, returns serialized result data, and rejects unsupported job types or unsafe paths
+- [x] #4 Focused tests cover job enqueueing, worker success and validation failures, MCP job-mode responses, and existing foreground regressions
+- [x] #5 Ruff, Bandit on touched production scope, focused pytest, and git diff --check pass before PR
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Created implementation plan at Docs/superpowers/plans/2026-05-05-native-codegraph-jobs-indexing-implementation-plan.md. Scope is limited to Jobs payload helpers, MCP job/background enqueue mode, and a CodeGraph Jobs worker entrypoint; no file watching, Scheduler integration, or automatic worker startup in this slice.
+
+Implemented CodeGraph Jobs payload helpers, a non-retryable validation worker handler, and MCP job/background mode enqueueing for codegraph.index and codegraph.sync. The worker validates job_type, operation, payload shape, workspace key, settings, language filters, max_files, and index_db_path containment before opening the CodeGraph repository. Foreground mode remains unchanged and still offloads blocking repository work through asyncio.to_thread.
+
+Verification passed:
+
+- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_jobs.py tldw_Server_API/tests/CodeGraph/test_codegraph_jobs_worker.py tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py -q (58 passed)
+- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check tldw_Server_API/app/core/CodeGraph/jobs.py tldw_Server_API/app/core/CodeGraph/jobs_worker.py tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py tldw_Server_API/tests/CodeGraph/test_codegraph_jobs.py tldw_Server_API/tests/CodeGraph/test_codegraph_jobs_worker.py tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
+- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/CodeGraph/jobs.py tldw_Server_API/app/core/CodeGraph/jobs_worker.py tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py -f json -o /tmp/bandit_codegraph_jobs_indexing.json (0 findings)
+- git diff --check
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added a Jobs-backed execution path for native CodeGraph index and sync work while preserving bounded foreground behavior. codegraph.index and codegraph.sync now accept mode="job" or mode="background" to enqueue core Jobs rows with a JSON-safe workspace/index payload and owner id, and a new CodeGraph Jobs worker entrypoint validates and executes those jobs through the existing CodeGraphIndexer. No file watching, Scheduler integration, or automatic worker startup was added in this slice.
+
+No known blockers. Automatic worker deployment/startup remains intentionally out of scope for this task.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-70 - Add-CodeGraph-Jobs-backed-indexing-mode.md
+++ b/backlog/tasks/task-70 - Add-CodeGraph-Jobs-backed-indexing-mode.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@Codex'
 created_date: '2026-05-05 14:15'
-updated_date: '2026-05-05 14:24'
+updated_date: '2026-05-05 14:41'
 labels:
   - codegraph
   - mcp
@@ -42,6 +42,29 @@ Verification passed:
 - /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check tldw_Server_API/app/core/CodeGraph/jobs.py tldw_Server_API/app/core/CodeGraph/jobs_worker.py tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py tldw_Server_API/tests/CodeGraph/test_codegraph_jobs.py tldw_Server_API/tests/CodeGraph/test_codegraph_jobs_worker.py tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
 - /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/CodeGraph/jobs.py tldw_Server_API/app/core/CodeGraph/jobs_worker.py tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py -f json -o /tmp/bandit_codegraph_jobs_indexing.json (0 findings)
 - git diff --check
+
+PR review follow-up opened after #1304 review comments:
+
+- Fix worker index-base spoofing by enforcing path containment against local worker/server configuration instead of trusting payload settings.
+- Ensure job payload paths are absolute across MCP/worker process boundaries.
+- Move CodeGraphJobError to shared core exceptions while preserving WorkerSDK retryable semantics.
+- Reduce duplicated MCP job-mode enqueue dispatch.
+- Reply to the Gemini index_base self-path comment with the stricter DB-path contract; index_db_path must be a descendant database file path, not the base directory itself.
+
+PR review fixes implemented:
+
+- Worker now validates index_db_path containment against local worker config from CODEGRAPH_JOBS_INDEX_BASE_DIR or CODEGRAPH_INDEX_BASE_DIR instead of trusting payload settings.
+- Worker rejects mismatched payload settings.index_base_dir before opening SQLite while preserving non-security tuning from the payload after the local boundary check.
+- Jobs payloads now serialize workspace_root, index_db_path, and settings.index_base_dir as absolute paths.
+- CodeGraphJobError now lives in tldw_Server_API.app.core.exceptions.
+- MCP index/sync write dispatch now uses a shared helper for foreground and queued modes.
+
+Review-fix verification passed:
+
+- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_jobs.py tldw_Server_API/tests/CodeGraph/test_codegraph_jobs_worker.py tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py -q (60 passed)
+- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check tldw_Server_API/app/core/exceptions.py tldw_Server_API/app/core/CodeGraph/jobs.py tldw_Server_API/app/core/CodeGraph/jobs_worker.py tldw_Server_API/app/core/CodeGraph/workspace.py tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py tldw_Server_API/tests/CodeGraph/test_codegraph_jobs.py tldw_Server_API/tests/CodeGraph/test_codegraph_jobs_worker.py tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
+- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/exceptions.py tldw_Server_API/app/core/CodeGraph/jobs.py tldw_Server_API/app/core/CodeGraph/jobs_worker.py tldw_Server_API/app/core/CodeGraph/workspace.py tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py -f json -o /tmp/bandit_codegraph_jobs_review_fixes.json (0 findings)
+- git diff --check
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done
@@ -60,4 +83,6 @@ Verification passed:
 Added a Jobs-backed execution path for native CodeGraph index and sync work while preserving bounded foreground behavior. codegraph.index and codegraph.sync now accept mode="job" or mode="background" to enqueue core Jobs rows with a JSON-safe workspace/index payload and owner id, and a new CodeGraph Jobs worker entrypoint validates and executes those jobs through the existing CodeGraphIndexer. No file watching, Scheduler integration, or automatic worker startup was added in this slice.
 
 No known blockers. Automatic worker deployment/startup remains intentionally out of scope for this task.
+
+Review follow-up addressed Qodo and Gemini comments on PR #1304. The worker now uses a local index-base boundary, payload paths are absolute across process boundaries, CodeGraphJobError is centralized, and duplicate MCP write-mode dispatch is factored through a helper.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/tldw_Server_API/app/core/CodeGraph/jobs.py
+++ b/tldw_Server_API/app/core/CodeGraph/jobs.py
@@ -1,0 +1,93 @@
+"""Core Jobs helpers for native CodeGraph indexing."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from tldw_Server_API.app.core.Jobs.manager import JobManager
+
+from .config import CodeGraphSettings
+from .models import WorkspaceResolution
+
+CODEGRAPH_JOBS_DOMAIN = "codegraph"
+CODEGRAPH_INDEX_JOB_TYPE = "codegraph_index"
+
+
+def codegraph_jobs_queue() -> str:
+    """Return the queue name used by CodeGraph index/sync jobs."""
+    queue = (os.getenv("CODEGRAPH_JOBS_QUEUE") or "default").strip()
+    return queue or "default"
+
+
+def build_codegraph_index_job_payload(
+    *,
+    resolution: WorkspaceResolution,
+    settings: CodeGraphSettings,
+    operation: str,
+    force: bool,
+    languages: list[str] | None,
+    max_files: int | None,
+) -> dict[str, Any]:
+    """Serialize a CodeGraph index/sync request into a JSON-safe Jobs payload."""
+    normalized_operation = str(operation or "").strip().lower()
+    if normalized_operation not in {"index", "sync"}:
+        raise ValueError("operation must be index or sync")
+    return {
+        "operation": normalized_operation,
+        "workspace_root": str(resolution.workspace_root),
+        "workspace_key": resolution.workspace_key,
+        "workspace_id": resolution.workspace_id,
+        "workspace_source": resolution.source,
+        "index_db_path": str(resolution.index_db_path),
+        "settings": _settings_payload(settings),
+        "force": bool(force),
+        "languages": list(languages) if languages is not None else None,
+        "max_files": int(max_files) if max_files is not None else None,
+    }
+
+
+def enqueue_codegraph_index_job(
+    *,
+    resolution: WorkspaceResolution,
+    settings: CodeGraphSettings,
+    operation: str,
+    force: bool,
+    languages: list[str] | None,
+    max_files: int | None,
+    owner_user_id: str | None,
+    jm: JobManager | None = None,
+) -> dict[str, Any]:
+    """Create a core Jobs row for CodeGraph index or sync work."""
+    manager = jm or JobManager()
+    payload = build_codegraph_index_job_payload(
+        resolution=resolution,
+        settings=settings,
+        operation=operation,
+        force=force,
+        languages=languages,
+        max_files=max_files,
+    )
+    created = manager.create_job(
+        domain=CODEGRAPH_JOBS_DOMAIN,
+        queue=codegraph_jobs_queue(),
+        job_type=CODEGRAPH_INDEX_JOB_TYPE,
+        payload=payload,
+        owner_user_id=owner_user_id,
+        max_retries=0,
+    )
+    return manager.get_job(int(created["id"])) or created
+
+
+def _settings_payload(settings: CodeGraphSettings) -> dict[str, Any]:
+    """Return JSON-safe CodeGraph settings for a Jobs payload."""
+    return {
+        "index_base_dir": str(settings.index_base_dir),
+        "max_file_size_bytes": settings.max_file_size_bytes,
+        "foreground_max_files": settings.foreground_max_files,
+        "foreground_max_bytes": settings.foreground_max_bytes,
+        "max_index_seconds": settings.max_index_seconds,
+        "max_context_chars": settings.max_context_chars,
+        "max_search_results": settings.max_search_results,
+        "exclude_dirs": list(settings.exclude_dirs),
+    }

--- a/tldw_Server_API/app/core/CodeGraph/jobs.py
+++ b/tldw_Server_API/app/core/CodeGraph/jobs.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from typing import Any
 
 from tldw_Server_API.app.core.Jobs.manager import JobManager
@@ -35,11 +36,11 @@ def build_codegraph_index_job_payload(
         raise ValueError("operation must be index or sync")
     return {
         "operation": normalized_operation,
-        "workspace_root": str(resolution.workspace_root),
+        "workspace_root": _resolved_path(resolution.workspace_root),
         "workspace_key": resolution.workspace_key,
         "workspace_id": resolution.workspace_id,
         "workspace_source": resolution.source,
-        "index_db_path": str(resolution.index_db_path),
+        "index_db_path": _resolved_path(resolution.index_db_path),
         "settings": _settings_payload(settings),
         "force": bool(force),
         "languages": list(languages) if languages is not None else None,
@@ -82,7 +83,7 @@ def enqueue_codegraph_index_job(
 def _settings_payload(settings: CodeGraphSettings) -> dict[str, Any]:
     """Return JSON-safe CodeGraph settings for a Jobs payload."""
     return {
-        "index_base_dir": str(settings.index_base_dir),
+        "index_base_dir": _resolved_path(settings.index_base_dir),
         "max_file_size_bytes": settings.max_file_size_bytes,
         "foreground_max_files": settings.foreground_max_files,
         "foreground_max_bytes": settings.foreground_max_bytes,
@@ -91,3 +92,8 @@ def _settings_payload(settings: CodeGraphSettings) -> dict[str, Any]:
         "max_search_results": settings.max_search_results,
         "exclude_dirs": list(settings.exclude_dirs),
     }
+
+
+def _resolved_path(path: Path) -> str:
+    """Return a stable absolute path string for cross-process Jobs payloads."""
+    return str(path.expanduser().resolve(strict=False))

--- a/tldw_Server_API/app/core/CodeGraph/jobs_worker.py
+++ b/tldw_Server_API/app/core/CodeGraph/jobs_worker.py
@@ -12,6 +12,7 @@ from typing import Any
 from loguru import logger
 
 from tldw_Server_API.app.core.DB_Management.codegraph.repository import CodeGraphRepository
+from tldw_Server_API.app.core.exceptions import CodeGraphJobError
 from tldw_Server_API.app.core.Jobs.worker_sdk import WorkerConfig, WorkerSDK
 from tldw_Server_API.app.core.Jobs.worker_utils import coerce_int as _coerce_int
 from tldw_Server_API.app.core.Jobs.worker_utils import jobs_manager_from_env as _jobs_manager
@@ -20,14 +21,6 @@ from .config import CodeGraphSettings
 from .indexer import CodeGraphIndexer, IndexingResult
 from .jobs import CODEGRAPH_INDEX_JOB_TYPE, CODEGRAPH_JOBS_DOMAIN, codegraph_jobs_queue
 from .language_registry import CodeGraphLanguageRegistry
-
-
-class CodeGraphJobError(RuntimeError):
-    """Non-retryable CodeGraph Jobs validation or execution error."""
-
-    def __init__(self, message: str, *, retryable: bool = False) -> None:
-        super().__init__(message)
-        self.retryable = retryable
 
 
 async def handle_codegraph_index_job(job: dict[str, Any]) -> dict[str, Any]:
@@ -51,9 +44,12 @@ def _handle_codegraph_index_job_sync(job: dict[str, Any]) -> dict[str, Any]:
     if not workspace_key:
         raise CodeGraphJobError("missing workspace_key", retryable=False)
 
-    settings = CodeGraphSettings.from_mapping(_coerce_mapping(payload.get("settings"), "settings"))
+    settings_payload = _coerce_mapping(payload.get("settings"), "settings")
+    index_base_dir = _local_index_base_dir()
+    _validate_payload_index_base(settings_payload, index_base_dir)
+    settings = CodeGraphSettings.from_mapping({**settings_payload, "index_base_dir": str(index_base_dir)})
     index_db_path = _required_path(payload, "index_db_path").resolve(strict=False)
-    _validate_index_path(index_db_path=index_db_path, settings=settings)
+    _validate_index_path(index_db_path=index_db_path, index_base_dir=index_base_dir)
 
     repository = CodeGraphRepository(index_db_path)
     indexer = CodeGraphIndexer(settings=settings, registry=CodeGraphLanguageRegistry())
@@ -154,10 +150,26 @@ def _required_path(payload: dict[str, Any], field_name: str) -> Path:
     return Path(value).expanduser()
 
 
-def _validate_index_path(*, index_db_path: Path, settings: CodeGraphSettings) -> None:
+def _local_index_base_dir() -> Path:
+    """Return the trusted local CodeGraph index base for worker path checks."""
+    index_base_override = os.getenv("CODEGRAPH_JOBS_INDEX_BASE_DIR") or os.getenv("CODEGRAPH_INDEX_BASE_DIR")
+    values = {"index_base_dir": index_base_override} if index_base_override else {}
+    return CodeGraphSettings.from_mapping(values).index_base_dir.expanduser().resolve(strict=False)
+
+
+def _validate_payload_index_base(settings_payload: dict[str, Any], index_base_dir: Path) -> None:
+    """Reject jobs whose payload index base does not match trusted local worker config."""
+    raw_payload_base = settings_payload.get("index_base_dir")
+    if not isinstance(raw_payload_base, str) or not raw_payload_base.strip():
+        raise CodeGraphJobError("missing index_base_dir", retryable=False)
+    payload_index_base = Path(raw_payload_base).expanduser().resolve(strict=False)
+    if payload_index_base != index_base_dir:
+        raise CodeGraphJobError("index_base_dir_mismatch", retryable=False)
+
+
+def _validate_index_path(*, index_db_path: Path, index_base_dir: Path) -> None:
     """Ensure the job can only write below the configured CodeGraph index base."""
-    index_base = settings.index_base_dir.expanduser().resolve(strict=False)
-    if index_base not in index_db_path.parents:
+    if index_base_dir not in index_db_path.parents:
         raise CodeGraphJobError("index_db_path_outside_index_base", retryable=False)
 
 

--- a/tldw_Server_API/app/core/CodeGraph/jobs_worker.py
+++ b/tldw_Server_API/app/core/CodeGraph/jobs_worker.py
@@ -1,0 +1,207 @@
+"""Jobs worker entrypoint for native CodeGraph indexing."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from tldw_Server_API.app.core.DB_Management.codegraph.repository import CodeGraphRepository
+from tldw_Server_API.app.core.Jobs.worker_sdk import WorkerConfig, WorkerSDK
+from tldw_Server_API.app.core.Jobs.worker_utils import coerce_int as _coerce_int
+from tldw_Server_API.app.core.Jobs.worker_utils import jobs_manager_from_env as _jobs_manager
+
+from .config import CodeGraphSettings
+from .indexer import CodeGraphIndexer, IndexingResult
+from .jobs import CODEGRAPH_INDEX_JOB_TYPE, CODEGRAPH_JOBS_DOMAIN, codegraph_jobs_queue
+from .language_registry import CodeGraphLanguageRegistry
+
+
+class CodeGraphJobError(RuntimeError):
+    """Non-retryable CodeGraph Jobs validation or execution error."""
+
+    def __init__(self, message: str, *, retryable: bool = False) -> None:
+        super().__init__(message)
+        self.retryable = retryable
+
+
+async def handle_codegraph_index_job(job: dict[str, Any]) -> dict[str, Any]:
+    """Run one CodeGraph index or sync job and return serialized result data."""
+    return await asyncio.to_thread(_handle_codegraph_index_job_sync, job)
+
+
+def _handle_codegraph_index_job_sync(job: dict[str, Any]) -> dict[str, Any]:
+    """Synchronous implementation for one CodeGraph index or sync job."""
+    job_type = str(job.get("job_type") or "").strip()
+    if job_type != CODEGRAPH_INDEX_JOB_TYPE:
+        raise CodeGraphJobError(f"unsupported job_type: {job_type or '<missing>'}", retryable=False)
+
+    payload = _coerce_payload(job.get("payload"))
+    operation = str(payload.get("operation") or "").strip().lower()
+    if operation not in {"index", "sync"}:
+        raise CodeGraphJobError(f"unsupported operation: {operation or '<missing>'}", retryable=False)
+
+    workspace_root = _required_path(payload, "workspace_root").resolve(strict=False)
+    workspace_key = str(payload.get("workspace_key") or "").strip()
+    if not workspace_key:
+        raise CodeGraphJobError("missing workspace_key", retryable=False)
+
+    settings = CodeGraphSettings.from_mapping(_coerce_mapping(payload.get("settings"), "settings"))
+    index_db_path = _required_path(payload, "index_db_path").resolve(strict=False)
+    _validate_index_path(index_db_path=index_db_path, settings=settings)
+
+    repository = CodeGraphRepository(index_db_path)
+    indexer = CodeGraphIndexer(settings=settings, registry=CodeGraphLanguageRegistry())
+    languages = _coerce_languages(payload.get("languages"))
+    max_files = _coerce_optional_int(payload.get("max_files"), "max_files")
+
+    if operation == "index":
+        result = indexer.index_workspace(
+            workspace_root,
+            workspace_key,
+            repository,
+            force=bool(payload.get("force", False)),
+            languages=languages,
+            max_files=max_files,
+        )
+    else:
+        result = indexer.sync_workspace(
+            workspace_root,
+            workspace_key,
+            repository,
+            languages=languages,
+            max_files=max_files,
+        )
+
+    return _job_result_to_dict(
+        result,
+        operation=operation,
+        workspace_key=workspace_key,
+        index_db_path=index_db_path,
+    )
+
+
+async def run_codegraph_jobs_worker(stop_event: asyncio.Event | None = None) -> None:
+    """Run the CodeGraph Jobs worker loop until stopped."""
+    worker_id = (os.getenv("CODEGRAPH_JOBS_WORKER_ID") or f"codegraph-jobs-{os.getpid()}").strip()
+    queue = codegraph_jobs_queue()
+    cfg = WorkerConfig(
+        domain=CODEGRAPH_JOBS_DOMAIN,
+        queue=queue,
+        worker_id=worker_id,
+        lease_seconds=_coerce_int(os.getenv("CODEGRAPH_JOBS_LEASE_SECONDS") or os.getenv("JOBS_LEASE_SECONDS"), 60),
+        renew_jitter_seconds=_coerce_int(
+            os.getenv("CODEGRAPH_JOBS_RENEW_JITTER_SECONDS") or os.getenv("JOBS_LEASE_RENEW_JITTER_SECONDS"),
+            5,
+        ),
+        renew_threshold_seconds=_coerce_int(
+            os.getenv("CODEGRAPH_JOBS_RENEW_THRESHOLD_SECONDS") or os.getenv("JOBS_LEASE_RENEW_THRESHOLD_SECONDS"),
+            10,
+        ),
+    )
+    sdk = WorkerSDK(_jobs_manager(), cfg)
+    stop_watcher_task: asyncio.Task[None] | None = None
+
+    if stop_event is not None:
+
+        async def _watch_stop() -> None:
+            await stop_event.wait()
+            sdk.stop()
+
+        stop_watcher_task = asyncio.create_task(_watch_stop())
+
+    logger.info("CodeGraph Jobs worker starting: queue={} worker_id={}", queue, worker_id)
+    try:
+        await sdk.run(handler=handle_codegraph_index_job)
+    finally:
+        if stop_watcher_task is not None and not stop_watcher_task.done():
+            stop_watcher_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await stop_watcher_task
+
+
+def _coerce_payload(value: Any) -> dict[str, Any]:
+    """Return a JSON payload mapping from a Jobs row payload value."""
+    if isinstance(value, dict):
+        return dict(value)
+    if isinstance(value, str):
+        try:
+            loaded = json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise CodeGraphJobError(f"invalid payload json: {exc}", retryable=False) from exc
+        if isinstance(loaded, dict):
+            return loaded
+    raise CodeGraphJobError("payload must be an object", retryable=False)
+
+
+def _coerce_mapping(value: Any, field_name: str) -> dict[str, Any]:
+    """Return a dict payload field or raise a non-retryable worker error."""
+    if isinstance(value, dict):
+        return dict(value)
+    raise CodeGraphJobError(f"{field_name} must be an object", retryable=False)
+
+
+def _required_path(payload: dict[str, Any], field_name: str) -> Path:
+    """Return a non-empty payload path field."""
+    value = payload.get(field_name)
+    if not isinstance(value, str) or not value.strip():
+        raise CodeGraphJobError(f"missing {field_name}", retryable=False)
+    return Path(value).expanduser()
+
+
+def _validate_index_path(*, index_db_path: Path, settings: CodeGraphSettings) -> None:
+    """Ensure the job can only write below the configured CodeGraph index base."""
+    index_base = settings.index_base_dir.expanduser().resolve(strict=False)
+    if index_base not in index_db_path.parents:
+        raise CodeGraphJobError("index_db_path_outside_index_base", retryable=False)
+
+
+def _coerce_languages(value: Any) -> list[str] | None:
+    """Return optional language filters from a Jobs payload."""
+    if value is None:
+        return None
+    if isinstance(value, list) and all(isinstance(item, str) for item in value):
+        return list(value)
+    raise CodeGraphJobError("languages must be an array of strings", retryable=False)
+
+
+def _coerce_optional_int(value: Any, field_name: str) -> int | None:
+    """Return an optional integer payload field."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise CodeGraphJobError(f"{field_name} must be an integer", retryable=False)
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise CodeGraphJobError(f"{field_name} must be an integer", retryable=False) from exc
+    if parsed < 1:
+        raise CodeGraphJobError(f"{field_name} must be positive", retryable=False)
+    return parsed
+
+
+def _job_result_to_dict(
+    result: IndexingResult,
+    *,
+    operation: str,
+    workspace_key: str,
+    index_db_path: Path,
+) -> dict[str, Any]:
+    """Serialize a CodeGraph indexing result for Jobs completion storage."""
+    return {
+        "operation": operation,
+        "workspace_key": workspace_key,
+        "index_db_path": str(index_db_path),
+        "status": result.status,
+        "counters": dict(result.counters),
+        "errors": list(result.errors),
+    }
+
+
+if __name__ == "__main__":
+    asyncio.run(run_codegraph_jobs_worker())

--- a/tldw_Server_API/app/core/CodeGraph/jobs_worker.py
+++ b/tldw_Server_API/app/core/CodeGraph/jobs_worker.py
@@ -51,28 +51,33 @@ def _handle_codegraph_index_job_sync(job: dict[str, Any]) -> dict[str, Any]:
     index_db_path = _required_path(payload, "index_db_path").resolve(strict=False)
     _validate_index_path(index_db_path=index_db_path, index_base_dir=index_base_dir)
 
-    repository = CodeGraphRepository(index_db_path)
-    indexer = CodeGraphIndexer(settings=settings, registry=CodeGraphLanguageRegistry())
     languages = _coerce_languages(payload.get("languages"))
     max_files = _coerce_optional_int(payload.get("max_files"), "max_files")
 
-    if operation == "index":
-        result = indexer.index_workspace(
-            workspace_root,
-            workspace_key,
-            repository,
-            force=bool(payload.get("force", False)),
-            languages=languages,
-            max_files=max_files,
-        )
-    else:
-        result = indexer.sync_workspace(
-            workspace_root,
-            workspace_key,
-            repository,
-            languages=languages,
-            max_files=max_files,
-        )
+    try:
+        repository = CodeGraphRepository(index_db_path)
+        indexer = CodeGraphIndexer(settings=settings, registry=CodeGraphLanguageRegistry())
+        if operation == "index":
+            result = indexer.index_workspace(
+                workspace_root,
+                workspace_key,
+                repository,
+                force=bool(payload.get("force", False)),
+                languages=languages,
+                max_files=max_files,
+            )
+        else:
+            result = indexer.sync_workspace(
+                workspace_root,
+                workspace_key,
+                repository,
+                languages=languages,
+                max_files=max_files,
+            )
+    except CodeGraphJobError:
+        raise
+    except Exception as exc:
+        raise CodeGraphJobError("codegraph_job_execution_failed", retryable=False) from exc
 
     return _job_result_to_dict(
         result,

--- a/tldw_Server_API/app/core/CodeGraph/workspace.py
+++ b/tldw_Server_API/app/core/CodeGraph/workspace.py
@@ -88,7 +88,8 @@ class CodeGraphWorkspaceResolver:
             trust_source=source,
             workspace_root=workspace_root,
         )
-        index_db_path = self._settings.index_base_dir / workspace_key / "codegraph.db"
+        index_base_dir = self._settings.index_base_dir.expanduser().resolve(strict=False)
+        index_db_path = index_base_dir / workspace_key / "codegraph.db"
         return WorkspaceResolution(
             workspace_root=workspace_root,
             workspace_key=workspace_key,

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py
@@ -8,6 +8,7 @@ search, and same-file call relationship queries for trusted workspace roots.
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 from dataclasses import asdict
 from pathlib import Path
 from typing import Any
@@ -18,6 +19,7 @@ from tldw_Server_API.app.core.CodeGraph.config import CodeGraphSettings
 from tldw_Server_API.app.core.CodeGraph.context import CodeGraphContextBuilder
 from tldw_Server_API.app.core.CodeGraph.dependencies import probe_codegraph_dependencies
 from tldw_Server_API.app.core.CodeGraph.indexer import CodeGraphIndexer
+from tldw_Server_API.app.core.CodeGraph.jobs import enqueue_codegraph_index_job
 from tldw_Server_API.app.core.CodeGraph.language_registry import CodeGraphLanguageRegistry
 from tldw_Server_API.app.core.CodeGraph.models import (
     CodeGraphNode,
@@ -33,6 +35,7 @@ from ..base import BaseModule, ModuleConfig, create_tool_definition
 
 _EMPTY_COUNTS = {"files": 0, "nodes": 0, "edges": 0, "unresolved_refs": 0}
 _FOREGROUND_MODE = "foreground"
+_JOB_MODES = {"job", "background"}
 
 
 class CodeGraphModule(BaseModule):
@@ -42,6 +45,7 @@ class CodeGraphModule(BaseModule):
         self,
         config: ModuleConfig,
         workspace_root_resolver: WorkspaceRootResolver | None = None,
+        job_manager_factory: Callable[[], Any] | None = None,
     ) -> None:
         """Create module-scoped settings, dependency probes, and workspace resolver."""
         super().__init__(config)
@@ -49,6 +53,7 @@ class CodeGraphModule(BaseModule):
         self._dependency_health = probe_codegraph_dependencies()
         self._language_registry = CodeGraphLanguageRegistry(self._dependency_health)
         self._workspace = CodeGraphWorkspaceResolver(workspace_root_resolver, self._settings)
+        self._job_manager_factory = job_manager_factory
 
     async def on_initialize(self) -> None:
         """Log CodeGraph module initialization."""
@@ -97,10 +102,10 @@ class CodeGraphModule(BaseModule):
 
         index_tool = create_tool_definition(
             name="codegraph.index",
-            description="Run bounded foreground CodeGraph file indexing for the active workspace.",
+            description="Run bounded CodeGraph file indexing for the active workspace.",
             parameters={
                 "properties": {
-                    "mode": {"type": "string", "description": "Only foreground is supported in Stage 1"},
+                    "mode": {"type": "string", "description": "foreground, job, or background"},
                     "force": {"type": "boolean"},
                     "languages": {"type": "array"},
                     "max_files": {"type": "integer"},
@@ -116,10 +121,10 @@ class CodeGraphModule(BaseModule):
 
         sync_tool = create_tool_definition(
             name="codegraph.sync",
-            description="Run bounded foreground CodeGraph file sync for the active workspace.",
+            description="Run bounded CodeGraph file sync for the active workspace.",
             parameters={
                 "properties": {
-                    "mode": {"type": "string", "description": "Only foreground is supported in Stage 1"},
+                    "mode": {"type": "string", "description": "foreground, job, or background"},
                     "languages": {"type": "array"},
                     "max_files": {"type": "integer"},
                 },
@@ -297,6 +302,18 @@ class CodeGraphModule(BaseModule):
             return await self._status(resolution)
 
         if tool_name == "codegraph.index":
+            mode = str(args.get("mode") or _FOREGROUND_MODE)
+            if mode in _JOB_MODES:
+                return await asyncio.to_thread(
+                    self._enqueue_index_job,
+                    resolution,
+                    "index",
+                    mode,
+                    bool(args.get("force", False)),
+                    args.get("languages"),
+                    args.get("max_files"),
+                    self._owner_user_id(context),
+                )
             return await asyncio.to_thread(
                 self._run_index,
                 resolution,
@@ -306,6 +323,18 @@ class CodeGraphModule(BaseModule):
             )
 
         if tool_name == "codegraph.sync":
+            mode = str(args.get("mode") or _FOREGROUND_MODE)
+            if mode in _JOB_MODES:
+                return await asyncio.to_thread(
+                    self._enqueue_index_job,
+                    resolution,
+                    "sync",
+                    mode,
+                    False,
+                    args.get("languages"),
+                    args.get("max_files"),
+                    self._owner_user_id(context),
+                )
             return await asyncio.to_thread(
                 self._run_sync,
                 resolution,
@@ -394,7 +423,7 @@ class CodeGraphModule(BaseModule):
 
         if tool_name == "codegraph.index":
             self._reject_unknown(arguments, allowed={"mode", "force", "languages", "max_files"})
-            self._validate_foreground_mode(arguments.get("mode"))
+            self._validate_execution_mode(arguments.get("mode"))
             force = arguments.get("force")
             if force is not None and not isinstance(force, bool):
                 raise ValueError("force must be a boolean")
@@ -404,7 +433,7 @@ class CodeGraphModule(BaseModule):
 
         if tool_name == "codegraph.sync":
             self._reject_unknown(arguments, allowed={"mode", "languages", "max_files"})
-            self._validate_foreground_mode(arguments.get("mode"))
+            self._validate_execution_mode(arguments.get("mode"))
             self._validate_languages(arguments.get("languages"))
             self._validate_positive_int(arguments.get("max_files"), "max_files")
             return
@@ -557,6 +586,41 @@ class CodeGraphModule(BaseModule):
             max_files=max_files,
         )
         return _index_result_to_dict(result, resolution)
+
+    def _enqueue_index_job(
+        self,
+        resolution: WorkspaceResolution,
+        operation: str,
+        mode: str,
+        force: bool,
+        languages: list[str] | None,
+        max_files: int | None,
+        owner_user_id: str | None,
+    ) -> dict[str, Any]:
+        """Enqueue an index or sync job and serialize the queued Jobs row."""
+        manager = self._job_manager_factory() if self._job_manager_factory is not None else None
+        job = enqueue_codegraph_index_job(
+            resolution=resolution,
+            settings=self._settings,
+            operation=operation,
+            force=force,
+            languages=languages,
+            max_files=max_files,
+            owner_user_id=owner_user_id,
+            jm=manager,
+        )
+        return {
+            "status": "queued",
+            "mode": mode,
+            "operation": operation,
+            "workspace_key": resolution.workspace_key,
+            "workspace_id": resolution.workspace_id,
+            "index_db_path": str(resolution.index_db_path),
+            "job_id": job.get("id"),
+            "job_uuid": job.get("uuid"),
+            "job_status": job.get("status"),
+            "queue": job.get("queue"),
+        }
 
     def _list_files(
         self,
@@ -809,10 +873,12 @@ class CodeGraphModule(BaseModule):
             raise ValueError(f"unknown languages: {', '.join(unknown)}")
 
     @staticmethod
-    def _validate_foreground_mode(mode: Any) -> None:
-        """Ensure Stage 1 callers only request foreground execution."""
-        if mode is not None and mode != _FOREGROUND_MODE:
-            raise ValueError("only foreground mode is supported")
+    def _validate_execution_mode(mode: Any) -> None:
+        """Validate the optional index/sync execution mode."""
+        if mode is None:
+            return
+        if not isinstance(mode, str) or mode not in {_FOREGROUND_MODE, *_JOB_MODES}:
+            raise ValueError("mode must be foreground, job, or background")
 
     @staticmethod
     def _validate_positive_int(value: Any, field_name: str) -> None:
@@ -843,6 +909,21 @@ class CodeGraphModule(BaseModule):
     def _bounded_limit(self, limit: int | None, *, default: int = 10) -> int:
         """Clamp user-provided result limits to configured maximums."""
         return min(max(1, int(limit or default)), self._settings.max_search_results)
+
+    @staticmethod
+    def _owner_user_id(context: Any | None) -> str | None:
+        """Extract a stable Jobs owner id from an MCP request context."""
+        if context is None:
+            return None
+        user_id = getattr(context, "user_id", None)
+        if user_id is None:
+            metadata = getattr(context, "metadata", None)
+            if isinstance(metadata, dict):
+                user_id = metadata.get("user_id")
+        if user_id is None:
+            return None
+        text = str(user_id).strip()
+        return text or None
 
 
 def _normalize_path_prefix(path: str | None) -> str | None:

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py
@@ -302,44 +302,19 @@ class CodeGraphModule(BaseModule):
             return await self._status(resolution)
 
         if tool_name == "codegraph.index":
-            mode = str(args.get("mode") or _FOREGROUND_MODE)
-            if mode in _JOB_MODES:
-                return await asyncio.to_thread(
-                    self._enqueue_index_job,
-                    resolution,
-                    "index",
-                    mode,
-                    bool(args.get("force", False)),
-                    args.get("languages"),
-                    args.get("max_files"),
-                    self._owner_user_id(context),
-                )
-            return await asyncio.to_thread(
-                self._run_index,
+            return await self._execute_write_tool(
                 resolution,
-                bool(args.get("force", False)),
-                args.get("languages"),
-                args.get("max_files"),
+                args,
+                context,
+                operation="index",
             )
 
         if tool_name == "codegraph.sync":
-            mode = str(args.get("mode") or _FOREGROUND_MODE)
-            if mode in _JOB_MODES:
-                return await asyncio.to_thread(
-                    self._enqueue_index_job,
-                    resolution,
-                    "sync",
-                    mode,
-                    False,
-                    args.get("languages"),
-                    args.get("max_files"),
-                    self._owner_user_id(context),
-                )
-            return await asyncio.to_thread(
-                self._run_sync,
+            return await self._execute_write_tool(
                 resolution,
-                args.get("languages"),
-                args.get("max_files"),
+                args,
+                context,
+                operation="sync",
             )
 
         if tool_name == "codegraph.files":
@@ -586,6 +561,45 @@ class CodeGraphModule(BaseModule):
             max_files=max_files,
         )
         return _index_result_to_dict(result, resolution)
+
+    async def _execute_write_tool(
+        self,
+        resolution: WorkspaceResolution,
+        args: dict[str, Any],
+        context: Any | None,
+        *,
+        operation: str,
+    ) -> dict[str, Any]:
+        """Execute or enqueue a CodeGraph index/sync write operation."""
+        mode = str(args.get("mode") or _FOREGROUND_MODE)
+        languages = args.get("languages")
+        max_files = args.get("max_files")
+        force = bool(args.get("force", False)) if operation == "index" else False
+        if mode in _JOB_MODES:
+            return await asyncio.to_thread(
+                self._enqueue_index_job,
+                resolution,
+                operation,
+                mode,
+                force,
+                languages,
+                max_files,
+                self._owner_user_id(context),
+            )
+        if operation == "index":
+            return await asyncio.to_thread(
+                self._run_index,
+                resolution,
+                force,
+                languages,
+                max_files,
+            )
+        return await asyncio.to_thread(
+            self._run_sync,
+            resolution,
+            languages,
+            max_files,
+        )
 
     def _enqueue_index_job(
         self,

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -62,6 +63,25 @@ class _CodeGraphRegistry:
         return None
 
 
+class _FakeJobManager:
+    """Capture CodeGraph Jobs rows created by MCP job-mode tests."""
+
+    def __init__(self) -> None:
+        self.created: list[dict[str, Any]] = []
+
+    def create_job(self, **kwargs: Any) -> dict[str, Any]:
+        """Record a fake Jobs create call."""
+        self.created.append(dict(kwargs))
+        return {"id": len(self.created), "uuid": f"job-{len(self.created)}", "status": "queued", **kwargs}
+
+    def get_job(self, job_id: int) -> dict[str, Any] | None:
+        """Return the recorded fake Jobs row by id."""
+        if job_id < 1 or job_id > len(self.created):
+            return None
+        created = self.created[job_id - 1]
+        return {"id": job_id, "uuid": f"job-{job_id}", "status": "queued", **created}
+
+
 def _context() -> RequestContext:
     """Build a request context with a workspace id for CodeGraph tests."""
     return RequestContext(
@@ -105,6 +125,8 @@ def _module_with_settings(
     tmp_path: Path,
     workspace_root: Path,
     settings: dict[str, Any],
+    *,
+    job_manager_factory: Callable[[], Any] | None = None,
 ) -> CodeGraphModule:
     """Create a CodeGraph module with overridden test settings."""
     resolver = _FakeWorkspaceRootResolver(
@@ -119,6 +141,7 @@ def _module_with_settings(
     return CodeGraphModule(
         ModuleConfig(name="CodeGraph", settings=module_settings),
         workspace_root_resolver=resolver,
+        job_manager_factory=job_manager_factory,
     )
 
 
@@ -208,6 +231,86 @@ async def test_codegraph_index_and_files_roundtrip(tmp_path: Path) -> None:
     assert index_result["counters"]["files_indexed"] == 2  # nosec B101
     assert [item["path"] for item in files_result["files"]] == ["app.py", "ui.ts"]  # nosec B101
     assert [item["path"] for item in filtered_result["files"]] == ["app.py"]  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_codegraph_index_job_mode_enqueues_without_creating_index(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    (workspace_root / "app.py").write_text("x = 1\n", encoding="utf-8")
+    jobs = _FakeJobManager()
+    module = _module_with_settings(
+        tmp_path,
+        workspace_root,
+        {},
+        job_manager_factory=lambda: jobs,
+    )
+
+    result = await module.execute_tool(
+        "codegraph.index",
+        {"mode": "job", "force": True, "languages": ["python"], "max_files": 10},
+        context=_context(),
+    )
+
+    assert result["status"] == "queued"  # nosec B101
+    assert result["mode"] == "job"  # nosec B101
+    assert result["operation"] == "index"  # nosec B101
+    assert result["job_id"] == 1  # nosec B101
+    assert result["job_uuid"] == "job-1"  # nosec B101
+    assert result["job_status"] == "queued"  # nosec B101
+    assert result["workspace_id"] == "workspace-1"  # nosec B101
+    assert result["workspace_key"].startswith("ws_")  # nosec B101
+    assert not result["index_db_path"].endswith("app.py")  # nosec B101
+    assert not Path(result["index_db_path"]).exists()  # nosec B101
+
+    created = jobs.created[0]
+    assert created["domain"] == "codegraph"  # nosec B101
+    assert created["queue"] == "default"  # nosec B101
+    assert created["job_type"] == "codegraph_index"  # nosec B101
+    assert created["owner_user_id"] == "7"  # nosec B101
+    assert created["max_retries"] == 0  # nosec B101
+    assert created["payload"]["operation"] == "index"  # nosec B101
+    assert created["payload"]["force"] is True  # nosec B101
+    assert created["payload"]["languages"] == ["python"]  # nosec B101
+    assert created["payload"]["max_files"] == 10  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_codegraph_sync_background_mode_enqueues_sync(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    jobs = _FakeJobManager()
+    module = _module_with_settings(
+        tmp_path,
+        workspace_root,
+        {},
+        job_manager_factory=lambda: jobs,
+    )
+
+    result = await module.execute_tool(
+        "codegraph.sync",
+        {"mode": "background", "languages": ["python"], "max_files": 5},
+        context=_context(),
+    )
+
+    assert result["status"] == "queued"  # nosec B101
+    assert result["mode"] == "background"  # nosec B101
+    assert result["operation"] == "sync"  # nosec B101
+    assert result["job_id"] == 1  # nosec B101
+    assert result["queue"] == "default"  # nosec B101
+    assert jobs.created[0]["payload"]["operation"] == "sync"  # nosec B101
+    assert jobs.created[0]["payload"]["force"] is False  # nosec B101
+    assert jobs.created[0]["payload"]["languages"] == ["python"]  # nosec B101
+    assert jobs.created[0]["payload"]["max_files"] == 5  # nosec B101
+
+
+def test_codegraph_rejects_unknown_execution_mode(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    module = _module(tmp_path, workspace_root)
+
+    with pytest.raises(ValueError, match="mode must be foreground, job, or background"):
+        module.validate_tool_arguments("codegraph.index", {"mode": "later"})
 
 
 @pytest.mark.asyncio
@@ -729,7 +832,8 @@ async def test_codegraph_offloads_blocking_repository_work(
     workspace_root = tmp_path / "workspace"
     workspace_root.mkdir()
     (workspace_root / "app.py").write_text("x = 1\n", encoding="utf-8")
-    module = _module(tmp_path, workspace_root)
+    jobs = _FakeJobManager()
+    module = _module_with_settings(tmp_path, workspace_root, {}, job_manager_factory=lambda: jobs)
     offloaded: list[str] = []
 
     async def _fake_to_thread(func, /, *args, **kwargs):  # noqa: ANN001
@@ -742,9 +846,13 @@ async def test_codegraph_offloads_blocking_repository_work(
     await module.execute_tool("codegraph.files", {}, context=_context())
     await module.execute_tool("codegraph.search", {"query": "app"}, context=_context())
     await module.execute_tool("codegraph.sync", {"mode": "foreground"}, context=_context())
+    await module.execute_tool("codegraph.index", {"mode": "job"}, context=_context())
     await module.execute_tool("codegraph.impact", {"symbol": "app"}, context=_context())
     await module.execute_tool("codegraph.context", {"task": "app"}, context=_context())
 
+    assert "_run_index" in offloaded  # nosec B101
+    assert "_run_sync" in offloaded  # nosec B101
+    assert "_enqueue_index_job" in offloaded  # nosec B101
     assert "_impact" in offloaded  # nosec B101
     assert "_build_context" in offloaded  # nosec B101
 

--- a/tldw_Server_API/app/core/exceptions.py
+++ b/tldw_Server_API/app/core/exceptions.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 from fastapi import FastAPI, HTTPException, Request, status
 from fastapi.responses import JSONResponse
@@ -51,6 +51,14 @@ class RecipeEnqueueError(RuntimeError):
     ) -> None:
         super().__init__(message)
         self.error_code = error_code
+
+
+class CodeGraphJobError(RuntimeError):
+    """Raised when a CodeGraph Jobs worker rejects or fails a job."""
+
+    def __init__(self, message: str, *, retryable: bool = False) -> None:
+        super().__init__(message)
+        self.retryable = retryable
 
 
 class AuditLogError(RuntimeError):
@@ -352,7 +360,7 @@ class AdapterInitializationError(FileArtifactsError):
 class ResourceNotFoundError(Exception):
     """Generic resource-not-found error for domain-level lookups."""
 
-    def __init__(self, resource: str, identifier: Optional[str] = None, detail: Optional[str] = None):
+    def __init__(self, resource: str, identifier: str | None = None, detail: str | None = None):
         message = f"{resource} not found"
         if identifier:
             message = f"{message}: {identifier}"
@@ -379,7 +387,7 @@ class ServiceInitializationTimeoutError(ServiceInitializationError):
 class DataTablesJobError(RuntimeError):
     """Raised for data table job processing failures."""
 
-    def __init__(self, message: str, *, retryable: bool = False, backoff_seconds: Optional[int] = None) -> None:
+    def __init__(self, message: str, *, retryable: bool = False, backoff_seconds: int | None = None) -> None:
         super().__init__(message)
         self.retryable = retryable
         if backoff_seconds is not None:
@@ -389,7 +397,7 @@ class DataTablesJobError(RuntimeError):
 class FileArtifactsJobError(RuntimeError):
     """Raised for file artifact job processing failures."""
 
-    def __init__(self, message: str, *, retryable: bool = False, backoff_seconds: Optional[int] = None) -> None:
+    def __init__(self, message: str, *, retryable: bool = False, backoff_seconds: int | None = None) -> None:
         super().__init__(message)
         self.retryable = retryable
         if backoff_seconds is not None:
@@ -399,7 +407,7 @@ class FileArtifactsJobError(RuntimeError):
 class ReadingDigestJobError(RuntimeError):
     """Raised for reading digest job processing failures."""
 
-    def __init__(self, message: str, *, retryable: bool = False, backoff_seconds: Optional[int] = None) -> None:
+    def __init__(self, message: str, *, retryable: bool = False, backoff_seconds: int | None = None) -> None:
         super().__init__(message)
         self.retryable = retryable
         if backoff_seconds is not None:

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_jobs.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_jobs.py
@@ -53,6 +53,36 @@ def test_codegraph_job_payload_is_json_safe(tmp_path: Path) -> None:
     assert isinstance(payload["settings"]["exclude_dirs"], list)
 
 
+def test_codegraph_job_payload_serializes_absolute_paths(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    workspace_root = Path("workspace")
+    index_db_path = Path("indexes") / "ws_test" / "codegraph.db"
+    resolution = WorkspaceResolution(
+        workspace_root=workspace_root,
+        workspace_key="ws_test",
+        index_db_path=index_db_path,
+        workspace_id="workspace-1",
+        source="test",
+    )
+    settings = CodeGraphSettings.from_mapping({"index_base_dir": "indexes"})
+
+    payload = build_codegraph_index_job_payload(
+        resolution=resolution,
+        settings=settings,
+        operation="index",
+        force=False,
+        languages=None,
+        max_files=None,
+    )
+
+    assert payload["workspace_root"] == str((tmp_path / "workspace").resolve(strict=False))
+    assert payload["index_db_path"] == str((tmp_path / "indexes" / "ws_test" / "codegraph.db").resolve(strict=False))
+    assert payload["settings"]["index_base_dir"] == str((tmp_path / "indexes").resolve(strict=False))
+
+
 def test_enqueue_codegraph_index_job_uses_codegraph_domain_queue_and_owner(
     tmp_path: Path,
     monkeypatch,

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_jobs.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_jobs.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tldw_Server_API.app.core.CodeGraph.config import CodeGraphSettings
+from tldw_Server_API.app.core.CodeGraph.jobs import (
+    CODEGRAPH_INDEX_JOB_TYPE,
+    CODEGRAPH_JOBS_DOMAIN,
+    build_codegraph_index_job_payload,
+    enqueue_codegraph_index_job,
+)
+from tldw_Server_API.app.core.CodeGraph.models import WorkspaceResolution
+from tldw_Server_API.app.core.Jobs.manager import JobManager
+
+
+def _workspace_resolution(tmp_path: Path) -> WorkspaceResolution:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    index_db_path = tmp_path / "indexes" / "ws_test" / "codegraph.db"
+    return WorkspaceResolution(
+        workspace_root=workspace_root,
+        workspace_key="ws_test",
+        index_db_path=index_db_path,
+        workspace_id="workspace-1",
+        source="test",
+    )
+
+
+def test_codegraph_job_payload_is_json_safe(tmp_path: Path) -> None:
+    settings = CodeGraphSettings.from_mapping({"index_base_dir": str(tmp_path / "indexes")})
+    payload = build_codegraph_index_job_payload(
+        resolution=_workspace_resolution(tmp_path),
+        settings=settings,
+        operation="index",
+        force=True,
+        languages=["python"],
+        max_files=25,
+    )
+
+    json.dumps(payload)
+
+    assert payload["operation"] == "index"
+    assert payload["force"] is True
+    assert payload["languages"] == ["python"]
+    assert payload["max_files"] == 25
+    assert payload["workspace_root"] == str(tmp_path / "workspace")
+    assert payload["workspace_key"] == "ws_test"
+    assert payload["workspace_id"] == "workspace-1"
+    assert payload["workspace_source"] == "test"
+    assert payload["index_db_path"] == str(tmp_path / "indexes" / "ws_test" / "codegraph.db")
+    assert payload["settings"]["index_base_dir"] == str(tmp_path / "indexes")
+    assert isinstance(payload["settings"]["exclude_dirs"], list)
+
+
+def test_enqueue_codegraph_index_job_uses_codegraph_domain_queue_and_owner(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("CODEGRAPH_JOBS_QUEUE", "low")
+    jobs = JobManager(tmp_path / "jobs.db")
+    settings = CodeGraphSettings.from_mapping({"index_base_dir": str(tmp_path / "indexes")})
+
+    job = enqueue_codegraph_index_job(
+        jm=jobs,
+        resolution=_workspace_resolution(tmp_path),
+        settings=settings,
+        operation="sync",
+        force=False,
+        languages=None,
+        max_files=None,
+        owner_user_id="7",
+    )
+
+    assert job["domain"] == CODEGRAPH_JOBS_DOMAIN
+    assert job["queue"] == "low"
+    assert job["job_type"] == CODEGRAPH_INDEX_JOB_TYPE
+    assert job["owner_user_id"] == "7"
+    assert job["status"] == "queued"
+    assert job["payload"]["operation"] == "sync"
+    assert job["payload"]["workspace_key"] == "ws_test"

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_jobs_worker.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_jobs_worker.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.CodeGraph.config import CodeGraphSettings
+from tldw_Server_API.app.core.CodeGraph.jobs import (
+    CODEGRAPH_INDEX_JOB_TYPE,
+    build_codegraph_index_job_payload,
+)
+from tldw_Server_API.app.core.CodeGraph.jobs_worker import (
+    CodeGraphJobError,
+    handle_codegraph_index_job,
+)
+from tldw_Server_API.app.core.CodeGraph.models import WorkspaceResolution
+from tldw_Server_API.app.core.DB_Management.codegraph.repository import CodeGraphRepository
+
+
+def _resolution(tmp_path: Path) -> WorkspaceResolution:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    return WorkspaceResolution(
+        workspace_root=workspace_root,
+        workspace_key="ws_test",
+        index_db_path=tmp_path / "indexes" / "ws_test" / "codegraph.db",
+        workspace_id="workspace-1",
+        source="test",
+    )
+
+
+def _payload(
+    tmp_path: Path,
+    *,
+    operation: str,
+    index_db_path: Path | None = None,
+) -> dict[str, object]:
+    resolution = _resolution(tmp_path)
+    if index_db_path is not None:
+        resolution = WorkspaceResolution(
+            workspace_root=resolution.workspace_root,
+            workspace_key=resolution.workspace_key,
+            index_db_path=index_db_path,
+            workspace_id=resolution.workspace_id,
+            source=resolution.source,
+        )
+    settings = CodeGraphSettings.from_mapping({"index_base_dir": str(tmp_path / "indexes")})
+    return build_codegraph_index_job_payload(
+        resolution=resolution,
+        settings=settings,
+        operation=operation,
+        force=True,
+        languages=["python"],
+        max_files=10,
+    )
+
+
+@pytest.mark.asyncio
+async def test_codegraph_jobs_worker_indexes_workspace(tmp_path: Path) -> None:
+    payload = _payload(tmp_path, operation="index")
+    workspace_root = Path(str(payload["workspace_root"]))
+    (workspace_root / "app.py").write_text(
+        "def helper():\n    return 1\n",
+        encoding="utf-8",
+    )
+
+    result = await handle_codegraph_index_job({"job_type": CODEGRAPH_INDEX_JOB_TYPE, "payload": payload})
+
+    repo = CodeGraphRepository(Path(str(payload["index_db_path"])))
+    assert result["status"] == "complete"
+    assert result["workspace_key"] == "ws_test"
+    assert result["counters"]["files_indexed"] == 1
+    assert repo.find_node_by_symbol("helper") is not None
+
+
+@pytest.mark.asyncio
+async def test_codegraph_jobs_worker_syncs_workspace(tmp_path: Path) -> None:
+    payload = _payload(tmp_path, operation="sync")
+    workspace_root = Path(str(payload["workspace_root"]))
+    (workspace_root / "app.py").write_text("value = 1\n", encoding="utf-8")
+
+    result = await handle_codegraph_index_job({"job_type": CODEGRAPH_INDEX_JOB_TYPE, "payload": payload})
+
+    assert result["status"] == "complete"
+    assert result["operation"] == "sync"
+    assert result["counters"]["files_indexed"] == 1
+
+
+@pytest.mark.asyncio
+async def test_codegraph_jobs_worker_rejects_unsupported_job_type(tmp_path: Path) -> None:
+    payload = _payload(tmp_path, operation="index")
+
+    with pytest.raises(CodeGraphJobError) as excinfo:
+        await handle_codegraph_index_job({"job_type": "other", "payload": payload})
+
+    assert excinfo.value.retryable is False
+    assert "unsupported job_type" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_codegraph_jobs_worker_rejects_missing_operation(tmp_path: Path) -> None:
+    payload = _payload(tmp_path, operation="index")
+    del payload["operation"]
+
+    with pytest.raises(CodeGraphJobError) as excinfo:
+        await handle_codegraph_index_job({"job_type": CODEGRAPH_INDEX_JOB_TYPE, "payload": payload})
+
+    assert excinfo.value.retryable is False
+    assert "unsupported operation: <missing>" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_codegraph_jobs_worker_rejects_unsupported_operation(tmp_path: Path) -> None:
+    payload = _payload(tmp_path, operation="index")
+    payload["operation"] = "watch"
+
+    with pytest.raises(CodeGraphJobError) as excinfo:
+        await handle_codegraph_index_job({"job_type": CODEGRAPH_INDEX_JOB_TYPE, "payload": payload})
+
+    assert excinfo.value.retryable is False
+    assert "unsupported operation: watch" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_codegraph_jobs_worker_rejects_missing_paths(tmp_path: Path) -> None:
+    payload = _payload(tmp_path, operation="index")
+    del payload["workspace_root"]
+
+    with pytest.raises(CodeGraphJobError) as excinfo:
+        await handle_codegraph_index_job({"job_type": CODEGRAPH_INDEX_JOB_TYPE, "payload": payload})
+
+    assert excinfo.value.retryable is False
+    assert "missing workspace_root" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_codegraph_jobs_worker_rejects_unsafe_index_path(tmp_path: Path) -> None:
+    payload = _payload(
+        tmp_path,
+        operation="index",
+        index_db_path=tmp_path / "outside" / "codegraph.db",
+    )
+
+    with pytest.raises(CodeGraphJobError) as excinfo:
+        await handle_codegraph_index_job({"job_type": CODEGRAPH_INDEX_JOB_TYPE, "payload": payload})
+
+    assert excinfo.value.retryable is False
+    assert "index_db_path_outside_index_base" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_codegraph_jobs_worker_rejects_index_base_as_database_path(tmp_path: Path) -> None:
+    payload = _payload(
+        tmp_path,
+        operation="index",
+        index_db_path=tmp_path / "indexes",
+    )
+
+    with pytest.raises(CodeGraphJobError) as excinfo:
+        await handle_codegraph_index_job({"job_type": CODEGRAPH_INDEX_JOB_TYPE, "payload": payload})
+
+    assert excinfo.value.retryable is False
+    assert "index_db_path_outside_index_base" in str(excinfo.value)

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_jobs_worker.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_jobs_worker.py
@@ -90,6 +90,33 @@ async def test_codegraph_jobs_worker_syncs_workspace(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_codegraph_jobs_worker_wraps_indexer_failures(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = _payload(tmp_path, operation="index")
+
+    class _ExplodingIndexer:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        def index_workspace(self, *_args, **_kwargs):
+            raise RuntimeError("indexer exploded")
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.CodeGraph.jobs_worker.CodeGraphIndexer",
+        _ExplodingIndexer,
+    )
+
+    with pytest.raises(CodeGraphJobError) as excinfo:
+        await handle_codegraph_index_job({"job_type": CODEGRAPH_INDEX_JOB_TYPE, "payload": payload})
+
+    assert excinfo.value.retryable is False
+    assert "codegraph_job_execution_failed" in str(excinfo.value)
+    assert isinstance(excinfo.value.__cause__, RuntimeError)
+
+
+@pytest.mark.asyncio
 async def test_codegraph_jobs_worker_rejects_unsupported_job_type(tmp_path: Path) -> None:
     payload = _payload(tmp_path, operation="index")
 

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_jobs_worker.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_jobs_worker.py
@@ -9,12 +9,15 @@ from tldw_Server_API.app.core.CodeGraph.jobs import (
     CODEGRAPH_INDEX_JOB_TYPE,
     build_codegraph_index_job_payload,
 )
-from tldw_Server_API.app.core.CodeGraph.jobs_worker import (
-    CodeGraphJobError,
-    handle_codegraph_index_job,
-)
+from tldw_Server_API.app.core.CodeGraph.jobs_worker import handle_codegraph_index_job
 from tldw_Server_API.app.core.CodeGraph.models import WorkspaceResolution
 from tldw_Server_API.app.core.DB_Management.codegraph.repository import CodeGraphRepository
+from tldw_Server_API.app.core.exceptions import CodeGraphJobError
+
+
+@pytest.fixture(autouse=True)
+def _worker_index_base_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CODEGRAPH_JOBS_INDEX_BASE_DIR", str(tmp_path / "indexes"))
 
 
 def _resolution(tmp_path: Path) -> WorkspaceResolution:
@@ -146,6 +149,22 @@ async def test_codegraph_jobs_worker_rejects_unsafe_index_path(tmp_path: Path) -
 
     assert excinfo.value.retryable is False
     assert "index_db_path_outside_index_base" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_codegraph_jobs_worker_rejects_spoofed_payload_index_base(tmp_path: Path) -> None:
+    payload = _payload(tmp_path, operation="index")
+    settings_payload = payload["settings"]
+    assert isinstance(settings_payload, dict)
+    settings = dict(settings_payload)
+    settings["index_base_dir"] = "/"
+    payload["settings"] = settings
+
+    with pytest.raises(CodeGraphJobError) as excinfo:
+        await handle_codegraph_index_job({"job_type": CODEGRAPH_INDEX_JOB_TYPE, "payload": payload})
+
+    assert excinfo.value.retryable is False
+    assert "index_base_dir_mismatch" in str(excinfo.value)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Change summary

Adds a Jobs-backed execution path for native CodeGraph index and sync work. `codegraph.index` and `codegraph.sync` keep foreground mode unchanged, but now also accept `mode=job` and `mode=background` to enqueue core Jobs rows with JSON-safe workspace/index payloads and owner metadata. The slice also adds a CodeGraph Jobs worker entrypoint that validates payload shape and index path containment before delegating to the existing CodeGraphIndexer.

This keeps large-workspace indexing off the MCP request path without adding file watching, Scheduler integration, or automatic worker startup in this PR.

Backlog: TASK-70 (`backlog/tasks/task-70 - Add-CodeGraph-Jobs-backed-indexing-mode.md`)

## Verification

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_jobs.py tldw_Server_API/tests/CodeGraph/test_codegraph_jobs_worker.py tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py -q` (58 passed)
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check tldw_Server_API/app/core/CodeGraph/jobs.py tldw_Server_API/app/core/CodeGraph/jobs_worker.py tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py tldw_Server_API/tests/CodeGraph/test_codegraph_jobs.py tldw_Server_API/tests/CodeGraph/test_codegraph_jobs_worker.py tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/CodeGraph/jobs.py tldw_Server_API/app/core/CodeGraph/jobs_worker.py tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py -f json -o /tmp/bandit_codegraph_jobs_indexing.json` (0 findings)
- `git diff --check`
