### PR TITLE
Add VN Play recovery controls

### DIFF
--- a/apps/tldw-frontend/__tests__/vn-play/VNPlayWorkspace.test.tsx
+++ b/apps/tldw-frontend/__tests__/vn-play/VNPlayWorkspace.test.tsx
@@ -1,29 +1,49 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import type { VNPlaySession } from '@web/types/vn-play';
+import type { VNPlayBranch, VNPlayCheckpoint, VNPlaySession } from '@web/types/vn-play';
 
 const mocks = vi.hoisted(() => ({
+  createVNPlayCheckpoint: vi.fn(),
   createVNPlaySession: vi.fn(),
   getVNPlaySession: vi.fn(),
+  listVNPlayBranches: vi.fn(),
+  listVNPlayCheckpoints: vi.fn(),
   listVNPlayEvents: vi.fn(),
   listVNPlaySessions: vi.fn(),
+  restoreVNPlaySession: vi.fn(),
+  retryLastVNPlayTurn: vi.fn(),
   submitVNPlayTurn: vi.fn(),
 }));
 
 vi.mock('@web/lib/api/vnPlay', () => ({
+  createVNPlayCheckpoint: (...args: unknown[]) => mocks.createVNPlayCheckpoint(...args),
   createVNPlaySession: (...args: unknown[]) => mocks.createVNPlaySession(...args),
   getVNPlaySession: (...args: unknown[]) => mocks.getVNPlaySession(...args),
+  listVNPlayBranches: (...args: unknown[]) => mocks.listVNPlayBranches(...args),
+  listVNPlayCheckpoints: (...args: unknown[]) => mocks.listVNPlayCheckpoints(...args),
   listVNPlayEvents: (...args: unknown[]) => mocks.listVNPlayEvents(...args),
   listVNPlaySessions: (...args: unknown[]) => mocks.listVNPlaySessions(...args),
+  restoreVNPlaySession: (...args: unknown[]) => mocks.restoreVNPlaySession(...args),
+  retryLastVNPlayTurn: (...args: unknown[]) => mocks.retryLastVNPlayTurn(...args),
   submitVNPlayTurn: (...args: unknown[]) => mocks.submitVNPlayTurn(...args),
 }));
 
 import VNPlayWorkspace from '@web/components/vn-play/VNPlayWorkspace';
 
-function mockVNPlayApi({ sessions = [] }: { sessions?: VNPlaySession[] } = {}) {
+function mockVNPlayApi({
+  branches = [],
+  checkpoints = [],
+  sessions = [],
+}: {
+  branches?: VNPlayBranch[];
+  checkpoints?: VNPlayCheckpoint[];
+  sessions?: VNPlaySession[];
+} = {}) {
   mocks.listVNPlaySessions.mockResolvedValue(sessions);
   mocks.listVNPlayEvents.mockResolvedValue([]);
+  mocks.listVNPlayCheckpoints.mockResolvedValue(checkpoints);
+  mocks.listVNPlayBranches.mockResolvedValue(branches);
   mocks.getVNPlaySession.mockImplementation(async (sessionId: number) =>
     sessions.find((session) => session.id === sessionId) ?? sessions[0]
   );
@@ -55,6 +75,23 @@ function mockVNPlayApi({ sessions = [] }: { sessions?: VNPlaySession[] } = {}) {
         source: 'model',
       },
     ],
+  });
+  mocks.createVNPlayCheckpoint.mockImplementation(async (_sessionId: number, request) => ({
+    id: 7,
+    session_id: _sessionId,
+    owner_user_id: 42,
+    label: request.label,
+    scene_version: request.scene_version ?? 0,
+  }));
+  mocks.restoreVNPlaySession.mockImplementation(async (sessionId: number) =>
+    sessions.find((session) => session.id === sessionId) ?? sessions[0]
+  );
+  mocks.retryLastVNPlayTurn.mockResolvedValue({
+    turn_request_id: 11,
+    status: 'completed',
+    scene_version: 2,
+    scene_state: { scene_version: 2 },
+    events: [],
   });
 }
 
@@ -148,5 +185,173 @@ describe('VNPlayWorkspace', () => {
       }));
     });
     expect(await screen.findByText('A quiet reply.')).toBeInTheDocument();
