### PR TITLE
Add manual VZ host failure drills

### DIFF
--- a/.github/workflows/vz-linux-host-gated.yml
+++ b/.github/workflows/vz-linux-host-gated.yml
@@ -16,6 +16,11 @@ on:
         required: false
         default: false
         type: boolean
+      include_failure_drills:
+        description: Run manual-only VZ Linux failure recovery drills
+        required: false
+        default: false
+        type: boolean
   schedule:
     - cron: '17 10 * * *'
 
@@ -91,6 +96,11 @@ jobs:
           case "${TLDW_SANDBOX_VZ_HELPER_SKIP_SIGN:-false}" in
             1|true|TRUE|True|yes|YES|Yes)
               args+=(--skip-sign)
+              ;;
+          esac
+          case "${{ inputs.include_failure_drills || false }}" in
+            1|true|TRUE|True|yes|YES|Yes)
+              args+=(--include-failure-drills)
               ;;
           esac
 

--- a/Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
+++ b/Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
@@ -52,9 +52,13 @@ Optional configuration:
 - `TLDW_SANDBOX_VZ_HELPER_ENTITLEMENTS_PATH` or manual `entitlements_path`
 - `TLDW_SANDBOX_VZ_HELPER_SKIP_SIGN`
 - `TLDW_SANDBOX_VZ_LINUX_HOST_GATED_NIGHTLY=1` to enable scheduled runs
+- manual `include_failure_drills=true` to run VM-invalidation recovery drills
+  scoped to VMs created by the drill itself
 
 Manual `skip_sign: false` must override a true repository variable. This keeps
 one-off signing validation possible without changing repository configuration.
+Failure drills are never enabled by repository variable or schedule in the
+current policy.
 
 ## Branch And Action Safety
 
@@ -98,6 +102,13 @@ host can compute macOS sandbox reconciliation state and produce a dry-run repair
 plan for stale VZ session-control metadata. It does not terminate VMs, delete
 session controls, or run image-store cleanup.
 
+Manual failure drills are separate from the default smoke. When a maintainer
+starts the workflow with `include_failure_drills=true`, the delegated smoke
+script runs additional tests that may invalidate VMs created by those tests. The
+current drill terminates only the session VM recorded by the drill's own
+session-control row, then verifies the next same-session command provisions a
+fresh VM and completes. Scheduled runs must not enable these drills by default.
+
 ## Expected Skips And Non-Blocking Conditions
 
 These are expected and should not block ordinary PRs:
@@ -108,6 +119,8 @@ These are expected and should not block ordinary PRs:
 - workflow skipped on refs other than `main` and `dev`
 - normal hosted CI lacking Apple silicon VZ support
 - local developer machines without a prepared bundle/helper environment
+- failure-drill coverage skipped because manual dispatch did not set
+  `include_failure_drills=true`
 
 A manual run that fails before VM execution because the runner is missing the
 configured bundle path is an operator setup failure, not a sandbox runtime
@@ -127,6 +140,8 @@ prepared host and fails one of the accepted runtime guarantees:
 - same-session VM reuse fails after the first command succeeds
 - recovery diagnostics or dry-run reconciliation repair planning fails after
   helper/template readiness passes
+- a manually requested failure drill cannot replace a drill-owned stale session
+  VM after helper-side termination
 - cleanup leaves the helper process or accepted socket path behind
 - helper protocol mismatch is introduced without a matching compatibility plan
 - artifacts/logs are not uploaded when the job fails
@@ -157,9 +172,11 @@ output and should not contain secrets or raw user data.
 - Keep this policy aligned with `.github/workflows/vz-linux-host-gated.yml`.
 - Update `tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py`
   when changing workflow triggers, labels, action pins, permissions, artifact
-  paths, or nightly opt-in behavior.
+  paths, failure-drill opt-in behavior, or nightly opt-in behavior.
 - Do not add PR or push triggers without a new security review.
 - Do not remove branch gating without replacing it with an equivalent trusted
   ref policy.
 - Prefer improving `run-host-e2e-smoke.sh` over adding ad hoc workflow-only
   helper lifecycle logic.
+- Keep failure drills disabled by default until repeated prepared-host runs show
+  they are stable enough for scheduled promotion.

