### PR TITLE
Phase 2.2: defer minimal guardian router imports

### DIFF
--- a/backlog/tasks/task-76 - Phase-2.2-minimal-guardian-router-conditional-cleanup-AH.md
+++ b/backlog/tasks/task-76 - Phase-2.2-minimal-guardian-router-conditional-cleanup-AH.md
@@ -1,0 +1,64 @@
+---
+id: TASK-76
+title: Phase 2.2 minimal guardian router conditional cleanup AH
+status: Done
+assignee: []
+created_date: '2026-05-05 16:17'
+updated_date: '2026-05-05 16:21'
+labels:
+  - phase2.2
+  - router-cleanup
+  - issue-1116
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+  - 'https://github.com/rmusser01/tldw_server/pull/1307'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue issue #1116 Phase 2.2 after PR #1307. Convert the next small minimal-test optional guardian/safety registrations from eager try/import RouterSpec blocks to ImportedRouterSpec-backed lazy router specs. Scope is limited to family_wizard, guardian_controls, and self_monitoring in tldw_Server_API/app/api/v1/router_groups/minimal.py. Preserve prefixes, tags, route_key behavior, default_stable behavior, and the existing minimal-test broad skip behavior for import-time failures.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Guardian controls, family wizard, and self-monitoring minimal optional specs defer module import and router attribute lookup until registration
+- [x] #2 Existing route metadata is preserved for guardian controls, family wizard, and self-monitoring
+- [x] #3 Focused router-group tests cover lazy behavior and broad import failure skipping with red/green verification
+- [x] #4 Router-group contract tests and touched-source Bandit pass
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused contract coverage for the minimal guardian/safety specs.
+2. Run the focused selection red against the current eager try/import blocks.
+3. Convert only family_wizard, guardian_controls, and self_monitoring to ImportedRouterSpec entries while preserving metadata and skip semantics.
+4. Rerun focused tests, full router_groups contract tests, Bandit on minimal.py, git diff --check, and status before commit.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Started after PR #1307 merge was verified at merge commit 6242560e22a4d9fce2b5d74679ce0f467943bd22. Worktree: /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/phase2-2-minimal-guardian-router-conditionals-ah. Branch: codex/phase2-2-minimal-guardian-router-conditionals-ah. Baseline full test_router_groups_contract.py passed with 77 tests before edits.
+
+Implemented the guardian/safety minimal router tranche. Added red/green focused contract coverage proving guardian_controls, family_wizard, and self_monitoring defer module import/router attribute lookup until registration and preserve broad skip_exceptions=(Exception,) behavior for RuntimeError import failures. Converted only those three eager try/import RouterSpec blocks to ImportedRouterSpec-backed lazy specs while preserving prefixes, tags, route_key, and default_stable behavior. Verification: focused selection guardian_safety_attr_lookup or guardian_safety_runtime_import_failures failed red before the source change and passed after implementation; full test_router_groups_contract.py passed with 79 tests; test_main_router_contract.py passed with 6 tests; Bandit on minimal.py reported 0 results and 0 errors; git diff --check was clean.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Converted minimal optional guardian controls, family wizard, and self-monitoring router registrations to ImportedRouterSpec-backed lazy specs. The change keeps the prior minimal-test broad import-failure skip behavior by explicitly setting skip_exceptions=(Exception,) while deferring endpoint imports until registration. Added focused regression coverage for lazy router resolution and RuntimeError import-failure skipping. Verification covered red/green focused tests, full router_groups contract tests, main router contract tests, Bandit, and diff check.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -499,35 +499,33 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
     ):
         append_imported_router_spec(specs, experience_spec)
 
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.family_wizard import router as family_wizard_router
-        from tldw_Server_API.app.api.v1.endpoints.guardian_controls import router as guardian_controls_router
-
-        specs.extend([
-            RouterSpec(
-                router=guardian_controls_router,
-                prefix=f"{API_V1_PREFIX}/guardian",
-                tags=("guardian",),
-            ),
-            RouterSpec(
-                router=family_wizard_router,
-                prefix=f"{API_V1_PREFIX}/guardian",
-                tags=("guardian",),
-            ),
-        ])
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping guardian controls router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.self_monitoring import router as self_monitoring_router
-
-        specs.append(RouterSpec(
-            router=self_monitoring_router,
+    for guardian_safety_spec in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.guardian_controls",
+            log_name="guardian_controls",
+            prefix=f"{API_V1_PREFIX}/guardian",
+            tags=("guardian",),
+            skip_context=minimal_skip_context,
+            skip_exceptions=(Exception,),
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.family_wizard",
+            log_name="family_wizard",
+            prefix=f"{API_V1_PREFIX}/guardian",
+            tags=("guardian",),
+            skip_context=minimal_skip_context,
+            skip_exceptions=(Exception,),
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.self_monitoring",
+            log_name="self_monitoring",
             prefix=f"{API_V1_PREFIX}/self-monitoring",
             tags=("self-monitoring",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping self-monitoring router in minimal test app: {e}")
+            skip_context=minimal_skip_context,
+            skip_exceptions=(Exception,),
+        ),
+    ):
+        append_imported_router_spec(specs, guardian_safety_spec)
 
     try:
         from tldw_Server_API.app.api.v1.endpoints.persona import router as persona_router

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -4973,6 +4973,210 @@ def test_iter_minimal_optional_router_specs_skips_experience_runtime_import_fail
     ]
 
 
