### PR TITLE
Add portable sandbox runtime capability gate

### DIFF
--- a/Docs/Sandbox/sandbox-runtime-capability-inventory.md
+++ b/Docs/Sandbox/sandbox-runtime-capability-inventory.md
@@ -67,6 +67,21 @@ Discovery is intentionally summarized. Admin/operator diagnostics can expose
 helper, template, reconciliation, and image-store details that should not be
 duplicated into the public discovery payload.
 
+## Portable Runtime Capability Gate
+
+The portable gate in
+`tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py` protects this
+inventory and `/api/v1/sandbox/runtimes` from drifting apart. It injects
+synthetic `RuntimePreflightResult` rows for `docker`, `firecracker`, `lima`,
+`vz_linux`, `vz_macos`, `seatbelt`, and `worktree` so the check does not require
+Docker, Lima, Firecracker, Apple Virtualization.framework, `sandbox-exec`, or a
+prepared VM host.
+
+The gate verifies every `RuntimeType` has implementation-state, isolation,
+network-policy, session-contract, normalized-reason, run-status taxonomy, schema,
+and inventory coverage. Host-gated smoke tests still own real runtime execution;
+this gate only proves the portable capability contract remains complete.
+
 ## Runtime Isolation Metadata
 
 Isolation posture is exposed as structured discovery metadata so clients do not

--- a/Docs/superpowers/plans/2026-05-05-portable-sandbox-runtime-capability-gate-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-05-portable-sandbox-runtime-capability-gate-implementation-plan.md
@@ -64,4 +64,3 @@ Run Bandit on touched production Python if production code changes. If this rema
 git add Docs/Sandbox/sandbox-runtime-capability-inventory.md Docs/superpowers/specs/2026-05-05-portable-sandbox-runtime-capability-gate-design.md Docs/superpowers/plans/2026-05-05-portable-sandbox-runtime-capability-gate-implementation-plan.md "backlog/tasks/task-72 - Add-portable-sandbox-runtime-capability-gate.md" tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py
 git commit -m "test(sandbox): add portable runtime capability gate"
 ```
-

--- a/Docs/superpowers/plans/2026-05-05-portable-sandbox-runtime-capability-gate-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-05-portable-sandbox-runtime-capability-gate-implementation-plan.md
@@ -1,0 +1,67 @@
+# Portable Sandbox Runtime Capability Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a portable sandbox runtime capability gate that catches runtime discovery, metadata, taxonomy, and documentation drift.
+
+**Architecture:** Keep the gate test-only unless it exposes a real contract gap. Inject synthetic runtime preflight rows into `SandboxService.feature_discovery()` so the test exercises the API-facing projection without host runtime probes.
+
+**Tech Stack:** Python, pytest, Pydantic schemas, existing sandbox runtime capability helpers.
+
+---
+
+### Task 1: Add Portable Capability Gate
+
+**Files:**
+- Create: `tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py`
+- Modify: `Docs/Sandbox/sandbox-runtime-capability-inventory.md`
+- Modify: `backlog/tasks/task-72 - Add-portable-sandbox-runtime-capability-gate.md`
+
+- [ ] **Step 1: Write the failing test**
+
+Create a test that:
+
+- builds one synthetic `RuntimePreflightResult` per `RuntimeType`
+- monkeypatches `SandboxService._collect_runtime_preflights`
+- calls `SandboxService().feature_discovery()`
+- validates the result with `SandboxRuntimesResponse`
+- asserts every runtime row has implementation state, normalized reasons, isolation metadata, network policy contract, and session contract
+- asserts every runtime appears in `Docs/Sandbox/sandbox-runtime-capability-inventory.md`
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py -q
+```
+
+Expected: fail on the current branch because the new gate is stricter than existing coverage.
+
+- [ ] **Step 3: Implement the smallest fix**
+
+If the failure is only missing docs about the portable gate, update `Docs/Sandbox/sandbox-runtime-capability-inventory.md`.
+
+If the failure exposes an actual metadata or taxonomy gap, patch the smallest source mapping or projection needed.
+
+- [ ] **Step 4: Run focused verification**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py -q
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py -q
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py
+git diff --check
+```
+
+Run Bandit on touched production Python if production code changes. If this remains test/docs-only, record the skip reason.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Docs/Sandbox/sandbox-runtime-capability-inventory.md Docs/superpowers/specs/2026-05-05-portable-sandbox-runtime-capability-gate-design.md Docs/superpowers/plans/2026-05-05-portable-sandbox-runtime-capability-gate-implementation-plan.md "backlog/tasks/task-72 - Add-portable-sandbox-runtime-capability-gate.md" tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py
+git commit -m "test(sandbox): add portable runtime capability gate"
+```
+

