### PR TITLE
Remove dayjs from WorldBooks relative formatting

### DIFF
--- a/Docs/Design/WebUI_Dependency_Audit.md
+++ b/Docs/Design/WebUI_Dependency_Audit.md
@@ -107,7 +107,7 @@ This audit does not remove packages or rewrite runtime code.
 | `cytoscape` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 6 | apps/packages/ui/src/components/Notes/NotesGraphModal.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesGraphModal.stage2.graph-view.test.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage21.accessibility-modal-focus.test.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage22.accessibility-regression.test.tsx | shared UI, shared UI tests | graph/rendering | `keep` | Low; import/config/package-script evidence in current WebUI or shared UI paths. | No immediate reduction; keep current behavior. | none |
 | `cytoscape-dagre` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 6 | apps/packages/ui/src/components/Notes/NotesGraphModal.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesGraphModal.stage2.graph-view.test.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage21.accessibility-modal-focus.test.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage22.accessibility-regression.test.tsx | shared UI, shared UI tests | graph/rendering | `keep` | Low; import/config/package-script evidence in current WebUI or shared UI paths. | No immediate reduction; keep current behavior. | none |
 | `d3-dsv` | `web:dependencies`, `extension:dependencies` | 0 | none found | web app, extension impact declaration only | parser/conversion | `investigate-lockfile` | Medium; no import/config/package-script evidence, but package sits in parser/conversion behavior. Confirm direct-vs-transitive ownership and CSV/DSV coverage before removal. | Potential install/bundle reduction if direct declaration proves unused. | Lockfile/parser-domain investigation slice. |
-| `dayjs` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 19 | apps/packages/ui/src/components/Flashcards/components/FlashcardEditDrawer.tsx, apps/packages/ui/src/components/Media/FilterPanel.tsx, apps/packages/ui/src/components/Option/DataTables/EditableCell.tsx, apps/packages/ui/src/components/Option/KanbanPlayground/CardDetailPanel.tsx | shared UI, shared UI tests | frontend/runtime | `defer-design` | Medium; some display formatting can move to native `Intl` or small local helpers, but several Ant Design DatePicker/DateRangePicker surfaces currently exchange `Dayjs` values and types. | No immediate dependency reduction until shared UI date-picker value contracts are redesigned or isolated. | Continue display-formatting replacement slices before date-picker design. |
+| `dayjs` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 17 | apps/packages/ui/src/components/Flashcards/components/FlashcardEditDrawer.tsx, apps/packages/ui/src/components/Media/FilterPanel.tsx, apps/packages/ui/src/components/Option/DataTables/EditableCell.tsx, apps/packages/ui/src/components/Option/KanbanPlayground/CardDetailPanel.tsx | shared UI, shared UI tests | frontend/runtime | `defer-design` | Medium; some display formatting can move to native `Intl` or small local helpers, but several Ant Design DatePicker/DateRangePicker surfaces currently exchange `Dayjs` values and types. | No immediate dependency reduction until shared UI date-picker value contracts are redesigned or isolated. | Continue display-formatting replacement slices before date-picker design. |
 | `dexie` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 6 | apps/packages/ui/src/db/dexie/chat.ts, apps/packages/ui/src/db/dexie/schema.ts, apps/packages/ui/src/hooks/document-workspace/__tests__/offlineQueue.test.ts, apps/packages/ui/src/hooks/document-workspace/offlineQueue.ts | shared UI, shared UI tests, web tests, web app | state/data | `keep` | Low; import/config/package-script evidence in current WebUI or shared UI paths. | No immediate reduction; keep current behavior. | none |
 | `dexie-react-hooks` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 1 | apps/packages/ui/src/components/Sidepanel/Chat/TtsClipsDrawer.tsx | shared UI | state/data | `keep` | Low; import/config/package-script evidence in current WebUI or shared UI paths. | No immediate reduction; keep current behavior. | none |
 | `dompurify` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 11 | apps/packages/ui/src/components/Common/CodeBlock.tsx, apps/packages/ui/src/components/Notes/NotesStudioDiagramCard.tsx, apps/packages/ui/src/components/Notes/export-utils.ts, apps/packages/ui/src/components/Option/Collections/ReadingList/ReadingItemDetail.tsx | shared UI | security/sanitization | `keep` | Low; import/config/package-script evidence in current WebUI or shared UI paths. | No immediate reduction; keep current behavior. | none |
