### PR TITLE
Adapt WatchlistsEmptyState to shared EmptyState

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -4202,17 +4202,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/shared/WatchlistsEmptyState.tsx:Empty",
-    "path": "src/components/Option/Watchlists/shared/WatchlistsEmptyState.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Empty",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Empty product-state UI in src/components/Option/Watchlists/shared/WatchlistsEmptyState.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Watchlists/shared/WatchlistsHealthBar.tsx:Tag#antd-tag-watchlistshealthbar-color-error-line-307-tfw62m",
     "path": "src/components/Option/Watchlists/shared/WatchlistsHealthBar.tsx",
     "rule": "antd-product-state-import",
@@ -5540,17 +5529,6 @@
     "state": "allowed_legacy_exception",
     "owner": "design-system",
     "reason": "Existing local SearchEmptyState empty-state wrapper before the guard.",
-    "replacement": "EmptyState",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "local-empty-state:src/components/Option/Watchlists/shared/WatchlistsEmptyState.tsx:WatchlistsEmptyState",
-    "path": "src/components/Option/Watchlists/shared/WatchlistsEmptyState.tsx",
-    "rule": "local-empty-state",
-    "subject": "WatchlistsEmptyState",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing local WatchlistsEmptyState empty-state wrapper before the guard.",
     "replacement": "EmptyState",
     "migrationQueue": "shared-product-state"
   },

--- a/apps/packages/ui/src/components/Option/Watchlists/shared/WatchlistsEmptyState.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/shared/WatchlistsEmptyState.tsx
@@ -1,5 +1,4 @@
 import React from "react"
