### PR TITLE
Adapt WorkspaceChatEmpty to shared EmptyState

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -5522,17 +5522,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "local-empty-state:src/components/Option/WorkspacePlayground/ChatPane/index.tsx:WorkspaceChatEmpty",
-    "path": "src/components/Option/WorkspacePlayground/ChatPane/index.tsx",
-    "rule": "local-empty-state",
-    "subject": "WorkspaceChatEmpty",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing local WorkspaceChatEmpty empty-state wrapper before the guard.",
-    "replacement": "EmptyState",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "local-loading-state:src/components/Common/UnifiedLoadingState.tsx:UnifiedLoadingState",
     "path": "src/components/Common/UnifiedLoadingState.tsx",
     "rule": "local-loading-state",

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/ChatPane/index.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/ChatPane/index.tsx
@@ -43,7 +43,7 @@ import {
 import { buildConversationShareUrl } from "@/components/Layouts/chat-share-links"
 import { PlaygroundMessage } from "@/components/Common/Playground/Message"
 import { Link } from "react-router-dom"
-import FeatureEmptyState from "@/components/Common/FeatureEmptyState"
+import { EmptyState } from "@/components/ui/feedback/EmptyState"
 import { buildChatLorebookDebugPath } from "@/routes/route-paths"
 import {
   WORKSPACE_SOURCE_DRAG_TYPE,
@@ -852,7 +852,7 @@ const WorkspaceChatEmpty: React.FC<{
 
   return (
     <div className={`mx-auto w-full ${emptyStateMaxWidthClass} px-4 pb-2 pt-3`}>
-      <FeatureEmptyState
+      <EmptyState
         className="max-w-none"
         icon={MessageSquarePlus}
         title={t("playground:chat.emptyTitle", "Start your research")}
@@ -875,6 +875,8 @@ const WorkspaceChatEmpty: React.FC<{
             </p>
           </div>
         }
+        size="lg"
+        variant="card"
         examples={examples.map((example, index) => (
           <button
             key={example}

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/ChatPane.stage2.test.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/ChatPane.stage2.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { ConnectionPhase } from "@/types/connection"
 import type { Message as StoreMessage } from "@/store/option/types"
@@ -281,6 +282,18 @@ vi.mock("antd", async () => {
   }
 })
 
+function renderChatPaneNode() {
+  return (
+    <MemoryRouter>
+      <ChatPane />
+    </MemoryRouter>
+  )
+}
+
+function renderChatPane() {
+  return render(renderChatPaneNode())
+}
+
 describe("ChatPane Stage 2 citation traceability and retrieval transparency", () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -332,7 +345,7 @@ describe("ChatPane Stage 2 citation traceability and retrieval transparency", ()
         title: `Source ${index + 1}`
       }))
 
-    render(<ChatPane />)
+    renderChatPane()
 
     const moreButton = screen.getByRole("button", {
       name: "Show more sources"
@@ -367,7 +380,7 @@ describe("ChatPane Stage 2 citation traceability and retrieval transparency", ()
       }
     ]
 
-    render(<ChatPane />)
+    renderChatPane()
     fireEvent.click(screen.getByRole("button", { name: "Open citation" }))
 
     expect(mockFocusSourceByMediaId).toHaveBeenCalledWith(42)
@@ -394,7 +407,7 @@ describe("ChatPane Stage 2 citation traceability and retrieval transparency", ()
       }
     ]
 
-    render(<ChatPane />)
+    renderChatPane()
     fireEvent.click(screen.getByRole("button", { name: "Open citation" }))
 
     expect(mockFocusSourceById).toHaveBeenCalledWith("source-alpha")
@@ -432,7 +445,7 @@ describe("ChatPane Stage 2 citation traceability and retrieval transparency", ()
       }
     ]
 
-    render(<ChatPane />)
+    renderChatPane()
 
     expect(screen.getByText("Retrieval info")).toBeInTheDocument()
     expect(screen.getByText(/Chunks retrieved/i)).toBeInTheDocument()
@@ -461,7 +474,7 @@ describe("ChatPane Stage 2 citation traceability and retrieval transparency", ()
       }
     ])
 
-    render(<ChatPane />)
+    renderChatPane()
 
     const modelSelect = await screen.findByRole("combobox", {
       name: "Select model"
@@ -486,7 +499,7 @@ describe("ChatPane Stage 2 citation traceability and retrieval transparency", ()
       }
     ]
 
-    render(<ChatPane />)
+    renderChatPane()
 
     expect(screen.getByText("Retrieval info")).toBeInTheDocument()
     expect(screen.getByText("0.600")).toBeInTheDocument()
@@ -510,7 +523,7 @@ describe("ChatPane Stage 2 citation traceability and retrieval transparency", ()
       }
     ]
 
-    render(<ChatPane />)
+    renderChatPane()
 
     expect(screen.getByText("Retrieval info")).toBeInTheDocument()
     expect(screen.getByText(/30 prompt \+ 70 completion = 100 tokens/i)).toBeInTheDocument()
@@ -531,7 +544,7 @@ describe("ChatPane Stage 2 citation traceability and retrieval transparency", ()
       }
     ]
 
-    render(<ChatPane />)
+    renderChatPane()
 
     expect(screen.getByText("0.350")).toBeInTheDocument()
     expect(screen.getByText("Low")).toBeInTheDocument()
@@ -547,7 +560,7 @@ describe("ChatPane Stage 2 citation traceability and retrieval transparency", ()
       }
     ]
 
