### PR TITLE
Add sandbox runtime reason details

### DIFF
--- a/Docs/API-related/Sandbox_API.md
+++ b/Docs/API-related/Sandbox_API.md
@@ -21,8 +21,9 @@ Current runtime identities are `docker`, `firecracker`, `lima`, `vz_linux`,
 guarantee:
 - Runtime discovery includes machine-readable `boundary_class`,
   `vm_grade_isolation`, `untrusted_eligible`, `isolation_warnings`, and
-  `network_policy_contract` fields, plus a `session_contract` object. Use
-  those fields for client decisions instead of parsing prose notes.
+  `network_policy_contract` fields, plus `normalized_reason_details` and a
+  `session_contract` object. Use those fields for client decisions instead of
+  parsing prose notes.
 - `isolation_warnings` are advisory metadata for client UX and operator
   context. They are not admission rejection reasons by themselves.
 - `seatbelt` is host-local. `seatbelt` is not `untrusted`-eligible.
@@ -127,6 +128,9 @@ Response (example):
     {
       "name": "docker",
       "available": true,
+      "reasons": [],
+      "normalized_reasons": [],
+      "normalized_reason_details": [],
       "default_images": ["python:3.11-slim", "node:20-alpine"],
       "max_cpu": 4.0,
       "max_mem_mb": 8192,
@@ -168,6 +172,11 @@ Response (example):
 }
 ```
 Runtime isolation fields mean:
+- `reasons`: raw runtime preflight facts for operator diagnostics.
+- `normalized_reasons`: stable reason codes derived from raw preflight facts.
+- `normalized_reason_details`: structured metadata derived from
+  `normalized_reasons`, including category, severity, availability-blocking
+  posture, operator action, and message key.
 - `boundary_class`: `container`, `host_local`, `vm_grade`, or
   `vm_grade_scaffold`.
 - `vm_grade_isolation`: whether the runtime boundary is VM-grade for isolation
@@ -246,8 +255,8 @@ GET `/api/v1/sandbox/admin/runtime-diagnostics`
 
 This admin-only, read-only endpoint derives from `/api/v1/sandbox/runtimes` and
 groups every runtime by readiness posture. It preserves raw `reasons`, additive
-`normalized_reasons`, isolation warning metadata, session reuse posture, and a
-`recommended_action` value for operator triage.
+`normalized_reasons`, `normalized_reason_details`, isolation warning metadata,
+session reuse posture, and a `recommended_action` value for operator triage.
 
 The response includes:
 

--- a/Docs/Published/API-related/Sandbox_API.md
+++ b/Docs/Published/API-related/Sandbox_API.md
@@ -21,8 +21,9 @@ Current runtime identities are `docker`, `firecracker`, `lima`, `vz_linux`,
 guarantee:
 - Runtime discovery includes machine-readable `boundary_class`,
   `vm_grade_isolation`, `untrusted_eligible`, `isolation_warnings`, and
-  `network_policy_contract` fields, plus a `session_contract` object. Use
-  those fields for client decisions instead of parsing prose notes.
+  `network_policy_contract` fields, plus `normalized_reason_details` and a
+  `session_contract` object. Use those fields for client decisions instead of
+  parsing prose notes.
 - `isolation_warnings` are advisory metadata for client UX and operator
   context. They are not admission rejection reasons by themselves.
 - `seatbelt` is host-local. `seatbelt` is not `untrusted`-eligible.
@@ -127,6 +128,9 @@ Response (example):
     {
       "name": "docker",
       "available": true,
+      "reasons": [],
+      "normalized_reasons": [],
+      "normalized_reason_details": [],
       "default_images": ["python:3.11-slim", "node:20-alpine"],
       "max_cpu": 4.0,
       "max_mem_mb": 8192,
@@ -168,6 +172,11 @@ Response (example):
 }
 ```
 Runtime isolation fields mean:
+- `reasons`: raw runtime preflight facts for operator diagnostics.
+- `normalized_reasons`: stable reason codes derived from raw preflight facts.
+- `normalized_reason_details`: structured metadata derived from
+  `normalized_reasons`, including category, severity, availability-blocking
+  posture, operator action, and message key.
 - `boundary_class`: `container`, `host_local`, `vm_grade`, or
   `vm_grade_scaffold`.
 - `vm_grade_isolation`: whether the runtime boundary is VM-grade for isolation

--- a/Docs/Sandbox/sandbox-runtime-capability-inventory.md
+++ b/Docs/Sandbox/sandbox-runtime-capability-inventory.md
@@ -124,6 +124,13 @@ Runtime discovery preserves raw `reasons` for operator diagnostics and exposes
 additive `normalized_reasons` for client logic. The normalized vocabulary is
 centralized in `runtime_capabilities.py`.
 
+Runtime discovery also exposes additive `normalized_reason_details` derived
+from `normalized_reasons`. Details include `category`, `severity`,
+`availability_blocking`, `operator_action`, and `user_message_key`; they are
+presentation and triage metadata, not a replacement for raw runtime preflight
+facts. Admin runtime diagnostics reuse the same metadata for recommended
+actions so clients do not need to duplicate raw reason matching.
+
 | Normalized reason | Meaning |
 | --- | --- |
 | `runtime_unavailable` | The runtime itself is not available on the current host. |
