### PR TITLE
Reconcile sandbox public and operator diagnostics docs

### DIFF
--- a/Docs/API-related/Sandbox_API.md
+++ b/Docs/API-related/Sandbox_API.md
@@ -234,6 +234,87 @@ is currently limited to the host-gated `vz_linux` path; host-local runtimes only
 participate through workspace-oriented session inputs and do not provide warm
 runtime reuse.
 
+## Admin diagnostics and recovery
+
+Admin diagnostics are operator surfaces. They are not substitutes for
+client-facing runtime discovery, and diagnostics endpoints do not mutate runtime
+state.
+
+### Cross-runtime diagnostics
+
+GET `/api/v1/sandbox/admin/runtime-diagnostics`
+
+This admin-only, read-only endpoint derives from `/api/v1/sandbox/runtimes` and
+groups every runtime by readiness posture. It preserves raw `reasons`, additive
+`normalized_reasons`, isolation warning metadata, session reuse posture, and a
+`recommended_action` value for operator triage.
+
+The response includes:
+
+- `source`: currently `feature_discovery`.
+- `summary`: counts for `total`, `ready`, `host_gated`, `scaffold`,
+  `unavailable`, plus `host_local_warning_runtimes` and
+  `repair_supported_runtimes`.
+- `runtimes`: one row per runtime with readiness, isolation, network, session,
+  repair, and recommended-action fields.
+- `startup_warning_summary`: compact current-process startup warning status
+  when the app startup-warning registry is present.
+
+Repair support remains scoped to runtimes whose session contract explicitly
+advertises it. Today that means `vz_linux`; this endpoint does not add generic
+repair or reconciliation behavior for Docker, Firecracker, Lima, `seatbelt`,
+`worktree`, or `vz_macos`.
+
+### macOS diagnostics
+
+GET `/api/v1/sandbox/admin/macos-diagnostics`
+
+This admin-only, read-only endpoint exposes macOS/VZ operator details that are
+intentionally omitted from public discovery:
+
+- host readiness, including macOS and Apple silicon checks
+- helper readiness, protocol, version, and transport metadata
+- `vz_linux` and `vz_macos` template readiness
+- runtime execution mode and remediation hints
+- reconciliation between persisted `vz_linux` session controls and live helper
+  VM state
+- image-store correlation for templates, persisted run manifests, and dry-run GC
+  candidate classification
+- helper stdout/stderr log pointers, per-VM serial log pointers, guest-agent
+  readiness metadata, and helper-provided resource counters when available
+- read-only `recovery_summary` with status, severity, issue codes, counts,
+  recommended action, and pointers to the existing dry-run-first admin actions
+- `startup_warning_summary` for current-process sandbox startup warnings
+
+Log diagnostics report paths, existence, and byte sizes only. They do not read
+or return log file contents.
+
+### Image-store cleanup
+
+GET `/api/v1/sandbox/admin/macos-image-store/cleanup-plan`
+
+Returns a read-only cleanup plan for image-store run directories and manifests,
+including planned actions, live-match blockers, planning-only manifests,
+inactive runs, and legacy run directories.
+
+POST `/api/v1/sandbox/admin/macos-image-store/cleanup`
+
+Runs the same plan through an explicit admin action. It defaults to
+`dry_run=true`; unfiltered mutating cleanup requires `confirm_all=true`.
+
+### VZ reconciliation repair
+
+POST `/api/v1/sandbox/admin/macos-reconciliation/repair`
+
+Runs explicit `vz_linux` repair actions. It defaults to dry-run, skips active
+sessions, and can delete stale or unhealthy inactive persisted session-control
+rows when requested. Orphan VM termination is never automatic: it requires
+`terminate_orphaned_vms=true` and helper metadata proving the VM is owned by
+this `tldw` `vz_linux` sandbox control plane.
+
+Helper-unavailable and helper-protocol-mismatch conditions fail closed and block
+mutating repair.
+
 ## Create a session
 POST `/api/v1/sandbox/sessions`
 Headers: `Idempotency-Key: <uuid>` (recommended)
@@ -288,11 +369,19 @@ Response (scaffold example):
   "runtime": "docker",
   "base_image": "python:3.11-slim",
   "phase": "completed",
