### PR TITLE
Phase 2.2: defer minimal privileges tools imports

### DIFF
--- a/backlog/tasks/task-98 - Phase-2.2-minimal-privileges-tools-router-conditional-cleanup-AU.md
+++ b/backlog/tasks/task-98 - Phase-2.2-minimal-privileges-tools-router-conditional-cleanup-AU.md
@@ -1,0 +1,62 @@
+---
+id: TASK-98
+title: Phase 2.2 minimal privileges/tools router conditional cleanup AU
+status: Done
+assignee: []
+created_date: '2026-05-06 19:24'
+updated_date: '2026-05-07 00:20'
+labels:
+  - phase2.2
+  - router-cleanup
+  - minimal
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+  - 'https://github.com/rmusser01/tldw_server/pull/1337'
+  - 'https://github.com/rmusser01/tldw_server/pull/1345'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Convert the minimal-test privileges and tools optional router blocks from eager try/except handling to lazy ImportedRouterSpec registration with precise optional-missing skip semantics. This keeps the Phase 2.2 router cleanup moving one adjacent minimal-test island at a time after the MCP trio merged.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Minimal privileges and tools routers are represented as lazy ImportedRouterSpec entries.
+- [x] #2 Missing target optional modules are skipped while runtime import defects propagate during registration.
+- [x] #3 Existing prefixes tags route keys and default stability behavior are preserved.
+- [x] #4 Focused router contract tests cover lazy attr lookup missing optional imports and runtime error propagation for this router family.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused router contract tests proving minimal privileges/tools specs are lazy and skip only missing optional modules. 2. Replace the two eager privileges/tools try/except blocks with ImportedRouterSpec registrations. 3. Run focused, router group, lifecycle, OpenAPI, Bandit, and diff checks. 4. Commit and open a PR against dev.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+RED: pytest test_router_groups_contract.py -k 'privileges_tools and (attr_lookup or missing_import_failures or runtime_import_failures)' failed with three expected failures against eager privileges/tools imports. GREEN: the same selector passed after the minimal.py change. Broader validation: router_groups_contract 116 passed, main_lifecycle_contract 54 passed, openapi_contracts 69 passed, Bandit results 0, git diff --check clean. No documentation change needed because this is an internal router registration cleanup. No known blockers.
+
+Opened PR #1345 against dev: https://github.com/rmusser01/tldw_server/pull/1345
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Converted the minimal-test privileges/tools router pair to lazy ImportedRouterSpec registration while preserving prefixes and tags. Added focused contract coverage for lazy module/attribute resolution, missing optional module skips, and runtime import defect propagation.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -804,27 +804,23 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
     ):
         append_imported_router_spec(specs, mcp_spec)
 
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.privileges import router as privileges_router
-
-        specs.append(RouterSpec(
-            router=privileges_router,
+    for privileges_tools_spec in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.privileges",
+            log_name="privileges",
             prefix=f"{API_V1_PREFIX}",
             tags=("privileges",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping privileges router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.tools import router as tools_router
-
-        specs.append(RouterSpec(
-            router=tools_router,
+            skip_context=minimal_skip_context,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.tools",
+            log_name="tools",
             prefix=f"{API_V1_PREFIX}",
             tags=("tools",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping tools router in minimal test app: {e}")
+            skip_context=minimal_skip_context,
+        ),
+    ):
+        append_imported_router_spec(specs, privileges_tools_spec)
 
     for acp_spec in (
         ImportedRouterSpec(

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -200,6 +200,22 @@ MCP_ROUTER_DEFINITION_DATA = (
         "/mcp/hub",
     ),
 )
+PRIVILEGES_TOOLS_ROUTER_DEFINITION_DATA = (
+    (
+        "tldw_Server_API.app.api.v1.endpoints.privileges",
+        "privileges",
+        "/api/v1",
+        ("privileges",),
+        "/privileges",
+    ),
+    (
+        "tldw_Server_API.app.api.v1.endpoints.tools",
+        "tools",
+        "/api/v1",
+        ("tools",),
+        "/tools",
+    ),
+)
 
 
 def _main_source_text() -> str:
@@ -7283,6 +7299,235 @@ def test_iter_minimal_optional_router_specs_propagates_mcp_runtime_import_failur
     )
 
     with pytest.raises(RuntimeError, match="mcp_unified_endpoint exploded during import"):
+        register_router_specs(FastAPI(), (selected_spec,))
+
+
+def test_iter_minimal_optional_router_specs_defers_privileges_tools_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal privileges/tools specs keep module import and attr lookup lazy."""
+    import builtins
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    definitions_by_module = {
+        module_name: {
+            "module_name": module_name,
+            "expected_name": expected_name,
+            "prefix": prefix,
+            "tags": tags,
+            "path": path,
+        }
+        for module_name, expected_name, prefix, tags, path in PRIVILEGES_TOOLS_ROUTER_DEFINITION_DATA
+    }
+    router_definitions = tuple(definitions_by_module.values())
+    access_count = {
+        f"{definition['module_name']}.router": 0
+        for definition in router_definitions
+    }
+    import_calls: list[str] = []
+
+    for module_name, definition in definitions_by_module.items():
+        fake_module = ModuleType(module_name)
+        router = APIRouter()
+
+        @router.get(str(definition["path"]))
+        def _endpoint() -> dict[str, str]:
+            """Return a deterministic response for the fake minimal privileges/tools router."""
+            return {"status": "ok"}
+
+        def _module_getattr(
+            name: str,
+            *,
+            module_name: str = module_name,
+            router: APIRouter = router,
+        ) -> APIRouter:
+            """Track lazy router attribute resolution for the fake module."""
+            if name != "router":
+                raise AttributeError(name)
+            access_count[f"{module_name}.router"] += 1
+            return router
+
+        fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    endpoints_package = "tldw_Server_API.app.api.v1.endpoints."
+    real_import = builtins.__import__
+
+    def _fake_endpoint_import(
+        name: str,
+        globals: dict[str, object] | None = None,
+        locals: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> ModuleType:
+        """Track selected imports and fake unrelated eager optional routers."""
+        if (
+            level == 0
+            and name.startswith(endpoints_package)
+        ):
+            if name in definitions_by_module:
+                import_calls.append(name)
+                return real_import(name, globals, locals, fromlist, level)
+            attrs = tuple(attr for attr in fromlist if attr != "*") or ("router",)
+            for attr_name in attrs:
+                _install_fake_router_module(
+                    monkeypatch,
+                    name,
+                    path="/minimal-unrelated-privileges-tools-fake",
+                    attr_name=attr_name,
+                )
+            return sys.modules[name]
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_endpoint_import)
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Track lazy module imports for selected minimal privileges/tools routers."""
+        if module_name in definitions_by_module:
+            import_calls.append(module_name)
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+    fake_main = ModuleType("tldw_Server_API.app.main")
+    fake_main.app = FastAPI()  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "tldw_Server_API.app.main", fake_main)
+
+    specs = list(iter_minimal_optional_router_specs())
+    assert [
+        module_name
+        for module_name in definitions_by_module
+        if module_name in import_calls
+    ] == []
+    assert access_count == {
+        f"{definition['module_name']}.router": 0
+        for definition in router_definitions
+    }
+    assert import_calls == []
+
+    selected_specs = {
+        spec.name: spec
+        for spec in specs
+        if spec.name in {
+            str(definition["expected_name"])
+            for definition in router_definitions
+        }
+    }
+    assert set(selected_specs) == {
+        str(definition["expected_name"])
+        for definition in router_definitions
+    }
+
+    for definition in router_definitions:
+        spec = selected_specs[str(definition["expected_name"])]
+        assert spec.prefix == definition["prefix"]
+        assert spec.tags == definition["tags"]
+        assert spec.route_key == ""
+        assert spec.skip_context == "in minimal test app"
+        assert spec.default_stable is True
+        assert [exc.__name__ for exc in spec.skip_exceptions] == [
+            "OptionalRouterMissingModule",
+            "OptionalRouterMissingAttribute",
+        ]
+        assert _first_router_path(spec.router) == definition["path"]
+
+    assert import_calls == [
+        str(definition["module_name"])
+        for definition in router_definitions
+    ]
+    assert access_count == {
+        f"{definition['module_name']}.router": 1
+        for definition in router_definitions
+    }
+
+
+def test_iter_minimal_optional_router_specs_skips_privileges_tools_missing_import_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal privileges/tools specs skip missing optional router modules."""
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    privileges_tools_modules = {
+        module_name
+        for module_name, _expected_name, _prefix, _tags, _path in PRIVILEGES_TOOLS_ROUTER_DEFINITION_DATA
+    }
+    expected_names = {
+        expected_name
+        for _module_name, expected_name, _prefix, _tags, _path in PRIVILEGES_TOOLS_ROUTER_DEFINITION_DATA
+    }
+
+    specs = list(iter_minimal_optional_router_specs())
+    selected_specs = {
+        spec.name: spec
+        for spec in specs
+        if spec.name in expected_names
+    }
+    assert set(selected_specs) == expected_names
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Fail only the selected privileges/tools router imports at registration."""
+        if module_name in privileges_tools_modules:
+            raise ModuleNotFoundError(f"{module_name} missing during import", name=module_name)
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    debug_messages: list[str] = []
+    monkeypatch.setattr("loguru.logger.debug", debug_messages.append)
+
+    assert register_router_specs(FastAPI(), selected_specs.values()) == 0
+    assert debug_messages == [
+        f"Skipping {expected_name} router in minimal test app: "
+        f"{module_name} missing during import"
+        for module_name, expected_name, _prefix, _tags, _path in PRIVILEGES_TOOLS_ROUTER_DEFINITION_DATA
+    ]
+
+
+def test_iter_minimal_optional_router_specs_propagates_privileges_tools_runtime_import_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal privileges/tools runtime import defects are not silently skipped."""
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    module_name = "tldw_Server_API.app.api.v1.endpoints.privileges"
+    specs = list(iter_minimal_optional_router_specs())
+    selected_spec = next(spec for spec in specs if spec.name == "privileges")
+
+    real_import_module = importlib.import_module
+
+    def _import_module(import_name: str, package: str | None = None) -> ModuleType:
+        """Crash only one selected privileges/tools router import at registration."""
+        if import_name == module_name:
+            raise RuntimeError(f"{module_name} exploded during import")
+        return real_import_module(import_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    with pytest.raises(RuntimeError, match="privileges exploded during import"):
         register_router_specs(FastAPI(), (selected_spec,))
 
 


### PR DESCRIPTION
## Change summary

This PR converts the minimal-test `privileges` and `tools` router registrations from eager `try/except Exception` imports to lazy `ImportedRouterSpec` entries. That keeps minimal app spec enumeration free of endpoint import side effects while preserving the existing prefixes, tags, and always-on route behavior.

The implementation follows the preceding minimal router cleanup slices: missing optional modules are skipped at registration time, but runtime import defects are allowed to propagate instead of being hidden by a broad eager exception handler.

## Validation

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "privileges_tools and (attr_lookup or missing_import_failures or runtime_import_failures)" -q`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_lifecycle_contract.py -q`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/router_groups/minimal.py -f json -o /tmp/bandit_minimal_privileges_tools_router_au.json`
- `jq '.results | length' /tmp/bandit_minimal_privileges_tools_router_au.json` returned `0`
- `git diff --check`
- `git diff --cached --check`

## Tracking

- Backlog: `TASK-98`
- Issue: #1116
