### PR TITLE
Add sandbox session contract gate

### DIFF
--- a/Docs/Sandbox/sandbox-runtime-capability-inventory.md
+++ b/Docs/Sandbox/sandbox-runtime-capability-inventory.md
@@ -295,7 +295,7 @@ for `untrusted` workloads.
 | Gap | Runtime(s) | Follow-up phase |
 | --- | --- | --- |
 | Additional real allowlist implementations remain limited beyond Docker granular enforcement. | all except unsupported paths | Future |
-| Cross-runtime session behavior contract tests and recovery flows remain incomplete beyond the discovery-level `session_contract`. | all | Phase 4 |
+| The portable session-contract gate covers discovery/admin projection, but real host-gated recovery flows remain incomplete. | all | Phase 4 |
 | Recovery/repair ownership exists only for `vz_linux`. | all except `vz_linux` | Phase 4 |
 | No single CI job proves real execution for every runtime; the portable capability gate covers capability contracts only. | all | Phase 5 |
 
@@ -309,6 +309,8 @@ for `untrusted` workloads.
   current `enforcement_ready` host/preflight truth.
 - Add session contract metadata for every runtime and keep it separate from
   current host availability and admin diagnostics.
+- Keep admin runtime diagnostics session fields aligned with `session_contract`
+  so operator surfaces do not invent separate reuse or repair claims.
 - Add runtime reason metadata for every `RuntimeReasonCode` and keep it derived
   from `normalized_reasons`, not raw runtime-specific reason strings.
 - Prefer `unsupported` over ambiguous wording when a guarantee cannot be

--- a/Docs/superpowers/plans/2026-05-08-sandbox-cross-runtime-session-reliability-contract-gate.md
+++ b/Docs/superpowers/plans/2026-05-08-sandbox-cross-runtime-session-reliability-contract-gate.md
@@ -1,0 +1,100 @@
+# Sandbox Cross-Runtime Session Reliability Contract Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a portable regression gate for sandbox session/recovery claims without changing runtime execution behavior.
+
+**Architecture:** Treat `session_contract` as the source of static runtime posture and verify its projection through public discovery plus admin diagnostics. Keep real repair/recovery behavior scoped to `vz_linux`; this slice only hardens portable contract coverage and clarifies the remaining host-gated gaps.
+
+**Tech Stack:** Python, pytest, Pydantic API schemas, sandbox runtime capability metadata.
+
+---
+
+## Design Review
+
+- Keep the slice contract-only. Do not generalize repair, do not add warm reuse for host-local runtimes, and do not change helper or runner behavior.
+- Avoid brittle tests that require Docker, Lima, Firecracker, or Apple Virtualization.framework availability. Use synthetic discovery rows and pure service projection helpers where possible.
+- Documentation must say what is now covered by portable tests and what remains uncovered. Do not remove the Phase 4 recovery/repair gap entirely.
+
+## Files
+
+- Modify: `tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py`
+- Modify: `Docs/Sandbox/sandbox-runtime-capability-inventory.md`
+- Modify: `backlog/tasks/task-124 - Add-sandbox-cross-runtime-session-reliability-contract-gate.md`
+
+## Task 1: Add Portable Session/Admin Projection Regression Coverage
+
+- [x] **Step 1: Write failing tests**
+
+Add tests in `tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py` that build synthetic runtime discovery rows and assert:
+
+- every runtime row keeps `session_contract` details through `SandboxRuntimesResponse`
+- `_runtime_diagnostics_item()` projects `session_reuse_model`, `requires_live_health_check`, and `repair_supported` from the same session contract
+- only `supported` or `host_gated` repair states become `repair_supported=true`
+- `seatbelt` and `worktree` remain `workspace_only`, do not require live health, and do not advertise repair
+
+- [x] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+python -m pytest tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py -q
+```
+
+Observed: failed on stale inventory wording because the new guard detected the old "beyond discovery-level `session_contract`" gap text. Admin projection assertions passed.
+
+- [x] **Step 3: Implement only the minimum needed**
+
+The current production projection already satisfied the contract, so no production code changed.
+
+- [x] **Step 4: Run the focused test and verify GREEN**
+
+Run:
+
+```bash
+python -m pytest tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py -q
+```
+
+Observed: pass with 8 tests.
+
+## Task 2: Update Capability Inventory Wording
+
+- [x] **Step 1: Update `Current Gaps`**
+
+Change the session semantics gap so it no longer says portable contract checks are absent. Preserve the remaining gap for real recovery flows and host-gated repair ownership.
+
+- [x] **Step 2: Add or adjust a maintenance rule**
+
+Ensure the inventory tells future runtime authors to keep admin diagnostics aligned with `session_contract`.
+
+- [x] **Step 3: Run docs/test guard**
+
+Run the same focused capability gate after the docs edit:
+
+```bash
+python -m pytest tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py -q
+```
+
+Observed: pass with 8 tests, then 36 tests across the capability gate and runtime inventory contract.
+
+## Task 3: Verification And Backlog Closeout
+
+- [x] **Step 1: Run Python syntax check**
+
+```bash
+python -m py_compile tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py
+```
+
+- [x] **Step 2: Run Bandit or record skip**
+
+No production Python changed. Ran Bandit against the touched test file with pytest assert noise excluded; results were empty.
+
+- [x] **Step 3: Run diff hygiene**
+
+```bash
+git diff --check
+```
+
+- [x] **Step 4: Update TASK-124**
+
+Check acceptance criteria and definition-of-done items, record verification results, and add a final summary.

--- a/backlog/tasks/task-124 - Add-sandbox-cross-runtime-session-reliability-contract-gate.md
+++ b/backlog/tasks/task-124 - Add-sandbox-cross-runtime-session-reliability-contract-gate.md
@@ -4,7 +4,7 @@ title: Add sandbox cross-runtime session reliability contract gate
 status: In Progress
 assignee: []
 created_date: '2026-05-08 19:35'
-updated_date: '2026-05-08 19:37'
+updated_date: '2026-05-09 00:16'
 labels:
   - sandbox
   - runtime-reliability
@@ -37,17 +37,29 @@ Add a narrow Phase 4 sandbox reliability slice that turns the current session_co
 <!-- SECTION:NOTES:BEGIN -->
 Plan/design review: kept the slice contract-only. The implementation does not generalize repair, add warm reuse to host-local runtimes, change helper behavior, or change runtime execution/admission.
 
-RED: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py -q` failed on `test_inventory_documents_portable_session_contract_gate_scope` because the inventory still claimed session behavior tests were incomplete beyond discovery-level `session_contract`.
+RED: `python -m pytest tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py -q` failed on `test_inventory_documents_portable_session_contract_gate_scope` because the inventory still claimed session behavior tests were incomplete beyond discovery-level `session_contract`.
 
