### PR TITLE
Replace WebUI clsx helper

### DIFF
--- a/apps/bun.lock
+++ b/apps/bun.lock
@@ -236,7 +236,6 @@
         "antd": "^6.2.0",
         "axios": "^1.7.2",
         "cheerio": "^1.1.2",
-        "clsx": "^2.1.1",
         "cytoscape": "^3.33.1",
         "cytoscape-dagre": "^2.5.0",
         "d3-dsv": "^3.0.1",

--- a/apps/packages/ui/src/components/Sidepanel/Chat/ControlRow.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/ControlRow.tsx
@@ -102,6 +102,11 @@ const ControlRowBase: React.FC<ControlRowProps> = ({
     resetToolFilter: resetMcpToolFilter
   } = useMcpTools()
   const chatMcpToolCount = chatMcpTools.length
+  const translateMcpToolSelector = React.useCallback(
+    (key: string, fallback?: string, options?: Record<string, unknown>) =>
+      t(key, fallback ?? key, options),
+    [t]
+  )
 
   const [catalogDraft, setCatalogDraft] = React.useState(toolCatalog)
   const [advancedToolsExpanded, setAdvancedToolsExpanded] = React.useState(false)
@@ -367,7 +372,7 @@ const ControlRowBase: React.FC<ControlRowProps> = ({
         onToolEnabledChange={setMcpToolEnabled}
         onReset={resetMcpToolFilter}
         compact
-        t={t}
+        t={translateMcpToolSelector}
       />
 
       <div className="panel-divider my-1" />

--- a/apps/tldw-frontend/__tests__/extension/route-registry.mcp-hub.test.ts
+++ b/apps/tldw-frontend/__tests__/extension/route-registry.mcp-hub.test.ts
@@ -71,7 +71,7 @@ describe("extension route registry MCP Hub parity", () => {
 
     expect(await screen.findByTestId("standalone-mcp-hub")).toBeVisible()
     expect(screen.queryByTestId("settings-mcp-hub")).not.toBeInTheDocument()
-  })
+  }, 15_000)
 
   it("renders the settings MCP Hub route from the extension registry", async () => {
     const { ROUTE_DEFINITIONS } = await import(
@@ -90,7 +90,7 @@ describe("extension route registry MCP Hub parity", () => {
     expect(await screen.findByTestId("settings-mcp-hub")).toBeVisible()
     expect(routeMocks.settingsMcpHub).toHaveBeenCalledTimes(1)
     expect(screen.queryByTestId("standalone-mcp-hub")).not.toBeInTheDocument()
-  })
+  }, 15_000)
 
   it("uses react-router redirects for legacy extension routes", async () => {
     const { ROUTE_DEFINITIONS } = await import(

--- a/apps/tldw-frontend/__tests__/pages/research-run-console.test.tsx
+++ b/apps/tldw-frontend/__tests__/pages/research-run-console.test.tsx
@@ -412,8 +412,9 @@ describe('ResearchRunsPage', () => {
     renderWithProviders(<ResearchRunsPage />);
 
     await screen.findByText('Investigate local evidence');
-    await user.clear(screen.getByLabelText('Focus areas'));
-    await user.type(screen.getByLabelText('Focus areas'), 'background{enter}counterevidence{enter}primary sources');
+    const focusAreasField = await screen.findByLabelText('Focus areas');
+    await user.clear(focusAreasField);
+    await user.type(focusAreasField, 'background{enter}counterevidence{enter}primary sources');
     await user.clear(screen.getByLabelText('Minimum sources'));
     await user.type(screen.getByLabelText('Minimum sources'), '3');
     await user.click(screen.getByRole('button', { name: 'Approve checkpoint' }));
@@ -460,7 +461,7 @@ describe('ResearchRunsPage', () => {
     renderWithProviders(<ResearchRunsPage />);
 
     await screen.findByText('Investigate local evidence');
-    await user.click(screen.getByRole('button', { name: 'Pin Primary memo' }));
+    await user.click(await screen.findByRole('button', { name: 'Pin Primary memo' }));
     await user.click(screen.getByRole('button', { name: 'Drop Counter note' }));
     await user.click(screen.getByRole('button', { name: 'Prioritize Primary memo' }));
     await user.click(screen.getByLabelText('Recollect sources'));

--- a/apps/tldw-frontend/__tests__/pages/researchers-page.test.tsx
+++ b/apps/tldw-frontend/__tests__/pages/researchers-page.test.tsx
@@ -34,17 +34,13 @@ describe('ResearchersPage CTA routing', () => {
       'href',
       '/docs'
     );
-    expect(screen.getByRole('link', { name: 'Download' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Download Free' })).toHaveAttribute(
       'href',
       '/docs/self-hosting'
     );
-    expect(screen.getByRole('link', { name: 'Start Trial' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Read the Docs' })).toHaveAttribute(
       'href',
-      '/research'
-    );
-    expect(screen.getByRole('link', { name: 'Contact Us' })).toHaveAttribute(
-      'href',
-      '/contact'
+      '/docs'
     );
   });
 });

--- a/apps/tldw-frontend/__tests__/utils-cn.test.ts
+++ b/apps/tldw-frontend/__tests__/utils-cn.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+import { describe, expect, it } from "vitest"
+
+import { cn } from "@web/lib/utils"
+
+const projectRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  ".."
+)
+
+function readProjectFile(...segments: string[]) {
+  return readFileSync(path.join(projectRoot, ...segments), "utf8")
+}
+
+describe("cn", () => {
+  it("joins supported class values while dropping falsey values", () => {
+    expect(
+      cn(
+        "base",
+        undefined,
+        null,
+        false,
+        true,
+        0,
+        ["nested", ["deep", { active: true, hidden: false }]],
+        { selected: 1, disabled: 0 },
+        42,
+        BigInt(7)
+      )
+    ).toBe("base nested deep active selected 42")
+  })
+
+  it("keeps Tailwind conflict resolution", () => {
+    expect(cn("px-2 text-sm", "px-4", ["text-lg"])).toBe("px-4 text-lg")
+  })
+
+  it("does not depend on clsx directly", () => {
+    const packageJson = JSON.parse(readProjectFile("package.json")) as {
+      dependencies?: Record<string, string>
+      devDependencies?: Record<string, string>
+    }
+    const utilsSource = readProjectFile("lib", "utils.ts")
+
+    expect(packageJson.dependencies).not.toHaveProperty("clsx")
+    expect(packageJson.devDependencies).not.toHaveProperty("clsx")
+    expect(utilsSource).not.toMatch(/from\s+['"]clsx['"]/)
+  })
+})

--- a/apps/tldw-frontend/lib/utils.ts
+++ b/apps/tldw-frontend/lib/utils.ts
@@ -1,12 +1,53 @@
-import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
+
+type ClassDictionary = Record<string, unknown>;
+
+export type ClassValue =
+  | string
+  | number
+  | bigint
+  | boolean
+  | null
+  | undefined
+  | ClassDictionary
+  | ClassValue[];
+
+function appendClassValue(value: ClassValue, classes: string[]): void {
+  if (!value || typeof value === 'boolean' || typeof value === 'bigint') {
+    return;
+  }
+
+  if (typeof value === 'string' || typeof value === 'number') {
+    classes.push(String(value));
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item) => appendClassValue(item, classes));
+    return;
+  }
+
+  Object.entries(value).forEach(([className, enabled]) => {
+    if (enabled) {
+      classes.push(className);
+    }
+  });
+}
+
+function classNames(values: ClassValue[]): string {
+  const classes: string[] = [];
+
+  values.forEach((value) => appendClassValue(value, classes));
+
+  return classes.join(' ');
+}
 
 /**
  * Utility function to merge Tailwind CSS classes
- * Combines clsx for conditional classes and tailwind-merge to handle conflicts
+ * Combines conditional classes and uses tailwind-merge to handle conflicts
  */
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
+  return twMerge(classNames(inputs));
 }
 
 /**

--- a/apps/tldw-frontend/package.json
+++ b/apps/tldw-frontend/package.json
@@ -89,7 +89,6 @@
     "antd": "^6.2.0",
     "axios": "^1.7.2",
     "cheerio": "^1.1.2",
-    "clsx": "^2.1.1",
     "cytoscape": "^3.33.1",
     "cytoscape-dagre": "^2.5.0",
     "d3-dsv": "^3.0.1",

--- a/backlog/tasks/task-117 - Replace-WebUI-clsx-helper-for-issue-1346.md
+++ b/backlog/tasks/task-117 - Replace-WebUI-clsx-helper-for-issue-1346.md
@@ -1,0 +1,77 @@
+---
+id: TASK-117
+title: Replace WebUI clsx helper for issue 1346
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-05-07 19:34'
+updated_date: '2026-05-07 20:16'
+labels:
+  - webui
+  - dependencies
+  - cleanup
+dependencies:
+  - TASK-104
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1346'
+  - 'https://github.com/rmusser01/tldw_server/pull/1365'
+documentation:
+  - Docs/Design/WebUI_Dependency_Audit.md
+  - Docs/superpowers/specs/2026-05-07-webui-dependency-trimming-design.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the clsx cleanup slice from the WebUI dependency audit for issue #1346. Replace the tiny local WebUI class-name helper usage with a compatibility-safe local implementation, remove the direct clsx declaration, and update the Bun lockfile. Do not change unrelated styling helpers or Tailwind merge behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The direct clsx dependency is removed from apps/tldw-frontend/package.json and apps/bun.lock is updated consistently.
+- [x] #2 Focused tests cover the local class-name helper behavior and fail before the replacement.
+- [x] #3 Focused install, lint, compile/build, and relevant WebUI verification are run or blockers documented.
+- [x] #4 Bandit is skipped with rationale if this slice changes only WebUI TypeScript/package metadata and Backlog documentation.
+- [x] #5 The WebUI cn helper preserves the input shapes currently delegated to clsx, including strings, nested arrays, object maps, falsey values, and numbers while keeping unsupported standalone bigint and boolean values ignored.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Inspect current clsx usage and package declarations. 2. Add focused tests for the WebUI cn helper compatibility and dependency guard. 3. Replace the clsx import with a local class-name flattener while preserving twMerge behavior. 4. Remove the direct clsx declaration and regenerate apps/bun.lock. 5. Run focused tests and WebUI verification, update task, commit, push, and open a draft PR against dev.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+RED verification: bunx vitest run __tests__/utils-cn.test.ts initially failed before implementation. The dependency guard failed on package.json clsx. The first draft also revealed that current clsx ignores standalone bigint values, so AC/test expectations were corrected to preserve observed behavior.
+
+Changed-test sweep also surfaced a stale researchers-page CTA assertion unrelated to class joining. Current page renders Download Free / Read the Docs, so the test was updated to match the existing page contract before continuing verification.
+
+GREEN verification: bunx vitest run __tests__/utils-cn.test.ts passed after the local class helper replacement. NEXT_PUBLIC_API_URL=http://127.0.0.1:8000 bunx vitest run --changed=origin/dev passed 21 files / 82 tests after the stale researchers CTA assertion was corrected. bun install --frozen-lockfile passed with no lockfile changes after regeneration. bun run lint passed with 0 errors and the existing 127 warning backlog. NEXT_PUBLIC_API_URL=http://127.0.0.1:8000 bun run compile passed and token sync succeeded. bunx tsc --noEmit -p tsconfig.json --pretty false passed. git diff --check passed. Bandit skipped because this slice touches only WebUI TypeScript/package metadata and Backlog documentation, with no Python files.
+
+Post-rebase verification on latest origin/dev surfaced a research-run-console test timing issue: the plan checkpoint editor is populated from selectedSnapshot checkpoint state in an effect, so the test now waits for the Focus areas field before editing it.
+
+Post-rebase final verification: NEXT_PUBLIC_API_URL=http://127.0.0.1:8000 bunx vitest run --changed=origin/dev passed 23 files / 89 tests. bun run lint passed with 0 errors and the existing 127 warning backlog. bunx tsc --noEmit -p tsconfig.json --pretty false passed after adapting ControlRow's translator prop for McpToolSelector. NEXT_PUBLIC_API_URL=http://127.0.0.1:8000 bun run compile passed after rebase and token sync succeeded. git diff --check passed.
+
+PR #1368 review sweep found Gemini feedback to remove lockfile parsing from the cn helper test because it was brittle against package-manager formatting. Keeping package.json and source import guards instead.
+
+PR #1368 review fix removed bun.lock parsing from the cn helper dependency guard while retaining package.json and utils.ts source guards. Verification after the review fix: bunx vitest run __tests__/utils-cn.test.ts passed 1 file / 3 tests; NEXT_PUBLIC_API_URL=http://127.0.0.1:8000 bunx vitest run --changed=origin/dev passed 23 files / 89 tests; bun run lint passed with 0 errors and the existing 127-warning backlog; bunx tsc --noEmit -p tsconfig.json --pretty false passed; NEXT_PUBLIC_API_URL=http://127.0.0.1:8000 bun run compile passed with token sync OK; git diff --check passed. Bandit remains skipped because the review fix touches only WebUI TypeScript tests and Backlog documentation, with no Python files.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Replaced the WebUI cn helper's direct clsx dependency with a small local class-value flattener that preserves existing supported input behavior and keeps tailwind-merge conflict handling. Removed clsx from apps/tldw-frontend/package.json and the tldw-frontend importer section of apps/bun.lock, added focused guard/behavior tests, corrected stale/timing-sensitive tests surfaced by changed-test verification, and adapted the sidepanel MCP tool selector translator prop to satisfy the current TypeScript contract on latest dev.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary

- Replaced the WebUI `cn` helper's direct `clsx` dependency with a small local class-value flattener while preserving `tailwind-merge` behavior.
- Removed the direct `clsx` declaration from `apps/tldw-frontend/package.json` and the `tldw-frontend` importer section of `apps/bun.lock`.
- Added focused guard/behavior coverage for `cn`, and fixed stale/timing-sensitive frontend tests surfaced by the changed-test sweep on latest `dev`.
- Adapted the sidepanel MCP tool selector translation prop to satisfy the current TypeScript contract after rebasing onto latest `dev`.

## Verification

- `bun install --frozen-lockfile`
- `bunx vitest run __tests__/utils-cn.test.ts`
- `NEXT_PUBLIC_API_URL=http://127.0.0.1:8000 bunx vitest run --changed=origin/dev`
- `bun run lint` (0 errors, existing warning backlog remains)
- `bunx tsc --noEmit -p tsconfig.json --pretty false`
- `NEXT_PUBLIC_API_URL=http://127.0.0.1:8000 bun run compile`
- `git diff --check`
- Bandit skipped: WebUI TypeScript/package metadata and Backlog task only; no Python touched.

## Human Change Summary

Draft until the requester adds the required human-written Change summary explaining what changed and why these implementation choices were made.
