### PR TITLE
Phase 2.2: tighten minimal persona router skips

### DIFF
--- a/backlog/tasks/task-90 - Phase-2.2-minimal-persona-notes-router-skip-exception-cleanup-AO.md
+++ b/backlog/tasks/task-90 - Phase-2.2-minimal-persona-notes-router-skip-exception-cleanup-AO.md
@@ -1,0 +1,55 @@
+---
+id: TASK-90
+title: Phase 2.2 minimal persona/notes router skip exception cleanup AO
+status: Done
+assignee: []
+created_date: '2026-05-05 23:10'
+updated_date: '2026-05-05 23:13'
+labels:
+  - phase2.2
+  - router-cleanup
+  - minimal
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+  - 'https://github.com/rmusser01/tldw_server/pull/1329'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Tighten minimal-test persona, archetype, and notes optional router registration so missing optional imports remain skippable while runtime defects propagate during lazy router resolution.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Minimal persona, archetype, and notes router specs skip only ImportError and AttributeError during lazy resolution.
+- [x] #2 Runtime exceptions raised while importing those router modules propagate instead of being silently skipped.
+- [x] #3 Existing prefixes, tags, route keys, and default stability behavior are preserved.
+- [x] #4 Focused router contract tests cover lazy attr lookup, missing import skipping, and runtime error propagation.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Baseline persona/notes focused contract tests passed before edits: 2 passed, 92 deselected. RED after test update: 2 failed and 1 passed; failures showed persona/notes still used skip_exceptions=(Exception,) and runtime import errors were still skipped. GREEN after implementation: focused persona/notes contract tests passed with 3 passed, 92 deselected.
+
+Verification: full test_router_groups_contract.py passed with 95 passed; test_main_router_contract.py passed with 6 passed; test_openapi_contracts.py passed with 69 passed; Bandit on minimal.py wrote /tmp/bandit_minimal_persona_notes_ao.json with empty errors/results.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Narrowed minimal-test persona, archetype, and notes ImportedRouterSpec skip_exceptions from broad Exception to ImportError and AttributeError. Added focused contract coverage for lazy attr lookup metadata, missing optional import skipping, and runtime import error propagation while preserving prefixes, tags, route keys, and default stability.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-90 - Phase-2.2-minimal-persona-notes-router-skip-exception-cleanup-AO.md
+++ b/backlog/tasks/task-90 - Phase-2.2-minimal-persona-notes-router-skip-exception-cleanup-AO.md
@@ -4,7 +4,7 @@ title: Phase 2.2 minimal persona/notes router skip exception cleanup AO
 status: Done
 assignee: []
 created_date: '2026-05-05 23:10'
-updated_date: '2026-05-05 23:15'
+updated_date: '2026-05-05 23:49'
 labels:
   - phase2.2
   - router-cleanup
@@ -23,30 +23,6 @@ priority: medium
 Tighten minimal-test persona, archetype, and notes optional router registration so missing optional imports remain skippable while runtime defects propagate during lazy router resolution.
 <!-- SECTION:DESCRIPTION:END -->
 
