### PR TITLE
Adapt DocumentWorkspace sidebar loading states

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -308,7 +308,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/DocumentWorkspace/LeftSidebar/ReferencesTab.tsx:Empty#antd-empty-errorstate-line-396-fnj2vo",
+    "id": "antd-product-state-import:src/components/DocumentWorkspace/LeftSidebar/ReferencesTab.tsx:Empty#antd-empty-errorstate-line-413-wx7ci2",
     "path": "src/components/DocumentWorkspace/LeftSidebar/ReferencesTab.tsx",
     "rule": "antd-product-state-import",
     "subject": "Empty",

--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -319,7 +319,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/DocumentWorkspace/LeftSidebar/ReferencesTab.tsx:Empty#antd-empty-serverunavailablestate-line-346-1t92rx8",
+    "id": "antd-product-state-import:src/components/DocumentWorkspace/LeftSidebar/ReferencesTab.tsx:Empty#antd-empty-serverunavailablestate-line-347-1tj2dm7",
     "path": "src/components/DocumentWorkspace/LeftSidebar/ReferencesTab.tsx",
     "rule": "antd-product-state-import",
     "subject": "Empty",
@@ -5519,28 +5519,6 @@
     "owner": "design-system",
     "reason": "Existing hardcoded \"Ready\" state label in src/utils/demo-content.ts before the stable duplicate-id guard.",
     "replacement": "getDesignSystemState(...)",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "local-loading-state:src/components/DocumentWorkspace/LeftSidebar/QuickInsightsTab.tsx:LoadingState",
