### PR TITLE
Adapt Collections StatusBadge to shared Badge

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -5599,17 +5599,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "local-status-badge:src/components/Option/Collections/common/StatusBadge.tsx:StatusBadge",
-    "path": "src/components/Option/Collections/common/StatusBadge.tsx",
-    "rule": "local-status-badge",
-    "subject": "StatusBadge",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing local StatusBadge status wrapper before the guard.",
-    "replacement": "Badge with design-system state registry mapping",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "local-status-badge:src/components/Option/PresentationStudio/PresentationStudioStatusBadge.tsx:PresentationStudioStatusBadge",
     "path": "src/components/Option/PresentationStudio/PresentationStudioStatusBadge.tsx",
     "rule": "local-status-badge",

--- a/apps/packages/ui/src/components/Option/Collections/common/StatusBadge.tsx
+++ b/apps/packages/ui/src/components/Option/Collections/common/StatusBadge.tsx
@@ -61,7 +61,6 @@ export const StatusBadge: React.FC<StatusBadgeProps> = ({
     <Badge
       variant={SEVERITY_BADGE_VARIANTS[state.severity]}
       size={size === "small" ? "sm" : "md"}
-      className={size === "small" ? "py-0 text-xs" : undefined}
     >
       <Icon
         className={size === "small" ? "h-3 w-3" : "h-3.5 w-3.5"}

--- a/apps/packages/ui/src/components/Option/Collections/common/StatusBadge.tsx
+++ b/apps/packages/ui/src/components/Option/Collections/common/StatusBadge.tsx
@@ -1,7 +1,8 @@
 import React from "react"
-import { Tag } from "antd"
-import { Bookmark, BookOpen, CheckCircle, Archive } from "lucide-react"
+import { Bookmark, BookOpen, CheckCircle, Archive, type LucideIcon } from "lucide-react"
 import { useTranslation } from "react-i18next"
+import { getDesignSystemState, type DesignSystemStateKey } from "@/design-system"
+import { Badge, type BadgeVariant } from "@/components/ui/primitives"
 import type { ReadingStatus } from "@/types/collections"
 
 interface StatusBadgeProps {
@@ -11,29 +12,41 @@ interface StatusBadgeProps {
 
 const STATUS_CONFIG: Record<
   ReadingStatus,
-  { color: string; icon: React.ComponentType<{ className?: string }>; labelKey: string }
+  {
+    stateKey: DesignSystemStateKey
+    icon: LucideIcon
+    labelKey: string
+  }
 > = {
   saved: {
-    color: "blue",
+    stateKey: "ready",
     icon: Bookmark,
     labelKey: "saved"
   },
   reading: {
-    color: "orange",
+    stateKey: "retrying",
     icon: BookOpen,
     labelKey: "reading"
   },
   read: {
-    color: "green",
+    stateKey: "ready",
     icon: CheckCircle,
     labelKey: "read"
   },
   archived: {
-    color: "default",
+    stateKey: "empty",
     icon: Archive,
     labelKey: "archived"
   }
 }
+
+const SEVERITY_BADGE_VARIANTS = {
+  success: "success",
+  error: "danger",
+  warning: "warning",
+  info: "info",
+  neutral: "secondary",
+} satisfies Record<ReturnType<typeof getDesignSystemState>["severity"], BadgeVariant>
 
 export const StatusBadge: React.FC<StatusBadgeProps> = ({
   status,
@@ -41,15 +54,21 @@ export const StatusBadge: React.FC<StatusBadgeProps> = ({
 }) => {
   const { t } = useTranslation("collections")
   const config = STATUS_CONFIG[status]
+  const state = getDesignSystemState(config.stateKey)
   const Icon = config.icon
 
   return (
-    <Tag
-      color={config.color}
-      className={`flex items-center gap-1 ${size === "small" ? "text-xs py-0" : ""}`}
+    <Badge
+      variant={SEVERITY_BADGE_VARIANTS[state.severity]}
+      size={size === "small" ? "sm" : "md"}
+      className={size === "small" ? "py-0 text-xs" : undefined}
     >
-      <Icon className={size === "small" ? "h-3 w-3" : "h-3.5 w-3.5"} />
+      <Icon
+        className={size === "small" ? "h-3 w-3" : "h-3.5 w-3.5"}
+        data-testid={`collections-status-icon-${status}`}
+        aria-hidden
+      />
       <span>{t(`status.${config.labelKey}`, config.labelKey)}</span>
-    </Tag>
+    </Badge>
   )
 }

--- a/apps/packages/ui/src/components/Option/Collections/common/__tests__/StatusBadge.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Option/Collections/common/__tests__/StatusBadge.design-system.test.tsx
@@ -28,10 +28,13 @@ describe("Collections StatusBadge design-system adapter", () => {
     }
   )
 
-  it("preserves compact sizing for small badges", () => {
+  it("uses the shared Badge compact sizing for small badges", () => {
     const { container } = render(<StatusBadge status="saved" size="small" />)
     const badge = container.querySelector('[data-ds-component="Badge"]')
 
-    expect(badge).toHaveClass("py-0")
+    expect(badge).toHaveClass("py-0.5")
+    expect(badge).toHaveClass("text-[10px]")
+    expect(badge).not.toHaveClass("py-0")
+    expect(badge).not.toHaveClass("text-xs")
   })
 })

--- a/apps/packages/ui/src/components/Option/Collections/common/__tests__/StatusBadge.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Option/Collections/common/__tests__/StatusBadge.design-system.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { StatusBadge } from "../StatusBadge"
+import type { ReadingStatus } from "@/types/collections"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback: string) => fallback,
+  }),
+}))
+
+describe("Collections StatusBadge design-system adapter", () => {
+  it.each([
+    ["saved", "saved"],
+    ["reading", "reading"],
+    ["read", "read"],
+    ["archived", "archived"],
+  ] satisfies Array<[ReadingStatus, string]>)(
+    "renders the %s status through the shared Badge primitive",
+    (status, label) => {
+      const { container } = render(<StatusBadge status={status} />)
+
+      expect(screen.getByText(label)).toBeInTheDocument()
+      expect(screen.getByTestId(`collections-status-icon-${status}`)).toBeInTheDocument()
+      expect(
+        container.querySelector('[data-ds-component="Badge"]')
+      ).toBeInTheDocument()
+    }
+  )
+
+  it("preserves compact sizing for small badges", () => {
+    const { container } = render(<StatusBadge status="saved" size="small" />)
+    const badge = container.querySelector('[data-ds-component="Badge"]')
+
+    expect(badge).toHaveClass("py-0")
+  })
+})

