### PR TITLE
Phase 2.2: remove minimal setup import

### DIFF
--- a/backlog/tasks/task-120 - Phase-2.2-minimal-setup-router-conditional-cleanup-BH.md
+++ b/backlog/tasks/task-120 - Phase-2.2-minimal-setup-router-conditional-cleanup-BH.md
@@ -4,7 +4,7 @@ title: Phase 2.2 minimal setup router conditional cleanup BH
 status: Done
 assignee: []
 created_date: '2026-05-08 02:27'
-updated_date: '2026-05-08 02:35'
+updated_date: '2026-05-08 02:54'
 labels:
   - phase-2.2
   - router-groups
@@ -31,19 +31,25 @@ Continue Phase 2.2 router cleanup after PR #1370 by removing the dead direct min
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-1. Add a RED source/contract assertion showing the remaining direct setup endpoint import in main.py is not allowed. 2. Remove the unused minimal-mode setup_router import/exception block from main.py. 3. Run focused router/main contract tests, Bandit on touched production file and test file, and git diff --check before committing.
+PR #1371 review fix pass: strengthen the setup-import regression contracts only. Replace the one-off literal source assertion with an AST-based direct-import detector for app/main.py, catch importlib.import_module/import_module/__import__ string-literal setup endpoint probes at source level, broaden the runtime import guard to catch package fromlist setup imports, run focused contract tests plus the previous validation slice, then reply to and resolve the two review threads.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
 RED: added a main source assertion for the remaining direct endpoints.setup import and verified it failed in test_main_source_delegates_minimal_optional_llm_routers_to_group. GREEN: removed the unused MINIMAL_TEST_APP setup_router import block from app/main.py and tightened the main import contract so direct setup imports raise AssertionError. Validation: focused router contract selector passed with 2 passed; focused main router selector passed with 1 passed; full router group contract suite passed with 170 passed; main router contracts passed with 6 passed; OpenAPI contracts passed with 69 passed; git diff --check passed. Bandit on app/main.py reported 0 results and 0 errors. Broader touched-scope Bandit reported pre-existing test-file B404/B603 findings on subprocess import/call lines outside this patch's changed lines; no new security findings introduced.
+
+Reopened for PR #1371 review comments. Qodo and CodeRabbit both found the same valid reliability gap: current tests reject only one exact setup import spelling. Plan is to strengthen tests without changing production behavior.
+
+PR #1371 review fix: replaced the brittle setup import substring assertion with an AST scan that catches Import, ImportFrom, and direct dynamic import calls for tldw_Server_API.app.api.v1.endpoints.setup. Broadened the runtime builtins.__import__ guard to reject direct setup module imports, setup submodule imports, and from tldw_Server_API.app.api.v1.endpoints import setup. Validation: focused router setup contract passed; focused main setup guard passed; full router group contracts passed with 170 passed; main router contracts passed with 6 passed; OpenAPI contracts passed with 69 passed; git diff --check passed; Bandit app/main.py passed with 0 results; filtered test Bandit passed with expected pre-existing B404/B603 skipped after unfiltered run showed only those existing subprocess-test findings outside this patch's changed lines.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Removed the dead direct setup endpoint import from the MINIMAL_TEST_APP branch in app/main.py so setup registration stays delegated to router groups. Added source/import contract coverage that prevents reintroducing the direct setup probe while preserving the existing minimal setup router spec metadata.
+
+PR #1371 review comments addressed by hardening the setup-import contract tests without changing production behavior: source scanning now catches alternate direct setup endpoint import forms, and the runtime guard now catches from ...endpoints import setup as well as direct setup module imports.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-120 - Phase-2.2-minimal-setup-router-conditional-cleanup-BH.md
+++ b/backlog/tasks/task-120 - Phase-2.2-minimal-setup-router-conditional-cleanup-BH.md
@@ -1,0 +1,57 @@
+---
+id: TASK-120
+title: Phase 2.2 minimal setup router conditional cleanup BH
+status: Done
+assignee: []
+created_date: '2026-05-08 02:27'
+updated_date: '2026-05-08 02:35'
+labels:
+  - phase-2.2
+  - router-groups
+  - minimal
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1371'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue Phase 2.2 router cleanup after PR #1370 by removing the dead direct minimal-mode setup endpoint import from app/main.py. The setup router is already represented by the minimal router group; main should rely on grouped registration instead of probing the endpoint directly.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 main.py no longer imports endpoints.setup directly for MINIMAL_TEST_APP
+- [x] #2 minimal router group continues to expose the setup router spec with the existing /api/v1 prefix and setup tag
+- [x] #3 minimal app/router contract tests validate the grouped setup path without the dead main import
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a RED source/contract assertion showing the remaining direct setup endpoint import in main.py is not allowed. 2. Remove the unused minimal-mode setup_router import/exception block from main.py. 3. Run focused router/main contract tests, Bandit on touched production file and test file, and git diff --check before committing.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+RED: added a main source assertion for the remaining direct endpoints.setup import and verified it failed in test_main_source_delegates_minimal_optional_llm_routers_to_group. GREEN: removed the unused MINIMAL_TEST_APP setup_router import block from app/main.py and tightened the main import contract so direct setup imports raise AssertionError. Validation: focused router contract selector passed with 2 passed; focused main router selector passed with 1 passed; full router group contract suite passed with 170 passed; main router contracts passed with 6 passed; OpenAPI contracts passed with 69 passed; git diff --check passed. Bandit on app/main.py reported 0 results and 0 errors. Broader touched-scope Bandit reported pre-existing test-file B404/B603 findings on subprocess import/call lines outside this patch's changed lines; no new security findings introduced.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Removed the dead direct setup endpoint import from the MINIMAL_TEST_APP branch in app/main.py so setup registration stays delegated to router groups. Added source/import contract coverage that prevents reintroducing the direct setup probe while preserving the existing minimal setup router spec metadata.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/main.py
+++ b/tldw_Server_API/app/main.py
@@ -1125,14 +1125,7 @@ if _ULTRA_MINIMAL_APP:
     # endpoint imports beyond control-plane health handling.
     pass
 elif _MINIMAL_TEST_APP:
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.setup import router as setup_router
-    except _IMPORT_EXCEPTIONS as _setup_min_import_err:
-        logger.debug(
-            "Skipping setup router import in minimal test app: {}",
-            _setup_min_import_err,
-        )
-        setup_router = None  # type: ignore[assignment]
+    _startup_trace("Minimal test app router imports delegated to router groups.")
 else:
     _startup_trace("Full app router imports delegated to router groups.")
 

