### PR TITLE
Phase 2.2: defer minimal audio router imports

### DIFF
--- a/backlog/tasks/task-117 - Phase-2.2-minimal-audio-router-conditional-cleanup-BE.md
+++ b/backlog/tasks/task-117 - Phase-2.2-minimal-audio-router-conditional-cleanup-BE.md
@@ -1,0 +1,69 @@
+---
+id: TASK-117
+title: Phase 2.2 minimal audio router conditional cleanup BE
+status: Done
+assignee: []
+created_date: '2026-05-07 19:42'
+updated_date: '2026-05-07 19:58'
+labels:
+  - phase-2.2
+  - router-groups
+  - minimal
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+  - 'https://github.com/rmusser01/tldw_server/pull/1366'
+  - 'https://github.com/rmusser01/tldw_server/pull/1367'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Move the gated minimal-test audio and audio websocket router factories onto the shared lazy optional-router registration path so they use the same missing-target skip semantics and diagnostics as other optional minimal router specs while preserving the existing /api/v1/audio metadata and MINIMAL_TEST_INCLUDE_AUDIO opt-in behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Minimal audio route metadata is represented through the shared optional router spec path while preserving prefix /api/v1/audio, audio tag, route_key audio, and existing opt-in gate.
+- [x] #2 Minimal audio websocket route metadata is represented through the shared optional router spec path while preserving prefix /api/v1/audio, audio-ws tag, route_key audio-websocket, and existing opt-in gate.
+- [x] #3 Focused contract coverage proves audio module import and router/ws_router attribute lookup stay deferred until router resolution.
+- [x] #4 Focused contract coverage verifies missing audio target skips while runtime import defects propagate.
+- [x] #5 Existing router group, main router, and OpenAPI contracts still pass for the touched scope.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add RED contract tests for the gated minimal audio and audio websocket routers using shared optional-router expectations.
+2. Replace the hand-written audio/router and audio/ws_router factories with ImportedRouterSpec while preserving the existing opt-in gate.
+3. Run focused, router-group, main-router, OpenAPI, Bandit, and diff hygiene verification.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+RED verification: python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "minimal_optional_router_specs and audio_router" -q failed before implementation with 6 failed, 159 deselected, and 6 warnings, showing the old hand-written factory behavior bypassed shared ImportedRouterSpec semantics.
+
+GREEN verification: focused selector passed 6 passed, 159 deselected, 6 warnings. Full router group contracts passed 165 passed, 30 warnings. Main router contracts passed 6 passed, 5 warnings. OpenAPI contracts passed 69 passed, 24 warnings. Bandit on tldw_Server_API/app/api/v1/router_groups/minimal.py reported 0 results and 0 errors. git diff --check passed.
+
+No documentation change required for this internal router-registration cleanup. No blockers or known skips beyond existing test-suite warnings.
+
+PR review follow-up: addressed Gemini comments by sharing the audio import path through a local audio_module_path variable and making the lazy attribute tracking test use an explicit ModuleType subclass. Verified the ModuleType instance __getattr__ behavior separately before changing the test, then kept the clearer subclass form. Post-review validation: focused selector passed 6 passed, 159 deselected, 6 warnings; router group contracts passed 165 passed, 30 warnings; main router contracts passed 6 passed, 5 warnings; OpenAPI contracts passed 69 passed, 24 warnings; Bandit reported 0 results and 0 errors; git diff --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Moved the gated minimal audio and audio websocket routers from hand-written lazy factories to the shared ImportedRouterSpec registration path. This preserves the MINIMAL_TEST_INCLUDE_AUDIO opt-in gate, /api/v1/audio prefixes, audio/audio-ws tags, route_key=audio and route_key=audio-websocket, and uses shared missing-module/missing-attribute skip semantics while runtime import defects propagate. Added focused contract coverage for lazy resolution, missing optional target skips, missing router/ws_router attribute skips, and runtime import failure propagation. Verification covered the focused selector, full router group contracts, main router contracts, OpenAPI contracts, Bandit on the touched production file, and git diff --check.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -153,30 +153,27 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
         append_imported_router_spec(specs, embedding_spec)
 
     if audio_imports_enabled_for_runtime():
