### PR TITLE
feat: rank codegraph context by relevance

### DIFF
--- a/Docs/superpowers/plans/2026-05-05-native-codegraph-context-ranking-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-05-native-codegraph-context-ranking-implementation-plan.md
@@ -1,0 +1,109 @@
+# Native CodeGraph Context Ranking Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
+
+**Goal:** Improve `codegraph.context` so selected context is ordered by task relevance and nearby graph relationships while preserving the existing response shape and safety bounds.
+
+**Architecture:** Keep ranking local to the CodeGraph context flow. Add a deterministic ranking helper under `app/core/CodeGraph/context.py`, call it from the MCP module before relationship collection and snippet assembly, and leave repository search, workspace resolution, and public tool schemas unchanged.
+
+**Tech Stack:** Python 3.11, existing CodeGraph repository/model objects, Unified MCP module tests, pytest, Ruff, Bandit.
+
+---
+
+### Task 1: Add Context Ranking Helper
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/CodeGraph/context.py`
+- Test: `tldw_Server_API/tests/CodeGraph/test_codegraph_context.py`
+
+- [x] **Step 1: Write RED ranking tests**
+
+Add tests proving a node with direct task-token matches is ordered before a weaker search result, and a node connected by a selected relationship is boosted ahead of an unrelated node when `max_files` would otherwise exclude it.
+
+- [x] **Step 2: Run focused context tests and verify RED**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/CodeGraph/test_codegraph_context.py -q
+```
+
+Expected: the new tests fail because the helper does not exist or preserves input order.
+
+- [x] **Step 3: Implement minimal ranking helper**
+
+Add a small exported helper, `rank_context_nodes(task, nodes, relationships)`, that:
+
+- tokenizes the task into lowercase alphanumeric terms;
+- scores matches in `name`, `qualified_name`, and `file_path`;
+- adds a relationship boost for nodes that appear in selected relationships;
+- preserves deterministic tie-breaking by original order, file path, line number, and qualified name.
+
+- [x] **Step 4: Run focused context tests and verify GREEN**
+
+Run the same context test command. Expected: all context tests pass.
+
+### Task 2: Wire Ranking Into MCP Context
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py`
+
+- [x] **Step 1: Write RED MCP context test**
+
+Add a regression showing `codegraph.context` chooses a related caller/callee pair within tight `max_nodes` or `max_files` bounds instead of returning an unrelated search result first.
+
+- [x] **Step 2: Run the focused MCP test and verify RED**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py::test_codegraph_context_ranks_task_and_relationship_relevance -q
+```
+
+Expected: failure because MCP context does not yet apply the ranking helper.
+
+- [x] **Step 3: Apply helper in `_build_context`**
+
+Fetch a small over-selection of candidates, collect one-hop relationships, rank nodes, clamp to `max_nodes`, then rebuild the relationship neighborhood for the ranked subset. Preserve existing missing-index, truncation, and response keys.
+
+- [x] **Step 4: Run focused MCP test and verify GREEN**
+
+Run the same focused MCP test. Expected: pass.
+
+### Task 3: Verification And Closeout
+
+**Files:**
+- Modify: `backlog/tasks/task-78 - Improve-CodeGraph-context-ranking.md`
+
+- [x] **Step 1: Run focused regression suite**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/CodeGraph tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py -q
+```
+
+- [x] **Step 2: Run style/security checks on touched scope**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check tldw_Server_API/app/core/CodeGraph/context.py tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py tldw_Server_API/tests/CodeGraph/test_codegraph_context.py tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/CodeGraph/context.py tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py -f json -o /tmp/bandit_codegraph_context_ranking.json
+git diff --check
+```
+
+- [x] **Step 3: Update Backlog task**
+
+Check all completed acceptance criteria, record verification, and add the final summary.
+
+- [x] **Step 4: Commit and open PR**
+
+```bash
+git add Docs/superpowers/plans/2026-05-05-native-codegraph-context-ranking-implementation-plan.md \
+  'backlog/tasks/task-78 - Improve-CodeGraph-context-ranking.md' \
+  tldw_Server_API/app/core/CodeGraph/context.py \
+  tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py \
+  tldw_Server_API/tests/CodeGraph/test_codegraph_context.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
+git commit -m "feat: rank codegraph context by relevance"
+git push -u origin codex/codegraph-context-ranking
+gh pr create --base dev --head codex/codegraph-context-ranking
+```

