### PR TITLE
Phase 2.2: narrow minimal experience skips

### DIFF
--- a/backlog/tasks/task-102 - Phase-2.2-minimal-experience-router-skip-semantics-AX.md
+++ b/backlog/tasks/task-102 - Phase-2.2-minimal-experience-router-skip-semantics-AX.md
@@ -1,0 +1,74 @@
+---
+id: TASK-102
+title: Phase 2.2 minimal experience router skip semantics AX
+status: Done
+assignee: []
+created_date: '2026-05-07 02:15'
+updated_date: '2026-05-07 02:31'
+labels:
+  - phase2.2
+  - router-cleanup
+  - minimal
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+  - 'https://github.com/rmusser01/tldw_server/pull/1348'
+  - 'https://github.com/rmusser01/tldw_server/pull/1352'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Narrow minimal experience router optional skip behavior after PR #1348 merged. The sharing, personalization, and companion ImportedRouterSpec entries should skip only genuinely missing optional router modules or missing router attributes, while runtime import defects propagate during registration instead of being hidden by skip_exceptions=(Exception,).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Minimal experience router specs no longer use skip_exceptions=(Exception,)
+- [x] #2 Missing target experience modules are skipped during registration
+- [x] #3 Runtime import defects from experience router modules propagate
+- [x] #4 Existing prefixes tags route keys and default stability behavior are preserved
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Update focused contract tests for precise experience optional skip semantics. 2. Verify RED against current broad skip behavior. 3. Remove broad skip_exceptions from experience ImportedRouterSpec entries. 4. Run focused and broader verification plus Bandit and diff checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Baseline focused selector passed before edits: minimal experience tests 2 passed, confirming current broad skip behavior is covered.
+
+TDD RED after test update failed as intended: experience specs still reported Exception and runtime import failures were skipped. GREEN focused selector passed after removing experience broad skip overrides: 3 passed.
+
+Broader validation passed: router groups 121 passed, lifecycle 54 passed, OpenAPI 69 passed, Bandit results 0, git diff --check clean.
+
+Scope note: remaining skip_exceptions=(Exception,) occurrences are in guardian_safety and utility minimal groups and should be handled in later narrow slices.
+
+Opened PR https://github.com/rmusser01/tldw_server/pull/1352 against dev for this slice.
+
+PR review follow-up: addressed valid test maintainability comments by asserting concrete optional skip exception classes, replacing exact debug-message equality with semantic log checks, and parameterizing runtime propagation across sharing, personalization, and companion.
+
+Review-fix validation: focused minimal experience selector passed 5 selected tests; full router group contract passed 123 tests; Bandit on minimal.py reported 0 results; git diff --check was clean.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Narrowed the minimal experience router ImportedRouterSpec entries for sharing, personalization, and companion by removing broad skip_exceptions=(Exception,) overrides. The experience specs now use the default precise optional-missing skip exceptions, so missing target modules still skip during registration while runtime import defects propagate. Validation: focused experience selector 3 passed after RED verification, router group contracts 121 passed, main lifecycle contracts 54 passed, OpenAPI contracts 69 passed, Bandit on minimal.py found 0 results, and git diff --check was clean.
+
+Review follow-up tightened the test contract without changing production behavior: exception assertions now compare concrete classes, missing-module debug checks are semantic, and runtime propagation is covered for all three experience routers. Review-fix validation: focused selector 5 passed, router group contracts 123 passed, Bandit 0 results, and git diff --check clean.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -475,7 +475,6 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
             prefix=f"{API_V1_PREFIX}",
             tags=("sharing",),
             skip_context=minimal_skip_context,
-            skip_exceptions=(Exception,),
         ),
         ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.personalization",
@@ -483,7 +482,6 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
             prefix=f"{API_V1_PREFIX}/personalization",
             tags=("personalization",),
             skip_context=minimal_skip_context,
-            skip_exceptions=(Exception,),
         ),
         ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.companion",
@@ -491,7 +489,6 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
             prefix=f"{API_V1_PREFIX}/companion",
             tags=("companion",),
             skip_context=minimal_skip_context,
-            skip_exceptions=(Exception,),
         ),
     ):
         append_imported_router_spec(specs, experience_spec)

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -10,6 +10,10 @@ import pytest
 from fastapi import APIRouter, FastAPI
 
 from tldw_Server_API.app.api.v1.router_groups.admin import iter_admin_router_specs
+from tldw_Server_API.app.api.v1.router_groups.conditional import (
+    OptionalRouterMissingAttribute,
+    OptionalRouterMissingModule,
+)
 from tldw_Server_API.app.api.v1.router_groups.content import iter_content_router_specs
 from tldw_Server_API.app.api.v1.router_groups.core import iter_core_router_specs
 from tldw_Server_API.app.api.v1.router_groups.spec import RouterSpec
