### PR TITLE
Phase 2.2: defer minimal experience router imports

### DIFF
--- a/backlog/tasks/task-73 - Phase-2.2-minimal-experience-router-conditional-cleanup-AG.md
+++ b/backlog/tasks/task-73 - Phase-2.2-minimal-experience-router-conditional-cleanup-AG.md
@@ -1,0 +1,70 @@
+---
+id: TASK-73
+title: Phase 2.2 minimal experience router conditional cleanup AG
+status: Done
+assignee: []
+created_date: '2026-05-05 14:45'
+updated_date: '2026-05-05 14:48'
+labels:
+  - phase2.2
+  - router-cleanup
+  - issue-1116
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+  - 'https://github.com/rmusser01/tldw_server/pull/1305'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue issue #1116 Phase 2.2 by converting the next small set of minimal-test optional single-router experience/support registrations from eager try/import RouterSpec blocks to ImportedRouterSpec-backed lazy router specs. Scope is limited to sharing, personalization, and companion in tldw_Server_API/app/api/v1/router_groups/minimal.py. Preserve existing prefixes, tags, route keys, default_stable values, and current optional-missing skip behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Selected minimal optional experience/support router specs defer module import and router attribute lookup until registration
+- [x] #2 Existing route metadata is preserved for sharing personalization and companion
+- [x] #3 Focused router-group test covers lazy behavior with red/green verification
+- [x] #4 Router-group contract tests and touched-source Bandit pass
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused lazy-import contract test for sharing, personalization, and companion.
+2. Run the focused test red against the current eager try/import blocks.
+3. Convert only those three blocks to ImportedRouterSpec while preserving prefix, tags, empty route_key, default_stable=True, and minimal skip context.
+4. Rerun the focused test, full router_groups contract file, Bandit on minimal.py, git diff --check, and status check before commit/PR.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Started after PR #1305 merge was verified at merge commit 67d13e1bc6621c3cd37e387eeea06dda657b07a5. Worktree: /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/phase2-2-minimal-experience-router-conditionals-ag. Branch: codex/phase2-2-minimal-experience-router-conditionals-ag.
+
+Implemented the minimal experience/support router tranche. Added a red/green focused contract test proving sharing, personalization, and companion defer router attribute lookup until ImportedRouterSpec resolution. Converted only those three eager try/import blocks while preserving prefixes, tags, empty route_key, default_stable=True, and minimal skip context.
+
+Verification: focused test failed red before implementation because router attributes were accessed during iter_minimal_optional_router_specs; focused test passed after implementation; full test_router_groups_contract.py passed with 76 tests; Bandit on minimal.py reported 0 results and 0 errors; git diff --check was clean.
+
+Additional router gates passed after task finalization: test_main_router_contract.py passed with 6 tests; test_openapi_contracts.py passed with 69 tests.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Converted minimal optional sharing, personalization, and companion router registrations to ImportedRouterSpec-backed lazy specs with focused contract coverage. Preserved existing route metadata and optional skip context. Verification covered red/green focused test, full router_groups contract suite, Bandit, and diff check.
+
+Additional verification: main router contract suite and OpenAPI contract suite passed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-73 - Phase-2.2-minimal-experience-router-conditional-cleanup-AG.md
+++ b/backlog/tasks/task-73 - Phase-2.2-minimal-experience-router-conditional-cleanup-AG.md
@@ -4,7 +4,7 @@ title: Phase 2.2 minimal experience router conditional cleanup AG
 status: Done
 assignee: []
 created_date: '2026-05-05 14:45'
-updated_date: '2026-05-05 14:48'
+updated_date: '2026-05-05 14:58'
 labels:
   - phase2.2
   - router-cleanup
@@ -37,6 +37,7 @@ Continue issue #1116 Phase 2.2 by converting the next small set of minimal-test 
 2. Run the focused test red against the current eager try/import blocks.
 3. Convert only those three blocks to ImportedRouterSpec while preserving prefix, tags, empty route_key, default_stable=True, and minimal skip context.
 4. Rerun the focused test, full router_groups contract file, Bandit on minimal.py, git diff --check, and status check before commit/PR.
