### PR TITLE
Adapt UnifiedLoadingState to shared LoadingState

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -5522,17 +5522,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "local-loading-state:src/components/Common/UnifiedLoadingState.tsx:UnifiedLoadingState",
-    "path": "src/components/Common/UnifiedLoadingState.tsx",
-    "rule": "local-loading-state",
-    "subject": "UnifiedLoadingState",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing local UnifiedLoadingState loading-state wrapper before the guard.",
-    "replacement": "LoadingState or StatePanel",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "local-loading-state:src/components/DocumentWorkspace/LeftSidebar/QuickInsightsTab.tsx:LoadingState",
     "path": "src/components/DocumentWorkspace/LeftSidebar/QuickInsightsTab.tsx",
     "rule": "local-loading-state",

--- a/apps/packages/ui/scripts/design-system-product-state-rules.mjs
+++ b/apps/packages/ui/scripts/design-system-product-state-rules.mjs
@@ -445,7 +445,7 @@ function collectCanonicalDesignSystemUsage(sourceFile, fileSubject) {
       imports.emptyState,
       fileSubject
     ),
-    loadingStateOwners: collectJsxTagOwners(
+    loadingStateOwners: collectReturnedJsxTagOwners(
       sourceFile,
       imports.loadingState,
       fileSubject
@@ -573,6 +573,173 @@ function collectJsxTagOwners(sourceFile, localNames, fallbackOwner) {
   })
 
   return owners
+}
+
+function collectReturnedJsxTagOwners(sourceFile, localNames, fallbackOwner) {
+  const owners = new Set()
+
+  if (!localNames || localNames.size === 0) {
+    return owners
+  }
+
+  walk(sourceFile, (node) => {
+    if (!isFunctionLikeNode(node)) {
+      return
+    }
+
+    const ownerName = returnedJsxOwnerName(node, fallbackOwner)
+    if (!ownerName) {
+      return
+    }
+
+    const returnsMatchingTag = collectOwnReturnExpressions(node).some(
+      (expression) => expressionDirectlyReturnsJsxTag(expression, localNames)
+    )
+    if (returnsMatchingTag) {
+      owners.add(ownerName)
+    }
+  })
+
+  return owners
+}
+
+function returnedJsxOwnerName(functionNode, fallbackOwner) {
+  if (functionNode.name && ts.isIdentifier(functionNode.name)) {
+    return functionNode.name.text
+  }
+
+  if (
+    ts.isArrowFunction(functionNode) ||
+    ts.isFunctionExpression(functionNode)
+  ) {
+    const variable = findVariableDeclarationOwner(functionNode)
+    if (
+      variable &&
+      ts.isIdentifier(variable.name) &&
+      isLikelyComponentName(variable.name.text)
+    ) {
+      return variable.name.text
+    }
+  }
+
+  if (isDefaultExportFunction(functionNode)) {
+    return fallbackOwner
+  }
+
+  return undefined
+}
+
+function isDefaultExportFunction(functionNode) {
+  return (
+    Boolean(
+      functionNode.modifiers?.some(
+        (modifier) => modifier.kind === ts.SyntaxKind.DefaultKeyword
+      )
+    ) ||
+    Boolean(functionNode.parent && ts.isExportAssignment(functionNode.parent))
+  )
+}
+
+function collectOwnReturnExpressions(functionNode) {
+  if (!functionNode.body) {
+    return []
+  }
+
+  if (!ts.isBlock(functionNode.body)) {
+    return [functionNode.body]
+  }
+
+  const expressions = []
+  walkOwnReturnStatements(functionNode.body, (returnStatement) => {
+    if (returnStatement.expression) {
+      expressions.push(returnStatement.expression)
+    }
+  })
+
+  return expressions
+}
+
+function walkOwnReturnStatements(node, visitor) {
+  const visit = (child) => {
+    if (
+      child !== node &&
+      (isFunctionLikeNode(child) ||
+        ts.isClassDeclaration(child) ||
+        ts.isClassExpression(child))
+    ) {
+      return
+    }
+
+    if (ts.isReturnStatement(child)) {
+      visitor(child)
+      return
+    }
+
+    ts.forEachChild(child, visit)
+  }
+
+  visit(node)
+}
+
+function expressionDirectlyReturnsJsxTag(expression, localNames) {
+  const unwrapped = unwrapReturnedExpression(expression)
+
+  if (ts.isJsxSelfClosingElement(unwrapped)) {
+    const localName = jsxTagName(unwrapped.tagName)
+    return Boolean(localName && localNames.has(localName))
+  }
+
+  if (ts.isJsxElement(unwrapped)) {
+    const localName = jsxTagName(unwrapped.openingElement.tagName)
+    return Boolean(localName && localNames.has(localName))
+  }
+
+  if (ts.isConditionalExpression(unwrapped)) {
+    return (
+      expressionDirectlyReturnsJsxTag(unwrapped.whenTrue, localNames) ||
+      expressionDirectlyReturnsJsxTag(unwrapped.whenFalse, localNames)
+    )
+  }
+
+  return false
+}
+
+function unwrapReturnedExpression(expression) {
+  let current = expression
+
+  while (true) {
+    if (
+      ts.isParenthesizedExpression(current) ||
+      ts.isAsExpression(current) ||
+      ts.isTypeAssertionExpression(current) ||
+      ts.isNonNullExpression(current)
+    ) {
+      current = current.expression
+      continue
+    }
+
+    if (
+      typeof ts.isSatisfiesExpression === "function" &&
+      ts.isSatisfiesExpression(current)
+    ) {
+      current = current.expression
+      continue
+    }
+
+    return current
+  }
+}
+
+function isFunctionLikeNode(node) {
+  return (
+    ts.isFunctionDeclaration(node) ||
+    ts.isFunctionExpression(node) ||
+    ts.isArrowFunction(node) ||
+    ts.isMethodDeclaration(node) ||
+    ts.isConstructorDeclaration(node) ||
+    ts.isGetAccessorDeclaration(node) ||
+    ts.isSetAccessorDeclaration(node)
+  )
 }
 
 function pushCanonicalLabelFindings(findings, relativePath, sourceFile) {

--- a/apps/packages/ui/scripts/design-system-product-state-rules.mjs
+++ b/apps/packages/ui/scripts/design-system-product-state-rules.mjs
@@ -397,7 +397,8 @@ function collectAntdProductStateImports(sourceFile) {
 
 function collectCanonicalDesignSystemUsage(sourceFile, fileSubject) {
   const imports = {
-    emptyState: new Set()
+    emptyState: new Set(),
+    loadingState: new Set()
   }
 
   for (const statement of sourceFile.statements) {
@@ -424,11 +425,17 @@ function collectCanonicalDesignSystemUsage(sourceFile, fileSubject) {
         if (importedName === "EmptyState") {
           imports.emptyState.add(element.name.text)
         }
+        if (importedName === "LoadingState") {
+          imports.loadingState.add(element.name.text)
+        }
       }
     }
 
     if (importClause?.name && /\/EmptyState$/.test(importPath)) {
       imports.emptyState.add(importClause.name.text)
+    }
+    if (importClause?.name && /\/LoadingState$/.test(importPath)) {
+      imports.loadingState.add(importClause.name.text)
     }
   }
 
@@ -436,6 +443,11 @@ function collectCanonicalDesignSystemUsage(sourceFile, fileSubject) {
     emptyStateOwners: collectJsxTagOwners(
       sourceFile,
       imports.emptyState,
+      fileSubject
+    ),
+    loadingStateOwners: collectJsxTagOwners(
+      sourceFile,
+      imports.loadingState,
       fileSubject
     )
   }
@@ -515,7 +527,10 @@ function pushLocalComponentFinding(
     })
   }
 
