### PR TITLE
Migrate Playground modal footers to ModalFooter

### DIFF
--- a/apps/packages/ui/src/components/Common/Playground/DocumentGeneratorDrawer.tsx
+++ b/apps/packages/ui/src/components/Common/Playground/DocumentGeneratorDrawer.tsx
@@ -19,6 +19,7 @@ import { tldwClient } from "@/services/tldw/TldwApiClient"
 import { useUiModeStore } from "@/store/ui-mode"
 import { useServerCapabilities } from "@/hooks/useServerCapabilities"
 import { Alert } from "@/components/ui/primitives"
+import { ModalFooter } from "@/components/ui/layout"
 import { RefreshCw, Trash2 } from "lucide-react"
 
 const Markdown = React.lazy(() => import("../Markdown"))
@@ -793,24 +794,31 @@ export const DocumentGeneratorDrawer: React.FC<DocumentGeneratorDrawerProps> = (
           </div>
         )}
 
-        <div className="flex flex-wrap items-center gap-2">
-          <Button
-            type="primary"
-            onClick={handleGenerate}
-            loading={isGenerating}
-            disabled={!canGenerate}
-            title={t("common:generate", "Generate") as string}
-          >
-            {t("common:generate", "Generate")}
-          </Button>
-          <Button
-            onClick={refreshDocuments}
-            disabled={!conversationId}
-            title={t("common:refresh", "Refresh") as string}
-          >
-            {t("common:refresh", "Refresh")}
-          </Button>
-        </div>
+        <ModalFooter
+          align="left"
+          hideCancel
+          data-testid="document-generator-drawer-footer"
+          actions={[
+            {
+              label: t("common:generate", "Generate"),
+              onClick: () => {
+                void handleGenerate()
+              },
+              loading: isGenerating,
+              disabled: !canGenerate,
+              title: t("common:generate", "Generate") as string,
+              variant: "primary"
+            },
+            {
+              label: t("common:refresh", "Refresh"),
+              onClick: () => {
+                void refreshDocuments()
+              },
+              disabled: !conversationId,
+              title: t("common:refresh", "Refresh") as string
+            }
+          ]}
+        />
 
         <div className="space-y-2">
           <div className="text-xs font-semibold uppercase tracking-wide text-text-subtle">

--- a/apps/packages/ui/src/components/Common/Playground/__tests__/DocumentGeneratorDrawer.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Common/Playground/__tests__/DocumentGeneratorDrawer.design-system.test.tsx
@@ -113,7 +113,7 @@ vi.mock("../Markdown", () => ({
 }))
 
 describe("DocumentGeneratorDrawer design-system recovery alerts", () => {
-  it("renders availability and conversation recovery through shared alerts", () => {
+  it("renders availability recovery and drawer actions through shared primitives", () => {
     capabilitiesState.hasChatDocuments = false
 
     render(
@@ -154,5 +154,10 @@ describe("DocumentGeneratorDrawer design-system recovery alerts", () => {
     expect(
       screen.getByText("Start a server-backed chat to generate documents.")
     ).toBeInTheDocument()
+
+    const footer = screen.getByTestId("document-generator-drawer-footer")
+    expect(footer).toHaveAttribute("data-ds-component", "ModalFooter")
+    expect(screen.getByRole("button", { name: "Generate" })).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Refresh" })).toBeDisabled()
   })
 })

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundContextWindowModal.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundContextWindowModal.tsx
@@ -1,5 +1,6 @@
 import React from "react"
-import { Button, InputNumber, Modal } from "antd"
+import { InputNumber, Modal } from "antd"
+import { ModalFooter } from "@/components/ui/layout"
 import { ContextFootprintPanel } from "./ContextFootprintPanel"
 import { SessionInsightsPanel } from "./SessionInsightsPanel"
 import { CONTEXT_FOOTPRINT_THRESHOLD_PERCENT } from "./hooks"
@@ -93,20 +94,22 @@ export const PlaygroundContextWindowModal: React.FC<PlaygroundContextWindowModal
           okText={t("common:save", "Save")}
           destroyOnHidden
           footer={
-            <div className="flex flex-wrap justify-end gap-2">
-              <Button onClick={onCloseContextWindow}>
-                {t("common:cancel", "Cancel")}
-              </Button>
-              <Button onClick={onResetContextWindow}>
-                {t(
+            <ModalFooter
+              data-testid="context-window-modal-footer"
+              onCancel={onCloseContextWindow}
+              cancelLabel={t("common:cancel", "Cancel")}
+              secondaryAction={{
+                label: t(
                   "playground:tokens.useModelDefault",
                   "Use model default"
-                )}
-              </Button>
-              <Button type="primary" onClick={onSaveContextWindow}>
-                {t("common:save", "Save")}
-              </Button>
-            </div>
+                ),
+                onClick: onResetContextWindow
+              }}
+              primaryAction={{
+                label: t("common:save", "Save"),
+                onClick: onSaveContextWindow
+              }}
+            />
           }
         >
           <div className="space-y-3">
@@ -226,11 +229,16 @@ export const PlaygroundContextWindowModal: React.FC<PlaygroundContextWindowModal
           destroyOnHidden
           width={760}
           footer={
-            <div className="flex justify-end">
-              <Button onClick={onCloseSessionInsights}>
-                {t("common:close", "Close")}
-              </Button>
-            </div>
+            <ModalFooter
+              hideCancel
+              data-testid="session-insights-modal-footer"
+              actions={[
+                {
+                  label: t("common:close", "Close"),
+                  onClick: onCloseSessionInsights
+                }
+              ]}
+            />
           }
         >
           <SessionInsightsPanel t={t} insights={sessionInsights} />

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundImageGenModal.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundImageGenModal.tsx
@@ -8,6 +8,7 @@ import {
   Select
 } from "antd"
 import { WandSparkles } from "lucide-react"
+import { ModalFooter } from "@/components/ui/layout"
 import { getProviderDisplayName } from "@/utils/provider-registry"
 import type { ReferenceImageCandidate } from "@/services/tldw/TldwApiClient"
 import {
@@ -226,51 +227,53 @@ export const PlaygroundImageGenModal: React.FC<PlaygroundImageGenModalProps> =
         width={720}
         destroyOnHidden
         footer={
-          <div className="flex flex-wrap items-center justify-between gap-2">
-            <div className="flex flex-wrap items-center gap-2">
-              <Button
-                onClick={onCreateDraft}
-                icon={<WandSparkles className="h-4 w-4" />}
-                disabled={busy}
-              >
-                {t(
+          <ModalFooter
+            align="between"
+            data-testid="image-generation-modal-footer"
+            leftActions={[
+              {
+                label: t(
                   "playground:imageGeneration.createPrompt",
                   "Create prompt"
-                )}
-              </Button>
-              <Button
-                onClick={() => {
-                  void onRefine()
-                }}
-                loading={refineSubmitting}
-                disabled={submitting}
-                data-testid="image-refine-with-llm"
-              >
-                {t(
+                ),
+                onClick: onCreateDraft,
+                icon: <WandSparkles className="h-4 w-4" />,
+                disabled: busy
+              },
+              {
+                label: t(
                   "playground:imageGeneration.refineWithLlm",
                   "Refine with LLM"
-                )}
-              </Button>
-            </div>
-            <div className="flex flex-wrap justify-end gap-2">
-              <Button onClick={onClose} disabled={busy}>
-                {t("common:cancel", "Cancel")}
-              </Button>
-              <Button
-                type="primary"
-                onClick={() => {
-                  void onSubmit()
-                }}
-                loading={submitting}
-                disabled={refineSubmitting}
-              >
-                {t(
-                  "playground:imageGeneration.generateNow",
-                  "Generate image"
-                )}
-              </Button>
-            </div>
-          </div>
+                ),
+                onClick: () => {
+                  void onRefine()
+                },
+                loading: refineSubmitting,
+                disabled: submitting,
+                "data-testid": "image-refine-with-llm"
+              }
+            ]}
+            hideCancel
+            actions={[
+              {
+                label: t("common:cancel", "Cancel"),
+                onClick: onClose,
+                disabled: busy,
+                variant: "ghost"
+              }
+            ]}
+            primaryAction={{
+              label: t(
+                "playground:imageGeneration.generateNow",
+                "Generate image"
+              ),
+              onClick: () => {
+                void onSubmit()
+              },
+              loading: submitting,
+              disabled: refineSubmitting
+            }}
+          />
         }
       >
         <div className="space-y-4">

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundImageGenModal.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundImageGenModal.tsx
@@ -248,8 +248,8 @@ export const PlaygroundImageGenModal: React.FC<PlaygroundImageGenModalProps> =
                 onClick: () => {
                   void onRefine()
                 },
-                loading: refineSubmitting,
-                disabled: submitting,
+                loading: busy || refineSubmitting,
+                disabled: busy || submitting,
                 "data-testid": "image-refine-with-llm"
               }
             ]}
@@ -271,7 +271,7 @@ export const PlaygroundImageGenModal: React.FC<PlaygroundImageGenModalProps> =
                 void onSubmit()
               },
               loading: submitting,
-              disabled: refineSubmitting
+              disabled: busy || refineSubmitting
             }}
           />
         }

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundMcpSettingsModal.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundMcpSettingsModal.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { InputNumber, Modal, Select, Switch, Input } from "antd"
+import { ModalFooter } from "@/components/ui/layout"
 
 // ---------------------------------------------------------------------------
 // Types