-GREEN: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py -q` passed with 8 tests.
+GREEN: `python -m pytest tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py -q` passed with 8 tests.
 
-Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py -q` passed with 36 tests.
+Verification: `python -m pytest tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py -q` passed with 36 tests.
 
-Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py` passed.
+Verification: `python -m py_compile tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py` passed.
 
-Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py -s B101 -f json -o /tmp/bandit_sandbox_session_contract_gate_tests.json` reported zero findings after excluding pytest assert-use noise.
+Verification: `python -m bandit -r tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py -s B101 -f json -o /tmp/bandit_sandbox_session_contract_gate_tests.json` reported zero findings after excluding pytest assert-use noise.
 
 Verification: `git diff --check` passed.
+
+PR review fixes: wrapped the overlong session-contract assertion, replaced exact docs-prose checks with case-insensitive semantic regexes, and changed task verification snippets from local absolute interpreter paths to portable `python -m ...` commands.
+
+Review verification: `python -m pytest tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py -q` passed with 36 tests.
+
+Review verification: `python -m py_compile tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py` passed.
+
+Review verification: `python -m ruff check tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py` passed.
+
+Review verification: `python -m bandit -r tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py -s B101 -f json -o /tmp/bandit_sandbox_session_contract_gate_tests_review_fixes.json` reported zero findings after excluding pytest assert-use noise.
+
+Review verification: `git diff --check` passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-124 - Add-sandbox-cross-runtime-session-reliability-contract-gate.md
+++ b/backlog/tasks/task-124 - Add-sandbox-cross-runtime-session-reliability-contract-gate.md
@@ -1,0 +1,67 @@
+---
+id: TASK-124
+title: Add sandbox cross-runtime session reliability contract gate
+status: In Progress
+assignee: []
+created_date: '2026-05-08 19:35'
+updated_date: '2026-05-08 19:37'
+labels:
+  - sandbox
+  - runtime-reliability
+  - testing
+dependencies: []
+documentation:
+  - Docs/Sandbox/sandbox-architecture-doctrine.md
+  - Docs/Sandbox/sandbox-runtime-capability-inventory.md
+  - Docs/superpowers/specs/2026-05-02-sandbox-module-roadmap-design.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add a narrow Phase 4 sandbox reliability slice that turns the current session_contract posture into portable regression coverage. Scope should verify cross-runtime session/recovery claims through runtime discovery and admin diagnostics, preserve the rule that only vz_linux currently advertises repair/warm-VM health requirements, and update the capability inventory to distinguish newly-covered portable contract checks from still-host-gated recovery behavior. Do not generalize repair or change runtime execution semantics in this slice.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Portable sandbox tests verify every runtime's session_contract is projected consistently through public runtime discovery and admin runtime diagnostics where applicable.
+- [x] #2 Tests assert only runtimes with supported or host_gated repair_state appear as repair-supported in admin diagnostics, and host-local runtimes remain workspace_only with no live-health or repair claims.
+- [x] #3 Docs/Sandbox/sandbox-runtime-capability-inventory.md is updated so the Current Gaps section reflects portable session-contract coverage while preserving remaining host-gated recovery/repair gaps.
+- [x] #4 No runtime execution, helper boot, networking, or repair mutation behavior changes are introduced unless a failing test proves an existing contract bug.
+- [x] #5 Focused sandbox tests, py_compile for touched Python tests, git diff --check, and Bandit skip/rationale or touched-scope Bandit are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Plan/design review: kept the slice contract-only. The implementation does not generalize repair, add warm reuse to host-local runtimes, change helper behavior, or change runtime execution/admission.
+
+RED: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py -q` failed on `test_inventory_documents_portable_session_contract_gate_scope` because the inventory still claimed session behavior tests were incomplete beyond discovery-level `session_contract`.
+
+GREEN: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py -q` passed with 8 tests.
+
+Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py -q` passed with 36 tests.
+
+Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py` passed.
+
+Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py -s B101 -f json -o /tmp/bandit_sandbox_session_contract_gate_tests.json` reported zero findings after excluding pytest assert-use noise.
+
+Verification: `git diff --check` passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added a portable session-contract regression gate that validates every runtime's `session_contract` through public runtime discovery and checks that admin diagnostics derive session reuse, live-health, and repair support from the same metadata. The new coverage preserves the rule that host-local runtimes are workspace-only and repair-unsupported while `vz_linux` remains the only warm-VM host-gated repair path. Updated the sandbox capability inventory so it records the new portable contract gate while keeping real host-gated recovery flows and non-`vz_linux` repair ownership as remaining Phase 4 gaps.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py
+++ b/tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py
@@ -116,6 +116,21 @@ def _runtime_reason_details_contract_is_documented(text: str) -> bool:
     )
 
 
+def _session_contract_gap_is_documented(text: str) -> bool:
+    current_gaps = _markdown_section(text, "Current Gaps")
+    has_portable_gate = re.search(
+        r"\bportable\b.*\bsession[- ]contract\b.*\bgate\b",
+        current_gaps,
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+    has_host_gated_recovery_gap = re.search(
+        r"\bhost[- ]gated\b.*\brecovery\b",
+        current_gaps,
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+    return bool(has_portable_gate and has_host_gated_recovery_gap)
+
+
 def test_portable_runtime_capability_gate_covers_all_runtime_discovery_rows(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -199,7 +214,10 @@ def test_portable_session_contract_gate_projects_to_admin_diagnostics(
         expected_repair_supported = contract.repair_state in {"supported", "host_gated"}
 
         assert row.session_contract.reuse_model == contract.reuse_model
-        assert row.session_contract.requires_live_health_check is contract.requires_live_health_check
+        assert (
+            row.session_contract.requires_live_health_check
+            is contract.requires_live_health_check
+        )
         assert item["session_reuse_model"] == contract.reuse_model
         assert item["requires_live_health_check"] is contract.requires_live_health_check
         assert item["repair_supported"] is expected_repair_supported
@@ -272,9 +290,12 @@ def test_inventory_documents_portable_session_contract_gate_scope(
     text = inventory.read_text(encoding="utf-8")
     current_gaps = _markdown_section(text, "Current Gaps")
 
-    assert "beyond the discovery-level `session_contract`" not in current_gaps
-    assert "portable session-contract gate" in current_gaps
-    assert "host-gated recovery" in current_gaps
+    assert not re.search(
+        r"\bincomplete\b.*\bbeyond\b.*\bdiscovery[- ]level\b.*`?session_contract`?",
+        current_gaps,
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+    assert _session_contract_gap_is_documented(text)
 
 
 def test_inventory_documents_status_reason_details_metadata(

--- a/tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py
+++ b/tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py
@@ -170,6 +170,57 @@ def test_portable_runtime_capability_gate_covers_all_runtime_discovery_rows(
     assert discovery[RuntimeType.vz_linux.value].session_contract.repair_state == "host_gated"
 
 
+def test_portable_session_contract_gate_projects_to_admin_diagnostics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SANDBOX_STORE_BACKEND", "memory")
+    monkeypatch.setattr(
+        SandboxService,
+        "_collect_runtime_preflights",
+        lambda self, network_policy=None: _synthetic_preflights(),
+    )
+
+    rows = SandboxService().feature_discovery()
+    response = SandboxRuntimesResponse(runtimes=rows)
+    validated_rows = {
+        row.name.value if isinstance(row.name, RuntimeType) else str(row.name): row
+        for row in response.runtimes
+    }
+    diagnostics = {
+        str(row["name"]): SandboxService._runtime_diagnostics_item(row)
+        for row in rows
+    }
+
+    assert set(diagnostics) == {runtime.value for runtime in RuntimeType}
+    for runtime in RuntimeType:
+        contract = runtime_caps.runtime_session_contract_metadata(runtime)
+        row = validated_rows[runtime.value]
+        item = diagnostics[runtime.value]
+        expected_repair_supported = contract.repair_state in {"supported", "host_gated"}
+
+        assert row.session_contract.reuse_model == contract.reuse_model
+        assert row.session_contract.requires_live_health_check is contract.requires_live_health_check
+        assert item["session_reuse_model"] == contract.reuse_model
+        assert item["requires_live_health_check"] is contract.requires_live_health_check
+        assert item["repair_supported"] is expected_repair_supported
+
+    for runtime in (RuntimeType.seatbelt, RuntimeType.worktree):
+        row = validated_rows[runtime.value]
+        item = diagnostics[runtime.value]
+        assert row.session_contract.reuse_model == "workspace_only"
+        assert row.session_contract.requires_live_health_check is False
+        assert row.session_contract.repair_state == "unsupported"
+        assert item["session_reuse_model"] == "workspace_only"
+        assert item["requires_live_health_check"] is False
+        assert item["repair_supported"] is False
+
+    vz_linux = validated_rows[RuntimeType.vz_linux.value]
+    vz_linux_item = diagnostics[RuntimeType.vz_linux.value]
+    assert vz_linux.session_contract.reuse_model == "warm_vm"
+    assert vz_linux.session_contract.requires_live_health_check is True
+    assert vz_linux_item["repair_supported"] is True
+
+
 def test_portable_runtime_capability_gate_covers_emitted_status_reason_aliases() -> None:
     for message in _EMITTED_POLICY_FAILURE_MESSAGES:
         assert normalize_run_status_reason(
@@ -211,6 +262,19 @@ def test_portable_runtime_capability_gate_inventory_no_longer_lists_gate_as_miss
 
     assert "CI has no single cross-runtime capability gate" not in text
     assert _portable_gate_scope_is_documented(text)
+
+
+def test_inventory_documents_portable_session_contract_gate_scope(
+    pytestconfig: pytest.Config,
+) -> None:
+    repo_root = Path(pytestconfig.rootpath)
+    inventory = repo_root / "Docs" / "Sandbox" / "sandbox-runtime-capability-inventory.md"
+    text = inventory.read_text(encoding="utf-8")
+    current_gaps = _markdown_section(text, "Current Gaps")
+
+    assert "beyond the discovery-level `session_contract`" not in current_gaps
+    assert "portable session-contract gate" in current_gaps
+    assert "host-gated recovery" in current_gaps
 
 
 def test_inventory_documents_status_reason_details_metadata(


### PR DESCRIPTION
## Summary
- Add a portable sandbox session-contract regression gate for runtime discovery and admin diagnostics projection.
- Keep host-local runtimes workspace-only and repair-unsupported while preserving vz_linux as the warm-VM, host-gated repair path.
- Update the sandbox runtime capability inventory to distinguish new portable session-contract coverage from remaining host-gated recovery gaps.

## Test Plan
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py -q
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py -q
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/tests/sandbox/test_runtime_capability_gate.py -s B101 -f json -o /tmp/bandit_sandbox_session_contract_gate_tests.json
- [x] git diff --cached --check

## Change summary
Human-authored change summary required before merge per project policy.