-    "path": "src/components/DocumentWorkspace/LeftSidebar/QuickInsightsTab.tsx",
-    "rule": "local-loading-state",
-    "subject": "LoadingState",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing local LoadingState loading-state wrapper before the guard.",
-    "replacement": "LoadingState or StatePanel",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "local-loading-state:src/components/DocumentWorkspace/LeftSidebar/ReferencesTab.tsx:LoadingState",
-    "path": "src/components/DocumentWorkspace/LeftSidebar/ReferencesTab.tsx",
-    "rule": "local-loading-state",
-    "subject": "LoadingState",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing local LoadingState loading-state wrapper before the guard.",
-    "replacement": "LoadingState or StatePanel",
     "migrationQueue": "shared-product-state"
   },
   {

--- a/apps/packages/ui/src/components/DocumentWorkspace/LeftSidebar/QuickInsightsTab.tsx
+++ b/apps/packages/ui/src/components/DocumentWorkspace/LeftSidebar/QuickInsightsTab.tsx
@@ -191,13 +191,25 @@ const ErrorState: React.FC<{
 /**
  * Loading state during generation.
  */
-const LoadingState: React.FC = () => {
+const InsightPlaceholders: React.FC = () => {
   return (
-    <SharedLoadingState
-      mode="skeleton"
-      rows={6}
-      className="p-4"
-    />
+    <div className="space-y-3 p-4">
+      <SharedLoadingState
+        mode="skeleton"
+        rows={2}
+        className="!items-start !p-0"
+      />
+      <SharedLoadingState
+        mode="skeleton"
+        rows={2}
+        className="!items-start !p-0"
+      />
+      <SharedLoadingState
+        mode="skeleton"
+        rows={2}
+        className="!items-start !p-0"
+      />
+    </div>
   )
 }
 
@@ -251,7 +263,7 @@ export const QuickInsightsTab: React.FC = () => {
 
   // Loading state during generation
   if (generateMutation.isPending || isLoading) {
-    return <LoadingState />
+    return <InsightPlaceholders />
   }
 
   // Error state

--- a/apps/packages/ui/src/components/DocumentWorkspace/LeftSidebar/QuickInsightsTab.tsx
+++ b/apps/packages/ui/src/components/DocumentWorkspace/LeftSidebar/QuickInsightsTab.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { useTranslation } from "react-i18next"
-import { Button, Empty, Skeleton, Collapse, Segmented } from "antd"
+import { Button, Empty, Collapse, Segmented } from "antd"
 import {
   Lightbulb,
   AlertTriangle,
@@ -15,6 +15,7 @@ import {
   type InsightItem,
 } from "@/hooks/document-workspace"
 import { useConnectionStore } from "@/store/connection"
+import { LoadingState as SharedLoadingState } from "@/components/ui/feedback/LoadingState"
 import type { InsightDetailLevel } from "../types"
 import { CATEGORY_ICONS } from "../config"
 
@@ -192,11 +193,11 @@ const ErrorState: React.FC<{
  */
 const LoadingState: React.FC = () => {
   return (
-    <div className="space-y-3 p-4">
-      <Skeleton active paragraph={{ rows: 2 }} />
-      <Skeleton active paragraph={{ rows: 2 }} />
-      <Skeleton active paragraph={{ rows: 2 }} />
-    </div>
+    <SharedLoadingState
+      mode="skeleton"
+      rows={6}
+      className="p-4"
+    />
   )
 }
 

--- a/apps/packages/ui/src/components/DocumentWorkspace/LeftSidebar/ReferencesTab.tsx
+++ b/apps/packages/ui/src/components/DocumentWorkspace/LeftSidebar/ReferencesTab.tsx
@@ -376,13 +376,30 @@ const NoFilteredReferencesState: React.FC = () => {
 /**
  * Loading state.
  */
-const LoadingState: React.FC = () => {
+const ReferencePlaceholders: React.FC = () => {
   return (
-    <SharedLoadingState
-      mode="skeleton"
-      rows={8}
-      className="p-4"
-    />
+    <div className="space-y-3 p-4">
+      <SharedLoadingState
+        mode="skeleton"
+        rows={2}
+        className="!items-start !p-0"
+      />
+      <SharedLoadingState
+        mode="skeleton"
+        rows={2}
+        className="!items-start !p-0"
+      />
+      <SharedLoadingState
+        mode="skeleton"
+        rows={2}
+        className="!items-start !p-0"
+      />
+      <SharedLoadingState
+        mode="skeleton"
+        rows={2}
+        className="!items-start !p-0"
+      />
+    </div>
   )
 }
 
@@ -499,7 +516,7 @@ export const ReferencesTab: React.FC = () => {
 
   // Loading state
   if (isLoading) {
-    return <LoadingState />
+    return <ReferencePlaceholders />
   }
 
   // Error state

--- a/apps/packages/ui/src/components/DocumentWorkspace/LeftSidebar/ReferencesTab.tsx
+++ b/apps/packages/ui/src/components/DocumentWorkspace/LeftSidebar/ReferencesTab.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { useTranslation } from "react-i18next"
-import { Empty, Skeleton, Tag, Tooltip, Input, message, Button, Select } from "antd"
+import { Empty, Tag, Tooltip, Input, message, Button, Select } from "antd"
 import {
   BookOpen,
   ExternalLink,
@@ -23,6 +23,7 @@ import {
 import { useConnectionStore } from "@/store/connection"
 import { tldwClient } from "@/services/tldw"
 import { useQueryClient } from "@tanstack/react-query"
+import { LoadingState as SharedLoadingState } from "@/components/ui/feedback/LoadingState"
 
 /** FNV-1a 32-bit hash for generating stable, short identifiers from reference text. */
 const hashReferenceText = (value: string): string => {
@@ -377,12 +378,11 @@ const NoFilteredReferencesState: React.FC = () => {
  */
 const LoadingState: React.FC = () => {
   return (
-    <div className="space-y-3 p-4">
-      <Skeleton active paragraph={{ rows: 2 }} />
-      <Skeleton active paragraph={{ rows: 2 }} />
-      <Skeleton active paragraph={{ rows: 2 }} />
-      <Skeleton active paragraph={{ rows: 2 }} />
-    </div>
+    <SharedLoadingState
+      mode="skeleton"
+      rows={8}
+      className="p-4"
+    />
   )
 }
 

--- a/apps/packages/ui/src/components/DocumentWorkspace/LeftSidebar/__tests__/QuickInsightsTab.loading-state.test.tsx
+++ b/apps/packages/ui/src/components/DocumentWorkspace/LeftSidebar/__tests__/QuickInsightsTab.loading-state.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest"
+import { render, cleanup } from "@testing-library/react"
+import { QuickInsightsTab } from "../QuickInsightsTab"
+import { useDocumentWorkspaceStore } from "@/store/document-workspace"
+import { useConnectionStore } from "@/store/connection"
+
+const mockUseDocumentInsights = vi.fn()
+const mockUseGenerateInsightsMutation = vi.fn()
+
+vi.mock("@/hooks/document-workspace", async () => {
+  const actual = await vi.importActual<any>("@/hooks/document-workspace")
+  return {
+    ...actual,
+    useDocumentInsights: (...args: any[]) => mockUseDocumentInsights(...args),
+    useGenerateInsightsMutation: () => mockUseGenerateInsightsMutation(),
+  }
+})
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, defaultValue?: string) => defaultValue || _key,
+  }),
+}))
+
+describe("QuickInsightsTab loading state", () => {
+  beforeEach(() => {
+    useDocumentWorkspaceStore.setState({ activeDocumentId: 1 })
+    const prev = useConnectionStore.getState().state
+    useConnectionStore.setState({
+      state: { ...prev, isConnected: true, mode: "normal" },
+    })
+    mockUseDocumentInsights.mockReturnValue({
+      data: null,
+      isLoading: true,
+      error: null,
+    })
+    mockUseGenerateInsightsMutation.mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+      error: null,
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    useDocumentWorkspaceStore.setState({ activeDocumentId: null })
+    const prev = useConnectionStore.getState().state
+    useConnectionStore.setState({
+      state: { ...prev, isConnected: false, mode: "normal" },
+    })
+    vi.clearAllMocks()
+  })
+
+  it("renders the loading branch through the canonical LoadingState primitive", () => {
+    const { container } = render(<QuickInsightsTab />)
+
+    expect(
+      container.querySelector('[data-ds-component="LoadingState"]')
+    ).toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/components/DocumentWorkspace/LeftSidebar/__tests__/QuickInsightsTab.loading-state.test.tsx
+++ b/apps/packages/ui/src/components/DocumentWorkspace/LeftSidebar/__tests__/QuickInsightsTab.loading-state.test.tsx
@@ -23,11 +23,20 @@ vi.mock("react-i18next", () => ({
 }))
 
 describe("QuickInsightsTab loading state", () => {
+  let previousWorkspaceState = useDocumentWorkspaceStore.getState()
+  let previousConnectionStoreState = useConnectionStore.getState()
+
   beforeEach(() => {
+    previousWorkspaceState = useDocumentWorkspaceStore.getState()
+    previousConnectionStoreState = useConnectionStore.getState()
+
     useDocumentWorkspaceStore.setState({ activeDocumentId: 1 })
-    const prev = useConnectionStore.getState().state
     useConnectionStore.setState({
-      state: { ...prev, isConnected: true, mode: "normal" },
+      state: {
+        ...previousConnectionStoreState.state,
+        isConnected: true,
+        mode: "normal",
+      },
     })
     mockUseDocumentInsights.mockReturnValue({
       data: null,
@@ -43,11 +52,8 @@ describe("QuickInsightsTab loading state", () => {
 
   afterEach(() => {
     cleanup()
-    useDocumentWorkspaceStore.setState({ activeDocumentId: null })
-    const prev = useConnectionStore.getState().state
-    useConnectionStore.setState({
-      state: { ...prev, isConnected: false, mode: "normal" },
-    })
+    useDocumentWorkspaceStore.setState(previousWorkspaceState)
+    useConnectionStore.setState(previousConnectionStoreState)
     vi.clearAllMocks()
   })
 
@@ -55,7 +61,7 @@ describe("QuickInsightsTab loading state", () => {
     const { container } = render(<QuickInsightsTab />)
 
     expect(
-      container.querySelector('[data-ds-component="LoadingState"]')
-    ).toBeInTheDocument()
+      container.querySelectorAll('[data-ds-component="LoadingState"]')
+    ).toHaveLength(3)
   })
 })

--- a/apps/packages/ui/src/components/DocumentWorkspace/LeftSidebar/__tests__/ReferencesTab.test.tsx
+++ b/apps/packages/ui/src/components/DocumentWorkspace/LeftSidebar/__tests__/ReferencesTab.test.tsx
@@ -84,8 +84,8 @@ describe("ReferencesTab", () => {
     )
 
     expect(
-      container.querySelector('[data-ds-component="LoadingState"]')
-    ).toBeInTheDocument()
+      container.querySelectorAll('[data-ds-component="LoadingState"]')
+    ).toHaveLength(4)
   })
 
   it("passes search query to backend hook for cross-page filtering", async () => {

--- a/apps/packages/ui/src/components/DocumentWorkspace/LeftSidebar/__tests__/ReferencesTab.test.tsx
+++ b/apps/packages/ui/src/components/DocumentWorkspace/LeftSidebar/__tests__/ReferencesTab.test.tsx
@@ -69,6 +69,25 @@ describe("ReferencesTab", () => {
     vi.clearAllMocks()
   })
 
+  it("renders the loading branch through the canonical LoadingState primitive", () => {
+    mockUseDocumentReferences.mockImplementation(() => ({
+      data: null,
+      isLoading: true,
+      error: null,
+      isFetching: false,
+    }))
+
+    const { container } = render(
+      <QueryClientProvider client={queryClient}>
+        <ReferencesTab />
+      </QueryClientProvider>
+    )
+
+    expect(
+      container.querySelector('[data-ds-component="LoadingState"]')
+    ).toBeInTheDocument()
+  })
+
   it("passes search query to backend hook for cross-page filtering", async () => {
     mockReferencesResponse = {
       media_id: 1,

--- a/backlog/tasks/task-45.19 - Adapt-DocumentWorkspace-sidebar-loading-states-to-shared-LoadingState.md
+++ b/backlog/tasks/task-45.19 - Adapt-DocumentWorkspace-sidebar-loading-states-to-shared-LoadingState.md
@@ -1,0 +1,74 @@
+---
+id: TASK-45.19
+title: Adapt DocumentWorkspace sidebar loading states to shared LoadingState
+status: Done
+assignee: []
+created_date: '2026-05-09 00:06'
+updated_date: '2026-05-09 00:10'
+labels:
+  - design-system
+  - webui
+  - guard
+  - document-workspace
+dependencies: []
+references:
+  - >-
+    apps/packages/ui/src/components/DocumentWorkspace/LeftSidebar/QuickInsightsTab.tsx
+  - >-
+    apps/packages/ui/src/components/DocumentWorkspace/LeftSidebar/ReferencesTab.tsx
+  - apps/packages/ui/src/components/ui/feedback/LoadingState.tsx
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+parent_task_id: TASK-45
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Finish the current local-loading-state migration queue by routing the DocumentWorkspace left-sidebar QuickInsights and References loading adapters through the shared LoadingState primitive while preserving their loading branch behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 QuickInsightsTab loading branch renders through shared LoadingState.
+- [x] #2 ReferencesTab loading branch renders through shared LoadingState.
+- [x] #3 The product-state guard baseline no longer contains DocumentWorkspace local-loading-state exceptions.
+- [x] #4 Focused sidebar tests and the design-system product-state verifier pass.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused loading-branch coverage for QuickInsightsTab and ReferencesTab.
+2. Replace the local AntD Skeleton wrappers with the shared design-system LoadingState primitive while preserving sidebar spacing and approximate skeleton density.
+3. Remove the migrated local-loading-state baseline exceptions and refresh only the adjacent ReferencesTab AntD Empty baseline id affected by line movement.
+4. Verify with focused Vitest, product-state guard tests, product-state verifier, and diff whitespace checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+TDD red path: focused sidebar tests failed before implementation because neither loading branch rendered data-ds-component="LoadingState". Implementation replaced the local Skeleton wrappers with SharedLoadingState in both sidebar tabs.
+
+Verification: focused sidebar Vitest passed (2 files, 4 tests); product-state guard Vitest passed (42 tests); bun run verify:design-system-state passed with 516 allowed legacy exceptions and no local-loading-state bucket; git diff --check passed. Bandit was not run because the touched implementation scope is TypeScript/TSX, JSON, and Backlog metadata with no Python files.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Adapted the DocumentWorkspace left-sidebar QuickInsights and References loading branches to render through the shared design-system LoadingState primitive instead of local AntD Skeleton wrappers. This removes the final local-loading-state baseline exceptions while preserving the existing sidebar loading layout density through skeleton row counts.
+
+Added focused tests for both loading branches, removed the migrated baseline entries, and refreshed the single ReferencesTab AntD Empty baseline id caused by import/line movement.
+
+Verification: bunx vitest run src/components/DocumentWorkspace/LeftSidebar/__tests__/QuickInsightsTab.loading-state.test.tsx src/components/DocumentWorkspace/LeftSidebar/__tests__/ReferencesTab.test.tsx --reporter=dot; bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot; bun run verify:design-system-state; git diff --check. Bandit was not applicable because no Python files were touched.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.19 - Adapt-DocumentWorkspace-sidebar-loading-states-to-shared-LoadingState.md
+++ b/backlog/tasks/task-45.19 - Adapt-DocumentWorkspace-sidebar-loading-states-to-shared-LoadingState.md
@@ -4,7 +4,7 @@ title: Adapt DocumentWorkspace sidebar loading states to shared LoadingState
 status: Done
 assignee: []
 created_date: '2026-05-09 00:06'
-updated_date: '2026-05-09 00:10'
+updated_date: '2026-05-09 00:43'
 labels:
   - design-system
   - webui
@@ -51,14 +51,18 @@ Finish the current local-loading-state migration queue by routing the DocumentWo
 TDD red path: focused sidebar tests failed before implementation because neither loading branch rendered data-ds-component="LoadingState". Implementation replaced the local Skeleton wrappers with SharedLoadingState in both sidebar tabs.
 
 Verification: focused sidebar Vitest passed (2 files, 4 tests); product-state guard Vitest passed (42 tests); bun run verify:design-system-state passed with 516 allowed legacy exceptions and no local-loading-state bucket; git diff --check passed. Bandit was not run because the touched implementation scope is TypeScript/TSX, JSON, and Backlog metadata with no Python files.
+
+PR review follow-up: Gemini flagged that a single shared LoadingState collapsed the original per-item loading structure in QuickInsightsTab and ReferencesTab. CodeRabbit flagged hardcoded store teardown in the QuickInsights loading-state test. Reopening this task to address those comments on the same PR branch.
+
+Review fix verification: focused sidebar Vitest passed (2 files, 4 tests); product-state guard Vitest passed (42 tests); bun run verify:design-system-state passed after refreshing the ReferencesTab Empty baseline id; git diff --check passed. Bandit remains not applicable because no Python files are touched.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Adapted the DocumentWorkspace left-sidebar QuickInsights and References loading branches to render through the shared design-system LoadingState primitive instead of local AntD Skeleton wrappers. This removes the final local-loading-state baseline exceptions while preserving the existing sidebar loading layout density through skeleton row counts.
+Adapted the DocumentWorkspace left-sidebar QuickInsights and References loading branches to render through the shared design-system LoadingState primitive instead of local AntD Skeleton wrappers. The PR review follow-up now preserves the original per-item loading structure by rendering three shared placeholders for QuickInsights and four shared placeholders for References, left-aligned within the existing spaced containers.
 
-Added focused tests for both loading branches, removed the migrated baseline entries, and refreshed the single ReferencesTab AntD Empty baseline id caused by import/line movement.
+Added focused tests for both loading branches, strengthened those tests to assert the expected shared LoadingState counts, and updated the QuickInsights loading test to snapshot and restore the exact Zustand store states between tests. Removed the migrated local-loading-state baseline entries and refreshed ReferencesTab AntD Empty baseline ids caused by line movement.
 
 Verification: bunx vitest run src/components/DocumentWorkspace/LeftSidebar/__tests__/QuickInsightsTab.loading-state.test.tsx src/components/DocumentWorkspace/LeftSidebar/__tests__/ReferencesTab.test.tsx --reporter=dot; bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot; bun run verify:design-system-state; git diff --check. Bandit was not applicable because no Python files were touched.
 <!-- SECTION:FINAL_SUMMARY:END -->


### PR DESCRIPTION
## Summary
- Route QuickInsightsTab and ReferencesTab loading branches through the shared design-system LoadingState primitive instead of local AntD Skeleton wrappers.
- Add focused loading-state coverage for both left-sidebar tabs.
- Remove the migrated local-loading-state baseline exceptions and refresh the adjacent ReferencesTab AntD Empty baseline id caused by line movement.

## Verification
- bunx vitest run src/components/DocumentWorkspace/LeftSidebar/__tests__/QuickInsightsTab.loading-state.test.tsx src/components/DocumentWorkspace/LeftSidebar/__tests__/ReferencesTab.test.tsx --reporter=dot
- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot
- bun run verify:design-system-state
- git diff --check

## Notes
- Bandit was not applicable because this slice only touches TypeScript/TSX, JSON, and Backlog metadata.
- Draft pending the required human-written Change summary for AI-generated PRs.