### PR TITLE
Phase 2.2: defer minimal writing imports

### DIFF
--- a/backlog/tasks/task-88 - Phase-2.2-minimal-writing-email-router-conditional-cleanup-AN.md
+++ b/backlog/tasks/task-88 - Phase-2.2-minimal-writing-email-router-conditional-cleanup-AN.md
@@ -4,7 +4,7 @@ title: Phase 2.2 minimal writing/email router conditional cleanup AN
 status: Done
 assignee: []
 created_date: '2026-05-05 21:58'
-updated_date: '2026-05-05 22:02'
+updated_date: '2026-05-05 22:11'
 labels:
   - phase2.2
   - router-cleanup
@@ -13,6 +13,7 @@ dependencies: []
 references:
   - 'https://github.com/rmusser01/tldw_server/issues/1116'
   - 'https://github.com/rmusser01/tldw_server/pull/1327'
+  - 'https://github.com/rmusser01/tldw_server/pull/1329'
 priority: medium
 ---
 
@@ -52,6 +53,8 @@ GREEN verification: converted writing, writing_manuscripts, and email to Importe
 Converted the minimal-test writing/email router family, limited to writing, writing_manuscripts, and email, from eager try/import RouterSpec blocks to ImportedRouterSpec-backed lazy specs. The change preserves prefixes, tags, default route_key/default_stable behavior, and minimal skip context while using narrow missing-optional skip semantics: ImportError and AttributeError are skipped, but runtime import defects propagate through register_router_specs.
 
 Added focused contract coverage for lazy module import/router attribute lookup, missing optional import skipping, and RuntimeError propagation. Verification: focused writing/email tests passed with 3 passed after a failing RED run; full router group contract tests passed with 94 passed; main router contract tests passed with 6 passed; OpenAPI contract tests passed with 69 passed; Bandit on minimal.py reported 0 results and 0 errors; git diff --check passed.
