### PR TITLE
TASK-96.8: Implement auto chunking boundary assistant

### DIFF
--- a/Docs/superpowers/plans/2026-05-07-auto-chunk-boundary-assistant-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-07-auto-chunk-boundary-assistant-implementation-plan.md
@@ -1,0 +1,128 @@
+# Auto Chunk Boundary Assistant Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an explicitly opt-in LLM boundary assistant for Auto Chunking that refines deterministic plans and falls back deterministically on every unavailable/error path.
+
+**Architecture:** Keep the current sync resolver as the deterministic/manual compatibility layer. Add a small assistant module and an async resolver that calls the assistant only for Auto requests with `auto_chunking_use_llm=true`. Wire async ingestion paths to the async resolver without changing frontend contracts.
+
+**Tech Stack:** Python, FastAPI async request handlers, existing `perform_chat_api_call_async`, existing LLM provider registry/config helpers, pytest.
+
+---
+
+### Task 1: Boundary Assistant Contract
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Chunking/auto_boundary_assistant.py`
+- Test: `tldw_Server_API/tests/Chunking/test_auto_boundary_assistant.py`
+
+- [ ] **Step 1: Write failing tests for interface/result and validation**
+
+Tests should assert that `AutoChunkBoundaryAssistant` can be implemented by a fake async assistant, `AutoChunkBoundaryAssistantResult` can represent success and fallback, valid JSON suggestions refine only allowed fields, and invalid method/size/overlap/view values return fallback metadata.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Chunking/test_auto_boundary_assistant.py -v`
+Expected: FAIL because the module and types do not exist.
+
+- [ ] **Step 3: Implement the minimal contract and validators**
+
+Create dataclasses/protocol for request/result/availability. Add bounded helpers for excerpt creation, fallback reason appending, response text extraction, JSON parsing, and suggestion validation.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run the same focused test file and confirm PASS.
+
+### Task 2: LLM Adapter
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Chunking/auto_boundary_assistant.py`
+- Test: `tldw_Server_API/tests/Chunking/test_auto_boundary_assistant.py`
+
+- [ ] **Step 1: Write failing tests for availability and provider call behavior**
+
+Tests should mock provider/model/config resolution and chat calls. Cover missing opt-in no-call, missing provider/model/adapter/key fallback, explicit success, timeout, provider exception, empty response, and invalid JSON.
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run the focused assistant test file. Expected: FAIL because concrete adapter behavior is absent.
+
+- [ ] **Step 3: Implement concrete assistant**
+
+Resolve provider from request fields or defaults, resolve model from request fields or config, verify adapter registration and required key availability, call `perform_chat_api_call_async` through `asyncio.wait_for`, and parse strict JSON. Do not send full source text; cap excerpts.
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run the focused assistant test file and confirm PASS.
+
+### Task 3: Async Resolver
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Ingestion_Media_Processing/chunking_options.py`
+- Modify: `tldw_Server_API/app/core/Chunking/auto_planner.py` if plan metadata helper support is needed
+- Test: `tldw_Server_API/tests/Chunking/test_auto_chunking_resolver.py`
+
+- [ ] **Step 1: Write failing resolver tests**
+
+Tests should cover default no-call behavior, explicit opt-in success updating both `chunk_options` and `chunking_plan`, fallback preserving deterministic options on timeout/error/invalid response, and `used_llm` semantics.
+
+- [ ] **Step 2: Run resolver tests to verify failure**
+
+Run: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Chunking/test_auto_chunking_resolver.py -v`
+Expected: FAIL because no async resolver exists.
+
+- [ ] **Step 3: Implement async resolver**
+
+Add `async_resolve_chunking_options_and_plan()` and `async_resolve_chunking_for_result()` wrappers. They call the existing deterministic resolver first, then invoke the assistant only when Auto plan exists and `auto_chunking_use_llm=true`. Preserve sync resolver behavior.
+
+- [ ] **Step 4: Run resolver tests to verify pass**
+
+Run the resolver test file and confirm PASS.
+
+### Task 4: Async Ingestion Wiring
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Ingestion_Media_Processing/persistence.py`
+- Modify: `tldw_Server_API/app/services/media_ingest_jobs_worker.py`
+- Modify: direct process endpoints under `tldw_Server_API/app/api/v1/endpoints/media/process_*.py`
+- Modify: `tldw_Server_API/app/services/web_scraping_service.py`
+- Modify: `tldw_Server_API/app/services/enhanced_web_scraping_service.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/media/ingest_web_content.py`
+- Test: existing Auto Chunking media, worker, and web ingestion tests
+
+- [ ] **Step 1: Write or extend failing wiring tests**
+
+At minimum, prove one media-add/persistence path and the jobs worker call the async resolver and pass refined `chunk_options` downstream while returned/stored metadata contains the same plan.
+
+- [ ] **Step 2: Run focused wiring tests to verify failure**
+
+Run the targeted media add, jobs worker, and web Auto Chunking tests. Expected: FAIL while call sites still use the sync resolver.
+
+- [ ] **Step 3: Wire async resolver**
+
+Replace async call sites with awaits to the async resolver. Keep `apply_chunking_template_if_any()` gated by `chunking_plan is None`.
+
+- [ ] **Step 4: Run focused wiring tests to verify pass**
+
+Run the same focused tests and confirm PASS.
+
+### Task 5: Verification and Closeout
+
+**Files:**
+- Modify: `backlog/tasks/task-96.8 - Implement-real-Auto-Chunking-boundary-assistant-adapter.md`
+
+- [ ] **Step 1: Run focused backend test suite**
+
+Run the new assistant/resolver tests plus existing Auto Chunking planner, process endpoint, jobs worker, persistence metadata, and web ingest tests.
+
+- [ ] **Step 2: Run Bandit on touched production files**
+
+Run: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Chunking/auto_boundary_assistant.py tldw_Server_API/app/core/Ingestion_Media_Processing/chunking_options.py tldw_Server_API/app/core/Ingestion_Media_Processing/persistence.py tldw_Server_API/app/services/media_ingest_jobs_worker.py tldw_Server_API/app/services/web_scraping_service.py tldw_Server_API/app/services/enhanced_web_scraping_service.py tldw_Server_API/app/api/v1/endpoints/media -f json -o /tmp/bandit_auto_chunk_boundary_assistant.json`
+
+- [ ] **Step 3: Run whitespace diff check**
+
+Run: `git diff --check`
+
+- [ ] **Step 4: Update Backlog**
+
+Check acceptance criteria and Definition of Done items with verification evidence and add final summary.

--- a/Docs/superpowers/specs/2026-05-07-auto-chunk-boundary-assistant-design.md
+++ b/Docs/superpowers/specs/2026-05-07-auto-chunk-boundary-assistant-design.md
@@ -1,0 +1,48 @@
+# Auto Chunk Boundary Assistant Design
+
+## Goal
+
+Add the real LLM-backed boundary assistant deferred by Auto Chunking V1. The assistant refines deterministic Auto Chunking decisions only when a request explicitly sets `auto_chunking_use_llm=true`, and every unavailable, timeout, provider, or invalid-response path must keep the deterministic Auto plan.
+
+## Scope
+
+This is a backend-only slice. It does not change Quick Ingest UI controls or add new public chunking fields. Existing Manual and legacy requests continue to use `prepare_chunking_options_dict()` and template application. Auto requests continue to start with the deterministic planner so the LLM assistant can only refine bounded planner outputs, not replace source text or invent arbitrary chunk payloads.
+
+## Assistant Contract
+
+Introduce a narrow `AutoChunkBoundaryAssistant` interface under `tldw_Server_API/app/core/Chunking/`. The interface accepts a deterministic plan, deterministic chunk options, request profile, media hints, and a bounded text excerpt. It returns a result with either validated refined options plus metadata or a typed fallback reason. The result type is defined before provider calls so tests can exercise the resolver without invoking an LLM.
+
+The concrete assistant wraps the existing async chat service path, `perform_chat_api_call_async`, because this is a legacy async ingestion call site and the LLM adapter guide points legacy async callers there. The prompt requests strict JSON only. Accepted refinements are intentionally small: method, max size, overlap, derived views, and rationale. Raw chunk text, rewritten content, direct chunk bodies, file paths, URLs to fetch, and code-like instructions are ignored.
+
+## Availability
+
+Availability is explicit and separate from provider key presence. The assistant is available only when all of these are true:
+
+- The request is Auto mode and `auto_chunking_use_llm=true`.
+- A provider can be resolved from request fields or server defaults.
+- A model can be resolved from request fields or provider config defaults.
+- The provider has a registered chat adapter.
+- Required API-key providers have a resolved API key.
+
+If any requirement fails, the resolver preserves deterministic options and records an `ai_assist_unavailable` fallback reason.
+
+## Data Flow
+
+The existing sync resolver remains the deterministic/manual compatibility path. A new async resolver first calls the sync resolver. If no Auto plan is produced, it returns unchanged results. If Auto is active and LLM assist is not requested, it returns unchanged deterministic results. If opt-in is present, it checks assistant availability and then calls the assistant with bounded input.
+
+On a valid assistant result, the async resolver updates `chunk_options` and `chunking_plan` consistently and sets `used_llm=true`. On timeout, provider error, invalid JSON, invalid values, or unavailable config, it returns the original deterministic `chunk_options` and `chunking_plan`, sets `used_llm=false`, and appends fallback metadata.
+
+## Wiring
+
+Async ingestion paths should call the async resolver:
+
+- `/api/v1/media/add` orchestration in persistence
+- media ingest jobs worker
+- direct process endpoints that already run in async request handlers
+- web/article ingestion services
+
+Template application remains manual/legacy-only. Call sites should only run `apply_chunking_template_if_any()` when the returned `chunking_plan is None`.
+
+## Testing
+
+Tests cover the interface/result shape before provider calls, default no-call behavior, explicit opt-in success, unavailable provider fallback, timeout/provider error fallback, invalid-response fallback, and `used_llm` semantics. Focused integration tests cover at least one async resolver call and one ingestion worker/media-add path so the resolved options used for chunk generation/FTS match the returned metadata.

--- a/backlog/tasks/task-96.8 - Implement-real-Auto-Chunking-boundary-assistant-adapter.md
+++ b/backlog/tasks/task-96.8 - Implement-real-Auto-Chunking-boundary-assistant-adapter.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-96.8
 title: Implement real Auto Chunking boundary assistant adapter
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - Codex
 created_date: '2026-05-06 17:53'
+updated_date: '2026-05-07 02:42'
 labels:
   - backend
   - chunking
@@ -14,6 +16,9 @@ dependencies:
 documentation:
   - Docs/superpowers/specs/2026-05-06-auto-chunking-design.md
   - Docs/superpowers/plans/2026-05-06-auto-chunking-implementation-plan.md
+  - Docs/superpowers/specs/2026-05-07-auto-chunk-boundary-assistant-design.md
+  - >-
+    Docs/superpowers/plans/2026-05-07-auto-chunk-boundary-assistant-implementation-plan.md
 parent_task_id: TASK-96
 priority: medium
 ---
@@ -26,19 +31,41 @@ Follow-up for Auto Chunking V1. Add a real LLM-backed boundary assistant only af
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Define a narrow AutoChunkBoundaryAssistant interface and result type before adding provider calls.
-- [ ] #2 Availability checks are explicit and do not rely only on provider keys being configured.
-- [ ] #3 Adapter is invoked only when auto_chunking_use_llm=true.
-- [ ] #4 Timeout, provider error, and invalid response paths preserve deterministic Auto plans with fallback metadata.
-- [ ] #5 Tests cover default no-call behavior, explicit opt-in success, timeout/error fallback, and metadata used_llm semantics.
+- [x] #1 Define a narrow AutoChunkBoundaryAssistant interface and result type before adding provider calls.
+- [x] #2 Availability checks are explicit and do not rely only on provider keys being configured.
+- [x] #3 Adapter is invoked only when auto_chunking_use_llm=true.
+- [x] #4 Timeout, provider error, and invalid response paths preserve deterministic Auto plans with fallback metadata.
+- [x] #5 Tests cover default no-call behavior, explicit opt-in success, timeout/error fallback, and metadata used_llm semantics.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Document the approved TASK-96.8 design and implementation plan in the worktree, scoped to backend-only Auto Chunking LLM assistance with no UI changes. 2. Add tests first for a narrow AutoChunkBoundaryAssistant interface/result, explicit availability, no-call default behavior, opt-in success, timeout/provider/invalid-response fallback, and used_llm metadata semantics. 3. Implement a focused boundary assistant module that wraps perform_chat_api_call_async with bounded prompt/input/output, explicit provider/model/adapter/key availability checks, timeout handling, strict JSON parsing, and deterministic validation. 4. Add an async resolver alongside the existing sync deterministic resolver so legacy/manual behavior and existing sync call sites remain stable, while async ingestion paths can refine Auto plans only when auto_chunking_use_llm=true. 5. Wire async media add, ingest jobs, process endpoints, and web/article ingestion paths to the async resolver; preserve template application only when no Auto plan is returned. 6. Run focused backend tests, Bandit on touched production code, and git diff --check; update Backlog acceptance criteria and final notes with verification results.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Started in isolated worktree /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/auto-chunk-boundary-assistant on branch codex/auto-chunk-boundary-assistant from origin/dev@204212ed7d1029b47e20f1a3a9866b46af032f62. User approved backend-only bounded JSON LLM boundary assistant scope: no UI changes, explicit opt-in only, deterministic fallback on unavailable/error paths.
+
+Added TASK-96.8-specific spec and implementation plan. External spec/plan review via subagent was not used because this session's developer constraints only allow subagents when the user explicitly asks for them; proceeding with inline self-review and TDD.
+
+Implemented backend-only LLM boundary assistant behind explicit auto_chunking_use_llm opt-in. Added bounded strict-JSON chat adapter with explicit provider/model/adapter/API-key availability checks, timeout/provider/invalid-response deterministic fallbacks, canonical provider alias handling, async resolver wiring for media add/jobs/process/web ingestion paths, and focused tests for no-call default, success, fallback, metadata, and worker wiring. Verification: focused pytest suite passed 59 tests; py_compile passed for touched production modules; Bandit JSON scan of touched production files reported zero results; git diff --check passed. No known skips or blockers.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the real Auto Chunking boundary assistant adapter as a backend-only opt-in refinement path. The new assistant uses the existing chat adapter stack through a narrow protocol/result type, sends only bounded excerpt/context, validates strict JSON suggestions before applying them, canonicalizes provider aliases, and preserves deterministic Auto Chunking plans with explicit fallback metadata on unavailable, timeout, provider-error, or invalid-response paths. The async resolver now layers LLM refinement on top of the deterministic planner only when auto_chunking_use_llm=true, and async ingestion paths use the resolved chunk options for media add/jobs/process/web flows while preserving legacy/manual behavior and template fallback semantics. Verification: focused pytest suite passed 59 tests; py_compile passed for touched production modules; Bandit scan of touched production files reported zero findings; git diff --check passed. No known skips or blockers.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-96.8 - Implement-real-Auto-Chunking-boundary-assistant-adapter.md
+++ b/backlog/tasks/task-96.8 - Implement-real-Auto-Chunking-boundary-assistant-adapter.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - Codex
 created_date: '2026-05-06 17:53'
-updated_date: '2026-05-07 02:42'
+updated_date: '2026-05-07 04:28'
 labels:
   - backend
   - chunking
@@ -52,12 +52,16 @@ Started in isolated worktree /Users/macbook-dev/Documents/GitHub/tldw_server2/.w
 Added TASK-96.8-specific spec and implementation plan. External spec/plan review via subagent was not used because this session's developer constraints only allow subagents when the user explicitly asks for them; proceeding with inline self-review and TDD.
 
 Implemented backend-only LLM boundary assistant behind explicit auto_chunking_use_llm opt-in. Added bounded strict-JSON chat adapter with explicit provider/model/adapter/API-key availability checks, timeout/provider/invalid-response deterministic fallbacks, canonical provider alias handling, async resolver wiring for media add/jobs/process/web ingestion paths, and focused tests for no-call default, success, fallback, metadata, and worker wiring. Verification: focused pytest suite passed 59 tests; py_compile passed for touched production modules; Bandit JSON scan of touched production files reported zero results; git diff --check passed. No known skips or blockers.
+
+PR #1354 review-fix pass started. Actionable review items verified from GitHub review threads and review bodies: avoid sync config loading on async assistant path, wrap overlong availability line, keep pre-assistant Auto plan deterministic, avoid TypeError retry masking in API-key resolver, reuse one LLM boundary resolution per process_* batch, reject ebook_chapters outside ebook media, preserve api_name-encoded model when api_provider is already present, propagate asyncio cancellation in persistence resolver awaits, and propagate web request LLM selection into synthetic chunking forms.
+
+PR #1354 review-fix pass completed. Implemented all actionable review findings: availability checks now run off the event loop; API-key resolver signatures are inspected instead of retrying broad TypeError; pre-assistant plans remain deterministic; ebook_chapters is ebook-only; api_name provider/model parsing preserves encoded model values; process_* endpoints reuse one LLM boundary resolution per batch; persistence re-raises asyncio.CancelledError; and web chunking forms carry api_name/provider/model fields. Verification: focused pytest suite passed 66 tests; py_compile passed for touched production modules; Bandit JSON scan of touched production files reported zero results; git diff --check passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented the real Auto Chunking boundary assistant adapter as a backend-only opt-in refinement path. The new assistant uses the existing chat adapter stack through a narrow protocol/result type, sends only bounded excerpt/context, validates strict JSON suggestions before applying them, canonicalizes provider aliases, and preserves deterministic Auto Chunking plans with explicit fallback metadata on unavailable, timeout, provider-error, or invalid-response paths. The async resolver now layers LLM refinement on top of the deterministic planner only when auto_chunking_use_llm=true, and async ingestion paths use the resolved chunk options for media add/jobs/process/web flows while preserving legacy/manual behavior and template fallback semantics. Verification: focused pytest suite passed 59 tests; py_compile passed for touched production modules; Bandit scan of touched production files reported zero findings; git diff --check passed. No known skips or blockers.
+Implemented the real Auto Chunking boundary assistant adapter as a backend-only opt-in refinement path, then addressed PR #1354 review findings. The assistant now runs availability checks off the event loop, validates provider/model/key availability without masking resolver TypeError retries, canonicalizes provider aliases, rejects ebook-only methods outside ebook media, and preserves deterministic Auto plans until an assistant result is actually applied. Async ingestion paths use the resolved chunk options for media add/jobs/process/web flows, with process_* endpoints reusing one LLM boundary resolution per batch and persistence preserving asyncio cancellation semantics. Web chunking forms now propagate request LLM selection fields so api_name-encoded models are honored. Verification: focused pytest suite passed 66 tests; py_compile passed for touched production modules; Bandit scan of touched production files reported zero findings; git diff --check passed. No known skips or blockers.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/api/v1/endpoints/media/ingest_web_content.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/ingest_web_content.py
@@ -19,8 +19,8 @@ from tldw_Server_API.app.api.v1.schemas.media_request_models import (
     IngestWebContentRequest,
 )
 from tldw_Server_API.app.core.Ingestion_Media_Processing.chunking_options import (
+    async_resolve_chunking_options_and_plan,
     attach_chunking_plan_to_result,
-    resolve_chunking_options_and_plan,
 )
 from tldw_Server_API.app.services.web_scraping_service import (
     ingest_web_content_orchestrate,
@@ -113,7 +113,7 @@ async def ingest_web_content(
             if not isinstance(item, dict):
                 continue
             content = item.get("content")
-            _, chunking_plan = resolve_chunking_options_and_plan(
+            _, chunking_plan = await async_resolve_chunking_options_and_plan(
                 request,
                 media_type="web",
                 source_name=str(item.get("url") or ""),

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_audios.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_audios.py
@@ -324,6 +324,9 @@ async def process_audios_endpoint(
             )
 
             ck: _Chunker | None = None
+            batch_auto_chunk_options = chunk_options_dict
+            batch_auto_chunking_plan = chunking_plan
+            batch_llm_chunking_resolved = False
 
             for res in batch_result.get("results", []):
                 if not isinstance(res, dict):
@@ -341,10 +344,15 @@ async def process_audios_endpoint(
                     form_data,
                     res,
                     media_type="audio",
-                    default_chunk_options=chunk_options_dict,
-                    default_chunking_plan=chunking_plan,
+                    default_chunk_options=batch_auto_chunk_options,
+                    default_chunking_plan=batch_auto_chunking_plan,
+                    allow_llm_assist=not batch_llm_chunking_resolved,
                 )
                 attach_chunking_plan_to_result(res, result_chunking_plan)
+                if getattr(form_data, "auto_chunking_use_llm", False) and result_chunking_plan:
+                    batch_auto_chunk_options = result_chunk_options
+                    batch_auto_chunking_plan = result_chunking_plan
+                    batch_llm_chunking_resolved = True
                 if not result_chunk_options:
                     continue
 

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_audios.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_audios.py
@@ -35,8 +35,8 @@ from tldw_Server_API.app.api.v1.endpoints import media as media_mod
 from tldw_Server_API.app.api.v1.schemas.media_request_models import ProcessAudiosForm
 from tldw_Server_API.app.core.Ingestion_Media_Processing.chunking_options import (
     apply_chunking_template_if_any,
+    async_resolve_chunking_for_result,
     attach_chunking_plan_to_result,
-    resolve_chunking_for_result,
     resolve_chunking_options_and_plan,
     uses_hierarchical_chunking,
 )
@@ -337,7 +337,7 @@ async def process_audios_endpoint(
                     attach_chunking_plan_to_result(res, chunking_plan)
                     continue
 
-                result_chunk_options, result_chunking_plan = resolve_chunking_for_result(
+                result_chunk_options, result_chunking_plan = await async_resolve_chunking_for_result(
                     form_data,
                     res,
                     media_type="audio",

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_documents.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_documents.py
@@ -26,8 +26,8 @@ from tldw_Server_API.app.api.v1.endpoints import media as media_mod
 from tldw_Server_API.app.api.v1.schemas.media_request_models import ProcessDocumentsForm
 from tldw_Server_API.app.core.Ingestion_Media_Processing.chunking_options import (
     apply_chunking_template_if_any,
+    async_resolve_chunking_for_result,
     attach_chunking_plan_to_result,
-    resolve_chunking_for_result,
     resolve_chunking_options_and_plan,
     uses_hierarchical_chunking,
 )
@@ -535,7 +535,7 @@ async def process_documents_endpoint(
                     attach_chunking_plan_to_result(res, chunking_plan)
                     continue
 
-                result_chunk_options, result_chunking_plan = resolve_chunking_for_result(
+                result_chunk_options, result_chunking_plan = await async_resolve_chunking_for_result(
                     form_data,
                     res,
                     media_type="document",

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_documents.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_documents.py
@@ -523,6 +523,9 @@ async def process_documents_endpoint(
             )
 
             ck: _Chunker | None = None
+            batch_auto_chunk_options = chunk_options_dict
+            batch_auto_chunking_plan = chunking_plan
+            batch_llm_chunking_resolved = False
 
             for res in batch_result.get("results", []):
                 if not isinstance(res, dict):
@@ -539,10 +542,15 @@ async def process_documents_endpoint(
                     form_data,
                     res,
                     media_type="document",
-                    default_chunk_options=chunk_options_dict,
-                    default_chunking_plan=chunking_plan,
+                    default_chunk_options=batch_auto_chunk_options,
+                    default_chunking_plan=batch_auto_chunking_plan,
+                    allow_llm_assist=not batch_llm_chunking_resolved,
                 )
                 attach_chunking_plan_to_result(res, result_chunking_plan)
+                if getattr(form_data, "auto_chunking_use_llm", False) and result_chunking_plan:
+                    batch_auto_chunk_options = result_chunk_options
+                    batch_auto_chunking_plan = result_chunking_plan
+                    batch_llm_chunking_resolved = True
                 if not result_chunk_options:
                     continue
 

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_ebooks.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_ebooks.py
@@ -31,8 +31,8 @@ from tldw_Server_API.app.api.v1.endpoints import media as media_mod
 from tldw_Server_API.app.api.v1.schemas.media_request_models import ProcessEbooksForm
 from tldw_Server_API.app.core.Ingestion_Media_Processing.chunking_options import (
     apply_chunking_template_if_any,
+    async_resolve_chunking_for_result,
     attach_chunking_plan_to_result,
-    resolve_chunking_for_result,
     resolve_chunking_options_and_plan,
     uses_hierarchical_chunking,
 )
@@ -490,7 +490,7 @@ async def process_ebooks_endpoint(
                     attach_chunking_plan_to_result(res, chunking_plan)
                     continue
 
-                result_chunk_options, result_chunking_plan = resolve_chunking_for_result(
+                result_chunk_options, result_chunking_plan = await async_resolve_chunking_for_result(
                     form_data,
                     res,
                     media_type="ebook",

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_ebooks.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_ebooks.py
@@ -478,6 +478,9 @@ async def process_ebooks_endpoint(
             )
 
             ck: _Chunker | None = None
+            batch_auto_chunk_options = chunk_options_dict
+            batch_auto_chunking_plan = chunking_plan
+            batch_llm_chunking_resolved = False
 
             for res in batch.get("results", []):
                 if not isinstance(res, dict):
@@ -494,10 +497,15 @@ async def process_ebooks_endpoint(
                     form_data,
                     res,
                     media_type="ebook",
-                    default_chunk_options=chunk_options_dict,
-                    default_chunking_plan=chunking_plan,
+                    default_chunk_options=batch_auto_chunk_options,
+                    default_chunking_plan=batch_auto_chunking_plan,
+                    allow_llm_assist=not batch_llm_chunking_resolved,
                 )
                 attach_chunking_plan_to_result(res, result_chunking_plan)
+                if getattr(form_data, "auto_chunking_use_llm", False) and result_chunking_plan:
+                    batch_auto_chunk_options = result_chunk_options
+                    batch_auto_chunking_plan = result_chunking_plan
+                    batch_llm_chunking_resolved = True
                 if not result_chunk_options:
                     continue
 

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_emails.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_emails.py
@@ -19,8 +19,8 @@ from tldw_Server_API.app.api.v1.endpoints import media as media_mod
 from tldw_Server_API.app.api.v1.schemas.media_request_models import ProcessEmailsForm
 from tldw_Server_API.app.core.Ingestion_Media_Processing.chunking_options import (
     apply_chunking_template_if_any,
+    async_resolve_chunking_for_result,
     attach_chunking_plan_to_result,
-    resolve_chunking_for_result,
     resolve_chunking_options_and_plan,
     uses_hierarchical_chunking,
 )
@@ -407,7 +407,7 @@ async def process_emails_endpoint(
                     attach_chunking_plan_to_result(res, chunking_plan)
                     continue
 
-                result_chunk_options, result_chunking_plan = resolve_chunking_for_result(
+                result_chunk_options, result_chunking_plan = await async_resolve_chunking_for_result(
                     form_data,
                     res,
                     media_type="email",

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_emails.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_emails.py
@@ -395,6 +395,9 @@ async def process_emails_endpoint(
             )
 
             ck: _Chunker | None = None
+            batch_auto_chunk_options = chunk_options_dict
+            batch_auto_chunking_plan = chunking_plan
+            batch_llm_chunking_resolved = False
 
             for res in batch.get("results", []):
                 if not isinstance(res, dict):
@@ -411,10 +414,15 @@ async def process_emails_endpoint(
                     form_data,
                     res,
                     media_type="email",
-                    default_chunk_options=chunk_options_dict,
-                    default_chunking_plan=chunking_plan,
+                    default_chunk_options=batch_auto_chunk_options,
+                    default_chunking_plan=batch_auto_chunking_plan,
+                    allow_llm_assist=not batch_llm_chunking_resolved,
                 )
                 attach_chunking_plan_to_result(res, result_chunking_plan)
+                if getattr(form_data, "auto_chunking_use_llm", False) and result_chunking_plan:
+                    batch_auto_chunk_options = result_chunk_options
+                    batch_auto_chunking_plan = result_chunking_plan
+                    batch_llm_chunking_resolved = True
                 if not result_chunk_options:
                     continue
 

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_pdfs.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_pdfs.py
@@ -425,6 +425,9 @@ async def process_pdfs_endpoint(
             )
 
             ck: _Chunker | None = None
+            batch_auto_chunk_options = chunk_options_dict
+            batch_auto_chunking_plan = chunking_plan
+            batch_llm_chunking_resolved = False
 
             for res in batch.get("results", []):
                 if not isinstance(res, dict):
@@ -441,10 +444,15 @@ async def process_pdfs_endpoint(
                     form_data,
                     res,
                     media_type="pdf",
-                    default_chunk_options=chunk_options_dict,
-                    default_chunking_plan=chunking_plan,
+                    default_chunk_options=batch_auto_chunk_options,
+                    default_chunking_plan=batch_auto_chunking_plan,
+                    allow_llm_assist=not batch_llm_chunking_resolved,
                 )
                 attach_chunking_plan_to_result(res, result_chunking_plan)
+                if getattr(form_data, "auto_chunking_use_llm", False) and result_chunking_plan:
+                    batch_auto_chunk_options = result_chunk_options
+                    batch_auto_chunking_plan = result_chunking_plan
+                    batch_llm_chunking_resolved = True
                 if not result_chunk_options:
                     continue
 

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_pdfs.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_pdfs.py
@@ -35,8 +35,8 @@ from tldw_Server_API.app.api.v1.endpoints import media as media_mod
 from tldw_Server_API.app.api.v1.schemas.media_request_models import ProcessPDFsForm
 from tldw_Server_API.app.core.Ingestion_Media_Processing.chunking_options import (
     apply_chunking_template_if_any,
+    async_resolve_chunking_for_result,
     attach_chunking_plan_to_result,
-    resolve_chunking_for_result,
     resolve_chunking_options_and_plan,
     uses_hierarchical_chunking,
 )
@@ -437,7 +437,7 @@ async def process_pdfs_endpoint(
                     attach_chunking_plan_to_result(res, chunking_plan)
                     continue
 
-                result_chunk_options, result_chunking_plan = resolve_chunking_for_result(
+                result_chunk_options, result_chunking_plan = await async_resolve_chunking_for_result(
                     form_data,
                     res,
                     media_type="pdf",

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_videos.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_videos.py
@@ -36,8 +36,8 @@ from tldw_Server_API.app.core.AuthNZ.permissions import (
 )
 from tldw_Server_API.app.core.Ingestion_Media_Processing.chunking_options import (
     apply_chunking_template_if_any,
+    async_resolve_chunking_for_result,
     attach_chunking_plan_to_result,
-    resolve_chunking_for_result,
     resolve_chunking_options_and_plan,
     uses_hierarchical_chunking,
 )
@@ -342,7 +342,7 @@ async def process_videos_endpoint(
                     attach_chunking_plan_to_result(res, chunking_plan)
                     continue
 
-                result_chunk_options, result_chunking_plan = resolve_chunking_for_result(
+                result_chunk_options, result_chunking_plan = await async_resolve_chunking_for_result(
                     form_data,
                     res,
                     media_type="video",

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_videos.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_videos.py
@@ -330,6 +330,9 @@ async def process_videos_endpoint(
             )
 
             ck: _Chunker | None = None
+            batch_auto_chunk_options = chunk_options_dict
+            batch_auto_chunking_plan = chunking_plan
+            batch_llm_chunking_resolved = False
 
             for res in batch_result.get("results", []):
                 if not isinstance(res, dict):
@@ -346,10 +349,15 @@ async def process_videos_endpoint(
                     form_data,
                     res,
                     media_type="video",
-                    default_chunk_options=chunk_options_dict,
-                    default_chunking_plan=chunking_plan,
+                    default_chunk_options=batch_auto_chunk_options,
+                    default_chunking_plan=batch_auto_chunking_plan,
+                    allow_llm_assist=not batch_llm_chunking_resolved,
                 )
                 attach_chunking_plan_to_result(res, result_chunking_plan)
+                if getattr(form_data, "auto_chunking_use_llm", False) and result_chunking_plan:
+                    batch_auto_chunk_options = result_chunk_options
+                    batch_auto_chunking_plan = result_chunking_plan
+                    batch_llm_chunking_resolved = True
                 if not result_chunk_options:
                     continue
 

--- a/tldw_Server_API/app/core/Chunking/auto_boundary_assistant.py
+++ b/tldw_Server_API/app/core/Chunking/auto_boundary_assistant.py
@@ -161,7 +161,14 @@ class ChatAutoChunkBoundaryAssistant:
         self._max_tokens = max(1, int(max_tokens))
 
     async def refine(self, request: AutoChunkBoundaryAssistantRequest) -> AutoChunkBoundaryAssistantResult:
-        availability = self._check_availability(request)
+        try:
+            availability = await asyncio.to_thread(self._check_availability, request)
+        except Exception as exc:
+            logger.debug("Auto Chunking boundary assistant availability check failed: {}", type(exc).__name__)
+            return AutoChunkBoundaryAssistantResult.fallback(
+                reason="ai_assist_provider_error",
+                rationale=f"{type(exc).__name__}: availability check failed.",
+            )
         if not availability.available:
             return AutoChunkBoundaryAssistantResult.fallback(
                 reason="ai_assist_unavailable",
@@ -211,7 +218,12 @@ class ChatAutoChunkBoundaryAssistant:
 
         api_key = self._resolve_api_key(provider, app_config)
         if self._provider_requires_key(provider) and not api_key:
-            return _Availability(False, provider=provider, model=model, reason=f"API key is not configured for provider '{provider}'.")
+            return _Availability(
+                False,
+                provider=provider,
+                model=model,
+                reason=f"API key is not configured for provider '{provider}'.",
+            )
 
         return _Availability(True, provider=provider, model=model, api_key=api_key, app_config=app_config)
 
@@ -223,12 +235,9 @@ class ChatAutoChunkBoundaryAssistant:
         return loaded if isinstance(loaded, dict) else {}
 
     def _resolve_api_key(self, provider: str, app_config: dict[str, Any]) -> str | None:
-        try:
+        if _callable_accepts_positional_args(self._api_key_resolver, 2):
             return self._api_key_resolver(provider, app_config)
-        except TypeError:
-            return self._api_key_resolver(provider)
-        except Exception:
-            return None
+        return self._api_key_resolver(provider)
 
     async def _call_chat(self, request: AutoChunkBoundaryAssistantRequest, availability: _Availability) -> Any:
         chat_call = self._chat_call
@@ -355,6 +364,17 @@ def _validate_suggestion(
     method = str(payload.get("method") or base_options.get("method") or "").strip()
     if method not in _ALLOWED_ASSISTANT_METHODS:
         raise ValueError(f"Assistant response method '{method}' is not allowed.")
+    media_type = str(
+        request.media_type
+        or (
+            request.chunking_plan.get("profile", {}).get("media_type")
+            if isinstance(request.chunking_plan.get("profile"), dict)
+            else ""
+        )
+        or ""
+    ).strip().lower()
+    if method == "ebook_chapters" and media_type != "ebook":
+        raise ValueError("Assistant response method 'ebook_chapters' is only allowed for ebook media.")
 
     max_size = _coerce_int(payload.get("max_size", base_options.get("max_size")), "max_size")
     if max_size < _MIN_ASSISTANT_MAX_SIZE or max_size > _MAX_ASSISTANT_MAX_SIZE:
@@ -452,6 +472,23 @@ def _canonical_provider_from_adapter(adapter: Any, *, fallback: str) -> str:
     if isinstance(adapter_name, str) and adapter_name.strip():
         return normalize_provider(adapter_name)
     return fallback
+
+
+def _callable_accepts_positional_args(func: Callable[..., Any], count: int) -> bool:
+    try:
+        signature = inspect.signature(func)
+    except (TypeError, ValueError):
+        return True
+    positional_count = 0
+    for parameter in signature.parameters.values():
+        if parameter.kind == inspect.Parameter.VAR_POSITIONAL:
+            return True
+        if parameter.kind in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        ):
+            positional_count += 1
+    return positional_count >= count
 
 
 def _configured_default_provider(app_config: dict[str, Any]) -> str | None:

--- a/tldw_Server_API/app/core/Chunking/auto_boundary_assistant.py
+++ b/tldw_Server_API/app/core/Chunking/auto_boundary_assistant.py
@@ -1,0 +1,501 @@
+"""LLM boundary assistant for Auto Chunking plans."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from loguru import logger
+
+from tldw_Server_API.app.core.Chat.chat_helpers import extract_response_content
+from tldw_Server_API.app.core.LLM_Calls.adapter_utils import (
+    ensure_app_config,
+    normalize_provider,
+    resolve_provider_api_key_from_config,
+    resolve_provider_model,
+)
+from tldw_Server_API.app.core.LLM_Calls.adapter_registry import get_registry
+from tldw_Server_API.app.core.LLM_Calls.provider_metadata import provider_requires_api_key
+
+_DEFAULT_MAX_EXCERPT_CHARS = 12_000
+_DEFAULT_TIMEOUT_SECONDS = 8.0
+_DEFAULT_MAX_TOKENS = 600
+_MIN_ASSISTANT_MAX_SIZE = 128
+_MAX_ASSISTANT_MAX_SIZE = 4_000
+_ALLOWED_ASSISTANT_METHODS = {
+    "sentences",
+    "words",
+    "paragraphs",
+    "semantic",
+    "structure_aware",
+    "ebook_chapters",
+}
+_DERIVED_VIEW_RE = re.compile(r"^[a-z][a-z0-9_:-]{0,63}$")
+
+_SYSTEM_PROMPT = """\
+You refine ingestion-time Auto Chunking plans.
+
+Return ONLY one JSON object. Do not include Markdown, comments, or chunk text.
+
+Allowed fields:
+- method: one of sentences, words, paragraphs, semantic, structure_aware, ebook_chapters
+- max_size: integer from 128 to 4000
+- overlap: integer >= 0 and less than max_size
+- derived_views: array of short snake_case labels
+- rationale: one concise sentence explaining the refinement
+
+Rules:
+- Refine only the deterministic plan and bounded excerpt supplied by the server.
+- Do not rewrite source content.
+- Do not return chunk bodies, file paths to read, URLs to fetch, code, or prompts.
+- If the deterministic plan is already appropriate, return the same method, max_size, and overlap with a short rationale.
+"""
+
+
+@dataclass(frozen=True)
+class AutoChunkBoundaryAssistantRequest:
+    """Input for one bounded boundary-assistant refinement attempt."""
+
+    chunk_options: dict[str, Any]
+    chunking_plan: dict[str, Any]
+    media_type: str | None = None
+    source_name: str | None = None
+    extracted_text: str | None = None
+    provider: str | None = None
+    model: str | None = None
+    timeout_sec: float = _DEFAULT_TIMEOUT_SECONDS
+
+
+@dataclass(frozen=True)
+class AutoChunkBoundaryAssistantResult:
+    """Validated assistant result or deterministic fallback marker."""
+
+    used_llm: bool
+    chunk_options: dict[str, Any] | None = None
+    derived_views: tuple[str, ...] = ()
+    rationale: str = ""
+    fallback_reason: str | None = None
+    provider: str | None = None
+    model: str | None = None
+
+    @classmethod
+    def success(
+        cls,
+        *,
+        chunk_options: dict[str, Any],
+        derived_views: tuple[str, ...] = (),
+        rationale: str = "",
+        provider: str | None = None,
+        model: str | None = None,
+    ) -> "AutoChunkBoundaryAssistantResult":
+        return cls(
+            used_llm=True,
+            chunk_options=dict(chunk_options),
+            derived_views=tuple(derived_views),
+            rationale=str(rationale or "").strip(),
+            fallback_reason=None,
+            provider=provider,
+            model=model,
+        )
+
+    @classmethod
+    def fallback(
+        cls,
+        *,
+        reason: str,
+        rationale: str,
+    ) -> "AutoChunkBoundaryAssistantResult":
+        return cls(
+            used_llm=False,
+            chunk_options=None,
+            derived_views=(),
+            rationale=str(rationale or "").strip(),
+            fallback_reason=str(reason or "ai_assist_provider_error"),
+        )
+
+
+class AutoChunkBoundaryAssistant(Protocol):
+    """Narrow interface for Auto Chunking boundary refinement."""
+
+    async def refine(self, request: AutoChunkBoundaryAssistantRequest) -> AutoChunkBoundaryAssistantResult:
+        """Return validated refinements or a fallback marker."""
+
+
+@dataclass(frozen=True)
+class _Availability:
+    available: bool
+    provider: str | None = None
+    model: str | None = None
+    api_key: str | None = None
+    app_config: dict[str, Any] | None = None
+    reason: str = ""
+
+
+class ChatAutoChunkBoundaryAssistant:
+    """Boundary assistant backed by the existing async chat service."""
+
+    def __init__(
+        self,
+        *,
+        chat_call: Callable[..., Any] | None = None,
+        config_loader: Callable[[], dict[str, Any] | None] | None = None,
+        registry_getter: Callable[[], Any] | None = None,
+        api_key_resolver: Callable[..., str | None] | None = None,
+        provider_requires_key: Callable[[str], bool] | None = None,
+        default_provider: str | None = None,
+        max_excerpt_chars: int = _DEFAULT_MAX_EXCERPT_CHARS,
+        max_tokens: int = _DEFAULT_MAX_TOKENS,
+    ) -> None:
+        self._chat_call = chat_call
+        self._config_loader = config_loader or ensure_app_config
+        self._registry_getter = registry_getter or get_registry
+        self._api_key_resolver = api_key_resolver or resolve_provider_api_key_from_config
+        self._provider_requires_key = provider_requires_key or provider_requires_api_key
+        self._default_provider = default_provider
+        self._max_excerpt_chars = max(0, int(max_excerpt_chars))
+        self._max_tokens = max(1, int(max_tokens))
+
+    async def refine(self, request: AutoChunkBoundaryAssistantRequest) -> AutoChunkBoundaryAssistantResult:
+        availability = self._check_availability(request)
+        if not availability.available:
+            return AutoChunkBoundaryAssistantResult.fallback(
+                reason="ai_assist_unavailable",
+                rationale=availability.reason or "LLM boundary assistant is unavailable.",
+            )
+
+        try:
+            raw_response = await asyncio.wait_for(
+                self._call_chat(request, availability),
+                timeout=max(0.001, float(request.timeout_sec or _DEFAULT_TIMEOUT_SECONDS)),
+            )
+        except asyncio.TimeoutError:
+            return AutoChunkBoundaryAssistantResult.fallback(
+                reason="ai_assist_timeout",
+                rationale=f"Timed out after {request.timeout_sec:g} seconds.",
+            )
+        except Exception as exc:
+            logger.debug("Auto Chunking boundary assistant provider call failed: {}", type(exc).__name__)
+            return AutoChunkBoundaryAssistantResult.fallback(
+                reason="ai_assist_provider_error",
+                rationale=f"{type(exc).__name__}: provider call failed.",
+            )
+
+        response_text = _extract_llm_response_text(raw_response)
+        return parse_boundary_assistant_response(
+            response_text,
+            request=request,
+            provider=availability.provider,
+            model=availability.model,
+        )
+
+    def _check_availability(self, request: AutoChunkBoundaryAssistantRequest) -> _Availability:
+        app_config = self._load_config()
+        provider = normalize_provider(request.provider or self._default_provider or _configured_default_provider(app_config))
+        if not provider:
+            return _Availability(False, reason="LLM provider is not configured.")
+
+        registry = self._registry_getter()
+        adapter = registry.get_adapter(provider) if registry is not None else None
+        if adapter is None:
+            return _Availability(False, provider=provider, reason=f"LLM adapter unavailable for provider '{provider}'.")
+        provider = _canonical_provider_from_adapter(adapter, fallback=provider)
+
+        model = str(request.model or "").strip() or resolve_provider_model(provider, app_config) or None
+        if not model:
+            return _Availability(False, provider=provider, reason=f"Model is not configured for provider '{provider}'.")
+
+        api_key = self._resolve_api_key(provider, app_config)
+        if self._provider_requires_key(provider) and not api_key:
+            return _Availability(False, provider=provider, model=model, reason=f"API key is not configured for provider '{provider}'.")
+
+        return _Availability(True, provider=provider, model=model, api_key=api_key, app_config=app_config)
+
+    def _load_config(self) -> dict[str, Any]:
+        try:
+            loaded = self._config_loader()
+        except Exception:
+            loaded = {}
+        return loaded if isinstance(loaded, dict) else {}
+
+    def _resolve_api_key(self, provider: str, app_config: dict[str, Any]) -> str | None:
+        try:
+            return self._api_key_resolver(provider, app_config)
+        except TypeError:
+            return self._api_key_resolver(provider)
+        except Exception:
+            return None
+
+    async def _call_chat(self, request: AutoChunkBoundaryAssistantRequest, availability: _Availability) -> Any:
+        chat_call = self._chat_call
+        if chat_call is None:
+            from tldw_Server_API.app.core.Chat.chat_service import perform_chat_api_call_async
+
+            chat_call = perform_chat_api_call_async
+
+        call_kwargs: dict[str, Any] = {
+            "api_provider": availability.provider,
+            "model": availability.model,
+            "api_key": availability.api_key,
+            "messages": _build_messages(request, max_excerpt_chars=self._max_excerpt_chars),
+            "temperature": 0.1,
+            "max_tokens": self._max_tokens,
+            "stream": False,
+            "response_format": {"type": "json_object"},
+            "app_config": availability.app_config,
+        }
+        result = chat_call(**call_kwargs)
+        if inspect.isawaitable(result):
+            return await result
+        return result
+
+
+def extract_bounded_text_excerpt(text: str | None, *, max_chars: int = _DEFAULT_MAX_EXCERPT_CHARS) -> str:
+    """Return a bounded prefix excerpt for assistant context."""
+    if not text:
+        return ""
+    return text[: max(0, int(max_chars))]
+
+
+def parse_boundary_assistant_response(
+    response_text: str | None,
+    *,
+    request: AutoChunkBoundaryAssistantRequest,
+    provider: str | None,
+    model: str | None,
+) -> AutoChunkBoundaryAssistantResult:
+    """Parse and validate strict JSON suggestions from the assistant."""
+    text = (response_text or "").strip()
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        return AutoChunkBoundaryAssistantResult.fallback(
+            reason="ai_assist_invalid_response",
+            rationale="Assistant response was not valid JSON.",
+        )
+    if not isinstance(payload, dict):
+        return AutoChunkBoundaryAssistantResult.fallback(
+            reason="ai_assist_invalid_response",
+            rationale="Assistant response JSON was not an object.",
+        )
+
+    try:
+        chunk_options, derived_views, rationale = _validate_suggestion(payload, request=request)
+    except ValueError as exc:
+        return AutoChunkBoundaryAssistantResult.fallback(
+            reason="ai_assist_invalid_response",
+            rationale=str(exc),
+        )
+
+    return AutoChunkBoundaryAssistantResult.success(
+        chunk_options=chunk_options,
+        derived_views=derived_views,
+        rationale=rationale,
+        provider=provider,
+        model=model,
+    )
+
+
+def append_auto_chunking_fallback(
+    chunk_options: dict[str, Any] | None,
+    chunking_plan: dict[str, Any],
+    reason: str,
+    rationale: str,
+) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+    """Return deterministic options and plan with AI-assist fallback metadata."""
+    updated_plan = dict(chunking_plan)
+    updated_plan["used_llm"] = False
+    updated_plan["fallback_reason"] = _append_fallback_reason(updated_plan.get("fallback_reason"), reason)
+    updated_plan["rationale"] = _append_rationale(updated_plan.get("rationale"), rationale)
+    return (dict(chunk_options) if isinstance(chunk_options, dict) else chunk_options), updated_plan
+
+
+def apply_auto_chunk_boundary_result(
+    chunk_options: dict[str, Any],
+    chunking_plan: dict[str, Any],
+    result: AutoChunkBoundaryAssistantResult,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Apply a successful assistant result to options and plan metadata."""
+    if not result.used_llm or not isinstance(result.chunk_options, dict):
+        reason = result.fallback_reason or "ai_assist_provider_error"
+        return append_auto_chunking_fallback(chunk_options, chunking_plan, reason, result.rationale)
+
+    refined_options = dict(chunk_options)
+    refined_options.update(result.chunk_options)
+    updated_plan = dict(chunking_plan)
+    updated_plan.update(
+        {
+            "used_llm": True,
+            "method": refined_options.get("method"),
+            "max_size": refined_options.get("max_size"),
+            "overlap": refined_options.get("overlap"),
+            "fallback_reason": None,
+            "rationale": result.rationale or "AI assist refined the deterministic Auto Chunking plan.",
+        }
+    )
+    if result.derived_views:
+        updated_plan["derived_views"] = list(result.derived_views)
+    if result.provider:
+        updated_plan["provider"] = result.provider
+    if result.model:
+        updated_plan["model"] = result.model
+    return refined_options, updated_plan
+
+
+def _validate_suggestion(
+    payload: dict[str, Any],
+    *,
+    request: AutoChunkBoundaryAssistantRequest,
+) -> tuple[dict[str, Any], tuple[str, ...], str]:
+    base_options = dict(request.chunk_options)
+    method = str(payload.get("method") or base_options.get("method") or "").strip()
+    if method not in _ALLOWED_ASSISTANT_METHODS:
+        raise ValueError(f"Assistant response method '{method}' is not allowed.")
+
+    max_size = _coerce_int(payload.get("max_size", base_options.get("max_size")), "max_size")
+    if max_size < _MIN_ASSISTANT_MAX_SIZE or max_size > _MAX_ASSISTANT_MAX_SIZE:
+        raise ValueError(
+            f"Assistant response max_size must be between {_MIN_ASSISTANT_MAX_SIZE} and {_MAX_ASSISTANT_MAX_SIZE}."
+        )
+
+    overlap = _coerce_int(payload.get("overlap", base_options.get("overlap", 0)), "overlap")
+    if overlap < 0 or overlap >= max_size:
+        raise ValueError("Assistant response overlap must be non-negative and less than max_size.")
+
+    derived_views = _validate_derived_views(payload.get("derived_views", request.chunking_plan.get("derived_views")))
+    rationale = _bounded_string(payload.get("rationale"), max_chars=300)
+    if not rationale:
+        rationale = "Assistant refined the deterministic Auto Chunking plan."
+
+    refined_options = dict(base_options)
+    refined_options.update(
+        {
+            "method": method,
+            "max_size": max_size,
+            "overlap": overlap,
+        }
+    )
+    return refined_options, derived_views, rationale
+
+
+def _coerce_int(value: Any, field_name: str) -> int:
+    try:
+        if isinstance(value, bool):
+            raise TypeError
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Assistant response {field_name} must be an integer.") from exc
+
+
+def _validate_derived_views(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list):
+        raise ValueError("Assistant response derived_views must be a list.")
+    views: list[str] = []
+    for raw_view in value[:8]:
+        if not isinstance(raw_view, str):
+            raise ValueError("Assistant response derived_views entries must be strings.")
+        view = raw_view.strip()
+        if not _DERIVED_VIEW_RE.match(view):
+            raise ValueError("Assistant response derived_views entries must be short machine labels.")
+        if view not in views:
+            views.append(view)
+    return tuple(views)
+
+
+def _bounded_string(value: Any, *, max_chars: int) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()[: max(0, int(max_chars))]
+
+
+def _append_fallback_reason(existing: Any, reason: str) -> str:
+    reasons = [
+        item
+        for item in str(existing or "").split(";")
+        if item and not (item == "ai_assist_unavailable" and reason != "ai_assist_unavailable")
+    ]
+    if reason not in reasons:
+        reasons.append(reason)
+    return ";".join(reasons)
+
+
+def _append_rationale(existing: Any, rationale: str) -> str:
+    existing_text = str(existing or "").strip()
+    rationale_text = str(rationale or "").strip()
+    if not existing_text:
+        return rationale_text
+    if not rationale_text or rationale_text in existing_text:
+        return existing_text
+    return f"{existing_text} {rationale_text}"
+
+
+def _extract_llm_response_text(raw_response: Any) -> str:
+    extracted = extract_response_content(raw_response)
+    if extracted is not None:
+        return extracted
+    if isinstance(raw_response, dict):
+        for key in ("content", "text"):
+            value = raw_response.get(key)
+            if isinstance(value, str):
+                return value
+    return str(raw_response or "")
+
+
+def _canonical_provider_from_adapter(adapter: Any, *, fallback: str) -> str:
+    adapter_name = getattr(adapter, "name", None)
+    if isinstance(adapter_name, str) and adapter_name.strip():
+        return normalize_provider(adapter_name)
+    return fallback
+
+
+def _configured_default_provider(app_config: dict[str, Any]) -> str | None:
+    for section_name in ("llm_api_settings", "API", "Chat-API"):
+        section = app_config.get(section_name)
+        if not isinstance(section, dict):
+            continue
+        for key in ("default_api", "default_chat_provider"):
+            value = section.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    try:
+        from tldw_Server_API.app.api.v1.schemas.chat_request_schemas import DEFAULT_LLM_PROVIDER
+
+        return str(DEFAULT_LLM_PROVIDER or "").strip() or None
+    except Exception:
+        return None
+
+
+def _build_messages(
+    request: AutoChunkBoundaryAssistantRequest,
+    *,
+    max_excerpt_chars: int,
+) -> list[dict[str, str]]:
+    excerpt = extract_bounded_text_excerpt(request.extracted_text, max_chars=max_excerpt_chars)
+    payload = {
+        "media_type": request.media_type,
+        "source_name": request.source_name,
+        "deterministic_chunk_options": request.chunk_options,
+        "deterministic_chunking_plan": {
+            key: request.chunking_plan.get(key)
+            for key in (
+                "goal",
+                "method",
+                "max_size",
+                "overlap",
+                "derived_views",
+                "rationale",
+                "profile",
+            )
+        },
+        "bounded_excerpt": excerpt,
+    }
+    return [
+        {"role": "system", "content": _SYSTEM_PROMPT},
+        {"role": "user", "content": json.dumps(payload, ensure_ascii=False)},
+    ]

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/chunking_options.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/chunking_options.py
@@ -261,6 +261,7 @@ def resolve_chunking_options_and_plan(
     template_status: str | None = None,
     template_error: str | None = None,
     llm_available: bool = False,
+    llm_requested_override: bool | None = None,
     semantic_available: bool = True,
 ) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
     """
@@ -285,6 +286,11 @@ def resolve_chunking_options_and_plan(
     )
     text_profile = profile_from_text(extracted_text)
     profile = merge_profiles(source_profile, text_profile)
+    requested_llm = (
+        _coerce_raw_bool(_get_raw_form_value(form_data, "auto_chunking_use_llm", False))
+        if llm_requested_override is None
+        else bool(llm_requested_override)
+    )
 
     decision = plan_auto_chunking(
         perform_chunking=True,
@@ -295,7 +301,7 @@ def resolve_chunking_options_and_plan(
         template_name=template_name or _get_raw_form_value(form_data, "chunking_template_name"),
         template_status=template_status,
         template_error=template_error,
-        requested_llm=_coerce_raw_bool(_get_raw_form_value(form_data, "auto_chunking_use_llm", False)),
+        requested_llm=requested_llm,
         llm_available=llm_available,
         semantic_available=semantic_available,
     )
@@ -325,7 +331,8 @@ async def async_resolve_chunking_options_and_plan(
         template_name=template_name,
         template_status=template_status,
         template_error=template_error,
-        llm_available=llm_requested,
+        llm_available=False,
+        llm_requested_override=False,
         semantic_available=semantic_available,
     )
     if not chunk_options or not chunking_plan:
@@ -419,9 +426,12 @@ async def async_resolve_chunking_for_result(
     default_chunk_options: dict[str, Any] | None = None,
     default_chunking_plan: dict[str, Any] | None = None,
     boundary_assistant: AutoChunkBoundaryAssistant | None = None,
+    allow_llm_assist: bool = True,
 ) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
     """Async final chunking resolver for completed process results."""
     if _get_raw_form_value(form_data, "chunking_mode") != "auto":
+        return default_chunk_options, default_chunking_plan
+    if not allow_llm_assist:
         return default_chunk_options, default_chunking_plan
 
     extracted_text = result.get("content")
@@ -490,14 +500,15 @@ def _resolve_boundary_assistant_provider_model(form_data: Any) -> tuple[str | No
     provider = _get_raw_form_value(form_data, "api_provider")
     model = _get_raw_form_value(form_data, "model_name")
     api_name = _get_raw_form_value(form_data, "api_name")
-    if not provider and api_name:
+    if api_name:
         api_name_text = str(api_name).strip()
         if "/" in api_name_text:
             provider_part, model_part = api_name_text.split("/", 1)
-            provider = provider_part.strip() or None
+            if not provider:
+                provider = provider_part.strip() or None
             if not model:
                 model = model_part.strip() or None
-        else:
+        elif not provider:
             provider = api_name_text or None
     return (
         str(provider).strip() if provider else None,

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/chunking_options.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/chunking_options.py
@@ -11,6 +11,12 @@ from tldw_Server_API.app.core.Chunking.auto_planner import (
     profile_from_source,
     profile_from_text,
 )
+from tldw_Server_API.app.core.Chunking.auto_boundary_assistant import (
+    AutoChunkBoundaryAssistant,
+    AutoChunkBoundaryAssistantRequest,
+    ChatAutoChunkBoundaryAssistant,
+    apply_auto_chunk_boundary_result,
+)
 from tldw_Server_API.app.core.config import load_and_log_configs
 from tldw_Server_API.app.core.Utils.Utils import logging
 
@@ -296,6 +302,65 @@ def resolve_chunking_options_and_plan(
     return decision.chunk_options, decision.chunking_plan
 
 
+async def async_resolve_chunking_options_and_plan(
+    form_data: Any,
+    *,
+    media_type: str | None = None,
+    source_name: str | None = None,
+    extracted_text: str | None = None,
+    template_name: str | None = None,
+    template_status: str | None = None,
+    template_error: str | None = None,
+    semantic_available: bool = True,
+    boundary_assistant: AutoChunkBoundaryAssistant | None = None,
+    assistant_timeout_sec: float = 8.0,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    """Async Auto Chunking resolver with optional LLM boundary refinement."""
+    llm_requested = _coerce_raw_bool(_get_raw_form_value(form_data, "auto_chunking_use_llm", False))
+    chunk_options, chunking_plan = resolve_chunking_options_and_plan(
+        form_data,
+        media_type=media_type,
+        source_name=source_name,
+        extracted_text=extracted_text,
+        template_name=template_name,
+        template_status=template_status,
+        template_error=template_error,
+        llm_available=llm_requested,
+        semantic_available=semantic_available,
+    )
+    if not chunk_options or not chunking_plan:
+        return chunk_options, chunking_plan
+    if not llm_requested:
+        return chunk_options, chunking_plan
+
+    provider, model = _resolve_boundary_assistant_provider_model(form_data)
+    assistant = boundary_assistant or ChatAutoChunkBoundaryAssistant()
+    assistant_plan = dict(chunking_plan)
+    assistant_plan["used_llm"] = False
+    request = AutoChunkBoundaryAssistantRequest(
+        chunk_options=chunk_options,
+        chunking_plan=assistant_plan,
+        media_type=media_type or _get_raw_form_value(form_data, "media_type"),
+        source_name=source_name or _first_form_source_name(form_data),
+        extracted_text=extracted_text,
+        provider=provider,
+        model=model,
+        timeout_sec=assistant_timeout_sec,
+    )
+    try:
+        result = await assistant.refine(request)
+    except _CHUNKING_OPTIONS_NONCRITICAL_EXCEPTIONS as exc:
+        from tldw_Server_API.app.core.Chunking.auto_boundary_assistant import (
+            AutoChunkBoundaryAssistantResult,
+        )
+
+        result = AutoChunkBoundaryAssistantResult.fallback(
+            reason="ai_assist_provider_error",
+            rationale=f"{type(exc).__name__}: assistant failed.",
+        )
+    return apply_auto_chunk_boundary_result(chunk_options, chunking_plan, result)
+
+
 def attach_chunking_plan_to_result(
     result: dict[str, Any],
     chunking_plan: dict[str, Any] | None,
@@ -346,6 +411,39 @@ def resolve_chunking_for_result(
     )
 
 
+async def async_resolve_chunking_for_result(
+    form_data: Any,
+    result: dict[str, Any],
+    *,
+    media_type: str | None = None,
+    default_chunk_options: dict[str, Any] | None = None,
+    default_chunking_plan: dict[str, Any] | None = None,
+    boundary_assistant: AutoChunkBoundaryAssistant | None = None,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    """Async final chunking resolver for completed process results."""
+    if _get_raw_form_value(form_data, "chunking_mode") != "auto":
+        return default_chunk_options, default_chunking_plan
+
+    extracted_text = result.get("content")
+    if not isinstance(extracted_text, str):
+        extracted_text = None
+    source_name = result.get("input_ref") or result.get("processing_source")
+    if source_name is not None:
+        source_name = str(source_name)
+
+    chunk_options, chunking_plan = await async_resolve_chunking_options_and_plan(
+        form_data,
+        media_type=media_type,
+        source_name=source_name,
+        extracted_text=extracted_text,
+        boundary_assistant=boundary_assistant,
+    )
+    return (
+        chunk_options if chunk_options is not None else default_chunk_options,
+        chunking_plan if chunking_plan is not None else default_chunking_plan,
+    )
+
+
 def _profile_from_form_source(
     form_data: Any,
     *,
@@ -386,6 +484,25 @@ def _first_form_source_name(form_data: Any) -> str | None:
         if value:
             return str(value)
     return None
+
+
+def _resolve_boundary_assistant_provider_model(form_data: Any) -> tuple[str | None, str | None]:
+    provider = _get_raw_form_value(form_data, "api_provider")
+    model = _get_raw_form_value(form_data, "model_name")
+    api_name = _get_raw_form_value(form_data, "api_name")
+    if not provider and api_name:
+        api_name_text = str(api_name).strip()
+        if "/" in api_name_text:
+            provider_part, model_part = api_name_text.split("/", 1)
+            provider = provider_part.strip() or None
+            if not model:
+                model = model_part.strip() or None
+        else:
+            provider = api_name_text or None
+    return (
+        str(provider).strip() if provider else None,
+        str(model).strip() if model else None,
+    )
 
 
 def apply_chunking_template_if_any(

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/persistence.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/persistence.py
@@ -42,6 +42,7 @@ from tldw_Server_API.app.core.DB_Management.media_db.legacy_transcripts import (
     upsert_transcript,
 )
 from tldw_Server_API.app.core.Ingestion_Media_Processing.chunking_options import (
+    async_resolve_chunking_options_and_plan,
     prepare_chunking_options_dict,
     prepare_common_options,
     resolve_chunking_options_and_plan,
@@ -3396,7 +3397,7 @@ async def persist_primary_av_item(
     resolved_chunk_options = chunk_options
     if getattr(form_data, "chunking_mode", None) == "auto":
         with contextlib.suppress(_PERSISTENCE_NONCRITICAL_EXCEPTIONS):
-            auto_chunking_options, auto_chunking_plan = resolve_chunking_options_and_plan(
+            auto_chunking_options, auto_chunking_plan = await async_resolve_chunking_options_and_plan(
                 form_data,
                 media_type=media_type,
                 source_name=str(original_input_ref or ""),
@@ -5327,7 +5328,7 @@ async def persist_doc_item_and_children(
     resolved_chunk_options = chunk_options
     if getattr(form_data, "chunking_mode", None) == "auto":
         with contextlib.suppress(_PERSISTENCE_NONCRITICAL_EXCEPTIONS):
-            auto_chunking_options, auto_chunking_plan = resolve_chunking_options_and_plan(
+            auto_chunking_options, auto_chunking_plan = await async_resolve_chunking_options_and_plan(
                 form_data,
                 media_type=media_type,
                 source_name=str(item_input_ref or processing_filename or ""),

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/persistence.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/persistence.py
@@ -3364,6 +3364,26 @@ async def add_media_persist(
     )
 
 
+async def _resolve_auto_chunking_options_for_persistence(
+    form_data: Any,
+    *,
+    media_type: Any,
+    source_name: str,
+    extracted_text: str | None,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    try:
+        return await async_resolve_chunking_options_and_plan(
+            form_data,
+            media_type=media_type,
+            source_name=source_name,
+            extracted_text=extracted_text,
+        )
+    except asyncio.CancelledError:
+        raise
+    except _PERSISTENCE_NONCRITICAL_EXCEPTIONS:
+        return None, None
+
+
 async def persist_primary_av_item(
     *,
     process_result: dict[str, Any],
@@ -3396,19 +3416,18 @@ async def persist_primary_av_item(
         metadata_for_db = {}
     resolved_chunk_options = chunk_options
     if getattr(form_data, "chunking_mode", None) == "auto":
-        with contextlib.suppress(_PERSISTENCE_NONCRITICAL_EXCEPTIONS):
-            auto_chunking_options, auto_chunking_plan = await async_resolve_chunking_options_and_plan(
-                form_data,
-                media_type=media_type,
-                source_name=str(original_input_ref or ""),
-                extracted_text=content_for_db if isinstance(content_for_db, str) else None,
-            )
-            if auto_chunking_options is not None:
-                resolved_chunk_options = auto_chunking_options
-            if auto_chunking_plan:
-                metadata_for_db = dict(metadata_for_db)
-                metadata_for_db["chunking_plan"] = auto_chunking_plan
-                process_result["metadata"] = metadata_for_db
+        auto_chunking_options, auto_chunking_plan = await _resolve_auto_chunking_options_for_persistence(
+            form_data,
+            media_type=media_type,
+            source_name=str(original_input_ref or ""),
+            extracted_text=content_for_db if isinstance(content_for_db, str) else None,
+        )
+        if auto_chunking_options is not None:
+            resolved_chunk_options = auto_chunking_options
+        if auto_chunking_plan:
+            metadata_for_db = dict(metadata_for_db)
+            metadata_for_db["chunking_plan"] = auto_chunking_plan
+            process_result["metadata"] = metadata_for_db
 
     # Use the model reported by the processor if available, else fall back.
     transcription_model_used = metadata_for_db.get(
@@ -5327,19 +5346,18 @@ async def persist_doc_item_and_children(
         metadata_for_db = {}
     resolved_chunk_options = chunk_options
     if getattr(form_data, "chunking_mode", None) == "auto":
-        with contextlib.suppress(_PERSISTENCE_NONCRITICAL_EXCEPTIONS):
-            auto_chunking_options, auto_chunking_plan = await async_resolve_chunking_options_and_plan(
-                form_data,
-                media_type=media_type,
-                source_name=str(item_input_ref or processing_filename or ""),
-                extracted_text=content_for_db if isinstance(content_for_db, str) else None,
-            )
-            if auto_chunking_options is not None:
-                resolved_chunk_options = auto_chunking_options
-            if auto_chunking_plan:
-                metadata_for_db = dict(metadata_for_db)
-                metadata_for_db["chunking_plan"] = auto_chunking_plan
-                final_result["metadata"] = metadata_for_db
+        auto_chunking_options, auto_chunking_plan = await _resolve_auto_chunking_options_for_persistence(
+            form_data,
+            media_type=media_type,
+            source_name=str(item_input_ref or processing_filename or ""),
+            extracted_text=content_for_db if isinstance(content_for_db, str) else None,
+        )
+        if auto_chunking_options is not None:
+            resolved_chunk_options = auto_chunking_options
+        if auto_chunking_plan:
+            metadata_for_db = dict(metadata_for_db)
+            metadata_for_db["chunking_plan"] = auto_chunking_plan
+            final_result["metadata"] = metadata_for_db
 
     extracted_keywords = final_result.get("keywords", [])
     combined_keywords = set(getattr(form_data, "keywords", None) or [])

--- a/tldw_Server_API/app/services/enhanced_web_scraping_service.py
+++ b/tldw_Server_API/app/services/enhanced_web_scraping_service.py
@@ -65,6 +65,9 @@ def _web_chunking_form(
     chunking_mode: str | None,
     auto_chunking_goal: str,
     auto_chunking_use_llm: bool,
+    api_name: str | None = None,
+    api_provider: str | None = None,
+    model_name: str | None = None,
 ) -> SimpleNamespace:
     return SimpleNamespace(
         media_type="web",
@@ -72,6 +75,9 @@ def _web_chunking_form(
         chunking_mode=chunking_mode,
         auto_chunking_goal=auto_chunking_goal,
         auto_chunking_use_llm=auto_chunking_use_llm,
+        api_name=api_name,
+        api_provider=api_provider,
+        model_name=model_name,
         chunk_method=None,
         chunk_size=500,
         chunk_overlap=200,
@@ -729,6 +735,7 @@ class WebScrapingService:
                 chunking_mode=chunking_mode,
                 auto_chunking_goal=auto_chunking_goal,
                 auto_chunking_use_llm=auto_chunking_use_llm,
+                api_name=api_name,
             )
             _batch_t0 = time.perf_counter()
             for article in result.get("articles", []):

--- a/tldw_Server_API/app/services/enhanced_web_scraping_service.py
+++ b/tldw_Server_API/app/services/enhanced_web_scraping_service.py
@@ -21,8 +21,8 @@ from tldw_Server_API.app.core.config import load_and_log_configs
 from tldw_Server_API.app.core.DB_Management.db_path_utils import get_user_media_db_path
 from tldw_Server_API.app.core.DB_Management.media_db.api import managed_media_database
 from tldw_Server_API.app.core.Ingestion_Media_Processing.chunking_options import (
+    async_resolve_chunking_options_and_plan,
     attach_chunking_plan_to_result,
-    resolve_chunking_options_and_plan,
 )
 from tldw_Server_API.app.core.LLM_Calls.Summarization_General_Lib import analyze
 from tldw_Server_API.app.core.Metrics import get_metrics_registry
@@ -795,7 +795,7 @@ class WebScrapingService:
                     chunk_options = None
                     chunking_plan = None
                     if perform_chunking:
-                        chunk_options, chunking_plan = resolve_chunking_options_and_plan(
+                        chunk_options, chunking_plan = await async_resolve_chunking_options_and_plan(
                             chunking_form,
                             media_type="web",
                             source_name=str(article.get("url") or ""),

--- a/tldw_Server_API/app/services/media_ingest_jobs_worker.py
+++ b/tldw_Server_API/app/services/media_ingest_jobs_worker.py
@@ -19,9 +19,9 @@ from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.core.DB_Management.media_db.api import create_media_database
 from tldw_Server_API.app.core.DB_Management.media_db.errors import ConflictError
 from tldw_Server_API.app.core.Ingestion_Media_Processing.chunking_options import (
+    async_resolve_chunking_options_and_plan,
     apply_chunking_template_if_any,
     prepare_chunking_options_dict,
-    resolve_chunking_options_and_plan,
 )
 from tldw_Server_API.app.core.Ingestion_Media_Processing.persistence import (
     process_batch_media,
@@ -254,7 +254,7 @@ async def _handle_job(job: dict[str, Any], jm: JobManager, progress: _ProgressSt
         def cancel_check():
             return _should_cancel(jm, job_id)
 
-        chunk_options, chunking_plan = resolve_chunking_options_and_plan(
+        chunk_options, chunking_plan = await async_resolve_chunking_options_and_plan(
             form_data,
             media_type=str(form_data.media_type) if form_data.media_type else None,
             source_name=str(input_ref or source),

--- a/tldw_Server_API/app/services/web_scraping_service.py
+++ b/tldw_Server_API/app/services/web_scraping_service.py
@@ -25,8 +25,8 @@ from tldw_Server_API.app.core.DB_Management.media_db.api import (
 )
 from tldw_Server_API.app.core.deprecations import log_runtime_deprecation
 from tldw_Server_API.app.core.Ingestion_Media_Processing.chunking_options import (
+    async_resolve_chunking_options_and_plan,
     attach_chunking_plan_to_result,
-    resolve_chunking_options_and_plan,
 )
 from tldw_Server_API.app.core.LLM_Calls.Summarization_General_Lib import analyze
 from tldw_Server_API.app.core.testing import env_flag_enabled
@@ -437,7 +437,7 @@ async def process_web_scraping_task(
                         if not isinstance(article, dict):
                             continue
                         content_text = article.get("content")
-                        chunk_options, chunking_plan = resolve_chunking_options_and_plan(
+                        chunk_options, chunking_plan = await async_resolve_chunking_options_and_plan(
                             chunking_form,
                             media_type="web",
                             source_name=str(article.get("url") or ""),
@@ -479,7 +479,7 @@ async def process_web_scraping_task(
                         chunk_options = None
                         chunking_plan = None
                         if perform_chunking:
-                            chunk_options, chunking_plan = resolve_chunking_options_and_plan(
+                            chunk_options, chunking_plan = await async_resolve_chunking_options_and_plan(
                                 chunking_form,
                                 media_type="web",
                                 source_name=str(article.get("url") or ""),

--- a/tldw_Server_API/app/services/web_scraping_service.py
+++ b/tldw_Server_API/app/services/web_scraping_service.py
@@ -121,6 +121,9 @@ def _web_chunking_form(
     chunking_mode: str | None,
     auto_chunking_goal: str,
     auto_chunking_use_llm: bool,
+    api_name: str | None = None,
+    api_provider: str | None = None,
+    model_name: str | None = None,
 ) -> SimpleNamespace:
     return SimpleNamespace(
         media_type="web",
@@ -128,6 +131,9 @@ def _web_chunking_form(
         chunking_mode=chunking_mode,
         auto_chunking_goal=auto_chunking_goal,
         auto_chunking_use_llm=auto_chunking_use_llm,
+        api_name=api_name,
+        api_provider=api_provider,
+        model_name=model_name,
         chunk_method=None,
         chunk_size=500,
         chunk_overlap=200,
@@ -407,6 +413,7 @@ async def process_web_scraping_task(
                 chunking_mode=chunking_mode,
                 auto_chunking_goal=auto_chunking_goal,
                 auto_chunking_use_llm=auto_chunking_use_llm,
+                api_name=api_name,
             )
 
             # 2) Summarize after the fact, if the method doesn't handle it

--- a/tldw_Server_API/tests/Chunking/test_auto_boundary_assistant.py
+++ b/tldw_Server_API/tests/Chunking/test_auto_boundary_assistant.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_Server_API.app.core.Chunking.auto_boundary_assistant import (
+    AutoChunkBoundaryAssistantRequest,
+    AutoChunkBoundaryAssistantResult,
+    ChatAutoChunkBoundaryAssistant,
+    append_auto_chunking_fallback,
+    extract_bounded_text_excerpt,
+    parse_boundary_assistant_response,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _request(**overrides):
+    values = {
+        "chunk_options": {
+            "method": "structure_aware",
+            "max_size": 900,
+            "overlap": 120,
+            "adaptive": False,
+            "multi_level": False,
+            "language": "en",
+        },
+        "chunking_plan": {
+            "mode": "auto",
+            "goal": "balanced",
+            "used_llm": False,
+            "method": "structure_aware",
+            "max_size": 900,
+            "overlap": 120,
+            "template_name": None,
+            "derived_views": ["section_titles"],
+            "fallback_reason": None,
+            "rationale": "Detected document structure.",
+            "profile": {"media_type": "document", "text_length": 2000},
+        },
+        "media_type": "document",
+        "source_name": "notes.md",
+        "extracted_text": "# Intro\n\nSome content.\n\n## Details\n\nMore content.",
+        "provider": "openai",
+        "model": "gpt-test",
+        "timeout_sec": 0.5,
+    }
+    values.update(overrides)
+    return AutoChunkBoundaryAssistantRequest(**values)
+
+
+def test_boundary_assistant_result_types_represent_success_and_fallback():
+    success = AutoChunkBoundaryAssistantResult.success(
+        chunk_options={"method": "semantic", "max_size": 800, "overlap": 80},
+        derived_views=("topic_sections",),
+        rationale="Topic shifts are clearer than headings.",
+        provider="openai",
+        model="gpt-test",
+    )
+    fallback = AutoChunkBoundaryAssistantResult.fallback(
+        reason="ai_assist_invalid_response",
+        rationale="Assistant response did not match the strict schema.",
+    )
+
+    assert success.used_llm is True
+    assert success.fallback_reason is None
+    assert success.provider == "openai"
+    assert success.model == "gpt-test"
+    assert fallback.used_llm is False
+    assert fallback.chunk_options is None
+    assert fallback.fallback_reason == "ai_assist_invalid_response"
+
+
+def test_extract_bounded_text_excerpt_limits_context_without_reordering_text():
+    text = "a" * 1200 + "TAIL"
+
+    excerpt = extract_bounded_text_excerpt(text, max_chars=64)
+
+    assert excerpt == "a" * 64
+    assert "TAIL" not in excerpt
+
+
+def test_parse_boundary_assistant_response_accepts_strict_bounded_json():
+    request = _request()
+
+    result = parse_boundary_assistant_response(
+        '{"method":"semantic","max_size":840,"overlap":84,'
+        '"derived_views":["topic_sections","outline"],'
+        '"rationale":"The document uses topic shifts more than headings."}',
+        request=request,
+        provider="openai",
+        model="gpt-test",
+    )
+
+    assert result.used_llm is True
+    assert result.chunk_options == {
+        "method": "semantic",
+        "max_size": 840,
+        "overlap": 84,
+        "adaptive": False,
+        "multi_level": False,
+        "language": "en",
+    }
+    assert result.derived_views == ("topic_sections", "outline")
+    assert result.rationale == "The document uses topic shifts more than headings."
+
+
+@pytest.mark.parametrize(
+    ("response_text", "reason_fragment"),
+    [
+        ("not-json", "not valid JSON"),
+        ('{"method":"shell","max_size":840,"overlap":84}', "method"),
+        ('{"method":"semantic","max_size":10,"overlap":1}', "max_size"),
+        ('{"method":"semantic","max_size":840,"overlap":840}', "overlap"),
+        ('{"method":"semantic","max_size":840,"overlap":84,"derived_views":["bad view"]}', "derived_views"),
+    ],
+)
+def test_parse_boundary_assistant_response_rejects_invalid_suggestions(response_text, reason_fragment):
+    result = parse_boundary_assistant_response(
+        response_text,
+        request=_request(),
+        provider="openai",
+        model="gpt-test",
+    )
+
+    assert result.used_llm is False
+    assert result.fallback_reason == "ai_assist_invalid_response"
+    assert reason_fragment in result.rationale
+
+
+def test_append_auto_chunking_fallback_preserves_deterministic_plan_and_options():
+    request = _request()
+    plan = dict(request.chunking_plan)
+    options = dict(request.chunk_options)
+
+    updated_options, updated_plan = append_auto_chunking_fallback(
+        options,
+        plan,
+        "ai_assist_timeout",
+        "Timed out after 0.5 seconds.",
+    )
+
+    assert updated_options == options
+    assert updated_plan["method"] == plan["method"]
+    assert updated_plan["max_size"] == plan["max_size"]
+    assert updated_plan["overlap"] == plan["overlap"]
+    assert updated_plan["used_llm"] is False
+    assert updated_plan["fallback_reason"] == "ai_assist_timeout"
+    assert "Timed out after 0.5 seconds." in updated_plan["rationale"]
+
+
+@pytest.mark.asyncio
+async def test_chat_assistant_returns_unavailable_when_provider_cannot_be_resolved():
+    assistant = ChatAutoChunkBoundaryAssistant(
+        chat_call=lambda **_: pytest.fail("chat call should not run"),
+        config_loader=lambda: {},
+        registry_getter=lambda: SimpleNamespace(get_adapter=lambda _provider: object()),
+        api_key_resolver=lambda _provider, _config=None: None,
+        provider_requires_key=lambda _provider: False,
+        default_provider=None,
+    )
+
+    result = await assistant.refine(_request(provider=None, model=None))
+
+    assert result.used_llm is False
+    assert result.fallback_reason == "ai_assist_unavailable"
+    assert "provider" in result.rationale
+
+
+@pytest.mark.asyncio
+async def test_chat_assistant_calls_provider_when_available_and_valid():
+    calls = []
+
+    async def chat_call(**kwargs):
+        calls.append(kwargs)
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "content": (
+                            '{"method":"semantic","max_size":820,"overlap":82,'
+                            '"derived_views":["topic_sections"],'
+                            '"rationale":"Clear topic transitions."}'
+                        )
+                    }
+                }
+            ]
+        }
+
+    assistant = ChatAutoChunkBoundaryAssistant(
+        chat_call=chat_call,
+        config_loader=lambda: {"openai_api": {"model": "gpt-config"}},
+        registry_getter=lambda: SimpleNamespace(get_adapter=lambda _provider: object()),
+        api_key_resolver=lambda _provider, _config=None: "key",
+        provider_requires_key=lambda _provider: True,
+        default_provider="openai",
+    )
+
+    result = await assistant.refine(_request(provider=None, model=None))
+
+    assert result.used_llm is True
+    assert result.chunk_options["method"] == "semantic"
+    assert result.chunk_options["max_size"] == 820
+    assert calls[0]["api_provider"] == "openai"
+    assert calls[0]["model"] == "gpt-config"
+    assert calls[0]["stream"] is False
+
+
+@pytest.mark.asyncio
+async def test_chat_assistant_uses_adapter_canonical_provider_for_alias_availability():
+    calls = []
+
+    async def chat_call(**kwargs):
+        calls.append(kwargs)
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "content": (
+                            '{"method":"semantic","max_size":820,"overlap":82,'
+                            '"derived_views":["topic_sections"],'
+                            '"rationale":"Clear topic transitions."}'
+                        )
+                    }
+                }
+            ]
+        }
+
+    seen_requires_key = []
+    assistant = ChatAutoChunkBoundaryAssistant(
+        chat_call=chat_call,
+        config_loader=lambda: {"local_llm": {"model": "local-model"}},
+        registry_getter=lambda: SimpleNamespace(get_adapter=lambda _provider: SimpleNamespace(name="local-llm")),
+        api_key_resolver=lambda _provider, _config=None: None,
+        provider_requires_key=lambda provider: seen_requires_key.append(provider) or False,
+    )
+
+    result = await assistant.refine(_request(provider="local_llm", model=None))
+
+    assert result.used_llm is True
+    assert result.provider == "local-llm"
+    assert calls[0]["api_provider"] == "local-llm"
+    assert calls[0]["model"] == "local-model"
+    assert seen_requires_key == ["local-llm"]
+
+
+@pytest.mark.asyncio
+async def test_chat_assistant_timeout_falls_back_without_raising():
+    async def chat_call(**_kwargs):
+        await asyncio.sleep(0.05)
+        return "{}"
+
+    assistant = ChatAutoChunkBoundaryAssistant(
+        chat_call=chat_call,
+        config_loader=lambda: {"openai_api": {"model": "gpt-config"}},
+        registry_getter=lambda: SimpleNamespace(get_adapter=lambda _provider: object()),
+        api_key_resolver=lambda _provider, _config=None: "key",
+        provider_requires_key=lambda _provider: True,
+        default_provider="openai",
+    )
+
+    result = await assistant.refine(_request(provider=None, model=None, timeout_sec=0.001))
+
+    assert result.used_llm is False
+    assert result.fallback_reason == "ai_assist_timeout"
+
+
+@pytest.mark.asyncio
+async def test_chat_assistant_provider_error_falls_back_without_raising():
+    async def chat_call(**_kwargs):
+        raise RuntimeError("provider exploded")
+
+    assistant = ChatAutoChunkBoundaryAssistant(
+        chat_call=chat_call,
+        config_loader=lambda: {"openai_api": {"model": "gpt-config"}},
+        registry_getter=lambda: SimpleNamespace(get_adapter=lambda _provider: object()),
+        api_key_resolver=lambda _provider, _config=None: "key",
+        provider_requires_key=lambda _provider: True,
+        default_provider="openai",
+    )
+
+    result = await assistant.refine(_request(provider=None, model=None))
+
+    assert result.used_llm is False
+    assert result.fallback_reason == "ai_assist_provider_error"
+    assert "RuntimeError" in result.rationale

--- a/tldw_Server_API/tests/Chunking/test_auto_boundary_assistant.py
+++ b/tldw_Server_API/tests/Chunking/test_auto_boundary_assistant.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 from types import SimpleNamespace
 
 import pytest
@@ -115,6 +116,7 @@ def test_parse_boundary_assistant_response_accepts_strict_bounded_json():
         ('{"method":"semantic","max_size":10,"overlap":1}', "max_size"),
         ('{"method":"semantic","max_size":840,"overlap":840}', "overlap"),
         ('{"method":"semantic","max_size":840,"overlap":84,"derived_views":["bad view"]}', "derived_views"),
+        ('{"method":"ebook_chapters","max_size":840,"overlap":84}', "ebook_chapters"),
     ],
 )
 def test_parse_boundary_assistant_response_rejects_invalid_suggestions(response_text, reason_fragment):
@@ -209,6 +211,46 @@ async def test_chat_assistant_calls_provider_when_available_and_valid():
 
 
 @pytest.mark.asyncio
+async def test_chat_assistant_runs_availability_checks_off_event_loop_thread():
+    main_thread = threading.get_ident()
+    loader_threads = []
+
+    async def chat_call(**_kwargs):
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "content": (
+                            '{"method":"semantic","max_size":820,"overlap":82,'
+                            '"derived_views":["topic_sections"],'
+                            '"rationale":"Clear topic transitions."}'
+                        )
+                    }
+                }
+            ]
+        }
+
+    def config_loader():
+        loader_threads.append(threading.get_ident())
+        return {"openai_api": {"model": "gpt-config"}}
+
+    assistant = ChatAutoChunkBoundaryAssistant(
+        chat_call=chat_call,
+        config_loader=config_loader,
+        registry_getter=lambda: SimpleNamespace(get_adapter=lambda _provider: object()),
+        api_key_resolver=lambda _provider, _config=None: "key",
+        provider_requires_key=lambda _provider: True,
+        default_provider="openai",
+    )
+
+    result = await assistant.refine(_request(provider=None, model=None))
+
+    assert result.used_llm is True
+    assert loader_threads
+    assert loader_threads[0] != main_thread
+
+
+@pytest.mark.asyncio
 async def test_chat_assistant_uses_adapter_canonical_provider_for_alias_availability():
     calls = []
 
@@ -244,6 +286,27 @@ async def test_chat_assistant_uses_adapter_canonical_provider_for_alias_availabi
     assert calls[0]["api_provider"] == "local-llm"
     assert calls[0]["model"] == "local-model"
     assert seen_requires_key == ["local-llm"]
+
+
+@pytest.mark.asyncio
+async def test_chat_assistant_does_not_retry_typeerror_from_api_key_resolver_body():
+    def api_key_resolver(_provider, _config=None):
+        raise TypeError("inner resolver failure")
+
+    assistant = ChatAutoChunkBoundaryAssistant(
+        chat_call=lambda **_: pytest.fail("chat call should not run"),
+        config_loader=lambda: {"openai_api": {"model": "gpt-config"}},
+        registry_getter=lambda: SimpleNamespace(get_adapter=lambda _provider: object()),
+        api_key_resolver=api_key_resolver,
+        provider_requires_key=lambda _provider: True,
+        default_provider="openai",
+    )
+
+    result = await assistant.refine(_request(provider=None, model=None))
+
+    assert result.used_llm is False
+    assert result.fallback_reason == "ai_assist_provider_error"
+    assert "TypeError" in result.rationale
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Chunking/test_auto_chunking_resolver.py
+++ b/tldw_Server_API/tests/Chunking/test_auto_chunking_resolver.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 import pytest
 
 from tldw_Server_API.app.core.Ingestion_Media_Processing.chunking_options import (
+    async_resolve_chunking_for_result,
     async_resolve_chunking_options_and_plan,
     resolve_chunking_options_and_plan,
 )
@@ -180,6 +181,7 @@ async def test_async_resolver_applies_valid_opt_in_assistant_result():
         async def refine(self, request):
             assert request.media_type == "document"
             assert request.chunking_plan["used_llm"] is False
+            assert request.chunking_plan["fallback_reason"] is None
             from tldw_Server_API.app.core.Chunking.auto_boundary_assistant import (
                 AutoChunkBoundaryAssistantResult,
             )
@@ -248,3 +250,65 @@ async def test_async_resolver_preserves_deterministic_plan_on_assistant_fallback
     assert chunking_plan["used_llm"] is False
     assert chunking_plan["fallback_reason"] == "ai_assist_timeout"
     assert "Timed out after 0.5 seconds." in chunking_plan["rationale"]
+
+
+@pytest.mark.asyncio
+async def test_async_resolver_preserves_api_name_model_when_provider_is_present():
+    seen = {}
+
+    class Assistant:
+        async def refine(self, request):
+            seen["provider"] = request.provider
+            seen["model"] = request.model
+            from tldw_Server_API.app.core.Chunking.auto_boundary_assistant import (
+                AutoChunkBoundaryAssistantResult,
+            )
+
+            return AutoChunkBoundaryAssistantResult.fallback(
+                reason="ai_assist_unavailable",
+                rationale="test fallback",
+            )
+
+    await async_resolve_chunking_options_and_plan(
+        _form(
+            chunking_mode="auto",
+            auto_chunking_use_llm=True,
+            api_provider="openai",
+            api_name="openai/gpt-4o",
+            model_name=None,
+        ),
+        media_type="document",
+        extracted_text="# Intro\n\nBody",
+        boundary_assistant=Assistant(),
+    )
+
+    assert seen == {"provider": "openai", "model": "gpt-4o"}
+
+
+@pytest.mark.asyncio
+async def test_async_resolve_chunking_for_result_can_reuse_batch_llm_resolution():
+    class Assistant:
+        async def refine(self, request):
+            raise AssertionError("assistant should not be called when reusing batch resolution")
+
+    default_options = {"method": "semantic", "max_size": 820, "overlap": 82}
+    default_plan = {
+        "mode": "auto",
+        "used_llm": True,
+        "method": "semantic",
+        "max_size": 820,
+        "overlap": 82,
+    }
+
+    chunk_options, chunking_plan = await async_resolve_chunking_for_result(
+        _form(chunking_mode="auto", auto_chunking_use_llm=True),
+        {"content": "# Intro\n\nBody"},
+        media_type="document",
+        default_chunk_options=default_options,
+        default_chunking_plan=default_plan,
+        boundary_assistant=Assistant(),
+        allow_llm_assist=False,
+    )
+
+    assert chunk_options == default_options
+    assert chunking_plan == default_plan

--- a/tldw_Server_API/tests/Chunking/test_auto_chunking_resolver.py
+++ b/tldw_Server_API/tests/Chunking/test_auto_chunking_resolver.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 import pytest
 
 from tldw_Server_API.app.core.Ingestion_Media_Processing.chunking_options import (
+    async_resolve_chunking_options_and_plan,
     resolve_chunking_options_and_plan,
 )
 
@@ -149,3 +150,101 @@ def test_resolver_accepts_mapping_backed_auto_payload():
     assert chunking_plan["profile"]["title"] == "Planning Notes"
     assert chunking_plan["profile"]["source_name"] == "https://example.test/planning.md"
     assert "outline" in chunking_plan["derived_views"]
+
+
+@pytest.mark.asyncio
+async def test_async_resolver_does_not_call_assistant_without_explicit_opt_in():
+    calls = []
+
+    class Assistant:
+        async def refine(self, request):
+            calls.append(request)
+            raise AssertionError("assistant should not be called")
+
+    chunk_options, chunking_plan = await async_resolve_chunking_options_and_plan(
+        _form(chunking_mode="auto", auto_chunking_use_llm=False),
+        media_type="document",
+        extracted_text="# Intro\n\nBody",
+        boundary_assistant=Assistant(),
+    )
+
+    assert calls == []
+    assert chunk_options["method"] == "structure_aware"
+    assert chunking_plan["used_llm"] is False
+    assert chunking_plan["fallback_reason"] is None
+
+
+@pytest.mark.asyncio
+async def test_async_resolver_applies_valid_opt_in_assistant_result():
+    class Assistant:
+        async def refine(self, request):
+            assert request.media_type == "document"
+            assert request.chunking_plan["used_llm"] is False
+            from tldw_Server_API.app.core.Chunking.auto_boundary_assistant import (
+                AutoChunkBoundaryAssistantResult,
+            )
+
+            return AutoChunkBoundaryAssistantResult.success(
+                chunk_options={
+                    "method": "semantic",
+                    "max_size": 840,
+                    "overlap": 84,
+                    "adaptive": False,
+                    "multi_level": False,
+                    "language": None,
+                },
+                derived_views=("topic_sections",),
+                rationale="Assistant selected topic shifts.",
+                provider="openai",
+                model="gpt-test",
+            )
+
+    chunk_options, chunking_plan = await async_resolve_chunking_options_and_plan(
+        _form(chunking_mode="auto", auto_chunking_use_llm=True),
+        media_type="document",
+        extracted_text="# Intro\n\nBody",
+        boundary_assistant=Assistant(),
+    )
+
+    assert chunk_options["method"] == "semantic"
+    assert chunk_options["max_size"] == 840
+    assert chunking_plan["used_llm"] is True
+    assert chunking_plan["method"] == "semantic"
+    assert chunking_plan["provider"] == "openai"
+    assert chunking_plan["model"] == "gpt-test"
+    assert chunking_plan["fallback_reason"] is None
+    assert chunking_plan["derived_views"] == ["topic_sections"]
+
+
+@pytest.mark.asyncio
+async def test_async_resolver_preserves_deterministic_plan_on_assistant_fallback():
+    class Assistant:
+        async def refine(self, request):
+            from tldw_Server_API.app.core.Chunking.auto_boundary_assistant import (
+                AutoChunkBoundaryAssistantResult,
+            )
+
+            return AutoChunkBoundaryAssistantResult.fallback(
+                reason="ai_assist_timeout",
+                rationale="Timed out after 0.5 seconds.",
+            )
+
+    baseline_options, baseline_plan = resolve_chunking_options_and_plan(
+        _form(chunking_mode="auto", auto_chunking_use_llm=False),
+        media_type="document",
+        extracted_text="# Intro\n\nBody",
+    )
+    chunk_options, chunking_plan = await async_resolve_chunking_options_and_plan(
+        _form(chunking_mode="auto", auto_chunking_use_llm=True),
+        media_type="document",
+        extracted_text="# Intro\n\nBody",
+        boundary_assistant=Assistant(),
+    )
+
+    assert chunk_options == baseline_options
+    assert chunking_plan["method"] == baseline_plan["method"]
+    assert chunking_plan["max_size"] == baseline_plan["max_size"]
+    assert chunking_plan["overlap"] == baseline_plan["overlap"]
+    assert chunking_plan["used_llm"] is False
+    assert chunking_plan["fallback_reason"] == "ai_assist_timeout"
+    assert "Timed out after 0.5 seconds." in chunking_plan["rationale"]

--- a/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_auto_chunking_persistence_metadata.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_auto_chunking_persistence_metadata.py
@@ -1,4 +1,5 @@
 import json
+from types import SimpleNamespace
 
 import pytest
 
@@ -49,3 +50,28 @@ def test_safe_metadata_subset_preserves_json_safe_chunking_plan():
     assert "pmid" not in safe_meta
     assert "callable" not in safe_meta["chunking_plan"]
     assert "unsafe_object" not in safe_meta
+
+
+@pytest.mark.asyncio
+async def test_persistence_auto_chunking_resolution_propagates_cancellation(monkeypatch):
+    import asyncio
+
+    from tldw_Server_API.app.core.Ingestion_Media_Processing import persistence
+
+    async def _cancelled_resolver(*_args, **_kwargs):
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(
+        persistence,
+        "async_resolve_chunking_options_and_plan",
+        _cancelled_resolver,
+        raising=True,
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await persistence._resolve_auto_chunking_options_for_persistence(
+            SimpleNamespace(chunking_mode="auto"),
+            media_type="document",
+            source_name="doc.md",
+            extracted_text="content",
+        )

--- a/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_worker.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_worker.py
@@ -204,6 +204,98 @@ async def test_media_ingest_worker_returns_auto_chunking_plan(monkeypatch, tmp_p
 
 
 @pytest.mark.asyncio
+async def test_media_ingest_worker_uses_async_auto_chunking_resolver(monkeypatch, tmp_path):
+    monkeypatch.setenv("JOBS_DB_PATH", str(tmp_path / "jobs.db"))
+    monkeypatch.delenv("JOBS_DB_URL", raising=False)
+
+    from tldw_Server_API.app.core.Jobs.manager import JobManager
+    import tldw_Server_API.app.services.media_ingest_jobs_worker as worker
+
+    class _DummyDB:
+        def __init__(self, path: str):
+            self.db_path_str = path
+            self.client_id = "media_ingest_test"
+
+        def close_connection(self):
+            return None
+
+    async_resolver_calls = []
+    seen: dict[str, object] = {}
+
+    async def _fake_async_resolver(*args, **kwargs):
+        async_resolver_calls.append((args, kwargs))
+        return (
+            {
+                "method": "semantic",
+                "max_size": 820,
+                "overlap": 82,
+                "adaptive": False,
+                "multi_level": False,
+                "language": None,
+            },
+            {
+                "mode": "auto",
+                "goal": "balanced",
+                "used_llm": True,
+                "method": "semantic",
+                "max_size": 820,
+                "overlap": 82,
+                "template_name": None,
+                "derived_views": ["topic_sections"],
+                "fallback_reason": None,
+                "rationale": "Assistant selected topic shifts.",
+                "profile": {"media_type": "document"},
+                "provider": "openai",
+                "model": "gpt-test",
+            },
+        )
+
+    async def _fake_process_document_like_item(**kwargs):
+        seen["chunk_options"] = kwargs.get("chunk_options")
+        return {
+            "status": "Success",
+            "db_id": 235,
+            "media_uuid": "media-uuid-235",
+            "warnings": None,
+            "db_message": "Media added to database.",
+            "metadata": {},
+        }
+
+    monkeypatch.setattr(worker, "_create_db", lambda _user_id: _DummyDB(str(tmp_path / "media.db")), raising=True)
+    monkeypatch.setattr(worker, "async_resolve_chunking_options_and_plan", _fake_async_resolver, raising=True)
+    monkeypatch.setattr(worker, "process_document_like_item", _fake_process_document_like_item, raising=True)
+
+    jm = JobManager()
+    row = jm.create_job(
+        domain="media_ingest",
+        queue="default",
+        job_type="media_ingest_item",
+        payload={
+            "batch_id": "batch-auto-async",
+            "media_type": "document",
+            "source": str(tmp_path / "doc.md"),
+            "source_kind": "file",
+            "input_ref": "doc.md",
+            "options": {
+                "media_type": "document",
+                "perform_chunking": True,
+                "chunking_mode": "auto",
+                "auto_chunking_use_llm": True,
+            },
+        },
+        owner_user_id="1",
+    )
+
+    result = await worker._handle_job(jm.get_job(int(row.get("id"))), jm, worker._ProgressState())
+
+    assert async_resolver_calls
+    assert seen["chunk_options"]["method"] == "semantic"
+    assert seen["chunk_options"]["max_size"] == 820
+    assert result["chunking_plan"]["used_llm"] is True
+    assert result["chunking_plan"]["provider"] == "openai"
+
+
+@pytest.mark.asyncio
 async def test_media_ingest_worker_returns_existing_media_id_for_skipped_dedupe_result(monkeypatch, tmp_path):
     monkeypatch.setenv("JOBS_DB_PATH", str(tmp_path / "jobs.db"))
     monkeypatch.delenv("JOBS_DB_URL", raising=False)

--- a/tldw_Server_API/tests/Web_Scraping/test_auto_chunking_web_ingest.py
+++ b/tldw_Server_API/tests/Web_Scraping/test_auto_chunking_web_ingest.py
@@ -7,6 +7,7 @@ from contextlib import contextmanager
 import pytest
 
 from tldw_Server_API.app.services import web_scraping_service as ws_service
+from tldw_Server_API.app.services import enhanced_web_scraping_service as enhanced_ws_service
 
 
 pytestmark = pytest.mark.unit
@@ -46,6 +47,26 @@ def _force_fallback(monkeypatch):
         raise RuntimeError("enhanced service unavailable in test")
 
     monkeypatch.setattr(ws_service, "get_web_scraping_service", _raise, raising=True)
+
+
+def test_web_chunking_forms_preserve_request_llm_selection():
+    legacy_form = ws_service._web_chunking_form(
+        perform_chunking=True,
+        chunking_mode="auto",
+        auto_chunking_goal="balanced",
+        auto_chunking_use_llm=True,
+        api_name="openai/gpt-4o",
+    )
+    enhanced_form = enhanced_ws_service._web_chunking_form(
+        perform_chunking=True,
+        chunking_mode="auto",
+        auto_chunking_goal="balanced",
+        auto_chunking_use_llm=True,
+        api_name="openai/gpt-4o",
+    )
+
+    assert legacy_form.api_name == "openai/gpt-4o"
+    assert enhanced_form.api_name == "openai/gpt-4o"
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary
- Adds a narrow backend AutoChunkBoundaryAssistant adapter/result type that refines deterministic Auto Chunking plans only when auto_chunking_use_llm=true.
- Adds bounded strict-JSON chat refinement with explicit provider/model/adapter/API-key availability checks, canonical provider alias handling, and deterministic fallback metadata for unavailable, timeout, provider-error, and invalid-response paths.
- Wires async resolution through media add persistence, ingest jobs, direct process endpoints, and web ingestion so refined chunk_options drive chunk generation and FTS metadata.

## Test Plan
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Chunking/test_auto_boundary_assistant.py tldw_Server_API/tests/Chunking/test_auto_chunking_resolver.py tldw_Server_API/tests/Chunking/test_auto_chunking_planner.py tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_worker.py tldw_Server_API/tests/Media/test_auto_chunking_process_endpoints.py tldw_Server_API/tests/Web_Scraping/test_auto_chunking_web_ingest.py tldw_Server_API/tests/MediaIngestion_NEW/unit/test_auto_chunking_persistence_metadata.py tldw_Server_API/tests/MediaIngestion_NEW/unit/test_persistence_original_storage.py -v
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile touched production modules
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r touched production files -f json -o /tmp/bandit_auto_chunk_boundary_assistant.json
- [x] git diff --check

## Change Summary
This PR is draft because the implementation was materially authored by AI. Per project policy, a human maintainer must replace this section with a human-owned Change summary that explains what changed and why before merge.