### PR TITLE
Add sandbox runtime diagnostics summary

### DIFF
--- a/Docs/Sandbox/sandbox-runtime-capability-inventory.md
+++ b/Docs/Sandbox/sandbox-runtime-capability-inventory.md
@@ -67,6 +67,15 @@ Discovery is intentionally summarized. Admin/operator diagnostics can expose
 helper, template, reconciliation, and image-store details that should not be
 duplicated into the public discovery payload.
 
+`/api/v1/sandbox/admin/runtime-diagnostics` is the cross-runtime operator
+summary. It is read-only and derived from `/api/v1/sandbox/runtimes` discovery
+rows, so it does not introduce another readiness source. The summary groups
+runtimes by readiness posture, preserves raw and normalized reasons, reports
+host-local isolation warnings, and identifies runtimes with explicit repair
+support. Repair support remains scoped to runtimes whose session contract
+advertises it; current generalized diagnostics must not imply generic repair
+for Docker, Firecracker, Lima, `seatbelt`, `worktree`, or `vz_macos`.
+
 ## Portable Runtime Capability Gate
 
 The portable gate in

--- a/backlog/tasks/task-87 - Add-cross-runtime-sandbox-diagnostics-summary.md
+++ b/backlog/tasks/task-87 - Add-cross-runtime-sandbox-diagnostics-summary.md
@@ -4,7 +4,7 @@ title: Add cross-runtime sandbox diagnostics summary
 status: Done
 assignee: []
 created_date: '2026-05-05 21:01'
-updated_date: '2026-05-05 21:34'
+updated_date: '2026-05-05 21:37'
 labels:
   - sandbox
   - diagnostics
@@ -43,12 +43,16 @@ PR #1328 review follow-up fixed: runtime diagnostics now offloads synchronous di
 PR #1328 CodeRabbit follow-up: accepting fail-open startup-warning helper handling; skipping the bucket reclassification suggestion because it conflicts with the readiness-posture contract and would again make available host-gated runtimes not count as ready.
 
 PR #1328 CodeRabbit accepted fix: _sandbox_startup_warning_summary now fail-opens to {present:false, blocking:false, codes:[]} when registry is missing or errors, and both diagnostics endpoints always project the same summary shape. Added regression tests for missing and broken registries. Kept readiness-based bucket logic; CodeRabbit's alternative implementation-state-first suggestion was skipped because it conflicts with the documented readiness posture semantics.
+
+PR #1328 CodeRabbit bucket follow-up: re-verified the second comment and found a still-valid double-count issue in unavailable because it included all non-ready runtimes. Fixing with readiness-based mutually exclusive buckets, not implementation_state-first classification.
+
+PR #1328 final CodeRabbit bucket fix: unavailable now counts only readiness values unavailable/unsupported/not_applicable, making ready/host_gated/scaffold/unavailable mutually exclusive readiness buckets. Regression expectation updated for available host_gated runtime plus host-gated unavailable runtime.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added an admin-only, read-only cross-runtime diagnostics endpoint backed by existing sandbox runtime discovery. The response groups runtime readiness, preserves raw and normalized reason codes, surfaces host-local isolation warnings and startup warning summaries, and keeps repair semantics scoped to runtimes that explicitly advertise repair support. PR review follow-up fixed async event-loop blocking, readiness aggregation, docstrings, test typing, and fail-open startup-warning projection. Verification: targeted sandbox pytest 31 passed, py_compile passed, Ruff F/E9 passed, Bandit touched production scope reported zero findings, test-file Ruff passed, and git diff --check passed. Full default Ruff on all touched production files remains blocked by pre-existing file-level I001/SIM300/B904 findings.
+Added an admin-only, read-only cross-runtime diagnostics endpoint backed by existing sandbox runtime discovery. The response groups runtime readiness, preserves raw and normalized reason codes, surfaces host-local isolation warnings and startup warning summaries, and keeps repair semantics scoped to runtimes that explicitly advertise repair support. PR review follow-up fixed async event-loop blocking, mutually exclusive readiness aggregation, docstrings, test typing, and fail-open startup-warning projection. Verification: targeted sandbox pytest 31 passed, py_compile passed, Ruff F/E9 passed, Bandit touched production scope reported zero findings, test-file Ruff passed, and git diff --check passed. Full default Ruff on all touched production files remains blocked by pre-existing file-level I001/SIM300/B904 findings.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-87 - Add-cross-runtime-sandbox-diagnostics-summary.md
+++ b/backlog/tasks/task-87 - Add-cross-runtime-sandbox-diagnostics-summary.md
@@ -1,0 +1,54 @@
+---
+id: TASK-87
+title: Add cross-runtime sandbox diagnostics summary
+status: Done
+assignee: []
+created_date: '2026-05-05 21:01'
+updated_date: '2026-05-05 21:09'
+labels:
+  - sandbox
+  - diagnostics
+dependencies: []
+documentation:
+  - Docs/Sandbox/sandbox-architecture-doctrine.md
+  - Docs/Sandbox/sandbox-runtime-capability-inventory.md
+  - Docs/superpowers/specs/2026-05-02-sandbox-module-roadmap-design.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add a narrow read-only operator diagnostics summary for all sandbox runtimes using existing runtime discovery/preflight truth. This follows the sandbox roadmap Phase 5 direction: help operators understand runtime readiness and warnings without generalizing vz_linux repair or mutating diagnostics state.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A new additive sandbox admin diagnostics summary exposes per-runtime readiness posture derived from existing runtime discovery/preflight data.
+- [x] #2 The summary clearly distinguishes available runtimes from unavailable/scaffold/host-gated runtimes and includes raw plus normalized reason codes where available.
+- [x] #3 The design preserves vz_linux-specific reconciliation/repair ownership and does not add generic repair behavior for Docker, Firecracker, Lima, seatbelt, worktree, or vz_macos.
+- [x] #4 Focused tests cover mixed runtime states and prove the summary is read-only and derived from existing discovery data.
+- [x] #5 Relevant sandbox docs mention the new operator summary without overstating host-local or scaffold runtime guarantees.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented additive GET /api/v1/sandbox/admin/runtime-diagnostics backed by SandboxService.feature_discovery(), with schema coverage, admin RBAC coverage, startup warning projection, and docs updates. Verification: focused pytest 28 passed; py_compile passed; ruff F/E9 passed; Bandit touched production files produced zero findings; git diff --check passed. Full default Ruff remains blocked by pre-existing file-level I/SIM/B904 findings in touched files.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added an admin-only, read-only cross-runtime diagnostics endpoint backed by existing sandbox runtime discovery. The new response groups runtime readiness, preserves raw and normalized reason codes, surfaces host-local isolation warnings and startup warning summaries, and keeps repair semantics scoped to runtimes that explicitly advertise repair support. Updated focused tests, admin RBAC coverage, and sandbox docs. Verification: targeted sandbox pytest 28 passed, py_compile passed, Ruff F/E9 passed, Bandit touched production scope reported zero findings, and git diff --check passed. Full default Ruff remains blocked by pre-existing file-level I/SIM/B904 findings in touched files.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-87 - Add-cross-runtime-sandbox-diagnostics-summary.md
+++ b/backlog/tasks/task-87 - Add-cross-runtime-sandbox-diagnostics-summary.md
@@ -4,7 +4,7 @@ title: Add cross-runtime sandbox diagnostics summary
 status: Done
 assignee: []
 created_date: '2026-05-05 21:01'