--- a/Docs/superpowers/plans/2026-05-09-vz-linux-host-failure-drills-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-09-vz-linux-host-failure-drills-implementation-plan.md
@@ -1,0 +1,227 @@
+# VZ Linux Host Failure Drills Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add manual opt-in VZ Linux host failure drills that verify stale same-session VM recovery on prepared Apple Silicon hosts.
+
+**Architecture:** Reuse the existing host smoke script as the single helper lifecycle entrypoint. Keep default smoke stable by running only the existing host-smoke marker unless `--include-failure-drills` is passed. The drill itself lives in the real-host pytest module and invalidates only a VM created by the current test session.
+
+**Tech Stack:** Bash, GitHub Actions, pytest, FastAPI sandbox service internals, macOS Virtualization helper client.
+
+---
+
+## Preconditions
+
+- Worktree: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/sandbox-host-failure-drills`
+- Branch: `codex/sandbox-host-failure-drills`
+- Backlog: `TASK-145`
+- Spec: `Docs/superpowers/specs/2026-05-09-vz-linux-host-failure-drills-design.md`
+- Base branch: `origin/dev`
+
+## File Map
+
+- Modify: `.github/workflows/vz-linux-host-gated.yml`
+  - Add manual `include_failure_drills` input and conditionally pass
+    `--include-failure-drills` to the smoke script.
+- Modify: `tools/vz-linux-image/scripts/run-host-e2e-smoke.sh`
+  - Add script flag, usage text, dry-run behavior, and conditional pytest marker
+    invocation.
+- Modify: `tools/vz-linux-image/tests/test_host_e2e_smoke_script.py`
+  - Add script dry-run/help coverage for the new flag.
+- Modify: `tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py`
+  - Add the real-host stale session VM recovery drill behind a dedicated marker.
+- Modify: `pyproject.toml`
+  - Register the new strict pytest marker.
+- Modify: `tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py`
+  - Add workflow contract coverage for the new manual input and conditional flag
+    wiring.
+- Modify: `Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md`
+  - Document manual-only failure drills and default scheduled-run behavior.
+- Modify: `tldw_Server_API/app/core/Sandbox/README.md`
+  - Briefly mention the opt-in failure-drill coverage.
+- Modify: `backlog/tasks/task-145 - Add-manual-opt-in-VZ-Linux-host-failure-drills.md`
+  - Keep status, verification, and final notes current.
+
+## Task 1: Script Flag And Focused Tests
+
+**Files:**
+- Modify: `tools/vz-linux-image/scripts/run-host-e2e-smoke.sh`
+- Modify: `tools/vz-linux-image/tests/test_host_e2e_smoke_script.py`
+
+- [ ] **Step 1: Add failing tests for default and opt-in dry-run behavior**
+
+Add assertions that `--help` includes `--include-failure-drills`, that default
+dry-run output does not include `vz_linux_host_failure_drill`, and that dry-run
+with `--include-failure-drills` does include it.
+
+- [ ] **Step 2: Run focused script tests and confirm failure**
+
+Run:
+
+```bash
+python -m pytest tools/vz-linux-image/tests/test_host_e2e_smoke_script.py -q
+```
+
+Expected: fail because the flag is not implemented.
+
+- [ ] **Step 3: Implement the script flag**
+
+Add `INCLUDE_FAILURE_DRILLS=0`, parse `--include-failure-drills`, document it in
+usage, add `run_real_vz_linux_failure_drills`, and conditionally call it after
+`run_real_vz_linux_host_smoke`.
+
+- [ ] **Step 4: Re-run focused script tests**
+
+Run:
+
+```bash
+python -m pytest tools/vz-linux-image/tests/test_host_e2e_smoke_script.py -q
+```
+
+Expected: pass.
+
+## Task 2: Workflow Input And Contract Tests
+
+**Files:**
+- Modify: `.github/workflows/vz-linux-host-gated.yml`
+- Modify: `tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py`
+
+- [ ] **Step 1: Add failing workflow contract assertions**
+
+Assert the workflow defines `workflow_dispatch.inputs.include_failure_drills`,
+that it defaults to false, and that the managed smoke step conditionally appends
+`--include-failure-drills`.
+
+- [ ] **Step 2: Run the workflow contract test and confirm failure**
+
+Run:
+
+```bash
+python -m pytest tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py -q
+```
+
+Expected: fail because the input and wiring do not exist.
+
+- [ ] **Step 3: Add workflow input and conditional script argument**
+
+Add a boolean manual input and append `--include-failure-drills` only for truthy
+manual input values. Do not enable it for scheduled runs by default and do not
+change branch gating or triggers.
+
+- [ ] **Step 4: Re-run the workflow contract test**
+
+Run:
+
+```bash
+python -m pytest tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py -q
+```
+
+Expected: pass.
+
+## Task 3: Real-Host Failure Drill
+
+**Files:**
+- Modify: `tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py`
+- Modify: `pyproject.toml`
+
+- [ ] **Step 1: Add the failing real-host drill test**
+
+Add `@pytest.mark.vz_linux_host_failure_drill` to a test that:
+
+- creates a real `vz_linux` session
+- runs a first command
+- reads the session-control VM ID
+- terminates that VM through `VZLinuxRunner.helper_client_cls()`
+- runs a second command in the same session
+- asserts completion and a changed VM ID
+- destroys the session in `finally`
+
+- [ ] **Step 2: Register the pytest marker**
+
+Add `vz_linux_host_failure_drill` to the `pyproject.toml` pytest marker list so
+strict marker collection works on every host.
+
+- [ ] **Step 3: Run marker selection in host-independent mode**
+
+Run:
+
+```bash
+python -m pytest tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py -m vz_linux_host_failure_drill -q -rs
+```
+
+Expected on non-prepared hosts: skipped with the existing opt-in/host reasons.
+
+- [ ] **Step 4: Ensure the drill uses existing fallback behavior**
+
+No production code change should be needed if `VZLinuxRunner` already treats
+failed or absent VM status probes as not healthy and provisions a fresh VM.
+Only adjust production code if the test exposes a still-valid regression.
+
+## Task 4: Documentation
+
+**Files:**
+- Modify: `Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md`
+- Modify: `tldw_Server_API/app/core/Sandbox/README.md`
+
+- [ ] **Step 1: Document the manual-only failure drill contract**
+
+Update the host-gated policy to explain that failure drills are available only
+through manual dispatch or explicit script flag, are disabled for scheduled runs
+by default, and must stay scoped to resources created by the drill itself.
+
+- [ ] **Step 2: Add a short sandbox README note**
+
+Mention `--include-failure-drills` near the existing host smoke guidance.
+
+## Task 5: Verification And Backlog Closeout
+
+**Files:**
+- Modify: `backlog/tasks/task-145 - Add-manual-opt-in-VZ-Linux-host-failure-drills.md`
+
+- [ ] **Step 1: Run focused verification**
+
+Run:
+
+```bash
+python -m pytest tools/vz-linux-image/tests/test_host_e2e_smoke_script.py -q
+python -m pytest tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py -q
+python -m pytest tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py -m vz_linux_host_failure_drill -q -rs
+python -m bandit -r tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py -s B101 -f json -o /tmp/bandit_vz_host_failure_drills.json
+```
+
+Expected: focused tests pass or host-gated drill test skips on non-prepared
+hosts; Bandit produces no new findings outside skipped test assert noise.
+
+- [ ] **Step 2: Update Backlog task**
+
+Check completed acceptance criteria, record verification results, add final
+summary, and document any real-host skip reason if the local host is not
+prepared for VZ execution.
+
+- [ ] **Step 3: Self-review changed files**
+
+Review the diff for:
+
+- failure drills disabled by default
+- no schedule/nightly enablement
+- no PR/push trigger changes
+- no broad VM cleanup
+- clear docs and operator wording
+
+- [ ] **Step 4: Commit**
+
+Commit all changes with a concise message such as:
+
+```bash
+git add .github/workflows/vz-linux-host-gated.yml \
+  tools/vz-linux-image/scripts/run-host-e2e-smoke.sh \
+  tools/vz-linux-image/tests/test_host_e2e_smoke_script.py \
+  tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py \
+  tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py \
+  Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md \
+  tldw_Server_API/app/core/Sandbox/README.md \
+  Docs/superpowers/specs/2026-05-09-vz-linux-host-failure-drills-design.md \
+  Docs/superpowers/plans/2026-05-09-vz-linux-host-failure-drills-implementation-plan.md \
+  "backlog/tasks/task-145 - Add-manual-opt-in-VZ-Linux-host-failure-drills.md"
+git commit -m "test(sandbox): add manual VZ host failure drills"
+```

--- a/Docs/superpowers/specs/2026-05-09-vz-linux-host-failure-drills-design.md
+++ b/Docs/superpowers/specs/2026-05-09-vz-linux-host-failure-drills-design.md
@@ -1,0 +1,164 @@
+# VZ Linux Host Failure Drills Design
+
+**Date:** 2026-05-09
+**Status:** Approved for implementation planning
+**Backlog:** TASK-145
+**Scope:** Host-gated `vz_linux` smoke workflow, operator smoke script, real-host pytest coverage, and host-gated policy docs.
+
+## Summary
+
+The `vz_linux` host-gated path now verifies helper build/sign/start, real
+ephemeral execution, same-session VM reuse, recovery diagnostics, and dry-run
+repair planning. The next stability slice should add manual opt-in failure
+drills that prove the runner can recover from stale session-control metadata
+without making normal nightly/manual smoke riskier.
+
+This PR should add a manual-only failure-drill mode. The first drill should
+create a real session VM, invalidate only that VM through helper truth, run a
+second command in the same sandbox session, and assert the runner detects the
+stale or unhealthy reuse candidate, clears stale control state, provisions a
+fresh VM, and completes.
+
+## Goals
+
+- Add a failure-drill flag to the host smoke script that is disabled by default.
+- Expose a manual `workflow_dispatch` input for failure drills without enabling
+  drills for scheduled runs.
+- Add one real-host failure drill for stale session VM recovery.
+- Keep normal host-gated smoke stable and non-destructive.
+- Document that failure drills are manual-only operator coverage.
+- Add host-independent tests for script and workflow wiring.
+
+## Non-Goals
+
+- Do not make failure drills part of scheduled nightly smoke by default.
+- Do not add PR or push triggers to the host-gated workflow.
+- Do not add helper crash, stale socket, launchd restart, or host reboot drills
+  in this PR.
+- Do not terminate orphaned VMs or repair VMs not created by the current test.
+- Do not change public sandbox API contracts.
+- Do not relax the prepared-host branch gate.
+
+## Chosen Approach
+
+Add a `--include-failure-drills` option to
+`tools/vz-linux-image/scripts/run-host-e2e-smoke.sh`. The existing smoke script
+already owns helper build/sign/start, runtime path setup, and helper cleanup, so
+reusing it avoids a second lifecycle path. By default it should keep running
+only the established `vz_linux_host_smoke` marker.
+
+When `--include-failure-drills` is present, the script should run a second
+pytest invocation for a new marker such as `vz_linux_host_failure_drill` after
+the baseline smoke passes. This sequencing matters: failure drills should only
+run after proving the prepared host and canonical bundle are basically healthy.
+
+Wire the flag through `.github/workflows/vz-linux-host-gated.yml` as a
+`workflow_dispatch` boolean input. The scheduled path should never enable it
+implicitly. Manual dispatch should allow maintainers to run the drill when
+validating recovery behavior or investigating a real-host regression.
+
+## Failure Drill Contract
+
+The first drill should be scoped to stale session VM recovery:
+
+1. Configure an isolated SQLite sandbox store and temporary sandbox root.
+2. Create a `vz_linux` sandbox session with the canonical real-host base image.
+3. Run a first command in that session and assert completion.
+4. Read the persisted VZ session-control row and capture the VM ID.
+5. Terminate only that VM through the helper client.
+6. Run a second command in the same sandbox session.
+7. Assert the second command completes.
+8. Read the session-control row again and assert the VM ID changed.
+9. Destroy the session in `finally` and tolerate already-gone VM cleanup.
+
+The drill must not use broad helper cleanup, orphan termination, or socket
+deletion. It should only act on the VM ID created by the same test and recorded
+in the current test's session-control row.
+
+## Safety Constraints
+
+- The drill is opt-in and not part of scheduled runs by default.
+- The workflow keeps the existing branch gate for `main` and `dev`.
+- The test must use a unique session ID/run context through normal service APIs.
+- The test must terminate only the VM ID captured from its own session control.
+- The test should verify the helper operation succeeds or skip/fail with a clear
+  reason rather than continuing after ambiguous invalidation.
+- Cleanup must destroy the sandbox session in `finally`.
+- No test should mutate persistent operator configuration or global image-store
+  state beyond the existing temporary store setup.
+
+## Workflow Shape
+
+Add manual input:
+
+```yaml
+include_failure_drills:
+  description: Run manual-only VZ Linux failure recovery drills
+  required: false
+  default: false
+  type: boolean
+```
+
+In the managed host smoke step, append `--include-failure-drills` only when the
+manual input is truthy. Scheduled runs should resolve this input to false.
+
+## Script Shape
+
+`run-host-e2e-smoke.sh` should gain:
+
+- usage text for `--include-failure-drills`
+- an `INCLUDE_FAILURE_DRILLS=0` variable
+- argument parsing for `--include-failure-drills`
+- a `run_real_vz_linux_failure_drills` helper that calls pytest with the new
+  marker
+- a conditional call after `run_real_vz_linux_host_smoke`
+
+Dry-run mode should print the failure-drill pytest command only when the flag is
+present. Existing dry-run output without the flag should remain unchanged except
+for help text.
+
+## Test Strategy
+
+Host-independent tests should cover:
+
+- the smoke script help mentions `--include-failure-drills`
+- default dry-run output does not include the failure-drill marker
+- dry-run output with `--include-failure-drills` includes the failure-drill
+  pytest invocation
+- workflow contract tests verify the new input exists, defaults false, and is
+  only passed to the script conditionally
+
+Real-host coverage should remain opt-in:
+
+- the new pytest drill is marked `vz_linux_host_failure_drill`
+- it is skipped outside macOS Apple Silicon or without the existing real-host
+  opt-in variables
+- it runs only when the smoke script flag or a direct pytest marker selection
+  asks for it
+
+## Risks And Mitigations
+
+- **Risk:** The drill terminates a VM that does not belong to it.
+  **Mitigation:** Only terminate the VM ID read from the session-control row
+  created by the same service/session flow, then destroy that session in
+  `finally`.
+- **Risk:** Failure drill makes nightly CI flaky.
+  **Mitigation:** Keep drills disabled by default and wired only to manual
+  dispatch input.
+- **Risk:** The second command fails because helper status probing fails instead
+  of falling through to fresh provisioning.
+  **Mitigation:** The test intentionally exercises the existing graceful fallback
+  contract: absent/unhealthy probe results should clear control state and create
+  a fresh VM.
+- **Risk:** Helper crash/stale socket behavior remains untested.
+  **Mitigation:** Leave those as later drills after the VM-scoped invalidation
+  path proves safe and useful.
+
+## Open Follow-Ups
+
+- Promote selected failure drills to scheduled nightly only after repeated
+  prepared-host success.
+- Add helper crash and stale socket drills once helper restart semantics are
+  less manual and less likely to produce false failures.
+- Add explicit artifact summaries for failure-drill outcomes if operators need
+  richer evidence than pytest logs.

--- a/backlog/tasks/task-145 - Add-manual-opt-in-VZ-Linux-host-failure-drills.md
+++ b/backlog/tasks/task-145 - Add-manual-opt-in-VZ-Linux-host-failure-drills.md
@@ -4,7 +4,7 @@ title: Add manual opt-in VZ Linux host failure drills
 status: Done
 assignee: []
 created_date: '2026-05-09 03:50'
-updated_date: '2026-05-09 03:59'
+updated_date: '2026-05-09 04:10'
 labels:
   - sandbox
   - vz_linux
@@ -50,12 +50,20 @@ Implementation approach: add a manual-only failure-drill script flag and workflo
 
 <!-- SECTION:NOTES:BEGIN -->
 Verification: python -m pytest tools/vz-linux-image/tests/test_host_e2e_smoke_script.py -q -> 9 passed, 1 skipped; python -m pytest tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py -q -> 13 passed; python -m pytest tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py -m vz_linux_host_failure_drill -q -rs -> 1 skipped because TLDW_SANDBOX_VZ_LINUX_E2E is not set locally; git diff --check -> clean; Bandit on touched real-host test with B101 skipped -> 0 results.
+
+Follow-up PR review pass: verified current Qodo findings on brittle helper terminate assertion and workflow_dispatch input access before patching.
+
+Review fixes completed: the failure drill now verifies VM health before and after helper termination and only skips if helper termination cannot invalidate a still-healthy VM; workflow contract test now validates workflow_dispatch/input shape before indexing.
+
+Review verification: python -m pytest tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py -q -> 13 passed; python -m pytest tools/vz-linux-image/tests/test_host_e2e_smoke_script.py -q -> 9 passed, 1 skipped; python -m pytest tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py -m vz_linux_host_failure_drill -q -rs -> 1 skipped because TLDW_SANDBOX_VZ_LINUX_E2E is not set locally; git diff --check -> clean; Bandit on touched tests with B101 skipped -> 0 results.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Added manual opt-in VZ Linux host failure drills. The host smoke script and GitHub workflow now expose failure-drill wiring disabled by default, the real-host pytest module has a dedicated stale session VM replacement drill, docs describe the manual-only safety contract, and focused verification passed with the real VZ drill skipped locally due missing TLDW_SANDBOX_VZ_LINUX_E2E opt-in.
+
+PR review follow-up hardened the stale-session drill and workflow contract test. The drill now treats helper terminate false results as operational state to verify with VM health instead of a hard assertion, while still requiring the VM to be unhealthy/missing before testing fresh provisioning. The workflow test now fails with explicit shape assertions instead of a KeyError if workflow_dispatch inputs are missing.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-145 - Add-manual-opt-in-VZ-Linux-host-failure-drills.md
+++ b/backlog/tasks/task-145 - Add-manual-opt-in-VZ-Linux-host-failure-drills.md
@@ -1,0 +1,69 @@
+---
+id: TASK-145
+title: Add manual opt-in VZ Linux host failure drills
+status: Done
+assignee: []
+created_date: '2026-05-09 03:50'
+updated_date: '2026-05-09 03:59'
+labels:
+  - sandbox
+  - vz_linux
+  - host-gated
+  - recovery
+dependencies: []
+references:
+  - .github/workflows/vz-linux-host-gated.yml
+  - tools/vz-linux-image/scripts/run-host-e2e-smoke.sh
+  - tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py
+  - tools/vz-linux-image/tests/test_host_e2e_smoke_script.py
+documentation:
+  - Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
+  - tldw_Server_API/app/core/Sandbox/README.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add a focused host-gated recovery drill path for real vz_linux execution on prepared Apple Silicon runners. The drill must stay manual opt-in so normal nightly/manual smoke remains stable while operators can explicitly validate stale-session recovery behavior after the baseline real execution smoke passes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The host E2E smoke script exposes a manual opt-in failure-drill flag that is disabled by default.
+- [x] #2 The GitHub host-gated workflow exposes a workflow_dispatch input for failure drills and does not enable them for scheduled runs by default.
+- [x] #3 A real-host pytest drill verifies a session VM can be invalidated through the helper and that the next same-session command provisions a fresh VM and completes without reusing stale control state.
+- [x] #4 The failure drill is guarded by a dedicated marker or equivalent so normal host smoke can run without the drill.
+- [x] #5 Host-gated policy or sandbox docs describe the manual-only failure-drill contract and safety constraints.
+- [x] #6 Focused tests validate script/workflow wiring without requiring a real VZ host.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Spec: Docs/superpowers/specs/2026-05-09-vz-linux-host-failure-drills-design.md
+Plan: Docs/superpowers/plans/2026-05-09-vz-linux-host-failure-drills-implementation-plan.md
+Implementation approach: add a manual-only failure-drill script flag and workflow input, a dedicated pytest marker for stale session VM recovery, focused host-independent wiring tests, and policy docs.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verification: python -m pytest tools/vz-linux-image/tests/test_host_e2e_smoke_script.py -q -> 9 passed, 1 skipped; python -m pytest tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py -q -> 13 passed; python -m pytest tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py -m vz_linux_host_failure_drill -q -rs -> 1 skipped because TLDW_SANDBOX_VZ_LINUX_E2E is not set locally; git diff --check -> clean; Bandit on touched real-host test with B101 skipped -> 0 results.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added manual opt-in VZ Linux host failure drills. The host smoke script and GitHub workflow now expose failure-drill wiring disabled by default, the real-host pytest module has a dedicated stale session VM replacement drill, docs describe the manual-only safety contract, and focused verification passed with the real VZ drill skipped locally due missing TLDW_SANDBOX_VZ_LINUX_E2E opt-in.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -607,6 +607,7 @@ markers = [
     "sandbox_no_reload: marks sandbox tests that should not reload app.main",
     "sandbox_real_docker: marks sandbox tests that require real Docker execution paths",
     "vz_linux_host_smoke: marks opt-in Apple silicon VZ Linux host smoke tests",
+    "vz_linux_host_failure_drill: marks manual opt-in Apple silicon VZ Linux host failure drills",
     "legacy_tts: marks legacy TTS tests",
     "concurrent: marks concurrency tests",
     "streaming: marks streaming tests",

--- a/tldw_Server_API/app/core/Sandbox/README.md
+++ b/tldw_Server_API/app/core/Sandbox/README.md
@@ -162,6 +162,11 @@ Current limitations:
   `TLDW_SANDBOX_MACOS_HELPER_SOCKET=<socket>`, `SANDBOX_ENABLE_EXECUTION=1`,
   and `SANDBOX_BACKGROUND_EXECUTION=0`.
 - Real helper-daemon smoke coverage is opt-in through `tldw_Server_API/tests/sandbox/test_macos_virtualization_helper_daemon_host_gated.py` and requires `TLDW_SANDBOX_MACOS_HELPER_DAEMON_SMOKE=1`.
+- Manual host failure drills are available through
+  `tools/vz-linux-image/scripts/run-host-e2e-smoke.sh --include-failure-drills`
+  or the host-gated workflow's `include_failure_drills` dispatch input. These
+  drills are disabled by default and currently verify that a drill-owned stale
+  session VM is replaced before the next same-session command completes.
 - The host-gated CI acceptance policy for real `vz_linux` smoke lives in
   `Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md`. It defines
   manual/nightly gates, expected skips, artifact upload expectations, branch

--- a/tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py
+++ b/tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py
@@ -32,11 +32,14 @@ def test_vz_linux_host_gated_workflow_is_manual_and_nightly() -> None:
     """The real VZ workflow should remain manual/nightly instead of normal CI."""
     workflow = _load_workflow()
     triggers = _workflow_triggers(workflow)
-    inputs = triggers["workflow_dispatch"]["inputs"]
 
     assert set(triggers) == {"workflow_dispatch", "schedule"}  # nosec B101
     assert "workflow_dispatch" in triggers  # nosec B101
     assert "schedule" in triggers  # nosec B101
+    workflow_dispatch = triggers["workflow_dispatch"]
+    assert isinstance(workflow_dispatch, dict)  # nosec B101
+    inputs = workflow_dispatch.get("inputs")
+    assert isinstance(inputs, dict)  # nosec B101
     assert inputs["bundle_path"]["required"] is False  # nosec B101
     assert inputs["include_failure_drills"]["required"] is False  # nosec B101
     assert inputs["include_failure_drills"]["default"] is False  # nosec B101

--- a/tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py
+++ b/tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py
@@ -32,11 +32,15 @@ def test_vz_linux_host_gated_workflow_is_manual_and_nightly() -> None:
     """The real VZ workflow should remain manual/nightly instead of normal CI."""
     workflow = _load_workflow()
     triggers = _workflow_triggers(workflow)
+    inputs = triggers["workflow_dispatch"]["inputs"]
 
     assert set(triggers) == {"workflow_dispatch", "schedule"}  # nosec B101
     assert "workflow_dispatch" in triggers  # nosec B101
     assert "schedule" in triggers  # nosec B101
-    assert triggers["workflow_dispatch"]["inputs"]["bundle_path"]["required"] is False  # nosec B101
+    assert inputs["bundle_path"]["required"] is False  # nosec B101
+    assert inputs["include_failure_drills"]["required"] is False  # nosec B101
+    assert inputs["include_failure_drills"]["default"] is False  # nosec B101
+    assert inputs["include_failure_drills"]["type"] == "boolean"  # nosec B101
 
 
 def test_vz_linux_host_gated_workflow_targets_prepared_apple_silicon_runner() -> None:
@@ -93,6 +97,20 @@ def test_vz_linux_host_gated_workflow_uses_operator_smoke_script() -> None:
     assert "TLDW_SANDBOX_VZ_LINUX_BUNDLE_PATH" in run_blocks  # nosec B101
 
 
+def test_vz_linux_host_gated_workflow_failure_drills_are_manual_opt_in() -> None:
+    """Failure drills should only run when manual dispatch opts in."""
+    workflow = _load_workflow()
+    job = workflow["jobs"]["vz-linux-host-gated-smoke"]
+    steps = job["steps"]
+    run_blocks = "\n".join(str(step.get("run", "")) for step in steps)
+
+    assert "include_failure_drills" in _workflow_triggers(workflow)["workflow_dispatch"]["inputs"]  # nosec B101
+    assert "TLDW_SANDBOX_VZ_INCLUDE_FAILURE_DRILLS" not in job["env"]  # nosec B101
+    assert "inputs.include_failure_drills" in run_blocks  # nosec B101
+    assert "--include-failure-drills" in run_blocks  # nosec B101
+    assert "vars.TLDW_SANDBOX_VZ_LINUX_HOST_GATED_NIGHTLY" not in run_blocks  # nosec B101
+
+
 def test_vz_linux_host_gated_operator_smoke_runs_recovery_slice() -> None:
     """The delegated operator smoke should include the non-destructive recovery slice."""
     script = SMOKE_SCRIPT_PATH.read_text(encoding="utf-8")
@@ -100,6 +118,15 @@ def test_vz_linux_host_gated_operator_smoke_runs_recovery_slice() -> None:
     assert "run_real_vz_linux_pytest" in script  # nosec B101
     assert "run_real_vz_linux_host_smoke" in script  # nosec B101
     assert "-m vz_linux_host_smoke" in script  # nosec B101
+
+
+def test_vz_linux_host_gated_operator_smoke_has_manual_failure_drill_slice() -> None:
+    """The operator smoke should expose failure drills without enabling them by default."""
+    script = SMOKE_SCRIPT_PATH.read_text(encoding="utf-8")
+
+    assert "--include-failure-drills" in script  # nosec B101
+    assert "run_real_vz_linux_failure_drills" in script  # nosec B101
+    assert "-m vz_linux_host_failure_drill" in script  # nosec B101
 
 
 def test_vz_linux_host_gated_acceptance_policy_requires_recovery_smoke() -> None:

--- a/tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py
+++ b/tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py
@@ -333,3 +333,96 @@ def test_vz_linux_real_recovery_diagnostics_dry_run_smoke(
         )
     finally:
         service._orch.delete_vz_session_control(stale_session_id)
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS host only")
+@pytest.mark.vz_linux_host_failure_drill
+def test_vz_linux_real_session_recreates_vm_after_helper_termination(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Verify a stale session VM is not reused after helper-side termination."""
+    base_image = _require_vz_linux_real_host_e2e(monkeypatch, tmp_path)
+    monkeypatch.delenv("TEST_MODE", raising=False)
+    monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_FAKE_EXEC", raising=False)
+    monkeypatch.delenv("TLDW_SANDBOX_MACOS_HELPER_READY", raising=False)
+    monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_TEMPLATE_READY", raising=False)
+    monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_AVAILABLE", raising=False)
+
+    service = SandboxService()
+    helper = VZLinuxRunner.helper_client_cls()
+    session_id: str | None = None
+    destroyed = False
+    try:
+        session = service.create_session(
+            user_id="e2e-user",
+            spec=SessionSpec(
+                runtime=RuntimeType.vz_linux,
+                base_image=base_image,
+                network_policy="deny_all",
+            ),
+            spec_version="1.0",
+            idem_key=None,
+            raw_body={"spec_version": "1.0", "runtime": "vz_linux", "base_image": base_image},
+        )
+        session_id = session.id
+
+        first = service.start_run_scaffold(
+            user_id="e2e-user",
+            spec=RunSpec(
+                session_id=session.id,
+                runtime=RuntimeType.vz_linux,
+                base_image=base_image,
+                command=["/bin/echo", "failure-drill-first"],
+                network_policy="deny_all",
+            ),
+            spec_version="1.0",
+            idem_key=None,
+            raw_body={
+                "session_id": session.id,
+                "runtime": "vz_linux",
+                "command": ["/bin/echo", "failure-drill-first"],
+            },
+        )
+        control_after_first = service._orch.get_vz_session_control(session.id)
+        _expect(first.phase == RunPhase.completed, f"Expected first run completed, got {first.phase!r}")
+        _expect(isinstance(control_after_first, dict), "Expected VZ session control after first run")
+        first_vm_id = str(control_after_first.get("vm_id") or "").strip() if control_after_first else ""
+        _expect(bool(first_vm_id), f"Expected first run VM id, got {control_after_first!r}")
+
+        terminated = helper.terminate_vm(first_vm_id)
+        _expect(terminated is True, f"Expected helper to terminate drill VM {first_vm_id!r}")
+
+        second = service.start_run_scaffold(
+            user_id="e2e-user",
+            spec=RunSpec(
+                session_id=session.id,
+                runtime=RuntimeType.vz_linux,
+                base_image=base_image,
+                command=["/bin/echo", "failure-drill-second"],
+                network_policy="deny_all",
+            ),
+            spec_version="1.0",
+            idem_key=None,
+            raw_body={
+                "session_id": session.id,
+                "runtime": "vz_linux",
+                "command": ["/bin/echo", "failure-drill-second"],
+            },
+        )
+        control_after_second = service._orch.get_vz_session_control(session.id)
+        _expect(second.phase == RunPhase.completed, f"Expected second run completed, got {second.phase!r}")
+        _expect(isinstance(control_after_second, dict), "Expected VZ session control after second run")
+        second_vm_id = str(control_after_second.get("vm_id") or "").strip() if control_after_second else ""
+        _expect(bool(second_vm_id), f"Expected second run VM id, got {control_after_second!r}")
+        _expect(
+            second_vm_id != first_vm_id,
+            f"Expected stale VM replacement after helper termination, got {first_vm_id!r}",
+        )
+
+        _expect(service.destroy_session(session.id) is True, "Expected session destruction to succeed")
+        destroyed = True
+        _expect(service._orch.get_vz_session_control(session.id) is None, "Expected VZ session control cleanup")
+    finally:
+        if session_id and not destroyed:
+            service.destroy_session(session_id)

--- a/tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py
+++ b/tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py
@@ -390,8 +390,22 @@ def test_vz_linux_real_session_recreates_vm_after_helper_termination(
         first_vm_id = str(control_after_first.get("vm_id") or "").strip() if control_after_first else ""
         _expect(bool(first_vm_id), f"Expected first run VM id, got {control_after_first!r}")
 
+        status_before_terminate = helper.get_vm_status(first_vm_id)
+        _expect(
+            bool(getattr(status_before_terminate, "healthy", False)),
+            f"Expected drill VM {first_vm_id!r} healthy before termination, got {status_before_terminate!r}",
+        )
         terminated = helper.terminate_vm(first_vm_id)
-        _expect(terminated is True, f"Expected helper to terminate drill VM {first_vm_id!r}")
+        status_after_terminate = helper.get_vm_status(first_vm_id)
+        healthy_after_terminate = bool(getattr(status_after_terminate, "healthy", False))
+        if not terminated and healthy_after_terminate:
+            pytest.skip(
+                f"Could not invalidate drill VM {first_vm_id!r}; helper returned False and VM remained healthy"
+            )
+        _expect(
+            not healthy_after_terminate,
+            f"Expected drill VM {first_vm_id!r} unhealthy or missing after termination, got {status_after_terminate!r}",
+        )
 
         second = service.start_run_scaffold(
             user_id="e2e-user",

--- a/tools/vz-linux-image/scripts/run-host-e2e-smoke.sh
+++ b/tools/vz-linux-image/scripts/run-host-e2e-smoke.sh
@@ -15,6 +15,7 @@ PYTHON_BIN=""
 DRY_RUN=0
 SKIP_BUILD=0
 SKIP_SIGN=0
+INCLUDE_FAILURE_DRILLS=0
 HELPER_PID=""
 
 usage() {
@@ -35,6 +36,8 @@ Options:
   --python PATH          Python executable for pytest
   --skip-build           Do not build the helper even if the binary is missing
   --skip-sign            Do not codesign the helper
+  --include-failure-drills
+                         Run manual-only host failure recovery drills after baseline smoke
   --dry-run              Print commands without starting helper or VMs
   -h, --help             Show this help
 EOF
@@ -119,6 +122,10 @@ while [[ "$#" -gt 0 ]]; do
       ;;
     --skip-sign)
       SKIP_SIGN=1
+      shift
+      ;;
+    --include-failure-drills)
+      INCLUDE_FAILURE_DRILLS=1
       shift
       ;;
     --dry-run)
@@ -339,6 +346,10 @@ run_real_vz_linux_host_smoke() {
   run_real_vz_linux_pytest -m vz_linux_host_smoke -q -rs
 }
 
+run_real_vz_linux_failure_drills() {
+  run_real_vz_linux_pytest -m vz_linux_host_failure_drill -q -rs
+}
+
 if [[ "${DRY_RUN}" -eq 1 ]]; then
   echo "dry-run: printing host smoke commands without starting helper or VMs"
 fi
@@ -354,3 +365,6 @@ run_helper_daemon_smoke
 start_helper_for_real_e2e
 wait_for_helper_socket
 run_real_vz_linux_host_smoke
+if [[ "${INCLUDE_FAILURE_DRILLS}" -eq 1 ]]; then
+  run_real_vz_linux_failure_drills
+fi

--- a/tools/vz-linux-image/tests/test_host_e2e_smoke_script.py
+++ b/tools/vz-linux-image/tests/test_host_e2e_smoke_script.py
@@ -34,6 +34,7 @@ def test_host_e2e_smoke_script_help_mentions_required_bundle() -> None:
     assert result.returncode == 0
     assert "Usage:" in result.stdout
     assert "--bundle PATH" in result.stdout
+    assert "--include-failure-drills" in result.stdout
 
 
 def test_host_e2e_smoke_script_requires_bundle() -> None:
@@ -81,7 +82,31 @@ def test_host_e2e_smoke_script_dry_run_prints_helper_and_pytest_commands(tmp_pat
     assert "test_macos_virtualization_helper_daemon_host_gated.py" in result.stdout
     assert "test_vz_linux_real_host_e2e.py" in result.stdout
     assert "-m vz_linux_host_smoke" in result.stdout
+    assert "vz_linux_host_failure_drill" not in result.stdout
     assert not serial_log_dir.exists()
+
+
+def test_host_e2e_smoke_script_dry_run_includes_failure_drills_when_requested(tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    (bundle / "kernel").write_bytes(b"kernel")
+    (bundle / "rootfs.img").write_bytes(b"rootfs")
+    helper = tmp_path / "macos-vz-helper"
+
+    result = _run_smoke_script(
+        "--dry-run",
+        "--include-failure-drills",
+        "--bundle",
+        str(bundle),
+        "--helper",
+        str(helper),
+        "--python",
+        sys.executable,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "-m vz_linux_host_smoke" in result.stdout
+    assert "-m vz_linux_host_failure_drill" in result.stdout
 
 
 def test_host_e2e_smoke_script_default_socket_uses_private_runtime_dir(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Adds manual opt-in failure-drill wiring to the VZ Linux host-gated workflow and operator smoke script.
- Adds a dedicated real-host pytest drill that terminates a drill-owned session VM and verifies the next same-session command provisions a replacement VM.
- Updates the host-gated policy, sandbox README, Backlog task, and spec/plan docs for the manual-only safety contract.

## Verification

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tools/vz-linux-image/tests/test_host_e2e_smoke_script.py -q` -> 9 passed, 1 skipped
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py -q` -> 13 passed
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py -m vz_linux_host_failure_drill -q -rs` -> 1 skipped because `TLDW_SANDBOX_VZ_LINUX_E2E` is not set locally
- `git diff --check` -> clean
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py -s B101 -f json -o /tmp/bandit_vz_host_failure_drills.json` -> 0 results

## Change Summary

Human-authored change summary required before merge per repo policy. Please replace this placeholder with the human-written summary.
