### PR TITLE
Phase 2.2: defer minimal audio jobs router import

### DIFF
--- a/backlog/tasks/task-115 - Phase-2.2-minimal-audio-jobs-router-conditional-cleanup-BD.md
+++ b/backlog/tasks/task-115 - Phase-2.2-minimal-audio-jobs-router-conditional-cleanup-BD.md
@@ -1,0 +1,66 @@
+---
+id: TASK-115
+title: Phase 2.2 minimal audio jobs router conditional cleanup BD
+status: Done
+assignee: []
+created_date: '2026-05-07 15:02'
+updated_date: '2026-05-07 19:30'
+labels:
+  - phase-2.2
+  - router-groups
+  - minimal
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+  - 'https://github.com/rmusser01/tldw_server/pull/1363'
+  - 'https://github.com/rmusser01/tldw_server/pull/1366'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Move the gated minimal-test audio jobs router factory onto the shared lazy optional-router registration path so it uses the same missing-target skip semantics and diagnostics as other optional minimal router specs while preserving the existing /api/v1/audio metadata and MINIMAL_TEST_INCLUDE_AUDIO_JOBS opt-in behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Minimal audio-jobs route metadata is represented through the shared optional router spec path while preserving prefix /api/v1/audio, audio-jobs tag, route_key audio-jobs, and existing opt-in gate.
+- [x] #2 Focused contract coverage proves audio_jobs module import and router attribute lookup stay deferred until router resolution.
+- [x] #3 Focused contract coverage verifies missing audio_jobs target skips while runtime import defects propagate.
+- [x] #4 Existing router group, main router, and OpenAPI contracts still pass for the touched scope.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add RED contract tests for the gated minimal audio_jobs router using the shared optional-router expectations.
+2. Replace the hand-written audio_jobs router factory with ImportedRouterSpec while preserving the existing opt-in gate.
+3. Run focused, router-group, main-router, OpenAPI, Bandit, and diff hygiene verification.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+RED: python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "minimal_optional_router_specs and audio_jobs" -q failed with the expected old-factory behavior: 6 failed, 2 passed. Failures showed missing shared spec metadata, bypassed ImportedRouterSpec import hooks, and broad skip diagnostics.
+
+GREEN/validation: focused selector passed 8 passed; router_groups_contract.py passed 159 passed; test_main_router_contract.py passed 6 passed; test_openapi_contracts.py passed 69 passed; Bandit on tldw_Server_API/app/api/v1/router_groups/minimal.py reported 0 results/errors; git diff --check passed.
+
+No documentation update was required for this internal router-registration cleanup. No skips or blockers remain.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Moved the gated minimal audio_jobs router from a hand-written lazy factory to the shared ImportedRouterSpec registration path. This preserves the MINIMAL_TEST_INCLUDE_AUDIO_JOBS opt-in gate, /api/v1/audio prefix, audio-jobs tag, route_key=audio-jobs, and uses the shared missing-module/missing-attribute skip semantics while runtime import defects propagate. Added focused contract coverage for lazy resolution, missing optional target skips, missing router attribute skips, and runtime import failure propagation.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -193,17 +193,17 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
     )
 
     if _audio_jobs_imports_enabled_for_runtime():
