### PR TITLE
Phase 2.2: defer minimal persona notes imports

### DIFF
--- a/backlog/tasks/task-77 - Phase-2.2-minimal-persona-notes-router-conditional-cleanup-AI.md
+++ b/backlog/tasks/task-77 - Phase-2.2-minimal-persona-notes-router-conditional-cleanup-AI.md
@@ -1,0 +1,64 @@
+---
+id: TASK-77
+title: Phase 2.2 minimal persona notes router conditional cleanup AI
+status: Done
+assignee: []
+created_date: '2026-05-05 16:35'
+updated_date: '2026-05-05 16:37'
+labels:
+  - phase2.2
+  - router-cleanup
+  - issue-1116
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+  - 'https://github.com/rmusser01/tldw_server/pull/1309'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue issue #1116 Phase 2.2 after PR #1309. Convert the next small minimal-test optional persona/notes registrations from eager try/import RouterSpec blocks to ImportedRouterSpec-backed lazy router specs. Scope is limited to persona, archetype_endpoints, and notes in tldw_Server_API/app/api/v1/router_groups/minimal.py. Preserve prefixes, tags, route_key behavior, default_stable behavior, and the existing minimal-test broad skip behavior for import-time failures.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Persona, persona archetype, and notes minimal optional specs defer module import and router attribute lookup until registration
+- [x] #2 Existing route metadata is preserved for persona, persona archetype, and notes
+- [x] #3 Focused router-group tests cover lazy behavior and broad import failure skipping with red/green verification
+- [x] #4 Router-group contract tests and touched-source Bandit pass
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused contract coverage for the minimal persona/notes specs.
+2. Run the focused selection red against the current eager try/import blocks.
+3. Convert only persona, archetype_endpoints, and notes to ImportedRouterSpec entries while preserving metadata and skip semantics.
+4. Rerun focused tests, full router_groups contract tests, Bandit on minimal.py, git diff --check, and status before commit.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Started after PR #1309 merge was verified at merge commit dda18105ac1f739d05c373e68f06b2c269e14dc4. Worktree: /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/phase2-2-minimal-persona-notes-router-conditionals-ai. Branch: codex/phase2-2-minimal-persona-notes-router-conditionals-ai. Baseline full test_router_groups_contract.py passed with 79 tests before edits.
+
+Implemented the persona/notes minimal router tranche. Added red/green focused contract coverage proving persona, archetype_endpoints, and notes defer module import/router attribute lookup until registration and preserve broad skip_exceptions=(Exception,) behavior for RuntimeError import failures. Converted only those three eager try/import RouterSpec blocks to ImportedRouterSpec-backed lazy specs while preserving prefixes, tags, route_key, and default_stable behavior. Verification: focused selection persona_notes_attr_lookup or persona_notes_runtime_import_failures failed red before the source change and passed after implementation; full test_router_groups_contract.py passed with 81 tests; test_main_router_contract.py passed with 6 tests; Bandit on minimal.py reported 0 results and 0 errors; git diff --check was clean.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Converted minimal optional persona, persona archetype, and notes router registrations to ImportedRouterSpec-backed lazy specs. The change keeps the prior minimal-test broad import-failure skip behavior by explicitly setting skip_exceptions=(Exception,) while deferring endpoint imports until registration. Added focused regression coverage for lazy router resolution and RuntimeError import-failure skipping. Verification covered red/green focused tests, full router_groups contract tests, main router contract tests, Bandit, and diff check.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-77 - Phase-2.2-minimal-persona-notes-router-conditional-cleanup-AI.md
+++ b/backlog/tasks/task-77 - Phase-2.2-minimal-persona-notes-router-conditional-cleanup-AI.md
@@ -4,7 +4,7 @@ title: Phase 2.2 minimal persona notes router conditional cleanup AI
 status: Done
 assignee: []
 created_date: '2026-05-05 16:35'
-updated_date: '2026-05-05 16:37'
+updated_date: '2026-05-05 17:31'
 labels:
   - phase2.2
   - router-cleanup
@@ -26,17 +26,17 @@ Continue issue #1116 Phase 2.2 after PR #1309. Convert the next small minimal-te
 <!-- AC:BEGIN -->
 - [x] #1 Persona, persona archetype, and notes minimal optional specs defer module import and router attribute lookup until registration
 - [x] #2 Existing route metadata is preserved for persona, persona archetype, and notes
