### PR TITLE
Phase 2.2: defer minimal always router imports

### DIFF
--- a/backlog/tasks/task-119 - Phase-2.2-minimal-always-included-router-lazy-import-cleanup-BG.md
+++ b/backlog/tasks/task-119 - Phase-2.2-minimal-always-included-router-lazy-import-cleanup-BG.md
@@ -1,0 +1,53 @@
+---
+id: TASK-119
+title: Phase 2.2 minimal always-included router lazy import cleanup BG
+status: Done
+assignee: []
+created_date: '2026-05-08 02:00'
+updated_date: '2026-05-08 02:08'
+labels:
+  - phase-2.2
+  - router-groups
+  - minimal
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1370'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue Phase 2.2 router cleanup after PR #1369 by deferring the always-included minimal-test router imports in router_groups/minimal.py while preserving prefixes, tags, and runtime defect behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 iter_minimal_test_router_specs returns RouterSpec entries without importing endpoint modules during spec construction
+- [x] #2 health/auth/research/chat/character/workspace minimal router metadata remains unchanged
+- [x] #3 runtime import defects for always-included minimal routers propagate instead of being silently skipped
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Baseline selector passed before edits with 2 passed, 165 deselected, 6 warnings. RED selector failed as expected because iter_minimal_test_router_specs eagerly imported auth and the source still contained direct endpoint imports. GREEN selector passed with 5 passed, 165 deselected, 6 warnings after converting always-included minimal routers to required ImportedRouterSpec factories.
+
+Validation: full router group contracts passed with 170 passed, 30 warnings; main router contracts passed with 6 passed, 5 warnings; OpenAPI contracts passed with 69 passed, 24 warnings; Bandit on tldw_Server_API/app/api/v1/router_groups/minimal.py reported 0 results and 0 errors; git diff --check passed. No documentation change required for this internal router-registration cleanup.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Deferred always-included minimal-test router imports through ImportedRouterSpec while preserving prefixes/tags and required-router failure propagation. Added contract coverage for no eager endpoint imports, source cleanup, and runtime defect propagation.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-119 - Phase-2.2-minimal-always-included-router-lazy-import-cleanup-BG.md
+++ b/backlog/tasks/task-119 - Phase-2.2-minimal-always-included-router-lazy-import-cleanup-BG.md
@@ -4,7 +4,7 @@ title: Phase 2.2 minimal always-included router lazy import cleanup BG
 status: Done
 assignee: []
 created_date: '2026-05-08 02:00'
-updated_date: '2026-05-08 02:08'
+updated_date: '2026-05-08 02:18'
 labels:
   - phase-2.2
   - router-groups
@@ -28,18 +28,30 @@ Continue Phase 2.2 router cleanup after PR #1369 by deferring the always-include
 - [x] #3 runtime import defects for always-included minimal routers propagate instead of being silently skipped
 <!-- AC:END -->
 
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+PR #1370 review fix pass: verify each review finding against current code, fix only still-valid issues, keep edits minimal, validate with focused pytest/diff/Bandit checks, then reply to and resolve handled GitHub review threads.
+<!-- SECTION:PLAN:END -->
+
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
 Baseline selector passed before edits with 2 passed, 165 deselected, 6 warnings. RED selector failed as expected because iter_minimal_test_router_specs eagerly imported auth and the source still contained direct endpoint imports. GREEN selector passed with 5 passed, 165 deselected, 6 warnings after converting always-included minimal routers to required ImportedRouterSpec factories.
 
 Validation: full router group contracts passed with 170 passed, 30 warnings; main router contracts passed with 6 passed, 5 warnings; OpenAPI contracts passed with 69 passed, 24 warnings; Bandit on tldw_Server_API/app/api/v1/router_groups/minimal.py reported 0 results and 0 errors; git diff --check passed. No documentation change required for this internal router-registration cleanup.
