### PR TITLE
Adapt SearchEmptyState to shared EmptyState

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -5522,17 +5522,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "local-empty-state:src/components/Knowledge/SearchTab/SearchEmptyState.tsx:SearchEmptyState",
-    "path": "src/components/Knowledge/SearchTab/SearchEmptyState.tsx",
-    "rule": "local-empty-state",
-    "subject": "SearchEmptyState",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing local SearchEmptyState empty-state wrapper before the guard.",
-    "replacement": "EmptyState",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "local-empty-state:src/components/Option/WorkspacePlayground/ChatPane/index.tsx:WorkspaceChatEmpty",
     "path": "src/components/Option/WorkspacePlayground/ChatPane/index.tsx",
     "rule": "local-empty-state",

--- a/apps/packages/ui/src/components/Knowledge/SearchTab/SearchEmptyState.tsx
+++ b/apps/packages/ui/src/components/Knowledge/SearchTab/SearchEmptyState.tsx
@@ -1,7 +1,7 @@
 import React from "react"
-import { Button } from "antd"
 import { AlertCircle, Search, RefreshCw } from "lucide-react"
 import { useTranslation } from "react-i18next"
+import { EmptyState } from "@/components/ui/feedback/EmptyState"
 
 type EmptyStateVariant = "initial" | "no-results" | "timeout" | "disconnected"
 