@@ -206,6 +206,12 @@ This audit does not remove packages or rewrite runtime code.
   arithmetic. The shared UI `dayjs` import count dropped from 21 to 19 while
   leaving the package declared for remaining relative-time and Ant Design
   `Dayjs` value-contract surfaces.
+- TASK-149 removed `dayjs` relative-time usage from the display-only
+  WorldBooks last-modified formatter by replacing it with a local helper that
+  preserves representative relative labels and UTC absolute formatting. The
+  shared UI `dayjs` import count dropped from 19 to 17 while leaving the
+  package declared for remaining Flashcards/Models display formatting and Ant
+  Design `Dayjs` value-contract surfaces.
 
 ### Quick Cleanup Candidates
 
@@ -354,9 +360,21 @@ ownership checks, or complex-domain packages that should stay on the
 - 2026-05-09 TASK-147 verification: `bunx vitest run
   src/utils/__tests__/humanize-milliseconds.test.ts` from `apps/packages/ui`
   passed after first failing on the dependency guard before implementation.
+- 2026-05-09 TASK-149 active-code scan: exact shared UI package-import scan
+  found 17 remaining `dayjs` import lines after removing both imports from
+  `apps/packages/ui/src/components/Option/WorldBooks/worldBookListUtils.ts`.
+  Remaining imports are concentrated in Flashcards relative-time displays,
+  Models last-refresh formatting, and Ant Design `Dayjs` value/type surfaces
+  in media, reading list, items, data table, and kanban code.
+- 2026-05-09 TASK-149 verification: `bunx vitest run
+  src/components/Option/WorldBooks/__tests__/worldBookListUtils.test.ts` from
+  `apps/packages/ui` passed after first failing on the dependency guard before
+  implementation.
 - Bandit: skipped for TASK-144 because the slice changed documentation and
   Backlog metadata only; no Python files were modified.
 - Bandit: skipped for TASK-147 because the slice changed TypeScript,
+  documentation, and Backlog metadata only; no Python files were modified.
+- Bandit: skipped for TASK-149 because the slice changed TypeScript,
   documentation, and Backlog metadata only; no Python files were modified.
 
 ## Known Skips And Blockers

--- a/apps/packages/ui/src/components/Option/WorldBooks/__tests__/worldBookListUtils.test.ts
+++ b/apps/packages/ui/src/components/Option/WorldBooks/__tests__/worldBookListUtils.test.ts
@@ -9,6 +9,10 @@ import {
   UNKNOWN_LAST_MODIFIED_LABEL
 } from "../worldBookListUtils"
 
