### PR TITLE
Adapt TemplateCodeEditor loading state

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -5544,17 +5544,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "local-loading-state:src/components/Option/Watchlists/TemplatesTab/TemplateCodeEditor.tsx:MonacoLoading",
-    "path": "src/components/Option/Watchlists/TemplatesTab/TemplateCodeEditor.tsx",
-    "rule": "local-loading-state",
-    "subject": "MonacoLoading",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing local MonacoLoading loading-state wrapper before the guard.",
-    "replacement": "LoadingState or StatePanel",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "local-recovery-banner:src/components/Common/ConnectionProblemBanner.tsx:ConnectionProblemBanner",
     "path": "src/components/Common/ConnectionProblemBanner.tsx",
     "rule": "local-recovery-banner",

--- a/apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/TemplateCodeEditor.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/TemplateCodeEditor.tsx
@@ -10,15 +10,18 @@ import React, {
 } from "react"
 import type { ReactNode } from "react"
 import type { Monaco, OnMount } from "@monaco-editor/react"
+import { LoadingState } from "@/components/ui/feedback/LoadingState"
 
 const Monaco = React.lazy(() => import("@monaco-editor/react"))
 
 const MonacoLoading = ({ height }: { height: number | string }) => (
-  <div
-    className="flex items-center justify-center rounded border border-border bg-bg p-4 text-xs text-text-muted"
-    style={{ height }}>
-    Loading editor…
-  </div>
+  <LoadingState
+    mode="spinner"
+    size="sm"
+    label="Loading editor…"
+    className="justify-center rounded border border-border bg-bg p-4 text-xs text-text-muted"
+    style={{ height }}
+  />
 )
 
 /** Error boundary that catches Monaco load/render failures and triggers fallback. */

--- a/apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/__tests__/TemplateCodeEditor.loading-state.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/__tests__/TemplateCodeEditor.loading-state.test.tsx
@@ -3,9 +3,13 @@ import { render } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 import { TemplateCodeEditor } from "../TemplateCodeEditor"
 
