### PR TITLE
Adapt Watchlists StatusTag to shared Badge

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -5621,17 +5621,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "local-status-badge:src/components/Option/Watchlists/shared/StatusTag.tsx:StatusTag",
-    "path": "src/components/Option/Watchlists/shared/StatusTag.tsx",
-    "rule": "local-status-badge",
-    "subject": "StatusTag",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing local StatusTag status wrapper before the guard.",
-    "replacement": "Badge with design-system state registry mapping",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "local-status-badge:src/components/Sidepanel/Chat/StatusDot.tsx:StatusDot",
     "path": "src/components/Sidepanel/Chat/StatusDot.tsx",
     "rule": "local-status-badge",

--- a/apps/packages/ui/src/components/Option/Watchlists/shared/StatusTag.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/shared/StatusTag.tsx
@@ -1,7 +1,8 @@
 import React from "react"
-import { Tag } from "antd"
-import { AlertTriangle, Ban, CheckCircle2, Circle, Clock3, LoaderCircle } from "lucide-react"
+import { AlertTriangle, Ban, CheckCircle2, Circle, Clock3, LoaderCircle, type LucideIcon } from "lucide-react"
 import { useTranslation } from "react-i18next"
+import { getDesignSystemState, type DesignSystemStateKey } from "@/design-system"
+import { Badge, type BadgeVariant } from "@/components/ui/primitives"
 import type { RunStatus } from "@/types/watchlists"
 
 interface StatusTagProps {
@@ -12,42 +13,73 @@ interface StatusTagProps {
 type StatusIconToken = "pending" | "running" | "completed" | "failed" | "cancelled" | "unknown"
 
 const STATUS_CONFIG: Record<string, {
-  color: string
+  stateKey: DesignSystemStateKey
   labelKey: string
   fallbackLabel: string
   iconToken: StatusIconToken
+  icon: LucideIcon
 }> = {
   pending: {
-    color: "default",
+    stateKey: "loading",
     labelKey: "watchlists:runs.statusLabels.pending",
     fallbackLabel: "Pending",
-    iconToken: "pending"
+    iconToken: "pending",
+    icon: Clock3
+  },
+  queued: {
+    stateKey: "loading",
+    labelKey: "watchlists:runs.statusLabels.queued",
+    fallbackLabel: "Queued",
+    iconToken: "pending",
+    icon: Clock3
   },
   running: {
-    color: "processing",
+    stateKey: "retrying",
     labelKey: "watchlists:runs.statusLabels.running",
     fallbackLabel: "Running",
-    iconToken: "running"
+    iconToken: "running",
+    icon: LoaderCircle
   },
   completed: {
-    color: "success",
+    stateKey: "ready",
     labelKey: "watchlists:runs.statusLabels.completed",
     fallbackLabel: "Completed",
-    iconToken: "completed"
+    iconToken: "completed",
+    icon: CheckCircle2
   },
   failed: {
-    color: "error",
+    stateKey: "error",
     labelKey: "watchlists:runs.statusLabels.failed",
     fallbackLabel: "Failed",
-    iconToken: "failed"
+    iconToken: "failed",
+    icon: AlertTriangle
   },
   cancelled: {
-    color: "warning",
+    stateKey: "degraded",
     labelKey: "watchlists:runs.statusLabels.cancelled",
     fallbackLabel: "Cancelled",
-    iconToken: "cancelled"
+    iconToken: "cancelled",
+    icon: Ban
   }
 }
+
+const UNKNOWN_STATUS_CONFIG = {
+  stateKey: "empty",
+  iconToken: "unknown",
+  icon: Circle
+} satisfies {
+  stateKey: DesignSystemStateKey
+  iconToken: StatusIconToken
+  icon: LucideIcon
+}
+
+const SEVERITY_BADGE_VARIANTS = {
+  success: "success",
+  error: "danger",
+  warning: "warning",
+  info: "info",
+  neutral: "secondary",
+} satisfies Record<ReturnType<typeof getDesignSystemState>["severity"], BadgeVariant>
 
 const toTitleCase = (value: string): string =>
   value
@@ -56,19 +88,11 @@ const toTitleCase = (value: string): string =>
     .trim()
     .replace(/\b\w/g, (char) => char.toUpperCase())
 
-const renderStatusIcon = (iconToken: StatusIconToken) => {
-  if (iconToken === "pending") return <Clock3 className="h-3.5 w-3.5" aria-hidden />
-  if (iconToken === "running") return <LoaderCircle className="h-3.5 w-3.5" aria-hidden />
-  if (iconToken === "completed") return <CheckCircle2 className="h-3.5 w-3.5" aria-hidden />
-  if (iconToken === "failed") return <AlertTriangle className="h-3.5 w-3.5" aria-hidden />
-  if (iconToken === "cancelled") return <Ban className="h-3.5 w-3.5" aria-hidden />
-  return <Circle className="h-3.5 w-3.5" aria-hidden />
-}
-
 export const StatusTag: React.FC<StatusTagProps> = ({ status, size = "default" }) => {
   const { t } = useTranslation(["watchlists"])
   const normalizedStatus = String(status || "").trim().toLowerCase()
   const config = STATUS_CONFIG[normalizedStatus]
+  const statusConfig = config || UNKNOWN_STATUS_CONFIG
   const fallbackLabel = normalizedStatus
     ? toTitleCase(normalizedStatus)
     : t("watchlists:runs.statusLabels.unknown", "Unknown")
@@ -76,21 +100,20 @@ export const StatusTag: React.FC<StatusTagProps> = ({ status, size = "default" }
     ? t(config.labelKey, config.fallbackLabel)
     : fallbackLabel
   const ariaLabel = t("watchlists:runs.statusAria", "Run status: {{status}}", { status: label })
-  const iconToken = config?.iconToken || "unknown"
+  const state = getDesignSystemState(statusConfig.stateKey)
+  const Icon = statusConfig.icon
 
   return (
-    <Tag
-      color={config?.color || "default"}
-      className={size === "small" ? "text-xs" : ""}
+    <Badge
+      variant={SEVERITY_BADGE_VARIANTS[state.severity]}
+      size={size === "small" ? "sm" : "md"}
       aria-label={ariaLabel}
       title={ariaLabel}
     >
-      <span className="inline-flex items-center gap-1">
-        <span data-testid={`watchlists-status-icon-${iconToken}`}>
-          {renderStatusIcon(iconToken)}
-        </span>
-        <span>{label}</span>
+      <span data-testid={`watchlists-status-icon-${statusConfig.iconToken}`}>
+        <Icon className={size === "small" ? "h-3 w-3" : "h-3.5 w-3.5"} aria-hidden />
       </span>
-    </Tag>
+      <span>{label}</span>
+    </Badge>
   )
 }

--- a/apps/packages/ui/src/components/Option/Watchlists/shared/StatusTag.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/shared/StatusTag.tsx
@@ -34,7 +34,7 @@ const STATUS_CONFIG: Record<string, {
     icon: Clock3
   },
   running: {
-    stateKey: "retrying",
+    stateKey: "loading",
     labelKey: "watchlists:runs.statusLabels.running",
     fallbackLabel: "Running",
     iconToken: "running",

--- a/apps/packages/ui/src/components/Option/Watchlists/shared/__tests__/StatusTag.accessibility.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/shared/__tests__/StatusTag.accessibility.test.tsx
@@ -13,20 +13,31 @@ vi.mock("react-i18next", () => ({
   })
 }))
 
-vi.mock("antd", () => ({
-  Tag: ({ children, ...rest }: any) => <span {...rest}>{children}</span>
-}))
-
 describe("StatusTag accessibility labels", () => {
   it("exposes a descriptive SR label for known run statuses", () => {
-    render(<StatusTag status="running" />)
+    const { container } = render(<StatusTag status="running" />)
+
     expect(screen.getByLabelText("Run status: Running")).toHaveTextContent("Running")
+    expect(screen.getByLabelText("Run status: Running")).toHaveAttribute("title", "Run status: Running")
     expect(screen.getByTestId("watchlists-status-icon-running")).toBeInTheDocument()
+    expect(container.querySelector('[data-ds-component="Badge"]')).toBeInTheDocument()
   })
 
   it("humanizes unknown statuses and keeps descriptive SR labels", () => {
-    render(<StatusTag status="in_progress" />)
+    const { container } = render(<StatusTag status="in_progress" />)
+
     expect(screen.getByLabelText("Run status: In Progress")).toHaveTextContent("In Progress")
+    expect(screen.getByLabelText("Run status: In Progress")).toHaveAttribute("title", "Run status: In Progress")
     expect(screen.getByTestId("watchlists-status-icon-unknown")).toBeInTheDocument()
+    expect(container.querySelector('[data-ds-component="Badge"]')).toBeInTheDocument()
+  })
+
+  it("uses the shared Badge compact sizing for small status tags", () => {
+    const { container } = render(<StatusTag status="pending" size="small" />)
+    const badge = container.querySelector('[data-ds-component="Badge"]')
+
+    expect(badge).toHaveClass("py-0.5")
+    expect(badge).toHaveClass("text-[10px]")
+    expect(badge).not.toHaveClass("text-xs")
   })
 })

--- a/apps/packages/ui/src/components/Option/Watchlists/shared/__tests__/StatusTag.accessibility.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/shared/__tests__/StatusTag.accessibility.test.tsx
@@ -16,11 +16,12 @@ vi.mock("react-i18next", () => ({
 describe("StatusTag accessibility labels", () => {
   it("exposes a descriptive SR label for known run statuses", () => {
     const { container } = render(<StatusTag status="running" />)
+    const badge = container.querySelector('[data-ds-component="Badge"]')
 
     expect(screen.getByLabelText("Run status: Running")).toHaveTextContent("Running")
     expect(screen.getByLabelText("Run status: Running")).toHaveAttribute("title", "Run status: Running")
     expect(screen.getByTestId("watchlists-status-icon-running")).toBeInTheDocument()
-    expect(container.querySelector('[data-ds-component="Badge"]')).toBeInTheDocument()
+    expect(badge).toHaveAttribute("data-ds-variant", "secondary")
   })
 
   it("humanizes unknown statuses and keeps descriptive SR labels", () => {
@@ -32,12 +33,10 @@ describe("StatusTag accessibility labels", () => {
     expect(container.querySelector('[data-ds-component="Badge"]')).toBeInTheDocument()
   })
 
-  it("uses the shared Badge compact sizing for small status tags", () => {
+  it("passes the compact Badge size for small status tags", () => {
     const { container } = render(<StatusTag status="pending" size="small" />)
     const badge = container.querySelector('[data-ds-component="Badge"]')
 
-    expect(badge).toHaveClass("py-0.5")
-    expect(badge).toHaveClass("text-[10px]")
-    expect(badge).not.toHaveClass("text-xs")
+    expect(badge).toHaveAttribute("data-ds-size", "sm")
   })
 })

--- a/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
@@ -46,6 +46,7 @@ import type {
   PersonaVisualPortabilityJobResponse,
   PersonaVisualStateId
 } from "@/types/persona-visuals"
+import { getDesignSystemState } from "@/design-system"
 
 type VisualPackEditorProps = {
   selectedPersonaId: string
@@ -80,6 +81,8 @@ const VISUAL_STATES: PersonaVisualStateId[] = [
   ...REQUIRED_VISUAL_STATES,
   ...OPTIONAL_VISUAL_STATES
 ]
+
+const LOADING_STATE_LABEL = getDesignSystemState("loading").label
 
 const ASSET_ROLES: PersonaVisualAssetRole[] = [
   "frame",
@@ -1000,7 +1003,7 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
             disabled={loading}
           >
             {loading
-              ? t("common:loading", "Loading")
+              ? t("common:loading", LOADING_STATE_LABEL)
               : t("common:refresh", "Refresh")}
           </Button>
         </div>
@@ -1689,7 +1692,7 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
                 Generated Candidates
               </div>
               <Button size="small" onClick={() => void loadCandidates()}>
-                {candidatesLoading ? "Loading" : "Refresh"}
+                {candidatesLoading ? LOADING_STATE_LABEL : "Refresh"}
               </Button>
             </div>
             <div className="mt-3 grid gap-2 md:grid-cols-[minmax(180px,1fr)_150px_minmax(120px,160px)_auto]">

--- a/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
@@ -82,8 +82,6 @@ const VISUAL_STATES: PersonaVisualStateId[] = [
   ...OPTIONAL_VISUAL_STATES
 ]
 
-const LOADING_STATE_LABEL = getDesignSystemState("loading").label
-
 const ASSET_ROLES: PersonaVisualAssetRole[] = [
   "frame",
   "still_pose",
@@ -277,6 +275,8 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
   isActive = false
 }) => {
   const { t } = useTranslation(["sidepanel", "common"])
+  const loadingLabel = t("common:loading", getDesignSystemState("loading").label)
+  const refreshLabel = t("common:refresh", "Refresh")
   const [packs, setPacks] = React.useState<PersonaVisualPack[]>([])
   const [selectedPackId, setSelectedPackId] = React.useState("")
   const [draftTitle, setDraftTitle] = React.useState("")
@@ -1002,9 +1002,7 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
             onClick={() => void loadPacks()}
             disabled={loading}
           >
-            {loading
-              ? t("common:loading", LOADING_STATE_LABEL)
-              : t("common:refresh", "Refresh")}
+            {loading ? loadingLabel : refreshLabel}
           </Button>
         </div>
         <div className="mt-3 grid gap-2 md:grid-cols-[minmax(180px,1fr)_minmax(180px,1fr)_auto]">
@@ -1692,7 +1690,7 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
                 Generated Candidates
               </div>
               <Button size="small" onClick={() => void loadCandidates()}>
-                {candidatesLoading ? LOADING_STATE_LABEL : "Refresh"}
+                {candidatesLoading ? loadingLabel : refreshLabel}
               </Button>
             </div>
             <div className="mt-3 grid gap-2 md:grid-cols-[minmax(180px,1fr)_150px_minmax(120px,160px)_auto]">

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
@@ -3,12 +3,9 @@ import { fireEvent, render, screen, waitFor, within } from "@testing-library/rea
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const mocks = vi.hoisted(() => ({
-  fetchWithAuth: vi.fn()
-}))
-
-vi.mock("react-i18next", () => ({
-  useTranslation: () => ({
-    t: (
+  fetchWithAuth: vi.fn(),
+  translate: vi.fn(
+    (
       key: string,
       defaultValueOrOptions?:
         | string
@@ -20,6 +17,12 @@ vi.mock("react-i18next", () => ({
       if (defaultValueOrOptions?.defaultValue) return defaultValueOrOptions.defaultValue
       return key
     }
+  )
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (...args: Parameters<typeof mocks.translate>) => mocks.translate(...args)
   })
 }))
 
@@ -110,6 +113,94 @@ describe("VisualPackEditor", () => {
   beforeEach(() => {
     vi.restoreAllMocks()
     mocks.fetchWithAuth.mockReset()
+    mocks.translate.mockReset()
+    mocks.translate.mockImplementation(
+      (
+        key: string,
+        defaultValueOrOptions?:
+          | string
+          | {
+              defaultValue?: string
+            }
+      ) => {
+        if (typeof defaultValueOrOptions === "string") return defaultValueOrOptions
+        if (defaultValueOrOptions?.defaultValue) return defaultValueOrOptions.defaultValue
+        return key
+      }
+    )
+  })
+
+  it("localizes loading and refresh labels while candidates are loading", async () => {
+    const pack = {
+      id: "pack-1",
+      persona_id: "persona-1",
+      title: "Animated pack",
+      renderer_type: "sprite_frames",
+      status: "draft",
+      manifest: structuredClone(baseManifest),
+      assets: visualAssets,
+      version: 3
+    }
+    let resolveCandidates: (value: unknown) => void = () => undefined
+
+    mocks.translate.mockImplementation(
+      (
+        key: string,
+        defaultValueOrOptions?:
+          | string
+          | {
+              defaultValue?: string
+            }
+      ) => {
+        if (key === "common:loading") return "Localized loading"
+        if (key === "common:refresh") return "Localized refresh"
+        if (typeof defaultValueOrOptions === "string") return defaultValueOrOptions
+        if (defaultValueOrOptions?.defaultValue) return defaultValueOrOptions.defaultValue
+        return key
+      }
+    )
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string }) => {
+      const method = init?.method || "GET"
+      if (path === "/api/v1/persona/profiles/persona-1/visual-packs" && method === "GET") {
+        return okResponse([pack])
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/pack-1/generated-candidates" &&
+        method === "GET"
+      ) {
+        return new Promise((resolve) => {
+          resolveCandidates = resolve
+        })
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        error: `Unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(
+      <VisualPackEditor
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Garden Helper"
+        isActive
+      />
+    )
+
+    expect(await screen.findByTestId("persona-visual-pack-status")).toHaveTextContent("draft")
+    await waitFor(() =>
+      expect(screen.getAllByRole("button", { name: "Localized loading" })).toHaveLength(1)
+    )
+
+    resolveCandidates({
+      ok: true,
+      json: async () => ({ candidates: [] })
+    })
+
+    await waitFor(() =>
+      expect(screen.getAllByRole("button", { name: "Localized refresh" })).toHaveLength(2)
+    )
   })
 
   it("loads pack list, creates a draft pack, and uploads the selected asset role", async () => {

--- a/apps/packages/ui/src/components/ui/primitives/Badge.tsx
+++ b/apps/packages/ui/src/components/ui/primitives/Badge.tsx
@@ -124,6 +124,8 @@ export const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
         )}
         aria-label={ariaLabel}
         data-ds-component="Badge"
+        data-ds-size={size}
+        data-ds-variant={variant}
         data-testid={dataTestId}
         title={title}
       >

--- a/apps/packages/ui/src/components/ui/primitives/Badge.tsx
+++ b/apps/packages/ui/src/components/ui/primitives/Badge.tsx
@@ -27,6 +27,10 @@ export interface BadgeProps {
   outline?: boolean
   /** Screen reader label (if different from visible text) */
   srLabel?: string
+  /** Accessible label for the badge itself */
+  "aria-label"?: string
+  /** Native tooltip text */
+  title?: string
   /** Additional CSS classes */
   className?: string
   /** Test ID */
@@ -99,6 +103,8 @@ export const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
       dot = false,
       outline = false,
       srLabel,
+      "aria-label": ariaLabel,
+      title,
       className,
       "data-testid": dataTestId,
     },
@@ -116,8 +122,10 @@ export const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
           outline ? `border ${styles.outline} bg-transparent` : styles.filled,
           className
         )}
+        aria-label={ariaLabel}
         data-ds-component="Badge"
         data-testid={dataTestId}
+        title={title}
       >
         {dot && (
           <span

--- a/backlog/tasks/task-45.23 - Adapt-Watchlists-StatusTag-to-shared-Badge.md
+++ b/backlog/tasks/task-45.23 - Adapt-Watchlists-StatusTag-to-shared-Badge.md
@@ -1,0 +1,66 @@
+---
+id: TASK-45.23
+title: Adapt Watchlists StatusTag to shared Badge
+status: Done
+assignee: []
+created_date: '2026-05-09 04:33'
+updated_date: '2026-05-09 04:41'
+labels:
+  - design-system
+  - webui
+  - guard
+dependencies: []
+references:
+  - apps/packages/ui/src/components/Option/Watchlists/shared/StatusTag.tsx
+  - >-
+    apps/packages/ui/src/components/Option/Watchlists/shared/__tests__/StatusTag.accessibility.test.tsx
+  - apps/packages/ui/src/components/ui/primitives/Badge.tsx
+  - apps/packages/ui/src/design-system/states.ts
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+parent_task_id: TASK-45
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate the Watchlists run-status tag adapter from AntD Tag to the shared design-system Badge primitive with explicit canonical state mapping, while preserving accessibility labels, icons, fallback labels, and removing its local-status-badge baseline exception.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Watchlists StatusTag renders through the shared Badge primitive while preserving known and unknown status labels, icons, title, and aria-label behavior.
+- [x] #2 Run statuses map through the design-system state registry before selecting Badge variants.
+- [x] #3 The local-status-badge baseline exception for src/components/Option/Watchlists/shared/StatusTag.tsx is removed without introducing new unbaselined findings.
+- [x] #4 Focused StatusTag tests, product-state guard tests, the design-system verifier, and diff checks pass.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Red evidence: after removing the AntD Tag mock, the focused StatusTag accessibility test failed because StatusTag did not render a shared Badge marker yet.
+
+Implementation: StatusTag now maps Watchlists run statuses through getDesignSystemState before choosing shared Badge variants, preserves known/unknown labels and icons, forwards aria-label/title through Badge, and removes the StatusTag local-status-badge baseline exception.
+
+Verification: bunx vitest run src/components/Option/Watchlists/shared/__tests__/StatusTag.accessibility.test.tsx --reporter=dot passed 3/3; bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed 46/46; bun run verify:design-system-state passed with baseline exceptions 512 and local-status-badge 6; git diff --check passed.
+
+TypeScript caveat: bunx tsc --noEmit --pretty false still fails on the existing repo-wide frontend baseline, but a filtered tsc pass for StatusTag, Badge, VisualPackEditor, and design-system-product-state-baseline produced no touched-file errors.
+
+Bandit: skipped because this slice only changes TypeScript, JSON, and Backlog task metadata.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Adapted Watchlists StatusTag from AntD Tag to the shared Badge primitive with design-system state mapping, preserving the accessibility/title behavior and removing its local-status-badge baseline exception. Verification passed for the focused StatusTag test, product-state guard suite, design-system verifier, and diff checks; full tsc remains blocked by unrelated baseline errors outside this slice.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.23.1 - Address-PR-1403-StatusTag-review-comments.md
+++ b/backlog/tasks/task-45.23.1 - Address-PR-1403-StatusTag-review-comments.md
@@ -1,0 +1,67 @@
+---
+id: TASK-45.23.1
+title: Address PR 1403 StatusTag review comments
+status: Done
+assignee: []
+created_date: '2026-05-09 05:11'
+updated_date: '2026-05-09 05:15'
+labels:
+  - design-system
+  - webui
+  - review
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1403'
+  - apps/packages/ui/src/components/Option/Watchlists/shared/StatusTag.tsx
+  - >-
+    apps/packages/ui/src/components/Option/Watchlists/shared/__tests__/StatusTag.accessibility.test.tsx
+  - apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+parent_task_id: TASK-45.23
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address actionable PR #1403 review comments on the Watchlists StatusTag shared Badge migration. Scope: keep PersonaGarden loading labels locale-reactive while still using the design-system state fallback, map Watchlists running status to the most appropriate canonical state, and remove brittle Badge internal class assertions from StatusTag tests.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 PersonaGarden loading and refresh labels are evaluated inside VisualPackEditor render through translation APIs and design-system fallback labels
+- [x] #2 Watchlists running status maps to a semantically appropriate canonical state without reintroducing product-state guard findings
+- [x] #3 StatusTag small-size coverage verifies the adapter contract without asserting Badge internal Tailwind class strings
+- [x] #4 Focused tests, product-state guard tests, design-system verifier, diff checks, and touched-file TypeScript filter are recorded
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Review surface inspected on PR #1403. Actionable unresolved threads: PersonaGarden module-level loading fallback should move into render/t(), candidate Refresh should be localized, StatusTag running should avoid retrying semantics, and StatusTag small-size test should avoid Badge internal Tailwind class assertions. CI was pending at inspection time.
+
+Red evidence: StatusTag focused test failed on missing data-ds-variant/data-ds-size attributes and VisualPackEditor focused test failed because candidate loading used the static Loading fallback instead of the localized loading label.
+
+Implementation: Badge now exposes stable data-ds-size and data-ds-variant attributes for adapter contract tests; StatusTag maps running to loading instead of retrying; VisualPackEditor computes loading/refresh labels inside render via t(...) with getDesignSystemState("loading").label as the loading fallback.
+
+Verification: bunx vitest run src/components/Option/Watchlists/shared/__tests__/StatusTag.accessibility.test.tsx --reporter=dot passed 3/3; bunx vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx --reporter=dot passed 7/7; bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed 46/46; bun run verify:design-system-state passed with baseline exceptions 512 and local-status-badge 6; git diff --check passed.
+
+TypeScript caveat: bunx tsc --noEmit --pretty false still fails on existing repo-wide frontend baseline errors, but filtering the output for StatusTag, VisualPackEditor, Badge, and their focused tests returned no touched-file errors.
+
+Bandit: skipped because this review pass only changes TypeScript/TSX and Backlog metadata.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed PR #1403 review comments by making PersonaGarden loading/refresh labels render-time localized, mapping Watchlists running status to the loading state, and replacing brittle Tailwind class assertions with stable Badge adapter contract attributes. Focused tests, guard tests, design-system verifier, and diff checks passed; full tsc remains blocked by unrelated baseline errors.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.24 - Normalize-PersonaGarden-loading-labels-for-product-state-guard.md
+++ b/backlog/tasks/task-45.24 - Normalize-PersonaGarden-loading-labels-for-product-state-guard.md
@@ -1,0 +1,61 @@
+---
+id: TASK-45.24
+title: Normalize PersonaGarden loading labels for product-state guard
+status: Done
+assignee: []
+created_date: '2026-05-09 04:37'
+updated_date: '2026-05-09 04:41'
+labels:
+  - design-system
+  - webui
+  - guard
+dependencies: []
+references:
+  - apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+  - apps/packages/ui/src/design-system/states.ts
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+parent_task_id: TASK-45
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replace the new PersonaGarden hardcoded Loading fallbacks flagged by the product-state verifier with design-system state registry labels so fresh dev guard output returns to the accepted baseline.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 PersonaGarden loading button labels use getDesignSystemState("loading").label instead of hardcoded Loading strings.
+- [x] #2 The design-system verifier has no blocked PersonaGarden canonical-state-label findings after the change.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Initial verifier run failed on fresh origin/dev plus the StatusTag slice with two blocked canonical-state-label findings for hardcoded Loading fallbacks in VisualPackEditor.tsx. Using that verifier output as the red guard evidence for this small cleanup.
+
+Implementation: VisualPackEditor now uses getDesignSystemState("loading").label for its loading button fallbacks instead of new hardcoded Loading strings.
+
+Verification: bun run verify:design-system-state passed with no blocked PersonaGarden canonical-state-label findings; the final verifier summary reported baseline exceptions 512 and local-status-badge 6. The focused StatusTag test, product-state guard test suite, and git diff --check also passed on the combined slice.
+
+TypeScript caveat: bunx tsc --noEmit --pretty false still fails on unrelated repo-wide frontend baseline errors; a filtered tsc pass for the touched files produced no VisualPackEditor errors.
+
+Bandit: skipped because this cleanup only changes TypeScript and Backlog task metadata.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Normalized PersonaGarden loading labels to the design-system state registry so the product-state verifier returns to the accepted baseline while the Watchlists StatusTag slice removes its own baseline exception.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Codex summary
- Migrates Watchlists `StatusTag` from AntD `Tag` to the shared design-system `Badge` primitive.
- Maps run statuses through `getDesignSystemState(...)` before choosing Badge variants, while preserving labels, icons, `aria-label`, and `title`.
- Lets the Badge primitive forward `aria-label`/`title`, removes the Watchlists `local-status-badge` baseline exception, and normalizes two PersonaGarden loading labels that blocked the verifier on fresh `dev`.
- Adds Backlog task records TASK-45.23 and TASK-45.24 with verification evidence.

## Verification
- `bunx vitest run src/components/Option/Watchlists/shared/__tests__/StatusTag.accessibility.test.tsx --reporter=dot` passed 3/3.
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed 46/46.
- `bun run verify:design-system-state` passed; summary reports baseline exceptions 512 and `local-status-badge` 6.
- `git diff --check` passed.
- `bunx tsc --noEmit --pretty false` still fails on the existing repo-wide frontend baseline; a filtered tsc pass for touched files produced no errors.

## Merge note
Per the AI-generated PR policy, this PR still needs a human-authored Change summary before merge.