### PR TITLE
Stabilize workspace playground Vitest mocks

### DIFF
--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/WorkspacePlayground.stage13.source-transfer.test.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/WorkspacePlayground.stage13.source-transfer.test.tsx
@@ -265,7 +265,12 @@ vi.mock("@/store/tutorials", () => ({
 
 vi.mock("@/store/workspace", () => ({
   useWorkspaceStore: (selector: (state: typeof testState) => unknown) =>
-    selector(testState)
+    selector(testState),
+  createWorkspaceStorage: () => ({
+    getItem: vi.fn(() => null),
+    setItem: vi.fn(),
+    removeItem: vi.fn()
+  })
 }))
 
 vi.mock("@/utils/workspace-playground-prefill", () => ({

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/WorkspacePlayground.stage13.source-transfer.test.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/WorkspacePlayground.stage13.source-transfer.test.tsx
@@ -40,6 +40,23 @@ const mockMessageApi = {
   error: vi.fn(),
   destroy: vi.fn()
 }
+const { workspaceStorage, workspaceStorageItems } = vi.hoisted(() => {
+  const storageItems = new Map<string, string>()
+  const storage = {
+    getItem: vi.fn((key: string) => storageItems.get(key) ?? null),
+    setItem: vi.fn(async (key: string, value: string) => {
+      storageItems.set(key, value)
+    }),
+    removeItem: vi.fn(async (key: string) => {
+      storageItems.delete(key)
+    })
+  }
+
+  return {
+    workspaceStorage: storage,
+    workspaceStorageItems: storageItems
+  }
+})
 
 const destinationWorkspaceId = "workspace-destination"
 const archivedWorkspaceId = "workspace-archived"
@@ -266,11 +283,7 @@ vi.mock("@/store/tutorials", () => ({
 vi.mock("@/store/workspace", () => ({
   useWorkspaceStore: (selector: (state: typeof testState) => unknown) =>
     selector(testState),
-  createWorkspaceStorage: () => ({
-    getItem: vi.fn(() => null),
-    setItem: vi.fn(),
-    removeItem: vi.fn()
-  })
+  createWorkspaceStorage: () => workspaceStorage
 }))
 
 vi.mock("@/utils/workspace-playground-prefill", () => ({
@@ -412,6 +425,7 @@ describe("WorkspacePlayground stage 13 source transfer", () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    workspaceStorageItems.clear()
     clearWorkspaceUndoActionsForTests()
     testState.isMobile = false
     testState.storeHydrated = true

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/WorkspacePlayground.stage9.persistence.test.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/WorkspacePlayground.stage9.persistence.test.tsx
@@ -7,10 +7,30 @@ import {
 } from "@/store/workspace-events"
 import { WorkspacePlayground } from "../index"
 
-const { mockGetMediaDetails, useWorkspaceStoreMock } = vi.hoisted(() => ({
-  mockGetMediaDetails: vi.fn(),
-  useWorkspaceStoreMock: vi.fn()
-}))
+const {
+  mockGetMediaDetails,
+  useWorkspaceStoreMock,
+  workspaceStorage,
+  workspaceStorageItems
+} = vi.hoisted(() => {
+  const storageItems = new Map<string, string>()
+  const storage = {
+    getItem: vi.fn((key: string) => storageItems.get(key) ?? null),
+    setItem: vi.fn(async (key: string, value: string) => {
+      storageItems.set(key, value)
+    }),
+    removeItem: vi.fn(async (key: string) => {
+      storageItems.delete(key)
+    })
+  }
+
+  return {
+    mockGetMediaDetails: vi.fn(),
+    useWorkspaceStoreMock: vi.fn(),
+    workspaceStorage: storage,
+    workspaceStorageItems: storageItems
+  }
+})
 
 const testState = {
   isMobile: false,
@@ -95,11 +115,7 @@ vi.mock("@/hooks/useMediaQuery", () => ({
 
 vi.mock("@/store/workspace", () => ({
   useWorkspaceStore: useWorkspaceStoreMock,
-  createWorkspaceStorage: () => ({
-    getItem: vi.fn(() => null),
-    setItem: vi.fn(),
-    removeItem: vi.fn()
-  })
+  createWorkspaceStorage: () => workspaceStorage
 }))
 
 vi.mock("@/services/tldw/TldwApiClient", () => ({
@@ -169,6 +185,7 @@ describe("WorkspacePlayground stage 9 persistence resilience", () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    workspaceStorageItems.clear()
     useWorkspaceStoreMock.mockImplementation(
       (selector: (state: typeof testState) => unknown) => selector(testState)
     )

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/WorkspacePlayground.stage9.persistence.test.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/WorkspacePlayground.stage9.persistence.test.tsx
@@ -94,7 +94,12 @@ vi.mock("@/hooks/useMediaQuery", () => ({
 }))
 
 vi.mock("@/store/workspace", () => ({
-  useWorkspaceStore: useWorkspaceStoreMock
+  useWorkspaceStore: useWorkspaceStoreMock,
+  createWorkspaceStorage: () => ({
+    getItem: vi.fn(() => null),
+    setItem: vi.fn(),
+    removeItem: vi.fn()
+  })
 }))
 
 vi.mock("@/services/tldw/TldwApiClient", () => ({
@@ -213,8 +218,11 @@ describe("WorkspacePlayground stage 9 persistence resilience", () => {
     expect(screen.getByRole("button", { name: "Save as new workspace" })).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Keep this version" })).toBeInTheDocument()
     expect(
+      screen.getByText("Recommended: Reload to get the latest version.")
+    ).toBeInTheDocument()
+    expect(
       screen.getByText(
-        "Reload from other tab refreshes this tab. Keep this version ignores the update. Save as new workspace copies your current state."
+        "Keep this version ignores the update. Save as new workspace copies your current state."
       )
     ).toBeInTheDocument()
   })


### PR DESCRIPTION
Summary:
- Add the missing createWorkspaceStorage export to WorkspacePlayground parent-test mocks that render the full route shell.
- Update the stage 9 storage-sync banner assertion to match the current visible recovery copy.

Why:
- The next local frontend Vitest baseline showed repeated failures before assertions because these tests fully mocked @/store/workspace after WorkspacePlayground started reading onboarding-dismissed state through createWorkspaceStorage.
- This keeps the follow-up PR narrow after the TypeScript gate PR merged.

Verification:
- bunx vitest run src/components/Option/WorkspacePlayground/__tests__/WorkspacePlayground.stage9.persistence.test.tsx src/components/Option/WorkspacePlayground/__tests__/WorkspacePlayground.stage13.source-transfer.test.tsx --testTimeout=10000
- node node_modules/typescript/bin/tsc --noEmit --pretty false -p tsconfig.json
- git diff --check

Task: TASK-60

Merge note:
- Per project policy, this AI-authored PR still needs the human requester to add or confirm a human-owned Change summary before merge.