-vi.mock("@monaco-editor/react", () => ({
-  default: () => <div data-testid="monaco-editor" />
-}))
+vi.mock("@monaco-editor/react", () => {
+  const PendingMonaco = () => {
+    throw new Promise(() => {})
+  }
+
+  return { default: PendingMonaco }
+})
 
 describe("TemplateCodeEditor loading state", () => {
   it("renders the Suspense fallback through the canonical LoadingState primitive", () => {

--- a/apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/__tests__/TemplateCodeEditor.loading-state.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/__tests__/TemplateCodeEditor.loading-state.test.tsx
@@ -1,0 +1,27 @@
+import React from "react"
+import { render } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { TemplateCodeEditor } from "../TemplateCodeEditor"
+
+vi.mock("@monaco-editor/react", () => ({
+  default: () => <div data-testid="monaco-editor" />
+}))
+
+describe("TemplateCodeEditor loading state", () => {
+  it("renders the Suspense fallback through the canonical LoadingState primitive", () => {
+    const { container } = render(
+      <TemplateCodeEditor
+        value="# Template"
+        onChange={vi.fn()}
+        format="md"
+        height={240}
+      />
+    )
+
+    const loadingState = container.querySelector(
+      '[data-ds-component="LoadingState"]'
+    )
+    expect(loadingState).toBeInTheDocument()
+    expect(loadingState).toHaveStyle({ height: "240px" })
+  })
+})

--- a/apps/packages/ui/src/components/ui/feedback/LoadingState.tsx
+++ b/apps/packages/ui/src/components/ui/feedback/LoadingState.tsx
@@ -40,7 +40,7 @@ export interface LoadingStateProps {
   loading?: boolean
   /** Additional CSS classes */
   className?: string
-  /** Inline style for surface-specific sizing */
+  /** Inline style for surface-specific sizing; ignored for fullscreen mode */
   style?: React.CSSProperties
   /** Test ID */
   "data-testid"?: string
@@ -224,7 +224,6 @@ export const LoadingState = React.forwardRef<HTMLDivElement, LoadingStateProps>(
             "fixed inset-0 z-50 flex items-center justify-center bg-bg/80 backdrop-blur-sm",
             className
           )}
-          style={style}
           data-testid={dataTestId}
           data-ds-component="LoadingState"
         >

--- a/apps/packages/ui/src/components/ui/feedback/LoadingState.tsx
+++ b/apps/packages/ui/src/components/ui/feedback/LoadingState.tsx
@@ -40,6 +40,8 @@ export interface LoadingStateProps {
   loading?: boolean
   /** Additional CSS classes */
   className?: string
+  /** Inline style for surface-specific sizing */
+  style?: React.CSSProperties
   /** Test ID */
   "data-testid"?: string
 }
@@ -105,6 +107,7 @@ export const LoadingState = React.forwardRef<HTMLDivElement, LoadingStateProps>(
       children,
       loading: forcedLoading,
       className,
+      style,
       "data-testid": dataTestId,
     },
     ref
@@ -221,6 +224,7 @@ export const LoadingState = React.forwardRef<HTMLDivElement, LoadingStateProps>(
             "fixed inset-0 z-50 flex items-center justify-center bg-bg/80 backdrop-blur-sm",
             className
           )}
+          style={style}
           data-testid={dataTestId}
           data-ds-component="LoadingState"
         >
@@ -236,6 +240,7 @@ export const LoadingState = React.forwardRef<HTMLDivElement, LoadingStateProps>(
         <div
           ref={ref}
           className={cn("relative", className)}
+          style={style}
           data-ds-component="LoadingState"
         >
           {children}
@@ -255,6 +260,7 @@ export const LoadingState = React.forwardRef<HTMLDivElement, LoadingStateProps>(
       <div
         ref={ref}
         className={cn("flex flex-col items-center px-2 py-4", className)}
+        style={style}
         data-testid={dataTestId}
         data-ds-component="LoadingState"
       >

--- a/apps/packages/ui/src/components/ui/feedback/__tests__/LoadingState.style.test.tsx
+++ b/apps/packages/ui/src/components/ui/feedback/__tests__/LoadingState.style.test.tsx
@@ -1,0 +1,30 @@
+import React from "react"
+import { render } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { LoadingState } from "../LoadingState"
+
+describe("LoadingState style", () => {
+  it("applies surface styles to the standard loading container", () => {
+    const { container } = render(
+      <LoadingState mode="spinner" style={{ height: 240 }} />
+    )
+
+    const loadingState = container.querySelector(
+      '[data-ds-component="LoadingState"]'
+    )
+    expect(loadingState).toBeInTheDocument()
+    expect(loadingState).toHaveStyle({ height: "240px" })
+  })
+
+  it("keeps fullscreen sizing controlled by the fixed inset layout", () => {
+    const { container } = render(
+      <LoadingState fullscreen mode="spinner" style={{ height: 240 }} />
+    )
+
+    const loadingState = container.querySelector(
+      '[data-ds-component="LoadingState"]'
+    )
+    expect(loadingState).toBeInTheDocument()
+    expect(loadingState).not.toHaveStyle({ height: "240px" })
+  })
+})

--- a/backlog/tasks/task-45.18 - Adapt-TemplateCodeEditor-MonacoLoading-to-shared-LoadingState.md
+++ b/backlog/tasks/task-45.18 - Adapt-TemplateCodeEditor-MonacoLoading-to-shared-LoadingState.md
@@ -4,7 +4,7 @@ title: Adapt TemplateCodeEditor MonacoLoading to shared LoadingState
 status: Done
 assignee: []
 created_date: '2026-05-08 05:54'
-updated_date: '2026-05-08 06:16'
+updated_date: '2026-05-08 13:52'
 labels:
   - design-system
   - webui
@@ -58,12 +58,16 @@ Bandit: skipped because touched implementation files are TypeScript/JSON/Backlog
 PR #1377 review fix pass: Gemini flagged that applying the new LoadingState style prop to the fullscreen fixed/inset container can conflict with the fullscreen layout. Reopening to add a focused contract test and adjust fullscreen handling.
 
 Review fix verification: added LoadingState.style.test.tsx. RED run failed because fullscreen mode received height: 240px from the style prop. After removing style from the fullscreen fixed container and documenting fullscreen behavior, the focused LoadingState style test passed. Full focused verification also passed: TemplateCodeEditor plus LoadingState tests (3 files, 4 tests), product-state guard tests (42 tests), bun run verify:design-system-state (518 baseline exceptions, local-loading-state 2), and git diff --check.
+
+PR #1377 review fix pass: TemplateCodeEditor.loading-state.test.tsx mocked @monaco-editor/react with a synchronous component, making the Suspense fallback assertion dependent on lazy import timing. Reopening to switch the mock to a deterministic suspending component following the ChatComposer lazy variant test pattern.
+
+Review fix verification: TemplateCodeEditor.loading-state.test.tsx now mocks @monaco-editor/react with a PendingMonaco component that throws a never-resolving Promise, matching the ChatComposer lazy/Suspense test pattern so the fallback remains visible during assertion. Verification passed: focused TemplateCodeEditor loading test (1 test), TemplateCodeEditor plus LoadingState focused tests (3 files, 4 tests), product-state guard tests (42 tests), bun run verify:design-system-state (518 baseline exceptions, local-loading-state 2), and git diff --check.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Adapted TemplateCodeEditor's Monaco Suspense loading fallback to render through the shared LoadingState primitive while preserving its editor-height layout. LoadingState now accepts an inline style prop for non-fullscreen surface sizing and explicitly keeps fullscreen sizing controlled by the fixed inset layout. The obsolete TemplateCodeEditor MonacoLoading local-loading-state baseline exception was removed. Focused tests and the design-system verifier passed; the package-wide TypeScript check remains blocked by unrelated existing baseline errors.
+Adapted TemplateCodeEditor's Monaco Suspense loading fallback to render through the shared LoadingState primitive while preserving its editor-height layout. LoadingState accepts an inline style prop for non-fullscreen surface sizing and keeps fullscreen sizing controlled by the fixed inset layout. TemplateCodeEditor.loading-state.test.tsx now deterministically holds the lazy Monaco mock in Suspense by throwing a never-resolving Promise. The obsolete TemplateCodeEditor MonacoLoading local-loading-state baseline exception was removed. Focused tests and the design-system verifier passed; the package-wide TypeScript check remains blocked by unrelated existing baseline errors.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.18 - Adapt-TemplateCodeEditor-MonacoLoading-to-shared-LoadingState.md
+++ b/backlog/tasks/task-45.18 - Adapt-TemplateCodeEditor-MonacoLoading-to-shared-LoadingState.md
@@ -1,0 +1,73 @@
+---
+id: TASK-45.18
+title: Adapt TemplateCodeEditor MonacoLoading to shared LoadingState
+status: Done
+assignee: []
+created_date: '2026-05-08 05:54'
+updated_date: '2026-05-08 05:59'
+labels:
+  - design-system
+  - webui
+  - guard
+dependencies: []
+references:
+  - >-
+    apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/TemplateCodeEditor.tsx
+  - apps/packages/ui/src/components/ui/feedback/LoadingState.tsx
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+parent_task_id: TASK-45
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue the design-system product-state migration by routing the Watchlists TemplateCodeEditor Monaco loading fallback through the shared LoadingState primitive while preserving the editor loading, error, and ready behaviors.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 TemplateCodeEditor loading fallback renders through shared LoadingState.
+- [x] #2 Existing Monaco editor loading, error, and content behavior remains covered.
+- [x] #3 The product-state guard baseline no longer contains the TemplateCodeEditor MonacoLoading local-loading-state exception.
+- [x] #4 Focused component tests and the design-system product-state verifier pass.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused failing test proving TemplateCodeEditor's Suspense fallback renders the canonical LoadingState primitive and preserves editor height.
+2. Replace the local MonacoLoading div with a direct LoadingState return, extending LoadingState only as needed for surface sizing.
+3. Remove the obsolete product-state baseline exception for TemplateCodeEditor MonacoLoading.
+4. Run focused component tests, guard tests, the design-system verifier, whitespace checks, and record wider type-check status.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+RED: bunx vitest run src/components/Option/Watchlists/TemplatesTab/__tests__/TemplateCodeEditor.loading-state.test.tsx --reporter=dot failed because the Suspense fallback did not expose data-ds-component="LoadingState".
+
+Implementation: MonacoLoading now directly returns the shared LoadingState primitive in spinner mode, with the existing editor height preserved via a new LoadingState style prop. The TemplateCodeEditor local-loading-state baseline entry was removed.
+
+Verification: focused TemplateCodeEditor tests passed (2 files, 2 tests); product-state guard tests passed (42 tests); bun run verify:design-system-state passed with 518 baseline exceptions and local-loading-state reduced to 2; git diff --check passed.
+
+Known wider check: bunx tsc --noEmit --pretty false still fails on existing repo-wide type errors in unrelated tests/services such as audio capture tests, Chat composer mocks, Flashcards deck fixtures, Playground tests, and service tests. The visible errors did not target this loading-state slice.
+
+Bandit: skipped because touched implementation files are TypeScript/JSON/Backlog records only.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Adapted TemplateCodeEditor's Monaco Suspense loading fallback to render through the shared LoadingState primitive while preserving its editor-height layout. LoadingState now accepts an inline style prop for surface-specific sizing, and the obsolete TemplateCodeEditor MonacoLoading local-loading-state baseline exception was removed. Focused tests and the design-system verifier passed; the package-wide TypeScript check remains blocked by unrelated existing baseline errors.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.18 - Adapt-TemplateCodeEditor-MonacoLoading-to-shared-LoadingState.md
+++ b/backlog/tasks/task-45.18 - Adapt-TemplateCodeEditor-MonacoLoading-to-shared-LoadingState.md
@@ -4,7 +4,7 @@ title: Adapt TemplateCodeEditor MonacoLoading to shared LoadingState
 status: Done
 assignee: []
 created_date: '2026-05-08 05:54'
-updated_date: '2026-05-08 05:59'
+updated_date: '2026-05-08 06:16'
 labels:
   - design-system
   - webui
@@ -54,12 +54,16 @@ Verification: focused TemplateCodeEditor tests passed (2 files, 2 tests); produc
 Known wider check: bunx tsc --noEmit --pretty false still fails on existing repo-wide type errors in unrelated tests/services such as audio capture tests, Chat composer mocks, Flashcards deck fixtures, Playground tests, and service tests. The visible errors did not target this loading-state slice.
 
 Bandit: skipped because touched implementation files are TypeScript/JSON/Backlog records only.
+
+PR #1377 review fix pass: Gemini flagged that applying the new LoadingState style prop to the fullscreen fixed/inset container can conflict with the fullscreen layout. Reopening to add a focused contract test and adjust fullscreen handling.
+
+Review fix verification: added LoadingState.style.test.tsx. RED run failed because fullscreen mode received height: 240px from the style prop. After removing style from the fullscreen fixed container and documenting fullscreen behavior, the focused LoadingState style test passed. Full focused verification also passed: TemplateCodeEditor plus LoadingState tests (3 files, 4 tests), product-state guard tests (42 tests), bun run verify:design-system-state (518 baseline exceptions, local-loading-state 2), and git diff --check.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Adapted TemplateCodeEditor's Monaco Suspense loading fallback to render through the shared LoadingState primitive while preserving its editor-height layout. LoadingState now accepts an inline style prop for surface-specific sizing, and the obsolete TemplateCodeEditor MonacoLoading local-loading-state baseline exception was removed. Focused tests and the design-system verifier passed; the package-wide TypeScript check remains blocked by unrelated existing baseline errors.
+Adapted TemplateCodeEditor's Monaco Suspense loading fallback to render through the shared LoadingState primitive while preserving its editor-height layout. LoadingState now accepts an inline style prop for non-fullscreen surface sizing and explicitly keeps fullscreen sizing controlled by the fixed inset layout. The obsolete TemplateCodeEditor MonacoLoading local-loading-state baseline exception was removed. Focused tests and the design-system verifier passed; the package-wide TypeScript check remains blocked by unrelated existing baseline errors.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary
- Route TemplateCodeEditor's Monaco Suspense fallback through the shared LoadingState primitive.
- Add a LoadingState style prop so the editor fallback preserves its configured height.
- Remove the obsolete TemplateCodeEditor local-loading-state baseline exception.

## Verification
- bunx vitest run src/components/Option/Watchlists/TemplatesTab/__tests__/TemplateCodeEditor.loading-state.test.tsx src/components/Option/Watchlists/TemplatesTab/__tests__/TemplateCodeEditor.bundle-contract.test.ts --reporter=dot
- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot
- bun run verify:design-system-state
- git diff --check

## Known wider check
- bunx tsc --noEmit --pretty false still fails on unrelated existing package-wide type errors in tests/services outside this loading-state slice.

## Merge note
Draft until the required human-written Change summary is added per the AI-generated PR merge gate.