-        def _audio_router_factory():
-            from tldw_Server_API.app.api.v1.endpoints.audio.audio import router as audio_router
-
-            return audio_router
-
-        def _audio_ws_router_factory():
-            from tldw_Server_API.app.api.v1.endpoints.audio.audio import ws_router as audio_ws_router
-
-            return audio_ws_router
-
-        specs.extend([
-            RouterSpec(
-                router=_audio_router_factory,
+        audio_module_path = "tldw_Server_API.app.api.v1.endpoints.audio.audio"
+        for audio_spec in (
+            ImportedRouterSpec(
+                import_path=audio_module_path,
+                log_name="audio",
                 prefix=f"{API_V1_PREFIX}/audio",
                 tags=("audio",),
                 route_key="audio",
+                skip_context=minimal_skip_context,
             ),
-            RouterSpec(
-                router=_audio_ws_router_factory,
+            ImportedRouterSpec(
+                import_path=audio_module_path,
+                log_name="audio-websocket",
                 prefix=f"{API_V1_PREFIX}/audio",
                 tags=("audio-ws",),
                 route_key="audio-websocket",
+                attr_name="ws_router",
+                skip_context=minimal_skip_context,
             ),
-        ])
+        ):
+            append_imported_router_spec(specs, audio_spec)
     else:
         logger.info("Skipping audio routers in minimal test app (set MINIMAL_TEST_INCLUDE_AUDIO=1 to enable)")
 

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -10186,6 +10186,241 @@ def test_iter_minimal_optional_router_specs_includes_media_audio_when_opted_in(
     assert by_first_path["/stream/transcribe"].route_key == "audio-websocket"
 
 
+def test_iter_minimal_optional_router_specs_defers_audio_router_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal audio specs keep router attr lookup lazy."""
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "test_media_audio")
+    monkeypatch.setenv("MINIMAL_TEST_INCLUDE_AUDIO", "1")
+    module_name = "tldw_Server_API.app.api.v1.endpoints.audio.audio"
+    routers_by_attr: dict[str, APIRouter] = {
+        "router": APIRouter(),
+        "ws_router": APIRouter(),
+    }
+    routers_by_attr["router"].get("/transcriptions")(lambda: {"status": "ok"})
+    routers_by_attr["ws_router"].get("/stream/transcribe")(lambda: {"status": "ok"})
+    fake_module = ModuleType(module_name)
+    access_count = {
+        f"{module_name}.router": 0,
+        f"{module_name}.ws_router": 0,
+    }
+    import_calls: list[str] = []
+
+    class TrackingAudioModule(ModuleType):
+        """Fake audio module that tracks lazy router attribute resolution."""
+
+        def __getattr__(self, name: str) -> APIRouter:
+            if name not in routers_by_attr:
+                raise AttributeError(name)
+            access_count[f"{module_name}.{name}"] += 1
+            return routers_by_attr[name]
+
+    fake_module = TrackingAudioModule(module_name)
+    monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    real_import_module = importlib.import_module
+
+    def _import_module(import_name: str, package: str | None = None) -> ModuleType:
+        """Track lazy audio router module imports."""
+        if import_name == module_name:
+            import_calls.append(import_name)
+        return real_import_module(import_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    specs = list(iter_minimal_optional_router_specs())
+    assert import_calls == []
+    assert access_count == {
+        f"{module_name}.router": 0,
+        f"{module_name}.ws_router": 0,
+    }
+
+    selected_specs = {
+        spec.route_key: spec
+        for spec in specs
+        if spec.route_key in {"audio", "audio-websocket"}
+    }
+    assert set(selected_specs) == {"audio", "audio-websocket"}
+
+    audio_spec = selected_specs["audio"]
+    assert audio_spec.name == "audio"
+    assert audio_spec.prefix == "/api/v1/audio"
+    assert audio_spec.tags == ("audio",)
+    assert audio_spec.skip_context == "in minimal test app"
+    assert audio_spec.default_stable is True
+    assert audio_spec.skip_exceptions == (
+        OptionalRouterMissingModule,
+        OptionalRouterMissingAttribute,
+    )
+    assert _first_router_path(audio_spec.router) == "/transcriptions"
+
+    audio_ws_spec = selected_specs["audio-websocket"]
+    assert audio_ws_spec.name == "audio-websocket"
+    assert audio_ws_spec.prefix == "/api/v1/audio"
+    assert audio_ws_spec.tags == ("audio-ws",)
+    assert audio_ws_spec.skip_context == "in minimal test app"
+    assert audio_ws_spec.default_stable is True
+    assert audio_ws_spec.skip_exceptions == (
+        OptionalRouterMissingModule,
+        OptionalRouterMissingAttribute,
+    )
+    assert _first_router_path(audio_ws_spec.router) == "/stream/transcribe"
+
+    assert import_calls == [module_name, module_name]
+    assert access_count == {
+        f"{module_name}.router": 1,
+        f"{module_name}.ws_router": 1,
+    }
+
+
+def test_iter_minimal_optional_router_specs_skips_audio_router_missing_import_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal audio specs skip missing optional router module."""
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "test_media_audio")
+    monkeypatch.setenv("MINIMAL_TEST_INCLUDE_AUDIO", "1")
+    module_name = "tldw_Server_API.app.api.v1.endpoints.audio.audio"
+    specs = list(iter_minimal_optional_router_specs())
+    selected_specs = [
+        spec for spec in specs if spec.route_key in {"audio", "audio-websocket"}
+    ]
+    assert {spec.route_key for spec in selected_specs} == {"audio", "audio-websocket"}
+
+    real_import_module = importlib.import_module
+
+    def _import_module(import_name: str, package: str | None = None) -> ModuleType:
+        """Fail only the selected missing audio router import."""
+        if import_name == module_name:
+            raise ModuleNotFoundError(
+                f"{module_name} missing during import",
+                name=module_name,
+            )
+        return real_import_module(import_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    debug_messages: list[str] = []
+    monkeypatch.setattr("loguru.logger.debug", debug_messages.append)
+
+    assert register_router_specs(FastAPI(), selected_specs) == 0
+    skip_debug_messages = [
+        message for message in debug_messages if message.startswith("Skipping ")
+    ]
+    assert len(skip_debug_messages) == 2
+    assert any(
+        message.startswith("Skipping audio router in minimal test app:")
+        and module_name in message
+        and "missing during import" in message
+        for message in skip_debug_messages
+    )
+    assert any(
+        message.startswith("Skipping audio-websocket router in minimal test app:")
+        and module_name in message
+        and "missing during import" in message
+        for message in skip_debug_messages
+    )
+
+
+def test_iter_minimal_optional_router_specs_skips_audio_router_missing_attribute_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal audio specs skip missing optional router attributes."""
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "test_media_audio")
+    monkeypatch.setenv("MINIMAL_TEST_INCLUDE_AUDIO", "1")
+    module_name = "tldw_Server_API.app.api.v1.endpoints.audio.audio"
+    monkeypatch.setitem(sys.modules, module_name, ModuleType(module_name))
+
+    specs = list(iter_minimal_optional_router_specs())
+    selected_specs = [
+        spec for spec in specs if spec.route_key in {"audio", "audio-websocket"}
+    ]
+    assert {spec.route_key for spec in selected_specs} == {"audio", "audio-websocket"}
+
+    debug_messages: list[str] = []
+    monkeypatch.setattr("loguru.logger.debug", debug_messages.append)
+
+    assert register_router_specs(FastAPI(), selected_specs) == 0
+    skip_debug_messages = [
+        message for message in debug_messages if message.startswith("Skipping ")
+    ]
+    assert len(skip_debug_messages) == 2
+    assert any(
+        message.startswith("Skipping audio router in minimal test app:")
+        and f"{module_name}.router" in message
+        for message in skip_debug_messages
+    )
+    assert any(
+        message.startswith("Skipping audio-websocket router in minimal test app:")
+        and f"{module_name}.ws_router" in message
+        for message in skip_debug_messages
+    )
+
+
+@pytest.mark.parametrize(
+    ("exception_type", "message"),
+    (
+        (RuntimeError, "audio exploded during import"),
+        (ImportError, "audio dependency failed during import"),
+        (AttributeError, "audio attribute failed during import"),
+    ),
+)
+def test_iter_minimal_optional_router_specs_propagates_audio_router_runtime_import_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    exception_type: type[Exception],
+    message: str,
+) -> None:
+    """Verify minimal audio runtime import defects are not silently skipped."""
+    import importlib
+
+    from tldw_Server_API.app.api.v1.router_groups.minimal import (
+        iter_minimal_optional_router_specs,
+    )
+
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "test_media_audio")
+    monkeypatch.setenv("MINIMAL_TEST_INCLUDE_AUDIO", "1")
+    module_name = "tldw_Server_API.app.api.v1.endpoints.audio.audio"
+    specs = list(iter_minimal_optional_router_specs())
+    selected_spec = next(spec for spec in specs if spec.route_key == "audio")
+
+    real_import_module = importlib.import_module
+
+    def _import_module(import_name: str, package: str | None = None) -> ModuleType:
+        """Crash only the selected audio router import at registration."""
+        if import_name == module_name:
+            raise exception_type(message)
+        return real_import_module(import_name, package)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+
+    with pytest.raises(exception_type, match=message):
+        register_router_specs(FastAPI(), (selected_spec,))
+
+
 def test_iter_minimal_optional_router_specs_skips_audio_during_pytest_without_opt_in(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- Move the gated minimal audio and audio websocket router registrations onto the shared ImportedRouterSpec path.
- Preserve MINIMAL_TEST_INCLUDE_AUDIO gating, /api/v1/audio prefixes, audio/audio-ws tags, route_key=audio, route_key=audio-websocket, and minimal skip context metadata.
- Add focused contract coverage for lazy resolution, missing optional target skips, missing router/ws_router attr skips, and runtime import defect propagation.

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "minimal_optional_router_specs and audio_router" -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/router_groups/minimal.py -f json -o /tmp/bandit_phase2_2_minimal_audio_router_conditional_be.json
- git diff --check

## Change summary
Human-authored change summary required before merge per Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md.

Refs #1116
Follows #1366