### PR TITLE
Add CodeGraph cross-file reference resolution

### DIFF
--- a/Docs/superpowers/plans/2026-05-05-native-codegraph-cross-file-resolution-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-05-native-codegraph-cross-file-resolution-implementation-plan.md
@@ -1,0 +1,247 @@
+# Native CodeGraph Cross-File Resolution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve conservative same-workspace import and call references across indexed files so CodeGraph caller/callee, impact, and context tools can return useful cross-file relationships.
+
+**Architecture:** Keep extractors conservative and language-local. Add a small resolution pass after file graph persistence that reads import nodes and unresolved references from the SQLite repository, resolves only workspace-bounded targets, and writes deterministic edges while preserving enough reference state for later stale cleanup and re-resolution.
+
+**Tech Stack:** Python 3.11, stdlib AST, Tree-sitter JS/TS extractors, SQLite repository helpers, Unified MCP CodeGraphModule, pytest/pytest-asyncio, Ruff, Bandit.
+
+---
+
+## Scope
+
+Implement only:
+
+- Python `from module import symbol` and aliased import call resolution.
+- JavaScript/TypeScript relative and `tsconfig`/`jsconfig` path-alias import call resolution for named exports.
+- Deterministic cross-file `calls` and `imports` edges for resolved references.
+- Stale edge cleanup when source or target files are replaced or removed.
+- Focused repository, indexer, and MCP tests proving cross-file relationships show up in existing read tools.
+
+Do not implement:
+
+- Full language-server semantics, package managers, `node_modules`, `sys.path`, class instance inference, overload resolution, wildcard imports, or dynamic imports.
+- New MCP tools or a public schema rename.
+- File watching, Scheduler sync, or automatic worker startup.
+- Cross-language resolution between unrelated language ecosystems.
+
+## File Structure
+
+- Create `tldw_Server_API/app/core/CodeGraph/resolver.py`
+  - `CodeGraphReferenceResolver` reads repository imports and unresolved refs.
+  - Resolves same-workspace Python and JS/TS imports to existing target nodes.
+  - Emits deterministic `imports` and `calls` edges with provenance.
+- Modify `tldw_Server_API/app/core/DB_Management/codegraph/schema.sql`
+  - Add nullable resolution columns to `unresolved_refs` for target node, edge id, resolution kind, and timestamp.
+- Modify `tldw_Server_API/app/core/DB_Management/codegraph/repository.py`
+  - Add compatibility migration for the new nullable columns.
+  - Add query/update helpers used by the resolver.
+  - Count only currently unresolved references in `counts()["unresolved_refs"]`.
+- Modify `tldw_Server_API/app/core/CodeGraph/indexer.py`
+  - Run the resolver after file graph replacement and once more after full candidate processing.
+- Modify `tldw_Server_API/app/core/CodeGraph/extractors/python_extractor.py`
+  - Emit import reference metadata sufficient for resolver input.
+- Modify JS/TS extractor behavior only if needed to preserve named import metadata.
+- Add or modify tests:
+  - `tldw_Server_API/tests/CodeGraph/test_codegraph_repository.py`
+  - `tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py`
+  - `tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py`
+  - New `tldw_Server_API/tests/CodeGraph/test_codegraph_resolver.py` if repository tests become too large.
+- Modify `backlog/tasks/task-74 - Implement-native-CodeGraph-cross-file-symbol-resolution.md`
+  - Record plan, implementation notes, verification, and final summary.
+
+## Task 1: Repository Reference State
+
+**Files:**
+
+- Modify `tldw_Server_API/app/core/DB_Management/codegraph/schema.sql`
+- Modify `tldw_Server_API/app/core/DB_Management/codegraph/repository.py`
+- Test `tldw_Server_API/tests/CodeGraph/test_codegraph_repository.py`
+
+- [x] **Step 1: Write failing repository tests**
+
+Add tests proving:
+
+- Existing unresolved refs can be marked resolved without disappearing from the reference table.
+- `counts()["unresolved_refs"]` counts only refs with no live resolved target.
+- Deleting or replacing a target file clears stale resolved state and removes dangling edges.
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_repository.py -q
+```
+
+Expected: fail because repository has no resolved-reference state helpers.
+
+- [x] **Step 2: Implement schema compatibility and helpers**
+
+Add nullable columns if absent:
+
+- `resolved_target TEXT`
+- `resolved_edge TEXT`
+- `resolution_kind TEXT`
+- `resolved_at TEXT`
+
+Add repository helpers to list import nodes, list unresolved/current refs, insert deterministic resolved edges, mark refs resolved, and clear stale resolved refs whose target or edge no longer exists.
+
+- [x] **Step 3: Verify repository tests pass**
+
+Run the repository test command again.
+
+Expected: pass.
+
+## Task 2: Resolver Core
+
+**Files:**
+
+- Create `tldw_Server_API/app/core/CodeGraph/resolver.py`
+- Modify `tldw_Server_API/app/core/CodeGraph/extractors/python_extractor.py`
+- Test `tldw_Server_API/tests/CodeGraph/test_codegraph_resolver.py`
+
+- [x] **Step 1: Write failing resolver tests**
+
+Add tests proving:
+
+- Python `from pkg.util import helper` resolves a call from `app.main` to `pkg/util.py::helper`.
+- Python aliased imports resolve `from pkg.util import helper as h` plus `h()`.
+- JS/TS named imports resolve through a precomputed `resolved_path` on import metadata.
+- Resolver ignores external/unresolved imports and paths outside the workspace.
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_resolver.py -q
+```
+
+Expected: fail because the resolver module does not exist.
+
+- [x] **Step 2: Implement minimal resolver**
+
+Build per-file import maps from import nodes:
+
+- Python: imported module/symbol and alias from existing import metadata.
+- JS/TS: `resolved_path`, imported name, local alias/name, and namespace imports from existing metadata.
+
+Resolve call refs by local import alias first, then dotted namespace alias when present. Insert `calls` edges from call source node to target node. Insert `imports` edges from import nodes to target module/symbol nodes for impact traversal, but keep callers/callees restricted to `calls`.
+
+- [x] **Step 3: Verify resolver tests pass**
+
+Run the resolver test command again.
+
+Expected: pass.
+
+## Task 3: Indexer Integration
+
+**Files:**
+
+- Modify `tldw_Server_API/app/core/CodeGraph/indexer.py`
+- Test `tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py`
+
+- [x] **Step 1: Write failing indexer integration tests**
+
+Add tests proving:
+
+- A Python workspace with two files produces a cross-file call edge after `index_workspace`.
+- Re-indexing after a target symbol rename removes the stale cross-file call edge.
+- A TS alias import resolves after indexing when TS/TSX parsers are available; otherwise the parser-dependent test skips via existing guard helpers.
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py -q
+```
+
+Expected: fail because indexer does not invoke cross-file resolution.
+
+- [x] **Step 2: Wire resolver into indexing**
+
+Instantiate `CodeGraphReferenceResolver` once per run and invoke it after file graph replacement. Run a final pass after all candidates are processed so references can resolve even when source files are indexed before target files.
+
+- [x] **Step 3: Verify indexer tests pass**
+
+Run the indexer test command again.
+
+Expected: pass.
+
+## Task 4: MCP Read Tool Coverage
+
+**Files:**
+
+- Modify `tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py`
+- Modify `tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py`
+
+- [x] **Step 1: Write failing MCP tests**
+
+Add tests proving:
+
+- `codegraph.callers` for a target function includes a caller from a different file.
+- `codegraph.callees` for a caller function includes a target from a different file.
+- `codegraph.impact` and `codegraph.context` include cross-file relationships while preserving configured limits and truncation metadata.
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py -q
+```
+
+Expected: fail before resolver integration is complete.
+
+- [x] **Step 2: Preserve read-tool caps and filter callers/callees**
+
+If `imports` edges are added, ensure `list_callers` and `list_callees` return only `calls` relationships. Keep `impact` and `context` able to include both imports and calls through existing traversal.
+
+- [x] **Step 3: Verify MCP tests pass**
+
+Run the MCP test command again.
+
+Expected: pass.
+
+## Task 5: Final Verification And Closeout
+
+**Files:**
+
+- Modify `backlog/tasks/task-74 - Implement-native-CodeGraph-cross-file-symbol-resolution.md`
+- Optionally update GitHub issue `#1259` with current merged stages and the new PR link after PR creation.
+
+- [x] **Step 1: Run focused CodeGraph/MCP tests**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/CodeGraph \
+  tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py \
+  -q
+```
+
+- [x] **Step 2: Run Ruff**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check \
+  tldw_Server_API/app/core/CodeGraph \
+  tldw_Server_API/app/core/DB_Management/codegraph \
+  tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py \
+  tldw_Server_API/tests/CodeGraph \
+  tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
+```
+
+- [x] **Step 3: Run Bandit**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r \
+  tldw_Server_API/app/core/CodeGraph \
+  tldw_Server_API/app/core/DB_Management/codegraph \
+  tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py \
+  -f json -o /tmp/bandit_codegraph_cross_file_resolution.json
+```
+
+- [x] **Step 4: Run whitespace check**
+
+```bash
+git diff --check
+```
+
+- [x] **Step 5: Update TASK-74 and commit**
+
+Record verification, mark acceptance criteria and DoD complete, then commit the plan, task, tests, and implementation.

--- a/backlog/tasks/task-74 - Implement-native-CodeGraph-cross-file-symbol-resolution.md
+++ b/backlog/tasks/task-74 - Implement-native-CodeGraph-cross-file-symbol-resolution.md
@@ -1,0 +1,72 @@
+---
+id: TASK-74
+title: Implement native CodeGraph cross-file symbol resolution
+status: Done
+assignee: []
+created_date: '2026-05-05 14:55'
+updated_date: '2026-05-05 15:06'
+labels:
+  - codegraph
+  - mcp
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1259'
+documentation:
+  - Docs/superpowers/specs/2026-05-03-native-codegraph-mcp-module-design.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add conservative same-workspace cross-file reference resolution for the native CodeGraph MCP module. The slice should resolve Python and JavaScript/TypeScript import-driven calls across indexed files, keep deterministic edge IDs and stale cleanup behavior, and surface the relationships through existing CodeGraph read tools without adding new public tools or broad language-server semantics.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Import and unresolved-reference data can resolve conservative same-workspace cross-file relationships without arbitrary host-path access.
+- [x] #2 Python and JavaScript/TypeScript imports resolve to indexed module/export symbols where the target file is inside the trusted workspace.
+- [x] #3 Repository and indexer behavior keeps deterministic IDs and stale-edge cleanup correct when source or target files are re-indexed or deleted.
+- [x] #4 Unified MCP caller/callee/impact/context results include newly resolved cross-file relationships while preserving existing output caps.
+- [x] #5 Focused CodeGraph/MCP tests, Ruff, Bandit on touched production scope, and git diff whitespace checks pass before PR.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-05-native-codegraph-cross-file-resolution-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Baseline from clean origin/dev worktree after PR #1304 merge: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/CodeGraph tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py -q -> 142 passed, 5 warnings.
+
+Implemented repository resolved-reference state, conservative Python/JS/TS import binding resolution, indexer resolution counters, stale cleanup, and MCP read-tool coverage for cross-file relationships.
+
+Verification: pytest tldw_Server_API/tests/CodeGraph tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py -q -> 152 passed, 5 warnings.
+
+Verification: ruff check touched CodeGraph/MCP scopes -> All checks passed.
+
+Verification: bandit touched production scopes -> zero findings in /tmp/bandit_codegraph_cross_file_resolution.json.
+
+Verification: git diff --check -> clean.
+
+Known skips/blockers: none for this focused slice. TypeScript alias tests use existing parser availability guards when tree-sitter TypeScript is unavailable.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added conservative same-workspace cross-file CodeGraph resolution. The repository now tracks resolved reference state and clears stale resolutions; the resolver turns import-bound Python and JS/TS calls into deterministic calls/imports edges; the indexer runs resolution after successful indexing; MCP callers/callees/impact/context now have test coverage for cross-file relationships. Focused tests, Ruff, Bandit, and whitespace checks passed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-74 - Implement-native-CodeGraph-cross-file-symbol-resolution.md
+++ b/backlog/tasks/task-74 - Implement-native-CodeGraph-cross-file-symbol-resolution.md
@@ -4,7 +4,7 @@ title: Implement native CodeGraph cross-file symbol resolution
 status: Done
 assignee: []
 created_date: '2026-05-05 14:55'
-updated_date: '2026-05-05 15:06'
+updated_date: '2026-05-05 16:28'
 labels:
   - codegraph
   - mcp
@@ -53,12 +53,22 @@ Verification: bandit touched production scopes -> zero findings in /tmp/bandit_c
 Verification: git diff --check -> clean.
 
 Known skips/blockers: none for this focused slice. TypeScript alias tests use existing parser availability guards when tree-sitter TypeScript is unavailable.
+
+PR #1308 review-fix pass: addressing unresolved Qodo/Gemini comments on resolver bounds, case-sensitive lookups, batched writes, read-only list helpers, NULL-safe stale cleanup, and binding lookup complexity.
+
+PR #1308 review fixes implemented: bounded resolver source scopes/deadlines/item caps, exact-case resolution lookups, batched edge/reference writes, read-only reference listing, O(1) direct binding lookup, and explicit NULL handling for resolved_edge stale cleanup/counting.
+
+Review-fix verification: targeted regression tests for repository/resolver/indexer review issues -> 8 passed, 5 warnings.
+
+Review-fix verification: focused CodeGraph/MCP suite -> 160 passed, 5 warnings.
+
+Review-fix verification: Ruff touched scopes -> All checks passed; Bandit touched production scopes -> zero findings; git diff --check -> clean.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added conservative same-workspace cross-file CodeGraph resolution. The repository now tracks resolved reference state and clears stale resolutions; the resolver turns import-bound Python and JS/TS calls into deterministic calls/imports edges; the indexer runs resolution after successful indexing; MCP callers/callees/impact/context now have test coverage for cross-file relationships. Focused tests, Ruff, Bandit, and whitespace checks passed.
+Added conservative same-workspace cross-file CodeGraph resolution and addressed PR #1308 review feedback. The resolver now runs within explicit foreground bounds, batches SQLite writes, uses exact-case resolution lookups, keeps listing read-only, handles NULL resolved_edge stale state, and exposes truncation/scan counters. Focused CodeGraph/MCP tests, Ruff, Bandit, and whitespace checks passed.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/core/CodeGraph/indexer.py
+++ b/tldw_Server_API/app/core/CodeGraph/indexer.py
@@ -24,6 +24,7 @@ from .extractors.tree_sitter_loader import load_parser
 from .extractors.typescript_extractor import TypeScriptTreeSitterExtractor
 from .language_registry import CodeGraphLanguageRegistry
 from .models import ExtractionResult
+from .resolver import CodeGraphReferenceResolver
 
 
 @dataclass(frozen=True)
@@ -258,6 +259,12 @@ class CodeGraphIndexer:
 
             if status == "complete" and not languages:
                 repository.delete_missing_files(discovered_paths or indexed_paths)
+
+            if status == "complete":
+                resolution = CodeGraphReferenceResolver(repository).resolve()
+                counters["cross_file_calls_resolved"] = resolution.resolved_calls
+                counters["cross_file_imports_resolved"] = resolution.resolved_imports
+                counters["stale_reference_resolutions_cleared"] = resolution.stale_resolutions_cleared
 
             repository.finish_index_run(
                 run_id,

--- a/tldw_Server_API/app/core/CodeGraph/indexer.py
+++ b/tldw_Server_API/app/core/CodeGraph/indexer.py
@@ -261,10 +261,23 @@ class CodeGraphIndexer:
                 repository.delete_missing_files(discovered_paths or indexed_paths)
 
             if status == "complete":
-                resolution = CodeGraphReferenceResolver(repository).resolve()
+                resolution_limit = _resolution_item_limit(
+                    max_files=limit,
+                    foreground_max_bytes=self._settings.foreground_max_bytes,
+                )
+                resolution = CodeGraphReferenceResolver(repository).resolve(
+                    source_file_paths=indexed_paths,
+                    max_import_nodes=resolution_limit,
+                    max_refs=resolution_limit,
+                    deadline_monotonic=start + self._settings.max_index_seconds,
+                    monotonic=self._monotonic,
+                )
                 counters["cross_file_calls_resolved"] = resolution.resolved_calls
                 counters["cross_file_imports_resolved"] = resolution.resolved_imports
                 counters["stale_reference_resolutions_cleared"] = resolution.stale_resolutions_cleared
+                counters["cross_file_resolution_truncated"] = int(resolution.truncated)
+                counters["cross_file_import_nodes_scanned"] = resolution.import_nodes_scanned
+                counters["cross_file_references_scanned"] = resolution.references_scanned
 
             repository.finish_index_run(
                 run_id,
@@ -425,3 +438,10 @@ def _empty_counters() -> dict[str, int]:
         "unsupported_language": 0,
         "errors": 0,
     }
+
+
+def _resolution_item_limit(*, max_files: int, foreground_max_bytes: int) -> int:
+    """Derive an explicit foreground cap for resolver import/ref rows."""
+    file_scaled_limit = max(1, int(max_files)) * 1000
+    byte_scaled_limit = max(1, int(foreground_max_bytes) // 16)
+    return max(1, min(file_scaled_limit, byte_scaled_limit))

--- a/tldw_Server_API/app/core/CodeGraph/models.py
+++ b/tldw_Server_API/app/core/CodeGraph/models.py
@@ -172,6 +172,25 @@ class CodeGraphUnresolvedRef:
 
 
 @dataclass(frozen=True)
+class StoredCodeGraphReference:
+    """Persisted reference row with optional resolved-edge state."""
+
+    id: int
+    from_node_id: str
+    reference_name: str
+    reference_kind: str
+    file_path: str
+    line: int | None = None
+    column: int | None = None
+    candidates: tuple[str, ...] = ()
+    language: str | None = None
+    resolved_target: str | None = None
+    resolved_edge: str | None = None
+    resolution_kind: str | None = None
+    resolved_at: str | None = None
+
+
+@dataclass(frozen=True)
 class ExtractionResult:
     """Extractor output for one file, including graph rows and parse errors."""
 

--- a/tldw_Server_API/app/core/CodeGraph/resolver.py
+++ b/tldw_Server_API/app/core/CodeGraph/resolver.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import time
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
@@ -21,6 +23,9 @@ class ResolutionResult:
     resolved_calls: int = 0
     resolved_imports: int = 0
     stale_resolutions_cleared: int = 0
+    truncated: bool = False
+    import_nodes_scanned: int = 0
+    references_scanned: int = 0
 
 
 @dataclass(frozen=True)
@@ -33,20 +38,68 @@ class _ImportBinding:
     target_file_path: str | None
 
 
+@dataclass(frozen=True)
+class _BindingIndex:
+    """Import bindings grouped for direct and namespace lookup."""
+
+    by_file: dict[str, list[_ImportBinding]]
+    by_local_name: dict[str, dict[str, _ImportBinding]]
+
+
 class CodeGraphReferenceResolver:
     """Resolve import-driven references against already indexed workspace nodes."""
 
     def __init__(self, repository: CodeGraphRepository) -> None:
         self._repository = repository
 
-    def resolve(self) -> ResolutionResult:
+    def resolve(
+        self,
+        *,
+        source_file_paths: set[str] | frozenset[str] | None = None,
+        max_import_nodes: int | None = None,
+        max_refs: int | None = None,
+        deadline_monotonic: float | None = None,
+        monotonic: Callable[[], float] | None = None,
+    ) -> ResolutionResult:
         """Resolve currently unresolved refs and write deterministic graph edges."""
-        stale = self._repository.clear_stale_reference_resolutions()
-        bindings = self._build_import_bindings()
-        resolved_imports = self._write_import_edges(bindings)
-        resolved_calls = 0
+        clock = monotonic or time.monotonic
+        if _deadline_expired(deadline_monotonic, clock):
+            return ResolutionResult(truncated=True)
 
-        for reference in self._repository.list_references_for_resolution():
+        stale = self._repository.clear_stale_reference_resolutions(file_paths=source_file_paths)
+        import_nodes = self._repository.list_import_nodes(
+            file_paths=source_file_paths,
+            limit=_limit_plus_one(max_import_nodes),
+        )
+        truncated = _over_limit(import_nodes, max_import_nodes)
+        if max_import_nodes is not None:
+            import_nodes = import_nodes[:max_import_nodes]
+        bindings = self._build_import_bindings(import_nodes, deadline_monotonic=deadline_monotonic, monotonic=clock)
+        if bindings is None:
+            return ResolutionResult(stale_resolutions_cleared=stale, truncated=True)
+
+        import_edges, import_truncated = self._collect_import_edges(
+            bindings,
+            deadline_monotonic=deadline_monotonic,
+            monotonic=clock,
+        )
+        truncated = truncated or import_truncated
+        if import_edges:
+            self._repository.upsert_edges(import_edges)
+
+        references = self._repository.list_references_for_resolution(
+            file_paths=source_file_paths,
+            limit=_limit_plus_one(max_refs),
+        )
+        truncated = truncated or _over_limit(references, max_refs)
+        if max_refs is not None:
+            references = references[:max_refs]
+
+        resolved_references: list[tuple[int, CodeGraphEdge, str]] = []
+        for reference in references:
+            if _deadline_expired(deadline_monotonic, clock):
+                truncated = True
+                break
             if reference.reference_kind != "call":
                 continue
             target = self._resolve_call_reference(reference, bindings)
@@ -65,24 +118,39 @@ class CodeGraphReferenceResolver:
                 metadata={"resolved_by": "import_binding"},
                 provenance="codegraph_resolver",
             )
-            self._repository.mark_reference_resolved(reference.id, edge=edge, resolution_kind="import_binding")
-            resolved_calls += 1
+            resolved_references.append((reference.id, edge, "import_binding"))
+
+        if resolved_references:
+            self._repository.mark_references_resolved(resolved_references)
 
         return ResolutionResult(
-            resolved_calls=resolved_calls,
-            resolved_imports=resolved_imports,
+            resolved_calls=len(resolved_references),
+            resolved_imports=len(import_edges),
             stale_resolutions_cleared=stale,
+            truncated=truncated,
+            import_nodes_scanned=len(import_nodes),
+            references_scanned=len(references),
         )
 
-    def _build_import_bindings(self) -> dict[str, list[_ImportBinding]]:
+    def _build_import_bindings(
+        self,
+        import_nodes: list[CodeGraphNode],
+        *,
+        deadline_monotonic: float | None,
+        monotonic: Callable[[], float],
+    ) -> _BindingIndex | None:
         """Build local import bindings grouped by source file."""
         by_file: dict[str, list[_ImportBinding]] = {}
-        for import_node in self._repository.list_import_nodes():
+        by_local_name: dict[str, dict[str, _ImportBinding]] = {}
+        for import_node in import_nodes:
+            if _deadline_expired(deadline_monotonic, monotonic):
+                return None
             binding = self._binding_for_import_node(import_node)
             if binding is None:
                 continue
             by_file.setdefault(import_node.file_path, []).append(binding)
-        return by_file
+            by_local_name.setdefault(import_node.file_path, {})[binding.local_name] = binding
+        return _BindingIndex(by_file=by_file, by_local_name=by_local_name)
 
     def _binding_for_import_node(self, import_node: CodeGraphNode) -> _ImportBinding | None:
         metadata = dict(import_node.metadata)
@@ -165,12 +233,20 @@ class CodeGraphReferenceResolver:
                 return node
         return None
 
-    def _write_import_edges(self, bindings: dict[str, list[_ImportBinding]]) -> int:
-        """Persist import dependency edges for impact/context traversal."""
-        resolved = 0
+    def _collect_import_edges(
+        self,
+        bindings: _BindingIndex,
+        *,
+        deadline_monotonic: float | None,
+        monotonic: Callable[[], float],
+    ) -> tuple[list[CodeGraphEdge], bool]:
+        """Build import dependency edges for impact/context traversal."""
+        edges: list[CodeGraphEdge] = []
         seen: set[str] = set()
-        for file_bindings in bindings.values():
+        for file_bindings in bindings.by_file.values():
             for binding in file_bindings:
+                if _deadline_expired(deadline_monotonic, monotonic):
+                    return edges, True
                 target = binding.target_node
                 if target is None:
                     continue
@@ -189,24 +265,41 @@ class CodeGraphReferenceResolver:
                 )
                 if edge.id in seen:
                     continue
-                self._repository.upsert_edge(edge)
+                edges.append(edge)
                 seen.add(edge.id)
-                resolved += 1
-        return resolved
+        return edges, False
 
     def _resolve_call_reference(
         self,
         reference: StoredCodeGraphReference,
-        bindings: dict[str, list[_ImportBinding]],
+        bindings: _BindingIndex,
     ) -> CodeGraphNode | None:
-        for binding in bindings.get(reference.file_path, ()):
-            if reference.reference_name == binding.local_name:
-                return binding.target_node if binding.target_node is not None and binding.target_node.kind != "module" else None
+        binding = bindings.by_local_name.get(reference.file_path, {}).get(reference.reference_name)
+        if binding is not None:
+            return binding.target_node if binding.target_node is not None and binding.target_node.kind != "module" else None
+        for binding in bindings.by_file.get(reference.file_path, ()):
             prefix = f"{binding.local_name}."
             if reference.reference_name.startswith(prefix) and binding.target_file_path:
                 symbol_name = reference.reference_name[len(prefix) :].rsplit(".", 1)[-1]
                 return self._resolve_target_in_file(binding.target_file_path, symbol_name)
         return None
+
+
+def _deadline_expired(deadline_monotonic: float | None, monotonic: Callable[[], float]) -> bool:
+    """Return whether a caller-provided foreground time budget is exhausted."""
+    return deadline_monotonic is not None and monotonic() >= deadline_monotonic
+
+
+def _limit_plus_one(limit: int | None) -> int | None:
+    """Return a SQLite row cap that lets callers detect deterministic truncation."""
+    if limit is None:
+        return None
+    return max(1, int(limit)) + 1
+
+
+def _over_limit(items: list[object], limit: int | None) -> bool:
+    """Return whether a result list includes the extra row used to detect truncation."""
+    return limit is not None and len(items) > max(1, int(limit))
 
 
 __all__ = ["CodeGraphReferenceResolver", "ResolutionResult"]

--- a/tldw_Server_API/app/core/CodeGraph/resolver.py
+++ b/tldw_Server_API/app/core/CodeGraph/resolver.py
@@ -1,0 +1,212 @@
+"""Conservative cross-file reference resolution for native CodeGraph indexes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from tldw_Server_API.app.core.CodeGraph.models import (
+    CodeGraphEdge,
+    CodeGraphNode,
+    StoredCodeGraphReference,
+    make_edge_id,
+)
+from tldw_Server_API.app.core.DB_Management.codegraph.repository import CodeGraphRepository
+
+
+@dataclass(frozen=True)
+class ResolutionResult:
+    """Summary returned by one cross-file resolution pass."""
+
+    resolved_calls: int = 0
+    resolved_imports: int = 0
+    stale_resolutions_cleared: int = 0
+
+
+@dataclass(frozen=True)
+class _ImportBinding:
+    """One local import binding in a source file."""
+
+    import_node: CodeGraphNode
+    local_name: str
+    target_node: CodeGraphNode | None
+    target_file_path: str | None
+
+
+class CodeGraphReferenceResolver:
+    """Resolve import-driven references against already indexed workspace nodes."""
+
+    def __init__(self, repository: CodeGraphRepository) -> None:
+        self._repository = repository
+
+    def resolve(self) -> ResolutionResult:
+        """Resolve currently unresolved refs and write deterministic graph edges."""
+        stale = self._repository.clear_stale_reference_resolutions()
+        bindings = self._build_import_bindings()
+        resolved_imports = self._write_import_edges(bindings)
+        resolved_calls = 0
+
+        for reference in self._repository.list_references_for_resolution():
+            if reference.reference_kind != "call":
+                continue
+            target = self._resolve_call_reference(reference, bindings)
+            if target is None:
+                continue
+            line = int(reference.line or 0)
+            column = int(reference.column or 0)
+            edge = CodeGraphEdge(
+                id=make_edge_id(reference.from_node_id, "calls", target.id, reference.file_path, line, column),
+                source=reference.from_node_id,
+                target=target.id,
+                kind="calls",
+                file_path=reference.file_path,
+                line=reference.line,
+                column=reference.column,
+                metadata={"resolved_by": "import_binding"},
+                provenance="codegraph_resolver",
+            )
+            self._repository.mark_reference_resolved(reference.id, edge=edge, resolution_kind="import_binding")
+            resolved_calls += 1
+
+        return ResolutionResult(
+            resolved_calls=resolved_calls,
+            resolved_imports=resolved_imports,
+            stale_resolutions_cleared=stale,
+        )
+
+    def _build_import_bindings(self) -> dict[str, list[_ImportBinding]]:
+        """Build local import bindings grouped by source file."""
+        by_file: dict[str, list[_ImportBinding]] = {}
+        for import_node in self._repository.list_import_nodes():
+            binding = self._binding_for_import_node(import_node)
+            if binding is None:
+                continue
+            by_file.setdefault(import_node.file_path, []).append(binding)
+        return by_file
+
+    def _binding_for_import_node(self, import_node: CodeGraphNode) -> _ImportBinding | None:
+        metadata = dict(import_node.metadata)
+        if import_node.language == "python":
+            return self._python_binding(import_node, metadata)
+        if import_node.language in {"javascript", "typescript"}:
+            return self._js_ts_binding(import_node, metadata)
+        return None
+
+    def _python_binding(self, import_node: CodeGraphNode, metadata: dict[str, Any]) -> _ImportBinding | None:
+        imported = str(metadata.get("imported") or import_node.qualified_name or "").strip()
+        if not imported or imported.startswith("."):
+            return None
+        local_name = str(metadata.get("alias") or import_node.name).strip()
+        if not local_name:
+            return None
+        target = self._resolve_python_import(imported)
+        return _ImportBinding(
+            import_node=import_node,
+            local_name=local_name,
+            target_node=target,
+            target_file_path=target.file_path if target is not None else None,
+        )
+
+    def _js_ts_binding(self, import_node: CodeGraphNode, metadata: dict[str, Any]) -> _ImportBinding | None:
+        resolved_path = metadata.get("resolved_path")
+        if not isinstance(resolved_path, str) or not resolved_path:
+            return None
+        imported = str(metadata.get("imported") or import_node.name).strip()
+        local_name = str(metadata.get("alias") or import_node.name).strip()
+        if not imported or not local_name:
+            return None
+        target = self._resolve_target_in_file(resolved_path, imported)
+        return _ImportBinding(
+            import_node=import_node,
+            local_name=local_name,
+            target_node=target,
+            target_file_path=resolved_path,
+        )
+
+    def _resolve_python_import(self, imported: str) -> CodeGraphNode | None:
+        module = self._repository.find_module_node(imported)
+        if module is not None:
+            return module
+
+        parts = imported.split(".")
+        for index in range(len(parts) - 1, 0, -1):
+            module_name = ".".join(parts[:index])
+            symbol_name = ".".join(parts[index:])
+            module = self._repository.find_module_node(module_name)
+            if module is None:
+                continue
+            target = self._resolve_target_in_file(module.file_path, symbol_name)
+            if target is not None:
+                return target
+        return None
+
+    def _resolve_target_in_file(self, file_path: str, imported: str) -> CodeGraphNode | None:
+        if imported in {"namespace", "side_effect"}:
+            return self._repository.find_module_node_for_file(file_path)
+        if imported == "default":
+            return self._first_exported_node(file_path) or self._repository.find_module_node_for_file(file_path)
+
+        candidates = self._repository.find_nodes_by_file_and_name(file_path=file_path, name=imported)
+        for node in candidates:
+            if node.kind != "import" and "exported" in node.flags:
+                return node
+        for node in candidates:
+            if node.kind not in {"import", "module"}:
+                return node
+        return candidates[0] if candidates else None
+
+    def _first_exported_node(self, file_path: str) -> CodeGraphNode | None:
+        module = self._repository.find_module_node_for_file(file_path)
+        if module is None:
+            return None
+        candidates = self._repository.find_nodes_by_file_and_name(file_path=file_path, name=module.name)
+        for node in candidates:
+            if "exported" in node.flags and node.kind != "module":
+                return node
+        return None
+
+    def _write_import_edges(self, bindings: dict[str, list[_ImportBinding]]) -> int:
+        """Persist import dependency edges for impact/context traversal."""
+        resolved = 0
+        seen: set[str] = set()
+        for file_bindings in bindings.values():
+            for binding in file_bindings:
+                target = binding.target_node
+                if target is None:
+                    continue
+                line = int(binding.import_node.start_line or 0)
+                column = int(binding.import_node.start_column or 0)
+                edge = CodeGraphEdge(
+                    id=make_edge_id(binding.import_node.id, "imports", target.id, binding.import_node.file_path, line, column),
+                    source=binding.import_node.id,
+                    target=target.id,
+                    kind="imports",
+                    file_path=binding.import_node.file_path,
+                    line=binding.import_node.start_line,
+                    column=binding.import_node.start_column,
+                    metadata={"local_name": binding.local_name},
+                    provenance="codegraph_resolver",
+                )
+                if edge.id in seen:
+                    continue
+                self._repository.upsert_edge(edge)
+                seen.add(edge.id)
+                resolved += 1
+        return resolved
+
+    def _resolve_call_reference(
+        self,
+        reference: StoredCodeGraphReference,
+        bindings: dict[str, list[_ImportBinding]],
+    ) -> CodeGraphNode | None:
+        for binding in bindings.get(reference.file_path, ()):
+            if reference.reference_name == binding.local_name:
+                return binding.target_node if binding.target_node is not None and binding.target_node.kind != "module" else None
+            prefix = f"{binding.local_name}."
+            if reference.reference_name.startswith(prefix) and binding.target_file_path:
+                symbol_name = reference.reference_name[len(prefix) :].rsplit(".", 1)[-1]
+                return self._resolve_target_in_file(binding.target_file_path, symbol_name)
+        return None
+
+
+__all__ = ["CodeGraphReferenceResolver", "ResolutionResult"]

--- a/tldw_Server_API/app/core/DB_Management/codegraph/repository.py
+++ b/tldw_Server_API/app/core/DB_Management/codegraph/repository.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import sqlite3
 import uuid
+from collections.abc import Sequence
 from contextlib import closing, contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -359,7 +360,7 @@ class CodeGraphRepository:
                 """
                 SELECT *
                 FROM nodes
-                WHERE kind = 'module' AND lower(qualified_name) = lower(?)
+                WHERE kind = 'module' AND qualified_name = ?
                 ORDER BY file_path, COALESCE(start_line, 0)
                 LIMIT 1
                 """,
@@ -380,9 +381,9 @@ class CodeGraphRepository:
                 SELECT *
                 FROM nodes
                 WHERE file_path = ?
-                  AND (lower(name) = lower(?) OR lower(qualified_name) = lower(?))
+                  AND (name = ? OR qualified_name = ?)
                 ORDER BY
-                    CASE WHEN lower(name) = lower(?) THEN 0 ELSE 1 END,
+                    CASE WHEN name = ? THEN 0 ELSE 1 END,
                     CASE WHEN kind = 'module' THEN 1 ELSE 0 END,
                     COALESCE(start_line, 0),
                     qualified_name,
@@ -407,17 +408,27 @@ class CodeGraphRepository:
             ).fetchone()
         return _node_from_row(row) if row else None
 
-    def list_import_nodes(self) -> list[CodeGraphNode]:
+    def list_import_nodes(
+        self,
+        *,
+        file_paths: set[str] | frozenset[str] | None = None,
+        limit: int | None = None,
+    ) -> list[CodeGraphNode]:
         """Return import nodes for cross-file reference resolution."""
-        with self._connection() as conn:
-            rows = conn.execute(
-                """
+        file_scope = _file_path_scope_json(file_paths)
+        sql = """
                 SELECT *
                 FROM nodes
                 WHERE kind = 'import'
+                  AND (? IS NULL OR file_path IN (SELECT value FROM json_each(?)))
                 ORDER BY file_path, COALESCE(start_line, 0), COALESCE(start_column, 0), id
                 """
-            ).fetchall()
+        params: list[Any] = [file_scope, file_scope]
+        if limit is not None:
+            sql += " LIMIT ?"
+            params.append(max(1, int(limit)))
+        with self._connection() as conn:
+            rows = conn.execute(sql, params).fetchall()
         return [_node_from_row(row) for row in rows]
 
     def list_callers(self, node_id: str, *, limit: int = 10) -> list[dict[str, Any]]:
@@ -506,21 +517,30 @@ class CodeGraphRepository:
         self,
         *,
         include_resolved: bool = False,
+        file_paths: set[str] | frozenset[str] | None = None,
+        limit: int | None = None,
     ) -> list[StoredCodeGraphReference]:
         """List unresolved reference rows used by cross-file resolution."""
-        with self._connection() as conn:
-            stale_count = _clear_stale_reference_resolutions(conn)
-            if stale_count:
-                conn.commit()
-            sql = """
+        file_scope = _file_path_scope_json(file_paths)
+        sql = """
                 SELECT *
                 FROM unresolved_refs
                 WHERE from_node_id IN (SELECT id FROM nodes)
+                  AND (? OR (
+                      resolved_target IS NULL
+                      OR resolved_target NOT IN (SELECT id FROM nodes)
+                      OR resolved_edge IS NULL
+                      OR resolved_edge NOT IN (SELECT id FROM edges)
+                  ))
+                  AND (? IS NULL OR file_path IN (SELECT value FROM json_each(?)))
+                ORDER BY file_path, COALESCE(line, 0), COALESCE(column, 0), id
             """
-            if not include_resolved:
-                sql += " AND resolved_target IS NULL"
-            sql += " ORDER BY file_path, COALESCE(line, 0), COALESCE(column, 0), id"
-            rows = conn.execute(sql).fetchall()
+        params: list[Any] = [int(include_resolved), file_scope, file_scope]
+        if limit is not None:
+            sql += " LIMIT ?"
+            params.append(max(1, int(limit)))
+        with self._connection() as conn:
+            rows = conn.execute(sql, params).fetchall()
         return [_reference_from_row(row) for row in rows]
 
     def mark_reference_resolved(
@@ -531,32 +551,57 @@ class CodeGraphRepository:
         resolution_kind: str,
     ) -> None:
         """Persist a resolved edge and mark the source reference as resolved."""
-        if edge.target is None:
-            raise ValueError("resolved reference edge must have a target")
+        self.mark_references_resolved(((ref_id, edge, resolution_kind),))
+
+    def mark_references_resolved(
+        self,
+        resolutions: Sequence[tuple[int, CodeGraphEdge, str]],
+    ) -> None:
+        """Persist resolved edges and reference markers in one transaction."""
+        items = tuple(resolutions)
+        if not items:
+            return
+        for _ref_id, edge, _resolution_kind in items:
+            if edge.target is None:
+                raise ValueError("resolved reference edge must have a target")
+        resolved_at = _utc_now()
         with self._connection() as conn:
-            _upsert_edge(conn, edge)
-            conn.execute(
+            for _ref_id, edge, _resolution_kind in items:
+                _upsert_edge(conn, edge)
+            conn.executemany(
                 """
                 UPDATE unresolved_refs
                 SET resolved_target = ?, resolved_edge = ?, resolution_kind = ?, resolved_at = ?
                 WHERE id = ?
                 """,
-                (edge.target, edge.id, resolution_kind, _utc_now(), int(ref_id)),
+                [
+                    (edge.target, edge.id, resolution_kind, resolved_at, int(ref_id))
+                    for ref_id, edge, resolution_kind in items
+                ],
             )
             conn.commit()
 
     def upsert_edge(self, edge: CodeGraphEdge) -> None:
         """Insert or replace one deterministic graph edge."""
-        if edge.target is None:
-            raise ValueError("persisted edge must have a target")
+        self.upsert_edges((edge,))
+
+    def upsert_edges(self, edges: Sequence[CodeGraphEdge]) -> None:
+        """Insert or replace deterministic graph edges in one transaction."""
+        items = tuple(edges)
+        if not items:
+            return
+        for edge in items:
+            if edge.target is None:
+                raise ValueError("persisted edge must have a target")
         with self._connection() as conn:
-            _upsert_edge(conn, edge)
+            for edge in items:
+                _upsert_edge(conn, edge)
             conn.commit()
 
-    def clear_stale_reference_resolutions(self) -> int:
+    def clear_stale_reference_resolutions(self, *, file_paths: set[str] | frozenset[str] | None = None) -> int:
         """Clear resolved-reference markers whose target node or edge is gone."""
         with self._connection() as conn:
-            cleared = _clear_stale_reference_resolutions(conn)
+            cleared = _clear_stale_reference_resolutions(conn, file_paths=file_paths)
             conn.commit()
         return cleared
 
@@ -728,6 +773,7 @@ class CodeGraphRepository:
                 FROM unresolved_refs
                 WHERE resolved_target IS NULL
                    OR resolved_target NOT IN (SELECT id FROM nodes)
+                   OR resolved_edge IS NULL
                    OR resolved_edge NOT IN (SELECT id FROM edges)
             """,
         }
@@ -769,8 +815,13 @@ def _ensure_schema_compat(conn: sqlite3.Connection) -> None:
             conn.execute(statement)
 
 
-def _clear_stale_reference_resolutions(conn: sqlite3.Connection) -> int:
+def _clear_stale_reference_resolutions(
+    conn: sqlite3.Connection,
+    *,
+    file_paths: set[str] | frozenset[str] | None = None,
+) -> int:
     """Clear resolved-reference markers when their target node or edge disappeared."""
+    file_scope = _file_path_scope_json(file_paths)
     cursor = conn.execute(
         """
         UPDATE unresolved_refs
@@ -781,11 +832,21 @@ def _clear_stale_reference_resolutions(conn: sqlite3.Connection) -> int:
         WHERE resolved_target IS NOT NULL
           AND (
               resolved_target NOT IN (SELECT id FROM nodes)
+              OR resolved_edge IS NULL
               OR resolved_edge NOT IN (SELECT id FROM edges)
           )
-        """
+          AND (? IS NULL OR file_path IN (SELECT value FROM json_each(?)))
+        """,
+        (file_scope, file_scope),
     )
     return int(cursor.rowcount or 0)
+
+
+def _file_path_scope_json(file_paths: set[str] | frozenset[str] | None) -> str | None:
+    """Serialize an optional file-path scope for constant SQL predicates."""
+    if file_paths is None:
+        return None
+    return json.dumps(sorted(file_paths))
 
 
 def _select_relationships_for_nodes(

--- a/tldw_Server_API/app/core/DB_Management/codegraph/repository.py
+++ b/tldw_Server_API/app/core/DB_Management/codegraph/repository.py
@@ -19,6 +19,7 @@ from tldw_Server_API.app.core.CodeGraph.models import (
     CodeGraphUnresolvedRef,
     IndexedFile,
     IndexRunSummary,
+    StoredCodeGraphReference,
     codegraph_node_to_dict,
 )
 from tldw_Server_API.app.core.DB_Management.sqlite_policy import configure_sqlite_connection
@@ -46,6 +47,7 @@ class CodeGraphRepository:
         schema = Path(__file__).with_name("schema.sql").read_text(encoding="utf-8")
         with self._connection() as conn:
             conn.executescript(schema)
+            _ensure_schema_compat(conn)
             _create_optional_fts(conn)
             conn.commit()
 
@@ -347,6 +349,77 @@ class CodeGraphRepository:
             ).fetchone()
         return _node_from_row(row) if row else None
 
+    def find_module_node(self, qualified_name: str) -> CodeGraphNode | None:
+        """Resolve an indexed module node by exact qualified name."""
+        text = qualified_name.strip()
+        if not text:
+            return None
+        with self._connection() as conn:
+            row = conn.execute(
+                """
+                SELECT *
+                FROM nodes
+                WHERE kind = 'module' AND lower(qualified_name) = lower(?)
+                ORDER BY file_path, COALESCE(start_line, 0)
+                LIMIT 1
+                """,
+                (text,),
+            ).fetchone()
+        return _node_from_row(row) if row else None
+
+    def find_nodes_by_file_and_name(
+        self,
+        *,
+        file_path: str,
+        name: str,
+    ) -> list[CodeGraphNode]:
+        """Find nodes in one file by simple or qualified name."""
+        with self._connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT *
+                FROM nodes
+                WHERE file_path = ?
+                  AND (lower(name) = lower(?) OR lower(qualified_name) = lower(?))
+                ORDER BY
+                    CASE WHEN lower(name) = lower(?) THEN 0 ELSE 1 END,
+                    CASE WHEN kind = 'module' THEN 1 ELSE 0 END,
+                    COALESCE(start_line, 0),
+                    qualified_name,
+                    id
+                """,
+                (file_path, name, name, name),
+            ).fetchall()
+        return [_node_from_row(row) for row in rows]
+
+    def find_module_node_for_file(self, file_path: str) -> CodeGraphNode | None:
+        """Return the module node for a workspace-relative file if one exists."""
+        with self._connection() as conn:
+            row = conn.execute(
+                """
+                SELECT *
+                FROM nodes
+                WHERE file_path = ? AND kind = 'module'
+                ORDER BY COALESCE(start_line, 0), qualified_name, id
+                LIMIT 1
+                """,
+                (file_path,),
+            ).fetchone()
+        return _node_from_row(row) if row else None
+
+    def list_import_nodes(self) -> list[CodeGraphNode]:
+        """Return import nodes for cross-file reference resolution."""
+        with self._connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT *
+                FROM nodes
+                WHERE kind = 'import'
+                ORDER BY file_path, COALESCE(start_line, 0), COALESCE(start_column, 0), id
+                """
+            ).fetchall()
+        return [_node_from_row(row) for row in rows]
+
     def list_callers(self, node_id: str, *, limit: int = 10) -> list[dict[str, Any]]:
         """List call edges whose target is the requested node."""
         with self._connection() as conn:
@@ -380,7 +453,7 @@ class CodeGraphRepository:
                 FROM edges e
                 JOIN nodes source_node ON source_node.id = e.source
                 JOIN nodes target_node ON target_node.id = e.target
-                WHERE e.target = ?
+                WHERE e.target = ? AND e.kind = 'calls'
                 ORDER BY e.file_path, COALESCE(e.line, 0), source_node.qualified_name
                 LIMIT ?
                 """,
@@ -421,13 +494,71 @@ class CodeGraphRepository:
                 FROM edges e
                 JOIN nodes source_node ON source_node.id = e.source
                 JOIN nodes target_node ON target_node.id = e.target
-                WHERE e.source = ?
+                WHERE e.source = ? AND e.kind = 'calls'
                 ORDER BY e.file_path, COALESCE(e.line, 0), target_node.qualified_name
                 LIMIT ?
                 """,
                 (node_id, max(1, int(limit))),
             ).fetchall()
         return [_relationship_from_joined_row(row) for row in rows]
+
+    def list_references_for_resolution(
+        self,
+        *,
+        include_resolved: bool = False,
+    ) -> list[StoredCodeGraphReference]:
+        """List unresolved reference rows used by cross-file resolution."""
+        with self._connection() as conn:
+            stale_count = _clear_stale_reference_resolutions(conn)
+            if stale_count:
+                conn.commit()
+            sql = """
+                SELECT *
+                FROM unresolved_refs
+                WHERE from_node_id IN (SELECT id FROM nodes)
+            """
+            if not include_resolved:
+                sql += " AND resolved_target IS NULL"
+            sql += " ORDER BY file_path, COALESCE(line, 0), COALESCE(column, 0), id"
+            rows = conn.execute(sql).fetchall()
+        return [_reference_from_row(row) for row in rows]
+
+    def mark_reference_resolved(
+        self,
+        ref_id: int,
+        *,
+        edge: CodeGraphEdge,
+        resolution_kind: str,
+    ) -> None:
+        """Persist a resolved edge and mark the source reference as resolved."""
+        if edge.target is None:
+            raise ValueError("resolved reference edge must have a target")
+        with self._connection() as conn:
+            _upsert_edge(conn, edge)
+            conn.execute(
+                """
+                UPDATE unresolved_refs
+                SET resolved_target = ?, resolved_edge = ?, resolution_kind = ?, resolved_at = ?
+                WHERE id = ?
+                """,
+                (edge.target, edge.id, resolution_kind, _utc_now(), int(ref_id)),
+            )
+            conn.commit()
+
+    def upsert_edge(self, edge: CodeGraphEdge) -> None:
+        """Insert or replace one deterministic graph edge."""
+        if edge.target is None:
+            raise ValueError("persisted edge must have a target")
+        with self._connection() as conn:
+            _upsert_edge(conn, edge)
+            conn.commit()
+
+    def clear_stale_reference_resolutions(self) -> int:
+        """Clear resolved-reference markers whose target node or edge is gone."""
+        with self._connection() as conn:
+            cleared = _clear_stale_reference_resolutions(conn)
+            conn.commit()
+        return cleared
 
     def traverse_impact(
         self,
@@ -592,7 +723,13 @@ class CodeGraphRepository:
             "files": "SELECT COUNT(*) AS count FROM files",
             "nodes": "SELECT COUNT(*) AS count FROM nodes",
             "edges": "SELECT COUNT(*) AS count FROM edges",
-            "unresolved_refs": "SELECT COUNT(*) AS count FROM unresolved_refs",
+            "unresolved_refs": """
+                SELECT COUNT(*) AS count
+                FROM unresolved_refs
+                WHERE resolved_target IS NULL
+                   OR resolved_target NOT IN (SELECT id FROM nodes)
+                   OR resolved_edge NOT IN (SELECT id FROM edges)
+            """,
         }
         row = conn.execute(count_sql[table]).fetchone()
         return int(row["count"])
@@ -604,6 +741,7 @@ class CodeGraphRepository:
         conn.execute("DELETE FROM edges WHERE file_path = ?", (path,))
         conn.execute("DELETE FROM nodes WHERE file_path = ?", (path,))
         _delete_dangling_edges(conn)
+        _clear_stale_reference_resolutions(conn)
 
 
 def _delete_file_rows(conn: sqlite3.Connection, paths: list[str]) -> None:
@@ -614,6 +752,40 @@ def _delete_file_rows(conn: sqlite3.Connection, paths: list[str]) -> None:
     conn.executemany("DELETE FROM nodes WHERE file_path = ?", params)
     conn.executemany("DELETE FROM files WHERE path = ?", params)
     _delete_dangling_edges(conn)
+    _clear_stale_reference_resolutions(conn)
+
+
+def _ensure_schema_compat(conn: sqlite3.Connection) -> None:
+    """Apply additive schema compatibility updates for existing CodeGraph DBs."""
+    columns = {str(row["name"]) for row in conn.execute("PRAGMA table_info(unresolved_refs)").fetchall()}
+    additions = {
+        "resolved_target": "ALTER TABLE unresolved_refs ADD COLUMN resolved_target TEXT",
+        "resolved_edge": "ALTER TABLE unresolved_refs ADD COLUMN resolved_edge TEXT",
+        "resolution_kind": "ALTER TABLE unresolved_refs ADD COLUMN resolution_kind TEXT",
+        "resolved_at": "ALTER TABLE unresolved_refs ADD COLUMN resolved_at TEXT",
+    }
+    for column, statement in additions.items():
+        if column not in columns:
+            conn.execute(statement)
+
+
+def _clear_stale_reference_resolutions(conn: sqlite3.Connection) -> int:
+    """Clear resolved-reference markers when their target node or edge disappeared."""
+    cursor = conn.execute(
+        """
+        UPDATE unresolved_refs
+        SET resolved_target = NULL,
+            resolved_edge = NULL,
+            resolution_kind = NULL,
+            resolved_at = NULL
+        WHERE resolved_target IS NOT NULL
+          AND (
+              resolved_target NOT IN (SELECT id FROM nodes)
+              OR resolved_edge NOT IN (SELECT id FROM edges)
+          )
+        """
+    )
+    return int(cursor.rowcount or 0)
 
 
 def _select_relationships_for_nodes(
@@ -818,6 +990,27 @@ def _insert_edges(
     )
 
 
+def _upsert_edge(conn: sqlite3.Connection, edge: CodeGraphEdge) -> None:
+    """Insert or replace a deterministic edge row using an existing transaction."""
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO edges(id, source, target, kind, file_path, line, column, metadata, provenance)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            edge.id,
+            edge.source,
+            edge.target,
+            edge.kind,
+            edge.file_path,
+            edge.line,
+            edge.column,
+            json.dumps(edge.metadata, sort_keys=True),
+            edge.provenance,
+        ),
+    )
+
+
 def _insert_unresolved_refs(
     conn: sqlite3.Connection,
     unresolved_refs: list[CodeGraphUnresolvedRef] | tuple[CodeGraphUnresolvedRef, ...],
@@ -948,6 +1141,25 @@ def _target_node_from_joined_row(row: sqlite3.Row) -> CodeGraphNode:
         visibility=str(row["target_visibility"]) if row["target_visibility"] is not None else None,
         flags=tuple(json.loads(row["target_flags"] or "[]")),
         metadata=dict(json.loads(row["target_metadata"] or "{}")),
+    )
+
+
+def _reference_from_row(row: sqlite3.Row) -> StoredCodeGraphReference:
+    """Convert an unresolved_refs row to a reference value object."""
+    return StoredCodeGraphReference(
+        id=int(row["id"]),
+        from_node_id=str(row["from_node_id"]),
+        reference_name=str(row["reference_name"]),
+        reference_kind=str(row["reference_kind"]),
+        file_path=str(row["file_path"]),
+        line=int(row["line"]) if row["line"] is not None else None,
+        column=int(row["column"]) if row["column"] is not None else None,
+        candidates=tuple(json.loads(row["candidates"] or "[]")),
+        language=str(row["language"]) if row["language"] else None,
+        resolved_target=str(row["resolved_target"]) if row["resolved_target"] else None,
+        resolved_edge=str(row["resolved_edge"]) if row["resolved_edge"] else None,
+        resolution_kind=str(row["resolution_kind"]) if row["resolution_kind"] else None,
+        resolved_at=str(row["resolved_at"]) if row["resolved_at"] else None,
     )
 
 

--- a/tldw_Server_API/app/core/DB_Management/codegraph/schema.sql
+++ b/tldw_Server_API/app/core/DB_Management/codegraph/schema.sql
@@ -64,7 +64,11 @@ CREATE TABLE IF NOT EXISTS unresolved_refs (
     line INTEGER,
     column INTEGER,
     candidates TEXT NOT NULL DEFAULT '[]',
-    language TEXT
+    language TEXT,
+    resolved_target TEXT,
+    resolved_edge TEXT,
+    resolution_kind TEXT,
+    resolved_at TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_unresolved_refs_file_path ON unresolved_refs(file_path);

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
@@ -371,6 +371,69 @@ def helper(value):
 
 
 @pytest.mark.asyncio
+async def test_codegraph_read_tools_return_cross_file_relationships(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    package = workspace_root / "pkg"
+    package.mkdir(parents=True)
+    (package / "util.py").write_text(
+        "def helper(value):\n    return value.upper()\n",
+        encoding="utf-8",
+    )
+    (package / "app.py").write_text(
+        "from pkg.util import helper\n\n\ndef entry(value):\n    return helper(value)\n",
+        encoding="utf-8",
+    )
+    module = _module(tmp_path, workspace_root)
+
+    index_result = await module.execute_tool(
+        "codegraph.index",
+        {"mode": "foreground", "force": True, "max_files": 10},
+        context=_context(),
+    )
+    helper_search = await module.execute_tool(
+        "codegraph.search",
+        {"query": "helper", "kind": "function", "limit": 10},
+        context=_context(),
+    )
+    entry_search = await module.execute_tool(
+        "codegraph.search",
+        {"query": "entry", "kind": "function", "limit": 10},
+        context=_context(),
+    )
+    helper_id = helper_search["results"][0]["id"]
+    entry_id = entry_search["results"][0]["id"]
+
+    callers = await module.execute_tool(
+        "codegraph.callers",
+        {"node_id": helper_id, "limit": 10},
+        context=_context(),
+    )
+    callees = await module.execute_tool(
+        "codegraph.callees",
+        {"node_id": entry_id, "limit": 10},
+        context=_context(),
+    )
+    impact = await module.execute_tool(
+        "codegraph.impact",
+        {"node_id": helper_id, "direction": "incoming", "depth": 1, "limit": 10},
+        context=_context(),
+    )
+    context_result = await module.execute_tool(
+        "codegraph.context",
+        {"task": "helper", "max_nodes": 5, "max_files": 2},
+        context=_context(),
+    )
+
+    assert index_result["status"] == "complete"  # nosec B101
+    assert [item["source"]["file_path"] for item in callers["relationships"]] == ["pkg/app.py"]  # nosec B101
+    assert [item["target"]["file_path"] for item in callees["relationships"]] == ["pkg/util.py"]  # nosec B101
+    assert "pkg/app.py" in {item["source"]["file_path"] for item in impact["relationships"]}  # nosec B101
+    assert any(
+        item["target"]["file_path"] == "pkg/util.py" for item in context_result["relationships"]
+    )  # nosec B101
+
+
+@pytest.mark.asyncio
 async def test_codegraph_search_finds_typescript_component_after_index(tmp_path: Path) -> None:
     _require_typescript_parsers()
     workspace_root = tmp_path / "workspace"

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py
@@ -217,6 +217,55 @@ def test_indexer_resolves_typescript_path_alias_import_call(tmp_path: Path) -> N
     ]
 
 
+def test_indexer_passes_foreground_bounds_to_resolver(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "app.py").write_text("def helper():\n    return 1\n", encoding="utf-8")
+    captured: dict[str, Any] = {}
+
+    class _FakeResolver:
+        def __init__(self, _repository: CodeGraphRepository) -> None:
+            pass
+
+        def resolve(self, **kwargs: Any) -> SimpleNamespace:
+            captured.update(kwargs)
+            return SimpleNamespace(
+                resolved_calls=0,
+                resolved_imports=0,
+                stale_resolutions_cleared=0,
+                truncated=False,
+                import_nodes_scanned=0,
+                references_scanned=0,
+            )
+
+    monkeypatch.setattr(indexer_module, "CodeGraphReferenceResolver", _FakeResolver)
+    repo = CodeGraphRepository(tmp_path / "codegraph.db")
+    indexer = CodeGraphIndexer(
+        settings=CodeGraphSettings.from_mapping({"max_index_seconds": 20}),
+        registry=CodeGraphLanguageRegistry(),
+        monotonic=lambda: 5.0,
+    )
+
+    result = indexer.index_workspace(
+        workspace_root=workspace,
+        workspace_key="ws_test",
+        repository=repo,
+        force=True,
+        languages=None,
+        max_files=10,
+    )
+
+    assert result.status == "complete"
+    assert captured["source_file_paths"] == {"app.py"}
+    assert captured["max_import_nodes"] > 0
+    assert captured["max_refs"] > 0
+    assert captured["deadline_monotonic"] == 25.0
+    assert captured["monotonic"]() == 5.0
+
+
 def test_indexer_extracts_javascript_typescript_graph_rows_during_index(tmp_path: Path) -> None:
     _require_typescript_parsers()
     workspace = tmp_path / "workspace"

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_indexer.py
@@ -107,6 +107,116 @@ def helper(value):
     ]
 
 
+def test_indexer_resolves_python_cross_file_import_call(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    package = workspace / "pkg"
+    package.mkdir(parents=True)
+    (package / "util.py").write_text(
+        """
+def helper(value):
+    return value.upper()
+""",
+        encoding="utf-8",
+    )
+    (package / "app.py").write_text(
+        """
+from pkg.util import helper
+
+
+def entry(value):
+    return helper(value)
+""",
+        encoding="utf-8",
+    )
+    repo = CodeGraphRepository(tmp_path / "codegraph.db")
+    indexer = CodeGraphIndexer(settings=CodeGraphSettings.from_mapping({}), registry=CodeGraphLanguageRegistry())
+
+    result = indexer.index_workspace(
+        workspace_root=workspace,
+        workspace_key="ws_test",
+        repository=repo,
+        force=True,
+        languages=None,
+        max_files=10,
+    )
+    helper = repo.find_nodes_by_file_and_name(file_path="pkg/util.py", name="helper")[0]
+
+    assert result.status == "complete"
+    assert [relationship["source"]["file_path"] for relationship in repo.list_callers(helper.id, limit=10)] == [
+        "pkg/app.py"
+    ]
+
+
+def test_indexer_removes_stale_cross_file_edges_after_target_rename(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    package = workspace / "pkg"
+    package.mkdir(parents=True)
+    util = package / "util.py"
+    util.write_text("def helper(value):\n    return value\n", encoding="utf-8")
+    (package / "app.py").write_text(
+        "from pkg.util import helper\n\n\ndef entry(value):\n    return helper(value)\n",
+        encoding="utf-8",
+    )
+    repo = CodeGraphRepository(tmp_path / "codegraph.db")
+    indexer = CodeGraphIndexer(settings=CodeGraphSettings.from_mapping({}), registry=CodeGraphLanguageRegistry())
+    indexer.index_workspace(
+        workspace_root=workspace,
+        workspace_key="ws_test",
+        repository=repo,
+        force=True,
+        languages=None,
+        max_files=10,
+    )
+    helper = repo.find_nodes_by_file_and_name(file_path="pkg/util.py", name="helper")[0]
+    assert repo.list_callers(helper.id, limit=10)
+
+    util.write_text("def renamed(value):\n    return value\n", encoding="utf-8")
+    result = indexer.sync_workspace(
+        workspace_root=workspace,
+        workspace_key="ws_test",
+        repository=repo,
+        languages=None,
+        max_files=10,
+    )
+
+    assert result.status == "complete"
+    assert repo.list_callers(helper.id, limit=10) == []
+    assert repo.counts()["unresolved_refs"] == 1
+
+
+def test_indexer_resolves_typescript_path_alias_import_call(tmp_path: Path) -> None:
+    _require_typescript_parsers()
+    workspace = tmp_path / "workspace"
+    source_dir = workspace / "src"
+    source_dir.mkdir(parents=True)
+    (workspace / "tsconfig.json").write_text(
+        '{"compilerOptions":{"baseUrl":".","paths":{"@/*":["src/*"]}}}',
+        encoding="utf-8",
+    )
+    (source_dir / "util.ts").write_text("export function helper(value: string) { return value; }\n", encoding="utf-8")
+    (source_dir / "app.ts").write_text(
+        'import { helper } from "@/util";\nexport function main(value: string) { return helper(value); }\n',
+        encoding="utf-8",
+    )
+    repo = CodeGraphRepository(tmp_path / "codegraph.db")
+    indexer = CodeGraphIndexer(settings=CodeGraphSettings.from_mapping({}), registry=CodeGraphLanguageRegistry())
+
+    result = indexer.index_workspace(
+        workspace_root=workspace,
+        workspace_key="ws_test",
+        repository=repo,
+        force=True,
+        languages=None,
+        max_files=10,
+    )
+    helper = repo.find_nodes_by_file_and_name(file_path="src/util.ts", name="helper")[0]
+
+    assert result.status == "complete"
+    assert [relationship["source"]["file_path"] for relationship in repo.list_callers(helper.id, limit=10)] == [
+        "src/app.ts"
+    ]
+
+
 def test_indexer_extracts_javascript_typescript_graph_rows_during_index(tmp_path: Path) -> None:
     _require_typescript_parsers()
     workspace = tmp_path / "workspace"

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_repository.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_repository.py
@@ -276,6 +276,69 @@ def test_repository_replacement_removes_stale_symbols_from_search(tmp_path: Path
     assert [node.id for node in repo.search_nodes("new_helper", limit=10)] == ["node_new"]
 
 
+def test_repository_marks_references_resolved_without_counting_them_unresolved(tmp_path: Path) -> None:
+    repo = CodeGraphRepository(tmp_path / "codegraph.db")
+    repo.initialize()
+    _seed_cross_file_resolution_graph(repo)
+
+    references = repo.list_references_for_resolution()
+    repo.mark_reference_resolved(
+        references[0].id,
+        edge=CodeGraphEdge(
+            id="edge_cross_file_call",
+            source="node_entry",
+            target="node_helper",
+            kind="calls",
+            file_path="pkg/app.py",
+            line=4,
+            column=12,
+            provenance="codegraph_resolver",
+        ),
+        resolution_kind="python_import",
+    )
+
+    all_references = repo.list_references_for_resolution(include_resolved=True)
+
+    assert repo.counts()["unresolved_refs"] == 0
+    assert [relationship["target"]["id"] for relationship in repo.list_callees("node_entry", limit=10)] == [
+        "node_helper"
+    ]
+    assert len(all_references) == 1
+    assert all_references[0].resolved_target == "node_helper"
+    assert all_references[0].resolved_edge == "edge_cross_file_call"
+
+
+def test_repository_clears_stale_reference_resolution_when_target_file_is_deleted(tmp_path: Path) -> None:
+    repo = CodeGraphRepository(tmp_path / "codegraph.db")
+    repo.initialize()
+    _seed_cross_file_resolution_graph(repo)
+    reference = repo.list_references_for_resolution()[0]
+    repo.mark_reference_resolved(
+        reference.id,
+        edge=CodeGraphEdge(
+            id="edge_cross_file_call",
+            source="node_entry",
+            target="node_helper",
+            kind="calls",
+            file_path="pkg/app.py",
+            line=4,
+            column=12,
+            provenance="codegraph_resolver",
+        ),
+        resolution_kind="python_import",
+    )
+
+    repo.delete_file("pkg/util.py")
+
+    references = repo.list_references_for_resolution(include_resolved=True)
+
+    assert repo.counts()["edges"] == 0
+    assert repo.counts()["unresolved_refs"] == 1
+    assert len(references) == 1
+    assert references[0].resolved_target is None
+    assert references[0].resolved_edge is None
+
+
 def test_repository_atomic_file_and_graph_replacement_rolls_back_on_graph_error(tmp_path: Path) -> None:
     repo = CodeGraphRepository(tmp_path / "codegraph.db")
     repo.initialize()
@@ -499,4 +562,58 @@ def _seed_impact_graph(repo: CodeGraphRepository) -> None:
             },
         ],
         unresolved_refs=[],
+    )
+
+
+def _seed_cross_file_resolution_graph(repo: CodeGraphRepository) -> None:
+    """Seed source and target files plus one cross-file call reference."""
+    repo.upsert_file(
+        path="pkg/app.py",
+        language="python",
+        size=64,
+        content_hash="app",
+        modified_at=1.0,
+        status="indexed",
+        errors=[],
+    )
+    repo.upsert_file(
+        path="pkg/util.py",
+        language="python",
+        size=64,
+        content_hash="util",
+        modified_at=1.0,
+        status="indexed",
+        errors=[],
+    )
+    repo.seed_graph_rows_for_test(
+        nodes=[
+            {
+                "id": "node_entry",
+                "identity_key": "entry",
+                "kind": "function",
+                "name": "entry",
+                "qualified_name": "entry",
+                "file_path": "pkg/app.py",
+            },
+            {
+                "id": "node_helper",
+                "identity_key": "helper",
+                "kind": "function",
+                "name": "helper",
+                "qualified_name": "helper",
+                "file_path": "pkg/util.py",
+            },
+        ],
+        edges=[],
+        unresolved_refs=[
+            {
+                "from_node_id": "node_entry",
+                "reference_name": "helper",
+                "reference_kind": "call",
+                "file_path": "pkg/app.py",
+                "line": 4,
+                "column": 12,
+                "language": "python",
+            }
+        ],
     )

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_repository.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_repository.py
@@ -339,6 +339,89 @@ def test_repository_clears_stale_reference_resolution_when_target_file_is_delete
     assert references[0].resolved_edge is None
 
 
+def test_repository_counts_and_clears_resolution_with_null_edge(tmp_path: Path) -> None:
+    db_path = tmp_path / "codegraph.db"
+    repo = CodeGraphRepository(db_path)
+    repo.initialize()
+    _seed_cross_file_resolution_graph(repo)
+    repo.upsert_edge(
+        CodeGraphEdge(
+            id="edge_unrelated",
+            source="node_entry",
+            target="node_helper",
+            kind="calls",
+            file_path="pkg/app.py",
+        )
+    )
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            UPDATE unresolved_refs
+            SET resolved_target = ?, resolved_edge = NULL, resolution_kind = ?
+            WHERE reference_name = ?
+            """,
+            ("node_helper", "test_fixture", "helper"),
+        )
+        conn.commit()
+
+    cleared = repo.clear_stale_reference_resolutions()
+    references = repo.list_references_for_resolution(include_resolved=True)
+
+    assert cleared == 1
+    assert repo.counts()["unresolved_refs"] == 1
+    assert references[0].resolved_target is None
+    assert references[0].resolved_edge is None
+
+
+def test_repository_list_references_for_resolution_is_read_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = CodeGraphRepository(tmp_path / "codegraph.db")
+    repo.initialize()
+    _seed_cross_file_resolution_graph(repo)
+
+    def _fail_stale_cleanup(_conn: sqlite3.Connection) -> int:
+        raise AssertionError("list_references_for_resolution must not mutate stale state")
+
+    monkeypatch.setattr(repository_module, "_clear_stale_reference_resolutions", _fail_stale_cleanup)
+
+    references = repo.list_references_for_resolution()
+
+    assert [reference.reference_name for reference in references] == ["helper"]
+
+
+def test_repository_batches_resolved_references_and_edges(tmp_path: Path) -> None:
+    repo = CodeGraphRepository(tmp_path / "codegraph.db")
+    repo.initialize()
+    _seed_cross_file_resolution_graph(repo)
+    reference = repo.list_references_for_resolution()[0]
+
+    repo.mark_references_resolved(
+        (
+            (
+                reference.id,
+                CodeGraphEdge(
+                    id="edge_cross_file_call",
+                    source="node_entry",
+                    target="node_helper",
+                    kind="calls",
+                    file_path="pkg/app.py",
+                    line=4,
+                    column=12,
+                    provenance="codegraph_resolver",
+                ),
+                "python_import",
+            ),
+        )
+    )
+
+    assert repo.counts()["unresolved_refs"] == 0
+    assert [relationship["target"]["id"] for relationship in repo.list_callees("node_entry", limit=10)] == [
+        "node_helper"
+    ]
+
+
 def test_repository_atomic_file_and_graph_replacement_rolls_back_on_graph_error(tmp_path: Path) -> None:
     repo = CodeGraphRepository(tmp_path / "codegraph.db")
     repo.initialize()

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_resolver.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_resolver.py
@@ -1,0 +1,217 @@
+"""Tests for CodeGraph cross-file reference resolution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tldw_Server_API.app.core.CodeGraph.models import CodeGraphNode, CodeGraphUnresolvedRef
+from tldw_Server_API.app.core.CodeGraph.resolver import CodeGraphReferenceResolver
+from tldw_Server_API.app.core.DB_Management.codegraph.repository import CodeGraphRepository
+
+
+def test_resolver_links_python_from_import_call_to_target_symbol(tmp_path: Path) -> None:
+    repo = CodeGraphRepository(tmp_path / "codegraph.db")
+    repo.initialize()
+    _seed_python_import_workspace(repo, import_local_name="helper", reference_name="helper")
+
+    result = CodeGraphReferenceResolver(repo).resolve()
+
+    callers = repo.list_callers("node_util_helper", limit=10)
+    callees = repo.list_callees("node_app_entry", limit=10)
+
+    assert result.resolved_calls == 1
+    assert result.resolved_imports == 1
+    assert repo.counts()["unresolved_refs"] == 0
+    assert [relationship["source"]["id"] for relationship in callers] == ["node_app_entry"]
+    assert [relationship["target"]["id"] for relationship in callees] == ["node_util_helper"]
+
+
+def test_resolver_links_python_aliased_import_call(tmp_path: Path) -> None:
+    repo = CodeGraphRepository(tmp_path / "codegraph.db")
+    repo.initialize()
+    _seed_python_import_workspace(repo, import_local_name="h", reference_name="h", import_alias="h")
+
+    result = CodeGraphReferenceResolver(repo).resolve()
+
+    assert result.resolved_calls == 1
+    assert [relationship["target"]["id"] for relationship in repo.list_callees("node_app_entry", limit=10)] == [
+        "node_util_helper"
+    ]
+
+
+def test_resolver_links_js_ts_named_import_with_resolved_path(tmp_path: Path) -> None:
+    repo = CodeGraphRepository(tmp_path / "codegraph.db")
+    repo.initialize()
+    _seed_js_ts_import_workspace(repo)
+
+    result = CodeGraphReferenceResolver(repo).resolve()
+
+    callers = repo.list_callers("node_ts_helper", limit=10)
+
+    assert result.resolved_calls == 1
+    assert result.resolved_imports == 1
+    assert [relationship["source"]["id"] for relationship in callers] == ["node_ts_main"]
+
+
+def test_resolver_keeps_unmatched_external_references_unresolved(tmp_path: Path) -> None:
+    repo = CodeGraphRepository(tmp_path / "codegraph.db")
+    repo.initialize()
+    _seed_js_ts_import_workspace(repo, resolved_path=None)
+
+    result = CodeGraphReferenceResolver(repo).resolve()
+
+    assert result.resolved_calls == 0
+    assert result.resolved_imports == 0
+    assert repo.counts()["unresolved_refs"] == 1
+
+
+def _seed_python_import_workspace(
+    repo: CodeGraphRepository,
+    *,
+    import_local_name: str,
+    reference_name: str,
+    import_alias: str | None = None,
+) -> None:
+    repo.upsert_file_and_replace_graph(
+        path="pkg/util.py",
+        language="python",
+        size=64,
+        content_hash="util",
+        modified_at=1.0,
+        status="indexed",
+        errors=[],
+        node_count=2,
+        nodes=[
+            _node("node_util_module", "module", "util", "pkg.util", "pkg/util.py", "python"),
+            _node("node_util_helper", "function", "helper", "helper", "pkg/util.py", "python"),
+        ],
+        edges=[],
+        unresolved_refs=[],
+    )
+    repo.upsert_file_and_replace_graph(
+        path="pkg/app.py",
+        language="python",
+        size=64,
+        content_hash="app",
+        modified_at=1.0,
+        status="indexed",
+        errors=[],
+        node_count=3,
+        nodes=[
+            _node("node_app_module", "module", "app", "pkg.app", "pkg/app.py", "python"),
+            _node(
+                "node_app_import",
+                "import",
+                import_local_name,
+                "pkg.util.helper",
+                "pkg/app.py",
+                "python",
+                metadata={"imported": "pkg.util.helper", "alias": import_alias},
+            ),
+            _node("node_app_entry", "function", "entry", "entry", "pkg/app.py", "python"),
+        ],
+        edges=[],
+        unresolved_refs=[
+            CodeGraphUnresolvedRef(
+                from_node_id="node_app_entry",
+                reference_name=reference_name,
+                reference_kind="call",
+                file_path="pkg/app.py",
+                line=4,
+                column=12,
+                language="python",
+            )
+        ],
+    )
+
+
+def _seed_js_ts_import_workspace(repo: CodeGraphRepository, *, resolved_path: str | None = "src/util.ts") -> None:
+    repo.upsert_file_and_replace_graph(
+        path="src/util.ts",
+        language="typescript",
+        size=64,
+        content_hash="util",
+        modified_at=1.0,
+        status="indexed",
+        errors=[],
+        node_count=2,
+        nodes=[
+            _node("node_ts_module", "module", "util", "src.util", "src/util.ts", "typescript"),
+            _node(
+                "node_ts_helper",
+                "function",
+                "helper",
+                "helper",
+                "src/util.ts",
+                "typescript",
+                flags=("exported",),
+            ),
+        ],
+        edges=[],
+        unresolved_refs=[],
+    )
+    repo.upsert_file_and_replace_graph(
+        path="src/app.ts",
+        language="typescript",
+        size=64,
+        content_hash="app",
+        modified_at=1.0,
+        status="indexed",
+        errors=[],
+        node_count=3,
+        nodes=[
+            _node("node_ts_app_module", "module", "app", "src.app", "src/app.ts", "typescript"),
+            _node(
+                "node_ts_import",
+                "import",
+                "helper",
+                "@/util:helper:helper",
+                "src/app.ts",
+                "typescript",
+                metadata={
+                    "source": "@/util",
+                    "imported": "helper",
+                    "alias": None,
+                    "resolved_path": resolved_path,
+                    "resolution_kind": "alias" if resolved_path else "external",
+                },
+            ),
+            _node("node_ts_main", "function", "main", "main", "src/app.ts", "typescript"),
+        ],
+        edges=[],
+        unresolved_refs=[
+            CodeGraphUnresolvedRef(
+                from_node_id="node_ts_main",
+                reference_name="helper",
+                reference_kind="call",
+                file_path="src/app.ts",
+                line=3,
+                column=10,
+                language="typescript",
+            )
+        ],
+    )
+
+
+def _node(
+    node_id: str,
+    kind: str,
+    name: str,
+    qualified_name: str,
+    file_path: str,
+    language: str,
+    *,
+    flags: tuple[str, ...] = (),
+    metadata: dict[str, object] | None = None,
+) -> CodeGraphNode:
+    return CodeGraphNode(
+        id=node_id,
+        identity_key=node_id,
+        kind=kind,
+        name=name,
+        qualified_name=qualified_name,
+        file_path=file_path,
+        language=language,
+        flags=flags,
+        metadata=dict(metadata or {}),
+    )

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_resolver.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_resolver.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from tldw_Server_API.app.core.CodeGraph.models import CodeGraphNode, CodeGraphUnresolvedRef
 from tldw_Server_API.app.core.CodeGraph.resolver import CodeGraphReferenceResolver
 from tldw_Server_API.app.core.DB_Management.codegraph.repository import CodeGraphRepository
@@ -65,13 +67,9 @@ def test_resolver_keeps_unmatched_external_references_unresolved(tmp_path: Path)
     assert repo.counts()["unresolved_refs"] == 1
 
 
-def _seed_python_import_workspace(
-    repo: CodeGraphRepository,
-    *,
-    import_local_name: str,
-    reference_name: str,
-    import_alias: str | None = None,
-) -> None:
+def test_resolver_matches_case_sensitive_python_symbols_exactly(tmp_path: Path) -> None:
+    repo = CodeGraphRepository(tmp_path / "codegraph.db")
+    repo.initialize()
     repo.upsert_file_and_replace_graph(
         path="pkg/util.py",
         language="python",
@@ -80,14 +78,110 @@ def _seed_python_import_workspace(
         modified_at=1.0,
         status="indexed",
         errors=[],
-        node_count=2,
+        node_count=3,
         nodes=[
             _node("node_util_module", "module", "util", "pkg.util", "pkg/util.py", "python"),
-            _node("node_util_helper", "function", "helper", "helper", "pkg/util.py", "python"),
+            _node("node_upper_helper", "function", "Helper", "Helper", "pkg/util.py", "python"),
+            _node("node_lower_helper", "function", "helper", "helper", "pkg/util.py", "python"),
         ],
         edges=[],
         unresolved_refs=[],
     )
+    _seed_python_import_workspace(repo, import_local_name="helper", reference_name="helper", include_target=False)
+
+    result = CodeGraphReferenceResolver(repo).resolve()
+
+    assert result.resolved_calls == 1
+    assert [relationship["target"]["id"] for relationship in repo.list_callees("node_app_entry", limit=10)] == [
+        "node_lower_helper"
+    ]
+
+
+def test_resolver_batches_persistence_writes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = CodeGraphRepository(tmp_path / "codegraph.db")
+    repo.initialize()
+    _seed_python_import_workspace(repo, import_local_name="helper", reference_name="helper")
+
+    def _fail_single_write(*_args, **_kwargs) -> None:
+        raise AssertionError("resolver should use repository batch write helpers")
+
+    monkeypatch.setattr(repo, "mark_reference_resolved", _fail_single_write)
+    monkeypatch.setattr(repo, "upsert_edge", _fail_single_write)
+
+    result = CodeGraphReferenceResolver(repo).resolve()
+
+    assert result.resolved_calls == 1
+    assert result.resolved_imports == 1
+
+
+def test_resolver_respects_reference_limit(tmp_path: Path) -> None:
+    repo = CodeGraphRepository(tmp_path / "codegraph.db")
+    repo.initialize()
+    _seed_python_import_workspace(repo, import_local_name="helper", reference_name="helper")
+    repo.seed_graph_rows_for_test(
+        nodes=[],
+        edges=[],
+        unresolved_refs=[
+            {
+                "from_node_id": "node_app_entry",
+                "reference_name": "helper",
+                "reference_kind": "call",
+                "file_path": "pkg/app.py",
+                "line": 5,
+                "column": 12,
+                "language": "python",
+            }
+        ],
+    )
+
+    result = CodeGraphReferenceResolver(repo).resolve(max_refs=1)
+
+    assert result.resolved_calls == 1
+    assert result.truncated is True
+    assert repo.counts()["unresolved_refs"] == 1
+
+
+def test_resolver_respects_expired_deadline(tmp_path: Path) -> None:
+    repo = CodeGraphRepository(tmp_path / "codegraph.db")
+    repo.initialize()
+    _seed_python_import_workspace(repo, import_local_name="helper", reference_name="helper")
+
+    result = CodeGraphReferenceResolver(repo).resolve(deadline_monotonic=1.0, monotonic=lambda: 2.0)
+
+    assert result.resolved_calls == 0
+    assert result.resolved_imports == 0
+    assert result.truncated is True
+    assert repo.counts()["unresolved_refs"] == 1
+
+
+def _seed_python_import_workspace(
+    repo: CodeGraphRepository,
+    *,
+    import_local_name: str,
+    reference_name: str,
+    import_alias: str | None = None,
+    include_target: bool = True,
+) -> None:
+    if include_target:
+        repo.upsert_file_and_replace_graph(
+            path="pkg/util.py",
+            language="python",
+            size=64,
+            content_hash="util",
+            modified_at=1.0,
+            status="indexed",
+            errors=[],
+            node_count=2,
+            nodes=[
+                _node("node_util_module", "module", "util", "pkg.util", "pkg/util.py", "python"),
+                _node("node_util_helper", "function", "helper", "helper", "pkg/util.py", "python"),
+            ],
+            edges=[],
+            unresolved_refs=[],
+        )
     repo.upsert_file_and_replace_graph(
         path="pkg/app.py",
         language="python",


### PR DESCRIPTION
## Summary
- Adds conservative same-workspace CodeGraph reference resolution for Python and JavaScript/TypeScript import-bound calls.
- Stores resolved reference state in the CodeGraph repository, writes deterministic calls/imports edges, and clears stale resolution state when indexed files change.
- Adds repository, resolver, indexer, and Unified MCP read-tool coverage so callers/callees/impact/context can surface cross-file relationships.

## Test Plan
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/CodeGraph tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check tldw_Server_API/app/core/CodeGraph tldw_Server_API/app/core/DB_Management/codegraph tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py tldw_Server_API/tests/CodeGraph tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/CodeGraph tldw_Server_API/app/core/DB_Management/codegraph tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py -f json -o /tmp/bandit_codegraph_cross_file_resolution.json
- git diff --check

## Backlog / Epic
- Backlog: TASK-74
- Epic: #1259

## Change Summary
Maintainer TODO: replace this section with a human-written Change summary before merge, per Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md.