### PR TITLE
Phase 2.2: narrow minimal admin fallback imports

### DIFF
--- a/backlog/tasks/task-118 - Phase-2.2-minimal-admin-fallback-router-conditional-cleanup-BF.md
+++ b/backlog/tasks/task-118 - Phase-2.2-minimal-admin-fallback-router-conditional-cleanup-BF.md
@@ -1,0 +1,71 @@
+---
+id: TASK-118
+title: Phase 2.2 minimal admin fallback router conditional cleanup BF
+status: Done
+assignee: []
+created_date: '2026-05-07 20:06'
+updated_date: '2026-05-08 00:43'
+labels:
+  - phase-2.2
+  - router-groups
+  - minimal
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+  - 'https://github.com/rmusser01/tldw_server/pull/1367'
+  - 'https://github.com/rmusser01/tldw_server/pull/1369'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Move the minimal-test admin/admin_byok fallback block onto shared optional-router semantics so missing optional targets are skippable without catching every runtime import defect. Preserve the primary admin router preference, admin_byok fallback behavior, prefixes, tags, and minimal-test contract metadata.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Minimal admin route metadata is represented through a shared optional-router-compatible path while preserving prefix /api/v1, admin tag, and primary admin preference.
+- [x] #2 Minimal admin_byok fallback metadata is represented through a shared optional-router-compatible path while preserving prefix /api/v1/admin, admin tag, and fallback behavior when the primary admin router is missing.
+- [x] #3 Focused contract coverage proves missing admin target skips to admin_byok while runtime import defects propagate instead of being swallowed by broad Exception handling.
+- [x] #4 Focused source/contract coverage removes the minimal admin broad except import block while existing minimal metadata contracts still pass.
+- [x] #5 Existing router group, main router, and OpenAPI contracts still pass for the touched scope.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add RED contract tests for admin/admin_byok fallback skip semantics and runtime defect propagation.
+2. Replace the broad try/except import block with shared optional-router resolution semantics while preserving fallback behavior.
+3. Run focused, router-group, main-router, OpenAPI, Bandit, and diff hygiene verification.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Baseline verification before edits: python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "minimal_optional_router_specs and admin" -q passed with 1 passed, 164 deselected, 10 warnings.
+
+RED verification: the new runtime-defect test failed before implementation because the broad admin import catch swallowed RuntimeError and fell through to admin_byok.
+
+GREEN verification: focused selector python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "admin_fallback or (minimal_optional_router_specs and admin)" -q passed with 3 passed, 164 deselected, 10 warnings. Full router group contracts passed with 167 passed, 30 warnings. Main router contracts passed with 6 passed, 5 warnings. OpenAPI contracts passed with 69 passed, 24 warnings. Bandit on tldw_Server_API/app/api/v1/router_groups/minimal.py reported 0 results and 0 errors. git diff --check passed.
+
+No documentation change required for this internal router-registration cleanup. No blockers or known skips beyond existing test-suite warnings.
+
+PR review follow-up: addressed Gemini/Qodo review comments by adding a defensive empty candidate guard, switching fallback skip handling to candidate_spec.skip_exceptions, restoring debug logging for skipped fallback candidates, and adding docstrings to the new source helper and tests. Post-review validation: focused selector passed with 3 passed, 164 deselected, 10 warnings; full router group contracts passed with 167 passed, 30 warnings; main router contracts passed with 6 passed, 5 warnings; OpenAPI contracts passed with 69 passed, 24 warnings; Bandit reported 0 results and 0 errors; git diff --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Moved the minimal admin/admin_byok fallback away from broad try/except imports and onto the shared ImportedRouterSpec resolution path. The primary admin router remains preferred with prefix /api/v1 and admin tags, while admin_byok remains the fallback with prefix /api/v1/admin when the primary optional target is missing. Missing optional modules or router attributes continue to skip/fallback, but runtime import defects now propagate instead of being silently swallowed. Added focused contract coverage for primary preference, fallback behavior, runtime defect propagation, and removal of the broad exception source pattern.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -69,6 +69,28 @@ def _audio_jobs_imports_enabled_for_runtime() -> bool:
     return not _is_explicit_pytest_runtime() or _env_flag_enabled("MINIMAL_TEST_INCLUDE_AUDIO_JOBS")
 
 
+def _append_first_available_imported_router_spec(
+    specs: list[RouterSpec],
+    definitions: tuple[ImportedRouterSpec, ...],
+) -> None:
+    """Append the first imported router whose optional target is available."""
+    for definition in definitions:
+        candidate_specs: list[RouterSpec] = []
+        append_imported_router_spec(candidate_specs, definition)
+        if not candidate_specs:
+            continue
+        candidate_spec = candidate_specs[0]
+        try:
+            candidate_spec.resolve_router()
+        except candidate_spec.skip_exceptions as e:
+            spec_name = candidate_spec.name or candidate_spec.route_key or "unnamed"
+            context = f" {candidate_spec.skip_context}" if candidate_spec.skip_context else ""
+            logger.debug(f"Skipping {spec_name} router{context}: {e}")
+            continue
+        specs.append(candidate_spec)
+        return
+
+
 def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
     """Yield optional minimal-test router specs, skipping unavailable imports."""
     specs: list[RouterSpec] = []
@@ -677,30 +699,25 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
     ):
         append_imported_router_spec(specs, ops_spec)
 
