### PR TITLE
Adapt WorldBookEmptyState to shared EmptyState

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -5544,17 +5544,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "local-empty-state:src/components/Option/WorldBooks/WorldBookEmptyState.tsx:WorldBookEmptyState",
-    "path": "src/components/Option/WorldBooks/WorldBookEmptyState.tsx",
-    "rule": "local-empty-state",
-    "subject": "WorldBookEmptyState",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing local WorldBookEmptyState empty-state wrapper before the guard.",
-    "replacement": "EmptyState",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "local-loading-state:src/components/Common/UnifiedLoadingState.tsx:UnifiedLoadingState",
     "path": "src/components/Common/UnifiedLoadingState.tsx",
     "rule": "local-loading-state",

--- a/apps/packages/ui/src/components/Option/WorldBooks/WorldBookEmptyState.tsx
+++ b/apps/packages/ui/src/components/Option/WorldBooks/WorldBookEmptyState.tsx
@@ -1,6 +1,8 @@
 import React from "react"
-import { Button } from "antd"
+import { BookOpen, FileText, Link, Plus, Upload } from "lucide-react"
 import { useTranslation } from "react-i18next"
+import { Button } from "@/components/Common/Button"
+import { EmptyState } from "@/components/ui/feedback/EmptyState"
 import { WORLD_BOOK_STARTER_TEMPLATES } from "./worldBookFormUtils"
 
 type WorldBookEmptyStateProps = {
@@ -15,82 +17,71 @@ export const WorldBookEmptyState: React.FC<WorldBookEmptyStateProps> = ({
   onImport
 }) => {
   const { t } = useTranslation(["option"])
+  const title = t("worldBooks.emptyState.title", {
+    defaultValue: "World Books"
+  })
+  const description = t("worldBooks.emptyState.description", {
+    defaultValue:
+      "World books inject background knowledge into every message. Define facts, rules, or lore once and the AI references them automatically when keywords match."
+  })
+  const step1 = t("worldBooks.emptyState.step1", {
+    defaultValue: "Create a world book to hold related knowledge"
+  })
+  const step2 = t("worldBooks.emptyState.step2", {
+    defaultValue: "Add entries with keywords that trigger injection"
+  })
+  const step3 = t("worldBooks.emptyState.step3", {
+    defaultValue: "Attach to a character or chat to activate"
+  })
+  const example = t("worldBooks.emptyState.example", {
+    defaultValue:
+      "Example: An entry with the keyword \"magic system\" will automatically inject its content whenever someone mentions magic system in conversation, giving the AI the context it needs without you repeating yourself."
+  })
+  const createLabel = t("worldBooks.emptyState.createFirst", {
+    defaultValue: "Create your first world book"
+  })
+  const quickStartLabel = t("worldBooks.emptyState.quickStart", {
+    defaultValue: "Or start from a template:"
+  })
+  const importLabel = t("worldBooks.emptyState.import", {
+    defaultValue: "Import from JSON"
+  })
 
   return (
-    <div className="mx-auto max-w-xl rounded-2xl border border-border bg-surface p-7 text-sm text-text">
-      <div className="space-y-5">
-        <h2 className="text-lg font-semibold text-text">
-          {t("worldBooks.emptyState.title", {
-            defaultValue: "World Books"
-          })}
-        </h2>
-
-        <p className="text-sm text-text-muted">
-          {t("worldBooks.emptyState.description", {
-            defaultValue:
-              "World books inject background knowledge into every message. Define facts, rules, or lore once and the AI references them automatically when keywords match."
-          })}
-        </p>
-
-        {/* 3-step visual flow */}
-        <ol className="space-y-2 text-sm text-text-muted">
-          <li className="flex items-start gap-2">
-            <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary">
-              1
-            </span>
-            <span>
-              {t("worldBooks.emptyState.step1", {
-                defaultValue: "Create a world book to hold related knowledge"
-              })}
-            </span>
-          </li>
-          <li className="flex items-start gap-2">
-            <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary">
-              2
-            </span>
-            <span>
-              {t("worldBooks.emptyState.step2", {
-                defaultValue: "Add entries with keywords that trigger injection"
-              })}
-            </span>
-          </li>
-          <li className="flex items-start gap-2">
-            <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary">
-              3
-            </span>
-            <span>
-              {t("worldBooks.emptyState.step3", {
-                defaultValue: "Attach to a character or chat to activate"
-              })}
-            </span>
-          </li>
-        </ol>
-
-        {/* Concrete example */}
-        <div className="rounded-lg bg-surface2/60 px-4 py-3 text-xs text-text-muted">
-          {t("worldBooks.emptyState.example", {
-            defaultValue:
-              "Example: An entry with the keyword \"magic system\" will automatically inject its content whenever someone mentions magic system in conversation, giving the AI the context it needs without you repeating yourself."
-          })}
+    <EmptyState
+      title={title}
+      description={description}
+      icon={BookOpen}
+      iconClassName="text-text-muted"
+      size="lg"
+      variant="card"
+      className="text-sm text-text"
+      steps={[
+        { icon: BookOpen, text: step1 },
+        { icon: FileText, text: step2 },
+        { icon: Link, text: step3 }
+      ]}
+      primaryAction={{
+        label: createLabel,
+        icon: <Plus className="h-4 w-4" />,
+        onClick: onCreateNew
+      }}
+      secondaryAction={{
+        label: importLabel,
+        icon: <Upload className="h-4 w-4" />,
+        onClick: onImport
+      }}
+    >
+      <div className="space-y-5 pt-2">
+        <div className="rounded-lg bg-surface2/60 px-4 py-3 text-left text-xs text-text-muted">
+          {example}
         </div>
 
-        {/* Primary CTA */}
-        <div>
-          <Button type="primary" onClick={onCreateNew}>
-            {t("worldBooks.emptyState.createFirst", {
-              defaultValue: "Create your first world book"
-            })}
-          </Button>
-        </div>
-
-        {/* Template quick-start buttons */}
         <div className="space-y-2">
           <p className="text-xs font-medium text-text-muted">
-            {t("worldBooks.emptyState.quickStart", {
-              defaultValue: "Or start from a template:"
-            })}
+            {quickStartLabel}
           </p>
-          <div className="flex flex-wrap gap-2">
+          <div className="flex flex-wrap justify-center gap-2">
             {WORLD_BOOK_STARTER_TEMPLATES.map((template) => (
               <Button
                 key={template.key}
@@ -102,16 +93,7 @@ export const WorldBookEmptyState: React.FC<WorldBookEmptyStateProps> = ({
             ))}
           </div>
         </div>
-
-        {/* Import button */}
-        <div>
-          <Button type="default" onClick={onImport}>
-            {t("worldBooks.emptyState.import", {
-              defaultValue: "Import from JSON"
-            })}
-          </Button>
-        </div>
       </div>
-    </div>
+    </EmptyState>
   )
 }

--- a/apps/packages/ui/src/components/Option/WorldBooks/__tests__/WorldBookEmptyState.test.tsx
+++ b/apps/packages/ui/src/components/Option/WorldBooks/__tests__/WorldBookEmptyState.test.tsx
@@ -28,8 +28,9 @@ describe("WorldBookEmptyState", () => {
   }
 
   it("renders the 3-step visual flow", () => {
-    render(<WorldBookEmptyState {...defaultProps} />)
+    const { container } = render(<WorldBookEmptyState {...defaultProps} />)
 
+    expect(container.querySelector('[data-ds-component="EmptyState"]')).toBeInTheDocument()
     expect(screen.getByText(/create a world book/i)).toBeInTheDocument()
     expect(screen.getByText(/add entries/i)).toBeInTheDocument()
     expect(screen.getByText(/attach/i)).toBeInTheDocument()

--- a/backlog/tasks/task-45.13 - Adapt-WorldBookEmptyState-to-shared-EmptyState.md
+++ b/backlog/tasks/task-45.13 - Adapt-WorldBookEmptyState-to-shared-EmptyState.md
@@ -4,7 +4,7 @@ title: Adapt WorldBookEmptyState to shared EmptyState
 status: Done
 assignee: []
 created_date: '2026-05-07 01:35'
-updated_date: '2026-05-07 01:45'
+updated_date: '2026-05-07 01:46'
 labels:
   - design-system
   - frontend
@@ -46,6 +46,8 @@ Baseline before implementation: after installing apps/packages/ui dependencies i
 TDD red/green: added a canonical EmptyState marker assertion to WorldBookEmptyState.test.tsx, then verified it failed against the local wrapper with received null for data-ds-component=EmptyState. Adapted WorldBookEmptyState to render components/ui/feedback/EmptyState and shared Button actions while preserving current title, description, steps, example copy, template quick starts, create callback, import callback, and translation fallbacks.
 
 Verification after implementation: focused bunx vitest run src/components/Option/WorldBooks/__tests__/WorldBookEmptyState.test.tsx passed 6/6; combined focused run for WorldBookEmptyState, FeatureEmptyState, and product-state-guard passed 47/47; bun run verify:design-system-state exited 0 with baseline exceptions reduced from 523 to 522 and local-empty-state reduced from 3 to 2; git diff --check exited 0 before task-finalization edits. Broader bun run test:worldbooks passed 62 test files, 192 tests passed, 6 skipped, with existing jsdom CSS parse warnings. Bandit is not applicable to this frontend-only TypeScript/JSON slice.
+
+PR opened: https://github.com/rmusser01/tldw_server/pull/1349
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-45.13 - Adapt-WorldBookEmptyState-to-shared-EmptyState.md
+++ b/backlog/tasks/task-45.13 - Adapt-WorldBookEmptyState-to-shared-EmptyState.md
@@ -1,0 +1,65 @@
+---
+id: TASK-45.13
+title: Adapt WorldBookEmptyState to shared EmptyState
+status: Done
+assignee: []
+created_date: '2026-05-07 01:35'
+updated_date: '2026-05-07 01:45'
+labels:
+  - design-system
+  - frontend
+  - worldbooks
+dependencies: []
+documentation:
+  - Docs/Design/tldw_web_design_system_contract.md
+  - Docs/Design/tldw_web_design_system_inventory.md
+parent_task_id: TASK-45
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue the shared product-state design-system migration by adapting the dedicated WorldBookEmptyState wrapper to render the canonical components/ui/feedback/EmptyState primitive. Preserve the current World Books first-run content, 3-step flow, example text, template quick-start actions, import action, callbacks, and translation fallbacks. Keep scope limited to WorldBookEmptyState, its focused tests, and the product-state baseline entry for this component.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 WorldBookEmptyState renders the canonical EmptyState design-system marker while preserving title, description, steps, example copy, template buttons, import action, callbacks, and i18n fallbacks.
+- [x] #2 Focused tests cover the canonical EmptyState marker plus the existing WorldBookEmptyState behavior for steps, example copy, template quick starts, primary create action, and import action.
+- [x] #3 The product-state guard passes without the WorldBookEmptyState local-empty-state baseline debt, and only the migrated stale baseline entry is removed.
+- [x] #4 Scope remains limited to the WorldBookEmptyState wrapper, its focused tests, and the design-system baseline; no unrelated World Books manager or broader empty-state migrations are included.
+- [x] #5 Focused Vitest coverage, design-system state verification, git diff checks, and Bandit applicability are recorded before completion.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add/adjust the focused WorldBookEmptyState test first so it requires the canonical EmptyState marker while preserving existing behavior assertions. 2. Run the focused test to verify the new assertion fails against the current local wrapper. 3. Adapt WorldBookEmptyState to compose components/ui/feedback/EmptyState and shared Button-compatible actions while preserving current copy, template callbacks, import callback, layout intent, and translation defaults. 4. Remove the migrated WorldBookEmptyState local-empty-state baseline entry only after the component renders the canonical primitive. 5. Rerun the focused WorldBookEmptyState, FeatureEmptyState, and product-state guard tests plus bun run verify:design-system-state and git diff --check; document frontend-only Bandit skip if applicable.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Baseline before implementation: after installing apps/packages/ui dependencies in the new worktree, bunx vitest run src/components/Option/WorldBooks/__tests__/WorldBookEmptyState.test.tsx src/components/Common/__tests__/FeatureEmptyState.test.tsx src/design-system/__tests__/product-state-guard.test.ts --maxWorkers=1 --reporter=dot passed 47/47. bun run verify:design-system-state exited 0 with 523 allowed legacy exceptions and WorldBookEmptyState still present as local-empty-state debt.
+
+TDD red/green: added a canonical EmptyState marker assertion to WorldBookEmptyState.test.tsx, then verified it failed against the local wrapper with received null for data-ds-component=EmptyState. Adapted WorldBookEmptyState to render components/ui/feedback/EmptyState and shared Button actions while preserving current title, description, steps, example copy, template quick starts, create callback, import callback, and translation fallbacks.
+
+Verification after implementation: focused bunx vitest run src/components/Option/WorldBooks/__tests__/WorldBookEmptyState.test.tsx passed 6/6; combined focused run for WorldBookEmptyState, FeatureEmptyState, and product-state-guard passed 47/47; bun run verify:design-system-state exited 0 with baseline exceptions reduced from 523 to 522 and local-empty-state reduced from 3 to 2; git diff --check exited 0 before task-finalization edits. Broader bun run test:worldbooks passed 62 test files, 192 tests passed, 6 skipped, with existing jsdom CSS parse warnings. Bandit is not applicable to this frontend-only TypeScript/JSON slice.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Adapted WorldBookEmptyState to the canonical EmptyState primitive while keeping the World Books first-run copy, step guidance, example text, template buttons, create action, import action, callbacks, and i18n fallbacks intact. Added focused coverage for the canonical design-system marker and removed the migrated WorldBookEmptyState local-empty-state baseline exception.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Adapt WorldBookEmptyState to render the canonical EmptyState primitive instead of local card markup and direct AntD Button usage.
- Preserve the existing World Books first-run copy, step guidance, example, template quick-start buttons, create action, import action, callbacks, and i18n fallbacks.
- Remove the migrated WorldBookEmptyState local-empty-state baseline exception and track the slice in Backlog task TASK-45.13.

## Test Plan
- bunx vitest run src/components/Option/WorldBooks/__tests__/WorldBookEmptyState.test.tsx --maxWorkers=1 --reporter=dot
- bunx vitest run src/components/Option/WorldBooks/__tests__/WorldBookEmptyState.test.tsx src/components/Common/__tests__/FeatureEmptyState.test.tsx src/design-system/__tests__/product-state-guard.test.ts --maxWorkers=1 --reporter=dot
- bun run verify:design-system-state
- bun run test:worldbooks
- git diff --check

## Change summary
WorldBookEmptyState now composes the shared EmptyState primitive so the World Books first-run surface follows the design-system product-state contract while keeping its existing user-facing behavior. The wrapper still owns World Books-specific copy and template actions, but layout/state semantics now come from the canonical primitive; the stale guard baseline entry is removed so future local empty-state regressions stay visible.