### PR TITLE
Phase 2.2: defer minimal study imports

### DIFF
--- a/backlog/tasks/task-87 - Phase-2.2-minimal-study-router-conditional-cleanup-AM.md
+++ b/backlog/tasks/task-87 - Phase-2.2-minimal-study-router-conditional-cleanup-AM.md
@@ -1,0 +1,68 @@
+---
+id: TASK-87
+title: Phase 2.2 minimal study router conditional cleanup AM
+status: Done
+assignee: []
+created_date: '2026-05-05 20:54'
+updated_date: '2026-05-05 20:57'
+labels:
+  - phase2.2
+  - router-cleanup
+  - issue-1116
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+  - 'https://github.com/rmusser01/tldw_server/pull/1324'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue issue #1116 Phase 2.2 after PR #1324. Convert the next small minimal-test study optional router family in tldw_Server_API/app/api/v1/router_groups/minimal.py from eager try/import RouterSpec blocks to ImportedRouterSpec-backed lazy router specs. Scope is limited to flashcards, quizzes, and study_suggestions. Preserve prefixes, tags, route_key/default_stable behavior, and minimal skip context while using narrow missing-optional skip semantics: ImportError/AttributeError are skippable, runtime import defects propagate.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Flashcards, quizzes, and study_suggestions minimal optional specs defer module import and router attribute lookup until registration
+- [x] #2 Existing route metadata is preserved for every study router in scope
+- [x] #3 Focused router-group tests cover lazy behavior, missing optional import skipping, and runtime import defect propagation with red-green verification
+- [x] #4 Router-group/main-router contract tests and touched-source Bandit pass
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused RED coverage for minimal study router lazy resolution: spec construction does not import flashcards/quizzes/study_suggestions, metadata is preserved, and router attr lookup happens only during registration.
+2. Add RED coverage for missing optional ImportError skip behavior and RuntimeError propagation through register_router_specs.
+3. Convert only flashcards, quizzes, and study_suggestions to ImportedRouterSpec entries in minimal.py using skip_exceptions=(ImportError, AttributeError).
+4. Run focused tests, full router group and main router contract tests, Bandit on minimal.py, and git diff --check before commit/PR.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Started after PR #1324 merge was verified on origin/dev as 8b87d7b2a in the git log. Worktree: /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/phase2-2-minimal-study-router-conditionals-am. Branch: codex/phase2-2-minimal-study-router-conditionals-am. Baseline focused Kanban minimal tests passed with 3 passed before edits.
+
+RED verification: focused study tests failed before production changes because flashcards, quizzes, and study_suggestions were imported during spec construction and no named lazy study specs existed for registration-time skip/propagation assertions.
+
+GREEN verification: converted flashcards, quizzes, and study_suggestions to ImportedRouterSpec-backed lazy specs with skip_exceptions=(ImportError, AttributeError). Focused study tests passed with 3 passed; full test_router_groups_contract.py passed with 91 passed; test_main_router_contract.py passed with 6 passed; Bandit on minimal.py reported 0 results and 0 errors; git diff --check was clean.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Converted the minimal-test study router family, limited to flashcards, quizzes, and study_suggestions, from eager try/import RouterSpec blocks to ImportedRouterSpec-backed lazy specs. The change preserves prefixes, tags, default route_key/default_stable behavior, and minimal skip context while using narrow missing-optional skip semantics: ImportError and AttributeError are skipped, but runtime import defects propagate through register_router_specs.
+
+Added focused contract coverage for lazy module import/router attribute lookup, missing optional import skipping, and RuntimeError propagation. Verification: focused study tests passed with 3 passed after a failing RED run; full router group contract tests passed with 91 passed; main router contract tests passed with 6 passed; Bandit on minimal.py reported 0 results and 0 errors; git diff --check passed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-87 - Phase-2.2-minimal-study-router-conditional-cleanup-AM.md
+++ b/backlog/tasks/task-87 - Phase-2.2-minimal-study-router-conditional-cleanup-AM.md
@@ -42,7 +42,7 @@ Continue issue #1116 Phase 2.2 after PR #1324. Convert the next small minimal-te
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Started after PR #1324 merge was verified on origin/dev as 8b87d7b2a in the git log. Worktree: /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/phase2-2-minimal-study-router-conditionals-am. Branch: codex/phase2-2-minimal-study-router-conditionals-am. Baseline focused Kanban minimal tests passed with 3 passed before edits.
+Started after PR #1324 merge was verified on origin/dev as 8b87d7b2a in the git log. Worktree: local feature worktree for phase2-2-minimal-study-router-conditionals-am. Branch: codex/phase2-2-minimal-study-router-conditionals-am. Baseline focused Kanban minimal tests passed with 3 passed before edits.
 
 RED verification: focused study tests failed before production changes because flashcards, quizzes, and study_suggestions were imported during spec construction and no named lazy study specs existed for registration-time skip/propagation assertions.
 

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -615,40 +615,33 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
             ),
         )
 
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.flashcards import router as flashcards_router
-
-        specs.append(RouterSpec(
-            router=flashcards_router,
+    for study_spec in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.flashcards",
+            log_name="flashcards",
             prefix=f"{API_V1_PREFIX}",
             tags=("flashcards",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping flashcards router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.quizzes import router as quizzes_router
-
-        specs.append(RouterSpec(
-            router=quizzes_router,
+            skip_context=minimal_skip_context,
+            skip_exceptions=(ImportError, AttributeError),
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.quizzes",
+            log_name="quizzes",
             prefix=f"{API_V1_PREFIX}",
             tags=("quizzes",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping quizzes router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.study_suggestions import (
-            router as study_suggestions_router,
-        )
-
-        specs.append(RouterSpec(
-            router=study_suggestions_router,
+            skip_context=minimal_skip_context,
+            skip_exceptions=(ImportError, AttributeError),
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.study_suggestions",
+            log_name="study_suggestions",
             prefix=f"{API_V1_PREFIX}",
             tags=("study-suggestions",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping study_suggestions router in minimal test app: {e}")
+            skip_context=minimal_skip_context,
+            skip_exceptions=(ImportError, AttributeError),
+        ),
+    ):
+        append_imported_router_spec(specs, study_spec)
 
     try:
         from tldw_Server_API.app.api.v1.endpoints.writing import router as writing_router

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -30,6 +30,29 @@ KANBAN_ROUTER_DEFINITION_DATA = (
     ("kanban_links", "/links"),
     ("kanban_workflow", "/workflow"),
 )
+STUDY_ROUTER_DEFINITION_DATA = (
+    (
+        "tldw_Server_API.app.api.v1.endpoints.flashcards",
+        "flashcards",
+        "/api/v1",
+        ("flashcards",),
+        "/flashcards",
+    ),
+    (
+        "tldw_Server_API.app.api.v1.endpoints.quizzes",
+        "quizzes",
+        "/api/v1",
+        ("quizzes",),
+        "/quizzes",
+    ),
+    (
+        "tldw_Server_API.app.api.v1.endpoints.study_suggestions",
+        "study_suggestions",
+        "/api/v1",
+        ("study-suggestions",),
+        "/study-suggestions",
+    ),
+)
 
 
 def _main_source_text() -> str:
@@ -5436,6 +5459,235 @@ def test_iter_minimal_optional_router_specs_propagates_kanban_runtime_import_fai
     )
 
     with pytest.raises(RuntimeError, match="kanban_boards exploded during import"):
+        register_router_specs(FastAPI(), (selected_spec,))
+
+
+def test_iter_minimal_optional_router_specs_defers_study_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal study specs keep router attr lookup lazy."""
+    import builtins
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    router_definitions = tuple(
+        {
+            "module_name": module_name,
+            "expected_name": expected_name,
+            "prefix": prefix,
+            "tags": tags,
+            "path": path,
+        }
+        for module_name, expected_name, prefix, tags, path in STUDY_ROUTER_DEFINITION_DATA
+    )
+    definitions_by_module = {
+        str(definition["module_name"]): definition
+        for definition in router_definitions
+    }
+    access_count = {
+        f"{definition['module_name']}.router": 0
+        for definition in router_definitions
+    }
+    import_calls: list[str] = []
+
+    for module_name, definition in definitions_by_module.items():
+        fake_module = ModuleType(module_name)
+        router = APIRouter()
+
+        @router.get(str(definition["path"]))
+        def _endpoint() -> dict[str, str]:
+            """Return a deterministic response for the fake minimal study router."""
+            return {"status": "ok"}
+
+        def _module_getattr(
+            name: str,
+            *,
+            module_name: str = module_name,
+            router: APIRouter = router,
+        ) -> APIRouter:
+            """Track lazy router attribute resolution for the fake module."""
+            if name != "router":
+                raise AttributeError(name)
+            access_count[f"{module_name}.router"] += 1
+            return router
+
+        fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    endpoints_package = "tldw_Server_API.app.api.v1.endpoints."
+    real_import = builtins.__import__
+
+    def _fake_endpoint_import(
+        name: str,
+        globals: dict[str, object] | None = None,
+        locals: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> ModuleType:
+        """Track selected imports and fake unrelated eager optional routers."""
+        if (
+            level == 0
+            and name.startswith(endpoints_package)
+        ):
+            if name in definitions_by_module:
+                import_calls.append(name)
+                return real_import(name, globals, locals, fromlist, level)
+            attrs = tuple(attr for attr in fromlist if attr != "*") or ("router",)
+            for attr_name in attrs:
+                _install_fake_router_module(
+                    monkeypatch,
+                    name,
+                    path="/minimal-unrelated-study-fake",
+                    attr_name=attr_name,
+                )
+            return sys.modules[name]
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_endpoint_import)
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Track lazy module imports for selected minimal study routers."""
+        if module_name in definitions_by_module:
+            import_calls.append(module_name)
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+    fake_main = ModuleType("tldw_Server_API.app.main")
+    fake_main.app = FastAPI()  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "tldw_Server_API.app.main", fake_main)
+
+    specs = list(iter_minimal_optional_router_specs())
+    assert [
+        module_name
+        for module_name in definitions_by_module
+        if module_name in import_calls
+    ] == []
+    assert access_count == {
+        f"{definition['module_name']}.router": 0
+        for definition in router_definitions
+    }
+    assert import_calls == []
+
+    selected_specs = {
+        spec.name: spec
+        for spec in specs
+        if spec.name in {
+            str(definition["expected_name"])
+            for definition in router_definitions
+        }
+    }
+    assert set(selected_specs) == {
+        str(definition["expected_name"])
+        for definition in router_definitions
+    }
+
+    for definition in router_definitions:
+        spec = selected_specs[str(definition["expected_name"])]
+        assert spec.prefix == definition["prefix"]
+        assert spec.tags == definition["tags"]
+        assert spec.route_key == ""
+        assert spec.skip_context == "in minimal test app"
+        assert spec.default_stable is True
+        assert spec.skip_exceptions == (ImportError, AttributeError)
+        assert _first_router_path(spec.router) == definition["path"]
+
+    assert import_calls == [
+        str(definition["module_name"])
+        for definition in router_definitions
+    ]
+    assert access_count == {
+        f"{definition['module_name']}.router": 1
+        for definition in router_definitions
+    }
+
+
+def test_iter_minimal_optional_router_specs_skips_study_missing_import_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal study specs skip missing optional router imports."""
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    study_modules = {
+        module_name
+        for module_name, _expected_name, _prefix, _tags, _path in STUDY_ROUTER_DEFINITION_DATA
+    }
+    expected_names = {
+        expected_name
+        for _module_name, expected_name, _prefix, _tags, _path in STUDY_ROUTER_DEFINITION_DATA
+    }
+
+    specs = list(iter_minimal_optional_router_specs())
+    selected_specs = {
+        spec.name: spec
+        for spec in specs
+        if spec.name in expected_names
+    }
+    assert set(selected_specs) == expected_names
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Fail only the selected study router imports at registration."""
+        if module_name in study_modules:
+            raise ImportError(f"{module_name} missing during import")
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    debug_messages: list[str] = []
+    monkeypatch.setattr("loguru.logger.debug", debug_messages.append)
+
+    assert register_router_specs(FastAPI(), selected_specs.values()) == 0
+    assert debug_messages == [
+        f"Skipping {expected_name} router in minimal test app: "
+        f"{module_name} missing during import"
+        for module_name, expected_name, _prefix, _tags, _path in STUDY_ROUTER_DEFINITION_DATA
+    ]
+
+
+def test_iter_minimal_optional_router_specs_propagates_study_runtime_import_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal study runtime import defects are not silently skipped."""
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    module_name = "tldw_Server_API.app.api.v1.endpoints.flashcards"
+    specs = list(iter_minimal_optional_router_specs())
+    selected_spec = next(spec for spec in specs if spec.name == "flashcards")
+
+    real_import_module = importlib.import_module
+
+    def _import_module(import_name: str, package: str | None = None) -> ModuleType:
+        """Crash only one selected study router import at registration."""
+        if import_name == module_name:
+            raise RuntimeError(f"{module_name} exploded during import")
+        return real_import_module(import_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    with pytest.raises(RuntimeError, match="flashcards exploded during import"):
         register_router_specs(FastAPI(), (selected_spec,))
 
 


### PR DESCRIPTION
## Summary
- Convert minimal-test flashcards, quizzes, and study_suggestions routers to ImportedRouterSpec-backed lazy specs.
- Preserve route metadata while using narrow ImportError/AttributeError skip semantics so runtime import defects propagate.
- Add focused router contract coverage for lazy resolution, missing optional import skipping, and RuntimeError propagation.

## Test Plan
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/router_groups/minimal.py -f json -o /tmp/bandit_minimal_study_router_am_post_rebase.json
- git diff --check origin/dev...HEAD

## Change Summary
This is an AI-authored PR. A human maintainer still needs to provide the merge-gate Change summary in their own words before merge.