### PR TITLE
Migrate Chat and Playground status chips to Badge

### DIFF
--- a/apps/packages/ui/src/components/Common/Playground/PlaygroundUserMessage.tsx
+++ b/apps/packages/ui/src/components/Common/Playground/PlaygroundUserMessage.tsx
@@ -3,7 +3,7 @@ import { useStorage } from "@plasmohq/storage/hook"
 import React from "react"
 import { useTranslation } from "react-i18next"
 import { EditMessageForm } from "./EditMessageForm"
-import { Image, Tag, Tooltip } from "antd"
+import { Image, Tooltip } from "antd"
 import {
   CheckIcon,
   CopyIcon,
@@ -19,13 +19,29 @@ import { DocumentChip } from "./DocumentChip"
 import { DocumentFile } from "./DocumentFile"
 import { buildChatTextClass } from "@/utils/chat-style"
 import { IconButton } from "../IconButton"
-import { tagColors } from "@/utils/color"
 import { useUiModeStore } from "@/store/ui-mode"
 import { useStoreMessageOption } from "@/store/option"
 import { EDIT_MESSAGE_EVENT } from "@/utils/timeline-actions"
+import { Badge, type BadgeVariant } from "@/components/ui/primitives"
 
 const ACTION_BUTTON_CLASS =
   "flex items-center justify-center rounded-full border border-border bg-surface2 text-text-muted hover:bg-surface hover:text-text transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-focus min-w-[44px] min-h-[44px]"
+
+const MESSAGE_TYPE_BADGE_VARIANT: Record<string, BadgeVariant> = {
+  summary: "info",
+  explain: "success",
+  translate: "demo",
+  custom: "primary",
+  rephrase: "warning",
+  greeting: "demo",
+  "character:greeting": "demo"
+}
+
+const getMessageTypeBadgeVariant = (messageType?: string): BadgeVariant => {
+  if (!messageType) return "secondary"
+  if (messageType.startsWith("compare")) return "secondary"
+  return MESSAGE_TYPE_BADGE_VARIANT[messageType] ?? "info"
+}
 
 type Props = {
   message: string
@@ -42,13 +58,13 @@ type Props = {
   onRegenerate: () => void
   onEditFormSubmit: (value: string, isSend: boolean) => void
   isProcessing: boolean
-  webSearch?: {}
+  webSearch?: unknown
   isSearchingInternet?: boolean
-  sources?: any[]
+  sources?: unknown[]
   hideEditAndRegenerate?: boolean
-  onSourceClick?: (source: any) => void
+  onSourceClick?: (source: unknown) => void
   isTTSEnabled?: boolean
-  generationInfo?: any
+  generationInfo?: unknown
   isStreaming: boolean
   reasoningTimeTaken?: number
   openReasoning?: boolean
@@ -168,9 +184,14 @@ export const PlaygroundUserMessageBubble: React.FC<Props> = (props) => {
       <div className="flex w-full flex-wrap items-center justify-end gap-2">
         <div className="flex flex-wrap items-center gap-2">
           {isSystemMessage ? (
-            <span className="inline-flex items-center rounded-full border border-warn/40 bg-warn/10 px-2 py-0.5 text-xs font-medium text-warn">
+            <Badge
+              data-testid="playground-system-message-badge"
+              variant="warning"
+              size="sm"
+              outline
+            >
               {systemLabel}
-            </span>
+            </Badge>
           ) : (
             <span className="text-caption font-semibold text-text">
               {userDisplayName.trim() || t("common:you", "You")}
@@ -182,11 +203,14 @@ export const PlaygroundUserMessageBubble: React.FC<Props> = (props) => {
             </span>
           )}
           {!editMode && props?.message_type && (
-            <Tag
+            <Badge
+              data-testid="playground-message-type-badge"
+              variant={getMessageTypeBadgeVariant(props.message_type)}
+              size="sm"
               className="!m-0"
-              color={tagColors[props?.message_type] || "default"}>
+            >
               {t(`copilot.${props?.message_type}`)}
-            </Tag>
+            </Badge>
           )}
         </div>
       </div>

--- a/apps/packages/ui/src/components/Common/Playground/PlaygroundUserMessage.tsx
+++ b/apps/packages/ui/src/components/Common/Playground/PlaygroundUserMessage.tsx
@@ -43,6 +43,20 @@ const getMessageTypeBadgeVariant = (messageType?: string): BadgeVariant => {
   return MESSAGE_TYPE_BADGE_VARIANT[messageType] ?? "info"
 }
 
+const formatMessageTypeFallback = (messageType?: string): string => {
+  if (!messageType) return "Unknown"
+  const words = messageType
+    .split(/[:_\-\s]+/)
+    .filter(Boolean)
+  if (words.length === 0) return "Unknown"
+  return words
+    .map((word) => word.toLowerCase())
+    .map((word, index) =>
+      index === 0 ? `${word.charAt(0).toUpperCase()}${word.slice(1)}` : word
+    )
+    .join(" ")
+}
+
 type Props = {
   message: string
   message_type?: string
@@ -209,7 +223,10 @@ export const PlaygroundUserMessageBubble: React.FC<Props> = (props) => {
               size="sm"
               className="!m-0"
             >
-              {t(`copilot.${props?.message_type}`)}
+              {t(
+                `copilot.${props.message_type}`,
+                formatMessageTypeFallback(props.message_type)
+              )}
             </Badge>
           )}
         </div>

--- a/apps/packages/ui/src/components/Common/Playground/__tests__/PlaygroundUserMessage.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Common/Playground/__tests__/PlaygroundUserMessage.design-system.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { PlaygroundUserMessageBubble } from "../PlaygroundUserMessage"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key
+  })
+}))
+
+vi.mock("@plasmohq/storage/hook", () => ({
+  useStorage: (_key: string, defaultValue: unknown) => [defaultValue, vi.fn()]
+}))
+
+vi.mock("antd", () => ({
+  Image: ({ src, alt }: { src?: string; alt?: string }) => (
+    <span role="img" aria-label={alt ?? ""} data-src={src ?? ""} />
+  ),
+  Tooltip: ({ children }: { children?: React.ReactNode }) => <>{children}</>
+}))
+
+vi.mock("@/hooks/useTTS", () => ({
+  useTTS: () => ({
+    cancel: vi.fn(),
+    isSpeaking: false,
+    speak: vi.fn()
+  })
+}))
+
+vi.mock("../HumanMessge", () => ({
+  HumanMessage: ({ message }: { message: string }) => <div>{message}</div>
+}))
+
+vi.mock("../EditMessageForm", () => ({
+  EditMessageForm: () => <div data-testid="edit-message-form" />
+}))
+
+vi.mock("../DocumentChip", () => ({
+  DocumentChip: () => <div data-testid="document-chip" />
+}))
+
+vi.mock("../DocumentFile", () => ({
+  DocumentFile: () => <div data-testid="document-file" />
+}))
+
+vi.mock("@/utils/chat-style", () => ({
+  buildChatTextClass: () => ""
+}))
+
+vi.mock("@/store/ui-mode", () => ({
+  useUiModeStore: (selector: (state: { mode: string }) => unknown) =>
+    selector({ mode: "standard" })
+}))
+
+vi.mock("@/store/option", () => ({
+  useStoreMessageOption: (
+    selector: (state: { setReplyTarget: (...args: unknown[]) => void }) => unknown
+  ) =>
+    selector({
+      setReplyTarget: vi.fn()
+    })
+}))
+
+const renderUserMessage = (
+  props: Partial<React.ComponentProps<typeof PlaygroundUserMessageBubble>> = {}
+) =>
+  render(
+    <PlaygroundUserMessageBubble
+      message="Review this research plan."
+      isBot={false}
+      name="You"
+      currentMessageIndex={0}
+      totalMessages={1}
+      onRegenerate={() => undefined}
+      onEditFormSubmit={() => undefined}
+      isProcessing
+      isStreaming={false}
+      {...props}
+    />
+  )
+
+describe("Playground user message design-system badges", () => {
+  it("renders system and message-type chips through the shared Badge", () => {
+    renderUserMessage({
+      role: "system",
+      message_type: "summary",
+      messageId: "message-1"
+    })
+
+    expect(screen.getByTestId("chat-message")).toHaveAttribute("data-role", "system")
+    expect(screen.getByText("Review this research plan.")).toBeInTheDocument()
+    expect(screen.getByTestId("playground-system-message-badge")).toHaveAttribute(
+      "data-ds-component",
+      "Badge"
+    )
+    expect(screen.getByTestId("playground-system-message-badge")).toHaveTextContent(
+      "System prompt"
+    )
+    expect(screen.getByTestId("playground-message-type-badge")).toHaveAttribute(
+      "data-ds-component",
+      "Badge"
+    )
+    expect(screen.getByTestId("playground-message-type-badge")).toHaveTextContent(
+      "copilot.summary"
+    )
+  })
+})