--- a/backlog/tasks/task-78 - Improve-CodeGraph-context-ranking.md
+++ b/backlog/tasks/task-78 - Improve-CodeGraph-context-ranking.md
@@ -1,0 +1,60 @@
+---
+id: TASK-78
+title: Improve CodeGraph context ranking
+status: Done
+assignee: []
+created_date: '2026-05-05 17:11'
+updated_date: '2026-05-05 17:22'
+labels:
+  - codegraph
+  - mcp
+  - context
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1314'
+documentation:
+  - Docs/MCP/Unified/CodeGraph.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Improve post-v1 native CodeGraph context assembly so codegraph.context selects and orders source context by task relevance and local graph relationships instead of relying only on repository search order. Keep the public MCP response shape, workspace safety, optional dependency contract, and bounded context limits intact.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 codegraph.context ranks candidate nodes using task-token matches in node names, qualified names, and file paths.
+- [x] #2 codegraph.context boosts nodes that participate in relationships with other selected nodes so related call neighborhoods are more likely to fit inside max_nodes/max_files bounds.
+- [x] #3 Existing context output shape, truncation behavior, path safety, and include_code=false behavior remain compatible.
+- [x] #4 Focused CodeGraph context and MCP regression tests, Ruff on touched scope, Bandit on touched production scope, and git diff --check are run or blockers are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implementation plan added at Docs/superpowers/plans/2026-05-05-native-codegraph-context-ranking-implementation-plan.md. While mapping the MCP flow, noted that context currently searches the full task string, so the implementation will also collect token-level candidates before ranking while preserving public response shape.
+
+Implemented context ranking and token-level candidate collection. Verification: context+MCP focused subset passed with 35 passed and 5 warnings; full CodeGraph plus MCP module suite passed with 163 passed and 5 warnings; Ruff touched scope passed; Bandit /tmp/bandit_codegraph_context_ranking.json reported 0 results; git diff --check passed.
+
+Self-review added a regression for early common-token candidate starvation and changed context candidate collection to distribute the bounded candidate budget across whole-task and token searches before ranking.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Improved native CodeGraph context selection by adding deterministic task-token and relationship-aware ranking. codegraph.context now searches whole-task and token-level candidate terms, overselects bounded candidates, ranks them by symbol/file relevance plus graph proximity, and then clamps back to the requested max_nodes/max_files behavior without changing the public response shape. Added helper-level and MCP regression coverage for direct token ranking, relationship tie-breaking, multi-word tasks, and tight context bounds. Verification passed locally: context+MCP subset 35 passed and 5 warnings; full CodeGraph plus MCP module suite 163 passed and 5 warnings; Ruff touched scope passed; Bandit touched production scope reported 0 results; git diff --check passed. Known blockers: none.
+
+Self-review also added and passed a regression where an early common token could otherwise exhaust the candidate budget before later task-specific terms were searched; candidate collection now gives each bounded search term a fair slice before ranking.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-81 - Address-PR-1317-CodeGraph-context-ranking-review-comments.md
+++ b/backlog/tasks/task-81 - Address-PR-1317-CodeGraph-context-ranking-review-comments.md
@@ -1,0 +1,57 @@
+---
+id: TASK-81
+title: 'Address PR #1317 CodeGraph context ranking review comments'
+status: Done
+assignee: []
+created_date: '2026-05-05 17:59'
+updated_date: '2026-05-05 18:04'
+labels:
+  - codegraph
+  - mcp
+  - review-fix
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1317'
+  - 'https://github.com/rmusser01/tldw_server/issues/1314'
+documentation:
+  - >-
+    Docs/superpowers/plans/2026-05-05-native-codegraph-context-ranking-implementation-plan.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve unresolved review comments on PR #1317 for the native CodeGraph context-ranking slice. Verify each external review finding against the current branch before changing code, keep the fix narrowly scoped, and preserve the public codegraph.context response shape and existing bounds.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Relationship ranking boosts count only candidate-to-candidate relationships or otherwise avoid boosting nodes for edges to non-candidate neighbors.
+- [x] #2 Candidate term collection remains bounded while ensuring later task terms are not dropped solely because the candidate budget is small.
+- [x] #3 Filename/path token scoring handles common file stems with extensions instead of giving only substring-level relevance.
+- [x] #4 Ranking tie-breakers are clear and reachable, or unreachable fields are removed if original-order stability is intended.
+- [x] #5 Focused CodeGraph/MCP tests, Ruff on touched scope, Bandit on touched production scope, and git diff --check pass or blockers are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verified PR #1317 review feedback against the branch. Fixed valid findings by filtering relationship ranking boosts to candidate-to-candidate edges, removing unreachable sort-key fields while preserving original-order tie stability, boosting filename stem matches such as pkg/app.py for token app, and replacing max_search_results-based term slicing with a fixed bounded search-term cap so small candidate budgets still rotate through later task terms.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Resolved all current PR #1317 review comments. Relationship boosts now ignore edges to non-candidate neighbors, candidate term search stays bounded without dropping later terms solely because max_search_results is small, filename stem path matches receive the stronger relevance score, and ranking tie-breakers now reflect the intended original-order fallback without unreachable fields. Added regressions for external hub relationships, filename stem scoring, and small-search-budget context ranking. Verification passed locally: focused CodeGraph/MCP suite 165 passed and 5 warnings; Ruff touched scope passed; Bandit touched production scope reported 0 results; git diff --check passed. Known blockers: none.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/CodeGraph/context.py
+++ b/tldw_Server_API/app/core/CodeGraph/context.py
@@ -145,7 +145,8 @@ def rank_context_nodes(
 ) -> tuple[CodeGraphNode, ...]:
     """Return context nodes ordered by task-token relevance and graph proximity."""
     tokens = _task_tokens(task)