-## Acceptance Criteria
-<!-- AC:BEGIN -->
-- [x] #1 Minimal persona, archetype, and notes router specs skip only ImportError and AttributeError during lazy resolution.
-- [x] #2 Runtime exceptions raised while importing those router modules propagate instead of being silently skipped.
-- [x] #3 Existing prefixes, tags, route keys, and default stability behavior are preserved.
-- [x] #4 Focused router contract tests cover lazy attr lookup, missing import skipping, and runtime error propagation.
-<!-- AC:END -->
-
-## Implementation Notes
-
-<!-- SECTION:NOTES:BEGIN -->
-Baseline persona/notes focused contract tests passed before edits: 2 passed, 92 deselected. RED after test update: 2 failed and 1 passed; failures showed persona/notes still used skip_exceptions=(Exception,) and runtime import errors were still skipped. GREEN after implementation: focused persona/notes contract tests passed with 3 passed, 92 deselected.
-
-Verification: full test_router_groups_contract.py passed with 95 passed; test_main_router_contract.py passed with 6 passed; test_openapi_contracts.py passed with 69 passed; Bandit on minimal.py wrote /tmp/bandit_minimal_persona_notes_ao.json with empty errors/results.
-<!-- SECTION:NOTES:END -->
-
-## Final Summary
-
-<!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Narrowed minimal-test persona, archetype, and notes ImportedRouterSpec skip_exceptions from broad Exception to ImportError and AttributeError. Added focused contract coverage for lazy attr lookup metadata, missing optional import skipping, and runtime import error propagation while preserving prefixes, tags, route keys, and default stability.
-
-PR opened: https://github.com/rmusser01/tldw_server/pull/1331
-<!-- SECTION:FINAL_SUMMARY:END -->
-
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [x] #1 Acceptance criteria completed
@@ -56,3 +32,37 @@ PR opened: https://github.com/rmusser01/tldw_server/pull/1331
 - [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Minimal persona archetype and notes router specs skip only dedicated optional missing module or missing router attribute exceptions.
+- [x] #2 Runtime exceptions and internal import-time dependency failures raised while importing those modules propagate instead of being skipped.
+- [x] #3 Existing prefixes tags route keys and default stability behavior are preserved.
+- [x] #4 Focused router contract tests cover lazy attr lookup true missing optional imports internal import failures and runtime error propagation.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Baseline persona/notes focused contract tests passed before edits: 2 passed, 92 deselected. RED after test update: 2 failed and 1 passed; failures showed persona/notes still used skip_exceptions=(Exception,) and runtime import errors were still skipped. GREEN after implementation: focused persona/notes contract tests passed with 3 passed, 92 deselected.
+
+Verification: full test_router_groups_contract.py passed with 95 passed; test_main_router_contract.py passed with 6 passed; test_openapi_contracts.py passed with 69 passed; Bandit on minimal.py wrote /tmp/bandit_minimal_persona_notes_ao.json with empty errors/results.
+
+PR review follow-up: Qodo flagged that ImportError/AttributeError skip types still hide internal import-time bugs. Reopening task to address the still-valid review comment with precise optional-router exceptions.
+
+Review RED: focused helper/persona selection failed with 4 failures before implementation. Failures showed default skip types were still ImportError/AttributeError and nested ModuleNotFoundError plus import-time AttributeError were still swallowed.
+
+Review GREEN: introduced OptionalRouterMissingModule and OptionalRouterMissingAttribute wrappers in conditional.py. The helper now wraps only target module misses and missing router attrs while internal ModuleNotFoundError and import-time AttributeError propagate. Persona/archetype/notes specs inherit the precise default.
+
+Review verification: focused append_imported_router_spec/persona_notes selection passed with 13 passed; full test_router_groups_contract.py passed with 98 passed; test_main_router_contract.py passed with 6 passed; test_openapi_contracts.py passed with 69 passed; Bandit on conditional.py and minimal.py wrote /tmp/bandit_minimal_persona_notes_review_ao.json with empty errors/results.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Narrowed minimal-test persona, archetype, and notes ImportedRouterSpec skip_exceptions from broad Exception to ImportError and AttributeError. Added focused contract coverage for lazy attr lookup metadata, missing optional import skipping, and runtime import error propagation while preserving prefixes, tags, route keys, and default stability.
+
+PR opened: https://github.com/rmusser01/tldw_server/pull/1331
+
+Review follow-up: addressed Qodo's import-time bug hiding comment by replacing broad optional ImportedRouterSpec defaults with dedicated optional-missing exceptions and updating persona/notes coverage for internal import failures.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-90 - Phase-2.2-minimal-persona-notes-router-skip-exception-cleanup-AO.md
+++ b/backlog/tasks/task-90 - Phase-2.2-minimal-persona-notes-router-skip-exception-cleanup-AO.md
@@ -4,7 +4,7 @@ title: Phase 2.2 minimal persona/notes router skip exception cleanup AO
 status: Done
 assignee: []
 created_date: '2026-05-05 23:10'
-updated_date: '2026-05-05 23:13'
+updated_date: '2026-05-05 23:15'
 labels:
   - phase2.2
   - router-cleanup
@@ -13,6 +13,7 @@ dependencies: []
 references:
   - 'https://github.com/rmusser01/tldw_server/issues/1116'
   - 'https://github.com/rmusser01/tldw_server/pull/1329'
+  - 'https://github.com/rmusser01/tldw_server/pull/1331'
 priority: medium
 ---
 
@@ -42,6 +43,8 @@ Verification: full test_router_groups_contract.py passed with 95 passed; test_ma
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Narrowed minimal-test persona, archetype, and notes ImportedRouterSpec skip_exceptions from broad Exception to ImportError and AttributeError. Added focused contract coverage for lazy attr lookup metadata, missing optional import skipping, and runtime import error propagation while preserving prefixes, tags, route keys, and default stability.
+
+PR opened: https://github.com/rmusser01/tldw_server/pull/1331
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/api/v1/router_groups/conditional.py
+++ b/tldw_Server_API/app/api/v1/router_groups/conditional.py
@@ -7,6 +7,14 @@ from dataclasses import dataclass
 from tldw_Server_API.app.api.v1.router_groups.spec import RouterSpec
 
 
+class OptionalRouterMissingModule(ImportError):
+    """Raised when the target optional router module itself is unavailable."""
+
+
+class OptionalRouterMissingAttribute(AttributeError):
+    """Raised when an optional router module is missing the configured router attr."""
+
+
 @dataclass(frozen=True)
 class ImportedRouterSpec:
     """RouterSpec metadata for a router imported inside a router group."""
@@ -19,7 +27,10 @@ class ImportedRouterSpec:
     default_stable: bool = True
     attr_name: str = "router"
     skip_context: str = ""
-    skip_exceptions: tuple[type[Exception], ...] = (ImportError, AttributeError)
+    skip_exceptions: tuple[type[Exception], ...] = (
+        OptionalRouterMissingModule,
+        OptionalRouterMissingAttribute,
+    )
 
 
 def append_imported_router_spec(
@@ -28,11 +39,18 @@ def append_imported_router_spec(
 ) -> None:
     """Append an imported router spec without importing until registration."""
     def _router_factory():
-        module = importlib.import_module(definition.import_path)
+        try:
+            module = importlib.import_module(definition.import_path)
+        except ModuleNotFoundError as e:
+            if e.name == definition.import_path:
+                raise OptionalRouterMissingModule(str(e)) from e
+            raise
         try:
             return getattr(module, definition.attr_name)
         except AttributeError as e:
-            raise AttributeError(f"{definition.import_path}.{definition.attr_name}") from e
+            raise OptionalRouterMissingAttribute(
+                f"{definition.import_path}.{definition.attr_name}"
+            ) from e
 
     specs.append(
         RouterSpec(

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -534,7 +534,7 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
             prefix=f"{API_V1_PREFIX}/persona",
             tags=("persona",),
             skip_context=minimal_skip_context,
-            skip_exceptions=(Exception,),
+            skip_exceptions=(ImportError, AttributeError),
         ),
         ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.archetype_endpoints",
@@ -542,7 +542,7 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
             prefix=f"{API_V1_PREFIX}/persona/archetypes",
             tags=("persona-archetypes",),
             skip_context=minimal_skip_context,
-            skip_exceptions=(Exception,),
+            skip_exceptions=(ImportError, AttributeError),
         ),
         ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.notes",
@@ -550,7 +550,7 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
             prefix=f"{API_V1_PREFIX}/notes",
             tags=("notes",),
             skip_context=minimal_skip_context,
-            skip_exceptions=(Exception,),
+            skip_exceptions=(ImportError, AttributeError),
         ),
     ):
         append_imported_router_spec(specs, persona_notes_spec)

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -534,7 +534,6 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
             prefix=f"{API_V1_PREFIX}/persona",
             tags=("persona",),
             skip_context=minimal_skip_context,