-- [x] #3 Focused router-group tests cover lazy behavior and broad import failure skipping with red/green verification
+- [x] #3 Focused router-group tests cover lazy behavior and broad import failure skipping with red-green verification
 - [x] #4 Router-group contract tests and touched-source Bandit pass
 <!-- AC:END -->
 
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-1. Add focused contract coverage for the minimal persona/notes specs.
-2. Run the focused selection red against the current eager try/import blocks.
-3. Convert only persona, archetype_endpoints, and notes to ImportedRouterSpec entries while preserving metadata and skip semantics.
-4. Rerun focused tests, full router_groups contract tests, Bandit on minimal.py, git diff --check, and status before commit.
+1. Keep the persona/notes lazy-spec implementation unchanged unless verification shows the review comments require source changes.
+2. Replace the branch-local task record's review-flagged wording with red-green.
+3. Harden test_iter_minimal_optional_router_specs_defers_persona_notes_attr_lookup so selected persona/archetype/notes imports through builtins.__import__ are recorded and asserted absent during spec construction.
+4. Run the focused router-group tests, Bandit on touched Python scope, git diff --check, update the task record, commit, push, and re-check unresolved PR review threads.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -44,13 +44,19 @@ Continue issue #1116 Phase 2.2 after PR #1309. Convert the next small minimal-te
 <!-- SECTION:NOTES:BEGIN -->
 Started after PR #1309 merge was verified at merge commit dda18105ac1f739d05c373e68f06b2c269e14dc4. Worktree: /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/phase2-2-minimal-persona-notes-router-conditionals-ai. Branch: codex/phase2-2-minimal-persona-notes-router-conditionals-ai. Baseline full test_router_groups_contract.py passed with 79 tests before edits.
 