+  });
+
+  it('loads checkpoints and branches for the selected session', async () => {
+    const session: VNPlaySession = {
+      id: 1,
+      mode: 'story',
+      title: 'Archive Door',
+      primary_character_id: 1,
+      vn_asset_pack_id: 2,
+      scene_version: 3,
+      scene_state: { scene_version: 3 },
+    };
+    mockVNPlayApi({
+      branches: [
+        {
+          id: 4,
+          session_id: 1,
+          owner_user_id: 42,
+          branch_label: 'Door branch',
+          status: 'active',
+        },
+      ],
+      checkpoints: [
+        {
+          id: 5,
+          session_id: 1,
+          owner_user_id: 42,
+          label: 'Before the door',
+          scene_version: 2,
+        },
+      ],
+      sessions: [session],
+    });
+
+    render(<VNPlayWorkspace />);
+
+    expect(await screen.findByText('Before the door')).toBeInTheDocument();
+    expect(screen.getByText('Door branch')).toBeInTheDocument();
+    expect(mocks.listVNPlayCheckpoints).toHaveBeenCalledWith(1);
+    expect(mocks.listVNPlayBranches).toHaveBeenCalledWith(1);
+  });
+
+  it('creates a checkpoint and refreshes recovery metadata', async () => {
+    const user = userEvent.setup();
+    const session: VNPlaySession = {
+      id: 1,
+      mode: 'freeform',
+      title: 'Library',
+      primary_character_id: 1,
+      vn_asset_pack_id: 2,
+      scene_version: 4,
+      scene_state: { scene_version: 4 },
+    };
+    mockVNPlayApi({ sessions: [session] });
+    mocks.listVNPlayCheckpoints
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          id: 9,
+          session_id: 1,
+          owner_user_id: 42,
+          label: 'Before choosing',
+          scene_version: 4,
+        },
+      ]);
+
+    render(<VNPlayWorkspace />);
+
+    await user.type(await screen.findByLabelText('Checkpoint label'), 'Before choosing');
+    await user.click(screen.getByRole('button', { name: 'Create checkpoint' }));
+
+    await waitFor(() => {
+      expect(mocks.createVNPlayCheckpoint).toHaveBeenCalledWith(1, {
+        label: 'Before choosing',
+        scene_version: 4,
+      });
+    });
+    expect(await screen.findByText('Before choosing')).toBeInTheDocument();
+  });
+
+  it('restores a checkpoint and refreshes the selected session', async () => {
+    const user = userEvent.setup();
+    const restoredSession: VNPlaySession = {
+      id: 1,
+      mode: 'story',
+      title: 'Archive Door',
+      primary_character_id: 1,
+      vn_asset_pack_id: 2,
+      scene_version: 2,
+      scene_state: { scene_version: 2 },
+    };
+    mockVNPlayApi({
+      checkpoints: [
+        {
+          id: 5,
+          session_id: 1,
+          owner_user_id: 42,
+          label: 'Before the door',
+          scene_version: 2,
+        },
+      ],
+      sessions: [restoredSession],
+    });
+    mocks.restoreVNPlaySession.mockResolvedValue(restoredSession);
+
+    render(<VNPlayWorkspace />);
+
+    await user.click(await screen.findByRole('button', { name: /restore checkpoint: before the door/i }));
+
+    await waitFor(() => {
+      expect(mocks.restoreVNPlaySession).toHaveBeenCalledWith(1, expect.objectContaining({
+        checkpoint_id: 5,
+        idempotency_key: expect.stringMatching(/^restore-/),
+      }));
+    });
+    expect(await screen.findByText('Scene version')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+
+  it('retries the last failed turn with a fresh idempotency key', async () => {
+    const user = userEvent.setup();
+    const session: VNPlaySession = {
+      id: 1,
+      mode: 'freeform',
+      title: 'Library',
+      primary_character_id: 1,
+      vn_asset_pack_id: 2,
+      scene_version: 0,
+      scene_state: { scene_version: 0 },
+    };
+    mockVNPlayApi({ sessions: [session] });
+    mocks.submitVNPlayTurn.mockRejectedValueOnce(Object.assign(new Error('parse_failed'), { status: 502 }));
+
+    render(<VNPlayWorkspace />);
+
+    await user.type(await screen.findByLabelText('Freeform input'), 'Look around');
+    await user.click(screen.getByRole('button', { name: 'Send turn' }));
+    await user.click(await screen.findByRole('button', { name: /retry last turn/i }));
+
+    await waitFor(() => {
+      expect(mocks.retryLastVNPlayTurn).toHaveBeenCalledWith(1, expect.objectContaining({
+        client_scene_version: 0,
+        idempotency_key: expect.stringMatching(/^retry-/),
+      }));
+    });
+  });
+
+  it('shows explicit recovery copy for stale scene conflicts', async () => {
+    const user = userEvent.setup();
+    const session: VNPlaySession = {
+      id: 1,
+      mode: 'freeform',
+      title: 'Library',
+      primary_character_id: 1,
+      vn_asset_pack_id: 2,
+      scene_version: 0,
+      scene_state: { scene_version: 0 },
+    };
+    mockVNPlayApi({ sessions: [session] });
+    mocks.submitVNPlayTurn.mockRejectedValueOnce(Object.assign(new Error('stale_scene_version'), { status: 409 }));
+
+    render(<VNPlayWorkspace />);
+
+    await user.type(await screen.findByLabelText('Freeform input'), 'Look around');
+    await user.click(screen.getByRole('button', { name: 'Send turn' }));
+
+    expect(await screen.findByText(/scene changed on another client/i)).toBeInTheDocument();
+    expect(screen.queryByText('stale_scene_version')).not.toBeInTheDocument();
   });
 });

--- a/apps/tldw-frontend/__tests__/vn-play/VNPlayWorkspace.test.tsx
+++ b/apps/tldw-frontend/__tests__/vn-play/VNPlayWorkspace.test.tsx
@@ -300,6 +300,7 @@ describe('VNPlayWorkspace', () => {
         idempotency_key: expect.stringMatching(/^restore-/),
       }));
     });
+    expect(mocks.getVNPlaySession).not.toHaveBeenCalled();
     expect(await screen.findByText('Scene version')).toBeInTheDocument();
     expect(screen.getByText('2')).toBeInTheDocument();
   });

--- a/apps/tldw-frontend/__tests__/vn-play/vnPlayRuntime.test.ts
+++ b/apps/tldw-frontend/__tests__/vn-play/vnPlayRuntime.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createVNPlayIdempotencyKey,
+  getVNPlayErrorInfo,
+  isRecoverableVNPlayConflict,
+} from '@web/components/vn-play/runtime';
+
+describe('VN Play runtime helpers', () => {
+  it('creates prefixed idempotency keys with random UUIDs when available', () => {
+    const originalCrypto = globalThis.crypto;
+    vi.stubGlobal('crypto', { randomUUID: () => 'uuid-1' });
+
+    expect(createVNPlayIdempotencyKey('retry')).toBe('retry-uuid-1');
+
+    vi.stubGlobal('crypto', originalCrypto);
+  });
+
+  it('extracts structured API error details without [object Object] fallback text', () => {
+    const info = getVNPlayErrorInfo({
+      status: 409,
+      detail: {
+        error_code: 'stale_scene_version',
+        message: 'Scene version is stale',
+      },
+    });
+
+    expect(info).toEqual({
+      code: 'stale_scene_version',
+      message: 'Scene version is stale',
+      status: 409,
+    });
+    expect(info.message).not.toBe('[object Object]');
+  });
+
+  it('recognizes recoverable stale and in-progress turn conflicts by code', () => {
+    expect(isRecoverableVNPlayConflict({ status: 400, error_code: 'turn_in_progress' })).toBe(true);
+    expect(isRecoverableVNPlayConflict({ status: 400, detail: { code: 'stale_scene_version' } })).toBe(true);
+    expect(isRecoverableVNPlayConflict(new Error('parse_failed'))).toBe(false);
+  });
+});

--- a/apps/tldw-frontend/components/vn-play/ChoicePanel.tsx
+++ b/apps/tldw-frontend/components/vn-play/ChoicePanel.tsx
@@ -1,6 +1,11 @@
 import React, { FormEvent, useState } from 'react';
 import { Button } from '@web/components/ui/Button';
 import { Input } from '@web/components/ui/Input';
+import {
+  createVNPlayIdempotencyKey,
+  getVNPlayErrorInfo,
+  isRecoverableVNPlayConflict,
+} from '@web/components/vn-play/runtime';
 import { submitVNPlayTurn } from '@web/lib/api/vnPlay';
 import type { VNPlayChoice, VNPlayTurnResponse } from '@web/types/vn-play';
 
