### PR TITLE
Add sandbox artifact and log cap contracts

### DIFF
--- a/backlog/tasks/task-78 - Add-shared-sandbox-artifact-and-log-cap-contracts.md
+++ b/backlog/tasks/task-78 - Add-shared-sandbox-artifact-and-log-cap-contracts.md
@@ -38,6 +38,8 @@ Verification: focused sandbox suite passed with 60 tests: test_sandbox_limits.py
 Opened PR #1319: https://github.com/rmusser01/tldw_server/pull/1319
 
 PR review fix pass: added docstrings/type annotations requested by Qodo; applied exclusions before artifact quota accounting; preserved artifact counter schema on collection errors; moved stream truncation publish/metrics outside the hub lock; used one Lima log cap for replay and accounting; cleared artifact counters for canceled seatbelt/worktree runs. Left the VZ Linux helper-unavailable/protocol-mismatch fallback suggestion unchanged because existing tests intentionally preserve session control rows when host truth is unavailable or untrusted. Verification: targeted red tests failed before fixes and passed after fixes; affected sandbox suite passed 88 tests; py_compile passed; Ruff passed; Bandit JSON at /tmp/bandit_sandbox_artifact_log_cap_review_fixes.json reported existing low-severity findings only with 0 findings on added lines; git diff --check passed.
+
+Additional VZ review follow-up: accepted the session-reuse fallback finding after explicit re-review. VZ Linux now treats helper status-probe unavailable/protocol failures and absent status replies as unhealthy candidate VMs, clears stale session control, and attempts fresh VM provisioning. Regression tests were updated from the older fail/preserve-control expectation and now cover unavailable, protocol mismatch, absent status, and unhealthy status fallback paths.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-78 - Add-shared-sandbox-artifact-and-log-cap-contracts.md
+++ b/backlog/tasks/task-78 - Add-shared-sandbox-artifact-and-log-cap-contracts.md
@@ -4,7 +4,7 @@ title: Add shared sandbox artifact and log cap contracts
 status: Done
 assignee: []
 created_date: '2026-05-05 17:12'
-updated_date: '2026-05-05 17:38'
+updated_date: '2026-05-05 17:46'
 labels:
   - sandbox
 dependencies: []
@@ -34,12 +34,16 @@ Phase 4 reliability slice: enforce shared artifact quota and log-cap reporting c
 
 <!-- SECTION:NOTES:BEGIN -->
 Verification: focused sandbox suite passed with 60 tests: test_sandbox_limits.py, test_streams_hub_lifecycle.py, test_seatbelt_runner.py, test_worktree_runner.py, test_run_status_reason_codes.py, and test_sandbox_run_limit_audit.py. py_compile passed for touched Sandbox app files. Ruff passed for touched app/test files. Bandit JSON at /tmp/bandit_sandbox_artifact_log_cap_contracts.json reported 105 existing low-severity subprocess findings in runner files; diff-line check found 0 findings on added lines. git diff --check passed. Known blocker: test_docker_runner_fake.py -q still stalls after the first TestClient case and was terminated; this matches the existing app-lifespan/TestClient hang pattern rather than the runner-only artifact/log cap changes.
+
+Opened PR #1319: https://github.com/rmusser01/tldw_server/pull/1319
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Added shared sandbox artifact/log cap contract plumbing. Seatbelt and worktree now use shared artifact byte caps and report aggregate counters; Docker, Firecracker, Lima, and VZ Linux paths reuse the shared helpers where applicable. Stream log truncation is tracked as resource_usage and included in audit/status limit signals. Added focused regression coverage for artifact caps, log truncation, and limit taxonomy/audit metadata.
+
+PR: https://github.com/rmusser01/tldw_server/pull/1319
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-78 - Add-shared-sandbox-artifact-and-log-cap-contracts.md
+++ b/backlog/tasks/task-78 - Add-shared-sandbox-artifact-and-log-cap-contracts.md
@@ -36,6 +36,8 @@ Phase 4 reliability slice: enforce shared artifact quota and log-cap reporting c
 Verification: focused sandbox suite passed with 60 tests: test_sandbox_limits.py, test_streams_hub_lifecycle.py, test_seatbelt_runner.py, test_worktree_runner.py, test_run_status_reason_codes.py, and test_sandbox_run_limit_audit.py. py_compile passed for touched Sandbox app files. Ruff passed for touched app/test files. Bandit JSON at /tmp/bandit_sandbox_artifact_log_cap_contracts.json reported 105 existing low-severity subprocess findings in runner files; diff-line check found 0 findings on added lines. git diff --check passed. Known blocker: test_docker_runner_fake.py -q still stalls after the first TestClient case and was terminated; this matches the existing app-lifespan/TestClient hang pattern rather than the runner-only artifact/log cap changes.
 
 Opened PR #1319: https://github.com/rmusser01/tldw_server/pull/1319
+
+PR review fix pass: added docstrings/type annotations requested by Qodo; applied exclusions before artifact quota accounting; preserved artifact counter schema on collection errors; moved stream truncation publish/metrics outside the hub lock; used one Lima log cap for replay and accounting; cleared artifact counters for canceled seatbelt/worktree runs. Left the VZ Linux helper-unavailable/protocol-mismatch fallback suggestion unchanged because existing tests intentionally preserve session control rows when host truth is unavailable or untrusted. Verification: targeted red tests failed before fixes and passed after fixes; affected sandbox suite passed 88 tests; py_compile passed; Ruff passed; Bandit JSON at /tmp/bandit_sandbox_artifact_log_cap_review_fixes.json reported existing low-severity findings only with 0 findings on added lines; git diff --check passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
@@ -44,6 +46,8 @@ Opened PR #1319: https://github.com/rmusser01/tldw_server/pull/1319
 Added shared sandbox artifact/log cap contract plumbing. Seatbelt and worktree now use shared artifact byte caps and report aggregate counters; Docker, Firecracker, Lima, and VZ Linux paths reuse the shared helpers where applicable. Stream log truncation is tracked as resource_usage and included in audit/status limit signals. Added focused regression coverage for artifact caps, log truncation, and limit taxonomy/audit metadata.
 
 PR: https://github.com/rmusser01/tldw_server/pull/1319
