### PR TITLE
Phase 2.2: defer minimal kanban imports

### DIFF
--- a/backlog/tasks/task-83 - Phase-2.2-minimal-kanban-router-conditional-cleanup-AL.md
+++ b/backlog/tasks/task-83 - Phase-2.2-minimal-kanban-router-conditional-cleanup-AL.md
@@ -4,7 +4,7 @@ title: Phase 2.2 minimal kanban router conditional cleanup AL
 status: Done
 assignee: []
 created_date: '2026-05-05 18:55'
-updated_date: '2026-05-05 18:59'
+updated_date: '2026-05-05 19:30'
 labels:
   - phase2.2
   - router-cleanup
@@ -42,12 +42,16 @@ Red-green Kanban tranche: add focused router-group tests for lazy minimal Kanban
 Red verification: focused minimal Kanban router tests failed before production changes because Kanban endpoint modules were imported during spec construction and named lazy specs were absent.
 
 Green verification: focused Kanban tests, full router group contract tests, main router contract tests, touched-source Bandit, and git diff --check all passed.
+
+Reopened for PR #1324 review feedback. Gemini requested deduplicating Kanban router test data. Qodo flagged broad skip_exceptions=(Exception,); verified against origin/dev that the old minimal-test Kanban block already used one broad except Exception and this task intentionally preserved that compatibility boundary. Address Gemini with a test-only dedupe and respond to Qodo with the compatibility rationale unless the local tests expose a safer narrow behavior.
+
+Review follow-up result: deduplicated Kanban test data through shared module suffix/path data, preserving the intentional minimal-test broad skip behavior. Qodo broad-skip thread will be answered with the base-code/task-contract rationale instead of changing PR semantics in this tranche.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Converted the minimal-test Kanban optional router family to ImportedRouterSpec-backed lazy specs. The new entries preserve /api/v1/kanban prefix, kanban tags, route_key=kanban, default_stable behavior, and broad minimal-test skip semantics with skip_exceptions=(Exception,) while deferring module import and router attribute lookup until registration. Added regression coverage for lazy Kanban resolution and RuntimeError skip behavior. Verification: focused red/green Kanban tests, full test_router_groups_contract.py, test_main_router_contract.py, Bandit on minimal.py with 0 results/0 errors, and git diff --check.
+Addressed PR #1324 review follow-up by deduplicating the Kanban router contract test data from one shared module/path table and deriving module names, expected names, selected modules, and debug expectations from it. Preserved skip_exceptions=(Exception,) because origin/dev used a broad except Exception for the minimal-test Kanban block and TASK-83 explicitly scoped this tranche to preserve that compatibility behavior; the broad-skip cleanup should be handled as a separate behavior-changing tranche if desired. Verification: focused Kanban router contract tests passed, full test_router_groups_contract.py passed, test_main_router_contract.py passed, Bandit on minimal.py reported 0 results/0 errors, and git diff --check passed.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-83 - Phase-2.2-minimal-kanban-router-conditional-cleanup-AL.md
+++ b/backlog/tasks/task-83 - Phase-2.2-minimal-kanban-router-conditional-cleanup-AL.md
@@ -4,7 +4,7 @@ title: Phase 2.2 minimal kanban router conditional cleanup AL
 status: Done
 assignee: []
 created_date: '2026-05-05 18:55'
-updated_date: '2026-05-05 19:30'
+updated_date: '2026-05-05 19:43'
 labels:
   - phase2.2
   - router-cleanup
@@ -19,21 +19,26 @@ priority: medium
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Continue issue #1116 Phase 2.2 after PR #1322. Convert the minimal-test Kanban optional router family in tldw_Server_API/app/api/v1/router_groups/minimal.py from one eager broad try/import RouterSpec block to ImportedRouterSpec-backed lazy router specs. Scope is limited to kanban_boards, kanban_lists, kanban_cards, kanban_labels, kanban_checklists, kanban_comments, kanban_search, kanban_links, and kanban_workflow. Preserve prefix /api/v1/kanban, tags, route_key=kanban, default_stable behavior, and existing minimal-test broad skip behavior for import-time failures.
+Continue issue #1116 Phase 2.2 after PR #1322. Convert the minimal-test Kanban optional router family in tldw_Server_API/app/api/v1/router_groups/minimal.py from one eager try/import RouterSpec block to ImportedRouterSpec-backed lazy router specs. Scope is limited to kanban_boards, kanban_lists, kanban_cards, kanban_labels, kanban_checklists, kanban_comments, kanban_search, kanban_links, and kanban_workflow. Preserve prefix /api/v1/kanban, tags, route_key=kanban, and default_stable behavior. After PR #1324 review, Kanban lazy resolution now skips only missing optional router failures via ImportError/AttributeError and propagates runtime defects.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
 - [x] #1 Kanban minimal optional specs defer module import and router attribute lookup until registration
 - [x] #2 Existing route metadata is preserved for every Kanban router in scope
