### PR TITLE
Phase 2.2: defer minimal workflow imports

### DIFF
--- a/backlog/tasks/task-80 - Phase-2.2-minimal-workflow-router-conditional-cleanup-AJ.md
+++ b/backlog/tasks/task-80 - Phase-2.2-minimal-workflow-router-conditional-cleanup-AJ.md
@@ -1,0 +1,56 @@
+---
+id: TASK-80
+title: Phase 2.2 minimal workflow router conditional cleanup AJ
+status: Done
+assignee: []
+created_date: '2026-05-05 17:48'
+labels:
+  - phase2.2
+  - router-cleanup
+  - issue-1116
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+  - 'https://github.com/rmusser01/tldw_server/pull/1313'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue issue #1116 Phase 2.2 after PR #1313. Convert the minimal-test workflow router registrations from an eager broad try/import RouterSpec block to ImportedRouterSpec-backed lazy router specs. Scope is limited to workflows, chat_workflows, and scheduler_workflows in tldw_Server_API/app/api/v1/router_groups/minimal.py. Preserve prefixes, tags, default route_key behavior, and the existing minimal-test broad skip behavior for import-time failures.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Workflow, chat workflow, and scheduler workflow minimal optional specs defer module import and router attribute lookup until registration
+- [x] #2 Existing workflow route metadata is preserved
+- [x] #3 Focused router-group tests cover lazy behavior and broad import failure skipping with red-green verification
+- [x] #4 Router-group contract tests and touched-source Bandit pass
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Started after PR #1313 merge was verified at merge commit 4db3d76fca5790a883f35db8ad93d5890bb61ed1. Worktree: /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/phase2-2-minimal-workflow-router-conditionals-aj. Branch: codex/phase2-2-minimal-workflow-router-conditionals-aj.
+
+Added focused red-green coverage for the minimal workflow router group. The focused tests failed red against the eager broad try/import block: spec construction imported workflows, chat_workflows, and scheduler_workflows through builtins.__import__, and the old eager RouterSpec entries did not expose named workflow specs for registration-time failure testing.
+
+Converted only workflows, chat_workflows, and scheduler_workflows to ImportedRouterSpec-backed lazy specs while preserving empty prefixes, tags, default route_key behavior, default_stable=True, and broad skip_exceptions=(Exception,) behavior in minimal test mode. Verification passed: focused selection workflow_attr_lookup or workflow_runtime_import_failures passed with 2 tests; full test_router_groups_contract.py passed with 83 tests; test_main_router_contract.py passed with 6 tests; Bandit on minimal.py reported 0 results and 0 errors; git diff --check was clean.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Converted the minimal workflow router registrations to lazy ImportedRouterSpec entries. The tranche defers workflow endpoint imports and router attribute lookup until registration while preserving the previous broad minimal-mode skip behavior for import-time failures. Added focused regression tests for lazy resolution and RuntimeError import-failure skipping.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -427,30 +427,30 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
     ):
         append_imported_router_spec(specs, control_support_spec)
 
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.chat_workflows import router as chat_workflows_router
-        from tldw_Server_API.app.api.v1.endpoints.scheduler_workflows import router as scheduler_workflows_router
-        from tldw_Server_API.app.api.v1.endpoints.workflows import router as workflows_router
-
-        specs.extend([
-            RouterSpec(
-                router=workflows_router,
-                prefix="",
-                tags=("workflows",),
-            ),
-            RouterSpec(
-                router=chat_workflows_router,
-                prefix="",
-                tags=("chat-workflows",),
-            ),
-            RouterSpec(
-                router=scheduler_workflows_router,
-                prefix="",
-                tags=("scheduler",),
-            ),
-        ])
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping workflow routers in minimal test app: {e}")
+    for workflow_spec in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.workflows",
+            log_name="workflows",
+            tags=("workflows",),
+            skip_context=minimal_skip_context,
+            skip_exceptions=(Exception,),
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.chat_workflows",
+            log_name="chat_workflows",
+            tags=("chat-workflows",),
+            skip_context=minimal_skip_context,
+            skip_exceptions=(Exception,),
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.scheduler_workflows",
+            log_name="scheduler_workflows",
+            tags=("scheduler",),
+            skip_context=minimal_skip_context,
+            skip_exceptions=(Exception,),
+        ),
+    ):
+        append_imported_router_spec(specs, workflow_spec)
 
     specs.append(RouterSpec(
         router=evaluations_router_factory,

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -4766,6 +4766,217 @@ def test_iter_minimal_optional_router_specs_defers_control_support_attr_lookup(
     }
 
 
+def test_iter_minimal_optional_router_specs_defers_workflow_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal workflow specs keep router attr lookup lazy."""
+    import builtins
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    router_definitions = (
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.workflows",
+            "expected_name": "workflows",
+            "path": "/workflows",
+            "prefix": "",
+            "tags": ("workflows",),
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.chat_workflows",
+            "expected_name": "chat_workflows",
+            "path": "/chat-workflows",
+            "prefix": "",
+            "tags": ("chat-workflows",),
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.scheduler_workflows",
+            "expected_name": "scheduler_workflows",
+            "path": "/scheduler-workflows",
+            "prefix": "",
+            "tags": ("scheduler",),
+        },
+    )
+    definitions_by_module = {
+        str(definition["module_name"]): definition
+        for definition in router_definitions
+    }
+    access_count = {
+        f"{definition['module_name']}.router": 0
+        for definition in router_definitions
+    }
+    import_calls: list[str] = []
+
+    for module_name, definition in definitions_by_module.items():
+        fake_module = ModuleType(module_name)
+        router = APIRouter()
+
+        @router.get(str(definition["path"]))
+        def _endpoint() -> dict[str, str]:
+            """Return a deterministic response for the fake minimal router."""
+            return {"status": "ok"}
+
+        def _module_getattr(
+            name: str,
+            *,
+            module_name: str = module_name,
+            router: APIRouter = router,
+        ) -> APIRouter:
+            """Track lazy router attribute resolution for the fake module."""
+            if name != "router":
+                raise AttributeError(name)
+            access_count[f"{module_name}.router"] += 1
+            return router
+
+        fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    endpoints_package = "tldw_Server_API.app.api.v1.endpoints."
+    real_import = builtins.__import__
+
+    def _fake_endpoint_import(
+        name: str,
+        globals: dict[str, object] | None = None,
+        locals: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> ModuleType:
+        """Track selected imports and fake unrelated eager optional routers."""
+        if (
+            level == 0
+            and name.startswith(endpoints_package)
+        ):
+            if name in definitions_by_module:
+                import_calls.append(name)
+                return real_import(name, globals, locals, fromlist, level)
+            attrs = tuple(attr for attr in fromlist if attr != "*") or ("router",)
+            for attr_name in attrs:
+                _install_fake_router_module(
+                    monkeypatch,
+                    name,
+                    path="/minimal-unrelated-workflow-fake",
+                    attr_name=attr_name,
+                )
+            return sys.modules[name]
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_endpoint_import)
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Track lazy module imports for selected minimal workflow routers."""
+        if module_name in definitions_by_module:
+            import_calls.append(module_name)
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+    fake_main = ModuleType("tldw_Server_API.app.main")
+    fake_main.app = FastAPI()  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "tldw_Server_API.app.main", fake_main)
+
+    specs = list(iter_minimal_optional_router_specs())
+    assert [
+        module_name
+        for module_name in definitions_by_module
+        if module_name in import_calls
+    ] == []
+    assert access_count == {
+        f"{definition['module_name']}.router": 0
+        for definition in router_definitions
+    }
+    assert import_calls == []
+
+    selected_specs = {
+        spec.name: spec
+        for spec in specs
+        if spec.name in {
+            str(definition["expected_name"])
+            for definition in router_definitions
+        }
+    }
+    assert set(selected_specs) == {
+        str(definition["expected_name"])
+        for definition in router_definitions
+    }
+
+    for definition in router_definitions:
+        spec = selected_specs[str(definition["expected_name"])]
+        assert spec.prefix == definition["prefix"]
+        assert spec.tags == definition["tags"]
+        assert spec.route_key == ""
+        assert spec.skip_context == "in minimal test app"
+        assert spec.default_stable is True
+        assert spec.skip_exceptions == (Exception,)
+        assert _first_router_path(spec.router) == definition["path"]
+
+    assert import_calls == [
+        str(definition["module_name"])
+        for definition in router_definitions
+    ]
+    assert access_count == {
+        f"{definition['module_name']}.router": 1
+        for definition in router_definitions
+    }
+
+
+def test_iter_minimal_optional_router_specs_skips_workflow_runtime_import_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal workflow specs preserve broad import failure skipping."""
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    workflow_modules = {
+        "tldw_Server_API.app.api.v1.endpoints.workflows",
+        "tldw_Server_API.app.api.v1.endpoints.chat_workflows",
+        "tldw_Server_API.app.api.v1.endpoints.scheduler_workflows",
+    }
+
+    specs = list(iter_minimal_optional_router_specs())
+    selected_specs = {
+        spec.name: spec
+        for spec in specs
+        if spec.name in {"workflows", "chat_workflows", "scheduler_workflows"}
+    }
+    assert set(selected_specs) == {"workflows", "chat_workflows", "scheduler_workflows"}
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Crash only the selected workflow router imports at registration."""
+        if module_name in workflow_modules:
+            raise RuntimeError(f"{module_name} exploded during import")
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    debug_messages: list[str] = []
+    monkeypatch.setattr("loguru.logger.debug", debug_messages.append)
+
+    assert register_router_specs(FastAPI(), selected_specs.values()) == 0
+    assert debug_messages == [
+        "Skipping workflows router in minimal test app: "
+        "tldw_Server_API.app.api.v1.endpoints.workflows exploded during import",
+        "Skipping chat_workflows router in minimal test app: "
+        "tldw_Server_API.app.api.v1.endpoints.chat_workflows exploded during import",
+        "Skipping scheduler_workflows router in minimal test app: "
+        "tldw_Server_API.app.api.v1.endpoints.scheduler_workflows exploded during import",
+    ]
+
+
 def test_iter_minimal_optional_router_specs_defers_experience_attr_lookup(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- Converts minimal-test workflows, chat workflows, and scheduler workflows router registrations to ImportedRouterSpec-backed lazy specs.
- Preserves existing empty prefixes, tags, route_key/default_stable behavior, and broad minimal-test import failure skipping with skip_exceptions=(Exception,).
- Adds TASK-80 tracking and focused regression coverage for lazy resolution plus RuntimeError skip behavior.

## Test Plan
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "workflow_attr_lookup or workflow_runtime_import_failures" -q (red before implementation, green after)
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/router_groups/minimal.py -f json -o /tmp/bandit_phase2_2_minimal_workflow_router_conditionals_rebased.json
- [x] git diff --check origin/dev...HEAD

Refs #1116