+
+PR opened: https://github.com/rmusser01/tldw_server/pull/1329
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-88 - Phase-2.2-minimal-writing-email-router-conditional-cleanup-AN.md
+++ b/backlog/tasks/task-88 - Phase-2.2-minimal-writing-email-router-conditional-cleanup-AN.md
@@ -1,0 +1,65 @@
+---
+id: TASK-88
+title: Phase 2.2 minimal writing/email router conditional cleanup AN
+status: Done
+assignee: []
+created_date: '2026-05-05 21:58'
+updated_date: '2026-05-05 22:02'
+labels:
+  - phase2.2
+  - router-cleanup
+  - issue-1116
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+  - 'https://github.com/rmusser01/tldw_server/pull/1327'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue issue #1116 Phase 2.2 after PR #1327. Convert the next small minimal-test optional router family in tldw_Server_API/app/api/v1/router_groups/minimal.py from eager try/import RouterSpec blocks to ImportedRouterSpec-backed lazy router specs. Scope is limited to writing, writing_manuscripts, and email. Preserve prefixes, tags, route_key/default_stable behavior, and minimal skip context while using narrow missing-optional skip semantics: ImportError/AttributeError are skippable, runtime import defects propagate.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Writing, manuscripts, and email minimal optional specs defer module import and router attribute lookup until registration
+- [x] #2 Existing route metadata is preserved for every router in scope
+- [x] #3 Focused router-group tests cover lazy behavior, missing optional import skipping, and runtime import defect propagation with red-green verification
+- [x] #4 Router-group/main-router/OpenAPI contract tests and touched-source Bandit pass
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused RED coverage for minimal writing/email router lazy resolution: spec construction does not import writing, writing_manuscripts, or email, metadata is preserved, and router attr lookup happens only during registration. 2. Add RED coverage for missing optional ImportError skip behavior and RuntimeError propagation through register_router_specs. 3. Convert only writing, writing_manuscripts, and email to ImportedRouterSpec entries in minimal.py using skip_exceptions=(ImportError, AttributeError). 4. Run focused tests, full router group/main/OpenAPI contract tests, Bandit on minimal.py, and git diff --check before commit/PR.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Started after PR #1327 merge was verified on origin/dev as 62002bcd8 in the git log. Worktree: local feature worktree for phase2-2-minimal-writing-router-conditionals-an. Branch: codex/phase2-2-minimal-writing-router-conditionals-an. Baseline router group contract tests passed with 91 passed before edits.
+
+RED verification: focused writing/email tests failed before production changes because writing, writing_manuscripts, and email were imported during spec construction and no named lazy specs existed for registration-time skip/propagation assertions.
+
+GREEN verification: converted writing, writing_manuscripts, and email to ImportedRouterSpec-backed lazy specs with skip_exceptions=(ImportError, AttributeError). Focused writing/email tests passed with 3 passed; full test_router_groups_contract.py passed with 94 passed; test_main_router_contract.py passed with 6 passed; test_openapi_contracts.py passed with 69 passed; Bandit on minimal.py reported 0 results and 0 errors; git diff --check was clean.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Converted the minimal-test writing/email router family, limited to writing, writing_manuscripts, and email, from eager try/import RouterSpec blocks to ImportedRouterSpec-backed lazy specs. The change preserves prefixes, tags, default route_key/default_stable behavior, and minimal skip context while using narrow missing-optional skip semantics: ImportError and AttributeError are skipped, but runtime import defects propagate through register_router_specs.
+
+Added focused contract coverage for lazy module import/router attribute lookup, missing optional import skipping, and RuntimeError propagation. Verification: focused writing/email tests passed with 3 passed after a failing RED run; full router group contract tests passed with 94 passed; main router contract tests passed with 6 passed; OpenAPI contract tests passed with 69 passed; Bandit on minimal.py reported 0 results and 0 errors; git diff --check passed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -643,38 +643,33 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
     ):
         append_imported_router_spec(specs, study_spec)
 
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.writing import router as writing_router
-
-        specs.append(RouterSpec(
-            router=writing_router,
+    for writing_email_spec in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.writing",
+            log_name="writing",
             prefix=f"{API_V1_PREFIX}/writing",
             tags=("writing",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping writing router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.writing_manuscripts import router as manuscripts_router
-
-        specs.append(RouterSpec(
-            router=manuscripts_router,
+            skip_context=minimal_skip_context,
+            skip_exceptions=(ImportError, AttributeError),
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.writing_manuscripts",
+            log_name="manuscripts",
             prefix=f"{API_V1_PREFIX}/writing/manuscripts",
             tags=("manuscripts",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping manuscripts router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.email import router as email_router
-
-        specs.append(RouterSpec(
-            router=email_router,
+            skip_context=minimal_skip_context,
+            skip_exceptions=(ImportError, AttributeError),
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.email",
+            log_name="email",
             prefix=f"{API_V1_PREFIX}/email",
             tags=("email",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping email router in minimal test app: {e}")
+            skip_context=minimal_skip_context,
+            skip_exceptions=(ImportError, AttributeError),
+        ),
+    ):
+        append_imported_router_spec(specs, writing_email_spec)
 
     try:
         from tldw_Server_API.app.api.v1.endpoints.jobs_admin import router as jobs_admin_router

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -53,6 +53,29 @@ STUDY_ROUTER_DEFINITION_DATA = (
         "/study-suggestions",
     ),
 )
+WRITING_EMAIL_ROUTER_DEFINITION_DATA = (
+    (
+        "tldw_Server_API.app.api.v1.endpoints.writing",
+        "writing",
+        "/api/v1/writing",
+        ("writing",),
+        "/writing",
+    ),
+    (
+        "tldw_Server_API.app.api.v1.endpoints.writing_manuscripts",
+        "manuscripts",
+        "/api/v1/writing/manuscripts",
+        ("manuscripts",),
+        "/writing/manuscripts",
+    ),
+    (
+        "tldw_Server_API.app.api.v1.endpoints.email",
+        "email",
+        "/api/v1/email",
+        ("email",),
+        "/email/search",
+    ),
+)
 
 
 def _main_source_text() -> str:
@@ -5688,6 +5711,235 @@ def test_iter_minimal_optional_router_specs_propagates_study_runtime_import_fail
     )
 
     with pytest.raises(RuntimeError, match="flashcards exploded during import"):
+        register_router_specs(FastAPI(), (selected_spec,))
+
+
+def test_iter_minimal_optional_router_specs_defers_writing_email_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal writing/email specs keep router attr lookup lazy."""
+    import builtins
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    router_definitions = tuple(
+        {
+            "module_name": module_name,
+            "expected_name": expected_name,
+            "prefix": prefix,
+            "tags": tags,
+            "path": path,
+        }
+        for module_name, expected_name, prefix, tags, path in WRITING_EMAIL_ROUTER_DEFINITION_DATA
+    )
+    definitions_by_module = {
+        str(definition["module_name"]): definition
+        for definition in router_definitions
+    }
+    access_count = {
+        f"{definition['module_name']}.router": 0
+        for definition in router_definitions
+    }
+    import_calls: list[str] = []
+
+    for module_name, definition in definitions_by_module.items():
+        fake_module = ModuleType(module_name)
+        router = APIRouter()
+
+        @router.get(str(definition["path"]))
+        def _endpoint() -> dict[str, str]:
+            """Return a deterministic response for the fake minimal writing/email router."""
+            return {"status": "ok"}
+
+        def _module_getattr(
+            name: str,
+            *,
+            module_name: str = module_name,
+            router: APIRouter = router,
+        ) -> APIRouter:
+            """Track lazy router attribute resolution for the fake module."""
+            if name != "router":
+                raise AttributeError(name)
+            access_count[f"{module_name}.router"] += 1
+            return router
+
+        fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    endpoints_package = "tldw_Server_API.app.api.v1.endpoints."
+    real_import = builtins.__import__
+
+    def _fake_endpoint_import(
+        name: str,
+        globals: dict[str, object] | None = None,
+        locals: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> ModuleType:
+        """Track selected imports and fake unrelated eager optional routers."""
+        if (
+            level == 0
+            and name.startswith(endpoints_package)
+        ):
+            if name in definitions_by_module:
+                import_calls.append(name)
+                return real_import(name, globals, locals, fromlist, level)
+            attrs = tuple(attr for attr in fromlist if attr != "*") or ("router",)
+            for attr_name in attrs:
+                _install_fake_router_module(
+                    monkeypatch,
+                    name,
+                    path="/minimal-unrelated-writing-email-fake",
+                    attr_name=attr_name,
+                )
+            return sys.modules[name]
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_endpoint_import)
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Track lazy module imports for selected minimal writing/email routers."""
+        if module_name in definitions_by_module:
+            import_calls.append(module_name)
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+    fake_main = ModuleType("tldw_Server_API.app.main")
+    fake_main.app = FastAPI()  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "tldw_Server_API.app.main", fake_main)
+
+    specs = list(iter_minimal_optional_router_specs())
+    assert [
+        module_name
+        for module_name in definitions_by_module
+        if module_name in import_calls
+    ] == []
+    assert access_count == {
+        f"{definition['module_name']}.router": 0
+        for definition in router_definitions
+    }
+    assert import_calls == []
+
+    selected_specs = {
+        spec.name: spec
+        for spec in specs
+        if spec.name in {
+            str(definition["expected_name"])
+            for definition in router_definitions
+        }
+    }
+    assert set(selected_specs) == {
+        str(definition["expected_name"])
+        for definition in router_definitions
+    }
+
+    for definition in router_definitions:
+        spec = selected_specs[str(definition["expected_name"])]
+        assert spec.prefix == definition["prefix"]
+        assert spec.tags == definition["tags"]
+        assert spec.route_key == ""
+        assert spec.skip_context == "in minimal test app"
+        assert spec.default_stable is True
+        assert spec.skip_exceptions == (ImportError, AttributeError)
+        assert _first_router_path(spec.router) == definition["path"]
+
+    assert import_calls == [
+        str(definition["module_name"])
+        for definition in router_definitions
+    ]
+    assert access_count == {
+        f"{definition['module_name']}.router": 1
+        for definition in router_definitions
+    }
+
+
+def test_iter_minimal_optional_router_specs_skips_writing_email_missing_import_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal writing/email specs skip missing optional router imports."""
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    writing_email_modules = {
+        module_name
+        for module_name, _expected_name, _prefix, _tags, _path in WRITING_EMAIL_ROUTER_DEFINITION_DATA
+    }
+    expected_names = {
+        expected_name
+        for _module_name, expected_name, _prefix, _tags, _path in WRITING_EMAIL_ROUTER_DEFINITION_DATA
+    }
+
+    specs = list(iter_minimal_optional_router_specs())
+    selected_specs = {
+        spec.name: spec
+        for spec in specs
+        if spec.name in expected_names
+    }
+    assert set(selected_specs) == expected_names
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Fail only the selected writing/email router imports at registration."""
+        if module_name in writing_email_modules:
+            raise ImportError(f"{module_name} missing during import")
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    debug_messages: list[str] = []
+    monkeypatch.setattr("loguru.logger.debug", debug_messages.append)
+
+    assert register_router_specs(FastAPI(), selected_specs.values()) == 0
+    assert debug_messages == [
+        f"Skipping {expected_name} router in minimal test app: "
+        f"{module_name} missing during import"
+        for module_name, expected_name, _prefix, _tags, _path in WRITING_EMAIL_ROUTER_DEFINITION_DATA
+    ]
+
+
+def test_iter_minimal_optional_router_specs_propagates_writing_email_runtime_import_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal writing/email runtime import defects are not silently skipped."""
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    module_name = "tldw_Server_API.app.api.v1.endpoints.writing"
+    specs = list(iter_minimal_optional_router_specs())
+    selected_spec = next(spec for spec in specs if spec.name == "writing")
+
+    real_import_module = importlib.import_module
+
+    def _import_module(import_name: str, package: str | None = None) -> ModuleType:
+        """Crash only one selected writing/email router import at registration."""
+        if import_name == module_name:
+            raise RuntimeError(f"{module_name} exploded during import")
+        return real_import_module(import_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    with pytest.raises(RuntimeError, match="writing exploded during import"):
         register_router_specs(FastAPI(), (selected_spec,))
 
 


### PR DESCRIPTION
## Summary
- convert minimal-test writing, writing_manuscripts, and email optional routers to lazy ImportedRouterSpec entries
- preserve prefixes, tags, default route policy behavior, and narrow ImportError/AttributeError skip semantics
- add focused red/green router-group coverage for lazy resolution, missing optional imports, and runtime import propagation

## Tests
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "writing_email" -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/router_groups/minimal.py -f json -o /tmp/bandit_minimal_writing_router_an.json
- git diff --check
- git diff --cached --check

## Change summary
TODO(user): This PR is materially AI-authored. Before merge, add a human-written summary explaining what changed and why these implementation choices were made.

Refs #1116