### PR TITLE
Add VZ host-gated recovery smoke

### DIFF
--- a/Docs/Sandbox/macos-runtime-operator-notes.md
+++ b/Docs/Sandbox/macos-runtime-operator-notes.md
@@ -410,7 +410,14 @@ builds the Swift helper when the binary is missing, ad hoc signs it with the
 supplied entitlements unless the helper is already signed with
 `com.apple.security.virtualization`, runs the helper-daemon smoke, starts one
 helper daemon for real `vz_linux` E2E, verifies ephemeral execution, verifies
-same-session VM reuse, and stops the helper on exit.
+same-session VM reuse, verifies recovery diagnostics plus dry-run
+reconciliation repair planning, and stops the helper on exit.
+
+The recovery smoke is non-destructive. It seeds an isolated test-store stale VZ
+session-control row, verifies `/api/v1/sandbox/admin/macos-diagnostics` style
+reconciliation and `recovery_summary` output through the service layer, then
+verifies `repair_macos_reconciliation(dry_run=true)` produces a planned delete
+without deleting state or terminating VMs.
 
 The lower-level fallback remains available when operators need to bypass the
 managed defaults:

--- a/Docs/Sandbox/sandbox-runtime-capability-inventory.md
+++ b/Docs/Sandbox/sandbox-runtime-capability-inventory.md
@@ -295,7 +295,7 @@ for `untrusted` workloads.
 | Gap | Runtime(s) | Follow-up phase |
 | --- | --- | --- |
 | Additional real allowlist implementations remain limited beyond Docker granular enforcement. | all except unsupported paths | Future |
-| The portable session-contract gate covers discovery/admin projection, but real host-gated recovery flows remain incomplete. | all | Phase 4 |
+| Host-gated recovery smoke covers `vz_linux` diagnostics and dry-run repair planning, but destructive repair, host reboot, and helper crash recovery remain manual/operator-verified. | all | Phase 4 |
 | Recovery/repair ownership exists only for `vz_linux`. | all except `vz_linux` | Phase 4 |
 | No single CI job proves real execution for every runtime; the portable capability gate covers capability contracts only. | all | Phase 5 |
 

--- a/Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
+++ b/Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
@@ -89,8 +89,14 @@ cover:
 - helper startup on a private Unix socket
 - real `vz_linux` ephemeral execution
 - same-session VM reuse with a second command in the same VM
+- recovery diagnostics plus dry-run reconciliation repair planning
 - helper shutdown/cleanup on exit
 - helper stdout/stderr and serial-log artifact upload
+
+The recovery smoke is intentionally non-destructive. It verifies that a prepared
+host can compute macOS sandbox reconciliation state and produce a dry-run repair
+plan for stale VZ session-control metadata. It does not terminate VMs, delete
+session controls, or run image-store cleanup.
 
 ## Expected Skips And Non-Blocking Conditions
 
@@ -119,6 +125,8 @@ prepared host and fails one of the accepted runtime guarantees:
   same runner
 - real ephemeral command execution fails after helper/template readiness passes
 - same-session VM reuse fails after the first command succeeds
+- recovery diagnostics or dry-run reconciliation repair planning fails after
+  helper/template readiness passes
 - cleanup leaves the helper process or accepted socket path behind
 - helper protocol mismatch is introduced without a matching compatibility plan
 - artifacts/logs are not uploaded when the job fails

--- a/backlog/tasks/task-133 - Add-host-gated-VZ-Linux-recovery-smoke-coverage.md
+++ b/backlog/tasks/task-133 - Add-host-gated-VZ-Linux-recovery-smoke-coverage.md
@@ -40,10 +40,12 @@ Extend the existing Apple Silicon host-gated VZ Linux operator/CI smoke path so 
 
 <!-- SECTION:NOTES:BEGIN -->
 - Added explicit host-gated recovery smoke coverage after ephemeral execution and same-session reuse. The recovery smoke seeds only the isolated test store and verifies diagnostics plus `repair_macos_reconciliation(dry_run=true)`.
+- Addressed PR review comments by adding a `pytest.MonkeyPatch` type annotation and docstring to the new recovery test, using safe diagnostics `.get()` access with `_expect` failure messages, and refactoring the smoke script to run one registered `vz_linux_host_smoke` marker through a shared pytest/env helper.
 - Verification:
   - `python -m pytest tools/vz-linux-image/tests/test_host_e2e_smoke_script.py -q` passed with 8 passed, 1 skipped.
   - `python -m pytest tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py -q` passed with 11 passed.
   - `python -m pytest tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py -q` passed with 4 passed, 3 skipped on this host because real VZ E2E env was not enabled.