-- [x] #3 Focused router-group tests cover lazy behavior and broad import failure skipping with red-green verification
-- [x] #4 Router-group contract tests and touched-source Bandit pass
+- [x] #3 Router-group contract tests and touched-source Bandit pass
+- [x] #4 Kanban minimal optional specs skip only missing optional router import or attr lookup failures and propagate runtime defects
+- [x] #5 Focused router-group tests cover lazy behavior, missing optional import skipping, and runtime import defect propagation with red-green verification
 <!-- AC:END -->
 
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-Red-green Kanban tranche: add focused router-group tests for lazy minimal Kanban module import/router attribute lookup and broad runtime import-failure skipping; then replace only the eager minimal Kanban try/import block with ImportedRouterSpec entries preserving prefix, tags, route_key, default_stable, and minimal skip context.
+Review fix plan:
+1. Add focused RED coverage showing Kanban lazy import RuntimeError from module import is not swallowed by register_router_specs.
+2. Change only the Kanban ImportedRouterSpec skip_exceptions tuple from broad Exception to missing optional router failures.
+3. Update existing Kanban metadata/runtime tests and Backlog notes to reflect narrow skip semantics.
+4. Run focused Kanban tests, full router group/main router contracts, Bandit on minimal.py, and git diff --check.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -41,17 +46,17 @@ Red-green Kanban tranche: add focused router-group tests for lazy minimal Kanban
 <!-- SECTION:NOTES:BEGIN -->
 Red verification: focused minimal Kanban router tests failed before production changes because Kanban endpoint modules were imported during spec construction and named lazy specs were absent.
 
-Green verification: focused Kanban tests, full router group contract tests, main router contract tests, touched-source Bandit, and git diff --check all passed.
+PR #1324 review follow-up: verified Kanban minimal specs used skip_exceptions=(Exception,), which register_router_specs would treat as skippable for any lazy import or attr resolution exception. Added RED coverage proving RuntimeError import defects were swallowed; the focused run failed with DID NOT RAISE RuntimeError.
 
