### PR TITLE
Add sandbox status reason details

### DIFF
--- a/Docs/API-related/Sandbox_API.md
+++ b/Docs/API-related/Sandbox_API.md
@@ -370,19 +370,30 @@ Response (scaffold example):
   "base_image": "python:3.11-slim",
   "phase": "completed",
   "status_reason_code": "completed",
+  "status_reason_details": {
+    "code": "completed",
+    "category": "success",
+    "severity": "info",
+    "terminal": true,
+    "retryable": false,
+    "operator_action": "none",
+    "user_message_key": "sandbox.status.completed"
+  },
   "exit_code": 0,
   "policy_hash": "<hash>",
   "log_stream_url": "ws://host/api/v1/sandbox/runs/<run_id>/stream?from_seq=100"
 }
 ```
 
-`status_reason_code` is additive and derived from existing status data. Clients
-should use the exact returned literals for stable grouping: `queued`,
-`starting`, `running`, `completed`, `limits_applied`, `nonzero_exit`,
-`policy_failed`, `runtime_unavailable`, `startup_timeout`,
+`status_reason_code` and `status_reason_details` are additive and derived from
+existing status data. Clients should use the exact returned literals for stable
+grouping: `queued`, `starting`, `running`, `completed`, `limits_applied`,
+`nonzero_exit`, `policy_failed`, `runtime_unavailable`, `startup_timeout`,
 `execution_timeout`, `canceled_by_user`, `killed`, `queue_ttl_expired`,
-`runtime_error`, and `unknown`. Raw `phase`, `message`, and `exit_code` remain
-available for display and operator diagnostics.
+`runtime_error`, and `unknown`. Details add stable grouping metadata such as
+`category`, `severity`, `terminal`, `retryable`, `operator_action`, and
+`user_message_key`. Raw `phase`, `message`, and `exit_code` remain available
+for display and operator diagnostics.
 
 ## Stream logs (WebSocket)
 WS `/api/v1/sandbox/runs/{id}/stream`

--- a/Docs/Sandbox/sandbox-runtime-capability-inventory.md
+++ b/Docs/Sandbox/sandbox-runtime-capability-inventory.md
@@ -173,6 +173,11 @@ limit signals. Raw runner messages remain available for operator diagnostics;
 clients should group by `status_reason_code` instead of matching runtime
 message strings.
 
+Run status responses also expose additive `status_reason_details` derived from
+the same code. Details include `category`, `severity`, `terminal`, `retryable`,
+`operator_action`, and `user_message_key`; they are response metadata, not
+additional persisted run state.
+
 ## Trust-Level Support
 
 | Runtime | `trusted` | `standard` | `untrusted` | Notes |
@@ -283,7 +288,7 @@ for `untrusted` workloads.
 | Gap | Runtime(s) | Follow-up phase |
 | --- | --- | --- |
 | Additional real allowlist implementations remain limited beyond Docker granular enforcement. | all except unsupported paths | Future |
-| Rich structured error metadata beyond the first normalized alias pass remains incomplete. | all | Phase 3 |
+| Run status responses expose structured `status_reason_details`, but runtime discovery `normalized_reasons` still lack equivalent rich details. | all | Phase 3 |
 | Cross-runtime session behavior contract tests and recovery flows remain incomplete beyond the discovery-level `session_contract`. | all | Phase 4 |
 | Recovery/repair ownership exists only for `vz_linux`. | all except `vz_linux` | Phase 4 |
 | No single CI job proves real execution for every runtime; the portable capability gate covers capability contracts only. | all | Phase 5 |

--- a/Docs/superpowers/plans/2026-05-08-sandbox-status-reason-details-plan.md
+++ b/Docs/superpowers/plans/2026-05-08-sandbox-status-reason-details-plan.md
@@ -1,0 +1,255 @@
+# Sandbox Status Reason Details Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add additive structured metadata for existing sandbox `status_reason_code` values on public and admin run status responses.
+
+**Architecture:** Keep the taxonomy module as the single source of truth. Add a static completeness-checked metadata map keyed by existing `RunStatusReasonCode` literals, expose it through Pydantic schemas, and serialize it in endpoints from the same local helper that computes `status_reason_code`.
+
+**Tech Stack:** Python 3.11, FastAPI, Pydantic v2, pytest, Ruff, Bandit.
+
+---
+
+## Files
+
+- Modify: `tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/sandbox.py`
+- Modify: `tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py`
+- Modify: `tldw_Server_API/tests/sandbox/test_run_status_contract_durability.py`
+- Modify: `Docs/Sandbox/sandbox-runtime-capability-inventory.md`
+- Modify: `Docs/API-related/Sandbox_API.md`
+- Modify: `backlog/tasks/task-122 - Add-structured-sandbox-run-status-reason-metadata.md`
+
+## Task 1: Taxonomy Metadata Contract
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py`
+- Test: `tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py`
+
+- [x] **Step 1: Write failing completeness and sample metadata tests**
+
+Add tests that import `RUN_STATUS_REASON_METADATA`, `RunStatusReasonCode`, and `run_status_reason_details()` and assert:
+
+```python
+def test_run_status_reason_metadata_covers_every_reason_code() -> None:
+    assert set(RUN_STATUS_REASON_METADATA) == set(get_args(RunStatusReasonCode))
+
+
+def test_run_status_reason_details_exposes_stable_metadata() -> None:
+    assert run_status_reason_details("runtime_unavailable").category == "runtime"
+    assert run_status_reason_details("runtime_unavailable").severity == "error"
+    assert run_status_reason_details("runtime_unavailable").retryable is True
+    assert run_status_reason_details("policy_failed").operator_action == "review_policy"
+    assert run_status_reason_details("limits_applied").severity == "warning"
+```
+
+- [x] **Step 2: Run RED test**
+
+Run:
+
+```bash
+python -m pytest tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py::test_run_status_reason_metadata_covers_every_reason_code tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py::test_run_status_reason_details_exposes_stable_metadata -q
+```
+
+Expected: fails because metadata symbols do not exist.
+
+- [x] **Step 3: Implement minimal taxonomy metadata**
+
+Add literal types, frozen dataclass, static metadata map, import-time completeness validation, and `run_status_reason_details()`.
+
+Keep unknown external input safe:
+
+```python
+def run_status_reason_details(code: RunStatusReasonCode | str | None) -> RunStatusReasonDetails:
+    code_value = str(code or "unknown").strip()
+    metadata = RUN_STATUS_REASON_METADATA.get(code_value)
+    if metadata is None:
+        return RUN_STATUS_REASON_METADATA["unknown"]
+    return metadata
+```
+
+- [x] **Step 4: Run GREEN test**
+
+Run the same pytest command. Expected: both tests pass.
+
+## Task 2: Schema Exposure
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py`
+- Test: `tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py`
+
+- [x] **Step 1: Write failing schema tests**
+
+Extend the existing schema test:
+
+```python
+assert "status_reason_details" in public_schema["properties"]
+assert "status_reason_details" in admin_schema["properties"]
+```
+
+Also instantiate `SandboxRunStatus` and `SandboxAdminRunSummary` with a details object and assert `.model_dump()` preserves `code`, `category`, `severity`, `terminal`, `retryable`, `operator_action`, and `user_message_key`.
+
+- [x] **Step 2: Run RED test**
+
+Run:
+
+```bash
+python -m pytest tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py::test_public_and_admin_status_schemas_expose_reason_code -q
+```
+
+Expected: fails because the schema field does not exist.
+
+- [x] **Step 3: Add Pydantic details model and fields**
+
+Import taxonomy literal types and define `SandboxRunStatusReasonDetails`.
+Add nullable `status_reason_details` fields beside `status_reason_code` on `SandboxRunStatus` and `SandboxAdminRunSummary`.
+
+- [x] **Step 4: Run GREEN test**
+
+Run the same pytest command. Expected: passes.
+
+## Task 3: Endpoint Serialization
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/endpoints/sandbox.py`
+- Test: `tldw_Server_API/tests/sandbox/test_run_status_contract_durability.py`
+- Test: `tldw_Server_API/tests/sandbox/test_admin_details_resource_usage.py`
+- Test: `tldw_Server_API/tests/sandbox/test_admin_list_filters_pagination.py`
+
+- [x] **Step 1: Write failing response tests**
+
+Add or extend focused tests so public run status and admin run responses include:
+
+```python
+assert data["status_reason_code"] == "queued"
+assert data["status_reason_details"]["code"] == "queued"
+assert data["status_reason_details"]["category"] == "lifecycle"
+assert data["status_reason_details"]["terminal"] is False
+```
+
+For an admin completed run with truncation/resource usage, assert `limits_applied` details are returned.
+
+- [x] **Step 2: Run RED tests**
+
+Run:
+
+```bash
+python -m pytest tldw_Server_API/tests/sandbox/test_run_status_contract_durability.py tldw_Server_API/tests/sandbox/test_admin_details_resource_usage.py tldw_Server_API/tests/sandbox/test_admin_list_filters_pagination.py -q
+```
+
+Expected: at least one details assertion fails.
+
+- [x] **Step 3: Add endpoint helper**
+
+Replace `_status_reason_code()` with a helper that computes both:
+
+```python
+@dataclass(frozen=True)
+class _StatusReasonProjection:
+    code: str
+    details: SandboxRunStatusReasonDetails
+```
+
+Use `normalize_run_status_reason()` once, then `run_status_reason_details(code)`.
+Populate all four constructors:
+
+- `start_run()` response
+- `get_run_status()`
+- `admin_list_runs()`
+- `admin_get_run_details()`
+
+Implementation note: the final code uses a small `_status_reason_details()`
+helper plus a local `status_reason_code` variable instead of adding an internal
+projection dataclass. That keeps endpoint serialization explicit without adding
+a one-use abstraction.
+
+- [x] **Step 4: Run GREEN tests**
+
+Run the same pytest command. Expected: passes.
+
+## Task 4: Documentation And Inventory
+
+**Files:**
+- Modify: `Docs/Sandbox/sandbox-runtime-capability-inventory.md`
+- Modify: `Docs/API-related/Sandbox_API.md`
+- Modify: `backlog/tasks/task-122 - Add-structured-sandbox-run-status-reason-metadata.md`
+- Test: `tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py`
+
+- [x] **Step 1: Add failing docs guard if needed**
+
+If the portable capability gate does not already assert the structured metadata contract, add an assertion that the inventory mentions `status_reason_details` and preserves the Phase 3 limitation that runtime discovery reason metadata is still future work.
+
+- [x] **Step 2: Run RED docs guard**
+
+Run:
+
+```bash
+python -m pytest tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py::test_portable_runtime_capability_gate_inventory_no_longer_lists_gate_as_missing -q
+```
+
+Expected: fails if a new guard was added before docs are updated.
+
+- [x] **Step 3: Update docs**
+
+Document `status_reason_details` as additive metadata for run status responses. Update the inventory's Phase 3 gap to say run status metadata is covered, while runtime discovery `normalized_reasons` still lack equivalent rich details.
+
+- [x] **Step 4: Run GREEN docs guard**
+
+Run the focused capability gate test. Expected: passes.
+
+## Task 5: Verification And Commit
+
+**Files:**
+- All touched files
+
+- [x] **Step 1: Run focused pytest**
+
+```bash
+python -m pytest tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py tldw_Server_API/tests/sandbox/test_run_status_contract_durability.py tldw_Server_API/tests/sandbox/test_admin_details_resource_usage.py tldw_Server_API/tests/sandbox/test_admin_list_filters_pagination.py tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py -q
+```
+
+Expected: focused sandbox tests pass.
+
+- [x] **Step 2: Run compile check**
+
+```bash
+python -m py_compile tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py tldw_Server_API/app/api/v1/endpoints/sandbox.py tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py tldw_Server_API/tests/sandbox/test_run_status_contract_durability.py
+```
+
+Expected: exits 0.
+
+- [x] **Step 3: Run Ruff on touched Python files**
+
+```bash
+python -m ruff check tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py tldw_Server_API/app/api/v1/endpoints/sandbox.py tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py tldw_Server_API/tests/sandbox/test_run_status_contract_durability.py tldw_Server_API/tests/sandbox/test_admin_details_resource_usage.py tldw_Server_API/tests/sandbox/test_admin_list_filters_pagination.py tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py
+```
+
+Expected: no new Ruff failures. If pre-existing file-level warnings appear in broad files, rerun with `--select F,E9` for production files and record the limitation.
+
+- [x] **Step 4: Run Bandit on touched production Python**
+
+```bash
+python -m bandit -r tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py tldw_Server_API/app/api/v1/endpoints/sandbox.py -f json -o /tmp/bandit_sandbox_status_reason_details.json
+```
+
+Expected: zero new findings on changed production lines.
+
+- [x] **Step 5: Run whitespace check**
+
+```bash
+git diff --check
+```
+
+Expected: exits 0.
+
+- [ ] **Step 6: Update TASK-122**
+
+Check acceptance criteria and Definition of Done, add verification notes, and final summary.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Docs/superpowers/specs/2026-05-08-sandbox-status-reason-details-design.md Docs/superpowers/plans/2026-05-08-sandbox-status-reason-details-plan.md Docs/Sandbox/sandbox-runtime-capability-inventory.md Docs/API-related/Sandbox_API.md "backlog/tasks/task-122 - Add-structured-sandbox-run-status-reason-metadata.md" tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py tldw_Server_API/app/api/v1/endpoints/sandbox.py tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py tldw_Server_API/tests/sandbox/test_run_status_contract_durability.py tldw_Server_API/tests/sandbox/test_admin_details_resource_usage.py tldw_Server_API/tests/sandbox/test_admin_list_filters_pagination.py tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py
+git commit -m "feat(sandbox): expose status reason details"
+```

--- a/Docs/superpowers/specs/2026-05-08-sandbox-status-reason-details-design.md
+++ b/Docs/superpowers/specs/2026-05-08-sandbox-status-reason-details-design.md
@@ -1,0 +1,202 @@
+# Sandbox Status Reason Details Design
+
+**Status:** Approved design for a narrow Phase 3 sandbox runtime-taxonomy slice.
+**Date:** 2026-05-08.
+**Task:** TASK-122.
+
+## Goal
+
+Expose structured metadata for existing sandbox `status_reason_code` values so
+clients and operator surfaces can present stable severity, category, retry, and
+action guidance without parsing raw runner messages.
+
+This is an additive API contract. It must not change run phases, raw messages,
+stored run rows, runner behavior, or existing `status_reason_code` literals.
+
+## Context
+
+The sandbox module already exposes `status_reason_code` on public run status and
+admin run summary responses. The code is derived from existing status facts in
+`tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py`.
+
+The remaining Phase 3 gap in
+`Docs/Sandbox/sandbox-runtime-capability-inventory.md` is richer structured
+error metadata beyond the first normalized alias pass. This design closes the
+first practical part of that gap for run status responses.
+
+## Non-Goals
+
+- Do not introduce a new persisted state machine.
+- Do not rename or remove `status_reason_code`.
+- Do not change runner message text or phase transitions.
+- Do not add per-runtime special cases in API schemas.
+- Do not create a general FastAPI error-envelope migration.
+- Do not claim richer metadata for runtime discovery `normalized_reasons`; that
+  can be a later slice if needed.
+
+## API Shape
+
+Add a nullable `status_reason_details` field next to `status_reason_code` on:
+
+- `SandboxRunStatus`
+- `SandboxAdminRunSummary`
+- `SandboxAdminRunDetails` through inheritance
+
+The field is present when `status_reason_code` can be derived. It is `None` only
+when no reason code is available.
+
+Proposed details object:
+
+```json
+{
+  "code": "runtime_unavailable",
+  "category": "runtime",
+  "severity": "error",
+  "terminal": true,
+  "retryable": true,
+  "operator_action": "check_runtime_readiness",
+  "user_message_key": "sandbox.status.runtime_unavailable"
+}
+```
+
+### Field Meanings
+
+| Field | Meaning |
+| --- | --- |
+| `code` | Mirrors the existing `status_reason_code` literal. |
+| `category` | Stable grouping for client UI and diagnostics. |
+| `severity` | Presentation-level severity, not a security guarantee. |
+| `terminal` | Whether the run is in a terminal lifecycle outcome. |
+| `retryable` | Whether retry may be reasonable after conditions change. |
+| `operator_action` | Stable action hint key for operator UX. |
+| `user_message_key` | Stable localization/display key, not full prose. |
+
+Initial categories:
+
+- `lifecycle`
+- `success`
+- `limits`
+- `policy`
+- `runtime`
+- `timeout`
+- `cancellation`
+- `execution`
+- `unknown`
+
+Initial severities:
+
+- `info`
+- `warning`
+- `error`
+
+Initial operator actions:
+
+- `none`
+- `inspect_logs`
+- `review_limits`
+- `review_policy`
+- `check_runtime_readiness`
+- `retry_later`
+- `review_exit_code`
+- `unknown`
+
+## Implementation Design
+
+Centralize the contract in `run_status_taxonomy.py`:
+
+- Define `RunStatusReasonCategory`, `RunStatusReasonSeverity`, and
+  `RunStatusOperatorAction` literal types.
+- Define a frozen dataclass `RunStatusReasonDetails`.
+- Add a completeness-checked `RUN_STATUS_REASON_METADATA` map keyed by every
+  `RunStatusReasonCode`.
+- Add `run_status_reason_details(code)` to return the metadata for a code.
+- Add `normalize_run_status_reason_details(...)` as a convenience wrapper that
+  derives the code and returns details.
+
+The API endpoint should call the same helper currently used to compute
+`status_reason_code`, then derive `status_reason_details` from that code. To
+avoid double normalization and future drift, the endpoint should use one local
+helper that returns both values.
+
+The Pydantic schema should define a `SandboxRunStatusReasonDetails` model with
+literal fields matching the taxonomy module. The endpoint converts the dataclass
+to this schema model.
+
+## Metadata Policy
+
+The metadata should describe normalized outcomes, not runtime internals.
+
+Examples:
+
+- `policy_failed` is terminal, non-retryable by default, category `policy`,
+  operator action `review_policy`.
+- `runtime_unavailable` is terminal for that run, retryable after host/runtime
+  readiness changes, category `runtime`, operator action
+  `check_runtime_readiness`.
+- `limits_applied` is terminal, warning severity, category `limits`, operator
+  action `review_limits`.
+- `queued`, `starting`, and `running` are non-terminal, info severity,
+  category `lifecycle`.
+- `unknown` uses category `unknown`, warning severity, and action `unknown`.
+
+## Error Handling
+
+Missing metadata for a known code is a developer error. The module should fail
+fast at import time if `RUN_STATUS_REASON_METADATA` does not exactly cover every
+`RunStatusReasonCode` literal.
+
+Unexpected external input should not crash response serialization. If an
+unknown string reaches `run_status_reason_details()`, it should return the
+`unknown` metadata with `code="unknown"` rather than raising from API paths.
+
+## Testing
+
+Use TDD for implementation.
+
+Required focused tests:
+
+- `run_status_taxonomy.py` has metadata for every `RunStatusReasonCode`.
+- representative metadata values are correct for lifecycle, success, limits,
+  policy, runtime-unavailable, timeout, cancellation, nonzero, and unknown.
+- public and admin schemas expose `status_reason_details`.
+- public run status response includes both `status_reason_code` and matching
+  `status_reason_details`.
+- admin run list/details paths include matching details.
+- the portable runtime capability gate or inventory guard references the new
+  metadata contract so docs and code do not drift.
+
+## Documentation
+
+Update:
+
+- `Docs/Sandbox/sandbox-runtime-capability-inventory.md`
+- `Docs/API-related/Sandbox_API.md` if it already documents
+  `status_reason_code`
+- TASK-122 implementation notes and final summary
+
+The inventory should describe this as a first structured metadata pass. It
+should not remove the Phase 3 gap entirely if runtime discovery
+`normalized_reasons` still lacks equivalent rich metadata.
+
+## Design Review Notes
+
+Potential issue: duplicating `status_reason_code` inside details can drift.
+
+Resolution: details are derived from the code in the same helper and the schema
+model includes the mirrored `code` to make client rendering self-contained.
+
+Potential issue: retryability can be interpreted as a guarantee.
+
+Resolution: document `retryable` as guidance only. It means retry may be
+reasonable after conditions change; it does not promise automatic recovery.
+
+Potential issue: long prose in the API becomes compatibility-sensitive.
+
+Resolution: expose stable keys, not full human prose. UI/client layers can map
+keys to copy.
+
+Potential issue: adding metadata to all admin list rows could make response
+construction noisy.
+
+Resolution: metadata is static and derived in-process. It does not require DB
+queries or helper calls.

--- a/backlog/tasks/task-122 - Add-structured-sandbox-run-status-reason-metadata.md
+++ b/backlog/tasks/task-122 - Add-structured-sandbox-run-status-reason-metadata.md
@@ -1,0 +1,79 @@
+---
+id: TASK-122
+title: Add structured sandbox run status reason metadata
+status: Done
+assignee: []
+created_date: '2026-05-08 03:16'
+labels:
+  - sandbox
+  - runtime-taxonomy
+dependencies: []
+documentation:
+  - Docs/superpowers/specs/2026-05-08-sandbox-status-reason-details-design.md
+  - Docs/Sandbox/sandbox-runtime-capability-inventory.md
+  - Docs/Sandbox/sandbox-architecture-doctrine.md
+  - Docs/superpowers/specs/2026-05-02-sandbox-module-roadmap-design.md
+  - tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py
+  - tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add a narrow Phase 3 sandbox slice that exposes structured metadata for existing sandbox run status_reason_code values. Keep this strictly additive: do not change runner behavior, stored run rows, phases, raw messages, or existing status_reason_code literals. The goal is to let clients and operator surfaces display severity/category/retry/action guidance without runtime-specific message parsing.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Public run status responses expose additive structured details for the existing status_reason_code value without removing or renaming existing fields.
+- [x] #2 Admin run summary/detail responses expose the same additive structured details derived from the same central metadata contract.
+- [x] #3 Every RunStatusReasonCode literal has complete metadata and a focused completeness test fails if a new code is added without metadata.
+- [x] #4 Focused tests cover representative queued/running/completed/limit/policy/runtime-unavailable/timeout/canceled/nonzero/unknown metadata behavior and schema exposure.
+- [x] #5 Sandbox capability/API documentation records the structured metadata contract and updates the current Phase 3 gap wording without overstating runtime guarantees.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Design approved and captured in `Docs/superpowers/specs/2026-05-08-sandbox-status-reason-details-design.md`. Implementation followed `Docs/superpowers/plans/2026-05-08-sandbox-status-reason-details-plan.md` using a narrow additive response-field slice.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Created a fresh worktree from `origin/dev` at merge commit `182a29c2e` on branch `codex/sandbox-status-reason-details`. The design keeps the API additive: derive `status_reason_details` from existing `status_reason_code` without changing runner behavior, persisted run rows, phases, raw messages, or existing code literals.
+
+Implemented `RunStatusReasonDetails`, literal metadata types, `RUN_STATUS_REASON_METADATA`, import-time completeness validation, and `run_status_reason_details()` in `run_status_taxonomy.py`. Added nullable `status_reason_details` fields to public and admin schemas and populated them in public start/status responses plus admin list/detail responses.
+
+Updated `Docs/API-related/Sandbox_API.md` and `Docs/Sandbox/sandbox-runtime-capability-inventory.md` to document the additive details object while preserving the Phase 3 gap that runtime discovery `normalized_reasons` still lack equivalent rich details.
+
+Verification recorded:
+- RED: taxonomy metadata tests failed before metadata symbols existed.
+- RED: schema test failed before `status_reason_details` existed.
+- RED: docs guard failed before inventory updates.
+- GREEN: `python -m pytest tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py -q` passed with 17 tests.
+- GREEN: the four endpoint response tests passed individually: queued POST status, POST/GET consistency, admin details resource usage, and admin list filters/pagination.
+- Static: `python -m py_compile ...` passed for touched production modules.
+- Static: `python -m ruff check ...` passed for touched Python files after safe import/style fixes.
+- Security: `python -m bandit -r tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py tldw_Server_API/app/api/v1/endpoints/sandbox.py -f json -o /tmp/bandit_sandbox_status_reason_details.json` reported zero results.
+- Whitespace: `git diff --check` passed.
+
+Known limitation: grouping the four TestClient endpoint checks in one pytest process hung in the existing TestClient shutdown path after the first test. The same endpoint checks passed as isolated pytest processes, so this slice records the grouped run as an existing lifecycle limitation rather than a status metadata failure.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added additive structured sandbox run status reason metadata to public and admin responses, backed by a complete central taxonomy map and docs/tests that guard the contract. No runner behavior, persisted status rows, existing phases, raw messages, or `status_reason_code` literals were changed.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-122 - Add-structured-sandbox-run-status-reason-metadata.md
+++ b/backlog/tasks/task-122 - Add-structured-sandbox-run-status-reason-metadata.md
@@ -70,6 +70,8 @@ Verification recorded:
 - Whitespace: `git diff --check` passed.
 
 Known limitation: grouping the four TestClient endpoint checks in one pytest process hung in the existing TestClient shutdown path after the first test. The same endpoint checks passed as isolated pytest processes, so this slice records the grouped run as an existing lifecycle limitation rather than a status metadata failure.
+
+PR review follow-up: addressed two Gemini Code Assist threads by adding bounded caching for status reason detail schema objects and strengthening taxonomy validation so each metadata key must match its internal `code`. Added a focused mismatch regression test.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/tldw_Server_API/app/api/v1/endpoints/sandbox.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sandbox.py
@@ -11,6 +11,7 @@ import tempfile
 import threading
 import time
 from collections.abc import Mapping
+from functools import lru_cache
 from typing import Any
 
 from fastapi import (
@@ -189,12 +190,22 @@ def _status_reason_code(
     )
 
 
+@lru_cache(maxsize=32)
+def _cached_status_reason_details(
+    code: str,
+) -> SandboxRunStatusReasonDetails:
+    """Cache schema metadata for the finite normalized status reason vocabulary."""
+
+    return SandboxRunStatusReasonDetails.model_validate(run_status_reason_details(code))
+
+
 def _status_reason_details(
     code: str | None,
 ) -> SandboxRunStatusReasonDetails:
     """Build the public schema metadata for a normalized status reason code."""
 
-    return SandboxRunStatusReasonDetails.model_validate(run_status_reason_details(code))
+    return _cached_status_reason_details(str(code or "unknown").strip())
+
 
 
 @router.on_event("startup")

--- a/tldw_Server_API/app/api/v1/endpoints/sandbox.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sandbox.py
@@ -45,15 +45,16 @@ from tldw_Server_API.app.api.v1.schemas.sandbox_schemas import (
     SandboxAdminMacOSImageStoreCleanupResponse,
     SandboxAdminMacOSReconciliationRepairRequest,
     SandboxAdminMacOSReconciliationRepairResponse,
-    SandboxAdminRuntimeDiagnosticsResponse,
     SandboxAdminRunDetails,
     SandboxAdminRunListResponse,
     SandboxAdminRunSummary,
+    SandboxAdminRuntimeDiagnosticsResponse,
     SandboxAdminUsageItem,
     SandboxAdminUsageResponse,
     SandboxFileUploadResponse,
     SandboxRunCreateRequest,
     SandboxRunStatus,
+    SandboxRunStatusReasonDetails,
     SandboxRuntimesResponse,
     SandboxSession,
     SandboxSessionCreateRequest,
@@ -86,7 +87,10 @@ from tldw_Server_API.app.core.Sandbox.orchestrator import (
     SessionActiveRunsConflict,
 )
 from tldw_Server_API.app.core.Sandbox.policy import SandboxPolicy
-from tldw_Server_API.app.core.Sandbox.run_status_taxonomy import normalize_run_status_reason
+from tldw_Server_API.app.core.Sandbox.run_status_taxonomy import (
+    normalize_run_status_reason,
+    run_status_reason_details,
+)
 from tldw_Server_API.app.core.Sandbox.service import (
     SandboxImageStoreCleanupError,
     SandboxReconciliationRepairError,
@@ -185,6 +189,14 @@ def _status_reason_code(
     )
 
 
+def _status_reason_details(
+    code: str | None,
+) -> SandboxRunStatusReasonDetails:
+    """Build the public schema metadata for a normalized status reason code."""
+
+    return SandboxRunStatusReasonDetails.model_validate(run_status_reason_details(code))
+
+
 @router.on_event("startup")
 async def _sandbox_startup() -> None:
     with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
@@ -250,7 +262,7 @@ def _sandbox_ws_try_acquire_quota(
     run_key = str(run_id).strip() if run_id else None
 
     with _SANDBOX_WS_QUOTA_LOCK:
-        if total_limit > 0 and _SANDBOX_WS_ACTIVE_TOTAL >= total_limit:
+        if total_limit > 0 and total_limit <= _SANDBOX_WS_ACTIVE_TOTAL:
             return None, "total_connections_quota_exceeded"
         if per_user_limit > 0 and int(_SANDBOX_WS_ACTIVE_BY_USER.get(user_key, 0)) >= per_user_limit:
             return None, "user_connections_quota_exceeded"
@@ -1586,6 +1598,12 @@ async def start_run(
         # Fail open: omit URL on error
         log_stream_url = None
 
+    status_reason_code = _status_reason_code(
+        phase=status.phase,
+        message=status.message,
+        exit_code=status.exit_code,
+        resource_usage=status.resource_usage,
+    )
     return SandboxRunStatus(
         id=status.id,
         spec_version=payload.spec_version,
@@ -1595,12 +1613,8 @@ async def start_run(
         image_digest=status.image_digest,
         policy_hash=status.policy_hash,
         phase=status.phase.value,
-        status_reason_code=_status_reason_code(
-            phase=status.phase,
-            message=status.message,
-            exit_code=status.exit_code,
-            resource_usage=status.resource_usage,
-        ),
+        status_reason_code=status_reason_code,
+        status_reason_details=_status_reason_details(status_reason_code),
         exit_code=status.exit_code,
         started_at=status.started_at,
         finished_at=status.finished_at,
@@ -1625,6 +1639,12 @@ async def get_run_status(
     st = _service.get_run(run_id)
     if not st:
         raise HTTPException(status_code=404, detail="run_not_found")
+    status_reason_code = _status_reason_code(
+        phase=st.phase,
+        message=st.message,
+        exit_code=st.exit_code,
+        resource_usage=st.resource_usage,
+    )
     return SandboxRunStatus(
         id=st.id,
         spec_version=st.spec_version,
@@ -1634,12 +1654,8 @@ async def get_run_status(
         image_digest=st.image_digest,
         policy_hash=st.policy_hash,
         phase=st.phase.value,
-        status_reason_code=_status_reason_code(
-            phase=st.phase,
-            message=st.message,
-            exit_code=st.exit_code,
-            resource_usage=st.resource_usage,
-        ),
+        status_reason_code=status_reason_code,
+        status_reason_details=_status_reason_details(status_reason_code),
         exit_code=st.exit_code,
         started_at=st.started_at,
         finished_at=st.finished_at,
@@ -2402,6 +2418,12 @@ async def admin_list_runs(
     )
     items: list[SandboxAdminRunSummary] = []
     for r in items_raw:
+        status_reason_code = _status_reason_code(
+            phase=r.get("phase"),
+            message=r.get("message"),
+            exit_code=r.get("exit_code"),
+            resource_usage=r.get("resource_usage"),
+        )
         items.append(
             SandboxAdminRunSummary(
                 id=str(r.get("id")),
@@ -2413,12 +2435,8 @@ async def admin_list_runs(
                 image_digest=r.get("image_digest"),
                 policy_hash=r.get("policy_hash"),
                 phase=r.get("phase"),
-                status_reason_code=_status_reason_code(
-                    phase=r.get("phase"),
-                    message=r.get("message"),
-                    exit_code=r.get("exit_code"),
-                    resource_usage=r.get("resource_usage"),
-                ),
+                status_reason_code=status_reason_code,
+                status_reason_details=_status_reason_details(status_reason_code),
                 exit_code=r.get("exit_code"),
                 started_at=(r.get("started_at") if isinstance(r.get("started_at"), str) else r.get("started_at")),
                 finished_at=(r.get("finished_at") if isinstance(r.get("finished_at"), str) else r.get("finished_at")),
@@ -2464,6 +2482,12 @@ async def admin_get_run_details(
         owner = _service._orch.get_run_owner(run_id)  # type: ignore[attr-defined]
     except _SANDBOX_NONCRITICAL_EXCEPTIONS:
         owner = None
+    status_reason_code = _status_reason_code(
+        phase=st.phase,
+        message=st.message,
+        exit_code=st.exit_code,
+        resource_usage=st.resource_usage,
+    )
     return SandboxAdminRunDetails(
         id=st.id,
         user_id=(owner if owner is not None else None),
@@ -2474,6 +2498,8 @@ async def admin_get_run_details(
         image_digest=st.image_digest,
         policy_hash=st.policy_hash,
         phase=st.phase.value,
+        status_reason_code=status_reason_code,
+        status_reason_details=_status_reason_details(status_reason_code),
         exit_code=st.exit_code,
         started_at=st.started_at,
         finished_at=st.finished_at,

--- a/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 try:
     from pydantic import model_validator
@@ -11,7 +11,12 @@ except ImportError:  # pragma: no cover - pydantic v1 fallback
     from pydantic import root_validator as model_validator  # type: ignore
 
 from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
-from tldw_Server_API.app.core.Sandbox.run_status_taxonomy import RunStatusReasonCode
+from tldw_Server_API.app.core.Sandbox.run_status_taxonomy import (
+    RunStatusOperatorAction,
+    RunStatusReasonCategory,
+    RunStatusReasonCode,
+    RunStatusReasonSeverity,
+)
 from tldw_Server_API.app.core.Sandbox.runtime_capabilities import (
     RuntimeBoundaryClass,
     RuntimeImplementationState,
@@ -298,6 +303,20 @@ class SandboxRun(BaseModel):
     created_at: datetime
 
 
+class SandboxRunStatusReasonDetails(BaseModel):
+    """Structured metadata for a normalized sandbox run status reason."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    code: RunStatusReasonCode
+    category: RunStatusReasonCategory
+    severity: RunStatusReasonSeverity
+    terminal: bool
+    retryable: bool
+    operator_action: RunStatusOperatorAction
+    user_message_key: str
+
+
 class SandboxRunStatus(BaseModel):
     id: str
     spec_version: str | None = None
@@ -320,6 +339,13 @@ class SandboxRunStatus(BaseModel):
         description=(
             "Stable client-facing reason code derived from phase, message, exit_code, "
             "and aggregate limit counters. Existing phase/message fields remain raw."
+        ),
+    )
+    status_reason_details: SandboxRunStatusReasonDetails | None = Field(
+        default=None,
+        description=(
+            "Structured metadata derived from status_reason_code for client and "
+            "operator presentation. Existing raw status fields remain authoritative."
         ),
     )
     exit_code: int | None = None
@@ -374,6 +400,13 @@ class SandboxAdminRunSummary(BaseModel):
     status_reason_code: RunStatusReasonCode | None = Field(
         default=None,
         description="Stable client-facing reason code derived from the run status summary",
+    )
+    status_reason_details: SandboxRunStatusReasonDetails | None = Field(
+        default=None,
+        description=(
+            "Structured metadata derived from status_reason_code for admin/operator "
+            "presentation."
+        ),
     )
     exit_code: int | None = None
     started_at: datetime | None = None

--- a/tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py
+++ b/tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py
@@ -252,6 +252,16 @@ def _validate_run_status_reason_metadata() -> None:
             "Run status reason metadata map is incomplete: "
             f"missing={missing}, extra={extra}"
         )
+    mismatched = sorted(
+        (key, metadata.code)
+        for key, metadata in RUN_STATUS_REASON_METADATA.items()
+        if metadata.code != key
+    )
+    if mismatched:
+        raise RuntimeError(
+            "Run status reason metadata code mismatch: "
+            f"mismatched={mismatched}"
+        )
 
 
 _validate_run_status_reason_metadata()

--- a/tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py
+++ b/tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py
@@ -8,7 +8,8 @@ the raw phase, message, and exit code remain available for operator debugging.
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, Literal
+from dataclasses import dataclass
+from typing import Any, Literal, get_args
 
 from .models import RunPhase
 
@@ -29,6 +30,180 @@ RunStatusReasonCode = Literal[
     "runtime_error",
     "unknown",
 ]
+RunStatusReasonCategory = Literal[
+    "lifecycle",
+    "success",
+    "limits",
+    "policy",
+    "runtime",
+    "timeout",
+    "cancellation",
+    "execution",
+    "unknown",
+]
+RunStatusReasonSeverity = Literal["info", "warning", "error"]
+RunStatusOperatorAction = Literal[
+    "none",
+    "inspect_logs",
+    "review_limits",
+    "review_policy",
+    "check_runtime_readiness",
+    "retry_later",
+    "review_exit_code",
+    "unknown",
+]
+
+
+@dataclass(frozen=True)
+class RunStatusReasonDetails:
+    """Structured client/operator metadata for a normalized run status reason."""
+
+    code: RunStatusReasonCode
+    category: RunStatusReasonCategory
+    severity: RunStatusReasonSeverity
+    terminal: bool
+    retryable: bool
+    operator_action: RunStatusOperatorAction
+    user_message_key: str
+
+
+RUN_STATUS_REASON_METADATA: Mapping[str, RunStatusReasonDetails] = {
+    "queued": RunStatusReasonDetails(
+        code="queued",
+        category="lifecycle",
+        severity="info",
+        terminal=False,
+        retryable=False,
+        operator_action="none",
+        user_message_key="sandbox.status.queued",
+    ),
+    "starting": RunStatusReasonDetails(
+        code="starting",
+        category="lifecycle",
+        severity="info",
+        terminal=False,
+        retryable=False,
+        operator_action="none",
+        user_message_key="sandbox.status.starting",
+    ),
+    "running": RunStatusReasonDetails(
+        code="running",
+        category="lifecycle",
+        severity="info",
+        terminal=False,
+        retryable=False,
+        operator_action="none",
+        user_message_key="sandbox.status.running",
+    ),
+    "completed": RunStatusReasonDetails(
+        code="completed",
+        category="success",
+        severity="info",
+        terminal=True,
+        retryable=False,
+        operator_action="none",
+        user_message_key="sandbox.status.completed",
+    ),
+    "limits_applied": RunStatusReasonDetails(
+        code="limits_applied",
+        category="limits",
+        severity="warning",
+        terminal=True,
+        retryable=False,
+        operator_action="review_limits",
+        user_message_key="sandbox.status.limits_applied",
+    ),
+    "nonzero_exit": RunStatusReasonDetails(
+        code="nonzero_exit",
+        category="execution",
+        severity="error",
+        terminal=True,
+        retryable=True,
+        operator_action="review_exit_code",
+        user_message_key="sandbox.status.nonzero_exit",
+    ),
+    "policy_failed": RunStatusReasonDetails(
+        code="policy_failed",
+        category="policy",
+        severity="error",
+        terminal=True,
+        retryable=False,
+        operator_action="review_policy",
+        user_message_key="sandbox.status.policy_failed",
+    ),
+    "runtime_unavailable": RunStatusReasonDetails(
+        code="runtime_unavailable",
+        category="runtime",
+        severity="error",
+        terminal=True,
+        retryable=True,
+        operator_action="check_runtime_readiness",
+        user_message_key="sandbox.status.runtime_unavailable",
+    ),
+    "startup_timeout": RunStatusReasonDetails(
+        code="startup_timeout",
+        category="timeout",
+        severity="error",
+        terminal=True,
+        retryable=True,
+        operator_action="check_runtime_readiness",
+        user_message_key="sandbox.status.startup_timeout",
+    ),
+    "execution_timeout": RunStatusReasonDetails(
+        code="execution_timeout",
+        category="timeout",
+        severity="error",
+        terminal=True,
+        retryable=True,
+        operator_action="retry_later",
+        user_message_key="sandbox.status.execution_timeout",
+    ),
+    "canceled_by_user": RunStatusReasonDetails(
+        code="canceled_by_user",
+        category="cancellation",
+        severity="warning",
+        terminal=True,
+        retryable=False,
+        operator_action="none",
+        user_message_key="sandbox.status.canceled_by_user",
+    ),
+    "killed": RunStatusReasonDetails(
+        code="killed",
+        category="cancellation",
+        severity="error",
+        terminal=True,
+        retryable=True,
+        operator_action="inspect_logs",
+        user_message_key="sandbox.status.killed",
+    ),
+    "queue_ttl_expired": RunStatusReasonDetails(
+        code="queue_ttl_expired",
+        category="lifecycle",
+        severity="warning",
+        terminal=True,
+        retryable=True,
+        operator_action="retry_later",
+        user_message_key="sandbox.status.queue_ttl_expired",
+    ),
+    "runtime_error": RunStatusReasonDetails(
+        code="runtime_error",
+        category="execution",
+        severity="error",
+        terminal=True,
+        retryable=True,
+        operator_action="inspect_logs",
+        user_message_key="sandbox.status.runtime_error",
+    ),
+    "unknown": RunStatusReasonDetails(
+        code="unknown",
+        category="unknown",
+        severity="warning",
+        terminal=False,
+        retryable=False,
+        operator_action="unknown",
+        user_message_key="sandbox.status.unknown",
+    ),
+}
 
 _LIMIT_COUNTER_KEYS = (
     "stdout_truncated",
@@ -65,6 +240,21 @@ _POLICY_FAILED_MESSAGES = frozenset({
 
 _RUNTIME_CONTEXT_TERMS = ("runtime", "provision")
 _RUNTIME_UNAVAILABLE_TERMS = ("unavailable", "not found", "missing")
+
+
+def _validate_run_status_reason_metadata() -> None:
+    expected = set(get_args(RunStatusReasonCode))
+    actual = set(RUN_STATUS_REASON_METADATA)
+    missing = sorted(expected - actual)
+    extra = sorted(actual - expected)
+    if missing or extra:
+        raise RuntimeError(
+            "Run status reason metadata map is incomplete: "
+            f"missing={missing}, extra={extra}"
+        )
+
+
+_validate_run_status_reason_metadata()
 
 
 def _phase_text(phase: RunPhase | str | None) -> str:
@@ -167,3 +357,33 @@ def normalize_run_status_reason(
         return "runtime_error"
 
     return "unknown"
+
+
+def run_status_reason_details(
+    code: RunStatusReasonCode | str | None,
+) -> RunStatusReasonDetails:
+    """Return structured metadata for a run status reason code."""
+
+    code_value = str(code or "unknown").strip()
+    metadata = RUN_STATUS_REASON_METADATA.get(code_value)
+    if metadata is None:
+        return RUN_STATUS_REASON_METADATA["unknown"]
+    return metadata
+
+
+def normalize_run_status_reason_details(
+    *,
+    phase: RunPhase | str | None,
+    message: str | None,
+    exit_code: int | str | None,
+    resource_usage: Mapping[str, Any] | None,
+) -> RunStatusReasonDetails:
+    """Derive structured reason metadata from existing status data."""
+
+    code = normalize_run_status_reason(
+        phase=phase,
+        message=message,
+        exit_code=exit_code,
+        resource_usage=resource_usage,
+    )
+    return run_status_reason_details(code)

--- a/tldw_Server_API/tests/sandbox/test_admin_details_resource_usage.py
+++ b/tldw_Server_API/tests/sandbox/test_admin_details_resource_usage.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Dict
+from typing import Any
 
 from fastapi.testclient import TestClient
 
@@ -40,7 +40,7 @@ def test_admin_details_includes_resource_usage(monkeypatch) -> None:
 
     with _client(monkeypatch) as client:
         client.app.dependency_overrides[get_request_user] = _admin_user_dep
-        body: Dict[str, Any] = {
+        body: dict[str, Any] = {
             "spec_version": "1.0",
             "runtime": "docker",
             "base_image": "python:3.11-slim",
@@ -56,6 +56,9 @@ def test_admin_details_includes_resource_usage(monkeypatch) -> None:
         assert rd.status_code == 200
         j = rd.json()
         assert j.get("id") == run_id
+        assert j.get("status_reason_code") == "completed"
+        assert j.get("status_reason_details", {}).get("code") == "completed"
+        assert j.get("status_reason_details", {}).get("category") == "success"
         ru = j.get("resource_usage")
         assert isinstance(ru, dict)
         # Expect keys; values are ints (may be 0 in fake exec)

--- a/tldw_Server_API/tests/sandbox/test_admin_list_filters_pagination.py
+++ b/tldw_Server_API/tests/sandbox/test_admin_list_filters_pagination.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-import os
 from datetime import datetime, timedelta, timezone
-from typing import Any
 
 from fastapi.testclient import TestClient
 
+from tldw_Server_API.app.core.Sandbox.models import RunPhase, RunStatus, RuntimeType
 from tldw_Server_API.app.main import app
-from tldw_Server_API.app.core.Sandbox.models import RunStatus, RunPhase, RuntimeType
 
 
 def _client(monkeypatch) -> TestClient:
@@ -28,7 +26,6 @@ def _admin_user_dep():
 
 def _seed_run(run_id: str, user_id: int, image_digest: str, started_offset_sec: int, phase: str = "completed") -> None:
     from tldw_Server_API.app.api.v1.endpoints import sandbox as sb
-    from tldw_Server_API.app.core.Sandbox.models import RunPhase
     st = RunStatus(
         id=run_id,
         phase=RunPhase(phase),
@@ -72,6 +69,9 @@ def test_admin_list_filters_and_pagination(monkeypatch):
         assert j["pagination"]["has_more"] is True
         assert j["pagination"]["next_offset"] == 1
         assert len(j["items"]) == 1
+        item_details = j["items"][0].get("status_reason_details")
+        assert item_details["code"] == j["items"][0]["status_reason_code"]
+        assert item_details["category"] == "success"
 
         # Next page
         r2 = client.get("/api/v1/sandbox/admin/runs", params={"image_digest": "d1", "limit": 1, "offset": 1})

--- a/tldw_Server_API/tests/sandbox/test_run_status_contract_durability.py
+++ b/tldw_Server_API/tests/sandbox/test_run_status_contract_durability.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Dict
+from typing import Any
 
-from fastapi.testclient import TestClient
 import pytest
+from fastapi.testclient import TestClient
 
 
 def _client(monkeypatch) -> TestClient:
@@ -25,7 +25,7 @@ def _client(monkeypatch) -> TestClient:
 
 def test_queued_post_run_status_has_no_started_or_finished_markers(monkeypatch) -> None:
     with _client(monkeypatch) as client:
-        body: Dict[str, Any] = {
+        body: dict[str, Any] = {
             "spec_version": "1.0",
             "runtime": "docker",
             "base_image": "python:3.11-slim",
@@ -46,11 +46,22 @@ def test_queued_post_run_status_has_no_started_or_finished_markers(monkeypatch) 
             pytest.fail(f"Queued run should not include exit_code, got {data['exit_code']!r}")
         if data.get("status_reason_code") != "queued":
             pytest.fail(f"Queued run should expose status_reason_code='queued', got {data.get('status_reason_code')!r}")
+        details = data.get("status_reason_details")
+        if details != {
+            "code": "queued",
+            "category": "lifecycle",
+            "severity": "info",
+            "terminal": False,
+            "retryable": False,
+            "operator_action": "none",
+            "user_message_key": "sandbox.status.queued",
+        }:
+            pytest.fail(f"Queued run should expose queued status_reason_details, got {details!r}")
 
 
 def test_post_run_response_fields_are_persisted_consistently_for_get(monkeypatch) -> None:
     with _client(monkeypatch) as client:
-        body: Dict[str, Any] = {
+        body: dict[str, Any] = {
             "spec_version": "1.0",
             "runtime": "docker",
             "base_image": "python:3.11-slim",
@@ -77,6 +88,7 @@ def test_post_run_response_fields_are_persisted_consistently_for_get(monkeypatch
             "runtime",
             "phase",
             "status_reason_code",
+            "status_reason_details",
             "exit_code",
             "started_at",
             "finished_at",

--- a/tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py
+++ b/tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py
@@ -1,16 +1,21 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import datetime, timezone
 from typing import get_args
+
+import pytest
 
 from tldw_Server_API.app.api.v1.schemas.sandbox_schemas import (
     SandboxAdminRunSummary,
     SandboxRunStatus,
 )
+from tldw_Server_API.app.core.Sandbox import run_status_taxonomy
 from tldw_Server_API.app.core.Sandbox.models import RunPhase, RunStatus, RuntimeType
 from tldw_Server_API.app.core.Sandbox.run_status_taxonomy import (
     RUN_STATUS_REASON_METADATA,
     RunStatusReasonCode,
+    _validate_run_status_reason_metadata,
     normalize_run_status_reason,
     run_status_reason_details,
 )
@@ -192,6 +197,28 @@ def test_run_status_reason_metadata_covers_every_reason_code() -> None:
     """Ensure every public reason code has structured metadata."""
 
     assert set(RUN_STATUS_REASON_METADATA) == set(get_args(RunStatusReasonCode))
+    for key, metadata in RUN_STATUS_REASON_METADATA.items():
+        assert metadata.code == key
+
+
+def test_run_status_reason_metadata_validation_rejects_code_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reject metadata entries whose internal code does not match their key."""
+
+    mismatched_metadata = dict(RUN_STATUS_REASON_METADATA)
+    mismatched_metadata["queued"] = replace(
+        RUN_STATUS_REASON_METADATA["queued"],
+        code="running",
+    )
+    monkeypatch.setattr(
+        run_status_taxonomy,
+        "RUN_STATUS_REASON_METADATA",
+        mismatched_metadata,
+    )
+
+    with pytest.raises(RuntimeError, match="code mismatch"):
+        _validate_run_status_reason_metadata()
 
 
 def test_run_status_reason_details_exposes_stable_metadata() -> None:

--- a/tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py
+++ b/tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from typing import get_args
 
 from tldw_Server_API.app.api.v1.schemas.sandbox_schemas import (
     SandboxAdminRunSummary,
@@ -8,7 +9,10 @@ from tldw_Server_API.app.api.v1.schemas.sandbox_schemas import (
 )
 from tldw_Server_API.app.core.Sandbox.models import RunPhase, RunStatus, RuntimeType
 from tldw_Server_API.app.core.Sandbox.run_status_taxonomy import (
+    RUN_STATUS_REASON_METADATA,
+    RunStatusReasonCode,
     normalize_run_status_reason,
+    run_status_reason_details,
 )
 from tldw_Server_API.app.core.Sandbox.store import SQLiteStore
 
@@ -184,12 +188,68 @@ def test_run_status_reason_taxonomy_accepts_string_phase_values() -> None:
     ) == "runtime_error"
 
 
+def test_run_status_reason_metadata_covers_every_reason_code() -> None:
+    """Ensure every public reason code has structured metadata."""
+
+    assert set(RUN_STATUS_REASON_METADATA) == set(get_args(RunStatusReasonCode))
+
+
+def test_run_status_reason_details_exposes_stable_metadata() -> None:
+    """Verify representative status reason details are stable and complete."""
+
+    runtime_unavailable = run_status_reason_details("runtime_unavailable")
+    assert runtime_unavailable.category == "runtime"
+    assert runtime_unavailable.severity == "error"
+    assert runtime_unavailable.retryable is True
+    assert runtime_unavailable.operator_action == "check_runtime_readiness"
+    assert runtime_unavailable.terminal is True
+    assert runtime_unavailable.user_message_key == "sandbox.status.runtime_unavailable"
+
+    assert run_status_reason_details("policy_failed").operator_action == "review_policy"
+    assert run_status_reason_details("limits_applied").severity == "warning"
+    assert run_status_reason_details("unknown").category == "unknown"
+    assert run_status_reason_details("not-a-real-code").code == "unknown"
+
+
 def test_public_and_admin_status_schemas_expose_reason_code() -> None:
     public_schema = SandboxRunStatus.model_json_schema()
     admin_schema = SandboxAdminRunSummary.model_json_schema()
 
     assert "status_reason_code" in public_schema["properties"]
     assert "status_reason_code" in admin_schema["properties"]
+    assert "status_reason_details" in public_schema["properties"]
+    assert "status_reason_details" in admin_schema["properties"]
+
+
+def test_public_and_admin_status_models_preserve_reason_details() -> None:
+    """Ensure public and admin status models serialize structured details."""
+
+    details = run_status_reason_details("limits_applied")
+    public_status = SandboxRunStatus(
+        id="run-1",
+        runtime="docker",
+        phase="completed",
+        status_reason_code=details.code,
+        status_reason_details=details,
+    )
+    admin_status = SandboxAdminRunSummary(
+        id="run-1",
+        runtime="docker",
+        phase="completed",
+        status_reason_code=details.code,
+        status_reason_details=details,
+    )
+
+    assert public_status.model_dump()["status_reason_details"] == {
+        "code": "limits_applied",
+        "category": "limits",
+        "severity": "warning",
+        "terminal": True,
+        "retryable": False,
+        "operator_action": "review_limits",
+        "user_message_key": "sandbox.status.limits_applied",
+    }
+    assert admin_status.model_dump()["status_reason_details"]["code"] == "limits_applied"
 
 
 def test_sqlite_run_listing_preserves_resource_usage_for_admin_reason_codes(tmp_path) -> None:

--- a/tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py
+++ b/tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py
@@ -91,6 +91,18 @@ def _portable_gate_scope_is_documented(text: str) -> bool:
     return bool(has_host_gated_real_execution and has_portable_capability_contract)
 
 
+def _status_reason_details_contract_is_documented(text: str) -> bool:
+    """Return whether the inventory documents structured status details."""
+
+    section = _markdown_section(text, "Normalized Run Status Reason Codes")
+    return (
+        "status_reason_details" in section
+        and "status_reason_code" in section
+        and "category" in section
+        and "operator_action" in section
+    )
+
+
 def test_portable_runtime_capability_gate_covers_all_runtime_discovery_rows(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -182,6 +194,20 @@ def test_portable_runtime_capability_gate_inventory_no_longer_lists_gate_as_miss
 
     assert "CI has no single cross-runtime capability gate" not in text
     assert _portable_gate_scope_is_documented(text)
+
+
+def test_inventory_documents_status_reason_details_metadata(
+    pytestconfig: pytest.Config,
+) -> None:
+    """Guard the docs contract for structured status reason details."""
+
+    repo_root = Path(pytestconfig.rootpath)
+    inventory = repo_root / "Docs" / "Sandbox" / "sandbox-runtime-capability-inventory.md"
+    text = inventory.read_text(encoding="utf-8")
+    current_gaps = _markdown_section(text, "Current Gaps")
+
+    assert _status_reason_details_contract_is_documented(text)
+    assert "runtime discovery `normalized_reasons` still lack equivalent rich details" in current_gaps
 
 
 def test_inventory_no_longer_lists_host_local_warning_ui_as_missing(


### PR DESCRIPTION
## Summary
- Adds additive status_reason_details metadata for existing sandbox status_reason_code values.
- Exposes the details object on public run status plus admin run list/detail responses.
- Documents the API/inventory contract and records the remaining runtime discovery normalized_reasons metadata gap.

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py -q
- Individual endpoint pytest checks for queued POST, POST/GET persistence, admin details, and admin list pagination
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py tldw_Server_API/app/api/v1/endpoints/sandbox.py
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check touched Python files
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r touched production Python files -f json -o /tmp/bandit_sandbox_status_reason_details.json
- git diff --check

## Merge note
Human-authored Change summary still required before this AI-authored PR is merge-ready.