### PR TITLE
Adapt FeatureEmptyState to shared EmptyState

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -803,28 +803,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "canonical-state-label:src/components/Option/Admin/MonitoringDashboardPage.tsx:Ready",
-    "path": "src/components/Option/Admin/MonitoringDashboardPage.tsx",
-    "rule": "canonical-state-label",
-    "subject": "Ready",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing canonical-state-label product-state UI in src/components/Option/Admin/MonitoringDashboardPage.tsx before the guard.",
-    "replacement": "design-system state registry",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "canonical-state-label:src/components/Option/Admin/MonitoringDashboardPage.tsx:Unavailable",
-    "path": "src/components/Option/Admin/MonitoringDashboardPage.tsx",
-    "rule": "canonical-state-label",
-    "subject": "Unavailable",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing canonical-state-label product-state UI in src/components/Option/Admin/MonitoringDashboardPage.tsx before the guard.",
-    "replacement": "design-system state registry",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-error-access-den-15hzb7i",
     "path": "src/components/Option/Admin/MonitoringDashboardPage.tsx",
     "rule": "antd-product-state-import",
@@ -5189,6 +5167,28 @@
     "owner": "design-system",
     "reason": "Existing hardcoded \"Ready\" state label in src/components/Option/ACPPlayground/ACPSessionCreateModal.tsx before the guard.",
     "replacement": "getDesignSystemState(...)",
+    "migrationQueue": "shared-product-state"
+  },
+  {
+    "id": "canonical-state-label:src/components/Option/Admin/MonitoringDashboardPage.tsx:Ready",
+    "path": "src/components/Option/Admin/MonitoringDashboardPage.tsx",
+    "rule": "canonical-state-label",
+    "subject": "Ready",
+    "state": "allowed_legacy_exception",
+    "owner": "design-system",
+    "reason": "Existing canonical-state-label product-state UI in src/components/Option/Admin/MonitoringDashboardPage.tsx before the guard.",
+    "replacement": "design-system state registry",
+    "migrationQueue": "shared-product-state"
+  },
+  {
+    "id": "canonical-state-label:src/components/Option/Admin/MonitoringDashboardPage.tsx:Unavailable",
+    "path": "src/components/Option/Admin/MonitoringDashboardPage.tsx",
+    "rule": "canonical-state-label",
+    "subject": "Unavailable",
+    "state": "allowed_legacy_exception",
+    "owner": "design-system",
+    "reason": "Existing canonical-state-label product-state UI in src/components/Option/Admin/MonitoringDashboardPage.tsx before the guard.",
+    "replacement": "design-system state registry",
     "migrationQueue": "shared-product-state"
   },
   {

--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -803,7 +803,29 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-error-access-den-jtxcdw",
+    "id": "canonical-state-label:src/components/Option/Admin/MonitoringDashboardPage.tsx:Ready",
+    "path": "src/components/Option/Admin/MonitoringDashboardPage.tsx",
+    "rule": "canonical-state-label",
+    "subject": "Ready",
+    "state": "allowed_legacy_exception",
+    "owner": "design-system",
+    "reason": "Existing canonical-state-label product-state UI in src/components/Option/Admin/MonitoringDashboardPage.tsx before the guard.",
+    "replacement": "design-system state registry",
+    "migrationQueue": "shared-product-state"
+  },
+  {
+    "id": "canonical-state-label:src/components/Option/Admin/MonitoringDashboardPage.tsx:Unavailable",
+    "path": "src/components/Option/Admin/MonitoringDashboardPage.tsx",
+    "rule": "canonical-state-label",
+    "subject": "Unavailable",
+    "state": "allowed_legacy_exception",
+    "owner": "design-system",
+    "reason": "Existing canonical-state-label product-state UI in src/components/Option/Admin/MonitoringDashboardPage.tsx before the guard.",
+    "replacement": "design-system state registry",
+    "migrationQueue": "shared-product-state"
+  },
+  {
+    "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-error-access-den-15hzb7i",
     "path": "src/components/Option/Admin/MonitoringDashboardPage.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -814,7 +836,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-info-no-alert-ru-tdtxs4",
+    "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-warning-not-avai-fzf6y",
     "path": "src/components/Option/Admin/MonitoringDashboardPage.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -825,7 +847,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-info-no-recent-a-4nh5p8",
+    "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-info-no-system-d-1qxngtg",
     "path": "src/components/Option/Admin/MonitoringDashboardPage.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -836,7 +858,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-info-no-system-d-ve9d2w",
+    "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-warning-host-loc-14cd7e9",
     "path": "src/components/Option/Admin/MonitoringDashboardPage.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -847,13 +869,35 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-warning-not-avai-7mpwwo",
+    "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-info-no-sandbox-uqls7g",
     "path": "src/components/Option/Admin/MonitoringDashboardPage.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
     "state": "allowed_legacy_exception",
     "owner": "design-system",
     "reason": "Existing AntD Alert product-state UI in src/components/Option/Admin/MonitoringDashboardPage.tsx before the stable duplicate-id guard.",
+    "replacement": "tldw design-system state primitive",
+    "migrationQueue": "shared-product-state"
+  },
+  {
+    "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-info-no-alert-ru-1esujwv",
+    "path": "src/components/Option/Admin/MonitoringDashboardPage.tsx",
+    "rule": "antd-product-state-import",
+    "subject": "Alert",
+    "state": "allowed_legacy_exception",
+    "owner": "design-system",
+    "reason": "Existing antd-product-state-import product-state UI in src/components/Option/Admin/MonitoringDashboardPage.tsx before the guard.",
+    "replacement": "tldw design-system state primitive",
+    "migrationQueue": "shared-product-state"
+  },
+  {
+    "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-info-no-recent-a-xv18cq",
+    "path": "src/components/Option/Admin/MonitoringDashboardPage.tsx",
+    "rule": "antd-product-state-import",
+    "subject": "Alert",
+    "state": "allowed_legacy_exception",
+    "owner": "design-system",
+    "reason": "Existing antd-product-state-import product-state UI in src/components/Option/Admin/MonitoringDashboardPage.tsx before the guard.",
     "replacement": "tldw design-system state primitive",
     "migrationQueue": "shared-product-state"
   },
