### PR TITLE
Phase 2.2: defer minimal media router import

### DIFF
--- a/backlog/tasks/task-114 - Phase-2.2-minimal-media-router-conditional-cleanup-BC.md
+++ b/backlog/tasks/task-114 - Phase-2.2-minimal-media-router-conditional-cleanup-BC.md
@@ -1,0 +1,66 @@
+---
+id: TASK-114
+title: Phase 2.2 minimal media router conditional cleanup BC
+status: Done
+assignee: []
+created_date: '2026-05-07 14:37'
+updated_date: '2026-05-07 14:45'
+labels:
+  - phase-2.2
+  - router-groups
+  - minimal
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+  - 'https://github.com/rmusser01/tldw_server/pull/1362'
+  - 'https://github.com/rmusser01/tldw_server/pull/1363'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Move the remaining minimal-test media router factory onto the shared lazy optional-router registration path so it uses the same missing-target skip semantics and diagnostics as other optional minimal router specs while preserving the existing media route metadata.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Minimal media route metadata is represented through the shared optional router spec path while preserving prefix /api/v1/media, media tag, and route_key media.
+- [x] #2 Focused contract coverage proves media module import and router attribute lookup stay deferred until router resolution.
+- [x] #3 Focused contract coverage verifies missing media target skips while runtime import defects propagate.
+- [x] #4 Existing router group, main router, and OpenAPI contracts still pass for the touched scope.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add RED contract tests for minimal media lazy resolution, missing optional-target skips, and runtime defect propagation.
+2. Move minimal media registration from a hand-written factory to ImportedRouterSpec.
+3. Run focused, router-group, main-router, OpenAPI, Bandit, and diff hygiene verification.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+RED: python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "minimal_optional_router_specs and media" -q failed with expected StopIteration because no shared media ImportedRouterSpec existed yet.
+
+GREEN/validation: focused selector passed 7 passed; router_groups_contract.py passed 153 passed; test_main_router_contract.py passed 6 passed; test_openapi_contracts.py passed 69 passed; Bandit on tldw_Server_API/app/api/v1/router_groups/minimal.py reported 0 results/errors; git diff --check passed.
+
+No documentation update was required for this internal router-registration cleanup. No skips or blockers remain.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Moved the minimal media router from a hand-written lazy factory to the shared ImportedRouterSpec registration path. This preserves /api/v1/media, the media tag, route_key=media, and the minimal skip context while using the shared missing-module/missing-attribute skip semantics and allowing runtime import defects to propagate. Added focused contract coverage for lazy resolution, optional missing-target skips, missing router attribute skips, and runtime import failure propagation.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -180,17 +180,17 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
     else:
         logger.info("Skipping audio routers in minimal test app (set MINIMAL_TEST_INCLUDE_AUDIO=1 to enable)")
 
-    def _media_router_factory():
-        from tldw_Server_API.app.api.v1.endpoints.media import router as media_router
-
-        return media_router
-
-    specs.append(RouterSpec(
-        router=_media_router_factory,
-        prefix=f"{API_V1_PREFIX}/media",
-        tags=("media",),
-        route_key="media",
-    ))
+    append_imported_router_spec(
+        specs,
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.media",
+            log_name="media",
+            prefix=f"{API_V1_PREFIX}/media",
+            tags=("media",),
+            route_key="media",
+            skip_context=minimal_skip_context,
+        ),
+    )
 
     if _audio_jobs_imports_enabled_for_runtime():
         def _audio_jobs_router_factory():

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -5624,6 +5624,181 @@ def test_iter_minimal_optional_router_specs_propagates_monitoring_runtime_import
         register_router_specs(FastAPI(), (selected_spec,))
 
 
