### PR TITLE
Refresh sandbox host-local warning inventory

### DIFF
--- a/Docs/Sandbox/sandbox-runtime-capability-inventory.md
+++ b/Docs/Sandbox/sandbox-runtime-capability-inventory.md
@@ -271,11 +271,17 @@ image-store correlation, reconciliation, read-only recovery-summary projection,
 dry-run repair, and host-gated real VM smoke. Those details are intentionally
 not generalized until other runtimes have an equally clear ownership model.
 
+Host-local isolation warnings are now carried through public discovery,
+cross-runtime admin diagnostics, and the admin Monitoring page's
+`Sandbox Runtime Isolation` card. This covers the operator-visible warning
+surface for `seatbelt` and `worktree` while preserving the core policy rule:
+host-local runtimes remain weaker than VM-grade isolation and are not eligible
+for `untrusted` workloads.
+
 ## Current Gaps
 
 | Gap | Runtime(s) | Follow-up phase |
 | --- | --- | --- |
-| Host-local runtime warnings need to be carried into future UI/operator dashboards, not just docs and API metadata. | `seatbelt`, `worktree` | Phase 2 |
 | Additional real allowlist implementations remain limited beyond Docker granular enforcement. | all except unsupported paths | Future |
 | Rich structured error metadata beyond the first normalized alias pass remains incomplete. | all | Phase 3 |
 | Cross-runtime session behavior contract tests and recovery flows remain incomplete beyond the discovery-level `session_contract`. | all | Phase 4 |

--- a/backlog/tasks/task-121 - Refresh-sandbox-inventory-after-host-local-warnings-UI.md
+++ b/backlog/tasks/task-121 - Refresh-sandbox-inventory-after-host-local-warnings-UI.md
@@ -1,0 +1,64 @@
+---
+id: TASK-121
+title: Refresh sandbox inventory after host-local warnings UI
+status: Done
+assignee: []
+created_date: '2026-05-08 02:52'
+labels:
+  - sandbox
+  - docs
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1336'
+documentation:
+  - Docs/Sandbox/sandbox-runtime-capability-inventory.md
+  - Docs/superpowers/specs/2026-05-02-sandbox-module-roadmap-design.md
+  - Docs/superpowers/plans/2026-05-06-sandbox-host-local-warnings-ui.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Reconcile the sandbox runtime capability inventory after PR #1336 delivered the admin Monitoring UI surface for host-local runtime warnings. Keep this narrow: update stale current-gap wording so the inventory no longer claims seatbelt/worktree warnings still need future UI/operator dashboard propagation, and add a focused guard test so the stale wording does not return.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Capability inventory no longer lists host-local warning UI/operator dashboard propagation as an open gap after PR #1336.
+- [x] #2 Inventory still preserves explicit weaker-isolation guidance for seatbelt and worktree.
+- [x] #3 Focused docs/capability guard test fails before the wording update and passes after it.
+- [x] #4 Verification records the focused test, diff check, and Bandit result/rationale for docs/test-only scope.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused failing guard assertion against the stale host-local warning gap wording. 2. Update sandbox-runtime-capability-inventory.md to record the UI/operator warning surface as covered and keep remaining gaps scoped to actual unresolved work. 3. Run the focused guard test and git diff --check; skip Bandit if the final diff remains docs/test-only.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+RED: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py::test_inventory_no_longer_lists_host_local_warning_ui_as_missing -q` failed because the inventory still contained `future UI/operator dashboards`.
+
+GREEN: Updated `Docs/Sandbox/sandbox-runtime-capability-inventory.md` to say host-local isolation warnings now flow through public discovery, cross-runtime admin diagnostics, and the admin Monitoring page `Sandbox Runtime Isolation` card. Removed the stale current-gap row while keeping seatbelt/worktree weaker-isolation and not-untrusted-eligible guidance.
+
+Verification: focused RED/GREEN guard passed after the doc update; full `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py -q` passed with 5 tests; `py_compile` passed for the touched test; Ruff passed for the touched test; Bandit on the touched test with pytest assert-use noise excluded (`-s B101`) reported zero findings; `git diff --check` passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Refreshed the sandbox runtime capability inventory after PR #1336. The inventory now records that host-local isolation warnings are surfaced through discovery, admin runtime diagnostics, and the admin Monitoring `Sandbox Runtime Isolation` card, and no longer lists UI/operator dashboard propagation as an open gap. Added a guard test so that stale gap wording does not return.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-121 - Refresh-sandbox-inventory-after-host-local-warnings-UI.md
+++ b/backlog/tasks/task-121 - Refresh-sandbox-inventory-after-host-local-warnings-UI.md
@@ -4,6 +4,7 @@ title: Refresh sandbox inventory after host-local warnings UI
 status: Done
 assignee: []
 created_date: '2026-05-08 02:52'
+updated_date: '2026-05-08 03:05'
 labels:
   - sandbox
   - docs
@@ -34,23 +35,29 @@ Reconcile the sandbox runtime capability inventory after PR #1336 delivered the 
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-1. Add a focused failing guard assertion against the stale host-local warning gap wording. 2. Update sandbox-runtime-capability-inventory.md to record the UI/operator warning surface as covered and keep remaining gaps scoped to actual unresolved work. 3. Run the focused guard test and git diff --check; skip Bandit if the final diff remains docs/test-only.
+PR #1373 review fix pass: remove local absolute paths from the task record, scope the stale-gap guard to the Current Gaps section, add the missing test docstring, make the host-local warning assertion match inventory text case-insensitively, rerun focused sandbox checks plus hygiene, then reply to and resolve review threads.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-RED: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py::test_inventory_no_longer_lists_host_local_warning_ui_as_missing -q` failed because the inventory still contained `future UI/operator dashboards`.
+RED: python -m pytest tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py::test_inventory_no_longer_lists_host_local_warning_ui_as_missing -q failed because the inventory still contained `future UI/operator dashboards`.
 
 GREEN: Updated `Docs/Sandbox/sandbox-runtime-capability-inventory.md` to say host-local isolation warnings now flow through public discovery, cross-runtime admin diagnostics, and the admin Monitoring page `Sandbox Runtime Isolation` card. Removed the stale current-gap row while keeping seatbelt/worktree weaker-isolation and not-untrusted-eligible guidance.
 
