### PR TITLE
Phase 2.2: defer content OCR router import

### DIFF
--- a/backlog/tasks/task-112 - Phase-2.2-content-OCR-router-conditional-cleanup-BB.md
+++ b/backlog/tasks/task-112 - Phase-2.2-content-OCR-router-conditional-cleanup-BB.md
@@ -1,0 +1,62 @@
+---
+id: TASK-112
+title: Phase 2.2 content OCR router conditional cleanup BB
+status: Done
+assignee: []
+created_date: '2026-05-07 06:21'
+updated_date: '2026-05-07 14:23'
+labels:
+  - phase-2.2
+  - router-groups
+  - content
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+  - 'https://github.com/rmusser01/tldw_server/pull/1361'
+  - 'https://github.com/rmusser01/tldw_server/pull/1362'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Move the remaining content-group OCR router factory onto the shared lazy optional-router registration path so it uses the same missing-target skip semantics and diagnostics as other optional content router specs while preserving the existing OCR route metadata.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Content OCR route metadata is represented through the shared optional router spec path while preserving prefix /api/v1, ocr tag, and route_key ocr.
+- [x] #2 Focused contract coverage proves OCR module import and router attribute lookup stay deferred until router resolution.
+- [x] #3 Focused contract coverage verifies missing OCR target skips while runtime import defects propagate.
+- [x] #4 Existing router group, main router, and OpenAPI contracts still pass for the touched scope.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Red/green evidence: focused selector tldw_Server_API/tests/Services/test_router_groups_contract.py -k 'content_router_specs and ocr' failed before production changes with 5 expected failures, then passed after moving OCR to ImportedRouterSpec with 5 passed, 141 deselected.
+
+Validation: router group contracts passed with 146 passed; main router contracts passed with 6 passed; OpenAPI contracts passed with 69 passed; Bandit on tldw_Server_API/app/api/v1/router_groups/content.py reported 0 results and 0 errors; git diff --check was clean.
+
+Docs: no user-facing documentation update was needed for this internal router registration cleanup. Known skips/blockers: none.
+
+Review follow-up: Gemini requested explicit coverage for OptionalRouterMissingAttribute skip behavior when the OCR module imports successfully but lacks the router attribute. This is a test-only gap; production behavior already routes missing attrs through ImportedRouterSpec.
+
+Review fix validation: added test_iter_content_router_specs_skips_ocr_missing_attribute_failures for the Gemini review thread. Focused OCR selector passed with 6 passed, 141 deselected; full router group contracts passed with 147 passed; git diff --check remained clean. No production files changed in this follow-up.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Moved the content OCR router from a hand-written lazy factory to the shared ImportedRouterSpec registration path. This preserves the existing /api/v1 prefix, ocr tag, and route key while using the shared missing-module/missing-attribute skip semantics and letting runtime import defects propagate.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/content.py
+++ b/tldw_Server_API/app/api/v1/router_groups/content.py
@@ -96,17 +96,16 @@ def iter_content_router_specs() -> Iterable[RouterSpec]:
         route_key="evaluations",
     ))
 
