### PR TITLE
Fix watchlist job delete confirmation test

### DIFF
--- a/apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/JobsTab.undo-delete.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/JobsTab.undo-delete.test.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { fireEvent, render, screen, waitFor } from "@testing-library/react"
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { Modal } from "antd"
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest"
 import { JobsTab } from "../JobsTab"
 
 const mocks = vi.hoisted(() => ({
@@ -13,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   triggerWatchlistRunMock: vi.fn(),
   messageErrorMock: vi.fn(),
   messageSuccessMock: vi.fn(),
+  modalConfirmMock: vi.fn(),
   showUndoNotificationMock: vi.fn(),
   storeStateRef: { current: {} as Record<string, any> }
 }))
@@ -64,6 +66,9 @@ vi.mock("antd", () => {
 
   return {
     Button,
+    Modal: {
+      confirm: mocks.modalConfirmMock
+    },
     Popconfirm,
     Space: ({ children }: any) => <>{children}</>,
     Switch: () => null,
@@ -110,6 +115,18 @@ vi.mock("../JobFormModal", () => ({
 vi.mock("../JobPreviewModal", () => ({
   JobPreviewModal: () => null
 }))
+
+type DeleteConfirmConfig = {
+  onOk?: () => unknown | Promise<unknown>
+  onCancel?: () => unknown | Promise<unknown>
+}
+
+const getDeleteConfirmConfig = async (): Promise<DeleteConfirmConfig> => {
+  await waitFor(() => {
+    expect(Modal.confirm).toHaveBeenCalledTimes(1)
+  })
+  return (Modal.confirm as Mock).mock.calls[0][0] as DeleteConfirmConfig
+}
 
 vi.mock("../../shared", () => ({
   CronDisplay: () => <span>Cron</span>,
@@ -200,6 +217,11 @@ describe("JobsTab undo delete flow", () => {
 
     fireEvent.click(screen.getByTestId("danger-button"))
 
+    const confirmConfig = await getDeleteConfirmConfig()
+    expect(mocks.deleteWatchlistJobMock).not.toHaveBeenCalled()
+
+    await confirmConfig.onOk?.()
+
     await waitFor(() => {
       expect(mocks.deleteWatchlistJobMock).toHaveBeenCalledWith(41)
       expect(mocks.storeStateRef.current.removeJob).toHaveBeenCalledWith(41)
@@ -228,6 +250,11 @@ describe("JobsTab undo delete flow", () => {
 
     fireEvent.click(screen.getByTestId("danger-button"))
 
+    const confirmConfig = await getDeleteConfirmConfig()
+    expect(mocks.showUndoNotificationMock).not.toHaveBeenCalled()
+
+    await confirmConfig.onOk?.()
+
     await waitFor(() => {
       expect(mocks.showUndoNotificationMock).toHaveBeenCalledTimes(1)
     })
@@ -241,6 +268,23 @@ describe("JobsTab undo delete flow", () => {
       expect(mocks.fetchWatchlistJobsMock.mock.calls.length).toBeGreaterThanOrEqual(2)
     })
     expect(mocks.restoreWatchlistJobMock).not.toHaveBeenCalled()
+  })
+
+  it("does not delete a monitor when delete confirmation is cancelled", async () => {
+    render(<JobsTab />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId("jobs-table")).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByTestId("danger-button"))
+
+    const confirmConfig = await getDeleteConfirmConfig()
+    await confirmConfig.onCancel?.()
+
+    expect(mocks.deleteWatchlistJobMock).not.toHaveBeenCalled()
+    expect(mocks.storeStateRef.current.removeJob).not.toHaveBeenCalled()
+    expect(mocks.showUndoNotificationMock).not.toHaveBeenCalled()
   })
 
   it("falls back to default undo window when backend returns invalid restore timing", async () => {
@@ -258,6 +302,11 @@ describe("JobsTab undo delete flow", () => {
     })
 
     fireEvent.click(screen.getByTestId("danger-button"))
+
+    const confirmConfig = await getDeleteConfirmConfig()
+    expect(mocks.showUndoNotificationMock).not.toHaveBeenCalled()
+
+    await confirmConfig.onOk?.()
 
     await waitFor(() => {
       expect(mocks.showUndoNotificationMock).toHaveBeenCalledTimes(1)

--- a/apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/JobsTab.undo-delete.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/JobsTab.undo-delete.test.tsx
@@ -123,9 +123,10 @@ type DeleteConfirmConfig = {
 
 const getDeleteConfirmConfig = async (): Promise<DeleteConfirmConfig> => {
   await waitFor(() => {
-    expect(Modal.confirm).toHaveBeenCalledTimes(1)
+    expect(Modal.confirm).toHaveBeenCalled()
   })
-  return (Modal.confirm as Mock).mock.calls[0][0] as DeleteConfirmConfig
+  const calls = (Modal.confirm as Mock).mock.calls
+  return calls[calls.length - 1][0] as DeleteConfirmConfig
 }
 
 vi.mock("../../shared", () => ({
@@ -270,7 +271,7 @@ describe("JobsTab undo delete flow", () => {
     expect(mocks.restoreWatchlistJobMock).not.toHaveBeenCalled()
   })
 
-  it("does not delete a monitor when delete confirmation is cancelled", async () => {
+  it("does not delete a monitor when confirmation is not accepted", async () => {
     render(<JobsTab />)
 
     await waitFor(() => {
@@ -280,7 +281,7 @@ describe("JobsTab undo delete flow", () => {
     fireEvent.click(screen.getByTestId("danger-button"))
 
     const confirmConfig = await getDeleteConfirmConfig()
-    await confirmConfig.onCancel?.()
+    expect(confirmConfig.onCancel).toBeUndefined()
 
     expect(mocks.deleteWatchlistJobMock).not.toHaveBeenCalled()
     expect(mocks.storeStateRef.current.removeJob).not.toHaveBeenCalled()

--- a/backlog/tasks/task-84 - Fix-Watchlists-job-delete-confirmation-test.md
+++ b/backlog/tasks/task-84 - Fix-Watchlists-job-delete-confirmation-test.md
@@ -1,0 +1,68 @@
+---
+id: TASK-84
+title: Fix Watchlists job delete confirmation test
+status: Done
+assignee:
+  - codex
+created_date: '2026-05-05 19:15'
+updated_date: '2026-05-05 19:17'
+labels:
+  - frontend
+  - watchlists
+  - tests
+dependencies: []
+documentation:
+  - >-
+    apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/JobsTab.undo-delete.test.tsx
+  - apps/packages/ui/src/components/Option/Watchlists/JobsTab/JobsTab.tsx
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix the JobsTab undo-delete test so it models the production Modal.confirm gate. The test should not delete immediately when the trash button is clicked; it should assert Modal.confirm is shown and explicitly invoke onOk to simulate user confirmation. Add cancel coverage if practical so a dismissed confirmation does not call deleteWatchlistJob.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The JobsTab undo-delete antd Modal.confirm mock stores confirmation config without auto-running onOk.
+- [x] #2 Existing delete/undo test explicitly invokes the stored onOk callback before expecting deleteWatchlistJob and undo notification behavior.
+- [x] #3 Cancel/dismiss coverage asserts invoking onCancel, when present, does not call deleteWatchlistJob.
+- [x] #4 Focused JobsTab undo-delete Vitest coverage passes.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Verify the current JobsTab undo-delete test behavior in the clean worktree with the focused Vitest file.
+2. Update only apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/JobsTab.undo-delete.test.tsx so the antd Modal.confirm mock records its config and never auto-runs onOk.
+3. Add small test helpers to retrieve the latest confirm config, explicitly await config.onOk?.() in delete/undo flows, and add cancel coverage that proves deleteWatchlistJob is not called when the confirmation is dismissed.
+4. Run focused Vitest for JobsTab.undo-delete.test.tsx, then run git diff --check and targeted ESLint if available. Document Bandit as not applicable because the change is frontend test-only.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verified the review target in origin/dev: JobsTab production deletion is gated through Modal.confirm with onOk executing executeDelete(job.id). The focused test baseline failed because the antd mock did not expose Modal, so clicking delete never reached a valid confirmation path.
+
+Updated JobsTab.undo-delete.test.tsx only: added a Modal.confirm mock that records config without auto-confirming, added a helper to assert/retrieve the confirm config, explicitly invokes onOk in delete-path tests, and added cancel/dismiss coverage that does not call deleteWatchlistJob.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed the Watchlists JobsTab undo-delete test so it models the production confirmation gate. The antd mock now includes Modal.confirm as a passive vi.fn that stores the config. Delete-path tests assert the confirmation was requested and explicitly invoke onOk before expecting deleteWatchlistJob, removeJob, and undo notification behavior. Added cancel/dismiss coverage that invokes onCancel when present and verifies no delete side effects occur.
+
+Verification: focused JobsTab.undo-delete Vitest file passes with 4 tests. git diff --check passes. Targeted ESLint exits 0 with no errors; it reports pre-existing no-explicit-any warnings in this test mock. Bandit is not applicable because this is frontend test-only TypeScript/React code.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-86 - Address-PR-review-comments-on-JobsTab-delete-confirmation-test.md
+++ b/backlog/tasks/task-86 - Address-PR-review-comments-on-JobsTab-delete-confirmation-test.md
@@ -1,0 +1,53 @@
+---
+id: TASK-86
+title: Address PR review comments on JobsTab delete confirmation test
+status: Done
+assignee: []
+created_date: '2026-05-05 19:53'
+updated_date: '2026-05-05 19:53'
+labels:
+  - frontend
+  - watchlists
+  - tests
+  - review-fix
+dependencies: []
+documentation:
+  - >-
+    apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/JobsTab.undo-delete.test.tsx
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Follow up on PR #1325 review comments by clarifying the no-confirmation test behavior and making the Modal.confirm helper resilient to multiple calls.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The confirmation helper returns the latest Modal.confirm call config without requiring exactly one call.
+- [x] #2 The no-confirmation test name and assertions do not imply an onCancel handler exists when production does not provide one.
+- [x] #3 Focused JobsTab undo-delete Vitest coverage passes after the review fix.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented PR #1325 review fix in the branch worktree: getDeleteConfirmConfig now waits for any Modal.confirm call and returns the most recent config. The no-acceptance test no longer calls a nonexistent onCancel handler; it asserts onCancel is undefined and verifies no delete side effects occur until confirmation is accepted.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed PR #1325 review comments on JobsTab undo-delete coverage. The Modal.confirm helper now returns the latest confirm config without assuming exactly one call. The no-confirmation test has been renamed to avoid implying production provides onCancel, asserts onCancel is undefined, and still verifies deleteWatchlistJob, removeJob, and undo notification side effects do not run unless onOk is invoked. Verification: focused JobsTab undo-delete Vitest file passes. Bandit is not applicable because this is frontend test-only TypeScript/React code.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary

- Mock `antd` `Modal.confirm` in `JobsTab.undo-delete.test.tsx` as a passive config recorder instead of letting delete behavior happen implicitly.
- Update delete-path tests to assert the confirmation is opened and explicitly invoke `onOk` before expecting delete and undo side effects.
- Add cancel/dismiss coverage proving the delete service, local removal, and undo notification are not called when the confirmation is not accepted.

## Verification

- `bunx vitest run src/components/Option/Watchlists/JobsTab/__tests__/JobsTab.undo-delete.test.tsx`
- `git diff --check`
- `apps/tldw-frontend/node_modules/.bin/eslint -c apps/tldw-frontend/eslint.config.mjs apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/JobsTab.undo-delete.test.tsx` exits 0 with no errors; existing `no-explicit-any` warnings remain in this test mock.
- Bandit skipped because this is frontend test-only TypeScript/React code.

## Change summary

AI-generated draft. Human owner should replace this section with their own explanation of what changed and why before merge, per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.
