### PR TITLE
Phase 2.2: narrow minimal utility skips

### DIFF
--- a/backlog/tasks/task-105 - Phase-2.2-minimal-utility-router-skip-semantics-AY.md
+++ b/backlog/tasks/task-105 - Phase-2.2-minimal-utility-router-skip-semantics-AY.md
@@ -1,0 +1,68 @@
+---
+id: TASK-105
+title: Phase 2.2 minimal utility router skip semantics AY
+status: Done
+assignee: []
+created_date: '2026-05-07 04:32'
+updated_date: '2026-05-07 04:39'
+labels:
+  - phase2.2
+  - router-cleanup
+  - minimal
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+  - 'https://github.com/rmusser01/tldw_server/pull/1352'
+  - 'https://github.com/rmusser01/tldw_server/pull/1355'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Narrow minimal utility router optional skip behavior after PR #1352 merged. The web clipper, skills, translate, and slides ImportedRouterSpec entries should skip genuinely missing optional target modules or missing router attributes, while runtime import defects propagate during registration instead of being hidden by skip_exceptions=(Exception,).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Minimal utility router specs no longer use skip_exceptions=(Exception,)
+- [x] #2 Missing target utility modules are skipped during registration
+- [x] #3 Runtime import defects from utility router modules propagate
+- [x] #4 Existing prefixes tags route keys and default stability behavior are preserved
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Update focused contract tests for precise utility optional skip semantics. 2. Verify RED against current broad skip behavior. 3. Remove broad skip_exceptions from utility ImportedRouterSpec entries. 4. Run focused and broader verification plus Bandit and diff checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Baseline focused selector before edits passed: minimal utility tests 2 passed, confirming current broad skip behavior was covered.
+
+TDD RED after test update failed as intended: utility specs still reported Exception and runtime import failures were skipped. GREEN focused selector passed after removing utility broad skip overrides: 6 passed.
+
+Broader validation passed: router groups 127 passed, lifecycle 54 passed, OpenAPI 69 passed, Bandit results 0, git diff --check clean.
+
+Scope note: remaining skip_exceptions=(Exception,) occurrences are the guardian/safety minimal group and should be handled in a later narrow slice.
+
+Opened PR https://github.com/rmusser01/tldw_server/pull/1355 against dev for this slice.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Narrowed the minimal utility router ImportedRouterSpec entries for web clipper, skills, translate, and slides by removing broad skip_exceptions=(Exception,) overrides. The utility specs now use the default precise optional-missing skip exceptions, so missing target modules still skip during registration while runtime import defects propagate. Validation: focused utility selector 6 passed after RED verification, router group contracts 127 passed, main lifecycle contracts 54 passed, OpenAPI contracts 69 passed, Bandit on minimal.py found 0 results, and git diff --check was clean.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -553,7 +553,6 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
             prefix=f"{API_V1_PREFIX}/web-clipper",
             tags=("web-clipper",),
             skip_context=minimal_skip_context,
-            skip_exceptions=(Exception,),
         ),
         ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.skills",
@@ -561,7 +560,6 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
             prefix=f"{API_V1_PREFIX}/skills",
             tags=("skills",),
             skip_context=minimal_skip_context,
-            skip_exceptions=(Exception,),
         ),
         ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.translate",
@@ -569,7 +567,6 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
             prefix=f"{API_V1_PREFIX}",
             tags=("translation",),
             skip_context=minimal_skip_context,
-            skip_exceptions=(Exception,),
         ),
         ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.slides",
@@ -577,7 +574,6 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
             prefix=f"{API_V1_PREFIX}",
             tags=("slides",),
             skip_context=minimal_skip_context,