-            skip_exceptions=(ImportError, AttributeError),
         ),
         ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.archetype_endpoints",
@@ -542,7 +541,6 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
             prefix=f"{API_V1_PREFIX}/persona/archetypes",
             tags=("persona-archetypes",),
             skip_context=minimal_skip_context,
-            skip_exceptions=(ImportError, AttributeError),
         ),
         ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.notes",
@@ -550,7 +548,6 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
             prefix=f"{API_V1_PREFIX}/notes",
             tags=("notes",),
             skip_context=minimal_skip_context,
-            skip_exceptions=(ImportError, AttributeError),
         ),
     ):
         append_imported_router_spec(specs, persona_notes_spec)

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -76,6 +76,29 @@ WRITING_EMAIL_ROUTER_DEFINITION_DATA = (
         "/email/search",
     ),
 )
+PERSONA_NOTES_ROUTER_DEFINITION_DATA = (
+    (
+        "tldw_Server_API.app.api.v1.endpoints.persona",
+        "persona",
+        "/api/v1/persona",
+        ("persona",),
+        "/persona/status",
+    ),
+    (
+        "tldw_Server_API.app.api.v1.endpoints.archetype_endpoints",
+        "archetype",
+        "/api/v1/persona/archetypes",
+        ("persona-archetypes",),
+        "/archetypes",
+    ),
+    (
+        "tldw_Server_API.app.api.v1.endpoints.notes",
+        "notes",
+        "/api/v1/notes",
+        ("notes",),
+        "/notes",
+    ),
+)
 
 
 def _main_source_text() -> str:
@@ -6365,33 +6388,17 @@ def test_iter_minimal_optional_router_specs_defers_persona_notes_attr_lookup(
         iter_minimal_optional_router_specs,
     )
 
-    router_definitions = (
-        {
-            "module_name": "tldw_Server_API.app.api.v1.endpoints.persona",
-            "expected_name": "persona",
-            "path": "/persona/status",
-            "prefix": "/api/v1/persona",
-            "tags": ("persona",),
-        },
-        {
-            "module_name": "tldw_Server_API.app.api.v1.endpoints.archetype_endpoints",
-            "expected_name": "archetype",
-            "path": "/archetypes",
-            "prefix": "/api/v1/persona/archetypes",
-            "tags": ("persona-archetypes",),
-        },
-        {
-            "module_name": "tldw_Server_API.app.api.v1.endpoints.notes",
-            "expected_name": "notes",
-            "path": "/notes",
-            "prefix": "/api/v1/notes",
-            "tags": ("notes",),
-        },
-    )
     definitions_by_module = {
-        str(definition["module_name"]): definition
-        for definition in router_definitions
+        module_name: {
+            "module_name": module_name,
+            "expected_name": expected_name,
+            "prefix": prefix,
+            "tags": tags,
+            "path": path,
+        }
+        for module_name, expected_name, prefix, tags, path in PERSONA_NOTES_ROUTER_DEFINITION_DATA
     }