+  "status_reason_code": "completed",
   "exit_code": 0,
   "policy_hash": "<hash>",
   "log_stream_url": "ws://host/api/v1/sandbox/runs/<run_id>/stream?from_seq=100"
 }
 ```
+
+`status_reason_code` is additive and derived from existing status data. Clients
+should use it for stable grouping of queued, starting, running, completed,
+limit-applied, nonzero-exit, policy-failed, runtime-unavailable, timeout,
+canceled, killed, queue-expired, runtime-error, and unknown outcomes. Raw
+`phase`, `message`, and `exit_code` remain available for display and operator
+diagnostics.
 
 ## Stream logs (WebSocket)
 WS `/api/v1/sandbox/runs/{id}/stream`

--- a/Docs/API-related/Sandbox_API.md
+++ b/Docs/API-related/Sandbox_API.md
@@ -377,11 +377,12 @@ Response (scaffold example):
 ```
 
 `status_reason_code` is additive and derived from existing status data. Clients
-should use it for stable grouping of queued, starting, running, completed,
-limit-applied, nonzero-exit, policy-failed, runtime-unavailable, timeout,
-canceled, killed, queue-expired, runtime-error, and unknown outcomes. Raw
-`phase`, `message`, and `exit_code` remain available for display and operator
-diagnostics.
+should use the exact returned literals for stable grouping: `queued`,
+`starting`, `running`, `completed`, `limits_applied`, `nonzero_exit`,
+`policy_failed`, `runtime_unavailable`, `startup_timeout`,
+`execution_timeout`, `canceled_by_user`, `killed`, `queue_ttl_expired`,
+`runtime_error`, and `unknown`. Raw `phase`, `message`, and `exit_code` remain
+available for display and operator diagnostics.
 
 ## Stream logs (WebSocket)
 WS `/api/v1/sandbox/runs/{id}/stream`

--- a/Docs/Sandbox/macos-runtime-operator-notes.md
+++ b/Docs/Sandbox/macos-runtime-operator-notes.md
@@ -234,9 +234,19 @@ item and reports `live_vm_matches_blocked_cleanup` instead of deleting files.
 
 - runtime availability
 - preflight reasons
+- normalized runtime reason codes
+- isolation boundary metadata and host-local warnings
+- session contract metadata
 - supported trust levels
 - enforcement readiness
 - host facts
+
+`/api/v1/sandbox/admin/runtime-diagnostics` is the cross-runtime operator
+summary. It is admin-only, read-only, and derived from `/api/v1/sandbox/runtimes`
+rather than a separate readiness source. Use it for dashboard-style triage
+across Docker, Firecracker, Lima, `vz_linux`, `vz_macos`, `seatbelt`, and
+`worktree`; use `/api/v1/sandbox/admin/macos-diagnostics` when you need
+helper/template/image-store details for the macOS runtime family.
 
 `/api/v1/sandbox/admin/macos-diagnostics` is the operator-focused companion surface.
 It is admin-only and returns:
@@ -262,7 +272,7 @@ It is admin-only and returns:
 
 `GET /api/v1/admin/startup-warnings` is the generic app-level companion surface
 for the same startup records. It is also admin-only and returns the full
-current-process startup warning list plus grouped summary counts. In this PR the
+current-process startup warning list plus grouped summary counts. The warning
 scope is intentionally limited to the current API process and current boot; it
 is not cluster-wide or persisted across restarts.
 

--- a/Docs/Sandbox/sandbox-runtime-capability-inventory.md
+++ b/Docs/Sandbox/sandbox-runtime-capability-inventory.md
@@ -275,7 +275,7 @@ not generalized until other runtimes have an equally clear ownership model.
 
 | Gap | Runtime(s) | Follow-up phase |
 | --- | --- | --- |
-| Host-local runtimes need clearer docs/API warnings that they are not VM-grade. | `seatbelt`, `worktree` | Phase 2 |
+| Host-local runtime warnings need to be carried into future UI/operator dashboards, not just docs and API metadata. | `seatbelt`, `worktree` | Phase 2 |
 | Additional real allowlist implementations remain limited beyond Docker granular enforcement. | all except unsupported paths | Future |
 | Rich structured error metadata beyond the first normalized alias pass remains incomplete. | all | Phase 3 |
 | Cross-runtime session behavior contract tests and recovery flows remain incomplete beyond the discovery-level `session_contract`. | all | Phase 4 |