+
+Review fixes addressed Qodo/CodeRabbit findings for documentation, typing, artifact exclusion/error counters, stream lock side effects, Lima log cap consistency, and canceled-run artifact accounting.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-78 - Add-shared-sandbox-artifact-and-log-cap-contracts.md
+++ b/backlog/tasks/task-78 - Add-shared-sandbox-artifact-and-log-cap-contracts.md
@@ -1,0 +1,53 @@
+---
+id: TASK-78
+title: Add shared sandbox artifact and log cap contracts
+status: Done
+assignee: []
+created_date: '2026-05-05 17:12'
+updated_date: '2026-05-05 17:38'
+labels:
+  - sandbox
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Phase 4 reliability slice: enforce shared artifact quota and log-cap reporting contracts across applicable sandbox runtimes without changing runtime availability semantics.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Seatbelt and worktree runners apply shared artifact byte caps and report aggregate counters.
+- [x] #2 Log-cap truncation is visible in resource_usage and maps to limits_applied.
+- [x] #3 Focused sandbox tests and touched-scope security checks pass.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing tests for host-local artifact caps and log-cap status signals. 2. Reuse shared limit helpers in applicable runners. 3. Add minimal stream-hub truncation reporting and taxonomy/audit coverage. 4. Run focused tests, compile, lint, Bandit, and diff checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verification: focused sandbox suite passed with 60 tests: test_sandbox_limits.py, test_streams_hub_lifecycle.py, test_seatbelt_runner.py, test_worktree_runner.py, test_run_status_reason_codes.py, and test_sandbox_run_limit_audit.py. py_compile passed for touched Sandbox app files. Ruff passed for touched app/test files. Bandit JSON at /tmp/bandit_sandbox_artifact_log_cap_contracts.json reported 105 existing low-severity subprocess findings in runner files; diff-line check found 0 findings on added lines. git diff --check passed. Known blocker: test_docker_runner_fake.py -q still stalls after the first TestClient case and was terminated; this matches the existing app-lifespan/TestClient hang pattern rather than the runner-only artifact/log cap changes.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added shared sandbox artifact/log cap contract plumbing. Seatbelt and worktree now use shared artifact byte caps and report aggregate counters; Docker, Firecracker, Lima, and VZ Linux paths reuse the shared helpers where applicable. Stream log truncation is tracked as resource_usage and included in audit/status limit signals. Added focused regression coverage for artifact caps, log truncation, and limit taxonomy/audit metadata.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/Sandbox/limits.py
+++ b/tldw_Server_API/app/core/Sandbox/limits.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import fnmatch
 import os
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -49,6 +49,7 @@ _ARTIFACT_LIMIT_COUNTER_KEYS = (
     "artifact_limit_total_bytes",
     "artifact_files_collected",
     "artifact_files_skipped",
+    "artifact_files_excluded",
     "artifact_bytes_collected",
     "artifact_skip_file_limit",
     "artifact_skip_total_limit",
@@ -147,23 +148,15 @@ def collect_limited_artifacts(
     *,
     max_file_bytes: int | None,
     max_total_bytes: int | None,
+    exclude_names: Iterable[str] = (),
+    exclude_hidden: bool = False,
 ) -> ArtifactLimitResult:
     """Collect matching artifacts without reading files that exceed byte caps."""
-    counters = {
-        "artifact_limit_file_bytes": int(max_file_bytes or 0),
-        "artifact_limit_total_bytes": int(max_total_bytes or 0),
-        "artifact_files_collected": 0,
-        "artifact_files_skipped": 0,
-        "artifact_bytes_collected": 0,
-        "artifact_skip_file_limit": 0,
-        "artifact_skip_total_limit": 0,
-        "artifact_skip_symlink": 0,
-        "artifact_skip_invalid": 0,
-        "artifact_skip_read_error": 0,
-    }
+    counters = artifact_limit_counter_defaults(max_file_bytes, max_total_bytes)
     patterns = [str(pattern) for pattern in (capture_patterns or []) if str(pattern or "").strip()]
     if not patterns:
         return ArtifactLimitResult(artifacts={}, counters=counters)
+    excludes = {str(name).strip() for name in exclude_names if str(name).strip()}
 
     workspace_path = Path(workspace)
     if workspace_path.is_symlink():
@@ -187,6 +180,9 @@ def collect_limited_artifacts(
                 full_path = root_path / file_name
                 rel_posix = full_path.relative_to(workspace_root).as_posix()
                 if not any(fnmatch.fnmatchcase(rel_posix, pattern) for pattern in patterns):
+                    continue
+                if not _artifact_allowed(rel_posix, exclude_names=excludes, exclude_hidden=exclude_hidden):
+                    counters["artifact_files_excluded"] += 1
                     continue
                 if full_path.is_symlink():
                     _increment_artifact_skip(counters, "artifact_skip_symlink")
@@ -279,6 +275,26 @@ def limit_event_actions(resource_usage: Mapping[str, object] | None) -> list[str
     return actions
 
 
+def artifact_limit_counter_defaults(
+    max_file_bytes: int | None,
+    max_total_bytes: int | None,
+) -> dict[str, int]:
+    """Return the shared artifact counter schema with limit values and zero counts."""
+    return {
+        "artifact_limit_file_bytes": int(max_file_bytes or 0),
+        "artifact_limit_total_bytes": int(max_total_bytes or 0),
+        "artifact_files_collected": 0,
+        "artifact_files_skipped": 0,
+        "artifact_files_excluded": 0,
+        "artifact_bytes_collected": 0,
+        "artifact_skip_file_limit": 0,
+        "artifact_skip_total_limit": 0,
+        "artifact_skip_symlink": 0,
+        "artifact_skip_invalid": 0,
+        "artifact_skip_read_error": 0,
+    }
+
+
 def _increment_artifact_skip(counters: dict[str, int], reason_key: str) -> None:
     counters["artifact_files_skipped"] += 1
     counters[reason_key] += 1
@@ -332,3 +348,10 @@ def _path_within_root(root: Path, path: Path) -> bool:
         return True
     except ValueError:
         return False
+
+
+def _artifact_allowed(path: str, *, exclude_names: set[str], exclude_hidden: bool) -> bool:
+    rel = Path(path)
+    if exclude_hidden and any(part.startswith(".") for part in rel.parts):
+        return False
+    return rel.as_posix() not in exclude_names

--- a/tldw_Server_API/app/core/Sandbox/limits.py
+++ b/tldw_Server_API/app/core/Sandbox/limits.py
@@ -8,9 +8,10 @@ from __future__ import annotations
 
 import fnmatch
 import os
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any
 
 
 @dataclass(frozen=True, slots=True)
@@ -38,6 +39,10 @@ _OUTPUT_LIMIT_COUNTER_KEYS = (
     "stderr_bytes_returned",
     "stdout_truncated",
     "stderr_truncated",
+)
+_LOG_LIMIT_COUNTER_KEYS = (
+    "log_limit_bytes",
+    "log_truncated",
 )
 _ARTIFACT_LIMIT_COUNTER_KEYS = (
     "artifact_limit_file_bytes",
@@ -236,7 +241,7 @@ def build_limit_audit_metadata(resource_usage: Mapping[str, object] | None) -> d
         return {}
 
     metadata: dict[str, object] = {}
-    for key in _OUTPUT_LIMIT_COUNTER_KEYS + _ARTIFACT_LIMIT_COUNTER_KEYS:
+    for key in _OUTPUT_LIMIT_COUNTER_KEYS + _LOG_LIMIT_COUNTER_KEYS + _ARTIFACT_LIMIT_COUNTER_KEYS:
         value = _counter_value(resource_usage.get(key))
         if value is not None:
             metadata[key] = value
@@ -267,6 +272,8 @@ def limit_event_actions(resource_usage: Mapping[str, object] | None) -> list[str
     actions: list[str] = []
     if bool(metadata.get("output_truncated")):
         actions.append("output_truncated")
+    if int(metadata.get("log_truncated", 0) or 0) > 0:
+        actions.append("log_truncated")
     if bool(metadata.get("artifacts_limited")):
         actions.append("artifacts_limited")
     return actions

--- a/tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py
+++ b/tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py
@@ -33,6 +33,7 @@ RunStatusReasonCode = Literal[
 _LIMIT_COUNTER_KEYS = (
     "stdout_truncated",
     "stderr_truncated",
+    "log_truncated",
     "guest_output_limit_exceeded",
     "artifact_files_skipped",
     "artifact_skip_file_limit",

--- a/tldw_Server_API/app/core/Sandbox/runners/docker_runner.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/docker_runner.py
@@ -22,6 +22,7 @@ from ..network_policy import (
     expand_allowlist_to_targets,
 )
 from ..streams import get_hub
+from .resource_limits import collect_runner_artifacts, log_limit_counters
 
 _DOCKER_RUNNER_NONCRITICAL_EXCEPTIONS = (
     AssertionError,
@@ -803,6 +804,7 @@ class DockerRunner:
                 "log_bytes": int(get_hub().get_log_bytes(run_id)),
                 "artifact_bytes": 0,
             }
+            usage.update(log_limit_counters(hub, run_id, int(max_log or 10 * 1024 * 1024)))
             with contextlib.suppress(_DOCKER_RUNNER_NONCRITICAL_EXCEPTIONS):
                 subprocess.check_call(["docker", "rm", "-f", cid])
             self._cleanup_tracked_egress_resources(run_id)
@@ -836,25 +838,15 @@ class DockerRunner:
             image_digest = None
         # Step 4: Collect artifacts via docker cp of workspace and filter by glob allowlist
         artifacts_map: dict[str, bytes] = {}
+        artifact_counters: dict[str, int] = {}
         try:
             if spec.capture_patterns:
                 host_ws = tempfile.mkdtemp(prefix="tldw_ws_copy_")
                 try:
                     subprocess.check_call(["docker", "cp", f"{cid}:/workspace/.", f"{host_ws}/"])
-                    # Apply glob
-                    import fnmatch
-                    for root, _dirs, files in os.walk(host_ws):
-                        for fname in files:
-                            rel = os.path.relpath(os.path.join(root, fname), host_ws)
-                            # match posix style
-                            rel_posix = rel.replace(os.sep, "/")
-                            if any(fnmatch.fnmatchcase(rel_posix, pat) for pat in (spec.capture_patterns or [])):
-                                try:
-                                    with open(os.path.join(host_ws, rel), "rb") as rf:
-                                        data = rf.read()
-                                    artifacts_map[rel_posix] = data
-                                except _DOCKER_RUNNER_NONCRITICAL_EXCEPTIONS as e:
-                                    logger.debug(f"Skip artifact {rel}: {e}")
+                    artifact_result = collect_runner_artifacts(host_ws, spec.capture_patterns)
+                    artifacts_map = artifact_result.artifacts
+                    artifact_counters = artifact_result.counters
                 finally:
                     with contextlib.suppress(_DOCKER_RUNNER_NONCRITICAL_EXCEPTIONS):
                         shutil.rmtree(host_ws, ignore_errors=True)
@@ -898,6 +890,8 @@ class DockerRunner:
             "log_bytes": int(total_log),
             "artifact_bytes": int(art_bytes),
         }
+        usage.update(log_limit_counters(hub, run_id, int(max_log or 10 * 1024 * 1024)))
+        usage.update(artifact_counters)
         # Remove container after collecting stats
         with contextlib.suppress(_DOCKER_RUNNER_NONCRITICAL_EXCEPTIONS):
             subprocess.check_call(["docker", "rm", "-f", cid])

--- a/tldw_Server_API/app/core/Sandbox/runners/firecracker_runner.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/firecracker_runner.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import contextlib
-import fnmatch
 import hashlib
 import json
 import os
@@ -18,8 +17,10 @@ from pathlib import Path
 from loguru import logger
 
 from tldw_Server_API.app.core.testing import is_truthy
+
 from ..models import RunPhase, RunSpec, RunStatus
 from ..streams import get_hub
+from .resource_limits import collect_runner_artifacts, log_limit_counters
 
 _FIRECRACKER_RUNNER_NONCRITICAL_EXCEPTIONS = (
     OSError,
@@ -413,20 +414,15 @@ class FirecrackerRunner:
             finished = datetime.utcnow()
             # Collect artifacts
             artifacts_map: dict[str, bytes] = {}
+            artifact_counters: dict[str, int] = {}
             try:
                 if spec.capture_patterns:
-                    for root, _dirs, files in os.walk(workspace):
-                        for fn in files:
-                            rel = os.path.relpath(os.path.join(root, fn), workspace)
-                            rel_posix = rel.replace(os.sep, "/")
-                            if any(fnmatch.fnmatchcase(rel_posix, pat) for pat in (spec.capture_patterns or [])):
-                                try:
-                                    with open(os.path.join(root, fn), "rb") as rf:
-                                        artifacts_map[rel_posix] = rf.read()
-                                except _FIRECRACKER_RUNNER_NONCRITICAL_EXCEPTIONS:
-                                    pass
+                    artifact_result = collect_runner_artifacts(workspace, spec.capture_patterns)
+                    artifacts_map = artifact_result.artifacts
+                    artifact_counters = artifact_result.counters
             except _FIRECRACKER_RUNNER_NONCRITICAL_EXCEPTIONS:
                 artifacts_map = {}
+                artifact_counters = {}
 
             # Usage
             try:
@@ -434,6 +430,10 @@ class FirecrackerRunner:
             except _FIRECRACKER_RUNNER_NONCRITICAL_EXCEPTIONS:
                 log_bytes_total = 0
             art_bytes = sum(len(v) for v in artifacts_map.values()) if artifacts_map else 0
+            try:
+                max_log_bytes = int(os.getenv("SANDBOX_MAX_LOG_BYTES", "10485760"))
+            except _FIRECRACKER_RUNNER_NONCRITICAL_EXCEPTIONS:
+                max_log_bytes = 10 * 1024 * 1024
             usage: dict[str, int] = {
                 "cpu_time_sec": 0,
                 "wall_time_sec": int(max(0.0, (finished - started).total_seconds())),
@@ -441,6 +441,8 @@ class FirecrackerRunner:
                 "log_bytes": int(log_bytes_total),
                 "artifact_bytes": int(art_bytes),
             }
+            usage.update(log_limit_counters(hub, run_id, max_log_bytes))
+            usage.update(artifact_counters)
 
             return RunStatus(
                 id="",

--- a/tldw_Server_API/app/core/Sandbox/runners/lima_runner.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/lima_runner.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import contextlib
-import fnmatch
 import hashlib
 import json
 import os
@@ -17,10 +16,12 @@ from pathlib import Path
 from loguru import logger
 
 from tldw_Server_API.app.core.testing import is_truthy
+
 from ..models import RunPhase, RunSpec, RunStatus, RuntimeType
 from ..runtime_capabilities import RuntimePreflightResult
 from ..streams import get_hub
 from .lima_enforcer import build_lima_enforcer
+from .resource_limits import collect_runner_artifacts, log_limit_counters
 
 _LIMA_RUNNER_NONCRITICAL_EXCEPTIONS = (
     AssertionError,
@@ -415,6 +416,7 @@ class LimaRunner:
         exit_code: int | None = None
         image_digest: str | None = None
         artifacts_map: dict[str, bytes] = {}
+        artifact_counters: dict[str, int] = {}
         message = "Lima execution"
 
         try:
@@ -489,7 +491,14 @@ class LimaRunner:
                     pass
 
             # Collect artifacts
-            artifacts_map = self._collect_artifacts(workspace, spec.capture_patterns)
+            artifact_result = collect_runner_artifacts(
+                workspace,
+                spec.capture_patterns,
+                exclude_names={"entry.sh", "run.log", ".env"},
+                exclude_hidden=True,
+            )
+            artifacts_map = artifact_result.artifacts
+            artifact_counters = artifact_result.counters
 
             # Compute image digest based on Lima config hash
             try:
@@ -551,6 +560,10 @@ class LimaRunner:
             log_bytes_total = int(hub.get_log_bytes(run_id))
         except _LIMA_RUNNER_NONCRITICAL_EXCEPTIONS:
             log_bytes_total = 0
+        try:
+            max_log_bytes = int(os.getenv("SANDBOX_MAX_LOG_BYTES", "10485760"))
+        except _LIMA_RUNNER_NONCRITICAL_EXCEPTIONS:
+            max_log_bytes = 10 * 1024 * 1024
 
         art_bytes = sum(len(v) for v in artifacts_map.values()) if artifacts_map else 0
 
@@ -561,6 +574,8 @@ class LimaRunner:
             "log_bytes": int(log_bytes_total),
             "artifact_bytes": int(art_bytes),
         }
+        usage.update(log_limit_counters(hub, run_id, max_log_bytes))
+        usage.update(artifact_counters)
 
         return RunStatus(
             id="",
@@ -673,34 +688,9 @@ exit $exit_code
         workspace: str, capture_patterns: list[str] | None
     ) -> dict[str, bytes]:
         """Collect artifacts matching the capture patterns."""
-        if not capture_patterns:
-            return {}
-
-        artifacts_map: dict[str, bytes] = {}
-
-        try:
-            for root, _dirs, files in os.walk(workspace):
-                for fn in files:
-                    full = os.path.join(root, fn)
-                    rel = os.path.relpath(full, workspace)
-                    rel_posix = rel.replace(os.sep, "/")
-
-                    # Skip internal files
-                    if rel_posix.startswith("."):
-                        continue
-                    if rel_posix in ("entry.sh", "run.log", ".env"):
-                        continue
-
-                    if any(
-                        fnmatch.fnmatchcase(rel_posix, pat)
-                        for pat in capture_patterns
-                    ):
-                        try:
-                            with open(full, "rb") as rf:
-                                artifacts_map[rel_posix] = rf.read()
-                        except _LIMA_RUNNER_NONCRITICAL_EXCEPTIONS:
-                            pass
-        except _LIMA_RUNNER_NONCRITICAL_EXCEPTIONS:
-            pass
-
-        return artifacts_map
+        return collect_runner_artifacts(
+            workspace,
+            capture_patterns,
+            exclude_names={"entry.sh", "run.log", ".env"},
+            exclude_hidden=True,
+        ).artifacts

--- a/tldw_Server_API/app/core/Sandbox/runners/lima_runner.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/lima_runner.py
@@ -339,6 +339,7 @@ class LimaRunner:
         """Execute a real run in a Lima VM."""
         started = datetime.utcnow()
         hub = get_hub()
+        max_log_bytes = self._max_log_bytes()
 
         with contextlib.suppress(_LIMA_RUNNER_NONCRITICAL_EXCEPTIONS):
             hub.publish_event(run_id, "start", {
@@ -486,7 +487,7 @@ class LimaRunner:
                     with open(log_path, "rb") as f:
                         log_data = f.read()
                     if log_data:
-                        hub.publish_stdout(run_id, log_data, 10 * 1024 * 1024)
+                        hub.publish_stdout(run_id, log_data, max_log_bytes)
                 except _LIMA_RUNNER_NONCRITICAL_EXCEPTIONS:
                     pass
 
@@ -560,11 +561,6 @@ class LimaRunner:
             log_bytes_total = int(hub.get_log_bytes(run_id))
         except _LIMA_RUNNER_NONCRITICAL_EXCEPTIONS:
             log_bytes_total = 0
-        try:
-            max_log_bytes = int(os.getenv("SANDBOX_MAX_LOG_BYTES", "10485760"))
-        except _LIMA_RUNNER_NONCRITICAL_EXCEPTIONS:
-            max_log_bytes = 10 * 1024 * 1024
-
         art_bytes = sum(len(v) for v in artifacts_map.values()) if artifacts_map else 0
 
         usage: dict[str, int] = {
@@ -656,11 +652,7 @@ exit $exit_code
     def _tail_log(run_id: str, log_path: str, stop_flag: dict[str, bool]) -> None:
         """Tail the log file and stream to hub."""
         hub = get_hub()
-        max_log = None
-        try:
-            max_log = int(os.getenv("SANDBOX_MAX_LOG_BYTES", "10485760"))
-        except _LIMA_RUNNER_NONCRITICAL_EXCEPTIONS:
-            max_log = 10 * 1024 * 1024
+        max_log = LimaRunner._max_log_bytes()
 
         # Wait for log file to appear
         deadline = time.time() + 10
@@ -682,6 +674,14 @@ exit $exit_code
                     hub.publish_stdout(run_id, line, max_log)
         except _LIMA_RUNNER_NONCRITICAL_EXCEPTIONS:
             return
+
+    @staticmethod
+    def _max_log_bytes() -> int:
+        """Return the configured Lima stream log cap in bytes."""
+        try:
+            return int(os.getenv("SANDBOX_MAX_LOG_BYTES", "10485760"))
+        except _LIMA_RUNNER_NONCRITICAL_EXCEPTIONS:
+            return 10 * 1024 * 1024
 
     @staticmethod
     def _collect_artifacts(

--- a/tldw_Server_API/app/core/Sandbox/runners/resource_limits.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/resource_limits.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+from ..limits import ArtifactLimitResult, collect_limited_artifacts
+from ..policy import SandboxPolicyConfig
+
+_RESOURCE_LIMIT_EXCEPTIONS = (
+    AttributeError,
+    OSError,
+    PermissionError,
+    RuntimeError,
+    TypeError,
+    ValueError,
+)
+
+
+def sandbox_policy_config() -> SandboxPolicyConfig:
+    try:
+        return SandboxPolicyConfig.from_settings()
+    except _RESOURCE_LIMIT_EXCEPTIONS:
+        return SandboxPolicyConfig()
+
+
+def artifact_limit_values() -> tuple[int, int]:
+    cfg = sandbox_policy_config()
+    return (
+        _positive_int(getattr(cfg, "max_artifact_file_bytes", None), 64 * 1024 * 1024),
+        _positive_int(getattr(cfg, "max_artifact_total_bytes", None), 256 * 1024 * 1024),
+    )
+
+
+def collect_runner_artifacts(
+    workspace: str,
+    capture_patterns: list[str] | None,
+    *,
+    exclude_names: Iterable[str] = (),
+    exclude_hidden: bool = False,
+) -> ArtifactLimitResult:
+    max_file_bytes, max_total_bytes = artifact_limit_values()
+    try:
+        result = collect_limited_artifacts(
+            workspace,
+            capture_patterns,
+            max_file_bytes=max_file_bytes,
+            max_total_bytes=max_total_bytes,
+        )
+    except _RESOURCE_LIMIT_EXCEPTIONS:
+        return ArtifactLimitResult(artifacts={}, counters={})
+
+    excludes = {str(name).strip() for name in exclude_names if str(name).strip()}
+    if not excludes and not exclude_hidden:
+        return result
+
+    artifacts = {
+        path: data
+        for path, data in result.artifacts.items()
+        if _artifact_allowed(path, exclude_names=excludes, exclude_hidden=exclude_hidden)
+    }
+    if len(artifacts) == len(result.artifacts):
+        return result
+    counters = dict(result.counters)
+    counters["artifact_files_collected"] = len(artifacts)
+    counters["artifact_bytes_collected"] = sum(len(value) for value in artifacts.values())
+    return ArtifactLimitResult(artifacts=artifacts, counters=counters)
+
+
+def log_limit_counters(hub: Any, run_id: str, max_log_bytes: int) -> dict[str, int]:
+    try:
+        is_truncated = bool(hub.is_log_truncated(run_id))
+    except _RESOURCE_LIMIT_EXCEPTIONS:
+        is_truncated = False
+    if not is_truncated:
+        return {}
+    return {
+        "log_limit_bytes": int(max_log_bytes),
+        "log_truncated": 1,
+    }
+
+
+def _positive_int(value: Any, default: int) -> int:
+    try:
+        parsed = int(value)
+    except _RESOURCE_LIMIT_EXCEPTIONS:
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _artifact_allowed(path: str, *, exclude_names: set[str], exclude_hidden: bool) -> bool:
+    rel = Path(path)
+    if exclude_hidden and any(part.startswith(".") for part in rel.parts):
+        return False
+    return rel.as_posix() not in exclude_names

--- a/tldw_Server_API/app/core/Sandbox/runners/resource_limits.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/resource_limits.py
@@ -1,10 +1,17 @@
+"""Runner-facing artifact and log limit helpers.
+
+This module keeps runtime implementations on one shared reporting contract while
+letting each runner keep its own execution lifecycle. Helpers intentionally
+return aggregate counters only; they do not expose artifact paths in limit/audit
+metadata.
+"""
+
 from __future__ import annotations
 
 from collections.abc import Iterable
-from pathlib import Path
 from typing import Any
 
-from ..limits import ArtifactLimitResult, collect_limited_artifacts
+from ..limits import ArtifactLimitResult, artifact_limit_counter_defaults, collect_limited_artifacts
 from ..policy import SandboxPolicyConfig
 
 _RESOURCE_LIMIT_EXCEPTIONS = (
@@ -18,6 +25,7 @@ _RESOURCE_LIMIT_EXCEPTIONS = (
 
 
 def sandbox_policy_config() -> SandboxPolicyConfig:
+    """Load sandbox policy settings with safe defaults for runner cleanup paths."""
     try:
         return SandboxPolicyConfig.from_settings()
     except _RESOURCE_LIMIT_EXCEPTIONS:
@@ -25,6 +33,7 @@ def sandbox_policy_config() -> SandboxPolicyConfig:
 
 
 def artifact_limit_values() -> tuple[int, int]:
+    """Return positive per-file and total artifact byte caps for runner collection."""
     cfg = sandbox_policy_config()
     return (
         _positive_int(getattr(cfg, "max_artifact_file_bytes", None), 64 * 1024 * 1024),
@@ -39,6 +48,7 @@ def collect_runner_artifacts(
     exclude_names: Iterable[str] = (),
     exclude_hidden: bool = False,
 ) -> ArtifactLimitResult:
+    """Collect runner artifacts with shared caps and optional internal exclusions."""
     max_file_bytes, max_total_bytes = artifact_limit_values()
     try:
         result = collect_limited_artifacts(
@@ -46,28 +56,19 @@ def collect_runner_artifacts(
             capture_patterns,
             max_file_bytes=max_file_bytes,
             max_total_bytes=max_total_bytes,
+            exclude_names=exclude_names,
+            exclude_hidden=exclude_hidden,
         )
     except _RESOURCE_LIMIT_EXCEPTIONS:
-        return ArtifactLimitResult(artifacts={}, counters={})
-
-    excludes = {str(name).strip() for name in exclude_names if str(name).strip()}
-    if not excludes and not exclude_hidden:
-        return result
-
-    artifacts = {
-        path: data
-        for path, data in result.artifacts.items()
-        if _artifact_allowed(path, exclude_names=excludes, exclude_hidden=exclude_hidden)
-    }
-    if len(artifacts) == len(result.artifacts):
-        return result
-    counters = dict(result.counters)
-    counters["artifact_files_collected"] = len(artifacts)
-    counters["artifact_bytes_collected"] = sum(len(value) for value in artifacts.values())
-    return ArtifactLimitResult(artifacts=artifacts, counters=counters)
+        counters = artifact_limit_counter_defaults(max_file_bytes, max_total_bytes)
+        counters["artifact_files_skipped"] = 1
+        counters["artifact_skip_read_error"] = 1
+        return ArtifactLimitResult(artifacts={}, counters=counters)
+    return result
 
 
 def log_limit_counters(hub: Any, run_id: str, max_log_bytes: int) -> dict[str, int]:
+    """Return resource_usage counters when the stream hub observed log truncation."""
     try:
         is_truncated = bool(hub.is_log_truncated(run_id))
     except _RESOURCE_LIMIT_EXCEPTIONS:
@@ -86,10 +87,3 @@ def _positive_int(value: Any, default: int) -> int:
     except _RESOURCE_LIMIT_EXCEPTIONS:
         return default
     return parsed if parsed > 0 else default
-
-
-def _artifact_allowed(path: str, *, exclude_names: set[str], exclude_hidden: bool) -> bool:
-    rel = Path(path)
-    if exclude_hidden and any(part.startswith(".") for part in rel.parts):
-        return False
-    return rel.as_posix() not in exclude_names

--- a/tldw_Server_API/app/core/Sandbox/runners/seatbelt_runner.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/seatbelt_runner.py
@@ -391,12 +391,14 @@ class SeatbeltRunner:
                 phase = RunPhase.killed
                 exit_code = None
                 artifacts_map = {}
+                artifact_counters = {}
                 message = "canceled_by_user"
         except _SEATBELT_NONCRITICAL_EXCEPTIONS as exc:
             logger.error("Seatbelt execution error for run {}: {}", run_id, exc)
             message = f"seatbelt execution error: {exc}"
             if self._consume_cancelled(run_id):
                 phase = RunPhase.killed
+                artifact_counters = {}
                 message = "canceled_by_user"
         finally:
             finished = datetime.utcnow()

--- a/tldw_Server_API/app/core/Sandbox/runners/seatbelt_runner.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/seatbelt_runner.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import contextlib
-import fnmatch
 import os
 import shutil
 import signal
@@ -22,6 +21,7 @@ from ..policy import SandboxPolicy
 from ..runtime_capabilities import RuntimePreflightResult
 from ..snapshots import SnapshotManager
 from ..streams import get_hub
+from .resource_limits import collect_runner_artifacts, log_limit_counters
 from .seatbelt_policy import build_seatbelt_env, render_seatbelt_profile, resolve_command_argv
 from .vz_common import vz_host_facts
 
@@ -209,32 +209,7 @@ class SeatbeltRunner:
 
     @staticmethod
     def _collect_artifacts(workspace: str, capture_patterns: list[str] | None) -> dict[str, bytes]:
-        if not capture_patterns:
-            return {}
-
-        artifacts_map: dict[str, bytes] = {}
-        workspace_root = Path(workspace)
-        if workspace_root.is_symlink():
-            return {}
-        try:
-            for root, _dirs, files in os.walk(workspace):
-                root_path = Path(root)
-                if not SeatbeltRunner._path_within_root(workspace_root, root_path):
-                    continue
-                for file_name in files:
-                    full_path = root_path / file_name
-                    if full_path.is_symlink():
-                        continue
-                    if not SeatbeltRunner._path_within_root(workspace_root, full_path):
-                        continue
-                    full = os.path.join(root, file_name)
-                    rel = os.path.relpath(full, workspace)
-                    rel_posix = rel.replace(os.sep, "/")
-                    if any(fnmatch.fnmatchcase(rel_posix, pattern) for pattern in capture_patterns):
-                        artifacts_map[rel_posix] = full_path.read_bytes()
-        except _SEATBELT_NONCRITICAL_EXCEPTIONS:
-            return {}
-        return artifacts_map
+        return collect_runner_artifacts(workspace, capture_patterns).artifacts
 
     @staticmethod
     def _read_capped_output(path: Path, max_bytes: int) -> bytes:
@@ -248,6 +223,15 @@ class SeatbeltRunner:
                 return handle.read(max_bytes)
         except _SEATBELT_NONCRITICAL_EXCEPTIONS:
             return b""
+
+    @staticmethod
+    def _output_file_exceeds_cap(path: Path, max_bytes: int) -> bool:
+        if max_bytes <= 0 or not path.is_file():
+            return False
+        try:
+            return int(path.stat().st_size) > int(max_bytes)
+        except _SEATBELT_NONCRITICAL_EXCEPTIONS:
+            return False
 
     @classmethod
     def _terminate_process_group(cls, proc: subprocess.Popen[bytes]) -> None:
@@ -302,11 +286,13 @@ class SeatbeltRunner:
         hub = get_hub()
         max_log_bytes = self._max_log_bytes()
         artifacts_map: dict[str, bytes] = {}
+        artifact_counters: dict[str, int] = {}
         message = "seatbelt execution failed"
         exit_code: int | None = None
         phase = RunPhase.failed
         stdout_data = b""
         stderr_data = b""
+        log_truncated = False
         proc: subprocess.Popen[bytes] | None = None
         run_dir: str | None = None
 
@@ -384,14 +370,22 @@ class SeatbeltRunner:
 
             stdout_data = self._read_capped_output(stdout_path, max_log_bytes)
             stderr_data = self._read_capped_output(stderr_path, max_log_bytes)
+            log_truncated = self._output_file_exceeds_cap(
+                stdout_path,
+                max_log_bytes,
+            ) or self._output_file_exceeds_cap(stderr_path, max_log_bytes)
 
             if stdout_data:
                 hub.publish_stdout(run_id, stdout_data, max_log_bytes=max_log_bytes)
             if stderr_data:
                 hub.publish_stderr(run_id, stderr_data, max_log_bytes=max_log_bytes)
+            if log_truncated:
+                hub.mark_log_truncated(run_id)
 
             if phase != RunPhase.timed_out:
-                artifacts_map = self._collect_artifacts(workspace, spec.capture_patterns)
+                artifact_result = collect_runner_artifacts(workspace, spec.capture_patterns)
+                artifacts_map = artifact_result.artifacts
+                artifact_counters = artifact_result.counters
 
             if self._consume_cancelled(run_id):
                 phase = RunPhase.killed
@@ -431,6 +425,8 @@ class SeatbeltRunner:
             "log_bytes": int(total_log_bytes),
             "artifact_bytes": int(artifact_bytes),
         }
+        usage.update(log_limit_counters(hub, run_id, max_log_bytes))
+        usage.update(artifact_counters)
 
         return RunStatus(
             id="",

--- a/tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py
@@ -407,9 +407,11 @@ class VZLinuxRunner(VZBaseRunner):
                 and str(session_control.get("vm_id") or "").strip()
             ):
                 candidate_vm_id = str(session_control.get("vm_id") or "").strip()
-                # Host truth errors are allowed to bubble up; explicit admin repair owns row cleanup.
-                status = helper.get_vm_status(candidate_vm_id)
-                if bool(status.healthy):
+                try:
+                    status = helper.get_vm_status(candidate_vm_id)
+                except (MacOSVirtualizationHelperUnavailable, MacOSVirtualizationHelperProtocolError):
+                    status = None
+                if bool(getattr(status, "healthy", False)):
                     vm_id = candidate_vm_id
                     template_ref = str(session_control.get("template_id") or "").strip() or spec.base_image
                     should_terminate_vm = False

--- a/tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py
@@ -22,6 +22,7 @@ from ..models import RunPhase, RunSpec, RunStatus, RuntimeType
 from ..policy import SandboxPolicyConfig
 from ..runtime_capabilities import RuntimePreflightResult
 from ..streams import get_hub
+from .resource_limits import log_limit_counters
 from .vz_common import _VZ_NONCRITICAL_EXCEPTIONS, VZBaseRunner, vz_host_facts
 
 _VZ_LINUX_RUNNER_NONCRITICAL_EXCEPTIONS = (
@@ -406,11 +407,8 @@ class VZLinuxRunner(VZBaseRunner):
                 and str(session_control.get("vm_id") or "").strip()
             ):
                 candidate_vm_id = str(session_control.get("vm_id") or "").strip()
-                try:
-                    status = helper.get_vm_status(candidate_vm_id)
-                except (MacOSVirtualizationHelperUnavailable, MacOSVirtualizationHelperProtocolError):
-                    # Host truth is unavailable or untrusted; explicit admin repair owns row cleanup.
-                    raise
+                # Host truth errors are allowed to bubble up; explicit admin repair owns row cleanup.
+                status = helper.get_vm_status(candidate_vm_id)
                 if bool(status.healthy):
                     vm_id = candidate_vm_id
                     template_ref = str(session_control.get("template_id") or "").strip() or spec.base_image
@@ -547,6 +545,7 @@ class VZLinuxRunner(VZBaseRunner):
             "log_bytes": int(total_log_bytes),
             "artifact_bytes": int(artifact_bytes),
         }
+        usage.update(log_limit_counters(hub, run_id, max_log_bytes))
         usage.update(output_counters)
         usage.update(artifact_counters)
 

--- a/tldw_Server_API/app/core/Sandbox/runners/worktree_runner.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/worktree_runner.py
@@ -8,7 +8,6 @@ profile layering ready for a future iteration).  On Linux, requires
 from __future__ import annotations
 
 import contextlib
-import fnmatch
 import os
 import shutil
 import signal
@@ -18,7 +17,6 @@ import tempfile
 import threading
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
 
 from loguru import logger
 
@@ -28,6 +26,7 @@ from tldw_Server_API.app.core.testing import is_truthy
 from ..models import RunPhase, RunSpec, RunStatus, RuntimeType
 from ..runtime_capabilities import RuntimePreflightResult
 from ..streams import get_hub
+from .resource_limits import collect_runner_artifacts, log_limit_counters
 
 # ---------------------------------------------------------------------------
 # Env vars stripped from child processes for security
@@ -404,6 +403,15 @@ class WorktreeRunner:
             return b""
 
     @staticmethod
+    def _output_file_exceeds_cap(path: Path, max_bytes: int) -> bool:
+        if max_bytes <= 0 or not path.is_file():
+            return False
+        try:
+            return int(path.stat().st_size) > int(max_bytes)
+        except _WORKTREE_NONCRITICAL_EXCEPTIONS:
+            return False
+
+    @staticmethod
     def _path_within_root(root_path: Path, candidate: Path) -> bool:
         try:
             root = root_path.resolve()
@@ -417,31 +425,7 @@ class WorktreeRunner:
         workspace: str,
         capture_patterns: list[str] | None,
     ) -> dict[str, bytes]:
-        if not capture_patterns:
-            return {}
-        artifacts_map: dict[str, bytes] = {}
-        workspace_root = Path(workspace)
-        if workspace_root.is_symlink():
-            return {}
-        try:
-            for root, _dirs, files in os.walk(workspace):
-                root_path = Path(root)
-                if not WorktreeRunner._path_within_root(workspace_root, root_path):
-                    continue
-                for file_name in files:
-                    full_path = root_path / file_name
-                    if full_path.is_symlink():
-                        continue
-                    if not WorktreeRunner._path_within_root(workspace_root, full_path):
-                        continue
-                    full = os.path.join(root, file_name)
-                    rel = os.path.relpath(full, workspace)
-                    rel_posix = rel.replace(os.sep, "/")
-                    if any(fnmatch.fnmatchcase(rel_posix, p) for p in capture_patterns):
-                        artifacts_map[rel_posix] = full_path.read_bytes()
-        except _WORKTREE_NONCRITICAL_EXCEPTIONS:
-            return {}
-        return artifacts_map
+        return collect_runner_artifacts(workspace, capture_patterns).artifacts
 
     # ---- execution ----------------------------------------------------------
 
@@ -483,9 +467,11 @@ class WorktreeRunner:
         hub = get_hub()
         max_log_bytes = self._max_log_bytes()
         artifacts_map: dict[str, bytes] = {}
+        artifact_counters: dict[str, int] = {}
         message = "worktree execution failed"
         exit_code: int | None = None
         phase = RunPhase.failed
+        log_truncated = False
         proc: subprocess.Popen[bytes] | None = None
         run_dir: str | None = None
         repo_path_for_cleanup: str | None = None
@@ -612,16 +598,24 @@ class WorktreeRunner:
 
             stdout_data = self._read_capped_output(stdout_path, max_log_bytes)
             stderr_data = self._read_capped_output(stderr_path, max_log_bytes)
+            log_truncated = self._output_file_exceeds_cap(
+                stdout_path,
+                max_log_bytes,
+            ) or self._output_file_exceeds_cap(stderr_path, max_log_bytes)
 
             if stdout_data:
                 hub.publish_stdout(run_id, stdout_data, max_log_bytes=max_log_bytes)
             if stderr_data:
                 hub.publish_stderr(run_id, stderr_data, max_log_bytes=max_log_bytes)
+            if log_truncated:
+                hub.mark_log_truncated(run_id)
 
             if phase != RunPhase.timed_out:
-                artifacts_map = self._collect_artifacts(
+                artifact_result = collect_runner_artifacts(
                     worktree_path, spec.capture_patterns,
                 )
+                artifacts_map = artifact_result.artifacts
+                artifact_counters = artifact_result.counters
 
             if self._consume_cancelled(run_id):
                 phase = RunPhase.killed
@@ -672,6 +666,8 @@ class WorktreeRunner:
             "log_bytes": int(total_log_bytes),
             "artifact_bytes": int(artifact_bytes),
         }
+        usage.update(log_limit_counters(hub, run_id, max_log_bytes))
+        usage.update(artifact_counters)
 
         return RunStatus(
             id="",

--- a/tldw_Server_API/app/core/Sandbox/runners/worktree_runner.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/worktree_runner.py
@@ -621,6 +621,7 @@ class WorktreeRunner:
                 phase = RunPhase.killed
                 exit_code = None
                 artifacts_map = {}
+                artifact_counters = {}
                 message = "canceled_by_user"
 
         except _WORKTREE_NONCRITICAL_EXCEPTIONS as exc:
@@ -628,6 +629,7 @@ class WorktreeRunner:
             message = f"worktree execution error: {exc}"
             if self._consume_cancelled(run_id):
                 phase = RunPhase.killed
+                artifact_counters = {}
                 message = "canceled_by_user"
         finally:
             finished = datetime.now(timezone.utc)

--- a/tldw_Server_API/app/core/Sandbox/streams.py
+++ b/tldw_Server_API/app/core/Sandbox/streams.py
@@ -310,6 +310,11 @@ class RunStreamHub:
         """Publish a truncated frame with a reason code."""
         self._publish(run_id, {"type": "truncated", "reason": str(reason)})
 
+    def mark_log_truncated(self, run_id: str) -> None:
+        """Mark a run as log-truncated when a runner caps file-backed output."""
+        with self._lock:
+            self._mark_log_truncated_locked(run_id)
+
     def publish_stdout(self, run_id: str, chunk: bytes, max_log_bytes: int | None = None) -> None:
         self._publish_stream(run_id, "stdout", chunk, max_log_bytes=max_log_bytes)
 
@@ -321,21 +326,11 @@ class RunStreamHub:
         with self._lock:
             used = self._log_bytes.get(run_id, 0)
             if used >= cap:
-                if run_id not in self._truncated:
-                    self._truncated.add(run_id)
-                    self._publish(run_id, {"type": "truncated", "reason": "log_cap"})
-                    # Metrics: log truncations
-                    try:
-                        from tldw_Server_API.app.core.Metrics import increment_counter
-                        increment_counter(
-                            "sandbox_log_truncations_total",
-                            labels={"component": "sandbox", "reason": "log_cap"},
-                        )
-                    except _SANDBOX_STREAMS_NONCRITICAL_EXCEPTIONS:
-                        pass
+                self._mark_log_truncated_locked(run_id)
                 return
             remaining = cap - used
         data = chunk[:remaining]
+        truncated_chunk = len(chunk) > len(data)
         try:
             text = data.decode("utf-8")
             frame = {"type": kind, "encoding": "utf8", "data": text}
@@ -345,6 +340,23 @@ class RunStreamHub:
         with self._lock:
             self._log_bytes[run_id] = self._log_bytes.get(run_id, 0) + len(data)
         self._publish(run_id, frame)
+        if truncated_chunk:
+            with self._lock:
+                self._mark_log_truncated_locked(run_id)
+
+    def _mark_log_truncated_locked(self, run_id: str) -> None:
+        if run_id in self._truncated:
+            return
+        self._truncated.add(run_id)
+        self._publish(run_id, {"type": "truncated", "reason": "log_cap"})
+        try:
+            from tldw_Server_API.app.core.Metrics import increment_counter
+            increment_counter(
+                "sandbox_log_truncations_total",
+                labels={"component": "sandbox", "reason": "log_cap"},
+            )
+        except _SANDBOX_STREAMS_NONCRITICAL_EXCEPTIONS:
+            pass
 
     def drain_buffer(self, run_id: str, q: asyncio.Queue) -> None:
         with self._lock:
@@ -539,6 +551,11 @@ class RunStreamHub:
         """Return the total number of bytes published to stdout/stderr for a run."""
         with self._lock:
             return int(self._log_bytes.get(run_id, 0))
+
+    def is_log_truncated(self, run_id: str) -> bool:
+        """Return whether stdout/stderr streaming hit the configured byte cap."""
+        with self._lock:
+            return run_id in self._truncated
 
     def cleanup_run(self, run_id: str) -> None:
         """Remove all references for a run to avoid memory leaks.

--- a/tldw_Server_API/app/core/Sandbox/streams.py
+++ b/tldw_Server_API/app/core/Sandbox/streams.py
@@ -313,7 +313,9 @@ class RunStreamHub:
     def mark_log_truncated(self, run_id: str) -> None:
         """Mark a run as log-truncated when a runner caps file-backed output."""
         with self._lock:
-            self._mark_log_truncated_locked(run_id)
+            should_emit = self._mark_log_truncated_locked(run_id)
+        if should_emit:
+            self._emit_log_truncated(run_id)
 
     def publish_stdout(self, run_id: str, chunk: bytes, max_log_bytes: int | None = None) -> None:
         self._publish_stream(run_id, "stdout", chunk, max_log_bytes=max_log_bytes)
@@ -326,9 +328,15 @@ class RunStreamHub:
         with self._lock:
             used = self._log_bytes.get(run_id, 0)
             if used >= cap:
-                self._mark_log_truncated_locked(run_id)
-                return
-            remaining = cap - used
+                should_emit = self._mark_log_truncated_locked(run_id)
+                remaining = 0
+            else:
+                should_emit = False
+                remaining = cap - used
+        if used >= cap:
+            if should_emit:
+                self._emit_log_truncated(run_id)
+            return
         data = chunk[:remaining]
         truncated_chunk = len(chunk) > len(data)
         try:
@@ -342,12 +350,17 @@ class RunStreamHub:
         self._publish(run_id, frame)
         if truncated_chunk:
             with self._lock:
-                self._mark_log_truncated_locked(run_id)
+                should_emit = self._mark_log_truncated_locked(run_id)
+            if should_emit:
+                self._emit_log_truncated(run_id)
 
-    def _mark_log_truncated_locked(self, run_id: str) -> None:
+    def _mark_log_truncated_locked(self, run_id: str) -> bool:
         if run_id in self._truncated:
-            return
+            return False
         self._truncated.add(run_id)
+        return True
+
+    def _emit_log_truncated(self, run_id: str) -> None:
         self._publish(run_id, {"type": "truncated", "reason": "log_cap"})
         try:
             from tldw_Server_API.app.core.Metrics import increment_counter

--- a/tldw_Server_API/tests/sandbox/test_lima_runner_log_caps.py
+++ b/tldw_Server_API/tests/sandbox/test_lima_runner_log_caps.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import tldw_Server_API.app.core.Sandbox.runners.lima_runner as lima_module
+from tldw_Server_API.app.core.Sandbox.models import RunPhase, RunSpec, RuntimeType
+from tldw_Server_API.app.core.Sandbox.runners.lima_runner import LimaRunner
+
+
+def test_lima_real_run_replays_logs_with_configured_cap(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("SANDBOX_MAX_LOG_BYTES", "5")
+    monkeypatch.setenv("TLDW_SANDBOX_LIMA_VERSION", "0.0-test")
+
+    run_dir = tmp_path / "lima-run"
+    run_dir.mkdir()
+    workspace = run_dir / "workspace"
+
+    monkeypatch.setattr(lima_module.tempfile, "mkdtemp", lambda prefix: str(run_dir))
+    monkeypatch.setattr(LimaRunner, "_tail_log", staticmethod(lambda run_id, log_path, stop_flag: None))
+
+    def _fake_run(args: list[str], **kwargs: object) -> SimpleNamespace:
+        del kwargs
+        if args[:2] == ["limactl", "shell"]:
+            (workspace / "run.log").write_bytes(b"abcdef")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(lima_module.subprocess, "run", _fake_run)
+
+    status = LimaRunner()._run_real(
+        "run-lima-log-cap",
+        RunSpec(
+            session_id=None,
+            runtime=RuntimeType.lima,
+            base_image="ubuntu-24.04",
+            command=["/bin/echo", "ok"],
+            network_policy="deny_all",
+            timeout_sec=5,
+        ),
+    )
+
+    assert status.phase == RunPhase.completed
+    assert status.resource_usage["log_bytes"] == 5
+    assert status.resource_usage["log_limit_bytes"] == 5
+    assert status.resource_usage["log_truncated"] == 1

--- a/tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py
+++ b/tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py
@@ -89,6 +89,12 @@ def test_run_status_reason_taxonomy_reports_limit_signals() -> None:
         exit_code=None,
         resource_usage={"artifact_skip_total_limit": 1},
     ) == "limits_applied"
+    assert normalize_run_status_reason(
+        phase=RunPhase.completed,
+        message="worktree execution finished",
+        exit_code=0,
+        resource_usage={"log_truncated": 1, "log_limit_bytes": 5},
+    ) == "limits_applied"
 
 
 def test_run_status_reason_taxonomy_maps_known_policy_failures() -> None:

--- a/tldw_Server_API/tests/sandbox/test_runner_resource_limits.py
+++ b/tldw_Server_API/tests/sandbox/test_runner_resource_limits.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.Sandbox.policy import SandboxPolicyConfig
+from tldw_Server_API.app.core.Sandbox.runners import resource_limits as resource_limits_module
+from tldw_Server_API.app.core.Sandbox.runners.resource_limits import collect_runner_artifacts
+
+
+def test_collect_runner_artifacts_excludes_internal_files_before_quota(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Internal runner exclusions must not consume user-visible artifact quota."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / ".internal").write_bytes(b"aaaa")
+    (workspace / "visible.txt").write_bytes(b"bbbb")
+
+    def _policy_from_settings(cls: type[SandboxPolicyConfig]) -> SandboxPolicyConfig:
+        return cls(max_artifact_file_bytes=100, max_artifact_total_bytes=4)
+
+    monkeypatch.setattr(SandboxPolicyConfig, "from_settings", classmethod(_policy_from_settings))
+
+    result = collect_runner_artifacts(
+        str(workspace),
+        ["*"],
+        exclude_hidden=True,
+    )
+
+    assert result.artifacts == {"visible.txt": b"bbbb"}
+    assert result.counters["artifact_files_collected"] == 1
+    assert result.counters["artifact_files_excluded"] == 1
+    assert result.counters["artifact_files_skipped"] == 0
+
+
+def test_collect_runner_artifacts_preserves_counter_schema_on_collection_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Collection failures should still report the shared artifact counter contract."""
+
+    def _policy_from_settings(cls: type[SandboxPolicyConfig]) -> SandboxPolicyConfig:
+        return cls(max_artifact_file_bytes=5, max_artifact_total_bytes=8)
+
+    def _raise_collection_error(*args: object, **kwargs: object) -> object:
+        del args, kwargs
+        raise OSError("cannot read workspace")
+
+    monkeypatch.setattr(SandboxPolicyConfig, "from_settings", classmethod(_policy_from_settings))
+    monkeypatch.setattr(resource_limits_module, "collect_limited_artifacts", _raise_collection_error)
+
+    result = collect_runner_artifacts(str(tmp_path), ["*"])
+
+    assert result.artifacts == {}
+    assert result.counters["artifact_limit_file_bytes"] == 5
+    assert result.counters["artifact_limit_total_bytes"] == 8
+    assert result.counters["artifact_files_collected"] == 0
+    assert result.counters["artifact_bytes_collected"] == 0
+    assert result.counters["artifact_files_skipped"] == 1
+    assert result.counters["artifact_skip_read_error"] == 1

--- a/tldw_Server_API/tests/sandbox/test_sandbox_run_limit_audit.py
+++ b/tldw_Server_API/tests/sandbox/test_sandbox_run_limit_audit.py
@@ -25,6 +25,8 @@ def test_build_limit_audit_metadata_is_aggregate_and_path_minimized() -> None:
             "artifact_files_skipped": 2,
             "artifact_skip_file_limit": 1,
             "artifact_skip_total_limit": 1,
+            "log_limit_bytes": 5,
+            "log_truncated": 1,
             "artifact_paths": ["secret.txt"],
         }
     )
@@ -33,11 +35,14 @@ def test_build_limit_audit_metadata_is_aggregate_and_path_minimized() -> None:
     assert metadata["output_limit_bytes"] == 5
     assert metadata["artifact_files_skipped"] == 2
     assert metadata["artifact_skip_reasons"] == ["file_limit", "total_limit"]
+    assert metadata["log_limit_bytes"] == 5
+    assert metadata["log_truncated"] == 1
     assert "artifact_paths" not in metadata
 
 
 def test_limit_event_actions_reports_only_affected_limits() -> None:
     assert limit_event_actions({"stdout_truncated": 1}) == ["output_truncated"]
+    assert limit_event_actions({"log_truncated": 1}) == ["log_truncated"]
     assert limit_event_actions({"artifact_files_skipped": 1}) == ["artifacts_limited"]
     assert limit_event_actions({"stdout_truncated": 0, "artifact_files_skipped": 0}) == []
 

--- a/tldw_Server_API/tests/sandbox/test_seatbelt_runner.py
+++ b/tldw_Server_API/tests/sandbox/test_seatbelt_runner.py
@@ -7,7 +7,7 @@ import pytest
 
 import tldw_Server_API.app.core.Sandbox.runners.seatbelt_runner as seatbelt_module
 from tldw_Server_API.app.core.Sandbox.models import RunPhase, RunSpec, RuntimeType, TrustLevel
-from tldw_Server_API.app.core.Sandbox.policy import SandboxPolicy
+from tldw_Server_API.app.core.Sandbox.policy import SandboxPolicy, SandboxPolicyConfig
 from tldw_Server_API.app.core.Sandbox.runners.seatbelt_runner import SeatbeltRunner
 from tldw_Server_API.app.core.Sandbox.streams import get_hub
 
@@ -156,6 +156,74 @@ def test_seatbelt_start_run_executes_real_subprocess_and_collects_artifacts(monk
     assert any(frame.get("type") == "stdout" and "stdout-line" in frame.get("data", "") for frame in frames)
     assert any(frame.get("type") == "stderr" and "stderr-line" in frame.get("data", "") for frame in frames)
     assert not run_root.exists()
+
+
+def test_seatbelt_start_run_applies_artifact_and_log_caps(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("TLDW_SANDBOX_SEATBELT_FAKE_EXEC", raising=False)
+    monkeypatch.setattr(
+        SandboxPolicyConfig,
+        "from_settings",
+        classmethod(lambda cls: cls(max_artifact_file_bytes=5, max_artifact_total_bytes=8)),
+    )
+    monkeypatch.setattr(seatbelt_module, "_sandbox_exec_exists", lambda: True)
+    monkeypatch.setattr(SeatbeltRunner, "_max_log_bytes", staticmethod(lambda: 5))
+
+    run_root = tmp_path / "seatbelt-cap-run"
+    run_root.mkdir()
+    workspace_root = run_root / "workspace"
+
+    monkeypatch.setattr(seatbelt_module.tempfile, "mkdtemp", lambda prefix: str(run_root))
+
+    class _CapPopen:
+        def __init__(self, argv, cwd=None, env=None, stdout=None, stderr=None, stdin=None, start_new_session=None):
+            assert stdout is not None
+            assert stderr is not None
+            del argv, env, stdin, start_new_session
+            assert cwd == str(workspace_root)
+            (workspace_root / "small.txt").write_bytes(b"1234")
+            (workspace_root / "too-large.txt").write_bytes(b"123456")
+            (workspace_root / "would-exceed-total.txt").write_bytes(b"56789")
+            stdout.write(b"abcdef")
+            stdout.flush()
+            self.pid = 5151
+            self.returncode = 0
+
+        def wait(self, timeout=None):
+            return 0
+
+    monkeypatch.setattr(seatbelt_module.subprocess, "Popen", _CapPopen)
+
+    run_id = "run-seatbelt-cap-contract"
+    hub = get_hub()
+    hub.cleanup_run(run_id)
+
+    status = SeatbeltRunner().start_run(
+        run_id=run_id,
+        spec=RunSpec(
+            session_id=None,
+            runtime=RuntimeType.seatbelt,
+            base_image="host-local",
+            command=["/bin/echo", "ok"],
+            network_policy="deny_all",
+            trust_level=TrustLevel.trusted,
+            timeout_sec=7,
+            capture_patterns=["*.txt"],
+        ),
+        session_workspace=None,
+    )
+
+    assert status.phase == RunPhase.completed
+    assert status.artifacts == {"small.txt": b"1234"}
+    assert status.resource_usage["artifact_limit_file_bytes"] == 5
+    assert status.resource_usage["artifact_limit_total_bytes"] == 8
+    assert status.resource_usage["artifact_files_collected"] == 1
+    assert status.resource_usage["artifact_files_skipped"] == 2
+    assert status.resource_usage["artifact_skip_file_limit"] == 1
+    assert status.resource_usage["artifact_skip_total_limit"] == 1
+    assert status.resource_usage["artifact_bytes_collected"] == 4
+    assert status.resource_usage["artifact_bytes"] == 4
+    assert status.resource_usage["log_limit_bytes"] == 5
+    assert status.resource_usage["log_truncated"] == 1
 
 
 def test_seatbelt_start_run_times_out_and_cleans_up(monkeypatch, tmp_path: Path) -> None:

--- a/tldw_Server_API/tests/sandbox/test_seatbelt_runner.py
+++ b/tldw_Server_API/tests/sandbox/test_seatbelt_runner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import BinaryIO
 from unittest.mock import MagicMock
 
 import pytest
@@ -158,7 +159,11 @@ def test_seatbelt_start_run_executes_real_subprocess_and_collects_artifacts(monk
     assert not run_root.exists()
 
 
-def test_seatbelt_start_run_applies_artifact_and_log_caps(monkeypatch, tmp_path: Path) -> None:
+def test_seatbelt_start_run_applies_artifact_and_log_caps(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Seatbelt runs should share artifact and log-cap resource counters."""
     monkeypatch.delenv("TLDW_SANDBOX_SEATBELT_FAKE_EXEC", raising=False)
     monkeypatch.setattr(
         SandboxPolicyConfig,
@@ -175,7 +180,16 @@ def test_seatbelt_start_run_applies_artifact_and_log_caps(monkeypatch, tmp_path:
     monkeypatch.setattr(seatbelt_module.tempfile, "mkdtemp", lambda prefix: str(run_root))
 
     class _CapPopen:
-        def __init__(self, argv, cwd=None, env=None, stdout=None, stderr=None, stdin=None, start_new_session=None):
+        def __init__(
+            self,
+            argv: object,
+            cwd: str | None = None,
+            env: dict[str, str] | None = None,
+            stdout: BinaryIO | None = None,
+            stderr: BinaryIO | None = None,
+            stdin: object | None = None,
+            start_new_session: bool | None = None,
+        ) -> None:
             assert stdout is not None
             assert stderr is not None
             del argv, env, stdin, start_new_session
@@ -188,7 +202,8 @@ def test_seatbelt_start_run_applies_artifact_and_log_caps(monkeypatch, tmp_path:
             self.pid = 5151
             self.returncode = 0
 
-        def wait(self, timeout=None):
+        def wait(self, timeout: int | None = None) -> int:
+            del timeout
             return 0
 
     monkeypatch.setattr(seatbelt_module.subprocess, "Popen", _CapPopen)
@@ -224,6 +239,64 @@ def test_seatbelt_start_run_applies_artifact_and_log_caps(monkeypatch, tmp_path:
     assert status.resource_usage["artifact_bytes"] == 4
     assert status.resource_usage["log_limit_bytes"] == 5
     assert status.resource_usage["log_truncated"] == 1
+
+
+def test_seatbelt_cancelled_run_drops_artifact_counters(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Canceled seatbelt runs should not report artifact counters for discarded artifacts."""
+    monkeypatch.delenv("TLDW_SANDBOX_SEATBELT_FAKE_EXEC", raising=False)
+    monkeypatch.setattr(
+        SandboxPolicyConfig,
+        "from_settings",
+        classmethod(lambda cls: cls(max_artifact_file_bytes=100, max_artifact_total_bytes=100)),
+    )
+    monkeypatch.setattr(seatbelt_module, "_sandbox_exec_exists", lambda: True)
+
+    run_root = tmp_path / "seatbelt-cancel-run"
+    run_root.mkdir()
+    workspace_root = run_root / "workspace"
+
+    monkeypatch.setattr(seatbelt_module.tempfile, "mkdtemp", lambda prefix: str(run_root))
+    monkeypatch.setattr(SeatbeltRunner, "_consume_cancelled", classmethod(lambda cls, run_id: True))
+
+    class _CancelPopen:
+        pid = 5252
+        returncode = 0
+
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            del args
+            stdout = kwargs.get("stdout")
+            assert stdout is not None
+            (workspace_root / "artifact.txt").write_bytes(b"artifact")
+            stdout.write(b"ok")
+            stdout.flush()
+
+        def wait(self, timeout: int | None = None) -> int:
+            del timeout
+            return 0
+
+    monkeypatch.setattr(seatbelt_module.subprocess, "Popen", _CancelPopen)
+
+    status = SeatbeltRunner().start_run(
+        run_id="run-seatbelt-cancel-counters",
+        spec=RunSpec(
+            session_id=None,
+            runtime=RuntimeType.seatbelt,
+            base_image="host-local",
+            command=["/bin/echo", "ok"],
+            network_policy="deny_all",
+            trust_level=TrustLevel.trusted,
+            timeout_sec=7,
+            capture_patterns=["*.txt"],
+        ),
+        session_workspace=None,
+    )
+
+    assert status.phase == RunPhase.killed
+    assert status.artifacts is None
+    assert "artifact_files_collected" not in status.resource_usage
 
 
 def test_seatbelt_start_run_times_out_and_cleans_up(monkeypatch, tmp_path: Path) -> None:

--- a/tldw_Server_API/tests/sandbox/test_streams_hub_lifecycle.py
+++ b/tldw_Server_API/tests/sandbox/test_streams_hub_lifecycle.py
@@ -151,3 +151,23 @@ def test_hub_marks_single_oversized_chunk_as_log_truncated() -> None:
         frame.get("type") == "truncated" and frame.get("reason") == "log_cap"
         for frame in frames
     )
+
+
+@pytest.mark.unit
+def test_hub_log_truncation_publishes_after_releasing_lock(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tldw_Server_API.app.core.Sandbox.streams import RunStreamHub
+
+    hub = RunStreamHub()
+    run_id = "run-hub-6"
+    published: list[dict[str, object]] = []
+
+    def _publish_without_lock(_run_id: str, frame: dict[str, object]) -> None:
+        assert not hub._lock._is_owned()  # type: ignore[attr-defined]
+        published.append(dict(frame))
+
+    monkeypatch.setattr(hub, "_publish", _publish_without_lock)
+
+    hub.mark_log_truncated(run_id)
+
+    assert hub.is_log_truncated(run_id)
+    assert published == [{"type": "truncated", "reason": "log_cap"}]

--- a/tldw_Server_API/tests/sandbox/test_streams_hub_lifecycle.py
+++ b/tldw_Server_API/tests/sandbox/test_streams_hub_lifecycle.py
@@ -125,3 +125,29 @@ def test_hub_unsubscribe_removes_only_target_queue() -> None:
 
     hub.unsubscribe(run_id, q2)
     assert run_id not in hub._queues
+
+
+@pytest.mark.unit
+def test_hub_marks_single_oversized_chunk_as_log_truncated() -> None:
+    from tldw_Server_API.app.core.Sandbox.streams import RunStreamHub
+
+    hub = RunStreamHub()
+    run_id = "run-hub-5"
+    queue = hub.subscribe(run_id)
+
+    hub.publish_stdout(run_id, b"abcdef", max_log_bytes=5)
+    hub.drain_buffer(run_id, queue)
+
+    frames = []
+    while True:
+        try:
+            frames.append(queue.get_nowait())
+        except Exception:
+            break
+
+    assert hub.get_log_bytes(run_id) == 5
+    assert hub.is_log_truncated(run_id)
+    assert any(
+        frame.get("type") == "truncated" and frame.get("reason") == "log_cap"
+        for frame in frames
+    )

--- a/tldw_Server_API/tests/sandbox/test_vz_linux_runner.py
+++ b/tldw_Server_API/tests/sandbox/test_vz_linux_runner.py
@@ -590,9 +590,11 @@ def test_vz_linux_session_run_reuses_only_healthy_vm(monkeypatch, tmp_path) -> N
     assert calls == ["get_vm_status", "exec_guest"]
 
 
-def test_vz_linux_session_reuse_helper_unavailable_does_not_delete_control(monkeypatch, tmp_path) -> None:
+def test_vz_linux_session_reuse_helper_unavailable_recreates_vm(monkeypatch, tmp_path) -> None:
     monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_FAKE_EXEC", raising=False)
+    calls: list[str] = []
     deleted: list[str] = []
+    stored: list[dict[str, object]] = []
 
     class _Store:
         def get_vz_session_control(self, session_id: str) -> dict[str, object]:
@@ -609,13 +611,34 @@ def test_vz_linux_session_reuse_helper_unavailable_does_not_delete_control(monke
             deleted.append(session_id)
             return True
 
+        def put_vz_session_control(self, **kwargs) -> None:
+            stored.append(dict(kwargs))
+
     class _FakeHelper:
         def get_vm_status(self, vm_id: str) -> HelperVMStatusReply:
             assert vm_id == "vm-candidate"
+            calls.append("get_vm_status")
             raise MacOSVirtualizationHelperUnavailable("macos_virtualization_helper_unavailable")
 
         def validate_template(self, request: dict[str, object]) -> dict[str, object]:
-            raise AssertionError(f"validate_template should not run when helper status is unavailable: {request}")
+            calls.append("validate_template")
+            return {
+                "template_id": "vz_linux:new-template",
+                "ready": True,
+                "reasons": [],
+            }
+
+        def create_vm(self, request: dict[str, object]) -> HelperVMReply:
+            calls.append("create_vm")
+            assert request["run_id"] == "vz-run-helper-unavailable"
+            assert request["session_id"] == "sess-helper-unavailable"
+            assert request["session_mode"] is True
+            return HelperVMReply(vm_id="vm-new", state="created")
+
+        def exec_guest(self, *, vm_id: str, request: dict[str, object]) -> HelperExecReply:
+            calls.append("exec_guest")
+            assert vm_id == "vm-new"
+            return HelperExecReply(exit_code=0, stdout=b"recreated\n")
 
     monkeypatch.setattr(vz_linux_module.VZLinuxRunner, "helper_client_cls", _FakeHelper)
 
@@ -631,14 +654,18 @@ def test_vz_linux_session_reuse_helper_unavailable_does_not_delete_control(monke
         session_workspace=str(tmp_path),
     )
 
-    assert status.phase == RunPhase.failed
-    assert "macos_virtualization_helper_unavailable" in status.message
-    assert deleted == []
+    assert status.phase == RunPhase.completed
+    assert status.exit_code == 0
+    assert calls == ["get_vm_status", "validate_template", "create_vm", "exec_guest"]
+    assert deleted == ["sess-helper-unavailable"]
+    assert stored and stored[0]["vm_id"] == "vm-new"
 
 
-def test_vz_linux_session_reuse_protocol_mismatch_does_not_delete_control(monkeypatch, tmp_path) -> None:
+def test_vz_linux_session_reuse_protocol_mismatch_recreates_vm(monkeypatch, tmp_path) -> None:
     monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_FAKE_EXEC", raising=False)
+    calls: list[str] = []
     deleted: list[str] = []
+    stored: list[dict[str, object]] = []
 
     class _Store:
         def get_vz_session_control(self, session_id: str) -> dict[str, object]:
@@ -655,13 +682,34 @@ def test_vz_linux_session_reuse_protocol_mismatch_does_not_delete_control(monkey
             deleted.append(session_id)
             return True
 
+        def put_vz_session_control(self, **kwargs) -> None:
+            stored.append(dict(kwargs))
+
     class _FakeHelper:
         def get_vm_status(self, vm_id: str) -> HelperVMStatusReply:
             assert vm_id == "vm-candidate"
+            calls.append("get_vm_status")
             raise MacOSVirtualizationHelperProtocolError("macos_virtualization_helper_protocol_mismatch")
 
         def validate_template(self, request: dict[str, object]) -> dict[str, object]:
-            raise AssertionError(f"validate_template should not run on helper protocol mismatch: {request}")
+            calls.append("validate_template")
+            return {
+                "template_id": "vz_linux:new-template",
+                "ready": True,
+                "reasons": [],
+            }
+
+        def create_vm(self, request: dict[str, object]) -> HelperVMReply:
+            calls.append("create_vm")
+            assert request["run_id"] == "vz-run-protocol-mismatch"
+            assert request["session_id"] == "sess-protocol-mismatch"
+            assert request["session_mode"] is True
+            return HelperVMReply(vm_id="vm-new", state="created")
+
+        def exec_guest(self, *, vm_id: str, request: dict[str, object]) -> HelperExecReply:
+            calls.append("exec_guest")
+            assert vm_id == "vm-new"
+            return HelperExecReply(exit_code=0, stdout=b"recreated\n")
 
     monkeypatch.setattr(vz_linux_module.VZLinuxRunner, "helper_client_cls", _FakeHelper)
 
@@ -677,9 +725,82 @@ def test_vz_linux_session_reuse_protocol_mismatch_does_not_delete_control(monkey
         session_workspace=str(tmp_path),
     )
 
-    assert status.phase == RunPhase.failed
-    assert "macos_virtualization_helper_protocol_mismatch" in status.message
-    assert deleted == []
+    assert status.phase == RunPhase.completed
+    assert status.exit_code == 0
+    assert calls == ["get_vm_status", "validate_template", "create_vm", "exec_guest"]
+    assert deleted == ["sess-protocol-mismatch"]
+    assert stored and stored[0]["vm_id"] == "vm-new"
+
+
+def test_vz_linux_session_reuse_absent_status_recreates_vm(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_FAKE_EXEC", raising=False)
+    calls: list[str] = []
+    deleted: list[str] = []
+    stored: list[dict[str, object]] = []
+
+    class _Store:
+        def get_vz_session_control(self, session_id: str) -> dict[str, object]:
+            assert session_id == "sess-absent-status"
+            return {
+                "runtime": "vz_linux",
+                "vm_id": "vm-candidate",
+                "template_id": "vz_linux:existing",
+                "workspace_mount": str(tmp_path),
+                "agent_ready": True,
+            }
+
+        def delete_vz_session_control(self, session_id: str) -> bool:
+            deleted.append(session_id)
+            return True
+
+        def put_vz_session_control(self, **kwargs) -> None:
+            stored.append(dict(kwargs))
+
+    class _FakeHelper:
+        def get_vm_status(self, vm_id: str) -> HelperVMStatusReply | None:
+            assert vm_id == "vm-candidate"
+            calls.append("get_vm_status")
+            return None
+
+        def validate_template(self, request: dict[str, object]) -> dict[str, object]:
+            calls.append("validate_template")
+            return {
+                "template_id": "vz_linux:new-template",
+                "ready": True,
+                "reasons": [],
+            }
+
+        def create_vm(self, request: dict[str, object]) -> HelperVMReply:
+            calls.append("create_vm")
+            assert request["run_id"] == "vz-run-absent-status"
+            assert request["session_id"] == "sess-absent-status"
+            assert request["session_mode"] is True
+            return HelperVMReply(vm_id="vm-new", state="created")
+
+        def exec_guest(self, *, vm_id: str, request: dict[str, object]) -> HelperExecReply:
+            calls.append("exec_guest")
+            assert vm_id == "vm-new"
+            return HelperExecReply(exit_code=0, stdout=b"recreated\n")
+
+    monkeypatch.setattr(vz_linux_module.VZLinuxRunner, "helper_client_cls", _FakeHelper)
+
+    status = VZLinuxRunner(session_control_store=_Store()).start_run(
+        run_id="vz-run-absent-status",
+        spec=RunSpec(
+            session_id="sess-absent-status",
+            runtime=RuntimeType.vz_linux,
+            base_image="ubuntu-24.04",
+            command=["/bin/echo", "ok"],
+            network_policy="deny_all",
+        ),
+        session_workspace=str(tmp_path),
+    )
+
+    assert status.phase == RunPhase.completed
+    assert status.exit_code == 0
+    assert calls == ["get_vm_status", "validate_template", "create_vm", "exec_guest"]
+    assert deleted == ["sess-absent-status"]
+    assert stored and stored[0]["vm_id"] == "vm-new"
 
 
 def test_vz_linux_session_run_recreates_unhealthy_vm(monkeypatch, tmp_path) -> None:

--- a/tldw_Server_API/tests/sandbox/test_worktree_runner.py
+++ b/tldw_Server_API/tests/sandbox/test_worktree_runner.py
@@ -1,4 +1,5 @@
 """Tests for the git worktree sandbox runner."""
+
 from __future__ import annotations
 
 import os
@@ -13,14 +14,8 @@ import pytest
 
 import tldw_Server_API.app.core.Sandbox.runners.worktree_runner as worktree_module
 from tldw_Server_API.app.core.Sandbox.models import RunPhase, RunSpec, RuntimeType
-from tldw_Server_API.app.core.Sandbox.runners.worktree_runner import (
-    WorktreeRunner,
-    _SENSITIVE_ENV_VARS,
-    _check_git_version,
-    _check_unshare_available,
-    worktree_available,
-)
-
+from tldw_Server_API.app.core.Sandbox.policy import SandboxPolicyConfig
+from tldw_Server_API.app.core.Sandbox.runners.worktree_runner import WorktreeRunner
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -445,6 +440,109 @@ def test_start_run_timeout_cleans_worktree_run_dir_and_active_tracking(
             WorktreeRunner._active_proc.pop(run_id, None)  # type: ignore[attr-defined]
             WorktreeRunner._active_run_dir.pop(run_id, None)  # type: ignore[attr-defined]
             WorktreeRunner._cancelled_runs.discard(run_id)  # type: ignore[attr-defined]
+
+
+def test_start_run_applies_artifact_and_log_caps(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Worktree runs should share artifact and log-cap resource counters."""
+    monkeypatch.setattr(
+        SandboxPolicyConfig,
+        "from_settings",
+        classmethod(lambda cls: cls(max_artifact_file_bytes=5, max_artifact_total_bytes=8)),
+    )
+    monkeypatch.setattr(WorktreeRunner, "_max_log_bytes", staticmethod(lambda: 5))
+    monkeypatch.setattr(worktree_module.sys, "platform", "darwin")
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    run_dir = tmp_path / "run-dir"
+    created_worktree = tmp_path / "created-worktree"
+    destroy_calls: list[tuple[str, str]] = []
+
+    def _mkdtemp(prefix: str) -> str:
+        if prefix != "tldw_wt_run_":
+            pytest.fail(f"unexpected temp prefix: {prefix}")
+        run_dir.mkdir()
+        return str(run_dir)
+
+    def _create_worktree(repo_path: str, branch: str = "HEAD") -> str:
+        if repo_path != str(repo):
+            pytest.fail(f"unexpected repo path: {repo_path}")
+        if branch != "HEAD":
+            pytest.fail(f"unexpected branch: {branch}")
+        created_worktree.mkdir()
+        return str(created_worktree)
+
+    def _destroy_worktree(worktree_path: str, repo_path: str) -> None:
+        destroy_calls.append((worktree_path, repo_path))
+        shutil.rmtree(worktree_path)
+
+    class _CapProc:
+        pid = 6060
+        returncode = 0
+
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            cwd = kwargs.get("cwd")
+            stdout = kwargs.get("stdout")
+            assert cwd == str(created_worktree)
+            assert stdout is not None
+            (created_worktree / "small.txt").write_bytes(b"1234")
+            (created_worktree / "too-large.txt").write_bytes(b"123456")
+            (created_worktree / "would-exceed-total.txt").write_bytes(b"56789")
+            stdout.write(b"abcdef")
+            stdout.flush()
+
+        def wait(self, timeout: int | None = None) -> int:
+            del timeout
+            return 0
+
+    monkeypatch.setattr(worktree_module.tempfile, "mkdtemp", _mkdtemp)
+    monkeypatch.setattr(
+        WorktreeRunner,
+        "_is_git_repo",
+        staticmethod(lambda path: path == str(repo)),
+    )
+    monkeypatch.setattr(
+        WorktreeRunner,
+        "create_worktree",
+        staticmethod(_create_worktree),
+    )
+    monkeypatch.setattr(
+        WorktreeRunner,
+        "destroy_worktree",
+        staticmethod(_destroy_worktree),
+    )
+    monkeypatch.setattr(worktree_module.subprocess, "Popen", _CapProc)
+
+    run_id = "run-worktree-cap-contract"
+    result = WorktreeRunner(allowed_repo_dirs=[str(tmp_path)]).start_run(
+        run_id,
+        RunSpec(
+            session_id=None,
+            runtime=RuntimeType.worktree,
+            base_image=None,
+            command=["/bin/echo", "ok"],
+            timeout_sec=10,
+            capture_patterns=["*.txt"],
+        ),
+        session_workspace=str(repo),
+    )
+
+    assert result.phase == RunPhase.completed
+    assert result.artifacts == {"small.txt": b"1234"}
+    assert result.resource_usage["artifact_limit_file_bytes"] == 5
+    assert result.resource_usage["artifact_limit_total_bytes"] == 8
+    assert result.resource_usage["artifact_files_collected"] == 1
+    assert result.resource_usage["artifact_files_skipped"] == 2
+    assert result.resource_usage["artifact_skip_file_limit"] == 1
+    assert result.resource_usage["artifact_skip_total_limit"] == 1
+    assert result.resource_usage["artifact_bytes_collected"] == 4
+    assert result.resource_usage["artifact_bytes"] == 4
+    assert result.resource_usage["log_limit_bytes"] == 5
+    assert result.resource_usage["log_truncated"] == 1
+    assert destroy_calls == [(str(created_worktree), str(repo))]
 
 
 # ---------------------------------------------------------------------------

--- a/tldw_Server_API/tests/sandbox/test_worktree_runner.py
+++ b/tldw_Server_API/tests/sandbox/test_worktree_runner.py
@@ -545,6 +545,80 @@ def test_start_run_applies_artifact_and_log_caps(
     assert destroy_calls == [(str(created_worktree), str(repo))]
 
 
+def test_cancelled_run_drops_artifact_counters(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Canceled worktree runs should not report counters for discarded artifacts."""
+    monkeypatch.setattr(
+        SandboxPolicyConfig,
+        "from_settings",
+        classmethod(lambda cls: cls(max_artifact_file_bytes=100, max_artifact_total_bytes=100)),
+    )
+    monkeypatch.setattr(worktree_module.sys, "platform", "darwin")
+    monkeypatch.setattr(WorktreeRunner, "_consume_cancelled", classmethod(lambda cls, run_id: True))
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    run_dir = tmp_path / "run-dir"
+    created_worktree = tmp_path / "created-worktree"
+
+    def _mkdtemp(prefix: str) -> str:
+        assert prefix == "tldw_wt_run_"
+        run_dir.mkdir()
+        return str(run_dir)
+
+    def _create_worktree(repo_path: str, branch: str = "HEAD") -> str:
+        del branch
+        assert repo_path == str(repo)
+        created_worktree.mkdir()
+        return str(created_worktree)
+
+    def _destroy_worktree(worktree_path: str, repo_path: str) -> None:
+        assert worktree_path == str(created_worktree)
+        assert repo_path == str(repo)
+        shutil.rmtree(worktree_path)
+
+    class _CancelProc:
+        pid = 6161
+        returncode = 0
+
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            del args
+            stdout = kwargs.get("stdout")
+            assert stdout is not None
+            (created_worktree / "artifact.txt").write_bytes(b"artifact")
+            stdout.write(b"ok")
+            stdout.flush()
+
+        def wait(self, timeout: int | None = None) -> int:
+            del timeout
+            return 0
+
+    monkeypatch.setattr(worktree_module.tempfile, "mkdtemp", _mkdtemp)
+    monkeypatch.setattr(WorktreeRunner, "_is_git_repo", staticmethod(lambda path: path == str(repo)))
+    monkeypatch.setattr(WorktreeRunner, "create_worktree", staticmethod(_create_worktree))
+    monkeypatch.setattr(WorktreeRunner, "destroy_worktree", staticmethod(_destroy_worktree))
+    monkeypatch.setattr(worktree_module.subprocess, "Popen", _CancelProc)
+
+    result = WorktreeRunner(allowed_repo_dirs=[str(tmp_path)]).start_run(
+        "run-worktree-cancel-counters",
+        RunSpec(
+            session_id=None,
+            runtime=RuntimeType.worktree,
+            base_image=None,
+            command=["/bin/echo", "ok"],
+            timeout_sec=10,
+            capture_patterns=["*.txt"],
+        ),
+        session_workspace=str(repo),
+    )
+
+    assert result.phase == RunPhase.killed
+    assert result.artifacts is None
+    assert "artifact_files_collected" not in result.resource_usage
+
+
 # ---------------------------------------------------------------------------
 # Linux unshare refusal
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds shared artifact and log cap contracts for sandbox runners so host-local and VM-backed paths report consistent aggregate counters.
- Enforces artifact byte caps for seatbelt/worktree collection and reuses shared capped collection in Docker, Firecracker, and Lima where applicable.
- Surfaces log truncation through stream hub resource usage, audit metadata, and run status reason taxonomy.

## Test Plan
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_sandbox_limits.py tldw_Server_API/tests/sandbox/test_streams_hub_lifecycle.py tldw_Server_API/tests/sandbox/test_seatbelt_runner.py tldw_Server_API/tests/sandbox/test_worktree_runner.py tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py tldw_Server_API/tests/sandbox/test_sandbox_run_limit_audit.py -q
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile touched Sandbox app files
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check touched app/test files
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit touched Sandbox app files -f json -o /tmp/bandit_sandbox_artifact_log_cap_contracts.json; existing low-severity subprocess findings only, 0 findings on added lines
- [x] git diff --check

## Notes
- Human-authored Change summary is still required before merge per repo policy.
- `tldw_Server_API/tests/sandbox/test_docker_runner_fake.py -q` still stalls after the first TestClient case locally; this was recorded in TASK-78 as the existing app-lifespan/TestClient hang pattern rather than a runner-only artifact/log cap regression.