-  if (LOADING_COMPONENT_PATTERN.test(subject)) {
+  if (
+    LOADING_COMPONENT_PATTERN.test(subject) &&
+    !canonicalUsage.loadingStateOwners?.has(subject)
+  ) {
     pushFinding(findings, {
       relativePath,
       rule: "local-loading-state",

--- a/apps/packages/ui/src/components/Common/UnifiedLoadingState.tsx
+++ b/apps/packages/ui/src/components/Common/UnifiedLoadingState.tsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useMemo } from "react"
-import { Skeleton } from "antd"
 import { useTranslation } from "react-i18next"
-import { cn } from "@/libs/utils"
 import { translateMessage } from "@/i18n/translateMessage"
+import { LoadingState } from "@/components/ui/feedback/LoadingState"
 
 export interface LoadingSource {
   key: string
@@ -53,7 +52,6 @@ export function UnifiedLoadingState({
     () => sources.filter((source) => source.loading),
     [sources]
   )
-  const isAnyLoading = loadingSources.length > 0
 
   useEffect(() => {
     if (!showLabels) return
@@ -70,38 +68,35 @@ export function UnifiedLoadingState({
     }
   }, [loadingSources, showLabels])
 
-  if (!isAnyLoading) {
-    return <>{children}</>
-  }
+  const translatedLoadingSources = useMemo(
+    () =>
+      loadingSources.map((source) => {
+        const label = source.label
+          ? translateMessage(t, source.label, source.label)
+          : translateMessage(
+              t,
+              `common:loadingSource.${source.key}`,
+              `Loading: ${source.key}`
+            )
 
-  const getSourceLabel = (source: LoadingSource) => {
-    if (source.label) {
-      return translateMessage(t, source.label, source.label)
-    }
-    return translateMessage(
-      t,
-      `common:loadingSource.${source.key}`,
-      `Loading: ${source.key}`
-    )
-  }
+        return {
+          ...source,
+          label
+        }
+      }),
+    [loadingSources, t]
+  )
 
   return (
-    <div className={cn("flex flex-col items-center py-4 px-2", className)}>
-      {showLabels && loadingSources.length > 0 && (
-        <div className="flex flex-wrap gap-1 mb-3 text-xs text-text-subtle">
-          {loadingSources.map((source) => (
-            <span
-              key={source.key}
-              className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-surface2"
-            >
-              <span className="w-1.5 h-1.5 rounded-full bg-primary animate-pulse" />
-              {getSourceLabel(source)}
-            </span>
-          ))}
-        </div>
-      )}
-      <Skeleton active paragraph={{ rows }} className="w-full" />
-    </div>
+    <LoadingState
+      mode="skeleton"
+      rows={rows}
+      sources={translatedLoadingSources}
+      showLabels={showLabels}
+      className={className}
+    >
+      {children}
+    </LoadingState>
   )
 }
 

--- a/apps/packages/ui/src/components/Common/UnifiedLoadingState.tsx
+++ b/apps/packages/ui/src/components/Common/UnifiedLoadingState.tsx
@@ -71,21 +71,27 @@ export function UnifiedLoadingState({
   const translatedLoadingSources = useMemo(
     () =>
       loadingSources.map((source) => {
-        const label = source.label
-          ? translateMessage(t, source.label, source.label)
-          : translateMessage(
-              t,
-              `common:loadingSource.${source.key}`,
-              `Loading: ${source.key}`
-            )
+        const label = showLabels
+          ? source.label
+            ? translateMessage(t, source.label, source.label)
+            : translateMessage(
+                t,
+                `common:loadingSource.${source.key}`,
+                `Loading: ${source.key}`
+              )
+          : source.label
 
         return {
           ...source,
           label
         }
       }),
-    [loadingSources, t]
+    [loadingSources, showLabels, t]
   )
+
+  if (loadingSources.length === 0) {
+    return <>{children}</>
+  }
 
   return (
     <LoadingState

--- a/apps/packages/ui/src/components/Common/__tests__/UnifiedLoadingState.test.tsx
+++ b/apps/packages/ui/src/components/Common/__tests__/UnifiedLoadingState.test.tsx
@@ -3,9 +3,9 @@ import { render, screen } from "@testing-library/react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { UnifiedLoadingState } from "../UnifiedLoadingState"
 
-vi.mock("react-i18next", () => ({
-  useTranslation: () => ({
-    t: (
+const { tSpy } = vi.hoisted(() => ({
+  tSpy: vi.fn(
+    (
       key: string,
       fallbackOrOptions?: string | { defaultValue?: string }
     ) => {
@@ -15,10 +15,17 @@ vi.mock("react-i18next", () => ({
       }
       return key
     }
+  )
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: tSpy
   })
 }))
 
 afterEach(() => {
+  tSpy.mockClear()
   vi.restoreAllMocks()
 })
 
@@ -48,7 +55,7 @@ describe("UnifiedLoadingState", () => {
   })
 
   it("renders children once all sources finish loading", () => {
-    render(
+    const { container } = render(
       <UnifiedLoadingState
         sources={[
           { key: "local", loading: false, label: "Local data" },
@@ -61,7 +68,22 @@ describe("UnifiedLoadingState", () => {
     )
 
     expect(screen.getByText("Loaded content")).toBeInTheDocument()
+    expect(
+      container.querySelector('[data-ds-component="LoadingState"]')
+    ).not.toBeInTheDocument()
     expect(screen.queryByText("Local data")).not.toBeInTheDocument()
+  })
+
+  it("does not translate source labels when labels are hidden", () => {
+    render(
+      <UnifiedLoadingState
+        sources={[{ key: "folders", loading: true }]}
+        showLabels={false}
+      />
+    )
+
+    expect(tSpy).not.toHaveBeenCalled()
+    expect(screen.queryByText("Loading: folders")).not.toBeInTheDocument()
   })
 
   it("keeps the development warning for active sources without labels", () => {

--- a/apps/packages/ui/src/components/Common/__tests__/UnifiedLoadingState.test.tsx
+++ b/apps/packages/ui/src/components/Common/__tests__/UnifiedLoadingState.test.tsx
@@ -1,0 +1,82 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { UnifiedLoadingState } from "../UnifiedLoadingState"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      key: string,
+      fallbackOrOptions?: string | { defaultValue?: string }
+    ) => {
+      if (typeof fallbackOrOptions === "string") return fallbackOrOptions
+      if (fallbackOrOptions && typeof fallbackOrOptions === "object") {
+        return fallbackOrOptions.defaultValue || key
+      }
+      return key
+    }
+  })
+}))
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("UnifiedLoadingState", () => {
+  it("adapts active sources to the canonical LoadingState primitive", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined)
+    const { container } = render(
+      <UnifiedLoadingState
+        sources={[
+          { key: "local", loading: true, label: "Local data" },
+          { key: "server", loading: false, label: "Server sync" },
+          { key: "folders", loading: true }
+        ]}
+        showLabels
+      >
+        <div>Loaded content</div>
+      </UnifiedLoadingState>
+    )
+
+    expect(
+      container.querySelector('[data-ds-component="LoadingState"]')
+    ).toBeInTheDocument()
+    expect(screen.getByText("Local data")).toBeInTheDocument()
+    expect(screen.queryByText("Server sync")).not.toBeInTheDocument()
+    expect(screen.getByText("Loading: folders")).toBeInTheDocument()
+    expect(screen.queryByText("Loaded content")).not.toBeInTheDocument()
+  })
+
+  it("renders children once all sources finish loading", () => {
+    render(
+      <UnifiedLoadingState
+        sources={[
+          { key: "local", loading: false, label: "Local data" },
+          { key: "server", loading: false, label: "Server sync" }
+        ]}
+        showLabels
+      >
+        <div>Loaded content</div>
+      </UnifiedLoadingState>
+    )
+
+    expect(screen.getByText("Loaded content")).toBeInTheDocument()
+    expect(screen.queryByText("Local data")).not.toBeInTheDocument()
+  })
+
+  it("keeps the development warning for active sources without labels", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined)
+
+    render(
+      <UnifiedLoadingState
+        sources={[{ key: "folders", loading: true }]}
+        showLabels
+      />
+    )
+
+    expect(warn).toHaveBeenCalledWith(
+      "[UnifiedLoadingState] Missing labels for loading sources:",
+      ["folders"]
+    )
+  })
+})

--- a/apps/packages/ui/src/components/ui/feedback/LoadingState.tsx
+++ b/apps/packages/ui/src/components/ui/feedback/LoadingState.tsx
@@ -222,6 +222,7 @@ export const LoadingState = React.forwardRef<HTMLDivElement, LoadingStateProps>(
             className
           )}
           data-testid={dataTestId}
+          data-ds-component="LoadingState"
         >
           {renderSourceLabels()}
           {renderContent()}
@@ -232,7 +233,11 @@ export const LoadingState = React.forwardRef<HTMLDivElement, LoadingStateProps>(
     // Overlay loading
     if (overlay) {
       return (
-        <div ref={ref} className={cn("relative", className)}>
+        <div
+          ref={ref}
+          className={cn("relative", className)}
+          data-ds-component="LoadingState"
+        >
           {children}
           <div
             className="absolute inset-0 flex items-center justify-center bg-bg/60 backdrop-blur-[2px]"
@@ -251,6 +256,7 @@ export const LoadingState = React.forwardRef<HTMLDivElement, LoadingStateProps>(
         ref={ref}
         className={cn("flex flex-col items-center px-2 py-4", className)}
         data-testid={dataTestId}
+        data-ds-component="LoadingState"
       >
         {renderSourceLabels()}
         {renderContent()}

--- a/apps/packages/ui/src/design-system/__tests__/product-state-guard.test.ts
+++ b/apps/packages/ui/src/design-system/__tests__/product-state-guard.test.ts
@@ -109,6 +109,28 @@ describe("design-system product-state guard rules", () => {
     )
   })
 
+  it("allows compatibility loading-state adapters that render the canonical LoadingState", () => {
+    const findings = analyze(
+      "src/components/Common/FeatureLoadingState.tsx",
+      `
+        import { LoadingState } from "@/components/ui/feedback/LoadingState"
+
+        export function FeatureLoadingState() {
+          return <LoadingState mode="skeleton" />
+        }
+      `
+    )
+
+    expect(findings).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          rule: "local-loading-state",
+          subject: "FeatureLoadingState"
+        })
+      ])
+    )
+  })
+
   it("still flags sibling empty-state components that do not render canonical EmptyState", () => {
     const findings = analyze(
       "src/components/Common/FeatureEmptyState.tsx",

--- a/apps/packages/ui/src/design-system/__tests__/product-state-guard.test.ts
+++ b/apps/packages/ui/src/design-system/__tests__/product-state-guard.test.ts
@@ -131,6 +131,58 @@ describe("design-system product-state guard rules", () => {
     )
   })
 
+  it("allows compatibility loading-state adapters that conditionally return LoadingState", () => {
+    const findings = analyze(
+      "src/components/Common/FeatureLoadingState.tsx",
+      `
+        import { LoadingState } from "@/components/ui/feedback/LoadingState"
+
+        export function FeatureLoadingState({ loading, children }) {
+          if (!loading) {
+            return <>{children}</>
+          }
+
+          return loading ? <LoadingState mode="skeleton" /> : null
+        }
+      `
+    )
+
+    expect(findings).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          rule: "local-loading-state",
+          subject: "FeatureLoadingState"
+        })
+      ])
+    )
+  })
+
+  it("flags local loading wrappers that only nest the canonical LoadingState", () => {
+    const findings = analyze(
+      "src/components/Common/FeatureLoadingState.tsx",
+      `
+        import { LoadingState } from "@/components/ui/feedback/LoadingState"
+
+        export function FeatureLoadingState() {
+          return (
+            <div className="legacy-loading-shell">
+              <LoadingState mode="skeleton" />
+            </div>
+          )
+        }
+      `
+    )
+
+    expect(findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          rule: "local-loading-state",
+          subject: "FeatureLoadingState"
+        })
+      ])
+    )
+  })
+
   it("still flags sibling empty-state components that do not render canonical EmptyState", () => {
     const findings = analyze(
       "src/components/Common/FeatureEmptyState.tsx",

--- a/backlog/tasks/task-45.17 - Adapt-UnifiedLoadingState-to-shared-LoadingState.md
+++ b/backlog/tasks/task-45.17 - Adapt-UnifiedLoadingState-to-shared-LoadingState.md
@@ -1,0 +1,58 @@
+---
+id: TASK-45.17
+title: Adapt UnifiedLoadingState to shared LoadingState
+status: Done
+assignee: []
+created_date: '2026-05-08 03:05'
+updated_date: '2026-05-08 03:08'
+labels: []
+dependencies: []
+references:
+  - apps/packages/ui/src/components/Common/UnifiedLoadingState.tsx
+  - apps/packages/ui/src/components/ui/feedback/LoadingState.tsx
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+parent_task_id: TASK-45
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue the tldw_server WebUI design-system migration by replacing the legacy Common UnifiedLoadingState implementation with a compatibility adapter around the canonical shared LoadingState primitive while preserving existing caller behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 UnifiedLoadingState renders through the shared design-system LoadingState primitive for active loading sources.
+- [x] #2 Existing children fallback, source label translation, and missing-label development diagnostics are preserved.
+- [x] #3 The product-state guard baseline removes the UnifiedLoadingState local-loading-state exception without increasing other findings.
+- [x] #4 Focused tests and design-system guard verification pass for the touched slice.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add red coverage for LoadingState adapter conformance and UnifiedLoadingState behavior. 2. Adapt UnifiedLoadingState to the shared LoadingState primitive while preserving translated labels and children fallback. 3. Remove the obsolete baseline exception and verify the design-system guard count drops.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verification: bunx vitest run src/design-system/__tests__/product-state-guard.test.ts src/components/Common/__tests__/UnifiedLoadingState.test.tsx --reporter=dot passed with 43 tests. bun run verify:design-system-state passed and reports 519 baseline exceptions with local-loading-state down to 3. git diff --check passed. bunx tsc --noEmit --pretty false was attempted but still fails on pre-existing package-wide test/type errors outside this slice; no reported errors referenced the touched files. Bandit skipped because this slice only touches frontend TypeScript/JavaScript and JSON.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Adapted the legacy Common UnifiedLoadingState wrapper to render through the canonical design-system LoadingState primitive, added LoadingState design-system markers for conformance tests, taught the product-state guard to allow canonical LoadingState compatibility adapters, and removed the UnifiedLoadingState local-loading-state baseline entry.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.17.1 - Address-PR-1374-UnifiedLoadingState-review-comments.md
+++ b/backlog/tasks/task-45.17.1 - Address-PR-1374-UnifiedLoadingState-review-comments.md
@@ -1,0 +1,58 @@
+---
+id: TASK-45.17.1
+title: Address PR 1374 UnifiedLoadingState review comments
+status: Done
+assignee: []
+created_date: '2026-05-08 05:35'
+updated_date: '2026-05-08 05:36'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1374'
+  - apps/packages/ui/src/components/Common/UnifiedLoadingState.tsx
+  - >-
+    apps/packages/ui/src/components/Common/__tests__/UnifiedLoadingState.test.tsx
+parent_task_id: TASK-45.17
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address the actionable PR 1374 review feedback on the UnifiedLoadingState design-system adapter by making the loaded-state compatibility boundary explicit and documenting it in focused tests.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 UnifiedLoadingState returns children without the LoadingState wrapper when no sources are loading.
+- [x] #2 Label translation for active loading sources only performs fallback translation when labels are shown.
+- [x] #3 Focused UnifiedLoadingState and product-state guard tests pass after the review fix.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused review-regression coverage for the loaded state and hidden labels. 2. Restore the explicit no-loading fragment return while keeping hooks unconditional. 3. Skip translation fallback work when source labels are hidden and rerun focused verification.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Review comments addressed: restored explicit children-only return when loadingSources is empty; added a test that no LoadingState marker exists after loading; added a red-green test proving hidden labels do not call the translation fallback; kept product-state guard behavior unchanged. Verification: bunx vitest run src/components/Common/__tests__/UnifiedLoadingState.test.tsx src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed with 44 tests. bun run verify:design-system-state passed with baseline exceptions still at 519 and local-loading-state at 3. git diff --check passed. Bandit skipped because this is frontend TypeScript/test-only work.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed PR 1374 UnifiedLoadingState review comments by making the loaded-state fragment return explicit, avoiding hidden-label translation work, and extending tests to prevent the wrapper/layout regression.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.17.2 - Tighten-LoadingState-adapter-guard-return-detection.md
+++ b/backlog/tasks/task-45.17.2 - Tighten-LoadingState-adapter-guard-return-detection.md
@@ -1,0 +1,57 @@
+---
+id: TASK-45.17.2
+title: Tighten LoadingState adapter guard return detection
+status: Done
+assignee: []
+created_date: '2026-05-08 05:47'
+updated_date: '2026-05-08 05:49'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1374'
+  - apps/packages/ui/scripts/design-system-product-state-rules.mjs
+  - apps/packages/ui/src/design-system/__tests__/product-state-guard.test.ts
+parent_task_id: TASK-45.17
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address PR 1374 review feedback that the product-state guard currently treats any nested LoadingState JSX as a canonical loading adapter. Tighten the adapter allowance so local loading-state components are exempt only when their returned loading UI is the canonical LoadingState primitive.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Guard allows direct LoadingState return adapters, including simple conditional return expressions.
+- [x] #2 Guard still flags local loading components that merely nest LoadingState while returning bespoke loading UI.
+- [x] #3 Focused product-state guard tests and design-system verifier pass after the rule change.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add red guard coverage for nested-only LoadingState usage and conditional direct returns. 2. Replace loading adapter owner detection with direct return-expression detection while leaving EmptyState detection unchanged. 3. Rerun focused guard tests and the full design-system state verifier.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verification: bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot failed first because nested LoadingState usage produced no local-loading-state finding. After the rule change, bunx vitest run src/components/Common/__tests__/UnifiedLoadingState.test.tsx src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed with 46 tests. bun run verify:design-system-state passed and baseline exceptions remained 519 with local-loading-state at 3. git diff --check passed. Bandit skipped because this is frontend JavaScript/test-only guard work.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Tightened LoadingState adapter guard detection so local loading wrappers are exempt only when they directly return the canonical LoadingState primitive, including conditional returns, while nested-only LoadingState usage remains flagged.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Adapted Common UnifiedLoadingState to render through the canonical design-system LoadingState primitive while preserving active-source filtering, translated labels, children fallback, and development missing-label diagnostics.
- Added LoadingState data-ds-component markers and guard coverage so compatibility loading adapters are allowed only when they render the canonical primitive.
- Removed the UnifiedLoadingState local-loading-state baseline entry; remaining baseline count is now 519, with local-loading-state down to 3.

## Verification
- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts src/components/Common/__tests__/UnifiedLoadingState.test.tsx --reporter=dot
- bun run verify:design-system-state
- git diff --check
- bunx tsc --noEmit --pretty false attempted; package-wide compile still fails on existing unrelated test/type errors outside this slice, with no failures reported in touched files.

## Merge note
- Draft PR because the AI-generated PR merge gate still requires the human requester to add their own Change summary before marking ready/merging.