### PR TITLE
Phase 2.2: narrow minimal workflow skips

### DIFF
--- a/backlog/tasks/task-101 - Phase-2.2-minimal-workflow-router-skip-semantics-AW.md
+++ b/backlog/tasks/task-101 - Phase-2.2-minimal-workflow-router-skip-semantics-AW.md
@@ -1,0 +1,68 @@
+---
+id: TASK-101
+title: Phase 2.2 minimal workflow router skip semantics AW
+status: Done
+assignee: []
+created_date: '2026-05-07 01:35'
+updated_date: '2026-05-07 01:43'
+labels:
+  - phase2.2
+  - router-cleanup
+  - minimal
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+  - 'https://github.com/rmusser01/tldw_server/pull/1347'
+  - 'https://github.com/rmusser01/tldw_server/pull/1348'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Narrow minimal workflow router optional skip behavior after PR #1347 merged. The workflows, chat_workflows, and scheduler_workflows ImportedRouterSpec entries should skip only genuinely missing optional router modules or missing router attributes, while runtime import defects propagate during registration instead of being hidden by skip_exceptions=(Exception,).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Minimal workflow router specs no longer use skip_exceptions=(Exception,)
+- [x] #2 Missing target workflow modules are skipped during registration
+- [x] #3 Runtime import defects from workflow router modules propagate
+- [x] #4 Existing prefixes tags route keys and default stability behavior are preserved
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Update focused contract tests for precise workflow optional skip semantics. 2. Verify RED against current broad skip behavior. 3. Remove broad skip_exceptions from workflow ImportedRouterSpec entries. 4. Run focused and broader verification plus Bandit and diff checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Baseline focused selector passed before edits: minimal workflow tests 2 passed, confirming current broad skip behavior is covered.
+
+TDD RED after test update failed as intended: workflow specs still reported Exception and runtime import failures were skipped. GREEN focused selector passed after removing workflow broad skip overrides: 3 passed.
+
+Broader validation passed: router groups 120 passed, lifecycle 54 passed, OpenAPI 69 passed, Bandit results 0, git diff --check clean.
+
+Scope note: remaining skip_exceptions=(Exception,) occurrences are in non-workflow minimal groups and should be handled in later narrow slices.
+
+Opened PR https://github.com/rmusser01/tldw_server/pull/1348 against dev for this slice.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Narrowed the minimal workflow router ImportedRouterSpec entries for workflows, chat_workflows, and scheduler_workflows by removing broad skip_exceptions=(Exception,) overrides. The workflow specs now use the default precise optional-missing skip exceptions, so missing target modules still skip during registration while runtime import defects propagate. Validation: focused workflow selector 3 passed after RED verification, router group contracts 120 passed, main lifecycle contracts 54 passed, OpenAPI contracts 69 passed, Bandit on minimal.py found 0 results, and git diff --check was clean.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -433,21 +433,18 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
             log_name="workflows",
             tags=("workflows",),
             skip_context=minimal_skip_context,
-            skip_exceptions=(Exception,),
         ),
         ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.chat_workflows",
             log_name="chat_workflows",
             tags=("chat-workflows",),
             skip_context=minimal_skip_context,
-            skip_exceptions=(Exception,),
         ),
         ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.scheduler_workflows",
             log_name="scheduler_workflows",
             tags=("scheduler",),
             skip_context=minimal_skip_context,
