### PR TITLE
Phase 2.2: narrow minimal guardian safety skips

### DIFF
--- a/backlog/tasks/task-107 - Phase-2.2-minimal-guardian-safety-router-skip-semantics-AZ.md
+++ b/backlog/tasks/task-107 - Phase-2.2-minimal-guardian-safety-router-skip-semantics-AZ.md
@@ -1,0 +1,68 @@
+---
+id: TASK-107
+title: Phase 2.2 minimal guardian safety router skip semantics AZ
+status: Done
+assignee: []
+created_date: '2026-05-07 04:52'
+updated_date: '2026-05-07 05:00'
+labels:
+  - phase2.2
+  - router-cleanup
+  - minimal
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+  - 'https://github.com/rmusser01/tldw_server/pull/1355'
+  - 'https://github.com/rmusser01/tldw_server/pull/1358'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Narrow minimal guardian/safety router optional skip behavior after PR #1355 merged. The guardian controls, family wizard, and self monitoring ImportedRouterSpec entries should skip genuinely missing optional target modules or missing router attributes, while runtime import defects propagate during registration instead of being hidden by skip_exceptions=(Exception,).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Minimal guardian/safety router specs no longer use skip_exceptions=(Exception,)
+- [x] #2 Missing target guardian/safety modules are skipped during registration
+- [x] #3 Runtime import defects from guardian/safety router modules propagate
+- [x] #4 Existing prefixes tags route keys and default stability behavior are preserved
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Update focused contract tests for precise guardian/safety optional skip semantics. 2. Verify RED against current broad skip behavior. 3. Remove broad skip_exceptions from guardian/safety ImportedRouterSpec entries. 4. Run focused and broader verification plus Bandit and diff checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Baseline focused selector before edits passed: minimal guardian/safety tests 2 passed, confirming current broad skip behavior was covered.
+
+TDD RED after test update failed as intended: guardian/safety specs still reported Exception and runtime import failures were skipped. GREEN focused selector passed after removing guardian/safety broad skip overrides: 5 passed.
+
+Broader validation passed: router groups 130 passed, lifecycle 54 passed, OpenAPI 69 passed, Bandit results 0, git diff --check clean.
+
+Scope note: no skip_exceptions=(Exception,) occurrences remain in minimal.py after this slice.
+
+Opened PR https://github.com/rmusser01/tldw_server/pull/1358 against dev for this slice.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Narrowed the minimal guardian/safety router ImportedRouterSpec entries for guardian_controls, family_wizard, and self_monitoring by removing broad skip_exceptions=(Exception,) overrides. The guardian/safety specs now use the default precise optional-missing skip exceptions, so missing target modules still skip during registration while runtime import defects propagate. Validation: focused guardian/safety selector 5 passed after RED verification, router group contracts 130 passed, main lifecycle contracts 54 passed, OpenAPI contracts 69 passed, Bandit on minimal.py found 0 results, and git diff --check was clean.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -500,7 +500,6 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
             prefix=f"{API_V1_PREFIX}/guardian",
             tags=("guardian",),
             skip_context=minimal_skip_context,
-            skip_exceptions=(Exception,),
         ),
         ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.family_wizard",
@@ -508,7 +507,6 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
             prefix=f"{API_V1_PREFIX}/guardian",
             tags=("guardian",),
             skip_context=minimal_skip_context,
-            skip_exceptions=(Exception,),
         ),
         ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.self_monitoring",
@@ -516,7 +514,6 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
             prefix=f"{API_V1_PREFIX}/self-monitoring",
             tags=("self-monitoring",),
             skip_context=minimal_skip_context,