@@ -288,7 +295,6 @@ for `untrusted` workloads.
 | Gap | Runtime(s) | Follow-up phase |
 | --- | --- | --- |
 | Additional real allowlist implementations remain limited beyond Docker granular enforcement. | all except unsupported paths | Future |
-| Run status responses expose structured `status_reason_details`, but runtime discovery `normalized_reasons` still lack equivalent rich details. | all | Phase 3 |
 | Cross-runtime session behavior contract tests and recovery flows remain incomplete beyond the discovery-level `session_contract`. | all | Phase 4 |
 | Recovery/repair ownership exists only for `vz_linux`. | all except `vz_linux` | Phase 4 |
 | No single CI job proves real execution for every runtime; the portable capability gate covers capability contracts only. | all | Phase 5 |
@@ -303,6 +309,8 @@ for `untrusted` workloads.
   current `enforcement_ready` host/preflight truth.
 - Add session contract metadata for every runtime and keep it separate from
   current host availability and admin diagnostics.
+- Add runtime reason metadata for every `RuntimeReasonCode` and keep it derived
+  from `normalized_reasons`, not raw runtime-specific reason strings.
 - Prefer `unsupported` over ambiguous wording when a guarantee cannot be
   proven.
 - Update this document before expanding `vz_macos`, Apple `containerization`,

--- a/Docs/superpowers/plans/2026-05-08-runtime-reason-details-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-08-runtime-reason-details-implementation-plan.md
@@ -1,0 +1,23 @@
+## Stage 1: Contract Tests
+**Goal**: Add failing tests for structured runtime discovery reason details.
+**Success Criteria**: Focused tests fail because current runtime discovery lacks `normalized_reason_details` and metadata helpers.
+**Tests**: `pytest` targets for runtime inventory, runtime capability gate, and sandbox public docs contract.
+**Status**: Complete
+
+## Stage 2: Metadata Catalog
+**Goal**: Centralize `RuntimeReasonDetails` metadata for every `RuntimeReasonCode`.
+**Success Criteria**: Import-time validation catches missing, extra, or mismatched runtime reason metadata.
+**Tests**: Runtime inventory contract tests cover catalog completeness and unknown-code fallback.
+**Status**: Complete
+
+## Stage 3: API Projection
+**Goal**: Expose additive reason details on runtime discovery and admin diagnostics.
+**Success Criteria**: Existing raw `reasons` and `normalized_reasons` remain unchanged while details are populated from the shared catalog.
+**Tests**: Feature discovery and admin diagnostics schema/projection tests pass.
+**Status**: Complete
+
+## Stage 4: Documentation And Verification
+**Goal**: Update the runtime capability inventory and run focused validation.
+**Success Criteria**: Docs describe the new reason-details contract and no longer list it as a current gap; focused tests, compile check, Bandit, and diff whitespace checks pass.
+**Tests**: Runtime capability docs contract test plus verification commands in TASK-123.
+**Status**: Complete

--- a/backlog/tasks/task-123 - Add-structured-runtime-discovery-reason-details.md
+++ b/backlog/tasks/task-123 - Add-structured-runtime-discovery-reason-details.md
@@ -1,0 +1,76 @@
+---
+id: TASK-123
+title: Add structured runtime discovery reason details
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-05-08 13:41'
+updated_date: '2026-05-08 13:47'
+labels:
+  - api
+  - sandbox
+dependencies: []
+documentation:
+  - Docs/Sandbox/sandbox-runtime-capability-inventory.md
+  - tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
+  - tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Close the sandbox Phase 3 runtime discovery gap by exposing structured metadata for normalized runtime readiness reasons while preserving raw reasons and normalized reason codes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Runtime discovery exposes additive structured details for every normalized runtime reason without removing raw reasons or normalized_reasons.
+- [x] #2 Runtime reason metadata is centralized, complete for every RuntimeReasonCode, and fails fast on missing or mismatched entries.
+- [x] #3 Admin runtime diagnostics can consume the same structured reason metadata without duplicating operator-action logic.
+- [x] #4 Sandbox inventory docs describe the reason-details contract and no longer list the gap as current.
+- [x] #5 Focused tests cover schema exposure, feature discovery population, metadata completeness, diagnostics projection, and docs contract.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing tests for runtime reason metadata completeness, schema exposure, feature discovery details, diagnostics projection, and docs contract.
+2. Add RuntimeReasonDetails metadata/catalog helpers in runtime_capabilities.py with import-time completeness and code-match validation.
+3. Extend SandboxRuntimeInfo and admin runtime diagnostics schemas with additive normalized_reason_details.
+4. Populate details in SandboxService.feature_discovery() and reuse metadata-derived operator actions in runtime diagnostics.
+5. Update the sandbox runtime capability inventory and run focused pytest, py_compile, Bandit on touched Python, and git diff --check.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented structured runtime discovery reason details. Red test run failed with missing normalized_reason_details schema/payload fields, missing RUNTIME_REASON_METADATA, missing runtime_reason_details helper, and docs gap still present. Green verification passed after implementation.
+
+Verification:
+- Baseline before edits: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py tldw_Server_API/tests/Docs/test_sandbox_public_docs_contract.py -q -> 39 passed, 2 warnings.
+- Red test run after adding tests -> 8 failed, 35 passed, 2 warnings for the expected missing runtime reason-details contract.
+- Green focused test run -> 43 passed, 2 warnings.
+- py_compile on touched Python files -> passed.
+- Bandit production touched Python scan -> 0 results in /tmp/bandit_runtime_reason_details_prod.json.
+- Bandit touched tests with B101 skipped -> 0 results in /tmp/bandit_runtime_reason_details_tests.json.
+- git diff --check -> passed.
+
+Known skips/blockers: full repository test suite was not run; focused sandbox runtime/docs contract tests covered the changed surface.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added centralized runtime reason metadata and additive normalized_reason_details on runtime discovery/admin diagnostics, with docs and focused contract tests covering schema exposure, metadata completeness, feature discovery population, diagnostics projection, and the closed inventory gap.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-123 - Add-structured-runtime-discovery-reason-details.md
+++ b/backlog/tasks/task-123 - Add-structured-runtime-discovery-reason-details.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-05-08 13:41'
-updated_date: '2026-05-08 13:47'
+updated_date: '2026-05-08 13:59'
 labels:
   - api
   - sandbox
