### PR TITLE
Show sandbox host-local isolation warnings in admin monitoring

### DIFF
--- a/Docs/superpowers/plans/2026-05-06-sandbox-host-local-warnings-ui.md
+++ b/Docs/superpowers/plans/2026-05-06-sandbox-host-local-warnings-ui.md
@@ -1,0 +1,111 @@
+# Sandbox Host-Local Warnings UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface sandbox host-local isolation warnings in the existing admin monitoring UI so operators can see that `seatbelt` and `worktree` are weaker than VM-grade isolation.
+
+**Architecture:** Keep the backend unchanged and consume the existing `GET /api/v1/sandbox/admin/runtime-diagnostics` endpoint from the shared UI client. Add a read-only sandbox diagnostics card to `MonitoringDashboardPage` because it already aggregates admin health signals and has focused Vitest coverage. Render warning badges from API metadata instead of hard-coding runtime names as the source of truth.
+
+**Tech Stack:** React 18, Ant Design, shared `@tldw/ui` package, `bgRequest`, Vitest with Testing Library.
+
+---
+
+### Task 1: Add Sandbox Diagnostics Client Contract
+
+**Files:**
+- Modify: `apps/packages/ui/src/services/tldw/TldwApiClient.ts`
+
+- [x] **Step 1: Add typed response interfaces**
+
+Add lightweight interfaces for `SandboxAdminRuntimeDiagnosticsResponse`, summary, runtime item, and startup warning summary near the existing admin diagnostics types. Include only fields used by the UI while allowing optional extra metadata.
+
+- [x] **Step 2: Add the API method**
+
+Add `getSandboxRuntimeDiagnostics()` to `TldwApiClientBase` and call:
+
+```ts
+return await bgRequest<SandboxAdminRuntimeDiagnosticsResponse>({
+  path: "/api/v1/sandbox/admin/runtime-diagnostics",
+  method: "GET"
+})
+```
+
+### Task 2: Write Failing Monitoring UI Test
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/Admin/__tests__/MonitoringDashboardPage.test.tsx`
+
+- [x] **Step 1: Extend the client mock**
+
+Add a `getSandboxRuntimeDiagnostics` mock and default response with no warning runtimes.
+
+- [x] **Step 2: Add host-local warning test**
+
+Create a test that returns `seatbelt` and `worktree` runtime rows with `isolation_warnings`, renders `MonitoringDashboardPage`, and expects:
+
+```ts
+expect(screen.getByText("Sandbox Runtime Isolation")).toBeTruthy()
+expect(screen.getByText("Host-local sandbox runtimes require operator review")).toBeTruthy()
+expect(screen.getByText("seatbelt")).toBeTruthy()
+expect(screen.getByText("worktree")).toBeTruthy()
+expect(screen.getByText(/not VM-grade isolation/i)).toBeTruthy()
+```
+
+- [x] **Step 3: Verify red**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/Option/Admin/__tests__/MonitoringDashboardPage.test.tsx --maxWorkers=1 --no-file-parallelism
+```
+
+Expected: fail because the card is not implemented yet.
+
+### Task 3: Render Sandbox Runtime Isolation Card
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/Admin/MonitoringDashboardPage.tsx`
+
+- [x] **Step 1: Add loading and diagnostics state**
+
+Add `sandboxDiagnostics` and `sandboxDiagnosticsLoading` state plus a `loadSandboxDiagnostics` callback. Mark admin guard errors the same way as other admin calls.
+
+- [x] **Step 2: Include diagnostics in refresh paths**
+
+Call `loadSandboxDiagnostics()` during initial load and `refreshAll()`.
+
+- [x] **Step 3: Render the card**
+
+Add a `Card` below System Overview titled `Sandbox Runtime Isolation`. Include:
+- summary counts for ready, unavailable, host-gated, and scaffold runtimes
+- an `Alert` when `summary.host_local_warning_runtimes` is non-empty
+- a small table with runtime, readiness, boundary, VM-grade status, untrusted eligibility, warning badges, and recommended action
+
+- [x] **Step 4: Verify green**
+
+Run the same focused Vitest command and confirm the new test passes.
+
+### Task 4: Final Verification And Task Closeout
+
+**Files:**
+- Modify: `backlog/tasks/task-94 - Show-sandbox-host-local-runtime-warnings-in-admin-UI.md`
+
+- [x] **Step 1: Run touched-file checks**
+
+Run:
+
+```bash
+git diff --check
+bunx vitest run apps/packages/ui/src/components/Option/Admin/__tests__/MonitoringDashboardPage.test.tsx --maxWorkers=1 --no-file-parallelism
+```
+
+- [x] **Step 2: Record Backlog completion**
+
+Update TASK-94 acceptance criteria, implementation notes, final summary, and Bandit skip rationale. Bandit is not applicable if the final diff is frontend/docs/backlog only.
+
+- [x] **Step 3: Commit**
+
+```bash
+git add Docs/superpowers/plans/2026-05-06-sandbox-host-local-warnings-ui.md apps/packages/ui/src/services/tldw/TldwApiClient.ts apps/packages/ui/src/components/Option/Admin/MonitoringDashboardPage.tsx apps/packages/ui/src/components/Option/Admin/__tests__/MonitoringDashboardPage.test.tsx "backlog/tasks/task-94 - Show-sandbox-host-local-runtime-warnings-in-admin-UI.md"
+git commit -m "feat(admin): show sandbox isolation warnings"
+```

--- a/apps/packages/ui/src/components/Option/Admin/MonitoringDashboardPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/MonitoringDashboardPage.tsx
@@ -91,6 +91,12 @@ const RUNTIME_WARNING_LABELS: Record<string, string> = {
   weaker_than_vm_isolation: "Weaker than VM isolation"
 }
 
+type SandboxDiagnosticsErrorState = {
+  title: string
+  description: string
+  alertType: "warning" | "error"
+}
+
 const MonitoringDashboardPage: React.FC = () => {
   // Admin guard state
   const [adminGuard, setAdminGuard] = useState<"forbidden" | "notFound" | null>(null)
@@ -105,7 +111,7 @@ const MonitoringDashboardPage: React.FC = () => {
   const [securityLoading, setSecurityLoading] = useState(false)
   const [sandboxDiagnostics, setSandboxDiagnostics] = useState<SandboxAdminRuntimeDiagnosticsResponse | null>(null)
   const [sandboxDiagnosticsLoading, setSandboxDiagnosticsLoading] = useState(false)
-  const [sandboxDiagnosticsError, setSandboxDiagnosticsError] = useState<string | null>(null)
+  const [sandboxDiagnosticsError, setSandboxDiagnosticsError] = useState<SandboxDiagnosticsErrorState | null>(null)
 
   // Alert rules state
   const [alertRules, setAlertRules] = useState<any[]>([])
@@ -166,10 +172,21 @@ const MonitoringDashboardPage: React.FC = () => {
       setSandboxDiagnostics(diagnostics)
       setSandboxDiagnosticsError(null)
     } catch (err: any) {
+      const guardState = deriveAdminGuardFromError(err)
+      const isForbidden = guardState === "forbidden"
       setSandboxDiagnostics(null)
-      setSandboxDiagnosticsError(
-        sanitizeAdminErrorMessage(err, "Sandbox runtime diagnostics are not available.")
-      )
+      setSandboxDiagnosticsError({
+        title: isForbidden
+          ? "Sandbox diagnostics access denied"
+          : "Sandbox diagnostics unavailable",
+        description: sanitizeAdminErrorMessage(
+          err,
+          isForbidden
+            ? "You don't have permission to view sandbox runtime diagnostics."
+            : "Sandbox runtime diagnostics are not available."
+        ),
+        alertType: isForbidden ? "error" : "warning"
+      })
     } finally {
       setSandboxDiagnosticsLoading(false)
     }
@@ -550,9 +567,9 @@ const MonitoringDashboardPage: React.FC = () => {
         <Space orientation="vertical" style={{ width: "100%" }} size="middle">
           {sandboxDiagnosticsError && (
             <Alert
-              type="warning"
-              title="Sandbox diagnostics unavailable"
-              description={sandboxDiagnosticsError}
+              type={sandboxDiagnosticsError.alertType}
+              title={sandboxDiagnosticsError.title}
+              description={sandboxDiagnosticsError.description}
               showIcon
             />
           )}

--- a/apps/packages/ui/src/components/Option/Admin/MonitoringDashboardPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/MonitoringDashboardPage.tsx
@@ -3,6 +3,7 @@ import {
   AutoComplete,
   Card,
   Table,
+  Descriptions,
   Button,
   InputNumber,
   Form,
@@ -21,7 +22,11 @@ import {
   sanitizeAdminErrorMessage
 } from "./admin-error-utils"
 import { CollapsibleSection } from "./CollapsibleSection"
-import { tldwClient } from "@/services/tldw/TldwApiClient"
+import {
+  tldwClient,
+  type SandboxAdminRuntimeDiagnosticsItem,
+  type SandboxAdminRuntimeDiagnosticsResponse
+} from "@/services/tldw/TldwApiClient"
 
 /** Format a stat value for display — handles objects, arrays, booleans, numbers */
 function formatStatValue(value: unknown): React.ReactNode {
@@ -63,6 +68,29 @@ function formatStatKey(key: string): string {
     .replace(/\b\w/g, (c) => c.toUpperCase())
 }
 
+function formatRuntimeCode(value: string | null | undefined): string {
+  if (!value) return "\u2014"
+  return value
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase())
+}
+
+const RUNTIME_READINESS_TAG_COLORS: Record<string, string> = {
+  ready: "green",
+  unavailable: "red",
+  host_gated: "gold",
+  scaffold: "blue",
+  unsupported: "default",
+  not_applicable: "default"
+}
+
+const RUNTIME_WARNING_LABELS: Record<string, string> = {
+  host_local_boundary: "Host-local boundary",
+  not_untrusted_eligible: "Not untrusted eligible",
+  sandbox_exec_deprecated: "sandbox-exec deprecated",
+  weaker_than_vm_isolation: "Weaker than VM isolation"
+}
+
 const MonitoringDashboardPage: React.FC = () => {
   // Admin guard state
   const [adminGuard, setAdminGuard] = useState<"forbidden" | "notFound" | null>(null)
@@ -75,6 +103,9 @@ const MonitoringDashboardPage: React.FC = () => {
   const [statsLoading, setStatsLoading] = useState(false)
   const [securityStatus, setSecurityStatus] = useState<any>(null)
   const [securityLoading, setSecurityLoading] = useState(false)
+  const [sandboxDiagnostics, setSandboxDiagnostics] = useState<SandboxAdminRuntimeDiagnosticsResponse | null>(null)
+  const [sandboxDiagnosticsLoading, setSandboxDiagnosticsLoading] = useState(false)
+  const [sandboxDiagnosticsError, setSandboxDiagnosticsError] = useState<string | null>(null)
 
   // Alert rules state
   const [alertRules, setAlertRules] = useState<any[]>([])
@@ -127,6 +158,22 @@ const MonitoringDashboardPage: React.FC = () => {
       setSecurityLoading(false)
     }
   }, [markAdminGuardFromError])
+
+  const loadSandboxDiagnostics = useCallback(async () => {
+    setSandboxDiagnosticsLoading(true)
+    try {
+      const diagnostics = await tldwClient.getSandboxRuntimeDiagnostics()
+      setSandboxDiagnostics(diagnostics)
+      setSandboxDiagnosticsError(null)
+    } catch (err: any) {
+      setSandboxDiagnostics(null)
+      setSandboxDiagnosticsError(
+        sanitizeAdminErrorMessage(err, "Sandbox runtime diagnostics are not available.")
+      )
+    } finally {
+      setSandboxDiagnosticsLoading(false)
+    }
+  }, [])
 
   // ── Alert Rules ──
 
@@ -237,11 +284,12 @@ const MonitoringDashboardPage: React.FC = () => {
   const refreshAll = useCallback(() => {
     void loadSystemStats()
     void loadSecurityStatus()
+    void loadSandboxDiagnostics()
     void loadAlertRules()
     void loadAlertHistory()
     void loadActivity()
     setLastRefreshedAt(new Date())
-  }, [loadSystemStats, loadSecurityStatus, loadAlertRules, loadAlertHistory, loadActivity])
+  }, [loadSystemStats, loadSecurityStatus, loadSandboxDiagnostics, loadAlertRules, loadAlertHistory, loadActivity])
 
   // ── Initial Load ──
 
@@ -250,6 +298,7 @@ const MonitoringDashboardPage: React.FC = () => {
     initialLoadRef.current = true
     void loadSystemStats()
     void loadSecurityStatus()
+    void loadSandboxDiagnostics()
     void loadAlertRules()
     void loadAlertHistory()
     void loadActivity()
@@ -260,7 +309,7 @@ const MonitoringDashboardPage: React.FC = () => {
       },
       () => { /* non-critical */ }
     )
-  }, [loadSystemStats, loadSecurityStatus, loadAlertRules, loadAlertHistory, loadActivity])
+  }, [loadSystemStats, loadSecurityStatus, loadSandboxDiagnostics, loadAlertRules, loadAlertHistory, loadActivity])
 
   // Auto-refresh timer
   useEffect(() => {
@@ -381,6 +430,71 @@ const MonitoringDashboardPage: React.FC = () => {
     }
   ]
 
+  const sandboxRuntimeColumns = [
+    {
+      title: "Runtime",
+      dataIndex: "name",
+      key: "name",
+      render: (name: string) => <code>{name}</code>
+    },
+    {
+      title: "Readiness",
+      dataIndex: "readiness",
+      key: "readiness",
+      render: (readiness: string) => (
+        <Tag color={RUNTIME_READINESS_TAG_COLORS[readiness] || "default"}>
+          {formatRuntimeCode(readiness)}
+        </Tag>
+      )
+    },
+    {
+      title: "Boundary",
+      dataIndex: "boundary_class",
+      key: "boundary_class",
+      render: (boundaryClass: string | null | undefined) => formatRuntimeCode(boundaryClass)
+    },
+    {
+      title: "VM-grade",
+      dataIndex: "vm_grade_isolation",
+      key: "vm_grade_isolation",
+      render: (vmGrade: boolean) => (
+        <Tag color={vmGrade ? "green" : "orange"}>{vmGrade ? "Yes" : "No"}</Tag>
+      )
+    },
+    {
+      title: "Untrusted",
+      dataIndex: "untrusted_eligible",
+      key: "untrusted_eligible",
+      render: (eligible: boolean) => (
+        <Tag color={eligible ? "green" : "red"}>{eligible ? "Eligible" : "Not eligible"}</Tag>
+      )
+    },
+    {
+      title: "Warnings",
+      dataIndex: "isolation_warnings",
+      key: "isolation_warnings",
+      render: (warnings: string[] | undefined) => {
+        const values = Array.isArray(warnings) ? warnings : []
+        if (values.length === 0) return <Tag color="green">None</Tag>
+        return (
+          <Space size={[4, 4]} wrap>
+            {values.map((warning) => (
+              <Tag key={warning} color="gold">
+                {RUNTIME_WARNING_LABELS[warning] || formatRuntimeCode(warning)}
+              </Tag>
+            ))}
+          </Space>
+        )
+      }
+    },
+    {
+      title: "Action",
+      dataIndex: "recommended_action",
+      key: "recommended_action",
+      render: (action: string | undefined) => formatRuntimeCode(action || "none")
+    }
+  ]
+
   // ── Render ──
 
   if (adminGuard === "forbidden") {
@@ -391,6 +505,12 @@ const MonitoringDashboardPage: React.FC = () => {
   }
 
   const activityEntries = Array.isArray(activity?.entries) ? activity.entries : Array.isArray(activity) ? activity : []
+  const sandboxRuntimeRows: SandboxAdminRuntimeDiagnosticsItem[] = Array.isArray(sandboxDiagnostics?.runtimes)
+    ? sandboxDiagnostics.runtimes
+    : []
+  const hostLocalWarningRuntimes = Array.isArray(sandboxDiagnostics?.summary?.host_local_warning_runtimes)
+    ? sandboxDiagnostics.summary.host_local_warning_runtimes
+    : []
 
   return (
     <div style={{ padding: "24px", maxWidth: 1200 }}>
@@ -423,6 +543,62 @@ const MonitoringDashboardPage: React.FC = () => {
           {!systemStats && !securityStatus && !statsLoading && !securityLoading && (
             <Alert type="info" title="No system data available yet." showIcon />
           )}
+        </Space>
+      </Card>
+
+      <Card title="Sandbox Runtime Isolation" loading={sandboxDiagnosticsLoading} style={{ marginBottom: 16 }} extra={<Button onClick={() => loadSandboxDiagnostics()} size="small">Refresh</Button>}>
+        <Space orientation="vertical" style={{ width: "100%" }} size="middle">
+          {sandboxDiagnosticsError && (
+            <Alert
+              type="warning"
+              title="Sandbox diagnostics unavailable"
+              description={sandboxDiagnosticsError}
+              showIcon
+            />
+          )}
+          {sandboxDiagnostics?.summary && (
+            <Descriptions size="small" column={5}>
+              <Descriptions.Item label="Total">
+                {sandboxDiagnostics.summary.total}
+              </Descriptions.Item>
+              <Descriptions.Item label="Ready">
+                {sandboxDiagnostics.summary.ready}
+              </Descriptions.Item>
+              <Descriptions.Item label="Unavailable">
+                {sandboxDiagnostics.summary.unavailable}
+              </Descriptions.Item>
+              <Descriptions.Item label="Host-gated">
+                {sandboxDiagnostics.summary.host_gated}
+              </Descriptions.Item>
+              <Descriptions.Item label="Scaffold">
+                {sandboxDiagnostics.summary.scaffold}
+              </Descriptions.Item>
+            </Descriptions>
+          )}
+          {hostLocalWarningRuntimes.length > 0 && (
+            <Alert
+              type="warning"
+              title="Host-local sandbox runtimes require operator review"
+              description={
+                <span>
+                  {hostLocalWarningRuntimes.join(", ")} run on host-local boundaries,
+                  are not VM-grade isolation, and are not eligible for untrusted code.
+                </span>
+              }
+              showIcon
+            />
+          )}
+          {sandboxRuntimeRows.length > 0 ? (
+            <Table<SandboxAdminRuntimeDiagnosticsItem>
+              dataSource={sandboxRuntimeRows}
+              columns={sandboxRuntimeColumns as any}
+              rowKey="name"
+              pagination={false}
+              size="small"
+            />
+          ) : !sandboxDiagnosticsLoading && !sandboxDiagnosticsError ? (
+            <Alert type="info" title="No sandbox runtime diagnostics available yet." showIcon />
+          ) : null}
         </Space>
       </Card>
 

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/MonitoringDashboardPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/MonitoringDashboardPage.test.tsx
@@ -183,6 +183,24 @@ describe("MonitoringDashboardPage", () => {
     expect(screen.getByText(/not VM-grade isolation/i)).toBeTruthy()
   })
 
+  it("distinguishes forbidden sandbox diagnostics from unavailable diagnostics", async () => {
+    mocks.getSandboxRuntimeDiagnostics.mockRejectedValue(
+      Object.assign(
+        new Error("Request failed: 403 (GET /api/v1/sandbox/admin/runtime-diagnostics)"),
+        { status: 403 }
+      )
+    )
+
+    render(<MonitoringDashboardPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText("Sandbox diagnostics access denied")).toBeTruthy()
+    })
+    expect(screen.queryByText("Sandbox diagnostics unavailable")).toBeNull()
+    expect(screen.getByText(/Request failed: 403/)).toBeTruthy()
+    expect(screen.queryByText(/\/api\/v1\/sandbox\/admin\/runtime-diagnostics/)).toBeNull()
+  })
+
   describe("MON-001: alert assignment uses correct user ID and field name", () => {
     it("fetches current user profile on mount", async () => {
       render(<MonitoringDashboardPage />)

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/MonitoringDashboardPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/MonitoringDashboardPage.test.tsx
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   snoozeAlert: vi.fn(),
   escalateAlert: vi.fn(),
   getDashboardActivity: vi.fn(),
+  getSandboxRuntimeDiagnostics: vi.fn(),
   getCurrentUserProfile: vi.fn()
 }))
 
@@ -31,6 +32,7 @@ vi.mock("@/services/tldw/TldwApiClient", () => ({
     snoozeAlert: (...args: unknown[]) => mocks.snoozeAlert(...args),
     escalateAlert: (...args: unknown[]) => mocks.escalateAlert(...args),
     getDashboardActivity: (...args: unknown[]) => mocks.getDashboardActivity(...args),
+    getSandboxRuntimeDiagnostics: (...args: unknown[]) => mocks.getSandboxRuntimeDiagnostics(...args),
     getCurrentUserProfile: (...args: unknown[]) => mocks.getCurrentUserProfile(...args)
   }
 }))
@@ -63,6 +65,20 @@ describe("MonitoringDashboardPage", () => {
     mocks.listAlertRules.mockResolvedValue([])
     mocks.listAlertHistory.mockResolvedValue([])
     mocks.getDashboardActivity.mockResolvedValue({ entries: [] })
+    mocks.getSandboxRuntimeDiagnostics.mockResolvedValue({
+      source: "feature_discovery",
+      summary: {
+        total: 0,
+        ready: 0,
+        unavailable: 0,
+        host_gated: 0,
+        scaffold: 0,
+        host_local_warning_runtimes: [],
+        repair_supported_runtimes: []
+      },
+      runtimes: [],
+      startup_warning_summary: null
+    })
     mocks.getCurrentUserProfile.mockResolvedValue({ id: 42, username: "admin" })
     mocks.createAlertRule.mockResolvedValue({ item: { id: 1 } })
     mocks.assignAlert.mockResolvedValue({})
@@ -101,6 +117,70 @@ describe("MonitoringDashboardPage", () => {
     await waitFor(() => {
       expect(screen.queryByText("No alert rules configured")).toBeNull()
     })
+  })
+
+  it("shows host-local sandbox runtime warnings for weaker isolation runtimes", async () => {
+    mocks.getSandboxRuntimeDiagnostics.mockResolvedValue({
+      source: "feature_discovery",
+      summary: {
+        total: 2,
+        ready: 2,
+        unavailable: 0,
+        host_gated: 0,
+        scaffold: 0,
+        host_local_warning_runtimes: ["seatbelt", "worktree"],
+        repair_supported_runtimes: []
+      },
+      runtimes: [
+        {
+          name: "seatbelt",
+          available: true,
+          implementation_state: "supported",
+          readiness: "ready",
+          reasons: [],
+          normalized_reasons: [],
+          boundary_class: "host_local",
+          vm_grade_isolation: false,
+          untrusted_eligible: false,
+          isolation_warnings: ["host_local_boundary", "not_untrusted_eligible"],
+          strict_deny_all_supported: false,
+          strict_allowlist_supported: false,
+          session_reuse_model: "none",
+          requires_live_health_check: false,
+          repair_supported: false,
+          recommended_action: "none"
+        },
+        {
+          name: "worktree",
+          available: true,
+          implementation_state: "supported",
+          readiness: "ready",
+          reasons: [],
+          normalized_reasons: [],
+          boundary_class: "host_local",
+          vm_grade_isolation: false,
+          untrusted_eligible: false,
+          isolation_warnings: ["host_local_boundary", "not_untrusted_eligible"],
+          strict_deny_all_supported: false,
+          strict_allowlist_supported: false,
+          session_reuse_model: "ephemeral",
+          requires_live_health_check: false,
+          repair_supported: false,
+          recommended_action: "inspect_reasons"
+        }
+      ],
+      startup_warning_summary: null
+    })
+
+    render(<MonitoringDashboardPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText("Sandbox Runtime Isolation")).toBeTruthy()
+    })
+    expect(screen.getByText("Host-local sandbox runtimes require operator review")).toBeTruthy()
+    expect(screen.getByText("seatbelt")).toBeTruthy()
+    expect(screen.getByText("worktree")).toBeTruthy()
+    expect(screen.getByText(/not VM-grade isolation/i)).toBeTruthy()
   })
 
   describe("MON-001: alert assignment uses correct user ID and field name", () => {

--- a/apps/packages/ui/src/services/tldw/TldwApiClient.ts
+++ b/apps/packages/ui/src/services/tldw/TldwApiClient.ts
@@ -1172,6 +1172,48 @@ export interface MediaIngestionBudgetDiagnostics {
   error?: string | null
 }
 
+export interface SandboxAdminRuntimeDiagnosticsSummary {
+  total: number
+  ready: number
+  unavailable: number
+  host_gated: number
+  scaffold: number
+  host_local_warning_runtimes?: string[]
+  repair_supported_runtimes?: string[]
+}
+
+export interface SandboxAdminRuntimeDiagnosticsItem {
+  name: string
+  available: boolean
+  implementation_state?: string | null
+  readiness: string
+  reasons?: string[]
+  normalized_reasons?: string[]
+  boundary_class?: string | null
+  vm_grade_isolation?: boolean
+  untrusted_eligible?: boolean
+  isolation_warnings?: string[]
+  strict_deny_all_supported?: boolean
+  strict_allowlist_supported?: boolean
+  session_reuse_model?: string | null
+  requires_live_health_check?: boolean
+  repair_supported?: boolean
+  recommended_action?: string
+}
+
+export interface SandboxAdminStartupWarningSummary {
+  present: boolean
+  blocking: boolean
+  codes?: string[]
+}
+
+export interface SandboxAdminRuntimeDiagnosticsResponse {
+  source: "feature_discovery"
+  summary: SandboxAdminRuntimeDiagnosticsSummary
+  runtimes: SandboxAdminRuntimeDiagnosticsItem[]
+  startup_warning_summary?: SandboxAdminStartupWarningSummary | null
+}
+
 export class TldwApiClientBase {
   private storage: Storage
   private config: TldwConfig | null = null
@@ -2051,6 +2093,13 @@ export class TldwApiClientBase {
     })
     return await bgRequest<MediaIngestionBudgetDiagnostics>({
       path: `/api/v1/resource-governor/diag/media-budget${query}`,
+      method: "GET"
+    })
+  }
+
+  async getSandboxRuntimeDiagnostics(): Promise<SandboxAdminRuntimeDiagnosticsResponse> {
+    return await bgRequest<SandboxAdminRuntimeDiagnosticsResponse>({
+      path: "/api/v1/sandbox/admin/runtime-diagnostics",
       method: "GET"
     })
   }

--- a/backlog/tasks/task-94 - Show-sandbox-host-local-runtime-warnings-in-admin-UI.md
+++ b/backlog/tasks/task-94 - Show-sandbox-host-local-runtime-warnings-in-admin-UI.md
@@ -36,18 +36,24 @@ Implement the approved next sandbox roadmap slice by showing host-local sandbox 
 
 <!-- SECTION:PLAN:BEGIN -->
 1. Inspect existing admin monitoring/server UI and API helper patterns. 2. Add a focused sandbox diagnostics data contract/helper if needed. 3. Write failing frontend tests for host-local warning rendering. 4. Implement the minimal admin UI section showing sandbox runtime status and warning badges. 5. Run targeted tests and touched-file checks; update docs/task notes.
+
+Review fix: verify Qodo's 403 diagnostics finding, add a focused failing test that a 403 from sandbox diagnostics renders an access-denied card state rather than the generic unavailable state, then keep 404/optional endpoint behavior unchanged while reusing existing admin error classification.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
 Implemented a read-only Sandbox Runtime Isolation card in MonitoringDashboardPage backed by tldwClient.getSandboxRuntimeDiagnostics(). The card summarizes readiness counts, lists runtime rows, and emits an explicit host-local warning when diagnostics reports seatbelt/worktree or other host-local warning runtimes. Added focused Vitest coverage with mocked seatbelt/worktree diagnostics. Verification: first focused Vitest run failed on the missing card as expected; after implementation the focused Vitest file passed; git diff --check passed; bun run verify:openapi passed after leaving the sandbox admin endpoint out of ClientPath because the current OSS OpenAPI verifier does not publish that admin route and AllowedPath remains intentionally wide. Bandit skipped because only frontend TypeScript, docs, and backlog files changed.
+
+PR #1336 review fix: verified Qodo's sandbox diagnostics 403 finding. The root cause was that the sandbox diagnostics card stored only a string error and always rendered the fixed "Sandbox diagnostics unavailable" title. Added a RED Vitest case for a 403 diagnostics response, then changed the card to preserve a small error state with title, sanitized description, and severity. 403 now renders "Sandbox diagnostics access denied"; non-forbidden failures keep the unavailable path. Verification: focused Vitest file passed 8/8, git diff --check passed, and bun run verify:openapi passed with the existing reviewed exceptions.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Added admin Monitoring UI propagation for sandbox host-local runtime warnings. Operators now see a Sandbox Runtime Isolation card with runtime readiness, boundary class, VM-grade status, untrusted eligibility, warning badges, and recommended action. Host-local runtimes from diagnostics, including seatbelt and worktree, show a warning that they are not VM-grade isolation and are not eligible for untrusted code. Added a focused mocked diagnostics test for seatbelt/worktree. Verification: red/green focused Vitest, final focused Vitest pass, git diff --check, and verify:openapi. Bandit skipped as non-Python/frontend-docs-only.
+
+Review follow-up: sandbox diagnostics 403 responses are now labeled as access denied instead of generic unavailable diagnostics, while sanitized descriptions and optional-endpoint behavior remain scoped to the card. Added regression coverage for the 403 path.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-94 - Show-sandbox-host-local-runtime-warnings-in-admin-UI.md
+++ b/backlog/tasks/task-94 - Show-sandbox-host-local-runtime-warnings-in-admin-UI.md
@@ -1,0 +1,61 @@
+---
+id: TASK-94
+title: Show sandbox host-local runtime warnings in admin UI
+status: Done
+assignee: []
+created_date: '2026-05-06 01:28'
+updated_date: '2026-05-06 01:36'
+labels:
+  - sandbox
+  - frontend
+  - admin
+dependencies: []
+documentation:
+  - Docs/Sandbox/sandbox-runtime-capability-inventory.md
+  - Docs/API-related/Sandbox_API.md
+  - tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
+  - Docs/superpowers/plans/2026-05-06-sandbox-host-local-warnings-ui.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the approved next sandbox roadmap slice by showing host-local sandbox runtime warnings in the existing admin monitoring UI. The UI should consume the current admin runtime diagnostics endpoint, keep the surface read-only, and make weaker host-local isolation for seatbelt/worktree visible to operators without creating a new dashboard route.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Admin UI surfaces sandbox runtime diagnostics without adding a new dashboard route.
+- [x] #2 Host-local runtime warnings for seatbelt and worktree are visible to operators with clear weaker-isolation language.
+- [x] #3 Focused frontend tests cover mocked diagnostics payloads for seatbelt and worktree.
+- [x] #4 Verification includes targeted frontend tests, touched-file checks, and Bandit skip or run rationale.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Inspect existing admin monitoring/server UI and API helper patterns. 2. Add a focused sandbox diagnostics data contract/helper if needed. 3. Write failing frontend tests for host-local warning rendering. 4. Implement the minimal admin UI section showing sandbox runtime status and warning badges. 5. Run targeted tests and touched-file checks; update docs/task notes.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented a read-only Sandbox Runtime Isolation card in MonitoringDashboardPage backed by tldwClient.getSandboxRuntimeDiagnostics(). The card summarizes readiness counts, lists runtime rows, and emits an explicit host-local warning when diagnostics reports seatbelt/worktree or other host-local warning runtimes. Added focused Vitest coverage with mocked seatbelt/worktree diagnostics. Verification: first focused Vitest run failed on the missing card as expected; after implementation the focused Vitest file passed; git diff --check passed; bun run verify:openapi passed after leaving the sandbox admin endpoint out of ClientPath because the current OSS OpenAPI verifier does not publish that admin route and AllowedPath remains intentionally wide. Bandit skipped because only frontend TypeScript, docs, and backlog files changed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added admin Monitoring UI propagation for sandbox host-local runtime warnings. Operators now see a Sandbox Runtime Isolation card with runtime readiness, boundary class, VM-grade status, untrusted eligibility, warning badges, and recommended action. Host-local runtimes from diagnostics, including seatbelt and worktree, show a warning that they are not VM-grade isolation and are not eligible for untrusted code. Added a focused mocked diagnostics test for seatbelt/worktree. Verification: red/green focused Vitest, final focused Vitest pass, git diff --check, and verify:openapi. Bandit skipped as non-Python/frontend-docs-only.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Add a read-only Sandbox Runtime Isolation card to the admin Monitoring page, backed by GET /api/v1/sandbox/admin/runtime-diagnostics.
- Surface readiness counts, runtime boundary/isolation metadata, warning badges, and recommended actions for sandbox runtimes.
- Add focused mocked diagnostics coverage for host-local seatbelt and worktree warnings.

## Test Plan
- [x] git diff --check origin/dev..HEAD
- [x] ./node_modules/.bin/vitest run src/components/Option/Admin/__tests__/MonitoringDashboardPage.test.tsx --maxWorkers=1 --no-file-parallelism
- [x] bun run verify:openapi
- [x] Bandit skipped: frontend TypeScript/docs/backlog-only change

## Change summary
Human-written Change summary will be added by the maintainer before merge.