-updated_date: '2026-05-05 21:26'
+updated_date: '2026-05-05 21:34'
 labels:
   - sandbox
   - diagnostics
@@ -39,12 +39,16 @@ Implemented additive GET /api/v1/sandbox/admin/runtime-diagnostics backed by San
 PR #1328 review follow-up: Qodo posted five actionable findings. Verified against current branch: async handler calls synchronous runtime_diagnostics_summary directly, host_gated/scaffold summary uses implementation_state instead of readiness, new helpers lack docstrings, and new test monkeypatch parameter lacks type annotation.
 
 PR #1328 review follow-up fixed: runtime diagnostics now offloads synchronous discovery with asyncio.to_thread, summary host_gated/scaffold counts use readiness rather than static implementation_state, new helpers have docstrings, and the new test monkeypatch parameter is typed. Added regression coverage for offloading and ready host-gated runtime aggregation.
+
+PR #1328 CodeRabbit follow-up: accepting fail-open startup-warning helper handling; skipping the bucket reclassification suggestion because it conflicts with the readiness-posture contract and would again make available host-gated runtimes not count as ready.
+
+PR #1328 CodeRabbit accepted fix: _sandbox_startup_warning_summary now fail-opens to {present:false, blocking:false, codes:[]} when registry is missing or errors, and both diagnostics endpoints always project the same summary shape. Added regression tests for missing and broken registries. Kept readiness-based bucket logic; CodeRabbit's alternative implementation-state-first suggestion was skipped because it conflicts with the documented readiness posture semantics.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added an admin-only, read-only cross-runtime diagnostics endpoint backed by existing sandbox runtime discovery. The response groups runtime readiness, preserves raw and normalized reason codes, surfaces host-local isolation warnings and startup warning summaries, and keeps repair semantics scoped to runtimes that explicitly advertise repair support. PR review follow-up fixed async event-loop blocking, readiness aggregation, docstrings, and test typing. Verification: targeted sandbox pytest 29 passed, py_compile passed, Ruff F/E9 passed, Bandit touched production scope reported zero findings, test-file Ruff passed, and git diff --check passed. Full default Ruff on all touched production files remains blocked by pre-existing file-level I001/SIM300/B904 findings.
+Added an admin-only, read-only cross-runtime diagnostics endpoint backed by existing sandbox runtime discovery. The response groups runtime readiness, preserves raw and normalized reason codes, surfaces host-local isolation warnings and startup warning summaries, and keeps repair semantics scoped to runtimes that explicitly advertise repair support. PR review follow-up fixed async event-loop blocking, readiness aggregation, docstrings, test typing, and fail-open startup-warning projection. Verification: targeted sandbox pytest 31 passed, py_compile passed, Ruff F/E9 passed, Bandit touched production scope reported zero findings, test-file Ruff passed, and git diff --check passed. Full default Ruff on all touched production files remains blocked by pre-existing file-level I001/SIM300/B904 findings.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-87 - Add-cross-runtime-sandbox-diagnostics-summary.md
+++ b/backlog/tasks/task-87 - Add-cross-runtime-sandbox-diagnostics-summary.md
@@ -4,7 +4,7 @@ title: Add cross-runtime sandbox diagnostics summary
 status: Done
 assignee: []
 created_date: '2026-05-05 21:01'
-updated_date: '2026-05-05 21:09'
+updated_date: '2026-05-05 21:26'
 labels:
   - sandbox
   - diagnostics
@@ -35,12 +35,16 @@ Add a narrow read-only operator diagnostics summary for all sandbox runtimes usi
 
 <!-- SECTION:NOTES:BEGIN -->
 Implemented additive GET /api/v1/sandbox/admin/runtime-diagnostics backed by SandboxService.feature_discovery(), with schema coverage, admin RBAC coverage, startup warning projection, and docs updates. Verification: focused pytest 28 passed; py_compile passed; ruff F/E9 passed; Bandit touched production files produced zero findings; git diff --check passed. Full default Ruff remains blocked by pre-existing file-level I/SIM/B904 findings in touched files.