@@ -57,12 +57,25 @@ Verification:
 - git diff --check -> passed.
 
 Known skips/blockers: full repository test suite was not run; focused sandbox runtime/docs contract tests covered the changed surface.
+
+Reopened for PR #1378 review follow-up. Actionable findings verified from Qodo/Gemini: recommended_action should not depend on raw normalized reason order when multiple reason details exist, and SandboxRuntimeInfo.normalized_reason_details should be non-nullable because runtime discovery always emits a list.
+
+PR #1378 review follow-up implemented. Verified two findings: recommended_action was order-dependent, and normalized_reason_details was nullable in the public schema despite runtime discovery always emitting a list. Added failing regression checks for both, then fixed with explicit operator-action priority and a non-nullable list schema field.
+
+Review follow-up verification:
+- Red regression run: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py::test_runtime_diagnostics_summary_projects_feature_discovery_rows tldw_Server_API/tests/Docs/test_sandbox_public_docs_contract.py::test_sandbox_runtime_schema_exposes_reason_details -q -> 2 failed as expected.
+- Green regression run for same targets -> 2 passed, 2 warnings.
+- Focused sandbox/docs contract suite -> 43 passed, 2 warnings.
+- py_compile on touched Python files -> passed.
+- Bandit production touched Python scan -> 0 results in /tmp/bandit_runtime_reason_details_prod.json.
+- Bandit touched tests with B101 skipped -> 0 results in /tmp/bandit_runtime_reason_details_tests.json.
+- git diff --check -> passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added centralized runtime reason metadata and additive normalized_reason_details on runtime discovery/admin diagnostics, with docs and focused contract tests covering schema exposure, metadata completeness, feature discovery population, diagnostics projection, and the closed inventory gap.
+Added centralized runtime reason metadata and additive normalized_reason_details on runtime discovery/admin diagnostics. PR review follow-up made normalized_reason_details non-nullable and made recommended_action selection priority-based rather than reason-order-dependent.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
@@ -23,7 +23,10 @@ from tldw_Server_API.app.core.Sandbox.runtime_capabilities import (
     RuntimeIsolationWarningCode,
     RuntimeNetworkPolicyReadinessSource,
     RuntimeNetworkPolicySupportState,
+    RuntimeReasonCategory,
     RuntimeReasonCode,
+    RuntimeReasonOperatorAction,
+    RuntimeReasonSeverity,
     RuntimeSessionReuseModel,
 )
 
@@ -106,6 +109,19 @@ class SandboxRuntimeSessionContract(BaseModel):
     )
 
 
