### PR TITLE
Phase 2.2: defer minimal control router imports

### DIFF
--- a/backlog/tasks/task-71 - Phase-2.2-minimal-control-router-conditional-cleanup-AF.md
+++ b/backlog/tasks/task-71 - Phase-2.2-minimal-control-router-conditional-cleanup-AF.md
@@ -1,0 +1,58 @@
+---
+id: TASK-71
+title: Phase 2.2 minimal control router conditional cleanup AF
+status: Done
+assignee: []
+created_date: '2026-05-05 14:25'
+updated_date: '2026-05-05 14:28'
+labels:
+  - phase2.2
+  - router-cleanup
+  - issue-1116
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+  - 'https://github.com/rmusser01/tldw_server/pull/1301'
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue issue #1116 Phase 2.2 by converting the next minimal-test optional single-router control/support registrations from eager try/import RouterSpec blocks to ImportedRouterSpec-backed lazy router specs. Scope is limited to integrations_control_plane, scheduled_tasks_control_plane, notifications, and chatbooks in tldw_Server_API/app/api/v1/router_groups/minimal.py. Preserve existing prefixes, tags, route keys, skip context, and current optional-missing skip behavior while relying on the merged fail-closed registry behavior for unexpected import failures.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Selected minimal optional control/support router specs defer module import and router attribute lookup until registration
+- [x] #2 Existing route metadata is preserved for integrations scheduled-tasks notifications and chatbooks
+- [x] #3 Focused router-group test covers lazy behavior with red/green verification
+- [x] #4 Router-group main-router and OpenAPI contract tests pass for the touched scope
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused lazy-import contract test for integrations_control_plane, scheduled_tasks_control_plane, notifications, and chatbooks. 2. Run the focused test red against the current eager try/import blocks. 3. Convert only those four blocks to ImportedRouterSpec while preserving metadata. 4. Rerun focused/full router contract gates, main/OpenAPI contracts, Bandit, and diff checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the minimal control/support router tranche. Added red/green coverage proving integrations_control_plane, scheduled_tasks_control_plane, notifications, and chatbooks defer module import and router attr lookup until ImportedRouterSpec resolution. Converted only those four eager try/import blocks in minimal.py and centralized the shared skip_context value.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Converted selected minimal control/support optional router registrations to ImportedRouterSpec while preserving prefixes and tags. Verification: focused red/green test, full router_groups contract suite, main router contract suite, OpenAPI contracts, Bandit on minimal.py, and git diff --check.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-71 - Phase-2.2-minimal-control-router-conditional-cleanup-AF.md
+++ b/backlog/tasks/task-71 - Phase-2.2-minimal-control-router-conditional-cleanup-AF.md
@@ -4,7 +4,7 @@ title: Phase 2.2 minimal control router conditional cleanup AF
 status: Done
 assignee: []
 created_date: '2026-05-05 14:25'
-updated_date: '2026-05-05 14:28'
+updated_date: '2026-05-05 14:40'
 labels:
   - phase2.2
   - router-cleanup
@@ -32,19 +32,31 @@ Continue issue #1116 Phase 2.2 by converting the next minimal-test optional sing
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-1. Add a focused lazy-import contract test for integrations_control_plane, scheduled_tasks_control_plane, notifications, and chatbooks. 2. Run the focused test red against the current eager try/import blocks. 3. Convert only those four blocks to ImportedRouterSpec while preserving metadata. 4. Rerun focused/full router contract gates, main/OpenAPI contracts, Bandit, and diff checks.
+1. Add a focused lazy-import contract test for integrations_control_plane, scheduled_tasks_control_plane, notifications, and chatbooks.
+2. Run the focused test red against the current eager try/import blocks.
+3. Convert only those four blocks to ImportedRouterSpec while preserving metadata.
+4. Rerun focused/full router contract gates, main/OpenAPI contracts, Bandit, and diff checks.
+5. Review-fix tranche for PR #1305: centralize the duplicated minimal skip context for the recent data/resource and control/support blocks, add explicit default_stable=True expectations/assertions for the four converted control/support specs, then rerun the focused router contract test, full router contract suite, Bandit on minimal.py, diff check, and status check before committing/pushing.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
 Implemented the minimal control/support router tranche. Added red/green coverage proving integrations_control_plane, scheduled_tasks_control_plane, notifications, and chatbooks defer module import and router attr lookup until ImportedRouterSpec resolution. Converted only those four eager try/import blocks in minimal.py and centralized the shared skip_context value.