+def test_iter_minimal_optional_router_specs_defers_media_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal media spec keeps router attr lookup lazy."""
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    module_name = "tldw_Server_API.app.api.v1.endpoints.media"
+    fake_module = ModuleType(module_name)
+    router = APIRouter()
+    access_count = {f"{module_name}.router": 0}
+    import_calls: list[str] = []
+
+    @router.get("/media/list")
+    def _endpoint() -> dict[str, str]:
+        """Return a deterministic response for the fake media router."""
+        return {"status": "ok"}
+
+    def _module_getattr(name: str) -> APIRouter:
+        """Track lazy router attribute resolution for the fake module."""
+        if name != "router":
+            raise AttributeError(name)
+        access_count[f"{module_name}.router"] += 1
+        return router
+
+    fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    real_import_module = importlib.import_module
+
+    def _import_module(import_name: str, package: str | None = None) -> ModuleType:
+        """Track lazy media router module import."""
+        if import_name == module_name:
+            import_calls.append(import_name)
+        return real_import_module(import_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    specs = list(iter_minimal_optional_router_specs())
+    assert import_calls == []
+    assert access_count == {f"{module_name}.router": 0}
+
+    selected_spec = next(spec for spec in specs if spec.name == "media")
+    assert selected_spec.prefix == "/api/v1/media"
+    assert selected_spec.tags == ("media",)
+    assert selected_spec.route_key == "media"
+    assert selected_spec.skip_context == "in minimal test app"
+    assert selected_spec.default_stable is True
+    assert selected_spec.skip_exceptions == (
+        OptionalRouterMissingModule,
+        OptionalRouterMissingAttribute,
+    )
+    assert _first_router_path(selected_spec.router) == "/media/list"
+    assert import_calls == [module_name]
+    assert access_count == {f"{module_name}.router": 1}
+
+
+def test_iter_minimal_optional_router_specs_skips_media_missing_import_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal media spec skips missing optional router module."""
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    module_name = "tldw_Server_API.app.api.v1.endpoints.media"
+    specs = list(iter_minimal_optional_router_specs())
+    selected_spec = next(spec for spec in specs if spec.name == "media")
+
+    real_import_module = importlib.import_module
+
+    def _import_module(import_name: str, package: str | None = None) -> ModuleType:
+        """Fail only the selected missing media router import."""
+        if import_name == module_name:
+            raise ModuleNotFoundError(
+                f"{module_name} missing during import",
+                name=module_name,
+            )
+        return real_import_module(import_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    debug_messages: list[str] = []
+    monkeypatch.setattr("loguru.logger.debug", debug_messages.append)
+
+    assert register_router_specs(FastAPI(), (selected_spec,)) == 0
+    skip_debug_messages = [
+        message for message in debug_messages if message.startswith("Skipping ")
+    ]
+    assert len(skip_debug_messages) == 1
+    skip_message = skip_debug_messages[0]
+    assert skip_message.startswith("Skipping media router in minimal test app:")
+    assert module_name in skip_message
+    assert "missing during import" in skip_message
+
+
+def test_iter_minimal_optional_router_specs_skips_media_missing_attribute_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal media spec skips missing optional router attribute."""
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    module_name = "tldw_Server_API.app.api.v1.endpoints.media"
+    monkeypatch.setitem(sys.modules, module_name, ModuleType(module_name))
+
+    specs = list(iter_minimal_optional_router_specs())
+    selected_spec = next(spec for spec in specs if spec.name == "media")
+
+    debug_messages: list[str] = []
+    monkeypatch.setattr("loguru.logger.debug", debug_messages.append)
+
+    assert register_router_specs(FastAPI(), (selected_spec,)) == 0
+    skip_debug_messages = [
+        message for message in debug_messages if message.startswith("Skipping ")
+    ]
+    assert len(skip_debug_messages) == 1
+    skip_message = skip_debug_messages[0]
+    assert skip_message.startswith("Skipping media router in minimal test app:")
+    assert f"{module_name}.router" in skip_message
+
+
+@pytest.mark.parametrize(
+    ("exception_type", "message"),
+    (
+        (RuntimeError, "media exploded during import"),
+        (ImportError, "media dependency failed during import"),
+        (AttributeError, "media attribute failed during import"),
+    ),
+)
+def test_iter_minimal_optional_router_specs_propagates_media_runtime_import_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    exception_type: type[Exception],
+    message: str,
+) -> None:
+    """Verify minimal media runtime import defects are not silently skipped."""
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    module_name = "tldw_Server_API.app.api.v1.endpoints.media"
+    specs = list(iter_minimal_optional_router_specs())
+    selected_spec = next(spec for spec in specs if spec.name == "media")
+
+    real_import_module = importlib.import_module
+
+    def _import_module(import_name: str, package: str | None = None) -> ModuleType:
+        """Crash only the selected media router import at registration."""
+        if import_name == module_name:
+            raise exception_type(message)
+        return real_import_module(import_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    with pytest.raises(exception_type, match=message):
+        register_router_specs(FastAPI(), (selected_spec,))
+
+
 def test_iter_minimal_optional_router_specs_defers_utility_attr_lookup(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- Move the minimal media router registration onto the shared ImportedRouterSpec path.
- Preserve /api/v1/media, media tag, route_key=media, and minimal skip context metadata.
- Add focused contract coverage for lazy resolution, missing optional target skips, missing router attr skips, and runtime import defect propagation.

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "minimal_optional_router_specs and media" -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/router_groups/minimal.py -f json -o /tmp/bandit_phase2_2_minimal_media_router_conditional_bc.json
- git diff --check

## Change summary
Human-authored change summary required before merge per Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md.

Refs #1116
Follows #1362