### PR TITLE
Phase 2.2: defer minimal monitoring router import

### DIFF
--- a/backlog/tasks/task-111 - Phase-2.2-minimal-monitoring-router-conditional-cleanup-BB.md
+++ b/backlog/tasks/task-111 - Phase-2.2-minimal-monitoring-router-conditional-cleanup-BB.md
@@ -1,0 +1,60 @@
+---
+id: TASK-111
+title: Phase 2.2 minimal monitoring router conditional cleanup BB
+status: Done
+assignee: []
+created_date: '2026-05-07 05:40'
+updated_date: '2026-05-07 06:01'
+labels:
+  - phase-2.2
+  - router-groups
+  - minimal
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+  - 'https://github.com/rmusser01/tldw_server/pull/1360'
+  - 'https://github.com/rmusser01/tldw_server/pull/1361'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Move the remaining minimal-test monitoring router factory onto the shared lazy optional-router registration path so it has the same missing-target skip semantics and diagnostics as the rest of the minimal optional router group.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Minimal monitoring route metadata is represented through the shared optional router spec path while preserving prefix /api/v1, monitoring tag, and route_key monitoring.
+- [x] #2 Focused contract coverage proves monitoring module import and router attribute lookup stay deferred until router resolution.
+- [x] #3 Focused contract coverage verifies missing monitoring target skips while runtime import defects propagate.
+- [x] #4 Existing router group, main router, and OpenAPI contracts still pass for the touched scope.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Red/green evidence: focused selector tldw_Server_API/tests/Services/test_router_groups_contract.py -k 'minimal_optional_router_specs and monitoring' failed before production changes with 5 expected failures plus 1 pass, then passed after the ImportedRouterSpec change with 6 passed, 135 deselected.
+
+Validation: router group contracts passed with 141 passed; main router contracts passed with 6 passed; OpenAPI contracts passed with 69 passed; Bandit on tldw_Server_API/app/api/v1/router_groups/minimal.py reported 0 results and 0 errors; git diff --check was clean.
+
+Docs: no user-facing documentation update was needed for this internal router registration cleanup. Known skips/blockers: none.
+
+Post self-review validation after loosening the skip-log assertion: focused monitoring selector passed with 6 passed, 135 deselected; git diff --check remained clean.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Moved the minimal monitoring router from a hand-written lazy factory to the shared ImportedRouterSpec registration path. This preserves the existing /api/v1 prefix, monitoring tag, and route key while using the shared missing-module/missing-attribute skip semantics and letting runtime import defects propagate.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -456,17 +456,17 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
         route_key="evaluations",
     ))
 