--- a/tldw_Server_API/tests/Services/test_main_router_contract.py
+++ b/tldw_Server_API/tests/Services/test_main_router_contract.py
@@ -75,7 +75,7 @@ def test_minimal_app_uses_router_registry(client_user_only) -> None:
 
 
 @pytest.mark.unit
-def test_minimal_app_import_survives_setup_router_import_error(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_minimal_app_import_does_not_probe_setup_router_directly(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("TEST_MODE", "1")
     monkeypatch.setenv("MINIMAL_TEST_APP", "1")
     monkeypatch.setenv("ULTRA_MINIMAL_APP", "0")
@@ -86,7 +86,7 @@ def test_minimal_app_import_survives_setup_router_import_error(monkeypatch: pyte
 
     def _guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
         if name == "tldw_Server_API.app.api.v1.endpoints.setup":
-            raise ImportError("setup router unavailable")
+            raise AssertionError("setup router should be registered through router groups")
         return original_import(name, globals, locals, fromlist, level)
 
     monkeypatch.setattr(builtins, "__import__", _guarded_import)

--- a/tldw_Server_API/tests/Services/test_main_router_contract.py
+++ b/tldw_Server_API/tests/Services/test_main_router_contract.py
@@ -85,7 +85,14 @@ def test_minimal_app_import_does_not_probe_setup_router_directly(monkeypatch: py
     clear_app_main()
 
     def _guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
-        if name == "tldw_Server_API.app.api.v1.endpoints.setup":
+        setup_module = "tldw_Server_API.app.api.v1.endpoints.setup"
+        endpoints_module = "tldw_Server_API.app.api.v1.endpoints"
+        requested_attrs = {fromlist} if isinstance(fromlist, str) else set(fromlist or ())
+        if (
+            name == setup_module
+            or name.startswith(f"{setup_module}.")
+            or (name == endpoints_module and "setup" in requested_attrs)
+        ):
             raise AssertionError("setup router should be registered through router groups")
         return original_import(name, globals, locals, fromlist, level)
 

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -11522,6 +11522,7 @@ def test_main_source_delegates_minimal_optional_llm_routers_to_group() -> None:
     assert "from tldw_Server_API.app.api.v1.endpoints.acp_permissions import router as acp_permissions_router" not in source
     assert "from tldw_Server_API.app.api.v1.endpoints.acp_multiplex import router as acp_multiplex_router" not in source
     assert "from tldw_Server_API.app.api.v1.endpoints.agent_orchestration import router as orch_router" not in source
+    assert "from tldw_Server_API.app.api.v1.endpoints.setup import router as setup_router" not in source
     assert "from tldw_Server_API.app.api.v1.endpoints.metrics import router as metrics_router" not in source
     assert "from tldw_Server_API.app.api.v1.endpoints.authnz_debug import router as authnz_debug_router" not in source
     assert "from tldw_Server_API.app.api.v1.endpoints.sandbox import router as sandbox_router" not in source

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import builtins
 import sys
 from collections import Counter
@@ -23,6 +24,8 @@ from tldw_Server_API.app.core.testing import is_explicit_pytest_runtime
 
 pytestmark = pytest.mark.unit
 
+SETUP_ENDPOINT_MODULE = "tldw_Server_API.app.api.v1.endpoints.setup"
+SETUP_ENDPOINT_PACKAGE = "tldw_Server_API.app.api.v1.endpoints"
 KANBAN_ROUTER_MODULE_PREFIX = "tldw_Server_API.app.api.v1.endpoints.kanban."
 KANBAN_ROUTER_DEFINITION_DATA = (
     ("kanban_boards", "/boards"),
@@ -256,6 +259,58 @@ MINIMAL_TAIL_ROUTER_DEFINITION_DATA = (
 def _main_source_text() -> str:
     main_path = Path(__file__).resolve().parents[2] / "app" / "main.py"
     return main_path.read_text(encoding="utf-8")
+
+
+def _main_setup_endpoint_import_violations(source: str) -> list[str]:
+    """Return direct setup endpoint imports found in app/main.py source."""
+    tree = ast.parse(source)
+    violations: list[str] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if (
+                    alias.name == SETUP_ENDPOINT_MODULE
+                    or alias.name.startswith(f"{SETUP_ENDPOINT_MODULE}.")
+                ):
+                    violations.append(f"import {alias.name}")
+
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if (
+                module == SETUP_ENDPOINT_MODULE
+                or module.startswith(f"{SETUP_ENDPOINT_MODULE}.")
+            ):
+                violations.append(f"from {module} import ...")
+            elif module == SETUP_ENDPOINT_PACKAGE and any(
+                alias.name == "setup" for alias in node.names
+            ):
+                violations.append(f"from {module} import setup")
+
+        elif isinstance(node, ast.Call) and _imports_setup_endpoint_by_name(node):
+            violations.append("dynamic import of setup endpoint")
+
+    return violations
+
+
+def _imports_setup_endpoint_by_name(node: ast.Call) -> bool:
+    if not node.args:
+        return False
+
+    module_arg = node.args[0]
+    if not isinstance(module_arg, ast.Constant) or module_arg.value != SETUP_ENDPOINT_MODULE:
+        return False
+
+    func = node.func
+    return (
+        (
+            isinstance(func, ast.Attribute)
+            and func.attr == "import_module"
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "importlib"
+        )
+        or (isinstance(func, ast.Name) and func.id in {"import_module", "__import__"})
+    )
 
 
 def _minimal_group_source_text() -> str:
@@ -11522,7 +11577,7 @@ def test_main_source_delegates_minimal_optional_llm_routers_to_group() -> None:
     assert "from tldw_Server_API.app.api.v1.endpoints.acp_permissions import router as acp_permissions_router" not in source
     assert "from tldw_Server_API.app.api.v1.endpoints.acp_multiplex import router as acp_multiplex_router" not in source
     assert "from tldw_Server_API.app.api.v1.endpoints.agent_orchestration import router as orch_router" not in source
-    assert "from tldw_Server_API.app.api.v1.endpoints.setup import router as setup_router" not in source
+    assert not _main_setup_endpoint_import_violations(source)
     assert "from tldw_Server_API.app.api.v1.endpoints.metrics import router as metrics_router" not in source
     assert "from tldw_Server_API.app.api.v1.endpoints.authnz_debug import router as authnz_debug_router" not in source
     assert "from tldw_Server_API.app.api.v1.endpoints.sandbox import router as sandbox_router" not in source


### PR DESCRIPTION
## Change summary

This removes the last direct `endpoints.setup` probe from the minimal-test branch in `app/main.py`. The setup router is already represented in `iter_minimal_optional_router_specs()`, so `main.py` should delegate minimal router registration to the grouped registry rather than importing the endpoint just to tolerate failures.

The tests now cover that contract in two ways:
- the main source contract rejects reintroducing `from ...endpoints.setup import router as setup_router`
- the minimal app import contract fails if `main.py` tries to import `endpoints.setup` directly

## Tests

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "main_source_delegates_minimal_optional_llm_routers_to_group or iter_minimal_optional_router_specs_defers_tail_attr_lookup" -q`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -k "minimal_app_import_does_not_probe_setup_router_directly" -q`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/main.py -f json -o /tmp/bandit_phase2_2_minimal_setup_router_bh_main_only.json`
- `git diff --check`

Bandit note: broader touched-scope Bandit also reported pre-existing test-file `B404`/`B603` subprocess findings outside this patch's changed lines; `app/main.py` reported zero findings.