--- a/Docs/superpowers/specs/2026-05-05-portable-sandbox-runtime-capability-gate-design.md
+++ b/Docs/superpowers/specs/2026-05-05-portable-sandbox-runtime-capability-gate-design.md
@@ -60,4 +60,3 @@ Expected focused verification:
 - `python -m ruff check` for touched Python files
 - Bandit on touched production Python only, or document skip for test/docs-only changes
 - `git diff --check`
-

--- a/Docs/superpowers/specs/2026-05-05-portable-sandbox-runtime-capability-gate-design.md
+++ b/Docs/superpowers/specs/2026-05-05-portable-sandbox-runtime-capability-gate-design.md
@@ -1,0 +1,63 @@
+# Portable Sandbox Runtime Capability Gate Design
+
+**Date:** 2026-05-05
+**Status:** Approved working design for TASK-72
+**Scope:** Sandbox runtime discovery, metadata contracts, docs alignment, and portable tests
+
+## Goal
+
+Add a portable gate that prevents sandbox runtime capability drift as runtimes evolve. The gate must run on normal developer and CI hosts without Docker, Lima, Firecracker, Apple Virtualization.framework, or `sandbox-exec` availability.
+
+## Design
+
+The gate uses the existing runtime seams rather than adding a new runtime abstraction:
+
+- `RuntimeType` remains the source of truth for runtime names.
+- `runtime_capabilities.py` remains the source of truth for implementation state, isolation metadata, network policy metadata, session semantics, and normalized preflight reasons.
+- `SandboxService.feature_discovery()` remains the API-facing projection contract.
+- `Docs/Sandbox/sandbox-runtime-capability-inventory.md` remains the operator-facing inventory.
+
+The test should inject synthetic `RuntimePreflightResult` objects for every runtime through the service seam, then validate that each discovery row can be parsed by the public schema and contains the required capability fields. This avoids host probing while still exercising the API projection.
+
+## Contract Rules
+
+For every `RuntimeType`:
+
+- implementation state must be non-empty and in the supported vocabulary
+- isolation, network policy, and session contract metadata must exist
+- discovery output must include raw reasons and normalized reasons
+- discovery output must validate against `SandboxRuntimesResponse`
+- the runtime must be documented in the capability inventory
+
+For run status taxonomy:
+
+- current runtime-specific policy failure messages must normalize to `policy_failed`
+- current runtime-specific unavailable messages that are actually emitted must normalize to `runtime_unavailable`
+
+## Non-Goals
+
+- Do not require real runtime binaries or VM hosts.
+- Do not change runtime execution behavior.
+- Do not generalize VZ repair ownership beyond `vz_linux`.
+- Do not make host-local runtimes appear VM-grade.
+
+## Risks And Mitigations
+
+- Risk: a broad gate becomes brittle and blocks unrelated work.
+  Mitigation: assert stable contract fields and emitted reason vocabularies only, not host availability.
+- Risk: docs parsing becomes too strict.
+  Mitigation: check runtime row presence and named gate documentation, not exact table formatting beyond runtime names.
+- Risk: status taxonomy invents aliases for messages no runner emits.
+  Mitigation: cover emitted policy/unavailable messages from current service/runner paths only.
+
+## Verification
+
+Expected focused verification:
+
+- `python -m pytest tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py -q`
+- `python -m pytest tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py -q`
+- `python -m py_compile` for touched Python files
+- `python -m ruff check` for touched Python files
+- Bandit on touched production Python only, or document skip for test/docs-only changes
+- `git diff --check`
+