+
+Reopened for PR #1370 review comments. Gemini ModuleType import thread was invalid: from types import ModuleType already exists and the targeted test passes; replied and resolved. CodeRabbit's registry-path coverage comment is valid and will be handled with a minimal test-only update.
+
+PR #1370 review fix validation: focused pytest for test_iter_minimal_test_router_specs_propagates_runtime_import_failures passed with 1 passed, 169 deselected; full router group contract suite passed with 170 passed; Bandit on the touched test file with B101 skipped reported 0 results and 0 errors; git diff --check passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Deferred always-included minimal-test router imports through ImportedRouterSpec while preserving prefixes/tags and required-router failure propagation. Added contract coverage for no eager endpoint imports, source cleanup, and runtime defect propagation.
+
+Review fix: strengthened the required minimal-router runtime defect test to assert empty skip_exceptions and execute through register_router_specs(FastAPI(), (auth_spec,)), covering the registry skip-policy path requested by CodeRabbit.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -22,47 +22,106 @@ from tldw_Server_API.app.core.testing import (
 )
 
 API_V1_PREFIX = "/api/v1"
+REQUIRED_ROUTER_SKIP_EXCEPTIONS: tuple[type[Exception], ...] = ()
+
+
 def iter_minimal_test_router_specs() -> Iterable[RouterSpec]:
     """Yield the always-included minimal-test router specs."""