-Reopened for PR #1324 review feedback. Gemini requested deduplicating Kanban router test data. Qodo flagged broad skip_exceptions=(Exception,); verified against origin/dev that the old minimal-test Kanban block already used one broad except Exception and this task intentionally preserved that compatibility boundary. Address Gemini with a test-only dedupe and respond to Qodo with the compatibility rationale unless the local tests expose a safer narrow behavior.
-
-Review follow-up result: deduplicated Kanban test data through shared module suffix/path data, preserving the intentional minimal-test broad skip behavior. Qodo broad-skip thread will be answered with the base-code/task-contract rationale instead of changing PR semantics in this tranche.
+Green verification: narrowed Kanban skip_exceptions to (ImportError, AttributeError). Focused Kanban tests passed with 3 passed; full router group contract tests passed with 88 passed; main router contract tests passed with 6 passed; Bandit on minimal.py reported 0 results and 0 errors; git diff --check was clean. A broad Ruff check on touched files was not used as a completion gate because it reports unrelated pre-existing style findings across older test sections.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Addressed PR #1324 review follow-up by deduplicating the Kanban router contract test data from one shared module/path table and deriving module names, expected names, selected modules, and debug expectations from it. Preserved skip_exceptions=(Exception,) because origin/dev used a broad except Exception for the minimal-test Kanban block and TASK-83 explicitly scoped this tranche to preserve that compatibility behavior; the broad-skip cleanup should be handled as a separate behavior-changing tranche if desired. Verification: focused Kanban router contract tests passed, full test_router_groups_contract.py passed, test_main_router_contract.py passed, Bandit on minimal.py reported 0 results/0 errors, and git diff --check passed.
+Converted the minimal-test Kanban optional router family to ImportedRouterSpec-backed lazy specs and addressed the PR #1324 review finding by narrowing Kanban skip_exceptions from broad Exception to ImportError/AttributeError. This keeps missing optional router modules or router attributes skippable in the minimal test app while allowing runtime defects during lazy import/attr resolution to surface.
+
+Updated focused contract coverage to assert the narrower skip tuple, keep missing-import skip behavior, and prove RuntimeError import failures propagate through register_router_specs. Verification: focused Kanban router tests passed with 3 passed after first failing red; full test_router_groups_contract.py passed with 88 passed; test_main_router_contract.py passed with 6 passed; Bandit on minimal.py reported 0 results/0 errors; git diff --check passed. Ruff full touched-file check still reports unrelated pre-existing style findings in older test sections, so no broad lint cleanup was included in this review fix.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-83 - Phase-2.2-minimal-kanban-router-conditional-cleanup-AL.md
+++ b/backlog/tasks/task-83 - Phase-2.2-minimal-kanban-router-conditional-cleanup-AL.md
@@ -1,0 +1,61 @@
+---
+id: TASK-83
+title: Phase 2.2 minimal kanban router conditional cleanup AL
+status: Done
+assignee: []
+created_date: '2026-05-05 18:55'
+updated_date: '2026-05-05 18:59'
+labels:
+  - phase2.2
+  - router-cleanup
+  - issue-1116
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+  - 'https://github.com/rmusser01/tldw_server/pull/1322'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue issue #1116 Phase 2.2 after PR #1322. Convert the minimal-test Kanban optional router family in tldw_Server_API/app/api/v1/router_groups/minimal.py from one eager broad try/import RouterSpec block to ImportedRouterSpec-backed lazy router specs. Scope is limited to kanban_boards, kanban_lists, kanban_cards, kanban_labels, kanban_checklists, kanban_comments, kanban_search, kanban_links, and kanban_workflow. Preserve prefix /api/v1/kanban, tags, route_key=kanban, default_stable behavior, and existing minimal-test broad skip behavior for import-time failures.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Kanban minimal optional specs defer module import and router attribute lookup until registration
+- [x] #2 Existing route metadata is preserved for every Kanban router in scope
+- [x] #3 Focused router-group tests cover lazy behavior and broad import failure skipping with red-green verification
+- [x] #4 Router-group contract tests and touched-source Bandit pass
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Red-green Kanban tranche: add focused router-group tests for lazy minimal Kanban module import/router attribute lookup and broad runtime import-failure skipping; then replace only the eager minimal Kanban try/import block with ImportedRouterSpec entries preserving prefix, tags, route_key, default_stable, and minimal skip context.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Red verification: focused minimal Kanban router tests failed before production changes because Kanban endpoint modules were imported during spec construction and named lazy specs were absent.
+
+Green verification: focused Kanban tests, full router group contract tests, main router contract tests, touched-source Bandit, and git diff --check all passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Converted the minimal-test Kanban optional router family to ImportedRouterSpec-backed lazy specs. The new entries preserve /api/v1/kanban prefix, kanban tags, route_key=kanban, default_stable behavior, and broad minimal-test skip semantics with skip_exceptions=(Exception,) while deferring module import and router attribute lookup until registration. Added regression coverage for lazy Kanban resolution and RuntimeError skip behavior. Verification: focused red/green Kanban tests, full test_router_groups_contract.py, test_main_router_contract.py, Bandit on minimal.py with 0 results/0 errors, and git diff --check.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -611,7 +611,7 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
                 tags=("kanban",),
                 route_key="kanban",
                 skip_context=minimal_skip_context,