-Verification: focused RED/GREEN guard passed after the doc update; full `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py -q` passed with 5 tests; `py_compile` passed for the touched test; Ruff passed for the touched test; Bandit on the touched test with pytest assert-use noise excluded (`-s B101`) reported zero findings; `git diff --check` passed.
+Verification: focused RED/GREEN guard passed after the doc update; full python -m pytest tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py -q passed with 5 tests; py_compile passed for the touched test; Ruff passed for the touched test; Bandit on the touched test with pytest assert-use noise excluded (-s B101) reported zero findings; git diff --check passed.
+
+Reopened for PR #1373 review comments. Gemini and Qodo findings were valid against the reviewed code/task text: task notes contained local absolute paths; the stale phrase assertion scanned the whole document; the new guard test had no docstring; and the host-local phrase check was case-sensitive against capitalized inventory text.
+
+PR #1373 review fix validation: focused host-local inventory guard passed; full python -m pytest tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py -q passed with 5 tests; py_compile passed; Ruff passed; Bandit on the touched test with -s B101 reported zero findings; git diff --check passed. Review fixes removed local absolute paths from task verification text, scoped the stale-gap assertion to Current Gaps, added the test docstring, and made the host-local warning assertion case-insensitive within Recovery And Diagnostics Support.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Refreshed the sandbox runtime capability inventory after PR #1336. The inventory now records that host-local isolation warnings are surfaced through discovery, admin runtime diagnostics, and the admin Monitoring `Sandbox Runtime Isolation` card, and no longer lists UI/operator dashboard propagation as an open gap. Added a guard test so that stale gap wording does not return.
+Refreshed the sandbox runtime capability inventory after PR #1336. The inventory now records that host-local isolation warnings are surfaced through discovery, admin runtime diagnostics, and the admin Monitoring `Sandbox Runtime Isolation` card, and no longer lists UI/operator dashboard propagation as an open gap. Added and review-hardened a focused guard test so stale gap wording does not return and the host-local warning coverage is checked in the intended section.
+
+PR #1373 review comments addressed: task verification commands are now portable, and the sandbox inventory guard test now documents its intent while checking the relevant markdown sections instead of relying on whole-document substring matches.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py
+++ b/tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py
@@ -187,10 +187,17 @@ def test_portable_runtime_capability_gate_inventory_no_longer_lists_gate_as_miss
 def test_inventory_no_longer_lists_host_local_warning_ui_as_missing(
     pytestconfig: pytest.Config,
 ) -> None:
+    """Guard against re-listing delivered host-local warning UI work as a gap."""
     repo_root = Path(pytestconfig.rootpath)
     inventory = repo_root / "Docs" / "Sandbox" / "sandbox-runtime-capability-inventory.md"
     text = inventory.read_text(encoding="utf-8")
+    current_gaps = _markdown_section(text, "Current Gaps")
+    diagnostics_section = _markdown_section(text, "Recovery And Diagnostics Support")
 
-    assert "future UI/operator dashboards" not in text
-    assert "Sandbox Runtime Isolation" in text
-    assert "host-local isolation warnings" in text
+    assert "future UI/operator dashboards" not in current_gaps
+    assert "Sandbox Runtime Isolation" in diagnostics_section
+    assert re.search(
+        r"\bhost-local isolation warnings\b",
+        diagnostics_section,
+        flags=re.IGNORECASE,
+    )

--- a/tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py
+++ b/tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py
@@ -182,3 +182,15 @@ def test_portable_runtime_capability_gate_inventory_no_longer_lists_gate_as_miss
 
     assert "CI has no single cross-runtime capability gate" not in text
     assert _portable_gate_scope_is_documented(text)
+
+
+def test_inventory_no_longer_lists_host_local_warning_ui_as_missing(
+    pytestconfig: pytest.Config,
+) -> None:
+    repo_root = Path(pytestconfig.rootpath)
+    inventory = repo_root / "Docs" / "Sandbox" / "sandbox-runtime-capability-inventory.md"
+    text = inventory.read_text(encoding="utf-8")
+
+    assert "future UI/operator dashboards" not in text
+    assert "Sandbox Runtime Isolation" in text
+    assert "host-local isolation warnings" in text


### PR DESCRIPTION
## Summary
- Update the sandbox runtime capability inventory after PR #1336 delivered the admin Monitoring UI surface for host-local warning visibility.
- Remove the stale current-gap row that still said host-local warnings needed future UI/operator dashboard propagation.
- Add and review-harden a portable capability-gate guard so the stale gap wording does not return.

## Test Plan
- [x] RED before inventory update: `python -m pytest tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py::test_inventory_no_longer_lists_host_local_warning_ui_as_missing -q` failed on `future UI/operator dashboards`.
- [x] `python -m pytest tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py::test_inventory_no_longer_lists_host_local_warning_ui_as_missing -q`
- [x] `python -m pytest tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py -q`
- [x] `python -m py_compile tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py`
- [x] `python -m ruff check tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py`
- [x] `python -m bandit -r tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py -s B101 -f json -o /tmp/bandit_sandbox_host_local_inventory_reconciliation_review_fix.json`
- [x] `git diff --check`

## Change summary
Human-written Change summary will be added by the maintainer before merge.