### PR TITLE
Add MCP chat personal tool filter

### DIFF
--- a/Docs/superpowers/plans/2026-05-07-mcp-chat-personal-tool-filter-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-07-mcp-chat-personal-tool-filter-implementation-plan.md
@@ -70,13 +70,13 @@
 
 **Tests:** `bunx vitest run apps/packages/ui/src/hooks/__tests__/useMcpTools.gating.test.tsx apps/packages/ui/src/utils/__tests__/chat-tools.test.ts`
 
-**Status:** Not Started
+**Status:** Complete
 
-- [ ] Add failing hook tests for discovered-vs-available-vs-chat tools, disabled persistence, scoped isolation, and newly discovered tools defaulting enabled.
-- [ ] Run the hook tests and verify the expected failures.
-- [ ] Add `MCP_DISABLED_TOOLS_SETTING` and extend `mcp-tools` store state/actions.
-- [ ] Update `useMcpTools` to hydrate preferences, compute scope, store discovered/chat tools, and expose toggle helpers/counts.
-- [ ] Run focused hook and utility tests until green.
+- [x] Add failing hook tests for discovered-vs-available-vs-chat tools, disabled persistence, scoped isolation, and newly discovered tools defaulting enabled.
+- [x] Run the hook tests and verify the expected failures.
+- [x] Add `MCP_DISABLED_TOOLS_SETTING` and extend `mcp-tools` store state/actions.
+- [x] Update `useMcpTools` to hydrate preferences, compute scope, store discovered/chat tools, and expose toggle helpers/counts.
+- [x] Run focused hook and utility tests until green.
 
 ## Stage 3: Request Construction And Raw Preview Parity
 

--- a/Docs/superpowers/plans/2026-05-07-mcp-chat-personal-tool-filter-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-07-mcp-chat-personal-tool-filter-implementation-plan.md
@@ -86,15 +86,15 @@
 
 **Tests:** `bunx vitest run apps/packages/ui/src/models/__tests__/pageAssistModel.mcp-tools.test.ts apps/packages/ui/src/components/Option/Playground/__tests__/usePlaygroundRawPreview.mcp-tools.test.tsx`
 
-**Status:** Not Started
+**Status:** Complete
 
-- [ ] Write failing request tests showing disabled tools are excluded and no-tools requests omit both fields.
-- [ ] Write failing raw-preview parity tests for the same behavior.
-- [ ] Run the request/raw-preview tests and verify expected failures.
-- [ ] Refactor `ChatTldw` to import the shared normalization helper.
-- [ ] Update `pageAssistModel` to use `chatTools` from the MCP store by default.
-- [ ] Update raw preview dependencies and request building to use `chatTools` and shared no-tools behavior.
-- [ ] Run request/raw-preview tests until green.
+- [x] Write failing request tests showing disabled tools are excluded and no-tools requests omit both fields.
+- [x] Write failing raw-preview parity tests for the same behavior.
+- [x] Run the request/raw-preview tests and verify expected failures.
+- [x] Refactor `ChatTldw` to import the shared normalization helper.
+- [x] Update `pageAssistModel` to use `chatTools` from the MCP store by default.
+- [x] Update raw preview dependencies and request building to use `chatTools` and shared no-tools behavior.
+- [x] Run request/raw-preview tests until green.
 
 ## Stage 4: Shared Selector UI In Playground And Sidepanel
 

--- a/Docs/superpowers/plans/2026-05-07-mcp-chat-personal-tool-filter-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-07-mcp-chat-personal-tool-filter-implementation-plan.md
@@ -125,11 +125,11 @@
 - `bun run verify:openapi` in `apps/packages/ui`
 - `bun run verify:openapi` in `apps/extension`
 
-**Status:** Not Started
+**Status:** Complete
 
-- [ ] Run all focused Vitest coverage for the implementation slice.
-- [ ] Run OpenAPI verification in `apps/packages/ui`.
-- [ ] Run OpenAPI verification in `apps/extension`.
-- [ ] Run `git diff --check`.
-- [ ] Run Bandit if executable Python changed; otherwise document the non-Python skip.
-- [ ] Update `TASK-113` notes/final summary and commit.
+- [x] Run all focused Vitest coverage for the implementation slice.
+- [x] Run OpenAPI verification in `apps/packages/ui`.
+- [x] Run OpenAPI verification in `apps/extension`.
+- [x] Run `git diff --check`.
+- [x] Run Bandit if executable Python changed; otherwise document the non-Python skip.
+- [x] Update `TASK-113` notes/final summary and commit.

--- a/Docs/superpowers/plans/2026-05-07-mcp-chat-personal-tool-filter-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-07-mcp-chat-personal-tool-filter-implementation-plan.md
@@ -1,0 +1,135 @@
+# MCP Chat Personal Tool Filter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement per-user MCP tool enable/disable controls for chat, shared by WebUI `/chat`, extension options `/chat`, and extension sidepanel chat.
+
+**Architecture:** Keep backend MCP discovery/RBAC unchanged. Add shared client-side normalization, scoped disabled-tool preferences, filtered `chatTools`, and a reusable selector that both Playground and sidepanel surfaces can render. Request construction and raw preview must consume the same filtered/normalized tools and omit `tools`/`tool_choice` when no chat tools remain.
+
+**Tech Stack:** React, TypeScript, Zustand, Plasmo storage-backed settings registry, TanStack Query, Vitest, Testing Library.
+
+---
+
+## File Map
+
+- Create `apps/packages/ui/src/utils/chat-tools.ts`
+  - Shared tool-name extraction, sanitization, normalized identity, collision detection, grouping helpers, and no-tools filtering helpers.
+- Create `apps/packages/ui/src/utils/__tests__/chat-tools.test.ts`
+  - Unit tests for normalization, disabled filtering, collision exclusion, and grouping fallback.
+- Modify `apps/packages/ui/src/services/settings/ui-settings.ts`
+  - Add `MCP_DISABLED_TOOLS_SETTING` with a versioned scoped preference shape.
+- Modify `apps/packages/ui/src/store/mcp-tools.ts`
+  - Track discovered/raw tools, chat-filtered tools, scoped disabled preferences, active preference scope, collision names, and counts.
+- Modify `apps/packages/ui/src/hooks/useMcpTools.tsx`
+  - Hydrate scoped preferences, compute `discoveredTools`, `availableTools`, `chatTools`, collisions, counts, and expose toggle helpers.
+- Modify `apps/packages/ui/src/hooks/__tests__/useMcpTools.gating.test.tsx`
+  - Add hook tests for canExecute visibility, scoped persistence, default enabled new tools, and disabled filtering.
+- Modify `apps/packages/ui/src/models/index.ts`
+  - Use stored `chatTools` by default and shared executable/no-tools behavior.
+- Create `apps/packages/ui/src/models/__tests__/pageAssistModel.mcp-tools.test.ts`
+  - Request-building tests for disabled tools, no-tools omission, and collision filtering.
+- Modify `apps/packages/ui/src/services/tldw/TldwChat.ts`
+  - Use the shared normalization helper so `ChatTldw` and selector identity match.
+- Modify `apps/packages/ui/src/components/Option/Playground/hooks/usePlaygroundRawPreview.ts`
+  - Use the same `chatTools`/normalization/no-tools behavior as actual request construction.
+- Create `apps/packages/ui/src/components/Option/Playground/__tests__/usePlaygroundRawPreview.mcp-tools.test.tsx`
+  - Raw-preview parity tests.
+- Create `apps/packages/ui/src/components/Common/McpToolSelector.tsx`
+  - Shared selector UI for tool search, grouping, per-tool toggles, counts, and degraded state labels.
+- Create `apps/packages/ui/src/components/Common/__tests__/McpToolSelector.test.tsx`
+  - Selector toggle and state-rendering tests.
+- Modify `apps/packages/ui/src/components/Option/Playground/PlaygroundMcpSettingsModal.tsx`
+  - Render the shared selector alongside existing catalog/module controls.
+- Modify `apps/packages/ui/src/components/Sidepanel/Chat/ControlRow.tsx`
+  - Render the shared selector in the sidepanel tools area.
+- Modify `apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx`
+  - Pass `chatTools` counts to controls and raw preview.
+- Add `backlog/tasks/task-113 - Implement-MCP-chat-personal-tool-availability-filter.md`
+  - Mirror the Backlog task record into this worktree before committing.
+
+## Stage 1: Shared Tool Normalization And Filtering
+
+**Goal:** Build the pure utility layer first so all later code uses one identity contract.
+
+**Success Criteria:** Utility tests fail before implementation, then pass; helpers return normalized names, collision sets, filtered chat tools, and grouping labels.
+
+**Tests:** `bunx vitest run apps/packages/ui/src/utils/__tests__/chat-tools.test.ts`
+
+**Status:** Complete
+
+- [x] Write failing tests for `normalizeChatToolName`, `resolveMcpToolIdentity`, `buildChatToolFilterState`, and `getMcpToolGroupLabel`.
+- [x] Run the utility test and verify it fails because the helper module does not exist.
+- [x] Implement `apps/packages/ui/src/utils/chat-tools.ts` with shared normalization and collision-aware filtering.
+- [x] Run the utility test and verify it passes.
+
+## Stage 2: Store, Settings, And Hook Contract
+
+**Goal:** Expose discovered, available, and chat-filtered tools plus scoped disabled preferences from `useMcpTools`.
+
+**Success Criteria:** The hook keeps `canExecute: false` tools visible in `discoveredTools`, filters them from `availableTools`, filters disabled/colliding tools from `chatTools`, and persists disabled preferences per active scope.
+
+**Tests:** `bunx vitest run apps/packages/ui/src/hooks/__tests__/useMcpTools.gating.test.tsx apps/packages/ui/src/utils/__tests__/chat-tools.test.ts`
+
+**Status:** Not Started
+
+- [ ] Add failing hook tests for discovered-vs-available-vs-chat tools, disabled persistence, scoped isolation, and newly discovered tools defaulting enabled.
+- [ ] Run the hook tests and verify the expected failures.
+- [ ] Add `MCP_DISABLED_TOOLS_SETTING` and extend `mcp-tools` store state/actions.
+- [ ] Update `useMcpTools` to hydrate preferences, compute scope, store discovered/chat tools, and expose toggle helpers/counts.
+- [ ] Run focused hook and utility tests until green.
+
+## Stage 3: Request Construction And Raw Preview Parity
+
+**Goal:** Ensure actual chat requests and raw preview use the same chat-filtered tool list.
+
+**Success Criteria:** `pageAssistModel`, `ChatTldw`, and raw preview all use the shared normalization helper and omit `tools`/`tool_choice` when no chat tools remain.
+
+**Tests:** `bunx vitest run apps/packages/ui/src/models/__tests__/pageAssistModel.mcp-tools.test.ts apps/packages/ui/src/components/Option/Playground/__tests__/usePlaygroundRawPreview.mcp-tools.test.tsx`
+
+**Status:** Not Started
+
+- [ ] Write failing request tests showing disabled tools are excluded and no-tools requests omit both fields.
+- [ ] Write failing raw-preview parity tests for the same behavior.
+- [ ] Run the request/raw-preview tests and verify expected failures.
+- [ ] Refactor `ChatTldw` to import the shared normalization helper.
+- [ ] Update `pageAssistModel` to use `chatTools` from the MCP store by default.
+- [ ] Update raw preview dependencies and request building to use `chatTools` and shared no-tools behavior.
+- [ ] Run request/raw-preview tests until green.
+
+## Stage 4: Shared Selector UI In Playground And Sidepanel
+
+**Goal:** Add per-tool toggles through shared selector UI on both chat surfaces.
+
+**Success Criteria:** Users can toggle individual tools on/off, see counts and degraded states, and the same selector logic renders in Playground settings and sidepanel tools UI.
+
+**Tests:** `bunx vitest run apps/packages/ui/src/components/Common/__tests__/McpToolSelector.test.tsx apps/packages/ui/src/hooks/playground/__tests__/useMcpToolsControl.test.tsx`
+
+**Status:** Not Started
+
+- [ ] Write failing selector tests for toggle behavior, unexecutable display, disabled display, collision display, and empty/degraded state labels.
+- [ ] Run selector tests and verify expected failures.
+- [ ] Implement `McpToolSelector`.
+- [ ] Wire selector into `PlaygroundMcpSettingsModal`.
+- [ ] Wire selector into sidepanel `ControlRow`.
+- [ ] Update Playground count props to use `chatTools.length` for chat-enabled counts.
+- [ ] Run selector and focused existing MCP control tests until green.
+
+## Stage 5: Focused Verification And Cleanup
+
+**Goal:** Verify the implementation slice and record completion state.
+
+**Success Criteria:** Focused tests pass, WebUI/extension OpenAPI client path checks still pass when feasible, and docs/task records are current.
+
+**Tests:**
+- `bunx vitest run apps/packages/ui/src/utils/__tests__/chat-tools.test.ts apps/packages/ui/src/hooks/__tests__/useMcpTools.gating.test.tsx apps/packages/ui/src/models/__tests__/pageAssistModel.mcp-tools.test.ts apps/packages/ui/src/components/Option/Playground/__tests__/usePlaygroundRawPreview.mcp-tools.test.tsx apps/packages/ui/src/components/Common/__tests__/McpToolSelector.test.tsx`
+- `bun run verify:openapi` in `apps/packages/ui`
+- `bun run verify:openapi` in `apps/extension`
+
+**Status:** Not Started
+
+- [ ] Run all focused Vitest coverage for the implementation slice.
+- [ ] Run OpenAPI verification in `apps/packages/ui`.
+- [ ] Run OpenAPI verification in `apps/extension`.
+- [ ] Run `git diff --check`.
+- [ ] Run Bandit if executable Python changed; otherwise document the non-Python skip.
+- [ ] Update `TASK-113` notes/final summary and commit.

--- a/Docs/superpowers/plans/2026-05-07-mcp-chat-personal-tool-filter-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-07-mcp-chat-personal-tool-filter-implementation-plan.md
@@ -104,15 +104,15 @@
 
 **Tests:** `bunx vitest run apps/packages/ui/src/components/Common/__tests__/McpToolSelector.test.tsx apps/packages/ui/src/hooks/playground/__tests__/useMcpToolsControl.test.tsx`
 
-**Status:** Not Started
+**Status:** Complete
 
-- [ ] Write failing selector tests for toggle behavior, unexecutable display, disabled display, collision display, and empty/degraded state labels.
-- [ ] Run selector tests and verify expected failures.
-- [ ] Implement `McpToolSelector`.
-- [ ] Wire selector into `PlaygroundMcpSettingsModal`.
-- [ ] Wire selector into sidepanel `ControlRow`.
-- [ ] Update Playground count props to use `chatTools.length` for chat-enabled counts.
-- [ ] Run selector and focused existing MCP control tests until green.
+- [x] Write failing selector tests for toggle behavior, unexecutable display, disabled display, collision display, and empty/degraded state labels.
+- [x] Run selector tests and verify expected failures.
+- [x] Implement `McpToolSelector`.
+- [x] Wire selector into `PlaygroundMcpSettingsModal`.
+- [x] Wire selector into sidepanel `ControlRow`.
+- [x] Update Playground count props to use `chatTools.length` for chat-enabled counts.
+- [x] Run selector and focused existing MCP control tests until green.
 
 ## Stage 5: Focused Verification And Cleanup
 

--- a/Docs/superpowers/specs/2026-05-06-mcp-chat-personal-tool-filter-design.md
+++ b/Docs/superpowers/specs/2026-05-06-mcp-chat-personal-tool-filter-design.md
@@ -88,15 +88,45 @@ The same filtered result feeds:
 
 Extend the shared MCP tool store with durable personal filter state:
 
-- `disabledToolNames: string[]`
+- `disabledToolPreferences: DisabledToolPreferenceStore`
+- `activeToolPreferenceScope: string`
+- `disabledToolNames: string[]` for the active scope
 - `setToolEnabled(toolName, enabled)`
 - `enableTools(toolNames)`
 - `disableTools(toolNames)`
 - `resetToolFilter()`
 
-The stable identity is the effective function/tool name after client
-normalization. That is the name the chat request sends and the name tool calls
-refer back to.
+Persist disabled names in a versioned map rather than one global array:
+
+```ts
+type DisabledToolPreferenceStore = {
+  version: 1
+  scopes: Record<
+    string,
+    {
+      disabledToolNames: string[]
+      updatedAt?: string
+    }
+  >
+}
+```
+
+The scope key should include the normalized API base URL or connection profile
+fingerprint and, when available, the current user/principal identity. If user
+identity is unavailable, use the connection fingerprint plus an anonymous
+fallback segment. This prevents a disabled tool preference from one server,
+profile, or account from hiding a same-named tool in another environment.
+
+The stable identity is the effective chat tool name produced by one shared
+normalization helper. That helper must be used by the selector, hook filtering,
+raw preview, and `ChatTldw` request construction. It should preserve the raw MCP
+tool name for display/debugging while returning the sanitized name that the chat
+request actually sends.
+
+If two visible MCP tools normalize to the same chat tool name, do not silently
+let one toggle or request entry shadow the other. Mark the collision group in
+the selector, exclude colliding tools from `chatTools`, and surface a warning
+that the tool names must be made unique before chat can use them safely.
 
 Store disabled names rather than enabled names:
 
@@ -106,18 +136,23 @@ Store disabled names rather than enabled names:
   again if they return.
 
 Preferences should use the same local settings registry pattern as existing MCP
-catalog/module settings, with an explicit setting key such as
-`tldw:mcp:disabledTools`.
+catalog/module settings, with an explicit versioned setting key such as
+`tldw:mcp:disabledTools:v1`.
 
 ## Hook Contract
 
 `useMcpTools` should continue fetching health, catalogs, modules, and tool
 definitions. It should return both server-filtered and chat-filtered views:
 
-- `availableTools`: executable tools after MCP health, server discovery,
-  catalog/module filters, and `canExecute`.
-- `chatTools`: `availableTools` after the personal disabled-tool filter.
+- `discoveredTools`: tools returned by server discovery after catalog/module
+  filters, including tools with `canExecute: false`.
+- `availableTools`: executable tools from `discoveredTools` after MCP health
+  and `canExecute` filtering.
+- `chatTools`: `availableTools` after personal disabled-tool filtering and
+  normalized-name collision filtering.
 - `disabledToolNames`: persisted disabled tool names.