-                skip_exceptions=(Exception,),
+                skip_exceptions=(ImportError, AttributeError),
             ),
         )
 

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -591,30 +591,29 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
     ):
         append_imported_router_spec(specs, utility_spec)
 
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.kanban.kanban_boards import router as kanban_boards_router
-        from tldw_Server_API.app.api.v1.endpoints.kanban.kanban_cards import router as kanban_cards_router
-        from tldw_Server_API.app.api.v1.endpoints.kanban.kanban_checklists import router as kanban_checklists_router
-        from tldw_Server_API.app.api.v1.endpoints.kanban.kanban_comments import router as kanban_comments_router
-        from tldw_Server_API.app.api.v1.endpoints.kanban.kanban_labels import router as kanban_labels_router
-        from tldw_Server_API.app.api.v1.endpoints.kanban.kanban_links import router as kanban_links_router
-        from tldw_Server_API.app.api.v1.endpoints.kanban.kanban_lists import router as kanban_lists_router
-        from tldw_Server_API.app.api.v1.endpoints.kanban.kanban_search import router as kanban_search_router
-        from tldw_Server_API.app.api.v1.endpoints.kanban.kanban_workflow import router as kanban_workflow_router
-
-        specs.extend([
-            RouterSpec(router=kanban_boards_router, prefix=f"{API_V1_PREFIX}/kanban", tags=("kanban",), route_key="kanban"),
-            RouterSpec(router=kanban_lists_router, prefix=f"{API_V1_PREFIX}/kanban", tags=("kanban",), route_key="kanban"),
-            RouterSpec(router=kanban_cards_router, prefix=f"{API_V1_PREFIX}/kanban", tags=("kanban",), route_key="kanban"),
-            RouterSpec(router=kanban_labels_router, prefix=f"{API_V1_PREFIX}/kanban", tags=("kanban",), route_key="kanban"),
-            RouterSpec(router=kanban_checklists_router, prefix=f"{API_V1_PREFIX}/kanban", tags=("kanban",), route_key="kanban"),
-            RouterSpec(router=kanban_comments_router, prefix=f"{API_V1_PREFIX}/kanban", tags=("kanban",), route_key="kanban"),
-            RouterSpec(router=kanban_search_router, prefix=f"{API_V1_PREFIX}/kanban", tags=("kanban",), route_key="kanban"),
-            RouterSpec(router=kanban_links_router, prefix=f"{API_V1_PREFIX}/kanban", tags=("kanban",), route_key="kanban"),
-            RouterSpec(router=kanban_workflow_router, prefix=f"{API_V1_PREFIX}/kanban", tags=("kanban",), route_key="kanban"),
-        ])
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping kanban router in minimal test app: {e}")
+    for kanban_module in (
+        "kanban_boards",
+        "kanban_lists",
+        "kanban_cards",
+        "kanban_labels",
+        "kanban_checklists",
+        "kanban_comments",
+        "kanban_search",
+        "kanban_links",
+        "kanban_workflow",
+    ):
+        append_imported_router_spec(
+            specs,
+            ImportedRouterSpec(
+                import_path=f"tldw_Server_API.app.api.v1.endpoints.kanban.{kanban_module}",
+                log_name=kanban_module,
+                prefix=f"{API_V1_PREFIX}/kanban",
+                tags=("kanban",),
+                route_key="kanban",
+                skip_context=minimal_skip_context,
+                skip_exceptions=(Exception,),
+            ),
+        )
 
     try:
         from tldw_Server_API.app.api.v1.endpoints.flashcards import router as flashcards_router

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -18,6 +18,19 @@ from tldw_Server_API.app.core.testing import is_explicit_pytest_runtime
 
 pytestmark = pytest.mark.unit
 
+KANBAN_ROUTER_MODULE_PREFIX = "tldw_Server_API.app.api.v1.endpoints.kanban."
+KANBAN_ROUTER_DEFINITION_DATA = (
+    ("kanban_boards", "/boards"),
+    ("kanban_lists", "/lists"),
+    ("kanban_cards", "/cards"),
+    ("kanban_labels", "/labels"),
+    ("kanban_checklists", "/checklists"),
+    ("kanban_comments", "/comments"),
+    ("kanban_search", "/search"),
+    ("kanban_links", "/links"),
+    ("kanban_workflow", "/workflow"),
+)
+
 
 def _main_source_text() -> str:
     main_path = Path(__file__).resolve().parents[2] / "app" / "main.py"
@@ -5209,52 +5222,13 @@ def test_iter_minimal_optional_router_specs_defers_kanban_attr_lookup(
         iter_minimal_optional_router_specs,
     )
 
