### PR TITLE
Phase 2.2: defer minimal tail imports

### DIFF
--- a/backlog/tasks/task-99 - Phase-2.2-minimal-tail-router-conditional-cleanup-AV.md
+++ b/backlog/tasks/task-99 - Phase-2.2-minimal-tail-router-conditional-cleanup-AV.md
@@ -1,0 +1,66 @@
+---
+id: TASK-99
+title: Phase 2.2 minimal tail router conditional cleanup AV
+status: Done
+assignee: []
+created_date: '2026-05-07 00:44'
+updated_date: '2026-05-07 01:01'
+labels:
+  - phase2.2
+  - router-cleanup
+  - minimal
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+  - 'https://github.com/rmusser01/tldw_server/pull/1345'
+  - 'https://github.com/rmusser01/tldw_server/pull/1347'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Convert the minimal-test agent_orchestration setup metrics and authnz_debug optional router blocks from eager try/except handling to lazy ImportedRouterSpec registration with precise optional-missing skip semantics. This continues the Phase 2.2 minimal router cleanup after the privileges/tools pair merged, keeping the remaining tail routers aligned with the lazy optional router contract.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Minimal agent_orchestration setup metrics and authnz_debug routers are represented as lazy ImportedRouterSpec entries.
+- [x] #2 Missing target optional modules are skipped while runtime import defects propagate during registration.
+- [x] #3 Existing prefixes tags route keys and default stability behavior are preserved.
+- [x] #4 Focused router contract tests cover lazy attr lookup missing optional imports and runtime error propagation for this router family.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add contract coverage for the remaining minimal tail router family. 2. Replace eager broad try/except imports with lazy ImportedRouterSpec entries. 3. Verify router, lifecycle, OpenAPI, Bandit, and diff gates. 4. Publish a dev PR for review.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+TDD RED selector failed as expected before the implementation: 3 new tail tests failed against eager imports while an existing content-tail test passed.
+
+GREEN and broader validation passed: router groups 119 passed, lifecycle 54 passed, OpenAPI 69 passed, Bandit results 0, git diff --check clean.
+
+No docs update was required for this internal router registration cleanup. No known blockers remain.
+
+Opened PR https://github.com/rmusser01/tldw_server/pull/1347 against dev for this slice.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Converted the minimal agent_orchestration, setup, metrics, and authnz_debug router registrations to lazy ImportedRouterSpec entries. This preserves prefixes and tags while deferring import and router attribute resolution until registration, so missing optional modules remain skippable and runtime import defects still propagate. Validation: router group contracts 119 passed, main lifecycle contracts 54 passed, OpenAPI contracts 69 passed, Bandit on minimal.py found 0 results, and git diff --check was clean.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -861,49 +861,37 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
     ):
         append_imported_router_spec(specs, acp_spec)
 
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.agent_orchestration import router as orch_router
-
-        specs.append(RouterSpec(
-            router=orch_router,
+    for tail_spec in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.agent_orchestration",
+            log_name="agent_orchestration",
             prefix=f"{API_V1_PREFIX}",
             tags=("agent-orchestration",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping orchestration router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.setup import router as setup_router
-
-        specs.append(RouterSpec(
-            router=setup_router,
+            skip_context=minimal_skip_context,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.setup",
+            log_name="setup",
             prefix=f"{API_V1_PREFIX}",
             tags=("setup",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping setup router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.metrics import router as metrics_router
-
-        specs.append(RouterSpec(
-            router=metrics_router,
+            skip_context=minimal_skip_context,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.metrics",
+            log_name="metrics",
             prefix=f"{API_V1_PREFIX}",
             tags=("metrics",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping metrics router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.authnz_debug import router as authnz_debug_router
-
-        specs.append(RouterSpec(
-            router=authnz_debug_router,
+            skip_context=minimal_skip_context,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.authnz_debug",
+            log_name="authnz_debug",
             prefix=f"{API_V1_PREFIX}",
             tags=("authnz-debug",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping authnz_debug router in tests: {e}")
+            skip_context=minimal_skip_context,
+        ),
+    ):
+        append_imported_router_spec(specs, tail_spec)
 
     append_imported_router_spec(
         specs,

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -216,6 +216,36 @@ PRIVILEGES_TOOLS_ROUTER_DEFINITION_DATA = (
         "/tools",
     ),
 )
+MINIMAL_TAIL_ROUTER_DEFINITION_DATA = (
+    (
+        "tldw_Server_API.app.api.v1.endpoints.agent_orchestration",
+        "agent_orchestration",
+        "/api/v1",
+        ("agent-orchestration",),
+        "/agent-orchestration",
+    ),
+    (
+        "tldw_Server_API.app.api.v1.endpoints.setup",
+        "setup",
+        "/api/v1",
+        ("setup",),
+        "/setup/status",
+    ),
+    (
+        "tldw_Server_API.app.api.v1.endpoints.metrics",
+        "metrics",
+        "/api/v1",
+        ("metrics",),
+        "/metrics/text",
+    ),
+    (
+        "tldw_Server_API.app.api.v1.endpoints.authnz_debug",
+        "authnz_debug",
+        "/api/v1",
+        ("authnz-debug",),
+        "/authnz-debug/status",
+    ),
+)
 
 
 def _main_source_text() -> str:
@@ -7528,6 +7558,235 @@ def test_iter_minimal_optional_router_specs_propagates_privileges_tools_runtime_
     )
 
     with pytest.raises(RuntimeError, match="privileges exploded during import"):
+        register_router_specs(FastAPI(), (selected_spec,))
+
+
+def test_iter_minimal_optional_router_specs_defers_tail_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal tail specs keep module import and attr lookup lazy."""
+    import builtins
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    definitions_by_module = {
+        module_name: {
+            "module_name": module_name,
+            "expected_name": expected_name,
+            "prefix": prefix,
+            "tags": tags,
+            "path": path,
+        }
+        for module_name, expected_name, prefix, tags, path in MINIMAL_TAIL_ROUTER_DEFINITION_DATA
+    }
+    router_definitions = tuple(definitions_by_module.values())
+    access_count = {
+        f"{definition['module_name']}.router": 0
+        for definition in router_definitions
+    }
+    import_calls: list[str] = []
+
+    for module_name, definition in definitions_by_module.items():
+        fake_module = ModuleType(module_name)
+        router = APIRouter()
+
+        @router.get(str(definition["path"]))
+        def _endpoint() -> dict[str, str]:
+            """Return a deterministic response for the fake minimal tail router."""
+            return {"status": "ok"}
+
+        def _module_getattr(
+            name: str,
+            *,
+            module_name: str = module_name,
+            router: APIRouter = router,
+        ) -> APIRouter:
+            """Track lazy router attribute resolution for the fake module."""
+            if name != "router":
+                raise AttributeError(name)
+            access_count[f"{module_name}.router"] += 1
+            return router
+
+        fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    endpoints_package = "tldw_Server_API.app.api.v1.endpoints."
+    real_import = builtins.__import__
+
+    def _fake_endpoint_import(
+        name: str,
+        globals: dict[str, object] | None = None,
+        locals: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> ModuleType:
+        """Track selected imports and fake unrelated eager optional routers."""
+        if (
+            level == 0
+            and name.startswith(endpoints_package)
+        ):
+            if name in definitions_by_module:
+                import_calls.append(name)
+                return real_import(name, globals, locals, fromlist, level)
+            attrs = tuple(attr for attr in fromlist if attr != "*") or ("router",)
+            for attr_name in attrs:
+                _install_fake_router_module(
+                    monkeypatch,
+                    name,
+                    path="/minimal-unrelated-tail-fake",
+                    attr_name=attr_name,
+                )
+            return sys.modules[name]
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_endpoint_import)
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Track lazy module imports for selected minimal tail routers."""
+        if module_name in definitions_by_module:
+            import_calls.append(module_name)
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+    fake_main = ModuleType("tldw_Server_API.app.main")
+    fake_main.app = FastAPI()  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "tldw_Server_API.app.main", fake_main)
+
+    specs = list(iter_minimal_optional_router_specs())
+    assert [
+        module_name
+        for module_name in definitions_by_module
+        if module_name in import_calls
+    ] == []
+    assert access_count == {
+        f"{definition['module_name']}.router": 0
+        for definition in router_definitions
+    }
+    assert import_calls == []
+
+    selected_specs = {
+        spec.name: spec
+        for spec in specs
+        if spec.name in {
+            str(definition["expected_name"])
+            for definition in router_definitions
+        }
+    }
+    assert set(selected_specs) == {
+        str(definition["expected_name"])
+        for definition in router_definitions
+    }
+
+    for definition in router_definitions:
+        spec = selected_specs[str(definition["expected_name"])]
+        assert spec.prefix == definition["prefix"]
+        assert spec.tags == definition["tags"]
+        assert spec.route_key == ""
+        assert spec.skip_context == "in minimal test app"
+        assert spec.default_stable is True
+        assert [exc.__name__ for exc in spec.skip_exceptions] == [
+            "OptionalRouterMissingModule",
+            "OptionalRouterMissingAttribute",
+        ]
+        assert _first_router_path(spec.router) == definition["path"]
+
+    assert import_calls == [
+        str(definition["module_name"])
+        for definition in router_definitions
+    ]
+    assert access_count == {
+        f"{definition['module_name']}.router": 1
+        for definition in router_definitions
+    }
+
+
+def test_iter_minimal_optional_router_specs_skips_tail_missing_import_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal tail specs skip missing optional router modules."""
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    tail_modules = {
+        module_name
+        for module_name, _expected_name, _prefix, _tags, _path in MINIMAL_TAIL_ROUTER_DEFINITION_DATA
+    }
+    expected_names = {
+        expected_name
+        for _module_name, expected_name, _prefix, _tags, _path in MINIMAL_TAIL_ROUTER_DEFINITION_DATA
+    }
+
+    specs = list(iter_minimal_optional_router_specs())
+    selected_specs = {
+        spec.name: spec
+        for spec in specs
+        if spec.name in expected_names
+    }
+    assert set(selected_specs) == expected_names
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str, package: str | None = None) -> ModuleType:
+        """Fail only the selected minimal tail router imports at registration."""
+        if module_name in tail_modules:
+            raise ModuleNotFoundError(f"{module_name} missing during import", name=module_name)
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    debug_messages: list[str] = []
+    monkeypatch.setattr("loguru.logger.debug", debug_messages.append)
+
+    assert register_router_specs(FastAPI(), selected_specs.values()) == 0
+    assert debug_messages == [
+        f"Skipping {expected_name} router in minimal test app: "
+        f"{module_name} missing during import"
+        for module_name, expected_name, _prefix, _tags, _path in MINIMAL_TAIL_ROUTER_DEFINITION_DATA
+    ]
+
+
+def test_iter_minimal_optional_router_specs_propagates_tail_runtime_import_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal tail runtime import defects are not silently skipped."""
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    module_name = "tldw_Server_API.app.api.v1.endpoints.agent_orchestration"
+    specs = list(iter_minimal_optional_router_specs())
+    selected_spec = next(spec for spec in specs if spec.name == "agent_orchestration")
+
+    real_import_module = importlib.import_module
+
+    def _import_module(import_name: str, package: str | None = None) -> ModuleType:
+        """Crash only one selected minimal tail router import at registration."""
+        if import_name == module_name:
+            raise RuntimeError(f"{module_name} exploded during import")
+        return real_import_module(import_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    with pytest.raises(RuntimeError, match="agent_orchestration exploded during import"):
         register_router_specs(FastAPI(), (selected_spec,))
 
 


### PR DESCRIPTION
## Change summary

This PR converts the remaining minimal-test tail router registrations for `agent_orchestration`, `setup`, `metrics`, and `authnz_debug` from eager `try/except Exception` imports into lazy `ImportedRouterSpec` entries.

The implementation keeps the same prefixes and tags but defers module import and router attribute lookup until router registration. That keeps missing optional router modules skippable for the minimal app while allowing real runtime import defects to fail closed instead of being hidden by broad eager exception handling.

## Validation

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q` - 119 passed
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_lifecycle_contract.py -q` - 54 passed
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q` - 69 passed
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/router_groups/minimal.py -f json -o /tmp/bandit_minimal_tail_router_av.json` - 0 results
- `git diff --check`
- `git diff --cached --check`

## Tracking

- Continues #1116
- Backlog: `TASK-99`
