### PR TITLE
Add Auto Chunking for Quick Ingest

### DIFF
--- a/Docs/superpowers/plans/2026-05-06-auto-chunking-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-06-auto-chunking-implementation-plan.md
@@ -1,0 +1,986 @@
+# Auto Chunking Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement novice-facing Auto Chunking for Quick Ingest so enabling
+Chunking defaults to deterministic media-aware planning, with a Manual mode for
+existing detailed controls and an explicit opt-in flag for later AI-assisted
+boundary refinement.
+
+**Architecture:** Add a pure backend Auto Chunk Planner that translates media
+type, source hints, template matches, extracted content profiles, requested
+goal, and AI-assist availability into existing chunker options plus a
+user-visible `chunking_plan`. Wire the planner into media request parsing,
+direct processing, async ingest jobs, and persistence without changing legacy
+requests that omit `chunking_mode`. Update Quick Ingest state, payload builders,
+and UI controls so Auto is the default only when Chunking is enabled in the new
+Quick Ingest flow, while Manual keeps the current advanced fields.
+
+**Tech Stack:** FastAPI, Pydantic, existing media ingestion/chunking helpers,
+pytest, Next.js/React shared UI package, Ant Design controls, Bun, Vitest, and
+the existing extension background Quick Ingest submission path.
+
+---
+
+## Scope
+
+Implement the approved design from:
+
+- `Docs/superpowers/specs/2026-05-06-auto-chunking-design.md`
+- Backlog task `TASK-96`
+
+This plan covers implementation work for the full Auto Chunking product
+contract, but it deliberately separates deterministic Auto from AI-assisted
+Auto. The first shippable slice accepts and records the AI-assist preference,
+falls back deterministically when no AI adapter is available, and does not make
+LLM calls by default. True LLM boundary refinement is a later task in this plan
+after deterministic planning is stable and observable.
+
+This plan does not create multiple persistent chunk sets, replace the existing
+chunking engines, make Chunking Playground the novice flow, or change behavior
+for legacy clients that omit `chunking_mode`.
+
+## Current File Map
+
+Backend request and parsing:
+
+- Modify `tldw_Server_API/app/api/v1/schemas/media_request_models.py`
+  - Add `ChunkingMode` and `AutoChunkingGoal` literals.
+  - Add `chunking_mode`, `auto_chunking_goal`, and
+    `auto_chunking_use_llm` to `ChunkingOptions`.
+  - Add the same Auto fields to JSON web/article request models:
+    `WebScrapingRequest` and `IngestWebContentRequest`.
+  - Do not expose `structure_aware` as a new public Manual request value in
+    V1. Keep it as an internal Auto planner output passed to existing chunking
+    helpers after request validation.
+- Modify `tldw_Server_API/app/api/v1/API_Deps/media_add_deps.py`
+  - Parse the new Auto fields for `/media/add` and async ingest jobs.
+  - Close existing parity gaps by parsing `auto_apply_template`,
+    `chunking_template_name`, `hierarchical_chunking`, and
+    `hierarchical_template` where the schema already supports them.
+- Modify `tldw_Server_API/app/api/v1/API_Deps/media_processing_deps.py`
+  - Parse the same Auto fields for direct process endpoints.
+  - Keep PDF's existing template parsing and bring documents, audio, video,
+    ebooks, and email to the same request-field parity.
+
+Backend planner and wiring:
+
+- Create `tldw_Server_API/app/core/Chunking/auto_planner.py`
+  - Pure deterministic planner.
+  - Exports normalized plan/profile types and functions.
+  - Does not import FastAPI request objects or perform database writes.
+- Modify `tldw_Server_API/app/core/Ingestion_Media_Processing/chunking_options.py`
+  - Keep `prepare_chunking_options_dict()` behavior for legacy and Manual.
+  - Add a resolver that returns `(chunk_options, chunking_plan)` for Auto.
+  - Ensure Auto ignores stale saved Manual fields unless explicitly needed as
+    bounded defaults.
+- Modify direct process endpoints under
+  `tldw_Server_API/app/api/v1/endpoints/media/`
+  - `process_documents.py`
+  - `process_pdfs.py`
+  - `process_audios.py`
+  - `process_videos.py`
+  - `process_ebooks.py`
+  - `process_emails.py`
+  - `process_web_scraping.py`
+  - `ingest_web_content.py`
+  - Use the resolver and attach returned `chunking_plan` to response metadata.
+- Modify `tldw_Server_API/app/services/web_scraping_service.py`
+  - Apply Auto planning to the `/process-web-scraping` Quick Ingest path and
+    the legacy fallback persistence path.
+  - Preserve current behavior for web requests that omit `chunking_mode`.
+- Modify `tldw_Server_API/app/services/media_ingest_jobs_worker.py`
+  - Use the resolver for job payloads.
+  - Forward `chunking_plan` into the final job result.
+- Modify `tldw_Server_API/app/core/Ingestion_Media_Processing/persistence.py`
+  - Persist the plan under `safe_metadata.chunking_plan` where safe metadata is
+    already normalized.
+  - Update the local safe metadata allowlists/copy filters so `chunking_plan`
+    is preserved as a nested JSON object with only JSON-safe scalar/list values.
+  - Avoid creating a second chunk index or durable alternate chunk set.
+
+Backend tests:
+
+- Create `tldw_Server_API/tests/Chunking/test_auto_chunking_planner.py`
+- Modify `tldw_Server_API/tests/Media_Ingestion_Modification/test_process_endpoints_contract_parity.py`
+- Modify or create a focused request parsing test near
+  `tldw_Server_API/tests/Media_Ingestion_Modification/test_add_media_endpoint.py`
+- Modify `tldw_Server_API/tests/MediaIngestion_NEW/integration/test_media_ingest_jobs.py`
+- Create or modify web/article coverage near:
+  - `tldw_Server_API/tests/Web_Scraping/test_process_web_scraping_strategy_validation.py`
+  - `tldw_Server_API/tests/Media/test_ingest_web_content_endpoint_sanitization.py`
+  - or a focused new `tldw_Server_API/tests/WebScraping/test_auto_chunking_web_ingest.py`
+
+Frontend state, payload, and UI:
+
+- Modify `apps/packages/ui/src/components/Common/QuickIngest/types.ts`
+  - Add `ChunkingMode`, `AutoChunkingGoal`, and common option fields.
+- Modify `apps/packages/ui/src/components/Common/hooks/useIngestOptions.tsx`
+  - Default new Quick Ingest chunking mode to `auto`.
+  - Persist mode, goal, and AI-assist preference with conservative migration.
+  - Prevent old advanced Manual values from leaking into Auto submissions.
+- Modify `apps/packages/ui/src/components/Common/QuickIngest/IngestOptionsPanel.tsx`
+  - Add Auto/Manual mode control when Chunking is enabled.
+  - Show goal and AI-assist controls for Auto.
+  - Keep existing template and detailed chunking controls in Manual/advanced.
+- Modify `apps/packages/ui/src/components/Common/QuickIngest/WizardConfigureStep.tsx`
+  - Surface the same Auto default and Manual escape hatch in the wizard flow.
+- Modify `apps/packages/ui/src/components/Common/QuickIngestModal.tsx`
+  - Thread the new state through the submit flow.
+- Modify `apps/packages/ui/src/services/tldw/quick-ingest-batch.ts`
+  - Send Auto fields for Auto.
+  - Send current Manual fields for Manual.
+  - Do not send stale advanced chunk fields in Auto mode.
+  - Include the Auto fields in `processWebScrape()` JSON bodies for
+    `/api/v1/media/process-web-scraping`.
+- Modify `apps/packages/ui/src/entries/background.ts`
+  - Update the extension/background Quick Ingest path with the same payload
+    rules as the shared batch service.
+  - Include the same web/article `processWebScrape()` JSON field behavior.
+- Modify `apps/packages/ui/src/services/tldw/fallback-schemas.ts`
+  - Add the Auto fields to fallback field definitions if the runtime settings
+    schema is unavailable.
+- Modify tests:
+  - `apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts`
+  - `apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx`
+  - `apps/packages/ui/src/components/Common/QuickIngest/__tests__/IngestWizardContext.test.tsx`
+
+Tracking:
+
+- Update Backlog task `TASK-96.1` for this plan.
+- Create or update implementation child tasks before code edits begin.
+
+## Data Contract
+
+Requests:
+
+```text
+perform_chunking=true|false
+chunking_mode=auto|manual
+auto_chunking_goal=balanced|qa_search|navigation_summary
+auto_chunking_use_llm=false|true
+```
+
+Rules:
+
+- If `perform_chunking=false`, do not plan or chunk.
+- If `chunking_mode` is missing, preserve existing request behavior.
+- If `chunking_mode=manual`, use existing chunking fields and template
+  controls.
+- If `chunking_mode=auto`, use planner output and ignore stale saved Manual
+  chunking fields.
+- If `auto_chunking_use_llm=true` and the AI adapter is unavailable, continue
+  deterministically and record `fallback_reason`.
+- The same contract applies to multipart media forms and JSON web/article
+  requests (`WebScrapingRequest` and `IngestWebContentRequest`).
+
+Plan metadata shape:
+
+```json
+{
+  "mode": "auto",
+  "goal": "balanced",
+  "used_llm": false,
+  "method": "structure_aware",
+  "max_size": 900,
+  "overlap": 120,
+  "template_name": "academic_pdf",
+  "derived_views": ["outline", "section_titles"],
+  "fallback_reason": null,
+  "rationale": "Detected document structure; selected structure-aware chunks."
+}
+```
+
+Store this metadata in direct process responses, async job results, and durable
+safe metadata. Derived views are metadata only in this implementation.
+
+## Task 1: Backend Request Contract And Parsing Parity
+
+**Files:**
+
+- Modify `tldw_Server_API/app/api/v1/schemas/media_request_models.py`
+- Modify `tldw_Server_API/app/api/v1/API_Deps/media_add_deps.py`
+- Modify `tldw_Server_API/app/api/v1/API_Deps/media_processing_deps.py`
+- Modify `tldw_Server_API/tests/Media_Ingestion_Modification/test_process_endpoints_contract_parity.py`
+- Modify or create focused request parsing tests near
+  `tldw_Server_API/tests/Media_Ingestion_Modification/test_add_media_endpoint.py`
+
+- [x] **Step 1: Add failing schema and dependency tests**
+
+  Cover these cases:
+
+  - `AddMediaForm` accepts `chunking_mode=auto`,
+    `auto_chunking_goal=qa_search`, and `auto_chunking_use_llm=true`.
+  - `AddMediaForm` preserves legacy behavior when `chunking_mode` is missing.
+  - Invalid `chunking_mode` and invalid `auto_chunking_goal` fail through
+    normal request validation.
+  - `perform_chunking=false` with Auto fields present does not plan or chunk.
+  - All direct process form dependencies accept the same Auto fields.
+  - `WebScrapingRequest` and `IngestWebContentRequest` accept the same Auto
+    fields for web/article ingestion.
+  - Documents, audio, video, ebooks, and emails parse
+    `auto_apply_template` and `chunking_template_name` consistently with PDFs.
+  - `hierarchical_template` parsing is shared and does not accept malformed
+    JSON silently if it is supplied as a form string.
+
+  Run:
+
+  ```bash
+  source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Media_Ingestion_Modification/test_process_endpoints_contract_parity.py tldw_Server_API/tests/Media_Ingestion_Modification/test_add_media_endpoint.py -v
+  ```
+
+- [x] **Step 2: Add schema fields**
+
+  In `media_request_models.py`:
+
+  - Add `ChunkingMode = Literal["auto", "manual"]`.
+  - Add `AutoChunkingGoal = Literal["balanced", "qa_search", "navigation_summary"]`.
+  - Add optional fields to `ChunkingOptions`:
+    - `chunking_mode: ChunkingMode | None = None`
+    - `auto_chunking_goal: AutoChunkingGoal = "balanced"`
+    - `auto_chunking_use_llm: bool = False`
+  - Add the same three fields to `WebScrapingRequest` and
+    `IngestWebContentRequest`.
+  - Leave `ChunkMethod` unchanged for Manual requests. The Auto resolver may
+    emit internal methods like `structure_aware` after request-model
+    validation.
+
+- [x] **Step 3: Centralize form boolean and JSON parsing**
+
+  If the dependency modules already have local helpers, reuse them. Otherwise
+  add small private helpers in the dependency modules to normalize:
+
+  - String booleans from multipart form data.
+  - Optional string literals.
+  - Optional JSON object strings for `hierarchical_template`.
+
+  Do not add a new shared utility unless both dependency modules would
+  otherwise duplicate enough logic to justify it.
+
+- [x] **Step 4: Parse new and existing parity fields**
+
+  Update `media_add_deps.py` and all relevant process dependency functions in
+  `media_processing_deps.py` so API clients can send the same chunking mode and
+  template fields to direct processing and async ingest.
+
+- [x] **Step 5: Re-run focused backend contract tests**
+
+  ```bash
+  source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Media_Ingestion_Modification/test_process_endpoints_contract_parity.py tldw_Server_API/tests/Media_Ingestion_Modification/test_add_media_endpoint.py -v
+  ```
+
+## Task 2: Deterministic Auto Chunk Planner
+
+**Files:**
+
+- Create `tldw_Server_API/app/core/Chunking/auto_planner.py`
+- Create `tldw_Server_API/tests/Chunking/test_auto_chunking_planner.py`
+
+- [x] **Step 1: Write planner tests before implementation**
+
+  Test a pure planner API with no database, network, FastAPI request, or LLM
+  calls. Cover:
+
+  - Auto disabled when `perform_chunking=false`.
+  - Missing `chunking_mode` returns legacy/manual behavior marker and no Auto
+    plan.
+  - `chunking_mode=manual` returns no Auto plan.
+  - PDF/document with headings selects `structure_aware` or a documented
+    equivalent existing method.
+  - Unstructured document uses `semantic` only when a deterministic capability
+    check says semantic dependencies are available; otherwise it falls back to
+    `sentences` with a clear rationale.
+  - Audio/video selects transcript-friendly sentence chunks and derived time
+    view metadata when timecodes are present.
+  - Ebook selects `ebook_chapters` when chapter signals exist.
+  - Email preserves larger message/thread boundaries.
+  - Web/article content with headings or list/table signals uses a
+    structure-aware plan; plain articles fall back to paragraph/sentence
+    planning.
+  - `qa_search` chooses smaller or moderate chunks than `navigation_summary`.
+  - `auto_chunking_use_llm=true` with no adapter records
+    `fallback_reason` and `used_llm=false`.
+  - Template classifier no-match and classifier failure do not fail ingest and
+    record a fallback reason or rationale.
+
+  Run:
+
+  ```bash
+  source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Chunking/test_auto_chunking_planner.py -v
+  ```
+
+- [x] **Step 2: Implement planner data types**
+
+  In `auto_planner.py`, use simple typed structures that serialize cleanly:
+
+  - `AutoChunkingProfile`
+  - `AutoChunkingRequest`
+  - `AutoChunkingPlan`
+  - `AutoChunkingDecision`
+
+  Prefer `TypedDict` or Pydantic-free dataclasses with `asdict()` so the core
+  planner stays lightweight and easy to unit test.
+
+- [x] **Step 3: Implement profile builders**
+
+  Add pure helpers for source and content hints:
+
+  - `profile_from_source(media_type, filename=None, url=None, title=None, mime_type=None)`
+  - `profile_from_text(text, *, max_scan_chars=...)`
+  - `merge_profiles(base, extracted)`
+
+  Detect only durable, cheap signals:
+
+  - Approximate text length.
+  - Heading-like lines.
+  - Table-like density.
+  - Chapter-like markers.
+  - Transcript timecode markers.
+  - Speaker/diarization labels.
+  - File extension and media type.
+  - Web/article title and URL hints.
+
+  Avoid slow parsing or model calls in this deterministic layer.
+
+- [x] **Step 4: Implement deterministic rule table**
+
+  Keep rules explicit and easy to read. Suggested defaults:
+
+  - `balanced`: moderate chunks and overlap.
+  - `qa_search`: smaller chunks, stronger overlap, preserve offsets/timecodes.
+  - `navigation_summary`: larger chunks, structural boundaries, derived
+    outline/time range metadata.
+  - PDF/document with headings: prefer `structure_aware` if supported.
+  - Long unstructured document: prefer `semantic` only after a cheap
+    dependency/capability check; otherwise `sentences`.
+  - Audio/video: prefer `sentences`; include time-derived views if present.
+  - Ebook with chapter signals: prefer `ebook_chapters`.
+  - Email: prefer sentence or paragraph chunks with message-preserving sizing.
+  - Web/article: prefer `structure_aware` for headings/lists/tables and
+    paragraph or sentence chunks for plain article text.
+
+- [x] **Step 5: Normalize plan output**
+
+  Ensure planner output contains only JSON-serializable values:
+
+  - `mode`
+  - `goal`
+  - `used_llm`
+  - `method`
+  - `max_size`
+  - `overlap`
+  - `template_name`
+  - `derived_views`
+  - `fallback_reason`
+  - `rationale`
+
+- [x] **Step 6: Re-run planner tests**
+
+  ```bash
+  source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Chunking/test_auto_chunking_planner.py -v
+  ```
+
+## Task 3: Backend Planner Wiring, Job Results, And Metadata
+
+**Files:**
+
+- Modify `tldw_Server_API/app/core/Ingestion_Media_Processing/chunking_options.py`
+- Modify `tldw_Server_API/app/api/v1/endpoints/media/process_documents.py`
+- Modify `tldw_Server_API/app/api/v1/endpoints/media/process_pdfs.py`
+- Modify `tldw_Server_API/app/api/v1/endpoints/media/process_audios.py`
+- Modify `tldw_Server_API/app/api/v1/endpoints/media/process_videos.py`
+- Modify `tldw_Server_API/app/api/v1/endpoints/media/process_ebooks.py`
+- Modify `tldw_Server_API/app/api/v1/endpoints/media/process_emails.py`
+- Modify `tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py`
+- Modify `tldw_Server_API/app/api/v1/endpoints/media/ingest_web_content.py`
+- Modify `tldw_Server_API/app/services/web_scraping_service.py`
+- Modify `tldw_Server_API/app/services/media_ingest_jobs_worker.py`
+- Modify `tldw_Server_API/app/core/Ingestion_Media_Processing/persistence.py`
+- Modify `tldw_Server_API/tests/MediaIngestion_NEW/integration/test_media_ingest_jobs.py`
+- Modify or create web/article ingest tests near
+  `tldw_Server_API/tests/Web_Scraping/test_process_web_scraping_strategy_validation.py`
+  or `tldw_Server_API/tests/WebScraping/test_auto_chunking_web_ingest.py`
+- Add or modify focused media process tests as needed.
+
+- [x] **Step 1: Write backend integration tests**
+
+  Cover:
+
+  - Direct process response includes `metadata.chunking_plan` or equivalent
+    documented response metadata when `chunking_mode=auto`.
+  - Async job status `result` includes `chunking_plan`.
+  - Web/article Quick Ingest through `/api/v1/media/process-web-scraping`
+    accepts Auto fields and includes plan metadata when results are returned
+    or persisted.
+  - `/api/v1/media/ingest-web-content` accepts the same Auto fields.
+  - Persisted media safe metadata includes `chunking_plan`.
+  - Manual requests continue to use explicitly supplied `chunk_method`,
+    `chunk_max_size`, and `chunk_overlap`.
+  - Legacy requests that omit `chunking_mode` preserve previous chunk option
+    defaults.
+  - Auto ignores stale Manual advanced fields from the request payload.
+  - Template classifier no-match and classifier exception paths fall back
+    deterministically and do not fail ingest.
+
+  Run the narrowest tests first:
+
+  ```bash
+  source .venv/bin/activate && python -m pytest tldw_Server_API/tests/MediaIngestion_NEW/integration/test_media_ingest_jobs.py -v
+  ```
+
+- [x] **Step 2: Add a resolver in `chunking_options.py`**
+
+  Add a function with a narrow contract, for example:
+
+  ```python
+  def resolve_chunking_options_and_plan(
+      form_data: Any,
+      *,
+      media_type: str | None = None,
+      source_name: str | None = None,
+      extracted_text: str | None = None,
+      template_match: str | None = None,
+      llm_available: bool = False,
+  ) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+      ...
+  ```
+
+  Behavior:
+
+  - Return `(None, None)` when `perform_chunking` is false.
+  - Return existing `prepare_chunking_options_dict()` output and `None` plan
+    for legacy and Manual paths.
+  - Return planner options and serialized `chunking_plan` for Auto.
+  - Apply explicit or classifier template matches as planner input, not as a
+    hidden override that makes plan metadata inaccurate.
+  - In the first implementation slice, pass `llm_available=False` unless a real
+    AI boundary adapter is introduced in Task 6, so opt-in AI requests produce
+    an honest deterministic fallback.
+
+- [x] **Step 3: Wire direct process endpoints**
+
+  Replace local `prepare_chunking_options_dict()` calls only where enough
+  context is available. Keep endpoint-specific logic intact.
+
+  If an endpoint currently does a second chunking pass after extracted content
+  is available, finalize the Auto plan there with `extracted_text` rather than
+  locking the plan before parsing.
+
+  Attach `chunking_plan` to the same response metadata structure each endpoint
+  already returns. Do not invent a different top-level response field per media
+  type.
+
+- [x] **Step 4: Wire web/article ingest paths**
+
+  Quick Ingest web URLs use `processWebScrape()` in the frontend and post JSON
+  to `/api/v1/media/process-web-scraping`, not the multipart media form. Wire
+  Auto fields through:
+
+  - `WebScrapingRequest`
+  - `process_web_scraping.py`
+  - `web_scraping_service.process_web_scraping_task()`
+
+  The service currently builds web chunks directly with `Chunker()` in its
+  persistence fallback path. Replace those hard-coded defaults with resolver
+  output for `chunking_mode=auto`, and preserve existing sentence defaults when
+  `chunking_mode` is missing.
+
+  Also update `/api/v1/media/ingest-web-content` through
+  `IngestWebContentRequest` and `ingest_web_content_orchestrate()` so the
+  non-Quick-Ingest web API can use the same contract.
+
+- [x] **Step 5: Wire async ingest jobs**
+
+  In `media_ingest_jobs_worker.py`:
+
+  - Use the resolver for the preliminary plan before processor dispatch.
+  - Finalize the plan after extraction/transcription at the first point where
+    extracted text or transcript content is available. For job-backed media,
+    this should happen in the worker immediately after the processor returns,
+    before building the final job result and before persistence receives chunk
+    options.
+  - If the existing processor helper already finalizes chunking inside
+    `process_batch_media()` or document-like persistence, pass enough context
+    through to avoid planning twice with contradictory metadata.
+  - Include `chunking_plan` in the final result dictionary returned to job
+    status clients.
+  - Ensure worker retry/error paths do not fail if the plan is absent for
+    legacy requests.
+
+- [x] **Step 6: Persist plan metadata**
+
+  In `persistence.py`, store Auto plan metadata in existing safe metadata:
+
+  - Prefer `safe_metadata["chunking_plan"]`.
+  - Preserve any existing user safe metadata.
+  - Add `chunking_plan` to the local allowed-key filters used in AV and
+    document-like persistence paths.
+  - Preserve `chunking_plan` as a nested dict after recursively stripping values
+    that are not JSON-safe primitives, lists, or dicts.
+  - Confirm `normalize_safe_metadata()` does not remove the nested plan. If it
+    does, adjust the persistence-side copy step or add a targeted utility test.
+  - Do not store plan metadata inside every chunk unless existing chunk metadata
+    helpers already attach shared document metadata cheaply.
+
+- [x] **Step 7: Run focused backend tests**
+
+  ```bash
+  source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Chunking/test_auto_chunking_planner.py tldw_Server_API/tests/Media_Ingestion_Modification/test_process_endpoints_contract_parity.py tldw_Server_API/tests/MediaIngestion_NEW/integration/test_media_ingest_jobs.py tldw_Server_API/tests/Web_Scraping/test_process_web_scraping_strategy_validation.py tldw_Server_API/tests/Media/test_ingest_web_content_endpoint_sanitization.py -v
+  ```
+
+## Task 4: Quick Ingest State And Payload Plumbing
+
+**Files:**
+
+- Modify `apps/packages/ui/src/components/Common/QuickIngest/types.ts`
+- Modify `apps/packages/ui/src/components/Common/QuickIngest/presets.ts`
+- Modify `apps/packages/ui/src/components/Common/QuickIngest/IngestOptionsPanel.tsx`
+- Modify `apps/packages/ui/src/components/Common/hooks/useIngestOptions.tsx`
+- Modify `apps/packages/ui/src/components/Common/hooks/useIngestPresets.tsx`
+- Modify `apps/packages/ui/src/components/Common/QuickIngestModal.tsx`
+- Add `apps/packages/ui/src/services/tldw/quick-ingest-chunking.ts`
+- Modify `apps/packages/ui/src/services/tldw/quick-ingest-batch.ts`
+- Modify `apps/packages/ui/src/entries/background.ts`
+- Modify `apps/packages/ui/src/services/tldw/fallback-schemas.ts`
+- Modify `apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts`
+- Modify `apps/packages/ui/src/components/Common/QuickIngest/__tests__/IngestWizardContext.test.tsx`
+
+- [x] **Step 1: Add failing frontend payload tests**
+
+  In `quick-ingest-batch.test.ts`, cover:
+
+  - Chunking enabled with default Auto sends:
+    - `perform_chunking=true`
+    - `chunking_mode=auto`
+    - `auto_chunking_goal=balanced`
+    - `auto_chunking_use_llm=false`
+  - Auto with a selected goal sends the selected goal.
+  - Auto with AI assist sends `auto_chunking_use_llm=true`.
+  - Manual sends `chunking_mode=manual` and existing manual fields.
+  - Auto does not send stale advanced manual chunk fields.
+  - `processWebScrape()` sends Auto fields in the JSON body for web/article
+    entries and omits stale Manual fields in Auto mode.
+  - The extension/background path follows the same field rules or shares the
+    same helper.
+
+  Run:
+
+  ```bash
+  cd apps/packages/ui && bunx vitest run src/services/__tests__/quick-ingest-batch.test.ts --maxWorkers=1 --no-file-parallelism
+  ```
+
+- [x] **Step 2: Extend Quick Ingest types**
+
+  In `types.ts`, add:
+
+  ```ts
+  export type ChunkingMode = "auto" | "manual"
+  export type AutoChunkingGoal = "balanced" | "qa_search" | "navigation_summary"
+  ```
+
+  Add fields to the shared Quick Ingest options model:
+
+  - `chunking_mode?: ChunkingMode`
+  - `auto_chunking_goal?: AutoChunkingGoal`
+  - `auto_chunking_use_llm?: boolean`
+
+  Keep fields optional when this reduces migration risk for older stored
+  options.
+
+- [x] **Step 3: Update persisted state defaults and migration**
+
+  In `useIngestOptions.tsx`:
+
+  - Retain the existing new Quick Ingest default of:
+    - `perform_chunking: true`
+  - Add new Auto defaults for the enabled chunking state:
+    - `chunking_mode: "auto"`
+    - `auto_chunking_goal: "balanced"`
+    - `auto_chunking_use_llm: false`
+  - When hydrating older stored settings with `perform_chunking=true` and no
+    mode, choose `auto` only for the new Quick Ingest default path.
+  - Preserve existing advanced values in storage for Manual, but do not include
+    them in Auto payloads.
+
+- [x] **Step 4: Centralize payload construction**
+
+  Prefer one shared helper in `quick-ingest-batch.ts` that both WebUI and
+  extension/background paths can call. If the background entry cannot import
+  the helper cleanly, duplicate only the smallest field-mapping wrapper and add
+  a test that locks parity.
+
+  Field behavior:
+
+  - Always send `perform_chunking`.
+  - Send Auto fields only when `perform_chunking && chunking_mode === "auto"`.
+  - Send Manual fields only when `perform_chunking && chunking_mode === "manual"`.
+  - In `processWebScrape()`, map the same Auto fields into the JSON body sent
+    to `/api/v1/media/process-web-scraping`.
+  - Do not send `chunking_template_name` or `auto_apply_template` from old
+    saved advanced settings while Auto is active unless the UI explicitly models
+    them as Auto planner inputs.
+
+- [x] **Step 5: Update fallback schema**
+
+  Add `chunking_mode`, `auto_chunking_goal`, and
+  `auto_chunking_use_llm` to fallback schemas so local/offline settings screens
+  do not hide the fields when the backend schema fetch fails.
+
+- [x] **Step 6: Run focused frontend service tests**
+
+  ```bash
+  cd apps/packages/ui && bunx vitest run src/services/__tests__/quick-ingest-batch.test.ts src/components/Common/QuickIngest/__tests__/IngestWizardContext.test.tsx --maxWorkers=1 --no-file-parallelism
+  ```
+
+  Completed with local package runner:
+
+  ```bash
+  cd apps/packages/ui && bun run test -- src/services/__tests__/quick-ingest-batch.test.ts src/components/Common/QuickIngest/__tests__/IngestWizardContext.test.tsx --maxWorkers=1 --no-file-parallelism
+  ```
+
+## Task 5: Quick Ingest Auto/Manual UI
+
+**Files:**
+
+- Modify `apps/packages/ui/src/components/Common/QuickIngest/IngestOptionsPanel.tsx`
+- Modify `apps/packages/ui/src/components/Common/QuickIngest/WizardConfigureStep.tsx`
+- Modify `apps/packages/ui/src/components/Common/QuickIngestModal.tsx`
+- Modify `apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx`
+- Modify `apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx`
+
+- [x] **Step 1: Add failing UI tests**
+
+  Cover:
+
+  - Enabling Chunking shows Auto mode selected by default.
+  - Auto mode shows goal selection and AI assist toggle.
+  - Manual mode exposes existing detailed chunking controls.
+  - Switching from Manual back to Auto hides or disables Manual-only fields.
+  - Submitting from Auto sends Auto fields and not stale Manual fields.
+
+  Run:
+
+  ```bash
+  cd apps/packages/ui && bunx vitest run src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx --maxWorkers=1 --no-file-parallelism
+  ```
+
+- [x] **Step 2: Add controls to `IngestOptionsPanel.tsx`**
+
+  Use existing Ant Design patterns:
+
+  - `Segmented` or the local equivalent for `Auto | Manual`.
+  - `Select` for `Balanced`, `Search/Q&A`, and `Reading/Summary`.
+  - `Switch` for `Use AI to improve chunk boundaries`.
+
+  Keep text concise and task-facing. Do not add a marketing explanation panel.
+
+- [x] **Step 3: Add controls to `WizardConfigureStep.tsx`**
+
+  Keep the wizard compact:
+
+  - Chunking toggle remains the parent control.
+  - When enabled, show Auto selected by default.
+  - Let users switch to Manual and reveal existing advanced settings through the
+    same path used by the options panel.
+
+- [x] **Step 4: Preserve Manual advanced behavior**
+
+  Existing advanced options should remain available and should still work after
+  switching to Manual:
+
+  - method
+  - size
+  - overlap
+  - template selection
+  - auto-apply template
+  - contextual/proposition/hierarchical fields where the schema exposes them
+
+- [x] **Step 5: Run UI tests**
+
+  ```bash
+  cd apps/packages/ui && bunx vitest run src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx src/components/Common/QuickIngest/__tests__/IngestWizardContext.test.tsx --maxWorkers=1 --no-file-parallelism
+  ```
+
+  Completed with local package runner:
+
+  ```bash
+  cd apps/packages/ui && bun run test -- src/services/__tests__/quick-ingest-batch.test.ts src/components/Common/QuickIngest/__tests__/IngestWizardContext.test.tsx src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx --maxWorkers=1 --no-file-parallelism
+  ```
+
+## Task 6: AI-Assist Adapter Boundary
+
+**Files:**
+
+- Modify `tldw_Server_API/app/core/Chunking/auto_planner.py`
+- Create tests in `tldw_Server_API/tests/Chunking/test_auto_chunking_planner.py`
+- Add new adapter files only if the implementation actually makes LLM calls.
+
+- [x] **Step 1: Keep deterministic fallback explicit**
+
+  The first implementation should support this behavior even before any LLM
+  call exists:
+
+  - Request `auto_chunking_use_llm=true`.
+  - Planner sees no available AI boundary adapter because the first slice passes
+    `llm_available=False` from the resolver.
+  - Planner returns deterministic chunking options.
+  - Plan metadata has `used_llm=false` and a clear `fallback_reason`.
+
+  Do not infer availability from a configured chat provider until a real
+  `AutoChunkBoundaryAssistant` adapter is implemented and tested. A provider
+  key by itself is not enough to claim AI boundary refinement was used.
+
+- [x] **Step 2: Define adapter interface before adding model calls**
+
+  If implementing real AI-assisted boundaries in this feature branch, first add
+  a narrow interface, for example:
+
+  ```python
+  class AutoChunkBoundaryAssistant(Protocol):
+      async def suggest_boundaries(
+          self,
+          *,
+          text_profile: AutoChunkingProfile,
+          goal: str,
+          deterministic_plan: dict[str, Any],
+      ) -> AutoChunkingAssistantResult:
+          ...
+  ```
+
+  The adapter must:
+
+  - Use existing LLM provider plumbing.
+  - Define exactly how provider/model/key availability is checked before the
+    planner receives `llm_available=True`.
+  - Have strict timeout and token limits.
+  - Never be invoked unless `auto_chunking_use_llm=true`.
+  - Return bounded suggestions, not arbitrary code or chunk text.
+  - Fall back to deterministic Auto on any provider/config/runtime error.
+
+  Completed for this branch by deferring model calls. No adapter file was
+  added because no real AI boundary refinement is invoked in this V1 slice.
+  `TASK-96.8` tracks the follow-up adapter and test matrix.
+
+- [x] **Step 3: Add tests before real AI integration**
+
+  Mock the adapter. Cover:
+
+  - Adapter not called by default.
+  - Adapter called only for explicit opt-in.
+  - Adapter success sets `used_llm=true`.
+  - Adapter timeout/error preserves deterministic plan and records
+    `fallback_reason`.
+
+  Completed for this branch by adding no-adapter fallback regression coverage.
+  Adapter-specific mock tests move with `TASK-96.8`, where the adapter contract
+  will exist.
+
+- [x] **Step 4: Decide whether to defer real LLM calls**
+
+  If deterministic Auto, request/UI plumbing, and metadata are already a large
+  branch, defer real model calls to a follow-up Backlog task. The feature still
+  has an honest AI-assist affordance only if the UI and metadata make fallback
+  behavior clear. Do not silently pretend AI was used.
+
+  Decision: defer real LLM boundary refinement to `TASK-96.8`. This branch
+  keeps AI assist as explicit opt-in metadata and deterministic fallback only.
+
+## Task 7: Verification, Documentation, And Tracking
+
+**Files:**
+
+- Modify or create user-facing docs only if the implementation changes public
+  behavior in a way not already covered by API docs.
+- Update Backlog implementation tasks.
+- Do not edit the approved design spec except to add a link to the final
+  implementation PR if requested.
+
+- [x] **Step 1: Run backend focused tests**
+
+  ```bash
+  source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Chunking/test_auto_chunking_planner.py tldw_Server_API/tests/Media_Ingestion_Modification/test_process_endpoints_contract_parity.py tldw_Server_API/tests/Media_Ingestion_Modification/test_add_media_endpoint.py tldw_Server_API/tests/MediaIngestion_NEW/integration/test_media_ingest_jobs.py tldw_Server_API/tests/Web_Scraping/test_process_web_scraping_strategy_validation.py tldw_Server_API/tests/Media/test_ingest_web_content_endpoint_sanitization.py -v
+  ```
+
+  Completed with the current Auto Chunking focused backend suite:
+
+  ```bash
+  source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/MediaIngestion_NEW/unit/test_auto_chunking_request_contract.py tldw_Server_API/tests/Chunking/test_auto_chunking_planner.py tldw_Server_API/tests/Chunking/test_auto_chunking_resolver.py tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_worker.py tldw_Server_API/tests/Media/test_auto_chunking_process_endpoints.py tldw_Server_API/tests/Web_Scraping/test_auto_chunking_web_ingest.py tldw_Server_API/tests/MediaIngestion_NEW/unit/test_auto_chunking_persistence_metadata.py -v
+  ```
+
+  Result: 41 passed, 6 warnings.
+
+- [x] **Step 2: Run frontend focused tests**
+
+  ```bash
+  cd apps/packages/ui && bunx vitest run src/services/__tests__/quick-ingest-batch.test.ts src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx src/components/Common/QuickIngest/__tests__/IngestWizardContext.test.tsx --maxWorkers=1 --no-file-parallelism
+  ```
+
+  Completed with:
+
+  ```bash
+  cd apps/packages/ui && bun run test -- src/services/__tests__/quick-ingest-batch.test.ts src/components/Common/QuickIngest/__tests__/IngestWizardContext.test.tsx src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx --maxWorkers=1 --no-file-parallelism
+  ```
+
+  Result: 4 files passed, 83 tests passed. The test output still includes
+  pre-existing AntD mock DOM warnings and the expected
+  `useIngestWizard must be used within an IngestWizardProvider` guard-test
+  console error.
+
+  OpenAPI client verification also passed:
+
+  ```bash
+  cd apps/packages/ui && bun run verify:openapi
+  ```
+
+  Result: 256 client paths verified, 10 reviewed exception paths allowed, and
+  49 fallback media fields verified against `/api/v1/media/add`.
+
+- [x] **Step 3: Run compile checks if touched files require them**
+
+  ```bash
+  cd apps/packages/ui && bun run compile
+  ```
+
+  If extension/background packaging was materially changed, also run the
+  extension compile command used by the repo:
+
+  ```bash
+  cd apps/extension && bun run compile
+  ```
+
+  Completed with:
+
+  ```bash
+  cd apps/packages/ui && bunx tsc --noEmit --pretty false > /tmp/tldw_auto_chunking_tsc.log 2>&1
+  ```
+
+  Result: full typecheck exited 2 with existing repo-wide test typing errors.
+  Filtering `/tmp/tldw_auto_chunking_tsc.log` for the touched Auto Chunking UI
+  files returned no matches.
+
+- [x] **Step 4: Run Bandit on touched backend scope**
+
+  Adjust the path list to match the actual touched backend files:
+
+  ```bash
+  source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/schemas/media_request_models.py tldw_Server_API/app/api/v1/API_Deps/media_add_deps.py tldw_Server_API/app/api/v1/API_Deps/media_processing_deps.py tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py tldw_Server_API/app/api/v1/endpoints/media/ingest_web_content.py tldw_Server_API/app/core/Chunking/auto_planner.py tldw_Server_API/app/core/Ingestion_Media_Processing/chunking_options.py tldw_Server_API/app/services/media_ingest_jobs_worker.py tldw_Server_API/app/services/web_scraping_service.py tldw_Server_API/app/core/Ingestion_Media_Processing/persistence.py -f json -o /tmp/bandit_auto_chunking.json
+  ```
+
+  Completed for the current backend code delta with:
+
+  ```bash
+  source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Chunking/auto_planner.py -f json -o /tmp/bandit_auto_chunking_ai_boundary.json
+  ```
+
+  Result: zero findings.
+
+- [x] **Step 5: Run whitespace diff check**
+
+  ```bash
+  git diff --check
+  ```
+
+  Result: no whitespace errors.
+
+- [x] **Step 6: Manual API smoke test**
+
+  If a local server is already running, submit one small text/document ingest
+  with:
+
+  - `perform_chunking=true`
+  - `chunking_mode=auto`
+  - `auto_chunking_goal=balanced`
+
+  Verify:
+
+  - Response or job result includes `chunking_plan`.
+  - Existing Manual request still honors explicit `chunk_method`.
+  - A web/article request through `/api/v1/media/process-web-scraping` accepts
+    Auto fields and does not regress legacy JSON requests without
+    `chunking_mode`.
+
+  Do not start or configure external LLM services for this smoke test.
+
+  Skipped because no local API server was already running for this final pass.
+  Endpoint and job-result coverage above verifies the same request/metadata
+  contract without starting external services.
+
+- [x] **Step 7: Manual UI smoke test**
+
+  If the frontend dev server can run locally:
+
+  - Open Quick Ingest.
+  - Enable Chunking.
+  - Confirm Auto is selected by default.
+  - Switch to Manual and confirm advanced controls are available.
+  - Switch back to Auto and submit a dry-run/test fixture if the app supports
+    the local backend.
+
+  Skipped because no frontend dev server was already running for this final
+  pass. Focused UI tests cover the Auto default, Auto/Manual switch, Manual
+  controls, and submit payload behavior.
+
+- [x] **Step 8: Update Backlog and final summary**
+
+  Record:
+
+  - Files changed.
+  - Tests run and results.
+  - Any skipped checks and why.
+  - Whether real AI-assisted boundary refinement was implemented or deferred.
+
+  Completed in `TASK-96.7`. Real AI-assisted boundary refinement is deferred to
+  follow-up `TASK-96.8`.
+
+## Suggested Implementation Slices
+
+Use separate commits if the branch grows:
+
+1. Backend contract fields and parser parity.
+2. Deterministic planner with unit tests.
+3. Backend wiring, web/article ingest, job result, and persistence metadata.
+4. Frontend state, payload plumbing, and web/article JSON payload parity.
+5. Frontend Auto/Manual controls.
+6. AI-assist adapter boundary or deferral note.
+7. Verification and docs/tracking updates.
+
+## Risks And Guardrails
+
+- `structure_aware` exists in the chunking engine but not in current media
+  request validation. Keep it internal to Auto resolver output in V1 so Manual
+  API behavior remains unchanged.
+- Async ingest currently returns a narrow final result. Tests must prove
+  `chunking_plan` reaches job status clients.
+- Quick Ingest web/article entries use `/api/v1/media/process-web-scraping`
+  with JSON bodies, not multipart media forms. Tests must cover
+  `processWebScrape()` and the background entry path.
+- Existing persistence filters safe metadata by allowed keys and value shape.
+  `chunking_plan` must be explicitly preserved as a sanitized nested dict or it
+  will be dropped before storage.
+- Semantic chunking may depend on optional packages. The planner must check
+  capability before selecting semantic for unstructured documents, or fall back
+  to sentences.
+- Old saved Quick Ingest advanced fields can silently alter Auto if payload
+  construction merges all advanced values. Tests must lock this out.
+- The WebUI batch service and extension/background path can drift. Prefer a
+  shared payload helper or test parity directly.
+- AI assistance must remain explicit opt-in and must have deterministic
+  fallback on unavailable providers, timeouts, and errors.
+- Derived navigation views are metadata in this branch, not alternate chunk
+  stores or search indexes.
+
+## Completion Criteria
+
+- Auto fields are accepted by backend schemas and form dependencies.
+- Deterministic planner has focused unit coverage.
+- Direct media processing, web/article ingest, async ingest jobs, and persisted
+  safe metadata expose `chunking_plan` for Auto requests.
+- Legacy and Manual chunking behavior is preserved by tests.
+- Quick Ingest defaults to Auto when Chunking is enabled and sends the correct
+  payload for file/media and web/article entries.
+- Manual mode still exposes and submits existing advanced chunk settings.
+- AI-assist preference is explicit, disabled by default, and does not make model
+  calls unless the adapter is intentionally implemented.
+- Focused backend and frontend tests pass.
+- Bandit is run on touched backend files or a non-code skip is recorded.
+- Backlog tasks are updated with verification and final summary.

--- a/Docs/superpowers/specs/2026-05-06-auto-chunking-design.md
+++ b/Docs/superpowers/specs/2026-05-06-auto-chunking-design.md
@@ -1,0 +1,284 @@
+# Auto Chunking for Quick Ingest Design
+
+Task: TASK-96
+Status: Approved design, documentation-only spec
+Date: 2026-05-06
+
+## Goal
+
+Add a novice-facing Auto Chunking mode for Quick Ingest. The feature should let less technical users turn on chunking and get useful defaults for search, Q&A, navigation, and summaries without choosing chunk methods, sizes, overlaps, templates, or LLM settings.
+
+The product contract is:
+
+- Turning `Chunking` off disables chunking.
+- Turning `Chunking` on in the new Quick Ingest UI defaults to `Auto`.
+- `Auto` uses deterministic media-aware planning unless the user explicitly enables AI assistance.
+- `Manual` exposes the existing detailed chunking controls.
+- Auto supports `Balanced`, `Search/Q&A`, and `Reading/Summary` goals.
+
+## Existing System Inventory
+
+The repo already has substantial chunking functionality:
+
+- `tldw_Server_API/app/core/Chunking/` supports words, sentences, paragraphs, tokens, semantic, JSON, XML, ebook chapters, propositions, rolling summarize, structure-aware, code, hierarchical chunking, templates, classifier auto-apply, and template learning.
+- `tldw_Server_API/app/api/v1/endpoints/chunking.py` exposes standalone text/file chunking and advertises runtime capabilities.
+- `tldw_Server_API/app/api/v1/endpoints/chunking_templates.py` supports template CRUD, apply, validate, match, and learn.
+- `tldw_Server_API/app/api/v1/schemas/media_request_models.py` already defines `auto_apply_template` and `chunking_template_name`.
+- `apps/packages/ui/src/components/Option/ChunkingPlayground/` is a power-user test and template-authoring surface.
+- `apps/packages/ui/src/components/Common/QuickIngest/` already has simple chunking toggles plus a hidden-ish template selector and auto-detect switch.
+- `apps/packages/ui/src/services/tldw/quick-ingest-batch.ts` sends `chunking_template_name` and `auto_apply_template` when selected.
+- `apps/packages/ui/src/entries/background.ts` has a parallel Quick Ingest submission path that also needs any new Auto fields.
+
+The main gap is not missing chunking algorithms. The gap is a first-class, explainable Auto mode that turns existing primitives into a safe default for nontechnical users.
+
+## Existing Integration Gaps
+
+The implementation plan should account for these current inconsistencies:
+
+- General media-add/job parsing currently accepts basic chunking fields but appears not to parse `auto_apply_template`, `chunking_template_name`, `hierarchical_chunking`, or `hierarchical_template` through `get_add_media_form`.
+- PDF processing parses `auto_apply_template` and `chunking_template_name`, but documents, audio, video, ebooks, and emails appear to expose only basic chunking fields through their process-form dependencies.
+- `apply_chunking_template_if_any()` applies explicit or auto-selected templates only when the template contains hierarchical configuration. Template selection is therefore a partial planning input, not a complete Auto Chunking solution.
+- Async ingest job finalization currently returns a narrow result payload. Auto Chunking plan metadata must be explicitly forwarded there or persisted somewhere shared; adding it only to intermediate processing results will not make it visible to job status clients.
+- The existing Agentic Chunking design is query-time RAG evidence assembly. It is useful precedent but is not ingest-time Auto Chunking.
+
+## User-Facing Model
+
+Quick Ingest should show:
+
+```text
+Chunking: off | on
+
+When on:
+  Mode: Auto | Manual
+
+Auto:
+  Goal: Balanced | Search/Q&A | Reading/Summary
+  Use AI to improve chunk boundaries: off by default
+
+Manual:
+  Existing advanced settings:
+    method, size, overlap, adaptive, multi-level, template,
+    contextual chunking, proposition options, and related controls
+```
+
+Template auto-detect should move behind Auto as a planner input. Explicit template selection should remain available in Manual or advanced settings.
+
+Auto and Manual should have explicit precedence. In Auto mode, manual chunking controls from old saved advanced settings should not silently affect planning. Switching to Manual re-enables the detailed fields. The only LLM-related Auto control is `auto_chunking_use_llm`.
+
+## API Contract
+
+Add explicit fields while preserving old clients:
+
+```text
+perform_chunking=true
+chunking_mode=auto|manual
+auto_chunking_goal=balanced|qa_search|navigation_summary
+auto_chunking_use_llm=false|true
+```
+
+Compatibility rules:
+
+- If `chunking_mode` is missing, preserve today's behavior.
+- The new Quick Ingest UI should explicitly send `chunking_mode=auto` when a user enables Chunking and has not switched to Manual.
+- `auto_chunking_use_llm` defaults to false.
+- If `auto_chunking_use_llm=true` but provider/model/key support is unavailable, the ingest should fall back to deterministic Auto and record the fallback reason.
+- Manual mode keeps existing request fields and should not reinterpret advanced user settings.
+
+Auto mode should not require the client to send an existing `chunk_method`. If the planner chooses an internal method that is not currently accepted by media request validation, such as `structure_aware`, the implementation must either apply that method after request validation or extend the media chunk-method allowlist before exposing it as a request value.
+
+## Planner Component
+
+Introduce an Auto Chunk Planner that returns normalized existing chunker options plus user-visible metadata.
+
+Proposed input:
+
+- media type
+- filename, URL, title, MIME type, and extension
+- content length and extracted text profile when available
+- headings, chapters, table-like blocks, transcript timecodes, diarization, caption availability, OCR signal, and language when available
+- existing template classifier matches
+- user goal
+- explicit AI-assist preference
+- provider/model availability for AI assist
+
+Proposed output:
+
+```json
+{
+  "mode": "auto",
+  "goal": "balanced",
+  "used_llm": false,
+  "method": "structure_aware",
+  "max_size": 900,
+  "overlap": 120,
+  "template_name": "academic_pdf",
+  "derived_views": ["outline", "section_titles", "summary_anchors"],
+  "fallback_reason": null,
+  "rationale": "Detected headings and long sections; selected structure-aware chunking for retrieval plus readable section anchors."
+}
+```
+
+The planner should return chunking options in the same shape expected by existing chunking helpers so processors can reuse current chunking strategies.
+
+Derived navigation views in V1 are metadata outputs, not separate persistent chunk sets or secondary indexes. Examples include outline entries, section labels, time ranges, and summary anchors attached to the chunking plan or response metadata.
+
+## Planner Behavior by Goal
+
+`qa_search`:
+
+- Optimize for retrieval quality, citations, and chunk boundaries that do not bury the answer.
+- Prefer smaller or moderate chunks with appropriate overlap.
+- Preserve source offsets, section metadata, and timecodes.
+
+`navigation_summary`:
+
+- Optimize for human browsing, chapter-like sections, readable titles, summaries, and time spans.
+- Prefer structural boundaries and larger coherent segments.
+- Produce derived navigation metadata where possible.
+
+`balanced`:
+
+- Default novice goal.
+- Use a primary retrieval-friendly chunk set plus derived navigation views when possible.
+- Avoid dual persistent chunk sets in V1 unless the storage/indexing model already supports this cleanly.
+
+## Planner Behavior by Media Type
+
+PDF and document:
+
+- Prefer `structure_aware` or hierarchical sentence chunking when headings/sections are detected.
+- Use semantic chunking as a fallback for unstructured long prose.
+- Use OCR and table signals to preserve boundaries and adjust sizing.
+- With AI assist enabled, use the LLM to refine section labels or boundaries, not to rewrite chunks.
+
+Audio and video:
+
+- Use transcript length, sentence boundaries, timecodes, diarization, and caption availability.
+- Default to sentence chunks with timecode metadata.
+- For `navigation_summary`, preserve larger segments around topic shifts.
+- With AI assist enabled, optionally infer topic breaks from transcript windows.
+
+Ebook:
+
+- Prefer `ebook_chapters`.
+- If chapters are weak or missing, fall back to structure-aware, paragraph, or sentence chunks.
+- For `navigation_summary`, produce chapter-style navigation metadata.
+
+Email:
+
+- Preserve thread and message boundaries.
+- Prefer larger sentence or paragraph chunks.
+- If attachments are ingested, plan per attachment type instead of forcing email defaults onto every child item.
+
+Web or article content:
+
+- Prefer structure-aware headings, lists, and tables.
+- Fall back to paragraphs or sentences depending on length.
+- Template matching can help, but should be only one planner signal.
+
+## AI Assistance
+
+AI assistance is explicit opt-in through `auto_chunking_use_llm=true`.
+
+AI assistance may:
+
+- suggest topic breaks for long transcripts
+- refine section labels
+- identify weak headings or chapter-like boundaries
+- choose among deterministic candidate plans
+
+AI assistance must not:
+
+- rewrite source chunks as the canonical stored text
+- silently turn on because a provider is configured
+- fail the whole ingest when unavailable unless a future advanced policy explicitly requests strict failure
+
+If AI assistance is unavailable, the result metadata should state that deterministic Auto was used and why.
+
+## Persistence and Result Metadata
+
+Persist or return the final plan where users and jobs can inspect it. At minimum, job/result metadata should include:
+
+- common key: `chunking_plan`
+- `chunking_mode`
+- `auto_chunking_goal`
+- chosen method, size, overlap, and template
+- `used_llm`
+- fallback reason, if any
+- estimated or final chunk count when available
+- short rationale
+
+This is important for trust. The user should be able to understand why Auto made a choice without reading logs.
+
+Use the same `chunking_plan` object across direct process responses, async job result payloads, and durable media metadata where available. For persisted media items, prefer storing it under `safe_metadata.chunking_plan` unless implementation review finds a more appropriate existing metadata contract.
+
+## Data Flow
+
+1. Quick Ingest sends `perform_chunking=true`, `chunking_mode=auto`, selected goal, and AI-assist preference.
+2. Backend form dependencies preserve these fields for media-add, async ingest jobs, and process endpoints.
+3. Manual mode follows the current chunking option path.
+4. Auto mode builds a preliminary plan from request metadata.
+5. After extraction/transcription, Auto finalizes the plan using text/profile signals.
+6. Existing chunking helpers receive normalized options.
+7. Job/result metadata records the final plan and fallback details.
+
+## Error Handling
+
+- Invalid `chunking_mode` or `auto_chunking_goal` should produce normal validation errors.
+- If chunking is disabled, Auto fields should be ignored.
+- If AI assist is requested but unavailable, fall back to deterministic Auto and record the reason.
+- If template matching fails, continue without template and record the reason.
+- If Auto planning fails unexpectedly, use the existing safe default chunking behavior and record a planner fallback. Do not fail ingestion for planner-only errors unless the underlying chunker fails.
+
+## Rollout
+
+Suggested implementation sequence:
+
+1. Add schemas/form parsing for Auto fields and fix current template-field parity across media-add/jobs/process endpoints.
+2. Add deterministic planner with unit tests and no LLM dependency.
+3. Wire planner into media ingestion and process flows while preserving manual behavior.
+4. Persist/return plan metadata in job/result payloads.
+5. Update Quick Ingest UI so when Chunking is enabled, Mode defaults to Auto, the goal selector and AI-assist toggle are visible, and detailed controls move behind Manual.
+6. Update both Quick Ingest submission paths: the WebUI batch service and the extension/background entry.
+7. Migrate or hydrate persisted Quick Ingest options so existing saved `perform_chunking=true` settings default to Auto without leaking old manual advanced values.
+8. Add explicit AI-assist support after deterministic planning is stable.
+
+## Testing
+
+Backend tests:
+
+- Form dependencies preserve `chunking_mode`, `auto_chunking_goal`, `auto_chunking_use_llm`, `auto_apply_template`, and `chunking_template_name` for media-add/jobs and process endpoints.
+- Missing `chunking_mode` preserves old behavior.
+- Auto planner returns expected deterministic plans for representative media profiles.
+- AI-assist unavailable falls back without failing ingestion.
+- Template classifier failure or no match falls back without failing ingestion.
+- Manual mode preserves explicit method, size, overlap, template, and contextual settings.
+
+Frontend tests:
+
+- Enabling Chunking in Quick Ingest selects Auto by default.
+- Auto mode shows goal and AI-assist controls only.
+- Manual mode reveals existing advanced settings.
+- Quick Ingest request payload includes the new Auto fields.
+- Manual payloads continue to send existing advanced fields.
+
+Integration tests:
+
+- Async media ingest jobs retain Auto fields in job payload options.
+- Stored job/result metadata includes the final plan/rationale.
+- Async job status exposes `chunking_plan`, not only intermediate processor metadata.
+- PDF and at least one non-PDF media type exercise the same Auto contract.
+
+## Non-Goals for V1
+
+- Multiple persistent chunk sets per item.
+- LLM-only chunking.
+- A new chunking engine replacing the current strategies.
+- Breaking old clients that only send `perform_chunking=true`.
+- Making the Chunking Playground the novice workflow.
+
+## Open Implementation Risks
+
+- Some processing paths choose chunk options before extracted text is available. The implementation should introduce a clear finalization point after extraction/transcription so Auto can use text/profile signals.
+- Result metadata shape may differ across immediate process endpoints, media-add, and async jobs. The implementation should choose a common metadata key and document it.
+- Template JSON shapes should be checked before relying on form-created templates for Auto planning, because media ingestion currently only consumes hierarchical config from templates.

--- a/apps/packages/ui/src/components/Common/QuickIngest/IngestOptionsPanel.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/IngestOptionsPanel.tsx
@@ -3,6 +3,7 @@ import {
   Button,
   Input,
   Progress,
+  Segmented,
   Select,
   Space,
   Switch,
@@ -23,7 +24,21 @@ type CommonOptions = {
   perform_analysis: boolean
   perform_chunking: boolean
   overwrite_existing: boolean
+  chunking_mode?: "auto" | "manual"
+  auto_chunking_goal?: "balanced" | "qa_search" | "navigation_summary"
+  auto_chunking_use_llm?: boolean
 }
+
+const CHUNKING_MODE_OPTIONS = [
+  { label: "Auto", value: "auto" },
+  { label: "Manual", value: "manual" },
+]
+
+const AUTO_CHUNKING_GOAL_OPTIONS = [
+  { label: "Balanced", value: "balanced" },
+  { label: "Search/Q&A", value: "qa_search" },
+  { label: "Reading/Summary", value: "navigation_summary" },
+]
 
 type TypeDefaults = {
   audio?: { language?: string; diarize?: boolean }
@@ -172,7 +187,51 @@ export const IngestOptionsPanel: React.FC<IngestOptionsPanelProps> = ({
   )
   const handleChunkingToggle = React.useCallback(
     (value: boolean) => {
-      setCommon((current) => ({ ...current, perform_chunking: value }))
+      setCommon((current) => ({
+        ...current,
+        perform_chunking: value,
+        ...(value
+          ? {
+              chunking_mode: "auto",
+              auto_chunking_goal: current.auto_chunking_goal ?? "balanced",
+              auto_chunking_use_llm: current.auto_chunking_use_llm ?? false
+            }
+          : {})
+      }))
+    },
+    [setCommon]
+  )
+  const chunkingMode = common.chunking_mode === "manual" ? "manual" : "auto"
+  const autoChunkingGoal =
+    common.auto_chunking_goal === "qa_search" ||
+    common.auto_chunking_goal === "navigation_summary"
+      ? common.auto_chunking_goal
+      : "balanced"
+  const handleChunkingModeChange = React.useCallback(
+    (value: string | number) => {
+      const mode = value === "manual" ? "manual" : "auto"
+      setCommon((current) => ({
+        ...current,
+        chunking_mode: mode,
+        auto_chunking_goal: current.auto_chunking_goal ?? "balanced",
+        auto_chunking_use_llm: current.auto_chunking_use_llm ?? false
+      }))
+    },
+    [setCommon]
+  )
+  const handleAutoChunkingGoalChange = React.useCallback(
+    (value: string) => {
+      const goal =
+        value === "qa_search" || value === "navigation_summary"
+          ? value
+          : "balanced"
+      setCommon((current) => ({ ...current, auto_chunking_goal: goal }))
+    },
+    [setCommon]
+  )
+  const handleAutoChunkingUseLlmChange = React.useCallback(
+    (value: boolean) => {
+      setCommon((current) => ({ ...current, auto_chunking_use_llm: value }))
     },
     [setCommon]
   )
@@ -403,8 +462,63 @@ export const IngestOptionsPanel: React.FC<IngestOptionsPanelProps> = ({
         </Tooltip>
       </Space>
 
-      {/* Chunking template selector - visible when chunking is enabled */}
-      {common.perform_chunking && setChunkingTemplateName && (
+      {common.perform_chunking && (
+        <div className="mt-2 pt-2 border-t border-border space-y-2">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <span className="text-sm font-medium">
+              {qi("chunkingModeLabel", "Chunking mode")}
+            </span>
+            <Segmented
+              aria-label={qi("chunkingModeLabel", "Chunking mode")}
+              options={CHUNKING_MODE_OPTIONS}
+              value={chunkingMode}
+              onChange={handleChunkingModeChange}
+              disabled={running}
+            />
+          </div>
+          {chunkingMode === "auto" ? (
+            <div className="grid gap-2 md:grid-cols-[minmax(0,1fr)_auto]">
+              <label className="flex flex-col gap-1 text-sm text-text">
+                <span>{qi("autoChunkingGoalLabel", "Auto chunking goal")}</span>
+                <Select
+                  aria-label={qi("autoChunkingGoalLabel", "Auto chunking goal")}
+                  value={autoChunkingGoal}
+                  onChange={handleAutoChunkingGoalChange}
+                  options={AUTO_CHUNKING_GOAL_OPTIONS}
+                  disabled={running}
+                />
+              </label>
+              <Tooltip
+                title={qi(
+                  "autoChunkingUseLlmTooltip",
+                  "Allow configured AI providers to refine chunk boundaries when available."
+                )}
+              >
+                <Space align="center" size="small">
+                  <Switch
+                    checked={common.auto_chunking_use_llm === true}
+                    onChange={handleAutoChunkingUseLlmChange}
+                    disabled={running}
+                    aria-label={qi(
+                      "autoChunkingUseLlmLabel",
+                      "Use AI to improve chunk boundaries"
+                    )}
+                  />
+                  <span className="text-sm">
+                    {qi(
+                      "autoChunkingUseLlmLabel",
+                      "Use AI to improve chunk boundaries"
+                    )}
+                  </span>
+                </Space>
+              </Tooltip>
+            </div>
+          ) : null}
+        </div>
+      )}
+
+      {/* Chunking template selector - visible for manual chunking only */}
+      {common.perform_chunking && chunkingMode === "manual" && setChunkingTemplateName && (
         <div className="mt-2 pt-2 border-t border-border space-y-2">
           <div className="flex items-center gap-2">
             <span className="min-w-32 text-sm">

--- a/apps/packages/ui/src/components/Common/QuickIngest/WizardConfigureStep.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/WizardConfigureStep.tsx
@@ -482,9 +482,13 @@ export const WizardConfigureStep: React.FC<WizardConfigureStepProps> = ({
           return
         }
         const numericValue = Number.parseInt(rawValue, 10)
+        const clampedValue =
+          name === "chunk_size"
+            ? Math.max(1, numericValue)
+            : Math.max(0, numericValue)
         setAdvancedValue(
           name,
-          Number.isFinite(numericValue) ? numericValue : undefined
+          Number.isFinite(numericValue) ? clampedValue : undefined
         )
       },
     [setAdvancedValue]

--- a/apps/packages/ui/src/components/Common/QuickIngest/WizardConfigureStep.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/WizardConfigureStep.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Button, Input, Select, Switch, Tooltip, Typography } from "antd"
+import { Button, Input, Segmented, Select, Switch, Tooltip, Typography } from "antd"
 import { useTranslation } from "react-i18next"
 import { ArrowLeft, ArrowRight, ChevronRight } from "lucide-react"
 
@@ -11,6 +11,25 @@ import { tldwClient } from "@/services/tldw/TldwApiClient"
 
 const DRAFT_STORAGE_CAP_BYTES = 5 * 1024 * 1024
 const CUSTOM_AUDIO_LANGUAGE_SENTINEL = "__custom__"
+
+const CHUNKING_MODE_OPTIONS = [
+  { label: "Auto", value: "auto" },
+  { label: "Manual", value: "manual" },
+]
+
+const AUTO_CHUNKING_GOAL_OPTIONS = [
+  { label: "Balanced", value: "balanced" },
+  { label: "Search/Q&A", value: "qa_search" },
+  { label: "Reading/Summary", value: "navigation_summary" },
+]
+
+const CHUNK_METHOD_OPTIONS = [
+  { label: "Semantic", value: "semantic" },
+  { label: "Tokens", value: "tokens" },
+  { label: "Paragraphs", value: "paragraphs" },
+  { label: "Sentences", value: "sentences" },
+  { label: "Words", value: "words" },
+]
 
 const formatBytes = (bytes: number) => {
   if (bytes < 1024) return `${bytes} B`
@@ -67,6 +86,25 @@ export const WizardConfigureStep: React.FC<WizardConfigureStepProps> = ({
   const [transcriptionModelsLoading, setTranscriptionModelsLoading] =
     React.useState(false)
   const [showAdvanced, setShowAdvanced] = React.useState(false)
+  const chunkingMode =
+    presetConfig.common.chunking_mode === "manual" ? "manual" : "auto"
+  const autoChunkingGoal =
+    presetConfig.common.auto_chunking_goal === "qa_search" ||
+    presetConfig.common.auto_chunking_goal === "navigation_summary"
+      ? presetConfig.common.auto_chunking_goal
+      : "balanced"
+  const manualChunkMethod =
+    typeof presetConfig.advancedValues?.chunk_method === "string"
+      ? presetConfig.advancedValues.chunk_method
+      : "semantic"
+  const manualChunkSize =
+    presetConfig.advancedValues?.chunk_size == null
+      ? ""
+      : String(presetConfig.advancedValues.chunk_size)
+  const manualChunkOverlap =
+    presetConfig.advancedValues?.chunk_overlap == null
+      ? ""
+      : String(presetConfig.advancedValues.chunk_overlap)
 
   const hasDocumentItems =
     detectedTypes.has("document") ||
@@ -235,7 +273,54 @@ export const WizardConfigureStep: React.FC<WizardConfigureStepProps> = ({
 
   const handleChunkingToggle = React.useCallback(
     (checked: boolean) => {
-      setCommon((current) => ({ ...current, perform_chunking: checked }))
+      setCommon((current) => ({
+        ...current,
+        perform_chunking: checked,
+        ...(checked
+          ? {
+              chunking_mode: "auto",
+              auto_chunking_goal: current.auto_chunking_goal ?? "balanced",
+              auto_chunking_use_llm: current.auto_chunking_use_llm ?? false,
+            }
+          : {}),
+      }))
+    },
+    [setCommon]
+  )
+
+  const handleChunkingModeChange = React.useCallback(
+    (nextMode: string | number) => {
+      const mode = nextMode === "manual" ? "manual" : "auto"
+      setCommon((current) => ({
+        ...current,
+        chunking_mode: mode,
+        auto_chunking_goal: current.auto_chunking_goal ?? "balanced",
+        auto_chunking_use_llm: current.auto_chunking_use_llm ?? false,
+      }))
+    },
+    [setCommon]
+  )
+
+  const handleAutoChunkingGoalChange = React.useCallback(
+    (nextGoal: string) => {
+      const goal =
+        nextGoal === "qa_search" || nextGoal === "navigation_summary"
+          ? nextGoal
+          : "balanced"
+      setCommon((current) => ({
+        ...current,
+        auto_chunking_goal: goal,
+      }))
+    },
+    [setCommon]
+  )
+
+  const handleAutoChunkingUseLlmChange = React.useCallback(
+    (checked: boolean) => {
+      setCommon((current) => ({
+        ...current,
+        auto_chunking_use_llm: checked,
+      }))
     },
     [setCommon]
   )
@@ -370,6 +455,41 @@ export const WizardConfigureStep: React.FC<WizardConfigureStepProps> = ({
     })
   }, [setCustomOptions])
 
+  const setAdvancedValue = React.useCallback(
+    (name: string, value: unknown) => {
+      setCustomOptions({
+        advancedValues: {
+          [name]: value,
+        },
+      })
+    },
+    [setCustomOptions]
+  )
+
+  const handleManualChunkMethodChange = React.useCallback(
+    (nextMethod: string) => {
+      setAdvancedValue("chunk_method", nextMethod || undefined)
+    },
+    [setAdvancedValue]
+  )
+
+  const handleManualChunkNumberChange = React.useCallback(
+    (name: "chunk_size" | "chunk_overlap") =>
+      (event: React.ChangeEvent<HTMLInputElement>) => {
+        const rawValue = event.target.value.trim()
+        if (!rawValue) {
+          setAdvancedValue(name, undefined)
+          return
+        }
+        const numericValue = Number.parseInt(rawValue, 10)
+        setAdvancedValue(
+          name,
+          Number.isFinite(numericValue) ? numericValue : undefined
+        )
+      },
+    [setAdvancedValue]
+  )
+
   const storageLabel = presetConfig.reviewBeforeStorage
     ? qi("reviewModeStorageLabel", "Review drafts locally")
     : presetConfig.storeRemote
@@ -469,6 +589,86 @@ export const WizardConfigureStep: React.FC<WizardConfigureStepProps> = ({
               </div>
             </Tooltip>
           </div>
+
+          {presetConfig.common.perform_chunking && (
+            <div className="rounded-md border border-border bg-surface2 p-3">
+              <div className="flex flex-col gap-3">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <Typography.Text strong>
+                    {qi("chunkingModeLabel", "Chunking mode")}
+                  </Typography.Text>
+                  <Segmented
+                    aria-label={qi("chunkingModeLabel", "Chunking mode")}
+                    options={CHUNKING_MODE_OPTIONS}
+                    value={chunkingMode}
+                    onChange={handleChunkingModeChange}
+                  />
+                </div>
+
+                {chunkingMode === "auto" ? (
+                  <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_auto]">
+                    <label className="flex flex-col gap-1 text-sm text-text">
+                      <span>{qi("autoChunkingGoalLabel", "Auto chunking goal")}</span>
+                      <Select
+                        aria-label={qi("autoChunkingGoalLabel", "Auto chunking goal")}
+                        value={autoChunkingGoal}
+                        onChange={handleAutoChunkingGoalChange}
+                        options={AUTO_CHUNKING_GOAL_OPTIONS}
+                      />
+                    </label>
+                    <label className="flex items-center justify-between gap-3 rounded-md border border-border px-3 py-2 text-sm text-text">
+                      <span>
+                        {qi(
+                          "autoChunkingUseLlmLabel",
+                          "Use AI to improve chunk boundaries"
+                        )}
+                      </span>
+                      <Switch
+                        aria-label={qi(
+                          "autoChunkingUseLlmLabel",
+                          "Use AI to improve chunk boundaries"
+                        )}
+                        checked={presetConfig.common.auto_chunking_use_llm === true}
+                        onChange={handleAutoChunkingUseLlmChange}
+                      />
+                    </label>
+                  </div>
+                ) : (
+                  <div className="grid gap-3 md:grid-cols-3">
+                    <label className="flex flex-col gap-1 text-sm text-text">
+                      <span>{qi("chunkMethodLabel", "Chunk method")}</span>
+                      <Select
+                        aria-label={qi("chunkMethodLabel", "Chunk method")}
+                        value={manualChunkMethod}
+                        onChange={handleManualChunkMethodChange}
+                        options={CHUNK_METHOD_OPTIONS}
+                      />
+                    </label>
+                    <label className="flex flex-col gap-1 text-sm text-text">
+                      <span>{qi("chunkSizeLabel", "Chunk size")}</span>
+                      <Input
+                        aria-label={qi("chunkSizeLabel", "Chunk size")}
+                        type="number"
+                        min={1}
+                        value={manualChunkSize}
+                        onChange={handleManualChunkNumberChange("chunk_size")}
+                      />
+                    </label>
+                    <label className="flex flex-col gap-1 text-sm text-text">
+                      <span>{qi("chunkOverlapLabel", "Chunk overlap")}</span>
+                      <Input
+                        aria-label={qi("chunkOverlapLabel", "Chunk overlap")}
+                        type="number"
+                        min={0}
+                        value={manualChunkOverlap}
+                        onChange={handleManualChunkNumberChange("chunk_overlap")}
+                      />
+                    </label>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
 
           {/* Advanced options toggle */}
           <button

--- a/apps/packages/ui/src/components/Common/QuickIngest/__tests__/IngestWizardContext.test.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/__tests__/IngestWizardContext.test.tsx
@@ -54,6 +54,15 @@ function TestHarness() {
       <span data-testid="presetAnalysis">
         {String(state.presetConfig.common.perform_analysis)}
       </span>
+      <span data-testid="presetChunkingMode">
+        {state.presetConfig.common.chunking_mode || ""}
+      </span>
+      <span data-testid="presetAutoChunkingGoal">
+        {state.presetConfig.common.auto_chunking_goal || ""}
+      </span>
+      <span data-testid="presetAutoChunkingUseLlm">
+        {String(Boolean(state.presetConfig.common.auto_chunking_use_llm))}
+      </span>
       <span data-testid="presetAudioLanguage">
         {state.presetConfig.typeDefaults.audio?.language || ""}
       </span>
@@ -317,6 +326,15 @@ describe("IngestWizardContext", () => {
         await userEvent.click(screen.getByText("setDeep"))
       })
       expect(screen.getByTestId("preset").textContent).toBe("deep")
+    })
+
+    it("defaults chunking-enabled presets to auto chunking", () => {
+      renderWithProvider()
+
+      expect(screen.getByTestId("preset").textContent).toBe("standard")
+      expect(screen.getByTestId("presetChunkingMode").textContent).toBe("auto")
+      expect(screen.getByTestId("presetAutoChunkingGoal").textContent).toBe("balanced")
+      expect(screen.getByTestId("presetAutoChunkingUseLlm").textContent).toBe("false")
     })
 
     it("setCustomOptions merges custom options into presetConfig", async () => {

--- a/apps/packages/ui/src/components/Common/QuickIngest/__tests__/IngestWizardContext.test.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/__tests__/IngestWizardContext.test.tsx
@@ -6,6 +6,7 @@ import {
   IngestWizardProvider,
   useIngestWizard,
 } from "../IngestWizardContext"
+import { configMatchesPreset } from "../presets"
 import type { WizardQueueItem } from "../types"
 
 // ---------------------------------------------------------------------------
@@ -335,6 +336,38 @@ describe("IngestWizardContext", () => {
       expect(screen.getByTestId("presetChunkingMode").textContent).toBe("auto")
       expect(screen.getByTestId("presetAutoChunkingGoal").textContent).toBe("balanced")
       expect(screen.getByTestId("presetAutoChunkingUseLlm").textContent).toBe("false")
+    })
+
+    it("ignores inactive manual chunking fields when matching auto presets", () => {
+      const matchesStandard = configMatchesPreset(
+        {
+          common: {
+            perform_analysis: true,
+            perform_chunking: true,
+            overwrite_existing: false,
+            chunking_mode: "auto",
+            auto_chunking_goal: "balanced",
+            auto_chunking_use_llm: false,
+          },
+          storeRemote: true,
+          reviewBeforeStorage: false,
+          typeDefaults: {
+            audio: { diarize: false },
+            document: { ocr: true },
+            video: { captions: true },
+          },
+          advancedValues: {
+            chunk_method: "tokens",
+            chunk_size: 0,
+            chunk_overlap: -5,
+            hierarchical_chunking: true,
+            hierarchical_template: { boundaries: [{ kind: "heading" }] },
+          },
+        },
+        "standard"
+      )
+
+      expect(matchesStandard).toBe(true)
     })
 
     it("setCustomOptions merges custom options into presetConfig", async () => {

--- a/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx
@@ -982,7 +982,30 @@ describe("QuickIngestWizardModal — real configure step", () => {
     expect(screen.queryByLabelText("Chunk size")).not.toBeInTheDocument()
     expect(screen.queryByLabelText("Chunk overlap")).not.toBeInTheDocument()
     expect(screen.getByLabelText("Auto chunking goal")).toHaveValue("balanced")
-    expect(ctxRef!.state.presetConfig.advancedValues?.chunk_size).toBe(900)
+    expect(ctxRef!.state.presetConfig.advancedValues?.chunk_size).toBeUndefined()
+  })
+
+  it("clamps Manual chunking numbers before storing advanced values", async () => {
+    const user = userEvent.setup()
+    render(<WizardTestHarness onClose={vi.fn()} />)
+
+    await user.type(
+      screen.getByPlaceholderText(/https:\/\/example\.com/i),
+      "https://example.com/library/article"
+    )
+    await user.click(screen.getByRole("button", { name: /Add URLs to queue/i }))
+    await user.click(screen.getByText(/Configure 1 items/i))
+    await user.click(await screen.findByRole("button", { name: "Manual" }))
+
+    await user.clear(screen.getByLabelText("Chunk size"))
+    await user.type(screen.getByLabelText("Chunk size"), "0")
+    await user.clear(screen.getByLabelText("Chunk overlap"))
+    await user.type(screen.getByLabelText("Chunk overlap"), "-5")
+
+    await waitFor(() => {
+      expect(ctxRef!.state.presetConfig.advancedValues?.chunk_size).toBe(1)
+      expect(ctxRef!.state.presetConfig.advancedValues?.chunk_overlap).toBe(0)
+    })
   })
 
   it("keeps review mode anchored to remote storage and leaves audio defaults available for video-only batches", async () => {

--- a/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx
@@ -103,6 +103,25 @@ vi.mock("antd", () => ({
       </React.Fragment>
     )
   },
+  Segmented: ({ options, value, onChange, ...props }: any) => (
+    <div role="group" {...props}>
+      {options?.map((option: any) => {
+        const optionValue =
+          typeof option === "object" ? option.value : option
+        const label = typeof option === "object" ? option.label : option
+        return (
+          <button
+            key={optionValue}
+            type="button"
+            aria-pressed={value === optionValue}
+            onClick={() => onChange?.(optionValue)}
+          >
+            {label}
+          </button>
+        )
+      })}
+    </div>
+  ),
   Radio: Object.assign(
     ({ children, value, ...props }: any) => (
       <label>
@@ -901,6 +920,71 @@ describe("QuickIngestWizardModal — real configure step", () => {
     expect(screen.getByText(/using custom settings/i)).toBeInTheDocument()
   })
 
+  it("shows Auto chunking controls by default when chunking is enabled", async () => {
+    const user = userEvent.setup()
+    render(<WizardTestHarness onClose={vi.fn()} />)
+
+    await user.type(
+      screen.getByPlaceholderText(/https:\/\/example\.com/i),
+      "https://example.com/library/article"
+    )
+    await user.click(screen.getByRole("button", { name: /Add URLs to queue/i }))
+    await user.click(screen.getByText(/Configure 1 items/i))
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("group", { name: /chunking mode/i })
+      ).toBeInTheDocument()
+    })
+
+    expect(screen.getByRole("button", { name: "Auto" })).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    )
+    expect(screen.getByLabelText("Auto chunking goal")).toHaveValue("balanced")
+    expect(
+      screen.getByLabelText("Use AI to improve chunk boundaries")
+    ).not.toBeChecked()
+  })
+
+  it("reveals Manual chunking controls and hides them when switching back to Auto", async () => {
+    const user = userEvent.setup()
+    render(<WizardTestHarness onClose={vi.fn()} />)
+
+    await user.type(
+      screen.getByPlaceholderText(/https:\/\/example\.com/i),
+      "https://example.com/library/article"
+    )
+    await user.click(screen.getByRole("button", { name: /Add URLs to queue/i }))
+    await user.click(screen.getByText(/Configure 1 items/i))
+
+    await user.click(await screen.findByRole("button", { name: "Manual" }))
+
+    expect(screen.getByLabelText("Chunk method")).toBeInTheDocument()
+    expect(screen.getByLabelText("Chunk size")).toBeInTheDocument()
+    expect(screen.getByLabelText("Chunk overlap")).toBeInTheDocument()
+
+    await user.clear(screen.getByLabelText("Chunk size"))
+    await user.type(screen.getByLabelText("Chunk size"), "900")
+
+    expect(ctxRef).not.toBeNull()
+    await waitFor(() => {
+      expect(ctxRef!.state.presetConfig.common.chunking_mode).toBe("manual")
+      expect(ctxRef!.state.presetConfig.advancedValues?.chunk_size).toBe(900)
+    })
+
+    await user.click(screen.getByRole("button", { name: "Auto" }))
+
+    await waitFor(() => {
+      expect(ctxRef!.state.presetConfig.common.chunking_mode).toBe("auto")
+    })
+    expect(screen.queryByLabelText("Chunk method")).not.toBeInTheDocument()
+    expect(screen.queryByLabelText("Chunk size")).not.toBeInTheDocument()
+    expect(screen.queryByLabelText("Chunk overlap")).not.toBeInTheDocument()
+    expect(screen.getByLabelText("Auto chunking goal")).toHaveValue("balanced")
+    expect(ctxRef!.state.presetConfig.advancedValues?.chunk_size).toBe(900)
+  })
+
   it("keeps review mode anchored to remote storage and leaves audio defaults available for video-only batches", async () => {
     const user = userEvent.setup()
     render(<WizardTestHarness onClose={vi.fn()} />)
@@ -1148,6 +1232,7 @@ describe("QuickIngestWizardModal — real configure step", () => {
     expect(ctxRef).not.toBeNull()
     ctxRef!.setCustomOptions({
       common: {
+        ...ctxRef!.state.presetConfig.common,
         perform_analysis: false,
       },
       typeDefaults: {

--- a/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx
@@ -305,6 +305,12 @@ describe("QuickIngestWizardModal session runtime", () => {
     expect(mocks.submitQuickIngestBatch).toHaveBeenCalledWith(
       expect.objectContaining({
         __quickIngestSessionId: "qi-direct-test",
+        common: expect.objectContaining({
+          perform_chunking: true,
+          chunking_mode: "auto",
+          auto_chunking_goal: "balanced",
+          auto_chunking_use_llm: false,
+        }),
         entries: [
           expect.objectContaining({
             id: "queued-url-1",

--- a/apps/packages/ui/src/components/Common/QuickIngest/presets.ts
+++ b/apps/packages/ui/src/components/Common/QuickIngest/presets.ts
@@ -1,4 +1,5 @@
 import type { IngestPreset, PresetConfig, CommonOptions, TypeDefaults } from "./types"
+import { shouldSubmitQuickIngestAdvancedField } from "@/services/tldw/quick-ingest-chunking"
 
 /**
  * Preset configurations for Quick Ingest.
@@ -167,6 +168,16 @@ const serializeAdvancedValues = (values?: Record<string, unknown>) => {
   return JSON.stringify(normalizeAdvancedValue(values ?? {}))
 }
 
+const filterApplicableAdvancedValues = (
+  values: Record<string, unknown> | undefined,
+  common: CommonOptions,
+) =>
+  Object.fromEntries(
+    Object.entries(values ?? {}).filter(([fieldName]) =>
+      shouldSubmitQuickIngestAdvancedField(fieldName, common)
+    )
+  )
+
 /**
  * Check if current configuration matches a specific preset.
  */
@@ -232,8 +243,12 @@ export function configMatchesPreset(
   }
 
   if (
-    serializeAdvancedValues(config.advancedValues) !==
-    serializeAdvancedValues(preset.advancedValues)
+    serializeAdvancedValues(
+      filterApplicableAdvancedValues(config.advancedValues, config.common)
+    ) !==
+    serializeAdvancedValues(
+      filterApplicableAdvancedValues(preset.advancedValues, preset.common)
+    )
   ) {
     return false
   }

--- a/apps/packages/ui/src/components/Common/QuickIngest/presets.ts
+++ b/apps/packages/ui/src/components/Common/QuickIngest/presets.ts
@@ -11,7 +11,10 @@ export const DEFAULT_PRESETS: PresetMap = {
     common: {
       perform_analysis: false,
       perform_chunking: false,
-      overwrite_existing: false
+      overwrite_existing: false,
+      chunking_mode: "auto",
+      auto_chunking_goal: "balanced",
+      auto_chunking_use_llm: false
     },
     storeRemote: true,
     reviewBeforeStorage: false,
@@ -26,7 +29,10 @@ export const DEFAULT_PRESETS: PresetMap = {
     common: {
       perform_analysis: true,
       perform_chunking: true,
-      overwrite_existing: false
+      overwrite_existing: false,
+      chunking_mode: "auto",
+      auto_chunking_goal: "balanced",
+      auto_chunking_use_llm: false
     },
     storeRemote: true,
     reviewBeforeStorage: false,
@@ -41,7 +47,10 @@ export const DEFAULT_PRESETS: PresetMap = {
     common: {
       perform_analysis: true,
       perform_chunking: true,
-      overwrite_existing: true
+      overwrite_existing: true,
+      chunking_mode: "auto",
+      auto_chunking_goal: "balanced",
+      auto_chunking_use_llm: false
     },
     storeRemote: true,
     reviewBeforeStorage: true,
@@ -178,7 +187,13 @@ export function configMatchesPreset(
   if (
     config.common.perform_analysis !== preset.common.perform_analysis ||
     config.common.perform_chunking !== preset.common.perform_chunking ||
-    config.common.overwrite_existing !== preset.common.overwrite_existing
+    config.common.overwrite_existing !== preset.common.overwrite_existing ||
+    (config.common.chunking_mode ?? "auto") !==
+      (preset.common.chunking_mode ?? "auto") ||
+    (config.common.auto_chunking_goal ?? "balanced") !==
+      (preset.common.auto_chunking_goal ?? "balanced") ||
+    Boolean(config.common.auto_chunking_use_llm) !==
+      Boolean(preset.common.auto_chunking_use_llm)
   ) {
     return false
   }

--- a/apps/packages/ui/src/components/Common/QuickIngest/types.ts
+++ b/apps/packages/ui/src/components/Common/QuickIngest/types.ts
@@ -64,10 +64,20 @@ export type QuickIngestTab = "queue" | "options" | "results"
 /**
  * Common processing options shared across all media types.
  */
+export type ChunkingMode = "auto" | "manual"
+
+export type AutoChunkingGoal =
+  | "balanced"
+  | "qa_search"
+  | "navigation_summary"
+
 export type CommonOptions = {
   perform_analysis: boolean
   perform_chunking: boolean
   overwrite_existing: boolean
+  chunking_mode?: ChunkingMode
+  auto_chunking_goal?: AutoChunkingGoal
+  auto_chunking_use_llm?: boolean
 }
 
 /**

--- a/apps/packages/ui/src/components/Common/QuickIngestWizardModal.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngestWizardModal.tsx
@@ -38,6 +38,7 @@ import {
 } from "@/store/quick-ingest-session"
 import { useQuickIngestStore } from "@/store/quick-ingest"
 import type {
+  CommonOptions,
   DetectedMediaType,
   ItemProgress,
   ItemProgressStatus,
@@ -81,11 +82,7 @@ type QuickIngestRequestPayload = {
   }>
   storeRemote: boolean
   processOnly: boolean
-  common: {
-    perform_analysis: boolean
-    perform_chunking: boolean
-    overwrite_existing: boolean
-  }
+  common: CommonOptions
   advancedValues: Record<string, unknown>
   fileDefaults: TypeDefaults
   __quickIngestSessionId?: string
@@ -756,6 +753,9 @@ const buildQuickIngestPayload = async (
       perform_analysis: options.perform_analysis,
       perform_chunking: options.perform_chunking,
       overwrite_existing: options.overwrite_existing,
+      chunking_mode: options.chunking_mode,
+      auto_chunking_goal: options.auto_chunking_goal,
+      auto_chunking_use_llm: options.auto_chunking_use_llm,
     },
     advancedValues: options.advancedValues ?? {},
     fileDefaults: options.typeDefaults,

--- a/apps/packages/ui/src/components/Common/hooks/useIngestOptions.tsx
+++ b/apps/packages/ui/src/components/Common/hooks/useIngestOptions.tsx
@@ -75,6 +75,7 @@ const normalizeCommonOptions = (common?: {
   const chunkingMode: "auto" | "manual" =
     common?.chunking_mode === "manual" ? "manual" : "auto"
   return {
+    ...(common ?? {}),
     perform_analysis: common?.perform_analysis ?? true,
     perform_chunking: common?.perform_chunking ?? true,
     overwrite_existing: common?.overwrite_existing ?? false,

--- a/apps/packages/ui/src/components/Common/hooks/useIngestOptions.tsx
+++ b/apps/packages/ui/src/components/Common/hooks/useIngestOptions.tsx
@@ -59,6 +59,31 @@ const writeSpecCache = (next: Omit<QuickIngestSpecCache, 'cachedAt'>) => {
 
 const SAVE_DEBOUNCE_MS = 2000
 
+const normalizeCommonOptions = (common?: {
+  perform_analysis?: boolean
+  perform_chunking?: boolean
+  overwrite_existing?: boolean
+  chunking_mode?: string
+  auto_chunking_goal?: string
+  auto_chunking_use_llm?: boolean
+}) => {
+  const chunkingGoal: "balanced" | "qa_search" | "navigation_summary" =
+    common?.auto_chunking_goal === "qa_search" ||
+    common?.auto_chunking_goal === "navigation_summary"
+      ? common.auto_chunking_goal
+      : "balanced"
+  const chunkingMode: "auto" | "manual" =
+    common?.chunking_mode === "manual" ? "manual" : "auto"
+  return {
+    perform_analysis: common?.perform_analysis ?? true,
+    perform_chunking: common?.perform_chunking ?? true,
+    overwrite_existing: common?.overwrite_existing ?? false,
+    chunking_mode: chunkingMode,
+    auto_chunking_goal: chunkingGoal,
+    auto_chunking_use_llm: common?.auto_chunking_use_llm === true
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Deps interface
 // ---------------------------------------------------------------------------
@@ -104,10 +129,16 @@ export function useIngestOptions(deps: UseIngestOptionsDeps) {
     perform_analysis: boolean
     perform_chunking: boolean
     overwrite_existing: boolean
+    chunking_mode?: "auto" | "manual"
+    auto_chunking_goal?: "balanced" | "qa_search" | "navigation_summary"
+    auto_chunking_use_llm?: boolean
   }>("quickIngestCommon", {
     perform_analysis: true,
     perform_chunking: true,
-    overwrite_existing: false
+    overwrite_existing: false,
+    chunking_mode: "auto",
+    auto_chunking_goal: "balanced",
+    auto_chunking_use_llm: false
   })
   const [savedAdvValues, setSavedAdvValues] = useStorage<Record<string, any>>('quickIngestAdvancedValues', {})
   const [uiPrefs, setUiPrefs] = useStorage<{ advancedOpen?: boolean; fieldDetailsOpen?: Record<string, boolean> }>('quickIngestAdvancedUI', {})
@@ -644,6 +675,14 @@ export function useIngestOptions(deps: UseIngestOptionsDeps) {
       setStoreRemote(true)
     }
   }, [reviewBeforeStorage, storeRemote])
+
+  // Backfill Auto chunking defaults for older persisted Quick Ingest options.
+  React.useEffect(() => {
+    const normalized = normalizeCommonOptions(common)
+    if (JSON.stringify(normalized) !== JSON.stringify(common || {})) {
+      setCommon(normalized)
+    }
+  }, [common, setCommon])
 
   // Sync refs
   React.useEffect(() => {

--- a/apps/packages/ui/src/components/Common/hooks/useIngestPresets.tsx
+++ b/apps/packages/ui/src/components/Common/hooks/useIngestPresets.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useStorage } from '@plasmohq/storage/hook'
-import type { IngestPreset, TypeDefaults } from "../QuickIngest/types"
+import type { CommonOptions, IngestPreset, TypeDefaults } from "../QuickIngest/types"
 import {
   DEFAULT_PRESET,
   detectPreset,
@@ -16,12 +16,8 @@ import {
 export interface UseIngestPresetsDeps {
   open: boolean
   /** Common ingest options from the options hook */
-  common: {
-    perform_analysis: boolean
-    perform_chunking: boolean
-    overwrite_existing: boolean
-  }
-  setCommon: (v: { perform_analysis: boolean; perform_chunking: boolean; overwrite_existing: boolean }) => void
+  common: CommonOptions
+  setCommon: (v: CommonOptions) => void
   storeRemote: boolean
   setStoreRemote: (v: boolean) => void
   reviewBeforeStorage: boolean

--- a/apps/packages/ui/src/entries/background.ts
+++ b/apps/packages/ui/src/entries/background.ts
@@ -1951,7 +1951,11 @@ export default defineBackground({
           summarize_checkbox: Boolean(common.perform_analysis),
           ...normalizedBody,
         };
-        applyQuickIngestChunkingFields(body, { common });
+        applyQuickIngestChunkingFields(body, {
+          common,
+          chunkingTemplateName,
+          autoApplyTemplate,
+        });
         if (typeof entry?.keywords === "string") {
           const trimmed = entry.keywords.trim();
           if (trimmed) {

--- a/apps/packages/ui/src/entries/background.ts
+++ b/apps/packages/ui/src/entries/background.ts
@@ -17,7 +17,10 @@ import {
   normalizePersistentAddResponse,
   shouldFallbackToPersistentAdd,
 } from "@/services/tldw/quick-ingest-fallback";
-import { resolvePerformChunking } from "@/services/tldw/ingest-defaults";
+import {
+  applyQuickIngestChunkingFields,
+  shouldSubmitQuickIngestAdvancedField,
+} from "@/services/tldw/quick-ingest-chunking";
 import {
   ensureSidepanelOpen,
   pickFirstString,
@@ -1834,7 +1837,6 @@ export default defineBackground({
         const fields: Record<string, any> = {
           media_type: mediaType,
           perform_analysis: Boolean(common.perform_analysis),
-          perform_chunking: resolvePerformChunking(common.perform_chunking),
           overwrite_existing: Boolean(common.overwrite_existing),
         };
         const resolvedDefaults: {
@@ -1860,6 +1862,7 @@ export default defineBackground({
         for (const [k, v] of Object.entries(
           advancedValues as Record<string, any>,
         )) {
+          if (!shouldSubmitQuickIngestAdvancedField(k, common)) continue;
           if (k.includes(".")) assignPath(nested, k.split("."), v);
           else fields[k] = v;
         }
@@ -1900,12 +1903,11 @@ export default defineBackground({
         ) {
           fields.pdf_parsing_engine = document.ocr ? "pymupdf4llm" : "";
         }
-        if (chunkingTemplateName) {
-          fields.chunking_template_name = chunkingTemplateName;
-        }
-        if (autoApplyTemplate) {
-          fields.auto_apply_template = true;
-        }
+        applyQuickIngestChunkingFields(fields, {
+          common,
+          chunkingTemplateName,
+          autoApplyTemplate,
+        });
         return fields;
       };
 
@@ -1914,6 +1916,7 @@ export default defineBackground({
         for (const [k, v] of Object.entries(
           advancedValues as Record<string, any>,
         )) {
+          if (!shouldSubmitQuickIngestAdvancedField(k, common)) continue;
           if (k.includes(".")) assignPath(nestedBody, k.split("."), v);
           else nestedBody[k] = v;
         }
@@ -1948,6 +1951,7 @@ export default defineBackground({
           summarize_checkbox: Boolean(common.perform_analysis),
           ...normalizedBody,
         };
+        applyQuickIngestChunkingFields(body, { common });
         if (typeof entry?.keywords === "string") {
           const trimmed = entry.keywords.trim();
           if (trimmed) {

--- a/apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts
+++ b/apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts
@@ -261,10 +261,14 @@ describe("submitQuickIngestBatch", () => {
         auto_chunking_use_llm: true
       },
       advancedValues: {
+        perform_analysis: false,
+        overwrite_existing: true,
         chunk_method: "tokens",
         chunk_size: 1200,
         chunk_overlap: 200,
         use_adaptive_chunking: true,
+        hierarchical_chunking: true,
+        hierarchical_template: { boundaries: [{ kind: "heading" }] },
         transcription_model: "parakeet-standard"
       },
       chunkingTemplateName: "manual-template",
@@ -277,6 +281,8 @@ describe("submitQuickIngestBatch", () => {
         method: "POST",
         fields: expect.objectContaining({
           perform_chunking: true,
+          perform_analysis: true,
+          overwrite_existing: false,
           chunking_mode: "auto",
           auto_chunking_goal: "qa_search",
           auto_chunking_use_llm: true,
@@ -289,6 +295,8 @@ describe("submitQuickIngestBatch", () => {
     expect(fields).not.toHaveProperty("chunk_size")
     expect(fields).not.toHaveProperty("chunk_overlap")
     expect(fields).not.toHaveProperty("use_adaptive_chunking")
+    expect(fields).not.toHaveProperty("hierarchical_chunking")
+    expect(fields).not.toHaveProperty("hierarchical_template")
     expect(fields).not.toHaveProperty("chunking_template_name")
     expect(fields).not.toHaveProperty("auto_apply_template")
   })
@@ -977,6 +985,48 @@ describe("submitQuickIngestBatch", () => {
     expect(body).not.toHaveProperty("auto_chunking_use_llm")
     expect(body).not.toHaveProperty("chunk_size")
     expect(body).not.toHaveProperty("chunk_overlap")
+  })
+
+  it("passes manual chunking templates to process-web-scraping JSON requests", async () => {
+    mocks.bgRequest.mockResolvedValue({ content: "processed" })
+
+    await submitQuickIngestBatch({
+      entries: [
+        {
+          id: "entry-html-manual",
+          url: "https://example.com/manual-page",
+          type: "html"
+        }
+      ],
+      files: [],
+      storeRemote: false,
+      processOnly: true,
+      common: {
+        perform_analysis: true,
+        perform_chunking: true,
+        overwrite_existing: false,
+        chunking_mode: "manual",
+        auto_chunking_goal: "balanced",
+        auto_chunking_use_llm: false
+      },
+      advancedValues: {
+        chunk_method: "sentences",
+        chunk_size: 900
+      },
+      chunkingTemplateName: "article-template",
+      autoApplyTemplate: true
+    } as any)
+
+    const body = mocks.bgRequest.mock.calls[0][0].body
+    expect(body).toMatchObject({
+      url_input: "https://example.com/manual-page",
+      chunking_mode: "manual",
+      chunk_method: "sentences",
+      chunk_size: 900,
+      chunking_template_name: "article-template",
+      auto_apply_template: true
+    })
+    expect(body).not.toHaveProperty("auto_chunking_goal")
   })
 
   it("routes local files through direct process endpoints in web runtime", async () => {

--- a/apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts
+++ b/apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts
@@ -228,6 +228,187 @@ describe("submitQuickIngestBatch", () => {
     )
   })
 
+  it("sends auto chunking fields and suppresses stale manual fields", async () => {
+    mocks.bgUpload.mockResolvedValue({
+      batch_id: "batch-auto-chunking",
+      jobs: [{ id: 204 }]
+    })
+    mocks.bgRequest.mockResolvedValue({
+      ok: true,
+      data: {
+        status: "completed",
+        result: { media_id: "m-auto-chunking" }
+      }
+    })
+
+    await submitQuickIngestBatch({
+      entries: [
+        {
+          id: "entry-auto-chunking",
+          url: "https://example.com/auto-chunking",
+          type: "document"
+        }
+      ],
+      files: [],
+      storeRemote: true,
+      processOnly: false,
+      common: {
+        perform_analysis: true,
+        perform_chunking: true,
+        overwrite_existing: false,
+        chunking_mode: "auto",
+        auto_chunking_goal: "qa_search",
+        auto_chunking_use_llm: true
+      },
+      advancedValues: {
+        chunk_method: "tokens",
+        chunk_size: 1200,
+        chunk_overlap: 200,
+        use_adaptive_chunking: true,
+        transcription_model: "parakeet-standard"
+      },
+      chunkingTemplateName: "manual-template",
+      autoApplyTemplate: true
+    } as any)
+
+    expect(mocks.bgUpload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "/api/v1/media/ingest/jobs",
+        method: "POST",
+        fields: expect.objectContaining({
+          perform_chunking: true,
+          chunking_mode: "auto",
+          auto_chunking_goal: "qa_search",
+          auto_chunking_use_llm: true,
+          transcription_model: "parakeet-standard"
+        })
+      })
+    )
+    const fields = mocks.bgUpload.mock.calls[0][0].fields
+    expect(fields).not.toHaveProperty("chunk_method")
+    expect(fields).not.toHaveProperty("chunk_size")
+    expect(fields).not.toHaveProperty("chunk_overlap")
+    expect(fields).not.toHaveProperty("use_adaptive_chunking")
+    expect(fields).not.toHaveProperty("chunking_template_name")
+    expect(fields).not.toHaveProperty("auto_apply_template")
+  })
+
+  it("sends manual chunking fields and templates in manual mode", async () => {
+    mocks.bgUpload.mockResolvedValue({
+      batch_id: "batch-manual-chunking",
+      jobs: [{ id: 205 }]
+    })
+    mocks.bgRequest.mockResolvedValue({
+      ok: true,
+      data: {
+        status: "completed",
+        result: { media_id: "m-manual-chunking" }
+      }
+    })
+
+    await submitQuickIngestBatch({
+      entries: [
+        {
+          id: "entry-manual-chunking",
+          url: "https://example.com/manual-chunking",
+          type: "document"
+        }
+      ],
+      files: [],
+      storeRemote: true,
+      processOnly: false,
+      common: {
+        perform_analysis: true,
+        perform_chunking: true,
+        overwrite_existing: false,
+        chunking_mode: "manual",
+        auto_chunking_goal: "qa_search",
+        auto_chunking_use_llm: true
+      },
+      advancedValues: {
+        chunk_method: "tokens",
+        chunk_size: 900,
+        chunk_overlap: 100
+      },
+      chunkingTemplateName: "manual-template",
+      autoApplyTemplate: true
+    } as any)
+
+    expect(mocks.bgUpload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fields: expect.objectContaining({
+          perform_chunking: true,
+          chunking_mode: "manual",
+          chunk_method: "tokens",
+          chunk_size: 900,
+          chunk_overlap: 100,
+          chunking_template_name: "manual-template",
+          auto_apply_template: true
+        })
+      })
+    )
+    const fields = mocks.bgUpload.mock.calls[0][0].fields
+    expect(fields).not.toHaveProperty("auto_chunking_goal")
+    expect(fields).not.toHaveProperty("auto_chunking_use_llm")
+  })
+
+  it("omits auto and manual chunking controls when chunking is disabled", async () => {
+    mocks.bgUpload.mockResolvedValue({
+      batch_id: "batch-disabled-chunking",
+      jobs: [{ id: 206 }]
+    })
+    mocks.bgRequest.mockResolvedValue({
+      ok: true,
+      data: {
+        status: "completed",
+        result: { media_id: "m-disabled-chunking" }
+      }
+    })
+
+    await submitQuickIngestBatch({
+      entries: [
+        {
+          id: "entry-disabled-chunking",
+          url: "https://example.com/disabled-chunking",
+          type: "document"
+        }
+      ],
+      files: [],
+      storeRemote: true,
+      processOnly: false,
+      common: {
+        perform_analysis: true,
+        perform_chunking: false,
+        overwrite_existing: false,
+        chunking_mode: "auto",
+        auto_chunking_goal: "navigation_summary",
+        auto_chunking_use_llm: true
+      },
+      advancedValues: {
+        chunk_size: 900,
+        chunk_overlap: 100
+      },
+      chunkingTemplateName: "manual-template",
+      autoApplyTemplate: true
+    } as any)
+
+    expect(mocks.bgUpload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fields: expect.objectContaining({
+          perform_chunking: false
+        })
+      })
+    )
+    const fields = mocks.bgUpload.mock.calls[0][0].fields
+    expect(fields).not.toHaveProperty("chunking_mode")
+    expect(fields).not.toHaveProperty("auto_chunking_goal")
+    expect(fields).not.toHaveProperty("auto_chunking_use_llm")
+    expect(fields).not.toHaveProperty("chunk_size")
+    expect(fields).not.toHaveProperty("chunk_overlap")
+    expect(fields).not.toHaveProperty("chunking_template_name")
+    expect(fields).not.toHaveProperty("auto_apply_template")
+  })
+
   it("captures direct batch tracking metadata before polling completes", async () => {
     const onTrackingMetadata = vi.fn()
 
@@ -748,6 +929,54 @@ describe("submitQuickIngestBatch", () => {
       status: "ok",
       type: "html"
     })
+  })
+
+  it("passes auto chunking fields to process-web-scraping JSON requests", async () => {
+    mocks.bgRequest.mockResolvedValue({ content: "processed" })
+
+    await submitQuickIngestBatch({
+      entries: [
+        {
+          id: "entry-html-auto",
+          url: "https://example.com/page",
+          type: "html"
+        }
+      ],
+      files: [],
+      storeRemote: false,
+      processOnly: true,
+      common: {
+        perform_analysis: true,
+        perform_chunking: true,
+        overwrite_existing: false,
+        chunking_mode: "auto",
+        auto_chunking_goal: "navigation_summary",
+        auto_chunking_use_llm: false
+      },
+      advancedValues: {
+        custom_headers: '{"x-test":"1"}',
+        chunk_size: 1200,
+        chunk_overlap: 200
+      }
+    } as any)
+
+    expect(mocks.bgRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "/api/v1/media/process-web-scraping",
+        method: "POST",
+        body: expect.objectContaining({
+          url_input: "https://example.com/page",
+          scrape_method: "Individual URLs",
+          chunking_mode: "auto",
+          auto_chunking_goal: "navigation_summary",
+          custom_headers: { "x-test": "1" }
+        })
+      })
+    )
+    const body = mocks.bgRequest.mock.calls[0][0].body
+    expect(body).not.toHaveProperty("auto_chunking_use_llm")
+    expect(body).not.toHaveProperty("chunk_size")
+    expect(body).not.toHaveProperty("chunk_overlap")
   })
 
   it("routes local files through direct process endpoints in web runtime", async () => {

--- a/apps/packages/ui/src/services/tldw/fallback-schemas.ts
+++ b/apps/packages/ui/src/services/tldw/fallback-schemas.ts
@@ -77,6 +77,21 @@ export const MEDIA_ADD_SCHEMA_FALLBACK: Array<{
   { name: 'pdf_parsing_engine', type: 'string', description: 'PDF parsing engine', title: 'Pdf Parsing Engine' },
   { name: 'perform_analysis', type: 'boolean', description: 'Perform analysis', title: 'Perform Analysis' },
   { name: 'perform_chunking', type: 'boolean', description: 'Enable chunking', title: 'Perform Chunking' },
+  {
+    name: 'chunking_mode',
+    type: 'string',
+    description: 'Use automatic or manual chunking settings',
+    title: 'Chunking Mode',
+    enum: ['auto', 'manual']
+  },
+  {
+    name: 'auto_chunking_goal',
+    type: 'string',
+    description: 'Optimization goal when chunking mode is automatic',
+    title: 'Auto Chunking Goal',
+    enum: ['balanced', 'qa_search', 'navigation_summary']
+  },
+  { name: 'auto_chunking_use_llm', type: 'boolean', description: 'Allow LLM-assisted automatic chunk planning when available', title: 'Auto Chunking Use Llm' },
   { name: 'perform_claims_extraction', type: 'string', description: 'Extract factual claims', title: 'Perform Claims Extraction' },
   { name: 'perform_confabulation_check_of_analysis', type: 'boolean', description: 'Enable confabulation check', title: 'Confabulation Check' },
   { name: 'perform_rolling_summarization', type: 'boolean', description: 'Rolling summarization', title: 'Rolling Summarization' },
@@ -181,6 +196,27 @@ export const WEB_SCRAPING_SCHEMA_FALLBACK: Array<{
     description: 'Persist results or keep them ephemeral.',
     title: 'Mode',
     enum: ['persist', 'ephemeral']
+  },
+  { name: 'perform_chunking', type: 'boolean', description: 'Enable chunking.', title: 'Perform Chunking' },
+  {
+    name: 'chunking_mode',
+    type: 'string',
+    description: 'Use automatic or manual chunking settings.',
+    title: 'Chunking Mode',
+    enum: ['auto', 'manual']
+  },
+  {
+    name: 'auto_chunking_goal',
+    type: 'string',
+    description: 'Optimization goal when chunking mode is automatic.',
+    title: 'Auto Chunking Goal',
+    enum: ['balanced', 'qa_search', 'navigation_summary']
+  },
+  {
+    name: 'auto_chunking_use_llm',
+    type: 'boolean',
+    description: 'Allow LLM-assisted automatic chunk planning when available.',
+    title: 'Auto Chunking Use Llm'
   }
 ]
 

--- a/apps/packages/ui/src/services/tldw/quick-ingest-batch.ts
+++ b/apps/packages/ui/src/services/tldw/quick-ingest-batch.ts
@@ -7,7 +7,12 @@ import {
   normalizeMediaType,
   shouldKeepOriginalFile,
 } from "@/services/tldw/media-routing";
-import { resolvePerformChunking } from "@/services/tldw/ingest-defaults";
+import {
+  applyQuickIngestChunkingFields,
+  shouldSubmitQuickIngestAdvancedField,
+  type QuickIngestAutoChunkingGoal,
+  type QuickIngestChunkingMode,
+} from "@/services/tldw/quick-ingest-chunking";
 import {
   createIngestJobsTracker,
   extractIngestJobIds,
@@ -57,6 +62,9 @@ type QuickIngestBatchInput = {
     perform_analysis?: boolean;
     perform_chunking?: boolean;
     overwrite_existing?: boolean;
+    chunking_mode?: QuickIngestChunkingMode;
+    auto_chunking_goal?: QuickIngestAutoChunkingGoal;
+    auto_chunking_use_llm?: boolean;
   };
   advancedValues?: Record<string, any>;
   fileDefaults?: TypeDefaults;
@@ -391,13 +399,13 @@ const buildFields = ({
   const fields: Record<string, any> = {
     media_type: mediaType,
     perform_analysis: Boolean(common?.perform_analysis),
-    perform_chunking: resolvePerformChunking(common?.perform_chunking),
     overwrite_existing: Boolean(common?.overwrite_existing),
     keep_original_file: persist && shouldKeepOriginalFile(rawType),
   };
 
   const nested: Record<string, any> = {};
   for (const [key, value] of Object.entries(advancedValues || {})) {
+    if (!shouldSubmitQuickIngestAdvancedField(key, common)) continue;
     if (key.includes(".")) assignPath(nested, key.split("."), value);
     else fields[key] = value;
   }
@@ -448,12 +456,11 @@ const buildFields = ({
     fields.pdf_parsing_engine = document.ocr ? "pymupdf4llm" : "";
   }
 
-  if (chunkingTemplateName) {
-    fields.chunking_template_name = chunkingTemplateName;
-  }
-  if (autoApplyTemplate) {
-    fields.auto_apply_template = true;
-  }
+  applyQuickIngestChunkingFields(fields, {
+    common,
+    chunkingTemplateName,
+    autoApplyTemplate,
+  });
 
   return fields;
 };
@@ -471,6 +478,7 @@ const processWebScrape = async ({
 }): Promise<any> => {
   const nestedBody: Record<string, any> = {};
   for (const [key, value] of Object.entries(advancedValues || {})) {
+    if (!shouldSubmitQuickIngestAdvancedField(key, common)) continue;
     if (key.includes(".")) assignPath(nestedBody, key.split("."), value);
     else nestedBody[key] = value;
   }
@@ -489,6 +497,7 @@ const processWebScrape = async ({
     summarize_checkbox: Boolean(common?.perform_analysis),
     ...normalizedBody,
   };
+  applyQuickIngestChunkingFields(body, { common });
 
   if (typeof entry?.keywords === "string") {
     const trimmed = entry.keywords.trim();

--- a/apps/packages/ui/src/services/tldw/quick-ingest-batch.ts
+++ b/apps/packages/ui/src/services/tldw/quick-ingest-batch.ts
@@ -470,11 +470,15 @@ const processWebScrape = async ({
   entry,
   common,
   advancedValues,
+  chunkingTemplateName,
+  autoApplyTemplate,
 }: {
   url: string;
   entry?: QuickIngestEntry;
   common?: QuickIngestBatchInput["common"];
   advancedValues?: Record<string, any>;
+  chunkingTemplateName?: string;
+  autoApplyTemplate?: boolean;
 }): Promise<any> => {
   const nestedBody: Record<string, any> = {};
   for (const [key, value] of Object.entries(advancedValues || {})) {
@@ -497,7 +501,11 @@ const processWebScrape = async ({
     summarize_checkbox: Boolean(common?.perform_analysis),
     ...normalizedBody,
   };
-  applyQuickIngestChunkingFields(body, { common });
+  applyQuickIngestChunkingFields(body, {
+    common,
+    chunkingTemplateName,
+    autoApplyTemplate,
+  });
 
   if (typeof entry?.keywords === "string") {
     const trimmed = entry.keywords.trim();
@@ -650,6 +658,8 @@ const runDirectQuickIngestBatch = async (
             entry,
             common: input.common,
             advancedValues: input.advancedValues,
+            chunkingTemplateName: input.chunkingTemplateName,
+            autoApplyTemplate: input.autoApplyTemplate,
           });
         } else {
           const fields = buildFields({

--- a/apps/packages/ui/src/services/tldw/quick-ingest-chunking.ts
+++ b/apps/packages/ui/src/services/tldw/quick-ingest-chunking.ts
@@ -37,12 +37,16 @@ const MANUAL_CHUNKING_FIELDS = new Set([
   "contextual_llm_model",
   "custom_chapter_pattern",
   "enable_contextual_chunking",
+  "hierarchical_chunking",
+  "hierarchical_template",
   "use_adaptive_chunking",
   "use_multi_level_chunking",
 ])
 
 const CONTROLLED_COMMON_FIELDS = new Set([
+  "perform_analysis",
   "perform_chunking",
+  "overwrite_existing",
 ])
 
 const fieldNameParts = (fieldName: string): string[] =>

--- a/apps/packages/ui/src/services/tldw/quick-ingest-chunking.ts
+++ b/apps/packages/ui/src/services/tldw/quick-ingest-chunking.ts
@@ -1,0 +1,125 @@
+import { resolvePerformChunking } from "@/services/tldw/ingest-defaults"
+
+export type QuickIngestChunkingMode = "auto" | "manual"
+export type QuickIngestAutoChunkingGoal =
+  | "balanced"
+  | "qa_search"
+  | "navigation_summary"
+
+export type QuickIngestChunkingCommon = {
+  perform_chunking?: boolean
+  chunking_mode?: QuickIngestChunkingMode | string
+  auto_chunking_goal?: QuickIngestAutoChunkingGoal | string
+  auto_chunking_use_llm?: boolean
+}
+
+export const DEFAULT_QUICK_INGEST_CHUNKING_MODE: QuickIngestChunkingMode =
+  "auto"
+export const DEFAULT_QUICK_INGEST_AUTO_CHUNKING_GOAL: QuickIngestAutoChunkingGoal =
+  "balanced"
+
+const AUTO_CHUNKING_FIELDS = new Set([
+  "chunking_mode",
+  "auto_chunking_goal",
+  "auto_chunking_use_llm",
+])
+
+const MANUAL_CHUNKING_FIELDS = new Set([
+  "auto_apply_template",
+  "chunk_language",
+  "chunk_method",
+  "chunk_overlap",
+  "chunk_size",
+  "chunking_template_name",
+  "context_strategy",
+  "context_token_budget",
+  "context_window_size",
+  "contextual_llm_model",
+  "custom_chapter_pattern",
+  "enable_contextual_chunking",
+  "use_adaptive_chunking",
+  "use_multi_level_chunking",
+])
+
+const CONTROLLED_COMMON_FIELDS = new Set([
+  "perform_chunking",
+])
+
+const fieldNameParts = (fieldName: string): string[] =>
+  String(fieldName || "")
+    .split(".")
+    .map((part) => part.trim())
+    .filter(Boolean)
+
+const matchesField = (fieldName: string, names: Set<string>): boolean => {
+  const parts = fieldNameParts(fieldName)
+  return parts.some((part) => names.has(part))
+}
+
+export const resolveQuickIngestChunkingMode = (
+  value: QuickIngestChunkingCommon["chunking_mode"],
+): QuickIngestChunkingMode =>
+  value === "manual" ? "manual" : DEFAULT_QUICK_INGEST_CHUNKING_MODE
+
+export const resolveQuickIngestAutoChunkingGoal = (
+  value: QuickIngestChunkingCommon["auto_chunking_goal"],
+): QuickIngestAutoChunkingGoal => {
+  if (value === "qa_search" || value === "navigation_summary") {
+    return value
+  }
+  return DEFAULT_QUICK_INGEST_AUTO_CHUNKING_GOAL
+}
+
+export const shouldSubmitQuickIngestAdvancedField = (
+  fieldName: string,
+  common?: QuickIngestChunkingCommon,
+): boolean => {
+  if (matchesField(fieldName, CONTROLLED_COMMON_FIELDS)) return false
+  if (matchesField(fieldName, AUTO_CHUNKING_FIELDS)) return false
+
+  const performChunking = resolvePerformChunking(common?.perform_chunking)
+  const mode = resolveQuickIngestChunkingMode(common?.chunking_mode)
+  if (matchesField(fieldName, MANUAL_CHUNKING_FIELDS)) {
+    return performChunking && mode === "manual"
+  }
+
+  return true
+}
+
+export const applyQuickIngestChunkingFields = (
+  target: Record<string, any>,
+  options: {
+    common?: QuickIngestChunkingCommon
+    chunkingTemplateName?: string
+    autoApplyTemplate?: boolean
+  } = {},
+): Record<string, any> => {
+  const common = options.common
+  const performChunking = resolvePerformChunking(common?.perform_chunking)
+  target.perform_chunking = performChunking
+
+  if (!performChunking) {
+    return target
+  }
+
+  const mode = resolveQuickIngestChunkingMode(common?.chunking_mode)
+  target.chunking_mode = mode
+
+  if (mode === "auto") {
+    target.auto_chunking_goal = resolveQuickIngestAutoChunkingGoal(
+      common?.auto_chunking_goal,
+    )
+    if (common?.auto_chunking_use_llm === true) {
+      target.auto_chunking_use_llm = true
+    }
+    return target
+  }
+
+  if (options.chunkingTemplateName) {
+    target.chunking_template_name = options.chunkingTemplateName
+  }
+  if (options.autoApplyTemplate) {
+    target.auto_apply_template = true
+  }
+  return target
+}

--- a/backlog/tasks/task-96 - Design-Auto-Chunking-for-Quick-Ingest.md
+++ b/backlog/tasks/task-96 - Design-Auto-Chunking-for-Quick-Ingest.md
@@ -1,0 +1,61 @@
+---
+id: TASK-96
+title: Design Auto Chunking for Quick Ingest
+status: In Progress
+assignee:
+  - codex
+created_date: '2026-05-06 16:13'
+updated_date: '2026-05-06 16:29'
+labels:
+  - design
+  - chunking
+  - quick-ingest
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Write the approved design spec for novice-facing Auto Chunking in tldw_server. The design should capture the existing chunking/template inventory, the approved Quick Ingest UX where Chunking defaults to Auto with a Manual escape hatch, deterministic media-aware planner behavior, explicit AI-assist opt-in, API compatibility rules, and the backend wiring gaps found during discovery.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A design spec is written under Docs/superpowers/specs with the approved Auto Chunking product contract and constraints.
+- [x] #2 The spec documents existing backend/frontend chunking capabilities and the current integration gaps relevant to Auto Chunking.
+- [x] #3 The spec defines API fields, Quick Ingest behavior, media-aware planner behavior, AI-assist fallback behavior, and metadata/rationale output.
+- [x] #4 The spec includes testing and rollout considerations without implementing code changes.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Write a design-only spec at Docs/superpowers/specs/2026-05-06-auto-chunking-design.md using the user-approved brainstorming decisions.
+2. Ground the spec in discovered repo evidence: Chunking module capabilities, media request schemas, media-add/job parsing gap, PDF-specific template support, Quick Ingest UI/service behavior, and query-time Agentic Chunking distinction.
+3. Keep the spec implementation-ready but avoid code changes: product contract, API/UI fields, deterministic planner behavior by media type, AI-assist opt-in/fallback, storage/metadata outputs, testing, rollout, and open risks.
+4. Verify the spec file exists and contains the approved sections; run lightweight diff/status checks. No Bandit is required for documentation-only changes, but record that skip.
+5. Update TASK-96 with verification notes and acceptance criteria status after the spec is written.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+2026-05-06: Wrote Docs/superpowers/specs/2026-05-06-auto-chunking-design.md as a documentation-only spec. It captures the approved Quick Ingest Auto/Manual model, deterministic planner behavior, explicit AI-assist opt-in and fallback, API fields, metadata output, existing repo inventory, integration gaps, rollout, and testing considerations. Bandit is not applicable at this step because only documentation and Backlog task files were changed.
+
+2026-05-06: Staged the design spec and TASK-96 file, then attempted `git commit -m "docs: design auto chunking for quick ingest"`. Commit failed because the existing worktree has unrelated unresolved merge conflicts in Docs/superpowers/plans/2026-05-03-native-codegraph-foundation-implementation-plan.md, Docs/superpowers/plans/2026-05-03-worker-lifecycle-deprecated-code-removal-implementation-plan.md, and backlog/tasks/task-16 - Implement-native-CodeGraph-foundation-slice.md. I did not touch or resolve those unrelated conflicts.
+
+2026-05-06: Independent design review found planning risks and patched the spec: structure_aware/schema handling, async job result exposure via chunking_plan, Auto-vs-Manual precedence for saved advanced settings, both Quick Ingest submission paths, and V1 derived views as metadata only.
+
+2026-05-06: Second spec-review pass approved the updated spec with no blocking issues. Applied its advisory wording change so rollout says Mode defaults to Auto when Chunking is enabled, avoiding any implication that the global Chunking toggle default changes.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-96.1 - Create-Auto-Chunking-implementation-plan.md
+++ b/backlog/tasks/task-96.1 - Create-Auto-Chunking-implementation-plan.md
@@ -1,0 +1,64 @@
+---
+id: TASK-96.1
+title: Create Auto Chunking implementation plan
+status: Done
+assignee:
+  - codex
+created_date: '2026-05-06 16:32'
+updated_date: '2026-05-06 16:44'
+labels:
+  - planning
+  - chunking
+  - quick-ingest
+dependencies: []
+documentation:
+  - Docs/superpowers/specs/2026-05-06-auto-chunking-design.md
+parent_task_id: TASK-96
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create an implementation plan for the approved Auto Chunking design. The plan should be executable by a future agent without relying on this conversation and should break the feature into testable backend and frontend slices while preserving the approved deterministic-first Auto behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Implementation plan is written under Docs/superpowers/plans and references the approved Auto Chunking spec.
+- [x] #2 Plan maps files to responsibilities and decomposes backend, frontend, tests, rollout, and verification into task-sized steps.
+- [x] #3 Plan keeps deterministic Auto separate from AI-assisted Auto and avoids implementation code changes.
+- [x] #4 Plan review is run and blocking issues are resolved before execution handoff.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Plan document: Docs/superpowers/plans/2026-05-06-auto-chunking-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Plan document written under Docs/superpowers/plans. Remaining blocker is plan review before execution handoff.
+
+Plan review completed by subagent 019dfe28-001f-74d1-aa96-9cbf4ce64d74. Initial blockers were web/article Quick Ingest coverage and safe_metadata chunking_plan persistence specificity; both were patched. Follow-up review reported no remaining blocking issues or important improvements and approved execution handoff.
+
+Verification for this documentation-only planning task: git diff --check passed. Bandit was not run because this task changed only planning/backlog markdown, not backend code.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Created the Auto Chunking implementation plan at Docs/superpowers/plans/2026-05-06-auto-chunking-implementation-plan.md. The plan maps backend request parsing, deterministic planner work, media/web ingest wiring, safe metadata persistence, frontend Quick Ingest state/payload/UI changes, AI-assist gating, tests, and verification. A plan-review subagent found blockers around web/article ingestion and durable chunking_plan persistence; the plan was patched and the follow-up review approved it for execution handoff.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-96.2 - Implement-Auto-Chunking-backend-request-contract-parsing.md
+++ b/backlog/tasks/task-96.2 - Implement-Auto-Chunking-backend-request-contract-parsing.md
@@ -1,0 +1,61 @@
+---
+id: TASK-96.2
+title: Implement Auto Chunking backend request contract parsing
+status: Done
+assignee:
+  - codex
+created_date: '2026-05-06 16:55'
+updated_date: '2026-05-06 17:01'
+labels:
+  - backend
+  - chunking
+  - quick-ingest
+  - auto-chunking
+dependencies: []
+documentation:
+  - Docs/superpowers/specs/2026-05-06-auto-chunking-design.md
+  - Docs/superpowers/plans/2026-05-06-auto-chunking-implementation-plan.md
+parent_task_id: TASK-96
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the first execution slice from the approved Auto Chunking plan: add backend request contract support for chunking_mode, auto_chunking_goal, and auto_chunking_use_llm across media forms and web/article JSON request models while preserving legacy behavior for requests that omit chunking_mode. This task is limited to schema/dependency parsing and focused contract tests; planner behavior and runtime media processing wiring are later slices.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Backend schemas accept chunking_mode, auto_chunking_goal, and auto_chunking_use_llm for media chunking options and web/article request models.
+- [x] #2 Media add and direct process form dependencies parse the Auto fields consistently and preserve legacy defaults when chunking_mode is omitted.
+- [x] #3 Existing template/hierarchical chunking fields are parsed consistently across media add and direct process forms where schemas already expose them.
+- [x] #4 Invalid chunking_mode and invalid auto_chunking_goal fail through normal validation, and perform_chunking=false with Auto fields remains valid for later no-op planning.
+- [x] #5 Focused backend tests cover the new contract and parsing parity.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented backend request contract parsing for Auto Chunking fields across AddMediaForm, direct media process form dependencies, WebScrapingRequest, and IngestWebContentRequest. Added focused unit coverage in tldw_Server_API/tests/MediaIngestion_NEW/unit/test_auto_chunking_request_contract.py.
+
+Verification: RED run of the new contract test file failed on missing chunking_mode/auto fields as expected. GREEN run passed 13 tests. Broadened suite passed 24 tests: test_auto_chunking_request_contract.py, test_media_add_deps_error_mapping.py, test_process_endpoints_contract_parity.py, test_process_web_scraping_strategy_validation.py, and test_ingest_web_content_endpoint_sanitization.py. Bandit touched-scope check reported zero findings in /tmp/bandit_auto_chunking_contract.json. git diff --check passed.
+
+Known skips: did not run the large legacy test_add_media_endpoint.py integration file because this slice is covered by focused direct dependency and nearby endpoint contract tests.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added the Auto Chunking request contract fields for backend schemas and form dependencies: chunking_mode, auto_chunking_goal, and auto_chunking_use_llm. Media add and process dependencies now parse Auto fields plus template/hierarchical parity fields, including JSON validation for hierarchical_template. Web/article request models now accept the same Auto contract. Added focused unit tests for valid Auto parsing, legacy missing-mode behavior, invalid value validation, disabled chunking with Auto fields, malformed hierarchical_template JSON, and web/article request models.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-96.3 - Implement-deterministic-Auto-Chunking-planner.md
+++ b/backlog/tasks/task-96.3 - Implement-deterministic-Auto-Chunking-planner.md
@@ -1,0 +1,59 @@
+---
+id: TASK-96.3
+title: Implement deterministic Auto Chunking planner
+status: Done
+assignee:
+  - codex
+created_date: '2026-05-06 17:02'
+updated_date: '2026-05-06 17:07'
+labels:
+  - backend
+  - chunking
+  - quick-ingest
+  - auto-chunking
+dependencies:
+  - TASK-96.2
+documentation:
+  - Docs/superpowers/specs/2026-05-06-auto-chunking-design.md
+  - Docs/superpowers/plans/2026-05-06-auto-chunking-implementation-plan.md
+parent_task_id: TASK-96
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the second execution slice from the approved Auto Chunking plan: add a pure deterministic planner that maps media type, source hints, content profiles, template matches, requested Auto goal, and AI-assist availability into existing chunking options plus serializable chunking_plan metadata. This task must not wire runtime media ingestion yet and must not make LLM calls.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A pure backend planner module exists without FastAPI request, database, network, or LLM dependencies.
+- [x] #2 Planner returns normalized chunking options and JSON-serializable chunking_plan metadata for Auto requests.
+- [x] #3 Planner preserves legacy/manual/no-chunking markers by returning no Auto plan when chunking is disabled, chunking_mode is missing, or chunking_mode is manual.
+- [x] #4 Planner handles document/PDF, audio/video, ebook, email, and web/article profile cases across balanced, qa_search, and navigation_summary goals.
+- [x] #5 Planner records deterministic fallback reasons for missing AI adapter, template no-match/failure, and unavailable semantic capability where relevant.
+- [x] #6 Focused unit tests cover planner behavior without external services.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented pure planner module tldw_Server_API/app/core/Chunking/auto_planner.py with AutoChunkingProfile, AutoChunkingRequest, AutoChunkingPlan, AutoChunkingDecision, source/text profile builders, deterministic goal/media rules, JSON-safe metadata, and deterministic fallback reasons. Verification: RED import failure for missing request/plan types; GREEN python -m pytest tldw_Server_API/tests/Chunking/test_auto_chunking_planner.py -v -> 8 passed; broader python -m pytest tldw_Server_API/tests/Chunking/test_auto_chunking_planner.py tldw_Server_API/tests/MediaIngestion_NEW/unit/test_auto_chunking_request_contract.py -v -> 21 passed; Bandit on auto_planner.py -> zero findings; git diff --check clean.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added the deterministic Auto Chunking planner slice without runtime ingestion wiring or LLM calls. The planner now returns existing chunker-compatible options plus serializable chunking_plan metadata for Auto mode, and preserves legacy/manual/no-chunking behavior by returning no Auto plan.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-96.4 - Wire-Auto-Chunking-planner-into-backend-ingestion-paths.md
+++ b/backlog/tasks/task-96.4 - Wire-Auto-Chunking-planner-into-backend-ingestion-paths.md
@@ -1,0 +1,67 @@
+---
+id: TASK-96.4
+title: Wire Auto Chunking planner into backend ingestion paths
+status: Done
+assignee:
+  - codex
+created_date: '2026-05-06 17:09'
+updated_date: '2026-05-06 17:30'
+labels:
+  - backend
+  - chunking
+  - quick-ingest
+  - auto-chunking
+dependencies:
+  - TASK-96.3
+documentation:
+  - Docs/superpowers/specs/2026-05-06-auto-chunking-design.md
+  - Docs/superpowers/plans/2026-05-06-auto-chunking-implementation-plan.md
+parent_task_id: TASK-96
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the third execution slice from the approved Auto Chunking plan: add a resolver that combines existing manual chunk option behavior with deterministic Auto plans, wire backend process/web/job paths to return or persist chunking_plan metadata, and preserve legacy/manual behavior. Keep this slice deterministic and do not add real LLM boundary calls.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Resolver returns legacy/manual chunk options with no plan and Auto planner options with chunking_plan.
+- [x] #2 Direct process endpoints attach chunking_plan metadata for Auto requests without changing legacy/manual responses.
+- [x] #3 Web scraping and ingest-web-content JSON paths accept Auto fields and use the same resolver behavior.
+- [x] #4 Async media ingest job results include chunking_plan when Auto planning is used.
+- [x] #5 Persistence preserves safe_metadata.chunking_plan as JSON-safe nested metadata.
+- [x] #6 Focused backend tests cover Auto wiring and legacy/manual preservation.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented first backend wiring slice: added resolve_chunking_options_and_plan() in chunking_options.py, preserving legacy/manual prepare_chunking_options_dict behavior and routing chunking_mode=auto through the deterministic planner while ignoring stale manual fields. Updated media_ingest_jobs_worker to use the resolver and include chunking_plan in job results when Auto planning is active. Verification: RED resolver import failure before implementation; RED worker test showed stale manual method was still used; GREEN focused suite python -m pytest tldw_Server_API/tests/Chunking/test_auto_chunking_resolver.py tldw_Server_API/tests/Chunking/test_auto_chunking_planner.py tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_worker.py tldw_Server_API/tests/MediaIngestion_NEW/unit/test_auto_chunking_request_contract.py -v -> 35 passed; Bandit on chunking_options.py and media_ingest_jobs_worker.py -> zero findings; git diff --check clean. Remaining for this task: direct process endpoint metadata, web/article JSON paths, and safe_metadata persistence.
+
+Completed backend wiring slice: direct process endpoints finalize Auto plans from extracted content and attach metadata.chunking_plan; web scraping and ingest-web-content JSON paths forward Auto fields and record plan metadata; persistence now preserves JSON-safe safe_metadata.chunking_plan for AV and document-like writes. Verification: python -m pytest focused backend suite including resolver/planner/request/job/direct/web/persistence and media ingest integration -> 63 passed; Bandit touched backend scope -> zero findings; git diff --check clean.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Backend Auto Chunking wiring is complete for TASK-96.4. The resolver is used by direct process endpoints, async ingest jobs, web scraping JSON paths, and persistence. Auto requests return or persist chunking_plan metadata while legacy/manual requests keep existing chunk option behavior. Focused pytest suite passed with 63 tests, Bandit reported zero findings, and diff whitespace checks were clean.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+- [x] #7 Acceptance criteria completed
+- [x] #8 Tests or verification recorded
+- [x] #9 Bandit run for touched backend code
+- [x] #10 Plan documentation updated
+- [x] #11 Final summary added
+- [x] #12 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-96.5 - Wire-Auto-Chunking-into-Quick-Ingest-payload-state.md
+++ b/backlog/tasks/task-96.5 - Wire-Auto-Chunking-into-Quick-Ingest-payload-state.md
@@ -1,0 +1,63 @@
+---
+id: TASK-96.5
+title: Wire Auto Chunking into Quick Ingest payload state
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-05-06 17:31'
+updated_date: '2026-05-06 17:41'
+labels:
+  - frontend
+  - chunking
+  - quick-ingest
+  - auto-chunking
+dependencies:
+  - TASK-96.4
+documentation:
+  - Docs/superpowers/specs/2026-05-06-auto-chunking-design.md
+  - Docs/superpowers/plans/2026-05-06-auto-chunking-implementation-plan.md
+parent_task_id: TASK-96
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the frontend state and payload plumbing slice from the approved Auto Chunking plan. Quick Ingest should default enabled chunking to Auto, send Auto fields without stale Manual settings, preserve Manual as the advanced escape hatch, and keep web/article Quick Ingest payloads in parity with media payloads.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Quick Ingest option types include chunking_mode, auto_chunking_goal, and auto_chunking_use_llm.
+- [x] #2 Default Quick Ingest state uses Auto when chunking is enabled.
+- [x] #3 Media payload construction sends Auto fields for Auto and Manual fields only for Manual.
+- [x] #4 processWebScrape JSON payload sends the same Auto fields and omits stale Manual fields in Auto mode.
+- [x] #5 Fallback settings schemas expose the Auto fields.
+- [x] #6 Focused frontend service/state tests cover Auto, Manual, stale-field omission, and web payload parity.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Started Task 4 frontend payload/state slice after completing backend wiring TASK-96.4. Following TDD: add failing quick-ingest payload/state tests first, then update types, defaults, payload builder, background parity, and fallback schema.
+
+Implemented Quick Ingest Auto/Manual payload state plumbing in apps/packages/ui. Added shared quick-ingest chunking payload helper, wired direct/background payload builders, defaulted presets and persisted common options to Auto, updated fallback schemas, and covered Auto/Manual/stale-field/web parity tests.
+
+Verification: bun run test -- src/services/__tests__/quick-ingest-batch.test.ts src/components/Common/QuickIngest/__tests__/IngestWizardContext.test.tsx --maxWorkers=1 --no-file-parallelism passed with 43 tests. bun run verify:openapi passed. git diff --check passed. UI package-wide tsc still has unrelated existing failures; filtered touched-file diagnostics had no matches after the local normalization fix. Bandit not applicable for this TypeScript-only slice.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Wired Quick Ingest state and payload construction for Auto Chunking. Auto mode now sends chunking_mode and auto goal fields without stale manual/template settings, Manual mode preserves advanced/template chunking fields, disabled chunking sends no chunking controls, and web scraping JSON payloads stay in parity. Added focused tests and fallback schema entries.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-96.6 - Add-Quick-Ingest-Auto-Manual-chunking-controls.md
+++ b/backlog/tasks/task-96.6 - Add-Quick-Ingest-Auto-Manual-chunking-controls.md
@@ -1,0 +1,62 @@
+---
+id: TASK-96.6
+title: Add Quick Ingest Auto Manual chunking controls
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-05-06 17:43'
+updated_date: '2026-05-06 17:50'
+labels:
+  - frontend
+  - chunking
+  - quick-ingest
+  - auto-chunking
+dependencies:
+  - TASK-96.5
+documentation:
+  - Docs/superpowers/specs/2026-05-06-auto-chunking-design.md
+  - Docs/superpowers/plans/2026-05-06-auto-chunking-implementation-plan.md
+parent_task_id: TASK-96
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the Quick Ingest UI control slice from the approved Auto Chunking plan. The Chunking section should default to Auto when enabled, expose goal and AI-assist controls in Auto mode, reveal existing detailed/template controls only in Manual mode, and keep submission behavior aligned with the payload helper.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Chunking enabled shows Auto selected by default
+- [x] #2 Auto mode exposes goal selection and AI-assist toggle
+- [x] #3 Manual mode exposes existing detailed/template chunking controls
+- [x] #4 Switching back to Auto hides Manual-only settings and does not submit stale Manual fields
+- [x] #5 Focused UI tests cover Auto/Manual visibility and Auto submission payload
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Starting Task 5 UI controls after TASK-96.5 payload/state commit c4a0089bd. Following TDD: add focused QuickIngestWizardModal integration coverage first, then wire Auto/Manual controls into existing options panel patterns.
+
+Implemented Quick Ingest Auto/Manual UI controls. IngestOptionsPanel and WizardConfigureStep now show Auto/Manual segmented controls when chunking is enabled, Auto goal and AI-assist controls in Auto mode, and Manual-only chunk method/size/overlap or template controls in Manual mode. The wizard submit payload now carries Auto fields through buildQuickIngestPayload.
+
+Verification: bun run test -- src/services/__tests__/quick-ingest-batch.test.ts src/components/Common/QuickIngest/__tests__/IngestWizardContext.test.tsx src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx --maxWorkers=1 --no-file-parallelism passed with 83 tests. Filtered tsc diagnostics for touched files had no matches. git diff --check passed. Bandit not applicable for this TypeScript-only UI slice.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added Quick Ingest Auto/Manual chunking controls and wired the wizard submit payload through the Auto fields. Auto mode exposes goal and AI-assist controls, Manual mode reveals detailed/template chunking controls, and tests cover visibility, state preservation, stale-field hiding, and submitted Auto payloads.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-96.7 - Document-and-test-Auto-Chunking-AI-assist-fallback-boundary.md
+++ b/backlog/tasks/task-96.7 - Document-and-test-Auto-Chunking-AI-assist-fallback-boundary.md
@@ -1,0 +1,59 @@
+---
+id: TASK-96.7
+title: Document and test Auto Chunking AI-assist fallback boundary
+status: Done
+assignee: []
+created_date: '2026-05-06 17:53'
+updated_date: '2026-05-06 17:56'
+labels:
+  - backend
+  - chunking
+  - auto-chunking
+dependencies:
+  - TASK-96.6
+documentation:
+  - Docs/superpowers/specs/2026-05-06-auto-chunking-design.md
+  - Docs/superpowers/plans/2026-05-06-auto-chunking-implementation-plan.md
+parent_task_id: TASK-96
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Lock the first Auto Chunking AI-assist boundary so explicit opt-in does not imply real LLM usage until an adapter exists. The approved V1 behavior is deterministic Auto planning with used_llm=false and fallback metadata when auto_chunking_use_llm=true but no boundary adapter is available.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 AI-assist opt-in with no adapter returns deterministic chunking options and used_llm=false.
+- [x] #2 Fallback metadata records ai_assist_unavailable without inferring availability from configured providers.
+- [x] #3 Implementation plan and Backlog notes state that real LLM boundary refinement is deferred to a future adapter task.
+- [x] #4 Focused backend planner tests and Bandit/diff checks are run for the touched scope.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added regression coverage in tldw_Server_API/tests/Chunking/test_auto_chunking_planner.py that compares auto_chunking_use_llm=true with llm_available=false against the deterministic baseline and asserts used_llm=false plus ai_assist_unavailable metadata.
+
+Documented the adapter boundary in tldw_Server_API/app/core/Chunking/auto_planner.py and updated Docs/superpowers/plans/2026-05-06-auto-chunking-implementation-plan.md to defer real LLM boundary refinement to TASK-96.8.
+
+Verification: backend Auto Chunking focused suite 41 passed, 6 warnings; UI focused suite 83 passed; verify:openapi passed with 256 paths and 49 fallback media fields; Bandit on auto_planner.py produced zero findings; git diff --check passed. Full UI tsc exited 2 with existing repo-wide test typing failures, and filtering the tsc log for touched Auto Chunking UI files returned no matches.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Locked the V1 AI-assist boundary for Auto Chunking: explicit opt-in without an adapter remains deterministic, records used_llm=false and ai_assist_unavailable, and does not infer provider availability from configured chat keys. Real LLM boundary refinement is tracked separately in TASK-96.8.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-96.8 - Implement-real-Auto-Chunking-boundary-assistant-adapter.md
+++ b/backlog/tasks/task-96.8 - Implement-real-Auto-Chunking-boundary-assistant-adapter.md
@@ -1,0 +1,44 @@
+---
+id: TASK-96.8
+title: Implement real Auto Chunking boundary assistant adapter
+status: To Do
+assignee: []
+created_date: '2026-05-06 17:53'
+labels:
+  - backend
+  - chunking
+  - auto-chunking
+  - llm
+dependencies:
+  - TASK-96.7
+documentation:
+  - Docs/superpowers/specs/2026-05-06-auto-chunking-design.md
+  - Docs/superpowers/plans/2026-05-06-auto-chunking-implementation-plan.md
+parent_task_id: TASK-96
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Follow-up for Auto Chunking V1. Add a real LLM-backed boundary assistant only after defining an explicit adapter interface and availability checks. The adapter should refine boundaries or labels from deterministic candidate plans and must fall back deterministically on provider, timeout, config, or runtime errors.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Define a narrow AutoChunkBoundaryAssistant interface and result type before adding provider calls.
+- [ ] #2 Availability checks are explicit and do not rely only on provider keys being configured.
+- [ ] #3 Adapter is invoked only when auto_chunking_use_llm=true.
+- [ ] #4 Timeout, provider error, and invalid response paths preserve deterministic Auto plans with fallback metadata.
+- [ ] #5 Tests cover default no-call behavior, explicit opt-in success, timeout/error fallback, and metadata used_llm semantics.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-96.9 - Address-PR-1342-Auto-Chunking-review-comments.md
+++ b/backlog/tasks/task-96.9 - Address-PR-1342-Auto-Chunking-review-comments.md
@@ -1,0 +1,57 @@
+---
+id: TASK-96.9
+title: Address PR 1342 Auto Chunking review comments
+status: Done
+assignee: []
+created_date: '2026-05-07 00:35'
+updated_date: '2026-05-07 00:58'
+labels:
+  - review-fix
+  - auto-chunking
+  - backend
+  - frontend
+dependencies:
+  - TASK-96.7
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1342'
+parent_task_id: TASK-96
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve all actionable review comments on PR #1342 for the Auto Chunking branch. Scope includes backend Auto Chunking correctness, persistence consistency, web scraping runtime/logging fixes, frontend stale manual-field filtering, and review hygiene items from CodeRabbit, Qodo, and Gemini.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 All still-valid inline and summary review comments on PR #1342 are implemented or explicitly documented as not applicable.
+- [x] #2 Backend Auto Chunking persisted ingest paths use resolved Auto chunk options consistently with stored chunking_plan metadata.
+- [x] #3 Frontend Auto mode does not submit or compare stale Manual-only chunking fields.
+- [x] #4 Focused backend/frontend tests, OpenAPI verification where relevant, Bandit on touched backend scope, and git diff checks are run and recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented PR #1342 review fixes: shared chunking form coercion, mapping-aware Auto resolver, resolved Auto chunk options in persistence, finalized job chunking_plan preference, per-result hierarchical chunking decisions, web scraping logging/scope fixes, and Quick Ingest Auto/Manual stale-field filtering.
+
+Verification: backend focused suite 36 passed; frontend focused Vitest suite 69 passed; OpenAPI internal refs test passed; Bandit touched backend scope reported 0 findings in /tmp/bandit_auto_chunking_review.json; git diff --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Resolved PR #1342 review comments across backend Auto Chunking contracts, persistence, process endpoints, web scraping, and Quick Ingest frontend filtering. Added regression coverage for mapping-backed Auto payloads, safe metadata, empty template names, internal structure_aware schema values, finalized job chunking plans, stale Manual-field submission/preset matching, manual value clamping, and web-scrape template forwarding. Verification recorded in implementation notes.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-96.9 - Address-PR-1342-Auto-Chunking-review-comments.md
+++ b/backlog/tasks/task-96.9 - Address-PR-1342-Auto-Chunking-review-comments.md
@@ -4,7 +4,7 @@ title: Address PR 1342 Auto Chunking review comments
 status: Done
 assignee: []
 created_date: '2026-05-07 00:35'
-updated_date: '2026-05-07 00:58'
+updated_date: '2026-05-07 01:12'
 labels:
   - review-fix
   - auto-chunking
@@ -38,12 +38,18 @@ Resolve all actionable review comments on PR #1342 for the Auto Chunking branch.
 Implemented PR #1342 review fixes: shared chunking form coercion, mapping-aware Auto resolver, resolved Auto chunk options in persistence, finalized job chunking_plan preference, per-result hierarchical chunking decisions, web scraping logging/scope fixes, and Quick Ingest Auto/Manual stale-field filtering.
 
 Verification: backend focused suite 36 passed; frontend focused Vitest suite 69 passed; OpenAPI internal refs test passed; Bandit touched backend scope reported 0 findings in /tmp/bandit_auto_chunking_review.json; git diff --check passed.
+
+Follow-up PR review pass: verified live PR #1342 unresolved threads. Most are already fixed at branch tip; adding explicit /media/add Auto chunking regression coverage and removing the stale prepare_chunking_options_dict helper alias before resolving remaining review threads.
+
+Follow-up verification: tldw_Server_API/tests/MediaIngestion_NEW/unit/test_persistence_original_storage.py passed 12 tests; focused Auto Chunking backend suite passed 48 tests; targeted media/add regression tests passed 2 tests; Bandit on persistence.py reported 0 findings in /tmp/bandit_auto_chunking_media_add_followup.json; git diff --check passed.
+
+Frontend review verification rerun: direct root-level bunx vitest invocation failed before collection because UI alias config was not loaded; reran from apps/packages/ui with package vitest config and Quick Ingest focused suite passed 69 tests.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Resolved PR #1342 review comments across backend Auto Chunking contracts, persistence, process endpoints, web scraping, and Quick Ingest frontend filtering. Added regression coverage for mapping-backed Auto payloads, safe metadata, empty template names, internal structure_aware schema values, finalized job chunking plans, stale Manual-field submission/preset matching, manual value clamping, and web-scrape template forwarding. Verification recorded in implementation notes.
+Follow-up review issue addressed: /api/v1/media/add no longer carries the stale prepare_chunking_options_dict helper alias, and new regression tests prove Auto mode routes resolved planner chunk options into both document-like and audio/video batch processors instead of stale manual options. Existing unresolved PR threads were rechecked against the branch tip before resolution.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/api/v1/API_Deps/form_coercion.py
+++ b/tldw_Server_API/app/api/v1/API_Deps/form_coercion.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from fastapi import status
+
+from tldw_Server_API.app.core.exceptions import APIValidationError
+
+try:
+    HTTP_422_UNPROCESSABLE = status.HTTP_422_UNPROCESSABLE_CONTENT
+except AttributeError:  # Starlette < 0.27
+    HTTP_422_UNPROCESSABLE = status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def coerce_form_bool(value: Any) -> bool:
+    if hasattr(value, "default"):
+        value = value.default
+    if isinstance(value, str):
+        return value.strip().lower() in {"true", "1", "yes", "on"}
+    return bool(value)
+
+
+def coerce_form_string(value: Any) -> str | None:
+    if hasattr(value, "default"):
+        value = value.default
+    if value is None:
+        return None
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    return str(value)
+
+
+def coerce_hierarchical_template(value: Any) -> dict[str, Any] | None:
+    if hasattr(value, "default"):
+        value = value.default
+    if value is None or value == "":
+        return None
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise APIValidationError(
+                detail=[
+                    {
+                        "loc": ["body", "hierarchical_template"],
+                        "msg": "hierarchical_template must be a JSON object",
+                        "type": "value_error.jsondecode",
+                    }
+                ],
+                status_code=HTTP_422_UNPROCESSABLE,
+            ) from exc
+        if isinstance(parsed, dict):
+            return parsed
+    raise APIValidationError(
+        detail=[
+            {
+                "loc": ["body", "hierarchical_template"],
+                "msg": "hierarchical_template must be a JSON object",
+                "type": "type_error.dict",
+            }
+        ],
+        status_code=HTTP_422_UNPROCESSABLE,
+    )
+
+
+def chunking_contract_kwargs(
+    *,
+    chunking_mode: Any,
+    auto_chunking_goal: Any,
+    auto_chunking_use_llm: Any,
+    auto_apply_template: Any,
+    chunking_template_name: Any,
+    hierarchical_chunking: Any,
+    hierarchical_template: Any,
+) -> dict[str, Any]:
+    return {
+        "chunking_mode": coerce_form_string(chunking_mode),
+        "auto_chunking_goal": coerce_form_string(auto_chunking_goal) or "balanced",
+        "auto_chunking_use_llm": coerce_form_bool(auto_chunking_use_llm),
+        "auto_apply_template": coerce_form_bool(auto_apply_template),
+        "chunking_template_name": coerce_form_string(chunking_template_name),
+        "hierarchical_chunking": coerce_form_bool(hierarchical_chunking),
+        "hierarchical_template": coerce_hierarchical_template(hierarchical_template),
+    }

--- a/tldw_Server_API/app/api/v1/API_Deps/media_add_deps.py
+++ b/tldw_Server_API/app/api/v1/API_Deps/media_add_deps.py
@@ -7,6 +7,9 @@ from fastapi import Form, HTTPException, status
 from loguru import logger
 from pydantic import ValidationError
 
+from tldw_Server_API.app.api.v1.API_Deps.form_coercion import (
+    chunking_contract_kwargs,
+)
 from tldw_Server_API.app.api.v1.schemas.media_request_models import (
     TRANSCRIPTION_MODEL_ENUM,
     AddMediaForm,
@@ -47,60 +50,6 @@ def _resolve_transcription_model_or_default(
         )
         return default_model
     return model or default_model
-
-
-def _coerce_form_bool(value: Any) -> bool:
-    if hasattr(value, "default"):
-        value = value.default
-    if isinstance(value, str):
-        return value.strip().lower() in {"true", "1", "yes", "on"}
-    return bool(value)
-
-
-def _coerce_form_string(value: Any) -> str | None:
-    if hasattr(value, "default"):
-        value = value.default
-    if value is None:
-        return None
-    if isinstance(value, str):
-        stripped = value.strip()
-        return stripped or None
-    return str(value)
-
-
-def _coerce_hierarchical_template(value: Any) -> dict[str, Any] | None:
-    if hasattr(value, "default"):
-        value = value.default
-    if value is None or value == "":
-        return None
-    if isinstance(value, dict):
-        return value
-    if isinstance(value, str):
-        try:
-            parsed = json.loads(value)
-        except json.JSONDecodeError as exc:
-            raise HTTPException(
-                status_code=HTTP_422_UNPROCESSABLE,
-                detail=[
-                    {
-                        "loc": ["body", "hierarchical_template"],
-                        "msg": "hierarchical_template must be a JSON object",
-                        "type": "value_error.jsondecode",
-                    }
-                ],
-            ) from exc
-        if isinstance(parsed, dict):
-            return parsed
-    raise HTTPException(
-        status_code=HTTP_422_UNPROCESSABLE,
-        detail=[
-            {
-                "loc": ["body", "hierarchical_template"],
-                "msg": "hierarchical_template must be a JSON object",
-                "type": "type_error.dict",
-            }
-        ],
-    )
 
 
 async def get_add_media_form(
@@ -145,23 +94,15 @@ async def get_add_media_form(
     ),
     perform_claims_extraction: bool | None = Form(
         None,
-        description=(
-            "Extract factual claims during analysis "
-            "(defaults to server configuration)."
-        ),
+        description=("Extract factual claims during analysis " "(defaults to server configuration)."),
     ),
     claims_extractor_mode: str | None = Form(
         None,
-        description=(
-            "Override claims extractor mode (heuristic|ner|provider id)."
-        ),
+        description=("Override claims extractor mode (heuristic|ner|provider id)."),
     ),
     claims_max_per_chunk: int | None = Form(
         None,
-        description=(
-            "Maximum number of claims to extract per chunk "
-            "(uses config default when unset)."
-        ),
+        description=("Maximum number of claims to extract per chunk " "(uses config default when unset)."),
     ),
     api_name: str | None = Form(
         None,
@@ -297,16 +238,11 @@ async def get_add_media_form(
     # Email options
     ingest_attachments: bool = Form(
         False,
-        description=(
-            "For emails: parse nested .eml attachments and ingest as "
-            "separate items"
-        ),
+        description=("For emails: parse nested .eml attachments and ingest as " "separate items"),
     ),
     max_depth: int = Form(
         2,
-        description=(
-            "Max depth for nested email parsing when ingest_attachments is true"
-        ),
+        description=("Max depth for nested email parsing when ingest_attachments is true"),
     ),
     accept_archives: bool = Form(
         False,
@@ -318,10 +254,7 @@ async def get_add_media_form(
     ),
     accept_pst: bool = Form(
         False,
-        description=(
-            "Accept .pst/.ost containers (feature-flag; parsing may require "
-            "external tools)"
-        ),
+        description=("Accept .pst/.ost containers (feature-flag; parsing may require " "external tools)"),
     ),
     # Contextual chunking options
     enable_contextual_chunking: bool = Form(
@@ -392,36 +325,26 @@ async def get_add_media_form(
                     parsed = json.loads(first)
                     urls = parsed if isinstance(parsed, list) else [parsed]
                 except Exception:
-                    logger.debug(
-                        "Failed to parse JSON list for 'urls' form field; using raw fallback"
-                    )
+                    logger.debug("Failed to parse JSON list for 'urls' form field; using raw fallback")
 
         # Normalize common boolean/integer coercions for robust form handling
         if isinstance(enable_contextual_chunking, str):
-            enable_contextual_chunking = (
-                enable_contextual_chunking.strip().lower()
-                in {"true", "1", "yes", "on"}
-            )
+            enable_contextual_chunking = enable_contextual_chunking.strip().lower() in {"true", "1", "yes", "on"}
         if isinstance(use_adaptive_chunking, str):
-            use_adaptive_chunking = (
-                use_adaptive_chunking.strip().lower()
-                in {"true", "1", "yes", "on"}
-            )
+            use_adaptive_chunking = use_adaptive_chunking.strip().lower() in {"true", "1", "yes", "on"}
         if isinstance(use_multi_level_chunking, str):
-            use_multi_level_chunking = (
-                use_multi_level_chunking.strip().lower()
-                in {"true", "1", "yes", "on"}
-            )
+            use_multi_level_chunking = use_multi_level_chunking.strip().lower() in {"true", "1", "yes", "on"}
         if isinstance(perform_chunking, str):
-            perform_chunking = (
-                perform_chunking.strip().lower() in {"true", "1", "yes", "on"}
-            )
-        chunking_mode = _coerce_form_string(chunking_mode)
-        auto_chunking_goal = _coerce_form_string(auto_chunking_goal) or "balanced"
-        auto_chunking_use_llm = _coerce_form_bool(auto_chunking_use_llm)
-        auto_apply_template = _coerce_form_bool(auto_apply_template)
-        hierarchical_chunking = _coerce_form_bool(hierarchical_chunking)
-        hierarchical_template = _coerce_hierarchical_template(hierarchical_template)
+            perform_chunking = perform_chunking.strip().lower() in {"true", "1", "yes", "on"}
+        chunking_contract = chunking_contract_kwargs(
+            chunking_mode=chunking_mode,
+            auto_chunking_goal=auto_chunking_goal,
+            auto_chunking_use_llm=auto_chunking_use_llm,
+            auto_apply_template=auto_apply_template,
+            chunking_template_name=chunking_template_name,
+            hierarchical_chunking=hierarchical_chunking,
+            hierarchical_template=hierarchical_template,
+        )
         try:
             if isinstance(context_window_size, str):
                 context_window_size = int(context_window_size)
@@ -459,9 +382,7 @@ async def get_add_media_form(
             diarize=diarize,
             timestamp_option=timestamp_option,
             vad_use=vad_use,
-            perform_confabulation_check_of_analysis=(
-                perform_confabulation_check_of_analysis
-            ),
+            perform_confabulation_check_of_analysis=(perform_confabulation_check_of_analysis),
             pdf_parsing_engine=pdf_parsing_engine,
             enable_ocr=enable_ocr,
             ocr_backend=ocr_backend,
@@ -472,9 +393,9 @@ async def get_add_media_form(
             ocr_output_format=ocr_output_format,
             ocr_prompt_preset=ocr_prompt_preset,
             perform_chunking=perform_chunking,
-            chunking_mode=chunking_mode,
-            auto_chunking_goal=auto_chunking_goal,
-            auto_chunking_use_llm=auto_chunking_use_llm,
+            chunking_mode=chunking_contract["chunking_mode"],
+            auto_chunking_goal=chunking_contract["auto_chunking_goal"],
+            auto_chunking_use_llm=chunking_contract["auto_chunking_use_llm"],
             chunk_method=chunk_method,
             use_adaptive_chunking=use_adaptive_chunking,
             use_multi_level_chunking=use_multi_level_chunking,
@@ -482,10 +403,10 @@ async def get_add_media_form(
             chunk_size=chunk_size,
             chunk_overlap=chunk_overlap,
             custom_chapter_pattern=custom_chapter_pattern,
-            auto_apply_template=auto_apply_template,
-            chunking_template_name=chunking_template_name,
-            hierarchical_chunking=hierarchical_chunking,
-            hierarchical_template=hierarchical_template,
+            auto_apply_template=chunking_contract["auto_apply_template"],
+            chunking_template_name=chunking_contract["chunking_template_name"],
+            hierarchical_chunking=chunking_contract["hierarchical_chunking"],
+            hierarchical_template=chunking_contract["hierarchical_template"],
             perform_rolling_summarization=perform_rolling_summarization,
             summarize_recursively=summarize_recursively,
             enable_contextual_chunking=enable_contextual_chunking,

--- a/tldw_Server_API/app/api/v1/API_Deps/media_add_deps.py
+++ b/tldw_Server_API/app/api/v1/API_Deps/media_add_deps.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from typing import Any
 
 from fastapi import Form, HTTPException, status
 from loguru import logger
@@ -46,6 +47,60 @@ def _resolve_transcription_model_or_default(
         )
         return default_model
     return model or default_model
+
+
+def _coerce_form_bool(value: Any) -> bool:
+    if hasattr(value, "default"):
+        value = value.default
+    if isinstance(value, str):
+        return value.strip().lower() in {"true", "1", "yes", "on"}
+    return bool(value)
+
+
+def _coerce_form_string(value: Any) -> str | None:
+    if hasattr(value, "default"):
+        value = value.default
+    if value is None:
+        return None
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    return str(value)
+
+
+def _coerce_hierarchical_template(value: Any) -> dict[str, Any] | None:
+    if hasattr(value, "default"):
+        value = value.default
+    if value is None or value == "":
+        return None
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise HTTPException(
+                status_code=HTTP_422_UNPROCESSABLE,
+                detail=[
+                    {
+                        "loc": ["body", "hierarchical_template"],
+                        "msg": "hierarchical_template must be a JSON object",
+                        "type": "value_error.jsondecode",
+                    }
+                ],
+            ) from exc
+        if isinstance(parsed, dict):
+            return parsed
+    raise HTTPException(
+        status_code=HTTP_422_UNPROCESSABLE,
+        detail=[
+            {
+                "loc": ["body", "hierarchical_template"],
+                "msg": "hierarchical_template must be a JSON object",
+                "type": "type_error.dict",
+            }
+        ],
+    )
 
 
 async def get_add_media_form(
@@ -185,6 +240,18 @@ async def get_add_media_form(
         description="OCR prompt preset (general|doc|table|spotting|json)",
     ),
     perform_chunking: bool = Form(True, description="Enable chunking"),
+    chunking_mode: str | None = Form(
+        None,
+        description="Chunking mode: auto or manual. Omitted preserves legacy behavior.",
+    ),
+    auto_chunking_goal: str = Form(
+        "balanced",
+        description="Automatic chunking goal: balanced, qa_search, or navigation_summary",
+    ),
+    auto_chunking_use_llm: bool = Form(
+        False,
+        description="Explicitly allow AI-assisted automatic chunk boundary refinement",
+    ),
     chunk_method: ChunkMethod | None = Form(
         None,
         description="Chunking method",
@@ -206,6 +273,22 @@ async def get_add_media_form(
     custom_chapter_pattern: str | None = Form(
         None,
         description="Regex pattern for custom chapter splitting",
+    ),
+    auto_apply_template: bool = Form(
+        False,
+        description="Automatically select and apply a matching chunking template",
+    ),
+    chunking_template_name: str | None = Form(
+        None,
+        description="Explicit chunking template name",
+    ),
+    hierarchical_chunking: bool = Form(
+        False,
+        description="Enable hierarchical chunking",
+    ),
+    hierarchical_template: str | dict[str, Any] | None = Form(
+        None,
+        description="Custom hierarchical chunking template JSON object",
     ),
     perform_rolling_summarization: bool = Form(
         False,
@@ -333,6 +416,12 @@ async def get_add_media_form(
             perform_chunking = (
                 perform_chunking.strip().lower() in {"true", "1", "yes", "on"}
             )
+        chunking_mode = _coerce_form_string(chunking_mode)
+        auto_chunking_goal = _coerce_form_string(auto_chunking_goal) or "balanced"
+        auto_chunking_use_llm = _coerce_form_bool(auto_chunking_use_llm)
+        auto_apply_template = _coerce_form_bool(auto_apply_template)
+        hierarchical_chunking = _coerce_form_bool(hierarchical_chunking)
+        hierarchical_template = _coerce_hierarchical_template(hierarchical_template)
         try:
             if isinstance(context_window_size, str):
                 context_window_size = int(context_window_size)
@@ -383,6 +472,9 @@ async def get_add_media_form(
             ocr_output_format=ocr_output_format,
             ocr_prompt_preset=ocr_prompt_preset,
             perform_chunking=perform_chunking,
+            chunking_mode=chunking_mode,
+            auto_chunking_goal=auto_chunking_goal,
+            auto_chunking_use_llm=auto_chunking_use_llm,
             chunk_method=chunk_method,
             use_adaptive_chunking=use_adaptive_chunking,
             use_multi_level_chunking=use_multi_level_chunking,
@@ -390,6 +482,10 @@ async def get_add_media_form(
             chunk_size=chunk_size,
             chunk_overlap=chunk_overlap,
             custom_chapter_pattern=custom_chapter_pattern,
+            auto_apply_template=auto_apply_template,
+            chunking_template_name=chunking_template_name,
+            hierarchical_chunking=hierarchical_chunking,
+            hierarchical_template=hierarchical_template,
             perform_rolling_summarization=perform_rolling_summarization,
             summarize_recursively=summarize_recursively,
             enable_contextual_chunking=enable_contextual_chunking,
@@ -426,6 +522,8 @@ async def get_add_media_form(
             status_code=HTTP_422_UNPROCESSABLE,
             detail=serializable_errors,
         ) from exc
+    except HTTPException:
+        raise
     except Exception as exc:
         logger.error(
             "Unexpected error creating AddMediaForm: {}",

--- a/tldw_Server_API/app/api/v1/API_Deps/media_processing_deps.py
+++ b/tldw_Server_API/app/api/v1/API_Deps/media_processing_deps.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from typing import Any
 
 from fastapi import Form, status
 from loguru import logger
@@ -107,6 +108,83 @@ def _raise_422(exc: ValidationError) -> None:
     ) from exc
 
 
+def _coerce_form_bool(value: Any) -> bool:
+    if hasattr(value, "default"):
+        value = value.default
+    if isinstance(value, str):
+        return value.strip().lower() in {"true", "1", "yes", "on"}
+    return bool(value)
+
+
+def _coerce_form_string(value: Any) -> str | None:
+    if hasattr(value, "default"):
+        value = value.default
+    if value is None:
+        return None
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    return str(value)
+
+
+def _coerce_hierarchical_template(value: Any) -> dict[str, Any] | None:
+    if hasattr(value, "default"):
+        value = value.default
+    if value is None or value == "":
+        return None
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise APIValidationError(
+                detail=[
+                    {
+                        "loc": ["body", "hierarchical_template"],
+                        "msg": "hierarchical_template must be a JSON object",
+                        "type": "value_error.jsondecode",
+                    }
+                ],
+                status_code=HTTP_422_UNPROCESSABLE,
+            ) from exc
+        if isinstance(parsed, dict):
+            return parsed
+    raise APIValidationError(
+        detail=[
+            {
+                "loc": ["body", "hierarchical_template"],
+                "msg": "hierarchical_template must be a JSON object",
+                "type": "type_error.dict",
+            }
+        ],
+        status_code=HTTP_422_UNPROCESSABLE,
+    )
+
+
+def _chunking_contract_kwargs(
+    *,
+    chunking_mode: Any,
+    auto_chunking_goal: Any,
+    auto_chunking_use_llm: Any,
+    auto_apply_template: Any,
+    chunking_template_name: Any,
+    hierarchical_chunking: Any,
+    hierarchical_template: Any,
+) -> dict[str, Any]:
+    return {
+        "chunking_mode": _coerce_form_string(chunking_mode),
+        "auto_chunking_goal": _coerce_form_string(auto_chunking_goal) or "balanced",
+        "auto_chunking_use_llm": _coerce_form_bool(auto_chunking_use_llm),
+        "auto_apply_template": _coerce_form_bool(auto_apply_template),
+        "chunking_template_name": _coerce_form_string(chunking_template_name),
+        "hierarchical_chunking": _coerce_form_bool(hierarchical_chunking),
+        "hierarchical_template": _coerce_hierarchical_template(
+            hierarchical_template
+        ),
+    }
+
+
 async def get_process_documents_form(
     urls: list[str] | None = Form(None),
     title: str | None = Form(None),
@@ -123,6 +201,13 @@ async def get_process_documents_form(
     chunk_method: str | None = Form(None),
     chunk_size: int = Form(500),
     chunk_overlap: int = Form(200),
+    chunking_mode: str | None = Form(None),
+    auto_chunking_goal: str = Form("balanced"),
+    auto_chunking_use_llm: bool = Form(False),
+    auto_apply_template: bool = Form(False),
+    chunking_template_name: str | None = Form(None),
+    hierarchical_chunking: bool = Form(False),
+    hierarchical_template: str | dict[str, Any] | None = Form(None),
     api_provider: str | None = Form(None),
     model_name: str | None = Form(None),
     api_name: str | None = Form(None),
@@ -154,6 +239,15 @@ async def get_process_documents_form(
             chunk_method=chunk_method,
             chunk_size=chunk_size,
             chunk_overlap=chunk_overlap,
+            **_chunking_contract_kwargs(
+                chunking_mode=chunking_mode,
+                auto_chunking_goal=auto_chunking_goal,
+                auto_chunking_use_llm=auto_chunking_use_llm,
+                auto_apply_template=auto_apply_template,
+                chunking_template_name=chunking_template_name,
+                hierarchical_chunking=hierarchical_chunking,
+                hierarchical_template=hierarchical_template,
+            ),
             api_provider=api_provider,
             model_name=model_name,
             api_name=api_name,
@@ -195,6 +289,13 @@ async def get_process_videos_form(
     chunk_method: str | None = Form(None),
     chunk_size: int = Form(500),
     chunk_overlap: int = Form(200),
+    chunking_mode: str | None = Form(None),
+    auto_chunking_goal: str = Form("balanced"),
+    auto_chunking_use_llm: bool = Form(False),
+    auto_apply_template: bool = Form(False),
+    chunking_template_name: str | None = Form(None),
+    hierarchical_chunking: bool = Form(False),
+    hierarchical_template: str | dict[str, Any] | None = Form(None),
 ) -> ProcessVideosForm:
     """
     Dependency that parses multipart/form-data into a ProcessVideosForm.
@@ -235,6 +336,15 @@ async def get_process_videos_form(
             chunk_method=chunk_method,
             chunk_size=chunk_size,
             chunk_overlap=chunk_overlap,
+            **_chunking_contract_kwargs(
+                chunking_mode=chunking_mode,
+                auto_chunking_goal=auto_chunking_goal,
+                auto_chunking_use_llm=auto_chunking_use_llm,
+                auto_apply_template=auto_apply_template,
+                chunking_template_name=chunking_template_name,
+                hierarchical_chunking=hierarchical_chunking,
+                hierarchical_template=hierarchical_template,
+            ),
         )
     except ValidationError as exc:
         _raise_422(exc)
@@ -271,6 +381,13 @@ async def get_process_audios_form(
     chunk_method: str | None = Form(None),
     chunk_size: int = Form(500),
     chunk_overlap: int = Form(200),
+    chunking_mode: str | None = Form(None),
+    auto_chunking_goal: str = Form("balanced"),
+    auto_chunking_use_llm: bool = Form(False),
+    auto_apply_template: bool = Form(False),
+    chunking_template_name: str | None = Form(None),
+    hierarchical_chunking: bool = Form(False),
+    hierarchical_template: str | dict[str, Any] | None = Form(None),
 ) -> ProcessAudiosForm:
     """
     Dependency that parses multipart/form-data into a ProcessAudiosForm.
@@ -311,6 +428,15 @@ async def get_process_audios_form(
             chunk_method=chunk_method,
             chunk_size=chunk_size,
             chunk_overlap=chunk_overlap,
+            **_chunking_contract_kwargs(
+                chunking_mode=chunking_mode,
+                auto_chunking_goal=auto_chunking_goal,
+                auto_chunking_use_llm=auto_chunking_use_llm,
+                auto_apply_template=auto_apply_template,
+                chunking_template_name=chunking_template_name,
+                hierarchical_chunking=hierarchical_chunking,
+                hierarchical_template=hierarchical_template,
+            ),
         )
     except ValidationError as exc:
         _raise_422(exc)
@@ -329,8 +455,13 @@ async def get_process_pdfs_form(
     chunk_method: str | None = Form(None),
     chunk_size: int = Form(500),
     chunk_overlap: int = Form(200),
+    chunking_mode: str | None = Form(None),
+    auto_chunking_goal: str = Form("balanced"),
+    auto_chunking_use_llm: bool = Form(False),
     auto_apply_template: bool = Form(False),
     chunking_template_name: str | None = Form(None),
+    hierarchical_chunking: bool = Form(False),
+    hierarchical_template: str | dict[str, Any] | None = Form(None),
     pdf_parsing_engine: str = Form("pymupdf4llm"),
     enable_ocr: bool = Form(False),
     ocr_backend: str | None = Form(None),
@@ -368,8 +499,15 @@ async def get_process_pdfs_form(
             chunk_method=chunk_method,
             chunk_size=chunk_size,
             chunk_overlap=chunk_overlap,
-            auto_apply_template=auto_apply_template,
-            chunking_template_name=chunking_template_name,
+            **_chunking_contract_kwargs(
+                chunking_mode=chunking_mode,
+                auto_chunking_goal=auto_chunking_goal,
+                auto_chunking_use_llm=auto_chunking_use_llm,
+                auto_apply_template=auto_apply_template,
+                chunking_template_name=chunking_template_name,
+                hierarchical_chunking=hierarchical_chunking,
+                hierarchical_template=hierarchical_template,
+            ),
             pdf_parsing_engine=pdf_parsing_engine,
             enable_ocr=enable_ocr,
             ocr_backend=ocr_backend,
@@ -407,6 +545,13 @@ async def get_process_ebooks_form(
     chunk_overlap: int = Form(200),
     chunk_language: str | None = Form(None),
     custom_chapter_pattern: str | None = Form(None),
+    chunking_mode: str | None = Form(None),
+    auto_chunking_goal: str = Form("balanced"),
+    auto_chunking_use_llm: bool = Form(False),
+    auto_apply_template: bool = Form(False),
+    chunking_template_name: str | None = Form(None),
+    hierarchical_chunking: bool = Form(False),
+    hierarchical_template: str | dict[str, Any] | None = Form(None),
     extraction_method: str = Form("filtered"),
     api_name: str | None = Form(None),
     api_key: str | None = Form(None),
@@ -436,6 +581,15 @@ async def get_process_ebooks_form(
             chunk_overlap=chunk_overlap,
             chunk_language=chunk_language,
             custom_chapter_pattern=custom_chapter_pattern,
+            **_chunking_contract_kwargs(
+                chunking_mode=chunking_mode,
+                auto_chunking_goal=auto_chunking_goal,
+                auto_chunking_use_llm=auto_chunking_use_llm,
+                auto_apply_template=auto_apply_template,
+                chunking_template_name=chunking_template_name,
+                hierarchical_chunking=hierarchical_chunking,
+                hierarchical_template=hierarchical_template,
+            ),
             extraction_method=extraction_method,
             api_name=api_name,
             api_key=api_key,
@@ -464,6 +618,13 @@ async def get_process_emails_form(
     custom_chapter_pattern: str | None = Form(None),
     use_adaptive_chunking: bool = Form(False),
     use_multi_level_chunking: bool = Form(False),
+    chunking_mode: str | None = Form(None),
+    auto_chunking_goal: str = Form("balanced"),
+    auto_chunking_use_llm: bool = Form(False),
+    auto_apply_template: bool = Form(False),
+    chunking_template_name: str | None = Form(None),
+    hierarchical_chunking: bool = Form(False),
+    hierarchical_template: str | dict[str, Any] | None = Form(None),
     accept_archives: bool = Form(False),
     accept_mbox: bool = Form(False),
     accept_pst: bool = Form(False),
@@ -497,6 +658,15 @@ async def get_process_emails_form(
             custom_chapter_pattern=custom_chapter_pattern,
             use_adaptive_chunking=use_adaptive_chunking,
             use_multi_level_chunking=use_multi_level_chunking,
+            **_chunking_contract_kwargs(
+                chunking_mode=chunking_mode,
+                auto_chunking_goal=auto_chunking_goal,
+                auto_chunking_use_llm=auto_chunking_use_llm,
+                auto_apply_template=auto_apply_template,
+                chunking_template_name=chunking_template_name,
+                hierarchical_chunking=hierarchical_chunking,
+                hierarchical_template=hierarchical_template,
+            ),
             accept_archives=accept_archives,
             accept_mbox=accept_mbox,
             accept_pst=accept_pst,

--- a/tldw_Server_API/app/api/v1/API_Deps/media_processing_deps.py
+++ b/tldw_Server_API/app/api/v1/API_Deps/media_processing_deps.py
@@ -7,6 +7,9 @@ from fastapi import Form, status
 from loguru import logger
 from pydantic import ValidationError
 
+from tldw_Server_API.app.api.v1.API_Deps.form_coercion import (
+    chunking_contract_kwargs,
+)
 from tldw_Server_API.app.api.v1.schemas.media_request_models import (
     TRANSCRIPTION_MODEL_ENUM,
     ProcessAudiosForm,
@@ -97,92 +100,12 @@ def _raise_422(exc: ValidationError) -> None:
             loc = ["body"]
         err["loc"] = loc
         if isinstance(ctx, dict):
-            err["ctx"] = {
-                k: (str(v) if isinstance(v, Exception) else v)
-                for k, v in ctx.items()
-            }
+            err["ctx"] = {k: (str(v) if isinstance(v, Exception) else v) for k, v in ctx.items()}
         serializable_errors.append(err)
     raise APIValidationError(
         detail=serializable_errors,
         status_code=HTTP_422_UNPROCESSABLE,
     ) from exc
-
-
-def _coerce_form_bool(value: Any) -> bool:
-    if hasattr(value, "default"):
-        value = value.default
-    if isinstance(value, str):
-        return value.strip().lower() in {"true", "1", "yes", "on"}
-    return bool(value)
-
-
-def _coerce_form_string(value: Any) -> str | None:
-    if hasattr(value, "default"):
-        value = value.default
-    if value is None:
-        return None
-    if isinstance(value, str):
-        stripped = value.strip()
-        return stripped or None
-    return str(value)
-
-
-def _coerce_hierarchical_template(value: Any) -> dict[str, Any] | None:
-    if hasattr(value, "default"):
-        value = value.default
-    if value is None or value == "":
-        return None
-    if isinstance(value, dict):
-        return value
-    if isinstance(value, str):
-        try:
-            parsed = json.loads(value)
-        except json.JSONDecodeError as exc:
-            raise APIValidationError(
-                detail=[
-                    {
-                        "loc": ["body", "hierarchical_template"],
-                        "msg": "hierarchical_template must be a JSON object",
-                        "type": "value_error.jsondecode",
-                    }
-                ],
-                status_code=HTTP_422_UNPROCESSABLE,
-            ) from exc
-        if isinstance(parsed, dict):
-            return parsed
-    raise APIValidationError(
-        detail=[
-            {
-                "loc": ["body", "hierarchical_template"],
-                "msg": "hierarchical_template must be a JSON object",
-                "type": "type_error.dict",
-            }
-        ],
-        status_code=HTTP_422_UNPROCESSABLE,
-    )
-
-
-def _chunking_contract_kwargs(
-    *,
-    chunking_mode: Any,
-    auto_chunking_goal: Any,
-    auto_chunking_use_llm: Any,
-    auto_apply_template: Any,
-    chunking_template_name: Any,
-    hierarchical_chunking: Any,
-    hierarchical_template: Any,
-) -> dict[str, Any]:
-    return {
-        "chunking_mode": _coerce_form_string(chunking_mode),
-        "auto_chunking_goal": _coerce_form_string(auto_chunking_goal) or "balanced",
-        "auto_chunking_use_llm": _coerce_form_bool(auto_chunking_use_llm),
-        "auto_apply_template": _coerce_form_bool(auto_apply_template),
-        "chunking_template_name": _coerce_form_string(chunking_template_name),
-        "hierarchical_chunking": _coerce_form_bool(hierarchical_chunking),
-        "hierarchical_template": _coerce_hierarchical_template(
-            hierarchical_template
-        ),
-    }
 
 
 async def get_process_documents_form(
@@ -221,9 +144,7 @@ async def get_process_documents_form(
     """
     try:
         urls_norm = _coerce_urls(urls)
-        keywords_value = (
-            keywords if keywords is not None else (keywords_str if keywords_str is not None else "")
-        )
+        keywords_value = keywords if keywords is not None else (keywords_str if keywords_str is not None else "")
         title_val = title or titles
         return ProcessDocumentsForm(
             urls=urls_norm,
@@ -239,7 +160,7 @@ async def get_process_documents_form(
             chunk_method=chunk_method,
             chunk_size=chunk_size,
             chunk_overlap=chunk_overlap,
-            **_chunking_contract_kwargs(
+            **chunking_contract_kwargs(
                 chunking_mode=chunking_mode,
                 auto_chunking_goal=auto_chunking_goal,
                 auto_chunking_use_llm=auto_chunking_use_llm,
@@ -336,7 +257,7 @@ async def get_process_videos_form(
             chunk_method=chunk_method,
             chunk_size=chunk_size,
             chunk_overlap=chunk_overlap,
-            **_chunking_contract_kwargs(
+            **chunking_contract_kwargs(
                 chunking_mode=chunking_mode,
                 auto_chunking_goal=auto_chunking_goal,
                 auto_chunking_use_llm=auto_chunking_use_llm,
@@ -428,7 +349,7 @@ async def get_process_audios_form(
             chunk_method=chunk_method,
             chunk_size=chunk_size,
             chunk_overlap=chunk_overlap,
-            **_chunking_contract_kwargs(
+            **chunking_contract_kwargs(
                 chunking_mode=chunking_mode,
                 auto_chunking_goal=auto_chunking_goal,
                 auto_chunking_use_llm=auto_chunking_use_llm,
@@ -499,7 +420,7 @@ async def get_process_pdfs_form(
             chunk_method=chunk_method,
             chunk_size=chunk_size,
             chunk_overlap=chunk_overlap,
-            **_chunking_contract_kwargs(
+            **chunking_contract_kwargs(
                 chunking_mode=chunking_mode,
                 auto_chunking_goal=auto_chunking_goal,
                 auto_chunking_use_llm=auto_chunking_use_llm,
@@ -563,9 +484,7 @@ async def get_process_ebooks_form(
     """
     try:
         urls_norm = _coerce_urls(urls)
-        keywords_value = (
-            keywords if keywords is not None else (keywords_str if keywords_str is not None else "")
-        )
+        keywords_value = keywords if keywords is not None else (keywords_str if keywords_str is not None else "")
         return ProcessEbooksForm(
             urls=urls_norm,
             title=title,
@@ -581,7 +500,7 @@ async def get_process_ebooks_form(
             chunk_overlap=chunk_overlap,
             chunk_language=chunk_language,
             custom_chapter_pattern=custom_chapter_pattern,
-            **_chunking_contract_kwargs(
+            **chunking_contract_kwargs(
                 chunking_mode=chunking_mode,
                 auto_chunking_goal=auto_chunking_goal,
                 auto_chunking_use_llm=auto_chunking_use_llm,
@@ -658,7 +577,7 @@ async def get_process_emails_form(
             custom_chapter_pattern=custom_chapter_pattern,
             use_adaptive_chunking=use_adaptive_chunking,
             use_multi_level_chunking=use_multi_level_chunking,
-            **_chunking_contract_kwargs(
+            **chunking_contract_kwargs(
                 chunking_mode=chunking_mode,
                 auto_chunking_goal=auto_chunking_goal,
                 auto_chunking_use_llm=auto_chunking_use_llm,

--- a/tldw_Server_API/app/api/v1/endpoints/media/ingest_web_content.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/ingest_web_content.py
@@ -18,6 +18,10 @@ from tldw_Server_API.app.api.v1.API_Deps.personalization_deps import (
 from tldw_Server_API.app.api.v1.schemas.media_request_models import (
     IngestWebContentRequest,
 )
+from tldw_Server_API.app.core.Ingestion_Media_Processing.chunking_options import (
+    attach_chunking_plan_to_result,
+    resolve_chunking_options_and_plan,
+)
 from tldw_Server_API.app.services.web_scraping_service import (
     ingest_web_content_orchestrate,
 )
@@ -114,7 +118,17 @@ async def ingest_web_content(
     # Optional chunking stub (kept for behavioural parity with legacy).
     if request.perform_chunking:
         logger.info("Performing chunking on each article (placeholder).")
-        # Real chunking logic would go here.
+        for item in raw_results:
+            if not isinstance(item, dict):
+                continue
+            content = item.get("content")
+            _, chunking_plan = resolve_chunking_options_and_plan(
+                request,
+                media_type="web",
+                source_name=str(item.get("url") or ""),
+                extracted_text=content if isinstance(content, str) else None,
+            )
+            attach_chunking_plan_to_result(item, chunking_plan)
 
     # Timestamp results when requested.
     if request.timestamp_option:

--- a/tldw_Server_API/app/api/v1/endpoints/media/ingest_web_content.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/ingest_web_content.py
@@ -91,16 +91,7 @@ async def ingest_web_content(
     scrape_method = request.scrape_method
     logger.info("Selected scrape method: {}", scrape_method)
 
-    # Scrape method validation / logging.
-    scrape_method = request.scrape_method
-    logger.info("Selected scrape method: {}", scrape_method)
-
     if not raw_results:
-        return {
-            "status": "warning",
-            "message": "No articles were successfully scraped for this request.",
-            "results": [],
-        }
         return {
             "status": "warning",
             "message": "No articles were successfully scraped for this request.",

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_audios.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_audios.py
@@ -38,6 +38,7 @@ from tldw_Server_API.app.core.Ingestion_Media_Processing.chunking_options import
     attach_chunking_plan_to_result,
     resolve_chunking_for_result,
     resolve_chunking_options_and_plan,
+    uses_hierarchical_chunking,
 )
 from tldw_Server_API.app.core.Ingestion_Media_Processing.input_sourcing import (
     TempDirManager,
@@ -87,9 +88,7 @@ async def process_audios_endpoint(
     handling and batch orchestration.
     """
 
-    logger.info(
-        "Request received for /process-audios. Form data validated via dependency."
-    )
+    logger.info("Request received for /process-audios. Form data validated via dependency.")
     try:
         usage_log.log_event(
             "media.process.audio",
@@ -103,9 +102,7 @@ async def process_audios_endpoint(
     # Normalize the "urls=['']" sentinel used by some clients.
     legacy_urls_empty_sentinel_used = bool(form_data.urls and form_data.urls == [""])
     if legacy_urls_empty_sentinel_used:
-        logger.info(
-            "Received urls=[''], treating as no URLs provided for audio processing."
-        )
+        logger.info("Received urls=[''], treating as no URLs provided for audio processing.")
     form_data.urls = normalize_urls_field(form_data.urls)
     legacy_signal = (
         build_media_legacy_signal(
@@ -150,9 +147,7 @@ async def process_audios_endpoint(
 
     with TempDirManager(cleanup=True, prefix="process_audio_") as temp_dir:
         temp_dir_path = Path(temp_dir)
-        logger.info(
-            "Using temporary directory for /process-audios: {}", temp_dir_path.as_posix()
-        )
+        logger.info("Using temporary directory for /process-audios: {}", temp_dir_path.as_posix())
 
         # Preserve test-time monkeypatching of `media.file_validator_instance`
         # by resolving the validator from the media module export.
@@ -254,9 +249,7 @@ async def process_audios_endpoint(
 
     if total_items == 0:
         final_status_code = status.HTTP_400_BAD_REQUEST
-        logger.error(
-            "No results generated for /process-audios despite processing attempt."
-        )
+        logger.error("No results generated for /process-audios despite processing attempt.")
     elif final_error_count == 0 and final_processed_count > 0:
         final_status_code = status.HTTP_200_OK
         logger.info(
@@ -280,16 +273,10 @@ async def process_audios_endpoint(
         # environment-induced skips can be distinguished from real regressions.
         if is_test_mode():
             try:
-                errors_joined = " | ".join(
-                    str(e) for e in batch_result.get("errors", []) if e
-                )
-                if (
-                    "Download failed" in errors_joined
-                    or "Host could not be resolved" in errors_joined
-                ):
+                errors_joined = " | ".join(str(e) for e in batch_result.get("errors", []) if e)
+                if "Download failed" in errors_joined or "Host could not be resolved" in errors_joined:
                     logger.debug(
-                        "TEST_MODE: /process-audios returned 207 due to audio "
-                        "download/egress error: {}",
+                        "TEST_MODE: /process-audios returned 207 due to audio " "download/egress error: {}",
                         errors_joined,
                     )
             except Exception:
@@ -306,11 +293,12 @@ async def process_audios_endpoint(
                     first_filename = saved_files[0].get("original_filename")
             except Exception:
                 first_filename = None
+            first_input_source = str(all_inputs[0]) if all_inputs else first_url or first_filename
 
             chunk_options_dict, chunking_plan = resolve_chunking_options_and_plan(
                 form_data,
                 media_type="audio",
-                source_name=first_filename or first_url,
+                source_name=first_input_source,
             )
             try:
                 TemplateClassifier = getattr(media_mod, "TemplateClassifier", None)
@@ -335,11 +323,7 @@ async def process_audios_endpoint(
                 Chunker as _Chunker,
             )
 
-            use_hier = bool(
-                chunk_options_dict.get("hierarchical")
-                or isinstance(chunk_options_dict.get("hierarchical_template"), dict)
-            )
-            ck = _Chunker() if use_hier else None
+            ck: _Chunker | None = None
 
             for res in batch_result.get("results", []):
                 if not isinstance(res, dict):
@@ -364,27 +348,26 @@ async def process_audios_endpoint(
                 if not result_chunk_options:
                     continue
 
-                if use_hier and ck is not None:
+                if uses_hierarchical_chunking(result_chunk_options):
+                    ck = ck or _Chunker()
                     chunks = ck.chunk_text_hierarchical_flat(
                         text,
                         method=result_chunk_options.get("method") or "sentences",
                         max_size=result_chunk_options.get("max_size") or 500,
                         overlap=result_chunk_options.get("overlap") or 200,
                         language=result_chunk_options.get("language"),
-                        template=result_chunk_options.get("hierarchical_template")
-                        if isinstance(
-                            result_chunk_options.get("hierarchical_template"), dict
-                        )
-                        else None,
+                        template=(
+                            result_chunk_options.get("hierarchical_template")
+                            if isinstance(result_chunk_options.get("hierarchical_template"), dict)
+                            else None
+                        ),
                     )
                 else:
                     chunks = _improved_chunking_process(text, result_chunk_options)
 
                 res["chunks"] = chunks
     except Exception:
-        logger.warning(
-            "Best-effort audio chunking post-processing failed; leaving results unchunked"
-        )
+        logger.warning("Best-effort audio chunking post-processing failed; leaving results unchunked")
 
     response = JSONResponse(status_code=final_status_code, content=batch_result)
     if legacy_signal is not None:

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_audios.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_audios.py
@@ -35,7 +35,9 @@ from tldw_Server_API.app.api.v1.endpoints import media as media_mod
 from tldw_Server_API.app.api.v1.schemas.media_request_models import ProcessAudiosForm
 from tldw_Server_API.app.core.Ingestion_Media_Processing.chunking_options import (
     apply_chunking_template_if_any,
-    prepare_chunking_options_dict,
+    attach_chunking_plan_to_result,
+    resolve_chunking_for_result,
+    resolve_chunking_options_and_plan,
 )
 from tldw_Server_API.app.core.Ingestion_Media_Processing.input_sourcing import (
     TempDirManager,
@@ -144,6 +146,7 @@ async def process_audios_endpoint(
     temp_path_to_original_name: dict[str, str] = {}
     saved_files: list[dict[str, Any]] = []
     chunk_options_dict: dict[str, Any] | None = None
+    chunking_plan: dict[str, Any] | None = None
 
     with TempDirManager(cleanup=True, prefix="process_audio_") as temp_dir:
         temp_dir_path = Path(temp_dir)
@@ -296,21 +299,25 @@ async def process_audios_endpoint(
     # Optional template/hierarchical re-chunking of transcripts (best-effort).
     try:
         if form_data.perform_chunking:
-            chunk_options_dict = prepare_chunking_options_dict(form_data)
+            first_url = (form_data.urls or [None])[0]
+            first_filename = None
+            try:
+                if saved_files:
+                    first_filename = saved_files[0].get("original_filename")
+            except Exception:
+                first_filename = None
+
+            chunk_options_dict, chunking_plan = resolve_chunking_options_and_plan(
+                form_data,
+                media_type="audio",
+                source_name=first_filename or first_url,
+            )
             try:
                 TemplateClassifier = getattr(media_mod, "TemplateClassifier", None)
             except Exception:
                 TemplateClassifier = None
 
-            if chunk_options_dict is not None:
-                first_url = (form_data.urls or [None])[0]
-                first_filename = None
-                try:
-                    if saved_files:
-                        first_filename = saved_files[0].get("original_filename")
-                except Exception:
-                    first_filename = None
-
+            if chunk_options_dict is not None and chunking_plan is None:
                 chunk_options_dict = apply_chunking_template_if_any(
                     form_data=form_data,
                     db=db,
@@ -343,23 +350,35 @@ async def process_audios_endpoint(
                 # Audio results may store transcript under 'content'
                 text = res.get("content")
                 if not isinstance(text, str) or not text.strip():
+                    attach_chunking_plan_to_result(res, chunking_plan)
+                    continue
+
+                result_chunk_options, result_chunking_plan = resolve_chunking_for_result(
+                    form_data,
+                    res,
+                    media_type="audio",
+                    default_chunk_options=chunk_options_dict,
+                    default_chunking_plan=chunking_plan,
+                )
+                attach_chunking_plan_to_result(res, result_chunking_plan)
+                if not result_chunk_options:
                     continue
 
                 if use_hier and ck is not None:
                     chunks = ck.chunk_text_hierarchical_flat(
                         text,
-                        method=chunk_options_dict.get("method") or "sentences",
-                        max_size=chunk_options_dict.get("max_size") or 500,
-                        overlap=chunk_options_dict.get("overlap") or 200,
-                        language=chunk_options_dict.get("language"),
-                        template=chunk_options_dict.get("hierarchical_template")
+                        method=result_chunk_options.get("method") or "sentences",
+                        max_size=result_chunk_options.get("max_size") or 500,
+                        overlap=result_chunk_options.get("overlap") or 200,
+                        language=result_chunk_options.get("language"),
+                        template=result_chunk_options.get("hierarchical_template")
                         if isinstance(
-                            chunk_options_dict.get("hierarchical_template"), dict
+                            result_chunk_options.get("hierarchical_template"), dict
                         )
                         else None,
                     )
                 else:
-                    chunks = _improved_chunking_process(text, chunk_options_dict)
+                    chunks = _improved_chunking_process(text, result_chunk_options)
 
                 res["chunks"] = chunks
     except Exception:

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_documents.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_documents.py
@@ -26,7 +26,9 @@ from tldw_Server_API.app.api.v1.endpoints import media as media_mod
 from tldw_Server_API.app.api.v1.schemas.media_request_models import ProcessDocumentsForm
 from tldw_Server_API.app.core.Ingestion_Media_Processing.chunking_options import (
     apply_chunking_template_if_any,
-    prepare_chunking_options_dict,
+    attach_chunking_plan_to_result,
+    resolve_chunking_for_result,
+    resolve_chunking_options_and_plan,
 )
 from tldw_Server_API.app.core.Ingestion_Media_Processing.input_sourcing import (
     TempDirManager,
@@ -352,18 +354,21 @@ async def process_documents_endpoint(
         )
 
         # --- Prepare options for the worker ---
+        chunking_plan: dict[str, Any] | None = None
         if form_data.perform_chunking:
-            chunk_options_dict: dict[str, Any] | None = prepare_chunking_options_dict(
-                form_data
+            first_url = (form_data.urls or [None])[0]
+            first_filename = None
+            if saved_files_info:
+                first_filename = saved_files_info[0].get("original_filename")
+
+            chunk_options_dict, chunking_plan = resolve_chunking_options_and_plan(
+                form_data,
+                media_type="document",
+                source_name=first_filename or first_url,
             )
             TemplateClassifier = getattr(media_mod, "TemplateClassifier", None)
 
-            if chunk_options_dict is not None:
-                first_url = (form_data.urls or [None])[0]
-                first_filename = None
-                if saved_files_info:
-                    first_filename = saved_files_info[0].get("original_filename")
-
+            if chunk_options_dict is not None and chunking_plan is None:
                 chunk_options_dict = apply_chunking_template_if_any(
                     form_data=form_data,
                     db=db,
@@ -551,23 +556,35 @@ async def process_documents_endpoint(
                     continue
                 text = res.get("content")
                 if not isinstance(text, str) or not text.strip():
+                    attach_chunking_plan_to_result(res, chunking_plan)
+                    continue
+
+                result_chunk_options, result_chunking_plan = resolve_chunking_for_result(
+                    form_data,
+                    res,
+                    media_type="document",
+                    default_chunk_options=chunk_options_dict,
+                    default_chunking_plan=chunking_plan,
+                )
+                attach_chunking_plan_to_result(res, result_chunking_plan)
+                if not result_chunk_options:
                     continue
 
                 if use_hier and ck is not None:
                     chunks = ck.chunk_text_hierarchical_flat(
                         text,
-                        method=chunk_options_dict.get("method") or "sentences",
-                        max_size=chunk_options_dict.get("max_size") or 500,
-                        overlap=chunk_options_dict.get("overlap") or 200,
-                        language=chunk_options_dict.get("language"),
-                        template=chunk_options_dict.get("hierarchical_template")
+                        method=result_chunk_options.get("method") or "sentences",
+                        max_size=result_chunk_options.get("max_size") or 500,
+                        overlap=result_chunk_options.get("overlap") or 200,
+                        language=result_chunk_options.get("language"),
+                        template=result_chunk_options.get("hierarchical_template")
                         if isinstance(
-                            chunk_options_dict.get("hierarchical_template"), dict
+                            result_chunk_options.get("hierarchical_template"), dict
                         )
                         else None,
                     )
                 else:
-                    chunks = _improved_chunking_process(text, chunk_options_dict)
+                    chunks = _improved_chunking_process(text, result_chunk_options)
 
                 res["chunks"] = chunks
     except Exception:

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_documents.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_documents.py
@@ -29,6 +29,7 @@ from tldw_Server_API.app.core.Ingestion_Media_Processing.chunking_options import
     attach_chunking_plan_to_result,
     resolve_chunking_for_result,
     resolve_chunking_options_and_plan,
+    uses_hierarchical_chunking,
 )
 from tldw_Server_API.app.core.Ingestion_Media_Processing.input_sourcing import (
     TempDirManager,
@@ -105,8 +106,7 @@ async def process_documents_endpoint(
         # Usage logging is best-effort; never fail the request.
         logger.debug("Document process endpoint usage logging failed")
     logger.debug(
-        "Form data for /process-documents: has_urls={}, has_files={}, "
-        "perform_analysis={}, perform_chunking={}",
+        "Form data for /process-documents: has_urls={}, has_files={}, " "perform_analysis={}, perform_chunking={}",
         bool(form_data.urls),
         bool(files),
         form_data.perform_analysis,
@@ -114,9 +114,7 @@ async def process_documents_endpoint(
     )
     legacy_urls_empty_sentinel_used = bool(form_data.urls and form_data.urls == [""])
     if legacy_urls_empty_sentinel_used:
-        logger.info(
-            "Received urls=[''], treating as no URLs provided for document processing."
-        )
+        logger.info("Received urls=[''], treating as no URLs provided for document processing.")
     form_data.urls = normalize_urls_field(form_data.urls)
     legacy_signal = (
         build_media_legacy_signal(
@@ -175,10 +173,7 @@ async def process_documents_endpoint(
             saved_files_info = list(saved_files)
             # Add file saving/validation errors to batch_result
             for err_info in upload_errors:
-                original_filename = (
-                    err_info.get("input")
-                    or err_info.get("original_filename", "Unknown Upload")
-                )
+                original_filename = err_info.get("input") or err_info.get("original_filename", "Unknown Upload")
                 err_detail = f"Upload error: {err_info['error']}"
                 batch_result["results"].append(
                     {
@@ -300,9 +295,7 @@ async def process_documents_endpoint(
                             type(result),
                             original_url,
                         )
-                        err_detail = (
-                            f"Unexpected download result type: {type(result).__name__}"
-                        )
+                        err_detail = f"Unexpected download result type: {type(result).__name__}"
                         batch_result["results"].append(
                             {
                                 "status": "Error",
@@ -326,15 +319,11 @@ async def process_documents_endpoint(
 
         # --- Check if any files are ready for processing ---
         if not local_paths_to_process:
-            logger.warning(
-                "No valid document sources found or prepared after handling uploads/URLs."
-            )
+            logger.warning("No valid document sources found or prepared after handling uploads/URLs.")
             # When uploads/URLs were rejected, surface counts like other process-* endpoints.
             if batch_result["results"]:
                 batch_result["errors_count"] = sum(
-                    1
-                    for r in batch_result["results"]
-                    if str(r.get("status", "")).lower() == "error"
+                    1 for r in batch_result["results"] if str(r.get("status", "")).lower() == "error"
                 )
                 batch_result["processed_count"] = 0
                 status_code = status.HTTP_207_MULTI_STATUS
@@ -349,9 +338,7 @@ async def process_documents_endpoint(
             propagate_billing_headers(injected_response, response)
             return response
 
-        logger.info(
-            "Starting processing for {} document(s).", len(local_paths_to_process)
-        )
+        logger.info("Starting processing for {} document(s).", len(local_paths_to_process))
 
         # --- Prepare options for the worker ---
         chunking_plan: dict[str, Any] | None = None
@@ -510,23 +497,16 @@ async def process_documents_endpoint(
         final_status_code = status.HTTP_200_OK
     elif batch_result.get("errors_count", 0) > 0:
         final_status_code = status.HTTP_207_MULTI_STATUS
-    elif (
-        batch_result.get("processed_count", 0) == 0
-        and batch_result.get("errors_count", 0) == 0
-    ):
+    elif batch_result.get("processed_count", 0) == 0 and batch_result.get("errors_count", 0) == 0:
         final_status_code = status.HTTP_207_MULTI_STATUS if batch_result["results"] else status.HTTP_400_BAD_REQUEST
     else:
-        logger.warning(
-            "Reached unexpected state for final status code determination "
-            "in /process-documents."
-        )
+        logger.warning("Reached unexpected state for final status code determination " "in /process-documents.")
         final_status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
 
     log_level = "INFO" if final_status_code == status.HTTP_200_OK else "WARNING"
     logger.log(
         log_level,
-        "/process-documents request finished with status {}. "
-        "Processed: {}, Errors: {}",
+        "/process-documents request finished with status {}. " "Processed: {}, Errors: {}",
         final_status_code,
         batch_result.get("processed_count", 0),
         batch_result.get("errors_count", 0),
@@ -542,11 +522,7 @@ async def process_documents_endpoint(
                 Chunker as _Chunker,
             )
 
-            use_hier = bool(
-                chunk_options_dict.get("hierarchical")
-                or isinstance(chunk_options_dict.get("hierarchical_template"), dict)
-            )
-            ck = _Chunker() if use_hier else None
+            ck: _Chunker | None = None
 
             for res in batch_result.get("results", []):
                 if not isinstance(res, dict):
@@ -570,18 +546,19 @@ async def process_documents_endpoint(
                 if not result_chunk_options:
                     continue
 
-                if use_hier and ck is not None:
+                if uses_hierarchical_chunking(result_chunk_options):
+                    ck = ck or _Chunker()
                     chunks = ck.chunk_text_hierarchical_flat(
                         text,
                         method=result_chunk_options.get("method") or "sentences",
                         max_size=result_chunk_options.get("max_size") or 500,
                         overlap=result_chunk_options.get("overlap") or 200,
                         language=result_chunk_options.get("language"),
-                        template=result_chunk_options.get("hierarchical_template")
-                        if isinstance(
-                            result_chunk_options.get("hierarchical_template"), dict
-                        )
-                        else None,
+                        template=(
+                            result_chunk_options.get("hierarchical_template")
+                            if isinstance(result_chunk_options.get("hierarchical_template"), dict)
+                            else None
+                        ),
                     )
                 else:
                     chunks = _improved_chunking_process(text, result_chunk_options)

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_ebooks.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_ebooks.py
@@ -31,7 +31,9 @@ from tldw_Server_API.app.api.v1.endpoints import media as media_mod
 from tldw_Server_API.app.api.v1.schemas.media_request_models import ProcessEbooksForm
 from tldw_Server_API.app.core.Ingestion_Media_Processing.chunking_options import (
     apply_chunking_template_if_any,
-    prepare_chunking_options_dict,
+    attach_chunking_plan_to_result,
+    resolve_chunking_for_result,
+    resolve_chunking_options_and_plan,
 )
 from tldw_Server_API.app.core.Ingestion_Media_Processing.input_sourcing import (
     TempDirManager,
@@ -197,6 +199,7 @@ async def process_ebooks_endpoint(
     items: list[ProcessItem] = []
     saved_files_info: list[dict[str, Any]] = []
     chunk_options_dict: dict[str, Any] | None = None
+    chunking_plan: dict[str, Any] | None = None
 
     with TempDirManager(prefix="process_ebooks_") as temp_dir:
         temp_dir_path = Path(temp_dir)
@@ -336,21 +339,25 @@ async def process_ebooks_endpoint(
 
         # Prepare chunking options (with optional templates/hierarchical rules).
         if form_data.perform_chunking:
-            chunk_options_dict = prepare_chunking_options_dict(form_data)
+            first_url = (form_data.urls or [None])[0]
+            first_filename = None
+            try:
+                if saved_files_info:
+                    first_filename = saved_files_info[0].get("original_filename")
+            except Exception:
+                first_filename = None
+
+            chunk_options_dict, chunking_plan = resolve_chunking_options_and_plan(
+                form_data,
+                media_type="ebook",
+                source_name=first_filename or first_url,
+            )
             try:
                 TemplateClassifier = getattr(media_mod, "TemplateClassifier", None)
             except Exception:
                 TemplateClassifier = None
 
-            if chunk_options_dict is not None:
-                first_url = (form_data.urls or [None])[0]
-                first_filename = None
-                try:
-                    if saved_files_info:
-                        first_filename = saved_files_info[0].get("original_filename")
-                except Exception:
-                    first_filename = None
-
+            if chunk_options_dict is not None and chunking_plan is None:
                 chunk_options_dict = apply_chunking_template_if_any(
                     form_data=form_data,
                     db=db,
@@ -498,23 +505,35 @@ async def process_ebooks_endpoint(
                     continue
                 text = res.get("content")
                 if not isinstance(text, str) or not text.strip():
+                    attach_chunking_plan_to_result(res, chunking_plan)
+                    continue
+
+                result_chunk_options, result_chunking_plan = resolve_chunking_for_result(
+                    form_data,
+                    res,
+                    media_type="ebook",
+                    default_chunk_options=chunk_options_dict,
+                    default_chunking_plan=chunking_plan,
+                )
+                attach_chunking_plan_to_result(res, result_chunking_plan)
+                if not result_chunk_options:
                     continue
 
                 if use_hier and ck is not None:
                     chunks = ck.chunk_text_hierarchical_flat(
                         text,
-                        method=chunk_options_dict.get("method") or "sentences",
-                        max_size=chunk_options_dict.get("max_size") or 1000,
-                        overlap=chunk_options_dict.get("overlap") or 200,
-                        language=chunk_options_dict.get("language"),
-                        template=chunk_options_dict.get("hierarchical_template")
+                        method=result_chunk_options.get("method") or "sentences",
+                        max_size=result_chunk_options.get("max_size") or 1000,
+                        overlap=result_chunk_options.get("overlap") or 200,
+                        language=result_chunk_options.get("language"),
+                        template=result_chunk_options.get("hierarchical_template")
                         if isinstance(
-                            chunk_options_dict.get("hierarchical_template"), dict
+                            result_chunk_options.get("hierarchical_template"), dict
                         )
                         else None,
                     )
                 else:
-                    chunks = _improved_chunking_process(text, chunk_options_dict)
+                    chunks = _improved_chunking_process(text, result_chunk_options)
 
                 res["chunks"] = chunks
     except Exception:

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_ebooks.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_ebooks.py
@@ -34,6 +34,7 @@ from tldw_Server_API.app.core.Ingestion_Media_Processing.chunking_options import
     attach_chunking_plan_to_result,
     resolve_chunking_for_result,
     resolve_chunking_options_and_plan,
+    uses_hierarchical_chunking,
 )
 from tldw_Server_API.app.core.Ingestion_Media_Processing.input_sourcing import (
     TempDirManager,
@@ -110,7 +111,7 @@ def _process_single_ebook(
         return result_dict
     except Exception as exc:  # pragma: no cover - defensive fallback
         logger.error(
-            '_process_single_ebook error for {} ({}): {}',
+            "_process_single_ebook error for {} ({}): {}",
             original_ref,
             ebook_path,
             exc,
@@ -146,9 +147,7 @@ async def process_ebooks_endpoint(
     injected_response: Response,
     db: Any = Depends(get_media_db_for_user),
     form_data: ProcessEbooksForm = Depends(get_process_ebooks_form),
-    files: list[UploadFile] | None = File(
-        None, description="EPUB file uploads (.epub)"
-    ),
+    files: list[UploadFile] | None = File(None, description="EPUB file uploads (.epub)"),
     usage_log: UsageEventLogger = Depends(get_usage_event_logger),
 ):
     """
@@ -173,9 +172,7 @@ async def process_ebooks_endpoint(
     # Legacy endpoint treats urls=[""] as "no URLs".
     legacy_urls_empty_sentinel_used = bool(form_data.urls and form_data.urls == [""])
     if legacy_urls_empty_sentinel_used:
-        logger.info(
-            "Received urls=[''], treating as no URLs provided for ebook processing."
-        )
+        logger.info("Received urls=[''], treating as no URLs provided for ebook processing.")
     form_data.urls = normalize_urls_field(form_data.urls)
     legacy_signal = (
         build_media_legacy_signal(
@@ -223,11 +220,7 @@ async def process_ebooks_endpoint(
             saved_files_info = list(saved_files)
 
             for err_info in upload_errors:
-                original_filename = (
-                    err_info.get("original_filename")
-                    or err_info.get("input")
-                    or "Unknown Upload"
-                )
+                original_filename = err_info.get("original_filename") or err_info.get("input") or "Unknown Upload"
                 error_detail = str(err_info.get("error") or "Upload error")
                 batch["results"].append(
                     {
@@ -264,7 +257,7 @@ async def process_ebooks_endpoint(
         # ---- Handle URL inputs via shared downloader ----
         if form_data.urls:
             logger.info(
-                'Attempting to download {} EPUB URL(s) asynchronously...',
+                "Attempting to download {} EPUB URL(s) asynchronously...",
                 len(form_data.urls),
             )
             download_url_async = core_download_url_async
@@ -318,6 +311,7 @@ async def process_ebooks_endpoint(
         # - 207 when we have result entries (all errors)
         # - 400 when no inputs at all (handled by _validate_inputs above)
         if not items:
+
             async def _noop_processor(_: list[ProcessItem]) -> list[dict[str, Any]]:
                 return []
 
@@ -326,11 +320,7 @@ async def process_ebooks_endpoint(
                 processor=_noop_processor,
                 base_batch=batch,
             )
-            status_code = (
-                status.HTTP_207_MULTI_STATUS
-                if batch.get("results")
-                else status.HTTP_400_BAD_REQUEST
-            )
+            status_code = status.HTTP_207_MULTI_STATUS if batch.get("results") else status.HTTP_400_BAD_REQUEST
             response = JSONResponse(status_code=status_code, content=batch)
             if legacy_signal is not None:
                 apply_media_legacy_headers(response, legacy_signal)
@@ -400,7 +390,7 @@ async def process_ebooks_endpoint(
                     res = await loop.run_in_executor(None, partial_func)
                 except Exception as exc:  # pragma: no cover - defensive fallback
                     logger.error(
-                        'Task execution failed for {}: {}',
+                        "Task execution failed for {}: {}",
                         original_ref,
                         exc,
                         exc_info=True,
@@ -443,10 +433,7 @@ async def process_ebooks_endpoint(
                         msg = f"{res.get('input_ref', 'Unknown')}: [Warning] {warn}"
                         batch["errors"].append(msg)
                 elif status_value == "error":
-                    error_msg = (
-                        f"{res.get('input_ref', 'Unknown')}: "
-                        f"{res.get('error', 'Unknown processing error')}"
-                    )
+                    error_msg = f"{res.get('input_ref', 'Unknown')}: " f"{res.get('error', 'Unknown processing error')}"
                     if error_msg not in batch["errors"]:
                         batch["errors"].append(error_msg)
 
@@ -473,8 +460,7 @@ async def process_ebooks_endpoint(
     log_level = "INFO" if final_status_code == status.HTTP_200_OK else "WARNING"
     logger.log(
         log_level,
-        "/process-ebooks request finished with status {}. Results: {}, "
-        "Processed: {}, Errors: {}",
+        "/process-ebooks request finished with status {}. Results: {}, " "Processed: {}, Errors: {}",
         final_status_code,
         len(batch.get("results", [])),
         processed_count,
@@ -491,11 +477,7 @@ async def process_ebooks_endpoint(
                 Chunker as _Chunker,
             )
 
-            use_hier = bool(
-                chunk_options_dict.get("hierarchical")
-                or isinstance(chunk_options_dict.get("hierarchical_template"), dict)
-            )
-            ck = _Chunker() if use_hier else None
+            ck: _Chunker | None = None
 
             for res in batch.get("results", []):
                 if not isinstance(res, dict):
@@ -519,18 +501,19 @@ async def process_ebooks_endpoint(
                 if not result_chunk_options:
                     continue
 
-                if use_hier and ck is not None:
+                if uses_hierarchical_chunking(result_chunk_options):
+                    ck = ck or _Chunker()
                     chunks = ck.chunk_text_hierarchical_flat(
                         text,
                         method=result_chunk_options.get("method") or "sentences",
                         max_size=result_chunk_options.get("max_size") or 1000,
                         overlap=result_chunk_options.get("overlap") or 200,
                         language=result_chunk_options.get("language"),
-                        template=result_chunk_options.get("hierarchical_template")
-                        if isinstance(
-                            result_chunk_options.get("hierarchical_template"), dict
-                        )
-                        else None,
+                        template=(
+                            result_chunk_options.get("hierarchical_template")
+                            if isinstance(result_chunk_options.get("hierarchical_template"), dict)
+                            else None
+                        ),
                     )
                 else:
                     chunks = _improved_chunking_process(text, result_chunk_options)

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_emails.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_emails.py
@@ -19,7 +19,9 @@ from tldw_Server_API.app.api.v1.endpoints import media as media_mod
 from tldw_Server_API.app.api.v1.schemas.media_request_models import ProcessEmailsForm
 from tldw_Server_API.app.core.Ingestion_Media_Processing.chunking_options import (
     apply_chunking_template_if_any,
-    prepare_chunking_options_dict,
+    attach_chunking_plan_to_result,
+    resolve_chunking_for_result,
+    resolve_chunking_options_and_plan,
 )
 from tldw_Server_API.app.core.Ingestion_Media_Processing.input_sourcing import (
     TempDirManager,
@@ -69,11 +71,15 @@ async def process_emails_endpoint(
     items: list[ProcessItem] = []
     saved_files_info: list[dict[str, Any]] = []
     chunk_options_dict: dict[str, Any] | None = None
+    chunking_plan: dict[str, Any] | None = None
 
     # Prepare base chunking options before batch processing so the worker
     # closure can use them when invoking the email processing library.
     if form_data.perform_chunking:
-        chunk_options_dict = prepare_chunking_options_dict(form_data)
+        chunk_options_dict, chunking_plan = resolve_chunking_options_and_plan(
+            form_data,
+            media_type="email",
+        )
 
     # Resolve validator via media exports so tests that monkeypatch
     # media.file_validator_instance continue to work.
@@ -366,22 +372,26 @@ async def process_emails_endpoint(
     try:
         if form_data.perform_chunking:
             # Build chunk options once using shared helper + templates.
-            chunk_options_dict = prepare_chunking_options_dict(form_data)
+            first_filename = None
+            try:
+                if saved_files_info:
+                    first_filename = saved_files_info[0].get("original_filename")
+            except Exception:
+                logger.debug("Could not determine first filename")
+                first_filename = None
+
+            chunk_options_dict, chunking_plan = resolve_chunking_options_and_plan(
+                form_data,
+                media_type="email",
+                source_name=first_filename,
+            )
             try:
                 TemplateClassifier = getattr(media_mod, "TemplateClassifier", None)
             except Exception:
                 logger.debug("TemplateClassifier not available")
                 TemplateClassifier = None
 
-            if chunk_options_dict is not None:
-                first_filename = None
-                try:
-                    if saved_files_info:
-                        first_filename = saved_files_info[0].get("original_filename")
-                except Exception:
-                    logger.debug("Could not determine first filename")
-                    first_filename = None
-
+            if chunk_options_dict is not None and chunking_plan is None:
                 chunk_options_dict = apply_chunking_template_if_any(
                     form_data=form_data,
                     db=db,
@@ -413,23 +423,35 @@ async def process_emails_endpoint(
                     continue
                 text = res.get("content")
                 if not isinstance(text, str) or not text.strip():
+                    attach_chunking_plan_to_result(res, chunking_plan)
+                    continue
+
+                result_chunk_options, result_chunking_plan = resolve_chunking_for_result(
+                    form_data,
+                    res,
+                    media_type="email",
+                    default_chunk_options=chunk_options_dict,
+                    default_chunking_plan=chunking_plan,
+                )
+                attach_chunking_plan_to_result(res, result_chunking_plan)
+                if not result_chunk_options:
                     continue
 
                 if use_hier and ck is not None:
                     chunks = ck.chunk_text_hierarchical_flat(
                         text,
-                        method=chunk_options_dict.get("method") or "sentences",
-                        max_size=chunk_options_dict.get("max_size") or 1000,
-                        overlap=chunk_options_dict.get("overlap") or 200,
-                        language=chunk_options_dict.get("language"),
-                        template=chunk_options_dict.get("hierarchical_template")
+                        method=result_chunk_options.get("method") or "sentences",
+                        max_size=result_chunk_options.get("max_size") or 1000,
+                        overlap=result_chunk_options.get("overlap") or 200,
+                        language=result_chunk_options.get("language"),
+                        template=result_chunk_options.get("hierarchical_template")
                         if isinstance(
-                            chunk_options_dict.get("hierarchical_template"), dict
+                            result_chunk_options.get("hierarchical_template"), dict
                         )
                         else None,
                     )
                 else:
-                    chunks = _improved_chunking_process(text, chunk_options_dict)
+                    chunks = _improved_chunking_process(text, result_chunk_options)
 
                 res["chunks"] = chunks
     except Exception:

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_emails.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_emails.py
@@ -22,6 +22,7 @@ from tldw_Server_API.app.core.Ingestion_Media_Processing.chunking_options import
     attach_chunking_plan_to_result,
     resolve_chunking_for_result,
     resolve_chunking_options_and_plan,
+    uses_hierarchical_chunking,
 )
 from tldw_Server_API.app.core.Ingestion_Media_Processing.input_sourcing import (
     TempDirManager,
@@ -156,31 +157,19 @@ async def process_emails_endpoint(
                 try:
                     path = Path(pf["path"]).resolve()
                     # Read bytes
-                    async with media_mod.aiofiles.open(
-                        path, "rb"
-                    ) as f:
+                    async with media_mod.aiofiles.open(path, "rb") as f:
                         file_bytes = await f.read()
 
                     if form_data.perform_chunking and chunk_options_dict:
                         chunk_opts = {
                             "method": chunk_options_dict.get("method")
-                            or (
-                                form_data.chunk_method
-                                if form_data.chunk_method
-                                else "sentences"
-                            ),
-                            "max_size": chunk_options_dict.get("max_size")
-                            or form_data.chunk_size,
-                            "overlap": chunk_options_dict.get("overlap")
-                            or form_data.chunk_overlap,
+                            or (form_data.chunk_method if form_data.chunk_method else "sentences"),
+                            "max_size": chunk_options_dict.get("max_size") or form_data.chunk_size,
+                            "overlap": chunk_options_dict.get("overlap") or form_data.chunk_overlap,
                         }
                     else:
                         chunk_opts = {
-                            "method": (
-                                form_data.chunk_method
-                                if form_data.chunk_method
-                                else "sentences"
-                            ),
+                            "method": (form_data.chunk_method if form_data.chunk_method else "sentences"),
                             "max_size": form_data.chunk_size,
                             "overlap": form_data.chunk_overlap,
                         }
@@ -210,9 +199,7 @@ async def process_emails_endpoint(
                         res_list = await loop.run_in_executor(None, processor)
                         for r_item in res_list:
                             r_item.setdefault("media_type", "email")
-                            r_item.setdefault(
-                                "processing_source", f"archive:{str(path)}"
-                            )
+                            r_item.setdefault("processing_source", f"archive:{str(path)}")
                             r_item.setdefault(
                                 "input_ref",
                                 r_item.get("input_ref") or arch_name,
@@ -224,9 +211,7 @@ async def process_emails_endpoint(
                                 }
                             )
                             results.append(r_item)
-                    elif name_lower.endswith(".mbox") and getattr(
-                        form_data, "accept_mbox", False
-                    ):
+                    elif name_lower.endswith(".mbox") and getattr(form_data, "accept_mbox", False):
                         mbox_name = pf.get("original_filename") or path.name
                         processor = functools.partial(
                             email_lib.process_mbox_bytes,
@@ -261,9 +246,9 @@ async def process_emails_endpoint(
                                 }
                             )
                             results.append(r_item)
-                    elif (
-                        name_lower.endswith(".pst") or name_lower.endswith(".ost")
-                    ) and getattr(form_data, "accept_pst", False):
+                    elif (name_lower.endswith(".pst") or name_lower.endswith(".ost")) and getattr(
+                        form_data, "accept_pst", False
+                    ):
                         pst_name = pf.get("original_filename") or path.name
                         processor = functools.partial(
                             email_lib.process_pst_bytes,
@@ -409,11 +394,7 @@ async def process_emails_endpoint(
                 Chunker as _Chunker,
             )
 
-            use_hier = bool(
-                chunk_options_dict.get("hierarchical")
-                or isinstance(chunk_options_dict.get("hierarchical_template"), dict)
-            )
-            ck = _Chunker() if use_hier else None
+            ck: _Chunker | None = None
 
             for res in batch.get("results", []):
                 if not isinstance(res, dict):
@@ -437,18 +418,19 @@ async def process_emails_endpoint(
                 if not result_chunk_options:
                     continue
 
-                if use_hier and ck is not None:
+                if uses_hierarchical_chunking(result_chunk_options):
+                    ck = ck or _Chunker()
                     chunks = ck.chunk_text_hierarchical_flat(
                         text,
                         method=result_chunk_options.get("method") or "sentences",
                         max_size=result_chunk_options.get("max_size") or 1000,
                         overlap=result_chunk_options.get("overlap") or 200,
                         language=result_chunk_options.get("language"),
-                        template=result_chunk_options.get("hierarchical_template")
-                        if isinstance(
-                            result_chunk_options.get("hierarchical_template"), dict
-                        )
-                        else None,
+                        template=(
+                            result_chunk_options.get("hierarchical_template")
+                            if isinstance(result_chunk_options.get("hierarchical_template"), dict)
+                            else None
+                        ),
                     )
                 else:
                     chunks = _improved_chunking_process(text, result_chunk_options)

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_pdfs.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_pdfs.py
@@ -35,7 +35,9 @@ from tldw_Server_API.app.api.v1.endpoints import media as media_mod
 from tldw_Server_API.app.api.v1.schemas.media_request_models import ProcessPDFsForm
 from tldw_Server_API.app.core.Ingestion_Media_Processing.chunking_options import (
     apply_chunking_template_if_any,
-    prepare_chunking_options_dict,
+    attach_chunking_plan_to_result,
+    resolve_chunking_for_result,
+    resolve_chunking_options_and_plan,
 )
 from tldw_Server_API.app.core.Ingestion_Media_Processing.input_sourcing import (
     TempDirManager,
@@ -258,22 +260,27 @@ async def process_pdfs_endpoint(
             return response
 
         # Prepare chunking options (including templates/hierarchical when requested).
+        chunking_plan: dict[str, Any] | None = None
         if form_data.perform_chunking:
-            chunk_options_dict = prepare_chunking_options_dict(form_data)
+            first_url = (form_data.urls or [None])[0]
+            first_filename = None
+            try:
+                if saved_files_info:
+                    first_filename = saved_files_info[0].get("original_filename")
+            except Exception:
+                first_filename = None
+
+            chunk_options_dict, chunking_plan = resolve_chunking_options_and_plan(
+                form_data,
+                media_type="pdf",
+                source_name=first_filename or first_url,
+            )
             try:
                 TemplateClassifier = getattr(media_mod, "TemplateClassifier", None)
             except Exception:
                 TemplateClassifier = None
 
-            if chunk_options_dict is not None:
-                first_url = (form_data.urls or [None])[0]
-                first_filename = None
-                try:
-                    if saved_files_info:
-                        first_filename = saved_files_info[0].get("original_filename")
-                except Exception:
-                    first_filename = None
-
+            if chunk_options_dict is not None and chunking_plan is None:
                 chunk_options_dict = apply_chunking_template_if_any(
                     form_data=form_data,
                     db=db,
@@ -443,23 +450,35 @@ async def process_pdfs_endpoint(
                     continue
                 text = res.get("content")
                 if not isinstance(text, str) or not text.strip():
+                    attach_chunking_plan_to_result(res, chunking_plan)
+                    continue
+
+                result_chunk_options, result_chunking_plan = resolve_chunking_for_result(
+                    form_data,
+                    res,
+                    media_type="pdf",
+                    default_chunk_options=chunk_options_dict,
+                    default_chunking_plan=chunking_plan,
+                )
+                attach_chunking_plan_to_result(res, result_chunking_plan)
+                if not result_chunk_options:
                     continue
 
                 if use_hier and ck is not None:
                     chunks = ck.chunk_text_hierarchical_flat(
                         text,
-                        method=chunk_options_dict.get("method") or "sentences",
-                        max_size=chunk_options_dict.get("max_size") or 500,
-                        overlap=chunk_options_dict.get("overlap") or 200,
-                        language=chunk_options_dict.get("language"),
-                        template=chunk_options_dict.get("hierarchical_template")
+                        method=result_chunk_options.get("method") or "sentences",
+                        max_size=result_chunk_options.get("max_size") or 500,
+                        overlap=result_chunk_options.get("overlap") or 200,
+                        language=result_chunk_options.get("language"),
+                        template=result_chunk_options.get("hierarchical_template")
                         if isinstance(
-                            chunk_options_dict.get("hierarchical_template"), dict
+                            result_chunk_options.get("hierarchical_template"), dict
                         )
                         else None,
                     )
                 else:
-                    chunks = _improved_chunking_process(text, chunk_options_dict)
+                    chunks = _improved_chunking_process(text, result_chunk_options)
 
                 res["chunks"] = chunks
     except Exception:

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_pdfs.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_pdfs.py
@@ -38,6 +38,7 @@ from tldw_Server_API.app.core.Ingestion_Media_Processing.chunking_options import
     attach_chunking_plan_to_result,
     resolve_chunking_for_result,
     resolve_chunking_options_and_plan,
+    uses_hierarchical_chunking,
 )
 from tldw_Server_API.app.core.Ingestion_Media_Processing.input_sourcing import (
     TempDirManager,
@@ -168,9 +169,7 @@ async def process_pdfs_endpoint(
             saved_files_info = list(saved_files)
 
             for err_info in upload_errors:
-                original_filename = (
-                    err_info.get("original_filename") or err_info.get("input") or "Unknown Upload"
-                )
+                original_filename = err_info.get("original_filename") or err_info.get("input") or "Unknown Upload"
                 error_detail = str(err_info.get("error") or "Upload error")
                 normalized_err = normalise_pdf_result(
                     {
@@ -240,6 +239,7 @@ async def process_pdfs_endpoint(
         # - 207 when we have result entries (all errors)
         # - 400 when no inputs at all (handled by _validate_inputs above)
         if not items:
+
             async def _noop_processor(_: list[ProcessItem]) -> list[dict[str, Any]]:
                 return []
 
@@ -248,11 +248,7 @@ async def process_pdfs_endpoint(
                 processor=_noop_processor,
                 base_batch=batch,
             )
-            status_code = (
-                status.HTTP_207_MULTI_STATUS
-                if batch.get("results")
-                else status.HTTP_400_BAD_REQUEST
-            )
+            status_code = status.HTTP_207_MULTI_STATUS if batch.get("results") else status.HTTP_400_BAD_REQUEST
             response = JSONResponse(status_code=status_code, content=batch)
             if legacy_signal is not None:
                 apply_media_legacy_headers(response, legacy_signal)
@@ -301,7 +297,7 @@ async def process_pdfs_endpoint(
                     file_bytes = item.local_path.read_bytes()
                 except Exception as read_err:
                     logger.error(
-                        'Failed to read prepared PDF file {} from {}: {}',
+                        "Failed to read prepared PDF file {} from {}: {}",
                         original_ref,
                         item.local_path,
                         read_err,
@@ -327,20 +323,12 @@ async def process_pdfs_endpoint(
                         author_override=form_data.author,
                         keywords=form_data.keywords,
                         perform_chunking=form_data.perform_chunking or None,
-                        chunk_method=(
-                            (chunk_options_dict or {}).get("method")
-                            if form_data.perform_chunking
-                            else None
-                        ),
+                        chunk_method=((chunk_options_dict or {}).get("method") if form_data.perform_chunking else None),
                         max_chunk_size=(
-                            (chunk_options_dict or {}).get("max_size")
-                            if form_data.perform_chunking
-                            else None
+                            (chunk_options_dict or {}).get("max_size") if form_data.perform_chunking else None
                         ),
                         chunk_overlap=(
-                            (chunk_options_dict or {}).get("overlap")
-                            if form_data.perform_chunking
-                            else None
+                            (chunk_options_dict or {}).get("overlap") if form_data.perform_chunking else None
                         ),
                         perform_analysis=form_data.perform_analysis,
                         api_name=form_data.api_name,
@@ -378,7 +366,7 @@ async def process_pdfs_endpoint(
                     results.append(normalized_res)
                 except Exception as exc:
                     logger.error(
-                        'PDF processing failed for {}: {}',
+                        "PDF processing failed for {}: {}",
                         original_ref,
                         exc,
                         exc_info=True,
@@ -436,11 +424,7 @@ async def process_pdfs_endpoint(
                 Chunker as _Chunker,
             )
 
-            use_hier = bool(
-                chunk_options_dict.get("hierarchical")
-                or isinstance(chunk_options_dict.get("hierarchical_template"), dict)
-            )
-            ck = _Chunker() if use_hier else None
+            ck: _Chunker | None = None
 
             for res in batch.get("results", []):
                 if not isinstance(res, dict):
@@ -464,18 +448,19 @@ async def process_pdfs_endpoint(
                 if not result_chunk_options:
                     continue
 
-                if use_hier and ck is not None:
+                if uses_hierarchical_chunking(result_chunk_options):
+                    ck = ck or _Chunker()
                     chunks = ck.chunk_text_hierarchical_flat(
                         text,
                         method=result_chunk_options.get("method") or "sentences",
                         max_size=result_chunk_options.get("max_size") or 500,
                         overlap=result_chunk_options.get("overlap") or 200,
                         language=result_chunk_options.get("language"),
-                        template=result_chunk_options.get("hierarchical_template")
-                        if isinstance(
-                            result_chunk_options.get("hierarchical_template"), dict
-                        )
-                        else None,
+                        template=(
+                            result_chunk_options.get("hierarchical_template")
+                            if isinstance(result_chunk_options.get("hierarchical_template"), dict)
+                            else None
+                        ),
                     )
                 else:
                     chunks = _improved_chunking_process(text, result_chunk_options)

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_videos.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_videos.py
@@ -36,7 +36,9 @@ from tldw_Server_API.app.core.AuthNZ.permissions import (
 )
 from tldw_Server_API.app.core.Ingestion_Media_Processing.chunking_options import (
     apply_chunking_template_if_any,
-    prepare_chunking_options_dict,
+    attach_chunking_plan_to_result,
+    resolve_chunking_for_result,
+    resolve_chunking_options_and_plan,
 )
 from tldw_Server_API.app.core.Ingestion_Media_Processing.input_sourcing import (
     TempDirManager,
@@ -140,6 +142,7 @@ async def process_videos_endpoint(
     # Map temporary path -> original filename
     temp_path_to_original_name: dict[str, str] = {}
     chunk_options_dict: dict[str, Any] | None = None
+    chunking_plan: dict[str, Any] | None = None
 
     # --- Use TempDirManager for reliable cleanup ---
     with TempDirManager(cleanup=True, prefix="process_video_") as temp_dir:
@@ -309,21 +312,25 @@ async def process_videos_endpoint(
     # Optional template/hierarchical re-chunking of video transcripts (best-effort).
     try:
         if form_data.perform_chunking:
-            chunk_options_dict = prepare_chunking_options_dict(form_data)
+            first_url = (form_data.urls or [None])[0]
+            first_filename = None
+            try:
+                if saved_files_info:
+                    first_filename = saved_files_info[0].get("original_filename")
+            except Exception:
+                first_filename = None
+
+            chunk_options_dict, chunking_plan = resolve_chunking_options_and_plan(
+                form_data,
+                media_type="video",
+                source_name=first_filename or first_url,
+            )
             try:
                 TemplateClassifier = getattr(media_mod, "TemplateClassifier", None)
             except Exception:
                 TemplateClassifier = None
 
-            if chunk_options_dict is not None:
-                first_url = (form_data.urls or [None])[0]
-                first_filename = None
-                try:
-                    if saved_files_info:
-                        first_filename = saved_files_info[0].get("original_filename")
-                except Exception:
-                    first_filename = None
-
+            if chunk_options_dict is not None and chunking_plan is None:
                 chunk_options_dict = apply_chunking_template_if_any(
                     form_data=form_data,
                     db=db,
@@ -355,23 +362,35 @@ async def process_videos_endpoint(
                     continue
                 text = res.get("content")
                 if not isinstance(text, str) or not text.strip():
+                    attach_chunking_plan_to_result(res, chunking_plan)
+                    continue
+
+                result_chunk_options, result_chunking_plan = resolve_chunking_for_result(
+                    form_data,
+                    res,
+                    media_type="video",
+                    default_chunk_options=chunk_options_dict,
+                    default_chunking_plan=chunking_plan,
+                )
+                attach_chunking_plan_to_result(res, result_chunking_plan)
+                if not result_chunk_options:
                     continue
 
                 if use_hier and ck is not None:
                     chunks = ck.chunk_text_hierarchical_flat(
                         text,
-                        method=chunk_options_dict.get("method") or "sentences",
-                        max_size=chunk_options_dict.get("max_size") or 500,
-                        overlap=chunk_options_dict.get("overlap") or 200,
-                        language=chunk_options_dict.get("language"),
-                        template=chunk_options_dict.get("hierarchical_template")
+                        method=result_chunk_options.get("method") or "sentences",
+                        max_size=result_chunk_options.get("max_size") or 500,
+                        overlap=result_chunk_options.get("overlap") or 200,
+                        language=result_chunk_options.get("language"),
+                        template=result_chunk_options.get("hierarchical_template")
                         if isinstance(
-                            chunk_options_dict.get("hierarchical_template"), dict
+                            result_chunk_options.get("hierarchical_template"), dict
                         )
                         else None,
                     )
                 else:
-                    chunks = _improved_chunking_process(text, chunk_options_dict)
+                    chunks = _improved_chunking_process(text, result_chunk_options)
 
                 res["chunks"] = chunks
     except Exception:

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_videos.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_videos.py
@@ -39,6 +39,7 @@ from tldw_Server_API.app.core.Ingestion_Media_Processing.chunking_options import
     attach_chunking_plan_to_result,
     resolve_chunking_for_result,
     resolve_chunking_options_and_plan,
+    uses_hierarchical_chunking,
 )
 from tldw_Server_API.app.core.Ingestion_Media_Processing.input_sourcing import (
     TempDirManager,
@@ -89,14 +90,13 @@ async def process_videos_endpoint(
     """
 
     # --- Validation and Logging ---
-    logger.info(
-        "Request received for /process-videos. Form data validated via dependency."
-    )
+    logger.info("Request received for /process-videos. Form data validated via dependency.")
 
     # Lazy import to avoid import-time hard failures from optional transcriber backends.
     from tldw_Server_API.app.core.Ingestion_Media_Processing.video_batch import (
         run_video_batch,
     )
+
     try:
         usage_log.log_event(
             "media.process.video",
@@ -109,9 +109,7 @@ async def process_videos_endpoint(
 
     legacy_urls_empty_sentinel_used = bool(form_data.urls and form_data.urls == [""])
     if legacy_urls_empty_sentinel_used:
-        logger.info(
-            "Received urls=[''], treating as no URLs provided for video processing."
-        )
+        logger.info("Received urls=[''], treating as no URLs provided for video processing.")
     form_data.urls = normalize_urls_field(form_data.urls)
     legacy_signal = (
         build_media_legacy_signal(
@@ -169,26 +167,16 @@ async def process_videos_endpoint(
             if sf.get("path") and sf.get("original_filename"):
                 temp_path_to_original_name[str(sf["path"])] = sf["original_filename"]
             else:
-                logger.warning(
-                    f"Missing path or original_filename in saved_files_info item: {sf}"
-                )
+                logger.warning(f"Missing path or original_filename in saved_files_info item: {sf}")
 
         # Process file-handling errors into the response structure.
         if file_handling_errors_raw:
             batch_result["errors_count"] += len(file_handling_errors_raw)
             batch_result["errors"].extend(
-                [
-                    err.get("error", "Unknown file save error")
-                    for err in file_handling_errors_raw
-                ]
+                [err.get("error", "Unknown file save error") for err in file_handling_errors_raw]
             )
             for err in file_handling_errors_raw:
-                input_ref = (
-                    err.get("input_ref")
-                    or err.get("original_filename")
-                    or err.get("input")
-                    or "Unknown Upload"
-                )
+                input_ref = err.get("input_ref") or err.get("original_filename") or err.get("input") or "Unknown Upload"
                 file_handling_errors_structured.append(
                     {
                         "status": "Error",
@@ -201,9 +189,7 @@ async def process_videos_endpoint(
                         "chunks": None,
                         "analysis": None,
                         "analysis_details": {},
-                        "error": err.get(
-                            "error", "Failed to save uploaded file."
-                        ),
+                        "error": err.get("error", "Failed to save uploaded file."),
                         "warnings": None,
                         "db_id": None,
                         "db_message": "Processing only endpoint.",
@@ -220,9 +206,7 @@ async def process_videos_endpoint(
         # Check if there's anything left to process.
         if not all_inputs_to_process:
             if file_handling_errors_raw:
-                logger.warning(
-                    "No valid video sources to process after file saving errors."
-                )
+                logger.warning("No valid video sources to process after file saving errors.")
                 # Return 207 with the structured file errors.
                 response = JSONResponse(
                     status_code=status.HTTP_207_MULTI_STATUS,
@@ -253,9 +237,7 @@ async def process_videos_endpoint(
     final_error_count = batch_result.get("errors_count", 0)
     final_success_count = batch_result.get("processed_count", 0)
     total_items = len(batch_result.get("results", []))
-    has_warnings = any(
-        r.get("status") == "Warning" for r in batch_result.get("results", [])
-    )
+    has_warnings = any(r.get("status") == "Warning" for r in batch_result.get("results", []))
     # NOTE: `has_warnings` is currently unused but kept for parity/debugging.
     _ = has_warnings, final_success_count
 
@@ -275,8 +257,7 @@ async def process_videos_endpoint(
     log_level = "INFO" if final_status_code == status.HTTP_200_OK else "WARNING"
     logger.log(
         log_level,
-        "/process-videos request finished with status {}. Results count: {}, "
-        "Errors: {}",
+        "/process-videos request finished with status {}. Results count: {}, " "Errors: {}",
         final_status_code,
         total_items,
         final_error_count,
@@ -287,9 +268,9 @@ async def process_videos_endpoint(
         logger.debug("Final batch_result before JSONResponse:")
         logged_result = batch_result.copy()
         if len(logged_result.get("results", [])) > 5:
-            logged_result["results"] = logged_result["results"][
-                :5
-            ] + [{"message": "... remaining results truncated for logging ..."}]
+            logged_result["results"] = logged_result["results"][:5] + [
+                {"message": "... remaining results truncated for logging ..."}
+            ]
         logger.debug(
             "{}",
             logged_result,
@@ -348,11 +329,7 @@ async def process_videos_endpoint(
                 Chunker as _Chunker,
             )
 
-            use_hier = bool(
-                chunk_options_dict.get("hierarchical")
-                or isinstance(chunk_options_dict.get("hierarchical_template"), dict)
-            )
-            ck = _Chunker() if use_hier else None
+            ck: _Chunker | None = None
 
             for res in batch_result.get("results", []):
                 if not isinstance(res, dict):
@@ -376,18 +353,19 @@ async def process_videos_endpoint(
                 if not result_chunk_options:
                     continue
 
-                if use_hier and ck is not None:
+                if uses_hierarchical_chunking(result_chunk_options):
+                    ck = ck or _Chunker()
                     chunks = ck.chunk_text_hierarchical_flat(
                         text,
                         method=result_chunk_options.get("method") or "sentences",
                         max_size=result_chunk_options.get("max_size") or 500,
                         overlap=result_chunk_options.get("overlap") or 200,
                         language=result_chunk_options.get("language"),
-                        template=result_chunk_options.get("hierarchical_template")
-                        if isinstance(
-                            result_chunk_options.get("hierarchical_template"), dict
-                        )
-                        else None,
+                        template=(
+                            result_chunk_options.get("hierarchical_template")
+                            if isinstance(result_chunk_options.get("hierarchical_template"), dict)
+                            else None
+                        ),
                     )
                 else:
                     chunks = _improved_chunking_process(text, result_chunk_options)

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py
@@ -108,6 +108,10 @@ async def process_web_scraping_endpoint(
             crawl_strategy=payload.crawl_strategy,
             include_external=payload.include_external,
             score_threshold=payload.score_threshold,
+            perform_chunking=payload.perform_chunking,
+            chunking_mode=payload.chunking_mode,
+            auto_chunking_goal=payload.auto_chunking_goal,
+            auto_chunking_use_llm=payload.auto_chunking_use_llm,
         )
         return result
     except HTTPException:

--- a/tldw_Server_API/app/api/v1/schemas/media_request_models.py
+++ b/tldw_Server_API/app/api/v1/schemas/media_request_models.py
@@ -21,6 +21,7 @@ import yaml
 #
 # Functions:
 
+
 ######################## /api/v1/media/ Endpoint Models ########################
 #
 #
@@ -34,11 +35,13 @@ class MediaItemResponse(BaseModel):
 
     model_config = ConfigDict()
 
+
 class PaginationInfo(BaseModel):
     page: int
     per_page: int
     total: int
     total_pages: int
+
 
 class MediaItem(BaseModel):
     id: int
@@ -50,9 +53,11 @@ class MediaItem(BaseModel):
     date: Optional[datetime]
     keywords: list[str]
 
+
 class MediaSearchResponse(BaseModel):
     results: list[MediaItem]
     pagination: PaginationInfo
+
 
 class MediaUpdateRequest(BaseModel):
     title: Optional[str] = Field(None, max_length=500, description="Title (max 500 chars)")
@@ -65,18 +70,23 @@ class MediaUpdateRequest(BaseModel):
 
 class MediaKeywordsUpdateRequest(BaseModel):
     """Request payload for updating media keywords (add/remove/set)."""
+
     keywords: list[str] = Field(..., description="Keywords to apply")
     mode: Literal["add", "remove", "set"] = Field(
         "add",
         description="Update mode: add/remove/set (set replaces all keywords).",
     )
 
+
 # Make prompt and analysis_content REQUIRED so missing them yields 422
 class VersionCreateRequest(BaseModel):
     content: str = Field(..., max_length=5000000, description="Content (max 5MB)")
     prompt: str = Field(..., max_length=10000, description="Prompt (max 10KB)")
     analysis_content: str = Field(..., max_length=100000, description="Analysis content (max 100KB)")
-    safe_metadata: Optional[dict[str, Any]] = Field(None, description="Optional safe metadata JSON to store with this version.")
+    safe_metadata: Optional[dict[str, Any]] = Field(
+        None, description="Optional safe metadata JSON to store with this version."
+    )
+
 
 class VersionResponse(BaseModel):
     id: int
@@ -84,11 +94,13 @@ class VersionResponse(BaseModel):
     created_at: str
     content_length: int
 
+
 class VersionRollbackRequest(BaseModel):
     version_number: int
 
+
 class SearchRequest(BaseModel):
-    model_config = ConfigDict(extra='forbid')
+    model_config = ConfigDict(extra="forbid")
 
     query: Optional[str] = Field(None, max_length=1000, description="Search query (max 1000 chars)")
     fields: list[str] = ["title", "content"]
@@ -135,49 +147,76 @@ class ProcessCodeForm(BaseModel):
         description="Overlap: chars for 'code', lines for 'lines'",
     )
 
+
 class MetadataFilter(BaseModel):
     field: str = Field(..., description="Metadata key to search (e.g., doi, pmid, journal, license)")
-    op: Literal['eq','contains','icontains','startswith','endswith'] = Field('icontains', description="Match operator")
+    op: Literal["eq", "contains", "icontains", "startswith", "endswith"] = Field(
+        "icontains", description="Match operator"
+    )
     value: str = Field(..., description="Value to match")
+
 
 class MetadataSearchRequest(BaseModel):
     filters: Optional[list[MetadataFilter]] = Field(None, description="List of metadata filters")
-    match_mode: Literal['all','any'] = Field('all', description="Combine filters with AND/OR")
+    match_mode: Literal["all", "any"] = Field("all", description="Combine filters with AND/OR")
     group_by_media: bool = Field(True, description="Group results by media (latest matching version per media)")
     page: int = Field(1, ge=1)
     per_page: int = Field(20, ge=1, le=100)
+
 
 class MetadataPatchRequest(BaseModel):
     safe_metadata: dict[str, Any] = Field(..., description="Safe metadata JSON to set or merge")
     merge: bool = Field(True, description="Merge with existing metadata if present")
     new_version: bool = Field(False, description="Create a new version with updated metadata")
 
+
 class AdvancedVersionUpsertRequest(BaseModel):
-    content: Optional[str] = Field(None, description="Optional content; if omitted and new_version=true, uses latest content")
-    prompt: Optional[str] = Field(None, description="Optional prompt; if omitted and new_version=true, uses latest prompt")
-    analysis_content: Optional[str] = Field(None, description="Optional analysis; if omitted and new_version=true, uses latest analysis")
+    content: Optional[str] = Field(
+        None, description="Optional content; if omitted and new_version=true, uses latest content"
+    )
+    prompt: Optional[str] = Field(
+        None, description="Optional prompt; if omitted and new_version=true, uses latest prompt"
+    )
+    analysis_content: Optional[str] = Field(
+        None, description="Optional analysis; if omitted and new_version=true, uses latest analysis"
+    )
     safe_metadata: Optional[dict[str, Any]] = Field(None, description="Optional safe metadata JSON to set or merge")
     merge: bool = Field(True, description="Merge safe metadata when updating or creating new version")
-    new_version: bool = Field(True, description="Create a new version (default). If false, only safe_metadata may be updated in place")
+    new_version: bool = Field(
+        True, description="Create a new version (default). If false, only safe_metadata may be updated in place"
+    )
+
 
 # Define allowed media types using Literal for validation
-MediaType = Literal['video', 'audio', 'document', 'pdf', 'ebook', 'email', 'code']
+MediaType = Literal["video", "audio", "document", "pdf", "ebook", "email", "code"]
 
 # Define allowed chunking methods (adjust as needed based on your library)
-ChunkMethod = Literal['semantic', 'tokens', 'paragraphs', 'sentences','words', 'ebook_chapters', 'json', 'propositions']
+ChunkMethod = Literal[
+    "semantic",
+    "structure_aware",
+    "tokens",
+    "paragraphs",
+    "sentences",
+    "words",
+    "ebook_chapters",
+    "json",
+    "propositions",
+]
 
-ChunkingMode = Literal['auto', 'manual']
+ChunkingMode = Literal["auto", "manual"]
 
-AutoChunkingGoal = Literal['balanced', 'qa_search', 'navigation_summary']
+AutoChunkingGoal = Literal["balanced", "qa_search", "navigation_summary"]
 
 # Define allowed PDF parsing engines
-PdfEngine = Literal['pymupdf4llm', 'pymupdf', 'docling'] # Add others if supported
+PdfEngine = Literal["pymupdf4llm", "pymupdf", "docling"]  # Add others if supported
 
 # OCR options
-OcrMode = Literal['always', 'fallback']
+OcrMode = Literal["always", "fallback"]
+
 
 class ChunkingOptions(BaseModel):
     """Pydantic model for chunking specific options"""
+
     perform_chunking: bool = Field(True, description="Enable chunk-based processing of the media content")
     chunking_mode: Optional[ChunkingMode] = Field(
         None,
@@ -191,13 +230,19 @@ class ChunkingOptions(BaseModel):
         False,
         description="Explicit opt-in to AI-assisted automatic chunk boundary refinement when available",
     )
-    chunk_method: Optional[ChunkMethod] = Field(None, description="Method used to chunk content (e.g., 'sentences', 'recursive', 'chapter')")
+    chunk_method: Optional[ChunkMethod] = Field(
+        None, description="Method used to chunk content (e.g., 'sentences', 'recursive', 'chapter')"
+    )
     use_adaptive_chunking: bool = Field(False, description="Whether to enable adaptive chunking")
     use_multi_level_chunking: bool = Field(False, description="Whether to enable multi-level chunking")
-    chunk_language: Optional[str] = Field(None, description="Optional language override for chunking (ISO 639-1 code, e.g., 'en')")
+    chunk_language: Optional[str] = Field(
+        None, description="Optional language override for chunking (ISO 639-1 code, e.g., 'en')"
+    )
     chunk_size: int = Field(500, gt=0, description="Target size of each chunk (positive integer)")
     chunk_overlap: int = Field(200, ge=0, description="Overlap size between chunks (non-negative integer)")
-    custom_chapter_pattern: Optional[str] = Field(None, description="Optional regex pattern for custom chapter splitting (ebook/docs)")
+    custom_chapter_pattern: Optional[str] = Field(
+        None, description="Optional regex pattern for custom chapter splitting (ebook/docs)"
+    )
     proposition_engine: Optional[str] = Field(
         None,
         description="Override proposition extraction engine (heuristic|spacy|llm|auto)",
@@ -217,53 +262,67 @@ class ChunkingOptions(BaseModel):
         description="Prompt profile for proposition extraction (generic|claimify|gemma_aps)",
     )
     # Template auto-apply options
-    auto_apply_template: bool = Field(False, description="Automatically select and apply a matching chunking template by metadata")
+    auto_apply_template: bool = Field(
+        False, description="Automatically select and apply a matching chunking template by metadata"
+    )
     chunking_template_name: Optional[str] = Field(None, description="Explicit template name to apply for chunking")
     # Contextual Chunking Options
-    enable_contextual_chunking: bool = Field(False, description="Add LLM-generated context to chunks for better retrieval")
-    contextual_llm_model: Optional[str] = Field(None, description="LLM model to use for generating contextual summaries (e.g., 'gpt-3.5-turbo')")
-    context_window_size: Optional[int] = Field(None, ge=100, le=2000, description="Size of context window around chunks in characters")
-    context_strategy: Optional[Literal['auto','full','window','outline_window']] = Field(
+    enable_contextual_chunking: bool = Field(
+        False, description="Add LLM-generated context to chunks for better retrieval"
+    )
+    contextual_llm_model: Optional[str] = Field(
+        None, description="LLM model to use for generating contextual summaries (e.g., 'gpt-3.5-turbo')"
+    )
+    context_window_size: Optional[int] = Field(
+        None, ge=100, le=2000, description="Size of context window around chunks in characters"
+    )
+    context_strategy: Optional[Literal["auto", "full", "window", "outline_window"]] = Field(
         None, description="Context selection strategy: 'auto' (default), 'full', 'window', or 'outline_window'"
     )
     context_token_budget: Optional[int] = Field(
         None, ge=1000, le=200000, description="Approximate token budget for 'auto' strategy (len(text)/4 heuristic)"
     )
     # Hierarchical options (flattened into chunks for indexing)
-    hierarchical_chunking: Optional[bool] = Field(False, description="Enable hierarchical parsing and flattening to leaf chunks")
-    hierarchical_template: Optional[dict[str, Any]] = Field(None, description="Custom boundary rules: {'boundaries': [{'kind','pattern','flags'}]}")
+    hierarchical_chunking: Optional[bool] = Field(
+        False, description="Enable hierarchical parsing and flattening to leaf chunks"
+    )
+    hierarchical_template: Optional[dict[str, Any]] = Field(
+        None, description="Custom boundary rules: {'boundaries': [{'kind','pattern','flags'}]}"
+    )
 
-    @field_validator('chunk_method', mode='before')
+    @field_validator("chunk_method", mode="before")
     @classmethod
-    def empty_str_to_none(cls, v: Any) -> Optional[Any]: # Accept Any for input
+    def empty_str_to_none(cls, v: Any) -> Optional[Any]:  # Accept Any for input
         if v == "":
             return None
         return v
 
-    @field_validator('chunk_overlap')
+    @field_validator("chunk_overlap")
     @classmethod
     def overlap_less_than_size(cls, v: int, info: ValidationInfo) -> int:
         # Check if 'chunk_size' is available in the already validated data
-        if 'chunk_size' in info.data and info.data['chunk_size'] is not None:
-            chunk_size = info.data['chunk_size']
+        if "chunk_size" in info.data and info.data["chunk_size"] is not None:
+            chunk_size = info.data["chunk_size"]
             if v >= chunk_size:
-                raise ValueError('chunk_overlap must be less than chunk_size')
+                raise ValueError("chunk_overlap must be less than chunk_size")
         # If chunk_size hasn't been validated yet or is missing, this check might implicitly pass
         # or you might want to handle that case explicitly if chunk_size is always required before overlap.
         return v
 
-    @field_validator('custom_chapter_pattern')
+    @field_validator("custom_chapter_pattern")
     @classmethod
     def validate_regex(cls, v: Optional[str]) -> Optional[str]:
         if v is not None:
             try:
                 re.compile(v)
-            except re.error as e: # Catch specific error
+            except re.error as e:  # Catch specific error
                 raise ValueError(f"Invalid regex pattern provided for custom_chapter_pattern: {v}. Error: {e}") from e
         return v
 
+
 class TranscriptionModel(str, Enum):
     """Available transcription models and backends"""
+
     # Whisper Models (faster-whisper)
     WHISPER_TINY = "whisper-tiny"
     WHISPER_TINY_EN = "whisper-tiny.en"
@@ -312,11 +371,16 @@ class TranscriptionModel(str, Enum):
     VIBEVOICE_ASR = "vibevoice-asr"
     VIBEVOICE_HF = "microsoft/VibeVoice-ASR"
 
+
 TRANSCRIPTION_MODEL_ENUM = [m.value for m in TranscriptionModel]
+
 
 class AudioVideoOptions(BaseModel):
     """Pydantic model for Audio/Video specific options"""
-    transcription_model: str = Field("deepdml/faster-distil-whisper-large-v3.5", description="Model ID for audio/video transcription")
+
+    transcription_model: str = Field(
+        "deepdml/faster-distil-whisper-large-v3.5", description="Model ID for audio/video transcription"
+    )
     transcription_language: str = Field("en", description="Language for audio/video transcription (ISO 639-1 code)")
     hotwords: Optional[str] = Field(
         None,
@@ -324,18 +388,26 @@ class AudioVideoOptions(BaseModel):
     )
     diarize: bool = Field(False, description="Enable speaker diarization (audio/video)")
     timestamp_option: bool = Field(True, description="Include timestamps in the transcription (audio/video)")
-    vad_use: bool = Field(False, description="Enable Voice Activity Detection filter during transcription (audio/video)")
-    perform_confabulation_check_of_analysis: bool = Field(False, description="Enable a confabulation check on analysis (if applicable)")
+    vad_use: bool = Field(
+        False, description="Enable Voice Activity Detection filter during transcription (audio/video)"
+    )
+    perform_confabulation_check_of_analysis: bool = Field(
+        False, description="Enable a confabulation check on analysis (if applicable)"
+    )
+
 
 class PdfOptions(BaseModel):
     """Pydantic model for PDF specific options"""
+
     pdf_parsing_engine: Optional[PdfEngine] = Field("pymupdf4llm", description="PDF parsing engine to use")
     enable_ocr: bool = Field(False, description="Enable OCR for scanned/low-text PDFs")
     ocr_backend: Optional[str] = Field(None, description="OCR backend name (e.g., 'tesseract' or 'auto')")
     ocr_lang: Optional[str] = Field("eng", description="OCR language (ISO 639-2 Tesseract codes, e.g., 'eng')")
     ocr_dpi: int = Field(300, ge=72, le=600, description="DPI for page rendering before OCR (72-600)")
     ocr_mode: Optional[OcrMode] = Field("fallback", description="'always' to force OCR, 'fallback' when no text")
-    ocr_min_page_text_chars: int = Field(40, ge=0, description="Threshold to treat a page as 'no text' for OCR fallback")
+    ocr_min_page_text_chars: int = Field(
+        40, ge=0, description="Threshold to treat a page as 'no text' for OCR fallback"
+    )
     ocr_output_format: Optional[str] = Field(
         None,
         description="OCR output format: text|markdown|json (structured outputs persisted in analysis_details)",
@@ -345,11 +417,13 @@ class PdfOptions(BaseModel):
         description="OCR prompt preset (e.g., 'general', 'doc', 'table', 'spotting', 'json')",
     )
 
+
 class AddMediaForm(ChunkingOptions, AudioVideoOptions, PdfOptions):
     """
     Pydantic model representing the form data for the /add endpoint.
     Excludes 'files' (handled via File(...)) and 'token' (handled via Header(...)).
     """
+
     # --- Required Fields ---
     media_type: MediaType = Field(..., description="Type of media")
 
@@ -360,29 +434,35 @@ class AddMediaForm(ChunkingOptions, AudioVideoOptions, PdfOptions):
     # --- Common Optional Fields ---
     title: Optional[str] = Field(None, max_length=500, description="Optional title (max 500 chars)")
     author: Optional[str] = Field(None, max_length=255, description="Optional author (max 255 chars)")
-    keywords_str: str = Field("", alias="keywords", max_length=1000, description="Comma-separated keywords (max 1000 chars)")
+    keywords_str: str = Field(
+        "", alias="keywords", max_length=1000, description="Comma-separated keywords (max 1000 chars)"
+    )
     custom_prompt: Optional[str] = Field(None, max_length=100000, description="Optional custom prompt (max 100KB)")
     system_prompt: Optional[str] = Field(None, max_length=10000, description="Optional system prompt (max 10KB)")
-    overwrite_existing: bool = Field(False, description="Overwrite any existing media with the same identifier (URL/filename)")
+    overwrite_existing: bool = Field(
+        False, description="Overwrite any existing media with the same identifier (URL/filename)"
+    )
     keep_original_file: bool = Field(False, description="Whether to retain original uploaded files after processing")
-    perform_analysis: bool = Field(True, description="Perform analysis (e.g., summarization) if applicable (default=True)")
+    perform_analysis: bool = Field(
+        True, description="Perform analysis (e.g., summarization) if applicable (default=True)"
+    )
     perform_claims_extraction: Optional[bool] = Field(
-        None,
-        description="Extract factual claims during analysis (defaults to server configuration when unset)."
+        None, description="Extract factual claims during analysis (defaults to server configuration when unset)."
     )
     claims_extractor_mode: Optional[str] = Field(
-        None,
-        description="Optional override for claims extractor mode (e.g., 'heuristic', 'ner', provider id)."
+        None, description="Optional override for claims extractor mode (e.g., 'heuristic', 'ner', provider id)."
     )
     claims_max_per_chunk: Optional[int] = Field(
         None,
         ge=1,
         le=12,
-        description="Maximum number of claims to extract per chunk (uses configuration defaults when unset)."
+        description="Maximum number of claims to extract per chunk (uses configuration defaults when unset).",
     )
 
     # --- Video/Audio Specific Timing --- ADD THESE ---
-    start_time: Optional[str] = Field(None, description="Optional start time for processing (e.g., HH:MM:SS or seconds)")
+    start_time: Optional[str] = Field(
+        None, description="Optional start time for processing (e.g., HH:MM:SS or seconds)"
+    )
     end_time: Optional[str] = Field(None, description="Optional end time for processing (e.g., HH:MM:SS or seconds)")
     # -----------------------------------------------
 
@@ -397,11 +477,19 @@ class AddMediaForm(ChunkingOptions, AudioVideoOptions, PdfOptions):
     api_name: Optional[str] = Field(None, description="DEPRECATED - use api_provider instead")
 
     # --- Email-specific options (optional, used when media_type='email') ---
-    ingest_attachments: Optional[bool] = Field(False, description="For emails: parse nested .eml attachments and ingest as separate items")
-    max_depth: Optional[int] = Field(2, ge=1, le=5, description="Max depth for nested email parsing when ingest_attachments is true")
-    accept_archives: Optional[bool] = Field(False, description="Allow and expand .zip archives of .eml files for email ingestion")
+    ingest_attachments: Optional[bool] = Field(
+        False, description="For emails: parse nested .eml attachments and ingest as separate items"
+    )
+    max_depth: Optional[int] = Field(
+        2, ge=1, le=5, description="Max depth for nested email parsing when ingest_attachments is true"
+    )
+    accept_archives: Optional[bool] = Field(
+        False, description="Allow and expand .zip archives of .eml files for email ingestion"
+    )
     accept_mbox: Optional[bool] = Field(False, description="Allow and expand .mbox mailboxes for email ingestion")
-    accept_pst: Optional[bool] = Field(False, description="Enable PST/OST container uploads (feature-flag; parsing may require external tools")
+    accept_pst: Optional[bool] = Field(
+        False, description="Enable PST/OST container uploads (feature-flag; parsing may require external tools"
+    )
 
     # --- Embedding Options ---
     generate_embeddings: bool = Field(False, description="Generate embeddings after media processing")
@@ -409,12 +497,16 @@ class AddMediaForm(ChunkingOptions, AudioVideoOptions, PdfOptions):
         None,
         description="Embeddings dispatch strategy override for /media/add",
     )
-    embedding_model: Optional[str] = Field(None, description="Specific embedding model to use (e.g., 'Qwen/Qwen3-Embedding-4B-GGUF')")
+    embedding_model: Optional[str] = Field(
+        None, description="Specific embedding model to use (e.g., 'Qwen/Qwen3-Embedding-4B-GGUF')"
+    )
     embedding_provider: Optional[str] = Field(None, description="Embedding provider (huggingface, openai, etc)")
 
     # --- Deprecated/Less Common ---
     perform_rolling_summarization: bool = Field(False, description="Perform rolling summarization (legacy?)")
-    summarize_recursively: bool = Field(False, description="Perform recursive summarization on chunks (if chunking enabled)")
+    summarize_recursively: bool = Field(
+        False, description="Perform recursive summarization on chunks (if chunking enabled)"
+    )
 
     # --- Computed Fields / Validators ---
     @computed_field
@@ -427,9 +519,9 @@ class AddMediaForm(ChunkingOptions, AudioVideoOptions, PdfOptions):
 
     def model_post_init(self, __context):
         """Handle legacy api_name field by splitting into provider/model."""
-        if self.api_name and '/' in self.api_name:
+        if self.api_name and "/" in self.api_name:
             # If api_name contains '/', treat it as 'provider/model' format
-            provider, model = self.api_name.split('/', 1)
+            provider, model = self.api_name.split("/", 1)
             if not self.api_provider:
                 self.api_provider = provider
             if not self.model_name:
@@ -457,17 +549,17 @@ class AddMediaForm(ChunkingOptions, AudioVideoOptions, PdfOptions):
                 "generate_embeddings": True,
                 "embedding_dispatch_mode": "background",
                 "embedding_provider": "huggingface",
-                "embedding_model": "sentence-transformers/all-MiniLM-L6-v2"
+                "embedding_model": "sentence-transformers/all-MiniLM-L6-v2",
             }
-        }
+        },
     )
 
     # Provide a stable, test-friendly error message for invalid media_type values
-    @field_validator('media_type', mode='before')
+    @field_validator("media_type", mode="before")
     @classmethod
     def validate_media_type_choices(cls, v):
         # Accept only known values; for invalid input, emit the exact message expected by tests
-        allowed = {'video', 'audio', 'document', 'pdf', 'ebook', 'email', 'json'}
+        allowed = {"video", "audio", "document", "pdf", "ebook", "email", "json"}
         if isinstance(v, str):
             lv = v.strip().lower()
             if lv not in allowed:
@@ -476,24 +568,24 @@ class AddMediaForm(ChunkingOptions, AudioVideoOptions, PdfOptions):
             return lv
         return v
 
-    @field_validator('start_time', 'end_time')
+    @field_validator("start_time", "end_time")
     @classmethod
     def check_time_format(cls, v: Optional[str]) -> Optional[str]:
         if v is None or v == "":  # MODIFIED: Treat empty string like None
             return None  # Return None, which is valid for Optional[str]
 
         # Example basic check: Allow seconds or HH:MM:SS format
-        if re.fullmatch(r'\d+', v) or re.fullmatch(r'\d{1,2}:\d{2}:\d{2}', v):
+        if re.fullmatch(r"\d+", v) or re.fullmatch(r"\d{1,2}:\d{2}:\d{2}", v):
             return v
         raise ValueError("Time format must be seconds or HH:MM:SS")
 
     # Validator to ensure 'cookies' is provided if 'use_cookies' is True
-    @field_validator('cookies')
+    @field_validator("cookies")
     @classmethod
     def check_cookies_provided(cls, v: Optional[str], info: ValidationInfo) -> Optional[str]:
         # Access other validated fields via info.data
         # Check if 'use_cookies' exists in data AND is True
-        if info.data.get('use_cookies') and not v:
+        if info.data.get("use_cookies") and not v:
             raise ValueError("Cookie string must be provided when 'use_cookies' is set to True.")
         return v
 
@@ -502,27 +594,27 @@ class MediaItemProcessResponse(BaseModel):
     """
     Pydantic model for media item details after processing. Details returned from a processing request
     """
-    status: Literal['Success', 'Error', 'Warning']
-    input_ref: str # The original URL or filename provided by the user
-    processing_source: str # The actual path or URL used by the processor, e.g., temp file path
-    media_type: (Literal['video', 'audio', 'document', 'pdf', 'ebook', 'email']) # 'video', 'pdf', 'audio', etc.
-    metadata: dict[str, Any] # Extracted info like title, author, duration, etc.
-    content: str # The main extracted text or full transcript
-    segments: Optional[list[dict[str, Any]]] # For timestamped transcripts, if applicable
-    chunks: Optional[list[dict[str, Any]]] # If chunking happened within the processor
-    analysis: Optional[str] # The generated analysis, if analysis was performed
-    analysis_details: Optional[dict[str, Any]] # e.g., whisper model used, summarization prompt
+
+    status: Literal["Success", "Error", "Warning"]
+    input_ref: str  # The original URL or filename provided by the user
+    processing_source: str  # The actual path or URL used by the processor, e.g., temp file path
+    media_type: Literal["video", "audio", "document", "pdf", "ebook", "email"]  # 'video', 'pdf', 'audio', etc.
+    metadata: dict[str, Any]  # Extracted info like title, author, duration, etc.
+    content: str  # The main extracted text or full transcript
+    segments: Optional[list[dict[str, Any]]]  # For timestamped transcripts, if applicable
+    chunks: Optional[list[dict[str, Any]]]  # If chunking happened within the processor
+    analysis: Optional[str]  # The generated analysis, if analysis was performed
+    analysis_details: Optional[dict[str, Any]]  # e.g., whisper model used, summarization prompt
     claims: Optional[list[dict[str, Any]]] = Field(None, description="Extracted factual claims, if enabled")
     claims_details: Optional[dict[str, Any]] = Field(None, description="Metadata about the claims extraction process")
-    error: Optional[str] # Detailed error message if status != 'Success'
-    warnings: Optional[list[str]] # For non-critical issues
-    model_config = ConfigDict(
-        extra="forbid"  # Disallow extra fields not defined in the model
-    )
+    error: Optional[str]  # Detailed error message if status != 'Success'
+    warnings: Optional[list[str]]  # For non-critical issues
+    model_config = ConfigDict(extra="forbid")  # Disallow extra fields not defined in the model
 
 
 class ReprocessMediaRequest(ChunkingOptions):
     """Request model for reprocessing stored media content."""
+
     perform_chunking: bool = Field(True, description="Rebuild chunks for the current media content")
     generate_embeddings: bool = Field(False, description="Regenerate embeddings after re-chunking")
     embedding_model: Optional[str] = Field(None, description="Embedding model override")
@@ -531,6 +623,7 @@ class ReprocessMediaRequest(ChunkingOptions):
         False,
         description="Delete existing embeddings before regeneration when possible",
     )
+
 
 ######################## Processing-only Forms ###################################
 #
@@ -562,6 +655,7 @@ class ProcessVideosForm(AddMediaForm):
 
     media_type: Literal["video"] = "video"
     keep_original_file: bool = Field(False)
+
 
 class VideoIngestRequest(BaseModel):
     # You can rename / remove / add fields as you prefer:
@@ -596,6 +690,7 @@ class VideoIngestRequest(BaseModel):
 
     start_time: Optional[str] = None
     end_time: Optional[str] = None
+
 
 #
 # End of Video ingestion and analysis model schema
@@ -635,6 +730,7 @@ class ProcessEbooksForm(AddMediaForm):
     )
     keep_original_file: bool = Field(False)
 
+
 class ProcessEmailsForm(AddMediaForm):
     """
     Processing-only form for emails used by /process-emails (no DB writes).
@@ -643,27 +739,18 @@ class ProcessEmailsForm(AddMediaForm):
     media_type: Literal["email"] = "email"
     keep_original_file: bool = Field(False)
     perform_chunking: bool = Field(True)
-    chunk_method: Optional[ChunkMethod] = Field(
-        "sentences", description="Default chunking method for emails"
-    )
+    chunk_method: Optional[ChunkMethod] = Field("sentences", description="Default chunking method for emails")
     chunk_size: int = Field(1000, gt=0, description="Target chunk size for emails")
     chunk_overlap: int = Field(200, ge=0, description="Chunk overlap size for emails")
     ingest_attachments: bool = Field(
         False,
         description="Parse and include nested .eml attachments as children",
     )
-    max_depth: int = Field(
-        2, ge=1, le=5, description="Max depth for nested email parsing"
-    )
-    accept_archives: bool = Field(
-        False, description="Accept .zip archives of EMLs and expand members"
-    )
-    accept_mbox: bool = Field(
-        False, description="Accept .mbox mailboxes and expand/process messages"
-    )
-    accept_pst: bool = Field(
-        False, description="Accept .pst/.ost containers (feature-flag)"
-    )
+    max_depth: int = Field(2, ge=1, le=5, description="Max depth for nested email parsing")
+    accept_archives: bool = Field(False, description="Accept .zip archives of EMLs and expand members")
+    accept_mbox: bool = Field(False, description="Accept .mbox mailboxes and expand/process messages")
+    accept_pst: bool = Field(False, description="Accept .pst/.ost containers (feature-flag)")
+
 
 class AudioIngestRequest(BaseModel):
     mode: str = "persist"  # "ephemeral" or "persist"
@@ -692,6 +779,7 @@ class AudioIngestRequest(BaseModel):
     cookies: Optional[str] = None
     custom_title: Optional[str] = None
 
+
 #
 # End of Audio ingestion and analysis model schema
 ####################################################################################
@@ -701,10 +789,11 @@ class AudioIngestRequest(BaseModel):
 #
 # This is a schema for Web-Scraping ingestion and analysis.
 
+
 class ScrapeMethod(str, Enum):
-    INDIVIDUAL = "individual"          # “Individual URLs”
-    SITEMAP = "sitemap"               # “Sitemap”
-    URL_LEVEL = "url_level"           # “URL Level”
+    INDIVIDUAL = "individual"  # “Individual URLs”
+    SITEMAP = "sitemap"  # “Sitemap”
+    URL_LEVEL = "url_level"  # “URL Level”
     RECURSIVE = "recursive_scraping"  # “Recursive Scraping”
 
 
@@ -742,9 +831,10 @@ class WebScrapingRequest(BaseModel):
     auto_chunking_goal: AutoChunkingGoal = "balanced"
     auto_chunking_use_llm: bool = False
 
+
 class IngestWebContentRequest(BaseModel):
     # Core fields
-    urls: list[str]                      # Usually 1+ URLs.
+    urls: list[str]  # Usually 1+ URLs.
     titles: Optional[list[str]] = None
     authors: Optional[list[str]] = None
     keywords: Optional[list[str]] = None
@@ -792,6 +882,7 @@ class IngestWebContentRequest(BaseModel):
     include_external: Optional[bool] = None
     score_threshold: Optional[float] = None
 
+
 #
 # End of Web-Scraping ingestion and analysis model schema
 ####################################################################################
@@ -800,14 +891,11 @@ class IngestWebContentRequest(BaseModel):
 #
 # This is a schema for MediaWiki ingestion and analysis.
 
+
 def _load_mediawiki_global_config() -> dict[str, Any]:
     """Load MediaWiki defaults without importing heavy MediaWiki ingestion module."""
     try:
-        config_path = (
-            Path(__file__).resolve().parents[4]
-            / "Config_Files"
-            / "mediawiki_import_config.yaml"
-        )
+        config_path = Path(__file__).resolve().parents[4] / "Config_Files" / "mediawiki_import_config.yaml"
         with config_path.open("r", encoding="utf-8") as handle:
             parsed = yaml.safe_load(handle) or {}
             return parsed if isinstance(parsed, dict) else {}
@@ -817,15 +905,23 @@ def _load_mediawiki_global_config() -> dict[str, Any]:
 
 media_wiki_global_config = _load_mediawiki_global_config()
 
+
 class MediaWikiDumpOptionsForm(BaseModel):
     wiki_name: str = Field(..., description="A unique name for this MediaWiki instance (e.g., 'my_custom_wiki').")
-    namespaces_str: Optional[str] = Field(None, description="Comma-separated list of namespace IDs (e.g., '0,1'). Imports all if None.")
+    namespaces_str: Optional[str] = Field(
+        None, description="Comma-separated list of namespace IDs (e.g., '0,1'). Imports all if None."
+    )
     skip_redirects: bool = Field(True, description="Skip redirect pages.")
-    chunk_max_size: int = Field(default_factory=lambda: media_wiki_global_config.get('chunking', {}).get('default_size', 1000), description="Maximum chunk size for MediaWiki content processing.")
-    api_name_vector_db: Optional[str] = Field(None, description="API name for vector DB/embedding/summary service (e.g., 'openai') used during ingestion.")
+    chunk_max_size: int = Field(
+        default_factory=lambda: media_wiki_global_config.get("chunking", {}).get("default_size", 1000),
+        description="Maximum chunk size for MediaWiki content processing.",
+    )
+    api_name_vector_db: Optional[str] = Field(
+        None, description="API name for vector DB/embedding/summary service (e.g., 'openai') used during ingestion."
+    )
     api_key_vector_db: Optional[str] = Field(None, description="API key for the vector DB/embedding/summary service.")
 
-    @field_validator('wiki_name')
+    @field_validator("wiki_name")
     @classmethod
     def validate_wiki_name(cls, v: str) -> str:
         """Validate wiki name to prevent path traversal and injection attacks."""
@@ -833,11 +929,13 @@ class MediaWikiDumpOptionsForm(BaseModel):
             raise ValueError("Wiki name cannot be empty")
 
         # Only allow alphanumeric, underscore, hyphen, and spaces
-        if not re.match(r'^[a-zA-Z0-9_\- ]+$', v):
-            raise ValueError("Invalid wiki name: Only alphanumeric characters, underscores, hyphens, and spaces are allowed")
+        if not re.match(r"^[a-zA-Z0-9_\- ]+$", v):
+            raise ValueError(
+                "Invalid wiki name: Only alphanumeric characters, underscores, hyphens, and spaces are allowed"
+            )
 
         # Additional security checks for path traversal patterns
-        if any(pattern in v for pattern in ['..', '/', '\\', '\x00']):
+        if any(pattern in v for pattern in ["..", "/", "\\", "\x00"]):
             raise ValueError("Invalid wiki name: Contains forbidden characters")
 
         # Length validation
@@ -846,7 +944,7 @@ class MediaWikiDumpOptionsForm(BaseModel):
 
         return v
 
-    @field_validator('namespaces_str')
+    @field_validator("namespaces_str")
     @classmethod
     def validate_namespaces(cls, v: Optional[str]) -> Optional[str]:
         """Validate namespace string format."""
@@ -855,7 +953,7 @@ class MediaWikiDumpOptionsForm(BaseModel):
 
         # Check format: should be comma-separated integers
         try:
-            namespaces = [int(ns.strip()) for ns in v.split(',')]
+            namespaces = [int(ns.strip()) for ns in v.split(",")]
             # Validate namespace IDs are reasonable
             for ns in namespaces:
                 if ns < -2 or ns > 9999:  # MediaWiki namespace IDs typically range from -2 to a few hundred
@@ -865,23 +963,24 @@ class MediaWikiDumpOptionsForm(BaseModel):
 
         return v
 
+
 class ProcessedMediaWikiPage(BaseModel):
     title: str
-    content: str # The plain text content
+    content: str  # The plain text content
     namespace: Optional[int] = None
     page_id: Optional[int] = None
     revision_id: Optional[int] = None
-    timestamp: Optional[str] = None # ISO format
+    timestamp: Optional[str] = None  # ISO format
     chunks: list[dict[str, Any]] = []
-    media_id: Optional[int] = None # Populated if stored to DB
+    media_id: Optional[int] = None  # Populated if stored to DB
     message: Optional[str] = None
     status: str = "Pending"
     error_message: Optional[str] = None
 
+
 #
 # End of MediaWiki ingestion and analysis model schema
 ######################################################################################
-
 
 
 #

--- a/tldw_Server_API/app/api/v1/schemas/media_request_models.py
+++ b/tldw_Server_API/app/api/v1/schemas/media_request_models.py
@@ -166,6 +166,10 @@ MediaType = Literal['video', 'audio', 'document', 'pdf', 'ebook', 'email', 'code
 # Define allowed chunking methods (adjust as needed based on your library)
 ChunkMethod = Literal['semantic', 'tokens', 'paragraphs', 'sentences','words', 'ebook_chapters', 'json', 'propositions']
 
+ChunkingMode = Literal['auto', 'manual']
+
+AutoChunkingGoal = Literal['balanced', 'qa_search', 'navigation_summary']
+
 # Define allowed PDF parsing engines
 PdfEngine = Literal['pymupdf4llm', 'pymupdf', 'docling'] # Add others if supported
 
@@ -175,6 +179,18 @@ OcrMode = Literal['always', 'fallback']
 class ChunkingOptions(BaseModel):
     """Pydantic model for chunking specific options"""
     perform_chunking: bool = Field(True, description="Enable chunk-based processing of the media content")
+    chunking_mode: Optional[ChunkingMode] = Field(
+        None,
+        description="Chunking control mode. Omitted preserves legacy/manual behavior; 'auto' lets the server plan media-aware chunking.",
+    )
+    auto_chunking_goal: AutoChunkingGoal = Field(
+        "balanced",
+        description="Goal used by automatic chunking when chunking_mode='auto'",
+    )
+    auto_chunking_use_llm: bool = Field(
+        False,
+        description="Explicit opt-in to AI-assisted automatic chunk boundary refinement when available",
+    )
     chunk_method: Optional[ChunkMethod] = Field(None, description="Method used to chunk content (e.g., 'sentences', 'recursive', 'chapter')")
     use_adaptive_chunking: bool = Field(False, description="Whether to enable adaptive chunking")
     use_multi_level_chunking: bool = Field(False, description="Whether to enable multi-level chunking")
@@ -721,6 +737,10 @@ class WebScrapingRequest(BaseModel):
     crawl_strategy: Optional[str] = None
     include_external: Optional[bool] = None
     score_threshold: Optional[float] = None
+    perform_chunking: bool = True
+    chunking_mode: Optional[ChunkingMode] = None
+    auto_chunking_goal: AutoChunkingGoal = "balanced"
+    auto_chunking_use_llm: bool = False
 
 class IngestWebContentRequest(BaseModel):
     # Core fields
@@ -751,6 +771,9 @@ class IngestWebContentRequest(BaseModel):
     api_name: Optional[str] = None
     api_key: Optional[str] = None
     perform_chunking: bool = True
+    chunking_mode: Optional[ChunkingMode] = None
+    auto_chunking_goal: AutoChunkingGoal = "balanced"
+    auto_chunking_use_llm: bool = False
     chunk_method: Optional[str] = None
     use_adaptive_chunking: bool = False
     use_multi_level_chunking: bool = False

--- a/tldw_Server_API/app/core/Chunking/auto_planner.py
+++ b/tldw_Server_API/app/core/Chunking/auto_planner.py
@@ -1,0 +1,345 @@
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass
+from typing import Any, Literal
+
+AutoChunkingGoal = Literal["balanced", "qa_search", "navigation_summary"]
+
+
+@dataclass(frozen=True)
+class AutoChunkingProfile:
+    media_type: str | None = None
+    source_name: str | None = None
+    title: str | None = None
+    mime_type: str | None = None
+    extension: str | None = None
+    text_length: int = 0
+    has_headings: bool = False
+    has_tables: bool = False
+    has_lists: bool = False
+    has_timecodes: bool = False
+    has_speaker_labels: bool = False
+    has_chapters: bool = False
+    language: str | None = None
+
+
+@dataclass(frozen=True)
+class AutoChunkingRequest:
+    perform_chunking: bool
+    chunking_mode: str | None
+    media_type: str | None
+    goal: str = "balanced"
+    profile: AutoChunkingProfile | None = None
+    template_name: str | None = None
+    template_status: str | None = None
+    template_error: str | None = None
+    requested_llm: bool = False
+    llm_available: bool = False
+    semantic_available: bool = True
+
+
+@dataclass(frozen=True)
+class AutoChunkingPlan:
+    mode: Literal["auto"]
+    goal: AutoChunkingGoal
+    used_llm: bool
+    method: str
+    max_size: int
+    overlap: int
+    template_name: str | None
+    derived_views: tuple[str, ...]
+    fallback_reason: str | None
+    rationale: str
+    profile: dict[str, Any]
+
+    def to_metadata(self) -> dict[str, Any]:
+        return {
+            "mode": self.mode,
+            "goal": self.goal,
+            "used_llm": self.used_llm,
+            "method": self.method,
+            "max_size": self.max_size,
+            "overlap": self.overlap,
+            "template_name": self.template_name,
+            "derived_views": list(self.derived_views),
+            "fallback_reason": self.fallback_reason,
+            "rationale": self.rationale,
+            "profile": self.profile,
+        }
+
+    @classmethod
+    def from_metadata(cls, metadata: dict[str, Any]) -> "AutoChunkingPlan":
+        return cls(
+            mode="auto",
+            goal=_normalize_goal(metadata.get("goal")),
+            used_llm=bool(metadata.get("used_llm")),
+            method=str(metadata.get("method") or "sentences"),
+            max_size=int(metadata.get("max_size") or _GOAL_SIZES["balanced"][0]),
+            overlap=int(metadata.get("overlap") or _GOAL_SIZES["balanced"][1]),
+            template_name=metadata.get("template_name"),
+            derived_views=tuple(str(view) for view in metadata.get("derived_views") or []),
+            fallback_reason=metadata.get("fallback_reason"),
+            rationale=str(metadata.get("rationale") or ""),
+            profile=dict(metadata.get("profile") or {}),
+        )
+
+
+@dataclass(frozen=True)
+class AutoChunkingDecision:
+    chunk_options: dict[str, Any] | None
+    chunking_plan: dict[str, Any] | None
+
+
+_GOAL_SIZES: dict[str, tuple[int, int]] = {
+    "qa_search": (700, 140),
+    "balanced": (900, 120),
+    "navigation_summary": (1400, 100),
+}
+
+_TEXT_SCAN_CHARS = 200_000
+_HEADING_RE = re.compile(r"^\s{0,3}(#{1,6}\s+\S+|chapter\s+\d+|section\s+\d+)", re.IGNORECASE | re.MULTILINE)
+_LIST_RE = re.compile(r"^\s*(?:[-*+]\s+\S+|\d+[.)]\s+\S+)", re.MULTILINE)
+_TABLE_RE = re.compile(r"^\s*\|.+\|\s*$", re.MULTILINE)
+_TIMECODE_RE = re.compile(r"\b\d{1,2}:\d{2}(?::\d{2})?(?:[.,]\d{1,3})?\b")
+_SPEAKER_RE = re.compile(
+    r"^\s*(?:speaker\s*\d+|speaker|host|guest|interviewer|interviewee)\s*:", re.IGNORECASE | re.MULTILINE
+)
+_CHAPTER_RE = re.compile(r"^\s*(?:chapter|book|part)\s+[\w.-]+", re.IGNORECASE | re.MULTILINE)
+
+
+def profile_from_source(
+    *,
+    media_type: str | None = None,
+    filename: str | None = None,
+    url: str | None = None,
+    title: str | None = None,
+    mime_type: str | None = None,
+    language: str | None = None,
+) -> AutoChunkingProfile:
+    source_name = filename or url
+    extension = None
+    if filename and "." in filename:
+        extension = filename.rsplit(".", 1)[-1].lower()
+    return AutoChunkingProfile(
+        media_type=_normalize_media_type(media_type),
+        source_name=source_name,
+        title=title,
+        mime_type=mime_type,
+        extension=extension,
+        language=language,
+        has_chapters=bool(extension in {"epub", "mobi", "azw3"}),
+    )
+
+
+def profile_from_text(text: str | None, *, max_scan_chars: int = _TEXT_SCAN_CHARS) -> AutoChunkingProfile:
+    sample = (text or "")[: max(0, int(max_scan_chars))]
+    return AutoChunkingProfile(
+        text_length=len(text or ""),
+        has_headings=bool(_HEADING_RE.search(sample)),
+        has_tables=bool(_TABLE_RE.search(sample)),
+        has_lists=bool(_LIST_RE.search(sample)),
+        has_timecodes=bool(_TIMECODE_RE.search(sample)),
+        has_speaker_labels=bool(_SPEAKER_RE.search(sample)),
+        has_chapters=bool(_CHAPTER_RE.search(sample)),
+    )
+
+
+def merge_profiles(*profiles: AutoChunkingProfile | None) -> AutoChunkingProfile:
+    merged = AutoChunkingProfile()
+    for profile in profiles:
+        if profile is None:
+            continue
+        merged = AutoChunkingProfile(
+            media_type=merged.media_type or profile.media_type,
+            source_name=merged.source_name or profile.source_name,
+            title=merged.title or profile.title,
+            mime_type=merged.mime_type or profile.mime_type,
+            extension=merged.extension or profile.extension,
+            text_length=max(merged.text_length, profile.text_length),
+            has_headings=merged.has_headings or profile.has_headings,
+            has_tables=merged.has_tables or profile.has_tables,
+            has_lists=merged.has_lists or profile.has_lists,
+            has_timecodes=merged.has_timecodes or profile.has_timecodes,
+            has_speaker_labels=merged.has_speaker_labels or profile.has_speaker_labels,
+            has_chapters=merged.has_chapters or profile.has_chapters,
+            language=merged.language or profile.language,
+        )
+    return merged
+
+
+def plan_auto_chunking(
+    *,
+    perform_chunking: bool,
+    chunking_mode: str | None,
+    media_type: str | None,
+    goal: str = "balanced",
+    profile: AutoChunkingProfile | None = None,
+    template_name: str | None = None,
+    template_status: str | None = None,
+    template_error: str | None = None,
+    requested_llm: bool = False,
+    llm_available: bool = False,
+    semantic_available: bool = True,
+) -> AutoChunkingDecision:
+    if not perform_chunking or chunking_mode != "auto":
+        return AutoChunkingDecision(chunk_options=None, chunking_plan=None)
+
+    normalized_goal = _normalize_goal(goal)
+    base_profile = merge_profiles(
+        AutoChunkingProfile(media_type=_normalize_media_type(media_type)),
+        profile,
+    )
+    method, derived_views, rationale_bits, fallback_reasons = _choose_method(
+        base_profile,
+        normalized_goal,
+        semantic_available=semantic_available,
+    )
+    fallback_reasons.extend(_template_fallback_reasons(template_status, template_error, rationale_bits))
+
+    # Adapter availability is an explicit caller contract. Do not infer it from
+    # configured chat providers until a boundary assistant adapter owns that check.
+    used_llm = bool(requested_llm and llm_available)
+    if requested_llm and not llm_available:
+        fallback_reasons.append("ai_assist_unavailable")
+        rationale_bits.append("AI assist was requested but no boundary adapter is available.")
+
+    max_size, overlap = _size_for_goal(normalized_goal, base_profile)
+    if base_profile.media_type == "email":
+        max_size, overlap = 1000, 150
+
+    chunk_options = {
+        "method": method,
+        "max_size": max_size,
+        "overlap": overlap,
+        "adaptive": False,
+        "multi_level": False,
+        "language": base_profile.language,
+    }
+    plan = AutoChunkingPlan(
+        mode="auto",
+        goal=normalized_goal,
+        used_llm=used_llm,
+        method=method,
+        max_size=max_size,
+        overlap=overlap,
+        template_name=template_name,
+        derived_views=tuple(derived_views),
+        fallback_reason=";".join(fallback_reasons) if fallback_reasons else None,
+        rationale=" ".join(rationale_bits),
+        profile=asdict(base_profile),
+    )
+    return AutoChunkingDecision(
+        chunk_options=chunk_options,
+        chunking_plan=plan.to_metadata(),
+    )
+
+
+def plan_auto_chunking_request(request: AutoChunkingRequest) -> AutoChunkingDecision:
+    return plan_auto_chunking(
+        perform_chunking=request.perform_chunking,
+        chunking_mode=request.chunking_mode,
+        media_type=request.media_type,
+        goal=request.goal,
+        profile=request.profile,
+        template_name=request.template_name,
+        template_status=request.template_status,
+        template_error=request.template_error,
+        requested_llm=request.requested_llm,
+        llm_available=request.llm_available,
+        semantic_available=request.semantic_available,
+    )
+
+
+def _normalize_goal(goal: str | None) -> AutoChunkingGoal:
+    if goal in _GOAL_SIZES:
+        return goal  # type: ignore[return-value]
+    return "balanced"
+
+
+def _normalize_media_type(media_type: str | None) -> str | None:
+    normalized = (media_type or "").strip().lower()
+    if normalized in {"web_document", "webpage", "article", "html"}:
+        return "web"
+    return normalized or None
+
+
+def _size_for_goal(goal: str, profile: AutoChunkingProfile) -> tuple[int, int]:
+    max_size, overlap = _GOAL_SIZES[goal]
+    if profile.text_length > 60_000 and goal == "navigation_summary":
+        return 1800, overlap
+    return max_size, overlap
+
+
+def _choose_method(
+    profile: AutoChunkingProfile,
+    goal: str,
+    *,
+    semantic_available: bool,
+) -> tuple[str, list[str], list[str], list[str]]:
+    media_type = profile.media_type or ""
+    derived_views: list[str] = []
+    rationale_bits: list[str] = []
+    fallback_reasons: list[str] = []
+
+    if media_type == "ebook":
+        derived_views.append("chapter_outline")
+        rationale_bits.append("Detected ebook content; selected chapter-based chunking.")
+        return "ebook_chapters", derived_views, rationale_bits, fallback_reasons
+
+    if media_type == "email":
+        derived_views.append("message_boundaries")
+        rationale_bits.append("Detected email content; selected message-friendly sentence chunks.")
+        return "sentences", derived_views, rationale_bits, fallback_reasons
+
+    if media_type in {"audio", "video"}:
+        if profile.has_timecodes:
+            derived_views.append("time_ranges")
+        if profile.has_speaker_labels:
+            derived_views.append("speaker_segments")
+        rationale_bits.append("Detected transcript-like media; selected sentence chunks.")
+        return "sentences", derived_views, rationale_bits, fallback_reasons
+
+    if media_type in {"document", "pdf", "web"}:
+        if profile.has_headings or profile.has_tables or profile.has_lists:
+            derived_views.extend(_structure_views(profile, goal))
+            rationale_bits.append("Detected document structure; selected structure-aware chunking.")
+            return "structure_aware", derived_views, rationale_bits, fallback_reasons
+        if semantic_available:
+            rationale_bits.append("Detected unstructured long text; selected semantic chunking.")
+            return "semantic", derived_views, rationale_bits, fallback_reasons
+        fallback_reasons.append("semantic_unavailable")
+        rationale_bits.append("Semantic chunking is unavailable; selected sentence fallback.")
+        return "sentences", derived_views, rationale_bits, fallback_reasons
+
+    rationale_bits.append("No specialized media signals detected; selected sentence chunks.")
+    return "sentences", derived_views, rationale_bits, fallback_reasons
+
+
+def _structure_views(profile: AutoChunkingProfile, goal: str) -> list[str]:
+    views = ["section_titles"]
+    if goal == "navigation_summary" or profile.has_headings:
+        views.append("outline")
+    if profile.has_tables:
+        views.append("table_regions")
+    if profile.has_lists:
+        views.append("list_blocks")
+    return views
+
+
+def _template_fallback_reasons(
+    template_status: str | None,
+    template_error: str | None,
+    rationale_bits: list[str],
+) -> list[str]:
+    if template_status == "matched":
+        rationale_bits.append("Applied matched chunking template as a planner input.")
+        return []
+    if template_status == "no_match":
+        rationale_bits.append("No chunking template matched; used deterministic media rules.")
+        return ["template_no_match"]
+    if template_status == "error":
+        message = template_error or "template classifier error"
+        rationale_bits.append(f"Template classifier failed ({message}); used deterministic media rules.")
+        return ["template_error"]
+    return []

--- a/tldw_Server_API/app/core/Chunking/auto_planner.py
+++ b/tldw_Server_API/app/core/Chunking/auto_planner.py
@@ -1,3 +1,5 @@
+"""Deterministic Auto Chunking planner for ingestion request defaults."""
+
 from __future__ import annotations
 
 import re
@@ -9,6 +11,8 @@ AutoChunkingGoal = Literal["balanced", "qa_search", "navigation_summary"]
 
 @dataclass(frozen=True)
 class AutoChunkingProfile:
+    """Signals the planner uses to choose a chunking strategy."""
+
     media_type: str | None = None
     source_name: str | None = None
     title: str | None = None
@@ -26,6 +30,8 @@ class AutoChunkingProfile:
 
 @dataclass(frozen=True)
 class AutoChunkingRequest:
+    """Normalized inputs for a single Auto Chunking planning decision."""
+
     perform_chunking: bool
     chunking_mode: str | None
     media_type: str | None
@@ -41,6 +47,8 @@ class AutoChunkingRequest:
 
 @dataclass(frozen=True)
 class AutoChunkingPlan:
+    """Serializable explanation of the selected Auto Chunking behavior."""
+
     mode: Literal["auto"]
     goal: AutoChunkingGoal
     used_llm: bool
@@ -54,6 +62,7 @@ class AutoChunkingPlan:
     profile: dict[str, Any]
 
     def to_metadata(self) -> dict[str, Any]:
+        """Return a JSON-safe metadata representation of the plan."""
         return {
             "mode": self.mode,
             "goal": self.goal,
@@ -70,6 +79,7 @@ class AutoChunkingPlan:
 
     @classmethod
     def from_metadata(cls, metadata: dict[str, Any]) -> "AutoChunkingPlan":
+        """Rebuild a plan from previously stored metadata."""
         return cls(
             mode="auto",
             goal=_normalize_goal(metadata.get("goal")),
@@ -87,6 +97,8 @@ class AutoChunkingPlan:
 
 @dataclass(frozen=True)
 class AutoChunkingDecision:
+    """Resolved chunking options plus optional metadata plan."""
+
     chunk_options: dict[str, Any] | None
     chunking_plan: dict[str, Any] | None
 
@@ -117,6 +129,7 @@ def profile_from_source(
     mime_type: str | None = None,
     language: str | None = None,
 ) -> AutoChunkingProfile:
+    """Build planner signals from request source metadata."""
     source_name = filename or url
     extension = None
     if filename and "." in filename:
@@ -133,6 +146,7 @@ def profile_from_source(
 
 
 def profile_from_text(text: str | None, *, max_scan_chars: int = _TEXT_SCAN_CHARS) -> AutoChunkingProfile:
+    """Build planner signals by scanning extracted text."""
     sample = (text or "")[: max(0, int(max_scan_chars))]
     return AutoChunkingProfile(
         text_length=len(text or ""),
@@ -146,6 +160,7 @@ def profile_from_text(text: str | None, *, max_scan_chars: int = _TEXT_SCAN_CHAR
 
 
 def merge_profiles(*profiles: AutoChunkingProfile | None) -> AutoChunkingProfile:
+    """Merge source and content profiles without losing positive signals."""
     merged = AutoChunkingProfile()
     for profile in profiles:
         if profile is None:
@@ -182,6 +197,7 @@ def plan_auto_chunking(
     llm_available: bool = False,
     semantic_available: bool = True,
 ) -> AutoChunkingDecision:
+    """Choose effective chunking options and metadata for an Auto request."""
     if not perform_chunking or chunking_mode != "auto":
         return AutoChunkingDecision(chunk_options=None, chunking_plan=None)
 
@@ -236,6 +252,7 @@ def plan_auto_chunking(
 
 
 def plan_auto_chunking_request(request: AutoChunkingRequest) -> AutoChunkingDecision:
+    """Plan Auto Chunking from a normalized request object."""
     return plan_auto_chunking(
         perform_chunking=request.perform_chunking,
         chunking_mode=request.chunking_mode,

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/chunking_options.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/chunking_options.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping
 from typing import Any
 
 from tldw_Server_API.app.core.Chunking.auto_planner import (
+    AutoChunkingProfile,
     merge_profiles,
     plan_auto_chunking,
     profile_from_source,
@@ -66,17 +67,31 @@ _CHUNKING_OPTIONS_NONCRITICAL_EXCEPTIONS = (
 )
 
 
-def _get_raw_form_value(form_data: Any, key: str) -> Any:
+def _get_raw_form_value(form_data: Any, key: str, default: Any = None) -> Any:
     if isinstance(form_data, Mapping):
-        return form_data.get(key)
+        return form_data.get(key, default)
     if hasattr(form_data, "model_dump"):
         try:
             dumped = form_data.model_dump()
         except _CHUNKING_OPTIONS_COERCE_EXCEPTIONS:
             dumped = {}
         if isinstance(dumped, Mapping):
-            return dumped.get(key)
-    return getattr(form_data, key, None)
+            return dumped.get(key, default)
+    return getattr(form_data, key, default)
+
+
+def _coerce_raw_bool(value: Any) -> bool:
+    if hasattr(value, "default"):
+        value = value.default
+    if isinstance(value, str):
+        return value.strip().lower() in {"true", "1", "yes", "on"}
+    return bool(value)
+
+
+def uses_hierarchical_chunking(chunk_options: Mapping[str, Any] | None) -> bool:
+    if not chunk_options:
+        return False
+    return bool(chunk_options.get("hierarchical") or isinstance(chunk_options.get("hierarchical_template"), dict))
 
 
 def _find_unsupported_chunking_keys(form_data: Any) -> list[str]:
@@ -99,8 +114,7 @@ def _validate_media_chunking_options(form_data: Any) -> None:
         return
     allowed = ", ".join(_ALLOWED_MEDIA_CHUNKING_KEYS)
     raise ValueError(
-        "Unsupported chunking options for media processing: "
-        f"{', '.join(unsupported)}. Supported options: {allowed}."
+        "Unsupported chunking options for media processing: " f"{', '.join(unsupported)}. Supported options: {allowed}."
     )
 
 
@@ -111,24 +125,24 @@ def prepare_chunking_options_dict(form_data: Any) -> dict[str, Any] | None:
     This is extracted from the former endpoint-local chunking helper so it
     can be reused by core ingestion helpers and modular endpoints.
     """
-    if not getattr(form_data, "perform_chunking", False):
+    if not _coerce_raw_bool(_get_raw_form_value(form_data, "perform_chunking", False)):
         logging.info("Chunking disabled.")
         return None
 
     _validate_media_chunking_options(form_data)
 
     default_chunk_method = "sentences"
-    media_type = str(getattr(form_data, "media_type", "") or "")
+    media_type = str(_get_raw_form_value(form_data, "media_type", "") or "")
     if media_type == "ebook":
         default_chunk_method = "ebook_chapters"
         logging.info("Setting chunk method to 'ebook_chapters' for ebook type.")
     elif media_type in ["video", "audio"]:
         default_chunk_method = "sentences"
 
-    final_chunk_method = getattr(form_data, "chunk_method", None) or default_chunk_method
+    final_chunk_method = _get_raw_form_value(form_data, "chunk_method") or default_chunk_method
 
-    chunk_size_used = getattr(form_data, "chunk_size", None)
-    chunk_overlap_used = getattr(form_data, "chunk_overlap", None)
+    chunk_size_used = _get_raw_form_value(form_data, "chunk_size")
+    chunk_overlap_used = _get_raw_form_value(form_data, "chunk_overlap")
 
     if media_type in ["document", "email"]:
         try:
@@ -148,53 +162,52 @@ def prepare_chunking_options_dict(form_data: Any) -> dict[str, Any] | None:
         final_chunk_method = "ebook_chapters"
 
     inferred_enable_contextual = bool(
-        getattr(form_data, "contextual_llm_model", None)
-        or getattr(form_data, "context_window_size", None)
+        _get_raw_form_value(form_data, "contextual_llm_model") or _get_raw_form_value(form_data, "context_window_size")
     )
 
     language: str | None
     if media_type in ["audio", "video"]:
-        language = getattr(form_data, "chunk_language", None) or getattr(
-            form_data, "transcription_language", None
+        language = _get_raw_form_value(form_data, "chunk_language") or _get_raw_form_value(
+            form_data, "transcription_language"
         )
     else:
-        language = getattr(form_data, "chunk_language", None)
+        language = _get_raw_form_value(form_data, "chunk_language")
 
     chunk_options: dict[str, Any] = {
         "method": final_chunk_method,
         "max_size": chunk_size_used,
         "overlap": chunk_overlap_used,
-        "adaptive": getattr(form_data, "use_adaptive_chunking", False),
-        "multi_level": getattr(form_data, "use_multi_level_chunking", False),
+        "adaptive": _coerce_raw_bool(_get_raw_form_value(form_data, "use_adaptive_chunking", False)),
+        "multi_level": _coerce_raw_bool(_get_raw_form_value(form_data, "use_multi_level_chunking", False)),
         "language": language,
-        "custom_chapter_pattern": getattr(form_data, "custom_chapter_pattern", None),
+        "custom_chapter_pattern": _get_raw_form_value(form_data, "custom_chapter_pattern"),
         "enable_contextual_chunking": bool(
-            getattr(form_data, "enable_contextual_chunking", False)
+            _coerce_raw_bool(_get_raw_form_value(form_data, "enable_contextual_chunking", False))
             or inferred_enable_contextual
         ),
-        "contextual_llm_model": getattr(form_data, "contextual_llm_model", None),
-        "context_window_size": getattr(form_data, "context_window_size", None),
-        "context_strategy": getattr(form_data, "context_strategy", None),
-        "context_token_budget": getattr(form_data, "context_token_budget", None),
+        "contextual_llm_model": _get_raw_form_value(form_data, "contextual_llm_model"),
+        "context_window_size": _get_raw_form_value(form_data, "context_window_size"),
+        "context_strategy": _get_raw_form_value(form_data, "context_strategy"),
+        "context_token_budget": _get_raw_form_value(form_data, "context_token_budget"),
     }
 
-    proposition_engine = getattr(form_data, "proposition_engine", None)
+    proposition_engine = _get_raw_form_value(form_data, "proposition_engine")
     if proposition_engine:
         chunk_options["proposition_engine"] = proposition_engine
-    proposition_aggressiveness = getattr(form_data, "proposition_aggressiveness", None)
+    proposition_aggressiveness = _get_raw_form_value(form_data, "proposition_aggressiveness")
     if proposition_aggressiveness is not None:
         chunk_options["proposition_aggressiveness"] = proposition_aggressiveness
-    proposition_min_len = getattr(form_data, "proposition_min_proposition_length", None)
+    proposition_min_len = _get_raw_form_value(form_data, "proposition_min_proposition_length")
     if proposition_min_len is not None:
         chunk_options["proposition_min_proposition_length"] = proposition_min_len
-    proposition_prompt_profile = getattr(form_data, "proposition_prompt_profile", None)
+    proposition_prompt_profile = _get_raw_form_value(form_data, "proposition_prompt_profile")
     if proposition_prompt_profile:
         chunk_options["proposition_prompt_profile"] = proposition_prompt_profile
 
     try:
-        hier_flag = getattr(form_data, "hierarchical_chunking", None)
-        hier_template = getattr(form_data, "hierarchical_template", None)
-        if hier_flag is True or (hier_template and isinstance(hier_template, dict)):
+        hier_flag = _get_raw_form_value(form_data, "hierarchical_chunking")
+        hier_template = _get_raw_form_value(form_data, "hierarchical_template")
+        if _coerce_raw_bool(hier_flag) or (hier_template and isinstance(hier_template, dict)):
             chunk_options["hierarchical"] = True
             if isinstance(hier_template, dict):
                 chunk_options["hierarchical_template"] = hier_template
@@ -209,19 +222,12 @@ def prepare_chunking_options_dict(form_data: Any) -> dict[str, Any] | None:
             c = cfg_dict.get("chunking_config", {}) if isinstance(cfg_dict, dict) else {}
             if "proposition_engine" in c and "proposition_engine" not in chunk_options:
                 chunk_options["proposition_engine"] = c.get("proposition_engine")
-            if (
-                "proposition_prompt_profile" in c
-                and "proposition_prompt_profile" not in chunk_options
-            ):
-                chunk_options["proposition_prompt_profile"] = c.get(
-                    "proposition_prompt_profile"
-                )
+            if "proposition_prompt_profile" in c and "proposition_prompt_profile" not in chunk_options:
+                chunk_options["proposition_prompt_profile"] = c.get("proposition_prompt_profile")
             if "proposition_aggressiveness" in c:
                 try:
                     if "proposition_aggressiveness" not in chunk_options:
-                        chunk_options["proposition_aggressiveness"] = int(
-                            c.get("proposition_aggressiveness")
-                        )
+                        chunk_options["proposition_aggressiveness"] = int(c.get("proposition_aggressiveness"))
                 except _CHUNKING_OPTIONS_COERCE_EXCEPTIONS:
                     pass
             if "proposition_min_proposition_length" in c:
@@ -258,14 +264,14 @@ def resolve_chunking_options_and_plan(
     keep the existing ``prepare_chunking_options_dict`` behavior. Auto requests
     intentionally ignore stale manual fields and use the deterministic planner.
     """
-    if not getattr(form_data, "perform_chunking", False):
+    if not _coerce_raw_bool(_get_raw_form_value(form_data, "perform_chunking", False)):
         logging.info("Chunking disabled.")
         return None, None
 
-    if getattr(form_data, "chunking_mode", None) != "auto":
+    if _get_raw_form_value(form_data, "chunking_mode") != "auto":
         return prepare_chunking_options_dict(form_data), None
 
-    effective_media_type = media_type or getattr(form_data, "media_type", None)
+    effective_media_type = media_type or _get_raw_form_value(form_data, "media_type")
     source_profile = _profile_from_form_source(
         form_data,
         media_type=effective_media_type,
@@ -278,12 +284,12 @@ def resolve_chunking_options_and_plan(
         perform_chunking=True,
         chunking_mode="auto",
         media_type=effective_media_type,
-        goal=getattr(form_data, "auto_chunking_goal", "balanced"),
+        goal=_get_raw_form_value(form_data, "auto_chunking_goal", "balanced"),
         profile=profile,
-        template_name=template_name or getattr(form_data, "chunking_template_name", None),
+        template_name=template_name or _get_raw_form_value(form_data, "chunking_template_name"),
         template_status=template_status,
         template_error=template_error,
-        requested_llm=bool(getattr(form_data, "auto_chunking_use_llm", False)),
+        requested_llm=_coerce_raw_bool(_get_raw_form_value(form_data, "auto_chunking_use_llm", False)),
         llm_available=llm_available,
         semantic_available=semantic_available,
     )
@@ -318,7 +324,7 @@ def resolve_chunking_for_result(
     Auto requests can use extracted content signals here, while legacy/manual
     paths keep the options prepared before processor dispatch.
     """
-    if getattr(form_data, "chunking_mode", None) != "auto":
+    if _get_raw_form_value(form_data, "chunking_mode") != "auto":
         return default_chunk_options, default_chunking_plan
 
     extracted_text = result.get("content")
@@ -345,7 +351,7 @@ def _profile_from_form_source(
     *,
     media_type: str | None,
     source_name: str | None,
-):
+) -> AutoChunkingProfile:
     source = source_name or _first_form_source_name(form_data)
     filename: str | None = None
     url: str | None = None
@@ -356,27 +362,27 @@ def _profile_from_form_source(
         else:
             filename = source_text
 
-    language = getattr(form_data, "chunk_language", None)
+    language = _get_raw_form_value(form_data, "chunk_language")
     if not language:
-        language = getattr(form_data, "transcription_language", None)
+        language = _get_raw_form_value(form_data, "transcription_language")
 
     return profile_from_source(
         media_type=media_type,
         filename=filename,
         url=url,
-        title=getattr(form_data, "title", None),
+        title=_get_raw_form_value(form_data, "title"),
         language=language,
     )
 
 
 def _first_form_source_name(form_data: Any) -> str | None:
-    urls = getattr(form_data, "urls", None)
+    urls = _get_raw_form_value(form_data, "urls")
     if isinstance(urls, list) and urls:
         first = urls[0]
         if first:
             return str(first)
     for attr_name in ("original_filename", "filename", "source_name"):
-        value = getattr(form_data, attr_name, None)
+        value = _get_raw_form_value(form_data, attr_name)
         if value:
             return str(value)
     return None
@@ -495,7 +501,7 @@ def apply_chunking_template_if_any(
                 if score <= 0:
                     continue
 
-                priority = ((cfg.get("classifier") or {}).get("priority") or 0)  # type: ignore[assignment]
+                priority = (cfg.get("classifier") or {}).get("priority") or 0  # type: ignore[assignment]
                 key = (float(score), int(priority))
 
                 if best_cfg is None or best_key is None or key > best_key:
@@ -547,8 +553,6 @@ def prepare_common_options(
         "api_provider": getattr(form_data, "api_provider", None),
         "model_name": getattr(form_data, "model_name", None),
         "store_in_db": True,
-        "summarize_recursively": bool(
-            getattr(form_data, "summarize_recursively", False)
-        ),
+        "summarize_recursively": bool(getattr(form_data, "summarize_recursively", False)),
         "author": getattr(form_data, "author", None),
     }

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/chunking_options.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/chunking_options.py
@@ -4,6 +4,12 @@ import json
 from collections.abc import Mapping
 from typing import Any
 
+from tldw_Server_API.app.core.Chunking.auto_planner import (
+    merge_profiles,
+    plan_auto_chunking,
+    profile_from_source,
+    profile_from_text,
+)
 from tldw_Server_API.app.core.config import load_and_log_configs
 from tldw_Server_API.app.core.Utils.Utils import logging
 
@@ -231,6 +237,149 @@ def prepare_chunking_options_dict(form_data: Any) -> dict[str, Any] | None:
 
     logging.info("Chunking enabled with options: {}", chunk_options)
     return chunk_options
+
+
+def resolve_chunking_options_and_plan(
+    form_data: Any,
+    *,
+    media_type: str | None = None,
+    source_name: str | None = None,
+    extracted_text: str | None = None,
+    template_name: str | None = None,
+    template_status: str | None = None,
+    template_error: str | None = None,
+    llm_available: bool = False,
+    semantic_available: bool = True,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    """
+    Resolve effective chunking options and optional Auto Chunking plan metadata.
+
+    Legacy requests that omit ``chunking_mode`` and explicit Manual requests
+    keep the existing ``prepare_chunking_options_dict`` behavior. Auto requests
+    intentionally ignore stale manual fields and use the deterministic planner.
+    """
+    if not getattr(form_data, "perform_chunking", False):
+        logging.info("Chunking disabled.")
+        return None, None
+
+    if getattr(form_data, "chunking_mode", None) != "auto":
+        return prepare_chunking_options_dict(form_data), None
+
+    effective_media_type = media_type or getattr(form_data, "media_type", None)
+    source_profile = _profile_from_form_source(
+        form_data,
+        media_type=effective_media_type,
+        source_name=source_name,
+    )
+    text_profile = profile_from_text(extracted_text)
+    profile = merge_profiles(source_profile, text_profile)
+
+    decision = plan_auto_chunking(
+        perform_chunking=True,
+        chunking_mode="auto",
+        media_type=effective_media_type,
+        goal=getattr(form_data, "auto_chunking_goal", "balanced"),
+        profile=profile,
+        template_name=template_name or getattr(form_data, "chunking_template_name", None),
+        template_status=template_status,
+        template_error=template_error,
+        requested_llm=bool(getattr(form_data, "auto_chunking_use_llm", False)),
+        llm_available=llm_available,
+        semantic_available=semantic_available,
+    )
+    return decision.chunk_options, decision.chunking_plan
+
+
+def attach_chunking_plan_to_result(
+    result: dict[str, Any],
+    chunking_plan: dict[str, Any] | None,
+) -> None:
+    """Attach Auto Chunking plan metadata to an endpoint result in-place."""
+    if not chunking_plan:
+        return
+    metadata = result.get("metadata")
+    if not isinstance(metadata, dict):
+        metadata = {}
+        result["metadata"] = metadata
+    metadata["chunking_plan"] = chunking_plan
+
+
+def resolve_chunking_for_result(
+    form_data: Any,
+    result: dict[str, Any],
+    *,
+    media_type: str | None = None,
+    default_chunk_options: dict[str, Any] | None = None,
+    default_chunking_plan: dict[str, Any] | None = None,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    """
+    Resolve final chunking options for a completed process result.
+
+    Auto requests can use extracted content signals here, while legacy/manual
+    paths keep the options prepared before processor dispatch.
+    """
+    if getattr(form_data, "chunking_mode", None) != "auto":
+        return default_chunk_options, default_chunking_plan
+
+    extracted_text = result.get("content")
+    if not isinstance(extracted_text, str):
+        extracted_text = None
+    source_name = result.get("input_ref") or result.get("processing_source")
+    if source_name is not None:
+        source_name = str(source_name)
+
+    chunk_options, chunking_plan = resolve_chunking_options_and_plan(
+        form_data,
+        media_type=media_type,
+        source_name=source_name,
+        extracted_text=extracted_text,
+    )
+    return (
+        chunk_options if chunk_options is not None else default_chunk_options,
+        chunking_plan if chunking_plan is not None else default_chunking_plan,
+    )
+
+
+def _profile_from_form_source(
+    form_data: Any,
+    *,
+    media_type: str | None,
+    source_name: str | None,
+):
+    source = source_name or _first_form_source_name(form_data)
+    filename: str | None = None
+    url: str | None = None
+    if source:
+        source_text = str(source)
+        if "://" in source_text:
+            url = source_text
+        else:
+            filename = source_text
+
+    language = getattr(form_data, "chunk_language", None)
+    if not language:
+        language = getattr(form_data, "transcription_language", None)
+
+    return profile_from_source(
+        media_type=media_type,
+        filename=filename,
+        url=url,
+        title=getattr(form_data, "title", None),
+        language=language,
+    )
+
+
+def _first_form_source_name(form_data: Any) -> str | None:
+    urls = getattr(form_data, "urls", None)
+    if isinstance(urls, list) and urls:
+        first = urls[0]
+        if first:
+            return str(first)
+    for attr_name in ("original_filename", "filename", "source_name"):
+        value = getattr(form_data, attr_name, None)
+        if value:
+            return str(value)
+    return None
 
 
 def apply_chunking_template_if_any(

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/persistence.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/persistence.py
@@ -2506,7 +2506,6 @@ async def add_media_orchestrate(
         media_mod = None  # type: ignore[assignment]
 
     _validate_inputs = validate_add_media_inputs
-    _prepare_chunking_options_dict = prepare_chunking_options_dict
     _prepare_common_options = prepare_common_options
     _determine_final_status = determine_add_media_final_status
 

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/persistence.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/persistence.py
@@ -173,9 +173,7 @@ def _resolve_media_budget_context(
         app_state = getattr(request.app, "state", None)
         gov = getattr(app_state, "rg_governor", None)
         loader = getattr(app_state, "rg_policy_loader", None)
-        policy_id = str(
-            getattr(request.state, "rg_policy_id", None) or _MEDIA_INGESTION_POLICY_ID
-        )
+        policy_id = str(getattr(request.state, "rg_policy_id", None) or _MEDIA_INGESTION_POLICY_ID)
         policy: dict[str, Any] = {}
         if loader is not None:
             try:
@@ -283,10 +281,7 @@ def _callable_accepts_keyword(
     ):
         return True
 
-    return any(
-        candidate.kind == inspect.Parameter.VAR_KEYWORD
-        for candidate in signature.parameters.values()
-    )
+    return any(candidate.kind == inspect.Parameter.VAR_KEYWORD for candidate in signature.parameters.values())
 
 
 def _normalize_analysis_text_chunk(
@@ -411,9 +406,7 @@ def _extract_analysis_extra_chunks_for_indexing(
                     score = det.get("score")
                     bbox = det.get("bbox")
                     caption_text = _normalize_analysis_text_chunk(
-                        det.get("caption")
-                        or det.get("description")
-                        or det.get("summary"),
+                        det.get("caption") or det.get("description") or det.get("summary"),
                         max_chars=1200,
                     )
                     if caption_text:
@@ -574,12 +567,7 @@ def _classify_ingestion_validation_failure_reason(message: str | None) -> str:
         or "quota exceeded" in lower
     ):
         return "size_limit"
-    if (
-        "not allowed" in lower
-        or "unsupported media type" in lower
-        or "mime" in lower
-        or "extension" in lower
-    ):
+    if "not allowed" in lower or "unsupported media type" in lower or "mime" in lower or "extension" in lower:
         return "file_type"
     if "validation" in lower or "validator" in lower:
         return "validator_rejected"
@@ -993,9 +981,7 @@ def _enforce_metadata_contract_on_result(
         error_message = f"Metadata contract validation failed: {issue_text}"
         existing_error = str(result.get("error", "") or "").strip()
         result["status"] = "Error"
-        result["error"] = (
-            f"{existing_error} | {error_message}" if existing_error else error_message
-        )
+        result["error"] = f"{existing_error} | {error_message}" if existing_error else error_message
         result["db_message"] = "DB operation skipped (metadata contract failure)."
         result["db_id"] = None
         result["media_uuid"] = None
@@ -1029,9 +1015,7 @@ def _skip_chunk_consistency_for_db_message(db_message: Any) -> bool:
     normalized = str(db_message or "").strip().lower()
     if not normalized:
         return False
-    return any(
-        marker in normalized for marker in _CHUNK_CONSISTENCY_SKIP_DB_MESSAGE_MARKERS
-    )
+    return any(marker in normalized for marker in _CHUNK_CONSISTENCY_SKIP_DB_MESSAGE_MARKERS)
 
 
 async def _fetch_unvectorized_chunk_count(
@@ -1050,9 +1034,7 @@ async def _fetch_unvectorized_chunk_count(
             return _with_media_db_session(
                 db_path=db_path,
                 client_id=client_id,
-                operation=lambda worker_db: worker_db.get_unvectorized_chunk_count(
-                    media_id_int
-                ),
+                operation=lambda worker_db: worker_db.get_unvectorized_chunk_count(media_id_int),
             )
         except _PERSISTENCE_NONCRITICAL_EXCEPTIONS:
             return None
@@ -1112,10 +1094,7 @@ async def _enforce_chunk_consistency_after_persist(
     if persisted_chunk_count == expected:
         return
 
-    issue_text = (
-        f"expected {expected} chunk rows but found {persisted_chunk_count} "
-        f"(media_id={media_id_int})"
-    )
+    issue_text = f"expected {expected} chunk rows but found {persisted_chunk_count} " f"(media_id={media_id_int})"
     logger.warning(
         "Chunk consistency mismatch (policy={}) for {} via {} [{}]: {}",
         policy,
@@ -1133,16 +1112,10 @@ async def _enforce_chunk_consistency_after_persist(
         error_message = f"Chunk consistency validation failed: {issue_text}"
         existing_error = str(result.get("error", "") or "").strip()
         result["status"] = "Error"
-        result["error"] = (
-            f"{existing_error} | {error_message}" if existing_error else error_message
-        )
+        result["error"] = f"{existing_error} | {error_message}" if existing_error else error_message
         _ensure_warnings_list(result).append(error_message)
         existing_db_message = str(result.get("db_message", "") or "").strip()
-        result["db_message"] = (
-            f"{existing_db_message} | {error_message}"
-            if existing_db_message
-            else error_message
-        )
+        result["db_message"] = f"{existing_db_message} | {error_message}" if existing_db_message else error_message
         return
 
     warning_message = f"Chunk consistency warning: {issue_text}"
@@ -1197,10 +1170,7 @@ def _compute_source_hash_safe(
 def _media_has_source_hash_column(db: MediaDatabase) -> bool:
     for table_name in ("Media", "media"):
         try:
-            columns = {
-                col.get("name", "").lower()
-                for col in db.backend.get_table_info(table_name)
-            }
+            columns = {col.get("name", "").lower() for col in db.backend.get_table_info(table_name)}
             if columns:
                 return "source_hash" in columns
         except _PERSISTENCE_NONCRITICAL_EXCEPTIONS:
@@ -1260,9 +1230,7 @@ def _merge_video_lite_summary_safe_metadata(
     else:
         video_lite_meta = {}
 
-    summary_status = str(
-        process_result.get("video_lite_summary_status") or ""
-    ).strip().lower()
+    summary_status = str(process_result.get("video_lite_summary_status") or "").strip().lower()
     if summary_value is not None:
         summary_text = str(summary_value).strip()
         if summary_text:
@@ -1318,7 +1286,7 @@ def _json_safe_metadata_value(value: Any) -> Any:
         cleaned_list = []
         for item in value:
             cleaned = _json_safe_metadata_value(item)
-            if cleaned is not None:
+            if cleaned is not None or item is None:
                 cleaned_list.append(cleaned)
         return cleaned_list
     if isinstance(value, dict):
@@ -1351,7 +1319,8 @@ def build_safe_metadata_subset(metadata: dict[str, Any] | None) -> dict[str, Any
         for ext_key in ("DOI", "ArXiv", "PMID", "PMCID"):
             ext_value = ext_ids.get(ext_key)
             if ext_value:
-                safe_meta[ext_key.lower()] = ext_value
+                target_key = "arxiv_id" if ext_key == "ArXiv" else ext_key.lower()
+                safe_meta[target_key] = ext_value
 
     return safe_meta
 
@@ -1375,11 +1344,7 @@ def _shared_transcript_dedupe_candidates(
         "diarize": bool(getattr(form_data, "diarize", False)),
         "vad_use": bool(getattr(form_data, "vad_use", False)),
     }
-    normalized_signature = {
-        key: value
-        for key, value in signature_payload.items()
-        if value not in (None, "")
-    }
+    normalized_signature = {key: value for key, value in signature_payload.items() if value not in (None, "")}
     reuse_signature = json.dumps(
         normalized_signature,
         sort_keys=True,
@@ -1475,11 +1440,7 @@ def _build_reused_process_result(
     reusable_content_text = str(content_text or "").strip()
     if not reusable_content_text and isinstance(normalized_stt, dict):
         reusable_content_text = str(normalized_stt.get("text") or "").strip()
-    artifact_meta = (
-        dict(normalized_stt.get("metadata") or {})
-        if isinstance(normalized_stt, dict)
-        else {}
-    )
+    artifact_meta = dict(normalized_stt.get("metadata") or {}) if isinstance(normalized_stt, dict) else {}
     metadata = {
         "title": source_media.get("title"),
         "author": source_media.get("author"),
@@ -1503,11 +1464,7 @@ def _build_reused_process_result(
         "media_type": media_type,
         "metadata": metadata,
         "content": reusable_content_text,
-        "segments": (
-            normalized_stt.get("segments")
-            if isinstance(normalized_stt, dict)
-            else None
-        ),
+        "segments": (normalized_stt.get("segments") if isinstance(normalized_stt, dict) else None),
         "chunks": None,
         "analysis": None,
         "summary": None,
@@ -1672,9 +1629,7 @@ async def _populate_reused_transcript_summary(
         else:
             process_result["video_lite_summary_status"] = "failed"
     except _PERSISTENCE_NONCRITICAL_EXCEPTIONS as exc:
-        _ensure_warnings_list(process_result).append(
-            f"Summary generation failed during dedupe reuse: {exc}"
-        )
+        _ensure_warnings_list(process_result).append(f"Summary generation failed during dedupe reuse: {exc}")
         process_result["video_lite_summary_status"] = "failed"
 
 
@@ -1867,9 +1822,7 @@ def _validate_downloaded_url_file(
 
     validator = _resolve_ingestion_file_validator(media_mod)
     normalized_allowed_extensions = (
-        {str(ext).lower() for ext in allowed_extensions if ext}
-        if allowed_extensions is not None
-        else None
+        {str(ext).lower() for ext in allowed_extensions if ext} if allowed_extensions is not None else None
     )
 
     file_extension = downloaded_path.suffix.lower()
@@ -1885,11 +1838,7 @@ def _validate_downloaded_url_file(
     }
     validate_email_archive_contents = True
     try:
-        media_cfg = (
-            loaded_config_data.get("media_processing", {})
-            if loaded_config_data
-            else {}
-        )
+        media_cfg = loaded_config_data.get("media_processing", {}) if loaded_config_data else {}
         if isinstance(media_cfg, dict):
             validate_email_archive_contents = bool(
                 media_cfg.get("validate_email_archive_contents", True),
@@ -2051,8 +2000,7 @@ def sync_media_add_results_to_collections(
 
             source_url = (
                 input_ref
-                if isinstance(input_ref, str)
-                and input_ref.lower().startswith(("http://", "https://"))
+                if isinstance(input_ref, str) and input_ref.lower().startswith(("http://", "https://"))
                 else None
             )
             url_value = source_url or input_ref or f"media://{media_id}"
@@ -2063,9 +2011,7 @@ def sync_media_add_results_to_collections(
                     domain = (urlparse(source_url).hostname or "").lower() or None
 
             content_hash = (
-                hashlib.sha256(content_text.encode("utf-8", errors="ignore")).hexdigest()
-                if content_text
-                else None
+                hashlib.sha256(content_text.encode("utf-8", errors="ignore")).hexdigest() if content_text else None
             )
             word_count = len(content_text.split()) if content_text else None
             published_at = metadata_map.get("published_at") or metadata_map.get("publish_date")
@@ -2257,9 +2203,7 @@ def _resolve_media_add_embedding_config(form_data: Any) -> tuple[str, str, int, 
         or "sentence-transformers/all-MiniLM-L6-v2"
     )
     embedding_provider = (
-        getattr(form_data, "embedding_provider", None)
-        or embedding_settings.get("embedding_provider")
-        or "huggingface"
+        getattr(form_data, "embedding_provider", None) or embedding_settings.get("embedding_provider") or "huggingface"
     )
     chunk_size = _coerce_positive_int(getattr(form_data, "chunk_size", None), 1000)
     chunk_overlap = _coerce_positive_int(
@@ -2281,26 +2225,17 @@ def _build_media_add_embeddings_provenance(
     current_user: Any,
     media_id: int,
 ) -> dict[str, Any]:
-    origin = str(
-        result.get("collections_origin")
-        or getattr(form_data, "collections_origin", None)
-        or "media_add"
-    )
+    origin = str(result.get("collections_origin") or getattr(form_data, "collections_origin", None) or "media_add")
     media_type = str(result.get("media_type") or getattr(form_data, "media_type", "")).strip()
     input_ref = str(result.get("input_ref") or "")
     processing_source = str(result.get("processing_source") or "")
     source_url = (
-        input_ref
-        if isinstance(input_ref, str)
-        and input_ref.lower().startswith(("http://", "https://"))
-        else None
+        input_ref if isinstance(input_ref, str) and input_ref.lower().startswith(("http://", "https://")) else None
     )
 
     collections_item_id = result.get("collections_item_id")
     try:
-        collections_item_id = (
-            int(collections_item_id) if collections_item_id is not None else None
-        )
+        collections_item_id = int(collections_item_id) if collections_item_id is not None else None
     except _PERSISTENCE_NONCRITICAL_EXCEPTIONS:
         collections_item_id = None
 
@@ -2351,9 +2286,7 @@ async def schedule_media_add_embeddings(
         dispatch_mode,
     )
 
-    embedding_model, embedding_provider, chunk_size, chunk_overlap = (
-        _resolve_media_add_embedding_config(form_data)
-    )
+    embedding_model, embedding_provider, chunk_size, chunk_overlap = _resolve_media_add_embedding_config(form_data)
     user_id = str(getattr(current_user, "id", "1"))
 
     for result in results:
@@ -2398,9 +2331,7 @@ async def schedule_media_add_embeddings(
                     embedding_priority=None,
                     provenance=provenance,
                 )
-                job_id = str(
-                    (job_row or {}).get("uuid") or (job_row or {}).get("id") or ""
-                ).strip()
+                job_id = str((job_row or {}).get("uuid") or (job_row or {}).get("id") or "").strip()
                 result["embeddings_scheduled"] = True
                 result["embeddings_dispatch"] = "jobs"
                 if job_id:
@@ -2470,9 +2401,7 @@ async def schedule_media_add_embeddings(
                         _mark_media_embeddings_error(
                             db,
                             media_id,
-                            result_emb.get("error")
-                            or result_emb.get("message")
-                            or "Embedding generation failed",
+                            result_emb.get("error") or result_emb.get("message") or "Embedding generation failed",
                         )
                     logger.info(
                         "Embedding generation result for media {}: {}",
@@ -2543,10 +2472,7 @@ def determine_add_media_final_status(results: list[dict[str, Any]]) -> int:
     if not processing_results:
         return status.HTTP_200_OK
 
-    if all(
-        str(r.get("status", "")).lower() == "success"
-        for r in processing_results
-    ):
+    if all(str(r.get("status", "")).lower() == "success" for r in processing_results):
         return status.HTTP_200_OK
     return status.HTTP_207_MULTI_STATUS
 
@@ -2590,6 +2516,7 @@ async def add_media_orchestrate(
     from tldw_Server_API.app.core.Ingestion_Media_Processing import (  # type: ignore  # noqa: E501
         input_sourcing as input_sourcing_mod,
     )
+
     CoreTempDirManager = input_sourcing_mod.TempDirManager
 
     if media_mod is not None:
@@ -2658,12 +2585,7 @@ async def add_media_orchestrate(
         pass
 
     # --- 1b. Resource Governor per-user concurrency budget ---
-    if (
-        rg_governor is not None
-        and RGRequest is not None
-        and rg_entity
-        and rg_jobs_limit > 0
-    ):
+    if rg_governor is not None and RGRequest is not None and rg_entity and rg_jobs_limit > 0:
         try:
             rg_decision, rg_handle = await rg_governor.reserve(
                 RGRequest(
@@ -2677,13 +2599,11 @@ async def add_media_orchestrate(
                 op_id=f"media-add-jobs:{rg_entity}:{time.time_ns()}",
             )
             if not bool(getattr(rg_decision, "allowed", False)) or not rg_handle:
-                cat_details = (
-                    ((getattr(rg_decision, "details", {}) or {}).get("categories", {}) or {}).get("jobs")
-                    or {}
-                )
+                cat_details = ((getattr(rg_decision, "details", {}) or {}).get("categories", {}) or {}).get(
+                    "jobs"
+                ) or {}
                 retry_after = _safe_int(
-                    getattr(rg_decision, "retry_after", None)
-                    or cat_details.get("retry_after"),
+                    getattr(rg_decision, "retry_after", None) or cat_details.get("retry_after"),
                     1,
                 )
                 headers = _build_ingestion_budget_headers(
@@ -2710,9 +2630,7 @@ async def add_media_orchestrate(
     if not hasattr(db, "client_id") or not db.client_id:
         logger.error("CRITICAL: Database instance dependency missing client_id.")
         db.client_id = settings.get("SERVER_CLIENT_ID", "SERVER_API_V1_FALLBACK")
-        logger.warning(
-            "Manually set missing client_id on DB instance to: {}", db.client_id
-        )
+        logger.warning("Manually set missing client_id on DB instance to: {}", db.client_id)
 
     results: list[dict[str, Any]] = []
     temp_dir_manager = TempDirManagerCls(  # type: ignore[call-arg]
@@ -2755,11 +2673,7 @@ async def add_media_orchestrate(
                 "email": [".eml"]
                 + ([".zip"] if getattr(form_data, "accept_archives", False) else [])
                 + ([".mbox"] if getattr(form_data, "accept_mbox", False) else [])
-                + (
-                    [".pst", ".ost"]
-                    if getattr(form_data, "accept_pst", False)
-                    else []
-                ),
+                + ([".pst", ".ost"] if getattr(form_data, "accept_pst", False) else []),
                 "json": [".json"],
                 # For "document", allow a broad set; leave None to let validator handle.
             }
@@ -2771,8 +2685,7 @@ async def add_media_orchestrate(
                 validator=file_validator_instance,
                 allowed_extensions=allowed_exts,
                 skip_archive_scanning=(
-                    str(form_data.media_type).lower() == "email"
-                    and bool(getattr(form_data, "accept_archives", False))
+                    str(form_data.media_type).lower() == "email" and bool(getattr(form_data, "accept_archives", False))
                 ),
             )
 
@@ -2815,9 +2728,7 @@ async def add_media_orchestrate(
                     for pf in saved_files_info:
                         try:
                             # Use filesystem Path (not FastAPI's Path) to compute size.
-                            total_uploaded_bytes += FilePath(
-                                str(pf["path"]).strip()
-                            ).stat().st_size
+                            total_uploaded_bytes += FilePath(str(pf["path"]).strip()).stat().st_size
                         except _PERSISTENCE_NONCRITICAL_EXCEPTIONS:
                             pass
                     if total_uploaded_bytes > 0:
@@ -2894,18 +2805,14 @@ async def add_media_orchestrate(
                     )
                     if not bool(getattr(rg_decision, "allowed", False)):
                         cat_details = (
-                            (
-                                (getattr(rg_decision, "details", {}) or {}).get(
-                                    "categories",
-                                    {},
-                                )
-                                or {}
-                            ).get(_MEDIA_INGESTION_BYTES_CATEGORY)
+                            (getattr(rg_decision, "details", {}) or {}).get(
+                                "categories",
+                                {},
+                            )
                             or {}
-                        )
+                        ).get(_MEDIA_INGESTION_BYTES_CATEGORY) or {}
                         retry_after = _safe_int(
-                            getattr(rg_decision, "retry_after", None)
-                            or cat_details.get("retry_after"),
+                            getattr(rg_decision, "retry_after", None) or cat_details.get("retry_after"),
                             1,
                         )
                         headers = _build_ingestion_budget_headers(
@@ -2922,11 +2829,7 @@ async def add_media_orchestrate(
                         entity_scope, entity_value = rg_entity.split(":", 1)
                     else:
                         entity_scope, entity_value = "entity", rg_entity
-                    request_id_part = (
-                        request.headers.get("X-Request-ID", "")
-                        if request is not None
-                        else ""
-                    )
+                    request_id_part = request.headers.get("X-Request-ID", "") if request is not None else ""
                     if not request_id_part:
                         request_id_part = str(time.time_ns())
                     await _record_media_ingestion_bytes_ledger_entry(
@@ -2957,6 +2860,7 @@ async def add_media_orchestrate(
                     from tldw_Server_API.app.core.Ingestion_Media_Processing.Video.Video_DL_Ingestion_Lib import (
                         parse_and_expand_urls,
                     )
+
                     expanded_urls = parse_and_expand_urls(url_list)
                     if expanded_urls != url_list:
                         logger.info(
@@ -2974,23 +2878,17 @@ async def add_media_orchestrate(
             # Check if any valid sources remain after potential save errors
             if not all_valid_input_sources:
                 if file_save_errors:
-                    logger.warning(
-                        "No valid inputs remaining after file handling errors."
-                    )
+                    logger.warning("No valid inputs remaining after file handling errors.")
                     if upload_error_status and upload_error_status[0] == HTTP_413_TOO_LARGE:
                         raise HTTPException(
                             status_code=upload_error_status[0],
                             detail=upload_error_status[1],
                         )
                     if all(
-                        _is_nonfatal_upload_validation_error(
-                            str(err_info.get("error", "") or "")
-                        )
+                        _is_nonfatal_upload_validation_error(str(err_info.get("error", "") or ""))
                         for err_info in file_save_errors
                     ):
-                        logger.info(
-                            "Returning multi-status response for upload validation-only failures."
-                        )
+                        logger.info("Returning multi-status response for upload validation-only failures.")
                     elif upload_error_status:
                         raise HTTPException(
                             status_code=upload_error_status[0],
@@ -3002,39 +2900,44 @@ async def add_media_orchestrate(
                             detail="File upload failed; no valid media sources found to process.",
                         )
                 else:
-                    logger.error(
-                        "No input URLs or successfully saved files found for /media/add."
-                    )
+                    logger.error("No input URLs or successfully saved files found for /media/add.")
                     raise HTTPException(
                         status_code=status.HTTP_400_BAD_REQUEST,
                         detail="No valid media sources found to process.",
                     )
 
-            # Prepare chunking options and auto-apply templates
-            chunking_options_dict = _prepare_chunking_options_dict(form_data)
+            first_url = (form_data.urls or [None])[0]
+            first_filename = None
+            try:
+                if saved_files_info:
+                    first_filename = saved_files_info[0]["original_filename"]
+            except _PERSISTENCE_NONCRITICAL_EXCEPTIONS:
+                first_filename = None
+            first_source = all_valid_input_sources[0] if all_valid_input_sources else first_url or first_filename
 
-            # Apply explicit or auto-selected chunking templates when requested.
+            # Prepare chunking options and auto-apply templates.
+            chunking_options_dict, chunking_plan = resolve_chunking_options_and_plan(
+                form_data,
+                media_type=str(form_data.media_type) if form_data.media_type else None,
+                source_name=str(first_source) if first_source else None,
+            )
+
+            # Apply explicit or auto-selected chunking templates for legacy/manual
+            # requests. Auto requests already own the resolved planner options.
             try:
                 from tldw_Server_API.app.core.Ingestion_Media_Processing.chunking_options import (  # type: ignore  # noqa: E501
                     apply_chunking_template_if_any as _apply_tpl,
                 )
 
-                first_url = (form_data.urls or [None])[0]
-                first_filename = None
-                try:
-                    if saved_files_info:
-                        first_filename = saved_files_info[0]["original_filename"]
-                except _PERSISTENCE_NONCRITICAL_EXCEPTIONS:
-                    first_filename = None
-
-                chunking_options_dict = _apply_tpl(
-                    form_data=form_data,
-                    db=db,
-                    chunking_options_dict=chunking_options_dict,
-                    TemplateClassifier=TemplateClassifier,
-                    first_url=first_url,
-                    first_filename=first_filename,
-                )
+                if chunking_plan is None:
+                    chunking_options_dict = _apply_tpl(
+                        form_data=form_data,
+                        db=db,
+                        chunking_options_dict=chunking_options_dict,
+                        TemplateClassifier=TemplateClassifier,
+                        first_url=first_url,
+                        first_filename=first_filename,
+                    )
             except _PERSISTENCE_NONCRITICAL_EXCEPTIONS as auto_err:
                 logger.warning("Auto-apply chunking template failed: {}", auto_err)
 
@@ -3045,11 +2948,7 @@ async def add_media_orchestrate(
             # Map input sources back to original refs (URL or original filename)
             source_to_ref_map: dict[str, str] = {src: src for src in url_list}
             source_to_ref_map.update(
-                {
-                    str(path): pf["original_filename"]
-                    for pf in saved_files_info
-                    if (path := pf.get("path"))
-                }
+                {str(path): pf["original_filename"] for pf in saved_files_info if (path := pf.get("path"))}
             )
             for pf in saved_files_info:
                 path = pf.get("path")
@@ -3126,11 +3025,7 @@ async def add_media_orchestrate(
                             loop=loop,
                             db_path=db_path_for_workers,
                             client_id=client_id_for_workers,
-                            user_id=(
-                                current_user.id
-                                if hasattr(current_user, "id")
-                                else None
-                            ),
+                            user_id=(current_user.id if hasattr(current_user, "id") else None),
                         )
 
                 tasks = [_run_doc_item(source) for source in all_valid_input_sources]
@@ -3146,13 +3041,9 @@ async def add_media_orchestrate(
                         status_code = getattr(result, "status_code", None)
                         detail_text = str(detail) if detail else str(result)
                         if status_code:
-                            error_msg = (
-                                f"Processing failed (HTTP {status_code}): {detail_text}"
-                            )
+                            error_msg = f"Processing failed (HTTP {status_code}): {detail_text}"
                         else:
-                            error_msg = (
-                                f"Processing failed: {type(result).__name__}: {detail_text}"
-                            )
+                            error_msg = f"Processing failed: {type(result).__name__}: {detail_text}"
                         logger.error(
                             "Document-like processing failed for {}: {}",
                             source,
@@ -3215,9 +3106,7 @@ async def add_media_orchestrate(
                                 "Original file path rejected outside temp dir: {}",
                                 source_path,
                             )
-                            _ensure_warnings_list(result).append(
-                                "Original file not stored: unsafe local path"
-                            )
+                            _ensure_warnings_list(result).append("Original file not stored: unsafe local path")
                             continue
                         source_file = safe_source
                         if not source_file.exists():
@@ -3241,6 +3130,7 @@ async def add_media_orchestrate(
                             # Check storage quota before storing
                             try:
                                 from tldw_Server_API.app.services.storage_quota_service import StorageQuotaService
+
                                 quota_service = StorageQuotaService()
                                 await quota_service.initialize()
 
@@ -3308,24 +3198,17 @@ async def add_media_orchestrate(
                                 checksum=checksum,
                             )
 
-                            logger.info(
-                                f"Stored original file for media_id={media_id}: {storage_path}"
-                            )
+                            logger.info(f"Stored original file for media_id={media_id}: {storage_path}")
                             result["original_file_stored"] = True
 
                         except _PERSISTENCE_NONCRITICAL_EXCEPTIONS as store_err:
-                            logger.error(
-                                f"Failed to store original file for media_id={media_id}: {store_err}"
-                            )
+                            logger.error(f"Failed to store original file for media_id={media_id}: {store_err}")
                             # Non-fatal - don't fail the entire ingestion
                             result["original_file_stored"] = False
-                            _ensure_warnings_list(result).append(
-                                f"Failed to store original file: {store_err}"
-                            )
+                            _ensure_warnings_list(result).append(f"Failed to store original file: {store_err}")
 
                 except _PERSISTENCE_NONCRITICAL_EXCEPTIONS as storage_init_err:
                     logger.error(f"Failed to initialize storage backend: {storage_init_err}")
-
 
         # --- 6b. Dual-write to Collections content_items ---
         try:
@@ -3337,7 +3220,6 @@ async def add_media_orchestrate(
             )
         except _PERSISTENCE_NONCRITICAL_EXCEPTIONS as collections_err:
             logger.warning("Collections dual-write step failed: {}", collections_err)
-
 
         # --- 7. Generate Embeddings if Requested ---
         try:
@@ -3373,11 +3255,7 @@ async def add_media_orchestrate(
         except _PERSISTENCE_NONCRITICAL_EXCEPTIONS:
             pass
 
-        log_level = (
-            "INFO"
-            if final_status_code == status.HTTP_200_OK
-            else "WARNING"
-        )
+        log_level = "INFO" if final_status_code == status.HTTP_200_OK else "WARNING"
         logger.log(
             log_level,
             "Request finished with status {}. Results count: {}",
@@ -3389,20 +3267,14 @@ async def add_media_orchestrate(
         try:
             if is_test_mode() and response is not None:
                 try:
-                    _dbp = getattr(
-                        db, "db_path_str", getattr(db, "db_path", "?")
-                    )
+                    _dbp = getattr(db, "db_path_str", getattr(db, "db_path", "?"))
                 except _PERSISTENCE_NONCRITICAL_EXCEPTIONS:
                     _dbp = "?"
                 response.headers["X-TLDW-DB-Path"] = str(_dbp)
                 response.headers["X-TLDW-Add-Results-Len"] = str(len(results))
                 try:
                     ok_with_id = sum(
-                        1
-                        for r in results
-                        if isinstance(r, dict)
-                        and r.get("status") == "Success"
-                        and r.get("db_id")
+                        1 for r in results if isinstance(r, dict) and r.get("status") == "Success" and r.get("db_id")
                     )
                     response.headers["X-TLDW-Add-OK-With-Id"] = str(ok_with_id)
                 except _PERSISTENCE_NONCRITICAL_EXCEPTIONS:
@@ -3425,9 +3297,7 @@ async def add_media_orchestrate(
         raise
     except OSError as os_err:
         request_outcome = "error"
-        logger.error(
-            "OSError during /media/add setup: {}", os_err, exc_info=True
-        )
+        logger.error("OSError during /media/add setup: {}", os_err, exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"OS error during setup: {os_err}",
@@ -3524,14 +3394,17 @@ async def persist_primary_av_item(
     metadata_for_db = process_result.get("metadata", {}) or {}
     if not isinstance(metadata_for_db, dict):
         metadata_for_db = {}
+    resolved_chunk_options = chunk_options
     if getattr(form_data, "chunking_mode", None) == "auto":
         with contextlib.suppress(_PERSISTENCE_NONCRITICAL_EXCEPTIONS):
-            _, auto_chunking_plan = resolve_chunking_options_and_plan(
+            auto_chunking_options, auto_chunking_plan = resolve_chunking_options_and_plan(
                 form_data,
                 media_type=media_type,
                 source_name=str(original_input_ref or ""),
                 extracted_text=content_for_db if isinstance(content_for_db, str) else None,
             )
+            if auto_chunking_options is not None:
+                resolved_chunk_options = auto_chunking_options
             if auto_chunking_plan:
                 metadata_for_db = dict(metadata_for_db)
                 metadata_for_db["chunking_plan"] = auto_chunking_plan
@@ -3618,7 +3491,7 @@ async def persist_primary_av_item(
             raw_source_hash_str = str(raw_source_hash).strip()
             source_hash_for_db = raw_source_hash_str if raw_source_hash_str else None
 
-        effective_chunk_options = chunk_options
+        effective_chunk_options = resolved_chunk_options
         if effective_chunk_options is None and getattr(form_data, "perform_chunking", False):
             try:
                 effective_chunk_options = prepare_chunking_options_dict(form_data)
@@ -3709,6 +3582,7 @@ async def persist_primary_av_item(
                             from tldw_Server_API.app.core.Chunking.chunker import (  # type: ignore
                                 Chunker as _Chunker,
                             )
+
                             normalized_chunk_type = _Chunker.normalize_chunk_type(raw_chunk_type)
                         except _PERSISTENCE_NONCRITICAL_EXCEPTIONS:
                             normalized_chunk_type = raw_chunk_type
@@ -3745,9 +3619,7 @@ async def persist_primary_av_item(
             return _with_media_db_session(
                 db_path=db_path,
                 client_id=client_id,
-                operation=lambda worker_db: _resolve_media_writer(
-                    worker_db
-                ).add_media_with_keywords(**db_add_kwargs),
+                operation=lambda worker_db: _resolve_media_writer(worker_db).add_media_with_keywords(**db_add_kwargs),
             )
 
         media_id_result, media_uuid_result, db_message_result = await loop.run_in_executor(
@@ -3764,9 +3636,7 @@ async def persist_primary_av_item(
             media_type=media_type,
             path_kind=path_kind,
             processor=f"{_coerce_ingestion_label(media_type)}_primary_persist",
-            expected_chunk_count=(
-                len(chunks_for_sql) if isinstance(chunks_for_sql, list) else None
-            ),
+            expected_chunk_count=(len(chunks_for_sql) if isinstance(chunks_for_sql, list) else None),
             db_message=db_message_result,
             media_id=media_id_result,
             db_path=db_path,
@@ -3782,12 +3652,7 @@ async def persist_primary_av_item(
         # Optionally persist a normalized STT transcript into the Transcripts table
         # for audio/video items when a transcription model is known.
         try:
-            if (
-                media_type in ["audio", "video"]
-                and media_id_result
-                and transcription_model_used
-                and content_for_db
-            ):
+            if media_type in ["audio", "video"] and media_id_result and transcription_model_used and content_for_db:
                 artifact = process_result.get("normalized_stt")
                 provider_name = None
                 if isinstance(artifact, dict):
@@ -3819,9 +3684,7 @@ async def persist_primary_av_item(
                     )
                 serialized_artifact = json.dumps(artifact, default=str)
                 artifact_meta = artifact.get("metadata") or {}
-                whisper_model_value = str(
-                    artifact_meta.get("model") or transcription_model_used
-                )
+                whisper_model_value = str(artifact_meta.get("model") or transcription_model_used)
 
                 def _upsert_worker() -> dict[str, Any]:
                     return _with_media_db_session(
@@ -3936,7 +3799,7 @@ async def persist_primary_av_item(
             exc_info=True,
         )
         process_result["status"] = "Warning"
-        process_result["error"] = (process_result.get("error") or "")
+        process_result["error"] = process_result.get("error") or ""
         _ensure_warnings_list(process_result).append(
             f"Unexpected persistence error: {exc}",
         )
@@ -4012,9 +3875,7 @@ async def process_batch_media(
         reason = "Ready for processing."
         pre_check_warning: str | None = None
         source_hash: str | None = None
-        is_url = isinstance(source_path_or_url, str) and source_path_or_url.lower().startswith(
-            ("http://", "https://")
-        )
+        is_url = isinstance(source_path_or_url, str) and source_path_or_url.lower().startswith(("http://", "https://"))
         if is_url:
             url_dedupe_candidates = media_dedupe_url_candidates(identifier_for_check)
             if not url_dedupe_candidates:
@@ -4030,11 +3891,7 @@ async def process_batch_media(
                 )
 
                 block_override: bool | None = None
-                if (
-                    is_explicit_pytest_runtime()
-                    or env_flag_enabled("TESTING")
-                    or is_test_mode()
-                ):
+                if is_explicit_pytest_runtime() or env_flag_enabled("TESTING") or is_test_mode():
                     block_override = False
 
                 policy_result = evaluate_url_policy(
@@ -4088,9 +3945,7 @@ async def process_batch_media(
                 )
                 if hash_warning:
                     pre_check_warning = (
-                        hash_warning
-                        if not pre_check_warning
-                        else f"{pre_check_warning}; {hash_warning}"
+                        hash_warning if not pre_check_warning else f"{pre_check_warning}; {hash_warning}"
                     )
                 if source_hash and input_ref:
                     source_hash_by_ref.setdefault(str(input_ref), []).append(source_hash)
@@ -4114,12 +3969,11 @@ async def process_batch_media(
                     column="m.url",
                 )
                 if source_hash and not is_url:
+
                     def _source_hash_precheck(db: MediaDatabase) -> Any:
                         nonlocal source_hash_column_available
                         if source_hash_column_available is None:
-                            source_hash_column_available = _media_has_source_hash_column(
-                                db
-                            )
+                            source_hash_column_available = _media_has_source_hash_column(db)
                         if source_hash_column_available:
                             pre_check_query_template = """
                                 SELECT id
@@ -4130,9 +3984,7 @@ async def process_batch_media(
                                   AND deleted = 0
                                 LIMIT 1
                             """
-                            pre_check_query = pre_check_query_template.format(
-                                url_clause=url_clause
-                            )  # nosec B608
+                            pre_check_query = pre_check_query_template.format(url_clause=url_clause)  # nosec B608
                             cursor = db.execute_query(
                                 pre_check_query,
                                 (*url_params, source_hash),
@@ -4153,7 +4005,7 @@ async def process_batch_media(
                                 pre_check_query = pre_check_query_template.format(
                                     url_clause_alias=url_clause_alias
                                 )  # nosec B608
-                                hash_fragment = f"%\"source_hash\":\"{source_hash}\"%"
+                                hash_fragment = f'%"source_hash":"{source_hash}"%'
                                 cursor = db.execute_query(
                                     pre_check_query,
                                     (*url_params_alias, hash_fragment),
@@ -4174,7 +4026,7 @@ async def process_batch_media(
                             pre_check_query = pre_check_query_template.format(
                                 url_clause_alias=url_clause_alias
                             )  # nosec B608
-                            hash_fragment = f"%\"source_hash\":\"{source_hash}\"%"
+                            hash_fragment = f'%"source_hash":"{source_hash}"%'
                             cursor = db.execute_query(
                                 pre_check_query,
                                 (*url_params_alias, hash_fragment),
@@ -4198,15 +4050,12 @@ async def process_batch_media(
                         )
                     else:
                         should_process = True
-                        reason = (
-                            "Media not found with this filename and source hash."
-                        )
+                        reason = "Media not found with this filename and source hash."
                 elif not is_url and not source_hash:
                     should_process = True
-                    reason = (
-                        "Local file pre-check skipped (no source hash available)."
-                    )
+                    reason = "Local file pre-check skipped (no source hash available)."
                 else:
+
                     def _url_precheck(db: MediaDatabase) -> Any:
                         pre_check_query_template = """
                                           SELECT id
@@ -4216,9 +4065,7 @@ async def process_batch_media(
                                             AND deleted = 0
                                           LIMIT 1
                                           """
-                        pre_check_query = pre_check_query_template.format(
-                            url_clause=url_clause
-                        )  # nosec B608
+                        pre_check_query = pre_check_query_template.format(url_clause=url_clause)  # nosec B608
                         cursor = db.execute_query(
                             pre_check_query,
                             url_params,
@@ -4240,9 +4087,7 @@ async def process_batch_media(
                         )
                     else:
                         should_process = True
-                        reason = (
-                            "Media not found with this URL/identifier."
-                        )
+                        reason = "Media not found with this URL/identifier."
             except (DatabaseError, sqlite3.Error) as check_err:
                 logger.error(
                     "DB pre-check (custom query) failed for {}: {}",
@@ -4268,15 +4113,10 @@ async def process_batch_media(
                     None,
                     f"Unexpected pre-check error: {check_err}",
                 )
-                pre_check_warning = (
-                    f"Unexpected database pre-check error: {check_err}"
-                )
+                pre_check_warning = f"Unexpected database pre-check error: {check_err}"
         else:
             should_process = True
-            reason = (
-                "Overwrite requested or not applicable, proceeding regardless "
-                "of existence."
-            )
+            reason = "Overwrite requested or not applicable, proceeding regardless " "of existence."
 
         if should_process:
             reused_process_result = await _maybe_build_reused_transcript_process_result(
@@ -4402,31 +4242,19 @@ async def process_batch_media(
                 "perform_analysis": getattr(form_data, "perform_analysis", False),
                 "perform_chunking": getattr(form_data, "perform_chunking", True),
                 "chunk_method": chunk_options.get("method") if chunk_options else None,
-                "max_chunk_size": (
-                    chunk_options.get("max_size") if chunk_options else 500
-                ),
-                "chunk_overlap": (
-                    chunk_options.get("overlap") if chunk_options else 200
-                ),
-                "use_adaptive_chunking": (
-                    chunk_options.get("adaptive", False) if chunk_options else False
-                ),
-                "use_multi_level_chunking": (
-                    chunk_options.get("multi_level", False)
-                    if chunk_options
-                    else False
-                ),
-                "chunk_language": (
-                    chunk_options.get("language") if chunk_options else None
-                ),
+                "max_chunk_size": (chunk_options.get("max_size") if chunk_options else 500),
+                "chunk_overlap": (chunk_options.get("overlap") if chunk_options else 200),
+                "use_adaptive_chunking": (chunk_options.get("adaptive", False) if chunk_options else False),
+                "use_multi_level_chunking": (chunk_options.get("multi_level", False) if chunk_options else False),
+                "chunk_language": (chunk_options.get("language") if chunk_options else None),
                 "summarize_recursively": getattr(
                     form_data,
                     "summarize_recursively",
                     False,
                 ),
-                "api_name": getattr(form_data, "api_name", None)
-                if getattr(form_data, "perform_analysis", False)
-                else None,
+                "api_name": (
+                    getattr(form_data, "api_name", None) if getattr(form_data, "perform_analysis", False) else None
+                ),
                 "use_cookies": getattr(form_data, "use_cookies", False),
                 "cookies": getattr(form_data, "cookies", None),
                 "timestamp_option": getattr(form_data, "timestamp_option", None),
@@ -4477,30 +4305,18 @@ async def process_batch_media(
                 ),
                 "perform_chunking": getattr(form_data, "perform_chunking", True),
                 "chunk_method": chunk_options.get("method") if chunk_options else None,
-                "max_chunk_size": (
-                    chunk_options.get("max_size") if chunk_options else 500
-                ),
-                "chunk_overlap": (
-                    chunk_options.get("overlap") if chunk_options else 200
-                ),
-                "use_adaptive_chunking": (
-                    chunk_options.get("adaptive", False) if chunk_options else False
-                ),
-                "use_multi_level_chunking": (
-                    chunk_options.get("multi_level", False)
-                    if chunk_options
-                    else False
-                ),
-                "chunk_language": (
-                    chunk_options.get("language") if chunk_options else None
-                ),
+                "max_chunk_size": (chunk_options.get("max_size") if chunk_options else 500),
+                "chunk_overlap": (chunk_options.get("overlap") if chunk_options else 200),
+                "use_adaptive_chunking": (chunk_options.get("adaptive", False) if chunk_options else False),
+                "use_multi_level_chunking": (chunk_options.get("multi_level", False) if chunk_options else False),
+                "chunk_language": (chunk_options.get("language") if chunk_options else None),
                 "diarize": getattr(form_data, "diarize", False),
                 "vad_use": getattr(form_data, "vad_use", False),
                 "timestamp_option": getattr(form_data, "timestamp_option", None),
                 "perform_analysis": getattr(form_data, "perform_analysis", False),
-                "api_name": getattr(form_data, "api_name", None)
-                if getattr(form_data, "perform_analysis", False)
-                else None,
+                "api_name": (
+                    getattr(form_data, "api_name", None) if getattr(form_data, "perform_analysis", False) else None
+                ),
                 "custom_prompt_input": getattr(form_data, "custom_prompt", None),
                 "system_prompt_input": getattr(form_data, "system_prompt", None),
                 "summarize_recursively": getattr(
@@ -4626,22 +4442,16 @@ async def process_batch_media(
                     "for processing_source: {}. Falling back.",
                     processing_source,
                 )
-                original_input_ref = (
-                    process_result.get("input_ref") or processing_source or "Unknown Input"
-                )
+                original_input_ref = process_result.get("input_ref") or processing_source or "Unknown Input"
         else:
             original_input_ref = process_result.get("input_ref") or "Unknown Input (Missing Source)"
             logger.warning(
                 "Processing result missing 'processing_source'. Using fallback input_ref: {}",
                 original_input_ref,
             )
-            process_result["processing_source"] = (
-                str(original_input_ref) if original_input_ref else "Unknown"
-            )
+            process_result["processing_source"] = str(original_input_ref) if original_input_ref else "Unknown"
 
-        process_result["input_ref"] = (
-            str(original_input_ref) if original_input_ref else "Unknown"
-        )
+        process_result["input_ref"] = str(original_input_ref) if original_input_ref else "Unknown"
 
         pre_check_info = source_to_ref_map.get(processing_source) if processing_source else None
         pre_check_warning_msg = None
@@ -4666,8 +4476,7 @@ async def process_batch_media(
 
         path_kind = (
             "url"
-            if isinstance(original_input_ref, str)
-            and original_input_ref.lower().startswith(("http://", "https://"))
+            if isinstance(original_input_ref, str) and original_input_ref.lower().startswith(("http://", "https://"))
             else "upload"
         )
         _enforce_metadata_contract_on_result(
@@ -4842,11 +4651,7 @@ async def process_document_like_item(
                 # environment quirk so tests that stub downloads can
                 # still execute the ingestion path.
                 detail = getattr(exc, "detail", "")
-                if (
-                    is_test_mode()
-                    and isinstance(detail, str)
-                    and "Host could not be resolved" in detail
-                ):
+                if is_test_mode() and isinstance(detail, str) and "Host could not be resolved" in detail:
                     logger.warning(
                         "TEST_MODE: ignoring host resolution error for {}: {}",
                         processing_source,
@@ -4879,19 +4684,13 @@ async def process_document_like_item(
                 check_extension=check_extension,
                 media_type_key=None,
             )
-            if (
-                downloaded_path
-                and isinstance(downloaded_path, FilePath)
-                and downloaded_path.exists()
-            ):
+            if downloaded_path and isinstance(downloaded_path, FilePath) and downloaded_path.exists():
                 safe_downloaded_path = resolve_safe_local_path(
                     downloaded_path,
                     temp_dir,
                 )
                 if safe_downloaded_path is None:
-                    raise FileNotFoundError(
-                        "Downloaded file path rejected outside temp directory."
-                    )
+                    raise FileNotFoundError("Downloaded file path rejected outside temp directory.")
                 processing_filepath = safe_downloaded_path
                 processing_filename = safe_downloaded_path.name
                 _validate_downloaded_url_file(
@@ -5295,13 +5094,17 @@ async def process_document_like_item(
                 process_result_dict = await processing_func(**final_args)
 
             # Email containers may return a list of children.
-            if media_type_str == "email" and isinstance(
-                process_result_dict,
-                list,
-            ) and (
-                getattr(form_data, "accept_archives", False)
-                or getattr(form_data, "accept_mbox", False)
-                or getattr(form_data, "accept_pst", False)
+            if (
+                media_type_str == "email"
+                and isinstance(
+                    process_result_dict,
+                    list,
+                )
+                and (
+                    getattr(form_data, "accept_archives", False)
+                    or getattr(form_data, "accept_mbox", False)
+                    or getattr(form_data, "accept_pst", False)
+                )
             ):
                 final_result.update(
                     {
@@ -5309,10 +5112,7 @@ async def process_document_like_item(
                         "media_type": "email",
                         "content": None,
                         "metadata": {
-                            "title": (
-                                getattr(form_data, "title", None)
-                                or (processing_filename or item_input_ref)
-                            ),
+                            "title": (getattr(form_data, "title", None) or (processing_filename or item_input_ref)),
                             "parser_used": "builtin-email",
                         },
                         "children": process_result_dict,
@@ -5324,19 +5124,13 @@ async def process_document_like_item(
                     if archive_name:
                         lower_name = str(archive_name).lower()
                         if lower_name.endswith(".zip"):
-                            archive_keyword = (
-                                f"email_archive:{FilePath(archive_name).stem}"
-                            )
+                            archive_keyword = f"email_archive:{FilePath(archive_name).stem}"
                         elif lower_name.endswith(".mbox"):
-                            archive_keyword = (
-                                f"email_mbox:{FilePath(archive_name).stem}"
-                            )
+                            archive_keyword = f"email_mbox:{FilePath(archive_name).stem}"
                         elif lower_name.endswith(".pst") or lower_name.endswith(
                             ".ost",
                         ):
-                            archive_keyword = (
-                                f"email_pst:{FilePath(archive_name).stem}"
-                            )
+                            archive_keyword = f"email_pst:{FilePath(archive_name).stem}"
                     if archive_keyword:
                         base_keywords: list[str] = []
                         try:
@@ -5347,17 +5141,13 @@ async def process_document_like_item(
                             )
                             if isinstance(keywords_from_form, list):
                                 base_keywords = [
-                                    str(keyword).strip().lower()
-                                    for keyword in keywords_from_form
-                                    if keyword
+                                    str(keyword).strip().lower() for keyword in keywords_from_form if keyword
                                 ]
                         except _PERSISTENCE_NONCRITICAL_EXCEPTIONS:
                             base_keywords = []
                         merged = sorted(
                             set(
-                                (final_result.get("keywords") or [])
-                                + base_keywords
-                                + [archive_keyword],
+                                (final_result.get("keywords") or []) + base_keywords + [archive_keyword],
                             ),
                         )
                         final_result["keywords"] = merged
@@ -5367,15 +5157,13 @@ async def process_document_like_item(
             else:
                 if not isinstance(process_result_dict, dict):
                     raise TypeError(
-                        f"Processor '{func_name}' returned non-dict: "
-                        f"{type(process_result_dict)}",
+                        f"Processor '{func_name}' returned non-dict: " f"{type(process_result_dict)}",
                     )
                 if (
                     isinstance(process_result_dict, dict)
                     and process_result_dict.get("processing_source")
                     and final_result.get("processing_source")
-                    and final_result.get("processing_source")
-                    != process_result_dict.get("processing_source")
+                    and final_result.get("processing_source") != process_result_dict.get("processing_source")
                 ):
                     final_result.setdefault(
                         "original_processing_source",
@@ -5384,9 +5172,7 @@ async def process_document_like_item(
                 final_result.update(process_result_dict)
                 final_result["status"] = process_result_dict.get(
                     "status",
-                    "Error"
-                    if process_result_dict.get("error")
-                    else "Success",
+                    "Error" if process_result_dict.get("error") else "Success",
                 )
 
             proc_warnings: Any | None = None
@@ -5432,10 +5218,7 @@ async def process_document_like_item(
         final_result.update(
             {
                 "status": "Error",
-                "error": (
-                    "Processing error: "
-                    f"{type(proc_err).__name__}: {proc_err}"
-                ),
+                "error": ("Processing error: " f"{type(proc_err).__name__}: {proc_err}"),
             },
         )
 
@@ -5501,9 +5284,7 @@ async def process_document_like_item(
             claims_context=claims_context,
         )
     else:
-        final_result["db_message"] = (
-            "DB operation skipped (processing failed)."
-        )
+        final_result["db_message"] = "DB operation skipped (processing failed)."
         final_result["db_id"] = None
         final_result["media_uuid"] = None
 
@@ -5544,14 +5325,17 @@ async def persist_doc_item_and_children(
     metadata_for_db = final_result.get("metadata", {}) or {}
     if not isinstance(metadata_for_db, dict):
         metadata_for_db = {}
+    resolved_chunk_options = chunk_options
     if getattr(form_data, "chunking_mode", None) == "auto":
         with contextlib.suppress(_PERSISTENCE_NONCRITICAL_EXCEPTIONS):
-            _, auto_chunking_plan = resolve_chunking_options_and_plan(
+            auto_chunking_options, auto_chunking_plan = resolve_chunking_options_and_plan(
                 form_data,
                 media_type=media_type,
                 source_name=str(item_input_ref or processing_filename or ""),
                 extracted_text=content_for_db if isinstance(content_for_db, str) else None,
             )
+            if auto_chunking_options is not None:
+                resolved_chunk_options = auto_chunking_options
             if auto_chunking_plan:
                 metadata_for_db = dict(metadata_for_db)
                 metadata_for_db["chunking_plan"] = auto_chunking_plan
@@ -5560,11 +5344,7 @@ async def persist_doc_item_and_children(
     extracted_keywords = final_result.get("keywords", [])
     combined_keywords = set(getattr(form_data, "keywords", None) or [])
     if isinstance(extracted_keywords, list):
-        combined_keywords.update(
-            k.strip().lower()
-            for k in extracted_keywords
-            if isinstance(k, str) and k.strip()
-        )
+        combined_keywords.update(k.strip().lower() for k in extracted_keywords if isinstance(k, str) and k.strip())
 
     try:
         if media_type == "email":
@@ -5583,9 +5363,7 @@ async def persist_doc_item_and_children(
         if media_type == "email" and getattr(form_data, "ingest_attachments", False):
             parent_msg_id = None
             try:
-                parent_msg_id = ((metadata_for_db or {}).get("email") or {}).get(
-                    "message_id"
-                )
+                parent_msg_id = ((metadata_for_db or {}).get("email") or {}).get("message_id")
             except _PERSISTENCE_NONCRITICAL_EXCEPTIONS:
                 parent_msg_id = None
             if parent_msg_id:
@@ -5626,17 +5404,11 @@ async def persist_doc_item_and_children(
 
     model_used = metadata_for_db.get("parser_used", "Imported")
     if not model_used and media_type == "pdf":
-        model_used = (final_result.get("analysis_details") or {}).get(
-            "parser", "Imported"
-        )
+        model_used = (final_result.get("analysis_details") or {}).get("parser", "Imported")
 
     default_title = FilePath(item_input_ref).stem if item_input_ref else "Untitled"
 
-    title_for_db = (
-        getattr(form_data, "title", None)
-        or metadata_for_db.get("title")
-        or default_title
-    )
+    title_for_db = getattr(form_data, "title", None) or metadata_for_db.get("title") or default_title
     author_for_db = metadata_for_db.get(
         "author",
         getattr(form_data, "author", None) or "Unknown",
@@ -5680,7 +5452,7 @@ async def persist_doc_item_and_children(
 
             chunks_for_sql: list[dict[str, Any]] | None = None
             try:
-                opts = chunk_options or {}
+                opts = resolved_chunk_options or {}
                 if opts:
                     from tldw_Server_API.app.core.Chunking.chunker import (  # type: ignore
                         Chunker as _Chunker,
@@ -5696,9 +5468,9 @@ async def persist_doc_item_and_children(
                     chunks_for_sql = []
                     for item in flat_chunks:
                         meta = item.get("metadata") or {}
-                        chunk_type = chunker.normalize_chunk_type(
-                            meta.get("chunk_type") or meta.get("paragraph_kind")
-                        ) or "text"
+                        chunk_type = (
+                            chunker.normalize_chunk_type(meta.get("chunk_type") or meta.get("paragraph_kind")) or "text"
+                        )
                         small_meta: dict[str, Any] = {}
                         if meta.get("ancestry_titles"):
                             small_meta["ancestry_titles"] = meta.get("ancestry_titles")
@@ -5729,7 +5501,7 @@ async def persist_doc_item_and_children(
                 "transcription_model": model_used,
                 "author": author_for_db,
                 "overwrite": getattr(form_data, "overwrite_existing", False),
-                "chunk_options": chunk_options,
+                "chunk_options": resolved_chunk_options,
                 "chunks": chunks_for_sql,
             }
 
@@ -5750,9 +5522,11 @@ async def persist_doc_item_and_children(
                                     tenant_id=str(client_id),
                                     provider="upload",
                                     source_key=str(processing_filename or item_input_ref or "upload"),
-                                    labels=(metadata_for_db or {}).get("labels")
-                                    if isinstance(metadata_for_db, dict)
-                                    else None,
+                                    labels=(
+                                        (metadata_for_db or {}).get("labels")
+                                        if isinstance(metadata_for_db, dict)
+                                        else None
+                                    ),
                                 )
                                 _emit_email_native_persist_metric(
                                     path_kind="primary",
@@ -5816,9 +5590,7 @@ async def persist_doc_item_and_children(
                 media_type=media_type,
                 path_kind=path_kind,
                 processor=f"{_coerce_ingestion_label(media_type)}_document_persist",
-                expected_chunk_count=(
-                    len(chunks_for_sql) if isinstance(chunks_for_sql, list) else None
-                ),
+                expected_chunk_count=(len(chunks_for_sql) if isinstance(chunks_for_sql, list) else None),
                 db_message=db_message_result,
                 media_id=media_id_result,
                 db_path=db_path,
@@ -5827,7 +5599,7 @@ async def persist_doc_item_and_children(
             )
             _emit_ingestion_chunks_metric(
                 media_type=media_type,
-                chunk_method=(chunk_options or {}).get("method"),
+                chunk_method=(resolved_chunk_options or {}).get("method"),
                 chunk_count=len(chunks_for_sql) if isinstance(chunks_for_sql, list) else 0,
             )
             logger.info(
@@ -5839,16 +5611,10 @@ async def persist_doc_item_and_children(
             )
 
             try:
-                if media_type == "email" and getattr(
-                    form_data, "ingest_attachments", False
-                ):
+                if media_type == "email" and getattr(form_data, "ingest_attachments", False):
                     children = final_result.get("children") or []
                     if isinstance(children, list) and children:
-                        if any(
-                            isinstance(child, dict)
-                            and child.get("status") != "Success"
-                            for child in children
-                        ):
+                        if any(isinstance(child, dict) and child.get("status") != "Success" for child in children):
                             final_result["child_db_results"] = None
                         else:
                             child_db_results: list[dict[str, Any]] = []
@@ -5885,9 +5651,7 @@ async def persist_doc_item_and_children(
                                         key: value
                                         for key, value in child_meta.items()
                                         if key in allowed_keys_child
-                                        and isinstance(
-                                            value, (str, int, float, bool, list)
-                                        )
+                                        and isinstance(value, (str, int, float, bool, list))
                                     }
                                     safe_child_meta["parent_media_uuid"] = media_uuid_result
                                     try:
@@ -5895,59 +5659,45 @@ async def persist_doc_item_and_children(
                                             normalize_safe_metadata,
                                         )
 
-                                        safe_child_meta = normalize_safe_metadata(
-                                            safe_child_meta
-                                        )
-                                        safe_child_meta_json = json.dumps(
-                                            safe_child_meta, ensure_ascii=False
-                                        )
+                                        safe_child_meta = normalize_safe_metadata(safe_child_meta)
+                                        safe_child_meta_json = json.dumps(safe_child_meta, ensure_ascii=False)
                                     except _PERSISTENCE_NONCRITICAL_EXCEPTIONS:
                                         safe_child_meta_json = None
 
                                     child_chunks_for_sql: list[dict[str, Any]] | None = None
                                     try:
-                                        opts_child = chunk_options or {}
+                                        opts_child = resolved_chunk_options or {}
                                         if opts_child:
                                             from tldw_Server_API.app.core.Chunking.chunker import (  # type: ignore
                                                 Chunker as _Chunker,
                                             )
 
                                             chunker_child = _Chunker()
-                                            flat_child = (
-                                                chunker_child.chunk_text_hierarchical_flat(
-                                                    child_content,
-                                                    method=opts_child.get("method")
-                                                    or "sentences",
-                                                    max_size=opts_child.get("max_size")
-                                                    or 500,
-                                                    overlap=opts_child.get("overlap")
-                                                    or 50,
-                                                )
+                                            flat_child = chunker_child.chunk_text_hierarchical_flat(
+                                                child_content,
+                                                method=opts_child.get("method") or "sentences",
+                                                max_size=opts_child.get("max_size") or 500,
+                                                overlap=opts_child.get("overlap") or 50,
                                             )
                                             child_chunks_for_sql = []
                                             for item in flat_child:
                                                 meta = item.get("metadata") or {}
-                                                chunk_type = chunker_child.normalize_chunk_type(
-                                                    meta.get("chunk_type") or meta.get("paragraph_kind")
-                                                ) or "text"
+                                                chunk_type = (
+                                                    chunker_child.normalize_chunk_type(
+                                                        meta.get("chunk_type") or meta.get("paragraph_kind")
+                                                    )
+                                                    or "text"
+                                                )
                                                 small_meta: dict[str, Any] = {}
                                                 if meta.get("ancestry_titles"):
-                                                    small_meta["ancestry_titles"] = meta.get(
-                                                        "ancestry_titles"
-                                                    )
+                                                    small_meta["ancestry_titles"] = meta.get("ancestry_titles")
                                                 if meta.get("section_path"):
-                                                    small_meta["section_path"] = meta.get(
-                                                        "section_path"
-                                                    )
+                                                    small_meta["section_path"] = meta.get("section_path")
                                                 child_chunks_for_sql.append(
                                                     {
                                                         "text": item.get("text", ""),
-                                                        "start_char": meta.get(
-                                                            "start_offset"
-                                                        ),
-                                                        "end_char": meta.get(
-                                                            "end_offset"
-                                                        ),
+                                                        "start_char": meta.get("start_offset"),
+                                                        "end_char": meta.get("end_offset"),
                                                         "chunk_type": chunk_type,
                                                         "metadata": small_meta,
                                                     }
@@ -5965,21 +5715,22 @@ async def persist_doc_item_and_children(
                                         getattr(form_data, "author", None) or "Unknown",
                                     )
                                     child_url = (
-                                        f"{item_input_ref}::child::"
-                                        f"{child_meta.get('filename') or child_title}"
+                                        f"{item_input_ref}::child::" f"{child_meta.get('filename') or child_title}"
                                     )
 
                                     def _db_child_worker(
                                         child_url: str = child_url,
                                         child_title: str = child_title,
                                         child_content: str = child_content,
-                                        child_metadata_local: dict[str, Any] = child_meta if isinstance(child_meta, dict) else {},
+                                        child_metadata_local: dict[str, Any] = (
+                                            child_meta if isinstance(child_meta, dict) else {}
+                                        ),
                                         final_keywords: list[str] = final_keywords_list,
                                         safe_child_meta_json_local: str | None = safe_child_meta_json,
                                         model_used_local: str | None = model_used,
                                         child_author_local: str = child_author,
                                         child_chunks_for_sql_local: list[dict[str, Any]] | None = child_chunks_for_sql,
-                                        chunk_options_local: dict[str, Any] | None = chunk_options,
+                                        chunk_options_local: dict[str, Any] | None = resolved_chunk_options,
                                         form_data_local: Any = form_data,
                                         media_type_local: str = media_type,
                                         client_id_local: str = client_id,
@@ -5987,24 +5738,22 @@ async def persist_doc_item_and_children(
                                     ) -> Any:
                                         def _persist_child(worker_db: MediaDatabase) -> Any:
                                             media_writer = _resolve_media_writer(worker_db)
-                                            child_id_local, child_uuid_local, child_msg_local = media_writer.add_media_with_keywords(
-                                                url=_normalize_dedupe_url_for_db(child_url),
-                                                title=child_title,
-                                                media_type=media_type_local,
-                                                content=child_content,
-                                                keywords=final_keywords,
-                                                prompt=getattr(
-                                                    form_data_local, "custom_prompt", None
-                                                ),
-                                                analysis_content=None,
-                                                safe_metadata=safe_child_meta_json_local,
-                                                transcription_model=model_used_local,
-                                                author=child_author_local,
-                                                overwrite=getattr(
-                                                    form_data_local, "overwrite_existing", False
-                                                ),
-                                                chunk_options=chunk_options_local,
-                                                chunks=child_chunks_for_sql_local,
+                                            child_id_local, child_uuid_local, child_msg_local = (
+                                                media_writer.add_media_with_keywords(
+                                                    url=_normalize_dedupe_url_for_db(child_url),
+                                                    title=child_title,
+                                                    media_type=media_type_local,
+                                                    content=child_content,
+                                                    keywords=final_keywords,
+                                                    prompt=getattr(form_data_local, "custom_prompt", None),
+                                                    analysis_content=None,
+                                                    safe_metadata=safe_child_meta_json_local,
+                                                    transcription_model=model_used_local,
+                                                    author=child_author_local,
+                                                    overwrite=getattr(form_data_local, "overwrite_existing", False),
+                                                    chunk_options=chunk_options_local,
+                                                    chunks=child_chunks_for_sql_local,
+                                                )
                                             )
                                             if media_type_local == "email" and child_id_local:
                                                 if _is_email_native_persist_enabled():
@@ -6075,11 +5824,9 @@ async def persist_doc_item_and_children(
                                     )
                                     _emit_ingestion_chunks_metric(
                                         media_type=media_type,
-                                        chunk_method=(chunk_options or {}).get("method"),
+                                        chunk_method=(resolved_chunk_options or {}).get("method"),
                                         chunk_count=(
-                                            len(child_chunks_for_sql)
-                                            if isinstance(child_chunks_for_sql, list)
-                                            else 0
+                                            len(child_chunks_for_sql) if isinstance(child_chunks_for_sql, list) else 0
                                         ),
                                     )
                                     child_db_results.append(
@@ -6123,7 +5870,7 @@ async def persist_doc_item_and_children(
                 exc_info=True,
             )
             final_result["status"] = "Warning"
-            final_result["error"] = (final_result.get("error") or "")
+            final_result["error"] = final_result.get("error") or ""
             if not isinstance(final_result.get("warnings"), list):
                 final_result["warnings"] = []
             final_result["warnings"].append(f"Unexpected persistence error: {exc}")
@@ -6140,10 +5887,7 @@ async def persist_doc_item_and_children(
             try:
                 children = final_result.get("children") or []
                 if isinstance(children, list) and children:
-                    if any(
-                        isinstance(child, dict) and child.get("status") != "Success"
-                        for child in children
-                    ):
+                    if any(isinstance(child, dict) and child.get("status") != "Success" for child in children):
                         final_result["child_db_results"] = None
                         persisted_any_children = False
                     else:
@@ -6179,10 +5923,7 @@ async def persist_doc_item_and_children(
                                 safe_child_meta = {
                                     key: value
                                     for key, value in child_meta.items()
-                                    if key in allowed_keys_child
-                                    and isinstance(
-                                        value, (str, int, float, bool, list)
-                                    )
+                                    if key in allowed_keys_child and isinstance(value, (str, int, float, bool, list))
                                 }
                                 safe_child_meta_json: str | None = None
                                 try:
@@ -6190,55 +5931,44 @@ async def persist_doc_item_and_children(
                                         normalize_safe_metadata,
                                     )
 
-                                    safe_child_meta = normalize_safe_metadata(
-                                        safe_child_meta
-                                    )
-                                    safe_child_meta_json = json.dumps(
-                                        safe_child_meta, ensure_ascii=False
-                                    )
+                                    safe_child_meta = normalize_safe_metadata(safe_child_meta)
+                                    safe_child_meta_json = json.dumps(safe_child_meta, ensure_ascii=False)
                                 except _PERSISTENCE_NONCRITICAL_EXCEPTIONS:
                                     pass
 
                                 child_chunks_for_sql: list[dict[str, Any]] | None = None
                                 try:
-                                    opts_child = chunk_options or {}
+                                    opts_child = resolved_chunk_options or {}
                                     if opts_child:
                                         from tldw_Server_API.app.core.Chunking.chunker import (  # type: ignore
                                             Chunker as _Chunker,
                                         )
 
                                         chunker_child = _Chunker()
-                                        flat_child = (
-                                            chunker_child.chunk_text_hierarchical_flat(
-                                                child_content,
-                                                method=opts_child.get("method")
-                                                or "sentences",
-                                                max_size=opts_child.get("max_size")
-                                                or 500,
-                                                overlap=opts_child.get("overlap") or 50,
-                                            )
+                                        flat_child = chunker_child.chunk_text_hierarchical_flat(
+                                            child_content,
+                                            method=opts_child.get("method") or "sentences",
+                                            max_size=opts_child.get("max_size") or 500,
+                                            overlap=opts_child.get("overlap") or 50,
                                         )
                                         child_chunks_for_sql = []
                                         for item in flat_child:
                                             meta = item.get("metadata") or {}
-                                            chunk_type = chunker_child.normalize_chunk_type(
-                                                meta.get("chunk_type") or meta.get("paragraph_kind")
-                                            ) or "text"
+                                            chunk_type = (
+                                                chunker_child.normalize_chunk_type(
+                                                    meta.get("chunk_type") or meta.get("paragraph_kind")
+                                                )
+                                                or "text"
+                                            )
                                             small_meta: dict[str, Any] = {}
                                             if meta.get("ancestry_titles"):
-                                                small_meta["ancestry_titles"] = meta.get(
-                                                    "ancestry_titles"
-                                                )
+                                                small_meta["ancestry_titles"] = meta.get("ancestry_titles")
                                             if meta.get("section_path"):
-                                                small_meta["section_path"] = meta.get(
-                                                    "section_path"
-                                                )
+                                                small_meta["section_path"] = meta.get("section_path")
                                             child_chunks_for_sql.append(
                                                 {
                                                     "text": item.get("text", ""),
-                                                    "start_char": meta.get(
-                                                        "start_offset"
-                                                    ),
+                                                    "start_char": meta.get("start_offset"),
                                                     "end_char": meta.get("end_offset"),
                                                     "chunk_type": chunk_type,
                                                     "metadata": small_meta,
@@ -6257,15 +5987,16 @@ async def persist_doc_item_and_children(
                                     getattr(form_data, "author", None) or "Unknown",
                                 )
                                 child_url = (
-                                    f"{item_input_ref}::archive::"
-                                    f"{child_meta.get('filename') or child_title}"
+                                    f"{item_input_ref}::archive::" f"{child_meta.get('filename') or child_title}"
                                 )
 
                                 def _db_child_arch_worker(
                                     child_url_local: str = child_url,
                                     child_title_local: str = child_title,
                                     child_content_local: str = child_content,
-                                    child_metadata_local: dict[str, Any] = child_meta if isinstance(child_meta, dict) else {},
+                                    child_metadata_local: dict[str, Any] = (
+                                        child_meta if isinstance(child_meta, dict) else {}
+                                    ),
                                     final_keywords_local: list[str] = final_keywords_list,
                                     safe_child_meta_json_local: str | None = safe_child_meta_json,
                                     model_used_local: str | None = model_used,
@@ -6273,30 +6004,28 @@ async def persist_doc_item_and_children(
                                     child_chunks_for_sql_local: list[dict[str, Any]] | None = child_chunks_for_sql,
                                     media_type_local: str = media_type,
                                     form_data_local: Any = form_data,
-                                    chunk_options_local: dict[str, Any] | None = chunk_options,
+                                    chunk_options_local: dict[str, Any] | None = resolved_chunk_options,
                                     db_path_local: str = db_path,
                                     client_id_local: str = client_id,
                                 ) -> Any:
                                     def _persist_archive_child(worker_db: MediaDatabase) -> Any:
                                         media_writer = _resolve_media_writer(worker_db)
-                                        child_id_local, child_uuid_local, child_msg_local = media_writer.add_media_with_keywords(
-                                            url=_normalize_dedupe_url_for_db(child_url_local),
-                                            title=child_title_local,
-                                            media_type=media_type_local,
-                                            content=child_content_local,
-                                            keywords=final_keywords_local,
-                                            prompt=getattr(
-                                                form_data_local, "custom_prompt", None
-                                            ),
-                                            analysis_content=None,
-                                            safe_metadata=safe_child_meta_json_local,
-                                            transcription_model=model_used_local,
-                                            author=child_author_local,
-                                            overwrite=getattr(
-                                                form_data_local, "overwrite_existing", False
-                                            ),
-                                            chunk_options=chunk_options_local,
-                                            chunks=child_chunks_for_sql_local,
+                                        child_id_local, child_uuid_local, child_msg_local = (
+                                            media_writer.add_media_with_keywords(
+                                                url=_normalize_dedupe_url_for_db(child_url_local),
+                                                title=child_title_local,
+                                                media_type=media_type_local,
+                                                content=child_content_local,
+                                                keywords=final_keywords_local,
+                                                prompt=getattr(form_data_local, "custom_prompt", None),
+                                                analysis_content=None,
+                                                safe_metadata=safe_child_meta_json_local,
+                                                transcription_model=model_used_local,
+                                                author=child_author_local,
+                                                overwrite=getattr(form_data_local, "overwrite_existing", False),
+                                                chunk_options=chunk_options_local,
+                                                chunks=child_chunks_for_sql_local,
+                                            )
                                         )
                                         if media_type_local == "email" and child_id_local:
                                             if _is_email_native_persist_enabled():
@@ -6355,9 +6084,7 @@ async def persist_doc_item_and_children(
                                     path_kind=path_kind,
                                     processor="email_child_archive_persist",
                                     expected_chunk_count=(
-                                        len(child_chunks_for_sql)
-                                        if isinstance(child_chunks_for_sql, list)
-                                        else None
+                                        len(child_chunks_for_sql) if isinstance(child_chunks_for_sql, list) else None
                                     ),
                                     db_message=child_msg,
                                     media_id=child_id,
@@ -6367,11 +6094,9 @@ async def persist_doc_item_and_children(
                                 )
                                 _emit_ingestion_chunks_metric(
                                     media_type=media_type,
-                                    chunk_method=(chunk_options or {}).get("method"),
+                                    chunk_method=(resolved_chunk_options or {}).get("method"),
                                     chunk_count=(
-                                        len(child_chunks_for_sql)
-                                        if isinstance(child_chunks_for_sql, list)
-                                        else 0
+                                        len(child_chunks_for_sql) if isinstance(child_chunks_for_sql, list) else 0
                                     ),
                                 )
                                 child_db_results.append(

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/persistence.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/persistence.py
@@ -44,6 +44,7 @@ from tldw_Server_API.app.core.DB_Management.media_db.legacy_transcripts import (
 from tldw_Server_API.app.core.Ingestion_Media_Processing.chunking_options import (
     prepare_chunking_options_dict,
     prepare_common_options,
+    resolve_chunking_options_and_plan,
 )
 from tldw_Server_API.app.core.Ingestion_Media_Processing.path_utils import (
     open_safe_local_path,
@@ -729,6 +730,7 @@ _METADATA_COMMON_TYPED_KEYS: dict[str, tuple[type, ...]] = {
     "keywords": (list,),
     "tags": (list,),
     "email": (dict,),
+    "chunking_plan": (dict,),
 }
 
 _METADATA_CONTRACTS: dict[str, dict[str, Any]] = {
@@ -1279,6 +1281,79 @@ def _merge_video_lite_summary_safe_metadata(
 
     merged["video_lite"] = video_lite_meta
     return merged
+
+
+_SAFE_METADATA_ALLOWED_KEYS = frozenset(
+    {
+        "title",
+        "author",
+        "doi",
+        "pmid",
+        "pmcid",
+        "arxiv_id",
+        "s2_paper_id",
+        "url",
+        "pdf_url",
+        "pmc_url",
+        "date",
+        "year",
+        "venue",
+        "journal",
+        "license",
+        "license_url",
+        "publisher",
+        "source",
+        "creators",
+        "rights",
+        "source_hash",
+        "chunking_plan",
+    }
+)
+
+
+def _json_safe_metadata_value(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, list):
+        cleaned_list = []
+        for item in value:
+            cleaned = _json_safe_metadata_value(item)
+            if cleaned is not None:
+                cleaned_list.append(cleaned)
+        return cleaned_list
+    if isinstance(value, dict):
+        cleaned_dict: dict[str, Any] = {}
+        for key, item in value.items():
+            if key is None:
+                continue
+            cleaned = _json_safe_metadata_value(item)
+            if cleaned is not None or item is None:
+                cleaned_dict[str(key)] = cleaned
+        return cleaned_dict
+    return None
+
+
+def build_safe_metadata_subset(metadata: dict[str, Any] | None) -> dict[str, Any]:
+    """Copy safe metadata fields while preserving nested JSON-safe plan data."""
+    safe_meta: dict[str, Any] = {}
+    if not isinstance(metadata, dict):
+        return safe_meta
+
+    for key, value in metadata.items():
+        if key not in _SAFE_METADATA_ALLOWED_KEYS:
+            continue
+        cleaned = _json_safe_metadata_value(value)
+        if cleaned is not None:
+            safe_meta[key] = cleaned
+
+    ext_ids = metadata.get("externalIds")
+    if isinstance(ext_ids, dict):
+        for ext_key in ("DOI", "ArXiv", "PMID", "PMCID"):
+            ext_value = ext_ids.get(ext_key)
+            if ext_value:
+                safe_meta[ext_key.lower()] = ext_value
+
+    return safe_meta
 
 
 def _shared_transcript_dedupe_candidates(
@@ -3447,6 +3522,20 @@ async def persist_primary_av_item(
     content_for_db = process_result.get("transcript", process_result.get("content"))
     analysis_for_db = process_result.get("summary", process_result.get("analysis"))
     metadata_for_db = process_result.get("metadata", {}) or {}
+    if not isinstance(metadata_for_db, dict):
+        metadata_for_db = {}
+    if getattr(form_data, "chunking_mode", None) == "auto":
+        with contextlib.suppress(_PERSISTENCE_NONCRITICAL_EXCEPTIONS):
+            _, auto_chunking_plan = resolve_chunking_options_and_plan(
+                form_data,
+                media_type=media_type,
+                source_name=str(original_input_ref or ""),
+                extracted_text=content_for_db if isinstance(content_for_db, str) else None,
+            )
+            if auto_chunking_plan:
+                metadata_for_db = dict(metadata_for_db)
+                metadata_for_db["chunking_plan"] = auto_chunking_plan
+                process_result["metadata"] = metadata_for_db
 
     # Use the model reported by the processor if available, else fall back.
     transcription_model_used = metadata_for_db.get(
@@ -3497,40 +3586,7 @@ async def persist_primary_av_item(
         # Build a safe metadata subset for persistence.
         safe_meta: dict[str, Any] = {}
         try:
-            allowed_keys = {
-                "title",
-                "author",
-                "doi",
-                "pmid",
-                "pmcid",
-                "arxiv_id",
-                "s2_paper_id",
-                "url",
-                "pdf_url",
-                "pmc_url",
-                "date",
-                "year",
-                "venue",
-                "journal",
-                "license",
-                "license_url",
-                "publisher",
-                "source",
-                "creators",
-                "rights",
-                "source_hash",
-            }
-            for k, v in metadata_for_db.items():
-                if k in allowed_keys and isinstance(v, (str, int, float, bool)):
-                    safe_meta[k] = v
-                elif k in allowed_keys and isinstance(v, list):
-                    safe_meta[k] = [x for x in v if isinstance(x, (str, int, float, bool))]
-            # Extract from externalIds if present.
-            ext = metadata_for_db.get("externalIds")
-            if isinstance(ext, dict):
-                for kk in ("DOI", "ArXiv", "PMID", "PMCID"):
-                    if ext.get(kk):
-                        safe_meta[kk.lower()] = ext.get(kk)
+            safe_meta = build_safe_metadata_subset(metadata_for_db)
             safe_meta = _merge_video_lite_summary_safe_metadata(
                 safe_meta,
                 process_result=process_result,
@@ -5486,6 +5542,20 @@ async def persist_doc_item_and_children(
     content_for_db = final_result.get("content", "")
     analysis_for_db = final_result.get("summary") or final_result.get("analysis")
     metadata_for_db = final_result.get("metadata", {}) or {}
+    if not isinstance(metadata_for_db, dict):
+        metadata_for_db = {}
+    if getattr(form_data, "chunking_mode", None) == "auto":
+        with contextlib.suppress(_PERSISTENCE_NONCRITICAL_EXCEPTIONS):
+            _, auto_chunking_plan = resolve_chunking_options_and_plan(
+                form_data,
+                media_type=media_type,
+                source_name=str(item_input_ref or processing_filename or ""),
+                extracted_text=content_for_db if isinstance(content_for_db, str) else None,
+            )
+            if auto_chunking_plan:
+                metadata_for_db = dict(metadata_for_db)
+                metadata_for_db["chunking_plan"] = auto_chunking_plan
+                final_result["metadata"] = metadata_for_db
 
     extracted_keywords = final_result.get("keywords", [])
     combined_keywords = set(getattr(form_data, "keywords", None) or [])
@@ -5580,45 +5650,7 @@ async def persist_doc_item_and_children(
             )
             safe_meta: dict[str, Any] = {}
             try:
-                allowed_keys = {
-                    "title",
-                    "author",
-                    "doi",
-                    "pmid",
-                    "pmcid",
-                    "arxiv_id",
-                    "s2_paper_id",
-                    "url",
-                    "pdf_url",
-                    "pmc_url",
-                    "date",
-                    "year",
-                    "venue",
-                    "journal",
-                    "license",
-                    "license_url",
-                    "publisher",
-                    "source",
-                    "creators",
-                    "rights",
-                    "source_hash",
-                }
-                for key, value in (metadata_for_db or {}).items():
-                    if key in allowed_keys and isinstance(
-                        value, (str, int, float, bool)
-                    ):
-                        safe_meta[key] = value
-                    elif key in allowed_keys and isinstance(value, list):
-                        safe_meta[key] = [
-                            x
-                            for x in value
-                            if isinstance(x, (str, int, float, bool))
-                        ]
-                ext_ids = (metadata_for_db or {}).get("externalIds")
-                if isinstance(ext_ids, dict):
-                    for ext_key in ("DOI", "ArXiv", "PMID", "PMCID"):
-                        if ext_ids.get(ext_key):
-                            safe_meta[ext_key.lower()] = ext_ids.get(ext_key)
+                safe_meta = build_safe_metadata_subset(metadata_for_db)
             except _PERSISTENCE_NONCRITICAL_EXCEPTIONS:
                 safe_meta = {}
 

--- a/tldw_Server_API/app/services/enhanced_web_scraping_service.py
+++ b/tldw_Server_API/app/services/enhanced_web_scraping_service.py
@@ -10,6 +10,7 @@ import time
 import uuid
 from datetime import datetime
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Optional
 
 from fastapi import HTTPException
@@ -19,6 +20,10 @@ from tldw_Server_API.app.core.Chunking.chunker import Chunker
 from tldw_Server_API.app.core.config import load_and_log_configs
 from tldw_Server_API.app.core.DB_Management.db_path_utils import get_user_media_db_path
 from tldw_Server_API.app.core.DB_Management.media_db.api import managed_media_database
+from tldw_Server_API.app.core.Ingestion_Media_Processing.chunking_options import (
+    attach_chunking_plan_to_result,
+    resolve_chunking_options_and_plan,
+)
 from tldw_Server_API.app.core.LLM_Calls.Summarization_General_Lib import analyze
 from tldw_Server_API.app.core.Metrics import get_metrics_registry
 from tldw_Server_API.app.core.testing import is_truthy
@@ -52,6 +57,30 @@ _WEB_SCRAPE_NONCRITICAL_EXCEPTIONS = (
 )
 _PLATFORM_ADMIN_ROLES = frozenset({"admin"})
 _ADMIN_CLAIM_PERMISSIONS = frozenset({"*", "system.configure"})
+
+
+def _web_chunking_form(
+    *,
+    perform_chunking: bool,
+    chunking_mode: str | None,
+    auto_chunking_goal: str,
+    auto_chunking_use_llm: bool,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        media_type="web",
+        perform_chunking=perform_chunking,
+        chunking_mode=chunking_mode,
+        auto_chunking_goal=auto_chunking_goal,
+        auto_chunking_use_llm=auto_chunking_use_llm,
+        chunk_method=None,
+        chunk_size=500,
+        chunk_overlap=200,
+        chunk_language=None,
+        use_adaptive_chunking=False,
+        use_multi_level_chunking=False,
+        hierarchical_chunking=False,
+        hierarchical_template=None,
+    )
 
 
 def _normalized_claim_values(values: Any) -> set[str]:
@@ -121,6 +150,10 @@ class WebScrapingService:
         crawl_strategy: Optional[str] = None,
         include_external: Optional[bool] = None,
         score_threshold: Optional[float] = None,
+        perform_chunking: bool = True,
+        chunking_mode: Optional[str] = None,
+        auto_chunking_goal: str = "balanced",
+        auto_chunking_use_llm: bool = False,
     ) -> dict[str, Any]:
         """
         Process web scraping task with enhanced features.
@@ -602,6 +635,12 @@ class WebScrapingService:
                 reg.set_gauge("webscraping.persist.last_batch_articles", float(len(result.get("articles", []))), {"method": str(result.get("method", "unknown"))})
             except _WEB_SCRAPE_NONCRITICAL_EXCEPTIONS:
                 reg = None
+            chunking_form = _web_chunking_form(
+                perform_chunking=perform_chunking,
+                chunking_mode=chunking_mode,
+                auto_chunking_goal=auto_chunking_goal,
+                auto_chunking_use_llm=auto_chunking_use_llm,
+            )
             _batch_t0 = time.perf_counter()
             for article in result.get("articles", []):
                 logger.debug(f"Processing article: url={article.get('url')}, "
@@ -672,6 +711,16 @@ class WebScrapingService:
                             "crawl_score": crawl_score,
                         }
                     )
+                    chunk_options = None
+                    chunking_plan = None
+                    if perform_chunking:
+                        chunk_options, chunking_plan = resolve_chunking_options_and_plan(
+                            chunking_form,
+                            media_type="web",
+                            source_name=str(article.get("url") or ""),
+                            extracted_text=content_with_metadata,
+                        )
+                        attach_chunking_plan_to_result(article, chunking_plan)
 
                     # Prepare segments
 
@@ -691,47 +740,63 @@ class WebScrapingService:
                         "crawl_parent_url": crawl_parent,
                         "crawl_score": crawl_score,
                     }
+                    if chunking_plan:
+                        safe_meta["chunking_plan"] = chunking_plan
                     safe_metadata_json = json.dumps({k: v for k, v in safe_meta.items() if v is not None}, ensure_ascii=False)
 
                     # Build plaintext chunks for chunk-level FTS
-                    try:
-                        # Chunk in a worker thread to avoid blocking the event loop for long documents
-                        flat = await asyncio.to_thread(
-                            lambda _cwm=content_with_metadata: Chunker().chunk_text_hierarchical_flat(_cwm, method='sentences')
-                        )
-                        kind_map = {
-                            'paragraph': 'text',
-                            'list_unordered': 'list',
-                            'list_ordered': 'list',
-                            'code_fence': 'code',
-                            'table_md': 'table',
-                            'header_line': 'heading',
-                            'header_atx': 'heading',
-                        }
+                    if not perform_chunking:
                         chunks_for_sql = []
-                        for it in flat:
-                            md = it.get('metadata') or {}
-                            ctype = kind_map.get(str(md.get('paragraph_kind') or '').lower(), 'text')
-                            small = {}
-                            if md.get('ancestry_titles'):
-                                small['ancestry_titles'] = md.get('ancestry_titles')
-                            if md.get('section_path'):
-                                small['section_path'] = md.get('section_path')
-                            chunks_for_sql.append({
-                                'text': it.get('text',''),
-                                'start_char': md.get('start_offset'),
-                                'end_char': md.get('end_offset'),
-                                'chunk_type': ctype,
-                                'metadata': small,
-                            })
-                    except _WEB_SCRAPE_NONCRITICAL_EXCEPTIONS as e:
-                        logger.debug(f"webscraping.persist: chunking failed; storing without chunks: {e}")
+                    else:
                         try:
-                            if reg:
-                                reg.increment("app_warning_events_total", 1, {"component": "webscraping", "event": "chunking_failed"})
-                        except _WEB_SCRAPE_NONCRITICAL_EXCEPTIONS:
-                            logger.debug("metrics increment failed for webscraping chunking_failed")
-                        chunks_for_sql = []
+                        # Chunk in a worker thread to avoid blocking the event loop for long documents
+                            options = chunk_options or {
+                                "method": "sentences",
+                                "max_size": 500,
+                                "overlap": 200,
+                            }
+                            flat = await asyncio.to_thread(
+                                lambda _cwm=content_with_metadata, _opts=options: Chunker().chunk_text_hierarchical_flat(
+                                    _cwm,
+                                    method=_opts.get("method") or "sentences",
+                                    max_size=_opts.get("max_size") or 500,
+                                    overlap=_opts.get("overlap") or 200,
+                                    language=_opts.get("language"),
+                                )
+                            )
+                            kind_map = {
+                                'paragraph': 'text',
+                                'list_unordered': 'list',
+                                'list_ordered': 'list',
+                                'code_fence': 'code',
+                                'table_md': 'table',
+                                'header_line': 'heading',
+                                'header_atx': 'heading',
+                            }
+                            chunks_for_sql = []
+                            for it in flat:
+                                md = it.get('metadata') or {}
+                                ctype = kind_map.get(str(md.get('paragraph_kind') or '').lower(), 'text')
+                                small = {}
+                                if md.get('ancestry_titles'):
+                                    small['ancestry_titles'] = md.get('ancestry_titles')
+                                if md.get('section_path'):
+                                    small['section_path'] = md.get('section_path')
+                                chunks_for_sql.append({
+                                    'text': it.get('text',''),
+                                    'start_char': md.get('start_offset'),
+                                    'end_char': md.get('end_offset'),
+                                    'chunk_type': ctype,
+                                    'metadata': small,
+                                })
+                        except _WEB_SCRAPE_NONCRITICAL_EXCEPTIONS as e:
+                            logger.debug(f"webscraping.persist: chunking failed; storing without chunks: {e}")
+                            try:
+                                if reg:
+                                    reg.increment("app_warning_events_total", 1, {"component": "webscraping", "event": "chunking_failed"})
+                            except _WEB_SCRAPE_NONCRITICAL_EXCEPTIONS:
+                                logger.debug("metrics increment failed for webscraping chunking_failed")
+                            chunks_for_sql = []
 
                     # Run blocking DB write off the event loop and observe latency
                     _t0 = time.perf_counter()

--- a/tldw_Server_API/app/services/enhanced_web_scraping_service.py
+++ b/tldw_Server_API/app/services/enhanced_web_scraping_service.py
@@ -86,11 +86,7 @@ def _web_chunking_form(
 def _normalized_claim_values(values: Any) -> set[str]:
     if not isinstance(values, (list, tuple, set)):
         return set()
-    return {
-        str(value).strip().lower()
-        for value in values
-        if str(value).strip()
-    }
+    return {str(value).strip().lower() for value in values if str(value).strip()}
 
 
 class WebScrapingService:
@@ -115,6 +111,7 @@ class WebScrapingService:
             except Exception as e:
                 logger.error(f"Failed to initialize enhanced scraper: {e}")
                 import traceback
+
                 logger.error(f"Traceback: {traceback.format_exc()}")
                 raise
 
@@ -172,7 +169,8 @@ class WebScrapingService:
         try:
             # Read crawl feature flags (env > config.txt); keep behavior unchanged if params provided
             cfg = load_and_log_configs() or {}
-            wc = cfg.get('web_scraper', {}) if isinstance(cfg, dict) else {}
+            wc = cfg.get("web_scraper", {}) if isinstance(cfg, dict) else {}
+
             def _as_bool(v: Any, d: bool) -> bool:
                 try:
                     s = str(v).strip().lower()
@@ -183,21 +181,23 @@ class WebScrapingService:
                 except _WEB_SCRAPE_CONFIG_PARSE_EXCEPTIONS:
                     pass
                 return d
+
             def _as_int(v: Any, d: int) -> int:
                 try:
                     return int(v)
                 except _WEB_SCRAPE_CONFIG_PARSE_EXCEPTIONS:
                     return d
+
             def _as_float(v: Any, d: float) -> float:
                 try:
                     return float(v)
                 except _WEB_SCRAPE_CONFIG_PARSE_EXCEPTIONS:
                     return d
 
-            crawl_strategy_cfg: str = str(wc.get('web_crawl_strategy', 'default'))
-            include_external_cfg: bool = _as_bool(wc.get('web_crawl_include_external', False), False)
-            score_threshold_cfg: float = _as_float(wc.get('web_crawl_score_threshold', 0.0), 0.0)
-            default_max_pages: int = _as_int(wc.get('web_crawl_max_pages', 100), 100)
+            crawl_strategy_cfg: str = str(wc.get("web_crawl_strategy", "default"))
+            include_external_cfg: bool = _as_bool(wc.get("web_crawl_include_external", False), False)
+            score_threshold_cfg: float = _as_float(wc.get("web_crawl_score_threshold", 0.0), 0.0)
+            default_max_pages: int = _as_int(wc.get("web_crawl_max_pages", 100), 100)
 
             # Effective max-pages precedence:
             # - explicit request value wins
@@ -205,9 +205,7 @@ class WebScrapingService:
             requested_max_pages: Optional[int] = None
             if max_pages is not None:
                 requested_max_pages = _as_int(max_pages, default_max_pages)
-            effective_max_pages: int = (
-                requested_max_pages if requested_max_pages is not None else default_max_pages
-            )
+            effective_max_pages: int = requested_max_pages if requested_max_pages is not None else default_max_pages
             max_pages_source = "request" if requested_max_pages is not None else "config_default"
 
             # Effective overrides with explicit source tracking for observability.
@@ -238,7 +236,7 @@ class WebScrapingService:
                 "low": JobPriority.LOW,
                 "normal": JobPriority.NORMAL,
                 "high": JobPriority.HIGH,
-                "critical": JobPriority.CRITICAL
+                "critical": JobPriority.CRITICAL,
             }
             job_priority = priority_map.get(priority.lower(), JobPriority.NORMAL)
 
@@ -248,19 +246,37 @@ class WebScrapingService:
             # Process based on scraping method
             if scrape_method == "Individual URLs":
                 result = await self._scrape_individual_urls(
-                    url_input, custom_titles, summarize_checkbox,
-                    custom_prompt, api_name, api_key, keywords,
-                    system_prompt, temperature, custom_cookies,
-                    job_priority, user_agent, custom_headers,
+                    url_input,
+                    custom_titles,
+                    summarize_checkbox,
+                    custom_prompt,
+                    api_name,
+                    api_key,
+                    keywords,
+                    system_prompt,
+                    temperature,
+                    custom_cookies,
+                    job_priority,
+                    user_agent,
+                    custom_headers,
                     user_id=user_id,
                 )
 
             elif scrape_method == "Sitemap":
                 result = await self._scrape_sitemap(
-                    url_input, effective_max_pages, summarize_checkbox,
-                    custom_prompt, api_name, api_key, keywords,
-                    system_prompt, temperature, job_priority,
-                    custom_cookies, user_agent, custom_headers,
+                    url_input,
+                    effective_max_pages,
+                    summarize_checkbox,
+                    custom_prompt,
+                    api_name,
+                    api_key,
+                    keywords,
+                    system_prompt,
+                    temperature,
+                    job_priority,
+                    custom_cookies,
+                    user_agent,
+                    custom_headers,
                     user_id=user_id,
                     task_id=task_id,
                 )
@@ -269,10 +285,20 @@ class WebScrapingService:
                 if url_level is None:
                     raise ValueError("url_level must be provided for URL Level scraping")
                 result = await self._scrape_by_url_level(
-                    url_input, url_level, effective_max_pages, summarize_checkbox,
-                    custom_prompt, api_name, api_key, keywords,
-                    system_prompt, temperature, job_priority,
-                    custom_cookies, user_agent, custom_headers,
+                    url_input,
+                    url_level,
+                    effective_max_pages,
+                    summarize_checkbox,
+                    custom_prompt,
+                    api_name,
+                    api_key,
+                    keywords,
+                    system_prompt,
+                    temperature,
+                    job_priority,
+                    custom_cookies,
+                    user_agent,
+                    custom_headers,
                     user_id=user_id,
                     include_external=eff_include_external,
                     score_threshold=eff_score_threshold,
@@ -282,10 +308,20 @@ class WebScrapingService:
 
             elif scrape_method == "Recursive Scraping":
                 result = await self._scrape_recursive(
-                    url_input, effective_max_pages, max_depth, summarize_checkbox,
-                    custom_prompt, api_name, api_key, keywords,
-                    system_prompt, temperature, custom_cookies,
-                    job_priority, user_agent, custom_headers,
+                    url_input,
+                    effective_max_pages,
+                    max_depth,
+                    summarize_checkbox,
+                    custom_prompt,
+                    api_name,
+                    api_key,
+                    keywords,
+                    system_prompt,
+                    temperature,
+                    custom_cookies,
+                    job_priority,
+                    user_agent,
+                    custom_headers,
                     user_id=user_id,
                     include_external=eff_include_external,
                     score_threshold=eff_score_threshold,
@@ -298,27 +334,37 @@ class WebScrapingService:
 
             # Attach crawl configuration used (observable but non-breaking)
             if isinstance(result, dict):
-                result.setdefault('crawl_config', {})
-                result['crawl_config'].update({
-                    'strategy': eff_strategy,
-                    'strategy_source': strategy_source,
-                    'include_external': eff_include_external,
-                    'include_external_source': include_external_source,
-                    'score_threshold': eff_score_threshold,
-                    'score_threshold_source': score_threshold_source,
-                    'default_max_pages': default_max_pages,
-                    'requested_max_pages': requested_max_pages,
-                    'effective_max_pages': effective_max_pages,
-                    'max_pages_source': max_pages_source,
-                    'enable_keyword_scorer': bool(wc.get('web_crawl_enable_keyword_scorer', False)),
-                    'enable_domain_map': bool(wc.get('web_crawl_enable_domain_map', False)),
-                })
+                result.setdefault("crawl_config", {})
+                result["crawl_config"].update(
+                    {
+                        "strategy": eff_strategy,
+                        "strategy_source": strategy_source,
+                        "include_external": eff_include_external,
+                        "include_external_source": include_external_source,
+                        "score_threshold": eff_score_threshold,
+                        "score_threshold_source": score_threshold_source,
+                        "default_max_pages": default_max_pages,
+                        "requested_max_pages": requested_max_pages,
+                        "effective_max_pages": effective_max_pages,
+                        "max_pages_source": max_pages_source,
+                        "enable_keyword_scorer": bool(wc.get("web_crawl_enable_keyword_scorer", False)),
+                        "enable_domain_map": bool(wc.get("web_crawl_enable_domain_map", False)),
+                    }
+                )
 
             # Process results based on mode
             if mode == "ephemeral":
                 stored = await self._store_ephemeral(result, task_id, user_id)
             else:
-                stored = await self._store_persistent(result, keywords, user_id)
+                stored = await self._store_persistent(
+                    result,
+                    keywords,
+                    user_id,
+                    perform_chunking=perform_chunking,
+                    chunking_mode=chunking_mode,
+                    auto_chunking_goal=auto_chunking_goal,
+                    auto_chunking_use_llm=auto_chunking_use_llm,
+                )
                 if isinstance(stored, dict):
                     stored["task_id"] = task_id
             return stored
@@ -328,11 +374,17 @@ class WebScrapingService:
             raise HTTPException(status_code=500, detail="Enhanced web scraping task failed") from e
 
     async def _scrape_individual_urls(
-        self, url_input: str, custom_titles: Optional[str],
-        summarize: bool, custom_prompt: Optional[str],
-        api_name: Optional[str], api_key: Optional[str],
-        keywords: str, system_prompt: Optional[str],
-        temperature: float, custom_cookies: Optional[list[dict[str, Any]]],
+        self,
+        url_input: str,
+        custom_titles: Optional[str],
+        summarize: bool,
+        custom_prompt: Optional[str],
+        api_name: Optional[str],
+        api_key: Optional[str],
+        keywords: str,
+        system_prompt: Optional[str],
+        temperature: float,
+        custom_cookies: Optional[list[dict[str, Any]]],
         priority: JobPriority,
         user_agent: Optional[str],
         custom_headers: Optional[dict[str, str]],
@@ -341,8 +393,8 @@ class WebScrapingService:
     ) -> dict[str, Any]:
         """Scrape individual URLs with enhanced features"""
         # Parse URLs and titles
-        urls = [url.strip() for url in url_input.split('\n') if url.strip()]
-        titles = custom_titles.split('\n') if custom_titles else []
+        urls = [url.strip() for url in url_input.split("\n") if url.strip()]
+        titles = custom_titles.split("\n") if custom_titles else []
 
         # Check if scraper is available
         if self.scraper is None:
@@ -372,28 +424,31 @@ class WebScrapingService:
 
         logger.info(f"Scraping completed, got {len(results)} results")
         for i, result in enumerate(results):
-            logger.debug(f"Result {i}: extraction_successful={result.get('extraction_successful')}, "
-                        f"has_content={bool(result.get('content'))}, "
-                        f"error={result.get('error')}")
+            logger.debug(
+                f"Result {i}: extraction_successful={result.get('extraction_successful')}, "
+                f"has_content={bool(result.get('content'))}, "
+                f"error={result.get('error')}"
+            )
 
         # Apply custom titles if provided
         for i, result in enumerate(results):
             if i < len(titles) and titles[i]:
-                result['title'] = titles[i]
+                result["title"] = titles[i]
 
-        return {
-            "method": "Individual URLs",
-            "total_articles": len(results),
-            "articles": results,
-            "keywords": keywords
-        }
+        return {"method": "Individual URLs", "total_articles": len(results), "articles": results, "keywords": keywords}
 
     async def _scrape_sitemap(
-        self, sitemap_url: str, max_pages: int,
-        summarize: bool, custom_prompt: Optional[str],
-        api_name: Optional[str], api_key: Optional[str],
-        keywords: str, system_prompt: Optional[str],
-        temperature: float, priority: JobPriority,
+        self,
+        sitemap_url: str,
+        max_pages: int,
+        summarize: bool,
+        custom_prompt: Optional[str],
+        api_name: Optional[str],
+        api_key: Optional[str],
+        keywords: str,
+        system_prompt: Optional[str],
+        temperature: float,
+        priority: JobPriority,
         custom_cookies: Optional[list[dict[str, Any]]],
         user_agent: Optional[str],
         custom_headers: Optional[dict[str, str]],
@@ -422,28 +477,33 @@ class WebScrapingService:
         # Add summarization if requested
         if summarize:
             for result in results:
-                if result.get('extraction_successful') and result.get('content'):
+                if result.get("extraction_successful") and result.get("content"):
                     summary = await self._summarize_content(
-                        result['content'],
-                        custom_prompt, api_name, api_key,
-                        system_prompt, temperature
+                        result["content"], custom_prompt, api_name, api_key, system_prompt, temperature
                     )
-                    result['summary'] = summary
+                    result["summary"] = summary
 
         return {
             "method": "Sitemap",
             "total_articles": len(results),
             "articles": results,
             "keywords": keywords,
-            "sitemap_url": sitemap_url
+            "sitemap_url": sitemap_url,
         }
 
     async def _scrape_by_url_level(
-        self, base_url: str, url_level: int, max_pages: int,
-        summarize: bool, custom_prompt: Optional[str],
-        api_name: Optional[str], api_key: Optional[str],
-        keywords: str, system_prompt: Optional[str],
-        temperature: float, priority: JobPriority,
+        self,
+        base_url: str,
+        url_level: int,
+        max_pages: int,
+        summarize: bool,
+        custom_prompt: Optional[str],
+        api_name: Optional[str],
+        api_key: Optional[str],
+        keywords: str,
+        system_prompt: Optional[str],
+        temperature: float,
+        priority: JobPriority,
         custom_cookies: Optional[list[dict[str, Any]]],
         user_agent: Optional[str],
         custom_headers: Optional[dict[str, str]],
@@ -455,10 +515,12 @@ class WebScrapingService:
         task_id: Optional[str] = None,
     ) -> dict[str, Any]:
         """Scrape by URL level"""
+
         # Define URL level filter
         def url_level_filter(url: str) -> bool:
             from urllib.parse import urlparse
-            path_parts = urlparse(url).path.strip('/').split('/')
+
+            path_parts = urlparse(url).path.strip("/").split("/")
             return len(path_parts) <= url_level and is_content_page(url)
 
         # Recursive scrape with level filter
@@ -480,28 +542,33 @@ class WebScrapingService:
         # Add summarization if requested
         if summarize:
             for result in results:
-                if result.get('extraction_successful') and result.get('content'):
+                if result.get("extraction_successful") and result.get("content"):
                     summary = await self._summarize_content(
-                        result['content'],
-                        custom_prompt, api_name, api_key,
-                        system_prompt, temperature
+                        result["content"], custom_prompt, api_name, api_key, system_prompt, temperature
                     )
-                    result['summary'] = summary
+                    result["summary"] = summary
 
         return {
             "method": "URL Level",
             "total_articles": len(results),
             "articles": results,
             "keywords": keywords,
-            "url_level": url_level
+            "url_level": url_level,
         }
 
     async def _scrape_recursive(
-        self, base_url: str, max_pages: int, max_depth: int,
-        summarize: bool, custom_prompt: Optional[str],
-        api_name: Optional[str], api_key: Optional[str],
-        keywords: str, system_prompt: Optional[str],
-        temperature: float, custom_cookies: Optional[list[dict[str, Any]]],
+        self,
+        base_url: str,
+        max_pages: int,
+        max_depth: int,
+        summarize: bool,
+        custom_prompt: Optional[str],
+        api_name: Optional[str],
+        api_key: Optional[str],
+        keywords: str,
+        system_prompt: Optional[str],
+        temperature: float,
+        custom_cookies: Optional[list[dict[str, Any]]],
         priority: JobPriority,
         user_agent: Optional[str],
         custom_headers: Optional[dict[str, str]],
@@ -537,13 +604,11 @@ class WebScrapingService:
             # Add summarization if requested
             if summarize:
                 for result in results:
-                    if result.get('extraction_successful') and result.get('content'):
+                    if result.get("extraction_successful") and result.get("content"):
                         summary = await self._summarize_content(
-                            result['content'],
-                            custom_prompt, api_name, api_key,
-                            system_prompt, temperature
+                            result["content"], custom_prompt, api_name, api_key, system_prompt, temperature
                         )
-                        result['summary'] = summary
+                        result["summary"] = summary
 
             # Save final progress
             await self.scraper.save_progress(progress_key, progress_file)
@@ -554,7 +619,7 @@ class WebScrapingService:
                 "articles": results,
                 "keywords": keywords,
                 "max_depth": max_depth,
-                "progress_file": str(progress_file)
+                "progress_file": str(progress_file),
             }
 
         except Exception:
@@ -563,37 +628,47 @@ class WebScrapingService:
             raise
 
     async def _summarize_content(
-        self, content: str, custom_prompt: Optional[str],
-        api_name: Optional[str], api_key: Optional[str],
-        system_prompt: Optional[str], temperature: float
+        self,
+        content: str,
+        custom_prompt: Optional[str],
+        api_name: Optional[str],
+        api_key: Optional[str],
+        system_prompt: Optional[str],
+        temperature: float,
     ) -> str:
         """Summarize content using LLM"""
         try:
             # Provide default prompts from Prompts/webscraping if not supplied
-            custom_prompt = custom_prompt or load_prompt("webscraping", "article_summary_user") or "Summarize this article concisely."
-            system_prompt = system_prompt or load_prompt("webscraping", "article_summary_system") or "You are a professional summarizer."
+            custom_prompt = (
+                custom_prompt
+                or load_prompt("webscraping", "article_summary_user")
+                or "Summarize this article concisely."
+            )
+            system_prompt = (
+                system_prompt
+                or load_prompt("webscraping", "article_summary_system")
+                or "You are a professional summarizer."
+            )
             summary = analyze(
                 input_data=content,
                 custom_prompt_arg=custom_prompt,
                 api_name=api_name or "openai",
                 api_key=api_key,
                 temp=temperature,
-                system_message=system_prompt
+                system_message=system_prompt,
             )
             return summary
         except _WEB_SCRAPE_NONCRITICAL_EXCEPTIONS as e:
             logger.error(f"Summarization failed: {e}")
             return "Summary generation failed"
 
-    async def _store_ephemeral(
-        self, result: dict[str, Any], task_id: str, user_id: Optional[int]
-    ) -> dict[str, Any]:
+    async def _store_ephemeral(self, result: dict[str, Any], task_id: str, user_id: Optional[int]) -> dict[str, Any]:
         """Store results in ephemeral storage"""
         ephemeral_data = {
             "task_id": task_id,
             "user_id": user_id,
             "timestamp": datetime.now().isoformat(),
-            "result": result
+            "result": result,
         }
 
         ephemeral_id = ephemeral_storage.store_data(ephemeral_data)
@@ -606,12 +681,22 @@ class WebScrapingService:
             "method": result.get("method"),
             "preview": {
                 "articles": len(result.get("articles", [])),
-                "first_article": result.get("articles", [{}])[0].get("title", "N/A") if result.get("articles") else None
-            }
+                "first_article": (
+                    result.get("articles", [{}])[0].get("title", "N/A") if result.get("articles") else None
+                ),
+            },
         }
 
     async def _store_persistent(
-        self, result: dict[str, Any], keywords: str, user_id: Optional[int]
+        self,
+        result: dict[str, Any],
+        keywords: str,
+        user_id: Optional[int],
+        *,
+        perform_chunking: bool,
+        chunking_mode: str | None,
+        auto_chunking_goal: str,
+        auto_chunking_use_llm: bool,
     ) -> dict[str, Any]:
         """Store results in database"""
         media_ids = []
@@ -632,7 +717,11 @@ class WebScrapingService:
             # Metrics
             try:
                 reg = get_metrics_registry()
-                reg.set_gauge("webscraping.persist.last_batch_articles", float(len(result.get("articles", []))), {"method": str(result.get("method", "unknown"))})
+                reg.set_gauge(
+                    "webscraping.persist.last_batch_articles",
+                    float(len(result.get("articles", []))),
+                    {"method": str(result.get("method", "unknown"))},
+                )
             except _WEB_SCRAPE_NONCRITICAL_EXCEPTIONS:
                 reg = None
             chunking_form = _web_chunking_form(
@@ -643,8 +732,10 @@ class WebScrapingService:
             )
             _batch_t0 = time.perf_counter()
             for article in result.get("articles", []):
-                logger.debug(f"Processing article: url={article.get('url')}, "
-                            f"extraction_successful={article.get('extraction_successful')}")
+                logger.debug(
+                    f"Processing article: url={article.get('url')}, "
+                    f"extraction_successful={article.get('extraction_successful')}"
+                )
                 if not article.get("extraction_successful"):
                     error_msg = f"Failed to extract: {article.get('url', 'Unknown URL')}"
                     logger.warning(error_msg)
@@ -658,31 +749,21 @@ class WebScrapingService:
                         "author": article.get("author", "Unknown"),
                         "source": article.get("url", ""),
                         "scrape_method": result.get("method", "Unknown"),
-                        "extraction_date": datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+                        "extraction_date": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
                     }
 
                     # Format content with metadata
                     # Include crawl metadata (depth, parent_url, score) if present
                     md = article.get("metadata") if isinstance(article.get("metadata"), dict) else {}
-                    crawl_depth = (
-                        md.get("depth")
-                        if md.get("depth") is not None
-                        else md.get("crawl_depth")
-                    )
+                    crawl_depth = md.get("depth") if md.get("depth") is not None else md.get("crawl_depth")
                     if crawl_depth is None:
                         crawl_depth = article.get("crawl_depth")
                     crawl_parent = (
-                        md.get("parent_url")
-                        if md.get("parent_url") is not None
-                        else md.get("crawl_parent_url")
+                        md.get("parent_url") if md.get("parent_url") is not None else md.get("crawl_parent_url")
                     )
                     if crawl_parent is None:
                         crawl_parent = article.get("crawl_parent_url")
-                    crawl_score = (
-                        md.get("score")
-                        if md.get("score") is not None
-                        else md.get("crawl_score")
-                    )
+                    crawl_score = md.get("score") if md.get("score") is not None else md.get("crawl_score")
                     if crawl_score is None:
                         crawl_score = article.get("crawl_score")
 
@@ -709,7 +790,7 @@ class WebScrapingService:
                             "crawl_depth": crawl_depth,
                             "crawl_parent_url": crawl_parent,
                             "crawl_score": crawl_score,
-                        }
+                        },
                     )
                     chunk_options = None
                     chunking_plan = None
@@ -742,14 +823,16 @@ class WebScrapingService:
                     }
                     if chunking_plan:
                         safe_meta["chunking_plan"] = chunking_plan
-                    safe_metadata_json = json.dumps({k: v for k, v in safe_meta.items() if v is not None}, ensure_ascii=False)
+                    safe_metadata_json = json.dumps(
+                        {k: v for k, v in safe_meta.items() if v is not None}, ensure_ascii=False
+                    )
 
                     # Build plaintext chunks for chunk-level FTS
                     if not perform_chunking:
                         chunks_for_sql = []
                     else:
                         try:
-                        # Chunk in a worker thread to avoid blocking the event loop for long documents
+                            # Chunk in a worker thread to avoid blocking the event loop for long documents
                             options = chunk_options or {
                                 "method": "sentences",
                                 "max_size": 500,
@@ -765,35 +848,41 @@ class WebScrapingService:
                                 )
                             )
                             kind_map = {
-                                'paragraph': 'text',
-                                'list_unordered': 'list',
-                                'list_ordered': 'list',
-                                'code_fence': 'code',
-                                'table_md': 'table',
-                                'header_line': 'heading',
-                                'header_atx': 'heading',
+                                "paragraph": "text",
+                                "list_unordered": "list",
+                                "list_ordered": "list",
+                                "code_fence": "code",
+                                "table_md": "table",
+                                "header_line": "heading",
+                                "header_atx": "heading",
                             }
                             chunks_for_sql = []
                             for it in flat:
-                                md = it.get('metadata') or {}
-                                ctype = kind_map.get(str(md.get('paragraph_kind') or '').lower(), 'text')
+                                md = it.get("metadata") or {}
+                                ctype = kind_map.get(str(md.get("paragraph_kind") or "").lower(), "text")
                                 small = {}
-                                if md.get('ancestry_titles'):
-                                    small['ancestry_titles'] = md.get('ancestry_titles')
-                                if md.get('section_path'):
-                                    small['section_path'] = md.get('section_path')
-                                chunks_for_sql.append({
-                                    'text': it.get('text',''),
-                                    'start_char': md.get('start_offset'),
-                                    'end_char': md.get('end_offset'),
-                                    'chunk_type': ctype,
-                                    'metadata': small,
-                                })
+                                if md.get("ancestry_titles"):
+                                    small["ancestry_titles"] = md.get("ancestry_titles")
+                                if md.get("section_path"):
+                                    small["section_path"] = md.get("section_path")
+                                chunks_for_sql.append(
+                                    {
+                                        "text": it.get("text", ""),
+                                        "start_char": md.get("start_offset"),
+                                        "end_char": md.get("end_offset"),
+                                        "chunk_type": ctype,
+                                        "metadata": small,
+                                    }
+                                )
                         except _WEB_SCRAPE_NONCRITICAL_EXCEPTIONS as e:
                             logger.debug(f"webscraping.persist: chunking failed; storing without chunks: {e}")
                             try:
                                 if reg:
-                                    reg.increment("app_warning_events_total", 1, {"component": "webscraping", "event": "chunking_failed"})
+                                    reg.increment(
+                                        "app_warning_events_total",
+                                        1,
+                                        {"component": "webscraping", "event": "chunking_failed"},
+                                    )
                             except _WEB_SCRAPE_NONCRITICAL_EXCEPTIONS:
                                 logger.debug("metrics increment failed for webscraping chunking_failed")
                             chunks_for_sql = []
@@ -814,12 +903,16 @@ class WebScrapingService:
                         author=article.get("author", None),
                         ingestion_date=None,  # Will use current time
                         overwrite=False,
-                        chunks=chunks_for_sql
+                        chunks=chunks_for_sql,
                     )
                     _dt = max(0.0, time.perf_counter() - _t0)
                     try:
                         if reg:
-                            reg.observe("webscraping.persist.article_duration_seconds", _dt, {"method": str(result.get("method", "unknown"))})
+                            reg.observe(
+                                "webscraping.persist.article_duration_seconds",
+                                _dt,
+                                {"method": str(result.get("method", "unknown"))},
+                            )
                     except _WEB_SCRAPE_NONCRITICAL_EXCEPTIONS as me:
                         logger.debug(f"webscraping.persist: metric observe failed: {me}")
 
@@ -828,14 +921,22 @@ class WebScrapingService:
                         logger.info(f"Stored article with media_id: {media_id}, uuid: {media_uuid}")
                         try:
                             if reg:
-                                reg.increment("webscraping.persist.stored_total", 1, {"method": str(result.get("method", "unknown"))})
+                                reg.increment(
+                                    "webscraping.persist.stored_total",
+                                    1,
+                                    {"method": str(result.get("method", "unknown"))},
+                                )
                         except _WEB_SCRAPE_NONCRITICAL_EXCEPTIONS as me:
                             logger.debug(f"webscraping.persist: metric increment failed: {me}")
                     else:
                         logger.warning(f"Failed to get media_id for article: {article.get('url')}")
                         try:
                             if reg:
-                                reg.increment("webscraping.persist.failed_total", 1, {"method": str(result.get("method", "unknown"))})
+                                reg.increment(
+                                    "webscraping.persist.failed_total",
+                                    1,
+                                    {"method": str(result.get("method", "unknown"))},
+                                )
                         except _WEB_SCRAPE_NONCRITICAL_EXCEPTIONS as me:
                             logger.debug(f"webscraping.persist: metric increment failed: {me}")
 
@@ -844,14 +945,20 @@ class WebScrapingService:
                     errors.append("Storage failed for article")
                     try:
                         if reg:
-                            reg.increment("webscraping.persist.failed_total", 1, {"method": str(result.get("method", "unknown"))})
+                            reg.increment(
+                                "webscraping.persist.failed_total", 1, {"method": str(result.get("method", "unknown"))}
+                            )
                     except _WEB_SCRAPE_NONCRITICAL_EXCEPTIONS as me:
                         logger.debug(f"webscraping.persist: metric increment failed: {me}")
 
             try:
                 if reg:
                     _batch_dt = max(0.0, time.perf_counter() - _batch_t0)
-                    reg.observe("webscraping.persist.batch_duration_seconds", _batch_dt, {"method": str(result.get("method", "unknown"))})
+                    reg.observe(
+                        "webscraping.persist.batch_duration_seconds",
+                        _batch_dt,
+                        {"method": str(result.get("method", "unknown"))},
+                    )
             except _WEB_SCRAPE_NONCRITICAL_EXCEPTIONS as me:
                 logger.debug(f"webscraping.persist: batch metric observe failed: {me}")
 
@@ -861,15 +968,13 @@ class WebScrapingService:
             "total_articles": len(result.get("articles", [])),
             "stored_articles": len(media_ids),
             "method": result.get("method"),
-            "errors": errors if errors else None
+            "errors": errors if errors else None,
         }
 
     def _is_admin_user(self, user: Any) -> bool:
         if user is None:
             return False
-        role = str(
-            user.get("role", "") if isinstance(user, dict) else getattr(user, "role", "")
-        ).strip().lower()
+        role = str(user.get("role", "") if isinstance(user, dict) else getattr(user, "role", "")).strip().lower()
         if role in _PLATFORM_ADMIN_ROLES:
             return True
         roles = _normalized_claim_values(
@@ -936,10 +1041,7 @@ class WebScrapingService:
     def get_service_status(self) -> dict[str, Any]:
         """Get service status and statistics"""
         if not self._initialized:
-            return {
-                "status": "not_initialized",
-                "initialized": False
-            }
+            return {"status": "not_initialized", "initialized": False}
 
         if self.scraper is None:
             return {
@@ -949,9 +1051,7 @@ class WebScrapingService:
                 "queue": {
                     "active_jobs": 0,
                     "completed_jobs": 0,
-                    "pending_by_priority": {
-                        priority.name: 0 for priority in JobPriority
-                    },
+                    "pending_by_priority": {priority.name: 0 for priority in JobPriority},
                 },
                 "active_jobs": 0,
                 "rate_limiter": None,
@@ -967,8 +1067,8 @@ class WebScrapingService:
             "rate_limiter": {
                 "max_rps": self.scraper.rate_limiter.max_rps,
                 "max_rpm": self.scraper.rate_limiter.max_rpm,
-                "max_rph": self.scraper.rate_limiter.max_rph
-            }
+                "max_rph": self.scraper.rate_limiter.max_rph,
+            },
         }
 
 

--- a/tldw_Server_API/app/services/media_ingest_jobs_worker.py
+++ b/tldw_Server_API/app/services/media_ingest_jobs_worker.py
@@ -184,9 +184,7 @@ async def _schedule_embeddings(
             or "sentence-transformers/all-MiniLM-L6-v2"
         )
         embedding_provider = (
-            form_data.embedding_provider
-            or embedding_settings.get("embedding_provider")
-            or "huggingface"
+            form_data.embedding_provider or embedding_settings.get("embedding_provider") or "huggingface"
         )
 
         result = await generate_embeddings_for_media(
@@ -346,6 +344,13 @@ async def _handle_job(job: dict[str, Any], jm: JobManager, progress: _ProgressSt
         jm.update_job_progress(job_id, progress_percent=progress.percent, progress_message=progress.message)
 
         if isinstance(result_item, dict):
+            final_chunking_plan = chunking_plan
+            result_metadata = result_item.get("metadata")
+            if isinstance(result_metadata, dict) and isinstance(
+                result_metadata.get("chunking_plan"),
+                dict,
+            ):
+                final_chunking_plan = result_metadata["chunking_plan"]
             job_result = {
                 "status": result_item.get("status"),
                 "media_id": result_item.get("db_id"),
@@ -354,8 +359,8 @@ async def _handle_job(job: dict[str, Any], jm: JobManager, progress: _ProgressSt
                 "warnings": result_item.get("warnings"),
                 "db_message": result_item.get("db_message"),
             }
-            if chunking_plan is not None:
-                job_result["chunking_plan"] = chunking_plan
+            if final_chunking_plan is not None:
+                job_result["chunking_plan"] = final_chunking_plan
             return job_result
         return {"status": "Error", "error": "No result produced"}
 
@@ -374,17 +379,13 @@ async def run_media_ingest_jobs_worker(
     worker_id: str | None = None,
 ) -> None:
     if JobManager._ACQUIRE_GATE_ENABLED:
-        logger.warning(
-            "Media Ingest Jobs worker starting with acquire gate enabled; clearing stale gate state"
-        )
+        logger.warning("Media Ingest Jobs worker starting with acquire gate enabled; clearing stale gate state")
     JobManager.set_acquire_gate(False)
 
     jm = _jobs_manager()
     queue_name = _resolve_worker_queue(queue)
     resolved_worker_id = (
-        str(worker_id).strip()
-        if worker_id and str(worker_id).strip()
-        else f"media-ingest-worker-{queue_name}"
+        str(worker_id).strip() if worker_id and str(worker_id).strip() else f"media-ingest-worker-{queue_name}"
     )
     cfg = _build_worker_config(worker_id=resolved_worker_id, queue=queue_name)
     sdk = WorkerSDK(jm, cfg)
@@ -424,10 +425,7 @@ async def run_media_ingest_jobs_worker(
 
 
 async def run_media_ingest_heavy_jobs_worker(stop_event: asyncio.Event | None = None) -> None:
-    heavy_queue = (
-        (os.getenv("MEDIA_INGEST_JOBS_HEAVY_QUEUE") or "").strip()
-        or "low"
-    )
+    heavy_queue = (os.getenv("MEDIA_INGEST_JOBS_HEAVY_QUEUE") or "").strip() or "low"
     await run_media_ingest_jobs_worker(
         stop_event,
         queue=heavy_queue,

--- a/tldw_Server_API/app/services/media_ingest_jobs_worker.py
+++ b/tldw_Server_API/app/services/media_ingest_jobs_worker.py
@@ -21,6 +21,7 @@ from tldw_Server_API.app.core.DB_Management.media_db.errors import ConflictError
 from tldw_Server_API.app.core.Ingestion_Media_Processing.chunking_options import (
     apply_chunking_template_if_any,
     prepare_chunking_options_dict,
+    resolve_chunking_options_and_plan,
 )
 from tldw_Server_API.app.core.Ingestion_Media_Processing.persistence import (
     process_batch_media,
@@ -255,8 +256,12 @@ async def _handle_job(job: dict[str, Any], jm: JobManager, progress: _ProgressSt
         def cancel_check():
             return _should_cancel(jm, job_id)
 
-        chunk_options = prepare_chunking_options_dict(form_data)
-        if chunk_options is not None:
+        chunk_options, chunking_plan = resolve_chunking_options_and_plan(
+            form_data,
+            media_type=str(form_data.media_type) if form_data.media_type else None,
+            source_name=str(input_ref or source),
+        )
+        if chunk_options is not None and chunking_plan is None:
             try:
                 first_url = source if source_kind == "url" else None
                 first_filename = payload.get("original_filename")
@@ -341,7 +346,7 @@ async def _handle_job(job: dict[str, Any], jm: JobManager, progress: _ProgressSt
         jm.update_job_progress(job_id, progress_percent=progress.percent, progress_message=progress.message)
 
         if isinstance(result_item, dict):
-            return {
+            job_result = {
                 "status": result_item.get("status"),
                 "media_id": result_item.get("db_id"),
                 "media_uuid": result_item.get("media_uuid"),
@@ -349,6 +354,9 @@ async def _handle_job(job: dict[str, Any], jm: JobManager, progress: _ProgressSt
                 "warnings": result_item.get("warnings"),
                 "db_message": result_item.get("db_message"),
             }
+            if chunking_plan is not None:
+                job_result["chunking_plan"] = chunking_plan
+            return job_result
         return {"status": "Error", "error": "No result produced"}
 
     finally:

--- a/tldw_Server_API/app/services/web_scraping_service.py
+++ b/tldw_Server_API/app/services/web_scraping_service.py
@@ -8,6 +8,7 @@ import asyncio
 import contextlib
 import json
 import logging
+from types import SimpleNamespace
 from typing import Any, Optional
 
 #
@@ -22,6 +23,10 @@ from tldw_Server_API.app.core.DB_Management.media_db.api import (
     managed_media_database,
 )
 from tldw_Server_API.app.core.deprecations import log_runtime_deprecation
+from tldw_Server_API.app.core.Ingestion_Media_Processing.chunking_options import (
+    attach_chunking_plan_to_result,
+    resolve_chunking_options_and_plan,
+)
 from tldw_Server_API.app.core.LLM_Calls.Summarization_General_Lib import analyze
 from tldw_Server_API.app.core.testing import env_flag_enabled
 
@@ -111,6 +116,30 @@ def _collect_fallback_unsupported_controls(
     return sorted(set(unsupported))
 
 
+def _web_chunking_form(
+    *,
+    perform_chunking: bool,
+    chunking_mode: str | None,
+    auto_chunking_goal: str,
+    auto_chunking_use_llm: bool,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        media_type="web",
+        perform_chunking=perform_chunking,
+        chunking_mode=chunking_mode,
+        auto_chunking_goal=auto_chunking_goal,
+        auto_chunking_use_llm=auto_chunking_use_llm,
+        chunk_method=None,
+        chunk_size=500,
+        chunk_overlap=200,
+        chunk_language=None,
+        use_adaptive_chunking=False,
+        use_multi_level_chunking=False,
+        hierarchical_chunking=False,
+        hierarchical_template=None,
+    )
+
+
 def _build_fallback_context(
     *,
     fallback_error: Exception,
@@ -153,6 +182,10 @@ async def process_web_scraping_task(
     crawl_strategy: Optional[str] = None,
     include_external: Optional[bool] = None,
     score_threshold: Optional[float] = None,
+    perform_chunking: bool = True,
+    chunking_mode: Optional[str] = None,
+    auto_chunking_goal: str = "balanced",
+    auto_chunking_use_llm: bool = False,
 ) -> dict[str, Any]:
     """
     Enhanced web scraping with production features:
@@ -264,6 +297,10 @@ async def process_web_scraping_task(
             crawl_strategy=crawl_strategy,
             include_external=include_external,
             score_threshold=score_threshold,
+            perform_chunking=perform_chunking,
+            chunking_mode=chunking_mode,
+            auto_chunking_goal=auto_chunking_goal,
+            auto_chunking_use_llm=auto_chunking_use_llm,
         )
 
         return result
@@ -382,6 +419,12 @@ async def process_web_scraping_task(
                 )
 
             fallback_context["degraded_controls_applied"] = degraded_controls
+            chunking_form = _web_chunking_form(
+                perform_chunking=perform_chunking,
+                chunking_mode=chunking_mode,
+                auto_chunking_goal=auto_chunking_goal,
+                auto_chunking_use_llm=auto_chunking_use_llm,
+            )
 
             # 2) Summarize after the fact, if the method doesn't handle it
             #    (For "Individual URLs," you already did so inside scrape_and_summarize_multiple.)
@@ -406,6 +449,18 @@ async def process_web_scraping_task(
             # 3) If "persist" mode, insert into DB; if ephemeral, store ephemeral
             #    (We can store all articles in the DB or ephemeral. Typically you'd store each as a new "media" row.)
             if mode == "ephemeral":
+                if perform_chunking:
+                    for article in result_list:
+                        if not isinstance(article, dict):
+                            continue
+                        content_text = article.get("content")
+                        chunk_options, chunking_plan = resolve_chunking_options_and_plan(
+                            chunking_form,
+                            media_type="web",
+                            source_name=str(article.get("url") or ""),
+                            extracted_text=content_text if isinstance(content_text, str) else None,
+                        )
+                        attach_chunking_plan_to_result(article, chunking_plan)
                 # Just store the entire "result_list" in ephemeral, returning the ephemeral ID.
                 # Or store each article individually. Up to you. We'll do one ephemeral object:
                 ephemeral_id = ephemeral_storage.store_data({"articles": result_list})
@@ -438,6 +493,16 @@ async def process_web_scraping_task(
                         # We'll treat article['content'] as the main text
                         # Combine content and metadata
                         content_text = article.get("content", "")
+                        chunk_options = None
+                        chunking_plan = None
+                        if perform_chunking:
+                            chunk_options, chunking_plan = resolve_chunking_options_and_plan(
+                                chunking_form,
+                                media_type="web",
+                                source_name=str(article.get("url") or ""),
+                                extracted_text=content_text if isinstance(content_text, str) else None,
+                            )
+                            attach_chunking_plan_to_result(article, chunking_plan)
 
                         # Fix the function call to match the actual signature
                         # Build safe metadata
@@ -447,40 +512,55 @@ async def process_web_scraping_task(
                             "url": article.get("url"),
                             "source": "web",
                         }
+                        if chunking_plan:
+                            safe_meta["chunking_plan"] = chunking_plan
                         safe_metadata_json = json.dumps({k: v for k, v in safe_meta.items() if v is not None}, ensure_ascii=False)
 
                         # Build plaintext chunks for FTS-first retrieval
-                        try:
-                            ck = Chunker()
-                            # Use sane defaults in fallback path
-                            flat = ck.chunk_text_hierarchical_flat(content_text, method='sentences')
-                            kind_map = {
-                                'paragraph': 'text',
-                                'list_unordered': 'list',
-                                'list_ordered': 'list',
-                                'code_fence': 'code',
-                                'table_md': 'table',
-                                'header_line': 'heading',
-                                'header_atx': 'heading',
-                            }
+                        if not perform_chunking:
                             chunks_for_sql = []
-                            for it in flat:
-                                md = it.get('metadata') or {}
-                                ctype = kind_map.get(str(md.get('paragraph_kind') or '').lower(), 'text')
-                                small = {}
-                                if md.get('ancestry_titles'):
-                                    small['ancestry_titles'] = md.get('ancestry_titles')
-                                if md.get('section_path'):
-                                    small['section_path'] = md.get('section_path')
-                                chunks_for_sql.append({
-                                    'text': it.get('text',''),
-                                    'start_char': md.get('start_offset'),
-                                    'end_char': md.get('end_offset'),
-                                    'chunk_type': ctype,
-                                    'metadata': small,
-                                })
-                        except Exception:
-                            chunks_for_sql = []
+                        else:
+                            try:
+                                ck = Chunker()
+                                options = chunk_options or {
+                                    "method": "sentences",
+                                    "max_size": 500,
+                                    "overlap": 200,
+                                }
+                                flat = ck.chunk_text_hierarchical_flat(
+                                    content_text,
+                                    method=options.get("method") or "sentences",
+                                    max_size=options.get("max_size") or 500,
+                                    overlap=options.get("overlap") or 200,
+                                    language=options.get("language"),
+                                )
+                                kind_map = {
+                                    'paragraph': 'text',
+                                    'list_unordered': 'list',
+                                    'list_ordered': 'list',
+                                    'code_fence': 'code',
+                                    'table_md': 'table',
+                                    'header_line': 'heading',
+                                    'header_atx': 'heading',
+                                }
+                                chunks_for_sql = []
+                                for it in flat:
+                                    md = it.get('metadata') or {}
+                                    ctype = kind_map.get(str(md.get('paragraph_kind') or '').lower(), 'text')
+                                    small = {}
+                                    if md.get('ancestry_titles'):
+                                        small['ancestry_titles'] = md.get('ancestry_titles')
+                                    if md.get('section_path'):
+                                        small['section_path'] = md.get('section_path')
+                                    chunks_for_sql.append({
+                                        'text': it.get('text',''),
+                                        'start_char': md.get('start_offset'),
+                                        'end_char': md.get('end_offset'),
+                                        'chunk_type': ctype,
+                                        'metadata': small,
+                                    })
+                            except Exception:
+                                chunks_for_sql = []
 
                         media_id, media_uuid, message = get_media_repository(db).add_media_with_keywords(
                             url=article.get("url", ""),
@@ -772,6 +852,12 @@ async def ingest_web_content_orchestrate(
                 crawl_strategy=getattr(request, "crawl_strategy", None),
                 include_external=getattr(request, "include_external", None),
                 score_threshold=getattr(request, "score_threshold", None),
+                perform_chunking=bool(getattr(request, "perform_chunking", True)),
+                chunking_mode=getattr(request, "chunking_mode", None),
+                auto_chunking_goal=getattr(request, "auto_chunking_goal", "balanced"),
+                auto_chunking_use_llm=bool(
+                    getattr(request, "auto_chunking_use_llm", False)
+                ),
             )
             articles: list[dict[str, Any]] = []
             if isinstance(service_result, dict):
@@ -842,6 +928,12 @@ async def ingest_web_content_orchestrate(
                 crawl_strategy=getattr(request, "crawl_strategy", None),
                 include_external=getattr(request, "include_external", None),
                 score_threshold=getattr(request, "score_threshold", None),
+                perform_chunking=bool(getattr(request, "perform_chunking", True)),
+                chunking_mode=getattr(request, "chunking_mode", None),
+                auto_chunking_goal=getattr(request, "auto_chunking_goal", "balanced"),
+                auto_chunking_use_llm=bool(
+                    getattr(request, "auto_chunking_use_llm", False)
+                ),
             )
             articles: list[dict[str, Any]] = []
             if isinstance(service_result, list):

--- a/tldw_Server_API/app/services/web_scraping_service.py
+++ b/tldw_Server_API/app/services/web_scraping_service.py
@@ -14,6 +14,7 @@ from typing import Any, Optional
 #
 # Third-party Libraries
 from fastapi import HTTPException
+from loguru import logger
 
 from tldw_Server_API.app.api.v1.schemas.media_request_models import ScrapeMethod
 from tldw_Server_API.app.core.Chunking.chunker import Chunker
@@ -94,9 +95,7 @@ def _collect_fallback_unsupported_controls(
     if custom_headers:
         unsupported.append("custom_headers")
 
-    score_threshold_active = (
-        score_threshold is not None and float(score_threshold) > 0.0
-    )
+    score_threshold_active = score_threshold is not None and float(score_threshold) > 0.0
 
     if scrape_method == "Recursive Scraping":
         if normalized_strategy and normalized_strategy != "default":
@@ -158,6 +157,7 @@ def _build_fallback_context(
 
 def _legacy_web_scraping_fallback_enabled() -> bool:
     return env_flag_enabled("TLDW_ENABLE_LEGACY_WEB_SCRAPING_FALLBACK")
+
 
 async def process_web_scraping_task(
     scrape_method: str,
@@ -241,18 +241,12 @@ async def process_web_scraping_task(
         except (TypeError, ValueError):
             raise HTTPException(
                 status_code=400,
-                detail=(
-                    f"score_threshold must be a float between 0.0 and 1.0; "
-                    f"got {score_threshold!r}."
-                ),
+                detail=(f"score_threshold must be a float between 0.0 and 1.0; " f"got {score_threshold!r}."),
             ) from None
         if not 0.0 <= normalized_score_threshold <= 1.0:
             raise HTTPException(
                 status_code=400,
-                detail=(
-                    "score_threshold must be between 0.0 and 1.0 inclusive; "
-                    f"got {normalized_score_threshold}."
-                ),
+                detail=("score_threshold must be between 0.0 and 1.0 inclusive; " f"got {normalized_score_threshold}."),
             )
 
     if normalized_crawl_strategy is not None:
@@ -267,7 +261,7 @@ async def process_web_scraping_task(
         # Determine priority based on number of URLs or max_pages
         priority = "normal"
         if scrape_method == "Individual URLs":
-            url_count = len([u for u in url_input.split('\n') if u.strip()])
+            url_count = len([u for u in url_input.split("\n") if u.strip()])
             if url_count > 10:
                 priority = "high"
         elif (max_pages or 0) > 50:
@@ -306,17 +300,10 @@ async def process_web_scraping_task(
         return result
 
     except Exception as e:
-        # Log error with full details
-        import logging
-        import traceback
-        logging.exception(f"Enhanced scraping service failed: {str(e)}")
-        logging.exception(f"Full traceback: {traceback.format_exc()}")
+        logger.exception("Enhanced scraping service failed: {}", e)
         log_runtime_deprecation(
             "web_scraping_legacy_fallback",
-            message=(
-                "Enhanced web scraping service failed; using deprecated "
-                "runtime compatibility fallback."
-            ),
+            message=("Enhanced web scraping service failed; using deprecated " "runtime compatibility fallback."),
         )
         if not _legacy_web_scraping_fallback_enabled():
             raise HTTPException(
@@ -367,7 +354,7 @@ async def process_web_scraping_task(
                     system_prompt=system_prompt,
                     summarize_checkbox=summarize_checkbox,
                     custom_cookies=custom_cookies,
-                    temperature=temperature
+                    temperature=temperature,
                 )
             elif scrape_method == "Sitemap":
                 # Synchronous approach in your code, might need `asyncio.to_thread`
@@ -401,11 +388,7 @@ async def process_web_scraping_task(
 
             # 1b) Apply predictable max_pages cap for fallback methods that do not
             # natively support page-count control.
-            if (
-                max_pages is not None
-                and scrape_method in {"Sitemap", "URL Level"}
-                and isinstance(result_list, list)
-            ):
+            if max_pages is not None and scrape_method in {"Sitemap", "URL Level"} and isinstance(result_list, list):
                 before_count = len(result_list)
                 result_list = result_list[:max_pages]
                 if before_count != len(result_list):
@@ -440,7 +423,7 @@ async def process_web_scraping_task(
                             api_name=api_name,
                             api_key=api_key,
                             temp=temperature,
-                            system_message=system_prompt or ""
+                            system_message=system_prompt or "",
                         )
                         article["summary"] = summary
                     else:
@@ -514,7 +497,9 @@ async def process_web_scraping_task(
                         }
                         if chunking_plan:
                             safe_meta["chunking_plan"] = chunking_plan
-                        safe_metadata_json = json.dumps({k: v for k, v in safe_meta.items() if v is not None}, ensure_ascii=False)
+                        safe_metadata_json = json.dumps(
+                            {k: v for k, v in safe_meta.items() if v is not None}, ensure_ascii=False
+                        )
 
                         # Build plaintext chunks for FTS-first retrieval
                         if not perform_chunking:
@@ -535,31 +520,38 @@ async def process_web_scraping_task(
                                     language=options.get("language"),
                                 )
                                 kind_map = {
-                                    'paragraph': 'text',
-                                    'list_unordered': 'list',
-                                    'list_ordered': 'list',
-                                    'code_fence': 'code',
-                                    'table_md': 'table',
-                                    'header_line': 'heading',
-                                    'header_atx': 'heading',
+                                    "paragraph": "text",
+                                    "list_unordered": "list",
+                                    "list_ordered": "list",
+                                    "code_fence": "code",
+                                    "table_md": "table",
+                                    "header_line": "heading",
+                                    "header_atx": "heading",
                                 }
                                 chunks_for_sql = []
                                 for it in flat:
-                                    md = it.get('metadata') or {}
-                                    ctype = kind_map.get(str(md.get('paragraph_kind') or '').lower(), 'text')
+                                    md = it.get("metadata") or {}
+                                    ctype = kind_map.get(str(md.get("paragraph_kind") or "").lower(), "text")
                                     small = {}
-                                    if md.get('ancestry_titles'):
-                                        small['ancestry_titles'] = md.get('ancestry_titles')
-                                    if md.get('section_path'):
-                                        small['section_path'] = md.get('section_path')
-                                    chunks_for_sql.append({
-                                        'text': it.get('text',''),
-                                        'start_char': md.get('start_offset'),
-                                        'end_char': md.get('end_offset'),
-                                        'chunk_type': ctype,
-                                        'metadata': small,
-                                    })
-                            except Exception:
+                                    if md.get("ancestry_titles"):
+                                        small["ancestry_titles"] = md.get("ancestry_titles")
+                                    if md.get("section_path"):
+                                        small["section_path"] = md.get("section_path")
+                                    chunks_for_sql.append(
+                                        {
+                                            "text": it.get("text", ""),
+                                            "start_char": md.get("start_offset"),
+                                            "end_char": md.get("end_offset"),
+                                            "chunk_type": ctype,
+                                            "metadata": small,
+                                        }
+                                    )
+                            except Exception as chunk_err:
+                                logger.debug(
+                                    "Chunking failed for scraped article {}; using empty chunks: {}",
+                                    article.get("url", ""),
+                                    chunk_err,
+                                )
                                 chunks_for_sql = []
 
                         media_id, media_uuid, message = get_media_repository(db).add_media_with_keywords(
@@ -568,14 +560,18 @@ async def process_web_scraping_task(
                             media_type="web_document",
                             content=content_text,
                             keywords=keywords.split(",") if keywords else [],
-                            prompt=(system_prompt or "") + "\n\n" + (custom_prompt or "") if (system_prompt or custom_prompt) else None,
+                            prompt=(
+                                (system_prompt or "") + "\n\n" + (custom_prompt or "")
+                                if (system_prompt or custom_prompt)
+                                else None
+                            ),
                             analysis_content=article.get("summary", None),
                             safe_metadata=safe_metadata_json,
                             transcription_model="web-scraping-import",
                             author=article.get("author", None),
                             ingestion_date=None,
                             overwrite=False,
-                            chunks=chunks_for_sql
+                            chunks=chunks_for_sql,
                         )
                         if media_id:
                             media_ids.append(media_id)
@@ -616,9 +612,7 @@ async def ingest_web_content_orchestrate(
             tags=[str(getattr(request, "scrape_method", "") or "")],
             metadata={
                 "url_count": len(getattr(request, "urls", []) or []),
-                "perform_analysis": bool(
-                    getattr(request, "perform_analysis", False)
-                ),
+                "perform_analysis": bool(getattr(request, "perform_analysis", False)),
             },
         )
 
@@ -670,12 +664,10 @@ async def ingest_web_content_orchestrate(
 
         analysis_results = analyze(
             input_data=content,
-            custom_prompt_arg=getattr(request, "custom_prompt", None)
-            or "Summarize this article.",
+            custom_prompt_arg=getattr(request, "custom_prompt", None) or "Summarize this article.",
             api_name=getattr(request, "api_name", None),
             temp=0.7,
-            system_message=getattr(request, "system_prompt", None)
-            or "Act as a professional summarizer.",
+            system_message=getattr(request, "system_prompt", None) or "Act as a professional summarizer.",
         )
         article["analysis"] = analysis_results
 
@@ -694,44 +686,32 @@ async def ingest_web_content_orchestrate(
         of bubbling up as a 500 error.
         """
         custom_cookies_list: Optional[list[dict[str, Any]]] = None
-        if getattr(request, "use_cookies", False) and getattr(
-            request, "cookies", None
-        ):
+        if getattr(request, "use_cookies", False) and getattr(request, "cookies", None):
             raw_cookies = request.cookies
             if isinstance(raw_cookies, (bytes, bytearray)):
                 try:
                     raw_cookies = raw_cookies.decode("utf-8")
                 except UnicodeDecodeError:
-                    raise HTTPException(
-                        status_code=400, detail="Invalid cookies format"
-                    ) from None
+                    raise HTTPException(status_code=400, detail="Invalid cookies format") from None
 
             if isinstance(raw_cookies, str):
                 try:
                     parsed = json.loads(raw_cookies)
                 except json.JSONDecodeError:
-                    raise HTTPException(
-                        status_code=400, detail="Invalid JSON format for cookies"
-                    ) from None
+                    raise HTTPException(status_code=400, detail="Invalid JSON format for cookies") from None
             elif isinstance(raw_cookies, (dict, list)):
                 parsed = raw_cookies
             else:
-                raise HTTPException(
-                    status_code=400, detail="Invalid cookies format"
-                )
+                raise HTTPException(status_code=400, detail="Invalid cookies format")
 
             if isinstance(parsed, dict):
                 custom_cookies_list = [parsed]
             elif isinstance(parsed, list):
                 if not all(isinstance(item, dict) for item in parsed):
-                    raise HTTPException(
-                        status_code=400, detail="Invalid cookies format"
-                    )
+                    raise HTTPException(status_code=400, detail="Invalid cookies format")
                 custom_cookies_list = parsed
             else:
-                raise HTTPException(
-                    status_code=400, detail="Invalid cookies format"
-                )
+                raise HTTPException(status_code=400, detail="Invalid cookies format")
 
         return custom_cookies_list
 
@@ -818,9 +798,7 @@ async def ingest_web_content_orchestrate(
         try:
             from tldw_Server_API.app.api.v1.endpoints import media as media_mod
 
-            scrape_task = getattr(
-                media_mod, "process_web_scraping_task", process_web_scraping_task
-            )
+            scrape_task = getattr(media_mod, "process_web_scraping_task", process_web_scraping_task)
         except Exception:  # pragma: no cover - defensive fallback
             scrape_task = process_web_scraping_task
 
@@ -831,23 +809,21 @@ async def ingest_web_content_orchestrate(
                 url_level=level,
                 max_pages=requested_max_pages,
                 max_depth=level,
-                summarize_checkbox=bool(
-                    getattr(request, "perform_analysis", False)
-                ),
+                summarize_checkbox=bool(getattr(request, "perform_analysis", False)),
                 custom_prompt=getattr(request, "custom_prompt", None),
                 api_name=getattr(request, "api_name", None),
                 api_key=None,
-                keywords=",".join(request.keywords or [])
-                if isinstance(getattr(request, "keywords", None), list)
-                else (getattr(request, "keywords", None) or ""),
+                keywords=(
+                    ",".join(request.keywords or [])
+                    if isinstance(getattr(request, "keywords", None), list)
+                    else (getattr(request, "keywords", None) or "")
+                ),
                 custom_titles=None,
                 system_prompt=getattr(request, "system_prompt", None),
                 temperature=0.7,
                 custom_cookies=custom_cookies_list,
                 mode="ephemeral",
-                user_agent=getattr(request, "user_agent", None)
-                if hasattr(request, "user_agent")
-                else None,
+                user_agent=getattr(request, "user_agent", None) if hasattr(request, "user_agent") else None,
                 custom_headers=None,
                 crawl_strategy=getattr(request, "crawl_strategy", None),
                 include_external=getattr(request, "include_external", None),
@@ -855,9 +831,7 @@ async def ingest_web_content_orchestrate(
                 perform_chunking=bool(getattr(request, "perform_chunking", True)),
                 chunking_mode=getattr(request, "chunking_mode", None),
                 auto_chunking_goal=getattr(request, "auto_chunking_goal", "balanced"),
-                auto_chunking_use_llm=bool(
-                    getattr(request, "auto_chunking_use_llm", False)
-                ),
+                auto_chunking_use_llm=bool(getattr(request, "auto_chunking_use_llm", False)),
             )
             articles: list[dict[str, Any]] = []
             if isinstance(service_result, dict):
@@ -867,11 +841,7 @@ async def ingest_web_content_orchestrate(
                     articles = service_result["results"]
 
             for r in articles:
-                if (
-                    isinstance(r, dict)
-                    and "summary" in r
-                    and "analysis" not in r
-                ):
+                if isinstance(r, dict) and "summary" in r and "analysis" not in r:
                     r["analysis"] = r.get("summary")
 
             return articles
@@ -894,9 +864,7 @@ async def ingest_web_content_orchestrate(
         try:
             from tldw_Server_API.app.api.v1.endpoints import media as media_mod
 
-            scrape_task = getattr(
-                media_mod, "process_web_scraping_task", process_web_scraping_task
-            )
+            scrape_task = getattr(media_mod, "process_web_scraping_task", process_web_scraping_task)
         except Exception:  # pragma: no cover - defensive fallback
             scrape_task = process_web_scraping_task
 
@@ -907,23 +875,21 @@ async def ingest_web_content_orchestrate(
                 url_level=None,
                 max_pages=max_pages,
                 max_depth=max_depth,
-                summarize_checkbox=bool(
-                    getattr(request, "perform_analysis", False)
-                ),
+                summarize_checkbox=bool(getattr(request, "perform_analysis", False)),
                 custom_prompt=getattr(request, "custom_prompt", None),
                 api_name=getattr(request, "api_name", None),
                 api_key=None,
-                keywords=",".join(request.keywords or [])
-                if isinstance(getattr(request, "keywords", None), list)
-                else (getattr(request, "keywords", None) or ""),
+                keywords=(
+                    ",".join(request.keywords or [])
+                    if isinstance(getattr(request, "keywords", None), list)
+                    else (getattr(request, "keywords", None) or "")
+                ),
                 custom_titles=None,
                 system_prompt=getattr(request, "system_prompt", None),
                 temperature=0.7,
                 custom_cookies=custom_cookies_list,
                 mode="ephemeral",
-                user_agent=getattr(request, "user_agent", None)
-                if hasattr(request, "user_agent")
-                else None,
+                user_agent=getattr(request, "user_agent", None) if hasattr(request, "user_agent") else None,
                 custom_headers=None,
                 crawl_strategy=getattr(request, "crawl_strategy", None),
                 include_external=getattr(request, "include_external", None),
@@ -931,9 +897,7 @@ async def ingest_web_content_orchestrate(
                 perform_chunking=bool(getattr(request, "perform_chunking", True)),
                 chunking_mode=getattr(request, "chunking_mode", None),
                 auto_chunking_goal=getattr(request, "auto_chunking_goal", "balanced"),
-                auto_chunking_use_llm=bool(
-                    getattr(request, "auto_chunking_use_llm", False)
-                ),
+                auto_chunking_use_llm=bool(getattr(request, "auto_chunking_use_llm", False)),
             )
             articles: list[dict[str, Any]] = []
             if isinstance(service_result, list):
@@ -945,11 +909,7 @@ async def ingest_web_content_orchestrate(
                     articles = service_result.get("results") or []
 
             for r in articles:
-                if (
-                    isinstance(r, dict)
-                    and "summary" in r
-                    and "analysis" not in r
-                ):
+                if isinstance(r, dict) and "summary" in r and "analysis" not in r:
                     r["analysis"] = r.get("summary")
 
             return articles

--- a/tldw_Server_API/tests/Chunking/test_auto_chunking_planner.py
+++ b/tldw_Server_API/tests/Chunking/test_auto_chunking_planner.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tldw_Server_API.app.core.Chunking.auto_planner import (
+    AutoChunkingPlan,
+    AutoChunkingProfile,
+    AutoChunkingRequest,
+    merge_profiles,
+    plan_auto_chunking,
+    plan_auto_chunking_request,
+    profile_from_source,
+    profile_from_text,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_planner_returns_no_auto_plan_when_chunking_is_disabled_legacy_or_manual():
+    disabled = plan_auto_chunking(
+        perform_chunking=False,
+        chunking_mode="auto",
+        media_type="document",
+    )
+    legacy = plan_auto_chunking(
+        perform_chunking=True,
+        chunking_mode=None,
+        media_type="document",
+    )
+    manual = plan_auto_chunking(
+        perform_chunking=True,
+        chunking_mode="manual",
+        media_type="document",
+    )
+
+    assert disabled.chunk_options is None
+    assert disabled.chunking_plan is None
+    assert legacy.chunk_options is None
+    assert legacy.chunking_plan is None
+    assert manual.chunk_options is None
+    assert manual.chunking_plan is None
+
+
+def test_document_with_headings_prefers_structure_aware_and_goal_sizing():
+    profile = AutoChunkingProfile(
+        media_type="pdf",
+        source_name="research-paper.pdf",
+        text_length=25_000,
+        has_headings=True,
+        has_tables=True,
+    )
+
+    qa = plan_auto_chunking(
+        perform_chunking=True,
+        chunking_mode="auto",
+        media_type="pdf",
+        goal="qa_search",
+        profile=profile,
+        template_name="academic_pdf",
+    )
+    navigation = plan_auto_chunking(
+        perform_chunking=True,
+        chunking_mode="auto",
+        media_type="pdf",
+        goal="navigation_summary",
+        profile=profile,
+        template_name="academic_pdf",
+    )
+
+    assert qa.chunk_options == {
+        "method": "structure_aware",
+        "max_size": 700,
+        "overlap": 140,
+        "adaptive": False,
+        "multi_level": False,
+        "language": None,
+    }
+    assert qa.chunking_plan["template_name"] == "academic_pdf"
+    assert "outline" in qa.chunking_plan["derived_views"]
+    assert navigation.chunk_options["method"] == "structure_aware"
+    assert navigation.chunk_options["max_size"] > qa.chunk_options["max_size"]
+    assert navigation.chunking_plan["goal"] == "navigation_summary"
+    json.dumps(navigation.chunking_plan)
+
+
+def test_unstructured_document_falls_back_to_sentences_when_semantic_unavailable():
+    decision = plan_auto_chunking(
+        perform_chunking=True,
+        chunking_mode="auto",
+        media_type="document",
+        goal="balanced",
+        profile=AutoChunkingProfile(media_type="document", text_length=9_000),
+        semantic_available=False,
+    )
+
+    assert decision.chunk_options["method"] == "sentences"
+    assert "semantic_unavailable" in decision.chunking_plan["fallback_reason"]
+    assert decision.chunking_plan["used_llm"] is False
+
+
+def test_audio_video_profiles_use_sentence_chunks_and_time_views():
+    decision = plan_auto_chunking(
+        perform_chunking=True,
+        chunking_mode="auto",
+        media_type="video",
+        goal="balanced",
+        profile=AutoChunkingProfile(
+            media_type="video",
+            text_length=18_000,
+            has_timecodes=True,
+            has_speaker_labels=True,
+            language="en",
+        ),
+    )
+
+    assert decision.chunk_options["method"] == "sentences"
+    assert decision.chunk_options["language"] == "en"
+    assert "time_ranges" in decision.chunking_plan["derived_views"]
+    assert "speaker_segments" in decision.chunking_plan["derived_views"]
+
+
+def test_ebook_email_and_web_article_rules():
+    ebook = plan_auto_chunking(
+        perform_chunking=True,
+        chunking_mode="auto",
+        media_type="ebook",
+        profile=AutoChunkingProfile(media_type="ebook", has_chapters=True),
+    )
+    email = plan_auto_chunking(
+        perform_chunking=True,
+        chunking_mode="auto",
+        media_type="email",
+        profile=AutoChunkingProfile(media_type="email", text_length=5_000),
+    )
+    web = plan_auto_chunking(
+        perform_chunking=True,
+        chunking_mode="auto",
+        media_type="web",
+        profile=AutoChunkingProfile(
+            media_type="web",
+            source_name="https://example.test/post",
+            has_headings=True,
+            has_lists=True,
+        ),
+    )
+
+    assert ebook.chunk_options["method"] == "ebook_chapters"
+    assert "chapter_outline" in ebook.chunking_plan["derived_views"]
+    assert email.chunk_options["method"] == "sentences"
+    assert email.chunk_options["max_size"] == 1000
+    assert email.chunk_options["overlap"] == 150
+    assert "message_boundaries" in email.chunking_plan["derived_views"]
+    assert web.chunk_options["method"] == "structure_aware"
+    assert "section_titles" in web.chunking_plan["derived_views"]
+
+
+def test_ai_and_template_fallback_reasons_are_recorded_without_llm_calls():
+    decision = plan_auto_chunking(
+        perform_chunking=True,
+        chunking_mode="auto",
+        media_type="document",
+        profile=AutoChunkingProfile(media_type="document", text_length=3_000),
+        requested_llm=True,
+        llm_available=False,
+        template_status="error",
+        template_error="classifier unavailable",
+    )
+
+    assert decision.chunking_plan["used_llm"] is False
+    assert "ai_assist_unavailable" in decision.chunking_plan["fallback_reason"]
+    assert "template_error" in decision.chunking_plan["fallback_reason"]
+    assert "classifier unavailable" in decision.chunking_plan["rationale"]
+
+
+def test_ai_assist_opt_in_without_adapter_preserves_deterministic_plan():
+    profile = AutoChunkingProfile(
+        media_type="document",
+        text_length=24_000,
+        has_headings=True,
+        has_tables=True,
+    )
+    baseline = plan_auto_chunking(
+        perform_chunking=True,
+        chunking_mode="auto",
+        media_type="document",
+        goal="qa_search",
+        profile=profile,
+        requested_llm=False,
+        llm_available=False,
+    )
+    requested_without_adapter = plan_auto_chunking(
+        perform_chunking=True,
+        chunking_mode="auto",
+        media_type="document",
+        goal="qa_search",
+        profile=profile,
+        requested_llm=True,
+        llm_available=False,
+    )
+
+    assert requested_without_adapter.chunk_options == baseline.chunk_options
+    assert requested_without_adapter.chunking_plan["method"] == baseline.chunking_plan["method"]
+    assert requested_without_adapter.chunking_plan["max_size"] == baseline.chunking_plan["max_size"]
+    assert requested_without_adapter.chunking_plan["overlap"] == baseline.chunking_plan["overlap"]
+    assert requested_without_adapter.chunking_plan["used_llm"] is False
+    assert "ai_assist_unavailable" in requested_without_adapter.chunking_plan["fallback_reason"]
+    assert "no boundary adapter is available" in requested_without_adapter.chunking_plan["rationale"]
+
+
+def test_profile_builders_detect_text_signals_and_merge_source_hints():
+    source = profile_from_source(
+        media_type="document",
+        filename="report.md",
+        title="Quarterly Report",
+        language="en",
+    )
+    text = profile_from_text(
+        "# Intro\n\n- first item\n- second item\n\n| A | B |\n| - | - |\n\n"
+        "Speaker 1: hello\n00:01:03 topic shift\n\nChapter 2\n"
+    )
+    merged = merge_profiles(source, text)
+
+    assert merged.media_type == "document"
+    assert merged.source_name == "report.md"
+    assert merged.title == "Quarterly Report"
+    assert merged.language == "en"
+    assert merged.has_headings is True
+    assert merged.has_lists is True
+    assert merged.has_tables is True
+    assert merged.has_speaker_labels is True
+    assert merged.has_timecodes is True
+    assert merged.has_chapters is True
+
+
+def test_request_and_plan_types_are_serializable_and_drive_planning():
+    request = AutoChunkingRequest(
+        perform_chunking=True,
+        chunking_mode="auto",
+        media_type="document",
+        goal="balanced",
+        profile=AutoChunkingProfile(media_type="document", has_headings=True),
+        template_name="manual",
+    )
+
+    decision = plan_auto_chunking_request(request)
+    plan = AutoChunkingPlan.from_metadata(decision.chunking_plan)
+
+    assert decision.chunk_options["method"] == "structure_aware"
+    assert plan.goal == "balanced"
+    assert plan.template_name == "manual"
+    assert plan.to_metadata() == decision.chunking_plan
+    json.dumps(plan.to_metadata())

--- a/tldw_Server_API/tests/Chunking/test_auto_chunking_resolver.py
+++ b/tldw_Server_API/tests/Chunking/test_auto_chunking_resolver.py
@@ -120,3 +120,32 @@ def test_resolver_auto_records_template_fallback_status():
     assert chunk_options["method"] == "sentences"
     assert "semantic_unavailable" in chunking_plan["fallback_reason"]
     assert "template_no_match" in chunking_plan["fallback_reason"]
+
+
+def test_resolver_accepts_mapping_backed_auto_payload():
+    chunk_options, chunking_plan = resolve_chunking_options_and_plan(
+        {
+            "perform_chunking": True,
+            "media_type": "document",
+            "chunking_mode": "auto",
+            "auto_chunking_goal": "navigation_summary",
+            "auto_chunking_use_llm": True,
+            "chunk_language": "en",
+            "title": "Planning Notes",
+            "urls": ["https://example.test/planning.md"],
+            "chunk_method": "words",
+            "chunk_size": 333,
+            "chunk_overlap": 1,
+        },
+        media_type=None,
+        extracted_text="# Overview\n\n- first\n- second\n",
+    )
+
+    assert chunk_options["method"] == "structure_aware"
+    assert chunk_options["max_size"] == 1400
+    assert chunk_options["language"] == "en"
+    assert chunking_plan["mode"] == "auto"
+    assert chunking_plan["goal"] == "navigation_summary"
+    assert chunking_plan["profile"]["title"] == "Planning Notes"
+    assert chunking_plan["profile"]["source_name"] == "https://example.test/planning.md"
+    assert "outline" in chunking_plan["derived_views"]

--- a/tldw_Server_API/tests/Chunking/test_auto_chunking_resolver.py
+++ b/tldw_Server_API/tests/Chunking/test_auto_chunking_resolver.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_Server_API.app.core.Ingestion_Media_Processing.chunking_options import (
+    resolve_chunking_options_and_plan,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _form(**overrides):
+    values = {
+        "perform_chunking": True,
+        "media_type": "document",
+        "chunking_mode": None,
+        "auto_chunking_goal": "balanced",
+        "auto_chunking_use_llm": False,
+        "chunk_method": None,
+        "chunk_size": 500,
+        "chunk_overlap": 200,
+        "use_adaptive_chunking": False,
+        "use_multi_level_chunking": False,
+        "chunk_language": None,
+        "transcription_language": None,
+        "custom_chapter_pattern": None,
+        "enable_contextual_chunking": False,
+        "contextual_llm_model": None,
+        "context_window_size": None,
+        "context_strategy": None,
+        "context_token_budget": None,
+        "hierarchical_chunking": False,
+        "hierarchical_template": None,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_resolver_returns_no_options_when_chunking_disabled():
+    chunk_options, chunking_plan = resolve_chunking_options_and_plan(
+        _form(perform_chunking=False, chunking_mode="auto"),
+        media_type="document",
+    )
+
+    assert chunk_options is None
+    assert chunking_plan is None
+
+
+def test_resolver_preserves_legacy_chunking_options_when_mode_missing():
+    chunk_options, chunking_plan = resolve_chunking_options_and_plan(
+        _form(chunk_method="words", chunk_size=640, chunk_overlap=64),
+        media_type="document",
+    )
+
+    assert chunking_plan is None
+    assert chunk_options["method"] == "words"
+    assert chunk_options["max_size"] == 640
+    assert chunk_options["overlap"] == 64
+
+
+def test_resolver_preserves_manual_chunking_options():
+    chunk_options, chunking_plan = resolve_chunking_options_and_plan(
+        _form(
+            chunking_mode="manual",
+            chunk_method="tokens",
+            chunk_size=512,
+            chunk_overlap=32,
+        ),
+        media_type="document",
+    )
+
+    assert chunking_plan is None
+    assert chunk_options["method"] == "tokens"
+    assert chunk_options["max_size"] == 512
+    assert chunk_options["overlap"] == 32
+
+
+def test_resolver_auto_ignores_stale_manual_options_and_records_plan():
+    chunk_options, chunking_plan = resolve_chunking_options_and_plan(
+        _form(
+            chunking_mode="auto",
+            auto_chunking_goal="qa_search",
+            auto_chunking_use_llm=True,
+            chunk_method="words",
+            chunk_size=333,
+            chunk_overlap=1,
+        ),
+        media_type="document",
+        source_name="notes.md",
+        extracted_text="# Intro\n\nBody paragraph\n",
+    )
+
+    assert chunk_options == {
+        "method": "structure_aware",
+        "max_size": 700,
+        "overlap": 140,
+        "adaptive": False,
+        "multi_level": False,
+        "language": None,
+    }
+    assert chunking_plan["mode"] == "auto"
+    assert chunking_plan["goal"] == "qa_search"
+    assert chunking_plan["used_llm"] is False
+    assert "ai_assist_unavailable" in chunking_plan["fallback_reason"]
+    json.dumps(chunking_plan)
+
+
+def test_resolver_auto_records_template_fallback_status():
+    chunk_options, chunking_plan = resolve_chunking_options_and_plan(
+        _form(chunking_mode="auto"),
+        media_type="document",
+        extracted_text="plain article text",
+        template_status="no_match",
+        semantic_available=False,
+    )
+
+    assert chunk_options["method"] == "sentences"
+    assert "semantic_unavailable" in chunking_plan["fallback_reason"]
+    assert "template_no_match" in chunking_plan["fallback_reason"]

--- a/tldw_Server_API/tests/Media/test_auto_chunking_process_endpoints.py
+++ b/tldw_Server_API/tests/Media/test_auto_chunking_process_endpoints.py
@@ -1,0 +1,57 @@
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_process_pdfs_auto_chunking_adds_plan_metadata(
+    client_with_single_user,
+    bypass_api_limits,
+    monkeypatch,
+):
+    client, _ = client_with_single_user
+
+    import tldw_Server_API.app.api.v1.endpoints.media as media_mod
+    import tldw_Server_API.app.core.Chunking as chunking_mod
+
+    captured: dict[str, object] = {}
+
+    async def _stub_process_pdf_task(**kwargs):
+        captured["initial_chunk_method"] = kwargs.get("chunk_method")
+        return {
+            "status": "Success",
+            "content": "# Heading\n\nThis PDF content has enough structure to prefer sections.",
+            "metadata": {"title": "stub-pdf"},
+        }
+
+    def _stub_chunking(text, options):
+        captured["final_chunk_options"] = dict(options)
+        return [{"text": text, "metadata": {"chunk_num": 0}}]
+
+    monkeypatch.setattr(media_mod.pdf_lib, "process_pdf_task", _stub_process_pdf_task)
+    monkeypatch.setattr(chunking_mod, "improved_chunking_process", _stub_chunking)
+
+    response = client.post(
+        "/api/v1/media/process-pdfs",
+        data={
+            "perform_chunking": "true",
+            "chunking_mode": "auto",
+            "auto_chunking_goal": "navigation_summary",
+            "auto_chunking_use_llm": "true",
+            "chunk_method": "words",
+            "chunk_size": "333",
+            "chunk_overlap": "1",
+        },
+        files=[("files", ("paper.pdf", b"%PDF-1.4\n", "application/pdf"))],
+    )
+
+    assert response.status_code == 200, response.text
+    result = response.json()["results"][0]
+    plan = result["metadata"]["chunking_plan"]
+    assert plan["mode"] == "auto"
+    assert plan["goal"] == "navigation_summary"
+    assert plan["method"] == "structure_aware"
+    assert plan["used_llm"] is False
+    assert "ai_assist_unavailable" in plan["fallback_reason"]
+    assert captured["final_chunk_options"]["method"] == "structure_aware"
+    assert captured["final_chunk_options"]["max_size"] != 333

--- a/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_auto_chunking_persistence_metadata.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_auto_chunking_persistence_metadata.py
@@ -20,10 +20,15 @@ def test_safe_metadata_subset_preserves_json_safe_chunking_plan():
             "method": "semantic",
             "max_size": 900,
             "overlap": 120,
-            "derived_views": ["section_titles"],
+            "derived_views": ["section_titles", None, "outline"],
             "fallback_reason": None,
             "profile": {"media_type": "document", "text_length": 20},
             "callable": lambda: None,
+        },
+        "externalIds": {
+            "DOI": "10.1000/example",
+            "ArXiv": "2301.00001",
+            "PMID": None,
         },
         "unsafe_object": object(),
     }
@@ -33,5 +38,14 @@ def test_safe_metadata_subset_preserves_json_safe_chunking_plan():
     assert safe_meta["title"] == "Stored item"
     assert safe_meta["chunking_plan"]["mode"] == "auto"
     assert safe_meta["chunking_plan"]["profile"]["media_type"] == "document"
+    assert safe_meta["chunking_plan"]["derived_views"] == [
+        "section_titles",
+        None,
+        "outline",
+    ]
+    assert safe_meta["doi"] == "10.1000/example"
+    assert safe_meta["arxiv_id"] == "2301.00001"
+    assert "arxiv" not in safe_meta
+    assert "pmid" not in safe_meta
     assert "callable" not in safe_meta["chunking_plan"]
     assert "unsafe_object" not in safe_meta

--- a/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_auto_chunking_persistence_metadata.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_auto_chunking_persistence_metadata.py
@@ -1,0 +1,37 @@
+import json
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_safe_metadata_subset_preserves_json_safe_chunking_plan():
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.persistence import (
+        build_safe_metadata_subset,
+    )
+
+    metadata = {
+        "title": "Stored item",
+        "chunking_plan": {
+            "mode": "auto",
+            "goal": "balanced",
+            "used_llm": False,
+            "method": "semantic",
+            "max_size": 900,
+            "overlap": 120,
+            "derived_views": ["section_titles"],
+            "fallback_reason": None,
+            "profile": {"media_type": "document", "text_length": 20},
+            "callable": lambda: None,
+        },
+        "unsafe_object": object(),
+    }
+
+    safe_meta = build_safe_metadata_subset(metadata)
+    json.dumps(safe_meta)
+    assert safe_meta["title"] == "Stored item"
+    assert safe_meta["chunking_plan"]["mode"] == "auto"
+    assert safe_meta["chunking_plan"]["profile"]["media_type"] == "document"
+    assert "callable" not in safe_meta["chunking_plan"]
+    assert "unsafe_object" not in safe_meta

--- a/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_auto_chunking_request_contract.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_auto_chunking_request_contract.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from tldw_Server_API.app.api.v1.API_Deps import (
+    media_add_deps,
+    media_processing_deps,
+)
+from tldw_Server_API.app.api.v1.schemas.media_request_models import (
+    AddMediaForm,
+    IngestWebContentRequest,
+    WebScrapingRequest,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _dependency_kwargs(func: Callable[..., Any], **overrides: Any) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {}
+    for name, parameter in inspect.signature(func).parameters.items():
+        default = parameter.default
+        kwargs[name] = default.default if hasattr(default, "default") else default
+    kwargs.update(overrides)
+    return kwargs
+
+
+def _valid_hierarchical_template() -> dict[str, Any]:
+    return {
+        "boundaries": [
+            {
+                "kind": "heading",
+                "pattern": r"^#{1,3}\s+",
+                "flags": "m",
+            }
+        ]
+    }
+
+
+@pytest.mark.asyncio
+async def test_add_media_form_dependency_parses_auto_chunking_and_template_fields():
+    form = await media_add_deps.get_add_media_form(
+        **_dependency_kwargs(
+            media_add_deps.get_add_media_form,
+            media_type="document",
+            urls=["https://example.test/article.md"],
+            transcription_model=None,
+            chunking_mode="auto",
+            auto_chunking_goal="qa_search",
+            auto_chunking_use_llm=True,
+            auto_apply_template=True,
+            chunking_template_name="article-defaults",
+            hierarchical_chunking=True,
+            hierarchical_template=_valid_hierarchical_template(),
+        )
+    )
+
+    assert form.chunking_mode == "auto"
+    assert form.auto_chunking_goal == "qa_search"
+    assert form.auto_chunking_use_llm is True
+    assert form.auto_apply_template is True
+    assert form.chunking_template_name == "article-defaults"
+    assert form.hierarchical_chunking is True
+    assert form.hierarchical_template == _valid_hierarchical_template()
+
+
+@pytest.mark.asyncio
+async def test_add_media_form_dependency_preserves_legacy_missing_chunking_mode():
+    form = await media_add_deps.get_add_media_form(
+        **_dependency_kwargs(
+            media_add_deps.get_add_media_form,
+            media_type="document",
+            urls=["https://example.test/article.md"],
+            transcription_model=None,
+        )
+    )
+
+    assert form.chunking_mode is None
+    assert form.auto_chunking_goal == "balanced"
+    assert form.auto_chunking_use_llm is False
+
+
+@pytest.mark.asyncio
+async def test_add_media_form_dependency_rejects_invalid_auto_chunking_values():
+    with pytest.raises(HTTPException) as excinfo:
+        await media_add_deps.get_add_media_form(
+            **_dependency_kwargs(
+                media_add_deps.get_add_media_form,
+                media_type="document",
+                urls=["https://example.test/article.md"],
+                transcription_model=None,
+                chunking_mode="automatic",
+                auto_chunking_goal="summarize_everything",
+            )
+        )
+
+    assert excinfo.value.status_code == media_add_deps.HTTP_422_UNPROCESSABLE
+    rendered_detail = str(excinfo.value.detail)
+    assert "chunking_mode" in rendered_detail
+    assert "auto_chunking_goal" in rendered_detail
+
+
+@pytest.mark.asyncio
+async def test_form_dependencies_reject_malformed_hierarchical_template_json():
+    with pytest.raises(HTTPException) as add_excinfo:
+        await media_add_deps.get_add_media_form(
+            **_dependency_kwargs(
+                media_add_deps.get_add_media_form,
+                media_type="document",
+                urls=["https://example.test/article.md"],
+                transcription_model=None,
+                hierarchical_template="{not-json",
+            )
+        )
+
+    assert add_excinfo.value.status_code == media_add_deps.HTTP_422_UNPROCESSABLE
+    assert "hierarchical_template" in str(add_excinfo.value.detail)
+
+    with pytest.raises(HTTPException) as process_excinfo:
+        await media_processing_deps.get_process_documents_form(
+            **_dependency_kwargs(
+                media_processing_deps.get_process_documents_form,
+                urls=["https://example.test/article.md"],
+                hierarchical_template="{not-json",
+            )
+        )
+
+    assert process_excinfo.value.status_code == media_processing_deps.HTTP_422_UNPROCESSABLE
+    assert "hierarchical_template" in str(process_excinfo.value.detail)
+
+
+@pytest.mark.parametrize(
+    ("dependency", "expected_media_type"),
+    [
+        (media_processing_deps.get_process_documents_form, "document"),
+        (media_processing_deps.get_process_videos_form, "video"),
+        (media_processing_deps.get_process_audios_form, "audio"),
+        (media_processing_deps.get_process_pdfs_form, "pdf"),
+        (media_processing_deps.get_process_ebooks_form, "ebook"),
+        (media_processing_deps.get_process_emails_form, "email"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_process_form_dependencies_parse_auto_chunking_contract(
+    dependency: Callable[..., Any],
+    expected_media_type: str,
+):
+    form = await dependency(
+        **_dependency_kwargs(
+            dependency,
+            urls=["https://example.test/source"],
+            chunking_mode="auto",
+            auto_chunking_goal="navigation_summary",
+            auto_chunking_use_llm=True,
+            auto_apply_template=True,
+            chunking_template_name="detected-template",
+            hierarchical_chunking=True,
+            hierarchical_template=_valid_hierarchical_template(),
+        )
+    )
+
+    assert form.media_type == expected_media_type
+    assert form.chunking_mode == "auto"
+    assert form.auto_chunking_goal == "navigation_summary"
+    assert form.auto_chunking_use_llm is True
+    assert form.auto_apply_template is True
+    assert form.chunking_template_name == "detected-template"
+    assert form.hierarchical_chunking is True
+    assert form.hierarchical_template == _valid_hierarchical_template()
+
+
+def test_auto_chunking_schema_validates_unknown_modes_and_allows_disabled_chunking():
+    valid = AddMediaForm(
+        media_type="document",
+        perform_chunking=False,
+        chunking_mode="auto",
+        auto_chunking_goal="balanced",
+        auto_chunking_use_llm=True,
+    )
+
+    assert valid.perform_chunking is False
+    assert valid.chunking_mode == "auto"
+    assert valid.auto_chunking_goal == "balanced"
+    assert valid.auto_chunking_use_llm is True
+
+    with pytest.raises(ValidationError) as excinfo:
+        AddMediaForm(
+            media_type="document",
+            chunking_mode="automatic",
+            auto_chunking_goal="summarize_everything",
+        )
+
+    rendered_errors = str(excinfo.value)
+    assert "chunking_mode" in rendered_errors
+    assert "auto_chunking_goal" in rendered_errors
+
+
+def test_web_article_request_models_accept_auto_chunking_fields():
+    web_scrape = WebScrapingRequest(
+        scrape_method="individual",
+        url_input="https://example.test/article",
+        perform_chunking=False,
+        chunking_mode="auto",
+        auto_chunking_goal="qa_search",
+        auto_chunking_use_llm=True,
+    )
+    ingest_web = IngestWebContentRequest(
+        urls=["https://example.test/article"],
+        perform_chunking=False,
+        chunking_mode="auto",
+        auto_chunking_goal="navigation_summary",
+        auto_chunking_use_llm=True,
+    )
+
+    assert web_scrape.chunking_mode == "auto"
+    assert web_scrape.auto_chunking_goal == "qa_search"
+    assert web_scrape.auto_chunking_use_llm is True
+    assert ingest_web.chunking_mode == "auto"
+    assert ingest_web.auto_chunking_goal == "navigation_summary"
+    assert ingest_web.auto_chunking_use_llm is True
+
+
+def test_web_article_request_models_reject_invalid_auto_chunking_fields():
+    with pytest.raises(ValidationError) as excinfo:
+        WebScrapingRequest(
+            scrape_method="individual",
+            url_input="https://example.test/article",
+            chunking_mode="automatic",
+            auto_chunking_goal="summarize_everything",
+        )
+
+    rendered_errors = str(excinfo.value)
+    assert "chunking_mode" in rendered_errors
+    assert "auto_chunking_goal" in rendered_errors

--- a/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_auto_chunking_request_contract.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_auto_chunking_request_contract.py
@@ -14,6 +14,7 @@ from tldw_Server_API.app.api.v1.API_Deps import (
 )
 from tldw_Server_API.app.api.v1.schemas.media_request_models import (
     AddMediaForm,
+    ChunkingOptions,
     IngestWebContentRequest,
     WebScrapingRequest,
 )
@@ -67,6 +68,24 @@ async def test_add_media_form_dependency_parses_auto_chunking_and_template_field
     assert form.chunking_template_name == "article-defaults"
     assert form.hierarchical_chunking is True
     assert form.hierarchical_template == _valid_hierarchical_template()
+
+
+@pytest.mark.asyncio
+async def test_add_media_form_dependency_normalizes_empty_template_name():
+    form = await media_add_deps.get_add_media_form(
+        **_dependency_kwargs(
+            media_add_deps.get_add_media_form,
+            media_type="document",
+            urls=["https://example.test/article.md"],
+            transcription_model=None,
+            chunking_mode="manual",
+            chunking_template_name="",
+            hierarchical_template="",
+        )
+    )
+
+    assert form.chunking_template_name is None
+    assert form.hierarchical_template is None
 
 
 @pytest.mark.asyncio
@@ -198,6 +217,12 @@ def test_auto_chunking_schema_validates_unknown_modes_and_allows_disabled_chunki
     rendered_errors = str(excinfo.value)
     assert "chunking_mode" in rendered_errors
     assert "auto_chunking_goal" in rendered_errors
+
+
+def test_chunking_options_schema_allows_internal_structure_aware_method():
+    options = ChunkingOptions(chunk_method="structure_aware")
+
+    assert options.chunk_method == "structure_aware"
 
 
 def test_web_article_request_models_accept_auto_chunking_fields():

--- a/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_worker.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_worker.py
@@ -111,6 +111,84 @@ async def test_media_ingest_worker_updates_progress_fields(monkeypatch, tmp_path
 
 
 @pytest.mark.asyncio
+async def test_media_ingest_worker_returns_auto_chunking_plan(monkeypatch, tmp_path):
+    monkeypatch.setenv("JOBS_DB_PATH", str(tmp_path / "jobs.db"))
+    monkeypatch.delenv("JOBS_DB_URL", raising=False)
+
+    from tldw_Server_API.app.core.Jobs.manager import JobManager
+    import tldw_Server_API.app.services.media_ingest_jobs_worker as worker
+
+    class _DummyDB:
+        def __init__(self, path: str):
+            self.db_path_str = path
+            self.client_id = "media_ingest_test"
+
+        def close_connection(self):
+            return None
+
+    def _fake_create_db(_user_id: str):
+        return _DummyDB(str(tmp_path / "media.db"))
+
+    seen: dict[str, object] = {}
+
+    async def _fake_process_document_like_item(**kwargs):
+        seen["chunk_options"] = kwargs.get("chunk_options")
+        return {
+            "status": "Success",
+            "db_id": 234,
+            "media_uuid": "media-uuid-234",
+            "warnings": None,
+            "db_message": "Media added to database.",
+            "content": "# Intro\n\nChunkable body.",
+        }
+
+    monkeypatch.setattr(worker, "_create_db", _fake_create_db, raising=True)
+    monkeypatch.setattr(
+        worker,
+        "process_document_like_item",
+        _fake_process_document_like_item,
+        raising=True,
+    )
+
+    jm = JobManager()
+    payload = {
+        "batch_id": "batch-auto",
+        "media_type": "document",
+        "source": str(tmp_path / "doc.md"),
+        "source_kind": "file",
+        "input_ref": "doc.md",
+        "options": {
+            "media_type": "document",
+            "perform_chunking": True,
+            "chunking_mode": "auto",
+            "auto_chunking_goal": "qa_search",
+            "auto_chunking_use_llm": True,
+            "chunk_method": "words",
+            "chunk_size": 333,
+            "chunk_overlap": 1,
+        },
+    }
+    row = jm.create_job(
+        domain="media_ingest",
+        queue="default",
+        job_type="media_ingest_item",
+        payload=payload,
+        owner_user_id="1",
+    )
+
+    job = jm.get_job(int(row.get("id")))
+    progress = worker._ProgressState()
+    result = await worker._handle_job(job, jm, progress)
+
+    assert seen["chunk_options"]["method"] == "semantic"
+    assert seen["chunk_options"]["max_size"] == 700
+    assert result["chunking_plan"]["mode"] == "auto"
+    assert result["chunking_plan"]["goal"] == "qa_search"
+    assert result["chunking_plan"]["used_llm"] is False
+    assert "ai_assist_unavailable" in result["chunking_plan"]["fallback_reason"]
+
+
+@pytest.mark.asyncio
 async def test_media_ingest_worker_returns_existing_media_id_for_skipped_dedupe_result(monkeypatch, tmp_path):
     monkeypatch.setenv("JOBS_DB_PATH", str(tmp_path / "jobs.db"))
     monkeypatch.delenv("JOBS_DB_URL", raising=False)

--- a/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_worker.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_worker.py
@@ -140,6 +140,19 @@ async def test_media_ingest_worker_returns_auto_chunking_plan(monkeypatch, tmp_p
             "warnings": None,
             "db_message": "Media added to database.",
             "content": "# Intro\n\nChunkable body.",
+            "metadata": {
+                "chunking_plan": {
+                    "mode": "auto",
+                    "goal": "navigation_summary",
+                    "used_llm": False,
+                    "method": "structure_aware",
+                    "max_size": 1400,
+                    "overlap": 100,
+                    "fallback_reason": None,
+                    "derived_views": ["section_titles", "outline"],
+                    "profile": {"media_type": "document"},
+                }
+            },
         }
 
     monkeypatch.setattr(worker, "_create_db", _fake_create_db, raising=True)
@@ -183,9 +196,11 @@ async def test_media_ingest_worker_returns_auto_chunking_plan(monkeypatch, tmp_p
     assert seen["chunk_options"]["method"] == "semantic"
     assert seen["chunk_options"]["max_size"] == 700
     assert result["chunking_plan"]["mode"] == "auto"
-    assert result["chunking_plan"]["goal"] == "qa_search"
+    assert result["chunking_plan"]["goal"] == "navigation_summary"
+    assert result["chunking_plan"]["method"] == "structure_aware"
+    assert result["chunking_plan"]["max_size"] == 1400
     assert result["chunking_plan"]["used_llm"] is False
-    assert "ai_assist_unavailable" in result["chunking_plan"]["fallback_reason"]
+    assert "ai_assist_unavailable" not in str(result["chunking_plan"]["fallback_reason"])
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_persistence_original_storage.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_persistence_original_storage.py
@@ -309,6 +309,181 @@ async def test_add_media_orchestrate_handles_document_exceptions(monkeypatch, tm
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_add_media_orchestrate_passes_auto_chunk_options_to_document_processor(
+    monkeypatch,
+    fake_db,
+):
+    captured: Dict[str, Any] = {}
+
+    def fail_legacy_prepare(_form_data: Any) -> None:
+        raise AssertionError("legacy chunk option preparation should not run for Auto mode")
+
+    async def fake_process_doc_item_fn(
+        *,
+        chunk_options: Dict[str, Any] | None,
+        item_input_ref: str,
+        processing_source: str,
+        media_type: Any,
+        **_kwargs: Any,
+    ) -> Dict[str, Any]:
+        captured["chunk_options"] = dict(chunk_options or {})
+        return {
+            "status": "Success",
+            "input_ref": item_input_ref,
+            "processing_source": str(processing_source),
+            "media_type": media_type,
+            "metadata": {},
+            "content": "content",
+            "analysis": None,
+            "summary": None,
+            "analysis_details": None,
+            "db_id": 1,
+            "db_message": "ok",
+        }
+
+    monkeypatch.setattr(
+        ingestion_persistence,
+        "prepare_chunking_options_dict",
+        fail_legacy_prepare,
+    )
+    monkeypatch.setattr(ingestion_persistence, "process_document_like_item", fake_process_doc_item_fn)
+
+    form_data = SimpleNamespace(
+        media_type="document",
+        urls=["https://example.test/auto.md"],
+        keep_original_file=False,
+        perform_chunking=True,
+        chunking_mode="auto",
+        auto_chunking_goal="navigation_summary",
+        auto_chunking_use_llm=False,
+        chunk_method="words",
+        chunk_size=333,
+        chunk_overlap=1,
+        chunk_language=None,
+        transcription_language=None,
+        chunking_template_name=None,
+        auto_apply_template=True,
+        hierarchical_chunking=False,
+        hierarchical_template=None,
+        use_adaptive_chunking=False,
+        use_multi_level_chunking=False,
+        custom_chapter_pattern=None,
+        enable_contextual_chunking=False,
+        contextual_llm_model=None,
+        context_window_size=None,
+        context_strategy=None,
+        context_token_budget=None,
+        perform_analysis=False,
+        generate_embeddings=False,
+        keywords=[],
+        title=None,
+        author=None,
+        overwrite_existing=False,
+    )
+
+    response = await ingestion_persistence.add_media_orchestrate(
+        background_tasks=BackgroundTasks(),
+        form_data=form_data,
+        files=[],
+        db=fake_db,
+        current_user=SimpleNamespace(id=1),
+        usage_log=SimpleNamespace(log_event=lambda *_args, **_kwargs: None),
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert captured["chunk_options"]["method"] == "semantic"
+    assert captured["chunk_options"]["max_size"] == 1400
+    assert captured["chunk_options"]["overlap"] == 100
+    assert captured["chunk_options"]["method"] != "words"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_add_media_orchestrate_passes_auto_chunk_options_to_batch_processor(
+    monkeypatch,
+    fake_db,
+):
+    captured: Dict[str, Any] = {}
+
+    def fail_legacy_prepare(_form_data: Any) -> None:
+        raise AssertionError("legacy chunk option preparation should not run for Auto mode")
+
+    async def fake_process_batch_media(**kwargs: Any) -> List[Dict[str, Any]]:
+        captured["chunk_options"] = dict(kwargs.get("chunk_options") or {})
+        return [
+            {
+                "status": "Success",
+                "input_ref": "https://example.test/audio.mp3",
+                "processing_source": "https://example.test/audio.mp3",
+                "media_type": "audio",
+                "metadata": {},
+                "content": "transcript",
+                "analysis": None,
+                "summary": None,
+                "analysis_details": None,
+                "db_id": 1,
+                "db_message": "ok",
+            }
+        ]
+
+    monkeypatch.setattr(
+        ingestion_persistence,
+        "prepare_chunking_options_dict",
+        fail_legacy_prepare,
+    )
+    monkeypatch.setattr(ingestion_persistence, "process_batch_media", fake_process_batch_media)
+
+    form_data = SimpleNamespace(
+        media_type="audio",
+        urls=["https://example.test/audio.mp3"],
+        keep_original_file=False,
+        perform_chunking=True,
+        chunking_mode="auto",
+        auto_chunking_goal="qa_search",
+        auto_chunking_use_llm=False,
+        chunk_method="words",
+        chunk_size=333,
+        chunk_overlap=1,
+        chunk_language=None,
+        transcription_language=None,
+        chunking_template_name=None,
+        auto_apply_template=True,
+        hierarchical_chunking=False,
+        hierarchical_template=None,
+        use_adaptive_chunking=False,
+        use_multi_level_chunking=False,
+        custom_chapter_pattern=None,
+        enable_contextual_chunking=False,
+        contextual_llm_model=None,
+        context_window_size=None,
+        context_strategy=None,
+        context_token_budget=None,
+        perform_analysis=False,
+        generate_embeddings=False,
+        keywords=[],
+        title=None,
+        author=None,
+        overwrite_existing=False,
+    )
+
+    response = await ingestion_persistence.add_media_orchestrate(
+        background_tasks=BackgroundTasks(),
+        form_data=form_data,
+        files=[],
+        db=fake_db,
+        current_user=SimpleNamespace(id=1),
+        usage_log=SimpleNamespace(log_event=lambda *_args, **_kwargs: None),
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert captured["chunk_options"]["method"] == "sentences"
+    assert captured["chunk_options"]["max_size"] == 700
+    assert captured["chunk_options"]["overlap"] == 140
+    assert captured["chunk_options"]["method"] != "words"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_add_media_orchestrate_partial_upload_errors_returns_multi_status(monkeypatch, fake_db, fake_storage):
     db = fake_db
 

--- a/tldw_Server_API/tests/Web_Scraping/test_auto_chunking_web_ingest.py
+++ b/tldw_Server_API/tests/Web_Scraping/test_auto_chunking_web_ingest.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import json
+import os
+from contextlib import contextmanager
+
+import pytest
+
+from tldw_Server_API.app.services import web_scraping_service as ws_service
+
+
+pytestmark = pytest.mark.unit
+
+
+class _ClientWithToken:
+    def __init__(self, client):
+        self._client = client
+
+    def post(self, *args, **kwargs):
+        default_headers = dict(getattr(self._client, "headers", {}) or {})
+        request_headers = kwargs.pop("headers", {}) or {}
+        default_headers.update(request_headers)
+        default_headers.setdefault("token", "test-token")
+        default_headers.setdefault(
+            "X-API-KEY",
+            os.getenv("SINGLE_USER_API_KEY", "test-api-key-12345"),
+        )
+        return self._client.post(*args, headers=default_headers, **kwargs)
+
+
+class _FakeDB:
+    def __init__(self):
+        self.calls: list[dict] = []
+        self.closed = False
+
+    def add_media_with_keywords(self, **kwargs):
+        self.calls.append(kwargs)
+        return len(self.calls), f"uuid-{len(self.calls)}", "ok"
+
+    def close_connection(self):
+        self.closed = True
+
+
+def _force_fallback(monkeypatch):
+    def _raise():
+        raise RuntimeError("enhanced service unavailable in test")
+
+    monkeypatch.setattr(ws_service, "get_web_scraping_service", _raise, raising=True)
+
+
+@pytest.fixture(autouse=True)
+def _enable_legacy_web_scraping_fallback(monkeypatch):
+    monkeypatch.setenv("TLDW_ENABLE_LEGACY_WEB_SCRAPING_FALLBACK", "1")
+
+
+@pytest.mark.asyncio
+async def test_web_scraping_fallback_persists_auto_chunking_plan(monkeypatch):
+    _force_fallback(monkeypatch)
+    fake_db = _FakeDB()
+    chunk_calls: list[dict] = []
+
+    async def _fake_scrape_and_summarize_multiple(**_kwargs):
+        return [
+            {
+                "url": "https://example.com/article",
+                "title": "Article",
+                "author": "Author",
+                "content": "# Intro\n\n- one\n- two",
+                "summary": "summary",
+                "extraction_successful": True,
+            }
+        ]
+
+    @contextmanager
+    def _fake_managed_media_database(*_args, **_kwargs):
+        try:
+            yield fake_db
+        finally:
+            fake_db.close_connection()
+
+    class _Chunker:
+        def chunk_text_hierarchical_flat(self, text, **kwargs):
+            chunk_calls.append({"text": text, **kwargs})
+            return [
+                {
+                    "text": text,
+                    "metadata": {"paragraph_kind": "paragraph"},
+                }
+            ]
+
+    monkeypatch.setattr(
+        ws_service,
+        "scrape_and_summarize_multiple",
+        _fake_scrape_and_summarize_multiple,
+        raising=True,
+    )
+    monkeypatch.setattr(ws_service, "managed_media_database", _fake_managed_media_database)
+    monkeypatch.setattr(ws_service, "get_user_media_db_path", lambda _user_id: "/tmp/media.db")  # nosec B108
+    monkeypatch.setattr(ws_service, "get_media_repository", lambda db: db)
+    monkeypatch.setattr(ws_service, "Chunker", _Chunker)
+
+    result = await ws_service.process_web_scraping_task(
+        scrape_method="Individual URLs",
+        url_input="https://example.com/article",
+        url_level=None,
+        max_pages=1,
+        max_depth=1,
+        summarize_checkbox=False,
+        custom_prompt=None,
+        api_name=None,
+        api_key=None,
+        keywords="",
+        custom_titles=None,
+        system_prompt=None,
+        temperature=0.7,
+        custom_cookies=None,
+        mode="persist",
+        user_id=1,
+        user_agent=None,
+        custom_headers=None,
+        crawl_strategy=None,
+        include_external=None,
+        score_threshold=None,
+        perform_chunking=True,
+        chunking_mode="auto",
+        auto_chunking_goal="navigation_summary",
+        auto_chunking_use_llm=True,
+    )
+
+    assert result["status"] == "persist-ok"
+    assert fake_db.closed is True
+    assert chunk_calls[0]["method"] == "structure_aware"
+    safe_metadata = json.loads(fake_db.calls[0]["safe_metadata"])
+    plan = safe_metadata["chunking_plan"]
+    assert plan["mode"] == "auto"
+    assert plan["goal"] == "navigation_summary"
+    assert plan["method"] == "structure_aware"
+    assert "ai_assist_unavailable" in plan["fallback_reason"]
+
+
+def test_process_web_scraping_endpoint_forwards_auto_chunking_fields(
+    client_user_only,
+    monkeypatch,
+):
+    from tldw_Server_API.app.api.v1.endpoints.media import (
+        process_web_scraping as endpoint_mod,
+    )
+
+    captured: dict[str, object] = {}
+
+    async def _fake_task(**kwargs):
+        captured.update(kwargs)
+        return {"status": "ok", "results": []}
+
+    monkeypatch.setattr(endpoint_mod, "_resolve_process_web_scraping_task", lambda: _fake_task)
+
+    response = client_user_only.post(
+        "/api/v1/media/process-web-scraping",
+        json={
+            "scrape_method": "Individual URLs",
+            "url_input": "https://example.com",
+            "mode": "ephemeral",
+            "perform_chunking": True,
+            "chunking_mode": "auto",
+            "auto_chunking_goal": "qa_search",
+            "auto_chunking_use_llm": True,
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert captured["perform_chunking"] is True
+    assert captured["chunking_mode"] == "auto"
+    assert captured["auto_chunking_goal"] == "qa_search"
+    assert captured["auto_chunking_use_llm"] is True
+
+
+def test_ingest_web_content_auto_chunking_adds_plan_metadata(
+    client_user_only,
+    monkeypatch,
+):
+    from tldw_Server_API.app.api.v1.endpoints.media import (
+        ingest_web_content as endpoint_mod,
+    )
+
+    async def _fake_orchestrate(**_kwargs):
+        return [
+            {
+                "url": "https://example.com/article",
+                "title": "Article",
+                "content": "# Intro\n\nArticle body.",
+                "metadata": {"source": "test"},
+            }
+        ]
+
+    monkeypatch.setattr(endpoint_mod, "ingest_web_content_orchestrate", _fake_orchestrate)
+
+    response = _ClientWithToken(client_user_only).post(
+        "/api/v1/media/ingest-web-content",
+        json={
+            "urls": ["https://example.com/article"],
+            "scrape_method": "individual",
+            "perform_chunking": True,
+            "chunking_mode": "auto",
+            "auto_chunking_goal": "balanced",
+            "auto_chunking_use_llm": True,
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    result = response.json()["results"][0]
+    plan = result["metadata"]["chunking_plan"]
+    assert plan["mode"] == "auto"
+    assert plan["method"] == "structure_aware"
+    assert "ai_assist_unavailable" in plan["fallback_reason"]


### PR DESCRIPTION
## Summary
- Adds an approved Auto Chunking design and implementation plan for Quick Ingest.
- Adds backend Auto Chunking request fields, deterministic planning, ingestion/job/web persistence wiring, and metadata describing chosen plans and fallbacks.
- Updates Quick Ingest UI and payload plumbing so enabling chunking defaults to Auto, while Manual exposes existing detailed settings.
- Locks AI assist as explicit opt-in with deterministic fallback until a real boundary assistant adapter is implemented.

## Verification
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/MediaIngestion_NEW/unit/test_auto_chunking_request_contract.py tldw_Server_API/tests/Chunking/test_auto_chunking_planner.py tldw_Server_API/tests/Chunking/test_auto_chunking_resolver.py tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_worker.py tldw_Server_API/tests/Media/test_auto_chunking_process_endpoints.py tldw_Server_API/tests/Web_Scraping/test_auto_chunking_web_ingest.py tldw_Server_API/tests/MediaIngestion_NEW/unit/test_auto_chunking_persistence_metadata.py -v` -> 41 passed, 6 warnings
- `cd apps/packages/ui && bun run test -- src/services/__tests__/quick-ingest-batch.test.ts src/components/Common/QuickIngest/__tests__/IngestWizardContext.test.tsx src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx --maxWorkers=1 --no-file-parallelism` -> 83 passed
- `cd apps/packages/ui && bun run verify:openapi` -> passed, 256 client paths and 49 media fallback fields verified
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Chunking/auto_planner.py -f json -o /tmp/bandit_auto_chunking_ai_boundary.json` -> zero findings
- `git diff --check` -> passed

## Known Notes
- Full UI `bunx tsc --noEmit --pretty false` still exits 2 on existing repo-wide test typing issues. Filtering the log for touched Auto Chunking UI files returned no matches.
- Manual API/UI smoke tests were skipped because no local API/frontend dev server was already running for the final pass; focused endpoint/job/UI tests cover the request and metadata behavior.
- `TASK-96.8` tracks real LLM boundary assistant integration. This PR intentionally does not make model calls for chunk boundaries.

## Change Summary
Draft PR note: this repository requires a human-authored Change summary before merge. Please replace this section with the requester-owned summary of what changed and why these implementation choices were made.