-    router_definitions = (
+    router_definitions = tuple(
         {
-            "module_name": "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_boards",
-            "expected_name": "kanban_boards",
-            "path": "/boards",
-        },
-        {
-            "module_name": "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_lists",
-            "expected_name": "kanban_lists",
-            "path": "/lists",
-        },
-        {
-            "module_name": "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_cards",
-            "expected_name": "kanban_cards",
-            "path": "/cards",
-        },
-        {
-            "module_name": "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_labels",
-            "expected_name": "kanban_labels",
-            "path": "/labels",
-        },
-        {
-            "module_name": "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_checklists",
-            "expected_name": "kanban_checklists",
-            "path": "/checklists",
-        },
-        {
-            "module_name": "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_comments",
-            "expected_name": "kanban_comments",
-            "path": "/comments",
-        },
-        {
-            "module_name": "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_search",
-            "expected_name": "kanban_search",
-            "path": "/search",
-        },
-        {
-            "module_name": "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_links",
-            "expected_name": "kanban_links",
-            "path": "/links",
-        },
-        {
-            "module_name": "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_workflow",
-            "expected_name": "kanban_workflow",
-            "path": "/workflow",
-        },
+            "module_name": f"{KANBAN_ROUTER_MODULE_PREFIX}{module_suffix}",
+            "expected_name": module_suffix,
+            "path": path,
+        }
+        for module_suffix, path in KANBAN_ROUTER_DEFINITION_DATA
     )
     definitions_by_module = {
         str(definition["module_name"]): definition
@@ -5392,28 +5366,15 @@ def test_iter_minimal_optional_router_specs_skips_kanban_runtime_import_failures
         iter_minimal_optional_router_specs,
     )
 
+    kanban_module_suffixes = tuple(
+        module_suffix
+        for module_suffix, _path in KANBAN_ROUTER_DEFINITION_DATA
+    )
     kanban_modules = {
-        "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_boards",
-        "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_lists",
-        "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_cards",
-        "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_labels",
-        "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_checklists",
-        "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_comments",
-        "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_search",
-        "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_links",
-        "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_workflow",
+        f"{KANBAN_ROUTER_MODULE_PREFIX}{module_suffix}"
+        for module_suffix in kanban_module_suffixes
     }