@@ -5489,17 +5533,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "local-empty-state:src/components/Common/FeatureEmptyState.tsx:FeatureEmptyState",
-    "path": "src/components/Common/FeatureEmptyState.tsx",
-    "rule": "local-empty-state",
-    "subject": "FeatureEmptyState",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing local FeatureEmptyState empty-state wrapper before the guard.",
-    "replacement": "EmptyState",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "local-empty-state:src/components/Knowledge/SearchTab/SearchEmptyState.tsx:SearchEmptyState",
     "path": "src/components/Knowledge/SearchTab/SearchEmptyState.tsx",
     "rule": "local-empty-state",
@@ -5507,17 +5540,6 @@
     "state": "allowed_legacy_exception",
     "owner": "design-system",
     "reason": "Existing local SearchEmptyState empty-state wrapper before the guard.",
-    "replacement": "EmptyState",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "local-empty-state:src/components/Option/Playground/PlaygroundEmpty.tsx:PlaygroundEmpty",
-    "path": "src/components/Option/Playground/PlaygroundEmpty.tsx",
-    "rule": "local-empty-state",
-    "subject": "PlaygroundEmpty",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing local PlaygroundEmpty empty-state wrapper before the guard.",
     "replacement": "EmptyState",
     "migrationQueue": "shared-product-state"
   },