--- a/backlog/tasks/task-72 - Add-portable-sandbox-runtime-capability-gate.md
+++ b/backlog/tasks/task-72 - Add-portable-sandbox-runtime-capability-gate.md
@@ -56,10 +56,19 @@ Add a narrow sandbox maintenance slice that verifies runtime capability/discover
 - Verification: `python -m ruff check tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py` passed after import ordering fix.
 - Verification: `git diff --check` passed.
 - Bandit skipped: this slice touched only tests and documentation, not production Python.
+- Review fix RED: `python -m pytest tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py::test_portable_runtime_capability_gate_covers_emitted_status_reason_aliases -q` failed after adding the Lima `limactl_missing` alias because it normalized to `runtime_error`.
+- Review fix: added `limactl_missing` to the runtime-unavailable taxonomy, made runtime discovery assertions use explicit string keys, switched docs lookup to `pytestconfig.rootpath`, and made runtime-name documentation matching format-agnostic.
+- Review verification: `python -m pytest tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py -q` passed with 34 tests.
+- Review verification: `python -m py_compile tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py` passed.
+- Review verification: `python -m ruff check tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py` passed.
+- Review verification: `python -m bandit -r tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py -f json -o /tmp/bandit_sandbox_runtime_capability_gate_review.json` reported 0 findings.
+- Review verification: `git diff --check` passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Added a portable sandbox runtime capability gate that injects synthetic preflight rows for every runtime and validates the API-facing discovery projection through the public schema. The gate asserts complete runtime metadata maps, normalized preflight reasons, emitted run-status reason aliases, host-local isolation/session constraints, and inventory documentation coverage without requiring host-specific runtime availability. Updated the runtime capability inventory to document the gate and clarify that real execution remains covered by host-gated smoke paths.
+
+Review follow-up tightened the gate by explicitly covering Lima's `limactl_missing` emitted reason, avoiding brittle docs path/Markdown formatting assumptions, and avoiding implicit enum/string equality in runtime discovery assertions.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-72 - Add-portable-sandbox-runtime-capability-gate.md
+++ b/backlog/tasks/task-72 - Add-portable-sandbox-runtime-capability-gate.md
@@ -1,0 +1,65 @@
+---
+id: TASK-72
+title: Add portable sandbox runtime capability gate
+status: Done
+assignee: []
+created_date: '2026-05-05 14:38'
+labels:
+  - sandbox
+  - runtime-capability
+  - testing
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add a narrow sandbox maintenance slice that verifies runtime capability/discovery contracts stay aligned across all RuntimeType values without requiring host-specific runtimes. The gate should exercise the existing runtime metadata, feature discovery, inventory documentation, status taxonomy, and session semantics from portable tests so future sandbox runtime additions cannot drift silently.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [x] #1 A focused portable test fails if a RuntimeType lacks required capability/discovery metadata or runtime inventory documentation coverage.
+- [x] #2 The gate covers current runtime rows for isolation metadata, implementation state, session semantics, normalized reason/status metadata where applicable, and admin diagnostics/documentation references without requiring Docker, Lima, Firecracker, or Apple Virtualization.framework availability.
+- [x] #3 Runtime capability inventory or sandbox docs are updated to document the new gate and remaining non-portable host-gated coverage.
+- [x] #4 Focused sandbox tests, syntax/lint checks, Bandit for touched production code when applicable, and git diff checks are run and recorded.
+<!-- AC:END -->
+
+## Definition of Done
+
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Plan
+
+1. Add a portable runtime capability gate test that injects synthetic preflight rows instead of probing host runtimes.
+2. Verify the gate fails on the current branch for the missing cross-runtime capability contract.
+3. Add the smallest code/docs/test changes needed to make the gate pass.
+4. Run focused sandbox verification and record results.
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Scope is intentionally test/docs-first. Production changes should only happen if the red gate exposes a real contract gap.
+- RED: `python -m pytest tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py -q` failed because `Docs/Sandbox/sandbox-runtime-capability-inventory.md` did not document the Portable Runtime Capability Gate.
+- GREEN: Added the inventory section; the focused gate passed with 3 tests.
+- Verification: `python -m pytest tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py -q` passed with 34 tests.
+- Verification: `python -m py_compile tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py` passed.
+- Verification: `python -m ruff check tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py` passed after import ordering fix.
+- Verification: `git diff --check` passed.
+- Bandit skipped: this slice touched only tests and documentation, not production Python.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added a portable sandbox runtime capability gate that injects synthetic preflight rows for every runtime and validates the API-facing discovery projection through the public schema. The gate asserts complete runtime metadata maps, normalized preflight reasons, emitted run-status reason aliases, host-local isolation/session constraints, and inventory documentation coverage without requiring host-specific runtime availability. Updated the runtime capability inventory to document the gate and clarify that real execution remains covered by host-gated smoke paths.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py
+++ b/tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py
@@ -47,6 +47,7 @@ _RUNTIME_UNAVAILABLE_MESSAGES = frozenset({
     "runtime unavailable",
     "docker_unavailable",
     "firecracker_unavailable",
+    "limactl_missing",
     "vz_linux_unavailable",
     "vz_macos_unavailable",
     "seatbelt_unavailable",

--- a/tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py
+++ b/tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -38,6 +39,7 @@ _EMITTED_POLICY_FAILURE_MESSAGES = (
 _EMITTED_RUNTIME_UNAVAILABLE_MESSAGES = (
     "docker_unavailable",
     "firecracker_unavailable",
+    "limactl_missing",
     "vz_linux_unavailable",
     "vz_macos_unavailable",
     "seatbelt_unavailable",
@@ -60,6 +62,11 @@ def _synthetic_preflights() -> dict[RuntimeType, RuntimePreflightResult]:
     }
 
 
+def _runtime_name_is_documented(text: str, runtime: RuntimeType) -> bool:
+    pattern = rf"(?<![\w`])`?{re.escape(runtime.value)}`?(?![\w`])"
+    return re.search(pattern, text) is not None
+
+
 def test_portable_runtime_capability_gate_covers_all_runtime_discovery_rows(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -72,16 +79,19 @@ def test_portable_runtime_capability_gate_covers_all_runtime_discovery_rows(
 
     rows = SandboxService().feature_discovery()
     response = SandboxRuntimesResponse(runtimes=rows)
-    discovery = {row.name: row for row in response.runtimes}
+    discovery = {
+        row.name.value if isinstance(row.name, RuntimeType) else str(row.name): row
+        for row in response.runtimes
+    }
 
-    assert set(discovery) == set(RuntimeType)
+    assert set(discovery) == {runtime.value for runtime in RuntimeType}
     assert set(runtime_caps.RUNTIME_IMPLEMENTATION_STATES) == set(RuntimeType)
     assert set(runtime_caps.RUNTIME_ISOLATION_METADATA) == set(RuntimeType)
     assert set(runtime_caps.RUNTIME_NETWORK_POLICY_METADATA) == set(RuntimeType)
     assert set(runtime_caps.RUNTIME_SESSION_CONTRACT_METADATA) == set(RuntimeType)
 
     for runtime in RuntimeType:
-        row = discovery[runtime]
+        row = discovery[runtime.value]
         assert row.implementation_state in {
             "supported",
             "unsupported",
@@ -96,15 +106,15 @@ def test_portable_runtime_capability_gate_covers_all_runtime_discovery_rows(
         assert "unknown" not in row.normalized_reasons
 
     for runtime in (RuntimeType.seatbelt, RuntimeType.worktree):
-        row = discovery[runtime]
+        row = discovery[runtime.value]
         assert row.boundary_class == "host_local"
         assert row.vm_grade_isolation is False
         assert row.untrusted_eligible is False
         assert row.session_contract.reuse_model == "workspace_only"
         assert row.session_contract.repair_state == "unsupported"
 
-    assert discovery[RuntimeType.vz_linux].session_contract.requires_live_health_check is True
-    assert discovery[RuntimeType.vz_linux].session_contract.repair_state == "host_gated"
+    assert discovery[RuntimeType.vz_linux.value].session_contract.requires_live_health_check is True
+    assert discovery[RuntimeType.vz_linux.value].session_contract.repair_state == "host_gated"
 
 
 def test_portable_runtime_capability_gate_covers_emitted_status_reason_aliases() -> None:
@@ -125,11 +135,15 @@ def test_portable_runtime_capability_gate_covers_emitted_status_reason_aliases()
         ) == "runtime_unavailable"
 
 
-def test_portable_runtime_capability_gate_is_documented_for_every_runtime() -> None:
-    repo_root = Path(__file__).resolve().parents[3]
+def test_portable_runtime_capability_gate_is_documented_for_every_runtime(
+    pytestconfig: pytest.Config,
+) -> None:
+    repo_root = Path(pytestconfig.rootpath)
     inventory = repo_root / "Docs" / "Sandbox" / "sandbox-runtime-capability-inventory.md"
     text = inventory.read_text(encoding="utf-8")
 
     assert "Portable Runtime Capability Gate" in text
     for runtime in RuntimeType:
-        assert f"`{runtime.value}`" in text
+        assert _runtime_name_is_documented(text, runtime), (
+            f"{runtime.value} missing from inventory"
+        )

--- a/tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py
+++ b/tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.api.v1.schemas.sandbox_schemas import (
+    SandboxRuntimesResponse,
+)
+from tldw_Server_API.app.core.Sandbox import runtime_capabilities as runtime_caps
+from tldw_Server_API.app.core.Sandbox.models import RunPhase, RuntimeType
+from tldw_Server_API.app.core.Sandbox.run_status_taxonomy import (
+    normalize_run_status_reason,
+)
+from tldw_Server_API.app.core.Sandbox.runtime_capabilities import (
+    RuntimePreflightResult,
+)
+from tldw_Server_API.app.core.Sandbox.service import SandboxService
+
+_EMITTED_UNAVAILABLE_REASONS: dict[RuntimeType, str] = {
+    RuntimeType.docker: "docker_unavailable",
+    RuntimeType.firecracker: "firecracker_unavailable",
+    RuntimeType.lima: "limactl_missing",
+    RuntimeType.vz_linux: "vz_linux_unavailable",
+    RuntimeType.vz_macos: "vz_macos_unavailable",
+    RuntimeType.seatbelt: "seatbelt_unavailable",
+    RuntimeType.worktree: "worktree_unavailable",
+}
+
+_EMITTED_POLICY_FAILURE_MESSAGES = (
+    "lima_policy_failed",
+    "vz_linux_policy_failed",
+    "vz_macos_policy_failed",
+    "seatbelt_policy_failed",
+    "worktree_policy_failed",
+)
+
+_EMITTED_RUNTIME_UNAVAILABLE_MESSAGES = (
+    "docker_unavailable",
+    "firecracker_unavailable",
+    "vz_linux_unavailable",
+    "vz_macos_unavailable",
+    "seatbelt_unavailable",
+    "worktree_unavailable",
+)
+
+
+def _synthetic_preflights() -> dict[RuntimeType, RuntimePreflightResult]:
+    return {
+        runtime: RuntimePreflightResult(
+            runtime=runtime,
+            available=False,
+            reasons=[reason],
+            execution_mode="none",
+            supported_trust_levels=["trusted", "standard"],
+            host={"portable_gate": True},
+            enforcement_ready={"deny_all": False, "allowlist": False},
+        )
+        for runtime, reason in _EMITTED_UNAVAILABLE_REASONS.items()
+    }
+
+
+def test_portable_runtime_capability_gate_covers_all_runtime_discovery_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SANDBOX_STORE_BACKEND", "memory")
+    monkeypatch.setattr(
+        SandboxService,
+        "_collect_runtime_preflights",
+        lambda self, network_policy=None: _synthetic_preflights(),
+    )
+
+    rows = SandboxService().feature_discovery()
+    response = SandboxRuntimesResponse(runtimes=rows)
+    discovery = {row.name: row for row in response.runtimes}
+
+    assert set(discovery) == set(RuntimeType)
+    assert set(runtime_caps.RUNTIME_IMPLEMENTATION_STATES) == set(RuntimeType)
+    assert set(runtime_caps.RUNTIME_ISOLATION_METADATA) == set(RuntimeType)
+    assert set(runtime_caps.RUNTIME_NETWORK_POLICY_METADATA) == set(RuntimeType)
+    assert set(runtime_caps.RUNTIME_SESSION_CONTRACT_METADATA) == set(RuntimeType)
+
+    for runtime in RuntimeType:
+        row = discovery[runtime]
+        assert row.implementation_state in {
+            "supported",
+            "unsupported",
+            "scaffold",
+            "host_gated",
+            "not_applicable",
+        }
+        assert row.boundary_class == runtime_caps.runtime_isolation_metadata(runtime).boundary_class
+        assert row.network_policy_contract is not None
+        assert row.session_contract is not None
+        assert row.normalized_reasons
+        assert "unknown" not in row.normalized_reasons
+
+    for runtime in (RuntimeType.seatbelt, RuntimeType.worktree):
+        row = discovery[runtime]
+        assert row.boundary_class == "host_local"
+        assert row.vm_grade_isolation is False
+        assert row.untrusted_eligible is False
+        assert row.session_contract.reuse_model == "workspace_only"
+        assert row.session_contract.repair_state == "unsupported"
+
+    assert discovery[RuntimeType.vz_linux].session_contract.requires_live_health_check is True
+    assert discovery[RuntimeType.vz_linux].session_contract.repair_state == "host_gated"
+
+
+def test_portable_runtime_capability_gate_covers_emitted_status_reason_aliases() -> None:
+    for message in _EMITTED_POLICY_FAILURE_MESSAGES:
+        assert normalize_run_status_reason(
+            phase=RunPhase.failed,
+            message=message,
+            exit_code=None,
+            resource_usage=None,
+        ) == "policy_failed"
+
+    for message in _EMITTED_RUNTIME_UNAVAILABLE_MESSAGES:
+        assert normalize_run_status_reason(
+            phase=RunPhase.failed,
+            message=message,
+            exit_code=None,
+            resource_usage=None,
+        ) == "runtime_unavailable"
+
+
+def test_portable_runtime_capability_gate_is_documented_for_every_runtime() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    inventory = repo_root / "Docs" / "Sandbox" / "sandbox-runtime-capability-inventory.md"
+    text = inventory.read_text(encoding="utf-8")
+
+    assert "Portable Runtime Capability Gate" in text
+    for runtime in RuntimeType:
+        assert f"`{runtime.value}`" in text


### PR DESCRIPTION
## Summary
- Add a portable sandbox runtime capability gate that injects synthetic preflight rows for every RuntimeType and validates feature discovery through the public schema.
- Document the gate in the sandbox runtime capability inventory and capture the design/implementation plan plus TASK-72 tracking.
- Keep the slice test/docs-only; real runtime execution remains owned by host-gated smoke paths.

## Test Plan
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py -q
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py
- [x] git diff --check HEAD~2..HEAD

## Change summary
Human-authored merge summary required before merge per repo policy.