+5. PR #1307 review follow-up: verify Qodo narrowed-skip feedback against router_registry fail-closed tests, add focused assertions that the three converted experience specs keep the default optional-missing skip scope, rerun focused/full router contract tests and hygiene checks, then reply/resolve the thread.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -49,6 +50,12 @@ Implemented the minimal experience/support router tranche. Added a red/green foc
 Verification: focused test failed red before implementation because router attributes were accessed during iter_minimal_optional_router_specs; focused test passed after implementation; full test_router_groups_contract.py passed with 76 tests; Bandit on minimal.py reported 0 results and 0 errors; git diff --check was clean.
 
 Additional router gates passed after task finalization: test_main_router_contract.py passed with 6 tests; test_openapi_contracts.py passed with 69 tests.
+
+Reopened to address PR #1307 Qodo review thread PRRT_kwDOL1aGf85_sOPN. Verified existing router-registry contract: ImportedRouterSpec skips ImportError/AttributeError by default and unexpected RuntimeError import failures are intentionally re-raised by test_append_imported_router_spec_raises_unexpected_import_error_at_registration.
+
+Review follow-up implemented: added a focused assertion to the minimal experience/support lazy-import contract test that sharing, personalization, and companion keep skip_exceptions=(ImportError, AttributeError). This documents the intended optional-missing-only skip behavior and avoids weakening the router_registry fail-closed contract for unexpected import-time failures.
+
+Review follow-up verification: focused selection experience_attr_lookup or raises_unexpected_import_error passed with 2 tests; full test_router_groups_contract.py passed with 76 tests; Bandit on minimal.py reported 0 results and 0 errors; git diff --check was clean.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
@@ -57,6 +64,8 @@ Additional router gates passed after task finalization: test_main_router_contrac
 Converted minimal optional sharing, personalization, and companion router registrations to ImportedRouterSpec-backed lazy specs with focused contract coverage. Preserved existing route metadata and optional skip context. Verification covered red/green focused test, full router_groups contract suite, Bandit, and diff check.
 
 Additional verification: main router contract suite and OpenAPI contract suite passed.
+
+PR #1307 review follow-up: addressed Qodo narrowed-skip feedback by documenting the intentional fail-closed behavior in focused contract coverage rather than broadening skip_exceptions to Exception.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-73 - Phase-2.2-minimal-experience-router-conditional-cleanup-AG.md
+++ b/backlog/tasks/task-73 - Phase-2.2-minimal-experience-router-conditional-cleanup-AG.md
@@ -4,7 +4,7 @@ title: Phase 2.2 minimal experience router conditional cleanup AG
 status: Done
 assignee: []
 created_date: '2026-05-05 14:45'
-updated_date: '2026-05-05 14:58'
+updated_date: '2026-05-05 15:06'
 labels:
   - phase2.2
   - router-cleanup
@@ -38,6 +38,7 @@ Continue issue #1116 Phase 2.2 by converting the next small set of minimal-test 
 3. Convert only those three blocks to ImportedRouterSpec while preserving prefix, tags, empty route_key, default_stable=True, and minimal skip context.
 4. Rerun the focused test, full router_groups contract file, Bandit on minimal.py, git diff --check, and status check before commit/PR.
 5. PR #1307 review follow-up: verify Qodo narrowed-skip feedback against router_registry fail-closed tests, add focused assertions that the three converted experience specs keep the default optional-missing skip scope, rerun focused/full router contract tests and hygiene checks, then reply/resolve the thread.