+    router_definitions = tuple(definitions_by_module.values())
     access_count = {
         f"{definition['module_name']}.router": 0
         for definition in router_definitions
@@ -6501,7 +6508,7 @@ def test_iter_minimal_optional_router_specs_defers_persona_notes_attr_lookup(
         assert spec.route_key == ""
         assert spec.skip_context == "in minimal test app"
         assert spec.default_stable is True
-        assert spec.skip_exceptions == (Exception,)
+        assert spec.skip_exceptions == (ImportError, AttributeError)
         assert _first_router_path(spec.router) == definition["path"]
 
     assert import_calls == [
@@ -6514,10 +6521,10 @@ def test_iter_minimal_optional_router_specs_defers_persona_notes_attr_lookup(
     }
 
 
-def test_iter_minimal_optional_router_specs_skips_persona_notes_runtime_import_failures(
+def test_iter_minimal_optional_router_specs_skips_persona_notes_missing_import_failures(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Verify minimal persona/notes specs preserve broad import failure skipping."""
+    """Verify minimal persona/notes specs skip missing optional router imports."""
     import importlib
 
     from tldw_Server_API.app.api.v1.router_groups.minimal import (
@@ -6525,25 +6532,28 @@ def test_iter_minimal_optional_router_specs_skips_persona_notes_runtime_import_f
     )
 
     persona_notes_modules = {
-        "tldw_Server_API.app.api.v1.endpoints.persona",
-        "tldw_Server_API.app.api.v1.endpoints.archetype_endpoints",
-        "tldw_Server_API.app.api.v1.endpoints.notes",
+        module_name
+        for module_name, _expected_name, _prefix, _tags, _path in PERSONA_NOTES_ROUTER_DEFINITION_DATA
+    }
+    expected_names = {
+        expected_name
+        for _module_name, expected_name, _prefix, _tags, _path in PERSONA_NOTES_ROUTER_DEFINITION_DATA
     }
 
     specs = list(iter_minimal_optional_router_specs())
     selected_specs = {
         spec.name: spec
         for spec in specs
-        if spec.name in {"persona", "archetype", "notes"}
+        if spec.name in expected_names
     }
-    assert set(selected_specs) == {"persona", "archetype", "notes"}
+    assert set(selected_specs) == expected_names
 
     real_import_module = importlib.import_module
 
     def _import_module(module_name: str, package: str | None = None) -> ModuleType:
-        """Crash only the selected persona/notes router imports at registration."""
+        """Fail only the selected persona/notes router imports at registration."""
         if module_name in persona_notes_modules:
-            raise RuntimeError(f"{module_name} exploded during import")
+            raise ImportError(f"{module_name} missing during import")
         return real_import_module(module_name, package)
 
     monkeypatch.setattr(
@@ -6556,13 +6566,41 @@ def test_iter_minimal_optional_router_specs_skips_persona_notes_runtime_import_f
 
     assert register_router_specs(FastAPI(), selected_specs.values()) == 0
     assert debug_messages == [
-        "Skipping persona router in minimal test app: "
-        "tldw_Server_API.app.api.v1.endpoints.persona exploded during import",
-        "Skipping archetype router in minimal test app: "
-        "tldw_Server_API.app.api.v1.endpoints.archetype_endpoints exploded during import",
-        "Skipping notes router in minimal test app: "
-        "tldw_Server_API.app.api.v1.endpoints.notes exploded during import",
+        f"Skipping {expected_name} router in minimal test app: "
+        f"{module_name} missing during import"
+        for module_name, expected_name, _prefix, _tags, _path in PERSONA_NOTES_ROUTER_DEFINITION_DATA
     ]
+
+
+def test_iter_minimal_optional_router_specs_propagates_persona_notes_runtime_import_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal persona/notes runtime import defects are not silently skipped."""
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    module_name = "tldw_Server_API.app.api.v1.endpoints.persona"
+    specs = list(iter_minimal_optional_router_specs())
+    selected_spec = next(spec for spec in specs if spec.name == "persona")
+
+    real_import_module = importlib.import_module
+
+    def _import_module(import_name: str, package: str | None = None) -> ModuleType:
+        """Crash only one selected persona/notes router import at registration."""
+        if import_name == module_name:
+            raise RuntimeError(f"{module_name} exploded during import")
+        return real_import_module(import_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    with pytest.raises(RuntimeError, match="persona exploded during import"):
+        register_router_specs(FastAPI(), (selected_spec,))
 
 
 def test_iter_minimal_optional_router_specs_populates_llm_specs(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -194,7 +194,10 @@ def test_append_imported_router_spec_preserves_metadata(
     assert specs[0].tags == ("acp-schedules",)
     assert specs[0].route_key == "acp"
     assert specs[0].default_stable is False
-    assert specs[0].skip_exceptions == (ImportError, AttributeError)
+    assert [exc.__name__ for exc in specs[0].skip_exceptions] == [
+        "OptionalRouterMissingModule",
+        "OptionalRouterMissingAttribute",
+    ]
 
 
 def test_append_imported_router_spec_defers_router_attr_lookup_until_resolution(
@@ -321,8 +324,8 @@ def test_append_imported_router_spec_skips_optional_import_error_at_registration
         append_imported_router_spec,
     )
 
-    def _raise_import_error(_import_path: str) -> ModuleType:
-        raise ModuleNotFoundError("optional router is unavailable")
+    def _raise_import_error(import_path: str) -> ModuleType:
+        raise ModuleNotFoundError("optional router is unavailable", name=import_path)
 
     monkeypatch.setattr(
         "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
@@ -347,6 +350,77 @@ def test_append_imported_router_spec_skips_optional_import_error_at_registration
     assert debug_messages == [
         "Skipping optional-missing router in minimal test app: optional router is unavailable"
     ]
+
+
+def test_append_imported_router_spec_raises_nested_module_not_found_at_registration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify internal missing dependencies are not treated as missing optional routers."""
+    from tldw_Server_API.app.api.v1.router_groups.conditional import (
+        ImportedRouterSpec,
+        append_imported_router_spec,
+    )
+
+    def _raise_internal_missing_dependency(_import_path: str) -> ModuleType:
+        raise ModuleNotFoundError("internal dependency is unavailable", name="internal_dependency")
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _raise_internal_missing_dependency,
+    )
+    specs: list[RouterSpec] = []
+    debug_messages: list[str] = []
+
+    append_imported_router_spec(
+        specs,
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.internal_missing",
+            log_name="internal-missing",
+            skip_context="in minimal test app",
+        ),
+    )
+
+    monkeypatch.setattr("loguru.logger.debug", debug_messages.append)
+
+    assert len(specs) == 1
+    with pytest.raises(ModuleNotFoundError, match="internal dependency is unavailable"):
+        register_router_specs(FastAPI(), specs)
+    assert debug_messages == []
+
+
+def test_append_imported_router_spec_raises_import_time_attribute_error_at_registration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify import-time AttributeError defects are not treated as missing router attrs."""
+    from tldw_Server_API.app.api.v1.router_groups.conditional import (
+        ImportedRouterSpec,
+        append_imported_router_spec,
+    )
+
+    def _raise_import_time_attr_error(_import_path: str) -> ModuleType:
+        raise AttributeError("module initialization bug")
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _raise_import_time_attr_error,
+    )
+    specs: list[RouterSpec] = []
+    debug_messages: list[str] = []
+
+    append_imported_router_spec(
+        specs,
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.import_time_attr_error",
+            log_name="import-time-attr-error",
+        ),
+    )
+
+    monkeypatch.setattr("loguru.logger.debug", debug_messages.append)
+
+    assert len(specs) == 1
+    with pytest.raises(AttributeError, match="module initialization bug"):
+        register_router_specs(FastAPI(), specs)
+    assert debug_messages == []
 
 
 def test_append_imported_router_spec_raises_unexpected_import_error_at_registration(
@@ -6508,7 +6582,10 @@ def test_iter_minimal_optional_router_specs_defers_persona_notes_attr_lookup(
         assert spec.route_key == ""
         assert spec.skip_context == "in minimal test app"
         assert spec.default_stable is True
-        assert spec.skip_exceptions == (ImportError, AttributeError)
+        assert [exc.__name__ for exc in spec.skip_exceptions] == [
+            "OptionalRouterMissingModule",
+            "OptionalRouterMissingAttribute",
+        ]
         assert _first_router_path(spec.router) == definition["path"]
 
     assert import_calls == [
@@ -6553,7 +6630,7 @@ def test_iter_minimal_optional_router_specs_skips_persona_notes_missing_import_f
     def _import_module(module_name: str, package: str | None = None) -> ModuleType:
         """Fail only the selected persona/notes router imports at registration."""
         if module_name in persona_notes_modules:
-            raise ImportError(f"{module_name} missing during import")
+            raise ModuleNotFoundError(f"{module_name} missing during import", name=module_name)
         return real_import_module(module_name, package)
 
     monkeypatch.setattr(
@@ -6570,6 +6647,40 @@ def test_iter_minimal_optional_router_specs_skips_persona_notes_missing_import_f
         f"{module_name} missing during import"
         for module_name, expected_name, _prefix, _tags, _path in PERSONA_NOTES_ROUTER_DEFINITION_DATA
     ]
+
+
+def test_iter_minimal_optional_router_specs_propagates_persona_notes_internal_import_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify internal missing dependencies are not silently skipped for persona/notes."""
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    module_name = "tldw_Server_API.app.api.v1.endpoints.persona"
+    specs = list(iter_minimal_optional_router_specs())
+    selected_spec = next(spec for spec in specs if spec.name == "persona")
+
+    real_import_module = importlib.import_module
+
+    def _import_module(import_name: str, package: str | None = None) -> ModuleType:
+        """Raise a nested missing dependency only for one selected persona router import."""
+        if import_name == module_name:
+            raise ModuleNotFoundError(
+                "persona internal dependency missing",
+                name="persona_internal_dependency",
+            )
+        return real_import_module(import_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    with pytest.raises(ModuleNotFoundError, match="persona internal dependency missing"):
+        register_router_specs(FastAPI(), (selected_spec,))
 
 
 def test_iter_minimal_optional_router_specs_propagates_persona_notes_runtime_import_failures(


### PR DESCRIPTION
## Summary
- Narrow minimal-test persona, archetype, and notes router skip exceptions to ImportError/AttributeError.
- Add contract coverage for missing optional imports and runtime import error propagation.
- Track the slice in Backlog TASK-90.

## Validation
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "minimal_optional_router_specs and persona_notes" -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/router_groups/minimal.py -f json -o /tmp/bandit_minimal_persona_notes_ao.json
- git diff --check

## Change summary TODO(user)
AI-authored PR: before merge, please add the human-written Change summary required by Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md, explaining what changed and why this narrow implementation was chosen.