+- counts for discovered, executable, disabled, colliding, and chat-enabled
+  tools.
 - toggle helpers for one tool, visible groups, all tools, and reset.
 
 Existing `tools` consumers should migrate deliberately. A compatibility alias is
@@ -137,7 +172,20 @@ component should support:
 - reset personal filter
 - visible distinction between unavailable, unexecutable, disabled, and enabled
   tools
+- visible collision warnings for tools that normalize to the same chat tool name
 - link to MCP Hub for server/catalog/policy/credential management
+
+For grouping, use metadata already present on discovered tools before adding
+extra requests:
+
+- federated external tools: `metadata.server_name` when available, then
+  `metadata.server_id`, then the `ext.<server_id>.*` name segment
+- internal tools: `module`
+- fallback: `MCP`
+
+Do not call extra discovery or management tools solely to get friendly labels in
+the first implementation slice. If friendlier external server labels are needed
+later, add them to the tool metadata returned by MCP discovery.
 
 The existing `tool_choice` control remains:
 
@@ -157,11 +205,16 @@ Request preview should use the same filtered list so the raw payload matches the
 actual request behavior.
 
 If the user has `tool_choice` set to `auto` or `required` but no `chatTools`
-remain, request construction should defensively degrade to no tools and
-`tool_choice: none`.
+remain, request construction should defensively degrade to the no-tools path.
+Internally the effective choice should be treated as `none`, but the wire
+request should omit both `tools` and `tool_choice` to match the current
+`ChatTldw` no-tools contract.
 
 The UI should also prevent or clearly downgrade `required` when no tools remain,
 so the composer reflects what will actually be sent.
+
+Raw request preview must use the same normalized `chatTools` list and the same
+no-tools omission behavior as the actual request path.
 
 ## Error And Empty States
 
@@ -193,12 +246,17 @@ the same control.
 
 ### Unit Tests
 
-- `useMcpTools` returns `availableTools` and `chatTools`.
+- `useMcpTools` returns `discoveredTools`, `availableTools`, and `chatTools`.
 - Disabled tool names persist through the settings registry.
 - Newly discovered tools are enabled by default.
 - Disabled tools are excluded from `chatTools` but remain visible as available
   tools in the selector.
 - Missing or vanished disabled tool names do not break filtering.
+- Disabled preferences are scoped by connection/user and do not leak across
+  different server profiles or users.
+- Reloading or reopening the WebUI/extension preserves disabled preferences for
+  the active scope.
+- Normalized name collisions are detected and excluded from `chatTools`.
 
 ### Component Tests
 
@@ -211,13 +269,20 @@ the same control.
   - MCP unhealthy
   - no executable tools
   - all tools disabled by preference
+- The selector shows unexecutable tools distinctly from personally disabled
+  tools.
+- The selector shows collision warnings and does not allow colliding tools to be
+  exposed to chat silently.
 
 ### Request-Building Tests
 
 - `pageAssistModel` sends only personal-enabled MCP tools.
-- `pageAssistModel` coerces tool choice to `none` when filtered tools are empty.
-- Raw request preview mirrors the actual filtered tool payload.
+- `pageAssistModel` follows the no-tools path when filtered tools are empty.
+- Raw request preview mirrors the actual filtered tool payload and omits
+  `tools`/`tool_choice` whenever the actual request omits them.
 - Existing `canExecute: false` filtering is preserved.
+- Shared normalization produces the same chat tool names for selector state,
+  request construction, and raw preview.
 
 ### E2E Smoke
 
@@ -232,11 +297,12 @@ Use a mocked MCP server with two tools.
 
 This can ship incrementally:
 
-1. Add store/settings support and hook-level filtering behind existing MCP
-   controls.
-2. Migrate request construction and raw preview to `chatTools`.
-3. Replace Playground and sidepanel UI with the shared selector.
-4. Add e2e smoke coverage for WebUI `/chat` and sidepanel parity.
+1. Extract a shared chat tool normalization helper and add collision detection.
+2. Add scoped store/settings support and hook-level filtering behind existing
+   MCP controls.
+3. Migrate request construction and raw preview to `chatTools`.
+4. Replace Playground and sidepanel UI with the shared selector.
+5. Add e2e smoke coverage for WebUI `/chat` and sidepanel parity.
 
 The first implementation slice should avoid backend changes unless current tool
 metadata is insufficient to derive useful group labels.

--- a/Docs/superpowers/specs/2026-05-06-mcp-chat-personal-tool-filter-design.md
+++ b/Docs/superpowers/specs/2026-05-06-mcp-chat-personal-tool-filter-design.md
@@ -1,0 +1,252 @@
+# MCP Chat Personal Tool Filter Design
+
+Date: 2026-05-06
+Status: Approved in session
+Backlog: TASK-112
+
+## Goal
+
+Let users choose which already-available MCP tools are exposed to chat from:
+
+- WebUI `/chat`
+- extension options `/chat`
+- extension sidepanel chat
+
+The choice is a personal preference that persists across chats until changed. It
+does not mutate MCP Hub configuration, server policy, external server state, or
+RBAC.
+
+## Problem
+
+The current chat MCP controls mostly expose `tool_choice` plus catalog/module
+filters. That is useful for narrowing the tool list, but it does not give users
+a direct way to turn individual tools on or off for normal chat use.
+
+The implementation seams already exist:
+
+- `apps/packages/ui/src/hooks/useMcpTools.tsx` fetches MCP health, catalogs,
+  modules, and tools.
+- `apps/packages/ui/src/store/mcp-tools.ts` holds the shared MCP tool state.
+- `apps/packages/ui/src/models/index.ts` reads that store and injects tools into
+  `pageAssistModel`.
+- `apps/packages/ui/src/components/Option/Playground/PlaygroundMcpControl.tsx`
+  and `PlaygroundMcpSettingsModal.tsx` expose chat-page MCP controls.
+- `apps/packages/ui/src/components/Sidepanel/Chat/ControlRow.tsx` has a
+  separate extension sidepanel MCP control.
+- `Docs/MCP/mcp_hub_management.md` defines MCP Hub as the shared management
+  surface for ACP profiles, catalogs, external servers, and policy.
+
+The missing piece is a shared personal availability layer between server
+discovery and chat request construction.
+
+## Decisions
+
+- Use a personal availability filter, not server-side MCP Hub mutation.
+- Apply the same filter to WebUI `/chat`, extension options `/chat`, and
+  extension sidepanel chat.
+- Show MCP servers/modules as grouping and filtering concepts in chat.
+- Keep start/stop/connect/disconnect, credentials, catalogs, and policy changes
+  in MCP Hub.
+- Store preferences as local/personal state that persists across browser
+  sessions and chats.
+- Prefer storing disabled tool names so newly discovered tools are enabled by
+  default.
+
+## Non-Goals
+
+- No backend MCP Hub policy changes.
+- No external MCP server lifecycle controls in the chat composer.
+- No server-side persistence of the personal filter in this slice.
+- No changes to RBAC, `canExecute`, approval policies, or tool execution
+  semantics.
+- No redesign of the chat loop or tool approval protocol.
+
+## Architecture
+
+The chat MCP control becomes a shared personal tool availability layer in
+`apps/packages/ui`.
+
+Server truth remains unchanged:
+
+- `/api/v1/mcp/tools` decides what tools exist for the authenticated user.
+- Catalog and module filters shape discovery.
+- RBAC and policy determine `canExecute`.
+- MCP Hub manages external servers, credentials, catalogs, ACP profiles, and
+  governance.
+
+The client adds one local decision:
+
+`MCP discovery -> RBAC/canExecute filter -> personal disabled-tool filter -> chat tools payload`
+
+The same filtered result feeds:
+
+- WebUI `/chat`, which renders the shared Playground surface.
+- extension options `/chat`, which also renders the shared Playground surface.
+- extension sidepanel chat, which currently has separate control markup.
+
+## Data Model
+
+Extend the shared MCP tool store with durable personal filter state:
+
+- `disabledToolNames: string[]`
+- `setToolEnabled(toolName, enabled)`
+- `enableTools(toolNames)`
+- `disableTools(toolNames)`
+- `resetToolFilter()`
+
+The stable identity is the effective function/tool name after client
+normalization. That is the name the chat request sends and the name tool calls
+refer back to.
+
+Store disabled names rather than enabled names:
+
+- Existing behavior remains permissive by default.
+- Newly discovered tools become usable unless the user disables them.
+- Removed tools can remain in local disabled state harmlessly and take effect
+  again if they return.
+
+Preferences should use the same local settings registry pattern as existing MCP
+catalog/module settings, with an explicit setting key such as
+`tldw:mcp:disabledTools`.
+
+## Hook Contract
+
+`useMcpTools` should continue fetching health, catalogs, modules, and tool
+definitions. It should return both server-filtered and chat-filtered views:
+
+- `availableTools`: executable tools after MCP health, server discovery,
+  catalog/module filters, and `canExecute`.
+- `chatTools`: `availableTools` after the personal disabled-tool filter.
+- `disabledToolNames`: persisted disabled tool names.
+- toggle helpers for one tool, visible groups, all tools, and reset.
+
+Existing `tools` consumers should migrate deliberately. A compatibility alias is
+acceptable during migration, but request construction must be explicit about
+using `chatTools`.
+
+## UI Design
+
+Use one reusable MCP tool selector component for Playground and sidepanel. The
+component should support:
+
+- current MCP status and chat-enabled count
+- search by tool name or description
+- grouping by external server/source when available, then module, then `MCP`
+- per-tool on/off toggles
+- enable all/disable all for the current visible group
+- reset personal filter
+- visible distinction between unavailable, unexecutable, disabled, and enabled
+  tools
+- link to MCP Hub for server/catalog/policy/credential management
+
+The existing `tool_choice` control remains:
+
+- `none`: do not send tools.
+- `auto`: send `chatTools` and let the model choose.
+- `required`: require a tool only when at least one `chatTool` is available.
+
+Catalog/module filters remain advanced narrowing controls. They should not be
+presented as the only way to enable/disable tools.
+
+## Request Construction
+
+`pageAssistModel` should use the personal-filtered `chatTools` when it builds
+`ChatTldw`.
+
+Request preview should use the same filtered list so the raw payload matches the
+actual request behavior.
+
+If the user has `tool_choice` set to `auto` or `required` but no `chatTools`
+remain, request construction should defensively degrade to no tools and
+`tool_choice: none`.
+
+The UI should also prevent or clearly downgrade `required` when no tools remain,
+so the composer reflects what will actually be sent.
+
+## Error And Empty States
+
+The chat control should distinguish these states:
+
+### MCP unavailable
+
+The server does not expose MCP capabilities. Disable the control and link to
+setup or health information.
+
+### MCP unhealthy
+
+MCP endpoints exist but the health probe fails. Do not send tools. Show the
+health state and route the user toward health/MCP Hub.
+
+### No executable tools
+
+Tools may exist, but none are executable after RBAC, policy, catalog/module
+filters, and `canExecute`. Show that this is a permission or filter outcome, not
+a personal toggle outcome.
+
+### All chat tools disabled
+
+Executable tools exist, but the personal filter disables them all. Keep MCP
+available, show an "all disabled" state, and let the user re-enable tools from
+the same control.
+
+## Testing Strategy
+
+### Unit Tests
+
+- `useMcpTools` returns `availableTools` and `chatTools`.
+- Disabled tool names persist through the settings registry.
+- Newly discovered tools are enabled by default.
+- Disabled tools are excluded from `chatTools` but remain visible as available
+  tools in the selector.
+- Missing or vanished disabled tool names do not break filtering.
+
+### Component Tests
+
+- Playground MCP selector shows the same chat-enabled count used by requests.
+- Sidepanel MCP selector shows the same chat-enabled count used by requests.
+- Per-tool toggles update the shared filter.
+- Group enable/disable works for visible tools only.
+- The UI distinguishes:
+  - MCP unavailable
+  - MCP unhealthy
+  - no executable tools
+  - all tools disabled by preference
+
+### Request-Building Tests
+
+- `pageAssistModel` sends only personal-enabled MCP tools.
+- `pageAssistModel` coerces tool choice to `none` when filtered tools are empty.
+- Raw request preview mirrors the actual filtered tool payload.
+- Existing `canExecute: false` filtering is preserved.
+
+### E2E Smoke
+
+Use a mocked MCP server with two tools.
+
+- In WebUI `/chat`, disable one tool, send a chat request, and assert the chat
+  request payload contains only the enabled tool.
+- In extension sidepanel chat, repeat the same assertion.
+- Re-enable the disabled tool and verify both tools are sent.
+
+## Rollout Notes
+
+This can ship incrementally:
+
+1. Add store/settings support and hook-level filtering behind existing MCP
+   controls.
+2. Migrate request construction and raw preview to `chatTools`.
+3. Replace Playground and sidepanel UI with the shared selector.
+4. Add e2e smoke coverage for WebUI `/chat` and sidepanel parity.
+
+The first implementation slice should avoid backend changes unless current tool
+metadata is insufficient to derive useful group labels.
+
+## Acceptance Criteria
+
+- Chat exposes per-tool personal enable/disable controls for MCP tools.
+- Personal choices persist across chats until changed.
+- WebUI `/chat`, extension options `/chat`, and extension sidepanel chat use the
+  same filter.
+- Chat request payloads include only MCP tools enabled by the personal filter.
+- MCP Hub remains the management surface for server/admin configuration.
+- UI and request construction handle empty and degraded states consistently.