--- a/backlog/tasks/task-45.22 - Adapt-Collections-StatusBadge-to-shared-Badge.md
+++ b/backlog/tasks/task-45.22 - Adapt-Collections-StatusBadge-to-shared-Badge.md
@@ -4,7 +4,7 @@ title: Adapt Collections StatusBadge to shared Badge
 status: Done
 assignee: []
 created_date: '2026-05-09 04:03'
-updated_date: '2026-05-09 04:11'
+updated_date: '2026-05-09 04:27'
 labels:
   - design-system
   - webui
@@ -49,12 +49,18 @@ Bandit not run: touched implementation and test files are TypeScript/JSON/Backlo
 Post-rebase verification on origin/dev after commit 370706dde: focused StatusBadge test passed 5/5, product-state guard test passed 46/46, design-system verifier passed with local-status-badge still at 7, and git diff --check passed.
 
 Post-rebase TypeScript caveat: bunx tsc --noEmit --pretty false still exits 2 on unrelated existing frontend baseline errors; the rebased output contains no src/components/Option/Collections/common/StatusBadge.tsx errors.
+
+PR review follow-up: Gemini and Qodo both flagged the same sizing issue where StatusBadge passed Badge size="sm" and then overrode the primitive sizing with py-0 text-xs. Reopening the task to remove that override and keep the adapter aligned with the shared Badge size contract.
+
+Review fix verification: updated the focused compact-size test first and confirmed it failed because the small badge still included overriding py-0 text-xs classes. Removed the adapter className override so small badges now rely on Badge size="sm" tokens.
+
+Review fix verification after implementation: focused StatusBadge test passed 5/5, product-state guard test passed 46/46, design-system verifier passed with local-status-badge at 7, and git diff --check passed. bunx tsc --noEmit --pretty false still exits 2 on unrelated existing frontend baseline errors and reports no touched Collections StatusBadge errors.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Adapted Collections StatusBadge to the shared Badge primitive and design-system state registry, added focused regression coverage for labels/icons/shared Badge rendering and compact sizing, and removed the old local-status-badge baseline exception. Full frontend TypeScript remains blocked by unrelated baseline errors; focused tests, guard tests, verifier, and diff checks pass on the rebased branch.
+Adapted Collections StatusBadge to the shared Badge primitive and design-system state registry, added focused regression coverage for labels/icons/shared Badge rendering and compact sizing, removed the old local-status-badge baseline exception, and addressed PR review by relying on Badge size="sm" without overriding its sizing tokens. Full frontend TypeScript remains blocked by unrelated baseline errors; focused tests, guard tests, verifier, and diff checks pass.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.22 - Adapt-Collections-StatusBadge-to-shared-Badge.md
+++ b/backlog/tasks/task-45.22 - Adapt-Collections-StatusBadge-to-shared-Badge.md
@@ -1,0 +1,68 @@
+---
+id: TASK-45.22
+title: Adapt Collections StatusBadge to shared Badge
+status: Done
+assignee: []
+created_date: '2026-05-09 04:03'
+updated_date: '2026-05-09 04:11'
+labels:
+  - design-system
+  - webui
+  - guard
+dependencies: []
+references:
+  - apps/packages/ui/src/components/Option/Collections/common/StatusBadge.tsx
+  - apps/packages/ui/src/components/ui/primitives/Badge.tsx
+  - apps/packages/ui/src/design-system/states.ts
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+parent_task_id: TASK-45
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate the Collections reading-status badge adapter from AntD Tag to the shared design-system Badge primitive with explicit canonical state mapping, then remove its local-status-badge baseline exception.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Collections StatusBadge renders through the shared Badge primitive while preserving reading-status labels, icons, and small/default sizing.
+- [x] #2 Reading statuses map through the design-system state registry before selecting Badge variants.
+- [x] #3 The local-status-badge baseline exception for src/components/Option/Collections/common/StatusBadge.tsx is removed without introducing new unbaselined findings.
+- [x] #4 Focused StatusBadge tests, product-state guard tests, the design-system verifier, and diff checks pass.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the Collections StatusBadge adapter migration: replaced AntD Tag usage with the shared Badge primitive, mapped reading statuses through getDesignSystemState, preserved icon labels and compact sizing, and removed the old local-status-badge baseline exception.
+
+Verification: watched the new focused adapter test fail before implementation because the previous component did not expose the shared Badge marker or icon test ids; after implementation, bunx vitest run src/components/Option/Collections/common/__tests__/StatusBadge.design-system.test.tsx --reporter=dot passed 5/5 tests.
+
+Verification: bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed 46/46 tests; bun run verify:design-system-state passed and reports 513 baseline exceptions with local-status-badge reduced to 7; git diff --check passed.
+
+Verification caveat: bunx tsc --noEmit --pretty false still exits 2 on the existing frontend TypeScript baseline, but the latest output contains no errors for src/components/Option/Collections/common/StatusBadge.tsx or its new focused test.
+
+Bandit not run: touched implementation and test files are TypeScript/JSON/Backlog task metadata only, so the Python security scanner is not applicable to this slice.
+
+Post-rebase verification on origin/dev after commit 370706dde: focused StatusBadge test passed 5/5, product-state guard test passed 46/46, design-system verifier passed with local-status-badge still at 7, and git diff --check passed.
+
+Post-rebase TypeScript caveat: bunx tsc --noEmit --pretty false still exits 2 on unrelated existing frontend baseline errors; the rebased output contains no src/components/Option/Collections/common/StatusBadge.tsx errors.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Adapted Collections StatusBadge to the shared Badge primitive and design-system state registry, added focused regression coverage for labels/icons/shared Badge rendering and compact sizing, and removed the old local-status-badge baseline exception. Full frontend TypeScript remains blocked by unrelated baseline errors; focused tests, guard tests, verifier, and diff checks pass on the rebased branch.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Replace the Collections reading-status AntD Tag adapter with the shared Badge primitive.
- Map reading statuses through getDesignSystemState before selecting Badge variants.
- Add focused coverage for labels, icons, shared Badge rendering, compact sizing, and remove the local-status-badge baseline exception.

## Verification
- bunx vitest run src/components/Option/Collections/common/__tests__/StatusBadge.design-system.test.tsx --reporter=dot
- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot
- bun run verify:design-system-state
- git diff --check
- bunx tsc --noEmit --pretty false exits 2 on the existing frontend baseline; no errors are from src/components/Option/Collections/common/StatusBadge.tsx or the new focused test.

## Change summary
This migrates the Collections status wrapper onto the canonical Badge and state registry without broadening the design-system slice. The status-specific labels and icons remain local domain presentation, while severity and Badge styling now come from the shared product-state path so the guard can remove one more local-status-badge exception.