-    render(<ChatPane />)
+    renderChatPane()
 
     const dropZone = screen.getByTestId("chat-drop-zone")
     const dataTransfer = {
@@ -601,7 +614,7 @@ describe("ChatPane Stage 2 citation traceability and retrieval transparency", ()
       }
     ]
 
-    render(<ChatPane />)
+    renderChatPane()
 
     const dropZone = screen.getByTestId("chat-drop-zone")
     const dataTransfer = {
@@ -678,7 +691,7 @@ describe("ChatPane Stage 2 citation traceability and retrieval transparency", ()
       }
     ]
 
-    render(<ChatPane />)
+    renderChatPane()
 
     const dropZone = screen.getByTestId("chat-drop-zone")
     const dataTransfer = {
@@ -749,10 +762,10 @@ describe("ChatPane Stage 2 citation traceability and retrieval transparency", ()
       }
     ]
 
-    const { rerender } = render(<ChatPane />)
+    const { rerender } = renderChatPane()
 
     workspaceStoreState.selectedSourceIds = ["source-1"]
-    rerender(<ChatPane />)
+    rerender(renderChatPaneNode())
 
     expect(mockMessageInfo).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -772,7 +785,7 @@ describe("ChatPane Stage 2 citation traceability and retrieval transparency", ()
       }
     ]
 
-    render(<ChatPane />)
+    renderChatPane()
     fireEvent.click(screen.getByRole("button", { name: "Create branch" }))
 
     expect(mockCreateChatBranch).toHaveBeenCalledWith(0)
@@ -794,7 +807,7 @@ describe("ChatPane Stage 2 citation traceability and retrieval transparency", ()
       }
     ]
 
-    render(<ChatPane />)
+    renderChatPane()
     fireEvent.click(screen.getByRole("button", { name: "Variant next" }))
 
     const updater = mockSetMessages.mock.calls.at(-1)?.[0]

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/ChatPane.stage3.test.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/ChatPane.stage3.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import type { ReactNode } from "react"
+import { MemoryRouter } from "react-router-dom"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { ConnectionPhase } from "@/types/connection"
 import { ChatPane } from "../ChatPane"
@@ -261,6 +262,14 @@ vi.mock("antd", async () => {
   }
 })
 