@@ -79,7 +80,19 @@ export const PlaygroundMcpSettingsModal: React.FC<PlaygroundMcpSettingsModalProp
       <Modal
         open={open}
         onCancel={onClose}
-        footer={null}
+        footer={
+          <ModalFooter
+            hideCancel
+            data-testid="mcp-settings-modal-footer"
+            actions={[
+              {
+                label: t("common:close", "Close"),
+                onClick: onClose,
+                variant: "primary"
+              }
+            ]}
+          />
+        }
         width={560}
         title={t(
           "playground:composer.mcpSettingsTitle",

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundRawRequestModal.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundRawRequestModal.tsx
@@ -1,5 +1,6 @@
 import React from "react"
-import { Button, Input, Modal } from "antd"
+import { Input, Modal } from "antd"
+import { ModalFooter } from "@/components/ui/layout"
 
 // ---------------------------------------------------------------------------
 // Types
@@ -54,18 +55,27 @@ export const PlaygroundRawRequestModal: React.FC<PlaygroundRawRequestModalProps>
         width={780}
         destroyOnHidden
         footer={
-          <div className="flex flex-wrap justify-end gap-2">
-            <Button onClick={onRefresh}>
-              {t("common:refresh", "Refresh")}
-            </Button>
+          <ModalFooter
+            hideCancel
+            data-testid="raw-chat-request-modal-footer"
+            actions={[
+              {
+                label: t("common:refresh", "Refresh"),
+                onClick: onRefresh
+              }
+            ]}
+            secondaryAction={{
+              label: t("common:copy", "Copy"),
+              onClick: onCopy,
+              disabled: !json
+            }}
+            primaryAction={{
+              label: t("common:close", "Close"),
+              onClick: onClose
+            }}
+          >
             {extraFooter}
-            <Button onClick={onCopy} disabled={!json}>
-              {t("common:copy", "Copy")}
-            </Button>
-            <Button type="primary" onClick={onClose}>
-              {t("common:close", "Close")}
-            </Button>
-          </div>
+          </ModalFooter>
         }
       >
         <div className="space-y-3">

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundStartupTemplateModal.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundStartupTemplateModal.tsx
@@ -1,5 +1,6 @@
 import React from "react"
-import { Button, Modal } from "antd"
+import { Modal } from "antd"
+import { ModalFooter } from "@/components/ui/layout"
 import type { StartupTemplateBundle } from "./startup-template-bundles"
 import type { ParameterPreset } from "./ParameterPresets"
 import { toText } from "./hooks"
@@ -47,36 +48,34 @@ export const PlaygroundStartupTemplateModal: React.FC<PlaygroundStartupTemplateM
         destroyOnHidden
         data-testid="startup-template-preview-modal"
         footer={
-          <div className="flex flex-wrap justify-between gap-2">
-            <Button
-              danger
-              onClick={() => {
-                if (!preview) return
-                onDelete(preview.id)
-              }}
-              disabled={!preview}
-            >
-              {t(
-                "playground:composer.startupTemplateDelete",
-                "Delete template"
-              )}
-            </Button>
-            <div className="flex flex-wrap justify-end gap-2">
-              <Button onClick={onClose}>
-                {t("common:cancel", "Cancel")}
-              </Button>
-              <Button
-                type="primary"
-                onClick={onApply}
-                disabled={!preview}
-              >
-                {t(
-                  "playground:composer.startupTemplateApply",
-                  "Apply template"
-                )}
-              </Button>
-            </div>
-          </div>
+          <ModalFooter
+            align="between"
+            data-testid="startup-template-preview-modal-footer"
+            leftActions={[
+              {
+                label: t(
+                  "playground:composer.startupTemplateDelete",
+                  "Delete template"
+                ),
+                onClick: () => {
+                  if (!preview) return
+                  onDelete(preview.id)
+                },
+                disabled: !preview,
+                danger: true
+              }
+            ]}
+            onCancel={onClose}
+            cancelLabel={t("common:cancel", "Cancel")}
+            primaryAction={{
+              label: t(
+                "playground:composer.startupTemplateApply",
+                "Apply template"
+              ),
+              onClick: onApply,
+              disabled: !preview
+            }}
+          />
         }
       >
         {preview ? (

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundModalFooters.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundModalFooters.design-system.test.tsx
@@ -44,6 +44,7 @@ type MockButtonProps = Omit<
   React.ButtonHTMLAttributes<HTMLButtonElement>,
   "type"
 > & {
+  variant?: string
   type?: string
   htmlType?: "button" | "submit" | "reset"
   icon?: React.ReactNode
@@ -158,6 +159,7 @@ vi.mock("antd", () => {
       onClick,
       disabled,
       loading,
+      variant,
       type,
       htmlType,
       icon,
@@ -174,6 +176,7 @@ vi.mock("antd", () => {
         title={title}
         aria-label={ariaLabel}
         data-testid={dataTestId}
+        data-variant={variant}
         data-antd-type={type}
         aria-busy={loading || undefined}
       >
@@ -471,12 +474,17 @@ describe("Playground modal footers design-system migration", () => {
   })
 
   it("preserves image-generation footer disabled and loading states", () => {
+    const onRefine = vi.fn()
+    const onSubmit = vi.fn()
+
     render(
       <PlaygroundImageGenModal
         {...baseImageGenProps}
         busy={true}
-        refineSubmitting={true}
+        refineSubmitting={false}
         submitting={false}
+        onRefine={onRefine}
+        onSubmit={onSubmit}
       />
     )
 
@@ -497,6 +505,15 @@ describe("Playground modal footers design-system migration", () => {
     expect(
       within(footer).getByRole("button", { name: "Generate image" })
     ).toBeDisabled()
+
+    fireEvent.click(
+      within(footer).getByRole("button", { name: "Refine with LLM" })
+    )
+    fireEvent.click(
+      within(footer).getByRole("button", { name: "Generate image" })
+    )
+    expect(onRefine).not.toHaveBeenCalled()
+    expect(onSubmit).not.toHaveBeenCalled()
   })
 
   it("adds an explicit MCP settings close action through ModalFooter", () => {

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundModalFooters.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundModalFooters.design-system.test.tsx
@@ -1,0 +1,535 @@
+// @vitest-environment jsdom
+import React from "react"
+import { fireEvent, render, screen, within } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { PlaygroundContextWindowModal } from "../PlaygroundContextWindowModal"
+import {
+  PlaygroundImageGenModal,
+  type PlaygroundImageGenModalProps
+} from "../PlaygroundImageGenModal"
+import { PlaygroundMcpSettingsModal } from "../PlaygroundMcpSettingsModal"
+import { PlaygroundRawRequestModal } from "../PlaygroundRawRequestModal"
+import {
+  PlaygroundStartupTemplateModal,
+  type PlaygroundStartupTemplateModalProps
+} from "../PlaygroundStartupTemplateModal"
+
+type MockInputProps = React.InputHTMLAttributes<HTMLInputElement> & {
+  "data-testid"?: string
+}
+
+type MockTextAreaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
+  "data-testid"?: string
+}
+
+type MockSelectOption = {
+  value: string | number
+  label: React.ReactNode
+}
+
+type MockSelectProps = {
+  value?: string | number
+  options?: MockSelectOption[]
+  onChange?: (value: string | number | undefined) => void
+  disabled?: boolean
+  loading?: boolean
+  "data-testid"?: string
+  placeholder?: string
+  allowClear?: boolean
+  children?: React.ReactNode
+}
+
+type MockButtonProps = Omit<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  "type"
+> & {
+  type?: string
+  htmlType?: "button" | "submit" | "reset"
+  icon?: React.ReactNode
+  loading?: boolean
+  "data-testid"?: string
+}
+
+const t = (
+  key: string,
+  fallback?: string | { defaultValue?: string; count?: number },
+  options?: { count?: number }
+) => {
+  const value =
+    typeof fallback === "string" ? fallback : (fallback?.defaultValue ?? key)
+  const count =
+    options?.count ??
+    (typeof fallback === "object" ? fallback.count : undefined)
+  return typeof count === "number"
+    ? value.replace("{{count}}", String(count))
+    : value
+}
+
+vi.mock("antd", () => {
+  const InputComponent = ({
+    value,
+    onChange,
+    placeholder,
+    disabled,
+    readOnly,
+    className,
+    "data-testid": dataTestId
+  }: MockInputProps) => (
+    <input
+      value={String(value ?? "")}
+      onChange={(event) => onChange?.(event)}
+      placeholder={placeholder}
+      disabled={disabled}
+      readOnly={readOnly}
+      className={className}
+      data-testid={dataTestId}
+    />
+  )
+  InputComponent.TextArea = ({
+    value,
+    onChange,
+    placeholder,
+    readOnly,
+    disabled,
+    className,
+    "data-testid": dataTestId
+  }: MockTextAreaProps) => (
+    <textarea
+      value={String(value ?? "")}
+      onChange={(event) => onChange?.(event)}
+      placeholder={placeholder}
+      readOnly={readOnly}
+      disabled={disabled}
+      className={className}
+      data-testid={dataTestId}
+    />
+  )
+
+  const SelectComponent = ({
+    value,
+    options = [],
+    onChange,
+    disabled,
+    loading,
+    "data-testid": dataTestId,
+    placeholder,
+    allowClear,
+    children
+  }: MockSelectProps) => (
+    <select
+      aria-label={placeholder}
+      data-testid={dataTestId}
+      value={String(value ?? "")}
+      onChange={(event) =>
+        onChange?.(
+          event.target.value === ""
+            ? undefined
+            : Number.isNaN(Number(event.target.value))
+              ? event.target.value
+              : Number(event.target.value)
+        )
+      }
+      disabled={disabled || loading}
+    >
+      {allowClear ? <option value="" /> : null}
+      {options.map((option) => (
+        <option key={String(option.value)} value={String(option.value)}>
+          {String(option.label)}
+        </option>
+      ))}
+      {children}
+    </select>
+  )
+  SelectComponent.Option = ({
+    value,
+    children
+  }: {
+    value: string | number
+    children?: React.ReactNode
+  }) => <option value={value}>{children}</option>
+  SelectComponent.OptGroup = ({ children }: { children?: React.ReactNode }) => (
+    <>{children}</>
+  )
+
+  return {
+    Button: ({
+      children,
+      onClick,
+      disabled,
+      loading,
+      type,
+      htmlType,
+      icon,
+      className,
+      title,
+      "aria-label": ariaLabel,
+      "data-testid": dataTestId
+    }: MockButtonProps) => (
+      <button
+        type={htmlType || "button"}
+        onClick={onClick}
+        disabled={disabled || loading}
+        className={className}
+        title={title}
+        aria-label={ariaLabel}
+        data-testid={dataTestId}
+        data-antd-type={type}
+        aria-busy={loading || undefined}
+      >
+        {icon}
+        {children}
+      </button>
+    ),
+    Input: InputComponent,
+    InputNumber: ({
+      value,
+      onChange,
+      disabled,
+      placeholder
+    }: {
+      value?: number
+      onChange?: (value: number) => void
+      disabled?: boolean
+      placeholder?: string
+    }) => (
+      <input
+        type="number"
+        value={value ?? ""}
+        onChange={(event) => onChange?.(Number(event.target.value))}
+        disabled={disabled}
+        placeholder={placeholder}
+      />
+    ),
+    Modal: ({
+      open,
+      children,
+      footer,
+      title
+    }: {
+      open?: boolean
+      children?: React.ReactNode
+      footer?: React.ReactNode
+      title?: React.ReactNode
+    }) =>
+      open ? (
+        <section role="dialog" aria-label={String(title ?? "Modal")}>
+          {children}
+          {footer !== null && footer !== undefined ? (
+            <div data-testid="antd-modal-footer">{footer}</div>
+          ) : null}
+        </section>
+      ) : null,
+    Radio: {
+      Group: ({ children }: { children?: React.ReactNode }) => (
+        <div>{children}</div>
+      ),
+      Button: ({ children }: { children?: React.ReactNode }) => (
+        <button type="button">{children}</button>
+      )
+    },
+    Select: SelectComponent,
+    Switch: ({
+      checked,
+      onChange
+    }: {
+      checked?: boolean
+      onChange?: (checked: boolean) => void
+    }) => (
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(event) => onChange?.(event.target.checked)}
+      />
+    )
+  }
+})
+
+vi.mock("lucide-react", () => ({
+  Loader2: () => <span data-testid="loader-icon" />,
+  WandSparkles: () => <span data-testid="wand-icon" />
+}))
+
+vi.mock("@/utils/provider-registry", () => ({
+  getProviderDisplayName: (provider: string) => provider
+}))
+
+vi.mock("../ContextFootprintPanel", () => ({
+  ContextFootprintPanel: () => <div data-testid="context-footprint-panel" />
+}))
+
+vi.mock("../SessionInsightsPanel", () => ({
+  SessionInsightsPanel: () => <div data-testid="session-insights-panel" />
+}))
+
+vi.mock("../hooks", () => ({
+  CONTEXT_FOOTPRINT_THRESHOLD_PERCENT: 80,
+  toText: (value: unknown) => String(value ?? "")
+}))
+
+const baseImageGenProps: PlaygroundImageGenModalProps = {
+  open: true,
+  onClose: vi.fn(),
+  busy: false,
+  backend: "comfyui",
+  backendOptions: [{ value: "comfyui", label: "ComfyUI" }],
+  onBackendChange: vi.fn(),
+  onHydrateSettings: vi.fn(),
+  promptMode: "scene",
+  onPromptModeChange: vi.fn(),
+  promptStrategies: [{ id: "scene", label: "Scene" }],
+  syncPolicy: "inherit",
+  onSyncPolicyChange: vi.fn(),
+  syncChatMode: "off",
+  onSyncChatModeChange: vi.fn(),
+  syncGlobalDefault: "off",
+  onSyncGlobalDefaultChange: vi.fn(),
+  resolvedSyncMode: "off",
+  prompt: "A calm landscape",
+  onPromptChange: vi.fn(),
+  contextBreakdown: [],
+  onClearRefineState: vi.fn(),
+  refineSubmitting: false,
+  refineBaseline: "",
+  refineCandidate: null,
+  refineModel: null,
+  refineLatencyMs: null,
+  refineDiff: null,
+  onCreateDraft: vi.fn(),
+  onRefine: vi.fn(),
+  onApplyRefined: vi.fn(),
+  onRejectRefined: vi.fn(),
+  format: "png",
+  onFormatChange: vi.fn(),
+  width: undefined,
+  onWidthChange: vi.fn(),
+  height: undefined,
+  onHeightChange: vi.fn(),
+  steps: undefined,
+  onStepsChange: vi.fn(),
+  cfgScale: undefined,
+  onCfgScaleChange: vi.fn(),
+  seed: undefined,
+  onSeedChange: vi.fn(),
+  sampler: "",
+  onSamplerChange: vi.fn(),
+  model: "",
+  onModelChange: vi.fn(),
+  negativePrompt: "",
+  onNegativePromptChange: vi.fn(),
+  extraParams: "",
+  onExtraParamsChange: vi.fn(),
+  referenceFileId: undefined,
+  onReferenceFileIdChange: vi.fn(),
+  referenceImageCandidates: [],
+  referenceImageCandidatesLoading: false,
+  submitting: false,
+  onSubmit: vi.fn(),
+  t
+}
+
+describe("Playground modal footers design-system migration", () => {
+  it("renders startup template destructive, cancel, and apply actions through ModalFooter", () => {
+    const onDelete = vi.fn()
+    const onClose = vi.fn()
+    const onApply = vi.fn()
+
+    render(
+      <PlaygroundStartupTemplateModal
+        preview={
+          {
+            id: "template-1",
+            selectedModel: "llama",
+            character: { name: "Guide" },
+            ragPinnedResults: []
+          } as NonNullable<PlaygroundStartupTemplateModalProps["preview"]>
+        }
+        onClose={onClose}
+        onDelete={onDelete}
+        onApply={onApply}
+        promptDescription="Prompt"
+        promptResolution={null}
+        preset={undefined}
+        t={t}
+      />
+    )
+
+    const footer = screen.getByTestId("startup-template-preview-modal-footer")
+    expect(footer).toHaveAttribute("data-ds-component", "ModalFooter")
+
+    fireEvent.click(
+      within(footer).getByRole("button", { name: "Delete template" })
+    )
+    expect(onDelete).toHaveBeenCalledWith("template-1")
+
+    fireEvent.click(within(footer).getByRole("button", { name: "Cancel" }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(
+      within(footer).getByRole("button", { name: "Apply template" })
+    )
+    expect(onApply).toHaveBeenCalledTimes(1)
+  })
+
+  it("preserves ordered raw request footer actions and disabled copy state", () => {
+    const onRefresh = vi.fn()
+    const onCopy = vi.fn()
+    const onClose = vi.fn()
+    const onExtra = vi.fn()
+
+    render(
+      <PlaygroundRawRequestModal
+        open
+        onClose={onClose}
+        snapshot={null}
+        json=""
+        onRefresh={onRefresh}
+        onCopy={onCopy}
+        extraFooter={<button onClick={onExtra}>Run research</button>}
+        t={t}
+      />
+    )
+
+    const footer = screen.getByTestId("raw-chat-request-modal-footer")
+    expect(footer).toHaveAttribute("data-ds-component", "ModalFooter")
+    expect(
+      within(footer)
+        .getAllByRole("button")
+        .map((button) => button.textContent)
+    ).toEqual(["Refresh", "Run research", "Copy", "Close"])
+
+    fireEvent.click(within(footer).getByRole("button", { name: "Refresh" }))
+    expect(onRefresh).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(
+      within(footer).getByRole("button", { name: "Run research" })
+    )
+    expect(onExtra).toHaveBeenCalledTimes(1)
+
+    expect(within(footer).getByRole("button", { name: "Copy" })).toBeDisabled()
+
+    fireEvent.click(within(footer).getByRole("button", { name: "Close" }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(onCopy).not.toHaveBeenCalled()
+  })
+
+  it("renders context-window and session-insights actions through ModalFooter", () => {
+    const onCloseContextWindow = vi.fn()
+    const onSaveContextWindow = vi.fn()
+    const onResetContextWindow = vi.fn()
+    const onCloseSessionInsights = vi.fn()
+
+    render(
+      <PlaygroundContextWindowModal
+        contextWindowModalOpen
+        onCloseContextWindow={onCloseContextWindow}
+        onSaveContextWindow={onSaveContextWindow}
+        onResetContextWindow={onResetContextWindow}
+        contextWindowDraftValue={4096}
+        onContextWindowDraftChange={vi.fn()}
+        resolvedMaxContext={4096}
+        requestedContextWindowOverride={4096}
+        modelContextLength={8192}
+        isContextWindowOverrideActive
+        isContextWindowOverrideClamped={false}
+        nonMessageContextPercent={20}
+        showNonMessageContextWarning={false}
+        tokenBudgetRiskLabel="Low"
+        tokenBudgetRisk={{ overflowTokens: 0 }}
+        contextFootprintRows={[]}
+        formatContextWindowValue={(value) => String(value ?? "default")}
+        onClearPromptContext={vi.fn()}
+        onClearPinnedSourceContext={vi.fn()}
+        onClearHistoryContext={vi.fn()}
+        onCreateSummaryCheckpoint={vi.fn()}
+        onReviewCharacterContext={vi.fn()}
+        onTrimLargestContextContributor={vi.fn()}
+        sessionInsightsOpen
+        onCloseSessionInsights={onCloseSessionInsights}
+        sessionInsights={{}}
+        t={t}
+      />
+    )
+
+    const contextFooter = screen.getByTestId("context-window-modal-footer")
+    expect(contextFooter).toHaveAttribute("data-ds-component", "ModalFooter")
+
+    fireEvent.click(
+      within(contextFooter).getByRole("button", { name: "Use model default" })
+    )
+    expect(onResetContextWindow).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(within(contextFooter).getByRole("button", { name: "Save" }))
+    expect(onSaveContextWindow).toHaveBeenCalledTimes(1)
+
+    const insightsFooter = screen.getByTestId("session-insights-modal-footer")
+    expect(insightsFooter).toHaveAttribute("data-ds-component", "ModalFooter")
+    fireEvent.click(
+      within(insightsFooter).getByRole("button", { name: "Close" })
+    )
+    expect(onCloseSessionInsights).toHaveBeenCalledTimes(1)
+  })
+
+  it("preserves image-generation footer disabled and loading states", () => {
+    render(
+      <PlaygroundImageGenModal
+        {...baseImageGenProps}
+        busy={true}
+        refineSubmitting={true}
+        submitting={false}
+      />
+    )
+
+    const footer = screen.getByTestId("image-generation-modal-footer")
+    expect(footer).toHaveAttribute("data-ds-component", "ModalFooter")
+    expect(
+      within(footer).getByRole("button", { name: "Create prompt" })
+    ).toBeDisabled()
+    expect(
+      within(footer).getByRole("button", { name: "Cancel" })
+    ).toBeDisabled()
+    expect(
+      within(footer).getByRole("button", { name: "Refine with LLM" })
+    ).toBeDisabled()
+    expect(
+      within(footer).getByRole("button", { name: "Refine with LLM" })
+    ).toHaveAttribute("aria-busy", "true")
+    expect(
+      within(footer).getByRole("button", { name: "Generate image" })
+    ).toBeDisabled()
+  })
+
+  it("adds an explicit MCP settings close action through ModalFooter", () => {
+    const onClose = vi.fn()
+
+    render(
+      <PlaygroundMcpSettingsModal
+        open
+        onClose={onClose}
+        hasMcp={false}
+        mcpStatusLabel="Unavailable"
+        catalogsLoading={false}
+        catalogGroups={{ team: [], org: [], global: [] }}
+        catalogDraft=""
+        onCatalogDraftChange={vi.fn()}
+        onCatalogCommit={vi.fn()}
+        onCatalogSelect={vi.fn()}
+        toolCatalogId={null}
+        onToolCatalogIdChange={vi.fn()}
+        toolCatalogStrict={false}
+        onToolCatalogStrictChange={vi.fn()}
+        moduleOptions={[]}
+        moduleOptionsLoading={false}
+        toolModules={[]}
+        onModuleSelect={vi.fn()}
+        isSmallModel={false}
+        t={t}
+      />
+    )
+
+    const footer = screen.getByTestId("mcp-settings-modal-footer")
+    expect(footer).toHaveAttribute("data-ds-component", "ModalFooter")
+    fireEvent.click(within(footer).getByRole("button", { name: "Close" }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/packages/ui/src/components/ui/layout/ModalFooter.tsx
+++ b/apps/packages/ui/src/components/ui/layout/ModalFooter.tsx
@@ -30,7 +30,7 @@ export interface ModalFooterAction {
   /** Button type for forms */
   type?: "button" | "submit" | "reset"
   /** Accessible label for icon-heavy actions */
-  ariaLabel?: string
+  "aria-label"?: string
   /** Tooltip/title text */
   title?: string
   /** Additional CSS classes */
@@ -140,7 +140,7 @@ export const ModalFooter = React.forwardRef<HTMLDivElement, ModalFooterProps>(
           loading={action.loading}
           disabled={action.disabled}
           icon={action.icon}
-          ariaLabel={action.ariaLabel}
+          ariaLabel={action["aria-label"]}
           title={action.title}
           className={action.className}
           data-testid={action["data-testid"]}

--- a/apps/packages/ui/src/components/ui/layout/ModalFooter.tsx
+++ b/apps/packages/ui/src/components/ui/layout/ModalFooter.tsx
@@ -2,22 +2,48 @@ import React from "react"
 import { cn } from "@/libs/utils"
 import { Button } from "@/components/Common/Button"
 
+type ModalFooterActionVariant =
+  | "primary"
+  | "secondary"
+  | "danger"
+  | "ghost"
+  | "text"
+  | "outline"
+
 export interface ModalFooterAction {
+  /** Stable React key for ordered action groups */
+  key?: React.Key
   /** Button label */
   label: React.ReactNode
   /** Click handler */
-  onClick?: () => void
+  onClick?: React.MouseEventHandler<HTMLButtonElement>
   /** Show loading spinner */
   loading?: boolean
   /** Disable the button */
   disabled?: boolean
   /** Use danger styling */
   danger?: boolean
+  /** Explicit design-system button variant */
+  variant?: ModalFooterActionVariant
+  /** Optional leading icon */
+  icon?: React.ReactNode
   /** Button type for forms */
-  type?: "button" | "submit"
+  type?: "button" | "submit" | "reset"
+  /** Accessible label for icon-heavy actions */
+  ariaLabel?: string
+  /** Tooltip/title text */
+  title?: string
+  /** Additional CSS classes */
+  className?: string
+  /** Test ID */
+  "data-testid"?: string
 }
 
 export interface ModalFooterProps {
+  /** Ordered left-side actions */
+  leftActions?: ModalFooterAction[]
+  /** Ordered right-side actions rendered before cancel/secondary/primary */
+  actions?: ModalFooterAction[]
   /** Primary action (right side, emphasized) */
   primaryAction?: ModalFooterAction
   /** Secondary action (left of primary) */
@@ -32,6 +58,8 @@ export interface ModalFooterProps {
   align?: "left" | "center" | "right" | "between"
   /** Extra content on the left side */
   leftContent?: React.ReactNode
+  /** Custom action content rendered in the right action group */
+  children?: React.ReactNode
   /** Additional CSS classes */
   className?: string
   /** Test ID */
@@ -71,6 +99,8 @@ export interface ModalFooterProps {
 export const ModalFooter = React.forwardRef<HTMLDivElement, ModalFooterProps>(
   (
     {
+      leftActions,
+      actions,
       primaryAction,
       secondaryAction,
       onCancel,
@@ -78,6 +108,7 @@ export const ModalFooter = React.forwardRef<HTMLDivElement, ModalFooterProps>(
       hideCancel = false,
       align = "right",
       leftContent,
+      children,
       className,
       "data-testid": dataTestId,
     },
@@ -89,49 +120,73 @@ export const ModalFooter = React.forwardRef<HTMLDivElement, ModalFooterProps>(
       right: "justify-end",
       between: "justify-between",
     }
+    const hasLeftRegion = Boolean(leftContent) || Boolean(leftActions?.length)
+
+    const renderAction = (
+      action: ModalFooterAction,
+      defaultVariant: ModalFooterActionVariant,
+      index: number,
+      prefix: string
+    ) => {
+      const variant =
+        action.variant ?? (action.danger ? "danger" : defaultVariant)
+
+      return (
+        <Button
+          key={action.key ?? `${prefix}-${index}`}
+          variant={variant}
+          type={action.type || "button"}
+          onClick={action.onClick}
+          loading={action.loading}
+          disabled={action.disabled}
+          icon={action.icon}
+          ariaLabel={action.ariaLabel}
+          title={action.title}
+          className={action.className}
+          data-testid={action["data-testid"]}
+        >
+          {action.label}
+        </Button>
+      )
+    }
 
     return (
       <div
         ref={ref}
         className={cn(
-          "flex items-center gap-2 border-t border-border bg-surface px-4 py-3",
+          "flex flex-wrap items-center gap-2 border-t border-border bg-surface px-4 py-3",
           alignmentClasses[align],
           className
         )}
+        data-ds-component="ModalFooter"
         data-testid={dataTestId}
       >
-        {leftContent && <div className="flex-1">{leftContent}</div>}
+        {hasLeftRegion && (
+          <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
+            {leftActions?.map((action, index) =>
+              renderAction(action, "secondary", index, "left")
+            )}
+            {leftContent}
+          </div>
+        )}
 
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
+          {actions?.map((action, index) =>
+            renderAction(action, "secondary", index, "action")
+          )}
+          {children}
+
           {!hideCancel && onCancel && (
             <Button variant="ghost" onClick={onCancel}>
               {cancelLabel}
             </Button>
           )}
 
-          {secondaryAction && (
-            <Button
-              variant="secondary"
-              type={secondaryAction.type || "button"}
-              onClick={secondaryAction.onClick}
-              loading={secondaryAction.loading}
-              disabled={secondaryAction.disabled}
-            >
-              {secondaryAction.label}
-            </Button>
-          )}
+          {secondaryAction &&
+            renderAction(secondaryAction, "secondary", 0, "secondary")}
 
-          {primaryAction && (
-            <Button
-              variant={primaryAction.danger ? "danger" : "primary"}
-              type={primaryAction.type || "button"}
-              onClick={primaryAction.onClick}
-              loading={primaryAction.loading}
-              disabled={primaryAction.disabled}
-            >
-              {primaryAction.label}
-            </Button>
-          )}
+          {primaryAction &&
+            renderAction(primaryAction, "primary", 0, "primary")}
         </div>
       </div>
     )

--- a/backlog/tasks/task-45.7 - Migrate-Playground-modal-footers-to-design-system-ModalFooter.md
+++ b/backlog/tasks/task-45.7 - Migrate-Playground-modal-footers-to-design-system-ModalFooter.md
@@ -1,0 +1,72 @@
+---
+id: TASK-45.7
+title: Migrate Playground modal footers to design-system ModalFooter
+status: Done
+assignee:
+  - codex
+created_date: '2026-05-05 18:16'
+updated_date: '2026-05-05 18:41'
+labels:
+  - design-system
+  - frontend
+  - playground
+dependencies: []
+documentation:
+  - Docs/Design/tldw_web_design_system_contract.md
+  - Docs/Design/tldw_web_design_system_inventory.md
+parent_task_id: TASK-45
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the next Chat/Playground design-system inventory slice after status chips. Scope is limited to tldw-owned Playground modal footer action rows in PlaygroundStartupTemplateModal, PlaygroundContextWindowModal, PlaygroundImageGenModal, PlaygroundRawRequestModal, PlaygroundMcpSettingsModal, and Common/Playground/DocumentGeneratorDrawer. Keep AntD modal mechanics, forms, tables, popovers, and broad Button migration unchanged.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Target Playground modal footer action rows render through the shared ModalFooter primitive or an existing tldw-owned wrapper around it without changing modal open/close behavior.
+- [x] #2 Primary, secondary, destructive, loading, and disabled footer actions preserve their accessible names and callbacks.
+- [x] #3 AntD modal mechanics and non-footer controls remain unchanged in this slice.
+- [x] #4 Focused tests cover representative migrated footers and assert design-system markers plus preserved actions/states.
+- [x] #5 Verification includes focused Vitest coverage, targeted lint/diff checks, and Bandit is skipped or documented as not applicable for frontend-only changes.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused Vitest coverage for representative Playground footer migrations before production edits: the shared ModalFooter marker/action behavior, Startup template modal delete/cancel/apply callbacks, Raw request modal refresh/extra/copy/close actions, Image generation modal loading/disabled footer states, MCP settings close footer, and the Document generator drawer action row.
+2. Extend apps/packages/ui/src/components/ui/layout/ModalFooter.tsx conservatively so it exposes data-ds-component="ModalFooter" and can render ordered leftActions/right actions with the existing Common/Button while preserving existing primaryAction/secondaryAction/onCancel compatibility.
+3. Migrate only the scoped Playground surfaces to ModalFooter: PlaygroundStartupTemplateModal, PlaygroundRawRequestModal, PlaygroundContextWindowModal, PlaygroundImageGenModal, PlaygroundMcpSettingsModal, and Common/Playground/DocumentGeneratorDrawer. Keep AntD Modal/Drawer mechanics, forms, tables, selects, and non-footer controls unchanged.
+4. Run focused Vitest for the new/updated tests, then run targeted lint/diff checks. Document that Bandit is skipped because this is a frontend-only TypeScript/React slice.
+5. Update TASK-45.7 with verification notes/final summary, mirror the Backlog task file into the clean worktree, commit, push, and open the PR against dev.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Red/green cycle complete: the new focused tests first failed because the scoped Playground footers had no ModalFooter markers, then passed after migrating the target action rows to ModalFooter.
+
+Implemented ModalFooter ordered left/right action support plus data-ds-component="ModalFooter" while preserving existing primaryAction, secondaryAction, onCancel and leftContent compatibility.
+
+Verification: bunx vitest run src/components/Option/Playground/__tests__/PlaygroundModalFooters.design-system.test.tsx src/components/Common/Playground/__tests__/DocumentGeneratorDrawer.design-system.test.tsx src/components/Option/Playground/__tests__/PlaygroundForm.reference-image.integration.test.tsx passed with 8 tests. ESLint targeted touched files exited 0 with no errors; remaining warnings are pre-existing no-explicit-any warnings in older Playground component signatures. git diff --check passed. Package tsc is blocked by unrelated existing errors across ui tests/source; filtered tsc output for touched filenames was empty. Bandit skipped because this is frontend-only TypeScript/React code.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated the scoped Playground modal/drawer footer action rows to the shared ModalFooter primitive. ModalFooter now exposes a data-ds-component marker and supports ordered left/right action groups while preserving the existing primaryAction, secondaryAction, cancel, and leftContent API. The Startup template, raw request, context window/session insights, image generation, MCP settings, and document generator action rows now render through ModalFooter without changing AntD Modal/Drawer mechanics or non-footer controls.
+
+Focused tests cover representative footer markers, action ordering, destructive/cancel/primary callbacks, and disabled/loading states. Verification passed for the targeted Vitest suite, git diff whitespace, and targeted ESLint with no errors; package-wide tsc remains blocked by unrelated existing errors, with no touched-file matches in filtered output. Bandit is not applicable for this frontend-only slice.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.7 - Migrate-Playground-modal-footers-to-design-system-ModalFooter.md
+++ b/backlog/tasks/task-45.7 - Migrate-Playground-modal-footers-to-design-system-ModalFooter.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - codex
 created_date: '2026-05-05 18:16'
-updated_date: '2026-05-05 18:41'
+updated_date: '2026-05-05 19:52'
 labels:
   - design-system
   - frontend
@@ -51,14 +51,16 @@ Red/green cycle complete: the new focused tests first failed because the scoped 
 Implemented ModalFooter ordered left/right action support plus data-ds-component="ModalFooter" while preserving existing primaryAction, secondaryAction, onCancel and leftContent compatibility.
 
 Verification: bunx vitest run src/components/Option/Playground/__tests__/PlaygroundModalFooters.design-system.test.tsx src/components/Common/Playground/__tests__/DocumentGeneratorDrawer.design-system.test.tsx src/components/Option/Playground/__tests__/PlaygroundForm.reference-image.integration.test.tsx passed with 8 tests. ESLint targeted touched files exited 0 with no errors; remaining warnings are pre-existing no-explicit-any warnings in older Playground component signatures. git diff --check passed. Package tsc is blocked by unrelated existing errors across ui tests/source; filtered tsc output for touched filenames was empty. Bandit skipped because this is frontend-only TypeScript/React code.
+
+Reopened for PR #1323 review feedback. Unresolved threads: standardize ModalFooter action aria label key to aria-label while adapting to the existing Common/Button ariaLabel prop, add variant plumbing to the Playground test Button mock, and make ImageGen submit/refine footer actions respect busy. Keep changes limited to the reviewed files and focused tests.
+
+PR #1323 review feedback addressed: ModalFooterAction now uses the standard aria-label action key while adapting to Common/Button's ariaLabel prop, the Playground footer test Button mock carries variant through data-variant, and ImageGen refine/generate actions respect busy. Verification: focused Playground footer Vitest suite passed 3 files / 8 tests; tsc --noEmit passed; git diff --check passed; targeted ESLint exited 0 with only existing no-explicit-any warnings in PlaygroundImageGenModal.tsx.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Migrated the scoped Playground modal/drawer footer action rows to the shared ModalFooter primitive. ModalFooter now exposes a data-ds-component marker and supports ordered left/right action groups while preserving the existing primaryAction, secondaryAction, cancel, and leftContent API. The Startup template, raw request, context window/session insights, image generation, MCP settings, and document generator action rows now render through ModalFooter without changing AntD Modal/Drawer mechanics or non-footer controls.
-
-Focused tests cover representative footer markers, action ordering, destructive/cancel/primary callbacks, and disabled/loading states. Verification passed for the targeted Vitest suite, git diff whitespace, and targeted ESLint with no errors; package-wide tsc remains blocked by unrelated existing errors, with no touched-file matches in filtered output. Bandit is not applicable for this frontend-only slice.
+Migrated the scoped Playground modal/drawer footer action rows to the shared ModalFooter primitive and addressed PR #1323 review feedback. ModalFooter now exposes a standard aria-label action key while adapting to the existing Common/Button ariaLabel prop, the Playground design-system test mock preserves variant/type attributes, and the ImageGen footer submit/refine actions now respect the modal busy lock. Focused tests cover footer markers, action ordering, callbacks, disabled/loading states, and busy-lock click prevention. Verification passed for the focused Vitest suite, frontend tsc --noEmit, git diff --check, and targeted ESLint with no errors; ESLint still reports pre-existing no-explicit-any warnings in PlaygroundImageGenModal.tsx. Bandit is not applicable for this frontend-only TypeScript/React slice.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary

- Extended `ModalFooter` with a design-system marker plus ordered left/right action groups while keeping the existing primary, secondary, cancel, and left-content API.
- Migrated the scoped Playground modal/drawer footer action rows to `ModalFooter`: startup templates, raw request JSON, context/session insights, image generation, MCP settings, and document generator actions.
- Added TASK-45.7 and focused design-system tests for footer markers, action order, callbacks, destructive actions, and disabled/loading states.

## Verification

- `bunx vitest run src/components/Option/Playground/__tests__/PlaygroundModalFooters.design-system.test.tsx src/components/Common/Playground/__tests__/DocumentGeneratorDrawer.design-system.test.tsx src/components/Option/Playground/__tests__/PlaygroundForm.reference-image.integration.test.tsx`
- `apps/tldw-frontend/node_modules/.bin/eslint -c apps/tldw-frontend/eslint.config.mjs ...` exited 0 with no errors; remaining warnings are existing `no-explicit-any` warnings in older Playground component signatures.
- `git diff --check`
- Package-wide `tsc -p apps/packages/ui/tsconfig.json --noEmit` is blocked by unrelated existing errors across UI tests/source; filtered output for touched filenames was empty.
- Bandit skipped because this is frontend-only TypeScript/React code.

## Change summary

AI-generated draft. Human owner should replace this section with their own explanation of what changed and why before merge, per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.