@@ -10,11 +15,6 @@ export interface ChoicePanelProps {
   sessionId: number;
   onError?: (error: unknown) => void;
   onTurn: (response: VNPlayTurnResponse) => void;
-}
-
-function idempotencyKey(prefix: string): string {
-  const uuid = globalThis.crypto?.randomUUID?.();
-  return `${prefix}-${uuid ?? `${Date.now()}-${Math.random().toString(36).slice(2)}`}`;
 }
 
 export default function ChoicePanel({
@@ -36,11 +36,12 @@ export default function ChoicePanel({
       const response = await submitVNPlayTurn(sessionId, {
         choice_id: choiceId,
         client_scene_version: sceneVersion,
-        idempotency_key: idempotencyKey('choice'),
+        idempotency_key: createVNPlayIdempotencyKey('choice'),
       });
       onTurn(response);
     } catch (turnError) {
-      setError(turnError instanceof Error ? turnError.message : 'Failed to submit choice');
+      const errorInfo = getVNPlayErrorInfo(turnError);
+      setError(isRecoverableVNPlayConflict(turnError) ? null : errorInfo.message);
       onError?.(turnError);
     } finally {
       setSubmittingChoiceId(null);
@@ -58,12 +59,13 @@ export default function ChoicePanel({
       const response = await submitVNPlayTurn(sessionId, {
         custom_action: { text },
         client_scene_version: sceneVersion,
-        idempotency_key: idempotencyKey('action'),
+        idempotency_key: createVNPlayIdempotencyKey('action'),
       });
       setCustomAction('');
       onTurn(response);
     } catch (turnError) {
-      setError(turnError instanceof Error ? turnError.message : 'Failed to submit action');
+      const errorInfo = getVNPlayErrorInfo(turnError);
+      setError(isRecoverableVNPlayConflict(turnError) ? null : errorInfo.message);
       onError?.(turnError);
     } finally {
       setIsSubmittingAction(false);

--- a/apps/tldw-frontend/components/vn-play/DialoguePanel.tsx
+++ b/apps/tldw-frontend/components/vn-play/DialoguePanel.tsx
@@ -1,6 +1,11 @@
 import React, { FormEvent, useMemo, useState } from 'react';
 import { Button } from '@web/components/ui/Button';
 import { Input } from '@web/components/ui/Input';
+import {
+  createVNPlayIdempotencyKey,
+  getVNPlayErrorInfo,
+  isRecoverableVNPlayConflict,
+} from '@web/components/vn-play/runtime';
 import { submitVNPlayTurn } from '@web/lib/api/vnPlay';
 import type { VNPlayEvent, VNPlayMode, VNPlayTurnResponse } from '@web/types/vn-play';
 
@@ -16,11 +21,6 @@ export interface DialoguePanelProps {
 interface DialogueLine {
   speaker: string;
   text: string;
-}
-
-function idempotencyKey(prefix: string): string {
-  const uuid = globalThis.crypto?.randomUUID?.();
-  return `${prefix}-${uuid ?? `${Date.now()}-${Math.random().toString(36).slice(2)}`}`;
 }
 
 function latestDialogue(events: VNPlayEvent[]): DialogueLine[] {
@@ -70,17 +70,13 @@ export default function DialoguePanel({
       const response = await submitVNPlayTurn(sessionId, {
         input_text: trimmed,
         client_scene_version: sceneVersion,
-        idempotency_key: idempotencyKey('freeform'),
+        idempotency_key: createVNPlayIdempotencyKey('freeform'),
       });
       setInputText('');
       onTurn(response);
     } catch (turnError) {
-      const status = typeof turnError === 'object' && turnError !== null && 'status' in turnError
-        ? Number((turnError as { status?: number }).status)
-        : undefined;
-      const detail = turnError instanceof Error ? turnError.message : String(turnError);
-      const isRecoverableConflict = status === 409 || /stale_scene_version|turn_in_progress/i.test(detail);
-      setError(isRecoverableConflict ? null : detail || 'Failed to submit turn');
+      const errorInfo = getVNPlayErrorInfo(turnError);
+      setError(isRecoverableVNPlayConflict(turnError) ? null : errorInfo.message);
       onError?.(turnError);
     } finally {
       setIsSubmitting(false);

--- a/apps/tldw-frontend/components/vn-play/DialoguePanel.tsx
+++ b/apps/tldw-frontend/components/vn-play/DialoguePanel.tsx
@@ -75,7 +75,12 @@ export default function DialoguePanel({
       setInputText('');
       onTurn(response);
     } catch (turnError) {
-      setError(turnError instanceof Error ? turnError.message : 'Failed to submit turn');
+      const status = typeof turnError === 'object' && turnError !== null && 'status' in turnError
+        ? Number((turnError as { status?: number }).status)
+        : undefined;
+      const detail = turnError instanceof Error ? turnError.message : String(turnError);
+      const isRecoverableConflict = status === 409 || /stale_scene_version|turn_in_progress/i.test(detail);
+      setError(isRecoverableConflict ? null : detail || 'Failed to submit turn');
       onError?.(turnError);
     } finally {
       setIsSubmitting(false);

--- a/apps/tldw-frontend/components/vn-play/SceneInspector.tsx
+++ b/apps/tldw-frontend/components/vn-play/SceneInspector.tsx
@@ -1,21 +1,42 @@
-import React from 'react';
+import React, { FormEvent, useState } from 'react';
+import { BookmarkPlus, RotateCcw } from 'lucide-react';
+import { Button } from '@web/components/ui/Button';
+import { Input } from '@web/components/ui/Input';
 import type { VNPlayBranch, VNPlayCheckpoint, VNPlaySceneState, VNPlaySession } from '@web/types/vn-play';
 
 export interface SceneInspectorProps {
   branches?: VNPlayBranch[];
   checkpoints?: VNPlayCheckpoint[];
+  isCreatingCheckpoint?: boolean;
+  restoringCheckpointId?: number | null;
   sceneState: VNPlaySceneState;
   session: VNPlaySession;
+  onCreateCheckpoint?: (label: string) => void | Promise<void>;
+  onRestoreCheckpoint?: (checkpointId: number) => void | Promise<void>;
 }
 
 export default function SceneInspector({
   branches = [],
   checkpoints = [],
+  isCreatingCheckpoint = false,
+  restoringCheckpointId = null,
   sceneState,
   session,
+  onCreateCheckpoint,
+  onRestoreCheckpoint,
 }: SceneInspectorProps) {
+  const [checkpointLabel, setCheckpointLabel] = useState('');
   const sceneVersion = sceneState.scene_version ?? session.scene_version ?? 0;
   const warningCount = sceneState.warnings?.length ?? 0;
+
+  const submitCheckpoint = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const label = checkpointLabel.trim();
+    if (!label || !onCreateCheckpoint) return;
+    void Promise.resolve(onCreateCheckpoint(label))
+      .then(() => setCheckpointLabel(''))
+      .catch(() => undefined);
+  };
 
   return (
     <aside className="rounded-md border border-border bg-surface p-4">
@@ -50,6 +71,78 @@ export default function SceneInspector({
           <dd className="font-medium">{checkpoints.length}</dd>
         </div>
       </dl>
+
+      <section className="mt-5 border-t border-border pt-4">
+        <h3 className="mb-3 text-sm font-semibold uppercase tracking-normal text-text-muted">
+          Checkpoints
+        </h3>
+        {onCreateCheckpoint && (
+          <form className="grid gap-2" onSubmit={submitCheckpoint}>
+            <Input
+              label="Checkpoint label"
+              value={checkpointLabel}
+              onChange={(event) => setCheckpointLabel(event.target.value)}
+            />
+            <Button
+              className="gap-2"
+              disabled={!checkpointLabel.trim()}
+              loading={isCreatingCheckpoint}
+              type="submit"
+            >
+              <BookmarkPlus aria-hidden className="h-4 w-4" />
+              Create checkpoint
+            </Button>
+          </form>
+        )}
+        {checkpoints.length > 0 ? (
+          <ul className="mt-3 grid gap-2">
+            {checkpoints.map((checkpoint) => (
+              <li key={checkpoint.id} className="rounded-md border border-border bg-bg p-2 text-sm">
+                <div className="flex items-start justify-between gap-2">
+                  <div>
+                    <p className="font-medium">{checkpoint.label}</p>
+                    <p className="text-xs text-text-muted">Scene {checkpoint.scene_version}</p>
+                  </div>
+                  {onRestoreCheckpoint && (
+                    <Button
+                      aria-label={`Restore checkpoint: ${checkpoint.label}`}
+                      className="gap-1"
+                      loading={restoringCheckpointId === checkpoint.id}
+                      onClick={() => void onRestoreCheckpoint(checkpoint.id)}
+                      size="xs"
+                      type="button"
+                      variant="secondary"
+                    >
+                      <RotateCcw aria-hidden className="h-3.5 w-3.5" />
+                      Restore
+                    </Button>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="mt-3 text-sm text-text-muted">No checkpoints.</p>
+        )}
+      </section>
+
+      <section className="mt-5 border-t border-border pt-4">
+        <h3 className="mb-3 text-sm font-semibold uppercase tracking-normal text-text-muted">
+          Branches
+        </h3>
+        {branches.length > 0 ? (
+          <ul className="grid gap-2">
+            {branches.map((branch) => (
+              <li key={branch.id} className="rounded-md border border-border bg-bg p-2 text-sm">
+                <p className="font-medium">{branch.branch_label || `Branch ${branch.id}`}</p>
+                <p className="text-xs text-text-muted">{branch.status || 'unknown'}</p>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-sm text-text-muted">No branches.</p>
+        )}
+      </section>
     </aside>
   );
 }

--- a/apps/tldw-frontend/components/vn-play/VNPlayWorkspace.tsx
+++ b/apps/tldw-frontend/components/vn-play/VNPlayWorkspace.tsx
@@ -5,6 +5,11 @@ import { Button } from '@web/components/ui/Button';
 import ChoicePanel from '@web/components/vn-play/ChoicePanel';
 import DialoguePanel from '@web/components/vn-play/DialoguePanel';
 import NewSessionDialog from '@web/components/vn-play/NewSessionDialog';
+import {
+  createVNPlayIdempotencyKey,
+  getVNPlayErrorInfo,
+  isRecoverableVNPlayConflict,
+} from '@web/components/vn-play/runtime';
 import SceneInspector from '@web/components/vn-play/SceneInspector';
 import SceneStage from '@web/components/vn-play/SceneStage';
 import SessionList, { VNPlayModeFilter } from '@web/components/vn-play/SessionList';
@@ -42,11 +47,6 @@ function isVNPlayChoice(choice: VNPlayChoice | Record<string, unknown>): choice 
     typeof choice.id === 'string' &&
     typeof choice.text === 'string'
   );
-}
-
-function idempotencyKey(prefix: string): string {
-  const uuid = globalThis.crypto?.randomUUID?.();
-  return `${prefix}-${uuid ?? `${Date.now()}-${Math.random().toString(36).slice(2)}`}`;
 }
 
 function recoveryCopy(status: string | null): string | null {
@@ -172,22 +172,26 @@ export default function VNPlayWorkspace() {
     }
   }, []);
 
-  const reloadSelectedSession = useCallback(async (sessionId: number) => {
-    const [nextSession, nextEvents, nextCheckpoints, nextBranches] = await Promise.all([
-      getVNPlaySession(sessionId),
+  const reloadSessionCollections = useCallback(async (sessionId: number) => {
+    const [nextEvents, nextCheckpoints, nextBranches] = await Promise.all([
       listVNPlayEvents(sessionId),
       listVNPlayCheckpoints(sessionId),
       listVNPlayBranches(sessionId),
     ]);
+    setEvents(nextEvents);
+    setCheckpoints(nextCheckpoints);
+    setBranches(nextBranches);
+  }, []);
+
+  const reloadSelectedSession = useCallback(async (sessionId: number) => {
+    const nextSession = await getVNPlaySession(sessionId);
     setSelectedSession(nextSession);
     setSessions((previous) =>
       previous.map((session) => (session.id === nextSession.id ? nextSession : session))
     );
-    setEvents(nextEvents);
-    setCheckpoints(nextCheckpoints);
-    setBranches(nextBranches);
+    await reloadSessionCollections(sessionId);
     return nextSession;
-  }, []);
+  }, [reloadSessionCollections]);
 
   const handleTurn = useCallback(async (response: VNPlayTurnResponse) => {
     if (!selectedSession) return;
@@ -256,25 +260,26 @@ export default function VNPlayWorkspace() {
   }, [reloadSelectedSession, selectedSession]);
 
   const handleTurnError = useCallback(async (turnError: unknown) => {
-    const status = typeof turnError === 'object' && turnError !== null && 'status' in turnError
-      ? Number((turnError as { status?: number }).status)
-      : undefined;
-    const detail = turnError instanceof Error ? turnError.message : String(turnError);
-    const isConflict = status === 409 || /stale_scene_version|turn_in_progress/i.test(detail);
+    const errorInfo = getVNPlayErrorInfo(turnError);
+    const isConflict = isRecoverableVNPlayConflict(turnError);
 
     if (isConflict && selectedSession) {
-      setTurnStatus(/turn_in_progress/i.test(detail) ? 'turn_in_progress' : 'stale_scene_version');
+      setTurnStatus(
+        errorInfo.code === 'turn_in_progress' || /turn_in_progress/i.test(errorInfo.message)
+          ? 'turn_in_progress'
+          : 'stale_scene_version'
+      );
       setError(null);
       try {
         await reloadSelectedSession(selectedSession.id);
       } catch {
-        setError(detail);
+        setError(errorInfo.message);
       }
       return;
     }
 
     setTurnStatus('turn_failed');
-    setError(detail);
+    setError(errorInfo.message);
   }, [reloadSelectedSession, selectedSession]);
 
   const selectedMode = selectedSession ? sessionModeLabel(selectedSession.mode) : null;
@@ -290,14 +295,9 @@ export default function VNPlayWorkspace() {
     setIsCreatingCheckpoint(true);
     setError(null);
     try {
-      const currentSceneVersion =
-        selectedSession.scene_state?.scene_version ??
-        selectedSession.current_scene?.scene_version ??
-        selectedSession.scene_version ??
-        0;
       await createVNPlayCheckpoint(selectedSession.id, {
         label,
-        scene_version: currentSceneVersion,
+        scene_version: sceneVersion,
       });
       await reloadSelectedSession(selectedSession.id);
     } catch (checkpointError) {
@@ -305,7 +305,7 @@ export default function VNPlayWorkspace() {
     } finally {
       setIsCreatingCheckpoint(false);
     }
-  }, [reloadSelectedSession, selectedSession]);
+  }, [reloadSelectedSession, sceneVersion, selectedSession]);
 
   const handleRestoreCheckpoint = useCallback(async (checkpointId: number) => {
     if (!selectedSession) return;
@@ -315,19 +315,19 @@ export default function VNPlayWorkspace() {
     try {
       const restored = await restoreVNPlaySession(selectedSession.id, {
         checkpoint_id: checkpointId,
-        idempotency_key: idempotencyKey('restore'),
+        idempotency_key: createVNPlayIdempotencyKey('restore'),
       });
       setSelectedSession(restored);
       setSessions((previous) =>
         previous.map((session) => (session.id === restored.id ? restored : session))
       );
-      await reloadSelectedSession(selectedSession.id);
+      await reloadSessionCollections(selectedSession.id);
     } catch (restoreError) {
       setError(restoreError instanceof Error ? restoreError.message : 'Failed to restore checkpoint');
     } finally {
       setRestoringCheckpointId(null);
     }
-  }, [reloadSelectedSession, selectedSession]);
+  }, [reloadSessionCollections, selectedSession]);
 
   const handleRetryLastTurn = useCallback(async () => {
     if (!selectedSession) return;
@@ -335,14 +335,9 @@ export default function VNPlayWorkspace() {
     setIsRetryingTurn(true);
     setError(null);
     try {
-      const currentSceneVersion =
-        selectedSession.scene_state?.scene_version ??
-        selectedSession.current_scene?.scene_version ??
-        selectedSession.scene_version ??
-        0;
       const response = await retryLastVNPlayTurn(selectedSession.id, {
-        client_scene_version: currentSceneVersion,
-        idempotency_key: idempotencyKey('retry'),
+        client_scene_version: sceneVersion,
+        idempotency_key: createVNPlayIdempotencyKey('retry'),
       });
       await handleTurn(response);
     } catch (retryError) {
@@ -350,7 +345,7 @@ export default function VNPlayWorkspace() {
     } finally {
       setIsRetryingTurn(false);
     }
-  }, [handleTurn, selectedSession]);
+  }, [handleTurn, sceneVersion, selectedSession]);
 
   return (
     <main className="min-h-screen bg-bg text-text">

--- a/apps/tldw-frontend/components/vn-play/VNPlayWorkspace.tsx
+++ b/apps/tldw-frontend/components/vn-play/VNPlayWorkspace.tsx
@@ -9,12 +9,19 @@ import SceneInspector from '@web/components/vn-play/SceneInspector';
 import SceneStage from '@web/components/vn-play/SceneStage';
 import SessionList, { VNPlayModeFilter } from '@web/components/vn-play/SessionList';
 import {
+  createVNPlayCheckpoint,
   createVNPlaySession,
   getVNPlaySession,
+  listVNPlayBranches,
+  listVNPlayCheckpoints,
   listVNPlayEvents,
   listVNPlaySessions,
+  restoreVNPlaySession,
+  retryLastVNPlayTurn,
 } from '@web/lib/api/vnPlay';
 import type {
+  VNPlayBranch,
+  VNPlayCheckpoint,
   VNPlayChoice,
   VNPlayEvent,
   VNPlayMode,
@@ -37,15 +44,38 @@ function isVNPlayChoice(choice: VNPlayChoice | Record<string, unknown>): choice 
   );
 }
 
+function idempotencyKey(prefix: string): string {
+  const uuid = globalThis.crypto?.randomUUID?.();
+  return `${prefix}-${uuid ?? `${Date.now()}-${Math.random().toString(36).slice(2)}`}`;
+}
+
+function recoveryCopy(status: string | null): string | null {
+  if (status === 'stale_scene_version') {
+    return 'Scene changed on another client. The latest state was reloaded before you continue.';
+  }
+  if (status === 'turn_in_progress') {
+    return 'A turn is already in progress for this session. Wait for it to finish, then reload if needed.';
+  }
+  if (status === 'turn_failed') {
+    return 'The last turn failed before completion. You can retry the stored turn request without duplicating the user input.';
+  }
+  return null;
+}
+
 export default function VNPlayWorkspace() {
   const [sessions, setSessions] = useState<VNPlaySession[]>([]);
   const [selectedSession, setSelectedSession] = useState<VNPlaySession | null>(null);
   const [events, setEvents] = useState<VNPlayEvent[]>([]);
+  const [checkpoints, setCheckpoints] = useState<VNPlayCheckpoint[]>([]);
+  const [branches, setBranches] = useState<VNPlayBranch[]>([]);
   const [modeFilter, setModeFilter] = useState<VNPlayModeFilter>('all');
   const [dialogMode, setDialogMode] = useState<VNPlayMode>('freeform');
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [isCreating, setIsCreating] = useState(false);
+  const [isCreatingCheckpoint, setIsCreatingCheckpoint] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
+  const [isRetryingTurn, setIsRetryingTurn] = useState(false);
+  const [restoringCheckpointId, setRestoringCheckpointId] = useState<number | null>(null);
   const [turnStatus, setTurnStatus] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -80,24 +110,34 @@ export default function VNPlayWorkspace() {
   useEffect(() => {
     if (!selectedSession) {
       setEvents([]);
+      setCheckpoints([]);
+      setBranches([]);
       return;
     }
 
     let cancelled = false;
-    async function loadEvents() {
+    async function loadSessionCollections() {
       try {
-        const nextEvents = await listVNPlayEvents(selectedSession.id);
+        const [nextEvents, nextCheckpoints, nextBranches] = await Promise.all([
+          listVNPlayEvents(selectedSession.id),
+          listVNPlayCheckpoints(selectedSession.id),
+          listVNPlayBranches(selectedSession.id),
+        ]);
         if (!cancelled) {
           setEvents(nextEvents);
+          setCheckpoints(nextCheckpoints);
+          setBranches(nextBranches);
         }
       } catch {
         if (!cancelled) {
           setEvents([]);
+          setCheckpoints([]);
+          setBranches([]);
         }
       }
     }
 
-    void loadEvents();
+    void loadSessionCollections();
     return () => {
       cancelled = true;
     };
@@ -121,6 +161,8 @@ export default function VNPlayWorkspace() {
       setSessions((previous) => [created, ...previous.filter((session) => session.id !== created.id)]);
       setSelectedSession(created);
       setEvents([]);
+      setCheckpoints([]);
+      setBranches([]);
       setModeFilter('all');
       setIsDialogOpen(false);
     } catch (createError) {
@@ -131,21 +173,26 @@ export default function VNPlayWorkspace() {
   }, []);
 
   const reloadSelectedSession = useCallback(async (sessionId: number) => {
-    const [nextSession, nextEvents] = await Promise.all([
+    const [nextSession, nextEvents, nextCheckpoints, nextBranches] = await Promise.all([
       getVNPlaySession(sessionId),
       listVNPlayEvents(sessionId),
+      listVNPlayCheckpoints(sessionId),
+      listVNPlayBranches(sessionId),
     ]);
     setSelectedSession(nextSession);
     setSessions((previous) =>
       previous.map((session) => (session.id === nextSession.id ? nextSession : session))
     );
     setEvents(nextEvents);
+    setCheckpoints(nextCheckpoints);
+    setBranches(nextBranches);
     return nextSession;
   }, []);
 
   const handleTurn = useCallback(async (response: VNPlayTurnResponse) => {
     if (!selectedSession) return;
 
+    setError(null);
     setTurnStatus(response.status);
     const responseEvents = response.events ?? [];
     if (responseEvents.length > 0) {
@@ -217,6 +264,7 @@ export default function VNPlayWorkspace() {
 
     if (isConflict && selectedSession) {
       setTurnStatus(/turn_in_progress/i.test(detail) ? 'turn_in_progress' : 'stale_scene_version');
+      setError(null);
       try {
         await reloadSelectedSession(selectedSession.id);
       } catch {
@@ -225,6 +273,7 @@ export default function VNPlayWorkspace() {
       return;
     }
 
+    setTurnStatus('turn_failed');
     setError(detail);
   }, [reloadSelectedSession, selectedSession]);
 
@@ -233,6 +282,75 @@ export default function VNPlayWorkspace() {
     selectedSession?.scene_state ?? selectedSession?.current_scene ?? null;
   const sceneVersion = sceneState?.scene_version ?? selectedSession?.scene_version ?? 0;
   const choices = (sceneState?.visible_choices ?? []).filter(isVNPlayChoice);
+  const recoveryMessage = recoveryCopy(turnStatus);
+
+  const handleCreateCheckpoint = useCallback(async (label: string) => {
+    if (!selectedSession) return;
+
+    setIsCreatingCheckpoint(true);
+    setError(null);
+    try {
+      const currentSceneVersion =
+        selectedSession.scene_state?.scene_version ??
+        selectedSession.current_scene?.scene_version ??
+        selectedSession.scene_version ??
+        0;
+      await createVNPlayCheckpoint(selectedSession.id, {
+        label,
+        scene_version: currentSceneVersion,
+      });
+      await reloadSelectedSession(selectedSession.id);
+    } catch (checkpointError) {
+      setError(checkpointError instanceof Error ? checkpointError.message : 'Failed to create checkpoint');
+    } finally {
+      setIsCreatingCheckpoint(false);
+    }
+  }, [reloadSelectedSession, selectedSession]);
+
+  const handleRestoreCheckpoint = useCallback(async (checkpointId: number) => {
+    if (!selectedSession) return;
+
+    setRestoringCheckpointId(checkpointId);
+    setError(null);
+    try {
+      const restored = await restoreVNPlaySession(selectedSession.id, {
+        checkpoint_id: checkpointId,
+        idempotency_key: idempotencyKey('restore'),
+      });
+      setSelectedSession(restored);
+      setSessions((previous) =>
+        previous.map((session) => (session.id === restored.id ? restored : session))
+      );
+      await reloadSelectedSession(selectedSession.id);
+    } catch (restoreError) {
+      setError(restoreError instanceof Error ? restoreError.message : 'Failed to restore checkpoint');
+    } finally {
+      setRestoringCheckpointId(null);
+    }
+  }, [reloadSelectedSession, selectedSession]);
+
+  const handleRetryLastTurn = useCallback(async () => {
+    if (!selectedSession) return;
+
+    setIsRetryingTurn(true);
+    setError(null);
+    try {
+      const currentSceneVersion =
+        selectedSession.scene_state?.scene_version ??
+        selectedSession.current_scene?.scene_version ??
+        selectedSession.scene_version ??
+        0;
+      const response = await retryLastVNPlayTurn(selectedSession.id, {
+        client_scene_version: currentSceneVersion,
+        idempotency_key: idempotencyKey('retry'),
+      });
+      await handleTurn(response);
+    } catch (retryError) {
+      setError(retryError instanceof Error ? retryError.message : 'Failed to retry last turn');
+    } finally {
+      setIsRetryingTurn(false);
+    }
+  }, [handleTurn, selectedSession]);
 
   return (
     <main className="min-h-screen bg-bg text-text">
@@ -264,9 +382,22 @@ export default function VNPlayWorkspace() {
             {error}
           </div>
         )}
-        {turnStatus && turnStatus !== 'completed' && (
+        {recoveryMessage && (
           <div className="rounded-md border border-warn/30 bg-warn/10 px-3 py-2 text-sm text-warn">
-            {turnStatus}
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <span>{recoveryMessage}</span>
+              {turnStatus === 'turn_failed' && selectedSession && (
+                <Button
+                  loading={isRetryingTurn}
+                  onClick={() => void handleRetryLastTurn()}
+                  size="sm"
+                  type="button"
+                  variant="secondary"
+                >
+                  Retry last turn
+                </Button>
+              )}
+            </div>
           </div>
         )}
 
@@ -321,7 +452,16 @@ export default function VNPlayWorkspace() {
             </div>
 
             {selectedSession && sceneState ? (
-              <SceneInspector sceneState={sceneState} session={selectedSession} />
+              <SceneInspector
+                branches={branches}
+                checkpoints={checkpoints}
+                isCreatingCheckpoint={isCreatingCheckpoint}
+                restoringCheckpointId={restoringCheckpointId}
+                sceneState={sceneState}
+                session={selectedSession}
+                onCreateCheckpoint={handleCreateCheckpoint}
+                onRestoreCheckpoint={handleRestoreCheckpoint}
+              />
             ) : (
               <aside className="rounded-md border border-border bg-surface p-4">
                 <h2 className="mb-4 text-lg font-semibold">Runtime inspector</h2>

--- a/apps/tldw-frontend/components/vn-play/runtime.ts
+++ b/apps/tldw-frontend/components/vn-play/runtime.ts
@@ -1,0 +1,77 @@
+export interface VNPlayErrorInfo {
+  code?: string;
+  message: string;
+  status?: number;
+}
+
+const RECOVERABLE_TURN_CODES = new Set(['stale_scene_version', 'turn_in_progress']);
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function readNumber(value: unknown): number | undefined {
+  const parsed = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : Number.NaN;
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined;
+}
+
+function readCode(record: Record<string, unknown> | null): string | undefined {
+  if (!record) return undefined;
+  return (
+    readString(record.error_code) ??
+    readString(record.code) ??
+    readCode(asRecord(record.detail)) ??
+    readCode(asRecord(record.details))
+  );
+}
+
+function readMessage(record: Record<string, unknown> | null): string | undefined {
+  if (!record) return undefined;
+  const detail = record.detail;
+  const details = record.details;
+  return (
+    readString(detail) ??
+    readString(record.message) ??
+    readString(record.error) ??
+    readMessage(asRecord(detail)) ??
+    readMessage(asRecord(details)) ??
+    readCode(record)
+  );
+}
+
+export function createVNPlayIdempotencyKey(prefix: string): string {
+  const uuid = globalThis.crypto?.randomUUID?.();
+  return `${prefix}-${uuid ?? `${Date.now()}-${Math.random().toString(36).slice(2)}`}`;
+}
+
+export function getVNPlayErrorInfo(error: unknown): VNPlayErrorInfo {
+  const record = asRecord(error);
+  const status =
+    readNumber(record?.status) ??
+    readNumber(record?.statusCode) ??
+    readNumber(asRecord(record?.response)?.status);
+  const code = readCode(record);
+  const message =
+    readMessage(record) ??
+    (error instanceof Error && error.message.trim() ? error.message : undefined) ??
+    'Failed to submit turn';
+
+  return {
+    ...(code ? { code } : {}),
+    message,
+    ...(status !== undefined ? { status } : {}),
+  };
+}
+
+export function isRecoverableVNPlayConflict(error: unknown): boolean {
+  const info = getVNPlayErrorInfo(error);
+  if (info.code && RECOVERABLE_TURN_CODES.has(info.code)) return true;
+  if (info.status === 409) return true;
+  return /stale_scene_version|turn_in_progress/i.test(info.message);
+}

--- a/backlog/tasks/task-150 - Add-VN-Play-recovery-and-branch-controls.md
+++ b/backlog/tasks/task-150 - Add-VN-Play-recovery-and-branch-controls.md
@@ -1,0 +1,74 @@
+---
+id: TASK-150
+title: Add VN Play recovery and branch controls
+status: Done
+assignee: []
+created_date: '2026-05-09 04:29'
+updated_date: '2026-05-09 04:37'
+labels:
+  - vn-play
+  - webui
+  - implementation
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1401'
+  - 'https://github.com/rmusser01/tldw_server/issues/1391'
+documentation:
+  - Docs/superpowers/specs/2026-05-01-vn-play-runtime-design.md
+  - Docs/superpowers/plans/2026-05-01-vn-play-runtime-implementation.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the next VN Play WebUI usability slice from issue #1401: expose checkpoint, restore, branch metadata, retry-last-turn, and conflict recovery controls in the existing VN Play workspace. Keep this focused on the frontend/runtime UX over the already-merged backend endpoints; avoid realtime image generation or new backend orchestration unless a small API/test fix is required.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Loads checkpoints and branches for the selected VN Play session and passes them into the runtime inspector
+- [x] #2 Allows creating a checkpoint from the current scene and refreshes session metadata, events, checkpoints, and branches
+- [x] #3 Allows restoring a checkpoint with explicit user intent and refreshes selected session state coherently
+- [x] #4 Provides retry-last-turn behavior for recoverable failed turns using a fresh idempotency key
+- [x] #5 Stale scene and turn-in-progress conflicts show explicit recovery UI instead of generic errors
+- [x] #6 Focused VN Play frontend tests cover checkpoint create, restore, retry, and conflict-state behavior
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Inspect existing VN Play API helpers, types, workspace, inspector, dialogue, choice, and tests.
+2. Add failing tests for checkpoint/branch loading, checkpoint creation, restore refresh, retry-last-turn, and conflict state UI.
+3. Implement minimal VNPlayWorkspace/SceneInspector changes using existing API helpers and UI primitives.
+4. Re-run focused Vitest tests, run touched TypeScript checks where feasible, run git diff --check, and update the Backlog task.
+5. Commit, push, and open a PR against dev linked to #1401.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Red verification: bunx vitest run __tests__/vn-play/VNPlayWorkspace.test.tsx from apps/tldw-frontend failed with the intended missing behavior: checkpoint/branch metadata was not loaded, checkpoint create/restore controls were absent, retry-last-turn was absent, and stale_scene_version rendered as raw error text.
+
+Implementation: wired existing VN Play checkpoint/branch/retry API helpers into VNPlayWorkspace, added recovery controls to SceneInspector, and suppressed raw recoverable conflict text in DialoguePanel so workspace-level recovery copy owns stale/in-progress states.
+
+Focused verification: bunx vitest run __tests__/vn-play/VNPlayWorkspace.test.tsx __tests__/vn-play/SceneStage.test.tsx __tests__/vn-play/vnPlayApi.test.ts passed with 14 tests. git diff --check passed. Full frontend TypeScript check currently fails on pre-existing unrelated apps/packages/ui/src/services/persona-visuals.ts BlobPart typing; no touched VN Play diagnostics appeared in that run.
+
+Post-rebase verification: branch rebased cleanly onto origin/dev after 8f6f94a0b. Focused command bunx vitest run __tests__/vn-play/VNPlayWorkspace.test.tsx __tests__/vn-play/SceneStage.test.tsx __tests__/vn-play/vnPlayApi.test.ts passed with 14 tests. git diff --check origin/dev..HEAD passed. Full tldw-frontend TypeScript check still fails only on the pre-existing ../packages/ui/src/services/persona-visuals.ts BlobPart typing issue; this slice did not touch that file. Bandit skipped because this task only changes frontend TypeScript/React and Backlog metadata.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added VN Play recovery controls for the existing runtime surface. VNPlayWorkspace now loads checkpoints and branch metadata for the selected session, refreshes those collections alongside events, creates checkpoints at the current scene version, restores checkpoints with restore-scoped idempotency keys, and retries the latest failed turn with retry-scoped idempotency keys. SceneInspector now exposes checkpoint create/restore controls and branch/checkpoint listings, while DialoguePanel suppresses raw stale/in-progress conflict strings so the workspace can show explicit recovery guidance. Focused VN Play Vitest coverage passes; package-wide TypeScript remains blocked by an unrelated persona-visuals BlobPart baseline error.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-152 - Address-PR-1402-review-comments.md
+++ b/backlog/tasks/task-152 - Address-PR-1402-review-comments.md
@@ -1,0 +1,55 @@
+---
+id: TASK-152
+title: Address PR 1402 review comments
+status: Done
+assignee: []
+created_date: '2026-05-09 04:52'
+updated_date: '2026-05-09 05:05'
+labels:
+  - vn-play
+  - webui
+  - pr-review
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1402'
+  - 'https://github.com/rmusser01/tldw_server/issues/1401'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Evaluate and address all actionable PR #1402 review feedback and current check state. Scope includes structured VN Play error extraction, shared idempotency-key utility, scene-version simplification, restore refresh optimization, focused tests, verification, and GitHub thread replies/resolution.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 All unresolved PR #1402 inline review comments are evaluated and addressed or replied to with technical reasoning
+- [x] #2 VN Play turn error handling avoids raw [object Object] messages and prefers structured codes/details
+- [x] #3 VN Play idempotency key generation is shared across workspace dialogue and choice controls
+- [x] #4 Checkpoint and retry flows reuse the existing sceneVersion value instead of duplicating resolution logic
+- [x] #5 Checkpoint restore avoids redundant selected-session refresh while still refreshing events checkpoints and branches
+- [x] #6 Focused tests and hygiene checks pass or blockers are documented
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented review fixes: added shared VN Play runtime helper for idempotency keys and structured turn error extraction; refactored DialoguePanel ChoicePanel and VNPlayWorkspace to use it; reused sceneVersion for checkpoint creation and retry-last-turn; changed checkpoint restore to update the restored session then refresh only events/checkpoints/branches. Added helper tests and restore no-extra-session-GET assertion. Verification: bunx vitest run __tests__/vn-play/vnPlayRuntime.test.ts __tests__/vn-play/VNPlayWorkspace.test.tsx __tests__/vn-play/SceneStage.test.tsx __tests__/vn-play/vnPlayApi.test.ts passed with 17 tests. git diff --check origin/dev..HEAD passed. Full tldw-frontend TypeScript check still fails only on pre-existing ../packages/ui/src/services/persona-visuals.ts BlobPart typing. Bandit skipped because touched files are frontend TypeScript/React and Backlog metadata.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed PR #1402 review feedback by adding shared VN Play runtime helpers for idempotency keys and structured error extraction, refactoring dialogue/choice/workspace recovery paths to use them, reusing the computed sceneVersion for checkpoint/retry actions, and avoiding redundant selected-session GETs after checkpoint restore. Added focused helper coverage plus a restore regression assertion. Verification passed for focused VN Play tests and git diff hygiene; full frontend TypeScript remains blocked by the pre-existing packages/ui persona-visuals BlobPart typing issue outside this branch scope.
+<!-- SECTION:FINAL_SUMMARY:END -->


### PR DESCRIPTION
## Summary

- Loads VN Play checkpoints and branch metadata for the selected session and passes them into the runtime inspector.
- Adds checkpoint creation, checkpoint restore, and retry-last-turn controls using the existing VN Play API helpers and scoped idempotency keys.
- Replaces raw stale/in-progress turn conflict strings with explicit recovery guidance while preserving existing session reload behavior.
- Adds focused VNPlayWorkspace test coverage for checkpoint/branch loading, create, restore, retry, and stale-scene recovery.

## Change summary

Human-authored merge summary required before this PR is marked ready for review, per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

Suggested points for the human summary:

- Why the next VN sprint focuses on recovery controls instead of adding new generation/runtime backends.
- Why retry and restore use fresh scoped idempotency keys while scene state remains server-authoritative.
- Why branch/checkpoint metadata is surfaced in the inspector rather than a larger authoring workflow in this slice.

## Verification

- `bunx vitest run __tests__/vn-play/VNPlayWorkspace.test.tsx __tests__/vn-play/SceneStage.test.tsx __tests__/vn-play/vnPlayApi.test.ts` from `apps/tldw-frontend` -> 3 files passed, 14 tests passed.
- `git diff --check origin/dev..HEAD` -> clean.
- `bunx tsc --noEmit --pretty false` from `apps/tldw-frontend` -> fails on existing unrelated `../packages/ui/src/services/persona-visuals.ts(276,5)` BlobPart typing issue; this PR does not touch that file.
- Bandit skipped because this slice only changes frontend TypeScript/React and Backlog metadata.

## Tracking

Refs #1391
Closes #1401