+def test_iter_minimal_optional_router_specs_defers_guardian_safety_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal guardian/safety specs keep router attr lookup lazy."""
+    import builtins
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    router_definitions = (
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.guardian_controls",
+            "expected_name": "guardian_controls",
+            "path": "/controls",
+            "prefix": "/api/v1/guardian",
+            "tags": ("guardian",),
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.family_wizard",
+            "expected_name": "family_wizard",
+            "path": "/family-wizard",
+            "prefix": "/api/v1/guardian",
+            "tags": ("guardian",),
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.self_monitoring",
+            "expected_name": "self_monitoring",
+            "path": "/self-monitoring/status",
+            "prefix": "/api/v1/self-monitoring",
+            "tags": ("self-monitoring",),
+        },
+    )
+    definitions_by_module = {
+        str(definition["module_name"]): definition
+        for definition in router_definitions
+    }
+    access_count = {
+        f"{definition['module_name']}.router": 0
+        for definition in router_definitions
+    }
+    import_calls: list[str] = []
+
+    for module_name, definition in definitions_by_module.items():
+        fake_module = ModuleType(module_name)
+        router = APIRouter()
+
+        @router.get(str(definition["path"]))
+        def _endpoint() -> dict[str, str]:
+            """Return a deterministic response for the fake minimal router."""
+            return {"status": "ok"}
+
+        def _module_getattr(
+            name: str,
+            *,
+            module_name: str = module_name,
+            router: APIRouter = router,
+        ) -> APIRouter:
+            """Track lazy router attribute resolution for the fake module."""
+            if name != "router":
+                raise AttributeError(name)
+            access_count[f"{module_name}.router"] += 1
+            return router
+
+        fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    endpoints_package = "tldw_Server_API.app.api.v1.endpoints."
+    real_import = builtins.__import__
+
+    def _fake_endpoint_import(
+        name: str,
+        globals: dict[str, object] | None = None,
+        locals: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> ModuleType:
+        """Return fake routers for unrelated eager minimal optional imports."""
+        if (
+            level == 0
+            and name.startswith(endpoints_package)
+            and name not in definitions_by_module
+        ):
+            attrs = tuple(attr for attr in fromlist if attr != "*") or ("router",)
+            for attr_name in attrs:
+                _install_fake_router_module(
+                    monkeypatch,
+                    name,
+                    path="/minimal-unrelated-guardian-fake",
+                    attr_name=attr_name,
+                )
+            return sys.modules[name]
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_endpoint_import)
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Track lazy module imports for selected minimal guardian routers."""
+        if module_name in definitions_by_module:
+            import_calls.append(module_name)
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+    fake_main = ModuleType("tldw_Server_API.app.main")
+    fake_main.app = FastAPI()  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "tldw_Server_API.app.main", fake_main)
+
+    specs = list(iter_minimal_optional_router_specs())
+    assert access_count == {
+        f"{definition['module_name']}.router": 0
+        for definition in router_definitions
+    }
+    assert import_calls == []
+
+    selected_specs = {
+        spec.name: spec
+        for spec in specs
+        if spec.name in {
+            str(definition["expected_name"])
+            for definition in router_definitions
+        }
+    }
+    assert set(selected_specs) == {
+        str(definition["expected_name"])
+        for definition in router_definitions
+    }
+
+    for definition in router_definitions:
+        spec = selected_specs[str(definition["expected_name"])]
+        assert spec.prefix == definition["prefix"]
+        assert spec.tags == definition["tags"]
+        assert spec.route_key == ""
+        assert spec.skip_context == "in minimal test app"
+        assert spec.default_stable is True
+        assert spec.skip_exceptions == (Exception,)
+        assert _first_router_path(spec.router) == definition["path"]
+
+    assert import_calls == [
+        str(definition["module_name"])
+        for definition in router_definitions
+    ]
+    assert access_count == {
+        f"{definition['module_name']}.router": 1
+        for definition in router_definitions
+    }
+
+
+def test_iter_minimal_optional_router_specs_skips_guardian_safety_runtime_import_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal guardian/safety specs preserve broad import failure skipping."""
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    guardian_modules = {
+        "tldw_Server_API.app.api.v1.endpoints.guardian_controls",
+        "tldw_Server_API.app.api.v1.endpoints.family_wizard",
+        "tldw_Server_API.app.api.v1.endpoints.self_monitoring",
+    }
+
+    specs = list(iter_minimal_optional_router_specs())
+    selected_specs = {
+        spec.name: spec
+        for spec in specs
+        if spec.name in {"guardian_controls", "family_wizard", "self_monitoring"}
+    }
+    assert set(selected_specs) == {"guardian_controls", "family_wizard", "self_monitoring"}
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Crash only the selected guardian/safety router imports at registration."""
+        if module_name in guardian_modules:
+            raise RuntimeError(f"{module_name} exploded during import")
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    debug_messages: list[str] = []
+    monkeypatch.setattr("loguru.logger.debug", debug_messages.append)
+
+    assert register_router_specs(FastAPI(), selected_specs.values()) == 0
+    assert debug_messages == [
+        "Skipping guardian_controls router in minimal test app: "
+        "tldw_Server_API.app.api.v1.endpoints.guardian_controls exploded during import",
+        "Skipping family_wizard router in minimal test app: "
+        "tldw_Server_API.app.api.v1.endpoints.family_wizard exploded during import",
+        "Skipping self_monitoring router in minimal test app: "
+        "tldw_Server_API.app.api.v1.endpoints.self_monitoring exploded during import",
+    ]
+
+
 def test_iter_minimal_optional_router_specs_populates_llm_specs(monkeypatch: pytest.MonkeyPatch) -> None:
     from tldw_Server_API.app.api.v1.router_groups.minimal import iter_minimal_optional_router_specs
 


### PR DESCRIPTION
## Summary
- Converts minimal-test guardian controls, family wizard, and self-monitoring router registrations to ImportedRouterSpec-backed lazy specs.
- Preserves existing prefixes, tags, route_key/default_stable behavior, and broad minimal-test import failure skipping with skip_exceptions=(Exception,).
- Adds TASK-76 tracking and focused regression coverage for lazy resolution plus RuntimeError skip behavior.

## Test Plan
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "guardian_safety_attr_lookup or guardian_safety_runtime_import_failures" -q (red before implementation, green after)
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/router_groups/minimal.py -f json -o /tmp/bandit_phase2_2_minimal_guardian_router_conditionals.json
- [x] git diff --check

Refs #1116