@@ -7967,7 +7971,10 @@ def test_iter_minimal_optional_router_specs_defers_experience_attr_lookup(
         assert spec.route_key == ""
         assert spec.skip_context == "in minimal test app"
         assert spec.default_stable is definition["default_stable"]
-        assert spec.skip_exceptions == (Exception,)
+        assert spec.skip_exceptions == (
+            OptionalRouterMissingModule,
+            OptionalRouterMissingAttribute,
+        )
         assert _first_router_path(spec.router) == definition["path"]
 
     assert import_calls == [
@@ -7980,10 +7987,10 @@ def test_iter_minimal_optional_router_specs_defers_experience_attr_lookup(
     }
 
 
-def test_iter_minimal_optional_router_specs_skips_experience_runtime_import_failures(
+def test_iter_minimal_optional_router_specs_skips_experience_missing_import_failures(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Verify minimal experience specs preserve broad import failure skipping."""
+    """Verify minimal experience specs skip missing optional router modules."""
     import importlib
 
     from tldw_Server_API.app.api.v1.router_groups.minimal import (
@@ -7991,9 +7998,9 @@ def test_iter_minimal_optional_router_specs_skips_experience_runtime_import_fail
     )
 
     experience_modules = {
-        "tldw_Server_API.app.api.v1.endpoints.sharing",
-        "tldw_Server_API.app.api.v1.endpoints.personalization",
-        "tldw_Server_API.app.api.v1.endpoints.companion",
+        "sharing": "tldw_Server_API.app.api.v1.endpoints.sharing",
+        "personalization": "tldw_Server_API.app.api.v1.endpoints.personalization",
+        "companion": "tldw_Server_API.app.api.v1.endpoints.companion",
     }
 
     specs = list(iter_minimal_optional_router_specs())
@@ -8007,9 +8014,12 @@ def test_iter_minimal_optional_router_specs_skips_experience_runtime_import_fail
     real_import_module = importlib.import_module
 
     def _import_module(module_name: str, package: str | None = None) -> ModuleType:
-        """Crash only the selected experience router imports at registration."""
-        if module_name in experience_modules:
-            raise RuntimeError(f"{module_name} exploded during import")
+        """Fail only the selected experience router imports at registration."""
+        if module_name in experience_modules.values():
+            raise ModuleNotFoundError(
+                f"{module_name} missing during import",
+                name=module_name,
+            )
         return real_import_module(module_name, package)
 
     monkeypatch.setattr(
@@ -8021,14 +8031,54 @@ def test_iter_minimal_optional_router_specs_skips_experience_runtime_import_fail
     monkeypatch.setattr("loguru.logger.debug", debug_messages.append)
 
     assert register_router_specs(FastAPI(), selected_specs.values()) == 0
-    assert debug_messages == [
-        "Skipping sharing router in minimal test app: "
-        "tldw_Server_API.app.api.v1.endpoints.sharing exploded during import",
-        "Skipping personalization router in minimal test app: "
-        "tldw_Server_API.app.api.v1.endpoints.personalization exploded during import",
-        "Skipping companion router in minimal test app: "
-        "tldw_Server_API.app.api.v1.endpoints.companion exploded during import",
-    ]
+    assert len(debug_messages) == len(experience_modules)
+    for router_name, module_name in experience_modules.items():
+        assert any(
+            f"Skipping {router_name} router" in message
+            and "in minimal test app" in message
+            and module_name in message
+            for message in debug_messages
+        )
+
+
+@pytest.mark.parametrize(
+    ("router_name", "module_name"),
+    (
+        ("sharing", "tldw_Server_API.app.api.v1.endpoints.sharing"),
+        ("personalization", "tldw_Server_API.app.api.v1.endpoints.personalization"),
+        ("companion", "tldw_Server_API.app.api.v1.endpoints.companion"),
+    ),
+)
+def test_iter_minimal_optional_router_specs_propagates_experience_runtime_import_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    router_name: str,
+    module_name: str,
+) -> None:
+    """Verify minimal experience runtime import defects are not silently skipped."""
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    specs = list(iter_minimal_optional_router_specs())
+    selected_spec = next(spec for spec in specs if spec.name == router_name)
+
+    real_import_module = importlib.import_module
+
+    def _import_module(import_name: str, package: str | None = None) -> ModuleType:
+        """Crash only one selected experience router import at registration."""
+        if import_name == module_name:
+            raise RuntimeError(f"{module_name} exploded during import")
+        return real_import_module(import_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    with pytest.raises(RuntimeError, match="exploded during import"):
+        register_router_specs(FastAPI(), (selected_spec,))
 
 
 def test_iter_minimal_optional_router_specs_defers_guardian_safety_attr_lookup(


### PR DESCRIPTION
## Change summary

This PR narrows the optional skip behavior for the minimal experience routers: `sharing`, `personalization`, and `companion`.

Those `ImportedRouterSpec` entries previously used `skip_exceptions=(Exception,)`, which meant registration swallowed every runtime import failure for that router family. The implementation removes the broad overrides so the specs use the default optional-missing exceptions. Missing target modules or missing `router` attributes still skip in the minimal app, but real runtime defects now propagate instead of being hidden.

## Validation

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "minimal_optional_router_specs and experience" -q` - RED failed before implementation, then 3 passed after implementation
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q` - 121 passed
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_lifecycle_contract.py -q` - 54 passed
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q` - 69 passed
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/router_groups/minimal.py -f json -o /tmp/bandit_minimal_experience_skip_ax.json` - 0 results
- `git diff --check`
- `git diff --cached --check`

## Tracking

- Continues #1116
- Backlog: `TASK-102`