+  - `python -m pytest tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py -m vz_linux_host_smoke -q` selected the three marked real-host smoke tests and skipped them on this host because real VZ E2E env was not enabled.
   - `git diff --check` passed.
   - Bandit over touched Python with only `B101` skipped reported pre-existing test-harness findings in `tools/vz-linux-image/tests/test_host_e2e_smoke_script.py` (`B404`, `B603`, `B108`) on unchanged lines. Re-run with those known test-harness checks also skipped exited 0.
 <!-- SECTION:NOTES:END -->
@@ -54,6 +56,6 @@ Extend the existing Apple Silicon host-gated VZ Linux operator/CI smoke path so 
 - [x] #2 Tests or verification recorded
 - [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
+- [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-133 - Add-host-gated-VZ-Linux-recovery-smoke-coverage.md
+++ b/backlog/tasks/task-133 - Add-host-gated-VZ-Linux-recovery-smoke-coverage.md
@@ -1,0 +1,59 @@
+---
+id: TASK-133
+title: Add host-gated VZ Linux recovery smoke coverage
+status: In Progress
+assignee: []
+created_date: '2026-05-09 00:26'
+labels:
+  - sandbox
+  - vz_linux
+  - host-gated
+  - recovery
+dependencies: []
+references:
+  - .github/workflows/vz-linux-host-gated.yml
+  - tools/vz-linux-image/scripts/run-host-e2e-smoke.sh
+  - tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py
+  - tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py
+documentation:
+  - Docs/Sandbox/macos-runtime-operator-notes.md
+  - Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
+  - Docs/Sandbox/sandbox-runtime-capability-inventory.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Extend the existing Apple Silicon host-gated VZ Linux operator/CI smoke path so it exercises the existing read-only diagnostics and dry-run reconciliation repair surfaces after real ephemeral execution and same-session reuse. Keep the smoke non-destructive by default and preserve the existing operator-first workflow through run-host-e2e-smoke.sh and vz-helperctl smoke.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The host-gated smoke script runs a recovery/diagnostics pytest slice after the real execution/reuse checks without enabling destructive repair actions.
+- [x] #2 The host-gated workflow contract tests verify the operator smoke path includes recovery coverage and remains branch-gated/manual-or-nightly only.
+- [x] #3 Operator docs and the host-gated acceptance policy state that recovery smoke covers diagnostics plus dry-run repair only and does not terminate VMs or delete state.
+- [x] #4 Focused tests validate the new script/workflow behavior without requiring a real VZ host in normal CI.
+<!-- AC:END -->
+
+## Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Added explicit host-gated recovery smoke coverage after ephemeral execution and same-session reuse. The recovery smoke seeds only the isolated test store and verifies diagnostics plus `repair_macos_reconciliation(dry_run=true)`.
+- Verification:
+  - `python -m pytest tools/vz-linux-image/tests/test_host_e2e_smoke_script.py -q` passed with 8 passed, 1 skipped.
+  - `python -m pytest tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py -q` passed with 11 passed.
+  - `python -m pytest tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py -q` passed with 4 passed, 3 skipped on this host because real VZ E2E env was not enabled.
+  - `git diff --check` passed.
+  - Bandit over touched Python with only `B101` skipped reported pre-existing test-harness findings in `tools/vz-linux-image/tests/test_host_e2e_smoke_script.py` (`B404`, `B603`, `B108`) on unchanged lines. Re-run with those known test-harness checks also skipped exited 0.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -606,6 +606,7 @@ markers = [
     "sandbox_no_auth: marks sandbox tests that must run without default auth headers",
     "sandbox_no_reload: marks sandbox tests that should not reload app.main",
     "sandbox_real_docker: marks sandbox tests that require real Docker execution paths",
+    "vz_linux_host_smoke: marks opt-in Apple silicon VZ Linux host smoke tests",
     "legacy_tts: marks legacy TTS tests",
     "concurrent: marks concurrency tests",
     "streaming: marks streaming tests",

--- a/tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py
+++ b/tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py
@@ -97,9 +97,9 @@ def test_vz_linux_host_gated_operator_smoke_runs_recovery_slice() -> None:
     """The delegated operator smoke should include the non-destructive recovery slice."""
     script = SMOKE_SCRIPT_PATH.read_text(encoding="utf-8")
 
-    assert "run_real_vz_linux_recovery_smoke" in script  # nosec B101
-    assert "::test_vz_linux_real_recovery_diagnostics_dry_run_smoke" in script  # nosec B101
-    assert script.rfind("run_real_vz_linux_e2e") < script.rfind("run_real_vz_linux_recovery_smoke")  # nosec B101
+    assert "run_real_vz_linux_pytest" in script  # nosec B101
+    assert "run_real_vz_linux_host_smoke" in script  # nosec B101
+    assert "-m vz_linux_host_smoke" in script  # nosec B101
 
 
 def test_vz_linux_host_gated_acceptance_policy_requires_recovery_smoke() -> None:

--- a/tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py
+++ b/tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py
@@ -11,6 +11,7 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[3]
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "vz-linux-host-gated.yml"
 POLICY_PATH = REPO_ROOT / "Docs" / "Sandbox" / "vz-linux-host-gated-ci-acceptance-policy.md"
+SMOKE_SCRIPT_PATH = REPO_ROOT / "tools" / "vz-linux-image" / "scripts" / "run-host-e2e-smoke.sh"
 
 
 def _load_workflow() -> dict[str, Any]:
@@ -90,6 +91,24 @@ def test_vz_linux_host_gated_workflow_uses_operator_smoke_script() -> None:
     assert "--python" in run_blocks  # nosec B101
     assert 'chmod 700 "${runtime_dir}/serial"' in run_blocks  # nosec B101
     assert "TLDW_SANDBOX_VZ_LINUX_BUNDLE_PATH" in run_blocks  # nosec B101
+
+
+def test_vz_linux_host_gated_operator_smoke_runs_recovery_slice() -> None:
+    """The delegated operator smoke should include the non-destructive recovery slice."""
+    script = SMOKE_SCRIPT_PATH.read_text(encoding="utf-8")
+
+    assert "run_real_vz_linux_recovery_smoke" in script  # nosec B101
+    assert "::test_vz_linux_real_recovery_diagnostics_dry_run_smoke" in script  # nosec B101
+    assert script.rfind("run_real_vz_linux_e2e") < script.rfind("run_real_vz_linux_recovery_smoke")  # nosec B101
+
+
+def test_vz_linux_host_gated_acceptance_policy_requires_recovery_smoke() -> None:
+    """The host-gated policy should cover diagnostics plus dry-run repair."""
+    policy = POLICY_PATH.read_text(encoding="utf-8").lower()
+
+    assert "recovery diagnostics" in policy  # nosec B101
+    assert "dry-run reconciliation repair" in policy  # nosec B101
+    assert "does not terminate vms" in policy  # nosec B101
 
 
 def test_vz_linux_host_gated_workflow_pins_external_actions() -> None:

--- a/tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py
+++ b/tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py
@@ -262,3 +262,63 @@ def test_vz_linux_real_session_reuse_smoke(monkeypatch, tmp_path: Path) -> None:
     finally:
         if session_id and not destroyed:
             service.destroy_session(session_id)
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS host only")
+def test_vz_linux_real_recovery_diagnostics_dry_run_smoke(monkeypatch, tmp_path: Path) -> None:
+    base_image = _require_vz_linux_real_host_e2e(monkeypatch, tmp_path)
+    monkeypatch.delenv("TEST_MODE", raising=False)
+    monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_FAKE_EXEC", raising=False)
+    monkeypatch.delenv("TLDW_SANDBOX_MACOS_HELPER_READY", raising=False)
+    monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_TEMPLATE_READY", raising=False)
+    monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_AVAILABLE", raising=False)
+
+    service = SandboxService()
+    stale_session_id = f"vz-linux-real-recovery-stale-{os.getpid()}"
+    missing_vm_id = f"vz-linux-real-recovery-missing-vm-{os.getpid()}"
+    service._orch.put_vz_session_control(
+        session_id=stale_session_id,
+        runtime=RuntimeType.vz_linux.value,
+        vm_id=missing_vm_id,
+        template_id=base_image,
+        workspace_mount=None,
+        agent_ready=False,
+    )
+
+    try:
+        diagnostics = service.macos_diagnostics()
+        reconciliation = diagnostics["reconciliation"]
+        recovery_summary = diagnostics["recovery_summary"]
+        _expect(
+            reconciliation.get("computed") is True,
+            f"Expected reconciliation to compute, got reasons={reconciliation.get('reasons')!r}",
+        )
+        _expect(
+            stale_session_id in reconciliation.get("stale_session_ids", []),
+            f"Expected stale session id in reconciliation, got {reconciliation.get('stale_session_ids')!r}",
+        )
+        _expect(
+            recovery_summary.get("status") == "action_recommended",
+            f"Expected recovery action recommendation, got {recovery_summary!r}",
+        )
+        _expect(
+            "vz_stale_session_controls" in recovery_summary.get("codes", []),
+            f"Expected stale-session recovery code, got {recovery_summary.get('codes')!r}",
+        )
+
+        repair = service.repair_macos_reconciliation(dry_run=True)
+        planned_deletes = [
+            action
+            for action in repair.get("actions", [])
+            if action.get("type") == "delete_session_control"
+            and action.get("session_id") == stale_session_id
+            and action.get("status") == "planned"
+        ]
+        _expect(repair.get("dry_run") is True, f"Expected dry-run repair, got {repair!r}")
+        _expect(planned_deletes, f"Expected planned stale-session delete action, got {repair.get('actions')!r}")
+        _expect(
+            service._orch.get_vz_session_control(stale_session_id) is not None,
+            "Expected dry-run reconciliation repair to leave session control unchanged",
+        )
+    finally:
+        service._orch.delete_vz_session_control(stale_session_id)

--- a/tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py
+++ b/tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py
@@ -150,6 +150,7 @@ def test_vz_linux_real_host_e2e_requires_helper_ping(monkeypatch, tmp_path: Path
 
 
 @pytest.mark.skipif(sys.platform != "darwin", reason="macOS host only")
+@pytest.mark.vz_linux_host_smoke
 def test_vz_linux_real_ephemeral_run_smoke(monkeypatch, tmp_path: Path) -> None:
     base_image = _require_vz_linux_real_host_e2e(monkeypatch, tmp_path)
     monkeypatch.delenv("TEST_MODE", raising=False)
@@ -189,6 +190,7 @@ def test_vz_linux_real_ephemeral_run_smoke(monkeypatch, tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(sys.platform != "darwin", reason="macOS host only")
+@pytest.mark.vz_linux_host_smoke
 def test_vz_linux_real_session_reuse_smoke(monkeypatch, tmp_path: Path) -> None:
     base_image = _require_vz_linux_real_host_e2e(monkeypatch, tmp_path)
     monkeypatch.delenv("TEST_MODE", raising=False)
@@ -265,7 +267,12 @@ def test_vz_linux_real_session_reuse_smoke(monkeypatch, tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(sys.platform != "darwin", reason="macOS host only")
-def test_vz_linux_real_recovery_diagnostics_dry_run_smoke(monkeypatch, tmp_path: Path) -> None:
+@pytest.mark.vz_linux_host_smoke
+def test_vz_linux_real_recovery_diagnostics_dry_run_smoke(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Verify real-helper diagnostics and dry-run repair planning stay non-destructive."""
     base_image = _require_vz_linux_real_host_e2e(monkeypatch, tmp_path)
     monkeypatch.delenv("TEST_MODE", raising=False)
     monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_FAKE_EXEC", raising=False)
@@ -287,8 +294,12 @@ def test_vz_linux_real_recovery_diagnostics_dry_run_smoke(monkeypatch, tmp_path:
 
     try:
         diagnostics = service.macos_diagnostics()
-        reconciliation = diagnostics["reconciliation"]
-        recovery_summary = diagnostics["recovery_summary"]
+        reconciliation_raw = diagnostics.get("reconciliation")
+        recovery_summary_raw = diagnostics.get("recovery_summary")
+        _expect(isinstance(reconciliation_raw, dict), "Expected reconciliation data in diagnostics")
+        _expect(isinstance(recovery_summary_raw, dict), "Expected recovery_summary in diagnostics")
+        reconciliation = reconciliation_raw if isinstance(reconciliation_raw, dict) else {}
+        recovery_summary = recovery_summary_raw if isinstance(recovery_summary_raw, dict) else {}
         _expect(
             reconciliation.get("computed") is True,
             f"Expected reconciliation to compute, got reasons={reconciliation.get('reasons')!r}",

--- a/tools/vz-linux-image/README.md
+++ b/tools/vz-linux-image/README.md
@@ -199,8 +199,11 @@ On a prepared Apple silicon macOS host, that script builds the Swift helper
 when needed, signs it with `--entitlements` unless the helper is already signed
 with `com.apple.security.virtualization`, runs the helper-daemon bundle smoke,
 starts a helper daemon for the Python sandbox runtime, runs real `vz_linux`
-ephemeral execution, verifies same-session VM reuse, and stops the helper on
-exit.
+ephemeral execution, verifies same-session VM reuse, verifies recovery
+diagnostics plus dry-run reconciliation repair planning, and stops the helper
+on exit. The recovery step is non-destructive: it uses isolated test-store
+metadata and does not terminate VMs, delete session controls, or run image-store
+cleanup.
 
 The helper refuses sockets whose parent directory is not owner-only. Do not put
 the helper socket directly under `/tmp`; use the script defaults or create a
@@ -218,7 +221,7 @@ python -m pytest tldw_Server_API/tests/sandbox/test_macos_virtualization_helper_
 
 Use the direct module command for focused helper or bundle validation. Use
 `run-host-e2e-smoke.sh` for the full operator workflow because it also covers
-real sandbox execution and session VM reuse.
+real sandbox execution, session VM reuse, and recovery dry-run planning.
 
 The same script is the entrypoint for the host-gated GitHub Actions workflow at
 `.github/workflows/vz-linux-host-gated.yml`. That workflow is intentionally

--- a/tools/vz-linux-image/scripts/run-host-e2e-smoke.sh
+++ b/tools/vz-linux-image/scripts/run-host-e2e-smoke.sh
@@ -322,7 +322,7 @@ wait_for_helper_socket() {
   die "helper daemon did not create socket within timeout: ${SOCKET_PATH}"
 }
 
-run_real_vz_linux_e2e() {
+run_real_vz_linux_pytest() {
   run_cmd env \
     TEST_MODE=0 \
     TLDW_SANDBOX_VZ_LINUX_E2E=1 \
@@ -331,22 +331,12 @@ run_real_vz_linux_e2e() {
     SANDBOX_ENABLE_EXECUTION=1 \
     SANDBOX_BACKGROUND_EXECUTION=0 \
     "${PYTHON_BIN}" -m pytest \
-    "${REPO_ROOT}/tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py::test_vz_linux_real_ephemeral_run_smoke" \
-    "${REPO_ROOT}/tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py::test_vz_linux_real_session_reuse_smoke" \
-    -q -rs
+    "${REPO_ROOT}/tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py" \
+    "$@"
 }
 
-run_real_vz_linux_recovery_smoke() {
-  run_cmd env \
-    TEST_MODE=0 \
-    TLDW_SANDBOX_VZ_LINUX_E2E=1 \
-    TLDW_SANDBOX_VZ_LINUX_E2E_BASE_IMAGE="${BUNDLE_PATH}" \
-    TLDW_SANDBOX_MACOS_HELPER_SOCKET="${SOCKET_PATH}" \
-    SANDBOX_ENABLE_EXECUTION=1 \
-    SANDBOX_BACKGROUND_EXECUTION=0 \
-    "${PYTHON_BIN}" -m pytest \
-    "${REPO_ROOT}/tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py::test_vz_linux_real_recovery_diagnostics_dry_run_smoke" \
-    -q -rs
+run_real_vz_linux_host_smoke() {
+  run_real_vz_linux_pytest -m vz_linux_host_smoke -q -rs
 }
 
 if [[ "${DRY_RUN}" -eq 1 ]]; then
@@ -363,5 +353,4 @@ prepare_runtime_paths
 run_helper_daemon_smoke
 start_helper_for_real_e2e
 wait_for_helper_socket
-run_real_vz_linux_e2e
-run_real_vz_linux_recovery_smoke
+run_real_vz_linux_host_smoke

--- a/tools/vz-linux-image/scripts/run-host-e2e-smoke.sh
+++ b/tools/vz-linux-image/scripts/run-host-e2e-smoke.sh
@@ -23,7 +23,8 @@ Usage: run-host-e2e-smoke.sh --bundle PATH [options]
 
 Build/sign/start the macOS Virtualization.framework helper, run the helper
 daemon smoke, run real vz_linux ephemeral execution, verify same-session VM
-reuse, and stop the helper.
+reuse, verify recovery diagnostics plus dry-run repair planning, and stop the
+helper.
 
 Options:
   --bundle PATH          Canonical vz_linux bundle directory (required)
@@ -330,7 +331,21 @@ run_real_vz_linux_e2e() {
     SANDBOX_ENABLE_EXECUTION=1 \
     SANDBOX_BACKGROUND_EXECUTION=0 \
     "${PYTHON_BIN}" -m pytest \
-    "${REPO_ROOT}/tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py" \
+    "${REPO_ROOT}/tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py::test_vz_linux_real_ephemeral_run_smoke" \
+    "${REPO_ROOT}/tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py::test_vz_linux_real_session_reuse_smoke" \
+    -q -rs
+}
+
+run_real_vz_linux_recovery_smoke() {
+  run_cmd env \
+    TEST_MODE=0 \
+    TLDW_SANDBOX_VZ_LINUX_E2E=1 \
+    TLDW_SANDBOX_VZ_LINUX_E2E_BASE_IMAGE="${BUNDLE_PATH}" \
+    TLDW_SANDBOX_MACOS_HELPER_SOCKET="${SOCKET_PATH}" \
+    SANDBOX_ENABLE_EXECUTION=1 \
+    SANDBOX_BACKGROUND_EXECUTION=0 \
+    "${PYTHON_BIN}" -m pytest \
+    "${REPO_ROOT}/tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py::test_vz_linux_real_recovery_diagnostics_dry_run_smoke" \
     -q -rs
 }
 
@@ -349,3 +364,4 @@ run_helper_daemon_smoke
 start_helper_for_real_e2e
 wait_for_helper_socket
 run_real_vz_linux_e2e
+run_real_vz_linux_recovery_smoke

--- a/tools/vz-linux-image/tests/test_host_e2e_smoke_script.py
+++ b/tools/vz-linux-image/tests/test_host_e2e_smoke_script.py
@@ -80,6 +80,9 @@ def test_host_e2e_smoke_script_dry_run_prints_helper_and_pytest_commands(tmp_pat
     assert f"TLDW_SANDBOX_VZ_LINUX_SERIAL_LOG_DIR={serial_log_dir}" in result.stdout  # nosec B101
     assert "test_macos_virtualization_helper_daemon_host_gated.py" in result.stdout
     assert "test_vz_linux_real_host_e2e.py" in result.stdout
+    assert "::test_vz_linux_real_ephemeral_run_smoke" in result.stdout
+    assert "::test_vz_linux_real_session_reuse_smoke" in result.stdout
+    assert "::test_vz_linux_real_recovery_diagnostics_dry_run_smoke" in result.stdout
     assert not serial_log_dir.exists()
 
 

--- a/tools/vz-linux-image/tests/test_host_e2e_smoke_script.py
+++ b/tools/vz-linux-image/tests/test_host_e2e_smoke_script.py
@@ -80,9 +80,7 @@ def test_host_e2e_smoke_script_dry_run_prints_helper_and_pytest_commands(tmp_pat
     assert f"TLDW_SANDBOX_VZ_LINUX_SERIAL_LOG_DIR={serial_log_dir}" in result.stdout  # nosec B101
     assert "test_macos_virtualization_helper_daemon_host_gated.py" in result.stdout
     assert "test_vz_linux_real_host_e2e.py" in result.stdout
-    assert "::test_vz_linux_real_ephemeral_run_smoke" in result.stdout
-    assert "::test_vz_linux_real_session_reuse_smoke" in result.stdout
-    assert "::test_vz_linux_real_recovery_diagnostics_dry_run_smoke" in result.stdout
+    assert "-m vz_linux_host_smoke" in result.stdout
     assert not serial_log_dir.exists()
 
 


### PR DESCRIPTION
## Summary

- Adds an explicit non-destructive recovery smoke slice to the VZ Linux host-gated operator script.
- Extends the real-host E2E module with diagnostics plus dry-run reconciliation repair coverage using only isolated test-store state.
- Updates operator docs, host-gated acceptance policy, and capability inventory to describe the new coverage and remaining manual gaps.

## Verification

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tools/vz-linux-image/tests/test_host_e2e_smoke_script.py -q`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py -q`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py -q`
- `git diff --check`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py tools/vz-linux-image/tests/test_host_e2e_smoke_script.py -s B101,B404,B603,B108 -f json -o /tmp/bandit_host_gated_recovery_post_rebase.json`

## Notes

- The new real VZ recovery test skipped in local verification unless `TLDW_SANDBOX_VZ_LINUX_E2E=1` and `TLDW_SANDBOX_VZ_LINUX_E2E_BASE_IMAGE` are configured; this is expected for normal local/portable runs.
- A human-authored change summary is still required before merge.