--- a/apps/packages/ui/src/components/Common/McpToolSelector.tsx
+++ b/apps/packages/ui/src/components/Common/McpToolSelector.tsx
@@ -1,0 +1,232 @@
+import React from "react"
+import { Button, Input, Switch } from "antd"
+
+import type { ChatToolFilterCounts, ResolvedMcpTool } from "@/utils/chat-tools"
+
+type TranslateFn = (
+  key: string,
+  fallback?: string,
+  options?: Record<string, unknown>
+) => string
+
+export type McpToolSelectorProps = {
+  discoveredTools: ResolvedMcpTool[]
+  toolCounts: ChatToolFilterCounts
+  toolsLoading?: boolean
+  hasMcp?: boolean
+  healthState?: string
+  onToolEnabledChange: (toolName: string, enabled: boolean) => void
+  onReset?: () => void
+  t?: TranslateFn
+  compact?: boolean
+}
+
+const defaultT: TranslateFn = (_key, fallback, options) => {
+  const template = fallback ?? _key
+  if (!options) return template
+  return template.replace(/\{\{(\w+)\}\}/g, (_match, token) =>
+    options[token] == null ? "" : String(options[token])
+  )
+}
+
+const getToolStatus = (
+  tool: ResolvedMcpTool,
+  t: TranslateFn
+): { label: string; muted?: boolean } => {
+  if (!tool.canExecute) {
+    return {
+      label: t("mcpToolSelector.statusUnavailable", "Unavailable"),
+      muted: true
+    }
+  }
+  if (tool.colliding) {
+    return {
+      label: t("mcpToolSelector.statusConflict", "Name conflict"),
+      muted: true
+    }
+  }
+  if (tool.disabled) {
+    return {
+      label: t("mcpToolSelector.statusOff", "Off"),
+      muted: true
+    }
+  }
+  return {
+    label: t("mcpToolSelector.statusOn", "On")
+  }
+}
+
+export const McpToolSelector: React.FC<McpToolSelectorProps> = ({
+  discoveredTools,
+  toolCounts,
+  toolsLoading = false,
+  hasMcp = true,
+  healthState = "healthy",
+  onToolEnabledChange,
+  onReset,
+  t = defaultT,
+  compact = false
+}) => {
+  const [query, setQuery] = React.useState("")
+  const unavailableCount = Math.max(
+    0,
+    toolCounts.discovered - toolCounts.executable
+  )
+  const normalizedQuery = query.trim().toLowerCase()
+  const filteredTools = React.useMemo(() => {
+    if (!normalizedQuery) return discoveredTools
+    return discoveredTools.filter((tool) => {
+      const haystack = [
+        tool.rawName,
+        tool.chatName,
+        tool.description,
+        tool.groupLabel
+      ]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase()
+      return haystack.includes(normalizedQuery)
+    })
+  }, [discoveredTools, normalizedQuery])
+
+  const groupedTools = React.useMemo(() => {
+    const groups = new Map<string, ResolvedMcpTool[]>()
+    for (const tool of filteredTools) {
+      const label = tool.groupLabel || "MCP"
+      groups.set(label, [...(groups.get(label) ?? []), tool])
+    }
+    return [...groups.entries()].sort(([left], [right]) =>
+      left.localeCompare(right)
+    )
+  }, [filteredTools])
+
+  if (!hasMcp) {
+    return (
+      <div className="text-xs text-text-muted">
+        {t("mcpToolSelector.unavailable", "MCP tools unavailable")}
+      </div>
+    )
+  }
+
+  if (healthState === "unhealthy") {
+    return (
+      <div className="text-xs text-text-muted">
+        {t("mcpToolSelector.unhealthy", "MCP tools are offline")}
+      </div>
+    )
+  }
+
+  if (toolsLoading) {
+    return (
+      <div className="text-xs text-text-muted">
+        {t("mcpToolSelector.loading", "Loading tools...")}
+      </div>
+    )
+  }
+
+  if (discoveredTools.length === 0) {
+    return (
+      <div className="text-xs text-text-muted">
+        {t("mcpToolSelector.empty", "No MCP tools discovered")}
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-2" data-testid="mcp-tool-selector">
+      <div className="flex flex-wrap items-center gap-1 text-[11px] text-text-muted">
+        <span className="rounded border border-border px-1.5 py-0.5">
+          {t("mcpToolSelector.countEnabled", "{{count}} enabled", {
+            count: toolCounts.chatEnabled
+          })}
+        </span>
+        <span className="rounded border border-border px-1.5 py-0.5">
+          {t("mcpToolSelector.countDisabled", "{{count}} disabled", {
+            count: toolCounts.disabled
+          })}
+        </span>
+        <span className="rounded border border-border px-1.5 py-0.5">
+          {t("mcpToolSelector.countUnavailable", "{{count}} unavailable", {
+            count: unavailableCount
+          })}
+        </span>
+        {toolCounts.colliding > 0 && (
+          <span className="rounded border border-border px-1.5 py-0.5">
+            {t("mcpToolSelector.countConflicts", "{{count}} conflicts", {
+              count: toolCounts.colliding
+            })}
+          </span>
+        )}
+        {onReset && toolCounts.disabled > 0 && (
+          <Button
+            size="small"
+            type="link"
+            className="h-auto p-0 text-[11px]"
+            onClick={onReset}
+          >
+            {t("mcpToolSelector.reset", "Reset")}
+          </Button>
+        )}
+      </div>
+      <Input
+        size="small"
+        value={query}
+        onChange={(event) => setQuery(event.target.value)}
+        placeholder={t("mcpToolSelector.searchPlaceholder", "Search tools")}
+        aria-label={t("mcpToolSelector.searchAriaLabel", "Search MCP tools")}
+      />
+      <div className={compact ? "flex max-h-48 flex-col gap-2 overflow-auto" : "flex max-h-72 flex-col gap-3 overflow-auto"}>
+        {groupedTools.map(([groupLabel, tools]) => (
+          <div key={groupLabel} className="flex flex-col gap-1">
+            <div className="text-[11px] font-medium uppercase text-text-muted">
+              {groupLabel}
+            </div>
+            {tools.map((tool) => {
+              const status = getToolStatus(tool, t)
+              const switchDisabled = !tool.canExecute || tool.colliding
+              return (
+                <div
+                  key={`${tool.chatName}-${tool.rawName}`}
+                  className="flex items-start justify-between gap-3 rounded border border-border px-2 py-1.5"
+                >
+                  <div className="min-w-0">
+                    <div className="truncate text-sm text-text">
+                      {tool.displayName}
+                    </div>
+                    {tool.description && !compact && (
+                      <div className="line-clamp-2 text-[11px] text-text-muted">
+                        {tool.description}
+                      </div>
+                    )}
+                    <div
+                      className={
+                        status.muted
+                          ? "text-[11px] text-text-muted"
+                          : "text-[11px] text-accent"
+                      }
+                    >
+                      {status.label}
+                    </div>
+                  </div>
+                  <Switch
+                    size="small"
+                    checked={!tool.disabled && tool.canExecute && !tool.colliding}
+                    disabled={switchDisabled}
+                    aria-label={t(
+                      "mcpToolSelector.toggleAriaLabel",
+                      "{{name}} MCP tool",
+                      { name: tool.displayName }
+                    )}
+                    onChange={(checked) =>
+                      onToolEnabledChange(tool.chatName, checked)
+                    }
+                  />
+                </div>
+              )
+            })}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/packages/ui/src/components/Common/__tests__/McpToolSelector.test.tsx
+++ b/apps/packages/ui/src/components/Common/__tests__/McpToolSelector.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { McpToolSelector } from "../McpToolSelector"
+import { buildChatToolFilterState } from "@/utils/chat-tools"
+
+const t = (_key: string, fallback?: string, options?: Record<string, unknown>) => {
+  const template = fallback ?? _key
+  if (!options) return template
+  return template.replace(/\{\{(\w+)\}\}/g, (_match, token) =>
+    options[token] == null ? "" : String(options[token])
+  )
+}
+
+describe("McpToolSelector", () => {
+  it("renders tool counts and degraded state labels", () => {
+    const filterState = buildChatToolFilterState({
+      tools: [
+        { name: "notes.search", canExecute: true },
+        { name: "slides.list", canExecute: true },
+        { name: "media.search", canExecute: false },
+        { name: "docs.search", canExecute: true },
+        { name: "docs_search", canExecute: true }
+      ],
+      disabledToolNames: ["slides_list"]
+    })
+
+    render(
+      <McpToolSelector
+        discoveredTools={filterState.discoveredTools}
+        toolCounts={filterState.counts}
+        toolsLoading={false}
+        hasMcp
+        healthState="healthy"
+        onToolEnabledChange={vi.fn()}
+        t={t}
+      />
+    )
+
+    expect(screen.getByText("1 enabled")).toBeInTheDocument()
+    expect(screen.getByText("1 disabled")).toBeInTheDocument()
+    expect(screen.getByText("1 unavailable")).toBeInTheDocument()
+    expect(screen.getAllByText("Name conflict")).toHaveLength(2)
+    expect(screen.getByText("Unavailable")).toBeInTheDocument()
+    expect(screen.getByText("Off")).toBeInTheDocument()
+  })
+
+  it("toggles executable non-conflicting tools by normalized chat name", async () => {
+    const user = userEvent.setup()
+    const onToolEnabledChange = vi.fn()
+    const filterState = buildChatToolFilterState({
+      tools: [
+        { name: "notes.search", canExecute: true },
+        { name: "slides.list", canExecute: true }
+      ],
+      disabledToolNames: ["slides_list"]
+    })
+
+    render(
+      <McpToolSelector
+        discoveredTools={filterState.discoveredTools}
+        toolCounts={filterState.counts}
+        toolsLoading={false}
+        hasMcp
+        healthState="healthy"
+        onToolEnabledChange={onToolEnabledChange}
+        t={t}
+      />
+    )
+
+    await user.click(screen.getByRole("switch", { name: /notes.search/i }))
+    await user.click(screen.getByRole("switch", { name: /slides.list/i }))
+
+    expect(onToolEnabledChange).toHaveBeenNthCalledWith(1, "notes_search", false)
+    expect(onToolEnabledChange).toHaveBeenNthCalledWith(2, "slides_list", true)
+  })
+
+  it("does not toggle unavailable or colliding tools", async () => {
+    const user = userEvent.setup()
+    const onToolEnabledChange = vi.fn()
+    const filterState = buildChatToolFilterState({
+      tools: [
+        { name: "media.search", canExecute: false },
+        { name: "docs.search", canExecute: true },
+        { name: "docs_search", canExecute: true }
+      ]
+    })
+
+    render(
+      <McpToolSelector
+        discoveredTools={filterState.discoveredTools}
+        toolCounts={filterState.counts}
+        toolsLoading={false}
+        hasMcp
+        healthState="healthy"
+        onToolEnabledChange={onToolEnabledChange}
+        t={t}
+      />
+    )
+
+    expect(screen.getByRole("switch", { name: /media.search/i })).toBeDisabled()
+    expect(
+      screen.getByRole("switch", { name: "docs.search MCP tool" })
+    ).toBeDisabled()
+    await user.click(screen.getByRole("switch", { name: /media.search/i }))
+    await user.click(
+      screen.getByRole("switch", { name: "docs.search MCP tool" })
+    )
+
+    expect(onToolEnabledChange).not.toHaveBeenCalled()
+  })
+})

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx
@@ -662,7 +662,9 @@ export const PlaygroundForm = ({
   const {
     hasMcp,
     healthState: mcpHealthState,
-    tools: mcpTools,
+    discoveredTools: discoveredMcpTools,
+    chatTools: chatMcpTools,
+    toolCounts: mcpToolCounts,
     toolsLoading: mcpToolsLoading,
     catalogs: mcpCatalogs,
     catalogsLoading: mcpCatalogsLoading,
@@ -676,11 +678,13 @@ export const PlaygroundForm = ({
     setToolCatalogId,
     setToolModules,
     setToolCatalogStrict,
+    setToolEnabled: setMcpToolEnabled,
+    resetToolFilter: resetMcpToolFilter,
   } = useMcpTools({ enabled: mcpToolsEnabled });
   const mcpCtrl = useMcpToolsControl({
     hasMcp,
     mcpHealthState,
-    mcpTools,
+    mcpTools: chatMcpTools,
     mcpToolsLoading,
     mcpCatalogs,
     toolCatalog,
@@ -3231,7 +3235,7 @@ export const PlaygroundForm = ({
     systemPrompt,
     hasMcp,
     mcpHealthState,
-    mcpTools,
+    mcpTools: chatMcpTools,
     toolChoice,
     temporaryChat,
     serverChatId,
@@ -4036,7 +4040,7 @@ export const PlaygroundForm = ({
       hasMcp={hasMcp}
       mcpHealthState={mcpHealthState}
       mcpToolsLoading={mcpToolsLoading}
-      mcpToolsCount={mcpTools.length}
+      mcpToolsCount={chatMcpTools.length}
       toolChoice={toolChoice}
       onToolChoiceChange={setToolChoice}
       toolRunStatusLabel={toolRunStatusLabel}
@@ -5568,6 +5572,12 @@ export const PlaygroundForm = ({
               moduleOptionsLoading={moduleOptionsLoading}
               toolModules={toolModules}
               onModuleSelect={handleModuleSelect}
+              discoveredTools={discoveredMcpTools}
+              toolCounts={mcpToolCounts}
+              toolsLoading={mcpToolsLoading}
+              mcpHealthState={mcpHealthState}
+              onToolEnabledChange={setMcpToolEnabled}
+              onResetToolFilter={resetMcpToolFilter}
               isSmallModel={isSmallModel}
               t={t}
             />

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundMcpSettingsModal.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundMcpSettingsModal.tsx
@@ -1,6 +1,8 @@
 import React from "react"
 import { InputNumber, Modal, Select, Switch, Input } from "antd"
 import { ModalFooter } from "@/components/ui/layout"
+import { McpToolSelector } from "@/components/Common/McpToolSelector"
+import type { ChatToolFilterCounts, ResolvedMcpTool } from "@/utils/chat-tools"
 
 // ---------------------------------------------------------------------------
 // Types
@@ -41,6 +43,14 @@ export interface PlaygroundMcpSettingsModalProps {
   toolModules: string[]
   onModuleSelect: (value?: string[]) => void
 
+  // Personal tool filter
+  discoveredTools: ResolvedMcpTool[]
+  toolCounts: ChatToolFilterCounts
+  toolsLoading: boolean
+  mcpHealthState: string
+  onToolEnabledChange: (toolName: string, enabled: boolean) => void
+  onResetToolFilter: () => void
+
   // Small model hint
   isSmallModel: boolean
 
@@ -72,6 +82,12 @@ export const PlaygroundMcpSettingsModal: React.FC<PlaygroundMcpSettingsModalProp
       moduleOptionsLoading,
       toolModules,
       onModuleSelect,
+      discoveredTools,
+      toolCounts,
+      toolsLoading,
+      mcpHealthState,
+      onToolEnabledChange,
+      onResetToolFilter,
       isSmallModel,
       t
     } = props
@@ -110,6 +126,21 @@ export const PlaygroundMcpSettingsModal: React.FC<PlaygroundMcpSettingsModalProp
             </div>
           ) : (
             <div className="flex flex-col gap-3">
+              <div className="flex flex-col gap-1">
+                <label className="text-xs text-text-muted">
+                  {t("playground:composer.mcpToolSelectorLabel", "Tools")}
+                </label>
+                <McpToolSelector
+                  discoveredTools={discoveredTools}
+                  toolCounts={toolCounts}
+                  toolsLoading={toolsLoading}
+                  hasMcp={hasMcp}
+                  healthState={mcpHealthState}
+                  onToolEnabledChange={onToolEnabledChange}
+                  onReset={onResetToolFilter}
+                  t={t}
+                />
+              </div>
               <div className="flex flex-col gap-1">
                 <label className="text-xs text-text-muted">
                   {t("playground:composer.mcpCatalogLabel", "Catalog")}

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/usePlaygroundRawPreview.mcp-tools.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/usePlaygroundRawPreview.mcp-tools.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { usePlaygroundRawPreview } from "../hooks/usePlaygroundRawPreview"
+
+vi.mock("@/utils/resolve-api-provider", () => ({
+  resolveApiProviderForModel: vi.fn(async () => "openai")
+}))
+
+const buildDeps = (overrides: Partial<any> = {}) => ({
+  composerModels: [{ id: "tool-model", capabilities: ["tools"] }],
+  selectedModel: "tool-model",
+  compareModeActive: false,
+  compareSelectedModels: [],
+  compareMaxModels: 4,
+  currentChatModelSettings: {
+    apiProvider: "openai"
+  },
+  history: [],
+  systemPrompt: undefined,
+  hasMcp: true,
+  mcpHealthState: "healthy",
+  mcpTools: [],
+  toolChoice: "auto",
+  temporaryChat: true,
+  serverChatId: null,
+  serverChatState: null,
+  serverChatSource: null,
+  selectedCharacter: null,
+  messageSteeringMode: "none",
+  messageSteeringForceNarrate: false,
+  ragMediaIds: null,
+  selectedKnowledge: null,
+  ragPinnedResults: [],
+  fileRetrievalEnabled: false,
+  contextFiles: [],
+  documentContext: [],
+  selectedDocuments: [],
+  imageBackendDefaultTrimmed: "",
+  resolveSubmissionIntent: (message: string) => ({
+    message,
+    isImageCommand: false
+  }),
+  formImage: "",
+  formMessage: "hello",
+  researchContext: undefined,
+  notificationApi: {
+    error: vi.fn(),
+    success: vi.fn()
+  },
+  t: (_key: string, defaultValueOrOptions?: any) =>
+    typeof defaultValueOrOptions === "string" ? defaultValueOrOptions : _key,
+  setToolsPopoverOpen: vi.fn(),
+  ...overrides
+})
+
+describe("usePlaygroundRawPreview MCP tools", () => {
+  it("normalizes chat tools in the raw request preview", async () => {
+    const { result } = renderHook(() =>
+      usePlaygroundRawPreview(
+        buildDeps({
+          mcpTools: [
+            {
+              name: "notes.search",
+              description: "Search notes",
+              parameters: {
+                type: "object",
+                properties: { q: { type: "string" } }
+              },
+              canExecute: true
+            }
+          ]
+        })
+      )
+    )
+
+    await act(async () => {
+      await result.current.refreshRawRequestSnapshot()
+    })
+
+    const body = result.current.rawRequestSnapshot?.body as any
+    expect(body.tool_choice).toBe("auto")
+    expect(body.tools).toEqual([
+      {
+        type: "function",
+        function: {
+          name: "notes_search",
+          description: "Search notes",
+          parameters: {
+            type: "object",
+            properties: { q: { type: "string" } }
+          }
+        }
+      }
+    ])
+  })
+
+  it("omits tool fields when all candidate tools collide", async () => {
+    const { result } = renderHook(() =>
+      usePlaygroundRawPreview(
+        buildDeps({
+          mcpTools: [
+            { name: "docs.search", canExecute: true },
+            { name: "docs_search", canExecute: true }
+          ]
+        })
+      )
+    )
+
+    await act(async () => {
+      await result.current.refreshRawRequestSnapshot()
+    })
+
+    const body = result.current.rawRequestSnapshot?.body as any
+    expect(body).not.toHaveProperty("tool_choice")
+    expect(body).not.toHaveProperty("tools")
+  })
+})

--- a/apps/packages/ui/src/components/Option/Playground/hooks/usePlaygroundRawPreview.ts
+++ b/apps/packages/ui/src/components/Option/Playground/hooks/usePlaygroundRawPreview.ts
@@ -11,6 +11,7 @@ import type {
 } from "@/services/tldw/TldwApiClient"
 import { parseJsonObject } from "./utils"
 import { formatPinnedResults } from "@/utils/rag-format"
+import { normalizeChatToolsForRequest } from "@/utils/chat-tools"
 
 // ---------------------------------------------------------------------------
 // Deps interface
@@ -85,6 +86,11 @@ export interface UsePlaygroundRawPreviewDeps {
 // ---------------------------------------------------------------------------
 // Hook
 // ---------------------------------------------------------------------------
+
+const omitUndefinedFields = <T extends Record<string, unknown>>(payload: T): T =>
+  Object.fromEntries(
+    Object.entries(payload).filter(([, value]) => value !== undefined)
+  ) as T
 
 export function usePlaygroundRawPreview(deps: UsePlaygroundRawPreviewDeps) {
   const {
@@ -227,20 +233,21 @@ export function usePlaygroundRawPreview(deps: UsePlaygroundRawPreviewDeps) {
         hasMcp &&
         mcpHealthState !== "unavailable" &&
         mcpHealthState !== "unhealthy"
-      const executableTools = Array.isArray(mcpTools)
-        ? mcpTools.filter((tool) => {
-            if (!tool || typeof tool !== "object") return false
-            if (!("canExecute" in tool)) return true
-            return Boolean((tool as Record<string, unknown>).canExecute)
-          })
-        : []
+      const normalizedTools = normalizeChatToolsForRequest(mcpTools)
       const effectiveTools =
         toolsAllowed &&
         toolChoice !== "none" &&
-        executableTools.length > 0
-          ? executableTools
+        normalizedTools &&
+        normalizedTools.length > 0
+          ? normalizedTools
           : undefined
-      const request: ChatCompletionRequest = {
+      const rawPreviewToolChoice =
+        toolChoice === "auto" ||
+        toolChoice === "none" ||
+        toolChoice === "required"
+          ? toolChoice
+          : undefined
+      const request = omitUndefinedFields({
         messages: toPreviewHistoryMessages(normalizedModel, draftMessage, draftImage),
         model: normalizedModel,
         stream: true,
@@ -255,14 +262,14 @@ export function usePlaygroundRawPreview(deps: UsePlaygroundRawPreviewDeps) {
           currentChatModelSettings.reasoningEffort === "high"
             ? currentChatModelSettings.reasoningEffort
             : undefined,
-        tool_choice:
-          effectiveTools &&
-          (toolChoice === "auto" ||
-            toolChoice === "none" ||
-            toolChoice === "required")
-            ? toolChoice
-            : undefined,
-        tools: effectiveTools,
+        ...(effectiveTools
+          ? {
+              tools: effectiveTools,
+              ...(rawPreviewToolChoice
+                ? { tool_choice: rawPreviewToolChoice }
+                : {})
+            }
+          : {}),
         save_to_db: !temporaryChat && Boolean(serverChatId),
         conversation_id: !temporaryChat && serverChatId ? serverChatId : undefined,
         history_message_limit: currentChatModelSettings.historyMessageLimit,
@@ -286,7 +293,7 @@ export function usePlaygroundRawPreview(deps: UsePlaygroundRawPreviewDeps) {
           ? { type: "json_object" }
           : undefined,
         research_context: compareModeActive ? undefined : researchContext
-      }
+      } satisfies Record<string, unknown>) as ChatCompletionRequest
       return request
     },
     [

--- a/apps/packages/ui/src/components/Sidepanel/Chat/ControlRow.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/ControlRow.tsx
@@ -15,6 +15,7 @@ import { useTranslation } from "react-i18next"
 import { ModelSelect } from "@/components/Common/ModelSelect"
 import { PromptSelect } from "@/components/Common/PromptSelect"
 import { FeatureHint, useFeatureHintSeen } from "@/components/Common/FeatureHint"
+import { McpToolSelector } from "@/components/Common/McpToolSelector"
 import { CharacterSelect } from "./CharacterSelect"
 import { useChatMoodBadgePreference } from "@/hooks/useChatMoodBadgePreference"
 import { useServerCapabilities } from "@/hooks/useServerCapabilities"
@@ -81,7 +82,9 @@ const ControlRowBase: React.FC<ControlRowProps> = ({
   const {
     hasMcp,
     healthState: mcpHealthState,
-    tools: mcpTools,
+    discoveredTools: discoveredMcpTools,
+    chatTools: chatMcpTools,
+    toolCounts: mcpToolCounts,
     toolsLoading: mcpToolsLoading,
     catalogs: mcpCatalogs,
     catalogsLoading: mcpCatalogsLoading,
@@ -94,8 +97,11 @@ const ControlRowBase: React.FC<ControlRowProps> = ({
     setToolCatalog,
     setToolCatalogId,
     setToolModules,
-    setToolCatalogStrict
+    setToolCatalogStrict,
+    setToolEnabled: setMcpToolEnabled,
+    resetToolFilter: resetMcpToolFilter
   } = useMcpTools()
+  const chatMcpToolCount = chatMcpTools.length
 
   const [catalogDraft, setCatalogDraft] = React.useState(toolCatalog)
   const [advancedToolsExpanded, setAdvancedToolsExpanded] = React.useState(false)
@@ -309,7 +315,7 @@ const ControlRowBase: React.FC<ControlRowProps> = ({
               ? t("sidepanel:controlRow.mcpToolsUnhealthy", "MCP tools are offline")
               : mcpToolsLoading
                 ? t("sidepanel:controlRow.mcpToolsLoading", "Loading tools...")
-                : mcpTools.length === 0
+                : chatMcpToolCount === 0
                   ? t("sidepanel:controlRow.mcpToolsEmpty", "No MCP tools available")
                   : ""
         }
@@ -317,7 +323,7 @@ const ControlRowBase: React.FC<ControlRowProps> = ({
           !hasMcp ||
           mcpHealthState === "unhealthy" ||
           mcpToolsLoading ||
-          mcpTools.length === 0
+          chatMcpToolCount === 0
             ? undefined
             : false
         }
@@ -332,7 +338,7 @@ const ControlRowBase: React.FC<ControlRowProps> = ({
             !hasMcp ||
             mcpHealthState === "unhealthy" ||
             mcpToolsLoading ||
-            mcpTools.length === 0
+            chatMcpToolCount === 0
           }
         >
           <Radio.Button value="auto">
@@ -352,48 +358,17 @@ const ControlRowBase: React.FC<ControlRowProps> = ({
       <div className="text-caption text-text-muted font-medium">
         {t("sidepanel:controlRow.mcpToolsLabel", "MCP tools")}
       </div>
-      {mcpToolsLoading ? (
-        <div className="text-xs text-text-muted">
-          {t("sidepanel:controlRow.mcpToolsLoading", "Loading tools...")}
-        </div>
-      ) : mcpTools.length === 0 ? (
-        <div className="text-xs text-text-muted">
-          {!hasMcp
-            ? t("sidepanel:controlRow.mcpToolsUnavailable", "MCP tools unavailable")
-            : mcpHealthState === "unhealthy"
-              ? t("sidepanel:controlRow.mcpToolsUnhealthy", "MCP tools are offline")
-              : t("sidepanel:controlRow.mcpToolsEmpty", "No MCP tools available")}
-        </div>
-      ) : (
-        <div className="flex flex-wrap gap-1">
-          {mcpTools.slice(0, 6).map((tool, index) => {
-            const toolFn = (tool as any)?.function
-            const name =
-              (typeof tool?.name === "string" && tool.name) ||
-              (typeof toolFn?.name === "string" && toolFn.name) ||
-              (typeof (tool as any)?.id === "string" && (tool as any).id) ||
-              `tool-${index + 1}`
-            const description =
-              (typeof tool?.description === "string" && tool.description) ||
-              (typeof toolFn?.description === "string" && toolFn.description) ||
-              ""
-            return (
-              <span
-                key={`${name}-${index}`}
-                title={description || name}
-                className="rounded-full border border-border px-2 py-0.5 text-[11px] text-text"
-              >
-                {name}
-              </span>
-            )
-          })}
-          {mcpTools.length > 6 && (
-            <span className="rounded-full border border-border px-2 py-0.5 text-[11px] text-text-muted">
-              +{mcpTools.length - 6}
-            </span>
-          )}
-        </div>
-      )}
+      <McpToolSelector
+        discoveredTools={discoveredMcpTools}
+        toolCounts={mcpToolCounts}
+        toolsLoading={mcpToolsLoading}
+        hasMcp={hasMcp}
+        healthState={mcpHealthState}
+        onToolEnabledChange={setMcpToolEnabled}
+        onReset={resetMcpToolFilter}
+        compact
+        t={t}
+      />
 
       <div className="panel-divider my-1" />
       <div className="text-caption text-text-muted font-medium">

--- a/apps/packages/ui/src/hooks/__tests__/useMcpTools.gating.test.tsx
+++ b/apps/packages/ui/src/hooks/__tests__/useMcpTools.gating.test.tsx
@@ -85,6 +85,11 @@ vi.mock("@/services/tldw/mcp", () => ({
 }))
 
 const buildWrapper = () => {
+  const { wrapper } = buildWrapperWithClient()
+  return wrapper
+}
+
+const buildWrapperWithClient = () => {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
@@ -92,9 +97,10 @@ const buildWrapper = () => {
       }
     }
   })
-  return ({ children }: { children: React.ReactNode }) => (
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   )
+  return { queryClient, wrapper }
 }
 
 describe("useMcpTools gating", () => {
@@ -276,6 +282,63 @@ describe("useMcpTools gating", () => {
     )
     expect(result.current.disabledToolNames).toEqual([])
     expect(result.current.chatTools[0]?.rawName).toBe("notes.search")
+  })
+
+  it("scopes MCP query caches by the active connection identity", async () => {
+    const firstScope =
+      "server:http://127.0.0.1:8000|auth:single-user|org:none|principal:anonymous"
+    const secondScope =
+      "server:http://127.0.0.1:9000|auth:single-user|org:none|principal:anonymous"
+    state.apiSend.mockResolvedValue({ ok: true })
+    state.fetchMcpToolCatalogsViaDiscovery.mockResolvedValue([])
+    state.fetchMcpModulesViaDiscovery.mockResolvedValue([])
+    state.fetchMcpToolsViaDiscovery.mockImplementation(async () =>
+      state.connectionConfig.serverUrl === "http://127.0.0.1:9000"
+        ? [{ name: "slides.list", canExecute: true }]
+        : [{ name: "notes.search", canExecute: true }]
+    )
+    const { queryClient, wrapper } = buildWrapperWithClient()
+
+    const { result, rerender } = renderHook(() => useMcpTools(), {
+      wrapper
+    })
+
+    await waitFor(() => {
+      expect(result.current.chatTools.map((tool) => tool.rawName)).toEqual([
+        "notes.search"
+      ])
+    })
+
+    state.connectionConfig = {
+      serverUrl: "http://127.0.0.1:9000",
+      authMode: "single-user",
+      apiKey: "test-key"
+    }
+    rerender()
+
+    await waitFor(() => {
+      expect(result.current.chatTools.map((tool) => tool.rawName)).toEqual([
+        "slides.list"
+      ])
+    })
+
+    expect(state.fetchMcpToolsViaDiscovery).toHaveBeenCalledTimes(2)
+    const queryKeys = queryClient
+      .getQueryCache()
+      .getAll()
+      .map((query) => query.queryKey)
+    expect(queryKeys).toEqual(
+      expect.arrayContaining([
+        ["mcp-health", firstScope],
+        ["mcp-health", secondScope],
+        ["mcp-tools", firstScope, "", null, [], false],
+        ["mcp-tools", secondScope, "", null, [], false],
+        ["mcp-tool-catalogs", firstScope],
+        ["mcp-tool-catalogs", secondScope],
+        ["mcp-tool-modules", firstScope],
+        ["mcp-tool-modules", secondScope]
+      ])
+    )
   })
 
   it("defaults newly discovered executable tools to enabled in an existing scope", async () => {

--- a/apps/packages/ui/src/hooks/__tests__/useMcpTools.gating.test.tsx
+++ b/apps/packages/ui/src/hooks/__tests__/useMcpTools.gating.test.tsx
@@ -11,6 +11,13 @@ const state = vi.hoisted(() => ({
     hasMcp: true
   } as any,
   loading: false,
+  connectionConfig: {
+    serverUrl: "http://127.0.0.1:8000",
+    authMode: "single-user",
+    apiKey: "test-key"
+  } as any,
+  settingValues: new Map<string, unknown>(),
+  settingSetters: new Map<string, ReturnType<typeof vi.fn>>(),
   apiSend: vi.fn(),
   fetchMcpTools: vi.fn(),
   fetchMcpToolCatalogs: vi.fn(),
@@ -26,8 +33,35 @@ vi.mock("@/hooks/useServerCapabilities", () => ({
   })
 }))
 
+vi.mock("@/hooks/useCanonicalConnectionConfig", () => ({
+  useCanonicalConnectionConfig: () => ({
+    config: state.connectionConfig,
+    loading: false
+  })
+}))
+
 vi.mock("@/hooks/useSetting", () => ({
-  useSetting: () => [null, vi.fn()]
+  useSetting: (setting: { key: string; defaultValue: unknown }) => {
+    const setter =
+      state.settingSetters.get(setting.key) ??
+      vi.fn(async (next: unknown) => {
+        const current = state.settingValues.has(setting.key)
+          ? state.settingValues.get(setting.key)
+          : setting.defaultValue
+        const resolved =
+          typeof next === "function"
+            ? (next as (value: unknown) => unknown)(current)
+            : next
+        state.settingValues.set(setting.key, resolved)
+      })
+    state.settingSetters.set(setting.key, setter)
+    return [
+      state.settingValues.has(setting.key)
+        ? state.settingValues.get(setting.key)
+        : setting.defaultValue,
+      setter
+    ]
+  }
 }))
 
 vi.mock("@/services/api-send", () => ({
@@ -67,6 +101,13 @@ describe("useMcpTools gating", () => {
   beforeEach(() => {
     state.capabilities = { hasMcp: true }
     state.loading = false
+    state.connectionConfig = {
+      serverUrl: "http://127.0.0.1:8000",
+      authMode: "single-user",
+      apiKey: "test-key"
+    }
+    state.settingValues.clear()
+    state.settingSetters.clear()
     state.apiSend.mockReset()
     state.fetchMcpTools.mockReset()
     state.fetchMcpToolCatalogs.mockReset()
@@ -75,8 +116,22 @@ describe("useMcpTools gating", () => {
     state.fetchMcpToolsViaDiscovery.mockReset()
     useMcpToolsStore.setState({
       tools: [],
+      discoveredTools: [],
+      availableTools: [],
+      chatTools: [],
       healthState: "unknown",
       toolsLoading: false,
+      disabledToolPreferences: { version: 1, scopes: {} },
+      activeToolPreferenceScope: "default",
+      disabledToolNames: [],
+      collisionToolNames: [],
+      toolCounts: {
+        discovered: 0,
+        executable: 0,
+        disabled: 0,
+        colliding: 0,
+        chatEnabled: 0
+      },
       toolCatalog: "",
       toolCatalogId: null,
       toolModules: [],
@@ -103,5 +158,153 @@ describe("useMcpTools gating", () => {
     expect(state.fetchMcpToolCatalogsViaDiscovery).not.toHaveBeenCalled()
     expect(state.fetchMcpModulesViaDiscovery).not.toHaveBeenCalled()
     expect(state.fetchMcpToolsViaDiscovery).not.toHaveBeenCalled()
+  })
+
+  it("keeps discovered tools visible while filtering executable chat tools", async () => {
+    state.apiSend.mockResolvedValue({ ok: true })
+    state.fetchMcpToolCatalogsViaDiscovery.mockResolvedValue([])
+    state.fetchMcpModulesViaDiscovery.mockResolvedValue([])
+    state.fetchMcpToolsViaDiscovery.mockResolvedValue([
+      { name: "notes.search", canExecute: true },
+      { name: "media.search", canExecute: false },
+      { name: "slides.list", canExecute: true }
+    ])
+
+    const { result } = renderHook(() => useMcpTools(), {
+      wrapper: buildWrapper()
+    })
+
+    await waitFor(() => {
+      expect(result.current.discoveredTools).toHaveLength(3)
+    })
+
+    expect(result.current.discoveredTools.map((tool) => tool.rawName)).toEqual([
+      "notes.search",
+      "media.search",
+      "slides.list"
+    ])
+    expect(result.current.availableTools.map((tool) => tool.rawName)).toEqual([
+      "notes.search",
+      "slides.list"
+    ])
+    expect(result.current.chatTools.map((tool) => tool.rawName)).toEqual([
+      "notes.search",
+      "slides.list"
+    ])
+    expect(result.current.toolCounts).toMatchObject({
+      discovered: 3,
+      executable: 2,
+      disabled: 0,
+      colliding: 0,
+      chatEnabled: 2
+    })
+    expect(useMcpToolsStore.getState().tools.map((tool) => tool.name)).toEqual([
+      "notes.search",
+      "slides.list"
+    ])
+    expect(useMcpToolsStore.getState().chatTools.map((tool) => tool.rawName)).toEqual([
+      "notes.search",
+      "slides.list"
+    ])
+  })
+
+  it("persists disabled tool names in the active connection scope", async () => {
+    state.apiSend.mockResolvedValue({ ok: true })
+    state.fetchMcpToolCatalogsViaDiscovery.mockResolvedValue([])
+    state.fetchMcpModulesViaDiscovery.mockResolvedValue([])
+    state.fetchMcpToolsViaDiscovery.mockResolvedValue([
+      { name: "notes.search", canExecute: true },
+      { name: "slides.list", canExecute: true }
+    ])
+
+    const { result } = renderHook(() => useMcpTools(), {
+      wrapper: buildWrapper()
+    })
+
+    await waitFor(() => {
+      expect(result.current.chatTools).toHaveLength(2)
+    })
+
+    result.current.setToolEnabled("slides_list", false)
+
+    await waitFor(() => {
+      expect(result.current.chatTools.map((tool) => tool.rawName)).toEqual([
+        "notes.search"
+      ])
+    })
+
+    const persisted = state.settingValues.get("tldw:mcp:disabledTools:v1") as any
+    expect(result.current.activeToolPreferenceScope).toBe(
+      "server:http://127.0.0.1:8000|auth:single-user|org:none|principal:anonymous"
+    )
+    expect(
+      persisted.scopes[result.current.activeToolPreferenceScope].disabledToolNames
+    ).toEqual(["slides_list"])
+  })
+
+  it("isolates disabled preferences between server scopes", async () => {
+    state.settingValues.set("tldw:mcp:disabledTools:v1", {
+      version: 1,
+      scopes: {
+        "server:http://127.0.0.1:8000|auth:single-user|org:none|principal:anonymous": {
+          disabledToolNames: ["notes_search"]
+        }
+      }
+    })
+    state.connectionConfig = {
+      serverUrl: "http://127.0.0.1:9000",
+      authMode: "single-user",
+      apiKey: "test-key"
+    }
+    state.apiSend.mockResolvedValue({ ok: true })
+    state.fetchMcpToolCatalogsViaDiscovery.mockResolvedValue([])
+    state.fetchMcpModulesViaDiscovery.mockResolvedValue([])
+    state.fetchMcpToolsViaDiscovery.mockResolvedValue([
+      { name: "notes.search", canExecute: true }
+    ])
+
+    const { result } = renderHook(() => useMcpTools(), {
+      wrapper: buildWrapper()
+    })
+
+    await waitFor(() => {
+      expect(result.current.chatTools).toHaveLength(1)
+    })
+
+    expect(result.current.activeToolPreferenceScope).toBe(
+      "server:http://127.0.0.1:9000|auth:single-user|org:none|principal:anonymous"
+    )
+    expect(result.current.disabledToolNames).toEqual([])
+    expect(result.current.chatTools[0]?.rawName).toBe("notes.search")
+  })
+
+  it("defaults newly discovered executable tools to enabled in an existing scope", async () => {
+    state.settingValues.set("tldw:mcp:disabledTools:v1", {
+      version: 1,
+      scopes: {
+        "server:http://127.0.0.1:8000|auth:single-user|org:none|principal:anonymous": {
+          disabledToolNames: ["notes_search"]
+        }
+      }
+    })
+    state.apiSend.mockResolvedValue({ ok: true })
+    state.fetchMcpToolCatalogsViaDiscovery.mockResolvedValue([])
+    state.fetchMcpModulesViaDiscovery.mockResolvedValue([])
+    state.fetchMcpToolsViaDiscovery.mockResolvedValue([
+      { name: "notes.search", canExecute: true },
+      { name: "slides.list", canExecute: true }
+    ])
+
+    const { result } = renderHook(() => useMcpTools(), {
+      wrapper: buildWrapper()
+    })
+
+    await waitFor(() => {
+      expect(result.current.chatTools.map((tool) => tool.rawName)).toEqual([
+        "slides.list"
+      ])
+    })
+
+    expect(result.current.disabledToolNames).toEqual(["notes_search"])
   })
 })

--- a/apps/packages/ui/src/hooks/useMcpTools.tsx
+++ b/apps/packages/ui/src/hooks/useMcpTools.tsx
@@ -159,6 +159,24 @@ const normalizeDisabledToolNames = (toolNames: string[]): string[] => {
   return [...seen].sort((left, right) => left.localeCompare(right))
 }
 
+const normalizeDisabledToolPreferences = (
+  preferences: McpDisabledToolPreferences | null | undefined
+): McpDisabledToolPreferences => {
+  if (
+    preferences &&
+    typeof preferences === "object" &&
+    preferences.version === 1 &&
+    preferences.scopes &&
+    typeof preferences.scopes === "object"
+  ) {
+    return preferences
+  }
+  return {
+    version: 1,
+    scopes: {}
+  }
+}
+
 type UseMcpToolsOptions = {
   enabled?: boolean
 }
@@ -188,11 +206,17 @@ export const useMcpTools = (
   const [storedStrict, persistStrict] = useSetting(MCP_TOOL_CATALOG_STRICT_SETTING)
   const [storedDisabledToolPreferences, persistStoredDisabledToolPreferences] =
     useSetting(MCP_DISABLED_TOOLS_SETTING)
+  const normalizedStoredDisabledToolPreferences = React.useMemo(
+    () => normalizeDisabledToolPreferences(storedDisabledToolPreferences),
+    [storedDisabledToolPreferences]
+  )
   const [disabledToolPreferences, setDisabledToolPreferences] =
-    React.useState<McpDisabledToolPreferences>(storedDisabledToolPreferences)
+    React.useState<McpDisabledToolPreferences>(
+      normalizedStoredDisabledToolPreferences
+    )
   React.useEffect(() => {
-    setDisabledToolPreferences(storedDisabledToolPreferences)
-  }, [storedDisabledToolPreferences])
+    setDisabledToolPreferences(normalizedStoredDisabledToolPreferences)
+  }, [normalizedStoredDisabledToolPreferences])
   const activeToolPreferenceScope = React.useMemo(
     () => deriveMcpToolPreferenceScope(connectionConfig),
     [connectionConfig]

--- a/apps/packages/ui/src/hooks/useMcpTools.tsx
+++ b/apps/packages/ui/src/hooks/useMcpTools.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { useQuery } from "@tanstack/react-query"
 import { apiSend } from "@/services/api-send"
+import { useCanonicalConnectionConfig } from "@/hooks/useCanonicalConnectionConfig"
 import { useServerCapabilities } from "@/hooks/useServerCapabilities"
 import { useSetting } from "@/hooks/useSetting"
 import {
@@ -13,20 +14,37 @@ import {
   type McpToolDefinition
 } from "@/services/tldw/mcp"
 import {
+  MCP_DISABLED_TOOLS_SETTING,
   MCP_TOOL_CATALOG_SETTING,
   MCP_TOOL_CATALOG_ID_SETTING,
   MCP_TOOL_CATALOG_STRICT_SETTING,
-  MCP_TOOL_MODULE_SETTING
+  MCP_TOOL_MODULE_SETTING,
+  type McpDisabledToolPreferences
 } from "@/services/settings/ui-settings"
 import { useMcpToolsStore, type McpHealthState } from "@/store/mcp-tools"
+import {
+  buildChatToolFilterState,
+  normalizeChatToolName,
+  type ChatToolFilterCounts,
+  type ResolvedMcpTool
+} from "@/utils/chat-tools"
+import type { TldwConfig } from "@/services/tldw/TldwApiClient"
 
 type McpToolsStatus = {
   hasMcp: boolean
   healthState: McpHealthState
   healthLoading: boolean
   tools: McpToolDefinition[]
+  discoveredTools: ResolvedMcpTool[]
+  availableTools: ResolvedMcpTool[]
+  chatTools: ResolvedMcpTool[]
   toolsLoading: boolean
   toolsAvailable: boolean | null
+  disabledToolPreferences: McpDisabledToolPreferences
+  activeToolPreferenceScope: string
+  disabledToolNames: string[]
+  collisionToolNames: string[]
+  toolCounts: ChatToolFilterCounts
   catalogs: McpToolCatalog[]
   catalogsLoading: boolean
   toolCatalog: string
@@ -39,6 +57,9 @@ type McpToolsStatus = {
   setToolCatalogId: (catalogId: number | null) => void
   setToolModules: (moduleIds: string[]) => void
   setToolCatalogStrict: (strict: boolean) => void
+  setToolEnabled: (toolName: string, enabled: boolean) => void
+  setToolsEnabled: (toolNames: string[], enabled: boolean) => void
+  resetToolFilter: () => void
 }
 
 const normalizeModuleList = (modules: string[] | null | undefined): string[] => {
@@ -59,6 +80,85 @@ const areModuleListsEqual = (left: string[], right: string[]): boolean => {
   return left.every((value, index) => value === right[index])
 }
 
+const DEFAULT_TOOL_PREFERENCE_SCOPE =
+  "server:unknown|auth:single-user|org:none|principal:anonymous"
+
+const normalizePreferenceScopeServerUrl = (
+  serverUrl: string | null | undefined
+): string => {
+  const trimmed = typeof serverUrl === "string" ? serverUrl.trim() : ""
+  if (!trimmed) return "unknown"
+  try {
+    const parsed = new URL(trimmed)
+    const pathname =
+      parsed.pathname && parsed.pathname !== "/"
+        ? parsed.pathname.replace(/\/+$/g, "")
+        : ""
+    return `${parsed.protocol}//${parsed.host}${pathname}`
+  } catch {
+    return trimmed.replace(/\/+$/g, "")
+  }
+}
+
+const decodeJwtPayload = (token: string | null | undefined): unknown => {
+  if (typeof token !== "string" || !token.trim()) return null
+  const [, payload] = token.split(".")
+  if (!payload) return null
+  try {
+    const base64 = payload.replace(/-/g, "+").replace(/_/g, "/")
+    const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, "=")
+    const decoded = globalThis.atob(padded)
+    return JSON.parse(decoded)
+  } catch {
+    return null
+  }
+}
+
+const resolvePreferenceScopePrincipal = (
+  config: TldwConfig | null | undefined
+): string => {
+  const payload = decodeJwtPayload(config?.accessToken)
+  if (payload && typeof payload === "object") {
+    const data = payload as Record<string, unknown>
+    for (const key of ["sub", "user_id", "username", "email"]) {
+      const value = data[key]
+      if (typeof value === "string" && value.trim()) {
+        return value.trim()
+      }
+      if (typeof value === "number" && Number.isFinite(value)) {
+        return String(value)
+      }
+    }
+  }
+  return "anonymous"
+}
+
+const deriveMcpToolPreferenceScope = (
+  config: TldwConfig | null | undefined
+): string => {
+  if (!config) return DEFAULT_TOOL_PREFERENCE_SCOPE
+  const server = normalizePreferenceScopeServerUrl(config.serverUrl)
+  const auth =
+    config.authMode === "multi-user" || config.authMode === "single-user"
+      ? config.authMode
+      : "single-user"
+  const org =
+    typeof config.orgId === "number" && Number.isFinite(config.orgId)
+      ? String(config.orgId)
+      : "none"
+  const principal = resolvePreferenceScopePrincipal(config)
+  return `server:${server}|auth:${auth}|org:${org}|principal:${principal}`
+}
+
+const normalizeDisabledToolNames = (toolNames: string[]): string[] => {
+  const seen = new Set<string>()
+  for (const toolName of toolNames) {
+    const normalized = normalizeChatToolName(toolName)
+    if (normalized) seen.add(normalized)
+  }
+  return [...seen].sort((left, right) => left.localeCompare(right))
+}
+
 type UseMcpToolsOptions = {
   enabled?: boolean
 }
@@ -67,9 +167,10 @@ export const useMcpTools = (
   options: UseMcpToolsOptions = {}
 ): McpToolsStatus => {
   const { capabilities, loading } = useServerCapabilities()
+  const { config: connectionConfig } = useCanonicalConnectionConfig()
   const hasMcp = Boolean(capabilities?.hasMcp) && !loading
   const probeEnabled = options.enabled ?? true
-  const setTools = useMcpToolsStore((state) => state.setTools)
+  const setToolFilterState = useMcpToolsStore((state) => state.setToolFilterState)
   const setHealthState = useMcpToolsStore((state) => state.setHealthState)
   const setToolsLoading = useMcpToolsStore((state) => state.setToolsLoading)
   const toolCatalog = useMcpToolsStore((state) => state.toolCatalog)
@@ -85,6 +186,25 @@ export const useMcpTools = (
   const [storedCatalogId, persistCatalogId] = useSetting(MCP_TOOL_CATALOG_ID_SETTING)
   const [storedModule, persistModule] = useSetting(MCP_TOOL_MODULE_SETTING)
   const [storedStrict, persistStrict] = useSetting(MCP_TOOL_CATALOG_STRICT_SETTING)
+  const [storedDisabledToolPreferences, persistStoredDisabledToolPreferences] =
+    useSetting(MCP_DISABLED_TOOLS_SETTING)
+  const [disabledToolPreferences, setDisabledToolPreferences] =
+    React.useState<McpDisabledToolPreferences>(storedDisabledToolPreferences)
+  React.useEffect(() => {
+    setDisabledToolPreferences(storedDisabledToolPreferences)
+  }, [storedDisabledToolPreferences])
+  const activeToolPreferenceScope = React.useMemo(
+    () => deriveMcpToolPreferenceScope(connectionConfig),
+    [connectionConfig]
+  )
+  const disabledToolNames = React.useMemo(
+    () =>
+      normalizeDisabledToolNames(
+        disabledToolPreferences.scopes[activeToolPreferenceScope]
+          ?.disabledToolNames ?? []
+      ),
+    [activeToolPreferenceScope, disabledToolPreferences]
+  )
   const normalizedToolModules = React.useMemo(
     () => normalizeModuleList(toolModules),
     [toolModules]
@@ -205,16 +325,27 @@ export const useMcpTools = (
     refetchOnWindowFocus: false
   })
 
-  const tools = React.useMemo(
+  const toolFilterState = React.useMemo(
     () =>
-      (toolsQuery.data ?? []).filter((tool) => {
-        if (!tool || typeof tool !== "object") return false
-        if (!("canExecute" in tool)) return true
-        return (tool as McpToolDefinition).canExecute !== false
+      buildChatToolFilterState({
+        tools: toolsQuery.data ?? [],
+        disabledToolNames
       }),
-    [toolsQuery.data]
+    [disabledToolNames, toolsQuery.data]
   )
-  const toolsAvailable = !probeEnabled || toolsQuery.isLoading ? null : tools.length > 0
+  const {
+    discoveredTools,
+    availableTools,
+    chatTools,
+    collisionToolNames,
+    counts: toolCounts
+  } = toolFilterState
+  const tools = React.useMemo(
+    () => availableTools.map((tool) => tool.tool as McpToolDefinition),
+    [availableTools]
+  )
+  const toolsAvailable =
+    !probeEnabled || toolsQuery.isLoading ? null : availableTools.length > 0
   const catalogs = catalogsQuery.data ?? []
   const moduleOptionsSource =
     moduleOptionsQuery.data && moduleOptionsQuery.data.length > 0
@@ -281,15 +412,58 @@ export const useMcpTools = (
 
   React.useEffect(() => {
     if (!hasMcp && !loading) {
-      setTools([])
+      setToolFilterState({
+        discoveredTools: [],
+        availableTools: [],
+        chatTools: [],
+        disabledToolPreferences,
+        activeToolPreferenceScope,
+        disabledToolNames,
+        collisionToolNames: [],
+        toolCounts: {
+          discovered: 0,
+          executable: 0,
+          disabled: 0,
+          colliding: 0,
+          chatEnabled: 0
+        }
+      })
+      setToolsLoading(false)
+      return
+    }
+    if (!probeEnabled) {
       setToolsLoading(false)
       return
     }
     setToolsLoading(toolsQuery.isLoading)
     if (!toolsQuery.isLoading) {
-      setTools(tools)
+      setToolFilterState({
+        discoveredTools,
+        availableTools,
+        chatTools,
+        disabledToolPreferences,
+        activeToolPreferenceScope,
+        disabledToolNames,
+        collisionToolNames,
+        toolCounts
+      })
     }
-  }, [hasMcp, loading, setTools, setToolsLoading, tools, toolsQuery.isLoading])
+  }, [
+    activeToolPreferenceScope,
+    availableTools,
+    chatTools,
+    collisionToolNames,
+    disabledToolNames,
+    disabledToolPreferences,
+    discoveredTools,
+    hasMcp,
+    loading,
+    probeEnabled,
+    setToolFilterState,
+    setToolsLoading,
+    toolCounts,
+    toolsQuery.isLoading
+  ])
 
   const persistToolCatalog = React.useCallback(
     (catalog: string) => {
@@ -325,13 +499,93 @@ export const useMcpTools = (
     [persistStrict, setToolCatalogStrict]
   )
 
+  const updateDisabledToolPreferences = React.useCallback(
+    (
+      updater: (
+        current: McpDisabledToolPreferences
+      ) => McpDisabledToolPreferences
+    ) => {
+      const next = updater(disabledToolPreferences)
+      setDisabledToolPreferences(next)
+      void persistStoredDisabledToolPreferences(next)
+    },
+    [disabledToolPreferences, persistStoredDisabledToolPreferences]
+  )
+
+  const setToolsEnabled = React.useCallback(
+    (toolNames: string[], enabled: boolean) => {
+      const normalizedNames = normalizeDisabledToolNames(toolNames)
+      if (normalizedNames.length === 0) return
+      updateDisabledToolPreferences((current) => {
+        const currentScopePreference =
+          current.scopes[activeToolPreferenceScope]
+        const disabledSet = new Set(
+          normalizeDisabledToolNames(
+            currentScopePreference?.disabledToolNames ?? []
+          )
+        )
+        for (const toolName of normalizedNames) {
+          if (enabled) {
+            disabledSet.delete(toolName)
+          } else {
+            disabledSet.add(toolName)
+          }
+        }
+        const disabledToolNames = [...disabledSet].sort((left, right) =>
+          left.localeCompare(right)
+        )
+        const scopes = { ...current.scopes }
+        if (disabledToolNames.length > 0) {
+          scopes[activeToolPreferenceScope] = {
+            disabledToolNames,
+            updatedAt: new Date().toISOString()
+          }
+        } else {
+          delete scopes[activeToolPreferenceScope]
+        }
+        return {
+          version: 1,
+          scopes
+        }
+      })
+    },
+    [activeToolPreferenceScope, updateDisabledToolPreferences]
+  )
+
+  const setToolEnabled = React.useCallback(
+    (toolName: string, enabled: boolean) => {
+      setToolsEnabled([toolName], enabled)
+    },
+    [setToolsEnabled]
+  )
+
+  const resetToolFilter = React.useCallback(() => {
+    updateDisabledToolPreferences((current) => {
+      if (!current.scopes[activeToolPreferenceScope]) return current
+      const scopes = { ...current.scopes }
+      delete scopes[activeToolPreferenceScope]
+      return {
+        version: 1,
+        scopes
+      }
+    })
+  }, [activeToolPreferenceScope, updateDisabledToolPreferences])
+
   return {
     hasMcp,
     healthState,
     healthLoading: probeEnabled ? healthQuery.isLoading : false,
     tools,
+    discoveredTools,
+    availableTools,
+    chatTools,
     toolsLoading: probeEnabled ? toolsQuery.isLoading : false,
     toolsAvailable,
+    disabledToolPreferences,
+    activeToolPreferenceScope,
+    disabledToolNames,
+    collisionToolNames,
+    toolCounts,
     catalogs,
     catalogsLoading: probeEnabled ? catalogsQuery.isLoading : false,
     toolCatalog,
@@ -343,6 +597,9 @@ export const useMcpTools = (
     setToolCatalog: persistToolCatalog,
     setToolCatalogId: persistToolCatalogId,
     setToolModules: persistToolModule,
-    setToolCatalogStrict: persistToolCatalogStrict
+    setToolCatalogStrict: persistToolCatalogStrict,
+    setToolEnabled,
+    setToolsEnabled,
+    resetToolFilter
   }
 }

--- a/apps/packages/ui/src/hooks/useMcpTools.tsx
+++ b/apps/packages/ui/src/hooks/useMcpTools.tsx
@@ -244,7 +244,7 @@ export const useMcpTools = (
     toolCatalogStrict
   })
   const healthQuery = useQuery({
-    queryKey: ["mcp-health"],
+    queryKey: ["mcp-health", activeToolPreferenceScope],
     queryFn: async () => apiSend({ path: "/api/v1/mcp/health", method: "GET" }),
     enabled: hasMcp && probeEnabled,
     staleTime: 60_000,
@@ -270,6 +270,7 @@ export const useMcpTools = (
   const toolsQuery = useQuery({
     queryKey: [
       "mcp-tools",
+      activeToolPreferenceScope,
       toolCatalog,
       toolCatalogId,
       normalizedToolModules,
@@ -310,7 +311,7 @@ export const useMcpTools = (
   })
 
   const catalogsQuery = useQuery({
-    queryKey: ["mcp-tool-catalogs"],
+    queryKey: ["mcp-tool-catalogs", activeToolPreferenceScope],
     queryFn: async () => {
       try {
         return await fetchMcpToolCatalogsViaDiscovery("all")
@@ -325,7 +326,7 @@ export const useMcpTools = (
   })
 
   const moduleOptionsQuery = useQuery({
-    queryKey: ["mcp-tool-modules"],
+    queryKey: ["mcp-tool-modules", activeToolPreferenceScope],
     queryFn: async () => {
       try {
         return await fetchMcpModulesViaDiscovery()

--- a/apps/packages/ui/src/models/__tests__/pageAssistModel.mcp-tools.test.ts
+++ b/apps/packages/ui/src/models/__tests__/pageAssistModel.mcp-tools.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { pageAssistModel } from "../index"
+import { useMcpToolsStore } from "@/store/mcp-tools"
+import { useStoreChatModelSettings } from "@/store/model"
+import { useStoreMessageOption } from "@/store/option"
+import { buildChatToolFilterState } from "@/utils/chat-tools"
+
+vi.mock("@/services/model-settings", () => ({
+  getAllDefaultModelSettings: vi.fn(async () => ({})),
+  getModelSettings: vi.fn(async () => ({}))
+}))
+
+vi.mock("@/services/tldw-server", () => ({
+  getDefaultApiProvider: vi.fn(async () => "openai")
+}))
+
+vi.mock("@/services/tldw", () => ({
+  tldwModels: {
+    getModel: vi.fn(async () => ({ capabilities: ["tools"] }))
+  },
+  tldwChat: {
+    sendMessage: vi.fn(),
+    streamMessage: vi.fn()
+  }
+}))
+
+vi.mock("@/utils/resolve-api-provider", () => ({
+  resolveApiProviderForModel: vi.fn(async () => "openai")
+}))
+
+const buildResolvedTools = (tools: Record<string, unknown>[]) =>
+  buildChatToolFilterState({ tools }).chatTools
+
+describe("pageAssistModel MCP tools", () => {
+  beforeEach(() => {
+    useStoreChatModelSettings.getState().reset()
+    useStoreMessageOption.setState({
+      toolChoice: "auto",
+      serverChatId: null,
+      temporaryChat: true
+    })
+    useMcpToolsStore.setState({
+      tools: [],
+      discoveredTools: [],
+      availableTools: [],
+      chatTools: [],
+      healthState: "healthy",
+      toolsLoading: false,
+      disabledToolPreferences: { version: 1, scopes: {} },
+      activeToolPreferenceScope: "default",
+      disabledToolNames: [],
+      collisionToolNames: [],
+      toolCounts: {
+        discovered: 0,
+        executable: 0,
+        disabled: 0,
+        colliding: 0,
+        chatEnabled: 0
+      }
+    })
+  })
+
+  it("uses stored chatTools instead of all executable MCP tools", async () => {
+    const notesTool = {
+      name: "notes.search",
+      description: "Search notes",
+      parameters: { type: "object", properties: { q: { type: "string" } } },
+      canExecute: true
+    }
+    const slidesTool = {
+      name: "slides.list",
+      description: "List slides",
+      canExecute: true
+    }
+
+    useMcpToolsStore.setState({
+      tools: [notesTool, slidesTool],
+      chatTools: buildResolvedTools([notesTool])
+    })
+
+    const chat = await pageAssistModel({ model: "tool-model" })
+
+    expect(chat.toolChoice).toBe("auto")
+    expect(chat.tools).toEqual([
+      {
+        type: "function",
+        function: {
+          name: "notes_search",
+          description: "Search notes",
+          parameters: {
+            type: "object",
+            properties: { q: { type: "string" } }
+          }
+        }
+      }
+    ])
+  })
+
+  it("omits tool choice and tools when no chat tools remain", async () => {
+    useMcpToolsStore.setState({
+      tools: [
+        {
+          name: "notes.search",
+          description: "Search notes",
+          canExecute: true
+        }
+      ],
+      chatTools: []
+    })
+
+    const chat = await pageAssistModel({ model: "tool-model" })
+
+    expect(chat.toolChoice).toBeUndefined()
+    expect(chat.tools).toBeUndefined()
+    expect(chat.extraHeaders).toBeUndefined()
+  })
+})

--- a/apps/packages/ui/src/models/index.ts
+++ b/apps/packages/ui/src/models/index.ts
@@ -9,6 +9,7 @@ import { tldwModels } from "@/services/tldw"
 import { useStoreChatModelSettings } from "@/store/model"
 import { useStoreMessageOption, type ToolChoice } from "@/store/option"
 import { useMcpToolsStore } from "@/store/mcp-tools"
+import { normalizeChatToolsForRequest } from "@/utils/chat-tools"
 import { resolveApiProviderForModel } from "@/utils/resolve-api-provider"
 
 const isValidReasoningEffort = (
@@ -47,17 +48,6 @@ const parseJsonObject = (value?: string) => {
   return undefined
 }
 
-const filterExecutableTools = (
-  tools?: Record<string, unknown>[]
-): Record<string, unknown>[] | undefined => {
-  if (!Array.isArray(tools)) return tools
-  return tools.filter((tool) => {
-    if (!tool || typeof tool !== "object") return false
-    if (!("canExecute" in tool)) return true
-    return Boolean((tool as Record<string, unknown>).canExecute)
-  })
-}
-
 export const pageAssistModel = async ({
   model,
   toolChoice,
@@ -80,10 +70,13 @@ export const pageAssistModel = async ({
   } = useStoreMessageOption.getState()
   const {
     tools: storedTools,
+    chatTools: storedChatTools,
     healthState: mcpHealthState
   } = useMcpToolsStore.getState()
   const resolvedToolChoice = toolChoice ?? storedToolChoice
-  const resolvedTools = filterExecutableTools(tools ?? storedTools)
+  const resolvedTools = normalizeChatToolsForRequest(
+    tools ?? storedChatTools ?? storedTools
+  )
   const normalizedModelId = String(model || "").replace(/^tldw:/, "")
   let modelSupportsTools = false
   let modelSupportsMultimodal = false
@@ -108,7 +101,7 @@ export const pageAssistModel = async ({
     resolvedTools.length > 0
       ? resolvedTools
       : undefined
-  const effectiveToolChoice = effectiveTools ? resolvedToolChoice : "none"
+  const effectiveToolChoice = effectiveTools ? resolvedToolChoice : undefined
   const resolvedConversationId =
     conversationId && conversationId.trim().length > 0
       ? conversationId.trim()
@@ -160,7 +153,7 @@ export const pageAssistModel = async ({
     const headers = {
       ...(resolvedExtraHeadersBase ?? {})
     } as Record<string, unknown>
-    if (effectiveToolChoice !== "none") {
+    if (effectiveTools) {
       headers["X-TLDW-Loop-Compat"] = "1"
     }
     return Object.keys(headers).length > 0 ? headers : undefined

--- a/apps/packages/ui/src/services/settings/ui-settings.ts
+++ b/apps/packages/ui/src/services/settings/ui-settings.ts
@@ -229,6 +229,69 @@ export const MCP_TOOL_CATALOG_SETTING = defineSetting(
   }
 )
 
+export type McpDisabledToolScopePreference = {
+  disabledToolNames: string[]
+  updatedAt?: string
+}
+
+export type McpDisabledToolPreferences = {
+  version: 1
+  scopes: Record<string, McpDisabledToolScopePreference>
+}
+
+const DEFAULT_MCP_DISABLED_TOOL_PREFERENCES: McpDisabledToolPreferences = {
+  version: 1,
+  scopes: {}
+}
+
+const coerceMcpDisabledToolPreferences = (
+  value: unknown
+): McpDisabledToolPreferences => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return DEFAULT_MCP_DISABLED_TOOL_PREFERENCES
+  }
+  const data = value as Record<string, unknown>
+  if (data.version !== 1 || !data.scopes || typeof data.scopes !== "object") {
+    return DEFAULT_MCP_DISABLED_TOOL_PREFERENCES
+  }
+  const scopes: Record<string, McpDisabledToolScopePreference> = {}
+  for (const [scope, rawPreference] of Object.entries(
+    data.scopes as Record<string, unknown>
+  )) {
+    const normalizedScope = scope.trim()
+    if (!normalizedScope) continue
+    if (!rawPreference || typeof rawPreference !== "object") continue
+    const preference = rawPreference as Record<string, unknown>
+    const disabledToolNames = coerceStringArray(
+      preference.disabledToolNames,
+      []
+    )
+    const updatedAt =
+      typeof preference.updatedAt === "string" && preference.updatedAt.trim()
+        ? preference.updatedAt.trim()
+        : undefined
+    scopes[normalizedScope] = {
+      disabledToolNames,
+      ...(updatedAt ? { updatedAt } : {})
+    }
+  }
+  return {
+    version: 1,
+    scopes
+  }
+}
+
+export const MCP_DISABLED_TOOLS_SETTING = defineSetting(
+  "tldw:mcp:disabledTools:v1",
+  DEFAULT_MCP_DISABLED_TOOL_PREFERENCES,
+  coerceMcpDisabledToolPreferences,
+  {
+    area: "local",
+    localStorageKey: "tldw:mcp:disabledTools:v1",
+    mirrorToLocalStorage: true
+  }
+)
+
 export const MCP_TOOL_CATALOG_ID_SETTING = defineSetting(
   "tldw:mcp:catalogId",
   null as number | null,

--- a/apps/packages/ui/src/services/tldw/TldwChat.ts
+++ b/apps/packages/ui/src/services/tldw/TldwChat.ts
@@ -11,19 +11,7 @@ import {
   getLastChatCompletionDebugSnapshot,
   type ChatCompletionDebugSnapshot
 } from "./chat-request-debug"
-
-type ToolFunctionSchema = Record<string, unknown>
-type ToolFunction = {
-  name: string
-  description?: string
-  parameters?: ToolFunctionSchema
-}
-type OpenAiTool = {
-  type: "function"
-  function: ToolFunction
-}
-
-const TOOL_NAME_PATTERN = /^[a-zA-Z0-9_-]{1,64}$/
+import { normalizeChatToolsForRequest } from "@/utils/chat-tools"
 
 const normalizeProvider = (value?: string): string =>
   String(value || "").trim().toLowerCase()
@@ -259,85 +247,6 @@ const buildRequestMessages = (
   )
 }
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value)
-
-const sanitizeToolName = (name: string): string | null => {
-  const trimmed = name.trim()
-  if (!trimmed) return null
-  if (TOOL_NAME_PATTERN.test(trimmed)) return trimmed
-
-  let sanitized = trimmed.replace(/[^a-zA-Z0-9_-]+/g, "_")
-  sanitized = sanitized.replace(/^_+|_+$/g, "")
-  if (!sanitized) return null
-  if (sanitized.length > 64) sanitized = sanitized.slice(0, 64)
-  return TOOL_NAME_PATTERN.test(sanitized) ? sanitized : null
-}
-
-const normalizeChatTools = (
-  tools?: Record<string, unknown>[]
-): Record<string, unknown>[] | undefined => {
-  if (!Array.isArray(tools) || tools.length === 0) return undefined
-
-  const seen = new Set<string>()
-  const normalized = tools
-    .map((tool) => {
-      if (!isRecord(tool)) return null
-
-      const functionRecord = isRecord(tool.function) ? tool.function : undefined
-      const rawName =
-        (typeof tool.name === "string" && tool.name) ||
-        (functionRecord &&
-        typeof functionRecord.name === "string" &&
-        functionRecord.name
-          ? functionRecord.name
-          : "")
-      const name = rawName ? sanitizeToolName(rawName) : null
-      if (!name || seen.has(name)) return null
-
-      if (rawName !== name) {
-        console.warn(
-          `[tldw] Tool name "${rawName}" normalized to "${name}" to satisfy server schema.`
-        )
-      }
-      seen.add(name)
-
-      const description =
-        typeof tool.description === "string"
-          ? tool.description
-          : functionRecord &&
-              typeof functionRecord.description === "string"
-            ? functionRecord.description
-            : undefined
-
-      const schemaCandidates: Array<unknown> = [
-        functionRecord?.parameters,
-        tool.parameters,
-        tool.input_schema,
-        tool.json_schema
-      ]
-      const parameters =
-        (schemaCandidates.find((candidate) =>
-          isRecord(candidate)
-        ) as ToolFunctionSchema | undefined) || {
-          type: "object",
-          properties: {}
-        }
-
-      return {
-        type: "function",
-        function: {
-          name,
-          description,
-          parameters
-        }
-      } as OpenAiTool
-    })
-    .filter(Boolean) as Record<string, unknown>[]
-
-  return normalized.length > 0 ? normalized : undefined
-}
-
 export interface TldwChatOptions {
   model: string
   routing?: ChatCompletionRequest["routing"]
@@ -422,7 +331,7 @@ export class TldwChatService {
   ): Promise<string> {
     try {
       await tldwClient.initialize()
-      const normalizedTools = normalizeChatTools(options.tools)
+      const normalizedTools = normalizeChatToolsForRequest(options.tools)
       const toolChoice = normalizedTools ? options.toolChoice : undefined
       const requestMessages = buildRequestMessages(messages, options)
       if (requestMessages.length === 0) {
@@ -447,8 +356,12 @@ export class TldwChatService {
         frequency_penalty: options.frequencyPenalty,
         presence_penalty: options.presencePenalty,
         reasoning_effort: options.reasoningEffort,
-        tool_choice: toolChoice,
-        tools: normalizedTools,
+        ...(normalizedTools
+          ? {
+              tool_choice: toolChoice,
+              tools: normalizedTools
+            }
+          : {}),
         save_to_db: options.saveToDb,
         conversation_id: options.conversationId,
         history_message_limit: options.historyMessageLimit,
@@ -498,7 +411,7 @@ export class TldwChatService {
   ): AsyncGenerator<string, void, unknown> {
     try {
       await tldwClient.initialize()
-      const normalizedTools = normalizeChatTools(options.tools)
+      const normalizedTools = normalizeChatToolsForRequest(options.tools)
       const toolChoice = normalizedTools ? options.toolChoice : undefined
       const requestMessages = buildRequestMessages(messages, options)
       if (requestMessages.length === 0) {
@@ -536,8 +449,12 @@ export class TldwChatService {
         frequency_penalty: options.frequencyPenalty,
         presence_penalty: options.presencePenalty,
         reasoning_effort: options.reasoningEffort,
-        tool_choice: toolChoice,
-        tools: normalizedTools,
+        ...(normalizedTools
+          ? {
+              tool_choice: toolChoice,
+              tools: normalizedTools
+            }
+          : {}),
         save_to_db: options.saveToDb,
         conversation_id: options.conversationId,
         history_message_limit: options.historyMessageLimit,

--- a/apps/packages/ui/src/store/mcp-tools.ts
+++ b/apps/packages/ui/src/store/mcp-tools.ts
@@ -1,5 +1,10 @@
 import { createWithEqualityFn } from "zustand/traditional"
 import type { McpToolDefinition } from "@/services/tldw/mcp"
+import type {
+  ChatToolFilterCounts,
+  ResolvedMcpTool
+} from "@/utils/chat-tools"
+import type { McpDisabledToolPreferences } from "@/services/settings/ui-settings"
 
 export type McpHealthState =
   | "unknown"
@@ -7,7 +12,31 @@ export type McpHealthState =
   | "unhealthy"
   | "unavailable"
 
-type McpToolsState = {
+const EMPTY_TOOL_COUNTS: ChatToolFilterCounts = {
+  discovered: 0,
+  executable: 0,
+  disabled: 0,
+  colliding: 0,
+  chatEnabled: 0
+}
+
+const EMPTY_DISABLED_TOOL_PREFERENCES: McpDisabledToolPreferences = {
+  version: 1,
+  scopes: {}
+}
+
+type McpToolFilterStoreState = {
+  discoveredTools: ResolvedMcpTool[]
+  availableTools: ResolvedMcpTool[]
+  chatTools: ResolvedMcpTool[]
+  disabledToolPreferences: McpDisabledToolPreferences
+  activeToolPreferenceScope: string
+  disabledToolNames: string[]
+  collisionToolNames: string[]
+  toolCounts: ChatToolFilterCounts
+}
+
+export type McpToolsState = McpToolFilterStoreState & {
   tools: McpToolDefinition[]
   healthState: McpHealthState
   toolsLoading: boolean
@@ -16,6 +45,7 @@ type McpToolsState = {
   toolModules: string[]
   toolCatalogStrict: boolean
   setTools: (tools: McpToolDefinition[]) => void
+  setToolFilterState: (state: McpToolFilterStoreState) => void
   setHealthState: (state: McpHealthState) => void
   setToolsLoading: (loading: boolean) => void
   setToolCatalog: (catalog: string) => void
@@ -26,6 +56,14 @@ type McpToolsState = {
 
 export const useMcpToolsStore = createWithEqualityFn<McpToolsState>((set) => ({
   tools: [],
+  discoveredTools: [],
+  availableTools: [],
+  chatTools: [],
+  disabledToolPreferences: EMPTY_DISABLED_TOOL_PREFERENCES,
+  activeToolPreferenceScope: "default",
+  disabledToolNames: [],
+  collisionToolNames: [],
+  toolCounts: EMPTY_TOOL_COUNTS,
   healthState: "unknown",
   toolsLoading: false,
   toolCatalog: "",
@@ -33,6 +71,11 @@ export const useMcpToolsStore = createWithEqualityFn<McpToolsState>((set) => ({
   toolModules: [],
   toolCatalogStrict: false,
   setTools: (tools) => set({ tools }),
+  setToolFilterState: (state) =>
+    set({
+      ...state,
+      tools: state.availableTools.map((tool) => tool.tool as McpToolDefinition)
+    }),
   setHealthState: (healthState) => set({ healthState }),
   setToolsLoading: (toolsLoading) => set({ toolsLoading }),
   setToolCatalog: (toolCatalog) => set({ toolCatalog }),

--- a/apps/packages/ui/src/utils/__tests__/chat-tools.test.ts
+++ b/apps/packages/ui/src/utils/__tests__/chat-tools.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildChatToolFilterState,
+  getMcpToolGroupLabel,
+  normalizeChatToolName,
+  normalizeChatToolsForRequest,
+  resolveMcpToolIdentity
+} from "../chat-tools"
+
+describe("chat tool normalization", () => {
+  it("normalizes MCP tool names using the same chat-safe identity", () => {
+    expect(normalizeChatToolName("ext.docs.docs.search")).toBe(
+      "ext_docs_docs_search"
+    )
+    expect(normalizeChatToolName(" docs_search ")).toBe("docs_search")
+    expect(normalizeChatToolName("...")).toBeNull()
+  })
+
+  it("resolves identity from MCP and OpenAI-style tool shapes", () => {
+    expect(
+      resolveMcpToolIdentity({
+        name: "notes.search",
+        description: "Search notes"
+      })
+    ).toMatchObject({
+      rawName: "notes.search",
+      chatName: "notes_search",
+      displayName: "notes.search",
+      description: "Search notes"
+    })
+
+    expect(
+      resolveMcpToolIdentity({
+        type: "function",
+        function: {
+          name: "media-search",
+          description: "Search media"
+        }
+      })
+    ).toMatchObject({
+      rawName: "media-search",
+      chatName: "media-search",
+      displayName: "media-search",
+      description: "Search media"
+    })
+  })
+
+  it("filters disabled and unexecutable tools while keeping discovered tools available for display", () => {
+    const state = buildChatToolFilterState({
+      tools: [
+        { name: "notes.search", canExecute: true },
+        { name: "media.search", canExecute: false },
+        { name: "slides.list", canExecute: true }
+      ],
+      disabledToolNames: ["slides_list"]
+    })
+
+    expect(state.discoveredTools.map((tool) => tool.rawName)).toEqual([
+      "notes.search",
+      "media.search",
+      "slides.list"
+    ])
+    expect(state.availableTools.map((tool) => tool.rawName)).toEqual([
+      "notes.search",
+      "slides.list"
+    ])
+    expect(state.chatTools.map((tool) => tool.rawName)).toEqual(["notes.search"])
+    expect(state.counts).toMatchObject({
+      discovered: 3,
+      executable: 2,
+      disabled: 1,
+      colliding: 0,
+      chatEnabled: 1
+    })
+  })
+
+  it("excludes normalized name collisions from chat tools", () => {
+    const state = buildChatToolFilterState({
+      tools: [
+        { name: "docs.search", canExecute: true },
+        { name: "docs_search", canExecute: true },
+        { name: "notes.search", canExecute: true }
+      ],
+      disabledToolNames: []
+    })
+
+    expect(state.collisionToolNames).toEqual(["docs_search"])
+    expect(state.chatTools.map((tool) => tool.rawName)).toEqual(["notes.search"])
+    expect(state.counts).toMatchObject({
+      discovered: 3,
+      executable: 3,
+      disabled: 0,
+      colliding: 2,
+      chatEnabled: 1
+    })
+  })
+
+  it("normalizes request tools and omits empty tool payloads", () => {
+    expect(
+      normalizeChatToolsForRequest([
+        { name: "notes.search", description: "Search notes" },
+        { name: "docs.search" },
+        { name: "docs_search" }
+      ])
+    ).toEqual([
+      {
+        type: "function",
+        function: {
+          name: "notes_search",
+          description: "Search notes",
+          parameters: {
+            type: "object",
+            properties: {}
+          }
+        }
+      }
+    ])
+
+    expect(normalizeChatToolsForRequest([])).toBeUndefined()
+  })
+})
+
+describe("MCP tool grouping", () => {
+  it("uses external server metadata, ext server id, module, then MCP fallback", () => {
+    expect(
+      getMcpToolGroupLabel({
+        name: "ext.docs.search",
+        metadata: { server_name: "Docs Server", server_id: "docs" }
+      })
+    ).toBe("Docs Server")
+
+    expect(
+      getMcpToolGroupLabel({
+        name: "ext.docs.search",
+        metadata: { server_id: "docs" }
+      })
+    ).toBe("docs")
+
+    expect(
+      getMcpToolGroupLabel({
+        name: "ext.browser.search"
+      })
+    ).toBe("browser")
+
+    expect(
+      getMcpToolGroupLabel({
+        name: "notes.search",
+        module: "notes"
+      })
+    ).toBe("notes")
+
+    expect(getMcpToolGroupLabel({ name: "unknown" })).toBe("MCP")
+  })
+})

--- a/apps/packages/ui/src/utils/__tests__/chat-tools.test.ts
+++ b/apps/packages/ui/src/utils/__tests__/chat-tools.test.ts
@@ -119,6 +119,33 @@ describe("chat tool normalization", () => {
 
     expect(normalizeChatToolsForRequest([])).toBeUndefined()
   })
+
+  it("normalizes already resolved chat tools for request construction", () => {
+    const resolved = buildChatToolFilterState({
+      tools: [
+        {
+          name: "notes.search",
+          description: "Search notes",
+          parameters: { type: "object", properties: { q: { type: "string" } } },
+          canExecute: true
+        }
+      ]
+    })
+
+    expect(normalizeChatToolsForRequest(resolved.chatTools)).toEqual([
+      {
+        type: "function",
+        function: {
+          name: "notes_search",
+          description: "Search notes",
+          parameters: {
+            type: "object",
+            properties: { q: { type: "string" } }
+          }
+        }
+      }
+    ])
+  })
 })
 
 describe("MCP tool grouping", () => {

--- a/apps/packages/ui/src/utils/chat-tools.ts
+++ b/apps/packages/ui/src/utils/chat-tools.ts
@@ -1,0 +1,198 @@
+export type ChatToolRecord = Record<string, unknown>
+
+export type ResolvedMcpTool = {
+  tool: ChatToolRecord
+  rawName: string
+  chatName: string
+  displayName: string
+  description?: string
+  groupLabel: string
+  canExecute: boolean
+  disabled: boolean
+  colliding: boolean
+}
+
+export type ChatToolFilterCounts = {
+  discovered: number
+  executable: number
+  disabled: number
+  colliding: number
+  chatEnabled: number
+}
+
+export type ChatToolFilterState = {
+  discoveredTools: ResolvedMcpTool[]
+  availableTools: ResolvedMcpTool[]
+  chatTools: ResolvedMcpTool[]
+  collisionToolNames: string[]
+  counts: ChatToolFilterCounts
+}
+
+const TOOL_NAME_PATTERN = /^[a-zA-Z0-9_-]{1,64}$/
+
+const isRecord = (value: unknown): value is ChatToolRecord =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+export const normalizeChatToolName = (name: unknown): string | null => {
+  if (typeof name !== "string") return null
+  const trimmed = name.trim()
+  if (!trimmed) return null
+  if (TOOL_NAME_PATTERN.test(trimmed)) return trimmed
+
+  let sanitized = trimmed.replace(/[^a-zA-Z0-9_-]+/g, "_")
+  sanitized = sanitized.replace(/^_+|_+$/g, "")
+  if (!sanitized) return null
+  if (sanitized.length > 64) sanitized = sanitized.slice(0, 64)
+  return TOOL_NAME_PATTERN.test(sanitized) ? sanitized : null
+}
+
+const readFunctionRecord = (tool: ChatToolRecord): ChatToolRecord | undefined =>
+  isRecord(tool.function) ? tool.function : undefined
+
+const readRawToolName = (tool: ChatToolRecord): string | null => {
+  if (typeof tool.name === "string" && tool.name.trim()) {
+    return tool.name.trim()
+  }
+  const functionRecord = readFunctionRecord(tool)
+  if (typeof functionRecord?.name === "string" && functionRecord.name.trim()) {
+    return functionRecord.name.trim()
+  }
+  return null
+}
+
+const readDescription = (tool: ChatToolRecord): string | undefined => {
+  if (typeof tool.description === "string" && tool.description.trim()) {
+    return tool.description
+  }
+  const functionRecord = readFunctionRecord(tool)
+  if (
+    typeof functionRecord?.description === "string" &&
+    functionRecord.description.trim()
+  ) {
+    return functionRecord.description
+  }
+  return undefined
+}
+
+export const getMcpToolGroupLabel = (tool: ChatToolRecord): string => {
+  const metadata = isRecord(tool.metadata) ? tool.metadata : undefined
+  const serverName =
+    typeof metadata?.server_name === "string" ? metadata.server_name.trim() : ""
+  if (serverName) return serverName
+
+  const serverId =
+    typeof metadata?.server_id === "string" ? metadata.server_id.trim() : ""
+  if (serverId) return serverId
+
+  const rawName = readRawToolName(tool)
+  if (rawName?.startsWith("ext.")) {
+    const [, extServerId] = rawName.split(".")
+    if (extServerId?.trim()) return extServerId.trim()
+  }
+
+  const moduleId = typeof tool.module === "string" ? tool.module.trim() : ""
+  return moduleId || "MCP"
+}
+
+export const resolveMcpToolIdentity = (
+  tool: unknown
+): Omit<ResolvedMcpTool, "disabled" | "colliding"> | null => {
+  if (!isRecord(tool)) return null
+  const rawName = readRawToolName(tool)
+  const chatName = normalizeChatToolName(rawName)
+  if (!rawName || !chatName) return null
+  return {
+    tool,
+    rawName,
+    chatName,
+    displayName: rawName,
+    description: readDescription(tool),
+    groupLabel: getMcpToolGroupLabel(tool),
+    canExecute: tool.canExecute !== false
+  }
+}
+
+const normalizeDisabledSet = (disabledToolNames: Iterable<string>): Set<string> => {
+  const result = new Set<string>()
+  for (const name of disabledToolNames) {
+    const normalized = normalizeChatToolName(name)
+    if (normalized) result.add(normalized)
+  }
+  return result
+}
+
+export const buildChatToolFilterState = ({
+  tools,
+  disabledToolNames = []
+}: {
+  tools?: unknown[]
+  disabledToolNames?: string[]
+}): ChatToolFilterState => {
+  const disabledSet = normalizeDisabledSet(disabledToolNames)
+  const discoveredBase = (Array.isArray(tools) ? tools : [])
+    .map(resolveMcpToolIdentity)
+    .filter(Boolean) as Array<Omit<ResolvedMcpTool, "disabled" | "colliding">>
+
+  const nameCounts = new Map<string, number>()
+  for (const tool of discoveredBase) {
+    nameCounts.set(tool.chatName, (nameCounts.get(tool.chatName) ?? 0) + 1)
+  }
+
+  const collisionToolNames = [...nameCounts.entries()]
+    .filter(([, count]) => count > 1)
+    .map(([name]) => name)
+    .sort((left, right) => left.localeCompare(right))
+  const collisionSet = new Set(collisionToolNames)
+
+  const discoveredTools: ResolvedMcpTool[] = discoveredBase.map((tool) => ({
+    ...tool,
+    disabled: disabledSet.has(tool.chatName),
+    colliding: collisionSet.has(tool.chatName)
+  }))
+  const availableTools = discoveredTools.filter((tool) => tool.canExecute)
+  const chatTools = availableTools.filter(
+    (tool) => !tool.disabled && !tool.colliding
+  )
+
+  return {
+    discoveredTools,
+    availableTools,
+    chatTools,
+    collisionToolNames,
+    counts: {
+      discovered: discoveredTools.length,
+      executable: availableTools.length,
+      disabled: availableTools.filter((tool) => tool.disabled).length,
+      colliding: availableTools.filter((tool) => tool.colliding).length,
+      chatEnabled: chatTools.length
+    }
+  }
+}
+
+const readParameters = (tool: ChatToolRecord): ChatToolRecord => {
+  const functionRecord = readFunctionRecord(tool)
+  const candidates = [
+    functionRecord?.parameters,
+    tool.parameters,
+    tool.input_schema,
+    tool.inputSchema,
+    tool.json_schema
+  ]
+  const parameters = candidates.find(isRecord)
+  return parameters ?? { type: "object", properties: {} }
+}
+
+export const normalizeChatToolsForRequest = (
+  tools?: unknown[]
+): ChatToolRecord[] | undefined => {
+  const state = buildChatToolFilterState({ tools })
+  if (state.chatTools.length === 0) return undefined
+  return state.chatTools.map((tool) => ({
+    type: "function",
+    function: {
+      name: tool.chatName,
+      description: tool.description,
+      parameters: readParameters(tool.tool)
+    }
+  }))
+}

--- a/apps/packages/ui/src/utils/chat-tools.ts
+++ b/apps/packages/ui/src/utils/chat-tools.ts
@@ -33,6 +33,18 @@ const TOOL_NAME_PATTERN = /^[a-zA-Z0-9_-]{1,64}$/
 const isRecord = (value: unknown): value is ChatToolRecord =>
   typeof value === "object" && value !== null && !Array.isArray(value)
 
+const unwrapToolCandidate = (tool: unknown): unknown => {
+  if (!isRecord(tool)) return tool
+  if (
+    isRecord(tool.tool) &&
+    typeof tool.rawName === "string" &&
+    typeof tool.chatName === "string"
+  ) {
+    return tool.tool
+  }
+  return tool
+}
+
 export const normalizeChatToolName = (name: unknown): string | null => {
   if (typeof name !== "string") return null
   const trimmed = name.trim()
@@ -130,6 +142,7 @@ export const buildChatToolFilterState = ({
 }): ChatToolFilterState => {
   const disabledSet = normalizeDisabledSet(disabledToolNames)
   const discoveredBase = (Array.isArray(tools) ? tools : [])
+    .map(unwrapToolCandidate)
     .map(resolveMcpToolIdentity)
     .filter(Boolean) as Array<Omit<ResolvedMcpTool, "disabled" | "colliding">>
 

--- a/backlog/tasks/task-112 - Design-MCP-chat-personal-tool-availability-filter.md
+++ b/backlog/tasks/task-112 - Design-MCP-chat-personal-tool-availability-filter.md
@@ -1,0 +1,77 @@
+---
+id: TASK-112
+title: Design MCP chat personal tool availability filter
+status: Done
+assignee:
+  - Codex
+created_date: '2026-05-07 06:17'
+updated_date: '2026-05-07 06:19'
+labels:
+  - mcp
+  - chat
+  - webui
+  - extension
+  - design
+dependencies: []
+references:
+  - apps/packages/ui/src/hooks/useMcpTools.tsx
+  - apps/packages/ui/src/store/mcp-tools.ts
+  - apps/packages/ui/src/models/index.ts
+  - apps/packages/ui/src/components/Option/Playground/PlaygroundMcpControl.tsx
+  - >-
+    apps/packages/ui/src/components/Option/Playground/PlaygroundMcpSettingsModal.tsx
+  - apps/packages/ui/src/components/Sidepanel/Chat/ControlRow.tsx
+documentation:
+  - Docs/MCP/mcp_hub_management.md
+  - Docs/Plans/2026-03-04-chat-tool-calling-convergence-design.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create a reviewed design spec for making MCP server/tool availability from chat a personal preference filter across WebUI /chat, extension options /chat, and extension sidepanel chat. Server-side MCP Hub configuration, RBAC, catalogs, and external server connection management remain authoritative and out of scope for chat-surface mutation; chat only chooses which already-available executable tools are exposed to chat requests.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Design spec documents the approved personal availability filter behavior for WebUI /chat, extension options /chat, and extension sidepanel chat.
+- [x] #2 Spec distinguishes server authority from local personal chat preferences and keeps MCP Hub as the management surface for server/admin changes.
+- [x] #3 Spec covers data flow from MCP discovery through RBAC/catalog/module filters and personal per-tool toggles into chat request construction.
+- [x] #4 Spec covers UX/error states for unavailable MCP, unhealthy MCP, no executable tools, and all tools disabled by preference.
+- [x] #5 Spec covers testing expectations for hooks, components, request construction, raw preview, and mocked WebUI/extension chat smoke coverage.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Write `Docs/superpowers/specs/2026-05-06-mcp-chat-personal-tool-filter-design.md` capturing the approved design for a shared personal MCP tool availability filter across WebUI `/chat`, extension options `/chat`, and extension sidepanel chat.
+2. Ground the spec in current repo seams: `useMcpTools`, `mcp-tools` store, `pageAssistModel`, Playground MCP controls, sidepanel `ControlRow`, and MCP Hub docs.
+3. Include architecture, components, data flow, UX/error handling, testing strategy, non-goals, and implementation notes without making code changes in this step.
+4. Verify the spec file exists and review the diff for only the intended spec plus Backlog tracking changes.
+5. Finalize the Backlog task with acceptance criteria, non-code verification/Bandit skip, and final summary, then commit the spec/tracking work.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Created `Docs/superpowers/specs/2026-05-06-mcp-chat-personal-tool-filter-design.md` with the approved personal MCP tool availability filter design. Verification: reviewed the written spec and ran `git diff --check` scoped to the new spec and task path; no whitespace errors reported. Bandit skipped because this task only adds documentation/Backlog tracking and touches no executable code. Spec-review subagent was not dispatched because current tool policy requires explicit user authorization for subagent delegation; user review remains the next gate before implementation planning.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added a design spec for a shared personal MCP tool availability filter across WebUI `/chat`, extension options `/chat`, and extension sidepanel chat. The design keeps MCP Hub and server RBAC as the authority for availability and permissions, then applies a local persistent disabled-tool preference before chat request construction. It also documents request degradation when no chat tools remain, UI states for unavailable/unhealthy/empty/disabled cases, and focused test coverage for hooks, selector components, request building, raw preview, and mocked chat smoke tests.
+
+Verification: reviewed the spec content and ran scoped `git diff --check` with no whitespace errors. Bandit is documented as skipped because the change is documentation-only.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-112.1 - Refine-MCP-chat-personal-tool-filter-design-after-review.md
+++ b/backlog/tasks/task-112.1 - Refine-MCP-chat-personal-tool-filter-design-after-review.md
@@ -1,0 +1,68 @@
+---
+id: TASK-112.1
+title: Refine MCP chat personal tool filter design after review
+status: Done
+assignee:
+  - Codex
+created_date: '2026-05-07 14:15'
+updated_date: '2026-05-07 14:17'
+labels:
+  - mcp
+  - chat
+  - webui
+  - extension
+  - design
+  - review-fix
+dependencies: []
+references:
+  - Docs/superpowers/specs/2026-05-06-mcp-chat-personal-tool-filter-design.md
+parent_task_id: TASK-112
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address review findings on the MCP chat personal tool filter design before implementation planning. The spec needs to distinguish raw/discovered tools from executable/chat-filtered tools, scope persisted disabled-tool preferences by connection/user, define normalized tool identity and collision behavior, choose an exact no-tools wire contract, and strengthen tests/rollout notes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Spec distinguishes discoveredTools/raw tools from availableTools/chatTools and supports showing canExecute=false tools in the selector.
+- [x] #2 Spec scopes disabled-tool persistence by connection fingerprint and user/principal identity when available.
+- [x] #3 Spec defines shared normalized chat tool identity plus collision handling for toggles and request construction.
+- [x] #4 Spec chooses one no-tools wire behavior and requires raw preview to match actual request behavior.
+- [x] #5 Spec adds persistence reload/reopen coverage and external-server grouping fallback expectations.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Update the design spec with the four review corrections: discovered/raw tool exposure, scoped persistence, shared normalized identity/collision behavior, and exact no-tools wire behavior.
+2. Add improvements for reload/reopen persistence coverage and external-server grouping fallback.
+3. Mirror the Backlog task into the clean design worktree with the same final task record.
+4. Run docs-only verification with `git diff --check` and staged `git diff --cached --check`.
+5. Complete the Backlog task and commit the spec refinement on `codex/mcp-chat-tool-filter-design`.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Updated the MCP chat personal tool filter spec to address all review findings: hook contract now exposes discoveredTools separately from availableTools/chatTools; disabled preferences are versioned and scoped by connection/user; one shared chat tool normalization helper owns identity and collision behavior; no-tools requests omit tools/tool_choice on the wire while treating effective choice as none internally; tests now include scoped persistence, reload/reopen behavior, collisions, and grouping fallback. Verification: docs-only `git diff --check` passed before staging. Bandit skipped because only markdown/Backlog task documentation changed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Refined the approved MCP chat personal tool filter design after review. The spec now requires raw discovered tool exposure for UI state, scoped persisted disabled-tool preferences, shared normalized chat tool identity with collision exclusion, exact no-tools wire behavior matching `ChatTldw`, and stronger persistence/grouping/collision test coverage. Verification is documentation-only: `git diff --check` passed; Bandit is skipped because no executable code changed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-113 - Implement-MCP-chat-personal-tool-availability-filter.md
+++ b/backlog/tasks/task-113 - Implement-MCP-chat-personal-tool-availability-filter.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - Codex
 created_date: '2026-05-07 14:20'
-updated_date: '2026-05-07 14:22'
+updated_date: '2026-05-07 14:30'
 labels:
   - mcp
   - chat
@@ -59,6 +59,8 @@ Plan file: Docs/superpowers/plans/2026-05-07-mcp-chat-personal-tool-filter-imple
 
 <!-- SECTION:NOTES:BEGIN -->
 Stage 1 complete: added `apps/packages/ui/src/utils/chat-tools.ts` and `apps/packages/ui/src/utils/__tests__/chat-tools.test.ts`. Verified RED with module-not-found failure, then GREEN with `bunx vitest run apps/packages/ui/src/utils/__tests__/chat-tools.test.ts` reporting 1 file / 6 tests passed.
+
+Stage 2 complete: extended MCP disabled-tool setting/store/useMcpTools contract with scoped disabled preferences, discoveredTools, availableTools, chatTools, collision names, counts, and toggle helpers. Verified RED with hook tests failing on missing discoveredTools/chatTools fields, then GREEN with `bunx vitest run src/hooks/__tests__/useMcpTools.gating.test.tsx src/utils/__tests__/chat-tools.test.ts` in `apps/packages/ui` reporting 2 files / 11 tests passed.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-113 - Implement-MCP-chat-personal-tool-availability-filter.md
+++ b/backlog/tasks/task-113 - Implement-MCP-chat-personal-tool-availability-filter.md
@@ -1,0 +1,72 @@
+---
+id: TASK-113
+title: Implement MCP chat personal tool availability filter
+status: In Progress
+assignee:
+  - Codex
+created_date: '2026-05-07 14:20'
+updated_date: '2026-05-07 14:22'
+labels:
+  - mcp
+  - chat
+  - webui
+  - extension
+  - implementation
+dependencies:
+  - TASK-112
+  - TASK-112.1
+references:
+  - apps/packages/ui/src/hooks/useMcpTools.tsx
+  - apps/packages/ui/src/store/mcp-tools.ts
+  - apps/packages/ui/src/models/index.ts
+  - apps/packages/ui/src/services/tldw/TldwChat.ts
+  - >-
+    apps/packages/ui/src/components/Option/Playground/PlaygroundMcpSettingsModal.tsx
+  - apps/packages/ui/src/components/Sidepanel/Chat/ControlRow.tsx
+documentation:
+  - Docs/superpowers/specs/2026-05-06-mcp-chat-personal-tool-filter-design.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the approved MCP chat personal tool availability filter for the shared WebUI/extension UI layer. Chat must expose only personally enabled executable MCP tools while preserving server-side MCP Hub/RBAC authority. The first implementation slice should cover shared normalization/filtering state, request construction/raw preview parity, and minimal shared selector coverage for WebUI /chat and extension sidepanel chat.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 MCP tool discovery exposes discoveredTools, availableTools, chatTools, disabled preferences, collision state, and counts without removing canExecute=false tools from selector visibility.
+- [ ] #2 Disabled MCP tool preferences persist per connection/user scope and newly discovered tools remain enabled by default.
+- [ ] #3 Chat request construction and raw preview use the same normalized chatTools list and omit tools/tool_choice when no chat tools remain.
+- [ ] #4 WebUI /chat and extension sidepanel chat provide per-tool enable/disable controls through a shared selector or shared selector logic.
+- [ ] #5 Focused tests cover scoped persistence, normalization/collisions, hook filtering, request/raw-preview parity, and visible selector toggle behavior.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a shared chat tool utility layer for normalization, identity, collision detection, disabled filtering, grouping fallback, and no-tools behavior.
+2. Extend MCP settings/store/hook contract with scoped disabled preferences, discoveredTools, availableTools, chatTools, collision state, counts, and toggle helpers.
+3. Migrate pageAssistModel, ChatTldw normalization, and raw preview to the shared chatTools/no-tools contract.
+4. Add a shared MCP tool selector and wire it into Playground settings plus extension sidepanel ControlRow.
+5. Verify with focused Vitest coverage, OpenAPI client path checks when feasible, git diff checks, and Bandit skip documentation because this slice is frontend TypeScript-only unless Python changes appear.
+
+Plan file: Docs/superpowers/plans/2026-05-07-mcp-chat-personal-tool-filter-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Stage 1 complete: added `apps/packages/ui/src/utils/chat-tools.ts` and `apps/packages/ui/src/utils/__tests__/chat-tools.test.ts`. Verified RED with module-not-found failure, then GREEN with `bunx vitest run apps/packages/ui/src/utils/__tests__/chat-tools.test.ts` reporting 1 file / 6 tests passed.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-113 - Implement-MCP-chat-personal-tool-availability-filter.md
+++ b/backlog/tasks/task-113 - Implement-MCP-chat-personal-tool-availability-filter.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - Codex
 created_date: '2026-05-07 14:20'
-updated_date: '2026-05-07 14:30'
+updated_date: '2026-05-07 14:36'
 labels:
   - mcp
   - chat
@@ -61,6 +61,8 @@ Plan file: Docs/superpowers/plans/2026-05-07-mcp-chat-personal-tool-filter-imple
 Stage 1 complete: added `apps/packages/ui/src/utils/chat-tools.ts` and `apps/packages/ui/src/utils/__tests__/chat-tools.test.ts`. Verified RED with module-not-found failure, then GREEN with `bunx vitest run apps/packages/ui/src/utils/__tests__/chat-tools.test.ts` reporting 1 file / 6 tests passed.
 
 Stage 2 complete: extended MCP disabled-tool setting/store/useMcpTools contract with scoped disabled preferences, discoveredTools, availableTools, chatTools, collision names, counts, and toggle helpers. Verified RED with hook tests failing on missing discoveredTools/chatTools fields, then GREEN with `bunx vitest run src/hooks/__tests__/useMcpTools.gating.test.tsx src/utils/__tests__/chat-tools.test.ts` in `apps/packages/ui` reporting 2 files / 11 tests passed.
+
+Stage 3 complete: pageAssistModel now uses stored chatTools by default; ChatTldw and raw preview use the shared request normalizer; no-tools requests omit tools/tool_choice and loop-compat headers. Verified RED on new request/raw-preview/helper tests, then GREEN with `bunx vitest run src/utils/__tests__/chat-tools.test.ts src/models/__tests__/pageAssistModel.mcp-tools.test.ts src/components/Option/Playground/__tests__/usePlaygroundRawPreview.mcp-tools.test.tsx` in `apps/packages/ui` reporting 3 files / 11 tests passed.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-113 - Implement-MCP-chat-personal-tool-availability-filter.md
+++ b/backlog/tasks/task-113 - Implement-MCP-chat-personal-tool-availability-filter.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-113
 title: Implement MCP chat personal tool availability filter
-status: In Progress
+status: Done
 assignee:
   - Codex
 created_date: '2026-05-07 14:20'
-updated_date: '2026-05-07 14:41'
+updated_date: '2026-05-07 14:42'
 labels:
   - mcp
   - chat
@@ -36,11 +36,11 @@ Implement the approved MCP chat personal tool availability filter for the shared
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 MCP tool discovery exposes discoveredTools, availableTools, chatTools, disabled preferences, collision state, and counts without removing canExecute=false tools from selector visibility.
-- [ ] #2 Disabled MCP tool preferences persist per connection/user scope and newly discovered tools remain enabled by default.
-- [ ] #3 Chat request construction and raw preview use the same normalized chatTools list and omit tools/tool_choice when no chat tools remain.
-- [ ] #4 WebUI /chat and extension sidepanel chat provide per-tool enable/disable controls through a shared selector or shared selector logic.
-- [ ] #5 Focused tests cover scoped persistence, normalization/collisions, hook filtering, request/raw-preview parity, and visible selector toggle behavior.
+- [x] #1 MCP tool discovery exposes discoveredTools, availableTools, chatTools, disabled preferences, collision state, and counts without removing canExecute=false tools from selector visibility.
+- [x] #2 Disabled MCP tool preferences persist per connection/user scope and newly discovered tools remain enabled by default.
+- [x] #3 Chat request construction and raw preview use the same normalized chatTools list and omit tools/tool_choice when no chat tools remain.
+- [x] #4 WebUI /chat and extension sidepanel chat provide per-tool enable/disable controls through a shared selector or shared selector logic.
+- [x] #5 Focused tests cover scoped persistence, normalization/collisions, hook filtering, request/raw-preview parity, and visible selector toggle behavior.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -65,14 +65,21 @@ Stage 2 complete: extended MCP disabled-tool setting/store/useMcpTools contract 
 Stage 3 complete: pageAssistModel now uses stored chatTools by default; ChatTldw and raw preview use the shared request normalizer; no-tools requests omit tools/tool_choice and loop-compat headers. Verified RED on new request/raw-preview/helper tests, then GREEN with `bunx vitest run src/utils/__tests__/chat-tools.test.ts src/models/__tests__/pageAssistModel.mcp-tools.test.ts src/components/Option/Playground/__tests__/usePlaygroundRawPreview.mcp-tools.test.tsx` in `apps/packages/ui` reporting 3 files / 11 tests passed.
 
 Stage 4 complete: added shared `McpToolSelector`, wired it into Playground MCP settings and sidepanel ControlRow, and switched Playground MCP control/raw-preview counts to chatTools. Verified RED with the selector test failing on missing component, then GREEN with `bunx vitest run src/components/Common/__tests__/McpToolSelector.test.tsx src/hooks/playground/__tests__/useMcpToolsControl.test.tsx src/components/Option/Playground/__tests__/Playground.request-budget.test.tsx src/hooks/__tests__/useMcpTools.gating.test.tsx` in `apps/packages/ui` reporting 4 files / 10 tests passed.
+
+Stage 5 complete: final focused Vitest suite passed with 7 files / 21 tests; `bun run verify:openapi` passed in `apps/packages/ui`; `bun run verify:openapi` passed in `apps/extension`; `git diff --check` passed. Bandit skipped because no Python files changed in this frontend TypeScript/docs/task slice.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the personal MCP chat tool filter through the shared WebUI/extension UI layer. The hook now exposes discovered, available, and chat-enabled tools with scoped disabled preferences and counts; request construction and raw preview use the same normalized chatTools contract; Playground and sidepanel chat now render a shared per-tool selector for enabling or disabling tools in the active session scope.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-113 - Implement-MCP-chat-personal-tool-availability-filter.md
+++ b/backlog/tasks/task-113 - Implement-MCP-chat-personal-tool-availability-filter.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - Codex
 created_date: '2026-05-07 14:20'
-updated_date: '2026-05-07 14:36'
+updated_date: '2026-05-07 14:41'
 labels:
   - mcp
   - chat
@@ -63,6 +63,8 @@ Stage 1 complete: added `apps/packages/ui/src/utils/chat-tools.ts` and `apps/pac
 Stage 2 complete: extended MCP disabled-tool setting/store/useMcpTools contract with scoped disabled preferences, discoveredTools, availableTools, chatTools, collision names, counts, and toggle helpers. Verified RED with hook tests failing on missing discoveredTools/chatTools fields, then GREEN with `bunx vitest run src/hooks/__tests__/useMcpTools.gating.test.tsx src/utils/__tests__/chat-tools.test.ts` in `apps/packages/ui` reporting 2 files / 11 tests passed.
 
 Stage 3 complete: pageAssistModel now uses stored chatTools by default; ChatTldw and raw preview use the shared request normalizer; no-tools requests omit tools/tool_choice and loop-compat headers. Verified RED on new request/raw-preview/helper tests, then GREEN with `bunx vitest run src/utils/__tests__/chat-tools.test.ts src/models/__tests__/pageAssistModel.mcp-tools.test.ts src/components/Option/Playground/__tests__/usePlaygroundRawPreview.mcp-tools.test.tsx` in `apps/packages/ui` reporting 3 files / 11 tests passed.
+
+Stage 4 complete: added shared `McpToolSelector`, wired it into Playground MCP settings and sidepanel ControlRow, and switched Playground MCP control/raw-preview counts to chatTools. Verified RED with the selector test failing on missing component, then GREEN with `bunx vitest run src/components/Common/__tests__/McpToolSelector.test.tsx src/hooks/playground/__tests__/useMcpToolsControl.test.tsx src/components/Option/Playground/__tests__/Playground.request-budget.test.tsx src/hooks/__tests__/useMcpTools.gating.test.tsx` in `apps/packages/ui` reporting 4 files / 10 tests passed.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-116 - Address-PR-1364-MCP-query-cache-review-comment.md
+++ b/backlog/tasks/task-116 - Address-PR-1364-MCP-query-cache-review-comment.md
@@ -1,0 +1,56 @@
+---
+id: TASK-116
+title: Address PR 1364 MCP query cache review comment
+status: In Progress
+assignee: []
+created_date: '2026-05-07 19:29'
+labels:
+  - mcp
+  - chat
+  - webui
+  - extension
+  - review-fix
+dependencies:
+  - TASK-113
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1364#discussion_r3202498493'
+  - apps/packages/ui/src/hooks/useMcpTools.tsx
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the PR #1364 review finding that MCP React Query keys are not scoped by the active connection identity. Ensure health, tools, catalogs, and modules queries cannot reuse cached MCP results across server/auth/org/principal switches.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 MCP React Query keys include a stable active connection scope for health tools catalogs and modules queries
+- [x] #2 Focused tests assert cache keys change when the connection scope changes
+- [ ] #3 PR #1364 review surface is rechecked after pushing the fix
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added the active MCP tool preference scope to the React Query keys for MCP health, tools, tool catalogs, and tool modules. Added a focused hook regression test that switches the mocked connection URL from port 8000 to port 9000, verifies a second tool fetch occurs, and checks that both scopes appear in the query cache keys.
+
+Verification before push: `bunx vitest run src/hooks/__tests__/useMcpTools.gating.test.tsx` passed with 1 file / 6 tests. The broader focused MCP tool filter suite passed with 7 files / 22 tests. Bandit is not applicable because this review fix only changes TypeScript and Backlog task files.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL:BEGIN -->
+Resolved the PR #1364 MCP query cache bleed review finding by scoping all MCP React Query caches to the active connection identity. This prevents health, tools, catalogs, and module query results from being reused across server/auth/org/principal changes.
+<!-- SECTION:FINAL:END -->

--- a/backlog/tasks/task-116 - Address-PR-1364-MCP-query-cache-review-comment.md
+++ b/backlog/tasks/task-116 - Address-PR-1364-MCP-query-cache-review-comment.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-116
 title: Address PR 1364 MCP query cache review comment
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-07 19:29'
 labels:
@@ -28,12 +28,12 @@ Resolve the PR #1364 review finding that MCP React Query keys are not scoped by 
 <!-- AC:BEGIN -->
 - [x] #1 MCP React Query keys include a stable active connection scope for health tools catalogs and modules queries
 - [x] #2 Focused tests assert cache keys change when the connection scope changes
-- [ ] #3 PR #1364 review surface is rechecked after pushing the fix
+- [x] #3 PR #1364 review surface is rechecked after pushing the fix
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
+- [x] #1 Acceptance criteria completed
 - [x] #2 Tests or verification recorded
 - [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip


### PR DESCRIPTION
## Summary
- Adds shared MCP chat tool normalization, identity, collision detection, and request shaping utilities.
- Extends the MCP tools hook/store with discovered, executable, chat-enabled, scoped disabled preference, collision, and count state.
- Wires a shared MCP tool selector into Playground and sidepanel chat, and aligns chat requests plus raw preview with the filtered chatTools contract.

## Test Plan
- [x] bunx vitest run src/utils/__tests__/chat-tools.test.ts src/hooks/__tests__/useMcpTools.gating.test.tsx src/models/__tests__/pageAssistModel.mcp-tools.test.ts src/components/Option/Playground/__tests__/usePlaygroundRawPreview.mcp-tools.test.tsx src/components/Common/__tests__/McpToolSelector.test.tsx src/hooks/playground/__tests__/useMcpToolsControl.test.tsx src/components/Option/Playground/__tests__/Playground.request-budget.test.tsx
- [x] bun run verify:openapi in apps/packages/ui
- [x] bun run verify:openapi in apps/extension
- [x] git diff --check
- [x] Bandit skipped because this slice changes frontend TypeScript/docs/task files only

## Change summary
Human-authored Change summary required before merge per repository AI-generated PR policy.