-    def _ocr_router_factory():
-        from tldw_Server_API.app.api.v1.endpoints.ocr import router as ocr_router
-
-        return ocr_router
-
-    specs.append(RouterSpec(
-        router=_ocr_router_factory,
-        prefix=f"{API_V1_PREFIX}",
-        tags=("ocr",),
-        route_key="ocr",
-    ))
+    append_imported_router_spec(
+        specs,
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.ocr",
+            log_name="ocr",
+            prefix=f"{API_V1_PREFIX}",
+            tags=("ocr",),
+            route_key="ocr",
+        ),
+    )
 
     # Media endpoints
     append_imported_router_spec(

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -1863,6 +1863,164 @@ def test_iter_content_router_specs_defers_media_audio_router_attr_lookup(
     }
 
 
+def test_iter_content_router_specs_defers_ocr_router_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify content OCR spec keeps router attr lookup lazy."""
+    import importlib
+
+    module_name = "tldw_Server_API.app.api.v1.endpoints.ocr"
+    fake_module = ModuleType(module_name)
+    router = APIRouter()
+    access_count = {f"{module_name}.router": 0}
+    import_calls: list[str] = []
+
+    @router.get("/ocr/process")
+    def _endpoint() -> dict[str, str]:
+        """Return a deterministic response for the fake OCR router."""
+        return {"status": "ok"}
+
+    def _module_getattr(name: str) -> APIRouter:
+        """Track lazy router attribute resolution for the fake module."""
+        if name != "router":
+            raise AttributeError(name)
+        access_count[f"{module_name}.router"] += 1
+        return router
+
+    fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    real_import_module = importlib.import_module
+
+    def _import_module(import_name: str, package: str | None = None) -> ModuleType:
+        """Track lazy OCR router module import."""
+        if import_name == module_name:
+            import_calls.append(import_name)
+        return real_import_module(import_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    specs = list(iter_content_router_specs())
+    assert import_calls == []
+    assert access_count == {f"{module_name}.router": 0}
+
+    selected_spec = next(spec for spec in specs if spec.name == "ocr")
+    assert selected_spec.prefix == "/api/v1"
+    assert selected_spec.tags == ("ocr",)
+    assert selected_spec.route_key == "ocr"
+    assert selected_spec.default_stable is True
+    assert selected_spec.skip_exceptions == (
+        OptionalRouterMissingModule,
+        OptionalRouterMissingAttribute,
+    )
+    assert _first_router_path(selected_spec.router) == "/ocr/process"
+    assert import_calls == [module_name]
+    assert access_count == {f"{module_name}.router": 1}
+
+
+def test_iter_content_router_specs_skips_ocr_missing_import_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify content OCR spec skips missing optional router module."""
+    import importlib
+
+    module_name = "tldw_Server_API.app.api.v1.endpoints.ocr"
+    specs = list(iter_content_router_specs())
+    selected_spec = next(spec for spec in specs if spec.name == "ocr")
+
+    real_import_module = importlib.import_module
+
+    def _import_module(import_name: str, package: str | None = None) -> ModuleType:
+        """Fail only the selected missing OCR router import."""
+        if import_name == module_name:
+            raise ModuleNotFoundError(
+                f"{module_name} missing during import",
+                name=module_name,
+            )
+        return real_import_module(import_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    debug_messages: list[str] = []
+    monkeypatch.setattr("loguru.logger.debug", debug_messages.append)
+
+    assert register_router_specs(FastAPI(), (selected_spec,)) == 0
+    skip_debug_messages = [
+        message for message in debug_messages if message.startswith("Skipping ")
+    ]
+    assert len(skip_debug_messages) == 1
+    skip_message = skip_debug_messages[0]
+    assert skip_message.startswith("Skipping ocr router:")
+    assert module_name in skip_message
+    assert "missing during import" in skip_message
+
+
+def test_iter_content_router_specs_skips_ocr_missing_attribute_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify content OCR spec skips missing optional router attribute."""
+    module_name = "tldw_Server_API.app.api.v1.endpoints.ocr"
+    monkeypatch.setitem(sys.modules, module_name, ModuleType(module_name))
+
+    specs = list(iter_content_router_specs())
+    selected_spec = next(spec for spec in specs if spec.name == "ocr")
+
+    debug_messages: list[str] = []
+    monkeypatch.setattr("loguru.logger.debug", debug_messages.append)
+
+    assert register_router_specs(FastAPI(), (selected_spec,)) == 0
+    skip_debug_messages = [
+        message for message in debug_messages if message.startswith("Skipping ")
+    ]
+    assert len(skip_debug_messages) == 1
+    skip_message = skip_debug_messages[0]
+    assert skip_message.startswith("Skipping ocr router:")
+    assert f"{module_name}.router" in skip_message
+
+
+@pytest.mark.parametrize(
+    ("exception_type", "message"),
+    (
+        (RuntimeError, "ocr exploded during import"),
+        (ImportError, "ocr dependency failed during import"),
+        (AttributeError, "ocr attribute failed during import"),
+    ),
+)
+def test_iter_content_router_specs_propagates_ocr_runtime_import_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    exception_type: type[Exception],
+    message: str,
+) -> None:
+    """Verify content OCR runtime import defects are not silently skipped."""
+    import importlib
+
+    module_name = "tldw_Server_API.app.api.v1.endpoints.ocr"
+    specs = list(iter_content_router_specs())
+    selected_spec = next(spec for spec in specs if spec.name == "ocr")
+
+    real_import_module = importlib.import_module
+
+    def _import_module(import_name: str, package: str | None = None) -> ModuleType:
+        """Crash only the selected OCR router import at registration."""
+        if import_name == module_name:
+            raise exception_type(message)
+        return real_import_module(import_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    with pytest.raises(exception_type, match=message):
+        register_router_specs(FastAPI(), (selected_spec,))
+
+
 def test_iter_content_router_specs_defers_ingestion_adapter_router_attr_lookup(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- Move the content OCR router registration onto the shared ImportedRouterSpec path.
- Preserve /api/v1, ocr tag, and route_key=ocr metadata.
- Add focused contract coverage for lazy resolution, missing optional target skips, and runtime import defect propagation.

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "content_router_specs and ocr" -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/router_groups/content.py -f json -o /tmp/bandit_phase2_2_content_ocr_router_conditional_bb.json
- git diff --check

## Change summary
Human-authored change summary required before merge per Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md.

Refs #1116
Follows #1361