+6. User-directed review implementation: add a regression test proving the three minimal experience specs skip RuntimeError import failures during registration, then set skip_exceptions=(Exception,) on those three specs to preserve prior try/except Exception compatibility.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -56,6 +57,10 @@ Reopened to address PR #1307 Qodo review thread PRRT_kwDOL1aGf85_sOPN. Verified 
 Review follow-up implemented: added a focused assertion to the minimal experience/support lazy-import contract test that sharing, personalization, and companion keep skip_exceptions=(ImportError, AttributeError). This documents the intended optional-missing-only skip behavior and avoids weakening the router_registry fail-closed contract for unexpected import-time failures.
 
 Review follow-up verification: focused selection experience_attr_lookup or raises_unexpected_import_error passed with 2 tests; full test_router_groups_contract.py passed with 76 tests; Bandit on minimal.py reported 0 results and 0 errors; git diff --check was clean.
+
+Reopened after explicit user instruction to implement the review suggestion for PR #1307. Scope: sharing, personalization, companion in minimal.py. Plan is to add regression coverage for broad import failure skipping first, verify it fails, then set skip_exceptions=(Exception,) on the three ImportedRouterSpec definitions.
+
+User-directed review implementation completed: sharing, personalization, and companion now explicitly set skip_exceptions=(Exception,) to preserve the prior minimal-test try/except Exception behavior while keeping imports lazy. Added regression coverage proving RuntimeError import failures are skipped during registration for those three specs. Verification: focused selection experience_attr_lookup or experience_runtime_import_failures failed red before the source change and passed after implementation; full test_router_groups_contract.py passed with 77 tests; Bandit on minimal.py reported 0 results and 0 errors; git diff --check was clean.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
@@ -65,7 +70,7 @@ Converted minimal optional sharing, personalization, and companion router regist
 
 Additional verification: main router contract suite and OpenAPI contract suite passed.
 