+
+PR #1328 review follow-up: Qodo posted five actionable findings. Verified against current branch: async handler calls synchronous runtime_diagnostics_summary directly, host_gated/scaffold summary uses implementation_state instead of readiness, new helpers lack docstrings, and new test monkeypatch parameter lacks type annotation.
+
+PR #1328 review follow-up fixed: runtime diagnostics now offloads synchronous discovery with asyncio.to_thread, summary host_gated/scaffold counts use readiness rather than static implementation_state, new helpers have docstrings, and the new test monkeypatch parameter is typed. Added regression coverage for offloading and ready host-gated runtime aggregation.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added an admin-only, read-only cross-runtime diagnostics endpoint backed by existing sandbox runtime discovery. The new response groups runtime readiness, preserves raw and normalized reason codes, surfaces host-local isolation warnings and startup warning summaries, and keeps repair semantics scoped to runtimes that explicitly advertise repair support. Updated focused tests, admin RBAC coverage, and sandbox docs. Verification: targeted sandbox pytest 28 passed, py_compile passed, Ruff F/E9 passed, Bandit touched production scope reported zero findings, and git diff --check passed. Full default Ruff remains blocked by pre-existing file-level I/SIM/B904 findings in touched files.
+Added an admin-only, read-only cross-runtime diagnostics endpoint backed by existing sandbox runtime discovery. The response groups runtime readiness, preserves raw and normalized reason codes, surfaces host-local isolation warnings and startup warning summaries, and keeps repair semantics scoped to runtimes that explicitly advertise repair support. PR review follow-up fixed async event-loop blocking, readiness aggregation, docstrings, and test typing. Verification: targeted sandbox pytest 29 passed, py_compile passed, Ruff F/E9 passed, Bandit touched production scope reported zero findings, test-file Ruff passed, and git diff --check passed. Full default Ruff on all touched production files remains blocked by pre-existing file-level I001/SIM300/B904 findings.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/api/v1/endpoints/sandbox.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sandbox.py
@@ -2261,18 +2261,28 @@ async def stream_run_logs(websocket: WebSocket, run_id: str) -> None:
 # Admin API (list/details)
 # -----------------------
 
-def _sandbox_startup_warning_summary(request: Request) -> dict[str, object] | None:
+def _sandbox_startup_warning_summary(request: Request) -> dict[str, object]:
     """Return compact sandbox startup warnings when the app registry exists."""
 
+    empty_summary: dict[str, object] = {
+        "present": False,
+        "blocking": False,
+        "codes": [],
+    }
     registry = getattr(request.app.state, "startup_warning_registry", None)
     if registry is None:
-        return None
-    records = registry.list_warnings(component_prefix="sandbox.")
-    summary = registry.summary(component_prefix="sandbox.")
+        return empty_summary
+    try:
+        records = list(registry.list_warnings(component_prefix="sandbox.") or [])
+        summary = dict(registry.summary(component_prefix="sandbox.") or {})
+    except _SANDBOX_NONCRITICAL_EXCEPTIONS:
+        return empty_summary
     return {
         "present": bool(records),
-        "blocking": bool(summary["has_blocking"]),
-        "codes": sorted({record.code for record in records}),
+        "blocking": bool(summary.get("has_blocking")),
+        "codes": sorted(
+            str(record.code) for record in records if getattr(record, "code", None)
+        ),
     }
 
 
@@ -2288,9 +2298,7 @@ async def admin_runtime_diagnostics(
 ) -> SandboxAdminRuntimeDiagnosticsResponse:
     """Return read-only operator diagnostics derived from runtime discovery."""
     payload = dict(await asyncio.to_thread(_service.runtime_diagnostics_summary))
-    warning_summary = _sandbox_startup_warning_summary(request)
-    if warning_summary is not None:
-        payload["startup_warning_summary"] = warning_summary
+    payload["startup_warning_summary"] = _sandbox_startup_warning_summary(request)
     return SandboxAdminRuntimeDiagnosticsResponse.model_validate(payload)
 
 
@@ -2306,9 +2314,7 @@ async def admin_macos_diagnostics(
 ) -> SandboxAdminMacOSDiagnosticsResponse:
     """Return detailed macOS sandbox diagnostics for admin troubleshooting."""
     payload = dict(_service.macos_diagnostics())
-    warning_summary = _sandbox_startup_warning_summary(request)
-    if warning_summary is not None:
-        payload["startup_warning_summary"] = warning_summary
+    payload["startup_warning_summary"] = _sandbox_startup_warning_summary(request)
 
     return SandboxAdminMacOSDiagnosticsResponse.model_validate(payload)
 

--- a/tldw_Server_API/app/api/v1/endpoints/sandbox.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sandbox.py
@@ -2262,6 +2262,8 @@ async def stream_run_logs(websocket: WebSocket, run_id: str) -> None:
 # -----------------------
 
 def _sandbox_startup_warning_summary(request: Request) -> dict[str, object] | None:
+    """Return compact sandbox startup warnings when the app registry exists."""
+
     registry = getattr(request.app.state, "startup_warning_registry", None)
     if registry is None:
         return None
@@ -2285,7 +2287,7 @@ async def admin_runtime_diagnostics(
     _current_user: User = Depends(get_request_user),
 ) -> SandboxAdminRuntimeDiagnosticsResponse:
     """Return read-only operator diagnostics derived from runtime discovery."""
-    payload = dict(_service.runtime_diagnostics_summary())
+    payload = dict(await asyncio.to_thread(_service.runtime_diagnostics_summary))
     warning_summary = _sandbox_startup_warning_summary(request)
     if warning_summary is not None:
         payload["startup_warning_summary"] = warning_summary

