### PR TITLE
Refresh sandbox capability gate inventory

### DIFF
--- a/Docs/Sandbox/sandbox-runtime-capability-inventory.md
+++ b/Docs/Sandbox/sandbox-runtime-capability-inventory.md
@@ -271,7 +271,7 @@ not generalized until other runtimes have an equally clear ownership model.
 | Rich structured error metadata beyond the first normalized alias pass remains incomplete. | all | Phase 3 |
 | Cross-runtime session behavior contract tests and recovery flows remain incomplete beyond the discovery-level `session_contract`. | all | Phase 4 |
 | Recovery/repair ownership exists only for `vz_linux`. | all except `vz_linux` | Phase 4 |
-| CI has no single cross-runtime capability gate. | all | Phase 5 |
+| No single CI job proves real execution for every runtime; the portable capability gate covers capability contracts only. | all | Phase 5 |
 
 ## Maintenance Rules
 

--- a/backlog/tasks/task-75 - Refresh-sandbox-capability-inventory-after-portable-gate.md
+++ b/backlog/tasks/task-75 - Refresh-sandbox-capability-inventory-after-portable-gate.md
@@ -44,7 +44,7 @@ Update the sandbox runtime capability inventory after the portable runtime capab
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-- Worktree: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/sandbox-capability-inventory-refresh`.
+- Worktree: `<local-worktree-path>`.
 - Scope is intentionally docs/test-maintenance only. Do not change runtime behavior.
 - RED: `python -m pytest tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py::test_portable_runtime_capability_gate_inventory_no_longer_lists_gate_as_missing -q` failed because the inventory still contained `CI has no single cross-runtime capability gate`.
 - Updated the current gaps table to replace the stale capability-gate gap with a narrower real-execution CI gap: the portable gate covers capability contracts only.
@@ -53,7 +53,10 @@ Update the sandbox runtime capability inventory after the portable runtime capab
 - Verification: `python -m py_compile tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py` passed.
 - Verification: `python -m ruff check tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py` passed.
 - Verification: `git diff --check` passed.
-- Bandit skipped: this slice changed only tests, documentation, and Backlog task metadata; no production Python changed.
+- Review fix: replaced the exact positive documentation phrase assertion with a regex-backed section check that tolerates harmless wording and line wrapping while preserving the host-gated real-execution versus portable capability-contract distinction.
+- Review fix: removed the committed local absolute worktree path from the task notes.
+- Review verification: `python -m bandit -r tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py -f json -o /tmp/bandit_sandbox_capability_inventory_refresh_tests.json` ran on the touched test file and reported only pytest assert-use findings (`B101`).
+- Review verification: `python -m bandit -r tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py -s B101 -f json -o /tmp/bandit_sandbox_capability_inventory_refresh_tests_no_b101.json` reported 0 findings after excluding pytest assert-use noise.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-75 - Refresh-sandbox-capability-inventory-after-portable-gate.md
+++ b/backlog/tasks/task-75 - Refresh-sandbox-capability-inventory-after-portable-gate.md
@@ -1,0 +1,63 @@
+---
+id: TASK-75
+title: Refresh sandbox capability inventory after portable gate
+status: Done
+assignee: []
+created_date: '2026-05-05 16:13'
+labels:
+  - sandbox
+  - runtime-capability
+  - documentation
+dependencies: []
+documentation:
+  - Docs/Sandbox/sandbox-runtime-capability-inventory.md
+  - Docs/superpowers/specs/2026-05-02-sandbox-module-roadmap-design.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Update the sandbox runtime capability inventory after the portable runtime capability gate landed so the current gaps section no longer claims there is no single cross-runtime capability gate. Keep this as a narrow documentation/test-maintenance slice that preserves the distinction between portable capability-contract coverage and host-gated real runtime smoke coverage.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [x] #1 The inventory current gaps section no longer says CI has no single cross-runtime capability gate now that the portable gate exists.
+- [x] #2 The inventory still clearly states that real runtime execution remains covered by host-gated smoke tests and is not proven by the portable gate.
+- [x] #3 A focused docs or sandbox verification command is run and recorded.
+- [x] #4 No production runtime behavior is changed in this slice.
+<!-- AC:END -->
+
+## Definition of Done
+
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Worktree: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/sandbox-capability-inventory-refresh`.
+- Scope is intentionally docs/test-maintenance only. Do not change runtime behavior.
+- RED: `python -m pytest tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py::test_portable_runtime_capability_gate_inventory_no_longer_lists_gate_as_missing -q` failed because the inventory still contained `CI has no single cross-runtime capability gate`.
+- Updated the current gaps table to replace the stale capability-gate gap with a narrower real-execution CI gap: the portable gate covers capability contracts only.
+- GREEN: `python -m pytest tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py::test_portable_runtime_capability_gate_inventory_no_longer_lists_gate_as_missing -q` passed.
+- Verification: `python -m pytest tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py -q` passed with 4 tests.
+- Verification: `python -m py_compile tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py` passed.
+- Verification: `python -m ruff check tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py` passed.
+- Verification: `git diff --check` passed.
+- Bandit skipped: this slice changed only tests, documentation, and Backlog task metadata; no production Python changed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Refreshed the sandbox runtime capability inventory after the portable capability gate landed. The current gaps table no longer says the project lacks a cross-runtime capability gate; it now records the narrower remaining gap that no single CI job proves real execution for every runtime, while the portable gate covers capability contracts only. Added a regression assertion to keep the stale wording from returning.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py
+++ b/tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py
@@ -147,3 +147,14 @@ def test_portable_runtime_capability_gate_is_documented_for_every_runtime(
         assert _runtime_name_is_documented(text, runtime), (
             f"{runtime.value} missing from inventory"
         )
+
+
+def test_portable_runtime_capability_gate_inventory_no_longer_lists_gate_as_missing(
+    pytestconfig: pytest.Config,
+) -> None:
+    repo_root = Path(pytestconfig.rootpath)
+    inventory = repo_root / "Docs" / "Sandbox" / "sandbox-runtime-capability-inventory.md"
+    text = inventory.read_text(encoding="utf-8")
+
+    assert "CI has no single cross-runtime capability gate" not in text
+    assert "Host-gated smoke tests still own real runtime execution" in text

--- a/tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py
+++ b/tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py
@@ -67,6 +67,30 @@ def _runtime_name_is_documented(text: str, runtime: RuntimeType) -> bool:
     return re.search(pattern, text) is not None
 
 
+def _markdown_section(text: str, heading: str) -> str:
+    match = re.search(
+        rf"^## {re.escape(heading)}\n(?P<body>.*?)(?=^## |\Z)",
+        text,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    return match.group("body") if match else ""
+
+
+def _portable_gate_scope_is_documented(text: str) -> bool:
+    section = _markdown_section(text, "Portable Runtime Capability Gate")
+    has_host_gated_real_execution = re.search(
+        r"\bhost[- ]gated\b.*\breal\s+runtime\s+execution\b",
+        section,
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+    has_portable_capability_contract = re.search(
+        r"\bportable\b.*\bcapability\s+contract",
+        section,
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+    return bool(has_host_gated_real_execution and has_portable_capability_contract)
+
+
 def test_portable_runtime_capability_gate_covers_all_runtime_discovery_rows(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -157,4 +181,4 @@ def test_portable_runtime_capability_gate_inventory_no_longer_lists_gate_as_miss
     text = inventory.read_text(encoding="utf-8")
 
     assert "CI has no single cross-runtime capability gate" not in text
-    assert "Host-gated smoke tests still own real runtime execution" in text
+    assert _portable_gate_scope_is_documented(text)


### PR DESCRIPTION
## Summary
- Refresh the sandbox runtime capability inventory after the portable capability gate landed.
- Replace the stale gap that claimed there is no single cross-runtime capability gate with the narrower remaining real-execution CI gap.
- Add a regression assertion to keep the stale wording from returning, with a section-scoped docs check instead of exact prose coupling.

## Test Plan
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py -q`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py -s B101 -f json -o /tmp/bandit_sandbox_capability_inventory_refresh_tests_no_b101.json` (0 findings; raw Bandit on this pytest file reports only B101 assert-use findings)
- [x] `git diff --check`

## Change Summary

Pending human-authored change summary before merge.