### PR TITLE
Phase 2.2: narrow minimal learning skip semantics

### DIFF
--- a/backlog/tasks/task-110 - Phase-2.2-minimal-kanban-study-writing-skip-semantics-BA.md
+++ b/backlog/tasks/task-110 - Phase-2.2-minimal-kanban-study-writing-skip-semantics-BA.md
@@ -1,0 +1,55 @@
+---
+id: TASK-110
+title: Phase 2.2 minimal kanban study writing skip semantics BA
+status: Done
+assignee: []
+created_date: '2026-05-07 05:23'
+updated_date: '2026-05-07 05:30'
+labels:
+  - phase-2.2
+  - router-groups
+  - minimal
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+  - 'https://github.com/rmusser01/tldw_server/pull/1358'
+  - 'https://github.com/rmusser01/tldw_server/pull/1360'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Narrow the remaining minimal optional router skip semantics for Kanban, study, and writing/email router specs so missing optional modules/attrs remain skippable but internal runtime ImportError/AttributeError defects are not hidden.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Minimal Kanban, study, and writing/email optional router specs use the default OptionalRouterMissingModule/OptionalRouterMissingAttribute skip behavior instead of raw ImportError/AttributeError skips.
+- [x] #2 Focused router contract tests cover missing-target skips and propagation of internal ImportError/AttributeError runtime defects for the touched spec groups.
+- [x] #3 Existing router group, main router, and OpenAPI contracts still pass for the touched scope.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Red/green evidence: focused selector 'minimal_optional_router_specs and (kanban or study or writing_email)' failed before production changes with 9 expected failures for raw skip_exceptions and swallowed ImportError/AttributeError defects, then passed after removing the raw skip overrides (15 passed, 121 deselected).
+
+Validation: router group contracts 136 passed; main router contracts 6 passed; OpenAPI contracts 69 passed; Bandit on tldw_Server_API/app/api/v1/router_groups/minimal.py wrote /tmp/bandit_phase2_2_minimal_learning_kanban_skip_semantics_ba.json with results [] and errors []; git diff --check clean; no remaining skip_exceptions=(ImportError, AttributeError) or skip_exceptions=(Exception) matches in router_groups.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Removed the remaining raw ImportError/AttributeError skip overrides from minimal Kanban, study, and writing/email ImportedRouterSpec entries so only target missing-module/missing-attribute sentinel failures are skippable. Updated focused contract tests to use ModuleNotFoundError for missing optional modules, assert default sentinel skip behavior, and verify RuntimeError, ImportError, and AttributeError defects propagate for each touched group.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -595,7 +595,6 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
                 tags=("kanban",),
                 route_key="kanban",
                 skip_context=minimal_skip_context,
-                skip_exceptions=(ImportError, AttributeError),
             ),
         )
 
@@ -606,7 +605,6 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
             prefix=f"{API_V1_PREFIX}",
             tags=("flashcards",),
             skip_context=minimal_skip_context,
-            skip_exceptions=(ImportError, AttributeError),
         ),
         ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.quizzes",
@@ -614,7 +612,6 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
             prefix=f"{API_V1_PREFIX}",
             tags=("quizzes",),
             skip_context=minimal_skip_context,
-            skip_exceptions=(ImportError, AttributeError),
         ),
         ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.study_suggestions",
@@ -622,7 +619,6 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
             prefix=f"{API_V1_PREFIX}",
             tags=("study-suggestions",),
             skip_context=minimal_skip_context,
-            skip_exceptions=(ImportError, AttributeError),
         ),
     ):
         append_imported_router_spec(specs, study_spec)
@@ -634,7 +630,6 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
             prefix=f"{API_V1_PREFIX}/writing",
             tags=("writing",),
             skip_context=minimal_skip_context,
-            skip_exceptions=(ImportError, AttributeError),
         ),
         ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.writing_manuscripts",
@@ -642,7 +637,6 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
             prefix=f"{API_V1_PREFIX}/writing/manuscripts",
             tags=("manuscripts",),
             skip_context=minimal_skip_context,
-            skip_exceptions=(ImportError, AttributeError),
         ),
         ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.email",