-    relationship_counts = _relationship_endpoint_counts(relationships)
+    candidate_ids = {node.id for node in nodes}
+    relationship_counts = _relationship_endpoint_counts(relationships, candidate_ids=candidate_ids)
     indexed_nodes = tuple(enumerate(nodes))
 
     return tuple(
@@ -185,18 +186,31 @@ def _task_tokens(task: str) -> tuple[str, ...]:
     return tuple(seen)
 
 
-def _relationship_endpoint_counts(relationships: tuple[dict[str, Any], ...]) -> dict[str, int]:
-    """Count how often each node id appears in the selected relationship set."""
+def _relationship_endpoint_counts(
+    relationships: tuple[dict[str, Any], ...],
+    *,
+    candidate_ids: set[str],
+) -> dict[str, int]:
+    """Count candidate ids that participate in candidate-to-candidate relationships."""
     counts: dict[str, int] = {}
     for relationship in relationships:
-        for endpoint_name in ("source", "target"):
-            endpoint = relationship.get(endpoint_name)
-            if not isinstance(endpoint, dict):
-                continue
-            node_id = endpoint.get("id")
-            if isinstance(node_id, str) and node_id:
-                counts[node_id] = counts.get(node_id, 0) + 1
+        source_id = _relationship_endpoint_id(relationship, "source")
+        target_id = _relationship_endpoint_id(relationship, "target")
+        if source_id not in candidate_ids or target_id not in candidate_ids:
+            continue
+        counts[source_id] = counts.get(source_id, 0) + 1
+        counts[target_id] = counts.get(target_id, 0) + 1
     return counts
+
+
+def _relationship_endpoint_id(relationship: dict[str, Any], endpoint_name: str) -> str | None:
+    endpoint = relationship.get(endpoint_name)
+    if not isinstance(endpoint, dict):
+        return None
+    node_id = endpoint.get("id")
+    if not isinstance(node_id, str) or not node_id:
+        return None
+    return node_id
 
 
 def _ranking_key(
@@ -204,7 +218,7 @@ def _ranking_key(
     node: CodeGraphNode,
     tokens: tuple[str, ...],
     relationship_counts: dict[str, int],
-) -> tuple[int, int, int, str, int, str]:
+) -> tuple[int, int, int]:
     """Build a stable sort key where lower values represent more relevant context."""
     relevance_score = _node_relevance_score(node, tokens)
     relationship_score = relationship_counts.get(node.id, 0)
@@ -212,9 +226,6 @@ def _ranking_key(
         -relevance_score,
         -relationship_score,
         original_index,
-        node.file_path,
-        int(node.start_line or 0),
-        node.qualified_name,
     )
 
 
@@ -232,7 +243,7 @@ def _node_relevance_score(node: CodeGraphNode, tokens: tuple[str, ...]) -> int:
         for field in fields:
             if field == token:
                 score += 8
-            elif field.endswith(f".{token}") or field.endswith(f"/{token}"):
+            elif field.endswith(f".{token}") or field.endswith(f"/{token}") or f"/{token}." in field:
                 score += 5
             elif token in field:
                 score += 2

--- a/tldw_Server_API/app/core/CodeGraph/context.py
+++ b/tldw_Server_API/app/core/CodeGraph/context.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any
 
 from tldw_Server_API.app.core.CodeGraph.models import CodeGraphNode, codegraph_node_to_dict
 
 _SNIPPET_CONTEXT_LINES = 3
+_TOKEN_RE = re.compile(r"[a-zA-Z0-9_]+")
 
 
 class CodeGraphContextBuilder:
@@ -135,11 +137,106 @@ def _group_nodes_by_file(
     return list(grouped.items())
 
 
+def rank_context_nodes(
+    task: str,
+    nodes: tuple[CodeGraphNode, ...],
+    *,
+    relationships: tuple[dict[str, Any], ...],
+) -> tuple[CodeGraphNode, ...]:
+    """Return context nodes ordered by task-token relevance and graph proximity."""
+    tokens = _task_tokens(task)
+    relationship_counts = _relationship_endpoint_counts(relationships)
+    indexed_nodes = tuple(enumerate(nodes))
+
+    return tuple(
+        node
+        for _index, node in sorted(
+            indexed_nodes,
+            key=lambda item: _ranking_key(item[0], item[1], tokens, relationship_counts),
+        )
+    )
+
+
+def context_search_terms(task: str) -> tuple[str, ...]:
+    """Return a deterministic sequence of search terms for a context task."""
+    stripped = task.strip()
+    terms: dict[str, None] = {}
+    if stripped:
+        terms[stripped] = None
+    for token in _task_tokens(stripped):
+        terms.setdefault(token, None)
+    return tuple(terms)
+
+
 def _dominant_language(nodes: list[CodeGraphNode]) -> str | None:
     for node in nodes:
         if node.language:
             return node.language
     return None
+
+
+def _task_tokens(task: str) -> tuple[str, ...]:
+    """Tokenize a task string into deterministic lowercase search terms."""
+    seen: dict[str, None] = {}
+    for match in _TOKEN_RE.finditer(task.lower()):
+        token = match.group(0).strip("_")
+        if len(token) >= 2:
+            seen.setdefault(token, None)
+    return tuple(seen)
+
+
+def _relationship_endpoint_counts(relationships: tuple[dict[str, Any], ...]) -> dict[str, int]:
+    """Count how often each node id appears in the selected relationship set."""
+    counts: dict[str, int] = {}
+    for relationship in relationships:
+        for endpoint_name in ("source", "target"):
+            endpoint = relationship.get(endpoint_name)
+            if not isinstance(endpoint, dict):
+                continue
+            node_id = endpoint.get("id")
+            if isinstance(node_id, str) and node_id:
+                counts[node_id] = counts.get(node_id, 0) + 1
+    return counts
+
+
+def _ranking_key(
+    original_index: int,
+    node: CodeGraphNode,
+    tokens: tuple[str, ...],
+    relationship_counts: dict[str, int],
+) -> tuple[int, int, int, str, int, str]:
+    """Build a stable sort key where lower values represent more relevant context."""
+    relevance_score = _node_relevance_score(node, tokens)
+    relationship_score = relationship_counts.get(node.id, 0)
+    return (
+        -relevance_score,
+        -relationship_score,
+        original_index,
+        node.file_path,
+        int(node.start_line or 0),
+        node.qualified_name,
+    )
+
+
+def _node_relevance_score(node: CodeGraphNode, tokens: tuple[str, ...]) -> int:
+    """Score a node by exact and partial task-token matches in public identity fields."""
+    if not tokens:
+        return 0
+    fields = (
+        node.name.lower(),
+        node.qualified_name.lower(),
+        node.file_path.lower(),
+    )
+    score = 0
+    for token in tokens:
+        for field in fields:
+            if field == token:
+                score += 8
+            elif field.endswith(f".{token}") or field.endswith(f"/{token}"):
+                score += 5
+            elif token in field:
+                score += 2
+    return score
 
 
 def _make_snippet(node: CodeGraphNode, lines: list[str]) -> dict[str, Any]:

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py
@@ -40,6 +40,7 @@ from ..base import BaseModule, ModuleConfig, create_tool_definition
 _EMPTY_COUNTS = {"files": 0, "nodes": 0, "edges": 0, "unresolved_refs": 0}
 _FOREGROUND_MODE = "foreground"
 _JOB_MODES = {"job", "background"}
+_MAX_CONTEXT_CANDIDATE_SEARCH_TERMS = 16
 
 
 class CodeGraphModule(BaseModule):
@@ -864,7 +865,8 @@ class CodeGraphModule(BaseModule):
                 limit=self._settings.max_search_results,
             )
         )