-            skip_exceptions=(Exception,),
         ),
     ):
         append_imported_router_spec(specs, workflow_spec)

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -5216,7 +5216,10 @@ def test_iter_minimal_optional_router_specs_defers_workflow_attr_lookup(
         assert spec.route_key == ""
         assert spec.skip_context == "in minimal test app"
         assert spec.default_stable is True
-        assert spec.skip_exceptions == (Exception,)
+        assert [exc.__name__ for exc in spec.skip_exceptions] == [
+            "OptionalRouterMissingModule",
+            "OptionalRouterMissingAttribute",
+        ]
         assert _first_router_path(spec.router) == definition["path"]
 
     assert import_calls == [
@@ -5229,10 +5232,10 @@ def test_iter_minimal_optional_router_specs_defers_workflow_attr_lookup(
     }
 
 
-def test_iter_minimal_optional_router_specs_skips_workflow_runtime_import_failures(
+def test_iter_minimal_optional_router_specs_skips_workflow_missing_import_failures(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Verify minimal workflow specs preserve broad import failure skipping."""
+    """Verify minimal workflow specs skip missing optional router modules."""
     import importlib
 
     from tldw_Server_API.app.api.v1.router_groups.minimal import (
@@ -5256,9 +5259,9 @@ def test_iter_minimal_optional_router_specs_skips_workflow_runtime_import_failur
     real_import_module = importlib.import_module
 
     def _import_module(module_name: str, package: str | None = None) -> ModuleType:
-        """Crash only the selected workflow router imports at registration."""
+        """Fail only the selected workflow router imports at registration."""
         if module_name in workflow_modules:
-            raise RuntimeError(f"{module_name} exploded during import")
+            raise ModuleNotFoundError(f"{module_name} missing during import", name=module_name)
         return real_import_module(module_name, package)
 
     monkeypatch.setattr(
@@ -5272,12 +5275,43 @@ def test_iter_minimal_optional_router_specs_skips_workflow_runtime_import_failur
     assert register_router_specs(FastAPI(), selected_specs.values()) == 0
     assert debug_messages == [
         "Skipping workflows router in minimal test app: "
-        "tldw_Server_API.app.api.v1.endpoints.workflows exploded during import",
+        "tldw_Server_API.app.api.v1.endpoints.workflows missing during import",
         "Skipping chat_workflows router in minimal test app: "
-        "tldw_Server_API.app.api.v1.endpoints.chat_workflows exploded during import",
+        "tldw_Server_API.app.api.v1.endpoints.chat_workflows missing during import",
         "Skipping scheduler_workflows router in minimal test app: "
-        "tldw_Server_API.app.api.v1.endpoints.scheduler_workflows exploded during import",
+        "tldw_Server_API.app.api.v1.endpoints.scheduler_workflows missing during import",
     ]
+
+
+def test_iter_minimal_optional_router_specs_propagates_workflow_runtime_import_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal workflow runtime import defects are not silently skipped."""
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    module_name = "tldw_Server_API.app.api.v1.endpoints.workflows"
+    specs = list(iter_minimal_optional_router_specs())
+    selected_spec = next(spec for spec in specs if spec.name == "workflows")
+
+    real_import_module = importlib.import_module
+
+    def _import_module(import_name: str, package: str | None = None) -> ModuleType:
+        """Crash only one selected workflow router import at registration."""
+        if import_name == module_name:
+            raise RuntimeError(f"{module_name} exploded during import")
+        return real_import_module(import_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    with pytest.raises(RuntimeError, match="workflows exploded during import"):
+        register_router_specs(FastAPI(), (selected_spec,))
 
 
 def test_iter_minimal_optional_router_specs_defers_utility_attr_lookup(


### PR DESCRIPTION
## Change summary

This PR narrows the optional skip behavior for the minimal workflow routers: `workflows`, `chat_workflows`, and `scheduler_workflows`.

Those `ImportedRouterSpec` entries previously used `skip_exceptions=(Exception,)`, which meant registration swallowed every runtime import failure for that router family. The implementation removes the broad overrides so the specs use the default optional-missing exceptions. Missing target modules or missing `router` attributes still skip in the minimal app, but real runtime defects now propagate instead of being hidden.

## Validation

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "minimal_optional_router_specs and workflow" -q` - RED failed before implementation, then 3 passed after implementation
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q` - 120 passed
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_lifecycle_contract.py -q` - 54 passed
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q` - 69 passed
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/router_groups/minimal.py -f json -o /tmp/bandit_minimal_workflow_skip_aw.json` - 0 results
- `git diff --check`
- `git diff --cached --check`

## Tracking

- Continues #1116
- Backlog: `TASK-101`