+
+Reopened after PR #1305 review feedback. Live unresolved threads: Gemini requested deduplicating the repeated minimal skip context string; CodeRabbit requested default_stable assertions for the four converted specs. Verified existing RouterSpec/ImportedRouterSpec defaults and previous eager blocks preserve default_stable=True for all four converted specs.
+
+Review feedback addressed: minimal.py now uses one minimal_skip_context for the recent data/resource and control/support ImportedRouterSpec blocks; the control/support lazy-import contract test now asserts default_stable=True for integrations_control_plane, scheduled_tasks_control_plane, notifications, and chatbooks.
+
+Review-fix verification: focused control/support lazy-import contract test passed; full test_router_groups_contract.py passed; Bandit on tldw_Server_API/app/api/v1/router_groups/minimal.py reported 0 results and 0 errors; git diff --check was clean before commit.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Converted selected minimal control/support optional router registrations to ImportedRouterSpec while preserving prefixes and tags. Verification: focused red/green test, full router_groups contract suite, main router contract suite, OpenAPI contracts, Bandit on minimal.py, and git diff --check.
+
+PR #1305 review fix: addressed Gemini skip-context deduplication and CodeRabbit default_stable contract coverage feedback while preserving existing default_stable=True behavior.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -72,6 +72,7 @@ def _audio_jobs_imports_enabled_for_runtime() -> bool:
 def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
     """Yield optional minimal-test router specs, skipping unavailable imports."""
     specs: list[RouterSpec] = []
+    minimal_skip_context = "in minimal test app"
 
     append_imported_router_spec(
         specs,
@@ -348,82 +349,80 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
     ):
         append_imported_router_spec(specs, collections_social_spec)
 
-    data_resource_skip_context = "in minimal test app"
     for data_resource_spec in (
         ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.files",
             log_name="files",
             prefix=f"{API_V1_PREFIX}",
             tags=("files",),
-            skip_context=data_resource_skip_context,
+            skip_context=minimal_skip_context,
         ),
         ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.storage",
             log_name="storage",
             prefix=f"{API_V1_PREFIX}",
             tags=("storage",),
-            skip_context=data_resource_skip_context,
+            skip_context=minimal_skip_context,
         ),
         ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.data_tables",
             log_name="data_tables",
             prefix=f"{API_V1_PREFIX}",
             tags=("data-tables",),
-            skip_context=data_resource_skip_context,
+            skip_context=minimal_skip_context,
         ),
         ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.reading_highlights",
             log_name="reading_highlights",
             prefix=f"{API_V1_PREFIX}",
             tags=("reading-highlights",),
-            skip_context=data_resource_skip_context,
+            skip_context=minimal_skip_context,
         ),
         ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.items",
             log_name="items",
             prefix=f"{API_V1_PREFIX}",
             tags=("items",),
-            skip_context=data_resource_skip_context,
+            skip_context=minimal_skip_context,
         ),
         ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.reminders",
             log_name="reminders",
             prefix=f"{API_V1_PREFIX}",
             tags=("tasks",),
-            skip_context=data_resource_skip_context,
+            skip_context=minimal_skip_context,
         ),
     ):
         append_imported_router_spec(specs, data_resource_spec)
 
-    control_support_skip_context = "in minimal test app"
     for control_support_spec in (
         ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.integrations_control_plane",
             log_name="integrations_control_plane",
             prefix=f"{API_V1_PREFIX}",
             tags=("integrations",),
-            skip_context=control_support_skip_context,
+            skip_context=minimal_skip_context,
         ),
         ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.scheduled_tasks_control_plane",
             log_name="scheduled_tasks_control_plane",
             prefix=f"{API_V1_PREFIX}",
             tags=("scheduled-tasks",),
-            skip_context=control_support_skip_context,
+            skip_context=minimal_skip_context,
         ),
         ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.notifications",
             log_name="notifications",
             prefix=f"{API_V1_PREFIX}",
             tags=("notifications",),
-            skip_context=control_support_skip_context,
+            skip_context=minimal_skip_context,
         ),
         ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.chatbooks",
             log_name="chatbooks",
             prefix=f"{API_V1_PREFIX}",
             tags=("chatbooks",),