+class SandboxRuntimeReasonDetails(BaseModel):
+    """Structured metadata for a normalized sandbox runtime discovery reason."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    code: RuntimeReasonCode
+    category: RuntimeReasonCategory
+    severity: RuntimeReasonSeverity
+    availability_blocking: bool
+    operator_action: RuntimeReasonOperatorAction
+    user_message_key: str
+
+
 def _default_offset_pagination_aliases(response):
     if response.next_offset is None:
         response.next_offset = response.pagination.next_offset
@@ -128,6 +144,13 @@ class SandboxRuntimeInfo(BaseModel):
         description=(
             "Stable, client-facing reason codes derived from raw runtime preflight reasons; "
             "raw reasons are preserved for operator diagnostics"
+        ),
+    )
+    normalized_reason_details: list[SandboxRuntimeReasonDetails] | None = Field(
+        default=None,
+        description=(
+            "Structured metadata derived from normalized_reasons for client and "
+            "operator presentation. Existing raw reasons remain authoritative."
         ),
     )
     supported_trust_levels: list[TrustLevelType] | None = Field(default=None, description="Trust levels supported by this runtime under current host policy")
@@ -523,6 +546,7 @@ class SandboxAdminRuntimeDiagnosticsItem(BaseModel):
     readiness: RuntimeDiagnosticsReadiness
     reasons: list[str] = Field(default_factory=list)
     normalized_reasons: list[RuntimeReasonCode] = Field(default_factory=list)
+    normalized_reason_details: list[SandboxRuntimeReasonDetails] = Field(default_factory=list)
     boundary_class: RuntimeBoundaryClass | None = None
     vm_grade_isolation: bool = False
     untrusted_eligible: bool = False

--- a/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
@@ -146,8 +146,8 @@ class SandboxRuntimeInfo(BaseModel):
             "raw reasons are preserved for operator diagnostics"
         ),
     )
-    normalized_reason_details: list[SandboxRuntimeReasonDetails] | None = Field(
-        default=None,
+    normalized_reason_details: list[SandboxRuntimeReasonDetails] = Field(
+        default_factory=list,
         description=(
             "Structured metadata derived from normalized_reasons for client and "
             "operator presentation. Existing raw reasons remain authoritative."

--- a/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
+++ b/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass, field
-from typing import Any, Literal, Mapping
+from typing import Any, Literal, Mapping, get_args
 
 from loguru import logger
 
@@ -64,6 +64,28 @@ RuntimeReasonCode = Literal[
     "feature_not_implemented",
     "image_store_unavailable",
     "unknown",
+]
+RuntimeReasonCategory = Literal[
+    "runtime",
+    "platform",
+    "helper",
+    "template",
+    "network",
+    "policy",
+    "host",
+    "implementation",
+    "image_store",
+    "unknown",
+]
+RuntimeReasonSeverity = Literal["info", "warning", "error"]
+RuntimeReasonOperatorAction = Literal[
+    "none",
+    "check_helper",
+    "configure_template",
+    "prepare_host",
+    "adjust_request_policy",
+    "use_different_runtime",
+    "inspect_reasons",
 ]
 
 RUNTIME_IMPLEMENTATION_STATES: Mapping[RuntimeType, RuntimeImplementationState] = {
@@ -133,6 +155,28 @@ class RuntimeSessionContractMetadata:
             "requires_live_health_check": self.requires_live_health_check,
             "recovery_state": self.recovery_state,
             "repair_state": self.repair_state,
+        }
+
+
+@dataclass(frozen=True)
+class RuntimeReasonDetails:
+    """Structured client/operator metadata for a normalized runtime reason."""
+
+    code: RuntimeReasonCode
+    category: RuntimeReasonCategory
+    severity: RuntimeReasonSeverity
+    availability_blocking: bool
+    operator_action: RuntimeReasonOperatorAction
+    user_message_key: str
+
+    def as_dict(self) -> dict[str, str | bool]:
+        return {
+            "code": self.code,
+            "category": self.category,
+            "severity": self.severity,
+            "availability_blocking": self.availability_blocking,
+            "operator_action": self.operator_action,
+            "user_message_key": self.user_message_key,
         }
 
 
@@ -322,6 +366,130 @@ RUNTIME_NETWORK_POLICY_METADATA: Mapping[
 }
 
 
+RUNTIME_REASON_METADATA: Mapping[str, RuntimeReasonDetails] = {
+    "runtime_unavailable": RuntimeReasonDetails(
+        code="runtime_unavailable",
+        category="runtime",
+        severity="error",
+        availability_blocking=True,
+        operator_action="use_different_runtime",
+        user_message_key="sandbox.runtime.reason.runtime_unavailable",
+    ),
+    "unsupported_os": RuntimeReasonDetails(
+        code="unsupported_os",
+        category="platform",
+        severity="error",
+        availability_blocking=True,
+        operator_action="prepare_host",
+        user_message_key="sandbox.runtime.reason.unsupported_os",
+    ),
+    "unsupported_arch": RuntimeReasonDetails(
+        code="unsupported_arch",
+        category="platform",
+        severity="error",
+        availability_blocking=True,
+        operator_action="prepare_host",
+        user_message_key="sandbox.runtime.reason.unsupported_arch",
+    ),
+    "helper_unavailable": RuntimeReasonDetails(
+        code="helper_unavailable",
+        category="helper",
+        severity="error",
+        availability_blocking=True,
+        operator_action="check_helper",
+        user_message_key="sandbox.runtime.reason.helper_unavailable",
+    ),
+    "helper_protocol_mismatch": RuntimeReasonDetails(
+        code="helper_protocol_mismatch",
+        category="helper",
+        severity="error",
+        availability_blocking=True,
+        operator_action="check_helper",
+        user_message_key="sandbox.runtime.reason.helper_protocol_mismatch",
+    ),
+    "helper_missing": RuntimeReasonDetails(
+        code="helper_missing",
+        category="helper",
+        severity="error",
+        availability_blocking=True,
+        operator_action="check_helper",
+        user_message_key="sandbox.runtime.reason.helper_missing",
+    ),
+    "template_missing": RuntimeReasonDetails(
+        code="template_missing",
+        category="template",
+        severity="error",
+        availability_blocking=True,
+        operator_action="configure_template",
+        user_message_key="sandbox.runtime.reason.template_missing",
+    ),
+    "template_unconfigured": RuntimeReasonDetails(
+        code="template_unconfigured",
+        category="template",
+        severity="error",
+        availability_blocking=True,
+        operator_action="configure_template",
+        user_message_key="sandbox.runtime.reason.template_unconfigured",
+    ),
+    "network_policy_unsupported": RuntimeReasonDetails(
+        code="network_policy_unsupported",
+        category="network",
+        severity="error",
+        availability_blocking=True,
+        operator_action="adjust_request_policy",
+        user_message_key="sandbox.runtime.reason.network_policy_unsupported",
+    ),
+    "trust_policy_denied": RuntimeReasonDetails(
+        code="trust_policy_denied",
+        category="policy",
+        severity="error",
+        availability_blocking=True,
+        operator_action="adjust_request_policy",
+        user_message_key="sandbox.runtime.reason.trust_policy_denied",
+    ),
+    "host_prerequisite_missing": RuntimeReasonDetails(
+        code="host_prerequisite_missing",
+        category="host",
+        severity="error",
+        availability_blocking=True,
+        operator_action="prepare_host",
+        user_message_key="sandbox.runtime.reason.host_prerequisite_missing",
+    ),
+    "host_permission_denied": RuntimeReasonDetails(
+        code="host_permission_denied",
+        category="host",
+        severity="error",
+        availability_blocking=True,
+        operator_action="prepare_host",
+        user_message_key="sandbox.runtime.reason.host_permission_denied",
+    ),
+    "feature_not_implemented": RuntimeReasonDetails(
+        code="feature_not_implemented",
+        category="implementation",
+        severity="error",
+        availability_blocking=True,
+        operator_action="use_different_runtime",
+        user_message_key="sandbox.runtime.reason.feature_not_implemented",
+    ),
+    "image_store_unavailable": RuntimeReasonDetails(
+        code="image_store_unavailable",
+        category="image_store",
+        severity="error",
+        availability_blocking=True,
+        operator_action="prepare_host",
+        user_message_key="sandbox.runtime.reason.image_store_unavailable",
+    ),
+    "unknown": RuntimeReasonDetails(
+        code="unknown",
+        category="unknown",
+        severity="warning",
+        availability_blocking=True,
+        operator_action="inspect_reasons",
+        user_message_key="sandbox.runtime.reason.unknown",
+    ),
+}
+
+
 def _validate_runtime_isolation_metadata_map() -> None:
     expected = set(RuntimeType)
     actual = set(RUNTIME_ISOLATION_METADATA)
@@ -358,9 +526,32 @@ def _validate_runtime_session_contract_metadata_map() -> None:
         )
 
 
+def _validate_runtime_reason_metadata_map() -> None:
+    expected = set(get_args(RuntimeReasonCode))
+    actual = set(RUNTIME_REASON_METADATA)
+    missing = sorted(expected - actual)
+    extra = sorted(actual - expected)
+    if missing or extra:
+        raise RuntimeError(
+            "Runtime reason metadata map is incomplete: "
+            f"missing={missing}, extra={extra}"
+        )
+    mismatched = sorted(
+        (key, metadata.code)
+        for key, metadata in RUNTIME_REASON_METADATA.items()
+        if metadata.code != key
+    )
+    if mismatched:
+        raise RuntimeError(
+            "Runtime reason metadata code mismatch: "
+            f"mismatched={mismatched}"
+        )
+
+
 _validate_runtime_isolation_metadata_map()
 _validate_runtime_session_contract_metadata_map()
 _validate_runtime_network_policy_metadata_map()
+_validate_runtime_reason_metadata_map()
 
 
 _RUNTIME_REASON_CODE_MAP: Mapping[str, RuntimeReasonCode] = {
@@ -558,6 +749,26 @@ def normalize_runtime_reasons(
         seen.add(code)
         normalized.append(code)
     return normalized
+
+
+def runtime_reason_details(code: RuntimeReasonCode | str | None) -> RuntimeReasonDetails:
+    """Return structured metadata for a normalized runtime reason code."""
+
+    code_value = str(code or "unknown").strip()
+    metadata = RUNTIME_REASON_METADATA.get(code_value)
+    if metadata is None:
+        return RUNTIME_REASON_METADATA["unknown"]
+    return metadata
+
+
+def runtime_reason_details_for_codes(
+    codes: list[RuntimeReasonCode | str] | tuple[RuntimeReasonCode | str, ...] | None,
+) -> list[RuntimeReasonDetails]:
+    """Return reason metadata while preserving normalized reason order."""
+
+    if codes is None:
+        return []
+    return [runtime_reason_details(code) for code in codes]
 
 
 @dataclass

--- a/tldw_Server_API/app/core/Sandbox/service.py
+++ b/tldw_Server_API/app/core/Sandbox/service.py
@@ -112,6 +112,14 @@ except Exception:
 
 _SANDBOX_WORKSPACE_FALLBACK_LOCKS: dict[str, threading.Lock] = {}
 _SANDBOX_WORKSPACE_FALLBACK_LOCKS_GUARD = threading.Lock()
+_RUNTIME_OPERATOR_ACTION_PRIORITY = {
+    "check_helper": 0,
+    "configure_template": 1,
+    "prepare_host": 2,
+    "adjust_request_policy": 3,
+    "inspect_reasons": 4,
+    "use_different_runtime": 5,
+}
 
 
 class SandboxReconciliationRepairError(RuntimeError):
@@ -1200,10 +1208,16 @@ class SandboxService:
 
         if readiness == "ready":
             return "none"
+        best_action = ""
+        best_rank = len(_RUNTIME_OPERATOR_ACTION_PRIORITY) + 1
         for detail in normalized_reason_details:
             action = str(detail.get("operator_action") or "").strip()
-            if action and action != "none":
-                return action
+            rank = _RUNTIME_OPERATOR_ACTION_PRIORITY.get(action)
+            if rank is not None and rank < best_rank:
+                best_action = action
+                best_rank = rank
+        if best_action:
+            return best_action
         if readiness in {"scaffold", "unsupported", "not_applicable"}:
             return "use_different_runtime"
         return "inspect_reasons"

--- a/tldw_Server_API/app/core/Sandbox/service.py
+++ b/tldw_Server_API/app/core/Sandbox/service.py
@@ -64,6 +64,7 @@ from .runtime_capabilities import (
     runtime_implementation_state,
     runtime_network_policy_effective_support,
     runtime_network_policy_metadata,
+    runtime_reason_details_for_codes,
     runtime_session_contract_metadata,
 )
 from .snapshots import SnapshotManager
@@ -890,6 +891,7 @@ class SandboxService:
         ) -> dict[str, object]:
             enforcement_ready = dict((preflight.enforcement_ready if preflight else {}) or {})
             reasons = list((preflight.reasons if preflight else []) or [])
+            normalized_reasons = normalize_runtime_reasons(reasons)
             isolation = runtime_isolation_metadata(runtime)
             network_contract = runtime_network_policy_metadata(runtime)
             session_contract = runtime_session_contract_metadata(runtime)
@@ -900,7 +902,10 @@ class SandboxService:
             return {
                 "available": bool(preflight.available) if preflight is not None else False,
                 "reasons": reasons,
-                "normalized_reasons": normalize_runtime_reasons(reasons),
+                "normalized_reasons": normalized_reasons,
+                "normalized_reason_details": SandboxService._runtime_reason_details_payload(
+                    [str(reason) for reason in normalized_reasons]
+                ),
                 "supported_trust_levels": list((preflight.supported_trust_levels if preflight else []) or []),
                 "strict_deny_all_supported": effective_network_support["deny_all"],
                 "strict_allowlist_supported": effective_network_support["allowlist"],
@@ -1136,6 +1141,9 @@ class SandboxService:
 
         session_contract = dict(row.get("session_contract") or {})
         normalized_reasons = [str(reason) for reason in row.get("normalized_reasons") or []]
+        normalized_reason_details = SandboxService._runtime_reason_details_payload(
+            normalized_reasons
+        )
         readiness = SandboxService._runtime_readiness(row)
         repair_state = str(session_contract.get("repair_state") or "").strip().lower()
         return {
@@ -1145,6 +1153,7 @@ class SandboxService:
             "readiness": readiness,
             "reasons": [str(reason) for reason in row.get("reasons") or []],
             "normalized_reasons": normalized_reasons,
+            "normalized_reason_details": normalized_reason_details,
             "boundary_class": row.get("boundary_class"),
             "vm_grade_isolation": bool(row.get("vm_grade_isolation")),
             "untrusted_eligible": bool(row.get("untrusted_eligible")),
@@ -1156,7 +1165,7 @@ class SandboxService:
             "repair_supported": repair_state in {"supported", "host_gated"},
             "recommended_action": SandboxService._runtime_recommended_action(
                 readiness,
-                normalized_reasons,
+                normalized_reason_details,
             ),
         }
 
@@ -1172,25 +1181,29 @@ class SandboxService:
         return "unavailable"
 
     @staticmethod
-    def _runtime_recommended_action(readiness: str, normalized_reasons: list[str]) -> str:
-        """Map normalized readiness reasons to an operator next action."""
+    def _runtime_reason_details_payload(
+        normalized_reasons: list[str],
+    ) -> list[dict[str, str | bool]]:
+        """Return serialized runtime reason details for normalized reason codes."""
 
-        reasons = set(normalized_reasons)
+        return [
+            details.as_dict()
+            for details in runtime_reason_details_for_codes(normalized_reasons)
+        ]
+
+    @staticmethod
+    def _runtime_recommended_action(
+        readiness: str,
+        normalized_reason_details: list[dict[str, str | bool]],
+    ) -> str:
+        """Map runtime reason metadata to an operator next action."""
+
         if readiness == "ready":
             return "none"
-        if reasons & {"helper_unavailable", "helper_missing", "helper_protocol_mismatch"}:
-            return "check_helper"
-        if reasons & {"template_missing", "template_unconfigured"}:
-            return "configure_template"
-        if reasons & {
-            "host_prerequisite_missing",
-            "host_permission_denied",
-            "unsupported_os",
-            "unsupported_arch",
-        }:
-            return "prepare_host"
-        if reasons & {"network_policy_unsupported", "trust_policy_denied"}:
-            return "adjust_request_policy"
+        for detail in normalized_reason_details:
+            action = str(detail.get("operator_action") or "").strip()
+            if action and action != "none":
+                return action
         if readiness in {"scaffold", "unsupported", "not_applicable"}:
             return "use_different_runtime"
         return "inspect_reasons"

--- a/tldw_Server_API/tests/Docs/test_sandbox_public_docs_contract.py
+++ b/tldw_Server_API/tests/Docs/test_sandbox_public_docs_contract.py
@@ -165,3 +165,8 @@ def test_sandbox_runtime_schema_exposes_reason_details() -> None:
         "normalized_reason_details" in schema["properties"],
         "SandboxRuntimeInfo should expose normalized_reason_details",
     )
+    serialized = str(schema["properties"]["normalized_reason_details"])
+    _require(
+        "'type': 'null'" not in serialized,
+        "SandboxRuntimeInfo field normalized_reason_details should not be nullable",
+    )

--- a/tldw_Server_API/tests/Docs/test_sandbox_public_docs_contract.py
+++ b/tldw_Server_API/tests/Docs/test_sandbox_public_docs_contract.py
@@ -64,6 +64,7 @@ def test_public_sandbox_api_docs_do_not_overclaim_runtime_support(doc_path: Path
         "vm_grade_isolation",
         "untrusted_eligible",
         "network_policy_contract",
+        "normalized_reason_details",
         "session_contract",
     ):
         _require(
@@ -154,4 +155,13 @@ def test_sandbox_runtime_session_contract_schema_field_is_required() -> None:
     _require(
         "'type': 'null'" not in serialized,
         "SandboxRuntimeInfo field session_contract should not be nullable",
+    )
+
+
+def test_sandbox_runtime_schema_exposes_reason_details() -> None:
+    schema = SandboxRuntimeInfo.model_json_schema()
+
+    _require(
+        "normalized_reason_details" in schema["properties"],
+        "SandboxRuntimeInfo should expose normalized_reason_details",
     )

--- a/tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py
+++ b/tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py
@@ -103,6 +103,19 @@ def _status_reason_details_contract_is_documented(text: str) -> bool:
     )
 
 
+def _runtime_reason_details_contract_is_documented(text: str) -> bool:
+    """Return whether the inventory documents structured runtime reason details."""
+
+    section = _markdown_section(text, "Normalized Reason Codes")
+    return (
+        "normalized_reason_details" in section
+        and "normalized_reasons" in section
+        and "category" in section
+        and "operator_action" in section
+        and "availability_blocking" in section
+    )
+
+
 def test_portable_runtime_capability_gate_covers_all_runtime_discovery_rows(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -139,6 +152,10 @@ def test_portable_runtime_capability_gate_covers_all_runtime_discovery_rows(
         assert row.network_policy_contract is not None
         assert row.session_contract is not None
         assert row.normalized_reasons
+        assert row.normalized_reason_details
+        assert [details.code for details in row.normalized_reason_details] == list(
+            row.normalized_reasons
+        )
         assert "unknown" not in row.normalized_reasons
 
     for runtime in (RuntimeType.seatbelt, RuntimeType.worktree):
@@ -199,7 +216,7 @@ def test_portable_runtime_capability_gate_inventory_no_longer_lists_gate_as_miss
 def test_inventory_documents_status_reason_details_metadata(
     pytestconfig: pytest.Config,
 ) -> None:
-    """Guard the docs contract for structured status reason details."""
+    """Guard the docs contract for structured reason details."""
 
     repo_root = Path(pytestconfig.rootpath)
     inventory = repo_root / "Docs" / "Sandbox" / "sandbox-runtime-capability-inventory.md"
@@ -207,7 +224,8 @@ def test_inventory_documents_status_reason_details_metadata(
     current_gaps = _markdown_section(text, "Current Gaps")
 
     assert _status_reason_details_contract_is_documented(text)
-    assert "runtime discovery `normalized_reasons` still lack equivalent rich details" in current_gaps
+    assert _runtime_reason_details_contract_is_documented(text)
+    assert "runtime discovery `normalized_reasons` still lack equivalent rich details" not in current_gaps
 
 
 def test_inventory_no_longer_lists_host_local_warning_ui_as_missing(

--- a/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
+++ b/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import get_args
+
 import pytest
 
 from tldw_Server_API.app.api.v1.schemas.sandbox_schemas import (
@@ -349,6 +351,28 @@ def test_runtime_info_schema_exposes_session_contract() -> None:
     assert "session_contract" in schema["properties"]
 
 
+def test_runtime_info_schema_exposes_reason_details() -> None:
+    schema = SandboxRuntimeInfo.model_json_schema()
+
+    assert "normalized_reason_details" in schema["properties"]
+
+
+def test_runtime_reason_metadata_contract_covers_reason_codes() -> None:
+    expected = set(get_args(runtime_caps.RuntimeReasonCode))
+
+    assert set(runtime_caps.RUNTIME_REASON_METADATA) == expected
+    for code, details in runtime_caps.RUNTIME_REASON_METADATA.items():
+        assert details.code == code
+        assert details.user_message_key == f"sandbox.runtime.reason.{code}"
+
+
+def test_runtime_reason_details_unknown_code_falls_back_to_unknown() -> None:
+    unknown = runtime_caps.runtime_reason_details("not-a-real-code")
+
+    assert unknown.code == "unknown"
+    assert unknown.operator_action == "inspect_reasons"
+
+
 def test_feature_discovery_validates_against_runtime_response_schema(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -472,6 +496,16 @@ def test_runtime_diagnostics_summary_projects_feature_discovery_rows(
     assert rows["docker"]["readiness"] == "ready"
     assert rows["docker"]["recommended_action"] == "none"
     assert rows["vz_linux"]["readiness"] == "host_gated"
+    assert rows["vz_linux"]["normalized_reason_details"] == [
+        {
+            "code": "helper_unavailable",
+            "category": "helper",
+            "severity": "error",
+            "availability_blocking": True,
+            "operator_action": "check_helper",
+            "user_message_key": "sandbox.runtime.reason.helper_unavailable",
+        }
+    ]
     assert rows["vz_linux"]["recommended_action"] == "check_helper"
     assert rows["vz_linux"]["repair_supported"] is True
     assert rows["vz_macos"]["readiness"] == "ready"
@@ -633,6 +667,24 @@ def test_feature_discovery_preserves_raw_reasons_and_adds_normalized_codes(
     assert discovery["vz_linux"]["normalized_reasons"] == [
         "helper_unavailable",
         "template_missing",
+    ]
+    assert discovery["vz_linux"]["normalized_reason_details"] == [
+        {
+            "code": "helper_unavailable",
+            "category": "helper",
+            "severity": "error",
+            "availability_blocking": True,
+            "operator_action": "check_helper",
+            "user_message_key": "sandbox.runtime.reason.helper_unavailable",
+        },
+        {
+            "code": "template_missing",
+            "category": "template",
+            "severity": "error",
+            "availability_blocking": True,
+            "operator_action": "configure_template",
+            "user_message_key": "sandbox.runtime.reason.template_missing",
+        },
     ]
     assert discovery["seatbelt"]["normalized_reasons"] == [
         "unsupported_os",

--- a/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
+++ b/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
@@ -414,6 +414,29 @@ def test_runtime_diagnostics_summary_projects_feature_discovery_rows(
                 },
             },
             {
+                "name": "firecracker",
+                "available": False,
+                "implementation_state": "host_gated",
+                "reasons": ["firecracker_unavailable", "/dev/kvm_missing"],
+                "normalized_reasons": [
+                    "runtime_unavailable",
+                    "host_prerequisite_missing",
+                ],
+                "boundary_class": "vm_grade",
+                "vm_grade_isolation": True,
+                "untrusted_eligible": True,
+                "isolation_warnings": [],
+                "strict_deny_all_supported": False,
+                "strict_allowlist_supported": False,
+                "session_contract": {
+                    "support_state": "scaffold",
+                    "reuse_model": "scaffold",
+                    "requires_live_health_check": False,
+                    "recovery_state": "unsupported",
+                    "repair_state": "unsupported",
+                },
+            },
+            {
                 "name": "vz_linux",
                 "available": False,
                 "implementation_state": "host_gated",
@@ -484,10 +507,10 @@ def test_runtime_diagnostics_summary_projects_feature_discovery_rows(
 
     assert summary["source"] == "feature_discovery"
     assert summary["summary"] == {
-        "total": 4,
+        "total": 5,
         "ready": 2,
         "unavailable": 1,
-        "host_gated": 1,
+        "host_gated": 2,
         "scaffold": 0,
         "host_local_warning_runtimes": ["worktree"],
         "repair_supported_runtimes": ["vz_linux", "vz_macos"],
@@ -495,6 +518,8 @@ def test_runtime_diagnostics_summary_projects_feature_discovery_rows(
     rows = {row["name"]: row for row in summary["runtimes"]}
     assert rows["docker"]["readiness"] == "ready"
     assert rows["docker"]["recommended_action"] == "none"
+    assert rows["firecracker"]["readiness"] == "host_gated"
+    assert rows["firecracker"]["recommended_action"] == "prepare_host"
     assert rows["vz_linux"]["readiness"] == "host_gated"
     assert rows["vz_linux"]["normalized_reason_details"] == [
         {


### PR DESCRIPTION
## Summary
- Add centralized runtime reason metadata for every RuntimeReasonCode with category, severity, availability-blocking posture, operator action, and message key.
- Expose additive normalized_reason_details on runtime discovery and admin runtime diagnostics while preserving raw reasons and normalized_reasons.
- Update sandbox runtime/API docs plus Backlog task and implementation plan for the completed slice.

## Human Change summary
Pending human-authored summary before merge.

## Test Plan
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py tldw_Server_API/tests/Docs/test_sandbox_public_docs_contract.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile tldw_Server_API/app/core/Sandbox/runtime_capabilities.py tldw_Server_API/app/core/Sandbox/service.py tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py tldw_Server_API/tests/Docs/test_sandbox_public_docs_contract.py
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Sandbox/runtime_capabilities.py tldw_Server_API/app/core/Sandbox/service.py tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py -f json -o /tmp/bandit_runtime_reason_details_prod.json
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py tldw_Server_API/tests/Docs/test_sandbox_public_docs_contract.py -s B101 -f json -o /tmp/bandit_runtime_reason_details_tests.json
- git diff --check