-    def _monitoring_router_factory():
-        from tldw_Server_API.app.api.v1.endpoints.monitoring import router as monitoring_router
-
-        return monitoring_router
-
-    specs.append(RouterSpec(
-        router=_monitoring_router_factory,
-        prefix=f"{API_V1_PREFIX}",
-        tags=("monitoring",),
-        route_key="monitoring",
-    ))
+    append_imported_router_spec(
+        specs,
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.monitoring",
+            log_name="monitoring",
+            prefix=f"{API_V1_PREFIX}",
+            tags=("monitoring",),
+            route_key="monitoring",
+            skip_context=minimal_skip_context,
+        ),
+    )
 
     for experience_spec in (
         ImportedRouterSpec(

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -5318,6 +5318,154 @@ def test_iter_minimal_optional_router_specs_propagates_workflow_runtime_import_f
         register_router_specs(FastAPI(), (selected_spec,))
 
 
+def test_iter_minimal_optional_router_specs_defers_monitoring_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal monitoring spec keeps router attr lookup lazy."""
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    module_name = "tldw_Server_API.app.api.v1.endpoints.monitoring"
+    fake_module = ModuleType(module_name)
+    router = APIRouter()
+    access_count = {f"{module_name}.router": 0}
+    import_calls: list[str] = []
+
+    @router.get("/monitoring/status")
+    def _endpoint() -> dict[str, str]:
+        """Return a deterministic response for the fake monitoring router."""
+        return {"status": "ok"}
+
+    def _module_getattr(name: str) -> APIRouter:
+        """Track lazy router attribute resolution for the fake module."""
+        if name != "router":
+            raise AttributeError(name)
+        access_count[f"{module_name}.router"] += 1
+        return router
+
+    fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    real_import_module = importlib.import_module
+
+    def _import_module(import_name: str, package: str | None = None) -> ModuleType:
+        """Track lazy monitoring router module import."""
+        if import_name == module_name:
+            import_calls.append(import_name)
+        return real_import_module(import_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    specs = list(iter_minimal_optional_router_specs())
+    assert import_calls == []
+    assert access_count == {f"{module_name}.router": 0}
+
+    selected_spec = next(spec for spec in specs if spec.name == "monitoring")
+    assert selected_spec.prefix == "/api/v1"
+    assert selected_spec.tags == ("monitoring",)
+    assert selected_spec.route_key == "monitoring"
+    assert selected_spec.skip_context == "in minimal test app"
+    assert selected_spec.default_stable is True
+    assert selected_spec.skip_exceptions == (
+        OptionalRouterMissingModule,
+        OptionalRouterMissingAttribute,
+    )
+    assert _first_router_path(selected_spec.router) == "/monitoring/status"
+    assert import_calls == [module_name]
+    assert access_count == {f"{module_name}.router": 1}
+
+
+def test_iter_minimal_optional_router_specs_skips_monitoring_missing_import_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal monitoring spec skips missing optional router module."""
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    module_name = "tldw_Server_API.app.api.v1.endpoints.monitoring"
+    specs = list(iter_minimal_optional_router_specs())
+    selected_spec = next(spec for spec in specs if spec.name == "monitoring")
+
+    real_import_module = importlib.import_module
+
+    def _import_module(import_name: str, package: str | None = None) -> ModuleType:
+        """Fail only the selected missing monitoring router import."""
+        if import_name == module_name:
+            raise ModuleNotFoundError(
+                f"{module_name} missing during import",
+                name=module_name,
+            )
+        return real_import_module(import_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    debug_messages: list[str] = []
+    monkeypatch.setattr("loguru.logger.debug", debug_messages.append)
+
+    assert register_router_specs(FastAPI(), (selected_spec,)) == 0
+    skip_debug_messages = [
+        message for message in debug_messages if message.startswith("Skipping ")
+    ]
+    assert len(skip_debug_messages) == 1
+    skip_message = skip_debug_messages[0]
+    assert skip_message.startswith("Skipping monitoring router in minimal test app:")
+    assert module_name in skip_message
+    assert "missing during import" in skip_message
+
+
+@pytest.mark.parametrize(
+    ("exception_type", "message"),
+    (
+        (RuntimeError, "monitoring exploded during import"),
+        (ImportError, "monitoring dependency failed during import"),
+        (AttributeError, "monitoring attribute failed during import"),
+    ),
+)
+def test_iter_minimal_optional_router_specs_propagates_monitoring_runtime_import_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    exception_type: type[Exception],
+    message: str,
+) -> None:
+    """Verify minimal monitoring runtime import defects are not silently skipped."""
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    module_name = "tldw_Server_API.app.api.v1.endpoints.monitoring"
+    specs = list(iter_minimal_optional_router_specs())
+    selected_spec = next(spec for spec in specs if spec.name == "monitoring")
+
+    real_import_module = importlib.import_module
+
+    def _import_module(import_name: str, package: str | None = None) -> ModuleType:
+        """Crash only the selected monitoring router import at registration."""
+        if import_name == module_name:
+            raise exception_type(message)
+        return real_import_module(import_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    with pytest.raises(exception_type, match=message):
+        register_router_specs(FastAPI(), (selected_spec,))
+
+
 def test_iter_minimal_optional_router_specs_defers_utility_attr_lookup(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- Move the minimal monitoring router registration onto the shared ImportedRouterSpec path.
- Preserve /api/v1, monitoring tag, route_key=monitoring, and minimal skip context metadata.
- Add focused contract coverage for lazy resolution, missing optional target skips, and runtime import defect propagation.

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "minimal_optional_router_specs and monitoring" -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/router_groups/minimal.py -f json -o /tmp/bandit_phase2_2_minimal_monitoring_router_conditional_bb.json
- git diff --check

## Change summary
Human-authored change summary required before merge per Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md.

Refs #1116
Follows #1360