### PR TITLE
Phase 2.2: defer minimal utility imports

### DIFF
--- a/backlog/tasks/task-82 - Phase-2.2-minimal-utility-router-conditional-cleanup-AK.md
+++ b/backlog/tasks/task-82 - Phase-2.2-minimal-utility-router-conditional-cleanup-AK.md
@@ -1,0 +1,61 @@
+---
+id: TASK-82
+title: Phase 2.2 minimal utility router conditional cleanup AK
+status: Done
+assignee: []
+created_date: '2026-05-05 18:15'
+updated_date: '2026-05-05 18:21'
+labels:
+  - phase2.2
+  - router-cleanup
+  - issue-1116
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+  - 'https://github.com/rmusser01/tldw_server/pull/1320'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue issue #1116 Phase 2.2 after PR #1320. Convert the next small minimal-test optional utility router registrations from eager broad try/import RouterSpec blocks to ImportedRouterSpec-backed lazy router specs. Scope is limited to web_clipper, skills, translate, and slides in tldw_Server_API/app/api/v1/router_groups/minimal.py. Preserve prefixes, tags, default route_key/default_stable behavior, and existing minimal-test broad skip behavior for import-time failures.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Web clipper, skills, translate, and slides minimal optional specs defer module import and router attribute lookup until registration
+- [x] #2 Existing route metadata is preserved for web clipper, skills, translate, and slides
+- [x] #3 Focused router-group tests cover lazy behavior and broad import failure skipping with red-green verification
+- [x] #4 Router-group contract tests and touched-source Bandit pass
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Red-green utility tranche: add focused router-group tests for lazy web_clipper, skills, translate, and slides resolution plus broad runtime import-failure skipping; then replace only those eager minimal optional imports with ImportedRouterSpec entries preserving metadata and skip semantics.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Red verification: focused utility router tests failed before production changes because selected routers were imported during spec construction and named lazy specs were absent.
+
+Green verification: focused utility tests, full router group contract tests, main router contract tests, touched-source Bandit, and git diff --check all passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Converted minimal-test web clipper, skills, translate, and slides optional router registrations to ImportedRouterSpec-backed lazy specs. This preserves prefixes, tags, default route_key/default_stable behavior, and broad minimal-test skip semantics with skip_exceptions=(Exception,) while deferring endpoint module imports until router registration. Added regression tests for lazy import/router attribute lookup and RuntimeError skip behavior. Verification: focused red/green utility tests, full test_router_groups_contract.py, test_main_router_contract.py, Bandit on minimal.py with 0 results/0 errors, and git diff --check.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -555,49 +555,41 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
     ):
         append_imported_router_spec(specs, persona_notes_spec)
 
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.web_clipper import router as web_clipper_router
-
-        specs.append(RouterSpec(
-            router=web_clipper_router,
+    for utility_spec in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.web_clipper",
+            log_name="web clipper",
             prefix=f"{API_V1_PREFIX}/web-clipper",
             tags=("web-clipper",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping web clipper router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.skills import router as skills_router
-
-        specs.append(RouterSpec(
-            router=skills_router,
+            skip_context=minimal_skip_context,
+            skip_exceptions=(Exception,),
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.skills",
+            log_name="skills",
             prefix=f"{API_V1_PREFIX}/skills",
             tags=("skills",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping skills router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.translate import router as translate_router
-
-        specs.append(RouterSpec(
-            router=translate_router,
+            skip_context=minimal_skip_context,
+            skip_exceptions=(Exception,),
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.translate",
+            log_name="translate",
             prefix=f"{API_V1_PREFIX}",
             tags=("translation",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping translate router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.slides import router as slides_router
-
-        specs.append(RouterSpec(
-            router=slides_router,
+            skip_context=minimal_skip_context,
+            skip_exceptions=(Exception,),
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.slides",
+            log_name="slides",
             prefix=f"{API_V1_PREFIX}",
             tags=("slides",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping slides router in minimal test app: {e}")
+            skip_context=minimal_skip_context,
+            skip_exceptions=(Exception,),
+        ),
+    ):
+        append_imported_router_spec(specs, utility_spec)
 
     try:
         from tldw_Server_API.app.api.v1.endpoints.kanban.kanban_boards import router as kanban_boards_router

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -4977,6 +4977,227 @@ def test_iter_minimal_optional_router_specs_skips_workflow_runtime_import_failur
     ]
 
 
+def test_iter_minimal_optional_router_specs_defers_utility_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal utility specs keep router attr lookup lazy."""
+    import builtins
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    router_definitions = (
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.web_clipper",
+            "expected_name": "web clipper",
+            "path": "/web-clipper",
+            "prefix": "/api/v1/web-clipper",
+            "tags": ("web-clipper",),
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.skills",
+            "expected_name": "skills",
+            "path": "/skills",
+            "prefix": "/api/v1/skills",
+            "tags": ("skills",),
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.translate",
+            "expected_name": "translate",
+            "path": "/translate",
+            "prefix": "/api/v1",
+            "tags": ("translation",),
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.slides",
+            "expected_name": "slides",
+            "path": "/slides",
+            "prefix": "/api/v1",
+            "tags": ("slides",),
+        },
+    )
+    definitions_by_module = {
+        str(definition["module_name"]): definition
+        for definition in router_definitions
+    }
+    access_count = {
+        f"{definition['module_name']}.router": 0
+        for definition in router_definitions
+    }
+    import_calls: list[str] = []
+
+    for module_name, definition in definitions_by_module.items():
+        fake_module = ModuleType(module_name)
+        router = APIRouter()
+
+        @router.get(str(definition["path"]))
+        def _endpoint() -> dict[str, str]:
+            """Return a deterministic response for the fake minimal router."""
+            return {"status": "ok"}
+
+        def _module_getattr(
+            name: str,
+            *,
+            module_name: str = module_name,
+            router: APIRouter = router,
+        ) -> APIRouter:
+            """Track lazy router attribute resolution for the fake module."""
+            if name != "router":
+                raise AttributeError(name)
+            access_count[f"{module_name}.router"] += 1
+            return router
+
+        fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    endpoints_package = "tldw_Server_API.app.api.v1.endpoints."
+    real_import = builtins.__import__
+
+    def _fake_endpoint_import(
+        name: str,
+        globals: dict[str, object] | None = None,
+        locals: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> ModuleType:
+        """Track selected imports and fake unrelated eager optional routers."""
+        if (
+            level == 0
+            and name.startswith(endpoints_package)
+        ):
+            if name in definitions_by_module:
+                import_calls.append(name)
+                return real_import(name, globals, locals, fromlist, level)
+            attrs = tuple(attr for attr in fromlist if attr != "*") or ("router",)
+            for attr_name in attrs:
+                _install_fake_router_module(
+                    monkeypatch,
+                    name,
+                    path="/minimal-unrelated-utility-fake",
+                    attr_name=attr_name,
+                )
+            return sys.modules[name]
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_endpoint_import)
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Track lazy module imports for selected minimal utility routers."""
+        if module_name in definitions_by_module:
+            import_calls.append(module_name)
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+    fake_main = ModuleType("tldw_Server_API.app.main")
+    fake_main.app = FastAPI()  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "tldw_Server_API.app.main", fake_main)
+
+    specs = list(iter_minimal_optional_router_specs())
+    assert [
+        module_name
+        for module_name in definitions_by_module
+        if module_name in import_calls
+    ] == []
+    assert access_count == {
+        f"{definition['module_name']}.router": 0
+        for definition in router_definitions
+    }
+    assert import_calls == []
+
+    selected_specs = {
+        spec.name: spec
+        for spec in specs
+        if spec.name in {
+            str(definition["expected_name"])
+            for definition in router_definitions
+        }
+    }
+    assert set(selected_specs) == {
+        str(definition["expected_name"])
+        for definition in router_definitions
+    }
+
+    for definition in router_definitions:
+        spec = selected_specs[str(definition["expected_name"])]
+        assert spec.prefix == definition["prefix"]
+        assert spec.tags == definition["tags"]
+        assert spec.route_key == ""
+        assert spec.skip_context == "in minimal test app"
+        assert spec.default_stable is True
+        assert spec.skip_exceptions == (Exception,)
+        assert _first_router_path(spec.router) == definition["path"]
+
+    assert import_calls == [
+        str(definition["module_name"])
+        for definition in router_definitions
+    ]
+    assert access_count == {
+        f"{definition['module_name']}.router": 1
+        for definition in router_definitions
+    }
+
+
+def test_iter_minimal_optional_router_specs_skips_utility_runtime_import_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal utility specs preserve broad import failure skipping."""
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    utility_modules = {
+        "tldw_Server_API.app.api.v1.endpoints.web_clipper",
+        "tldw_Server_API.app.api.v1.endpoints.skills",
+        "tldw_Server_API.app.api.v1.endpoints.translate",
+        "tldw_Server_API.app.api.v1.endpoints.slides",
+    }
+
+    specs = list(iter_minimal_optional_router_specs())
+    selected_specs = {
+        spec.name: spec
+        for spec in specs
+        if spec.name in {"web clipper", "skills", "translate", "slides"}
+    }
+    assert set(selected_specs) == {"web clipper", "skills", "translate", "slides"}
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Crash only the selected utility router imports at registration."""
+        if module_name in utility_modules:
+            raise RuntimeError(f"{module_name} exploded during import")
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    debug_messages: list[str] = []
+    monkeypatch.setattr("loguru.logger.debug", debug_messages.append)
+
+    assert register_router_specs(FastAPI(), selected_specs.values()) == 0
+    assert debug_messages == [
+        "Skipping web clipper router in minimal test app: "
+        "tldw_Server_API.app.api.v1.endpoints.web_clipper exploded during import",
+        "Skipping skills router in minimal test app: "
+        "tldw_Server_API.app.api.v1.endpoints.skills exploded during import",
+        "Skipping translate router in minimal test app: "
+        "tldw_Server_API.app.api.v1.endpoints.translate exploded during import",
+        "Skipping slides router in minimal test app: "
+        "tldw_Server_API.app.api.v1.endpoints.slides exploded during import",
+    ]
+
+
 def test_iter_minimal_optional_router_specs_defers_experience_attr_lookup(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- Converts minimal-test web clipper, skills, translate, and slides router registrations to `ImportedRouterSpec`-backed lazy specs.
- Preserves existing prefixes, tags, default `route_key`/`default_stable` behavior, and broad minimal-test import failure skipping via `skip_exceptions=(Exception,)`.
- Adds TASK-82 tracking plus focused regression coverage for lazy resolution and runtime import-failure skipping.

## Test Plan
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "utility_attr_lookup or utility_runtime_import_failures" -q` (red before implementation, green after)
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/router_groups/minimal.py -f json -o /tmp/bandit_phase2_2_minimal_utility_router_conditionals.json` (`0` results, `0` errors)
- [x] `git diff --check`

Refs #1116