-            skip_exceptions=(Exception,),
         ),
     ):
         append_imported_router_spec(specs, utility_spec)

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -5472,7 +5472,10 @@ def test_iter_minimal_optional_router_specs_defers_utility_attr_lookup(
         assert spec.route_key == ""
         assert spec.skip_context == "in minimal test app"
         assert spec.default_stable is True
-        assert spec.skip_exceptions == (Exception,)
+        assert spec.skip_exceptions == (
+            OptionalRouterMissingModule,
+            OptionalRouterMissingAttribute,
+        )
         assert _first_router_path(spec.router) == definition["path"]
 
     assert import_calls == [
@@ -5485,10 +5488,10 @@ def test_iter_minimal_optional_router_specs_defers_utility_attr_lookup(
     }
 
 
-def test_iter_minimal_optional_router_specs_skips_utility_runtime_import_failures(
+def test_iter_minimal_optional_router_specs_skips_utility_missing_import_failures(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Verify minimal utility specs preserve broad import failure skipping."""
+    """Verify minimal utility specs skip missing optional router modules."""
     import importlib
 
     from tldw_Server_API.app.api.v1.router_groups.minimal import (
@@ -5496,10 +5499,10 @@ def test_iter_minimal_optional_router_specs_skips_utility_runtime_import_failure
     )
 
     utility_modules = {
-        "tldw_Server_API.app.api.v1.endpoints.web_clipper",
-        "tldw_Server_API.app.api.v1.endpoints.skills",
-        "tldw_Server_API.app.api.v1.endpoints.translate",
-        "tldw_Server_API.app.api.v1.endpoints.slides",
+        "web clipper": "tldw_Server_API.app.api.v1.endpoints.web_clipper",
+        "skills": "tldw_Server_API.app.api.v1.endpoints.skills",
+        "translate": "tldw_Server_API.app.api.v1.endpoints.translate",
+        "slides": "tldw_Server_API.app.api.v1.endpoints.slides",
     }
 
     specs = list(iter_minimal_optional_router_specs())
@@ -5513,9 +5516,12 @@ def test_iter_minimal_optional_router_specs_skips_utility_runtime_import_failure
     real_import_module = importlib.import_module
 
     def _import_module(module_name: str, package: str | None = None) -> ModuleType:
-        """Crash only the selected utility router imports at registration."""
-        if module_name in utility_modules:
-            raise RuntimeError(f"{module_name} exploded during import")
+        """Fail only the selected utility router imports at registration."""
+        if module_name in utility_modules.values():
+            raise ModuleNotFoundError(
+                f"{module_name} missing during import",
+                name=module_name,
+            )
         return real_import_module(module_name, package)
 
     monkeypatch.setattr(
@@ -5527,16 +5533,55 @@ def test_iter_minimal_optional_router_specs_skips_utility_runtime_import_failure
     monkeypatch.setattr("loguru.logger.debug", debug_messages.append)
 
     assert register_router_specs(FastAPI(), selected_specs.values()) == 0
-    assert debug_messages == [
-        "Skipping web clipper router in minimal test app: "
-        "tldw_Server_API.app.api.v1.endpoints.web_clipper exploded during import",
-        "Skipping skills router in minimal test app: "
-        "tldw_Server_API.app.api.v1.endpoints.skills exploded during import",
-        "Skipping translate router in minimal test app: "
-        "tldw_Server_API.app.api.v1.endpoints.translate exploded during import",
-        "Skipping slides router in minimal test app: "
-        "tldw_Server_API.app.api.v1.endpoints.slides exploded during import",
-    ]
+    assert len(debug_messages) == len(utility_modules)
+    for router_name, module_name in utility_modules.items():
+        assert any(
+            f"Skipping {router_name} router" in message
+            and "in minimal test app" in message
+            and module_name in message
+            for message in debug_messages
+        )
+
+
+@pytest.mark.parametrize(
+    ("router_name", "module_name"),
+    (
+        ("web clipper", "tldw_Server_API.app.api.v1.endpoints.web_clipper"),
+        ("skills", "tldw_Server_API.app.api.v1.endpoints.skills"),
+        ("translate", "tldw_Server_API.app.api.v1.endpoints.translate"),
+        ("slides", "tldw_Server_API.app.api.v1.endpoints.slides"),
+    ),
+)
+def test_iter_minimal_optional_router_specs_propagates_utility_runtime_import_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    router_name: str,
+    module_name: str,
+) -> None:
+    """Verify minimal utility runtime import defects are not silently skipped."""
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    specs = list(iter_minimal_optional_router_specs())
+    selected_spec = next(spec for spec in specs if spec.name == router_name)
+
+    real_import_module = importlib.import_module
+
+    def _import_module(import_name: str, package: str | None = None) -> ModuleType:
+        """Crash only one selected utility router import at registration."""
+        if import_name == module_name:
+            raise RuntimeError(f"{module_name} exploded during import")
+        return real_import_module(import_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    with pytest.raises(RuntimeError, match="exploded during import"):
+        register_router_specs(FastAPI(), (selected_spec,))
 
 
 def test_iter_minimal_optional_router_specs_defers_kanban_attr_lookup(


### PR DESCRIPTION
## Change summary

This narrows the minimal utility router optional-import behavior for web clipper, skills, translate, and slides. The prior specs used skip_exceptions=(Exception,), which meant runtime import defects were treated the same as optional missing modules. This PR removes those broad overrides so the specs use the shared ImportedRouterSpec defaults: missing target modules or router attrs are skipped, while real runtime defects propagate.

The implementation mirrors the already-merged minimal experience cleanup and keeps the remaining guardian/safety broad skips out of this PR so the router cleanup continues in reviewable slices.

## Validation

- RED: focused utility selector failed after test update because specs still used Exception and runtime RuntimeError was skipped
- GREEN: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "minimal_optional_router_specs and utility" -q => 6 passed
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q => 127 passed
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_lifecycle_contract.py -q => 54 passed
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q => 69 passed
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/router_groups/minimal.py -f json -o /tmp/bandit_minimal_utility_skip_ay.json => 0 results
- git diff --check => clean

References #1116