-    admin_router_added = False
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.admin import router as admin_router
-
-        specs.append(RouterSpec(
-            router=admin_router,
-            prefix=f"{API_V1_PREFIX}",
-            tags=("admin",),
-        ))
-        admin_router_added = True
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping admin router in minimal test app: {e}")
-
-    if not admin_router_added:
-        try:
-            from tldw_Server_API.app.api.v1.endpoints.admin.admin_byok import router as admin_byok_router
-
-            specs.append(RouterSpec(
-                router=admin_byok_router,
+    _append_first_available_imported_router_spec(
+        specs,
+        (
+            ImportedRouterSpec(
+                import_path="tldw_Server_API.app.api.v1.endpoints.admin",
+                log_name="admin",
+                prefix=f"{API_V1_PREFIX}",
+                tags=("admin",),
+                skip_context=minimal_skip_context,
+            ),
+            ImportedRouterSpec(
+                import_path="tldw_Server_API.app.api.v1.endpoints.admin.admin_byok",
+                log_name="admin_byok",
                 prefix=f"{API_V1_PREFIX}/admin",
                 tags=("admin",),
-            ))
-        except Exception as admin_byok_error:  # noqa: BLE001
-            logger.debug(f"Skipping admin_byok router in minimal test app: {admin_byok_error}")
+                skip_context=minimal_skip_context,
+            ),
+        ),
+    )
 
     for org_spec in (
         ImportedRouterSpec(

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -257,6 +257,19 @@ def _main_source_text() -> str:
     return main_path.read_text(encoding="utf-8")
 
 
+def _minimal_group_source_text() -> str:
+    """Return the minimal router group source for source-level contracts."""
+    minimal_path = (
+        Path(__file__).resolve().parents[2]
+        / "app"
+        / "api"
+        / "v1"
+        / "router_groups"
+        / "minimal.py"
+    )
+    return minimal_path.read_text(encoding="utf-8")
+
+
 def _install_fake_router_module(
     monkeypatch: pytest.MonkeyPatch,
     module_name: str,
@@ -9856,6 +9869,7 @@ def test_iter_minimal_optional_router_specs_populates_llm_specs(monkeypatch: pyt
     assert by_first_path["/admin/status"].prefix == "/api/v1"
     assert by_first_path["/admin/status"].tags == ("admin",)
     assert by_first_path["/admin/status"].route_key == ""
+    assert "/keys/shared" not in by_first_path
     assert by_first_path["/orgs"].prefix == "/api/v1"
     assert by_first_path["/orgs"].tags == ("organizations",)
     assert by_first_path["/orgs"].route_key == ""
@@ -9942,6 +9956,46 @@ def test_iter_minimal_optional_router_specs_falls_back_to_admin_byok_when_admin_
     assert by_first_path["/keys/shared"].prefix == "/api/v1/admin"
     assert by_first_path["/keys/shared"].tags == ("admin",)
     assert by_first_path["/keys/shared"].route_key == ""
+
+
+def test_iter_minimal_optional_router_specs_propagates_admin_runtime_import_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify admin fallback does not swallow runtime router import defects."""
+    from tldw_Server_API.app.api.v1.router_groups.minimal import iter_minimal_optional_router_specs
+
+    admin_module_name = "tldw_Server_API.app.api.v1.endpoints.admin"
+
+    class CrashingAdminModule(ModuleType):
+        """Fake admin module whose router lookup fails like a runtime defect."""
+
+        def __getattr__(self, name: str) -> APIRouter:
+            if name == "router":
+                raise RuntimeError("admin router crashed during import")
+            raise AttributeError(name)
+
+    admin_module = CrashingAdminModule(admin_module_name)
+    admin_module.__path__ = []  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, admin_module_name, admin_module)
+    _install_fake_router_module(
+        monkeypatch,
+        "tldw_Server_API.app.api.v1.endpoints.admin.admin_byok",
+        path="/keys/shared",
+    )
+
+    with pytest.raises(RuntimeError, match="admin router crashed during import"):
+        list(iter_minimal_optional_router_specs())
+
+
+def test_minimal_source_delegates_admin_fallback_to_narrow_optional_semantics() -> None:
+    """Verify minimal admin fallback no longer uses broad import exception handling."""
+    source = _minimal_group_source_text()
+
+    assert "from tldw_Server_API.app.api.v1.endpoints.admin import router as admin_router" not in source
+    assert "from tldw_Server_API.app.api.v1.endpoints.admin.admin_byok import router as admin_byok_router" not in source
+    assert "except Exception as e" not in source
+    assert "except Exception as admin_byok_error" not in source
+    assert "Skipping admin_byok router in minimal test app" not in source
 
 
 def test_iter_minimal_optional_router_specs_includes_audio_jobs_when_opted_in(


### PR DESCRIPTION
## Summary
- Replace the minimal admin/admin_byok broad try/except import fallback with shared ImportedRouterSpec resolution semantics.
- Preserve primary admin preference, admin_byok fallback behavior, prefixes, tags, and minimal-test metadata.
- Add focused contract coverage for admin fallback, runtime defect propagation, primary preference, and source removal of the broad exception block.

## Verification
- python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "minimal_optional_router_specs and admin" -q
- python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "admin_fallback or (minimal_optional_router_specs and admin)" -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/router_groups/minimal.py -f json -o /tmp/bandit_phase2_2_minimal_admin_fallback_router_conditional_bf.json
- git diff --check

## Change summary
Human-authored change summary required before merge per Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md.

Refs #1116
Follows #1367