-            skip_exceptions=(Exception,),
         ),
     ):
         append_imported_router_spec(specs, guardian_safety_spec)

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -8266,7 +8266,10 @@ def test_iter_minimal_optional_router_specs_defers_guardian_safety_attr_lookup(
         assert spec.route_key == ""
         assert spec.skip_context == "in minimal test app"
         assert spec.default_stable is True
-        assert spec.skip_exceptions == (Exception,)
+        assert spec.skip_exceptions == (
+            OptionalRouterMissingModule,
+            OptionalRouterMissingAttribute,
+        )
         assert _first_router_path(spec.router) == definition["path"]
 
     assert import_calls == [
@@ -8279,10 +8282,10 @@ def test_iter_minimal_optional_router_specs_defers_guardian_safety_attr_lookup(
     }
 
 
-def test_iter_minimal_optional_router_specs_skips_guardian_safety_runtime_import_failures(
+def test_iter_minimal_optional_router_specs_skips_guardian_safety_missing_import_failures(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Verify minimal guardian/safety specs preserve broad import failure skipping."""
+    """Verify minimal guardian/safety specs skip missing optional router modules."""
     import importlib
 
     from tldw_Server_API.app.api.v1.router_groups.minimal import (
@@ -8290,9 +8293,9 @@ def test_iter_minimal_optional_router_specs_skips_guardian_safety_runtime_import
     )
 
     guardian_modules = {
-        "tldw_Server_API.app.api.v1.endpoints.guardian_controls",
-        "tldw_Server_API.app.api.v1.endpoints.family_wizard",
-        "tldw_Server_API.app.api.v1.endpoints.self_monitoring",
+        "guardian_controls": "tldw_Server_API.app.api.v1.endpoints.guardian_controls",
+        "family_wizard": "tldw_Server_API.app.api.v1.endpoints.family_wizard",
+        "self_monitoring": "tldw_Server_API.app.api.v1.endpoints.self_monitoring",
     }
 
     specs = list(iter_minimal_optional_router_specs())
@@ -8306,9 +8309,12 @@ def test_iter_minimal_optional_router_specs_skips_guardian_safety_runtime_import
     real_import_module = importlib.import_module
 
     def _import_module(module_name: str, package: str | None = None) -> ModuleType:
-        """Crash only the selected guardian/safety router imports at registration."""
-        if module_name in guardian_modules:
-            raise RuntimeError(f"{module_name} exploded during import")
+        """Fail only the selected guardian/safety router imports at registration."""
+        if module_name in guardian_modules.values():
+            raise ModuleNotFoundError(
+                f"{module_name} missing during import",
+                name=module_name,
+            )
         return real_import_module(module_name, package)
 
     monkeypatch.setattr(
@@ -8320,14 +8326,54 @@ def test_iter_minimal_optional_router_specs_skips_guardian_safety_runtime_import
     monkeypatch.setattr("loguru.logger.debug", debug_messages.append)
 
     assert register_router_specs(FastAPI(), selected_specs.values()) == 0
-    assert debug_messages == [
-        "Skipping guardian_controls router in minimal test app: "
-        "tldw_Server_API.app.api.v1.endpoints.guardian_controls exploded during import",
-        "Skipping family_wizard router in minimal test app: "
-        "tldw_Server_API.app.api.v1.endpoints.family_wizard exploded during import",
-        "Skipping self_monitoring router in minimal test app: "
-        "tldw_Server_API.app.api.v1.endpoints.self_monitoring exploded during import",
-    ]
+    assert len(debug_messages) == len(guardian_modules)
+    for router_name, module_name in guardian_modules.items():
+        assert any(
+            f"Skipping {router_name} router" in message
+            and "in minimal test app" in message
+            and module_name in message
+            for message in debug_messages
+        )
+
+
+@pytest.mark.parametrize(
+    ("router_name", "module_name"),
+    (
+        ("guardian_controls", "tldw_Server_API.app.api.v1.endpoints.guardian_controls"),
+        ("family_wizard", "tldw_Server_API.app.api.v1.endpoints.family_wizard"),
+        ("self_monitoring", "tldw_Server_API.app.api.v1.endpoints.self_monitoring"),
+    ),
+)
+def test_iter_minimal_optional_router_specs_propagates_guardian_safety_runtime_import_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    router_name: str,
+    module_name: str,
+) -> None:
+    """Verify minimal guardian/safety runtime import defects are not silently skipped."""
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    specs = list(iter_minimal_optional_router_specs())
+    selected_spec = next(spec for spec in specs if spec.name == router_name)
+
+    real_import_module = importlib.import_module
+
+    def _import_module(import_name: str, package: str | None = None) -> ModuleType:
+        """Crash only one selected guardian/safety router import at registration."""
+        if import_name == module_name:
+            raise RuntimeError(f"{module_name} exploded during import")
+        return real_import_module(import_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    with pytest.raises(RuntimeError, match="exploded during import"):
+        register_router_specs(FastAPI(), (selected_spec,))
 
 
 def test_iter_minimal_optional_router_specs_defers_persona_notes_attr_lookup(


### PR DESCRIPTION
## Change summary

This narrows the minimal guardian/safety router optional-import behavior for guardian_controls, family_wizard, and self_monitoring. These specs still used skip_exceptions=(Exception,), which meant runtime import defects were treated the same as optional missing modules. This PR removes those broad overrides so the specs use the shared ImportedRouterSpec defaults: missing target modules or router attrs are skipped, while real runtime defects propagate.

This follows the already-merged minimal experience and utility skip-semantics cleanup. After this slice, minimal.py no longer contains skip_exceptions=(Exception,) overrides.

## Validation

- RED: focused guardian/safety selector failed after test update because specs still used Exception and runtime RuntimeError was skipped
- GREEN: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "minimal_optional_router_specs and guardian_safety" -q => 5 passed
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q => 130 passed
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_lifecycle_contract.py -q => 54 passed
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q => 69 passed
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/router_groups/minimal.py -f json -o /tmp/bandit_minimal_guardian_safety_skip_az.json => 0 results
- git diff --check => clean
- rg -n "skip_exceptions=\\(Exception" tldw_Server_API/app/api/v1/router_groups/minimal.py => no matches

References #1116