-    from tldw_Server_API.app.api.v1.endpoints.auth import router as auth_router
-    from tldw_Server_API.app.api.v1.endpoints.character_chat_sessions import (
-        router as character_chat_sessions_router,
-    )
-    from tldw_Server_API.app.api.v1.endpoints.character_memory import (
-        router as character_memory_router,
-    )
-    from tldw_Server_API.app.api.v1.endpoints.character_messages import (
-        router as character_messages_router,
-    )
-    from tldw_Server_API.app.api.v1.endpoints.characters_endpoint import router as character_router
-    from tldw_Server_API.app.api.v1.endpoints.chat import conversations_alias_router
-    from tldw_Server_API.app.api.v1.endpoints.chat import router as chat_router
-    from tldw_Server_API.app.api.v1.endpoints.chat_loop import router as chat_loop_router
-    from tldw_Server_API.app.api.v1.endpoints.health import router as health_router
-    from tldw_Server_API.app.api.v1.endpoints.paper_search import router as paper_search_router
-    from tldw_Server_API.app.api.v1.endpoints.research import router as research_router
-    from tldw_Server_API.app.api.v1.endpoints.research_runs import router as research_runs_router
-    from tldw_Server_API.app.api.v1.endpoints.workspaces import router as workspaces_router
-
-    return [
-        RouterSpec(router=health_router, prefix=f"{API_V1_PREFIX}", tags=("health",)),
-        RouterSpec(router=auth_router, prefix=f"{API_V1_PREFIX}", tags=("authentication",)),
-        RouterSpec(router=research_router, prefix=f"{API_V1_PREFIX}/research", tags=("research",)),
-        RouterSpec(router=research_runs_router, prefix=f"{API_V1_PREFIX}", tags=("research-runs",)),
-        RouterSpec(router=paper_search_router, prefix=f"{API_V1_PREFIX}/paper-search", tags=("paper-search",)),
-        RouterSpec(router=chat_router, prefix=f"{API_V1_PREFIX}/chat"),
-        RouterSpec(router=chat_loop_router, prefix=f"{API_V1_PREFIX}"),
-        RouterSpec(router=conversations_alias_router, prefix=f"{API_V1_PREFIX}/chats", tags=("chat",)),
-        RouterSpec(router=character_router, prefix=f"{API_V1_PREFIX}/characters", tags=("characters",)),
-        RouterSpec(router=character_memory_router, prefix=f"{API_V1_PREFIX}/characters", tags=("character-memory",)),
-        RouterSpec(
-            router=character_chat_sessions_router,
+    specs: list[RouterSpec] = []
+    for definition in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.health",
+            log_name="health",
+            prefix=f"{API_V1_PREFIX}",
+            tags=("health",),
+            skip_exceptions=REQUIRED_ROUTER_SKIP_EXCEPTIONS,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.auth",
+            log_name="auth",
+            prefix=f"{API_V1_PREFIX}",
+            tags=("authentication",),
+            skip_exceptions=REQUIRED_ROUTER_SKIP_EXCEPTIONS,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.research",
+            log_name="research",
+            prefix=f"{API_V1_PREFIX}/research",
+            tags=("research",),
+            skip_exceptions=REQUIRED_ROUTER_SKIP_EXCEPTIONS,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.research_runs",
+            log_name="research_runs",
+            prefix=f"{API_V1_PREFIX}",
+            tags=("research-runs",),
+            skip_exceptions=REQUIRED_ROUTER_SKIP_EXCEPTIONS,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.paper_search",
+            log_name="paper_search",
+            prefix=f"{API_V1_PREFIX}/paper-search",
+            tags=("paper-search",),
+            skip_exceptions=REQUIRED_ROUTER_SKIP_EXCEPTIONS,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.chat",
+            log_name="chat",
+            prefix=f"{API_V1_PREFIX}/chat",
+            skip_exceptions=REQUIRED_ROUTER_SKIP_EXCEPTIONS,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.chat_loop",
+            log_name="chat_loop",
+            prefix=f"{API_V1_PREFIX}",
+            skip_exceptions=REQUIRED_ROUTER_SKIP_EXCEPTIONS,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.chat",
+            log_name="conversations_alias",
+            prefix=f"{API_V1_PREFIX}/chats",
+            tags=("chat",),
+            attr_name="conversations_alias_router",
+            skip_exceptions=REQUIRED_ROUTER_SKIP_EXCEPTIONS,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.characters_endpoint",
+            log_name="characters",
+            prefix=f"{API_V1_PREFIX}/characters",
+            tags=("characters",),
+            skip_exceptions=REQUIRED_ROUTER_SKIP_EXCEPTIONS,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.character_memory",
+            log_name="character_memory",
+            prefix=f"{API_V1_PREFIX}/characters",
+            tags=("character-memory",),
+            skip_exceptions=REQUIRED_ROUTER_SKIP_EXCEPTIONS,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.character_chat_sessions",
+            log_name="character_chat_sessions",
             prefix=f"{API_V1_PREFIX}/chats",
             tags=("character-chat-sessions",),
+            skip_exceptions=REQUIRED_ROUTER_SKIP_EXCEPTIONS,
         ),
-        RouterSpec(router=character_messages_router, prefix=f"{API_V1_PREFIX}", tags=("character-messages",)),
-        RouterSpec(router=workspaces_router, prefix=f"{API_V1_PREFIX}/workspaces", tags=("workspaces",)),
-    ]
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.character_messages",
+            log_name="character_messages",
+            prefix=f"{API_V1_PREFIX}",
+            tags=("character-messages",),
+            skip_exceptions=REQUIRED_ROUTER_SKIP_EXCEPTIONS,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.workspaces",
+            log_name="workspaces",
+            prefix=f"{API_V1_PREFIX}/workspaces",
+            tags=("workspaces",),
+            skip_exceptions=REQUIRED_ROUTER_SKIP_EXCEPTIONS,
+        ),
+    ):
+        append_imported_router_spec(specs, definition)
+    return specs
 
 
 def _audio_jobs_imports_enabled_for_runtime() -> bool:

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -4145,9 +4145,10 @@ def test_iter_minimal_test_router_specs_propagates_runtime_import_failures(
 
     specs = list(iter_minimal_test_router_specs())
     auth_spec = next(spec for spec in specs if spec.name == "auth")
+    assert auth_spec.skip_exceptions == ()
 
     with pytest.raises(RuntimeError, match="auth router crashed during import"):
-        auth_spec.resolve_router()
+        register_router_specs(FastAPI(), (auth_spec,))
 
 
 def test_iter_minimal_optional_router_specs_defers_llamacpp_messages_attr_lookup(

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import builtins
 import sys
 from collections import Counter
 from pathlib import Path
@@ -4059,6 +4060,94 @@ def test_iter_minimal_test_router_specs_includes_health_and_auth(
     assert by_first_path["/auth/login"].prefix == "/api/v1"
     assert by_first_path["/auth/login"].tags == ("authentication",)
     assert by_first_path["/auth/login"].route_key == ""
+
+
+def test_iter_minimal_test_router_specs_defers_endpoint_imports(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify minimal always-included router specs do not import endpoints during construction."""
+    from tldw_Server_API.app.api.v1.router_groups.minimal import iter_minimal_test_router_specs
+
+    endpoint_modules = {
+        "tldw_Server_API.app.api.v1.endpoints.auth",
+        "tldw_Server_API.app.api.v1.endpoints.character_chat_sessions",
+        "tldw_Server_API.app.api.v1.endpoints.character_memory",
+        "tldw_Server_API.app.api.v1.endpoints.character_messages",
+        "tldw_Server_API.app.api.v1.endpoints.characters_endpoint",
+        "tldw_Server_API.app.api.v1.endpoints.chat",
+        "tldw_Server_API.app.api.v1.endpoints.chat_loop",
+        "tldw_Server_API.app.api.v1.endpoints.health",
+        "tldw_Server_API.app.api.v1.endpoints.paper_search",
+        "tldw_Server_API.app.api.v1.endpoints.research",
+        "tldw_Server_API.app.api.v1.endpoints.research_runs",
+        "tldw_Server_API.app.api.v1.endpoints.workspaces",
+    }
+    real_import = builtins.__import__
+
+    def fail_on_minimal_endpoint_import(
+        name: str,
+        globals: dict[str, object] | None = None,
+        locals: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> object:
+        if name in endpoint_modules:
+            raise AssertionError(f"unexpected eager minimal endpoint import: {name}")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fail_on_minimal_endpoint_import)
+
+    specs = list(iter_minimal_test_router_specs())
+
+    assert len(specs) == 13
+    assert all(not isinstance(spec.router, APIRouter) for spec in specs)
+
+
+def test_minimal_source_delegates_always_included_routers_to_imported_specs() -> None:
+    """Verify minimal always-included router specs no longer direct-import endpoints."""
+    source = _minimal_group_source_text()
+
+    assert "from tldw_Server_API.app.api.v1.endpoints.auth import router as auth_router" not in source
+    assert "from tldw_Server_API.app.api.v1.endpoints.character_chat_sessions import" not in source
+    assert "from tldw_Server_API.app.api.v1.endpoints.character_memory import" not in source
+    assert "from tldw_Server_API.app.api.v1.endpoints.character_messages import" not in source
+    assert (
+        "from tldw_Server_API.app.api.v1.endpoints.characters_endpoint import router as character_router"
+        not in source
+    )
+    assert "from tldw_Server_API.app.api.v1.endpoints.chat import conversations_alias_router" not in source
+    assert "from tldw_Server_API.app.api.v1.endpoints.chat import router as chat_router" not in source
+    assert "from tldw_Server_API.app.api.v1.endpoints.chat_loop import router as chat_loop_router" not in source
+    assert "from tldw_Server_API.app.api.v1.endpoints.health import router as health_router" not in source
+    assert "from tldw_Server_API.app.api.v1.endpoints.paper_search import router as paper_search_router" not in source
+    assert "from tldw_Server_API.app.api.v1.endpoints.research import router as research_router" not in source
+    assert "from tldw_Server_API.app.api.v1.endpoints.research_runs import router as research_runs_router" not in source
+    assert "from tldw_Server_API.app.api.v1.endpoints.workspaces import router as workspaces_router" not in source
+
+
+def test_iter_minimal_test_router_specs_propagates_runtime_import_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify required minimal routers propagate runtime import defects at resolution."""
+    from tldw_Server_API.app.api.v1.router_groups.minimal import iter_minimal_test_router_specs
+
+    auth_module_name = "tldw_Server_API.app.api.v1.endpoints.auth"
+
+    class CrashingAuthModule(ModuleType):
+        """Fake auth module whose router lookup fails like a runtime defect."""
+
+        def __getattr__(self, name: str) -> APIRouter:
+            if name == "router":
+                raise RuntimeError("auth router crashed during import")
+            raise AttributeError(name)
+
+    monkeypatch.setitem(sys.modules, auth_module_name, CrashingAuthModule(auth_module_name))
+
+    specs = list(iter_minimal_test_router_specs())
+    auth_spec = next(spec for spec in specs if spec.name == "auth")
+
+    with pytest.raises(RuntimeError, match="auth router crashed during import"):
+        auth_spec.resolve_router()
 
 
 def test_iter_minimal_optional_router_specs_defers_llamacpp_messages_attr_lookup(


### PR DESCRIPTION
## Change summary

Defers the always-included minimal-test router imports in `router_groups/minimal.py` through `ImportedRouterSpec`, keeping the same prefixes/tags while avoiding endpoint imports during spec construction. Required minimal routers use an empty skip-exception tuple so missing modules or runtime defects still fail instead of being treated as optional skips.

## Tests

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "minimal_test_router_specs or always_included" -q`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/router_groups/minimal.py -f json -o /tmp/bandit_phase2_2_minimal_always_router_conditionals_bg.json`
- `git diff --check`

Refs TASK-119 and continues #1116 after #1369.