@@ -650,7 +644,6 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
             prefix=f"{API_V1_PREFIX}/email",
             tags=("email",),
             skip_context=minimal_skip_context,
-            skip_exceptions=(ImportError, AttributeError),
         ),
     ):
         append_imported_router_spec(specs, writing_email_spec)

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -5716,7 +5716,10 @@ def test_iter_minimal_optional_router_specs_defers_kanban_attr_lookup(
         assert spec.route_key == "kanban"
         assert spec.skip_context == "in minimal test app"
         assert spec.default_stable is True
-        assert spec.skip_exceptions == (ImportError, AttributeError)
+        assert spec.skip_exceptions == (
+            OptionalRouterMissingModule,
+            OptionalRouterMissingAttribute,
+        )
         assert _first_router_path(spec.router) == definition["path"]
 
     assert import_calls == [
@@ -5760,9 +5763,12 @@ def test_iter_minimal_optional_router_specs_skips_kanban_missing_import_failures
     real_import_module = importlib.import_module
 
     def _import_module(module_name: str, package: str | None = None) -> ModuleType:
-        """Crash only the selected Kanban router imports at registration."""
+        """Fail only the selected missing Kanban router imports at registration."""
         if module_name in kanban_modules:
-            raise ImportError(f"{module_name} missing during import")
+            raise ModuleNotFoundError(
+                f"{module_name} missing during import",
+                name=module_name,
+            )
         return real_import_module(module_name, package)
 
     monkeypatch.setattr(
@@ -5774,15 +5780,31 @@ def test_iter_minimal_optional_router_specs_skips_kanban_missing_import_failures
     monkeypatch.setattr("loguru.logger.debug", debug_messages.append)
 
     assert register_router_specs(FastAPI(), selected_specs.values()) == 0
-    assert debug_messages == [
-        f"Skipping {name} router in minimal test app: "
-        f"tldw_Server_API.app.api.v1.endpoints.kanban.{name} missing during import"
-        for name in kanban_module_suffixes
+    skip_debug_messages = [
+        message for message in debug_messages if message.startswith("Skipping ")
     ]
+    assert len(skip_debug_messages) == len(kanban_module_suffixes)
+    for name in kanban_module_suffixes:
+        module_name = f"tldw_Server_API.app.api.v1.endpoints.kanban.{name}"
+        assert any(
+            message.startswith(f"Skipping {name} router in minimal test app: ")
+            and f"{module_name} missing during import" in message
+            for message in skip_debug_messages
+        )
 
 
+@pytest.mark.parametrize(
+    ("exception_type", "message"),
+    (
+        (RuntimeError, "kanban_boards exploded during import"),
+        (ImportError, "kanban_boards dependency failed during import"),
+        (AttributeError, "kanban_boards attribute failed during import"),
+    ),
+)
 def test_iter_minimal_optional_router_specs_propagates_kanban_runtime_import_failures(
     monkeypatch: pytest.MonkeyPatch,
+    exception_type: type[Exception],
+    message: str,
 ) -> None:
     """Verify minimal Kanban runtime import defects are not silently skipped."""
     import importlib
@@ -5800,7 +5822,7 @@ def test_iter_minimal_optional_router_specs_propagates_kanban_runtime_import_fai
     def _import_module(import_name: str, package: str | None = None) -> ModuleType:
         """Crash only one selected Kanban router import at registration."""
         if import_name == module_name:
-            raise RuntimeError(f"{module_name} exploded during import")
+            raise exception_type(message)
         return real_import_module(import_name, package)
 
     monkeypatch.setattr(
@@ -5808,7 +5830,7 @@ def test_iter_minimal_optional_router_specs_propagates_kanban_runtime_import_fai
         _import_module,
     )
 
-    with pytest.raises(RuntimeError, match="kanban_boards exploded during import"):
+    with pytest.raises(exception_type, match=message):
         register_router_specs(FastAPI(), (selected_spec,))
 
 
@@ -5946,7 +5968,10 @@ def test_iter_minimal_optional_router_specs_defers_study_attr_lookup(
         assert spec.route_key == ""
         assert spec.skip_context == "in minimal test app"
         assert spec.default_stable is True
-        assert spec.skip_exceptions == (ImportError, AttributeError)
+        assert spec.skip_exceptions == (
+            OptionalRouterMissingModule,
+            OptionalRouterMissingAttribute,
+        )
         assert _first_router_path(spec.router) == definition["path"]
 
     assert import_calls == [
@@ -5989,9 +6014,12 @@ def test_iter_minimal_optional_router_specs_skips_study_missing_import_failures(
     real_import_module = importlib.import_module
 
     def _import_module(module_name: str, package: str | None = None) -> ModuleType:
-        """Fail only the selected study router imports at registration."""
+        """Fail only the selected missing study router imports at registration."""
         if module_name in study_modules:
-            raise ImportError(f"{module_name} missing during import")
+            raise ModuleNotFoundError(
+                f"{module_name} missing during import",
+                name=module_name,
+            )
         return real_import_module(module_name, package)
 
     monkeypatch.setattr(
@@ -6003,15 +6031,30 @@ def test_iter_minimal_optional_router_specs_skips_study_missing_import_failures(
     monkeypatch.setattr("loguru.logger.debug", debug_messages.append)
 
     assert register_router_specs(FastAPI(), selected_specs.values()) == 0
-    assert debug_messages == [
-        f"Skipping {expected_name} router in minimal test app: "
-        f"{module_name} missing during import"
-        for module_name, expected_name, _prefix, _tags, _path in STUDY_ROUTER_DEFINITION_DATA
+    skip_debug_messages = [
+        message for message in debug_messages if message.startswith("Skipping ")
     ]
+    assert len(skip_debug_messages) == len(STUDY_ROUTER_DEFINITION_DATA)
+    for module_name, expected_name, _prefix, _tags, _path in STUDY_ROUTER_DEFINITION_DATA:
+        assert any(
+            message.startswith(f"Skipping {expected_name} router in minimal test app: ")
+            and f"{module_name} missing during import" in message
+            for message in skip_debug_messages
+        )
 
 
+@pytest.mark.parametrize(
+    ("exception_type", "message"),
+    (
+        (RuntimeError, "flashcards exploded during import"),
+        (ImportError, "flashcards dependency failed during import"),
+        (AttributeError, "flashcards attribute failed during import"),
+    ),
+)
 def test_iter_minimal_optional_router_specs_propagates_study_runtime_import_failures(
     monkeypatch: pytest.MonkeyPatch,
+    exception_type: type[Exception],
+    message: str,
 ) -> None:
     """Verify minimal study runtime import defects are not silently skipped."""
     import importlib
@@ -6029,7 +6072,7 @@ def test_iter_minimal_optional_router_specs_propagates_study_runtime_import_fail
     def _import_module(import_name: str, package: str | None = None) -> ModuleType:
         """Crash only one selected study router import at registration."""
         if import_name == module_name:
-            raise RuntimeError(f"{module_name} exploded during import")
+            raise exception_type(message)
         return real_import_module(import_name, package)
 
     monkeypatch.setattr(
@@ -6037,7 +6080,7 @@ def test_iter_minimal_optional_router_specs_propagates_study_runtime_import_fail
         _import_module,
     )
 
-    with pytest.raises(RuntimeError, match="flashcards exploded during import"):
+    with pytest.raises(exception_type, match=message):
         register_router_specs(FastAPI(), (selected_spec,))
 
 
@@ -6175,7 +6218,10 @@ def test_iter_minimal_optional_router_specs_defers_writing_email_attr_lookup(
         assert spec.route_key == ""
         assert spec.skip_context == "in minimal test app"
         assert spec.default_stable is True
-        assert spec.skip_exceptions == (ImportError, AttributeError)
+        assert spec.skip_exceptions == (
+            OptionalRouterMissingModule,
+            OptionalRouterMissingAttribute,
+        )
         assert _first_router_path(spec.router) == definition["path"]
 
     assert import_calls == [
@@ -6218,9 +6264,12 @@ def test_iter_minimal_optional_router_specs_skips_writing_email_missing_import_f
     real_import_module = importlib.import_module
 
     def _import_module(module_name: str, package: str | None = None) -> ModuleType:
-        """Fail only the selected writing/email router imports at registration."""
+        """Fail only the selected missing writing/email router imports at registration."""
         if module_name in writing_email_modules:
-            raise ImportError(f"{module_name} missing during import")
+            raise ModuleNotFoundError(
+                f"{module_name} missing during import",
+                name=module_name,
+            )
         return real_import_module(module_name, package)
 
     monkeypatch.setattr(
@@ -6232,15 +6281,30 @@ def test_iter_minimal_optional_router_specs_skips_writing_email_missing_import_f
     monkeypatch.setattr("loguru.logger.debug", debug_messages.append)
 
     assert register_router_specs(FastAPI(), selected_specs.values()) == 0
-    assert debug_messages == [
-        f"Skipping {expected_name} router in minimal test app: "
-        f"{module_name} missing during import"
-        for module_name, expected_name, _prefix, _tags, _path in WRITING_EMAIL_ROUTER_DEFINITION_DATA
+    skip_debug_messages = [
+        message for message in debug_messages if message.startswith("Skipping ")
     ]
+    assert len(skip_debug_messages) == len(WRITING_EMAIL_ROUTER_DEFINITION_DATA)
+    for module_name, expected_name, _prefix, _tags, _path in WRITING_EMAIL_ROUTER_DEFINITION_DATA:
+        assert any(
+            message.startswith(f"Skipping {expected_name} router in minimal test app: ")
+            and f"{module_name} missing during import" in message
+            for message in skip_debug_messages
+        )
 
 
+@pytest.mark.parametrize(
+    ("exception_type", "message"),
+    (
+        (RuntimeError, "writing exploded during import"),
+        (ImportError, "writing dependency failed during import"),
+        (AttributeError, "writing attribute failed during import"),
+    ),
+)
 def test_iter_minimal_optional_router_specs_propagates_writing_email_runtime_import_failures(
     monkeypatch: pytest.MonkeyPatch,
+    exception_type: type[Exception],
+    message: str,
 ) -> None:
     """Verify minimal writing/email runtime import defects are not silently skipped."""
     import importlib
@@ -6258,7 +6322,7 @@ def test_iter_minimal_optional_router_specs_propagates_writing_email_runtime_imp
     def _import_module(import_name: str, package: str | None = None) -> ModuleType:
         """Crash only one selected writing/email router import at registration."""
         if import_name == module_name:
-            raise RuntimeError(f"{module_name} exploded during import")
+            raise exception_type(message)
         return real_import_module(import_name, package)
 
     monkeypatch.setattr(
@@ -6266,7 +6330,7 @@ def test_iter_minimal_optional_router_specs_propagates_writing_email_runtime_imp
         _import_module,
     )
 
-    with pytest.raises(RuntimeError, match="writing exploded during import"):
+    with pytest.raises(exception_type, match=message):
         register_router_specs(FastAPI(), (selected_spec,))
 
 


### PR DESCRIPTION
## Summary
- Remove raw ImportError/AttributeError skip overrides from minimal Kanban, study, and writing/email ImportedRouterSpec entries.
- Keep missing optional target modules/attrs skippable through the shared OptionalRouterMissingModule/OptionalRouterMissingAttribute defaults.
- Expand focused router contract coverage so RuntimeError, ImportError, and AttributeError defects propagate for each touched group while missing targets still skip.
- Record TASK-110 for this narrow continuation slice.

## Verification
- RED: python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "minimal_optional_router_specs and (kanban or study or writing_email)" -q failed before production edits with 9 expected failures.
- GREEN: python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "minimal_optional_router_specs and (kanban or study or writing_email)" -q -> 15 passed, 121 deselected.
- python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q -> 136 passed.
- python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q -> 6 passed.
- python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q -> 69 passed.
- python -m bandit -r tldw_Server_API/app/api/v1/router_groups/minimal.py -f json -o /tmp/bandit_phase2_2_minimal_learning_kanban_skip_semantics_ba.json -> results [], errors [].
- git diff --check -> clean.

## Change summary
TODO(user): Human-authored summary required before merge by the AI-generated PR policy.