+function renderChatPane() {
+  return render(
+    <MemoryRouter>
+      <ChatPane />
+    </MemoryRouter>
+  )
+}
+
 describe("ChatPane Stage 3 adaptive mode controls and settings", () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -300,6 +309,15 @@ describe("ChatPane Stage 3 adaptive mode controls and settings", () => {
     mockGetWorkspaceChatSession.mockReturnValue(null)
   })
 
+  it("renders the empty chat shell through the canonical EmptyState primitive", () => {
+    const { container } = renderChatPane()
+
+    expect(
+      container.querySelector('[data-ds-component="EmptyState"]')
+    ).toBeInTheDocument()
+    expect(screen.getByText("Start your research")).toBeInTheDocument()
+  })
+
   it("adapts empty-state examples based on selected source types", () => {
     workspaceStoreState.selectedSourceIds = ["source-video-1"]
     workspaceStoreState.getSelectedSources = () => [
@@ -312,7 +330,7 @@ describe("ChatPane Stage 3 adaptive mode controls and settings", () => {
     ]
     workspaceStoreState.getSelectedMediaIds = () => [10]
 
-    render(<ChatPane />)
+    renderChatPane()
 
     expect(
       screen.getByText("What was discussed around minute 12?")
@@ -331,7 +349,7 @@ describe("ChatPane Stage 3 adaptive mode controls and settings", () => {
     ]
     workspaceStoreState.getSelectedMediaIds = () => [10]
 
-    render(<ChatPane />)
+    renderChatPane()
 
     const prompt = "What was discussed around minute 12?"
     fireEvent.click(screen.getByRole("button", { name: prompt }))
@@ -366,7 +384,7 @@ describe("ChatPane Stage 3 adaptive mode controls and settings", () => {
     ]
     workspaceStoreState.getSelectedMediaIds = () => [101]
 
-    render(<ChatPane />)
+    renderChatPane()
 
     const toolbar = screen.getByTestId("workspace-chat-controls-toolbar")
     expect(toolbar).toBeInTheDocument()
@@ -390,7 +408,7 @@ describe("ChatPane Stage 3 adaptive mode controls and settings", () => {
     ]
     workspaceStoreState.getSelectedMediaIds = () => [101]
 
-    render(<ChatPane />)
+    renderChatPane()
 
     await waitFor(() => {
       expect(mockSetRagMediaIds).toHaveBeenCalledWith([101])
@@ -425,7 +443,7 @@ describe("ChatPane Stage 3 adaptive mode controls and settings", () => {
     ]
     workspaceStoreState.getSelectedMediaIds = () => [101]
 
-    render(<ChatPane />)
+    renderChatPane()
 
     fireEvent.click(
       screen.getByRole("button", { name: "Advanced RAG settings" })
@@ -484,7 +502,7 @@ describe("ChatPane Stage 3 adaptive mode controls and settings", () => {
       }
     })
 
-    render(<ChatPane />)
+    renderChatPane()
 
     fireEvent.click(
       screen.getByRole("checkbox", { name: "Include full source contents" })
@@ -514,7 +532,7 @@ describe("ChatPane Stage 3 adaptive mode controls and settings", () => {
   })
 
   it("shows keyboard shortcut hint below the composer", () => {
-    render(<ChatPane />)
+    renderChatPane()
 
     expect(
       screen.getByText("Enter or Cmd/Ctrl+Enter to send, Shift+Enter for new line")
@@ -522,7 +540,7 @@ describe("ChatPane Stage 3 adaptive mode controls and settings", () => {
   })
 
   it("submits discuss-artifact payloads from Studio into chat", async () => {
-    render(<ChatPane />)
+    renderChatPane()
 
     window.dispatchEvent(
       new CustomEvent("workspace-playground:discuss-artifact", {
@@ -567,7 +585,7 @@ describe("ChatPane Stage 3 adaptive mode controls and settings", () => {
       }
     ]
 
-    render(<ChatPane />)
+    renderChatPane()
 
     expect(screen.getAllByRole("button", { name: "Save to Notes" })).toHaveLength(2)
   })
@@ -583,7 +601,7 @@ describe("ChatPane Stage 3 adaptive mode controls and settings", () => {
       }
     ]
 
-    render(<ChatPane />)
+    renderChatPane()
 
     fireEvent.click(screen.getByRole("button", { name: "Save to Notes" }))
 

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/ChatPane.stage5.folder-context.test.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/ChatPane.stage5.folder-context.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { ConnectionPhase } from "@/types/connection"
 import { ChatPane } from "../ChatPane"
@@ -234,6 +235,14 @@ vi.mock("antd", async () => {
   }
 })
 
+function renderChatPane() {
+  return render(
+    <MemoryRouter>
+      <ChatPane />
+    </MemoryRouter>
+  )
+}
+
 describe("ChatPane Stage 5 folder-derived context", () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -266,7 +275,7 @@ describe("ChatPane Stage 5 folder-derived context", () => {
   })
 
   it("shows folder-derived sources in the context indicator and syncs RAG scope", async () => {
-    render(<ChatPane />)
+    renderChatPane()
 
     expect(await screen.findByText("Folder Source")).toBeTruthy()
 

--- a/backlog/tasks/task-45.15 - Adapt-WorkspaceChatEmpty-to-shared-EmptyState.md
+++ b/backlog/tasks/task-45.15 - Adapt-WorkspaceChatEmpty-to-shared-EmptyState.md
@@ -1,0 +1,63 @@
+---
+id: TASK-45.15
+title: Adapt WorkspaceChatEmpty to shared EmptyState
+status: In Progress
+assignee: []
+created_date: '2026-05-07 02:10'
+updated_date: '2026-05-07 02:19'
+labels:
+  - design-system
+  - ui
+  - workspace-playground
+dependencies: []
+references:
+  - >-
+    apps/packages/ui/src/components/Option/WorkspacePlayground/ChatPane/index.tsx
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+documentation:
+  - Docs/Design/tldw_web_design_system_contract.md
+parent_task_id: TASK-45
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate the Workspace Playground chat empty-state wrapper onto the canonical EmptyState primitive so the design-system product-state guard no longer needs the WorkspaceChatEmpty local-empty-state baseline exception. Preserve the existing chat empty-state copy, source-aware examples, prompt seeding, add-source CTA, template actions, and Knowledge QA link.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 WorkspaceChatEmpty renders the canonical EmptyState primitive directly and preserves existing empty chat UX behavior.
+- [x] #2 The WorkspaceChatEmpty local-empty-state baseline entry is removed without introducing new unbaselined product-state guard findings.
+- [x] #3 Focused WorkspacePlayground ChatPane tests and the design-system product-state guard verification pass.
+- [x] #4 The task records verification results and any frontend-only Bandit skip rationale.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Use the product-state guard baseline removal as the red test for the remaining WorkspaceChatEmpty local-empty-state debt. 2. Migrate WorkspaceChatEmpty from the compatibility FeatureEmptyState adapter to the canonical EmptyState primitive while preserving visible behavior and actions. 3. Remove the matching baseline entry. 4. Run focused ChatPane tests, guard verification, diff checks, and update the task with results.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+TDD red checks: removing the WorkspaceChatEmpty baseline entry made bun run verify:design-system-state fail with the expected blocked local-empty-state finding for src/components/Option/WorkspacePlayground/ChatPane/index.tsx. Adding the focused runtime assertion initially failed because the canonical EmptyState marker was absent. Test harnesses in ChatPane stage 2, stage 3, and stage 5 were wrapped in MemoryRouter because direct EmptyState renders the existing Knowledge QA Link path instead of the previous mocked FeatureEmptyState adapter path.
+
+Implementation: WorkspaceChatEmpty now imports and renders the canonical EmptyState directly with size lg and card variant while preserving the existing title, description, source-aware prompt chips, Knowledge QA link, source guidance, add-source CTA, and template actions. Removed the matching local-empty-state baseline entry.
+
+Verification: bunx vitest run src/components/Option/WorkspacePlayground/__tests__/ChatPane.stage1.test.tsx src/components/Option/WorkspacePlayground/__tests__/ChatPane.stage2.test.tsx src/components/Option/WorkspacePlayground/__tests__/ChatPane.stage3.test.tsx src/components/Option/WorkspacePlayground/__tests__/ChatPane.stage4.lorebook-activity.test.tsx src/components/Option/WorkspacePlayground/__tests__/ChatPane.stage5.folder-context.test.tsx src/design-system/__tests__/product-state-guard.test.ts --maxWorkers=1 --reporter=dot passed with 6 files and 79 tests. bun run verify:design-system-state passed with 520 baseline exceptions and no local-empty-state bucket. git diff --check passed. Bandit skipped because touched code is frontend TypeScript/JSON and a Backlog task file, not Python.
+
+Broader check: bunx vitest run src/components/Option/WorkspacePlayground --maxWorkers=1 --reporter=dot was attempted and failed in unrelated existing WorkspacePlayground suites outside this slice: AddSourceModal tab ordering, StudioPane stage 3 output/audio expectations, and WorkspacePlayground tests whose workspace-store mocks lack createWorkspaceStorage. The touched ChatPane and guard tests passed after the scoped fix.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.15 - Adapt-WorkspaceChatEmpty-to-shared-EmptyState.md
+++ b/backlog/tasks/task-45.15 - Adapt-WorkspaceChatEmpty-to-shared-EmptyState.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-45.15
 title: Adapt WorkspaceChatEmpty to shared EmptyState
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-07 02:10'
-updated_date: '2026-05-07 02:19'
+updated_date: '2026-05-07 02:21'
 labels:
   - design-system
   - ui
@@ -14,6 +14,7 @@ references:
   - >-
     apps/packages/ui/src/components/Option/WorkspacePlayground/ChatPane/index.tsx
   - apps/packages/ui/scripts/design-system-product-state-baseline.json
+  - 'https://github.com/rmusser01/tldw_server/pull/1351'
 documentation:
   - Docs/Design/tldw_web_design_system_contract.md
 parent_task_id: TASK-45
@@ -52,12 +53,18 @@ Verification: bunx vitest run src/components/Option/WorkspacePlayground/__tests_
 Broader check: bunx vitest run src/components/Option/WorkspacePlayground --maxWorkers=1 --reporter=dot was attempted and failed in unrelated existing WorkspacePlayground suites outside this slice: AddSourceModal tab ordering, StudioPane stage 3 output/audio expectations, and WorkspacePlayground tests whose workspace-store mocks lack createWorkspaceStorage. The touched ChatPane and guard tests passed after the scoped fix.
 <!-- SECTION:NOTES:END -->
 
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Adapted WorkspaceChatEmpty to render the canonical EmptyState primitive directly while preserving its existing research-start copy, source-aware prompt chips, Knowledge QA link, source guidance, add-source CTA, and template actions. Removed the WorkspaceChatEmpty local-empty-state baseline exception so the product-state guard now has no local-empty-state bucket and 520 total baseline exceptions. Updated ChatPane stage 2, stage 3, and stage 5 tests to render with MemoryRouter now that the real empty shell path includes the existing Knowledge QA Link. Opened PR #1351 against dev. Verification passed for the full ChatPane focused suite plus the product-state guard test, the design-system guard CLI, and git diff --check. The broader WorkspacePlayground folder run was attempted and failed in unrelated existing suites outside this slice, documented in implementation notes.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [x] #1 Acceptance criteria completed
 - [x] #2 Tests or verification recorded
 - [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
+- [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-45.15 - Adapt-WorkspaceChatEmpty-to-shared-EmptyState.md
+++ b/backlog/tasks/task-45.15 - Adapt-WorkspaceChatEmpty-to-shared-EmptyState.md
@@ -4,7 +4,7 @@ title: Adapt WorkspaceChatEmpty to shared EmptyState
 status: Done
 assignee: []
 created_date: '2026-05-07 02:10'
-updated_date: '2026-05-07 02:21'
+updated_date: '2026-05-07 15:01'
 labels:
   - design-system
   - ui
@@ -50,13 +50,17 @@ Implementation: WorkspaceChatEmpty now imports and renders the canonical EmptySt
 
 Verification: bunx vitest run src/components/Option/WorkspacePlayground/__tests__/ChatPane.stage1.test.tsx src/components/Option/WorkspacePlayground/__tests__/ChatPane.stage2.test.tsx src/components/Option/WorkspacePlayground/__tests__/ChatPane.stage3.test.tsx src/components/Option/WorkspacePlayground/__tests__/ChatPane.stage4.lorebook-activity.test.tsx src/components/Option/WorkspacePlayground/__tests__/ChatPane.stage5.folder-context.test.tsx src/design-system/__tests__/product-state-guard.test.ts --maxWorkers=1 --reporter=dot passed with 6 files and 79 tests. bun run verify:design-system-state passed with 520 baseline exceptions and no local-empty-state bucket. git diff --check passed. Bandit skipped because touched code is frontend TypeScript/JSON and a Backlog task file, not Python.
 
-Broader check: bunx vitest run src/components/Option/WorkspacePlayground --maxWorkers=1 --reporter=dot was attempted and failed in unrelated existing WorkspacePlayground suites outside this slice: AddSourceModal tab ordering, StudioPane stage 3 output/audio expectations, and WorkspacePlayground tests whose workspace-store mocks lack createWorkspaceStorage. The touched ChatPane and guard tests passed after the scoped fix.
+Broader check on PR branch: bunx vitest run src/components/Option/WorkspacePlayground --maxWorkers=1 --reporter=dot was attempted and failed in WorkspacePlayground suites outside this slice: AddSourceModal tab ordering, StudioPane stage 3 output/audio expectations, and WorkspacePlayground tests whose workspace-store mocks lack createWorkspaceStorage. The touched ChatPane and guard tests passed after the scoped fix.
+
+Qodo review follow-up: verified the same broader WorkspacePlayground folder command against origin/dev at afe6990ee before applying PR #1351 changes. The base branch also failed that command, with 8 failed files, 23 failed tests, and 278 passed tests. Base failures included existing ChatPane Link router-context errors that this PR's MemoryRouter test harness update removes, plus WorkspacePlayground failures outside the touched ChatPane slice. This shows the broad folder command is already red on dev and the remaining PR-branch broad-run failures are not introduced by the WorkspaceChatEmpty design-system migration.
+
+Review-fix verification: focused ChatPane plus product-state guard Vitest command passed with 6 files and 79 tests after the Qodo evidence update. bun run verify:design-system-state passed with 520 baseline exceptions. git diff --check passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Adapted WorkspaceChatEmpty to render the canonical EmptyState primitive directly while preserving its existing research-start copy, source-aware prompt chips, Knowledge QA link, source guidance, add-source CTA, and template actions. Removed the WorkspaceChatEmpty local-empty-state baseline exception so the product-state guard now has no local-empty-state bucket and 520 total baseline exceptions. Updated ChatPane stage 2, stage 3, and stage 5 tests to render with MemoryRouter now that the real empty shell path includes the existing Knowledge QA Link. Opened PR #1351 against dev. Verification passed for the full ChatPane focused suite plus the product-state guard test, the design-system guard CLI, and git diff --check. The broader WorkspacePlayground folder run was attempted and failed in unrelated existing suites outside this slice, documented in implementation notes.
+Adapted WorkspaceChatEmpty to render the canonical EmptyState primitive directly while preserving its existing research-start copy, source-aware prompt chips, Knowledge QA link, source guidance, add-source CTA, and template actions. Removed the WorkspaceChatEmpty local-empty-state baseline exception so the product-state guard now has no local-empty-state bucket and 520 total baseline exceptions. Updated ChatPane stage 2, stage 3, and stage 5 tests to render with MemoryRouter now that the real empty shell path includes the existing Knowledge QA Link. Opened PR #1351 against dev. Verification passed for the full ChatPane focused suite plus the product-state guard test, the design-system guard CLI, and git diff --check. The broader WorkspacePlayground folder run remains red on current origin/dev before this PR, and the PR task now records that base evidence plus the remaining unrelated PR-branch broad-run failures outside the touched slice.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Change summary (AI draft - requester should replace before merge)\n- Migrates WorkspaceChatEmpty from the FeatureEmptyState compatibility adapter to the canonical EmptyState primitive while preserving the existing chat empty-state copy, prompt chips, Knowledge QA link, add-source CTA, and template actions.\n- Removes the WorkspaceChatEmpty local-empty-state baseline exception, reducing the design-system guard baseline to 520 entries with no local-empty-state bucket.\n- Wraps ChatPane stage 2, stage 3, and stage 5 tests in MemoryRouter because the real empty shell now renders the existing react-router Link path instead of a mocked adapter.\n\n## Verification\n- bunx vitest run src/components/Option/WorkspacePlayground/__tests__/ChatPane.stage1.test.tsx src/components/Option/WorkspacePlayground/__tests__/ChatPane.stage2.test.tsx src/components/Option/WorkspacePlayground/__tests__/ChatPane.stage3.test.tsx src/components/Option/WorkspacePlayground/__tests__/ChatPane.stage4.lorebook-activity.test.tsx src/components/Option/WorkspacePlayground/__tests__/ChatPane.stage5.folder-context.test.tsx src/design-system/__tests__/product-state-guard.test.ts --maxWorkers=1 --reporter=dot\n- bun run verify:design-system-state\n- git diff --check\n\n## Known broader-suite state\n- Attempted bunx vitest run src/components/Option/WorkspacePlayground --maxWorkers=1 --reporter=dot; it failed in unrelated existing suites outside this slice: AddSourceModal tab ordering, StudioPane stage 3 output/audio expectations, and WorkspacePlayground tests whose workspace-store mocks lack createWorkspaceStorage.\n\n## Backlog\n- TASK-45.15