### PR TITLE
Adapt Evaluations StatusBadge to shared Badge

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -5610,17 +5610,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "local-status-badge:src/components/Option/Evaluations/components/StatusBadge.tsx:StatusBadge",
-    "path": "src/components/Option/Evaluations/components/StatusBadge.tsx",
-    "rule": "local-status-badge",
-    "subject": "StatusBadge",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing local StatusBadge status wrapper before the guard.",
-    "replacement": "Badge with design-system state registry mapping",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "local-status-badge:src/components/Option/PresentationStudio/PresentationStudioStatusBadge.tsx:PresentationStudioStatusBadge",
     "path": "src/components/Option/PresentationStudio/PresentationStudioStatusBadge.tsx",
     "rule": "local-status-badge",

--- a/apps/packages/ui/src/components/Option/Evaluations/components/StatusBadge.tsx
+++ b/apps/packages/ui/src/components/Option/Evaluations/components/StatusBadge.tsx
@@ -30,7 +30,13 @@ const STATUS_CONFIG: Record<string, StatusConfig> = {
   pending: { stateKey: "loading" },
   running: {
     stateKey: "retrying",
-    icon: <Loader2 className="inline h-3 w-3 animate-spin" aria-hidden />
+    icon: (
+      <Loader2
+        className="inline h-3 w-3 animate-spin"
+        aria-hidden
+        data-testid="evaluations-status-running-spinner"
+      />
+    )
   },
   completed: { stateKey: "ready" },
   failed: { stateKey: "error" },
@@ -50,7 +56,11 @@ const UNKNOWN_STATUS_CONFIG = {
 } satisfies StatusConfig
 
 function getStatusConfig(status: string): StatusConfig {
-  return STATUS_CONFIG[status] || UNKNOWN_STATUS_CONFIG
+  if (Object.prototype.hasOwnProperty.call(STATUS_CONFIG, status)) {
+    return STATUS_CONFIG[status]
+  }
+
+  return UNKNOWN_STATUS_CONFIG
 }
 
 export const StatusBadge: React.FC<StatusBadgeProps> = ({
@@ -65,7 +75,6 @@ export const StatusBadge: React.FC<StatusBadgeProps> = ({
     <Badge
       variant={SEVERITY_BADGE_VARIANTS[state.severity]}
       className={className}
-      srLabel={state.label}
     >
       {config.icon}
       {status}

--- a/apps/packages/ui/src/components/Option/Evaluations/components/StatusBadge.tsx
+++ b/apps/packages/ui/src/components/Option/Evaluations/components/StatusBadge.tsx
@@ -4,7 +4,8 @@
  */
 
 import React from "react"
-import { Tag } from "antd"
+import { getDesignSystemState, type DesignSystemStateKey } from "@/design-system"
+import { Badge, type BadgeVariant } from "@/components/ui/primitives"
 import { Loader2 } from "lucide-react"
 
 export type RunStatus =
@@ -20,18 +21,36 @@ interface StatusBadgeProps {
   className?: string
 }
 
-const statusConfig: Record<
-  string,
-  { color: string; icon?: React.ReactNode }
-> = {
-  pending: { color: "default" },
+interface StatusConfig {
+  stateKey: DesignSystemStateKey
+  icon?: React.ReactNode
+}
+
+const STATUS_CONFIG: Record<string, StatusConfig> = {
+  pending: { stateKey: "loading" },
   running: {
-    color: "processing",
-    icon: <Loader2 className="inline h-3 w-3 animate-spin mr-1" />
+    stateKey: "retrying",
+    icon: <Loader2 className="inline h-3 w-3 animate-spin" aria-hidden />
   },
-  completed: { color: "success" },
-  failed: { color: "error" },
-  cancelled: { color: "warning" }
+  completed: { stateKey: "ready" },
+  failed: { stateKey: "error" },
+  cancelled: { stateKey: "degraded" }
+}
+
+const SEVERITY_BADGE_VARIANTS = {
+  success: "success",
+  error: "danger",
+  warning: "warning",
+  info: "info",
+  neutral: "secondary",
+} satisfies Record<ReturnType<typeof getDesignSystemState>["severity"], BadgeVariant>
+
+const UNKNOWN_STATUS_CONFIG = {
+  stateKey: "empty",
+} satisfies StatusConfig
+
+function getStatusConfig(status: string): StatusConfig {
+  return STATUS_CONFIG[status] || UNKNOWN_STATUS_CONFIG
 }
 
 export const StatusBadge: React.FC<StatusBadgeProps> = ({
@@ -39,13 +58,18 @@ export const StatusBadge: React.FC<StatusBadgeProps> = ({
   className
 }) => {
   const normalizedStatus = String(status || "").toLowerCase()
-  const config = statusConfig[normalizedStatus] || { color: "default" }
+  const config = getStatusConfig(normalizedStatus)
+  const state = getDesignSystemState(config.stateKey)
 
   return (
-    <Tag color={config.color} className={className}>
+    <Badge
+      variant={SEVERITY_BADGE_VARIANTS[state.severity]}
+      className={className}
+      srLabel={state.label}
+    >
       {config.icon}
       {status}
-    </Tag>
+    </Badge>
   )
 }
 

--- a/apps/packages/ui/src/components/Option/Evaluations/components/__tests__/StatusBadge.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Option/Evaluations/components/__tests__/StatusBadge.design-system.test.tsx
@@ -21,6 +21,17 @@ describe("Evaluations StatusBadge design-system adapter", () => {
     }
   )
 
+  it("renders unknown statuses through the shared Badge fallback", () => {
+    const status = "mystery-state" as RunStatus
+    const { container } = render(<StatusBadge status={status} />)
+
+    expect(screen.getByText(status)).toBeInTheDocument()
+    expect(screen.getByText("Empty")).toBeInTheDocument()
+    expect(
+      container.querySelector('[data-ds-component="Badge"]')
+    ).toBeInTheDocument()
+  })
+
   it("preserves the running status spinner affordance", () => {
     const { container } = render(<StatusBadge status="running" />)
 

--- a/apps/packages/ui/src/components/Option/Evaluations/components/__tests__/StatusBadge.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Option/Evaluations/components/__tests__/StatusBadge.design-system.test.tsx
@@ -26,15 +26,33 @@ describe("Evaluations StatusBadge design-system adapter", () => {
     const { container } = render(<StatusBadge status={status} />)
 
     expect(screen.getByText(status)).toBeInTheDocument()
-    expect(screen.getByText("Empty")).toBeInTheDocument()
     expect(
       container.querySelector('[data-ds-component="Badge"]')
     ).toBeInTheDocument()
   })
 
-  it("preserves the running status spinner affordance", () => {
-    const { container } = render(<StatusBadge status="running" />)
+  it("falls back safely for prototype property status keys", () => {
+    const status = "constructor" as RunStatus
+    const { container } = render(<StatusBadge status={status} />)
 
-    expect(container.querySelector(".animate-spin")).toBeInTheDocument()
+    expect(screen.getByText(status)).toBeInTheDocument()
+    expect(
+      container.querySelector('[data-ds-component="Badge"]')
+    ).toBeInTheDocument()
+  })
+
+  it("keeps canonical state labels out of hidden badge copy", () => {
+    render(<StatusBadge status="running" />)
+
+    expect(screen.getByText("running")).toBeInTheDocument()
+    expect(screen.queryByText("Retrying")).not.toBeInTheDocument()
+  })
+
+  it("preserves the running status spinner affordance", () => {
+    render(<StatusBadge status="running" />)
+
+    expect(
+      screen.getByTestId("evaluations-status-running-spinner")
+    ).toHaveAttribute("aria-hidden", "true")
   })
 })

--- a/apps/packages/ui/src/components/Option/Evaluations/components/__tests__/StatusBadge.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Option/Evaluations/components/__tests__/StatusBadge.design-system.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { StatusBadge, type RunStatus } from "../StatusBadge"
+
+describe("Evaluations StatusBadge design-system adapter", () => {
+  it.each([
+    "pending",
+    "running",
+    "completed",
+    "failed",
+    "cancelled",
+  ] satisfies RunStatus[])(
+    "renders the %s status through the shared Badge primitive",
+    (status) => {
+      const { container } = render(<StatusBadge status={status} />)
+
+      expect(screen.getByText(status)).toBeInTheDocument()
+      expect(
+        container.querySelector('[data-ds-component="Badge"]')
+      ).toBeInTheDocument()
+    }
+  )
+
+  it("preserves the running status spinner affordance", () => {
+    const { container } = render(<StatusBadge status="running" />)
+
+    expect(container.querySelector(".animate-spin")).toBeInTheDocument()
+  })
+})

--- a/backlog/tasks/task-45.21 - Adapt-Evaluations-StatusBadge-to-shared-Badge.md
+++ b/backlog/tasks/task-45.21 - Adapt-Evaluations-StatusBadge-to-shared-Badge.md
@@ -1,0 +1,67 @@
+---
+id: TASK-45.21
+title: Adapt Evaluations StatusBadge to shared Badge
+status: Done
+assignee: []
+created_date: '2026-05-09 03:33'
+updated_date: '2026-05-09 03:36'
+labels:
+  - design-system
+  - webui
+  - guard
+dependencies: []
+references:
+  - >-
+    apps/packages/ui/src/components/Option/Evaluations/components/StatusBadge.tsx
+  - apps/packages/ui/src/components/ui/primitives/Badge.tsx
+  - apps/packages/ui/src/design-system/states.ts
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+parent_task_id: TASK-45
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate the Evaluations run-status badge adapter from AntD Tag to the shared design-system Badge primitive with explicit canonical state mapping, then remove its local-status-badge baseline exception.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Evaluations StatusBadge renders through the shared Badge primitive while preserving known run status labels and spinner behavior for running status.
+- [x] #2 Run status styling is mapped through the design-system state registry before selecting Badge variants.
+- [x] #3 The local-status-badge baseline exception for src/components/Option/Evaluations/components/StatusBadge.tsx is removed without introducing new unbaselined findings.
+- [x] #4 Focused StatusBadge tests, product-state guard tests, the design-system verifier, and diff checks pass.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Red verification was performed before implementation: bunx vitest run src/components/Option/Evaluations/components/__tests__/StatusBadge.design-system.test.tsx --reporter=dot failed 5 tests because the existing component did not render the shared Badge primitive.
+
+Migrated Evaluations StatusBadge from AntD Tag to the shared Badge primitive. Known run statuses now map through getDesignSystemState before selecting Badge variants: pending -> loading, running -> retrying, completed -> ready, failed -> error, cancelled -> degraded, and unknown statuses -> empty. Running status keeps the Loader2 animate-spin affordance.
+
+Removed the src/components/Option/Evaluations/components/StatusBadge.tsx local-status-badge baseline exception.
+
+Fresh focused verification passed: bunx vitest run src/components/Option/Evaluations/components/__tests__/StatusBadge.design-system.test.tsx --reporter=dot (6 tests); bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot (46 tests); bun run verify:design-system-state (baseline 514, local-status-badge 8); git diff --check.
+
+Ran bunx tsc --noEmit --pretty false. It still fails on unrelated existing package-wide TypeScript errors in audio, chat composer, flashcards, playground, services, routes, store, etc.; after fixing the touched-file StatusBadge config type, no visible remaining errors are from the touched Evaluations StatusBadge files.
+
+Bandit was not run because this slice only touches TypeScript/TSX/JSON and Backlog metadata; no Python files were changed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Adapted the Evaluations run StatusBadge to render through the shared Badge primitive with canonical design-system state mapping and removed its baseline exception. Added focused regression coverage proving known statuses render through Badge and running status keeps its spinner. Focused tests, guard tests, the design-system verifier, and diff checks pass; broad local tsc remains blocked by unrelated existing package-wide errors.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.21.1 - Address-PR-1394-Evaluations-StatusBadge-review-comments.md
+++ b/backlog/tasks/task-45.21.1 - Address-PR-1394-Evaluations-StatusBadge-review-comments.md
@@ -4,7 +4,7 @@ title: Address PR 1394 Evaluations StatusBadge review comments
 status: Done
 assignee: []
 created_date: '2026-05-09 03:48'
-updated_date: '2026-05-09 03:49'
+updated_date: '2026-05-09 03:52'
 labels:
   - design-system
   - webui
@@ -28,18 +28,21 @@ Address the open PR 1394 review feedback for the Evaluations StatusBadge design-
 <!-- AC:BEGIN -->
 - [x] #1 Unknown run-status fallback behavior is covered by focused StatusBadge tests and still renders through the shared Badge primitive.
 - [x] #2 Focused tests and design-system guard verification are rerun after the review fix.
+- [x] #3 Prototype-key statuses such as toString fall back safely instead of crashing.
+- [x] #4 The running spinner regression test uses a stable test hook instead of a Tailwind class selector.
+- [x] #5 StatusBadge does not add contradictory screen-reader-only state labels beside the visible run status.
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Added the PR review regression coverage for an unknown Evaluations run status. The test now verifies that an arbitrary status string remains visible, maps through the shared Badge primitive, and exposes the canonical Empty fallback state label. Verification passed: bunx vitest run src/components/Option/Evaluations/components/__tests__/StatusBadge.design-system.test.tsx --reporter=dot (7 tests); bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot (46 tests); bun run verify:design-system-state; git diff --check. Bandit was not run because this review fix only touches TSX test code and Backlog metadata.
+Added PR review regression coverage for unknown and hostile Evaluations run statuses. The tests now verify arbitrary unknown text stays visible, prototype-property keys such as constructor fall back without crashing, running spinner coverage uses a stable test id instead of the animate-spin class, and canonical state labels are not appended as extra hidden badge copy. Production changes use an own-property guard for STATUS_CONFIG lookups, keep the running icon aria-hidden with a stable test hook, and remove the additive srLabel from this adapter so the visible run status remains the accessible label. Verification passed: bunx vitest run src/components/Option/Evaluations/components/__tests__/StatusBadge.design-system.test.tsx --reporter=dot (9 tests); bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot (46 tests); bun run verify:design-system-state; git diff --check. bunx tsc --noEmit --pretty false was rerun and still fails on existing unrelated package-wide TypeScript errors; no reported errors are from the touched Evaluations StatusBadge files. Bandit was not run because this review fix only touches TS/TSX test code and Backlog metadata.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Addressed the PR 1394 review comment by adding unknown-status fallback coverage for Evaluations StatusBadge. Focused adapter tests, product-state guard tests, design-system verifier, and diff checks pass.
+Addressed all PR 1394 review comments by adding unknown/prototype-key fallback coverage, hardening StatusBadge config lookup, removing the additive srLabel mismatch, and replacing the spinner class assertion with a stable test hook. Focused adapter tests, product-state guard tests, design-system verifier, and diff checks pass; broad tsc remains blocked by unrelated existing package-wide errors.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.21.1 - Address-PR-1394-Evaluations-StatusBadge-review-comments.md
+++ b/backlog/tasks/task-45.21.1 - Address-PR-1394-Evaluations-StatusBadge-review-comments.md
@@ -1,0 +1,53 @@
+---
+id: TASK-45.21.1
+title: Address PR 1394 Evaluations StatusBadge review comments
+status: Done
+assignee: []
+created_date: '2026-05-09 03:48'
+updated_date: '2026-05-09 03:49'
+labels:
+  - design-system
+  - webui
+  - guard
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1394'
+  - >-
+    apps/packages/ui/src/components/Option/Evaluations/components/__tests__/StatusBadge.design-system.test.tsx
+parent_task_id: TASK-45.21
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address the open PR 1394 review feedback for the Evaluations StatusBadge design-system adapter without broadening the implementation scope.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Unknown run-status fallback behavior is covered by focused StatusBadge tests and still renders through the shared Badge primitive.
+- [x] #2 Focused tests and design-system guard verification are rerun after the review fix.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added the PR review regression coverage for an unknown Evaluations run status. The test now verifies that an arbitrary status string remains visible, maps through the shared Badge primitive, and exposes the canonical Empty fallback state label. Verification passed: bunx vitest run src/components/Option/Evaluations/components/__tests__/StatusBadge.design-system.test.tsx --reporter=dot (7 tests); bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot (46 tests); bun run verify:design-system-state; git diff --check. Bandit was not run because this review fix only touches TSX test code and Backlog metadata.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed the PR 1394 review comment by adding unknown-status fallback coverage for Evaluations StatusBadge. Focused adapter tests, product-state guard tests, design-system verifier, and diff checks pass.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Implementation summary

- Adapt Evaluations StatusBadge from AntD Tag to the shared Badge primitive.
- Map run statuses through getDesignSystemState before selecting Badge variants.
- Preserve known run status labels and the running status spinner affordance.
- Remove the Evaluations StatusBadge local-status-badge baseline exception.
- Add focused design-system adapter coverage.

## Verification

- bunx vitest run src/components/Option/Evaluations/components/__tests__/StatusBadge.design-system.test.tsx --reporter=dot
- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot
- bun run verify:design-system-state
- git diff --check

## Known baseline

- bunx tsc --noEmit --pretty false still fails on existing unrelated package-wide TypeScript errors in audio, chat composer, flashcards, playground, services, routes, store, and other tests. After fixing the touched StatusBadge config type, no visible remaining errors are from the touched Evaluations StatusBadge files.
- Bandit was not run because this slice only touches TypeScript/TSX/JSON and Backlog metadata.

Draft until a human-written Change summary is added for the AI-generated PR merge gate.