@@ -25,82 +25,81 @@ export const SearchEmptyState: React.FC<SearchEmptyStateProps> = ({
 
   if (variant === "initial") {
     return (
-      <div className="flex flex-col items-center justify-center py-8 text-center">
-        <Search className="h-10 w-10 text-text-muted mb-3" />
-        <p className="text-sm text-text-muted mb-1">
-          {t("sidepanel:rag.initialState", "No results yet")}
-        </p>
-        <p className="text-xs text-text-muted">
-          {t(
-            "sidepanel:rag.hint.message",
-            "Search your knowledge base and insert results into your message."
-          )}
-        </p>
-        {showHint && onDismissHint && (
-          <Button
-            type="link"
-            size="small"
-            onClick={onDismissHint}
-            className="mt-2 text-xs"
-          >
-            {t("sidepanel:rag.hint.dismiss", "Dismiss")}
-          </Button>
+      <EmptyState
+        title={t("sidepanel:rag.initialState", "No results yet")}
+        description={t(
+          "sidepanel:rag.hint.message",
+          "Search your knowledge base and insert results into your message."
         )}
-      </div>
+        icon={Search}
+        iconClassName="text-text-muted"
+        size="md"
+        variant="inline"
+        className="py-8"
+        secondaryAction={
+          showHint && onDismissHint
+            ? {
+                label: t("sidepanel:rag.hint.dismiss", "Dismiss"),
+                onClick: onDismissHint
+              }
+            : undefined
+        }
+      />
     )
   }
 
   if (variant === "no-results") {
     return (
-      <div className="flex flex-col items-center justify-center py-8 text-center">
-        <Search className="h-10 w-10 text-text-muted mb-3" />
-        <p className="text-sm text-text-muted">
-          {t("sidepanel:rag.noResults", "No results found")}
-        </p>
-        <p className="text-xs text-text-muted mt-1">
-          {t(
-            "sidepanel:rag.tryDifferentQuery",
-            "Try a different search query or adjust your filters."
-          )}
-        </p>
-      </div>
+      <EmptyState
+        title={t("sidepanel:rag.noResults", "No results found")}
+        description={t(
+          "sidepanel:rag.tryDifferentQuery",
+          "Try a different search query or adjust your filters."
+        )}
+        icon={Search}
+        iconClassName="text-text-muted"
+        size="md"
+        variant="inline"
+        className="py-8"
+      />
     )
   }
 
   if (variant === "timeout") {
     return (
-      <div className="flex flex-col items-center justify-center py-8 text-center">
-        <AlertCircle className="h-10 w-10 text-warn mb-3" />
-        <p className="text-sm text-text mb-2">
-          {t("sidepanel:rag.timeout.message", "Request timed out.")}
-        </p>
-        <div className="flex gap-2">
-          {onRetry && (
-            <Button
-              type="primary"
-              size="small"
-              onClick={onRetry}
-              icon={<RefreshCw className="h-3.5 w-3.5" />}
-            >
-              {t("sidepanel:rag.timeout.retry", "Retry")}
-            </Button>
-          )}
-        </div>
-      </div>
+      <EmptyState
+        title={t("sidepanel:rag.timeout.message", "Request timed out.")}
+        icon={AlertCircle}
+        iconClassName="text-warn"
+        size="md"
+        variant="inline"
+        className="py-8"
+        primaryAction={
+          onRetry
+            ? {
+                label: t("sidepanel:rag.timeout.retry", "Retry"),
+                icon: <RefreshCw className="h-3.5 w-3.5" />,
+                onClick: onRetry
+              }
+            : undefined
+        }
+      />
     )
   }
 
   if (variant === "disconnected") {
     return (
-      <div className="flex flex-col items-center justify-center py-8 text-center">
-        <AlertCircle className="h-10 w-10 text-error mb-3" />
-        <p className="text-sm text-text">
-          {t(
-            "sidepanel:rag.disconnected",
-            "Connect to server to search knowledge base"
-          )}
-        </p>
-      </div>
+      <EmptyState
+        title={t(
+          "sidepanel:rag.disconnected",
+          "Connect to server to search knowledge base"
+        )}
+        icon={AlertCircle}
+        iconClassName="text-error"
+        size="md"
+        variant="inline"
+        className="py-8"
+      />
     )
   }
 

--- a/apps/packages/ui/src/components/Knowledge/SearchTab/__tests__/SearchEmptyState.test.tsx
+++ b/apps/packages/ui/src/components/Knowledge/SearchTab/__tests__/SearchEmptyState.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+import { SearchEmptyState } from "../SearchEmptyState"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: unknown) =>
+      typeof fallback === "string" ? fallback : key
+  })
+}))
+
+describe("SearchEmptyState", () => {
+  it("renders the initial state with canonical EmptyState semantics and dismissible hint", async () => {
+    const user = userEvent.setup()
+    const onDismissHint = vi.fn()
+    const { container } = render(
+      <SearchEmptyState
+        variant="initial"
+        showHint
+        onDismissHint={onDismissHint}
+      />
+    )
+
+    expect(container.querySelector('[data-ds-component="EmptyState"]')).toBeInTheDocument()
+    expect(screen.getByText("No results yet")).toBeInTheDocument()
+    expect(
+      screen.getByText("Search your knowledge base and insert results into your message.")
+    ).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Dismiss" }))
+    expect(onDismissHint).toHaveBeenCalledTimes(1)
+  })
+
+  it("renders no-results guidance with canonical EmptyState semantics", () => {
+    const { container } = render(<SearchEmptyState variant="no-results" />)
+
+    expect(container.querySelector('[data-ds-component="EmptyState"]')).toBeInTheDocument()
+    expect(screen.getByText("No results found")).toBeInTheDocument()
+    expect(
+      screen.getByText("Try a different search query or adjust your filters.")
+    ).toBeInTheDocument()
+  })
+
+  it("renders timeout recovery with retry action", async () => {
+    const user = userEvent.setup()
+    const onRetry = vi.fn()
+    const { container } = render(
+      <SearchEmptyState variant="timeout" onRetry={onRetry} />
+    )
+
+    expect(container.querySelector('[data-ds-component="EmptyState"]')).toBeInTheDocument()
+    expect(screen.getByText("Request timed out.")).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Retry" }))
+    expect(onRetry).toHaveBeenCalledTimes(1)
+  })
+
+  it("omits timeout retry action when no retry callback is provided", () => {
+    const { container } = render(<SearchEmptyState variant="timeout" />)
+
+    expect(container.querySelector('[data-ds-component="EmptyState"]')).toBeInTheDocument()
+    expect(screen.getByText("Request timed out.")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Retry" })).not.toBeInTheDocument()
+  })
+
+  it("renders disconnected guidance with canonical EmptyState semantics", () => {
+    const { container } = render(<SearchEmptyState variant="disconnected" />)
+
+    expect(container.querySelector('[data-ds-component="EmptyState"]')).toBeInTheDocument()
+    expect(
+      screen.getByText("Connect to server to search knowledge base")
+    ).toBeInTheDocument()
+  })
+})

--- a/backlog/tasks/task-45.14 - Adapt-SearchEmptyState-to-shared-EmptyState.md
+++ b/backlog/tasks/task-45.14 - Adapt-SearchEmptyState-to-shared-EmptyState.md
@@ -1,0 +1,65 @@
+---
+id: TASK-45.14
+title: Adapt SearchEmptyState to shared EmptyState
+status: Done
+assignee: []
+created_date: '2026-05-07 01:51'
+updated_date: '2026-05-07 01:53'
+labels:
+  - design-system
+  - frontend
+  - knowledge
+dependencies: []
+documentation:
+  - Docs/Design/tldw_web_design_system_contract.md
+  - Docs/Design/tldw_web_design_system_inventory.md
+parent_task_id: TASK-45
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue the shared product-state design-system migration by adapting the Knowledge SearchEmptyState wrapper to render the canonical components/ui/feedback/EmptyState primitive. Preserve the four existing variants (initial, no-results, timeout, disconnected), copy, retry callback, dismiss hint callback, showHint behavior, and i18n fallbacks across SearchTab, FileSearchTab, and QASearchTab consumers. Keep scope limited to SearchEmptyState, focused tests, and the product-state baseline entry for this component.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 SearchEmptyState renders the canonical EmptyState design-system marker for initial, no-results, timeout, and disconnected variants while preserving variant-specific copy and icon intent.
+- [x] #2 Focused tests cover dismiss hint behavior for initial, retry behavior for timeout, absent retry action when no callback is provided, no-results copy, disconnected copy, and the canonical EmptyState marker.
+- [x] #3 The product-state guard passes without the SearchEmptyState local-empty-state baseline debt, and only the migrated stale baseline entry is removed.
+- [x] #4 Scope remains limited to SearchEmptyState, its direct focused test, and the design-system baseline; no unrelated Knowledge search behavior or consumer rewrites are included.
+- [x] #5 Focused Vitest coverage, design-system state verification, git diff checks, and Bandit applicability are recorded before completion.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused SearchEmptyState test that requires the canonical EmptyState marker while preserving current variant copy and action behavior. 2. Run the focused test to verify the canonical-marker assertion fails against the current local wrapper. 3. Adapt SearchEmptyState to compose components/ui/feedback/EmptyState and shared Button-compatible actions while preserving current variants, callbacks, showHint behavior, and translation defaults. 4. Remove the migrated SearchEmptyState local-empty-state baseline entry only after the component renders the canonical primitive. 5. Rerun focused SearchEmptyState tests, nearby Knowledge tests, product-state guard tests, bun run verify:design-system-state, and git diff --check; document frontend-only Bandit skip if applicable.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Baseline before implementation: after installing apps/packages/ui dependencies in the new worktree, bunx vitest run src/components/Knowledge/__tests__/KnowledgeTabs.test.tsx src/components/Knowledge/__tests__/KnowledgePanelTabRouting.test.tsx src/components/Knowledge/QASearchTab/__tests__/GeneratedAnswerCard.test.tsx src/design-system/__tests__/product-state-guard.test.ts --maxWorkers=1 --reporter=dot passed 45/45 with existing tldw server not configured request warnings. bun run verify:design-system-state exited 0 with 522 allowed legacy exceptions and SearchEmptyState still present as local-empty-state debt.
+
+TDD red/green: added a focused SearchEmptyState test covering the canonical EmptyState marker for initial, no-results, timeout, and disconnected variants plus dismiss/retry action behavior. The red run failed as expected because data-ds-component=EmptyState was missing from the current local wrapper for all variants. Adapted SearchEmptyState to render components/ui/feedback/EmptyState and removed direct AntD Button usage while preserving variant copy, retry callback, dismiss callback, showHint behavior, and translation fallbacks.
+
+Verification after implementation: focused SearchEmptyState test passed 5/5; combined focused run for SearchEmptyState, nearby Knowledge tests, GeneratedAnswerCard, and product-state-guard passed 50/50 with existing tldw server not configured request warnings; bun run verify:design-system-state exited 0 with baseline exceptions reduced from 522 to 521 and local-empty-state reduced from 2 to 1; broader bunx vitest run src/components/Knowledge --maxWorkers=1 --reporter=dot passed 12 test files and 38 tests with existing tldw server not configured request warnings; git diff --check exited 0 before final task-record edits. Bandit is not applicable to this frontend-only TypeScript/JSON slice.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Adapted SearchEmptyState to the canonical EmptyState primitive while preserving the initial, no-results, timeout, and disconnected variants, including copy, retry behavior, dismiss hint behavior, showHint gating, and i18n fallbacks. Added focused coverage for the canonical design-system marker and removed the migrated SearchEmptyState local-empty-state baseline exception.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.14 - Adapt-SearchEmptyState-to-shared-EmptyState.md
+++ b/backlog/tasks/task-45.14 - Adapt-SearchEmptyState-to-shared-EmptyState.md
@@ -4,7 +4,7 @@ title: Adapt SearchEmptyState to shared EmptyState
 status: Done
 assignee: []
 created_date: '2026-05-07 01:51'
-updated_date: '2026-05-07 01:53'
+updated_date: '2026-05-07 01:56'
 labels:
   - design-system
   - frontend
@@ -46,6 +46,8 @@ Baseline before implementation: after installing apps/packages/ui dependencies i
 TDD red/green: added a focused SearchEmptyState test covering the canonical EmptyState marker for initial, no-results, timeout, and disconnected variants plus dismiss/retry action behavior. The red run failed as expected because data-ds-component=EmptyState was missing from the current local wrapper for all variants. Adapted SearchEmptyState to render components/ui/feedback/EmptyState and removed direct AntD Button usage while preserving variant copy, retry callback, dismiss callback, showHint behavior, and translation fallbacks.
 
 Verification after implementation: focused SearchEmptyState test passed 5/5; combined focused run for SearchEmptyState, nearby Knowledge tests, GeneratedAnswerCard, and product-state-guard passed 50/50 with existing tldw server not configured request warnings; bun run verify:design-system-state exited 0 with baseline exceptions reduced from 522 to 521 and local-empty-state reduced from 2 to 1; broader bunx vitest run src/components/Knowledge --maxWorkers=1 --reporter=dot passed 12 test files and 38 tests with existing tldw server not configured request warnings; git diff --check exited 0 before final task-record edits. Bandit is not applicable to this frontend-only TypeScript/JSON slice.
+
+PR opened: https://github.com/rmusser01/tldw_server/pull/1350
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary


### PR DESCRIPTION
## Summary
- Adapt Knowledge SearchEmptyState to render the canonical EmptyState primitive instead of local empty-state markup and direct AntD Button usage.
- Preserve initial, no-results, timeout, and disconnected variants, including copy, retry behavior, dismiss hint behavior, showHint gating, and i18n fallbacks.
- Remove the migrated SearchEmptyState local-empty-state baseline exception and track the slice in Backlog task TASK-45.14.

## Test Plan
- bunx vitest run src/components/Knowledge/SearchTab/__tests__/SearchEmptyState.test.tsx --maxWorkers=1 --reporter=dot
- bunx vitest run src/components/Knowledge/SearchTab/__tests__/SearchEmptyState.test.tsx src/components/Knowledge/__tests__/KnowledgeTabs.test.tsx src/components/Knowledge/__tests__/KnowledgePanelTabRouting.test.tsx src/components/Knowledge/QASearchTab/__tests__/GeneratedAnswerCard.test.tsx src/design-system/__tests__/product-state-guard.test.ts --maxWorkers=1 --reporter=dot
- bun run verify:design-system-state
- bunx vitest run src/components/Knowledge --maxWorkers=1 --reporter=dot
- git diff --check

## Change summary
SearchEmptyState now composes the shared EmptyState primitive so Knowledge search empty/recovery states follow the design-system product-state contract while keeping existing user-facing behavior. The wrapper still owns Knowledge-specific variant copy and callbacks, but layout/state semantics now come from the canonical primitive; the stale guard baseline entry is removed so future local empty-state regressions stay visible.