--- a/apps/packages/ui/src/components/Common/Playground/__tests__/PlaygroundUserMessage.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Common/Playground/__tests__/PlaygroundUserMessage.design-system.test.tsx
@@ -104,7 +104,20 @@ describe("Playground user message design-system badges", () => {
       "Badge"
     )
     expect(screen.getByTestId("playground-message-type-badge")).toHaveTextContent(
-      "copilot.summary"
+      "Summary"
     )
+  })
+
+  it("renders a human-readable fallback for unknown message-type chips", () => {
+    renderUserMessage({
+      message_type: "custom_review",
+      messageId: "message-2"
+    })
+
+    const badge = screen.getByTestId("playground-message-type-badge")
+
+    expect(badge).toHaveAttribute("data-ds-component", "Badge")
+    expect(badge).toHaveTextContent("Custom review")
+    expect(badge).not.toHaveTextContent("copilot.custom_review")
   })
 })

--- a/apps/packages/ui/src/components/Option/Playground/ResearchRunStatusStack.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/ResearchRunStatusStack.tsx
@@ -2,6 +2,7 @@ import React from "react"
 
 import type { ChatLinkedResearchRun } from "@/services/tldw/TldwApiClient"
 import type { ResearchFollowUpTarget } from "./research-chat-context"
+import { Badge, type BadgeVariant } from "@/components/ui/primitives"
 
 import {
   CHAT_LINKED_RESEARCH_VISIBLE_TERMINAL_ROWS,
@@ -17,13 +18,13 @@ type ResearchRunStatusStackProps = {
   onFollowUp?: (target: ResearchFollowUpTarget) => void
 }
 
-const STATUS_BADGE_CLASSNAME: Record<string, string> = {
-  Running: "bg-blue-500/10 text-blue-700 dark:text-blue-300",
-  "Needs review": "bg-amber-500/10 text-amber-700 dark:text-amber-300",
-  Completed: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
-  Failed: "bg-red-500/10 text-red-700 dark:text-red-300",
-  Cancelled: "bg-zinc-500/10 text-zinc-700 dark:text-zinc-300",
-  Paused: "bg-violet-500/10 text-violet-700 dark:text-violet-300"
+const STATUS_BADGE_VARIANT: Record<string, BadgeVariant> = {
+  Running: "info",
+  "Needs review": "warning",
+  Completed: "success",
+  Failed: "danger",
+  Cancelled: "secondary",
+  Paused: "warning"
 }
 
 export const ResearchRunStatusStack: React.FC<ResearchRunStatusStackProps> = ({
@@ -72,11 +73,13 @@ export const ResearchRunStatusStack: React.FC<ResearchRunStatusStackProps> = ({
                 <div className="min-w-0 flex-1">
                   <div className="truncate text-sm font-medium text-text">{run.query}</div>
                   <div className="mt-1 flex items-center gap-2 text-xs text-text-subtle">
-                    <span
-                      className={`inline-flex rounded-full px-2 py-0.5 font-medium ${STATUS_BADGE_CLASSNAME[statusLabel] ?? "bg-muted text-text-subtle"}`}
+                    <Badge
+                      data-testid="research-run-status-badge"
+                      variant={STATUS_BADGE_VARIANT[statusLabel] ?? "secondary"}
+                      size="sm"
                     >
                       {statusLabel}
-                    </span>
+                    </Badge>
                     {actionPolicy.reasonLabel ? <span>{actionPolicy.reasonLabel}</span> : null}
                     <span className="truncate">{run.run_id}</span>
                   </div>

--- a/apps/packages/ui/src/components/Option/Playground/ResearchRunStatusStack.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/ResearchRunStatusStack.tsx
@@ -74,7 +74,7 @@ export const ResearchRunStatusStack: React.FC<ResearchRunStatusStackProps> = ({
                   <div className="truncate text-sm font-medium text-text">{run.query}</div>
                   <div className="mt-1 flex items-center gap-2 text-xs text-text-subtle">
                     <Badge
-                      data-testid="research-run-status-badge"
+                      data-testid={`research-run-status-badge-${run.run_id}`}
                       variant={STATUS_BADGE_VARIANT[statusLabel] ?? "secondary"}
                       size="sm"
                     >

--- a/apps/packages/ui/src/components/Option/Playground/VoiceChatIndicator.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/VoiceChatIndicator.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { useTranslation } from "react-i18next"
 import { StopCircle } from "lucide-react"
+import { Badge, type BadgeVariant } from "@/components/ui/primitives"
 
 interface VoiceChatIndicatorProps {
   state: "idle" | "connecting" | "listening" | "thinking" | "speaking" | "error"
@@ -31,10 +32,31 @@ export const VoiceChatIndicator: React.FC<VoiceChatIndicatorProps> = ({
 
   const stateEmoji = emoji[state] || ""
 
+  const badgeVariant: BadgeVariant = (() => {
+    switch (state) {
+      case "listening":
+        return "success"
+      case "error":
+        return "danger"
+      case "connecting":
+      case "thinking":
+      case "speaking":
+      default:
+        return "primary"
+    }
+  })()
+
   return (
-    <div className="fixed bottom-20 right-4 z-50 flex items-center gap-2 rounded-full bg-surface border border-border px-3 py-2 shadow-lg">
-      <span className="text-lg" aria-hidden="true">{stateEmoji}</span>
-      <span className="text-sm font-medium">{statusLabel}</span>
+    <div className="fixed bottom-20 right-4 z-50 flex items-center gap-2 rounded-full bg-surface border border-border px-2 py-1.5 shadow-lg">
+      <Badge
+        data-testid="voice-chat-status-badge"
+        variant={badgeVariant}
+        size="md"
+        className="gap-1.5"
+      >
+        <span className="text-sm" aria-hidden="true">{stateEmoji}</span>
+        <span>{statusLabel}</span>
+      </Badge>
       <button
         type="button"
         onClick={onStop}

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundStatusBadges.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundStatusBadges.design-system.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import React from "react"
-import { fireEvent, render, screen } from "@testing-library/react"
+import { fireEvent, render, screen, within } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 
 import { ResearchRunStatusStack } from "../ResearchRunStatusStack"
@@ -26,13 +26,35 @@ const linkedRun = (overrides: Partial<ChatLinkedResearchRun>): ChatLinkedResearc
   }) as ChatLinkedResearchRun
 
 describe("Playground status design-system badges", () => {
-  it("renders linked research run status through the shared Badge", () => {
-    render(<ResearchRunStatusStack runs={[linkedRun({})]} />)
+  it("renders linked research run statuses through uniquely addressed shared Badges", () => {
+    render(
+      <ResearchRunStatusStack
+        runs={[
+          linkedRun({ run_id: "research-run-1" }),
+          linkedRun({
+            run_id: "research-run-2",
+            query: "Summarize the finished bundle",
+            status: "completed",
+            phase: "completed",
+            latest_checkpoint_id: null
+          })
+        ]}
+      />
+    )
 
-    const badge = screen.getByTestId("research-run-status-badge")
+    const rows = screen.getAllByTestId("research-run-status-row")
+    const reviewBadge = within(rows[0]).getByTestId(
+      "research-run-status-badge-research-run-1"
+    )
+    const completedBadge = within(rows[1]).getByTestId(
+      "research-run-status-badge-research-run-2"
+    )
 
-    expect(badge).toHaveAttribute("data-ds-component", "Badge")
-    expect(badge).toHaveTextContent("Needs review")
+    expect(reviewBadge).toHaveAttribute("data-ds-component", "Badge")
+    expect(reviewBadge).toHaveTextContent("Needs review")
+    expect(completedBadge).toHaveAttribute("data-ds-component", "Badge")
+    expect(completedBadge).toHaveTextContent("Completed")
+    expect(screen.queryAllByTestId("research-run-status-badge")).toHaveLength(0)
     expect(screen.getByText("Plan review needed")).toBeInTheDocument()
     expect(screen.getByRole("link", { name: "Review in Research" })).toHaveAttribute(
       "href",

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundStatusBadges.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundStatusBadges.design-system.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import React from "react"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { ResearchRunStatusStack } from "../ResearchRunStatusStack"
+import { VoiceChatIndicator } from "../VoiceChatIndicator"
+import type { ChatLinkedResearchRun } from "@/services/tldw/TldwApiClient"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key
+  })
+}))
+
+const linkedRun = (overrides: Partial<ChatLinkedResearchRun>): ChatLinkedResearchRun =>
+  ({
+    run_id: "research-run-1",
+    query: "Check original sources",
+    status: "waiting_human",
+    phase: "awaiting_plan_review",
+    control_state: "running",
+    latest_checkpoint_id: "checkpoint-1",
+    updated_at: "2026-05-05T12:00:00Z",
+    ...overrides
+  }) as ChatLinkedResearchRun
+
+describe("Playground status design-system badges", () => {
+  it("renders linked research run status through the shared Badge", () => {
+    render(<ResearchRunStatusStack runs={[linkedRun({})]} />)
+
+    const badge = screen.getByTestId("research-run-status-badge")
+
+    expect(badge).toHaveAttribute("data-ds-component", "Badge")
+    expect(badge).toHaveTextContent("Needs review")
+    expect(screen.getByText("Plan review needed")).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: "Review in Research" })).toHaveAttribute(
+      "href",
+      "/research?run=research-run-1"
+    )
+  })
+
+  it("renders the voice chat status through the shared Badge while preserving stop control", () => {
+    const onStop = vi.fn()
+
+    render(
+      <VoiceChatIndicator
+        state="listening"
+        statusLabel="Listening"
+        onStop={onStop}
+      />
+    )
+
+    const badge = screen.getByTestId("voice-chat-status-badge")
+
+    expect(badge).toHaveAttribute("data-ds-component", "Badge")
+    expect(badge).toHaveTextContent("Listening")
+
+    fireEvent.click(screen.getByRole("button", { name: "Stop voice chat" }))
+
+    expect(onStop).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/packages/ui/src/components/Sidepanel/Chat/SaveStatusIcon.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/SaveStatusIcon.tsx
@@ -3,6 +3,7 @@ import { Save } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { useEffect, useRef } from "react"
 import { useAntdNotification } from "@/hooks/useAntdNotification"
+import { Badge, type BadgeVariant } from "@/components/ui/primitives"
 
 type SaveMode = "ephemeral" | "local" | "server"
 
@@ -59,16 +60,15 @@ export const SaveStatusIcon = ({
     return "local"
   })()
 
-  const iconClassName = (() => {
-    const base = "size-4 transition-colors"
+  const badgeVariant: BadgeVariant = (() => {
     switch (saveMode) {
       case "ephemeral":
-        return `${base} text-primary`
+        return "primary"
       case "server":
-        return `${base} text-success`
+        return "success"
       case "local":
       default:
-        return `${base} text-text-subtle`
+        return "secondary"
     }
   })()
 
@@ -103,7 +103,16 @@ export const SaveStatusIcon = ({
         aria-label={tooltip}
         title={tooltip}
       >
-        <Save className={iconClassName} />
+        <Badge
+          data-testid="chat-save-status-badge"
+          variant={badgeVariant}
+          size="sm"
+          outline
+          srLabel={tooltip}
+          className="gap-0 leading-none"
+        >
+          <Save className="size-4 transition-colors" aria-hidden="true" />
+        </Badge>
       </button>
     </Tooltip>
   )

--- a/apps/packages/ui/src/components/Sidepanel/Chat/SaveStatusIcon.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/SaveStatusIcon.tsx
@@ -108,7 +108,6 @@ export const SaveStatusIcon = ({
           variant={badgeVariant}
           size="sm"
           outline
-          srLabel={tooltip}
           className="gap-0 leading-none"
         >
           <Save className="size-4 transition-colors" aria-hidden="true" />

--- a/apps/packages/ui/src/components/Sidepanel/Chat/StatusDot.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/StatusDot.tsx
@@ -5,6 +5,7 @@ import {
   useConnectionActions,
   useConnectionUxState
 } from "@/hooks/useConnectionState"
+import { Badge, type BadgeVariant } from "@/components/ui/primitives"
 
 /**
  * Compact connection status indicator with icon and color for accessibility.
@@ -18,7 +19,7 @@ import {
  */
 export const StatusDot = () => {
   const { t } = useTranslation(["sidepanel"])
-  const { uxState, mode, isConnectedUx, isChecking, isConfigOrError } =
+  const { mode, isConnectedUx, isChecking, isConfigOrError } =
     useConnectionUxState()
   const { checkOnce } = useConnectionActions()
 
@@ -78,6 +79,14 @@ export const StatusDot = () => {
     )
   }
 
+  const badgeVariant: BadgeVariant = (() => {
+    if (isChecking) return "warning"
+    if (isConnectedUx && mode === "demo") return "demo"
+    if (isConnectedUx) return "success"
+    if (isConfigOrError) return "warning"
+    return "danger"
+  })()
+
   return (
     <Tooltip title={tooltip}>
       <button
@@ -89,7 +98,16 @@ export const StatusDot = () => {
         aria-label={tooltip}
         title={tooltip}
       >
-        {renderStatusIcon()}
+        <Badge
+          data-testid="status-dot-badge"
+          variant={badgeVariant}
+          size="sm"
+          outline
+          srLabel={tooltip}
+          className="gap-0 leading-none"
+        >
+          {renderStatusIcon()}
+        </Badge>
       </button>
     </Tooltip>
   )

--- a/apps/packages/ui/src/components/Sidepanel/Chat/StatusDot.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/StatusDot.tsx
@@ -66,16 +66,16 @@ export const StatusDot = () => {
   const renderStatusIcon = () => {
     if (isChecking) {
       return (
-        <Loader2 className="h-3.5 w-3.5 animate-spin text-warn" />
+        <Loader2 className="h-3.5 w-3.5 animate-spin text-current" />
       )
     }
     if (isConnectedUx) {
       return (
-        <Check className="h-3.5 w-3.5 text-success" />
+        <Check className="h-3.5 w-3.5 text-current" />
       )
     }
     return (
-      <AlertCircle className="h-3.5 w-3.5 text-danger" />
+      <AlertCircle className="h-3.5 w-3.5 text-current" />
     )
   }
 
@@ -103,7 +103,6 @@ export const StatusDot = () => {
           variant={badgeVariant}
           size="sm"
           outline
-          srLabel={tooltip}
           className="gap-0 leading-none"
         >
           {renderStatusIcon()}

--- a/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/StatusBadges.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/StatusBadges.design-system.test.tsx
@@ -71,6 +71,8 @@ describe("Chat status design-system badges", () => {
 
     expect(statusButton).toHaveAccessibleName("Connection failed. Click to retry.")
     expect(badge).toHaveAttribute("data-ds-component", "Badge")
+    expect(badge.querySelector(".sr-only")).toBeNull()
+    expect(badge.querySelector("svg")).toHaveClass("text-current")
 
     fireEvent.click(statusButton)
 
@@ -93,9 +95,32 @@ describe("Chat status design-system badges", () => {
 
     expect(statusButton).toHaveAccessibleName("Saved to server")
     expect(badge).toHaveAttribute("data-ds-component", "Badge")
+    expect(badge.querySelector(".sr-only")).toBeNull()
 
     fireEvent.click(statusButton)
 
     expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it("keeps configured-but-unavailable status colors aligned with the Badge variant", () => {
+    connectionState.ux = {
+      uxState: "error_config",
+      mode: "full",
+      isConnectedUx: false,
+      isChecking: false,
+      isConfigOrError: true
+    }
+
+    render(<StatusDot />)
+
+    const badge = screen.getByTestId("status-dot-badge")
+    const icon = badge.querySelector("svg")
+
+    expect(screen.getByTestId("status-dot")).toHaveAccessibleName(
+      "Not connected. Open Settings to configure."
+    )
+    expect(badge).toHaveAttribute("data-ds-component", "Badge")
+    expect(icon).toHaveClass("text-current")
+    expect(icon).not.toHaveClass("text-danger")
   })
 })

--- a/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/StatusBadges.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/StatusBadges.design-system.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import React from "react"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { SaveStatusIcon } from "../SaveStatusIcon"
+import { StatusDot } from "../StatusDot"
+
+const connectionState = vi.hoisted(() => ({
+  ux: {
+    uxState: "connected",
+    mode: "full",
+    isConnectedUx: true,
+    isChecking: false,
+    isConfigOrError: false
+  },
+  checkOnce: vi.fn()
+}))
+
+const notificationMock = vi.hoisted(() => ({
+  warning: vi.fn()
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key
+  })
+}))
+
+vi.mock("antd", () => ({
+  Tooltip: ({ children }: { children?: React.ReactNode }) => <>{children}</>
+}))
+
+vi.mock("@/hooks/useConnectionState", () => ({
+  useConnectionUxState: () => connectionState.ux,
+  useConnectionActions: () => ({
+    checkOnce: connectionState.checkOnce
+  })
+}))
+
+vi.mock("@/hooks/useAntdNotification", () => ({
+  useAntdNotification: () => notificationMock
+}))
+
+describe("Chat status design-system badges", () => {
+  beforeEach(() => {
+    connectionState.ux = {
+      uxState: "connected",
+      mode: "full",
+      isConnectedUx: true,
+      isChecking: false,
+      isConfigOrError: false
+    }
+    connectionState.checkOnce.mockReset()
+    notificationMock.warning.mockReset()
+  })
+
+  it("renders the connection status through the shared Badge while preserving retry behavior", () => {
+    connectionState.ux = {
+      uxState: "failed",
+      mode: "full",
+      isConnectedUx: false,
+      isChecking: false,
+      isConfigOrError: false
+    }
+
+    render(<StatusDot />)
+
+    const statusButton = screen.getByTestId("status-dot")
+    const badge = screen.getByTestId("status-dot-badge")
+
+    expect(statusButton).toHaveAccessibleName("Connection failed. Click to retry.")
+    expect(badge).toHaveAttribute("data-ds-component", "Badge")
+
+    fireEvent.click(statusButton)
+
+    expect(connectionState.checkOnce).toHaveBeenCalledTimes(1)
+  })
+
+  it("renders the chat save status through the shared Badge while preserving the action", () => {
+    const onClick = vi.fn()
+
+    render(
+      <SaveStatusIcon
+        temporaryChat={false}
+        serverChatId="server-chat-1"
+        onClick={onClick}
+      />
+    )
+
+    const statusButton = screen.getByTestId("chat-save-status")
+    const badge = screen.getByTestId("chat-save-status-badge")
+
+    expect(statusButton).toHaveAccessibleName("Saved to server")
+    expect(badge).toHaveAttribute("data-ds-component", "Badge")
+
+    fireEvent.click(statusButton)
+
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/packages/ui/src/components/ui/primitives/Badge.tsx
+++ b/apps/packages/ui/src/components/ui/primitives/Badge.tsx
@@ -116,6 +116,7 @@ export const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
           outline ? `border ${styles.outline} bg-transparent` : styles.filled,
           className
         )}
+        data-ds-component="Badge"
         data-testid={dataTestId}
       >
         {dot && (

--- a/backlog/tasks/task-45.6 - Migrate-Chat-and-Playground-product-status-chips-to-design-system-primitives.md
+++ b/backlog/tasks/task-45.6 - Migrate-Chat-and-Playground-product-status-chips-to-design-system-primitives.md
@@ -1,0 +1,70 @@
+---
+id: TASK-45.6
+title: Migrate Chat and Playground product status chips to design-system primitives
+status: Done
+assignee: []
+created_date: '2026-05-05 17:14'
+updated_date: '2026-05-05 17:33'
+labels:
+  - design-system
+  - frontend
+  - playground
+  - chat
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1315'
+documentation:
+  - Docs/Design/tldw_web_design_system_contract.md
+  - Docs/Design/tldw_web_design_system_inventory.md
+parent_task_id: TASK-45
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the next bounded Chat/Playground migration slice from the design-system inventory after the empty/recovery banner slices. Scope is limited to product status indicators and chips: Sidepanel/Chat/StatusDot, Sidepanel/Chat/SaveStatusIcon, Option/Playground/ResearchRunStatusStack, Option/Playground/VoiceChatIndicator, and Common/Playground/PlaygroundUserMessage. Do not migrate generic visual pills, composer-only controls, modal footers, or broad AntD mechanics in this slice.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Chat status indicators use canonical Badge or state primitives for user-facing ready/saving/error/status semantics while preserving accessible labels and layout.
+- [x] #2 Playground research run and voice status indicators map domain statuses to canonical Badge or state variants without changing non-status controls or workflows.
+- [x] #3 Playground user-message status chips use canonical design-system status primitives for product state while preserving message actions and metadata behavior.
+- [x] #4 Focused tests cover migrated product status indicators and assert design-system markers, accessible labels, and status text/actions.
+- [x] #5 Verification includes focused Chat/Playground Vitest coverage, lint/diff checks, and Bandit is skipped or documented as not applicable for frontend-only changes.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Migrated the bounded Chat/Playground product status slice to the shared Badge primitive: StatusDot, SaveStatusIcon, ResearchRunStatusStack, VoiceChatIndicator, PlaygroundUserMessage system/message-type chips, plus a Badge data-ds-component marker for testable design-system ownership.
+
+Added focused design-system tests for Chat status badges, Playground research/voice status badges, and Playground user-message chips. Verified red first before implementation, then green after migration.
+
+Verification: bunx vitest run src/components/Sidepanel/Chat/__tests__/StatusBadges.design-system.test.tsx src/components/Option/Playground/__tests__/PlaygroundStatusBadges.design-system.test.tsx src/components/Common/Playground/__tests__/PlaygroundUserMessage.design-system.test.tsx src/components/Option/Playground/__tests__/PlaygroundChat.research-status.integration.test.tsx src/components/Option/Playground/__tests__/research-run-status.test.ts --reporter=dot passed 37/37 tests.
+
+Verification: tldw-frontend/node_modules/.bin/eslint --config tldw-frontend/eslint.config.mjs on the touched UI files exited 0. It emits the existing Next pages-directory notice when run from apps against packages/ui files, but no lint errors or warnings on the touched files.
+
+Verification: git diff --check exited 0.
+
+Bandit skipped: frontend-only TypeScript/React changes, no Python touched. Full package tsc is not a useful gate in this worktree because it currently fails on unrelated pre-existing package-wide test/type errors outside this slice.
+
+Draft PR opened: https://github.com/rmusser01/tldw_server/pull/1315
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated the next Chat/Playground design-system inventory slice by replacing local status spans/icons with the shared Badge primitive for connection status, chat save status, linked research run status, voice chat status, and Playground user-message system/message-type chips. Added focused Vitest coverage asserting design-system markers, accessible labels, visible status text, and preserved actions. Bandit is not applicable because this slice touches only frontend TypeScript/React files.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.6.1 - Address-PR-1315-review-comments.md
+++ b/backlog/tasks/task-45.6.1 - Address-PR-1315-review-comments.md
@@ -1,0 +1,60 @@
+---
+id: TASK-45.6.1
+title: Address PR 1315 review comments
+status: Done
+assignee: []
+created_date: '2026-05-05 18:07'
+updated_date: '2026-05-05 18:10'
+labels:
+  - design-system
+  - frontend
+  - review-fix
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1315'
+parent_task_id: TASK-45.6
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix actionable review feedback on PR #1315 for the Chat/Playground status Badge migration. Scope: remove redundant srLabel props from icon badge wrappers, make StatusDot icons inherit Badge variant colors, add message-type fallback labels in PlaygroundUserMessage, and make ResearchRunStatusStack badge test IDs unique per run. Keep changes limited to PR review fixes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 StatusDot and SaveStatusIcon Badge wrappers no longer duplicate parent button aria labels with sr-only text.
+- [x] #2 StatusDot icons inherit the Badge variant color for checking, demo, connected, config/error, and failed states.
+- [x] #3 PlaygroundUserMessage message-type Badge renders a human-friendly fallback when a copilot translation key is missing.
+- [x] #4 ResearchRunStatusStack status badge test IDs are unique per run while tests still assert Badge markers for multiple runs.
+- [x] #5 Focused Vitest, targeted ESLint, and git diff checks are recorded; Bandit skipped as frontend-only if no Python is touched.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Fixed PR #1315 review comments: removed redundant Badge srLabel props under aria-labeled buttons, changed StatusDot icons to text-current so they inherit Badge variant color, added human-readable message-type fallback labels, and made research-run status badge test IDs unique per run.
+
+Verification: bunx vitest run src/components/Sidepanel/Chat/__tests__/StatusBadges.design-system.test.tsx src/components/Option/Playground/__tests__/PlaygroundStatusBadges.design-system.test.tsx src/components/Common/Playground/__tests__/PlaygroundUserMessage.design-system.test.tsx src/components/Option/Playground/__tests__/PlaygroundChat.research-status.integration.test.tsx src/components/Option/Playground/__tests__/research-run-status.test.ts --reporter=dot passed 39/39 tests.
+
+Verification: tldw-frontend/node_modules/.bin/eslint --config tldw-frontend/eslint.config.mjs on the touched UI files exited 0. It emits the existing Next pages-directory notice when run from apps against packages/ui files, but no lint errors or warnings on touched files.
+
+Verification: git diff --check exited 0. Bandit skipped because this is frontend-only TypeScript/React with no Python changes.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed all actionable PR #1315 review comments by removing redundant hidden labels from icon badge wrappers, aligning StatusDot icon color with Badge variants, adding fallback text for missing message-type translations, and giving research-run status badges unique per-run test IDs. Focused Vitest and targeted ESLint passed; Bandit is not applicable for frontend-only changes.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrate Chat connection/save status, Playground research/voice status, and Playground user-message system/message-type chips to the shared Badge primitive.
- Add data-ds-component="Badge" to the Badge primitive so migrated status surfaces have a stable design-system marker.
- Add focused design-system tests for migrated status indicators and preserved actions/labels.

## Verification
- bunx vitest run src/components/Sidepanel/Chat/__tests__/StatusBadges.design-system.test.tsx src/components/Option/Playground/__tests__/PlaygroundStatusBadges.design-system.test.tsx src/components/Common/Playground/__tests__/PlaygroundUserMessage.design-system.test.tsx src/components/Option/Playground/__tests__/PlaygroundChat.research-status.integration.test.tsx src/components/Option/Playground/__tests__/research-run-status.test.ts --reporter=dot
- tldw-frontend/node_modules/.bin/eslint --config tldw-frontend/eslint.config.mjs packages/ui/src/components/Sidepanel/Chat/StatusDot.tsx packages/ui/src/components/Sidepanel/Chat/SaveStatusIcon.tsx packages/ui/src/components/Sidepanel/Chat/__tests__/StatusBadges.design-system.test.tsx packages/ui/src/components/Option/Playground/ResearchRunStatusStack.tsx packages/ui/src/components/Option/Playground/VoiceChatIndicator.tsx packages/ui/src/components/Option/Playground/__tests__/PlaygroundStatusBadges.design-system.test.tsx packages/ui/src/components/Common/Playground/PlaygroundUserMessage.tsx packages/ui/src/components/Common/Playground/__tests__/PlaygroundUserMessage.design-system.test.tsx packages/ui/src/components/ui/primitives/Badge.tsx
- git diff --check

## Notes
- Bandit skipped: frontend-only TypeScript/React changes, no Python touched.
- Draft until the human requester adds the required human-written Change summary before merge.