-        nodes = rank_context_nodes(task, candidate_nodes, relationships=candidate_relationships)[:effective_max_nodes]
+        ranking_relationships = _relationships_between_nodes(candidate_relationships, candidate_nodes)
+        nodes = rank_context_nodes(task, candidate_nodes, relationships=ranking_relationships)[:effective_max_nodes]
         relationships = tuple(_relationship_neighborhood(repository, nodes, limit=self._settings.max_search_results))
         builder = CodeGraphContextBuilder(
             workspace_root=resolution.workspace_root,
@@ -983,7 +985,7 @@ def _context_candidate_nodes(
 ) -> tuple[CodeGraphNode, ...]:
     """Collect deduplicated context candidates from whole-task and token searches."""
     normalized_limit = max(1, int(limit))
-    terms = context_search_terms(query)[:normalized_limit]
+    terms = _context_candidate_search_terms(query)
     if not terms:
         return ()
 
@@ -993,6 +995,44 @@ def _context_candidate_nodes(
         for node in repository.search_nodes(term, limit=per_term_limit):
             by_id.setdefault(node.id, node)
     return tuple(by_id.values())
+
+
+def _context_candidate_search_terms(query: str) -> tuple[str, ...]:
+    """Return bounded search terms while preserving later specific task tokens."""
+    terms = context_search_terms(query)
+    if len(terms) <= _MAX_CONTEXT_CANDIDATE_SEARCH_TERMS:
+        return terms
+
+    full_query, *tokens = terms
+    selected_tokens = sorted(
+        enumerate(tokens),
+        key=lambda item: (-len(item[1]), item[0]),
+    )[: _MAX_CONTEXT_CANDIDATE_SEARCH_TERMS - 1]
+    return (full_query, *(token for _index, token in sorted(selected_tokens)))
+
+
+def _relationships_between_nodes(
+    relationships: tuple[dict[str, Any], ...],
+    nodes: tuple[CodeGraphNode, ...],
+) -> tuple[dict[str, Any], ...]:
+    """Filter relationship dictionaries to edges whose endpoints are both candidate nodes."""
+    node_ids = {node.id for node in nodes}
+    return tuple(
+        relationship
+        for relationship in relationships
+        if _relationship_endpoint_id(relationship, "source") in node_ids
+        and _relationship_endpoint_id(relationship, "target") in node_ids
+    )
+
+
+def _relationship_endpoint_id(relationship: dict[str, Any], endpoint_name: str) -> str | None:
+    endpoint = relationship.get(endpoint_name)
+    if not isinstance(endpoint, dict):
+        return None
+    node_id = endpoint.get("id")
+    if not isinstance(node_id, str) or not node_id:
+        return None
+    return node_id
 
 
 def _empty_truncation(max_context_chars: int) -> dict[str, Any]:

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py
@@ -16,7 +16,11 @@ from typing import Any
 from loguru import logger
 
 from tldw_Server_API.app.core.CodeGraph.config import CodeGraphSettings
-from tldw_Server_API.app.core.CodeGraph.context import CodeGraphContextBuilder
+from tldw_Server_API.app.core.CodeGraph.context import (
+    CodeGraphContextBuilder,
+    context_search_terms,
+    rank_context_nodes,
+)
 from tldw_Server_API.app.core.CodeGraph.dependencies import probe_codegraph_dependencies
 from tldw_Server_API.app.core.CodeGraph.indexer import CodeGraphIndexer
 from tldw_Server_API.app.core.CodeGraph.jobs import enqueue_codegraph_index_job
@@ -844,7 +848,23 @@ class CodeGraphModule(BaseModule):
             }
 
         repository = CodeGraphRepository(resolution.index_db_path)
-        nodes = tuple(repository.search_nodes(query, limit=effective_max_nodes + 1)[:effective_max_nodes])
+        candidate_limit = min(
+            self._settings.max_search_results,
+            max(effective_max_nodes * 4, effective_max_nodes + 8),
+        )
+        candidate_nodes = _context_candidate_nodes(
+            repository,
+            query,
+            limit=candidate_limit,
+        )
+        candidate_relationships = tuple(
+            _relationship_neighborhood(
+                repository,
+                candidate_nodes,
+                limit=self._settings.max_search_results,
+            )
+        )
+        nodes = rank_context_nodes(task, candidate_nodes, relationships=candidate_relationships)[:effective_max_nodes]
         relationships = tuple(_relationship_neighborhood(repository, nodes, limit=self._settings.max_search_results))
         builder = CodeGraphContextBuilder(
             workspace_root=resolution.workspace_root,
@@ -953,6 +973,26 @@ def _normalize_path_prefix(path: str | None) -> str | None:
 def _context_query(task: str) -> str:
     """Derive the first-pass symbol search query from a task description."""
     return task.strip()
+
+
+def _context_candidate_nodes(
+    repository: CodeGraphRepository,
+    query: str,
+    *,
+    limit: int,
+) -> tuple[CodeGraphNode, ...]:
+    """Collect deduplicated context candidates from whole-task and token searches."""
+    normalized_limit = max(1, int(limit))
+    terms = context_search_terms(query)[:normalized_limit]
+    if not terms:
+        return ()
+
+    per_term_limit = max(1, (normalized_limit + len(terms) - 1) // len(terms))
+    by_id: dict[str, CodeGraphNode] = {}
+    for term in terms:
+        for node in repository.search_nodes(term, limit=per_term_limit):
+            by_id.setdefault(node.id, node)
+    return tuple(by_id.values())
 
 
 def _empty_truncation(max_context_chars: int) -> dict[str, Any]:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
@@ -842,6 +842,52 @@ def helper(value):
 
 
 @pytest.mark.asyncio
+async def test_codegraph_context_ranks_task_and_relationship_relevance(tmp_path: Path) -> None:
+    """Select related task-token matches for multi-word context requests."""
+    workspace_root = tmp_path / "workspace"
+    package = workspace_root / "pkg"
+    package.mkdir(parents=True)
+    (package / "__init__.py").write_text("", encoding="utf-8")
+    (package / "util.py").write_text(
+        "def helper(value):\n    return value + 1\n",
+        encoding="utf-8",
+    )
+    (package / "app.py").write_text(
+        "from pkg.util import helper\n\n\ndef entry(value):\n    return helper(value)\n",
+        encoding="utf-8",
+    )
+    (package / "noise.py").write_text(
+        "def helper_noise(value):\n    return value - 1\n",
+        encoding="utf-8",
+    )
+    for index in range(12):
+        (package / f"noise_{index:02}.py").write_text(
+            f"def update_noise_{index}(value):\n    return value - {index}\n",
+            encoding="utf-8",
+        )
+    module = _module(tmp_path, workspace_root)
+
+    await module.execute_tool(
+        "codegraph.index",
+        {"mode": "foreground", "force": True, "max_files": 25},
+        context=_context(),
+    )
+    result = await module.execute_tool(
+        "codegraph.context",
+        {"task": "update entry helper flow", "max_nodes": 2, "max_files": 2, "include_code": False},
+        context=_context(),
+    )
+
+    assert {node["name"] for node in result["nodes"]} == {"entry", "helper"}  # nosec B101
+    assert "helper_noise" not in {node["name"] for node in result["nodes"]}  # nosec B101
+    assert {file_context["path"] for file_context in result["files"]} == {"pkg/app.py", "pkg/util.py"}  # nosec B101
+    assert any(  # nosec B101
+        relationship["source"]["name"] == "entry" and relationship["target"]["name"] == "helper"
+        for relationship in result["relationships"]
+    )
+
+
+@pytest.mark.asyncio
 async def test_codegraph_context_treats_null_include_code_as_default_true(tmp_path: Path) -> None:
     """Treat JSON null include_code as the default source-including context mode."""
     workspace_root = tmp_path / "workspace"

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py
@@ -865,7 +865,7 @@ async def test_codegraph_context_ranks_task_and_relationship_relevance(tmp_path:
             f"def update_noise_{index}(value):\n    return value - {index}\n",
             encoding="utf-8",
         )
-    module = _module(tmp_path, workspace_root)
+    module = _module_with_settings(tmp_path, workspace_root, {"max_search_results": 3})
 
     await module.execute_tool(
         "codegraph.index",

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_context.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_context.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from tldw_Server_API.app.core.CodeGraph.context import CodeGraphContextBuilder
+from tldw_Server_API.app.core.CodeGraph.context import CodeGraphContextBuilder, rank_context_nodes
 from tldw_Server_API.app.core.CodeGraph.models import CodeGraphNode
 
 
@@ -49,6 +49,42 @@ def test_context_builder_reads_bounded_source_snippet(tmp_path: Path) -> None:
     assert snippet["end_line"] == 10
     assert "def helper" in snippet["text"]
     assert result["truncation"]["truncated"] is False
+
+
+def test_rank_context_nodes_prefers_task_token_matches() -> None:
+    """Rank direct task-token matches ahead of weaker search-order candidates."""
+    weak = _node("node_weak", "pkg/config.py", name="parse_config", qualified_name="parse_config")
+    strong = _node("node_strong", "pkg/helper.py", name="helper", qualified_name="services.helper")
+
+    ranked = rank_context_nodes("fix helper behavior", (weak, strong), relationships=())
+
+    assert [node.id for node in ranked] == ["node_strong", "node_weak"]
+
+
+def test_rank_context_nodes_boosts_related_nodes_on_ties() -> None:
+    """Prefer task-matching nodes connected to the selected relationship neighborhood."""
+    unrelated = _node(
+        "node_unrelated",
+        "pkg/helpers_misc.py",
+        name="helper_misc",
+        qualified_name="helpers.helper_misc",
+    )
+    related = _node(
+        "node_related",
+        "pkg/helpers_related.py",
+        name="helper_related",
+        qualified_name="helpers.helper_related",
+    )
+    entry = _node("node_entry", "pkg/entry.py", name="entry", qualified_name="entry")
+    relationship = {
+        "id": "edge_entry_related",
+        "source": {"id": "node_entry"},
+        "target": {"id": "node_related"},
+    }
+
+    ranked = rank_context_nodes("helper", (unrelated, related, entry), relationships=(relationship,))
+
+    assert [node.id for node in ranked[:2]] == ["node_related", "node_unrelated"]
 
 
 def test_context_builder_groups_duplicate_file_snippets(tmp_path: Path) -> None:
@@ -216,16 +252,19 @@ def _node(
     node_id: str,
     file_path: str,
     *,
+    name: str | None = None,
+    qualified_name: str | None = None,
     start_line: int | None = 1,
     end_line: int | None = 1,
 ) -> CodeGraphNode:
     """Build a minimal CodeGraph node for context builder tests."""
+    node_name = name or node_id.removeprefix("node_")
     return CodeGraphNode(
         id=node_id,
         identity_key=node_id,
         kind="function",
-        name=node_id.removeprefix("node_"),
-        qualified_name=node_id.removeprefix("node_"),
+        name=node_name,
+        qualified_name=qualified_name or node_name,
         file_path=file_path,
         language="python",
         start_line=start_line,

--- a/tldw_Server_API/tests/CodeGraph/test_codegraph_context.py
+++ b/tldw_Server_API/tests/CodeGraph/test_codegraph_context.py
@@ -87,6 +87,37 @@ def test_rank_context_nodes_boosts_related_nodes_on_ties() -> None:
     assert [node.id for node in ranked[:2]] == ["node_related", "node_unrelated"]
 
 
+def test_rank_context_nodes_ignores_relationships_to_non_candidate_nodes() -> None:
+    """Avoid ranking high-degree external hubs above local candidate relationships."""
+    hub = _node("node_hub", "pkg/helper_hub.py", name="helper_hub", qualified_name="helpers.helper_hub")
+    related = _node(
+        "node_related",
+        "pkg/helper_related.py",
+        name="helper_related",
+        qualified_name="helpers.helper_related",
+    )
+    peer = _node("node_peer", "pkg/helper_peer.py", name="helper_peer", qualified_name="helpers.helper_peer")
+    relationships = (
+        {"id": "edge_hub_external_a", "source": {"id": "node_hub"}, "target": {"id": "node_external_a"}},
+        {"id": "edge_hub_external_b", "source": {"id": "node_external_b"}, "target": {"id": "node_hub"}},
+        {"id": "edge_peer_related", "source": {"id": "node_peer"}, "target": {"id": "node_related"}},
+    )
+
+    ranked = rank_context_nodes("helper", (hub, related, peer), relationships=relationships)
+
+    assert [node.id for node in ranked[:2]] == ["node_related", "node_peer"]
+
+
+def test_rank_context_nodes_boosts_filename_stem_matches() -> None:
+    """Rank filename stem matches above weaker path substring matches."""
+    weak = _node("node_weak", "pkg/app_config.py", name="handler", qualified_name="handler")
+    strong = _node("node_strong", "pkg/app.py", name="handler", qualified_name="handler")
+
+    ranked = rank_context_nodes("update app", (weak, strong), relationships=())
+
+    assert [node.id for node in ranked] == ["node_strong", "node_weak"]
+
+
 def test_context_builder_groups_duplicate_file_snippets(tmp_path: Path) -> None:
     """Group multiple node snippets from the same file under one file entry."""
     source = tmp_path / "pkg" / "sample.py"


### PR DESCRIPTION
## Summary

- Add deterministic `codegraph.context` ranking based on task-token matches in symbol names, qualified names, and file paths.
- Boost nodes that participate in local graph relationships so tight context windows keep related caller/callee neighborhoods together.
- Search whole-task and token-level candidate terms with a fair bounded slice per term before ranking, avoiding common-token candidate starvation.
- Add Backlog task `TASK-78` and the implementation plan for this CodeGraph follow-up slice.

## Verification

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/CodeGraph tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py -q` -> `163 passed, 5 warnings`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check tldw_Server_API/app/core/CodeGraph/context.py tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py tldw_Server_API/tests/CodeGraph/test_codegraph_context.py tldw_Server_API/app/core/MCP_unified/tests/test_codegraph_module.py` -> `All checks passed!`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/CodeGraph/context.py tldw_Server_API/app/core/MCP_unified/modules/implementations/codegraph_module.py -f json -o /tmp/bandit_codegraph_context_ranking.json` -> `0` findings
- `git diff --check` -> clean

## Change summary

Human-authored Change summary required before merge per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

Refs #1314
