### PR TITLE
Adapt Common StatusBadge to shared Badge

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -5588,17 +5588,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "local-status-badge:src/components/Common/StatusBadge.tsx:StatusBadge",
-    "path": "src/components/Common/StatusBadge.tsx",
-    "rule": "local-status-badge",
-    "subject": "StatusBadge",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing local StatusBadge status wrapper before the guard.",
-    "replacement": "Badge with design-system state registry mapping",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "local-status-badge:src/components/Layouts/ConnectionStatus.tsx:StatusDot",
     "path": "src/components/Layouts/ConnectionStatus.tsx",
     "rule": "local-status-badge",

--- a/apps/packages/ui/scripts/design-system-product-state-rules.mjs
+++ b/apps/packages/ui/scripts/design-system-product-state-rules.mjs
@@ -466,7 +466,7 @@ function collectCanonicalDesignSystemUsage(sourceFile, fileSubject) {
     }
   }
 
-  const stateRegistryOwners = collectIdentifierOwners(
+  const stateRegistryOwners = collectCallExpressionOwners(
     sourceFile,
     imports.stateRegistry,
     fileSubject
@@ -617,7 +617,7 @@ function collectJsxTagOwners(sourceFile, localNames, fallbackOwner) {
   return owners
 }
 
-function collectIdentifierOwners(sourceFile, localNames, fallbackOwner) {
+function collectCallExpressionOwners(sourceFile, localNames, fallbackOwner) {
   const owners = new Set()
 
   if (!localNames || localNames.size === 0) {
@@ -629,7 +629,11 @@ function collectIdentifierOwners(sourceFile, localNames, fallbackOwner) {
       return
     }
 
-    if (isImportIdentifier(node) || isTypeQueryIdentifier(node)) {
+    if (
+      isImportIdentifier(node) ||
+      isTypeQueryIdentifier(node) ||
+      !isCallExpressionCallee(node)
+    ) {
       return
     }
 
@@ -653,6 +657,14 @@ function isImportIdentifier(node) {
 
 function isTypeQueryIdentifier(node) {
   return Boolean(node.parent && ts.isTypeQueryNode(node.parent))
+}
+
+function isCallExpressionCallee(node) {
+  return Boolean(
+    node.parent &&
+      ts.isCallExpression(node.parent) &&
+      node.parent.expression === node
+  )
 }
 
 function intersectSets(left, right) {

--- a/apps/packages/ui/scripts/design-system-product-state-rules.mjs
+++ b/apps/packages/ui/scripts/design-system-product-state-rules.mjs
@@ -398,7 +398,9 @@ function collectAntdProductStateImports(sourceFile) {
 function collectCanonicalDesignSystemUsage(sourceFile, fileSubject) {
   const imports = {
     emptyState: new Set(),
-    loadingState: new Set()
+    loadingState: new Set(),
+    badge: new Set(),
+    stateRegistry: new Set()
   }
 
   for (const statement of sourceFile.statements) {
@@ -410,10 +412,14 @@ function collectCanonicalDesignSystemUsage(sourceFile, fileSubject) {
     }
 
     const importPath = statement.moduleSpecifier.text
-    if (
-      !importPath.startsWith("@/components/ui") &&
-      !importPath.startsWith("@tldw/ui/components/ui")
-    ) {
+    const isCanonicalComponentImport =
+      importPath.startsWith("@/components/ui") ||
+      importPath.startsWith("@tldw/ui/components/ui")
+    const isDesignSystemImport =
+      importPath.startsWith("@/design-system") ||
+      importPath.startsWith("@tldw/ui/design-system")
+
+    if (!isCanonicalComponentImport && !isDesignSystemImport) {
       continue
     }
 
@@ -422,22 +428,54 @@ function collectCanonicalDesignSystemUsage(sourceFile, fileSubject) {
     if (namedBindings && ts.isNamedImports(namedBindings)) {
       for (const element of namedBindings.elements) {
         const importedName = element.propertyName?.text ?? element.name.text
-        if (importedName === "EmptyState") {
+        if (isCanonicalComponentImport && importedName === "EmptyState") {
           imports.emptyState.add(element.name.text)
         }
-        if (importedName === "LoadingState") {
+        if (isCanonicalComponentImport && importedName === "LoadingState") {
           imports.loadingState.add(element.name.text)
+        }
+        if (isCanonicalComponentImport && importedName === "Badge") {
+          imports.badge.add(element.name.text)
+        }
+        if (isDesignSystemImport && importedName === "getDesignSystemState") {
+          imports.stateRegistry.add(element.name.text)
         }
       }
     }
 
-    if (importClause?.name && /\/EmptyState$/.test(importPath)) {
+    if (
+      isCanonicalComponentImport &&
+      importClause?.name &&
+      /\/EmptyState$/.test(importPath)
+    ) {
       imports.emptyState.add(importClause.name.text)
     }
-    if (importClause?.name && /\/LoadingState$/.test(importPath)) {
+    if (
+      isCanonicalComponentImport &&
+      importClause?.name &&
+      /\/LoadingState$/.test(importPath)
+    ) {
       imports.loadingState.add(importClause.name.text)
     }
+    if (
+      isCanonicalComponentImport &&
+      importClause?.name &&
+      /\/Badge$/.test(importPath)
+    ) {
+      imports.badge.add(importClause.name.text)
+    }
   }
+
+  const stateRegistryOwners = collectIdentifierOwners(
+    sourceFile,
+    imports.stateRegistry,
+    fileSubject
+  )
+  const returnedBadgeOwners = collectReturnedJsxTagOwners(
+    sourceFile,
+    imports.badge,
+    fileSubject
+  )
 
   return {
     emptyStateOwners: collectJsxTagOwners(
@@ -449,7 +487,8 @@ function collectCanonicalDesignSystemUsage(sourceFile, fileSubject) {
       sourceFile,
       imports.loadingState,
       fileSubject
-    )
+    ),
+    statusBadgeOwners: intersectSets(returnedBadgeOwners, stateRegistryOwners)
   }
 }
 
@@ -539,7 +578,10 @@ function pushLocalComponentFinding(
     })
   }
 
-  if (STATUS_COMPONENT_PATTERN.test(subject)) {
+  if (
+    STATUS_COMPONENT_PATTERN.test(subject) &&
+    !canonicalUsage.statusBadgeOwners?.has(subject)
+  ) {
     pushFinding(findings, {
       relativePath,
       rule: "local-status-badge",
@@ -573,6 +615,56 @@ function collectJsxTagOwners(sourceFile, localNames, fallbackOwner) {
   })
 
   return owners
+}
+
+function collectIdentifierOwners(sourceFile, localNames, fallbackOwner) {
+  const owners = new Set()
+
+  if (!localNames || localNames.size === 0) {
+    return owners
+  }
+
+  walk(sourceFile, (node) => {
+    if (!ts.isIdentifier(node) || !localNames.has(node.text)) {
+      return
+    }
+
+    if (isImportIdentifier(node) || isTypeQueryIdentifier(node)) {
+      return
+    }
+
+    const ownerName = findNearestOwnerName(node) ?? fallbackOwner
+    if (ownerName) {
+      owners.add(ownerName)
+    }
+  })
+
+  return owners
+}
+
+function isImportIdentifier(node) {
+  return Boolean(
+    node.parent &&
+      (ts.isImportSpecifier(node.parent) ||
+        ts.isImportClause(node.parent) ||
+        ts.isNamespaceImport(node.parent))
+  )
+}
+
+function isTypeQueryIdentifier(node) {
+  return Boolean(node.parent && ts.isTypeQueryNode(node.parent))
+}
+
+function intersectSets(left, right) {
+  const intersection = new Set()
+
+  for (const value of left) {
+    if (right.has(value)) {
+      intersection.add(value)
+    }
+  }
+
+  return intersection
 }
 
 function collectReturnedJsxTagOwners(sourceFile, localNames, fallbackOwner) {

--- a/apps/packages/ui/src/components/Common/StatusBadge.tsx
+++ b/apps/packages/ui/src/components/Common/StatusBadge.tsx
@@ -21,24 +21,17 @@ const SEVERITY_BADGE_VARIANTS = {
   neutral: "secondary",
 } satisfies Record<ReturnType<typeof getDesignSystemState>["severity"], BadgeVariant>
 
-const getBadgeVariant = (variant: StatusBadgeProps["variant"]): BadgeVariant => {
-  if (variant === "demo") {
-    return "demo"
-  }
-
-  const state = getDesignSystemState(VARIANT_STATES[variant])
-  return SEVERITY_BADGE_VARIANTS[state.severity]
-}
-
 export const StatusBadge: React.FC<StatusBadgeProps> = ({
   variant,
   children
 }) => {
   const state = getDesignSystemState(VARIANT_STATES[variant])
+  const badgeVariant: BadgeVariant =
+    variant === "demo" ? "demo" : SEVERITY_BADGE_VARIANTS[state.severity]
 
   return (
     <Badge
-      variant={getBadgeVariant(variant)}
+      variant={badgeVariant}
       size="md"
       className="text-[11px]"
       srLabel={state.label}

--- a/apps/packages/ui/src/components/Common/StatusBadge.tsx
+++ b/apps/packages/ui/src/components/Common/StatusBadge.tsx
@@ -1,29 +1,50 @@
 import React from "react"
+import { getDesignSystemState, type DesignSystemStateKey } from "@/design-system"
+import { Badge, type BadgeVariant } from "@/components/ui/primitives"
 
 export interface StatusBadgeProps {
   variant: "demo" | "warning" | "error"
   children: React.ReactNode
 }
 
-const VARIANT_CLASSES: Record<StatusBadgeProps["variant"], string> = {
-  demo:
-    "bg-primary/10 text-primary",
-  warning:
-    "bg-warn/10 text-warn",
-  error:
-    "bg-danger/10 text-danger"
+const VARIANT_STATES: Record<StatusBadgeProps["variant"], DesignSystemStateKey> = {
+  demo: "degraded",
+  warning: "degraded",
+  error: "error",
+}
+
+const SEVERITY_BADGE_VARIANTS = {
+  success: "success",
+  error: "danger",
+  warning: "warning",
+  info: "info",
+  neutral: "secondary",
+} satisfies Record<ReturnType<typeof getDesignSystemState>["severity"], BadgeVariant>
+
+const getBadgeVariant = (variant: StatusBadgeProps["variant"]): BadgeVariant => {
+  if (variant === "demo") {
+    return "demo"
+  }
+
+  const state = getDesignSystemState(VARIANT_STATES[variant])
+  return SEVERITY_BADGE_VARIANTS[state.severity]
 }
 
 export const StatusBadge: React.FC<StatusBadgeProps> = ({
   variant,
   children
 }) => {
+  const state = getDesignSystemState(VARIANT_STATES[variant])
+
   return (
-    <span
-      className={`rounded-full px-2 py-0.5 text-[11px] font-medium ${VARIANT_CLASSES[variant]}`}
+    <Badge
+      variant={getBadgeVariant(variant)}
+      size="md"
+      className="text-[11px]"
+      srLabel={state.label}
     >
       {children}
-    </span>
+    </Badge>
   )
 }
 

--- a/apps/packages/ui/src/components/Common/__tests__/StatusBadge.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Common/__tests__/StatusBadge.design-system.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { StatusBadge, type StatusBadgeProps } from "../StatusBadge"
+
+describe("StatusBadge design-system adapter", () => {
+  it.each([
+    ["demo", "Demo mode"],
+    ["warning", "Setup required"],
+    ["error", "Feature unavailable"],
+  ] satisfies Array<[StatusBadgeProps["variant"], string]>)(
+    "renders the %s variant through the shared Badge primitive",
+    (variant, label) => {
+      const { container } = render(
+        <StatusBadge variant={variant}>{label}</StatusBadge>
+      )
+
+      expect(screen.getByText(label)).toBeInTheDocument()
+      expect(
+        container.querySelector('[data-ds-component="Badge"]')
+      ).toBeInTheDocument()
+    }
+  )
+})

--- a/apps/packages/ui/src/design-system/__tests__/product-state-guard.test.ts
+++ b/apps/packages/ui/src/design-system/__tests__/product-state-guard.test.ts
@@ -161,6 +161,28 @@ describe("design-system product-state guard rules", () => {
     )
   })
 
+  it("still flags status-badge adapters when the state registry import is referenced but not called", () => {
+    const findings = analyze(
+      "src/components/Common/StatusBadge.tsx",
+      `
+        import { getDesignSystemState } from "@/design-system"
+        import { Badge } from "@/components/ui/primitives"
+
+        export function StatusBadge() {
+          const stateResolver = getDesignSystemState
+          return <Badge variant="warning">{stateResolver.name}</Badge>
+        }
+      `
+    )
+
+    expect(findings).toContainEqual(
+      expect.objectContaining({
+        rule: "local-status-badge",
+        subject: "StatusBadge"
+      })
+    )
+  })
+
   it("allows compatibility empty-state adapters that render the canonical EmptyState", () => {
     const findings = analyze(
       "src/components/Common/FeatureEmptyState.tsx",

--- a/apps/packages/ui/src/design-system/__tests__/product-state-guard.test.ts
+++ b/apps/packages/ui/src/design-system/__tests__/product-state-guard.test.ts
@@ -87,6 +87,80 @@ describe("design-system product-state guard rules", () => {
     )
   })
 
+  it("allows compatibility status-badge adapters that return Badge and use the state registry", () => {
+    const findings = analyze(
+      "src/components/Common/StatusBadge.tsx",
+      `
+        import { getDesignSystemState } from "@/design-system"
+        import { Badge } from "@/components/ui/primitives"
+
+        export function StatusBadge() {
+          const state = getDesignSystemState("degraded")
+          return <Badge variant="warning">{state.label}</Badge>
+        }
+      `
+    )
+
+    expect(findings).not.toContainEqual(
+      expect.objectContaining({
+        rule: "local-status-badge",
+        subject: "StatusBadge"
+      })
+    )
+  })
+
+  it("still flags status-badge adapters that return Badge without state registry mapping", () => {
+    const findings = analyze(
+      "src/components/Common/StatusBadge.tsx",
+      `
+        import { Badge } from "@/components/ui/primitives"
+
+        export function StatusBadge() {
+          return <Badge variant="warning">Setup required</Badge>
+        }
+      `
+    )
+
+    expect(findings).toContainEqual(
+      expect.objectContaining({
+        rule: "local-status-badge",
+        subject: "StatusBadge"
+      })
+    )
+  })
+
+  it("still flags status-badge adapters when only another component uses the state registry", () => {
+    const findings = analyze(
+      "src/components/Common/StatusBadge.tsx",
+      `
+        import { getDesignSystemState } from "@/design-system"
+        import { Badge } from "@/components/ui/primitives"
+
+        export function StatusBadge() {
+          return <Badge variant="warning">Setup required</Badge>
+        }
+
+        export function OtherStatusBadge() {
+          const state = getDesignSystemState("degraded")
+          return <Badge variant="warning">{state.label}</Badge>
+        }
+      `
+    )
+
+    expect(findings).toContainEqual(
+      expect.objectContaining({
+        rule: "local-status-badge",
+        subject: "StatusBadge"
+      })
+    )
+    expect(findings).not.toContainEqual(
+      expect.objectContaining({
+        rule: "local-status-badge",
+        subject: "OtherStatusBadge"
+      })
+    )
+  })
+
   it("allows compatibility empty-state adapters that render the canonical EmptyState", () => {
     const findings = analyze(
       "src/components/Common/FeatureEmptyState.tsx",

--- a/backlog/tasks/task-45.20 - Adapt-Common-StatusBadge-to-shared-Badge.md
+++ b/backlog/tasks/task-45.20 - Adapt-Common-StatusBadge-to-shared-Badge.md
@@ -1,0 +1,73 @@
+---
+id: TASK-45.20
+title: Adapt Common StatusBadge to shared Badge
+status: Done
+assignee: []
+created_date: '2026-05-09 00:49'
+updated_date: '2026-05-09 00:56'
+labels:
+  - design-system
+  - webui
+  - guard
+dependencies: []
+references:
+  - apps/packages/ui/src/components/Common/StatusBadge.tsx
+  - apps/packages/ui/src/components/ui/primitives/Badge.tsx
+  - apps/packages/ui/src/design-system/states.ts
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+parent_task_id: TASK-45
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate the shared Common StatusBadge adapter onto the design-system Badge primitive with explicit state-registry mapping, then remove its local-status-badge baseline exception.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Common StatusBadge renders through the shared Badge primitive while preserving demo/warning/error labels.
+- [x] #2 The product-state guard recognizes status-badge compatibility adapters only when they return Badge and use the design-system state registry.
+- [x] #3 The local-status-badge baseline exception for src/components/Common/StatusBadge.tsx is removed without introducing new unbaselined findings.
+- [x] #4 Focused StatusBadge tests, product-state guard tests, the design-system verifier, and diff checks pass.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing focused tests for Common StatusBadge rendering through shared Badge and for the guard allowing only registry-backed Badge adapters.
+2. Update the product-state guard to recognize status-badge compatibility adapters that directly return Badge and use getDesignSystemState.
+3. Migrate Common/StatusBadge.tsx to Badge plus design-system state mapping while preserving its public API.
+4. Remove the Common StatusBadge baseline entry and verify the focused suite.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Red verification was performed before implementation: the new StatusBadge design-system test failed because Common/StatusBadge did not render the shared Badge primitive; the new guard test failed because StatusBadge adapters returning Badge were still reported as local-status-badge.
+
+Implemented Common/StatusBadge as a compatibility adapter over the shared Badge primitive with variant mapping through getDesignSystemState. The product-state guard now only allows status-badge adapters when the same owner directly returns Badge and uses the state registry.
+
+Fresh focused verification passed: bunx vitest run src/components/Common/__tests__/StatusBadge.design-system.test.tsx --reporter=dot (3 tests); bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot (45 tests); bun run verify:design-system-state (baseline 515, local-status-badge 9); git diff --check.
+
+Ran bunx tsc --noEmit --pretty false; it failed with existing unrelated package-wide TypeScript errors in audio, chat composer, flashcards, playground, services, routes, and store tests. No visible errors were from the touched StatusBadge, guard, or design-system test files.
+
+Bandit was not run because this slice only touches TypeScript/TSX/JavaScript/JSON and Backlog task metadata; no Python files were changed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Adapted Common/StatusBadge to render through the shared Badge primitive while preserving the existing demo/warning/error public API. The migration maps status variants through the design-system state registry, removes the Common StatusBadge local-status-badge baseline exception, and tightens the product-state guard so only same-owner adapters that directly return Badge and use getDesignSystemState are treated as canonical compatibility adapters. Focused StatusBadge tests, product-state guard tests, the design-system verifier, and diff checks pass; the broader TypeScript check remains blocked by unrelated existing package-wide errors.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.20.1 - Address-PR-1387-StatusBadge-review-comments.md
+++ b/backlog/tasks/task-45.20.1 - Address-PR-1387-StatusBadge-review-comments.md
@@ -1,0 +1,61 @@
+---
+id: TASK-45.20.1
+title: Address PR 1387 StatusBadge review comments
+status: Done
+assignee: []
+created_date: '2026-05-09 02:30'
+updated_date: '2026-05-09 02:32'
+labels:
+  - design-system
+  - webui
+  - guard
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1387'
+parent_task_id: TASK-45.20
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address review comments on PR 1387 for the Common StatusBadge design-system adapter and product-state guard.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Registry owner detection only counts actual getDesignSystemState calls
+- [x] #2 StatusBadge computes design-system state once per render
+- [x] #3 Focused guard and StatusBadge tests cover the review scenarios and pass
+- [x] #4 Design-system verifier and diff checks pass
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Reviewed PR #1387 live surfaces with gh pr view, GraphQL review threads, and gh pr checks. Actionable items were Qodo guard bypass via non-call getDesignSystemState identifier reference and Gemini StatusBadge duplicate state lookup. CodeRabbit and Qodo summary comments were informational.
+
+Added a red guard regression for a StatusBadge adapter that returns Badge while only referencing getDesignSystemState without calling it; it failed before implementation with findings [].
+
+Narrowed design-system state registry owner detection to actual call-expression callees, and simplified Common/StatusBadge so getDesignSystemState is called once per render.
+
+Fresh verification passed: bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot (46 tests); bunx vitest run src/components/Common/__tests__/StatusBadge.design-system.test.tsx --reporter=dot (3 tests); bun run verify:design-system-state (baseline 515, local-status-badge 9); git diff --check.
+
+Bandit was not run because this review-fix slice only touches TypeScript/TSX/JavaScript and Backlog metadata; no Python files were changed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed PR #1387 review comments by requiring actual getDesignSystemState calls for status-badge guard canonical ownership and by computing the StatusBadge design-system state once per render. Added regression coverage for the non-call identifier bypass and re-ran the focused design-system verification gates.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Implementation summary

- Adapt Common/StatusBadge to render through the shared Badge primitive while preserving the demo/warning/error API.
- Route StatusBadge variant mapping through getDesignSystemState and remove its local-status-badge baseline exception.
- Tighten the product-state guard so status-badge compatibility adapters are allowed only when the same owner directly returns Badge and uses the design-system state registry.
- Add focused StatusBadge adapter coverage and guard regression coverage.

## Verification

- bunx vitest run src/components/Common/__tests__/StatusBadge.design-system.test.tsx --reporter=dot
- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot
- bun run verify:design-system-state
- git diff --check

## Known baseline

- bunx tsc --noEmit --pretty false still fails on existing unrelated package-wide TypeScript errors in audio, chat composer, flashcards, playground, services, routes, and store tests; no visible errors were from the touched StatusBadge, guard, or design-system test files.
- Bandit was not run because this slice only touches TypeScript/TSX/JavaScript/JSON and Backlog metadata.

Draft until a human-written Change summary is added for the AI-generated PR merge gate.