-    expected_names = {
-        "kanban_boards",
-        "kanban_lists",
-        "kanban_cards",
-        "kanban_labels",
-        "kanban_checklists",
-        "kanban_comments",
-        "kanban_search",
-        "kanban_links",
-        "kanban_workflow",
-    }
+    expected_names = set(kanban_module_suffixes)
 
     specs = list(iter_minimal_optional_router_specs())
     selected_specs = {
@@ -5443,17 +5404,7 @@ def test_iter_minimal_optional_router_specs_skips_kanban_runtime_import_failures
     assert debug_messages == [
         f"Skipping {name} router in minimal test app: "
         f"tldw_Server_API.app.api.v1.endpoints.kanban.{name} exploded during import"
-        for name in (
-            "kanban_boards",
-            "kanban_lists",
-            "kanban_cards",
-            "kanban_labels",
-            "kanban_checklists",
-            "kanban_comments",
-            "kanban_search",
-            "kanban_links",
-            "kanban_workflow",
-        )
+        for name in kanban_module_suffixes
     ]
 
 

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -5343,7 +5343,7 @@ def test_iter_minimal_optional_router_specs_defers_kanban_attr_lookup(
         assert spec.route_key == "kanban"
         assert spec.skip_context == "in minimal test app"
         assert spec.default_stable is True
-        assert spec.skip_exceptions == (Exception,)
+        assert spec.skip_exceptions == (ImportError, AttributeError)
         assert _first_router_path(spec.router) == definition["path"]
 
     assert import_calls == [
@@ -5356,10 +5356,10 @@ def test_iter_minimal_optional_router_specs_defers_kanban_attr_lookup(
     }
 
 
-def test_iter_minimal_optional_router_specs_skips_kanban_runtime_import_failures(
+def test_iter_minimal_optional_router_specs_skips_kanban_missing_import_failures(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Verify minimal Kanban specs preserve broad import failure skipping."""
+    """Verify minimal Kanban specs skip missing optional router imports."""
     import importlib
 
     from tldw_Server_API.app.api.v1.router_groups.minimal import (
@@ -5389,7 +5389,7 @@ def test_iter_minimal_optional_router_specs_skips_kanban_runtime_import_failures
     def _import_module(module_name: str, package: str | None = None) -> ModuleType:
         """Crash only the selected Kanban router imports at registration."""
         if module_name in kanban_modules:
-            raise RuntimeError(f"{module_name} exploded during import")
+            raise ImportError(f"{module_name} missing during import")
         return real_import_module(module_name, package)
 
     monkeypatch.setattr(
@@ -5403,9 +5403,40 @@ def test_iter_minimal_optional_router_specs_skips_kanban_runtime_import_failures
     assert register_router_specs(FastAPI(), selected_specs.values()) == 0
     assert debug_messages == [
         f"Skipping {name} router in minimal test app: "
-        f"tldw_Server_API.app.api.v1.endpoints.kanban.{name} exploded during import"
+        f"tldw_Server_API.app.api.v1.endpoints.kanban.{name} missing during import"
         for name in kanban_module_suffixes
     ]
+
+
+def test_iter_minimal_optional_router_specs_propagates_kanban_runtime_import_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal Kanban runtime import defects are not silently skipped."""
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    module_name = f"{KANBAN_ROUTER_MODULE_PREFIX}kanban_boards"
+    specs = list(iter_minimal_optional_router_specs())
+    selected_spec = next(spec for spec in specs if spec.name == "kanban_boards")
+
+    real_import_module = importlib.import_module
+
+    def _import_module(import_name: str, package: str | None = None) -> ModuleType:
+        """Crash only one selected Kanban router import at registration."""
+        if import_name == module_name:
+            raise RuntimeError(f"{module_name} exploded during import")
+        return real_import_module(import_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    with pytest.raises(RuntimeError, match="kanban_boards exploded during import"):
+        register_router_specs(FastAPI(), (selected_spec,))
 
 
 def test_iter_minimal_optional_router_specs_defers_experience_attr_lookup(

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -5198,6 +5198,265 @@ def test_iter_minimal_optional_router_specs_skips_utility_runtime_import_failure
     ]
 
 
+def test_iter_minimal_optional_router_specs_defers_kanban_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal Kanban specs keep router attr lookup lazy."""
+    import builtins
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    router_definitions = (
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_boards",
+            "expected_name": "kanban_boards",
+            "path": "/boards",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_lists",
+            "expected_name": "kanban_lists",
+            "path": "/lists",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_cards",
+            "expected_name": "kanban_cards",
+            "path": "/cards",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_labels",
+            "expected_name": "kanban_labels",
+            "path": "/labels",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_checklists",
+            "expected_name": "kanban_checklists",
+            "path": "/checklists",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_comments",
+            "expected_name": "kanban_comments",
+            "path": "/comments",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_search",
+            "expected_name": "kanban_search",
+            "path": "/search",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_links",
+            "expected_name": "kanban_links",
+            "path": "/links",
+        },
+        {
+            "module_name": "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_workflow",
+            "expected_name": "kanban_workflow",
+            "path": "/workflow",
+        },
+    )
+    definitions_by_module = {
+        str(definition["module_name"]): definition
+        for definition in router_definitions
+    }
+    access_count = {
+        f"{definition['module_name']}.router": 0
+        for definition in router_definitions
+    }
+    import_calls: list[str] = []
+
+    for module_name, definition in definitions_by_module.items():
+        fake_module = ModuleType(module_name)
+        router = APIRouter()
+
+        @router.get(str(definition["path"]))
+        def _endpoint() -> dict[str, str]:
+            """Return a deterministic response for the fake minimal Kanban router."""
+            return {"status": "ok"}
+
+        def _module_getattr(
+            name: str,
+            *,
+            module_name: str = module_name,
+            router: APIRouter = router,
+        ) -> APIRouter:
+            """Track lazy router attribute resolution for the fake module."""
+            if name != "router":
+                raise AttributeError(name)
+            access_count[f"{module_name}.router"] += 1
+            return router
+
+        fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    endpoints_package = "tldw_Server_API.app.api.v1.endpoints."
+    real_import = builtins.__import__
+
+    def _fake_endpoint_import(
+        name: str,
+        globals: dict[str, object] | None = None,
+        locals: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> ModuleType:
+        """Track selected imports and fake unrelated eager optional routers."""
+        if (
+            level == 0
+            and name.startswith(endpoints_package)
+        ):
+            if name in definitions_by_module:
+                import_calls.append(name)
+                return real_import(name, globals, locals, fromlist, level)
+            attrs = tuple(attr for attr in fromlist if attr != "*") or ("router",)
+            for attr_name in attrs:
+                _install_fake_router_module(
+                    monkeypatch,
+                    name,
+                    path="/minimal-unrelated-kanban-fake",
+                    attr_name=attr_name,
+                )
+            return sys.modules[name]
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_endpoint_import)
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Track lazy module imports for selected minimal Kanban routers."""
+        if module_name in definitions_by_module:
+            import_calls.append(module_name)
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+    fake_main = ModuleType("tldw_Server_API.app.main")
+    fake_main.app = FastAPI()  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "tldw_Server_API.app.main", fake_main)
+
+    specs = list(iter_minimal_optional_router_specs())
+    assert [
+        module_name
+        for module_name in definitions_by_module
+        if module_name in import_calls
+    ] == []
+    assert access_count == {
+        f"{definition['module_name']}.router": 0
+        for definition in router_definitions
+    }
+    assert import_calls == []
+
+    selected_specs = {
+        spec.name: spec
+        for spec in specs
+        if spec.name in {
+            str(definition["expected_name"])
+            for definition in router_definitions
+        }
+    }
+    assert set(selected_specs) == {
+        str(definition["expected_name"])
+        for definition in router_definitions
+    }
+
+    for definition in router_definitions:
+        spec = selected_specs[str(definition["expected_name"])]
+        assert spec.prefix == "/api/v1/kanban"
+        assert spec.tags == ("kanban",)
+        assert spec.route_key == "kanban"
+        assert spec.skip_context == "in minimal test app"
+        assert spec.default_stable is True
+        assert spec.skip_exceptions == (Exception,)
+        assert _first_router_path(spec.router) == definition["path"]
+
+    assert import_calls == [
+        str(definition["module_name"])
+        for definition in router_definitions
+    ]
+    assert access_count == {
+        f"{definition['module_name']}.router": 1
+        for definition in router_definitions
+    }
+
+
+def test_iter_minimal_optional_router_specs_skips_kanban_runtime_import_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal Kanban specs preserve broad import failure skipping."""
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    kanban_modules = {
+        "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_boards",
+        "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_lists",
+        "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_cards",
+        "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_labels",
+        "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_checklists",
+        "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_comments",
+        "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_search",
+        "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_links",
+        "tldw_Server_API.app.api.v1.endpoints.kanban.kanban_workflow",
+    }
+    expected_names = {
+        "kanban_boards",
+        "kanban_lists",
+        "kanban_cards",
+        "kanban_labels",
+        "kanban_checklists",
+        "kanban_comments",
+        "kanban_search",
+        "kanban_links",
+        "kanban_workflow",
+    }
+
+    specs = list(iter_minimal_optional_router_specs())
+    selected_specs = {
+        spec.name: spec
+        for spec in specs
+        if spec.name in expected_names
+    }
+    assert set(selected_specs) == expected_names
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Crash only the selected Kanban router imports at registration."""
+        if module_name in kanban_modules:
+            raise RuntimeError(f"{module_name} exploded during import")
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    debug_messages: list[str] = []
+    monkeypatch.setattr("loguru.logger.debug", debug_messages.append)
+
+    assert register_router_specs(FastAPI(), selected_specs.values()) == 0
+    assert debug_messages == [
+        f"Skipping {name} router in minimal test app: "
+        f"tldw_Server_API.app.api.v1.endpoints.kanban.{name} exploded during import"
+        for name in (
+            "kanban_boards",
+            "kanban_lists",
+            "kanban_cards",
+            "kanban_labels",
+            "kanban_checklists",
+            "kanban_comments",
+            "kanban_search",
+            "kanban_links",
+            "kanban_workflow",
+        )
+    ]
+
+
 def test_iter_minimal_optional_router_specs_defers_experience_attr_lookup(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- Converts the minimal-test Kanban router family to `ImportedRouterSpec`-backed lazy specs.
- Preserves `/api/v1/kanban` prefix, `kanban` tags, `route_key="kanban"`, default stable behavior, and broad minimal-test import failure skipping via `skip_exceptions=(Exception,)`.
- Adds TASK-83 tracking plus focused regression coverage for lazy Kanban resolution and runtime import-failure skipping.

## Test Plan
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "kanban_attr_lookup or kanban_runtime_import_failures" -q` (red before implementation, green after)
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/router_groups/minimal.py -f json -o /tmp/bandit_phase2_2_minimal_kanban_router_conditionals.json` (`0` results, `0` errors)
- [x] `git diff --check`

Refs #1116