-PR #1307 review follow-up: addressed Qodo narrowed-skip feedback by documenting the intentional fail-closed behavior in focused contract coverage rather than broadening skip_exceptions to Exception.
+PR #1307 review follow-up: after explicit user direction, sharing, personalization, and companion now explicitly use skip_exceptions=(Exception,) to preserve the previous minimal-test broad skip behavior for import-time failures. Added a regression test covering RuntimeError import failures during registration. Verification covered the focused red/green selection, full router_groups contract suite, Bandit, and diff check.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -471,38 +471,30 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
         route_key="monitoring",
     ))
 
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.sharing import router as sharing_router
-
-        specs.append(RouterSpec(
-            router=sharing_router,
+    for experience_spec in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.sharing",
+            log_name="sharing",
             prefix=f"{API_V1_PREFIX}",
             tags=("sharing",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping sharing router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.personalization import router as personalization_router
-
-        specs.append(RouterSpec(
-            router=personalization_router,
+            skip_context=minimal_skip_context,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.personalization",
+            log_name="personalization",
             prefix=f"{API_V1_PREFIX}/personalization",
             tags=("personalization",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping personalization router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.companion import router as companion_router
-
-        specs.append(RouterSpec(
-            router=companion_router,
+            skip_context=minimal_skip_context,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.companion",
+            log_name="companion",
             prefix=f"{API_V1_PREFIX}/companion",
             tags=("companion",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping companion router in minimal test app: {e}")
+            skip_context=minimal_skip_context,
+        ),
+    ):
+        append_imported_router_spec(specs, experience_spec)
 
     try:
         from tldw_Server_API.app.api.v1.endpoints.family_wizard import router as family_wizard_router

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -478,6 +478,7 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
             prefix=f"{API_V1_PREFIX}",
             tags=("sharing",),
             skip_context=minimal_skip_context,
+            skip_exceptions=(Exception,),
         ),
         ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.personalization",
@@ -485,6 +486,7 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
             prefix=f"{API_V1_PREFIX}/personalization",
             tags=("personalization",),
             skip_context=minimal_skip_context,
+            skip_exceptions=(Exception,),
         ),
         ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.companion",
@@ -492,6 +494,7 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
             prefix=f"{API_V1_PREFIX}/companion",
             tags=("companion",),
             skip_context=minimal_skip_context,
+            skip_exceptions=(Exception,),
         ),
     ):
         append_imported_router_spec(specs, experience_spec)

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -4766,6 +4766,161 @@ def test_iter_minimal_optional_router_specs_defers_control_support_attr_lookup(
     }
 
 
+def test_iter_minimal_optional_router_specs_defers_experience_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal experience/support specs keep router attr lookup lazy."""
+    import builtins
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    router_definitions = (
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.sharing",
+            "expected_name": "sharing",
+            "path": "/sharing",
+            "prefix": "/api/v1",
+            "tags": ("sharing",),
+            "default_stable": True,
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.personalization",
+            "expected_name": "personalization",
+            "path": "/personalization",
+            "prefix": "/api/v1/personalization",
+            "tags": ("personalization",),
+            "default_stable": True,
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.companion",
+            "expected_name": "companion",
+            "path": "/companion",
+            "prefix": "/api/v1/companion",
+            "tags": ("companion",),
+            "default_stable": True,
+        },
+    )
+    definitions_by_module = {
+        str(definition["module_name"]): definition
+        for definition in router_definitions
+    }
+    access_count = {
+        f"{definition['module_name']}.router": 0
+        for definition in router_definitions
+    }
+    import_calls: list[str] = []
+
+    for module_name, definition in definitions_by_module.items():
+        fake_module = ModuleType(module_name)
+        router = APIRouter()
+
+        @router.get(str(definition["path"]))
+        def _endpoint() -> dict[str, str]:
+            """Return a deterministic response for the fake minimal router."""
+            return {"status": "ok"}
+
+        def _module_getattr(
+            name: str,
+            *,
+            module_name: str = module_name,
+            router: APIRouter = router,
+        ) -> APIRouter:
+            """Track lazy router attribute resolution for the fake module."""
+            if name != "router":
+                raise AttributeError(name)
+            access_count[f"{module_name}.router"] += 1
+            return router
+
+        fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    endpoints_package = "tldw_Server_API.app.api.v1.endpoints."
+    real_import = builtins.__import__
+
+    def _fake_endpoint_import(
+        name: str,
+        globals: dict[str, object] | None = None,
+        locals: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> ModuleType:
+        """Return fake routers for unrelated eager minimal optional imports."""
+        if (
+            level == 0
+            and name.startswith(endpoints_package)
+            and name not in definitions_by_module
+        ):
+            attrs = tuple(attr for attr in fromlist if attr != "*") or ("router",)
+            for attr_name in attrs:
+                _install_fake_router_module(
+                    monkeypatch,
+                    name,
+                    path="/minimal-unrelated-experience-fake",
+                    attr_name=attr_name,
+                )
+            return sys.modules[name]
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_endpoint_import)
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Track lazy module imports for selected minimal experience routers."""
+        if module_name in definitions_by_module:
+            import_calls.append(module_name)
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+    fake_main = ModuleType("tldw_Server_API.app.main")
+    fake_main.app = FastAPI()  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "tldw_Server_API.app.main", fake_main)
+
+    specs = list(iter_minimal_optional_router_specs())
+    assert access_count == {
+        f"{definition['module_name']}.router": 0
+        for definition in router_definitions
+    }
+    assert import_calls == []
+
+    selected_specs = {
+        spec.name: spec
+        for spec in specs
+        if spec.name in {
+            str(definition["expected_name"])
+            for definition in router_definitions
+        }
+    }
+    assert set(selected_specs) == {
+        str(definition["expected_name"])
+        for definition in router_definitions
+    }
+
+    for definition in router_definitions:
+        spec = selected_specs[str(definition["expected_name"])]
+        assert spec.prefix == definition["prefix"]
+        assert spec.tags == definition["tags"]
+        assert spec.route_key == ""
+        assert spec.skip_context == "in minimal test app"
+        assert spec.default_stable is definition["default_stable"]
+        assert _first_router_path(spec.router) == definition["path"]
+
+    assert import_calls == [
+        str(definition["module_name"])
+        for definition in router_definitions
+    ]
+    assert access_count == {
+        f"{definition['module_name']}.router": 1
+        for definition in router_definitions
+    }
+
+
 def test_iter_minimal_optional_router_specs_populates_llm_specs(monkeypatch: pytest.MonkeyPatch) -> None:
     from tldw_Server_API.app.api.v1.router_groups.minimal import iter_minimal_optional_router_specs
 

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -4909,6 +4909,7 @@ def test_iter_minimal_optional_router_specs_defers_experience_attr_lookup(
         assert spec.route_key == ""
         assert spec.skip_context == "in minimal test app"
         assert spec.default_stable is definition["default_stable"]
+        assert spec.skip_exceptions == (ImportError, AttributeError)
         assert _first_router_path(spec.router) == definition["path"]
 
     assert import_calls == [

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -4909,7 +4909,7 @@ def test_iter_minimal_optional_router_specs_defers_experience_attr_lookup(
         assert spec.route_key == ""
         assert spec.skip_context == "in minimal test app"
         assert spec.default_stable is definition["default_stable"]
-        assert spec.skip_exceptions == (ImportError, AttributeError)
+        assert spec.skip_exceptions == (Exception,)
         assert _first_router_path(spec.router) == definition["path"]
 
     assert import_calls == [
@@ -4920,6 +4920,57 @@ def test_iter_minimal_optional_router_specs_defers_experience_attr_lookup(
         f"{definition['module_name']}.router": 1
         for definition in router_definitions
     }
+
+
+def test_iter_minimal_optional_router_specs_skips_experience_runtime_import_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal experience specs preserve broad import failure skipping."""
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    experience_modules = {
+        "tldw_Server_API.app.api.v1.endpoints.sharing",
+        "tldw_Server_API.app.api.v1.endpoints.personalization",
+        "tldw_Server_API.app.api.v1.endpoints.companion",
+    }
+
+    specs = list(iter_minimal_optional_router_specs())
+    selected_specs = {
+        spec.name: spec
+        for spec in specs
+        if spec.name in {"sharing", "personalization", "companion"}
+    }
+    assert set(selected_specs) == {"sharing", "personalization", "companion"}
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Crash only the selected experience router imports at registration."""
+        if module_name in experience_modules:
+            raise RuntimeError(f"{module_name} exploded during import")
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    debug_messages: list[str] = []
+    monkeypatch.setattr("loguru.logger.debug", debug_messages.append)
+
+    assert register_router_specs(FastAPI(), selected_specs.values()) == 0
+    assert debug_messages == [
+        "Skipping sharing router in minimal test app: "
+        "tldw_Server_API.app.api.v1.endpoints.sharing exploded during import",
+        "Skipping personalization router in minimal test app: "
+        "tldw_Server_API.app.api.v1.endpoints.personalization exploded during import",
+        "Skipping companion router in minimal test app: "
+        "tldw_Server_API.app.api.v1.endpoints.companion exploded during import",
+    ]
 
 
 def test_iter_minimal_optional_router_specs_populates_llm_specs(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- convert minimal optional sharing, personalization, and companion router registrations to ImportedRouterSpec-backed lazy specs
- add red/green contract coverage proving router attribute lookup is deferred until spec resolution
- record TASK-73 for the Phase 2.2 AG tranche

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k experience_attr_lookup -q (red before implementation, green after)
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/router_groups/minimal.py -f json -o /tmp/bandit_phase2_2_minimal_experience_router_conditionals_ag.json
- git diff --check

Change summary: This continues the conservative Phase 2.2 router-group cleanup by moving only three adjacent single-router minimal optional registrations from eager try/import blocks to the shared ImportedRouterSpec helper. The focused test mirrors the previous lazy-import tranches and verifies metadata preservation while preventing import-time router attribute access regressions.