--- a/apps/packages/ui/scripts/design-system-product-state-rules.mjs
+++ b/apps/packages/ui/scripts/design-system-product-state-rules.mjs
@@ -143,13 +143,14 @@ export function analyzeSource({ relativePath, source }) {
 
   const findings = []
   const localAntdNames = collectAntdProductStateImports(sourceFile)
+  const canonicalUsage = collectCanonicalDesignSystemUsage(sourceFile)
   const fileSubject = subjectFromPath(normalizedPath)
   const localComponentSubjects = normalizedPath.endsWith(".tsx")
     ? collectLocalComponentSubjects(sourceFile, fileSubject)
     : []
 
   for (const subject of localComponentSubjects) {
-    pushLocalComponentFinding(findings, normalizedPath, subject)
+    pushLocalComponentFinding(findings, normalizedPath, subject, canonicalUsage)
   }
 
   pushCanonicalLabelFindings(findings, normalizedPath, sourceFile)
@@ -391,6 +392,48 @@ function collectAntdProductStateImports(sourceFile) {
   return localNames
 }
 
+function collectCanonicalDesignSystemUsage(sourceFile) {
+  const imports = {
+    emptyState: new Set()
+  }
+
+  for (const statement of sourceFile.statements) {
+    if (
+      !ts.isImportDeclaration(statement) ||
+      !ts.isStringLiteral(statement.moduleSpecifier)
+    ) {
+      continue
+    }
+
+    const importPath = statement.moduleSpecifier.text
+    if (
+      !importPath.startsWith("@/components/ui") &&
+      !importPath.startsWith("@tldw/ui/components/ui")
+    ) {
+      continue
+    }
+
+    const importClause = statement.importClause
+    const namedBindings = importClause?.namedBindings
+    if (namedBindings && ts.isNamedImports(namedBindings)) {
+      for (const element of namedBindings.elements) {
+        const importedName = element.propertyName?.text ?? element.name.text
+        if (importedName === "EmptyState") {
+          imports.emptyState.add(element.name.text)
+        }
+      }
+    }
+
+    if (importClause?.name && /\/EmptyState$/.test(importPath)) {
+      imports.emptyState.add(importClause.name.text)
+    }
+  }
+
+  return {
+    emptyState: hasJsxTag(sourceFile, imports.emptyState)
+  }
+}
+
 function collectLocalComponentSubjects(sourceFile, fileSubject) {
   const subjects = new Set([fileSubject])
 
@@ -434,7 +477,12 @@ function collectLocalComponentSubjects(sourceFile, fileSubject) {
   return subjects
 }
 
-function pushLocalComponentFinding(findings, relativePath, subject) {
+function pushLocalComponentFinding(
+  findings,
+  relativePath,
+  subject,
+  canonicalUsage = {}
+) {
   if (!subject) {
     return
   }
@@ -448,7 +496,7 @@ function pushLocalComponentFinding(findings, relativePath, subject) {
     })
   }
 
-  if (EMPTY_COMPONENT_PATTERN.test(subject)) {
+  if (EMPTY_COMPONENT_PATTERN.test(subject) && !canonicalUsage.emptyState) {
     pushFinding(findings, {
       relativePath,
       rule: "local-empty-state",
@@ -474,6 +522,25 @@ function pushLocalComponentFinding(findings, relativePath, subject) {
       message: `${subject} should map status through the design system.`
     })
   }
+}
+
+function hasJsxTag(sourceFile, localNames) {
+  if (!localNames || localNames.size === 0) {
+    return false
+  }
+
+  let hasMatch = false
+  walkUntil(sourceFile, (node) => {
+    if (!ts.isJsxSelfClosingElement(node) && !ts.isJsxOpeningElement(node)) {
+      return false
+    }
+
+    const localName = jsxTagName(node.tagName)
+    hasMatch = localName ? localNames.has(localName) : false
+    return hasMatch
+  })
+
+  return hasMatch
 }
 
 function pushCanonicalLabelFindings(findings, relativePath, sourceFile) {

--- a/apps/packages/ui/scripts/design-system-product-state-rules.mjs
+++ b/apps/packages/ui/scripts/design-system-product-state-rules.mjs
@@ -143,8 +143,11 @@ export function analyzeSource({ relativePath, source }) {
 
   const findings = []
   const localAntdNames = collectAntdProductStateImports(sourceFile)
-  const canonicalUsage = collectCanonicalDesignSystemUsage(sourceFile)
   const fileSubject = subjectFromPath(normalizedPath)
+  const canonicalUsage = collectCanonicalDesignSystemUsage(
+    sourceFile,
+    fileSubject
+  )
   const localComponentSubjects = normalizedPath.endsWith(".tsx")
     ? collectLocalComponentSubjects(sourceFile, fileSubject)
     : []
@@ -392,7 +395,7 @@ function collectAntdProductStateImports(sourceFile) {
   return localNames
 }
 
-function collectCanonicalDesignSystemUsage(sourceFile) {
+function collectCanonicalDesignSystemUsage(sourceFile, fileSubject) {
   const imports = {
     emptyState: new Set()
   }
@@ -430,7 +433,11 @@ function collectCanonicalDesignSystemUsage(sourceFile) {
   }
 
   return {
-    emptyState: hasJsxTag(sourceFile, imports.emptyState)
+    emptyStateOwners: collectJsxTagOwners(
+      sourceFile,
+      imports.emptyState,
+      fileSubject
+    )
   }
 }
 
@@ -496,7 +503,10 @@ function pushLocalComponentFinding(
     })
   }
 
-  if (EMPTY_COMPONENT_PATTERN.test(subject) && !canonicalUsage.emptyState) {
+  if (
+    EMPTY_COMPONENT_PATTERN.test(subject) &&
+    !canonicalUsage.emptyStateOwners?.has(subject)
+  ) {
     pushFinding(findings, {
       relativePath,
       rule: "local-empty-state",
@@ -524,23 +534,30 @@ function pushLocalComponentFinding(
   }
 }
 
-function hasJsxTag(sourceFile, localNames) {
+function collectJsxTagOwners(sourceFile, localNames, fallbackOwner) {
+  const owners = new Set()
+
   if (!localNames || localNames.size === 0) {
-    return false
+    return owners
   }
 
-  let hasMatch = false
-  walkUntil(sourceFile, (node) => {
+  walk(sourceFile, (node) => {
     if (!ts.isJsxSelfClosingElement(node) && !ts.isJsxOpeningElement(node)) {
-      return false
+      return
     }
 
     const localName = jsxTagName(node.tagName)
-    hasMatch = localName ? localNames.has(localName) : false
-    return hasMatch
+    if (!localName || !localNames.has(localName)) {
+      return
+    }
+
+    const ownerName = findNearestOwnerName(node) ?? fallbackOwner
+    if (ownerName) {
+      owners.add(ownerName)
+    }
   })
 
-  return hasMatch
+  return owners
 }
 
 function pushCanonicalLabelFindings(findings, relativePath, sourceFile) {

--- a/apps/packages/ui/src/components/Common/FeatureEmptyState.tsx
+++ b/apps/packages/ui/src/components/Common/FeatureEmptyState.tsx
@@ -1,6 +1,6 @@
 import React from "react"
-import { Button } from "antd"
 import type { LucideIcon } from "lucide-react"
+import { EmptyState } from "@/components/ui/feedback/EmptyState"
 
 type FeatureEmptyStateProps = {
   title: React.ReactNode
@@ -33,77 +33,43 @@ const FeatureEmptyState: React.FC<FeatureEmptyStateProps> = ({
   icon: Icon,
   iconClassName
 }) => {
-  const actionFocusClassName =
-    "focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
   return (
-    <div
-      className={
-        "mx-auto max-w-xl rounded-3xl border border-border/80 bg-surface/90 p-7 text-sm text-text shadow-card backdrop-blur " +
-        (className || "")
-      }>
-      <div className="space-y-3">
-        {Icon && (
-          <div className="flex justify-center">
-            <div className="rounded-full bg-surface2/80 p-3">
-              <Icon
-                className={iconClassName || "h-8 w-8 text-text-subtle"}
-                aria-hidden="true"
-              />
-            </div>
-          </div>
-        )}
-        <h2 className={`text-lg font-semibold text-text ${Icon ? "text-center" : ""}`}>
-          {title}
-        </h2>
-        {description && (
-          <div className="text-sm text-text-muted">
-            {description}
-          </div>
-        )}
-        {examples && examples.length > 0 && (
-          <div className="text-xs text-text-muted">
-            <ul className="list-disc pl-4 space-y-1">
-              {examples.map((example, index) => (
-                <li key={index}>{example}</li>
-              ))}
-            </ul>
-          </div>
-        )}
-        {(primaryActionLabel || secondaryActionLabel) && (
-          <div className="mt-3 flex flex-wrap gap-2">
-            {primaryActionLabel && (
-              <Button
-                type="primary"
-                size="small"
-                onClick={onPrimaryAction}
-                title={
-                  typeof primaryActionLabel === "string"
-                    ? primaryActionLabel
-                    : undefined
-                }
-                className={`mr-1 rounded-full px-4 text-[11px] font-semibold uppercase tracking-[0.08em] ${actionFocusClassName}`}
-                disabled={primaryDisabled}>
-                {primaryActionLabel}
-              </Button>
-            )}
-            {secondaryActionLabel && (
-              <Button
-                size="small"
-                onClick={onSecondaryAction}
-                title={
-                  typeof secondaryActionLabel === "string"
-                    ? secondaryActionLabel
-                    : undefined
-                }
-                className={`rounded-full px-4 text-[11px] font-semibold uppercase tracking-[0.08em] ${actionFocusClassName}`}
-                disabled={secondaryDisabled}>
-                {secondaryActionLabel}
-              </Button>
-            )}
-          </div>
-        )}
-      </div>
-    </div>
+    <EmptyState
+      title={title}
+      description={description}
+      examples={examples}
+      icon={Icon}
+      iconClassName={iconClassName}
+      size="lg"
+      variant="card"
+      className={className}
+      primaryAction={
+        primaryActionLabel
+          ? {
+              label: primaryActionLabel,
+              onClick: onPrimaryAction,
+              disabled: primaryDisabled,
+              title:
+                typeof primaryActionLabel === "string"
+                  ? primaryActionLabel
+                  : undefined
+            }
+          : undefined
+      }
+      secondaryAction={
+        secondaryActionLabel
+          ? {
+              label: secondaryActionLabel,
+              onClick: onSecondaryAction,
+              disabled: secondaryDisabled,
+              title:
+                typeof secondaryActionLabel === "string"
+                  ? secondaryActionLabel
+                  : undefined
+            }
+          : undefined
+      }
+    />
   )
 }
 

--- a/apps/packages/ui/src/components/Common/__tests__/FeatureEmptyState.test.tsx
+++ b/apps/packages/ui/src/components/Common/__tests__/FeatureEmptyState.test.tsx
@@ -1,53 +1,63 @@
 import React from "react"
+import { Archive } from "lucide-react"
 import { describe, expect, it, vi } from "vitest"
-import { render, screen } from "@testing-library/react"
+import { fireEvent, render, screen } from "@testing-library/react"
 import FeatureEmptyState from "../FeatureEmptyState"
 
-vi.mock("antd", () => ({
-  Button: ({ children, className, ...props }: any) => (
-    <button className={className} {...props}>
-      {children}
-    </button>
-  ),
-}))
-
 describe("FeatureEmptyState", () => {
-  it("uses semantic surface/text token classes for container content", () => {
+  it("adapts legacy empty states to the canonical EmptyState primitive", () => {
     const { container } = render(
       <FeatureEmptyState
+        className="library-empty"
+        icon={Archive}
+        iconClassName="text-primary"
         title="No items yet"
         description="Create your first item to continue."
+        examples={["Upload a document", "Import a saved item"]}
       />
     )
 
-    const root = container.firstElementChild
+    const root = container.querySelector('[data-ds-component="EmptyState"]')
     expect(root).toBeTruthy()
     expect(root?.className).toContain("bg-surface/90")
     expect(root?.className).toContain("border-border/80")
-    expect(root?.className).toContain("text-text")
+    expect(root?.className).toContain("library-empty")
+    expect(
+      screen.getByRole("heading", { name: "No items yet" })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("Create your first item to continue.")
+    ).toBeInTheDocument()
+    expect(screen.getByText("Upload a document")).toBeInTheDocument()
+    expect(screen.getByText("Import a saved item")).toBeInTheDocument()
   })
 
-  it("applies focus-visible classes to empty-state action buttons", () => {
+  it("preserves legacy action labels, handlers, disabled states and title attributes", () => {
+    const onPrimaryAction = vi.fn()
+    const onSecondaryAction = vi.fn()
+
     render(
       <FeatureEmptyState
         title="No prompts"
         primaryActionLabel="Create prompt"
         secondaryActionLabel="Import prompt"
-        onPrimaryAction={vi.fn()}
-        onSecondaryAction={vi.fn()}
+        onPrimaryAction={onPrimaryAction}
+        onSecondaryAction={onSecondaryAction}
+        secondaryDisabled
       />
     )
 
-    const controls = [
-      screen.getByRole("button", { name: "Create prompt" }),
-      screen.getByRole("button", { name: "Import prompt" }),
-    ]
+    const primary = screen.getByRole("button", { name: "Create prompt" })
+    const secondary = screen.getByRole("button", { name: "Import prompt" })
 
-    for (const control of controls) {
-      expect(control.className).toContain("focus-visible:ring-2")
-      expect(control.className).toContain("focus-visible:ring-focus")
-      expect(control.className).toContain("focus-visible:ring-offset-2")
-      expect(control.className).toContain("focus-visible:ring-offset-bg")
-    }
+    expect(primary).toHaveAttribute("title", "Create prompt")
+    expect(secondary).toHaveAttribute("title", "Import prompt")
+    expect(secondary).toBeDisabled()
+
+    fireEvent.click(primary)
+    fireEvent.click(secondary)
+
+    expect(onPrimaryAction).toHaveBeenCalledTimes(1)
+    expect(onSecondaryAction).not.toHaveBeenCalled()
   })
 })

--- a/apps/packages/ui/src/components/Review/__tests__/MediaTrashPage.connection.test.tsx
+++ b/apps/packages/ui/src/components/Review/__tests__/MediaTrashPage.connection.test.tsx
@@ -39,7 +39,10 @@ vi.mock("react-i18next", () => ({
     ) => {
       if (typeof fallbackOrOptions === "string") return fallbackOrOptions
       const template = fallbackOrOptions?.defaultValue || key
-      return interpolate(template, fallbackOrOptions as Record<string, unknown> | undefined)
+      return interpolate(
+        template,
+        fallbackOrOptions as Record<string, unknown> | undefined
+      )
     }
   })
 }))
@@ -51,7 +54,10 @@ vi.mock("react-router-dom", () => ({
 vi.mock("@tanstack/react-query", () => ({
   keepPreviousData: {},
   useQuery: () => ({
-    data: { items: [], pagination: { page: 1, total_pages: 1, total_items: 0 } },
+    data: {
+      items: [],
+      pagination: { page: 1, total_pages: 1, total_items: 0 }
+    },
     isLoading: false,
     isFetching: false,
     isError: false,
@@ -105,39 +111,6 @@ vi.mock("@/services/tldw/path-utils", () => ({
   toAllowedPath: (path: string) => path
 }))
 
-vi.mock("@/components/Common/FeatureEmptyState", () => ({
-  default: ({
-    title,
-    description,
-    primaryActionLabel,
-    onPrimaryAction,
-    secondaryActionLabel,
-    onSecondaryAction
-  }: {
-    title: React.ReactNode
-    description?: React.ReactNode
-    primaryActionLabel?: React.ReactNode
-    onPrimaryAction?: () => void
-    secondaryActionLabel?: React.ReactNode
-    onSecondaryAction?: () => void
-  }) => (
-    <div data-testid="feature-empty-state">
-      <div>{title}</div>
-      {description ? <div>{description}</div> : null}
-      {primaryActionLabel ? (
-        <button type="button" onClick={onPrimaryAction}>
-          {primaryActionLabel}
-        </button>
-      ) : null}
-      {secondaryActionLabel ? (
-        <button type="button" onClick={onSecondaryAction}>
-          {secondaryActionLabel}
-        </button>
-      ) : null}
-    </div>
-  )
-}))
-
 vi.mock("@/components/Media/Pagination", () => ({
   Pagination: () => <div />
 }))
@@ -161,7 +134,11 @@ describe("MediaTrashPage connection states", () => {
 
     render(<MediaTrashPage />)
 
-    expect(screen.getByText("Add your credentials to use Media")).toBeInTheDocument()
+    const title = screen.getByText("Add your credentials to use Media")
+    expect(title).toBeInTheDocument()
+    expect(
+      title.closest('[data-ds-component="EmptyState"]')
+    ).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole("button", { name: "Open Settings" }))
     expect(mocks.navigate).toHaveBeenCalledWith("/settings/tldw")
@@ -193,7 +170,9 @@ describe("MediaTrashPage connection states", () => {
     fireEvent.click(screen.getByRole("button", { name: "Retry connection" }))
     expect(mocks.checkOnce).toHaveBeenCalled()
 
-    fireEvent.click(screen.getByRole("button", { name: "Health & diagnostics" }))
+    fireEvent.click(
+      screen.getByRole("button", { name: "Health & diagnostics" })
+    )
     expect(mocks.navigate).toHaveBeenCalledWith("/settings/health")
   })
 })

--- a/apps/packages/ui/src/components/ui/feedback/EmptyState.tsx
+++ b/apps/packages/ui/src/components/ui/feedback/EmptyState.tsx
@@ -9,6 +9,8 @@ export type EmptyStateSize = "sm" | "md" | "lg";
 export interface EmptyStateAction {
   /** Button label */
   label: React.ReactNode;
+  /** Native title text for compatibility with legacy wrappers */
+  title?: string;
   /** Click handler */
   onClick?: () => void;
   /** Show loading spinner */
@@ -254,6 +256,7 @@ export const EmptyState = React.forwardRef<HTMLDivElement, EmptyStateProps>(
                   onClick={primaryAction.onClick}
                   loading={primaryAction.loading}
                   disabled={primaryAction.disabled}
+                  title={primaryAction.title}
                 >
                   {primaryAction.label}
                 </Button>
@@ -265,6 +268,7 @@ export const EmptyState = React.forwardRef<HTMLDivElement, EmptyStateProps>(
                   onClick={secondaryAction.onClick}
                   loading={secondaryAction.loading}
                   disabled={secondaryAction.disabled}
+                  title={secondaryAction.title}
                 >
                   {secondaryAction.label}
                 </Button>

--- a/apps/packages/ui/src/design-system/__tests__/product-state-guard.test.ts
+++ b/apps/packages/ui/src/design-system/__tests__/product-state-guard.test.ts
@@ -109,6 +109,40 @@ describe("design-system product-state guard rules", () => {
     )
   })
 
+  it("still flags sibling empty-state components that do not render canonical EmptyState", () => {
+    const findings = analyze(
+      "src/components/Common/FeatureEmptyState.tsx",
+      `
+        import { EmptyState } from "@/components/ui/feedback/EmptyState"
+
+        export function FeatureEmptyState() {
+          return <EmptyState title="No results yet" />
+        }
+
+        export function LegacyEmptyState() {
+          return <div>No results yet</div>
+        }
+      `
+    )
+
+    expect(findings).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          rule: "local-empty-state",
+          subject: "FeatureEmptyState"
+        })
+      ])
+    )
+    expect(findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          rule: "local-empty-state",
+          subject: "LegacyEmptyState"
+        })
+      ])
+    )
+  })
+
   it("flags AntD product-state JSX only when product-state context is present", () => {
     const findings = analyze(
       "src/components/Option/Settings/health-status.tsx",

--- a/apps/packages/ui/src/design-system/__tests__/product-state-guard.test.ts
+++ b/apps/packages/ui/src/design-system/__tests__/product-state-guard.test.ts
@@ -87,6 +87,28 @@ describe("design-system product-state guard rules", () => {
     )
   })
 
+  it("allows compatibility empty-state adapters that render the canonical EmptyState", () => {
+    const findings = analyze(
+      "src/components/Common/FeatureEmptyState.tsx",
+      `
+        import { EmptyState } from "@/components/ui/feedback/EmptyState"
+
+        export function FeatureEmptyState() {
+          return <EmptyState title="No results yet" />
+        }
+      `
+    )
+
+    expect(findings).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          rule: "local-empty-state",
+          subject: "FeatureEmptyState"
+        })
+      ])
+    )
+  })
+
   it("flags AntD product-state JSX only when product-state context is present", () => {
     const findings = analyze(
       "src/components/Option/Settings/health-status.tsx",

--- a/backlog/tasks/task-45.11 - Adapt-FeatureEmptyState-to-shared-EmptyState.md
+++ b/backlog/tasks/task-45.11 - Adapt-FeatureEmptyState-to-shared-EmptyState.md
@@ -4,7 +4,7 @@ title: Adapt FeatureEmptyState to shared EmptyState
 status: Done
 assignee: []
 created_date: '2026-05-06 05:50'
-updated_date: '2026-05-06 06:05'
+updated_date: '2026-05-06 15:12'
 labels:
   - design-system
   - frontend
@@ -41,12 +41,18 @@ Started Ingestion/Library design-system slice from current origin/dev. Scope: ad
 Implemented FeatureEmptyState as a compatibility adapter over components/ui/feedback/EmptyState, preserving legacy action/title/className/icon behavior. Added focused adapter coverage, MediaTrashPage consumer coverage, and a product-state guard regression for canonical EmptyState adapters. Baseline cleanup removes migrated/stale local-empty-state entries and reconciles existing MonitoringDashboard stale IDs found by the verifier.
 
 Verification: bunx vitest run src/components/Common/__tests__/FeatureEmptyState.test.tsx src/components/Review/__tests__/MediaTrashPage.connection.test.tsx src/design-system/__tests__/product-state-guard.test.ts --maxWorkers=1 --reporter=dot passed 43/43; bun run verify:design-system-state exited 0 with 525 allowed legacy exceptions; git diff --check exited 0. Full package tsc remains blocked by existing unrelated package-wide type errors. Bandit is not applicable to this frontend-only TypeScript/JSON slice.
+
+PR review pass started for PR #1341. Actionable findings: Qodo guard suppression should be scoped per owner instead of file-wide; CodeRabbit baseline canonical-state-label entries should be grouped with canonical labels.
+
+PR review fixes: scoped canonical EmptyState guard suppression to the owner component instead of a file-wide flag, added the sibling LegacyEmptyState regression, and moved MonitoringDashboard canonical-state-label baseline entries into the canonical-label group.
+
+Review-fix verification: bunx vitest run src/components/Common/__tests__/FeatureEmptyState.test.tsx src/components/Review/__tests__/MediaTrashPage.connection.test.tsx src/design-system/__tests__/product-state-guard.test.ts --maxWorkers=1 --reporter=dot passed 44/44; bun run verify:design-system-state exited 0 with 525 allowed legacy exceptions; git diff --check exited 0.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Adapted Common/FeatureEmptyState into a thin design-system compatibility adapter over the canonical EmptyState primitive, added the small EmptyState action title passthrough needed for legacy parity, covered both adapter and MediaTrashPage usage, and taught the product-state guard not to flag adapters that genuinely render canonical EmptyState. Reconciled the guard baseline by removing migrated/stale empty-state debt and refreshing pre-existing MonitoringDashboard entries required for the verifier to stay green on current dev.
+Adapted FeatureEmptyState to the shared EmptyState primitive and completed PR review fixes. The product-state guard now suppresses local-empty-state only for the component that actually renders canonical EmptyState, with regression coverage for sibling empty-state components, and the baseline canonical-state-label entries are grouped with the canonical-label section.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.11 - Adapt-FeatureEmptyState-to-shared-EmptyState.md
+++ b/backlog/tasks/task-45.11 - Adapt-FeatureEmptyState-to-shared-EmptyState.md
@@ -1,0 +1,60 @@
+---
+id: TASK-45.11
+title: Adapt FeatureEmptyState to shared EmptyState
+status: Done
+assignee: []
+created_date: '2026-05-06 05:50'
+updated_date: '2026-05-06 06:05'
+labels:
+  - design-system
+  - frontend
+  - library
+  - ingestion
+dependencies: []
+documentation:
+  - Docs/Design/tldw_web_design_system_inventory.md
+  - Docs/Design/tldw_web_design_system_contract.md
+parent_task_id: TASK-45
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the next Ingestion/Library design-system migration slice by turning the widely used Common/FeatureEmptyState compatibility component into a thin adapter around the canonical components/ui/feedback/EmptyState primitive. This should improve Media/Review/Knowledge empty-state consistency without broad consumer rewrites, Button migration, page-shell migration, or AntD mechanics changes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 FeatureEmptyState renders the canonical EmptyState design-system marker while preserving its existing public props, accessible title/description/example text, actions, disabled states, className passthrough, and icon support.
+- [x] #2 Focused tests cover the FeatureEmptyState adapter behavior and at least one Media/Review or Knowledge consumer path that relies on the compatibility component.
+- [x] #3 The product-state guard passes without adding unexplained baseline debt; any stale baseline entry caused by migrating FeatureEmptyState is removed or documented as intentional.
+- [x] #4 The PR stays scoped to the compatibility adapter and does not migrate every Media/Review/Knowledge empty state, direct AntD Empty, Button ownership, page shells, modal footers, or status chips.
+- [x] #5 Focused Vitest coverage, design-system state verification, git diff checks, and Bandit applicability are recorded before completion.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Started Ingestion/Library design-system slice from current origin/dev. Scope: adapt Common/FeatureEmptyState to canonical EmptyState as a compatibility layer before high-volume Media/Review/Knowledge empty-state migrations.
+
+Implemented FeatureEmptyState as a compatibility adapter over components/ui/feedback/EmptyState, preserving legacy action/title/className/icon behavior. Added focused adapter coverage, MediaTrashPage consumer coverage, and a product-state guard regression for canonical EmptyState adapters. Baseline cleanup removes migrated/stale local-empty-state entries and reconciles existing MonitoringDashboard stale IDs found by the verifier.
+
+Verification: bunx vitest run src/components/Common/__tests__/FeatureEmptyState.test.tsx src/components/Review/__tests__/MediaTrashPage.connection.test.tsx src/design-system/__tests__/product-state-guard.test.ts --maxWorkers=1 --reporter=dot passed 43/43; bun run verify:design-system-state exited 0 with 525 allowed legacy exceptions; git diff --check exited 0. Full package tsc remains blocked by existing unrelated package-wide type errors. Bandit is not applicable to this frontend-only TypeScript/JSON slice.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Adapted Common/FeatureEmptyState into a thin design-system compatibility adapter over the canonical EmptyState primitive, added the small EmptyState action title passthrough needed for legacy parity, covered both adapter and MediaTrashPage usage, and taught the product-state guard not to flag adapters that genuinely render canonical EmptyState. Reconciled the guard baseline by removing migrated/stale empty-state debt and refreshing pre-existing MonitoringDashboard entries required for the verifier to stay green on current dev.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Adapt `Common/FeatureEmptyState` into a thin compatibility wrapper around the canonical `components/ui/feedback/EmptyState` primitive.
- Preserve legacy action labels, disabled states, native `title` attributes, className passthrough, examples, and icon support.
- Add product-state guard coverage so canonical EmptyState adapters are not counted as duplicated local empty states, and reconcile the guard baseline on current `dev`.

## Verification
- `bunx vitest run src/components/Common/__tests__/FeatureEmptyState.test.tsx src/components/Review/__tests__/MediaTrashPage.connection.test.tsx src/design-system/__tests__/product-state-guard.test.ts --maxWorkers=1 --reporter=dot`
- `bun run verify:design-system-state`
- `git diff --check`

## Notes
- Bandit is not applicable to this frontend-only TypeScript/JSON slice.
- Full package `tsc --noEmit` remains blocked by unrelated existing package-wide type errors.
- Before merge, the human requester still needs to add the required human-owned `Change summary` explaining what changed and why these choices were made.