--- a/tldw_Server_API/app/api/v1/endpoints/sandbox.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sandbox.py
@@ -45,6 +45,7 @@ from tldw_Server_API.app.api.v1.schemas.sandbox_schemas import (
     SandboxAdminMacOSImageStoreCleanupResponse,
     SandboxAdminMacOSReconciliationRepairRequest,
     SandboxAdminMacOSReconciliationRepairResponse,
+    SandboxAdminRuntimeDiagnosticsResponse,
     SandboxAdminRunDetails,
     SandboxAdminRunListResponse,
     SandboxAdminRunSummary,
@@ -2260,6 +2261,37 @@ async def stream_run_logs(websocket: WebSocket, run_id: str) -> None:
 # Admin API (list/details)
 # -----------------------
 
+def _sandbox_startup_warning_summary(request: Request) -> dict[str, object] | None:
+    registry = getattr(request.app.state, "startup_warning_registry", None)
+    if registry is None:
+        return None
+    records = registry.list_warnings(component_prefix="sandbox.")
+    summary = registry.summary(component_prefix="sandbox.")
+    return {
+        "present": bool(records),
+        "blocking": bool(summary["has_blocking"]),
+        "codes": sorted({record.code for record in records}),
+    }
+
+
+@router.get(
+    "/admin/runtime-diagnostics",
+    response_model=SandboxAdminRuntimeDiagnosticsResponse,
+    summary="Admin: sandbox runtime diagnostics summary",
+)
+async def admin_runtime_diagnostics(
+    request: Request,
+    _principal: AuthPrincipal = Depends(RequireRole("admin")),
+    _current_user: User = Depends(get_request_user),
+) -> SandboxAdminRuntimeDiagnosticsResponse:
+    """Return read-only operator diagnostics derived from runtime discovery."""
+    payload = dict(_service.runtime_diagnostics_summary())
+    warning_summary = _sandbox_startup_warning_summary(request)
+    if warning_summary is not None:
+        payload["startup_warning_summary"] = warning_summary
+    return SandboxAdminRuntimeDiagnosticsResponse.model_validate(payload)
+
+
 @router.get(
     "/admin/macos-diagnostics",
     response_model=SandboxAdminMacOSDiagnosticsResponse,
@@ -2272,15 +2304,9 @@ async def admin_macos_diagnostics(
 ) -> SandboxAdminMacOSDiagnosticsResponse:
     """Return detailed macOS sandbox diagnostics for admin troubleshooting."""
     payload = dict(_service.macos_diagnostics())
-    registry = getattr(request.app.state, "startup_warning_registry", None)
-    if registry is not None:
-        records = registry.list_warnings(component_prefix="sandbox.")
-        summary = registry.summary(component_prefix="sandbox.")
-        payload["startup_warning_summary"] = {
-            "present": bool(records),
-            "blocking": bool(summary["has_blocking"]),
-            "codes": sorted({record.code for record in records}),
-        }
+    warning_summary = _sandbox_startup_warning_summary(request)
+    if warning_summary is not None:
+        payload["startup_warning_summary"] = warning_summary
 
     return SandboxAdminMacOSDiagnosticsResponse.model_validate(payload)
 

--- a/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
@@ -450,6 +450,75 @@ class SandboxAdminUsageResponse(BaseModel):
         return _default_offset_pagination_aliases(self)
 
 
+RuntimeDiagnosticsReadiness = Literal[
+    "ready",
+    "unavailable",
+    "host_gated",
+    "scaffold",
+    "unsupported",
+    "not_applicable",
+]
+RuntimeDiagnosticsAction = Literal[
+    "none",
+    "check_helper",
+    "configure_template",
+    "prepare_host",
+    "adjust_request_policy",
+    "use_different_runtime",
+    "inspect_reasons",
+]
+
+
+class SandboxAdminRuntimeDiagnosticsSummary(BaseModel):
+    """Aggregate operator posture for all sandbox runtimes."""
+
+    total: int
+    ready: int
+    unavailable: int
+    host_gated: int
+    scaffold: int
+    host_local_warning_runtimes: list[RuntimeType] = Field(default_factory=list)
+    repair_supported_runtimes: list[RuntimeType] = Field(default_factory=list)
+
+
+class SandboxAdminRuntimeDiagnosticsItem(BaseModel):
+    """Read-only operator projection for one sandbox runtime."""
+
+    name: RuntimeType
+    available: bool
+    implementation_state: RuntimeImplementationState | None = None
+    readiness: RuntimeDiagnosticsReadiness
+    reasons: list[str] = Field(default_factory=list)
+    normalized_reasons: list[RuntimeReasonCode] = Field(default_factory=list)
+    boundary_class: RuntimeBoundaryClass | None = None
+    vm_grade_isolation: bool = False
+    untrusted_eligible: bool = False
+    isolation_warnings: list[RuntimeIsolationWarningCode] = Field(default_factory=list)
+    strict_deny_all_supported: bool = False
+    strict_allowlist_supported: bool = False
+    session_reuse_model: RuntimeSessionReuseModel | None = None
+    requires_live_health_check: bool = False
+    repair_supported: bool = False
+    recommended_action: RuntimeDiagnosticsAction
+
+
+class SandboxAdminStartupWarningSummary(BaseModel):
+    """Compact startup warning summary projected into sandbox diagnostics."""
+
+    present: bool
+    blocking: bool
+    codes: list[str] = Field(default_factory=list)
+
+
+class SandboxAdminRuntimeDiagnosticsResponse(BaseModel):
+    """Admin-facing cross-runtime diagnostics derived from runtime discovery."""
+
+    source: Literal["feature_discovery"]
+    summary: SandboxAdminRuntimeDiagnosticsSummary
+    runtimes: list[SandboxAdminRuntimeDiagnosticsItem]
+    startup_warning_summary: SandboxAdminStartupWarningSummary | None = None
+
+
 class SandboxAdminMacOSHostDiagnostics(BaseModel):
     """Admin-facing host facts for macOS sandbox readiness checks."""
 
@@ -621,14 +690,6 @@ class SandboxAdminMacOSObservabilityDiagnostics(BaseModel):
     live_vms: int = 0
     vms: list[SandboxAdminMacOSVMObservability] = Field(default_factory=list)
     reasons: list[str] = Field(default_factory=list)
-
-
-class SandboxAdminStartupWarningSummary(BaseModel):
-    """Compact startup warning summary projected into sandbox diagnostics."""
-
-    present: bool
-    blocking: bool
-    codes: list[str] = Field(default_factory=list)
 
 
 class SandboxAdminMacOSRecoverySummary(BaseModel):

--- a/tldw_Server_API/app/core/Sandbox/README.md
+++ b/tldw_Server_API/app/core/Sandbox/README.md
@@ -168,6 +168,7 @@ Current limitations:
   - `/api/v1/sandbox/health`
   - `/api/v1/sandbox/runtimes`
   - `/api/v1/admin/startup-warnings`
+  - `/api/v1/sandbox/admin/runtime-diagnostics`
   - `/api/v1/sandbox/admin/macos-diagnostics`
   - `/api/v1/sandbox/admin/macos-image-store/cleanup-plan`
   - `POST /api/v1/sandbox/admin/macos-image-store/cleanup`
@@ -182,6 +183,15 @@ or maturity guarantees from availability alone.
 Runtime entries also preserve raw preflight `reasons` for operator diagnostics
 and expose additive `normalized_reasons` for stable client grouping across
 runtime-specific failures.
+`/api/v1/sandbox/admin/runtime-diagnostics` is an admin-only read-only operator
+summary derived from the same discovery data. It groups every runtime by
+readiness posture, preserves raw and normalized reason codes, exposes
+host-local isolation warnings, and identifies runtimes with explicit repair
+support. When the app startup-warning registry is available, it also includes
+the same compact `startup_warning_summary` used by macOS diagnostics. Today
+repair support remains scoped to `vz_linux`; this summary does
+not add generic repair or reconciliation behavior for Docker, Firecracker, Lima,
+`seatbelt`, `worktree`, or `vz_macos`.
 Run status responses preserve raw `phase`, `message`, and `exit_code` while
 adding additive `status_reason_code` for stable client grouping of queued,
 completed, timeout, cancellation, policy, runtime-unavailable, nonzero-exit, and

--- a/tldw_Server_API/app/core/Sandbox/service.py
+++ b/tldw_Server_API/app/core/Sandbox/service.py
@@ -1099,9 +1099,13 @@ class SandboxService:
         """Return a read-only operator summary derived from runtime discovery."""
         runtime_rows = [self._runtime_diagnostics_item(row) for row in self.feature_discovery()]
         ready = [row for row in runtime_rows if row["readiness"] == "ready"]
-        unavailable = [row for row in runtime_rows if row["readiness"] != "ready"]
         host_gated = [row for row in runtime_rows if row["readiness"] == "host_gated"]
         scaffold = [row for row in runtime_rows if row["readiness"] == "scaffold"]
+        unavailable = [
+            row
+            for row in runtime_rows
+            if row["readiness"] in {"unavailable", "unsupported", "not_applicable"}
+        ]
         host_local_warning_runtimes = [
             str(row["name"])
             for row in runtime_rows

--- a/tldw_Server_API/app/core/Sandbox/service.py
+++ b/tldw_Server_API/app/core/Sandbox/service.py
@@ -1095,6 +1095,96 @@ class SandboxService:
             },
         ]
 
+    def runtime_diagnostics_summary(self) -> dict[str, object]:
+        """Return a read-only operator summary derived from runtime discovery."""
+        runtime_rows = [self._runtime_diagnostics_item(row) for row in self.feature_discovery()]
+        ready = [row for row in runtime_rows if row["readiness"] == "ready"]
+        unavailable = [row for row in runtime_rows if row["readiness"] != "ready"]
+        host_gated = [row for row in runtime_rows if row["implementation_state"] == "host_gated"]
+        scaffold = [row for row in runtime_rows if row["implementation_state"] == "scaffold"]
+        host_local_warning_runtimes = [
+            str(row["name"])
+            for row in runtime_rows
+            if "host_local_boundary" in set(row.get("isolation_warnings") or [])
+        ]
+        repair_supported_runtimes = [
+            str(row["name"])
+            for row in runtime_rows
+            if bool(row.get("repair_supported"))
+        ]
+        return {
+            "source": "feature_discovery",
+            "summary": {
+                "total": len(runtime_rows),
+                "ready": len(ready),
+                "unavailable": len(unavailable),
+                "host_gated": len(host_gated),
+                "scaffold": len(scaffold),
+                "host_local_warning_runtimes": sorted(host_local_warning_runtimes),
+                "repair_supported_runtimes": sorted(repair_supported_runtimes),
+            },
+            "runtimes": runtime_rows,
+        }
+
+    @staticmethod
+    def _runtime_diagnostics_item(row: dict[str, object]) -> dict[str, object]:
+        session_contract = dict(row.get("session_contract") or {})
+        normalized_reasons = [str(reason) for reason in row.get("normalized_reasons") or []]
+        readiness = SandboxService._runtime_readiness(row)
+        repair_state = str(session_contract.get("repair_state") or "").strip().lower()
+        return {
+            "name": str(row.get("name") or ""),
+            "available": bool(row.get("available")),
+            "implementation_state": row.get("implementation_state"),
+            "readiness": readiness,
+            "reasons": [str(reason) for reason in row.get("reasons") or []],
+            "normalized_reasons": normalized_reasons,
+            "boundary_class": row.get("boundary_class"),
+            "vm_grade_isolation": bool(row.get("vm_grade_isolation")),
+            "untrusted_eligible": bool(row.get("untrusted_eligible")),
+            "isolation_warnings": [str(warning) for warning in row.get("isolation_warnings") or []],
+            "strict_deny_all_supported": bool(row.get("strict_deny_all_supported")),
+            "strict_allowlist_supported": bool(row.get("strict_allowlist_supported")),
+            "session_reuse_model": session_contract.get("reuse_model"),
+            "requires_live_health_check": bool(session_contract.get("requires_live_health_check")),
+            "repair_supported": repair_state in {"supported", "host_gated"},
+            "recommended_action": SandboxService._runtime_recommended_action(
+                readiness,
+                normalized_reasons,
+            ),
+        }
+
+    @staticmethod
+    def _runtime_readiness(row: dict[str, object]) -> str:
+        if bool(row.get("available")):
+            return "ready"
+        implementation_state = str(row.get("implementation_state") or "").strip().lower()
+        if implementation_state in {"host_gated", "scaffold", "unsupported", "not_applicable"}:
+            return implementation_state
+        return "unavailable"
+
+    @staticmethod
+    def _runtime_recommended_action(readiness: str, normalized_reasons: list[str]) -> str:
+        reasons = set(normalized_reasons)
+        if readiness == "ready":
+            return "none"
+        if reasons & {"helper_unavailable", "helper_missing", "helper_protocol_mismatch"}:
+            return "check_helper"
+        if reasons & {"template_missing", "template_unconfigured"}:
+            return "configure_template"
+        if reasons & {
+            "host_prerequisite_missing",
+            "host_permission_denied",
+            "unsupported_os",
+            "unsupported_arch",
+        }:
+            return "prepare_host"
+        if reasons & {"network_policy_unsupported", "trust_policy_denied"}:
+            return "adjust_request_policy"
+        if readiness in {"scaffold", "unsupported", "not_applicable"}:
+            return "use_different_runtime"
+        return "inspect_reasons"
+
     def macos_diagnostics(self) -> dict[str, object]:
         return collect_macos_diagnostics(self._orch)
 

--- a/tldw_Server_API/app/core/Sandbox/service.py
+++ b/tldw_Server_API/app/core/Sandbox/service.py
@@ -1100,8 +1100,8 @@ class SandboxService:
         runtime_rows = [self._runtime_diagnostics_item(row) for row in self.feature_discovery()]
         ready = [row for row in runtime_rows if row["readiness"] == "ready"]
         unavailable = [row for row in runtime_rows if row["readiness"] != "ready"]
-        host_gated = [row for row in runtime_rows if row["implementation_state"] == "host_gated"]
-        scaffold = [row for row in runtime_rows if row["implementation_state"] == "scaffold"]
+        host_gated = [row for row in runtime_rows if row["readiness"] == "host_gated"]
+        scaffold = [row for row in runtime_rows if row["readiness"] == "scaffold"]
         host_local_warning_runtimes = [
             str(row["name"])
             for row in runtime_rows
@@ -1128,6 +1128,8 @@ class SandboxService:
 
     @staticmethod
     def _runtime_diagnostics_item(row: dict[str, object]) -> dict[str, object]:
+        """Project one discovery row into the admin diagnostics shape."""
+
         session_contract = dict(row.get("session_contract") or {})
         normalized_reasons = [str(reason) for reason in row.get("normalized_reasons") or []]
         readiness = SandboxService._runtime_readiness(row)
@@ -1156,6 +1158,8 @@ class SandboxService:
 
     @staticmethod
     def _runtime_readiness(row: dict[str, object]) -> str:
+        """Classify current runtime readiness from availability and roadmap state."""
+
         if bool(row.get("available")):
             return "ready"
         implementation_state = str(row.get("implementation_state") or "").strip().lower()
@@ -1165,6 +1169,8 @@ class SandboxService:
 
     @staticmethod
     def _runtime_recommended_action(readiness: str, normalized_reasons: list[str]) -> str:
+        """Map normalized readiness reasons to an operator next action."""
+
         reasons = set(normalized_reasons)
         if readiness == "ready":
             return "none"

--- a/tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py
+++ b/tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py
@@ -357,6 +357,37 @@ def test_admin_runtime_diagnostics_offloads_runtime_discovery(
     assert calls == ["<lambda>"]
 
 
+def test_sandbox_startup_warning_summary_fails_open_without_registry() -> None:
+    request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace()))
+
+    assert sandbox_mod._sandbox_startup_warning_summary(request) == {
+        "present": False,
+        "blocking": False,
+        "codes": [],
+    }
+
+
+def test_sandbox_startup_warning_summary_fails_open_on_registry_error() -> None:
+    class BrokenRegistry:
+        def list_warnings(self, *, component_prefix: str) -> list[object]:
+            raise RuntimeError("registry unavailable")
+
+        def summary(self, *, component_prefix: str) -> dict[str, object]:
+            raise RuntimeError("registry unavailable")
+
+    request = SimpleNamespace(
+        app=SimpleNamespace(
+            state=SimpleNamespace(startup_warning_registry=BrokenRegistry())
+        )
+    )
+
+    assert sandbox_mod._sandbox_startup_warning_summary(request) == {
+        "present": False,
+        "blocking": False,
+        "codes": [],
+    }
+
+
 def test_admin_macos_diagnostics_allows_real_vz_linux_execution_mode(monkeypatch) -> None:
     payload = _diagnostics_payload()
     payload["helper"]["configured"] = True

--- a/tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py
+++ b/tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py
@@ -220,6 +220,99 @@ def test_admin_macos_diagnostics_returns_structured_payload(monkeypatch) -> None
     }
 
 