--- a/backlog/tasks/task-89 - Reconcile-sandbox-public-and-operator-docs-after-diagnostics-summary.md
+++ b/backlog/tasks/task-89 - Reconcile-sandbox-public-and-operator-docs-after-diagnostics-summary.md
@@ -1,0 +1,61 @@
+---
+id: TASK-89
+title: Reconcile sandbox public and operator docs after diagnostics summary
+status: Done
+assignee: []
+created_date: '2026-05-05 22:18'
+updated_date: '2026-05-05 22:20'
+labels:
+  - sandbox
+  - docs
+dependencies: []
+documentation:
+  - Docs/API-related/Sandbox_API.md
+  - tldw_Server_API/app/core/Sandbox/README.md
+  - Docs/Sandbox/sandbox-runtime-capability-inventory.md
+  - Docs/Sandbox/macos-runtime-operator-notes.md
+  - Docs/Sandbox/sandbox-architecture-doctrine.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Align public and operator-facing sandbox documentation after the merged runtime diagnostics, macOS diagnostics, image-store cleanup, recovery summary, and status reason-code slices. Keep the change docs-only and do not alter runtime behavior or API schemas. Essential constraints: host-local runtimes such as seatbelt and worktree must remain documented as weaker than VM-grade isolation and not untrusted-eligible; vz_linux repair/recovery remains scoped to explicit admin-only ownership-checked flows; runtime discovery and admin diagnostics remain the source of truth.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Sandbox API docs describe the current runtime discovery, admin runtime diagnostics, macOS diagnostics, image-store cleanup, recovery summary, and status reason-code surfaces without overstating guarantees.
+- [x] #2 Sandbox README and operator notes point to the same source-of-truth docs and preserve host-local versus VM-grade distinctions for seatbelt and worktree.
+- [x] #3 Capability inventory current gaps and maintenance guidance remain aligned with the merged diagnostics/recovery/status-reason slices.
+- [x] #4 Verification covers documentation references and whitespace hygiene; Bandit is documented as skipped because this is docs-only.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Compare current public Sandbox API docs, Sandbox README, macOS operator notes, and runtime inventory against merged runtime/admin diagnostics behavior. 2. Patch only documentation drift: endpoint list/semantics, diagnostics response purpose, image-store cleanup/recovery status, run status reason codes, and host-local caveats. 3. Verify docs references/links and whitespace; record Bandit skip because no production code changes.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Docs-only reconciliation completed. Updated Sandbox API quick guide with admin runtime diagnostics, macOS diagnostics, image-store cleanup, VZ reconciliation repair, and status_reason_code guidance. Updated Sandbox README source-of-truth pointers, macOS operator notes cross-runtime diagnostics guidance, and inventory current-gap wording for host-local warnings. Verification: listed referenced docs successfully; verified documented admin endpoint route strings exist in sandbox.py; verified status_reason_code schema/taxonomy references exist; git diff --check passed. Bandit skipped because no production code changed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Reconciled sandbox public/operator docs after the runtime diagnostics summary landed. The Sandbox API quick guide now documents admin runtime diagnostics, macOS diagnostics, image-store cleanup plan/mutation, VZ reconciliation repair, and status_reason_code semantics. The Sandbox README now points to the API guide and macOS operator notes as source-of-truth references. macOS operator notes now distinguish cross-runtime diagnostics from macOS helper/template diagnostics. The capability inventory now treats host-local docs/API warnings as covered and keeps future follow-up focused on UI/operator dashboard propagation. Verification: referenced docs exist; documented admin route strings exist in sandbox.py; status_reason_code exists in schema/taxonomy; git diff --check passed. Bandit skipped because only markdown/backlog docs changed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-91 - Fix-Sandbox-API-status_reason_code-docs-after-PR-review.md
+++ b/backlog/tasks/task-91 - Fix-Sandbox-API-status_reason_code-docs-after-PR-review.md
@@ -1,0 +1,62 @@
+---
+id: TASK-91
+title: Fix Sandbox API status_reason_code docs after PR review
+status: Done
+assignee: []
+created_date: '2026-05-06 00:04'
+updated_date: '2026-05-06 00:10'
+labels:
+  - sandbox
+  - docs
+  - pr-review
+dependencies:
+  - TASK-89
+documentation:
+  - Docs/API-related/Sandbox_API.md
+  - tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py
+  - Docs/Sandbox/sandbox-runtime-capability-inventory.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address PR #1330 review feedback that Docs/API-related/Sandbox_API.md documents status_reason_code outcomes with labels that do not match the server's RunStatusReasonCode literals. Keep the change docs-only and verify against run_status_taxonomy.py and the capability inventory.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Sandbox API guide lists the exact status_reason_code literals returned by the server.
+- [x] #2 Verification confirms the documented literals align with RunStatusReasonCode and the existing capability inventory table.
+- [x] #3 Whitespace verification passes and Bandit is documented as skipped because the change is docs-only.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Replace the generic/hyphenated status_reason_code outcome list in Docs/API-related/Sandbox_API.md with the exact RunStatusReasonCode literals from tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py.
+2. Cross-check the updated API guide against Docs/Sandbox/sandbox-runtime-capability-inventory.md so both docs use the same vocabulary.
+3. Run focused docs verification and whitespace checks, record the docs-only Bandit skip, then commit and push the PR review fix.
+<!-- SECTION:PLAN:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verified the PR finding against `tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py` and the existing normalized run status table in `Docs/Sandbox/sandbox-runtime-capability-inventory.md`. Updated `Docs/API-related/Sandbox_API.md` to list the exact returned literals instead of hyphenated or collapsed labels. Verification: `rg` confirmed the exact literals appear in the API guide, capability inventory, and canonical taxonomy; `git diff --check` passed. Bandit skipped because this is a docs/backlog-only change.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL:BEGIN -->
+Fixed PR #1330 review feedback by replacing the Sandbox API guide's generic/hyphenated `status_reason_code` outcome names with the exact `RunStatusReasonCode` literals returned by the server: `limits_applied`, `nonzero_exit`, `policy_failed`, `runtime_unavailable`, `startup_timeout`, `execution_timeout`, `canceled_by_user`, `queue_ttl_expired`, and the other canonical values. This keeps public API documentation aligned with the taxonomy implementation and capability inventory. Verification: focused `rg` cross-check and `git diff --check`; Bandit skipped because no production code changed.
+<!-- SECTION:FINAL:END -->