-            skip_context=control_support_skip_context,
+            skip_context=minimal_skip_context,
         ),
     ):
         append_imported_router_spec(specs, control_support_spec)

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -395,53 +395,38 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
     ):
         append_imported_router_spec(specs, data_resource_spec)
 
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.integrations_control_plane import (
-            router as integrations_control_plane_router,
-        )
-
-        specs.append(RouterSpec(
-            router=integrations_control_plane_router,
+    control_support_skip_context = "in minimal test app"
+    for control_support_spec in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.integrations_control_plane",
+            log_name="integrations_control_plane",
             prefix=f"{API_V1_PREFIX}",
             tags=("integrations",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping integrations control plane router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.scheduled_tasks_control_plane import (
-            router as scheduled_tasks_control_plane_router,
-        )
-
-        specs.append(RouterSpec(
-            router=scheduled_tasks_control_plane_router,
+            skip_context=control_support_skip_context,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.scheduled_tasks_control_plane",
+            log_name="scheduled_tasks_control_plane",
             prefix=f"{API_V1_PREFIX}",
             tags=("scheduled-tasks",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping scheduled tasks control plane router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.notifications import router as notifications_router
-
-        specs.append(RouterSpec(
-            router=notifications_router,
+            skip_context=control_support_skip_context,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.notifications",
+            log_name="notifications",
             prefix=f"{API_V1_PREFIX}",
             tags=("notifications",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping notifications router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.chatbooks import router as chatbooks_router
-
-        specs.append(RouterSpec(
-            router=chatbooks_router,
+            skip_context=control_support_skip_context,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.chatbooks",
+            log_name="chatbooks",
             prefix=f"{API_V1_PREFIX}",
             tags=("chatbooks",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping chatbooks router in minimal test app: {e}")
+            skip_context=control_support_skip_context,
+        ),
+    ):
+        append_imported_router_spec(specs, control_support_spec)
 
     try:
         from tldw_Server_API.app.api.v1.endpoints.chat_workflows import router as chat_workflows_router

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -4603,6 +4603,164 @@ def test_iter_minimal_optional_router_specs_defers_data_resource_attr_lookup(
     }
 
 
+def test_iter_minimal_optional_router_specs_defers_control_support_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal control/support specs keep router attr lookup lazy."""
+    import builtins
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    router_definitions = (
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.integrations_control_plane",
+            "expected_name": "integrations_control_plane",
+            "path": "/integrations",
+            "prefix": "/api/v1",
+            "tags": ("integrations",),
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.scheduled_tasks_control_plane",
+            "expected_name": "scheduled_tasks_control_plane",
+            "path": "/scheduled-tasks",
+            "prefix": "/api/v1",
+            "tags": ("scheduled-tasks",),
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.notifications",
+            "expected_name": "notifications",
+            "path": "/notifications",
+            "prefix": "/api/v1",
+            "tags": ("notifications",),
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.chatbooks",
+            "expected_name": "chatbooks",
+            "path": "/chatbooks",
+            "prefix": "/api/v1",
+            "tags": ("chatbooks",),
+        },
+    )
+    definitions_by_module = {
+        str(definition["module_name"]): definition
+        for definition in router_definitions
+    }
+    access_count = {
+        f"{definition['module_name']}.router": 0
+        for definition in router_definitions
+    }
+    import_calls: list[str] = []
+
+    for module_name, definition in definitions_by_module.items():
+        fake_module = ModuleType(module_name)
+        router = APIRouter()
+
+        @router.get(str(definition["path"]))
+        def _endpoint() -> dict[str, str]:
+            """Return a deterministic response for the fake minimal router."""
+            return {"status": "ok"}
+
+        def _module_getattr(
+            name: str,
+            *,
+            module_name: str = module_name,
+            router: APIRouter = router,
+        ) -> APIRouter:
+            """Track lazy router attribute resolution for the fake module."""
+            if name != "router":
+                raise AttributeError(name)
+            access_count[f"{module_name}.router"] += 1
+            return router
+
+        fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    endpoints_package = "tldw_Server_API.app.api.v1.endpoints."
+    real_import = builtins.__import__
+
+    def _fake_endpoint_import(
+        name: str,
+        globals: dict[str, object] | None = None,
+        locals: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> ModuleType:
+        """Return fake routers for unrelated eager minimal optional imports."""
+        if (
+            level == 0
+            and name.startswith(endpoints_package)
+            and name not in definitions_by_module
+        ):
+            attrs = tuple(attr for attr in fromlist if attr != "*") or ("router",)
+            for attr_name in attrs:
+                _install_fake_router_module(
+                    monkeypatch,
+                    name,
+                    path="/minimal-unrelated-control-support-fake",
+                    attr_name=attr_name,
+                )
+            return sys.modules[name]
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_endpoint_import)
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Track lazy module imports for selected minimal control/support routers."""
+        if module_name in definitions_by_module:
+            import_calls.append(module_name)
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+    fake_main = ModuleType("tldw_Server_API.app.main")
+    fake_main.app = FastAPI()  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "tldw_Server_API.app.main", fake_main)
+
+    specs = list(iter_minimal_optional_router_specs())
+    assert access_count == {
+        f"{definition['module_name']}.router": 0
+        for definition in router_definitions
+    }
+    assert import_calls == []
+
+    selected_specs = {
+        spec.name: spec
+        for spec in specs
+        if spec.name in {
+            str(definition["expected_name"])
+            for definition in router_definitions
+        }
+    }
+    assert set(selected_specs) == {
+        str(definition["expected_name"])
+        for definition in router_definitions
+    }
+
+    for definition in router_definitions:
+        spec = selected_specs[str(definition["expected_name"])]
+        assert spec.prefix == definition["prefix"]
+        assert spec.tags == definition["tags"]
+        assert spec.route_key == ""
+        assert spec.skip_context == "in minimal test app"
+        assert _first_router_path(spec.router) == definition["path"]
+
+    assert import_calls == [
+        str(definition["module_name"])
+        for definition in router_definitions
+    ]
+    assert access_count == {
+        f"{definition['module_name']}.router": 1
+        for definition in router_definitions
+    }
+
+
 def test_iter_minimal_optional_router_specs_populates_llm_specs(monkeypatch: pytest.MonkeyPatch) -> None:
     from tldw_Server_API.app.api.v1.router_groups.minimal import iter_minimal_optional_router_specs
 

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -4621,6 +4621,7 @@ def test_iter_minimal_optional_router_specs_defers_control_support_attr_lookup(
             "path": "/integrations",
             "prefix": "/api/v1",
             "tags": ("integrations",),
+            "default_stable": True,
         },
         {
             "module_name": "tldw_Server_API.app.api.v1.endpoints.scheduled_tasks_control_plane",
@@ -4628,6 +4629,7 @@ def test_iter_minimal_optional_router_specs_defers_control_support_attr_lookup(
             "path": "/scheduled-tasks",
             "prefix": "/api/v1",
             "tags": ("scheduled-tasks",),
+            "default_stable": True,
         },
         {
             "module_name": "tldw_Server_API.app.api.v1.endpoints.notifications",
@@ -4635,6 +4637,7 @@ def test_iter_minimal_optional_router_specs_defers_control_support_attr_lookup(
             "path": "/notifications",
             "prefix": "/api/v1",
             "tags": ("notifications",),
+            "default_stable": True,
         },
         {
             "module_name": "tldw_Server_API.app.api.v1.endpoints.chatbooks",
@@ -4642,6 +4645,7 @@ def test_iter_minimal_optional_router_specs_defers_control_support_attr_lookup(
             "path": "/chatbooks",
             "prefix": "/api/v1",
             "tags": ("chatbooks",),
+            "default_stable": True,
         },
     )
     definitions_by_module = {
@@ -4749,6 +4753,7 @@ def test_iter_minimal_optional_router_specs_defers_control_support_attr_lookup(
         assert spec.tags == definition["tags"]
         assert spec.route_key == ""
         assert spec.skip_context == "in minimal test app"
+        assert spec.default_stable is definition["default_stable"]
         assert _first_router_path(spec.router) == definition["path"]
 
     assert import_calls == [


### PR DESCRIPTION
## Summary
- Convert the next minimal-test optional control/support router cluster to ImportedRouterSpec.
- Cover integrations_control_plane, scheduled_tasks_control_plane, notifications, and chatbooks lazy import behavior with router-group contract coverage.
- Preserve existing prefixes, tags, route keys, and skip behavior through registration-time resolution.

## Verification
- python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k minimal_optional_router_specs_defers_control_support_attr_lookup -q (red before implementation, green after)
- python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q
- python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q
- python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q
- python -m bandit -r tldw_Server_API/app/api/v1/router_groups/minimal.py -f json -o /tmp/bandit_phase2_2_minimal_control_support.json (0 results, 0 errors)
- git diff --check

## Merge Gate
- Human owner still needs to provide the required AI-generated PR Change summary before merge.