### PR TITLE
Phase 2.2: defer minimal org imports

### DIFF
--- a/backlog/tasks/task-92 - Phase-2.2-minimal-organization-router-conditional-cleanup-AQ.md
+++ b/backlog/tasks/task-92 - Phase-2.2-minimal-organization-router-conditional-cleanup-AQ.md
@@ -1,0 +1,64 @@
+---
+id: TASK-92
+title: Phase 2.2 minimal organization router conditional cleanup AQ
+status: Done
+assignee: []
+created_date: '2026-05-06 00:31'
+updated_date: '2026-05-06 00:43'
+labels:
+  - phase2.2
+  - router-cleanup
+  - minimal
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+  - 'https://github.com/rmusser01/tldw_server/pull/1332'
+  - 'https://github.com/rmusser01/tldw_server/pull/1333'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Convert the minimal-test orgs and org_invites optional router block from eager try/import handling to lazy ImportedRouterSpec registration with precise optional-missing skip semantics.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Minimal orgs and org_invites routers are represented as lazy ImportedRouterSpec entries.
+- [x] #2 Missing target optional modules are skipped while runtime import defects propagate during registration.
+- [x] #3 Existing prefixes tags route keys and default stability behavior are preserved.
+- [x] #4 Focused router contract tests cover lazy attr lookup missing optional imports and runtime error propagation for this router family.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add RED router contract tests for minimal orgs/org_invites lazy import behavior, missing optional-module skips, and runtime import defect propagation. 2. Replace the eager minimal orgs and org_invites try/import blocks with lazy ImportedRouterSpec entries. 3. Run focused router tests, full router/main/OpenAPI contracts, Bandit on the touched router group, and git diff checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Baseline before edits: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q passed 101 tests. RED before production edits: focused selector -k 'minimal_optional_router_specs and org' failed on the three new organization tests because orgs and org_invites imported eagerly and did not expose named lazy specs.
+
+Implemented orgs and org_invites as ImportedRouterSpec entries using default precise optional-missing exceptions. Verification after implementation: focused org tests 3 passed; full router group contract 104 passed; main router contract 6 passed; OpenAPI contract 69 passed; Bandit on tldw_Server_API/app/api/v1/router_groups/minimal.py reported zero findings; git diff --check passed.
+
+Opened PR https://github.com/rmusser01/tldw_server/pull/1333 against dev for this slice.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Changed the minimal-test organization router tranche so orgs and org_invites are registered through lazy ImportedRouterSpec definitions instead of eager try/import blocks. This preserves prefixes and tags while narrowing skip behavior to the shared optional missing-module or missing-attribute cases, so real runtime import defects propagate during registration instead of being swallowed. Added router contract coverage for lazy attr lookup, optional missing import skips, and runtime import failure propagation. Verification: baseline router group contracts passed before edits; RED focused org tests failed before the production edit; after the edit, focused org tests passed 3/3, router group contracts passed 104/104, main router contracts passed 6/6, OpenAPI contracts passed 69/69, Bandit on minimal.py reported zero findings, and git diff --check passed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-92 - Phase-2.2-minimal-organization-router-conditional-cleanup-AQ.md
+++ b/backlog/tasks/task-92 - Phase-2.2-minimal-organization-router-conditional-cleanup-AQ.md
@@ -4,7 +4,7 @@ title: Phase 2.2 minimal organization router conditional cleanup AQ
 status: Done
 assignee: []
 created_date: '2026-05-06 00:31'
-updated_date: '2026-05-06 00:43'
+updated_date: '2026-05-06 01:03'
 labels:
   - phase2.2
   - router-cleanup
@@ -20,7 +20,7 @@ priority: medium
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Convert the minimal-test orgs and org_invites optional router block from eager try/import handling to lazy ImportedRouterSpec registration with precise optional-missing skip semantics.
+Convert the minimal-test orgs and org_invites optional router block from eager try/import handling to lazy ImportedRouterSpec registration with precise optional-missing skip semantics. This unblocks later Phase 2/3 router extraction work by removing another minimal-test eager import island that would otherwise keep optional router registration coupled to import-time side effects.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
@@ -45,12 +45,16 @@ Baseline before edits: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bi
 Implemented orgs and org_invites as ImportedRouterSpec entries using default precise optional-missing exceptions. Verification after implementation: focused org tests 3 passed; full router group contract 104 passed; main router contract 6 passed; OpenAPI contract 69 passed; Bandit on tldw_Server_API/app/api/v1/router_groups/minimal.py reported zero findings; git diff --check passed.
 
 Opened PR https://github.com/rmusser01/tldw_server/pull/1333 against dev for this slice.