--- a/tldw_Server_API/app/core/Sandbox/README.md
+++ b/tldw_Server_API/app/core/Sandbox/README.md
@@ -17,6 +17,8 @@
   - Stream run events over WebSocket
   - Serve guarded artifact download URLs
   - Expose runtime discovery with preflight reasons, host facts, and supported trust levels
+  - Expose admin-only read-only diagnostics for cross-runtime readiness and
+    macOS VZ operator troubleshooting
 
 ## Runtime Model
 
@@ -55,6 +57,13 @@ Trust-level rules:
   `Docs/Sandbox/sandbox-runtime-capability-inventory.md`. It classifies each
   runtime's current trust, network, lifecycle, recovery, diagnostics, and CI
   support states without treating host availability as a security guarantee.
+- The public Sandbox API quick guide lives in
+  `Docs/API-related/Sandbox_API.md`. It is the concise external-facing contract
+  for runtime discovery, run/session responses, admin diagnostics, and explicit
+  repair/cleanup surfaces.
+- macOS operator notes live in `Docs/Sandbox/macos-runtime-operator-notes.md`
+  and remain the source of truth for prepared-host `vz_linux` helper,
+  image-store, smoke-test, and repair workflows.
 - The sandbox security policy matrix lives in
   `Docs/Sandbox/sandbox-security-policy-matrix.md`. It records the trust,
   network, workspace, user, artifact, helper/request allowlisting, and audit


### PR DESCRIPTION
## Summary
- Document the current admin sandbox diagnostics/recovery surfaces in the public Sandbox API guide, including runtime diagnostics, macOS diagnostics, image-store cleanup, and VZ reconciliation repair.
- Add run `status_reason_code` guidance and source-of-truth pointers from the Sandbox README/operator notes.
- Update the runtime capability inventory gap wording so host-local docs/API warnings are no longer treated as the open gap; future follow-up is UI/operator dashboard propagation.

## Test Plan
- [x] `git diff --check`
- [x] Referenced docs exist via `ls ...`
- [x] Documented admin route strings exist in `tldw_Server_API/app/api/v1/endpoints/sandbox.py`
- [x] `status_reason_code` exists in schema/taxonomy references
- [x] Bandit skipped: docs/backlog-only change

Human-written Change summary will be added by the maintainer before merge.