-        def _audio_jobs_router_factory():
-            from tldw_Server_API.app.api.v1.endpoints.audio.audio_jobs import router as audio_jobs_router
-
-            return audio_jobs_router
-
-        specs.append(RouterSpec(
-            router=_audio_jobs_router_factory,
-            prefix=f"{API_V1_PREFIX}/audio",
-            tags=("audio-jobs",),
-            route_key="audio-jobs",
-        ))
+        append_imported_router_spec(
+            specs,
+            ImportedRouterSpec(
+                import_path="tldw_Server_API.app.api.v1.endpoints.audio.audio_jobs",
+                log_name="audio-jobs",
+                prefix=f"{API_V1_PREFIX}/audio",
+                tags=("audio-jobs",),
+                route_key="audio-jobs",
+                skip_context=minimal_skip_context,
+            ),
+        )
     else:
         logger.info("Skipping audio-jobs router in minimal test app (set MINIMAL_TEST_INCLUDE_AUDIO_JOBS=1 to enable)")
 

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -9965,6 +9965,189 @@ def test_iter_minimal_optional_router_specs_includes_audio_jobs_when_opted_in(
     assert by_first_path["/jobs"].route_key == "audio-jobs"
 
 
+def test_iter_minimal_optional_router_specs_defers_audio_jobs_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal audio_jobs spec keeps router attr lookup lazy."""
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "test_audio_jobs")
+    monkeypatch.setenv("MINIMAL_TEST_INCLUDE_AUDIO_JOBS", "1")
+    module_name = "tldw_Server_API.app.api.v1.endpoints.audio.audio_jobs"
+    fake_module = ModuleType(module_name)
+    router = APIRouter()
+    access_count = {f"{module_name}.router": 0}
+    import_calls: list[str] = []
+
+    @router.get("/jobs")
+    def _endpoint() -> dict[str, str]:
+        """Return a deterministic response for the fake audio jobs router."""
+        return {"status": "ok"}
+
+    def _module_getattr(name: str) -> APIRouter:
+        """Track lazy router attribute resolution for the fake module."""
+        if name != "router":
+            raise AttributeError(name)
+        access_count[f"{module_name}.router"] += 1
+        return router
+
+    fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    real_import_module = importlib.import_module
+
+    def _import_module(import_name: str, package: str | None = None) -> ModuleType:
+        """Track lazy audio jobs router module import."""
+        if import_name == module_name:
+            import_calls.append(import_name)
+        return real_import_module(import_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    specs = list(iter_minimal_optional_router_specs())
+    assert import_calls == []
+    assert access_count == {f"{module_name}.router": 0}
+
+    selected_spec = next(spec for spec in specs if spec.route_key == "audio-jobs")
+    assert selected_spec.name == "audio-jobs"
+    assert selected_spec.prefix == "/api/v1/audio"
+    assert selected_spec.tags == ("audio-jobs",)
+    assert selected_spec.skip_context == "in minimal test app"
+    assert selected_spec.default_stable is True
+    assert selected_spec.skip_exceptions == (
+        OptionalRouterMissingModule,
+        OptionalRouterMissingAttribute,
+    )
+    assert _first_router_path(selected_spec.router) == "/jobs"
+    assert import_calls == [module_name]
+    assert access_count == {f"{module_name}.router": 1}
+
+
+def test_iter_minimal_optional_router_specs_skips_audio_jobs_missing_import_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal audio_jobs spec skips missing optional router module."""
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "test_audio_jobs")
+    monkeypatch.setenv("MINIMAL_TEST_INCLUDE_AUDIO_JOBS", "1")
+    module_name = "tldw_Server_API.app.api.v1.endpoints.audio.audio_jobs"
+    specs = list(iter_minimal_optional_router_specs())
+    selected_spec = next(spec for spec in specs if spec.route_key == "audio-jobs")
+
+    real_import_module = importlib.import_module
+
+    def _import_module(import_name: str, package: str | None = None) -> ModuleType:
+        """Fail only the selected missing audio jobs router import."""
+        if import_name == module_name:
+            raise ModuleNotFoundError(
+                f"{module_name} missing during import",
+                name=module_name,
+            )
+        return real_import_module(import_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    debug_messages: list[str] = []
+    monkeypatch.setattr("loguru.logger.debug", debug_messages.append)
+
+    assert register_router_specs(FastAPI(), (selected_spec,)) == 0
+    skip_debug_messages = [
+        message for message in debug_messages if message.startswith("Skipping ")
+    ]
+    assert len(skip_debug_messages) == 1
+    skip_message = skip_debug_messages[0]
+    assert skip_message.startswith("Skipping audio-jobs router in minimal test app:")
+    assert module_name in skip_message
+    assert "missing during import" in skip_message
+
+
+def test_iter_minimal_optional_router_specs_skips_audio_jobs_missing_attribute_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal audio_jobs spec skips missing optional router attribute."""
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "test_audio_jobs")
+    monkeypatch.setenv("MINIMAL_TEST_INCLUDE_AUDIO_JOBS", "1")
+    module_name = "tldw_Server_API.app.api.v1.endpoints.audio.audio_jobs"
+    monkeypatch.setitem(sys.modules, module_name, ModuleType(module_name))
+
+    specs = list(iter_minimal_optional_router_specs())
+    selected_spec = next(spec for spec in specs if spec.route_key == "audio-jobs")
+
+    debug_messages: list[str] = []
+    monkeypatch.setattr("loguru.logger.debug", debug_messages.append)
+
+    assert register_router_specs(FastAPI(), (selected_spec,)) == 0
+    skip_debug_messages = [
+        message for message in debug_messages if message.startswith("Skipping ")
+    ]
+    assert len(skip_debug_messages) == 1
+    skip_message = skip_debug_messages[0]
+    assert skip_message.startswith("Skipping audio-jobs router in minimal test app:")
+    assert f"{module_name}.router" in skip_message
+
+
+@pytest.mark.parametrize(
+    ("exception_type", "message"),
+    (
+        (RuntimeError, "audio jobs exploded during import"),
+        (ImportError, "audio jobs dependency failed during import"),
+        (AttributeError, "audio jobs attribute failed during import"),
+    ),
+)
+def test_iter_minimal_optional_router_specs_propagates_audio_jobs_runtime_import_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    exception_type: type[Exception],
+    message: str,
+) -> None:
+    """Verify minimal audio_jobs runtime import defects are not silently skipped."""
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "test_audio_jobs")
+    monkeypatch.setenv("MINIMAL_TEST_INCLUDE_AUDIO_JOBS", "1")
+    module_name = "tldw_Server_API.app.api.v1.endpoints.audio.audio_jobs"
+    specs = list(iter_minimal_optional_router_specs())
+    selected_spec = next(spec for spec in specs if spec.route_key == "audio-jobs")
+
+    real_import_module = importlib.import_module
+
+    def _import_module(import_name: str, package: str | None = None) -> ModuleType:
+        """Crash only the selected audio jobs router import at registration."""
+        if import_name == module_name:
+            raise exception_type(message)
+        return real_import_module(import_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    with pytest.raises(exception_type, match=message):
+        register_router_specs(FastAPI(), (selected_spec,))
+
+
 def test_iter_minimal_optional_router_specs_includes_media_audio_when_opted_in(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- Move the gated minimal audio_jobs router registration onto the shared ImportedRouterSpec path.
- Preserve MINIMAL_TEST_INCLUDE_AUDIO_JOBS gating, /api/v1/audio prefix, audio-jobs tag, route_key=audio-jobs, and minimal skip context metadata.
- Add focused contract coverage for lazy resolution, missing optional target skips, missing router attr skips, and runtime import defect propagation.

## Verification
- python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "minimal_optional_router_specs and audio_jobs" -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/router_groups/minimal.py -f json -o /tmp/bandit_phase2_2_minimal_audio_jobs_router_conditional_bd.json
- git diff --check

## Change summary
Human-authored change summary required before merge per Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md.

Refs #1116
Follows #1363