### PR TITLE
Phase 2.2: defer minimal access/resource imports

### DIFF
--- a/backlog/tasks/task-93 - Phase-2.2-minimal-access-resource-router-conditional-cleanup-AR.md
+++ b/backlog/tasks/task-93 - Phase-2.2-minimal-access-resource-router-conditional-cleanup-AR.md
@@ -1,0 +1,66 @@
+---
+id: TASK-93
+title: Phase 2.2 minimal access/resource router conditional cleanup AR
+status: Done
+assignee: []
+created_date: '2026-05-06 01:13'
+updated_date: '2026-05-06 01:23'
+labels:
+  - phase2.2
+  - router-cleanup
+  - minimal
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+  - 'https://github.com/rmusser01/tldw_server/pull/1333'
+  - 'https://github.com/rmusser01/tldw_server/pull/1334'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Convert the minimal-test resource_governor and users optional router blocks from eager try/except handling to lazy ImportedRouterSpec registration with precise optional-missing skip semantics. This unblocks later Phase 2/3 router extraction work by removing another minimal-test eager import island that would otherwise keep optional router registration coupled to import-time side effects.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Minimal resource_governor and users routers are represented as lazy ImportedRouterSpec entries.
+- [x] #2 Missing target optional modules are skipped while runtime import defects propagate during registration.
+- [x] #3 Existing prefixes tags route keys and default stability behavior are preserved.
+- [x] #4 Focused router contract tests cover lazy attr lookup missing optional imports and runtime error propagation for this router family.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add RED router contract tests for minimal resource_governor/users lazy import behavior, missing optional-module skips, and runtime import defect propagation. 2. Replace the eager minimal resource_governor and users try/except blocks with lazy ImportedRouterSpec entries. 3. Run focused router tests, full router group contracts, main lifecycle contracts, OpenAPI contracts, Bandit on the touched router group, and git diff checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Baseline before edits: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k 'minimal_optional_router_specs and (resource or users)' -q passed 1 existing selected test. RED before production edits: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k 'access_resource' -q failed 3/3 because resource_governor and users imported eagerly, missing imports left no lazy specs, and runtime failures could not propagate during registration.
+
+Implemented resource_governor and users as ImportedRouterSpec entries using default precise optional-missing exceptions. Verification after implementation: focused access_resource tests passed 3/3; full router group contract passed 107/107; OpenAPI contract passed 69/69; main lifecycle contract passed 54/54. A stale selector command, test_main_lifecycle_contract.py -k router -q, selected zero tests on current dev and was not counted as validation. Bandit on tldw_Server_API/app/api/v1/router_groups/minimal.py reported zero findings; git diff --check passed.
+
+Opened PR https://github.com/rmusser01/tldw_server/pull/1334 against dev for this slice.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Changed the minimal-test access/resource router tranche so resource_governor and users are registered through lazy ImportedRouterSpec definitions instead of eager try/except blocks. This preserves prefixes and tags while narrowing skip behavior to the shared optional missing-module or missing-attribute cases, so real runtime import defects propagate during registration instead of being swallowed. Added router contract coverage for lazy attr lookup, optional missing import skips, and runtime import failure propagation. Verification: baseline selected router test passed before edits; RED focused access/resource tests failed before the production edit; after the edit, focused access/resource tests passed 3/3, router group contracts passed 107/107, main lifecycle contracts passed 54/54, OpenAPI contracts passed 69/69, Bandit on minimal.py reported zero findings, and git diff --check passed.
+
+Opened PR https://github.com/rmusser01/tldw_server/pull/1334 against dev.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -743,27 +743,23 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
     ):
         append_imported_router_spec(specs, org_spec)
 
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.resource_governor import router as resource_governor_router
-
-        specs.append(RouterSpec(
-            router=resource_governor_router,
+    for access_resource_spec in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.resource_governor",
+            log_name="resource_governor",
             prefix=f"{API_V1_PREFIX}",
             tags=("resource-governor",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping resource_governor router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.users import router as users_router
-
-        specs.append(RouterSpec(
-            router=users_router,
+            skip_context=minimal_skip_context,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.users",
+            log_name="users",
             prefix=f"{API_V1_PREFIX}",
             tags=("users",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping users router in minimal test app: {e}")
+            skip_context=minimal_skip_context,
+        ),
+    ):
+        append_imported_router_spec(specs, access_resource_spec)
 
     try:
         from tldw_Server_API.app.api.v1.endpoints.shared_keys_scoped import router as shared_keys_scoped_router

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -145,6 +145,22 @@ ORG_ROUTER_DEFINITION_DATA = (
         "/invites/preview",
     ),
 )
+ACCESS_RESOURCE_ROUTER_DEFINITION_DATA = (
+    (
+        "tldw_Server_API.app.api.v1.endpoints.resource_governor",
+        "resource_governor",
+        "/api/v1",
+        ("resource-governor",),
+        "/resource-governor/status",
+    ),
+    (
+        "tldw_Server_API.app.api.v1.endpoints.users",
+        "users",
+        "/api/v1",
+        ("users",),
+        "/users/me",
+    ),
+)
 
 
 def _main_source_text() -> str:
@@ -6541,6 +6557,235 @@ def test_iter_minimal_optional_router_specs_propagates_org_runtime_import_failur
     )
 
     with pytest.raises(RuntimeError, match="orgs exploded during import"):
+        register_router_specs(FastAPI(), (selected_spec,))
+
+
+def test_iter_minimal_optional_router_specs_defers_access_resource_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal access/resource specs keep module import and attr lookup lazy."""
+    import builtins
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    definitions_by_module = {
+        module_name: {
+            "module_name": module_name,
+            "expected_name": expected_name,
+            "prefix": prefix,
+            "tags": tags,
+            "path": path,
+        }
+        for module_name, expected_name, prefix, tags, path in ACCESS_RESOURCE_ROUTER_DEFINITION_DATA
+    }
+    router_definitions = tuple(definitions_by_module.values())
+    access_count = {
+        f"{definition['module_name']}.router": 0
+        for definition in router_definitions
+    }
+    import_calls: list[str] = []
+
+    for module_name, definition in definitions_by_module.items():
+        fake_module = ModuleType(module_name)
+        router = APIRouter()
+
+        @router.get(str(definition["path"]))
+        def _endpoint() -> dict[str, str]:
+            """Return a deterministic response for the fake minimal access/resource router."""
+            return {"status": "ok"}
+
+        def _module_getattr(
+            name: str,
+            *,
+            module_name: str = module_name,
+            router: APIRouter = router,
+        ) -> APIRouter:
+            """Track lazy router attribute resolution for the fake module."""
+            if name != "router":
+                raise AttributeError(name)
+            access_count[f"{module_name}.router"] += 1
+            return router
+
+        fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    endpoints_package = "tldw_Server_API.app.api.v1.endpoints."
+    real_import = builtins.__import__
+
+    def _fake_endpoint_import(
+        name: str,
+        globals: dict[str, object] | None = None,
+        locals: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> ModuleType:
+        """Track selected imports and fake unrelated eager optional routers."""
+        if (
+            level == 0
+            and name.startswith(endpoints_package)
+        ):
+            if name in definitions_by_module:
+                import_calls.append(name)
+                return real_import(name, globals, locals, fromlist, level)
+            attrs = tuple(attr for attr in fromlist if attr != "*") or ("router",)
+            for attr_name in attrs:
+                _install_fake_router_module(
+                    monkeypatch,
+                    name,
+                    path="/minimal-unrelated-access-resource-fake",
+                    attr_name=attr_name,
+                )
+            return sys.modules[name]
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_endpoint_import)
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Track lazy module imports for selected minimal access/resource routers."""
+        if module_name in definitions_by_module:
+            import_calls.append(module_name)
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+    fake_main = ModuleType("tldw_Server_API.app.main")
+    fake_main.app = FastAPI()  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "tldw_Server_API.app.main", fake_main)
+
+    specs = list(iter_minimal_optional_router_specs())
+    assert [
+        module_name
+        for module_name in definitions_by_module
+        if module_name in import_calls
+    ] == []
+    assert access_count == {
+        f"{definition['module_name']}.router": 0
+        for definition in router_definitions
+    }
+    assert import_calls == []
+
+    selected_specs = {
+        spec.name: spec
+        for spec in specs
+        if spec.name in {
+            str(definition["expected_name"])
+            for definition in router_definitions
+        }
+    }
+    assert set(selected_specs) == {
+        str(definition["expected_name"])
+        for definition in router_definitions
+    }
+
+    for definition in router_definitions:
+        spec = selected_specs[str(definition["expected_name"])]
+        assert spec.prefix == definition["prefix"]
+        assert spec.tags == definition["tags"]
+        assert spec.route_key == ""
+        assert spec.skip_context == "in minimal test app"
+        assert spec.default_stable is True
+        assert [exc.__name__ for exc in spec.skip_exceptions] == [
+            "OptionalRouterMissingModule",
+            "OptionalRouterMissingAttribute",
+        ]
+        assert _first_router_path(spec.router) == definition["path"]
+
+    assert import_calls == [
+        str(definition["module_name"])
+        for definition in router_definitions
+    ]
+    assert access_count == {
+        f"{definition['module_name']}.router": 1
+        for definition in router_definitions
+    }
+
+
+def test_iter_minimal_optional_router_specs_skips_access_resource_missing_import_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal access/resource specs skip missing optional router modules."""
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    access_resource_modules = {
+        module_name
+        for module_name, _expected_name, _prefix, _tags, _path in ACCESS_RESOURCE_ROUTER_DEFINITION_DATA
+    }
+    expected_names = {
+        expected_name
+        for _module_name, expected_name, _prefix, _tags, _path in ACCESS_RESOURCE_ROUTER_DEFINITION_DATA
+    }
+
+    specs = list(iter_minimal_optional_router_specs())
+    selected_specs = {
+        spec.name: spec
+        for spec in specs
+        if spec.name in expected_names
+    }
+    assert set(selected_specs) == expected_names
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Fail only the selected access/resource router imports at registration."""
+        if module_name in access_resource_modules:
+            raise ModuleNotFoundError(f"{module_name} missing during import", name=module_name)
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    debug_messages: list[str] = []
+    monkeypatch.setattr("loguru.logger.debug", debug_messages.append)
+
+    assert register_router_specs(FastAPI(), selected_specs.values()) == 0
+    assert debug_messages == [
+        f"Skipping {expected_name} router in minimal test app: "
+        f"{module_name} missing during import"
+        for module_name, expected_name, _prefix, _tags, _path in ACCESS_RESOURCE_ROUTER_DEFINITION_DATA
+    ]
+
+
+def test_iter_minimal_optional_router_specs_propagates_access_resource_runtime_import_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal access/resource runtime import defects are not silently skipped."""
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    module_name = "tldw_Server_API.app.api.v1.endpoints.resource_governor"
+    specs = list(iter_minimal_optional_router_specs())
+    selected_spec = next(spec for spec in specs if spec.name == "resource_governor")
+
+    real_import_module = importlib.import_module
+
+    def _import_module(import_name: str, package: str | None = None) -> ModuleType:
+        """Crash only one selected access/resource router import at registration."""
+        if import_name == module_name:
+            raise RuntimeError(f"{module_name} exploded during import")
+        return real_import_module(import_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    with pytest.raises(RuntimeError, match="resource_governor exploded during import"):
         register_router_specs(FastAPI(), (selected_spec,))
 
 


### PR DESCRIPTION
## Change summary

This PR converts the minimal-test resource_governor and users optional router registrations from eager try/except imports to lazy ImportedRouterSpec entries. The change keeps the existing prefixes and tags while narrowing skip behavior to optional missing-module or missing-attribute cases, so real runtime import defects surface during router registration instead of being swallowed.

This is a conservative Phase 2.2 follow-up slice for issue #1116. It unblocks later Phase 2/3 router extraction work by removing another minimal-test eager import island and its import-time side effects without changing the public route contract.

## Tests

- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "access_resource" -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_lifecycle_contract.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/router_groups/minimal.py -f json -o /tmp/bandit_minimal_access_router_ar.json
- git diff --check
- git diff --cached --check

## Notes

- The stale selector command test_main_lifecycle_contract.py -k router -q selected zero tests on current dev and is not counted as validation.
- Tracks TASK-93.