-Implemented the persona/notes minimal router tranche. Added red/green focused contract coverage proving persona, archetype_endpoints, and notes defer module import/router attribute lookup until registration and preserve broad skip_exceptions=(Exception,) behavior for RuntimeError import failures. Converted only those three eager try/import RouterSpec blocks to ImportedRouterSpec-backed lazy specs while preserving prefixes, tags, route_key, and default_stable behavior. Verification: focused selection persona_notes_attr_lookup or persona_notes_runtime_import_failures failed red before the source change and passed after implementation; full test_router_groups_contract.py passed with 81 tests; test_main_router_contract.py passed with 6 tests; Bandit on minimal.py reported 0 results and 0 errors; git diff --check was clean.
+Implemented the persona/notes minimal router tranche. Added red-green focused contract coverage proving persona, archetype_endpoints, and notes defer module import/router attribute lookup until registration and preserve broad skip_exceptions=(Exception,) behavior for RuntimeError import failures. Converted only those three eager try/import RouterSpec blocks to ImportedRouterSpec-backed lazy specs while preserving prefixes, tags, route_key, and default_stable behavior. Verification: focused selection persona_notes_attr_lookup or persona_notes_runtime_import_failures failed red before the source change and passed after implementation; full test_router_groups_contract.py passed with 81 tests; test_main_router_contract.py passed with 6 tests; Bandit on minimal.py reported 0 results and 0 errors; git diff --check was clean.
+
+Review follow-up for PR #1313 started. Verified two unresolved CodeRabbit threads: task wording red-green hyphenation and persona/notes lazy test import tracking through builtins.__import__.
+
+PR #1313 review follow-up implemented. Replaced branch-local task wording with red-green and hardened the persona/notes lazy-spec test to record selected endpoint imports through builtins.__import__ before asserting none occur during spec construction. Verification: focused router contract selection passed with 2 passed and 79 deselected; full test_router_groups_contract.py passed with 81 passed; git diff --check passed; Bandit on test_router_groups_contract.py with B101 skipped reported 0 results; Bandit on router_groups/minimal.py reported 0 results.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Converted minimal optional persona, persona archetype, and notes router registrations to ImportedRouterSpec-backed lazy specs. The change keeps the prior minimal-test broad import-failure skip behavior by explicitly setting skip_exceptions=(Exception,) while deferring endpoint imports until registration. Added focused regression coverage for lazy router resolution and RuntimeError import-failure skipping. Verification covered red/green focused tests, full router_groups contract tests, main router contract tests, Bandit, and diff check.
+Converted minimal optional persona, persona archetype, and notes router registrations to ImportedRouterSpec-backed lazy specs. The change keeps the prior minimal-test broad import-failure skip behavior by explicitly setting skip_exceptions=(Exception,) while deferring endpoint imports until registration. Added focused regression coverage for lazy router resolution and RuntimeError import-failure skipping. Verification covered red-green focused tests, full router_groups contract tests, main router contract tests, Bandit, and diff check.
+
+PR #1313 review follow-up addressed both unresolved CodeRabbit threads: task wording now uses red-green consistently, and persona/notes lazy-spec coverage now tracks selected builtins.__import__ imports during spec construction.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -527,38 +527,33 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
     ):
         append_imported_router_spec(specs, guardian_safety_spec)
 
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.persona import router as persona_router
-
-        specs.append(RouterSpec(
-            router=persona_router,
+    for persona_notes_spec in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.persona",
+            log_name="persona",
             prefix=f"{API_V1_PREFIX}/persona",
             tags=("persona",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping persona router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.archetype_endpoints import router as archetype_router
-
-        specs.append(RouterSpec(
-            router=archetype_router,
+            skip_context=minimal_skip_context,
+            skip_exceptions=(Exception,),
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.archetype_endpoints",
+            log_name="archetype",
             prefix=f"{API_V1_PREFIX}/persona/archetypes",
             tags=("persona-archetypes",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping archetype router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.notes import router as notes_router
-
-        specs.append(RouterSpec(
-            router=notes_router,
+            skip_context=minimal_skip_context,
+            skip_exceptions=(Exception,),
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.notes",
+            log_name="notes",
             prefix=f"{API_V1_PREFIX}/notes",
             tags=("notes",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping notes router in minimal test app: {e}")
+            skip_context=minimal_skip_context,
+            skip_exceptions=(Exception,),
+        ),
+    ):
+        append_imported_router_spec(specs, persona_notes_spec)
 
     try:
         from tldw_Server_API.app.api.v1.endpoints.web_clipper import router as web_clipper_router

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -5177,6 +5177,210 @@ def test_iter_minimal_optional_router_specs_skips_guardian_safety_runtime_import
     ]
 
 
+def test_iter_minimal_optional_router_specs_defers_persona_notes_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal persona/notes specs keep router attr lookup lazy."""
+    import builtins
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    router_definitions = (
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.persona",
+            "expected_name": "persona",
+            "path": "/persona/status",
+            "prefix": "/api/v1/persona",
+            "tags": ("persona",),
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.archetype_endpoints",
+            "expected_name": "archetype",
+            "path": "/archetypes",
+            "prefix": "/api/v1/persona/archetypes",
+            "tags": ("persona-archetypes",),
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.notes",
+            "expected_name": "notes",
+            "path": "/notes",
+            "prefix": "/api/v1/notes",
+            "tags": ("notes",),
+        },
+    )
+    definitions_by_module = {
+        str(definition["module_name"]): definition
+        for definition in router_definitions
+    }
+    access_count = {
+        f"{definition['module_name']}.router": 0
+        for definition in router_definitions
+    }
+    import_calls: list[str] = []
+
+    for module_name, definition in definitions_by_module.items():
+        fake_module = ModuleType(module_name)
+        router = APIRouter()
+
+        @router.get(str(definition["path"]))
+        def _endpoint() -> dict[str, str]:
+            """Return a deterministic response for the fake minimal router."""
+            return {"status": "ok"}
+
+        def _module_getattr(
+            name: str,
+            *,
+            module_name: str = module_name,
+            router: APIRouter = router,
+        ) -> APIRouter:
+            """Track lazy router attribute resolution for the fake module."""
+            if name != "router":
+                raise AttributeError(name)
+            access_count[f"{module_name}.router"] += 1
+            return router
+
+        fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    endpoints_package = "tldw_Server_API.app.api.v1.endpoints."
+    real_import = builtins.__import__
+
+    def _fake_endpoint_import(
+        name: str,
+        globals: dict[str, object] | None = None,
+        locals: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> ModuleType:
+        """Return fake routers for unrelated eager minimal optional imports."""
+        if (
+            level == 0
+            and name.startswith(endpoints_package)
+            and name not in definitions_by_module
+        ):
+            attrs = tuple(attr for attr in fromlist if attr != "*") or ("router",)
+            for attr_name in attrs:
+                _install_fake_router_module(
+                    monkeypatch,
+                    name,
+                    path="/minimal-unrelated-persona-notes-fake",
+                    attr_name=attr_name,
+                )
+            return sys.modules[name]
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_endpoint_import)
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Track lazy module imports for selected minimal persona/notes routers."""
+        if module_name in definitions_by_module:
+            import_calls.append(module_name)
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+    fake_main = ModuleType("tldw_Server_API.app.main")
+    fake_main.app = FastAPI()  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "tldw_Server_API.app.main", fake_main)
+
+    specs = list(iter_minimal_optional_router_specs())
+    assert access_count == {
+        f"{definition['module_name']}.router": 0
+        for definition in router_definitions
+    }
+    assert import_calls == []
+
+    selected_specs = {
+        spec.name: spec
+        for spec in specs
+        if spec.name in {
+            str(definition["expected_name"])
+            for definition in router_definitions
+        }
+    }
+    assert set(selected_specs) == {
+        str(definition["expected_name"])
+        for definition in router_definitions
+    }
+
+    for definition in router_definitions:
+        spec = selected_specs[str(definition["expected_name"])]
+        assert spec.prefix == definition["prefix"]
+        assert spec.tags == definition["tags"]
+        assert spec.route_key == ""
+        assert spec.skip_context == "in minimal test app"
+        assert spec.default_stable is True
+        assert spec.skip_exceptions == (Exception,)
+        assert _first_router_path(spec.router) == definition["path"]
+
+    assert import_calls == [
+        str(definition["module_name"])
+        for definition in router_definitions
+    ]
+    assert access_count == {
+        f"{definition['module_name']}.router": 1
+        for definition in router_definitions
+    }
+
+
+def test_iter_minimal_optional_router_specs_skips_persona_notes_runtime_import_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal persona/notes specs preserve broad import failure skipping."""
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    persona_notes_modules = {
+        "tldw_Server_API.app.api.v1.endpoints.persona",
+        "tldw_Server_API.app.api.v1.endpoints.archetype_endpoints",
+        "tldw_Server_API.app.api.v1.endpoints.notes",
+    }
+
+    specs = list(iter_minimal_optional_router_specs())
+    selected_specs = {
+        spec.name: spec
+        for spec in specs
+        if spec.name in {"persona", "archetype", "notes"}
+    }
+    assert set(selected_specs) == {"persona", "archetype", "notes"}
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Crash only the selected persona/notes router imports at registration."""
+        if module_name in persona_notes_modules:
+            raise RuntimeError(f"{module_name} exploded during import")
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    debug_messages: list[str] = []
+    monkeypatch.setattr("loguru.logger.debug", debug_messages.append)
+
+    assert register_router_specs(FastAPI(), selected_specs.values()) == 0
+    assert debug_messages == [
+        "Skipping persona router in minimal test app: "
+        "tldw_Server_API.app.api.v1.endpoints.persona exploded during import",
+        "Skipping archetype router in minimal test app: "
+        "tldw_Server_API.app.api.v1.endpoints.archetype_endpoints exploded during import",
+        "Skipping notes router in minimal test app: "
+        "tldw_Server_API.app.api.v1.endpoints.notes exploded during import",
+    ]
+
+
 def test_iter_minimal_optional_router_specs_populates_llm_specs(monkeypatch: pytest.MonkeyPatch) -> None:
     from tldw_Server_API.app.api.v1.router_groups.minimal import iter_minimal_optional_router_specs
 

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -5255,12 +5255,14 @@ def test_iter_minimal_optional_router_specs_defers_persona_notes_attr_lookup(
         fromlist: tuple[str, ...] = (),
         level: int = 0,
     ) -> ModuleType:
-        """Return fake routers for unrelated eager minimal optional imports."""
+        """Track selected imports and fake unrelated eager optional routers."""
         if (
             level == 0
             and name.startswith(endpoints_package)
-            and name not in definitions_by_module
         ):
+            if name in definitions_by_module:
+                import_calls.append(name)
+                return real_import(name, globals, locals, fromlist, level)
             attrs = tuple(attr for attr in fromlist if attr != "*") or ("router",)
             for attr_name in attrs:
                 _install_fake_router_module(
@@ -5291,6 +5293,11 @@ def test_iter_minimal_optional_router_specs_defers_persona_notes_attr_lookup(
     monkeypatch.setitem(sys.modules, "tldw_Server_API.app.main", fake_main)
 
     specs = list(iter_minimal_optional_router_specs())
+    assert [
+        module_name
+        for module_name in definitions_by_module
+        if module_name in import_calls
+    ] == []
     assert access_count == {
         f"{definition['module_name']}.router": 0
         for definition in router_definitions


### PR DESCRIPTION
## Summary
- Converts minimal-test persona, persona archetype, and notes router registrations to ImportedRouterSpec-backed lazy specs.
- Preserves existing prefixes, tags, route_key/default_stable behavior, and broad minimal-test import failure skipping with skip_exceptions=(Exception,).
- Adds TASK-77 tracking and focused regression coverage for lazy resolution plus RuntimeError skip behavior.

## Test Plan
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "persona_notes_attr_lookup or persona_notes_runtime_import_failures" -q (red before implementation, green after)
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/router_groups/minimal.py -f json -o /tmp/bandit_phase2_2_minimal_persona_notes_router_conditionals.json
- [x] git diff --check

Refs #1116