+def test_admin_runtime_diagnostics_returns_structured_payload(monkeypatch) -> None:
+    from tldw_Server_API.app.services.startup_warning_models import (
+        StartupWarningRecord,
+    )
+    from tldw_Server_API.app.services.startup_warning_registry import (
+        StartupWarningRegistry,
+    )
+
+    fake_service = SimpleNamespace(
+        runtime_diagnostics_summary=lambda: {
+            "source": "feature_discovery",
+            "summary": {
+                "total": 2,
+                "ready": 1,
+                "unavailable": 1,
+                "host_gated": 1,
+                "scaffold": 0,
+                "host_local_warning_runtimes": [],
+                "repair_supported_runtimes": ["vz_linux"],
+            },
+            "runtimes": [
+                {
+                    "name": "docker",
+                    "available": True,
+                    "implementation_state": "supported",
+                    "readiness": "ready",
+                    "reasons": [],
+                    "normalized_reasons": [],
+                    "boundary_class": "container",
+                    "vm_grade_isolation": False,
+                    "untrusted_eligible": True,
+                    "isolation_warnings": [],
+                    "strict_deny_all_supported": True,
+                    "strict_allowlist_supported": False,
+                    "session_reuse_model": "workspace_only",
+                    "requires_live_health_check": False,
+                    "repair_supported": False,
+                    "recommended_action": "none",
+                },
+                {
+                    "name": "vz_linux",
+                    "available": False,
+                    "implementation_state": "host_gated",
+                    "readiness": "host_gated",
+                    "reasons": ["macos_virtualization_helper_unavailable"],
+                    "normalized_reasons": ["helper_unavailable"],
+                    "boundary_class": "vm_grade",
+                    "vm_grade_isolation": True,
+                    "untrusted_eligible": True,
+                    "isolation_warnings": [],
+                    "strict_deny_all_supported": False,
+                    "strict_allowlist_supported": False,
+                    "session_reuse_model": "warm_vm",
+                    "requires_live_health_check": True,
+                    "repair_supported": True,
+                    "recommended_action": "check_helper",
+                },
+            ],
+        }
+    )
+    monkeypatch.setattr(sandbox_mod, "_service", fake_service, raising=True)
+
+    app = _build_app_with_overrides(_make_principal(is_admin=True))
+    registry = StartupWarningRegistry(startup_id="boot-1")
+    registry.add_warning(
+        StartupWarningRecord(
+            component="sandbox.vz_linux",
+            severity="warning",
+            startup_action="warn",
+            code="vz_stale_session_controls_detected",
+            summary="stale sessions detected",
+            remediation="review diagnostics",
+            details={"stale_session_controls": 1},
+        )
+    )
+    app.state.startup_warning_registry = registry
+
+    with TestClient(app) as client:
+        resp = client.get("/api/v1/sandbox/admin/runtime-diagnostics")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["source"] == "feature_discovery"
+    assert body["summary"]["repair_supported_runtimes"] == ["vz_linux"]
+    assert [row["name"] for row in body["runtimes"]] == ["docker", "vz_linux"]
+    assert body["runtimes"][1]["recommended_action"] == "check_helper"
+    assert body["startup_warning_summary"] == {
+        "present": True,
+        "blocking": False,
+        "codes": ["vz_stale_session_controls_detected"],
+    }
+
+
 def test_admin_macos_diagnostics_allows_real_vz_linux_execution_mode(monkeypatch) -> None:
     payload = _diagnostics_payload()
     payload["helper"]["configured"] = True