+const STABLE_NOW_MS = Date.parse("2026-02-18T12:00:00Z")
+const beforeStableNow = (deltaMs: number): string =>
+  new Date(STABLE_NOW_MS - deltaMs).toISOString()
+
 describe("worldBookListUtils", () => {
   it.each([
     ["2026-02-18T09:00:00Z", 1771405200000],
@@ -34,18 +38,29 @@ describe("worldBookListUtils", () => {
     ["2026-02-17T12:00:00Z", "a day ago"],
     ["2026-02-19T12:00:00Z", "in a day"],
   ])("formats %s with dayjs-compatible relative text", (value, relative) => {
-    const nowMs = Date.parse("2026-02-18T12:00:00Z")
-
     expect(
-      formatWorldBookLastModified(value, { nowMs }).relative
+      formatWorldBookLastModified(value, { nowMs: STABLE_NOW_MS }).relative
+    ).toBe(relative)
+  })
+
+  it.each([
+    [beforeStableNow(89_500), "a minute ago"],
+    [beforeStableNow(90_000), "2 minutes ago"],
+    [beforeStableNow(89.5 * 60_000), "an hour ago"],
+    [beforeStableNow(90 * 60_000), "2 hours ago"],
+    [beforeStableNow(35.5 * 60 * 60_000), "a day ago"],
+    [beforeStableNow(36 * 60 * 60_000), "2 days ago"],
+    [beforeStableNow(540 * 24 * 60 * 60_000), "a year ago"],
+    [beforeStableNow(550 * 24 * 60 * 60_000), "2 years ago"],
+  ])("formats rounding boundary %s as %s", (value, relative) => {
+    expect(
+      formatWorldBookLastModified(value, { nowMs: STABLE_NOW_MS }).relative
     ).toBe(relative)
   })
 
   it("formats absolute timestamps from a stable now", () => {
-    const nowMs = Date.parse("2026-02-18T12:00:00Z")
-
     expect(
-      formatWorldBookLastModified("2026-02-18T09:00:00Z", { nowMs })
+      formatWorldBookLastModified("2026-02-18T09:00:00Z", { nowMs: STABLE_NOW_MS })
     ).toMatchObject({
       absolute: "2026-02-18 09:00:00 UTC",
       timestamp: 1771405200000
@@ -55,7 +70,8 @@ describe("worldBookListUtils", () => {
   it("does not depend on dayjs for display-only relative timestamps", () => {
     const testDir = dirname(fileURLToPath(import.meta.url))
     const source = readFileSync(resolve(testDir, "../worldBookListUtils.ts"), "utf8")
+    const dayjsImportPattern = /^\s*import\s+(?:type\s+)?(?:.+?\s+from\s+)?["']dayjs(?:\/[^"']*)?["']/m
 
-    expect(source).not.toContain("dayjs")
+    expect(source).not.toMatch(dayjsImportPattern)
   })
 })

--- a/apps/packages/ui/src/components/Option/WorldBooks/__tests__/worldBookListUtils.test.ts
+++ b/apps/packages/ui/src/components/Option/WorldBooks/__tests__/worldBookListUtils.test.ts
@@ -1,3 +1,7 @@
+import { readFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
 import { describe, expect, it } from "vitest"
 import {
   formatWorldBookLastModified,
@@ -6,9 +10,11 @@ import {
 } from "../worldBookListUtils"
 
 describe("worldBookListUtils", () => {
-  it("parses string and second-based numeric timestamps", () => {
-    expect(parseWorldBookTimestamp("2026-02-18T09:00:00Z")).toBe(1771405200000)
-    expect(parseWorldBookTimestamp(1771405200)).toBe(1771405200000)
+  it.each([
+    ["2026-02-18T09:00:00Z", 1771405200000],
+    [1771405200, 1771405200000],
+  ])("parses %s as a millisecond timestamp", (value, expected) => {
+    expect(parseWorldBookTimestamp(value)).toBe(expected)
   })
 
   it("returns unknown-safe display values for null/invalid timestamps", () => {
@@ -20,14 +26,36 @@ describe("worldBookListUtils", () => {
     })
   })
 
-  it("formats relative and absolute timestamps from a stable now", () => {
+  it.each([
+    ["2026-02-18T11:59:30Z", "a few seconds ago"],
+    ["2026-02-18T11:59:00Z", "a minute ago"],
+    ["2026-02-18T11:58:00Z", "2 minutes ago"],
+    ["2026-02-18T09:00:00Z", "3 hours ago"],
+    ["2026-02-17T12:00:00Z", "a day ago"],
+    ["2026-02-19T12:00:00Z", "in a day"],
+  ])("formats %s with dayjs-compatible relative text", (value, relative) => {
     const nowMs = Date.parse("2026-02-18T12:00:00Z")
+
+    expect(
+      formatWorldBookLastModified(value, { nowMs }).relative
+    ).toBe(relative)
+  })
+
+  it("formats absolute timestamps from a stable now", () => {
+    const nowMs = Date.parse("2026-02-18T12:00:00Z")
+
     expect(
       formatWorldBookLastModified("2026-02-18T09:00:00Z", { nowMs })
-    ).toEqual({
-      relative: "3 hours ago",
+    ).toMatchObject({
       absolute: "2026-02-18 09:00:00 UTC",
       timestamp: 1771405200000
     })
+  })
+
+  it("does not depend on dayjs for display-only relative timestamps", () => {
+    const testDir = dirname(fileURLToPath(import.meta.url))
+    const source = readFileSync(resolve(testDir, "../worldBookListUtils.ts"), "utf8")
+
+    expect(source).not.toContain("dayjs")
   })
 })

--- a/apps/packages/ui/src/components/Option/WorldBooks/worldBookListUtils.ts
+++ b/apps/packages/ui/src/components/Option/WorldBooks/worldBookListUtils.ts
@@ -1,12 +1,12 @@
-import dayjs from "dayjs"
-import relativeTime from "dayjs/plugin/relativeTime"
-
-dayjs.extend(relativeTime)
-
 export const UNKNOWN_LAST_MODIFIED_LABEL = "Unknown"
 
 const SECONDS_TO_MS = 1000
 const SECOND_TIMESTAMP_CUTOFF = 1_000_000_000_000
+const MINUTES_TO_MS = 60 * SECONDS_TO_MS
+const HOURS_TO_MS = 60 * MINUTES_TO_MS
+const DAYS_TO_MS = 24 * HOURS_TO_MS
+const MONTHS_TO_MS = 30 * DAYS_TO_MS
+const YEARS_TO_MS = 365 * DAYS_TO_MS
 
 export const parseWorldBookTimestamp = (value: unknown): number | null => {
   if (value == null) return null
@@ -32,6 +32,36 @@ const formatUtcTimestamp = (timestamp: number): string =>
     .replace(/\.\d{3}Z$/, " UTC")
     .replace("T", " ")
 
+const formatRelativeTimestamp = (timestamp: number, nowMs: number): string => {
+  const diffMs = timestamp - nowMs
+  const absMs = Math.abs(diffMs)
+  const suffixRelative = (label: string): string =>
+    diffMs > 0 ? `in ${label}` : `${label} ago`
+
+  const seconds = Math.round(absMs / SECONDS_TO_MS)
+  if (seconds < 45) return suffixRelative("a few seconds")
+  if (seconds < 90) return suffixRelative("a minute")
+
+  const minutes = Math.round(absMs / MINUTES_TO_MS)
+  if (minutes < 45) return suffixRelative(`${minutes} minutes`)
+  if (minutes < 90) return suffixRelative("an hour")
+
+  const hours = Math.round(absMs / HOURS_TO_MS)
+  if (hours < 22) return suffixRelative(`${hours} hours`)
+  if (hours < 36) return suffixRelative("a day")
+
+  const days = Math.round(absMs / DAYS_TO_MS)
+  if (days < 26) return suffixRelative(`${days} days`)
+  if (days < 46) return suffixRelative("a month")
+
+  const months = Math.round(absMs / MONTHS_TO_MS)
+  if (months < 11) return suffixRelative(`${months} months`)
+  if (months < 18) return suffixRelative("a year")
+
+  const years = Math.round(absMs / YEARS_TO_MS)
+  return suffixRelative(`${years} years`)
+}
+
 export const formatWorldBookLastModified = (
   value: unknown,
   options?: { nowMs?: number }
@@ -51,7 +81,7 @@ export const formatWorldBookLastModified = (
       : Date.now()
 
   return {
-    relative: dayjs(timestamp).from(dayjs(nowMs)),
+    relative: formatRelativeTimestamp(timestamp, nowMs),
     absolute: formatUtcTimestamp(timestamp),
     timestamp
   }

--- a/apps/packages/ui/src/components/Option/WorldBooks/worldBookListUtils.ts
+++ b/apps/packages/ui/src/components/Option/WorldBooks/worldBookListUtils.ts
@@ -37,29 +37,33 @@ const formatRelativeTimestamp = (timestamp: number, nowMs: number): string => {
   const absMs = Math.abs(diffMs)
   const suffixRelative = (label: string): string =>
     diffMs > 0 ? `in ${label}` : `${label} ago`
+  const unitRelative = (count: number, singular: string, pluralUnit: string): string =>
+    suffixRelative(count === 1 ? singular : `${count} ${pluralUnit}`)
 
-  const seconds = Math.round(absMs / SECONDS_TO_MS)
-  if (seconds < 45) return suffixRelative("a few seconds")
-  if (seconds < 90) return suffixRelative("a minute")
+  if (absMs < 45 * SECONDS_TO_MS) return suffixRelative("a few seconds")
+  if (absMs < 90 * SECONDS_TO_MS) return suffixRelative("a minute")
 
-  const minutes = Math.round(absMs / MINUTES_TO_MS)
-  if (minutes < 45) return suffixRelative(`${minutes} minutes`)
-  if (minutes < 90) return suffixRelative("an hour")
+  if (absMs < 45 * MINUTES_TO_MS) {
+    return unitRelative(Math.round(absMs / MINUTES_TO_MS), "a minute", "minutes")
+  }
+  if (absMs < 90 * MINUTES_TO_MS) return suffixRelative("an hour")
 
-  const hours = Math.round(absMs / HOURS_TO_MS)
-  if (hours < 22) return suffixRelative(`${hours} hours`)
-  if (hours < 36) return suffixRelative("a day")
+  if (absMs < 22 * HOURS_TO_MS) {
+    return unitRelative(Math.round(absMs / HOURS_TO_MS), "an hour", "hours")
+  }
+  if (absMs < 36 * HOURS_TO_MS) return suffixRelative("a day")
 
-  const days = Math.round(absMs / DAYS_TO_MS)
-  if (days < 26) return suffixRelative(`${days} days`)
-  if (days < 46) return suffixRelative("a month")
+  if (absMs < 26 * DAYS_TO_MS) {
+    return unitRelative(Math.round(absMs / DAYS_TO_MS), "a day", "days")
+  }
+  if (absMs < 46 * DAYS_TO_MS) return suffixRelative("a month")
 
   const months = Math.round(absMs / MONTHS_TO_MS)
-  if (months < 11) return suffixRelative(`${months} months`)
+  if (months < 11) return unitRelative(months, "a month", "months")
   if (months < 18) return suffixRelative("a year")
 
   const years = Math.round(absMs / YEARS_TO_MS)
-  return suffixRelative(`${years} years`)
+  return unitRelative(years, "a year", "years")
 }
 
 export const formatWorldBookLastModified = (

--- a/backlog/tasks/task-149 - Remove-dayjs-from-WorldBooks-last-modified-relative-formatting.md
+++ b/backlog/tasks/task-149 - Remove-dayjs-from-WorldBooks-last-modified-relative-formatting.md
@@ -1,0 +1,62 @@
+---
+id: TASK-149
+title: Remove dayjs from WorldBooks last-modified relative formatting
+status: Done
+assignee: []
+created_date: '2026-05-09 04:06'
+updated_date: '2026-05-09 04:15'
+labels:
+  - webui
+  - dependencies
+  - cleanup
+  - dayjs
+  - worldbooks
+dependencies:
+  - TASK-147
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1346'
+  - 'https://github.com/rmusser01/tldw_server/pull/1396'
+  - 'https://github.com/rmusser01/tldw_server/pull/1398'
+documentation:
+  - Docs/Design/WebUI_Dependency_Audit.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue issue #1346 by replacing the display-only dayjs relative-time usage in apps/packages/ui/src/components/Option/WorldBooks/worldBookListUtils.ts with a native/local helper. Keep the existing timestamp parsing and UTC absolute display behavior unchanged, and leave dayjs declared for remaining Flashcards/Models display formatting and Ant Design Dayjs value-contract surfaces.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A focused guard test fails before implementation because worldBookListUtils imports dayjs, then passes after the dependency is removed from that utility.
+- [x] #2 WorldBooks last-modified formatting preserves timestamp parsing, unknown-safe display, UTC absolute formatting, and representative relative-time labels around existing behavior.
+- [x] #3 apps/packages/ui/src/components/Option/WorldBooks/worldBookListUtils.ts no longer imports dayjs or dayjs/plugin/relativeTime.
+- [x] #4 The WebUI dependency audit records the reduced dayjs import count and notes that dayjs remains declared for other display formatting and DatePicker/Dayjs contracts.
+- [x] #5 Focused tests and lint/format checks pass or blockers are documented; Bandit skip rationale is recorded if no Python files change.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the WorldBooks display-only dayjs reduction by replacing dayjs.from(...) usage in apps/packages/ui/src/components/Option/WorldBooks/worldBookListUtils.ts with a local relative-time helper. Added table-driven tests for dayjs-compatible representative labels, preserved UTC absolute formatting coverage, and added a source guard that failed before implementation and passes after removing dayjs imports.
+
+Verification: bunx vitest run src/components/Option/WorldBooks/__tests__/worldBookListUtils.test.ts exited 0 from apps/packages/ui; git diff --check exited 0; bun run lint exited 0 from apps/tldw-frontend with existing unrelated warnings only; rg found no dayjs in worldBookListUtils.ts and 17 remaining shared UI dayjs import lines. Bandit skipped because no Python files changed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Removed dayjs relative-time usage from the WorldBooks last-modified formatter, covered representative relative labels and the no-dayjs source guard with focused Vitest tests, and updated the dependency audit to record the active dayjs import count dropping from 19 to 17 while keeping the remaining Flashcards/Models and DatePicker/Dayjs contract blockers explicit.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-151 - Address-PR-1398-review-comments-on-WorldBooks-relative-time-helper.md
+++ b/backlog/tasks/task-151 - Address-PR-1398-review-comments-on-WorldBooks-relative-time-helper.md
@@ -1,0 +1,59 @@
+---
+id: TASK-151
+title: Address PR 1398 review comments on WorldBooks relative time helper
+status: In Progress
+assignee: []
+created_date: '2026-05-09 04:38'
+updated_date: '2026-05-09 04:48'
+labels:
+  - webui
+  - dependencies
+  - cleanup
+  - dayjs
+  - review-fix
+dependencies:
+  - TASK-149
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1398'
+  - 'https://github.com/rmusser01/tldw_server/pull/1398#discussion_r3212418048'
+  - 'https://github.com/rmusser01/tldw_server/pull/1398#discussion_r3212422167'
+documentation:
+  - Docs/Design/WebUI_Dependency_Audit.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address the actionable Gemini/Qodo review feedback on PR #1398 by preventing singular-unit pluralization at relative-time rounding boundaries and tightening the WorldBooks no-dayjs guard test to detect imports instead of any incidental substring.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Focused tests cover relative-time rounding boundaries that previously produced labels such as 1 minutes ago or 1 hours ago.
+- [x] #2 worldBookListUtils formats singular boundary labels with dayjs-compatible wording for representative seconds, minutes, hours, days, and years cases.
+- [x] #3 The no-dayjs guard detects dayjs import statements instead of any incidental dayjs substring.
+- [x] #4 Focused Vitest and git diff hygiene checks pass; lint result and Bandit skip rationale are recorded if applicable.
+- [ ] #5 The actionable PR review threads are answered and resolved after the fix is pushed.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Notes
+<!-- SECTION:NOTES:BEGIN -->
+TDD red check: focused WorldBooks utility test failed before the production fix with pluralized singular labels including 1 minutes ago, 1 hours ago, 1 days ago, and 1 years ago.
+
+Implemented review fix in worldBookListUtils by keeping dayjs-compatible raw millisecond thresholds for singular boundary ranges and routing counted units through a singular/plural helper.
+
+Tightened the no-dayjs test guard to match dayjs import statements instead of any incidental substring.
+
+Verification: bunx vitest run src/components/Option/WorldBooks/__tests__/worldBookListUtils.test.ts passed with 19 tests; bun run test:worldbooks passed with 62 files, 208 passed, 6 skipped; git diff --check passed; bun run lint in apps/tldw-frontend exited 0 with the existing 131 warnings baseline and no touched-file warnings; Bandit skipped because this review fix only touches TypeScript/test/Backlog files.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## Change summary

This PR removes the `dayjs` relative-time dependency from the WorldBooks last-modified formatter and replaces it with a small local helper. I kept the scope limited to this display-only utility because `dayjs` is still needed in other shared UI areas for Flashcards/Models formatting and Ant Design `Dayjs` value contracts.

The test coverage now locks representative dayjs-compatible labels, UTC absolute formatting, unknown timestamp handling, and a source guard that prevents `dayjs` from being reintroduced into `worldBookListUtils.ts`. The dependency audit is updated to show active shared UI `dayjs` import lines dropping from 19 to 17.

Refs #1346.

## Verification

- Red check: `bunx vitest run src/components/Option/WorldBooks/__tests__/worldBookListUtils.test.ts` first failed on the source guard while `worldBookListUtils.ts` still imported `dayjs`.
- `bunx vitest run src/components/Option/WorldBooks/__tests__/worldBookListUtils.test.ts` from `apps/packages/ui`
- `git diff --check`
- `bun run lint` from `apps/tldw-frontend` exited 0; existing unrelated warnings remain.
- `rg -n "dayjs" apps/packages/ui/src/components/Option/WorldBooks/worldBookListUtils.ts` returned no matches.
- Exact shared UI `dayjs` package-import scan now reports 17 remaining import lines.
- Bandit skipped: no Python files changed.