+
+Review follow-up: documented the later-phase unblocker explicitly. This AQ slice removes another minimal-test eager import island so later router extraction and optional-registration hardening can proceed without preserving organization import-time side effects.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Changed the minimal-test organization router tranche so orgs and org_invites are registered through lazy ImportedRouterSpec definitions instead of eager try/import blocks. This preserves prefixes and tags while narrowing skip behavior to the shared optional missing-module or missing-attribute cases, so real runtime import defects propagate during registration instead of being swallowed. Added router contract coverage for lazy attr lookup, optional missing import skips, and runtime import failure propagation. Verification: baseline router group contracts passed before edits; RED focused org tests failed before the production edit; after the edit, focused org tests passed 3/3, router group contracts passed 104/104, main router contracts passed 6/6, OpenAPI contracts passed 69/69, Bandit on minimal.py reported zero findings, and git diff --check passed.
+
+Review follow-up: documented the later-phase unblocker for this Phase 2.2 extraction in TASK-92.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -725,27 +725,23 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
         except Exception as admin_byok_error:  # noqa: BLE001
             logger.debug(f"Skipping admin_byok router in minimal test app: {admin_byok_error}")
 
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.orgs import router as orgs_router
-
-        specs.append(RouterSpec(
-            router=orgs_router,
+    for org_spec in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.orgs",
+            log_name="orgs",
             prefix=f"{API_V1_PREFIX}",
             tags=("organizations",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping orgs router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.org_invites import router as org_invites_router
-
-        specs.append(RouterSpec(
-            router=org_invites_router,
+            skip_context=minimal_skip_context,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.org_invites",
+            log_name="org_invites",
             prefix=f"{API_V1_PREFIX}",
             tags=("invites",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping org_invites router in minimal test app: {e}")
+            skip_context=minimal_skip_context,
+        ),
+    ):
+        append_imported_router_spec(specs, org_spec)
 
     try:
         from tldw_Server_API.app.api.v1.endpoints.resource_governor import router as resource_governor_router

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -129,6 +129,22 @@ OPS_ROUTER_DEFINITION_DATA = (
         "/config/effective",
     ),
 )
+ORG_ROUTER_DEFINITION_DATA = (
+    (
+        "tldw_Server_API.app.api.v1.endpoints.orgs",
+        "orgs",
+        "/api/v1",
+        ("organizations",),
+        "/orgs",
+    ),
+    (
+        "tldw_Server_API.app.api.v1.endpoints.org_invites",
+        "org_invites",
+        "/api/v1",
+        ("invites",),
+        "/invites/preview",
+    ),
+)
 
 
 def _main_source_text() -> str:
@@ -6296,6 +6312,235 @@ def test_iter_minimal_optional_router_specs_propagates_ops_runtime_import_failur
     )
 
     with pytest.raises(RuntimeError, match="jobs_admin exploded during import"):
+        register_router_specs(FastAPI(), (selected_spec,))
+
+
+def test_iter_minimal_optional_router_specs_defers_org_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal organization specs keep module import and attr lookup lazy."""
+    import builtins
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    definitions_by_module = {
+        module_name: {
+            "module_name": module_name,
+            "expected_name": expected_name,
+            "prefix": prefix,
+            "tags": tags,
+            "path": path,
+        }
+        for module_name, expected_name, prefix, tags, path in ORG_ROUTER_DEFINITION_DATA
+    }
+    router_definitions = tuple(definitions_by_module.values())
+    access_count = {
+        f"{definition['module_name']}.router": 0
+        for definition in router_definitions
+    }
+    import_calls: list[str] = []
+
+    for module_name, definition in definitions_by_module.items():
+        fake_module = ModuleType(module_name)
+        router = APIRouter()
+
+        @router.get(str(definition["path"]))
+        def _endpoint() -> dict[str, str]:
+            """Return a deterministic response for the fake minimal org router."""
+            return {"status": "ok"}
+
+        def _module_getattr(
+            name: str,
+            *,
+            module_name: str = module_name,
+            router: APIRouter = router,
+        ) -> APIRouter:
+            """Track lazy router attribute resolution for the fake module."""
+            if name != "router":
+                raise AttributeError(name)
+            access_count[f"{module_name}.router"] += 1
+            return router
+
+        fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    endpoints_package = "tldw_Server_API.app.api.v1.endpoints."
+    real_import = builtins.__import__
+
+    def _fake_endpoint_import(
+        name: str,
+        globals: dict[str, object] | None = None,
+        locals: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> ModuleType:
+        """Track selected imports and fake unrelated eager optional routers."""
+        if (
+            level == 0
+            and name.startswith(endpoints_package)
+        ):
+            if name in definitions_by_module:
+                import_calls.append(name)
+                return real_import(name, globals, locals, fromlist, level)
+            attrs = tuple(attr for attr in fromlist if attr != "*") or ("router",)
+            for attr_name in attrs:
+                _install_fake_router_module(
+                    monkeypatch,
+                    name,
+                    path="/minimal-unrelated-org-fake",
+                    attr_name=attr_name,
+                )
+            return sys.modules[name]
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_endpoint_import)
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Track lazy module imports for selected minimal organization routers."""
+        if module_name in definitions_by_module:
+            import_calls.append(module_name)
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+    fake_main = ModuleType("tldw_Server_API.app.main")
+    fake_main.app = FastAPI()  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "tldw_Server_API.app.main", fake_main)
+
+    specs = list(iter_minimal_optional_router_specs())
+    assert [
+        module_name
+        for module_name in definitions_by_module
+        if module_name in import_calls
+    ] == []
+    assert access_count == {
+        f"{definition['module_name']}.router": 0
+        for definition in router_definitions
+    }
+    assert import_calls == []
+
+    selected_specs = {
+        spec.name: spec
+        for spec in specs
+        if spec.name in {
+            str(definition["expected_name"])
+            for definition in router_definitions
+        }
+    }
+    assert set(selected_specs) == {
+        str(definition["expected_name"])
+        for definition in router_definitions
+    }
+
+    for definition in router_definitions:
+        spec = selected_specs[str(definition["expected_name"])]
+        assert spec.prefix == definition["prefix"]
+        assert spec.tags == definition["tags"]
+        assert spec.route_key == ""
+        assert spec.skip_context == "in minimal test app"
+        assert spec.default_stable is True
+        assert [exc.__name__ for exc in spec.skip_exceptions] == [
+            "OptionalRouterMissingModule",
+            "OptionalRouterMissingAttribute",
+        ]
+        assert _first_router_path(spec.router) == definition["path"]
+
+    assert import_calls == [
+        str(definition["module_name"])
+        for definition in router_definitions
+    ]
+    assert access_count == {
+        f"{definition['module_name']}.router": 1
+        for definition in router_definitions
+    }
+
+
+def test_iter_minimal_optional_router_specs_skips_org_missing_import_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal organization specs skip missing optional router modules."""
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    org_modules = {
+        module_name
+        for module_name, _expected_name, _prefix, _tags, _path in ORG_ROUTER_DEFINITION_DATA
+    }
+    expected_names = {
+        expected_name
+        for _module_name, expected_name, _prefix, _tags, _path in ORG_ROUTER_DEFINITION_DATA
+    }
+
+    specs = list(iter_minimal_optional_router_specs())
+    selected_specs = {
+        spec.name: spec
+        for spec in specs
+        if spec.name in expected_names
+    }
+    assert set(selected_specs) == expected_names
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Fail only the selected organization router imports at registration."""
+        if module_name in org_modules:
+            raise ModuleNotFoundError(f"{module_name} missing during import", name=module_name)
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    debug_messages: list[str] = []
+    monkeypatch.setattr("loguru.logger.debug", debug_messages.append)
+
+    assert register_router_specs(FastAPI(), selected_specs.values()) == 0
+    assert debug_messages == [
+        f"Skipping {expected_name} router in minimal test app: "
+        f"{module_name} missing during import"
+        for module_name, expected_name, _prefix, _tags, _path in ORG_ROUTER_DEFINITION_DATA
+    ]
+
+
+def test_iter_minimal_optional_router_specs_propagates_org_runtime_import_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal organization runtime import defects are not silently skipped."""
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    module_name = "tldw_Server_API.app.api.v1.endpoints.orgs"
+    specs = list(iter_minimal_optional_router_specs())
+    selected_spec = next(spec for spec in specs if spec.name == "orgs")
+
+    real_import_module = importlib.import_module
+
+    def _import_module(import_name: str, package: str | None = None) -> ModuleType:
+        """Crash only one selected organization router import at registration."""
+        if import_name == module_name:
+            raise RuntimeError(f"{module_name} exploded during import")
+        return real_import_module(import_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    with pytest.raises(RuntimeError, match="orgs exploded during import"):
         register_router_specs(FastAPI(), (selected_spec,))
 
 


### PR DESCRIPTION
## Summary
- Converted the minimal-test orgs and org_invites router tranche from eager try/import blocks to lazy ImportedRouterSpec entries.
- Preserved prefixes and tags while using the shared optional missing-module/missing-attribute skip semantics so runtime import defects propagate.
- Added router contract coverage for lazy attr lookup, missing optional imports, and runtime import failures.

## Validation
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q (baseline before edits: 101 passed)
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k 'minimal_optional_router_specs and org' -q (RED before production edit: 3 failed; GREEN after edit: 3 passed)
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q (104 passed)
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q (6 passed)
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q (69 passed)
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/router_groups/minimal.py -f json -o /tmp/bandit_minimal_org_aq.json (0 findings)
- git diff --check
- git diff --cached --check

## Backlog
- TASK-92
- Related: #1116, after #1332

## Change summary
TODO(user): Before merge, add a human-written summary explaining what changed and why this specific lazy ImportedRouterSpec approach was chosen.