-import type { LucideIcon } from "lucide-react"
 import {
   CalendarClock,
   FileOutput,
@@ -7,7 +6,8 @@ import {
   Newspaper,
   Play,
   Plus,
-  Rss
+  Rss,
+  type LucideIcon
 } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { EmptyState } from "@/components/ui/feedback/EmptyState"

--- a/apps/packages/ui/src/components/Option/Watchlists/shared/WatchlistsEmptyState.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/shared/WatchlistsEmptyState.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Button, Empty } from "antd"
+import type { LucideIcon } from "lucide-react"
 import {
   CalendarClock,
   FileOutput,
@@ -10,6 +10,7 @@ import {
   Rss
 } from "lucide-react"
 import { useTranslation } from "react-i18next"
+import { EmptyState } from "@/components/ui/feedback/EmptyState"
 
 type EntityType = "feeds" | "monitors" | "activity" | "articles" | "reports" | "templates"
 
@@ -28,7 +29,9 @@ interface WatchlistsEmptyStateProps {
 const entityConfig: Record<
   EntityType,
   {
-    icon: React.ReactNode
+    icon: LucideIcon
+    titleKey: string
+    titleDefault: string
     descriptionKey: string
     descriptionDefault: string
     primaryCtaKey: string
@@ -38,7 +41,9 @@ const entityConfig: Record<
   }
 > = {
   feeds: {
-    icon: <Rss className="h-8 w-8 text-text-muted" />,
+    icon: Rss,
+    titleKey: "watchlists:emptyState.feeds.title",
+    titleDefault: "No feeds yet",
     descriptionKey: "watchlists:emptyState.feeds.description",
     descriptionDefault: "Feeds are the sources your monitors check for new content.",
     primaryCtaKey: "watchlists:emptyState.feeds.primaryCta",
@@ -47,7 +52,9 @@ const entityConfig: Record<
     secondaryCtaDefault: "Import from OPML"
   },
   monitors: {
-    icon: <CalendarClock className="h-8 w-8 text-text-muted" />,
+    icon: CalendarClock,
+    titleKey: "watchlists:emptyState.monitors.title",
+    titleDefault: "No monitors yet",
     descriptionKey: "watchlists:emptyState.monitors.description",
     descriptionDefault:
       "Monitors run on a schedule to fetch and process content from your feeds.",
@@ -55,7 +62,9 @@ const entityConfig: Record<
     primaryCtaDefault: "Create your first monitor"
   },
   activity: {
-    icon: <Play className="h-8 w-8 text-text-muted" />,
+    icon: Play,
+    titleKey: "watchlists:emptyState.activity.title",
+    titleDefault: "No activity yet",
     descriptionKey: "watchlists:emptyState.activity.description",
     descriptionDefault:
       "Activity shows the history of monitor runs. Set up a monitor to start seeing activity here.",
@@ -63,7 +72,9 @@ const entityConfig: Record<
     primaryCtaDefault: "Set up a monitor"
   },
   articles: {
-    icon: <Newspaper className="h-8 w-8 text-text-muted" />,
+    icon: Newspaper,
+    titleKey: "watchlists:emptyState.articles.title",
+    titleDefault: "No articles yet",
     descriptionKey: "watchlists:emptyState.articles.description",
     descriptionDefault:
       "Articles are captured content from successful monitor runs, ready for review.",
@@ -71,7 +82,9 @@ const entityConfig: Record<
     primaryCtaDefault: "Set up a monitor to start capturing articles"
   },
   reports: {
-    icon: <FileOutput className="h-8 w-8 text-text-muted" />,
+    icon: FileOutput,
+    titleKey: "watchlists:emptyState.reports.title",
+    titleDefault: "No reports yet",
     descriptionKey: "watchlists:emptyState.reports.description",
     descriptionDefault:
       "Reports are generated briefings from monitor runs using your templates.",
@@ -79,7 +92,9 @@ const entityConfig: Record<
     primaryCtaDefault: "Run a monitor to generate your first report"
   },
   templates: {
-    icon: <FileText className="h-8 w-8 text-text-muted" />,
+    icon: FileText,
+    titleKey: "watchlists:emptyState.templates.title",
+    titleDefault: "No templates yet",
     descriptionKey: "watchlists:emptyState.templates.description",
     descriptionDefault:
       "Templates define the format and structure of your generated reports.",
@@ -98,11 +113,21 @@ export const WatchlistsEmptyState: React.FC<WatchlistsEmptyStateProps> = ({
 }) => {
   const { t } = useTranslation(["watchlists"])
   const config = entityConfig[entity]
+  const primaryActionLabel =
+    primaryLabel || t(config.primaryCtaKey, config.primaryCtaDefault)
+  const secondaryActionLabel =
+    secondaryLabel ||
+    (config.secondaryCtaKey
+      ? t(config.secondaryCtaKey, config.secondaryCtaDefault || "")
+      : undefined)
 
   return (
-    <Empty
-      image={config.icon}
-      imageStyle={{ height: 48, display: "flex", justifyContent: "center", alignItems: "center" }}
+    <EmptyState
+      title={t(config.titleKey, config.titleDefault)}
+      icon={config.icon}
+      iconClassName="text-text-muted"
+      size="md"
+      variant="card"
       description={
         <div className="space-y-2">
           <p className="text-sm text-text-muted">
@@ -114,28 +139,25 @@ export const WatchlistsEmptyState: React.FC<WatchlistsEmptyStateProps> = ({
         </div>
       }
       data-testid={`watchlists-empty-state-${entity}`}
-    >
-      <div className="flex flex-wrap justify-center gap-2">
-        {onPrimaryAction && (
-          <Button
-            type="primary"
-            icon={<Plus className="h-4 w-4" />}
-            onClick={onPrimaryAction}
-            data-testid={`watchlists-empty-state-${entity}-primary`}
-          >
-            {primaryLabel || t(config.primaryCtaKey, config.primaryCtaDefault)}
-          </Button>
-        )}
-        {onSecondaryAction && config.secondaryCtaKey && (
-          <Button
-            onClick={onSecondaryAction}
-            data-testid={`watchlists-empty-state-${entity}-secondary`}
-          >
-            {secondaryLabel ||
-              t(config.secondaryCtaKey, config.secondaryCtaDefault || "")}
-          </Button>
-        )}
-      </div>
-    </Empty>
+      primaryAction={
+        onPrimaryAction
+          ? {
+              label: primaryActionLabel,
+              icon: <Plus className="h-4 w-4" />,
+              onClick: onPrimaryAction,
+              "data-testid": `watchlists-empty-state-${entity}-primary`
+            }
+          : undefined
+      }
+      secondaryAction={
+        onSecondaryAction && config.secondaryCtaKey && secondaryActionLabel
+          ? {
+              label: secondaryActionLabel,
+              onClick: onSecondaryAction,
+              "data-testid": `watchlists-empty-state-${entity}-secondary`
+            }
+          : undefined
+      }
+    />
   )
 }

--- a/apps/packages/ui/src/components/Option/Watchlists/shared/__tests__/WatchlistsEmptyState.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/shared/__tests__/WatchlistsEmptyState.test.tsx
@@ -12,21 +12,6 @@ vi.mock("react-i18next", () => ({
   })
 }))
 
-vi.mock("antd", () => ({
-  Button: ({ children, icon, ...rest }: any) => (
-    <button type="button" {...rest}>
-      {icon}
-      {children}
-    </button>
-  ),
-  Empty: ({ children, description, ...rest }: any) => (
-    <div {...rest}>
-      {description}
-      {children}
-    </div>
-  )
-}))
-
 describe("WatchlistsEmptyState", () => {
   it("adapts feed empty states to the canonical EmptyState primitive", () => {
     const onPrimaryAction = vi.fn()

--- a/apps/packages/ui/src/components/Option/Watchlists/shared/__tests__/WatchlistsEmptyState.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/shared/__tests__/WatchlistsEmptyState.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+
+import React from "react"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { WatchlistsEmptyState } from "../WatchlistsEmptyState"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: unknown) =>
+      typeof fallback === "string" ? fallback : key
+  })
+}))
+
+vi.mock("antd", () => ({
+  Button: ({ children, icon, ...rest }: any) => (
+    <button type="button" {...rest}>
+      {icon}
+      {children}
+    </button>
+  ),
+  Empty: ({ children, description, ...rest }: any) => (
+    <div {...rest}>
+      {description}
+      {children}
+    </div>
+  )
+}))
+
+describe("WatchlistsEmptyState", () => {
+  it("adapts feed empty states to the canonical EmptyState primitive", () => {
+    const onPrimaryAction = vi.fn()
+    const onSecondaryAction = vi.fn()
+
+    render(
+      <WatchlistsEmptyState
+        entity="feeds"
+        primaryLabel="Add RSS feed"
+        secondaryLabel="Upload OPML"
+        contextHint="Import existing subscriptions to get started faster."
+        onPrimaryAction={onPrimaryAction}
+        onSecondaryAction={onSecondaryAction}
+      />
+    )
+
+    const root = screen.getByTestId("watchlists-empty-state-feeds")
+    expect(root).toHaveAttribute("data-ds-component", "EmptyState")
+    expect(
+      screen.getByText("Feeds are the sources your monitors check for new content.")
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("Import existing subscriptions to get started faster.")
+    ).toBeInTheDocument()
+
+    const primary = screen.getByTestId("watchlists-empty-state-feeds-primary")
+    const secondary = screen.getByTestId("watchlists-empty-state-feeds-secondary")
+    expect(primary).toHaveTextContent("Add RSS feed")
+    expect(secondary).toHaveTextContent("Upload OPML")
+
+    fireEvent.click(primary)
+    fireEvent.click(secondary)
+
+    expect(onPrimaryAction).toHaveBeenCalledTimes(1)
+    expect(onSecondaryAction).toHaveBeenCalledTimes(1)
+  })
+
+  it("omits secondary actions for entities without configured secondary copy", () => {
+    const onPrimaryAction = vi.fn()
+    const onSecondaryAction = vi.fn()
+
+    render(
+      <WatchlistsEmptyState
+        entity="monitors"
+        onPrimaryAction={onPrimaryAction}
+        onSecondaryAction={onSecondaryAction}
+      />
+    )
+
+    expect(screen.getByTestId("watchlists-empty-state-monitors")).toHaveAttribute(
+      "data-ds-component",
+      "EmptyState"
+    )
+    expect(
+      screen.getByText(
+        "Monitors run on a schedule to fetch and process content from your feeds."
+      )
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTestId("watchlists-empty-state-monitors-primary")
+    ).toHaveTextContent("Create your first monitor")
+    expect(
+      screen.queryByTestId("watchlists-empty-state-monitors-secondary")
+    ).not.toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/components/ui/feedback/EmptyState.tsx
+++ b/apps/packages/ui/src/components/ui/feedback/EmptyState.tsx
@@ -9,8 +9,12 @@ export type EmptyStateSize = "sm" | "md" | "lg";
 export interface EmptyStateAction {
   /** Button label */
   label: React.ReactNode;
+  /** Optional button icon */
+  icon?: React.ReactNode;
   /** Native title text for compatibility with legacy wrappers */
   title?: string;
+  /** Test ID for compatibility wrappers */
+  "data-testid"?: string;
   /** Click handler */
   onClick?: () => void;
   /** Show loading spinner */
@@ -257,6 +261,8 @@ export const EmptyState = React.forwardRef<HTMLDivElement, EmptyStateProps>(
                   loading={primaryAction.loading}
                   disabled={primaryAction.disabled}
                   title={primaryAction.title}
+                  icon={primaryAction.icon}
+                  data-testid={primaryAction["data-testid"]}
                 >
                   {primaryAction.label}
                 </Button>
@@ -269,6 +275,8 @@ export const EmptyState = React.forwardRef<HTMLDivElement, EmptyStateProps>(
                   loading={secondaryAction.loading}
                   disabled={secondaryAction.disabled}
                   title={secondaryAction.title}
+                  icon={secondaryAction.icon}
+                  data-testid={secondaryAction["data-testid"]}
                 >
                   {secondaryAction.label}
                 </Button>

--- a/backlog/tasks/task-45.12 - Adapt-WatchlistsEmptyState-to-shared-EmptyState.md
+++ b/backlog/tasks/task-45.12 - Adapt-WatchlistsEmptyState-to-shared-EmptyState.md
@@ -4,7 +4,7 @@ title: Adapt WatchlistsEmptyState to shared EmptyState
 status: Done
 assignee: []
 created_date: '2026-05-06 19:09'
-updated_date: '2026-05-06 19:13'
+updated_date: '2026-05-06 19:26'
 labels:
   - design-system
   - frontend
@@ -38,6 +38,12 @@ Continue the shared product-state design-system migration by replacing the Watch
 Implemented WatchlistsEmptyState as a compatibility adapter over components/ui/feedback/EmptyState. Preserved entity descriptions, contextual hint copy, entity icons, primary/secondary action behavior, override labels, and legacy test IDs via EmptyState action passthroughs.
 
 Verification: red WatchlistsEmptyState test failed on missing data-ds-component marker before implementation. After implementation, bunx vitest run src/components/Option/Watchlists/shared/__tests__/WatchlistsEmptyState.test.tsx src/components/Common/__tests__/FeatureEmptyState.test.tsx src/design-system/__tests__/product-state-guard.test.ts --maxWorkers=1 --reporter=dot passed 43/43; bun run verify:design-system-state exited 0 with 523 allowed legacy exceptions and no stale WatchlistsEmptyState entries; git diff --check exited 0. Package-wide bunx tsc --noEmit --pretty false -p tsconfig.json still exits 2 on unrelated existing frontend type errors outside touched Watchlists/EmptyState files. Bandit is not applicable to this frontend-only TypeScript/JSON slice.
+
+PR review pass started for PR #1343. Actionable findings: remove unused AntD mock and consolidate lucide-react imports. Gemini EmptyStateAction.icon type comment is response-only because action icons intentionally follow Button.icon React.ReactNode.
+
+PR review pass complete. Removed the unused AntD mock from WatchlistsEmptyState.test.tsx and consolidated the lucide-react type/value import in WatchlistsEmptyState.tsx. Rechecked EmptyStateAction.icon against Button.icon and kept it as React.ReactNode intentionally; this preserves JSX button adornment compatibility while EmptyStateProps.icon remains the hero LucideIcon type.
+
+Verification after review fixes: bunx vitest run src/components/Option/Watchlists/shared/__tests__/WatchlistsEmptyState.test.tsx src/components/Common/__tests__/FeatureEmptyState.test.tsx src/design-system/__tests__/product-state-guard.test.ts --maxWorkers=1 --reporter=dot passed 43/43; bun run verify:design-system-state exited 0 with 523 allowed legacy exceptions; git diff --check exited 0.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-45.12 - Adapt-WatchlistsEmptyState-to-shared-EmptyState.md
+++ b/backlog/tasks/task-45.12 - Adapt-WatchlistsEmptyState-to-shared-EmptyState.md
@@ -1,0 +1,57 @@
+---
+id: TASK-45.12
+title: Adapt WatchlistsEmptyState to shared EmptyState
+status: Done
+assignee: []
+created_date: '2026-05-06 19:09'
+updated_date: '2026-05-06 19:13'
+labels:
+  - design-system
+  - frontend
+  - watchlists
+dependencies: []
+documentation:
+  - Docs/Design/tldw_web_design_system_inventory.md
+  - Docs/Design/tldw_web_design_system_contract.md
+parent_task_id: TASK-45
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue the shared product-state design-system migration by replacing the Watchlists shared empty-state wrapper's direct AntD Empty/Button rendering with the canonical components/ui/feedback/EmptyState primitive. Keep this as a narrow compatibility slice for Watchlists shared empty-state behavior; do not migrate unrelated Watchlists alerts, status tags, loading states, page shells, or modal footers in this task.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 WatchlistsEmptyState renders the canonical EmptyState design-system marker while preserving entity-specific descriptions, context hints, icons, primary and secondary actions, override labels, test IDs, and i18n fallbacks.
+- [x] #2 Focused tests cover at least one entity with primary and secondary actions and one entity without secondary action, including absent secondary-action behavior where relevant.
+- [x] #3 The product-state guard passes without WatchlistsEmptyState local-empty-state or AntD Empty baseline debt, and any migrated stale baseline entries are removed.
+- [x] #4 Scope remains limited to the Watchlists shared empty-state wrapper and direct tests, without migrating unrelated Watchlists AntD Alert/Tag/loading/status surfaces.
+- [x] #5 Focused Vitest coverage, design-system state verification, git diff checks, and Bandit applicability are recorded before completion.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented WatchlistsEmptyState as a compatibility adapter over components/ui/feedback/EmptyState. Preserved entity descriptions, contextual hint copy, entity icons, primary/secondary action behavior, override labels, and legacy test IDs via EmptyState action passthroughs.
+
+Verification: red WatchlistsEmptyState test failed on missing data-ds-component marker before implementation. After implementation, bunx vitest run src/components/Option/Watchlists/shared/__tests__/WatchlistsEmptyState.test.tsx src/components/Common/__tests__/FeatureEmptyState.test.tsx src/design-system/__tests__/product-state-guard.test.ts --maxWorkers=1 --reporter=dot passed 43/43; bun run verify:design-system-state exited 0 with 523 allowed legacy exceptions and no stale WatchlistsEmptyState entries; git diff --check exited 0. Package-wide bunx tsc --noEmit --pretty false -p tsconfig.json still exits 2 on unrelated existing frontend type errors outside touched Watchlists/EmptyState files. Bandit is not applicable to this frontend-only TypeScript/JSON slice.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Adapted the shared WatchlistsEmptyState wrapper to the canonical EmptyState primitive, added focused coverage for feed and monitor empty states, extended EmptyState actions with icon and data-testid passthroughs needed for compatibility wrappers, and removed the migrated WatchlistsEmptyState AntD Empty/local-empty-state baseline debt.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Adapt `WatchlistsEmptyState` to render the canonical `components/ui/feedback/EmptyState` primitive instead of AntD `Empty`/`Button`.
- Preserve entity descriptions, context hints, icons, primary/secondary action behavior, override labels, and existing Watchlists empty-state test IDs.
- Extend `EmptyStateAction` with icon and `data-testid` passthroughs for compatibility wrappers, and remove the migrated Watchlists baseline debt.

## Verification
- `bunx vitest run src/components/Option/Watchlists/shared/__tests__/WatchlistsEmptyState.test.tsx src/components/Common/__tests__/FeatureEmptyState.test.tsx src/design-system/__tests__/product-state-guard.test.ts --maxWorkers=1 --reporter=dot`
- `bun run verify:design-system-state`
- `git diff --check`

## Notes
- Bandit is not applicable to this frontend-only TypeScript/JSON slice.
- `bunx tsc --noEmit --pretty false -p tsconfig.json` still exits 2 on existing unrelated frontend typecheck errors outside the touched Watchlists/EmptyState files.
- Before merge, the human requester still needs to add the required human-owned `Change summary` explaining what changed and why these choices were made.