--- a/tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py
+++ b/tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from types import SimpleNamespace
+from typing import Any
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from starlette.requests import Request
@@ -220,7 +223,9 @@ def test_admin_macos_diagnostics_returns_structured_payload(monkeypatch) -> None
     }
 
 
-def test_admin_runtime_diagnostics_returns_structured_payload(monkeypatch) -> None:
+def test_admin_runtime_diagnostics_returns_structured_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from tldw_Server_API.app.services.startup_warning_models import (
         StartupWarningRecord,
     )
@@ -311,6 +316,45 @@ def test_admin_runtime_diagnostics_returns_structured_payload(monkeypatch) -> No
         "blocking": False,
         "codes": ["vz_stale_session_controls_detected"],
     }
+
+
+def test_admin_runtime_diagnostics_offloads_runtime_discovery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    async def fake_to_thread(
+        func: Callable[..., Any],
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        calls.append(getattr(func, "__name__", "unknown"))
+        return func(*args, **kwargs)
+
+    fake_service = SimpleNamespace(
+        runtime_diagnostics_summary=lambda: {
+            "source": "feature_discovery",
+            "summary": {
+                "total": 0,
+                "ready": 0,
+                "unavailable": 0,
+                "host_gated": 0,
+                "scaffold": 0,
+                "host_local_warning_runtimes": [],
+                "repair_supported_runtimes": [],
+            },
+            "runtimes": [],
+        }
+    )
+    monkeypatch.setattr(sandbox_mod, "_service", fake_service, raising=True)
+    monkeypatch.setattr(sandbox_mod.asyncio, "to_thread", fake_to_thread)
+
+    app = _build_app_with_overrides(_make_principal(is_admin=True))
+    with TestClient(app) as client:
+        resp = client.get("/api/v1/sandbox/admin/runtime-diagnostics")
+
+    assert resp.status_code == 200
+    assert calls == ["<lambda>"]
 
 
 def test_admin_macos_diagnostics_allows_real_vz_linux_execution_mode(monkeypatch) -> None:

--- a/tldw_Server_API/tests/sandbox/test_admin_rbac.py
+++ b/tldw_Server_API/tests/sandbox/test_admin_rbac.py
@@ -44,6 +44,7 @@ def test_admin_endpoints_require_admin_role(monkeypatch) -> None:
         client.app.dependency_overrides[get_request_user] = _non_admin_dep
         for path in (
             "/api/v1/sandbox/admin/runs",
+            "/api/v1/sandbox/admin/runtime-diagnostics",
             "/api/v1/sandbox/admin/macos-diagnostics",
             "/api/v1/sandbox/admin/macos-image-store/cleanup-plan",
             "/api/v1/sandbox/admin/idempotency",

--- a/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
+++ b/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
@@ -410,6 +410,26 @@ def test_runtime_diagnostics_summary_projects_feature_discovery_rows(
                 },
             },
             {
+                "name": "vz_macos",
+                "available": True,
+                "implementation_state": "host_gated",
+                "reasons": [],
+                "normalized_reasons": [],
+                "boundary_class": "vm_grade",
+                "vm_grade_isolation": True,
+                "untrusted_eligible": True,
+                "isolation_warnings": [],
+                "strict_deny_all_supported": False,
+                "strict_allowlist_supported": False,
+                "session_contract": {
+                    "support_state": "scaffold",
+                    "reuse_model": "scaffold",
+                    "requires_live_health_check": True,
+                    "recovery_state": "scaffold",
+                    "repair_state": "host_gated",
+                },
+            },
+            {
                 "name": "worktree",
                 "available": False,
                 "implementation_state": "supported",
@@ -440,13 +460,13 @@ def test_runtime_diagnostics_summary_projects_feature_discovery_rows(
 
     assert summary["source"] == "feature_discovery"
     assert summary["summary"] == {
-        "total": 3,
-        "ready": 1,
+        "total": 4,
+        "ready": 2,
         "unavailable": 2,
         "host_gated": 1,
         "scaffold": 0,
         "host_local_warning_runtimes": ["worktree"],
-        "repair_supported_runtimes": ["vz_linux"],
+        "repair_supported_runtimes": ["vz_linux", "vz_macos"],
     }
     rows = {row["name"]: row for row in summary["runtimes"]}
     assert rows["docker"]["readiness"] == "ready"
@@ -454,6 +474,8 @@ def test_runtime_diagnostics_summary_projects_feature_discovery_rows(
     assert rows["vz_linux"]["readiness"] == "host_gated"
     assert rows["vz_linux"]["recommended_action"] == "check_helper"
     assert rows["vz_linux"]["repair_supported"] is True
+    assert rows["vz_macos"]["readiness"] == "ready"
+    assert rows["vz_macos"]["recommended_action"] == "none"
     assert rows["worktree"]["readiness"] == "unavailable"
     assert rows["worktree"]["recommended_action"] == "prepare_host"
     assert rows["worktree"]["vm_grade_isolation"] is False

--- a/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
+++ b/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from tldw_Server_API.app.api.v1.schemas.sandbox_schemas import (
+    SandboxAdminRuntimeDiagnosticsResponse,
     SandboxRuntimeInfo,
     SandboxRuntimesResponse,
 )
@@ -358,7 +359,120 @@ def test_feature_discovery_validates_against_runtime_response_schema(
     )
 
     assert response.runtimes
-    assert response.runtimes[0].session_contract is not None
+
+
+def test_runtime_diagnostics_summary_projects_feature_discovery_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    svc = SandboxService()
+    monkeypatch.setattr(
+        svc,
+        "feature_discovery",
+        lambda: [
+            {
+                "name": "docker",
+                "available": True,
+                "implementation_state": "supported",
+                "reasons": [],
+                "normalized_reasons": [],
+                "boundary_class": "container",
+                "vm_grade_isolation": False,
+                "untrusted_eligible": True,
+                "isolation_warnings": [],
+                "strict_deny_all_supported": True,
+                "strict_allowlist_supported": False,
+                "session_contract": {
+                    "support_state": "supported",
+                    "reuse_model": "workspace_only",
+                    "requires_live_health_check": False,
+                    "recovery_state": "unsupported",
+                    "repair_state": "unsupported",
+                },
+            },
+            {
+                "name": "vz_linux",
+                "available": False,
+                "implementation_state": "host_gated",
+                "reasons": ["macos_virtualization_helper_unavailable"],
+                "normalized_reasons": ["helper_unavailable"],
+                "boundary_class": "vm_grade",
+                "vm_grade_isolation": True,
+                "untrusted_eligible": True,
+                "isolation_warnings": [],
+                "strict_deny_all_supported": False,
+                "strict_allowlist_supported": False,
+                "session_contract": {
+                    "support_state": "host_gated",
+                    "reuse_model": "warm_vm",
+                    "requires_live_health_check": True,
+                    "recovery_state": "host_gated",
+                    "repair_state": "host_gated",
+                },
+            },
+            {
+                "name": "worktree",
+                "available": False,
+                "implementation_state": "supported",
+                "reasons": ["linux_unshare_unavailable"],
+                "normalized_reasons": ["host_prerequisite_missing"],
+                "boundary_class": "host_local",
+                "vm_grade_isolation": False,
+                "untrusted_eligible": False,
+                "isolation_warnings": [
+                    "host_local_boundary",
+                    "not_vm_grade_isolation",
+                    "not_untrusted_eligible",
+                ],
+                "strict_deny_all_supported": False,
+                "strict_allowlist_supported": False,
+                "session_contract": {
+                    "support_state": "scaffold",
+                    "reuse_model": "workspace_only",
+                    "requires_live_health_check": False,
+                    "recovery_state": "unsupported",
+                    "repair_state": "unsupported",
+                },
+            },
+        ],
+    )
+
+    summary = svc.runtime_diagnostics_summary()
+
+    assert summary["source"] == "feature_discovery"
+    assert summary["summary"] == {
+        "total": 3,
+        "ready": 1,
+        "unavailable": 2,
+        "host_gated": 1,
+        "scaffold": 0,
+        "host_local_warning_runtimes": ["worktree"],
+        "repair_supported_runtimes": ["vz_linux"],
+    }
+    rows = {row["name"]: row for row in summary["runtimes"]}
+    assert rows["docker"]["readiness"] == "ready"
+    assert rows["docker"]["recommended_action"] == "none"
+    assert rows["vz_linux"]["readiness"] == "host_gated"
+    assert rows["vz_linux"]["recommended_action"] == "check_helper"
+    assert rows["vz_linux"]["repair_supported"] is True
+    assert rows["worktree"]["readiness"] == "unavailable"
+    assert rows["worktree"]["recommended_action"] == "prepare_host"
+    assert rows["worktree"]["vm_grade_isolation"] is False
+    assert rows["worktree"]["untrusted_eligible"] is False
+
+
+def test_runtime_diagnostics_summary_validates_against_schema(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SANDBOX_STORE_BACKEND", "memory")
+
+    payload = SandboxService().runtime_diagnostics_summary()
+    model = SandboxAdminRuntimeDiagnosticsResponse.model_validate(payload)
+
+    assert model.source == "feature_discovery"
+    assert {item.name for item in model.runtimes} == {
+        runtime.value for runtime in RuntimeType
+    }
+    assert model.runtimes[0].session_reuse_model is not None
 
 
 def test_runtime_reason_normalization_maps_raw_runtime_reasons() -> None:

--- a/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
+++ b/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
@@ -462,7 +462,7 @@ def test_runtime_diagnostics_summary_projects_feature_discovery_rows(
     assert summary["summary"] == {
         "total": 4,
         "ready": 2,
-        "unavailable": 2,
+        "unavailable": 1,
         "host_gated": 1,
         "scaffold": 0,
         "host_local_warning_runtimes": ["worktree"],


### PR DESCRIPTION
## Summary
- Add an admin-only, read-only `/api/v1/sandbox/admin/runtime-diagnostics` endpoint derived from existing sandbox runtime discovery.
- Include per-runtime readiness posture, raw and normalized reason codes, host-local warnings, repair support flags, recommended actions, and sandbox startup-warning summary projection.
- Update sandbox docs and Backlog task record while preserving `vz_linux`-scoped repair/reconciliation semantics.

## Test Plan
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py::test_admin_macos_diagnostics_returns_structured_payload tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py::test_admin_runtime_diagnostics_returns_structured_payload tldw_Server_API/tests/sandbox/test_admin_rbac.py::test_admin_endpoints_require_admin_role -q`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile tldw_Server_API/app/core/Sandbox/service.py tldw_Server_API/app/api/v1/endpoints/sandbox.py tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py tldw_Server_API/tests/sandbox/test_admin_rbac.py`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check --select F,E9 tldw_Server_API/app/core/Sandbox/service.py tldw_Server_API/app/api/v1/endpoints/sandbox.py tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py tldw_Server_API/tests/sandbox/test_admin_rbac.py`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit tldw_Server_API/app/core/Sandbox/service.py tldw_Server_API/app/api/v1/endpoints/sandbox.py tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py -f json -o /tmp/bandit_sandbox_runtime_diagnostics_summary.json`
- `git diff --check`

## Notes
- Full default Ruff remains blocked by pre-existing file-level I001/SIM300/B904 findings in touched files; this PR passed the narrowed F/E9 check for syntax and undefined-name regressions.
- Human-authored Change summary still needs to be added before merge per project policy.