### PR TITLE
Add VN Play recovery controls

### DIFF
--- a/Docs/superpowers/plans/2026-05-09-vn-play-recovery-controls-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-09-vn-play-recovery-controls-implementation-plan.md
@@ -1,0 +1,102 @@
+# VN Play Recovery Controls Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add first-class VN Play WebUI controls for checkpoint creation, checkpoint restore, retry-last-turn recovery, and branch/checkpoint inspection.
+
+**Architecture:** Reuse the existing VN Play API client and workspace shell. Keep server-authoritative `scene_version` behavior: after checkpoint, restore, retry, stale-version, or in-progress recovery, refresh session, events, branches, and checkpoints from the backend instead of locally inventing state. Add focused React tests around the workspace because the backend endpoints and API client already exist.
+
+**Tech Stack:** Next.js/React 18, Vitest, Testing Library, existing `@web/lib/api/vnPlay` client, existing VN Play FastAPI endpoints.
+
+---
+
+## Source Inputs
+
+- Backlog: `TASK-151`
+- GitHub issue: `https://github.com/rmusser01/tldw_server/issues/1401`
+- Parent tracker: `https://github.com/rmusser01/tldw_server/issues/1391`
+- API docs: `Docs/API-related/VN_PLAY_API.md`
+- Runtime spec: `Docs/superpowers/specs/2026-05-01-vn-play-runtime-design.md`
+- Existing implementation plan: `Docs/superpowers/plans/2026-05-01-vn-play-runtime-implementation.md`
+
+## Current Code Shape
+
+- `apps/tldw-frontend/lib/api/vnPlay.ts` already exposes:
+  - `retryLastVNPlayTurn`
+  - `createVNPlayCheckpoint`
+  - `listVNPlayCheckpoints`
+  - `restoreVNPlaySession`
+  - `listVNPlayBranches`
+- `apps/tldw-frontend/components/vn-play/VNPlayWorkspace.tsx` currently loads sessions and events, handles turn responses, and reloads selected session/events after a turn.
+- `apps/tldw-frontend/components/vn-play/SceneInspector.tsx` accepts `branches` and `checkpoints`, but `VNPlayWorkspace` does not yet load or pass them.
+- Existing tests cover session creation and turn submission but not checkpoint/restore/retry/conflict recovery.
+
+## Stage 1: Load Branch And Checkpoint Metadata
+
+**Goal:** The selected session loads session details, events, branches, and checkpoints through one refresh path.
+
+**Success Criteria:** Selecting or reloading a session updates runtime inspector counts from backend branch/checkpoint endpoints.
+
+**Tests:** Add a failing `VNPlayWorkspace` test that mocks one branch and one checkpoint and expects the inspector to render `Branches 1` and `Checkpoints 1`.
+
+**Status:** Complete
+
+Steps:
+- [x] Add `listVNPlayBranches` and `listVNPlayCheckpoints` to the workspace API mock.
+- [x] Write failing workspace test for branch/checkpoint loading.
+- [x] Extend `VNPlayWorkspace` state with `branches` and `checkpoints`.
+- [x] Replace session/event refresh with `refreshSelectedSession(sessionId)` that loads session, events, branches, and checkpoints in parallel.
+- [x] Pass branch/checkpoint arrays into `SceneInspector`.
+
+## Stage 2: Checkpoint Create And Restore UX
+
+**Goal:** Users can create and restore checkpoints without raw API calls.
+
+**Success Criteria:** Runtime inspector exposes a compact checkpoint panel with create and restore controls, and restore refreshes session, events, branches, and checkpoints.
+
+**Tests:** Add failing workspace tests for creating a checkpoint and restoring one.
+
+**Status:** Complete
+
+Steps:
+- [x] Add mocked API calls for `createVNPlayCheckpoint` and `restoreVNPlaySession`.
+- [x] Write failing test for creating a checkpoint from the current scene.
+- [x] Write failing test for restoring a checkpoint and refreshing session/events/checkpoints/branches.
+- [x] Add create-checkpoint label state and a restore handler in `VNPlayWorkspace`.
+- [x] Extend `SceneInspector` with callback props for checkpoint create/restore.
+- [x] Render checkpoint rows with restore buttons and stable accessible labels.
+
+## Stage 3: Retry And Conflict Recovery UI
+
+**Goal:** Recoverable failed/interrupted turns expose explicit retry/reload/poll actions.
+
+**Success Criteria:** Stale scene version and in-progress turn conflicts render targeted guidance and actions; retry-last-turn uses a fresh idempotency key and refreshes state.
+
+**Tests:** Add failing workspace tests for stale-version recovery, turn-in-progress recovery, and retry-last-turn.
+
+**Status:** Complete
+
+Steps:
+- [x] Add mocked `retryLastVNPlayTurn` API call.
+- [x] Write failing test for a `stale_scene_version` turn error showing a reload action.
+- [x] Write failing test for a `turn_in_progress` turn error showing a poll action.
+- [x] Write failing test for retry-last-turn calling `/retry-last-turn` with current `sceneVersion`.
+- [x] Replace the generic `turnStatus` banner with structured recovery state.
+- [x] Add reload/poll/retry handlers that call the unified refresh path.
+
+## Stage 4: Smoke Coverage And Closeout
+
+**Goal:** Preserve the existing VN Play smoke path and cover the new recovery controls where feasible.
+
+**Success Criteria:** Focused Vitest coverage passes; smoke coverage is updated or blockers are documented; task and plan record verification.
+
+**Tests:** Run focused VN Play tests and, if the local Playwright server can bind, run `e2e/smoke/vn-play.spec.ts`.
+
+**Status:** Complete
+
+Steps:
+- [x] Update the VN Play smoke mock to respond to checkpoint and branch endpoints if the rendered page now calls them.
+- [x] Run `bunx vitest run __tests__/vn-play/VNPlayWorkspace.test.tsx __tests__/vn-play/vnPlayApi.test.ts __tests__/vn-play/SceneStage.test.tsx`.
+- [x] Run `bunx playwright test e2e/smoke/vn-play.spec.ts --reporter=line` if the local environment permits it.
+- [x] Run `git diff --check`.
+- [x] Update `TASK-151` with verification notes and final summary.

--- a/apps/tldw-frontend/__tests__/vn-play/VNPlayWorkspace.test.tsx
+++ b/apps/tldw-frontend/__tests__/vn-play/VNPlayWorkspace.test.tsx
@@ -1,29 +1,59 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import type { VNPlaySession } from '@web/types/vn-play';
+import type { VNPlayBranch, VNPlayCheckpoint, VNPlaySession } from '@web/types/vn-play';
 
 const mocks = vi.hoisted(() => ({
+  createVNPlayCheckpoint: vi.fn(),
   createVNPlaySession: vi.fn(),
   getVNPlaySession: vi.fn(),
+  listVNPlayBranches: vi.fn(),
+  listVNPlayCheckpoints: vi.fn(),
   listVNPlayEvents: vi.fn(),
   listVNPlaySessions: vi.fn(),
+  restoreVNPlaySession: vi.fn(),
+  retryLastVNPlayTurn: vi.fn(),
   submitVNPlayTurn: vi.fn(),
 }));
 
 vi.mock('@web/lib/api/vnPlay', () => ({
+  createVNPlayCheckpoint: (...args: unknown[]) => mocks.createVNPlayCheckpoint(...args),
   createVNPlaySession: (...args: unknown[]) => mocks.createVNPlaySession(...args),
   getVNPlaySession: (...args: unknown[]) => mocks.getVNPlaySession(...args),
+  listVNPlayBranches: (...args: unknown[]) => mocks.listVNPlayBranches(...args),
+  listVNPlayCheckpoints: (...args: unknown[]) => mocks.listVNPlayCheckpoints(...args),
   listVNPlayEvents: (...args: unknown[]) => mocks.listVNPlayEvents(...args),
   listVNPlaySessions: (...args: unknown[]) => mocks.listVNPlaySessions(...args),
+  restoreVNPlaySession: (...args: unknown[]) => mocks.restoreVNPlaySession(...args),
+  retryLastVNPlayTurn: (...args: unknown[]) => mocks.retryLastVNPlayTurn(...args),
   submitVNPlayTurn: (...args: unknown[]) => mocks.submitVNPlayTurn(...args),
 }));
 
 import VNPlayWorkspace from '@web/components/vn-play/VNPlayWorkspace';
 
-function mockVNPlayApi({ sessions = [] }: { sessions?: VNPlaySession[] } = {}) {
+function mockVNPlayApi({
+  branches = [],
+  checkpoints = [],
+  sessions = [],
+}: {
+  branches?: VNPlayBranch[];
+  checkpoints?: VNPlayCheckpoint[];
+  sessions?: VNPlaySession[];
+} = {}) {
+  mocks.createVNPlayCheckpoint.mockResolvedValue(
+    checkpoints[0] ?? {
+      id: 100,
+      session_id: 1,
+      owner_user_id: 42,
+      label: 'Checkpoint',
+      scene_version: 0,
+      scene_state_snapshot: { scene_version: 0 },
+    }
+  );
   mocks.listVNPlaySessions.mockResolvedValue(sessions);
   mocks.listVNPlayEvents.mockResolvedValue([]);
+  mocks.listVNPlayBranches.mockResolvedValue(branches);
+  mocks.listVNPlayCheckpoints.mockResolvedValue(checkpoints);
   mocks.getVNPlaySession.mockImplementation(async (sessionId: number) =>
     sessions.find((session) => session.id === sessionId) ?? sessions[0]
   );
@@ -37,6 +67,16 @@ function mockVNPlayApi({ sessions = [] }: { sessions?: VNPlaySession[] } = {}) {
     scene_state: { scene_version: 0 },
     ...request,
   }));
+  mocks.restoreVNPlaySession.mockImplementation(async (sessionId: number) =>
+    sessions.find((session) => session.id === sessionId) ?? sessions[0]
+  );
+  mocks.retryLastVNPlayTurn.mockResolvedValue({
+    turn_request_id: 11,
+    status: 'completed',
+    scene_version: 1,
+    scene_state: { scene_version: 1 },
+    events: [],
+  });
   mocks.submitVNPlayTurn.mockResolvedValue({
     turn_request_id: 10,
     status: 'completed',
@@ -148,5 +188,224 @@ describe('VNPlayWorkspace', () => {
       }));
     });
     expect(await screen.findByText('A quiet reply.')).toBeInTheDocument();
+  });
+
+  it('loads branch and checkpoint metadata for the selected session', async () => {
+    const session: VNPlaySession = {
+      id: 1,
+      mode: 'story',
+      title: 'Branching story',
+      primary_character_id: 1,
+      vn_asset_pack_id: 2,
+      scene_version: 3,
+      scene_state: { scene_version: 3 },
+    };
+    mockVNPlayApi({
+      branches: [
+        {
+          id: 7,
+          session_id: 1,
+          owner_user_id: 42,
+          branch_label: 'Archive path',
+          status: 'active',
+        },
+      ],
+      checkpoints: [
+        {
+          id: 5,
+          session_id: 1,
+          owner_user_id: 42,
+          label: 'Before archive',
+          scene_version: 2,
+          scene_state_snapshot: { scene_version: 2 },
+        },
+      ],
+      sessions: [session],
+    });
+
+    render(<VNPlayWorkspace />);
+
+    expect(await screen.findByTestId('vn-play-branch-count')).toHaveTextContent('1');
+    expect(screen.getByTestId('vn-play-checkpoint-count')).toHaveTextContent('1');
+    expect(screen.getByText('Archive path')).toBeInTheDocument();
+    expect(screen.getByText('Before archive')).toBeInTheDocument();
+  });
+
+  it('creates a checkpoint from the current scene and refreshes metadata', async () => {
+    const user = userEvent.setup();
+    const session: VNPlaySession = {
+      id: 1,
+      mode: 'story',
+      title: 'Checkpoint story',
+      primary_character_id: 1,
+      vn_asset_pack_id: 2,
+      scene_version: 4,
+      scene_state: { scene_version: 4 },
+    };
+    const checkpoint: VNPlayCheckpoint = {
+      id: 9,
+      session_id: 1,
+      owner_user_id: 42,
+      label: 'Before the tower',
+      scene_version: 4,
+      scene_state_snapshot: { scene_version: 4 },
+    };
+    mockVNPlayApi({ sessions: [session] });
+    mocks.listVNPlayCheckpoints
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([checkpoint]);
+    mocks.createVNPlayCheckpoint.mockResolvedValueOnce(checkpoint);
+
+    render(<VNPlayWorkspace />);
+
+    await screen.findByText('Checkpoint story');
+    await user.clear(screen.getByLabelText('Checkpoint label'));
+    await user.type(screen.getByLabelText('Checkpoint label'), 'Before the tower');
+    await user.click(screen.getByRole('button', { name: /create checkpoint/i }));
+
+    await waitFor(() => {
+      expect(mocks.createVNPlayCheckpoint).toHaveBeenCalledWith(1, {
+        label: 'Before the tower',
+        scene_version: 4,
+      });
+    });
+    expect(await screen.findByText('Before the tower')).toBeInTheDocument();
+  });
+
+  it('restores a checkpoint and refreshes session state', async () => {
+    const user = userEvent.setup();
+    const session: VNPlaySession = {
+      id: 1,
+      mode: 'story',
+      title: 'Restore story',
+      primary_character_id: 1,
+      vn_asset_pack_id: 2,
+      scene_version: 5,
+      scene_state: { scene_version: 5 },
+    };
+    const restoredSession: VNPlaySession = {
+      ...session,
+      scene_version: 2,
+      scene_state: { scene_version: 2 },
+    };
+    mockVNPlayApi({
+      checkpoints: [
+        {
+          id: 5,
+          session_id: 1,
+          owner_user_id: 42,
+          label: 'Before branch',
+          scene_version: 2,
+          scene_state_snapshot: { scene_version: 2 },
+        },
+      ],
+      sessions: [session],
+    });
+    mocks.restoreVNPlaySession.mockResolvedValueOnce(restoredSession);
+    mocks.getVNPlaySession.mockResolvedValue(restoredSession);
+
+    render(<VNPlayWorkspace />);
+
+    await user.click(await screen.findByRole('button', { name: /restore checkpoint before branch/i }));
+
+    await waitFor(() => {
+      expect(mocks.restoreVNPlaySession).toHaveBeenCalledWith(1, expect.objectContaining({
+        checkpoint_id: 5,
+      }));
+    });
+    expect(await screen.findByTestId('vn-play-scene-version')).toHaveTextContent('2');
+  });
+
+  it('shows stale scene recovery controls instead of a generic error', async () => {
+    const user = userEvent.setup();
+    const session: VNPlaySession = {
+      id: 1,
+      mode: 'freeform',
+      title: 'Stale story',
+      primary_character_id: 1,
+      vn_asset_pack_id: 2,
+      scene_version: 1,
+      scene_state: { scene_version: 1 },
+    };
+    mockVNPlayApi({ sessions: [session] });
+    mocks.submitVNPlayTurn.mockRejectedValueOnce(Object.assign(new Error('stale_scene_version'), { status: 409 }));
+
+    render(<VNPlayWorkspace />);
+
+    await screen.findByText('Stale story');
+    await user.type(screen.getByLabelText('Freeform input'), 'Open the archive');
+    await user.click(screen.getByRole('button', { name: 'Send turn' }));
+
+    expect(await screen.findByText('Scene changed on the server')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /reload session/i }));
+
+    await waitFor(() => {
+      expect(mocks.getVNPlaySession).toHaveBeenCalledWith(1);
+    });
+  });
+
+  it('shows in-progress turn recovery controls with a poll action', async () => {
+    const user = userEvent.setup();
+    const session: VNPlaySession = {
+      id: 1,
+      mode: 'freeform',
+      title: 'Busy story',
+      primary_character_id: 1,
+      vn_asset_pack_id: 2,
+      scene_version: 1,
+      scene_state: { scene_version: 1 },
+    };
+    mockVNPlayApi({ sessions: [session] });
+    mocks.submitVNPlayTurn.mockRejectedValueOnce(Object.assign(new Error('turn_in_progress'), { status: 409 }));
+
+    render(<VNPlayWorkspace />);
+
+    await screen.findByText('Busy story');
+    await user.type(screen.getByLabelText('Freeform input'), 'Ask again');
+    await user.click(screen.getByRole('button', { name: 'Send turn' }));
+
+    expect(await screen.findByText('Turn is still in progress')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /poll session/i }));
+
+    await waitFor(() => {
+      expect(mocks.getVNPlaySession).toHaveBeenCalledWith(1);
+    });
+  });
+
+  it('retries the last recoverable turn with a fresh idempotency key', async () => {
+    const user = userEvent.setup();
+    const session: VNPlaySession = {
+      id: 1,
+      mode: 'freeform',
+      title: 'Retry story',
+      primary_character_id: 1,
+      vn_asset_pack_id: 2,
+      scene_version: 6,
+      scene_state: { scene_version: 6 },
+    };
+    mockVNPlayApi({ sessions: [session] });
+    mocks.submitVNPlayTurn.mockResolvedValueOnce({
+      turn_request_id: 22,
+      status: 'model_failed',
+      scene_version: 6,
+      scene_state: { scene_version: 6 },
+      error_code: 'model_failed',
+      error_message: 'The model timed out.',
+      events: [],
+    });
+
+    render(<VNPlayWorkspace />);
+
+    await screen.findByText('Retry story');
+    await user.type(screen.getByLabelText('Freeform input'), 'Try the door');
+    await user.click(screen.getByRole('button', { name: 'Send turn' }));
+    await user.click(await screen.findByRole('button', { name: /retry last turn/i }));
+
+    await waitFor(() => {
+      expect(mocks.retryLastVNPlayTurn).toHaveBeenCalledWith(1, expect.objectContaining({
+        client_scene_version: 6,
+        idempotency_key: expect.stringMatching(/^retry-/),
+      }));
+    });
   });
 });

--- a/apps/tldw-frontend/components/vn-play/SceneInspector.tsx
+++ b/apps/tldw-frontend/components/vn-play/SceneInspector.tsx
@@ -1,18 +1,33 @@
 import React from 'react';
+import { RotateCcw, Save } from 'lucide-react';
+import { Button } from '@web/components/ui/Button';
+import { Input } from '@web/components/ui/Input';
 import type { VNPlayBranch, VNPlayCheckpoint, VNPlaySceneState, VNPlaySession } from '@web/types/vn-play';
 
 export interface SceneInspectorProps {
   branches?: VNPlayBranch[];
+  checkpointLabel?: string;
   checkpoints?: VNPlayCheckpoint[];
+  isCreatingCheckpoint?: boolean;
+  restoringCheckpointId?: number | null;
   sceneState: VNPlaySceneState;
   session: VNPlaySession;
+  onCheckpointLabelChange?: (label: string) => void;
+  onCreateCheckpoint?: () => void;
+  onRestoreCheckpoint?: (checkpointId: number) => void;
 }
 
 export default function SceneInspector({
   branches = [],
+  checkpointLabel = '',
   checkpoints = [],
+  isCreatingCheckpoint = false,
+  restoringCheckpointId = null,
   sceneState,
   session,
+  onCheckpointLabelChange,
+  onCreateCheckpoint,
+  onRestoreCheckpoint,
 }: SceneInspectorProps) {
   const sceneVersion = sceneState.scene_version ?? session.scene_version ?? 0;
   const warningCount = sceneState.warnings?.length ?? 0;
@@ -35,7 +50,7 @@ export default function SceneInspector({
         </div>
         <div>
           <dt className="text-xs uppercase tracking-normal text-text-muted">Scene version</dt>
-          <dd className="font-medium">{sceneVersion}</dd>
+          <dd className="font-medium" data-testid="vn-play-scene-version">{sceneVersion}</dd>
         </div>
         <div>
           <dt className="text-xs uppercase tracking-normal text-text-muted">Warnings</dt>
@@ -43,13 +58,79 @@ export default function SceneInspector({
         </div>
         <div>
           <dt className="text-xs uppercase tracking-normal text-text-muted">Branches</dt>
-          <dd className="font-medium">{branches.length}</dd>
+          <dd className="font-medium" data-testid="vn-play-branch-count">{branches.length}</dd>
         </div>
         <div>
           <dt className="text-xs uppercase tracking-normal text-text-muted">Checkpoints</dt>
-          <dd className="font-medium">{checkpoints.length}</dd>
+          <dd className="font-medium" data-testid="vn-play-checkpoint-count">{checkpoints.length}</dd>
         </div>
       </dl>
+      <section className="mt-5 border-t border-border pt-4">
+        <h3 className="mb-3 text-sm font-semibold uppercase tracking-normal text-text-muted">Branches</h3>
+        {branches.length > 0 ? (
+          <ul className="grid gap-2 text-sm" aria-label="VN play branches">
+            {branches.map((branch) => (
+              <li key={branch.id} className="flex items-center justify-between gap-2">
+                <span className="font-medium">{branch.branch_label || `Branch ${branch.id}`}</span>
+                {branch.status && <span className="text-xs text-text-muted">{branch.status}</span>}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-sm text-text-muted">No branches.</p>
+        )}
+      </section>
+      <section className="mt-5 border-t border-border pt-4">
+        <h3 className="mb-3 text-sm font-semibold uppercase tracking-normal text-text-muted">Checkpoints</h3>
+        <form
+          className="grid gap-2"
+          onSubmit={(event) => {
+            event.preventDefault();
+            onCreateCheckpoint?.();
+          }}
+        >
+          <Input
+            label="Checkpoint label"
+            value={checkpointLabel}
+            onChange={(event) => onCheckpointLabelChange?.(event.target.value)}
+          />
+          <Button
+            className="gap-2"
+            disabled={!onCreateCheckpoint}
+            loading={isCreatingCheckpoint}
+            type="submit"
+            variant="secondary"
+          >
+            <Save aria-hidden className="h-4 w-4" />
+            Create checkpoint
+          </Button>
+        </form>
+        {checkpoints.length > 0 ? (
+          <ul className="mt-4 grid gap-3 text-sm" aria-label="VN play checkpoints">
+            {checkpoints.map((checkpoint) => (
+              <li key={checkpoint.id} className="grid gap-2 border-t border-border pt-3 first:border-t-0 first:pt-0">
+                <div className="flex items-center justify-between gap-2">
+                  <span className="font-medium">{checkpoint.label}</span>
+                  <span className="text-xs text-text-muted">Scene {checkpoint.scene_version}</span>
+                </div>
+                <Button
+                  className="gap-2 justify-self-start"
+                  disabled={!onRestoreCheckpoint}
+                  loading={restoringCheckpointId === checkpoint.id}
+                  onClick={() => onRestoreCheckpoint?.(checkpoint.id)}
+                  type="button"
+                  variant="secondary"
+                >
+                  <RotateCcw aria-hidden className="h-4 w-4" />
+                  Restore checkpoint {checkpoint.label}
+                </Button>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="mt-3 text-sm text-text-muted">No checkpoints.</p>
+        )}
+      </section>
     </aside>
   );
 }

--- a/apps/tldw-frontend/components/vn-play/VNPlayWorkspace.tsx
+++ b/apps/tldw-frontend/components/vn-play/VNPlayWorkspace.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { BookOpen, MessageSquarePlus } from 'lucide-react';
+import { BookOpen, MessageSquarePlus, RefreshCw, RotateCcw } from 'lucide-react';
 import { Badge } from '@web/components/ui/Badge';
 import { Button } from '@web/components/ui/Button';
 import ChoicePanel from '@web/components/vn-play/ChoicePanel';
@@ -9,12 +9,19 @@ import SceneInspector from '@web/components/vn-play/SceneInspector';
 import SceneStage from '@web/components/vn-play/SceneStage';
 import SessionList, { VNPlayModeFilter } from '@web/components/vn-play/SessionList';
 import {
+  createVNPlayCheckpoint,
   createVNPlaySession,
   getVNPlaySession,
+  listVNPlayBranches,
+  listVNPlayCheckpoints,
   listVNPlayEvents,
   listVNPlaySessions,
+  restoreVNPlaySession,
+  retryLastVNPlayTurn,
 } from '@web/lib/api/vnPlay';
 import type {
+  VNPlayBranch,
+  VNPlayCheckpoint,
   VNPlayChoice,
   VNPlayEvent,
   VNPlayMode,
@@ -23,6 +30,22 @@ import type {
   VNPlaySessionCreate,
   VNPlayTurnResponse,
 } from '@web/types/vn-play';
+
+type RecoveryKind = 'retry_available' | 'stale_scene_version' | 'turn_in_progress';
+
+interface RecoveryState {
+  detail?: string;
+  kind: RecoveryKind;
+  message: string;
+  title: string;
+}
+
+const RECOVERABLE_TURN_STATUSES = new Set(['model_failed', 'parse_failed', 'abandoned', 'cancelled']);
+
+function idempotencyKey(prefix: string): string {
+  const uuid = globalThis.crypto?.randomUUID?.();
+  return `${prefix}-${uuid ?? `${Date.now()}-${Math.random().toString(36).slice(2)}`}`;
+}
 
 function sessionModeLabel(mode: VNPlayMode): string {
   return mode === 'story' ? 'Story/CYOA' : 'Freeform';
@@ -37,17 +60,33 @@ function isVNPlayChoice(choice: VNPlayChoice | Record<string, unknown>): choice 
   );
 }
 
+function describeTurnError(error: unknown): { detail: string; status?: number } {
+  const status = typeof error === 'object' && error !== null && 'status' in error
+    ? Number((error as { status?: number }).status)
+    : undefined;
+  const detail = error instanceof Error ? error.message : String(error);
+  return { detail, status };
+}
+
 export default function VNPlayWorkspace() {
   const [sessions, setSessions] = useState<VNPlaySession[]>([]);
   const [selectedSession, setSelectedSession] = useState<VNPlaySession | null>(null);
   const [events, setEvents] = useState<VNPlayEvent[]>([]);
+  const [branches, setBranches] = useState<VNPlayBranch[]>([]);
+  const [checkpoints, setCheckpoints] = useState<VNPlayCheckpoint[]>([]);
+  const [checkpointLabel, setCheckpointLabel] = useState('');
   const [modeFilter, setModeFilter] = useState<VNPlayModeFilter>('all');
   const [dialogMode, setDialogMode] = useState<VNPlayMode>('freeform');
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [isCreating, setIsCreating] = useState(false);
+  const [isCreatingCheckpoint, setIsCreatingCheckpoint] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
+  const [recoveryAction, setRecoveryAction] = useState<RecoveryKind | null>(null);
+  const [recoveryState, setRecoveryState] = useState<RecoveryState | null>(null);
+  const [restoringCheckpointId, setRestoringCheckpointId] = useState<number | null>(null);
   const [turnStatus, setTurnStatus] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const selectedSessionId = selectedSession?.id ?? null;
 
   useEffect(() => {
     let cancelled = false;
@@ -78,30 +117,40 @@ export default function VNPlayWorkspace() {
   }, []);
 
   useEffect(() => {
-    if (!selectedSession) {
+    if (selectedSessionId === null) {
       setEvents([]);
+      setBranches([]);
+      setCheckpoints([]);
       return;
     }
 
     let cancelled = false;
-    async function loadEvents() {
+    async function loadSessionMetadata() {
       try {
-        const nextEvents = await listVNPlayEvents(selectedSession.id);
+        const [nextEvents, nextBranches, nextCheckpoints] = await Promise.all([
+          listVNPlayEvents(selectedSessionId),
+          listVNPlayBranches(selectedSessionId),
+          listVNPlayCheckpoints(selectedSessionId),
+        ]);
         if (!cancelled) {
           setEvents(nextEvents);
+          setBranches(nextBranches);
+          setCheckpoints(nextCheckpoints);
         }
       } catch {
         if (!cancelled) {
           setEvents([]);
+          setBranches([]);
+          setCheckpoints([]);
         }
       }
     }
 
-    void loadEvents();
+    void loadSessionMetadata();
     return () => {
       cancelled = true;
     };
-  }, [selectedSession?.id]);
+  }, [selectedSessionId]);
 
   const filteredSessions = useMemo(() => {
     if (modeFilter === 'all') return sessions;
@@ -113,6 +162,13 @@ export default function VNPlayWorkspace() {
     setIsDialogOpen(true);
   }, []);
 
+  const handleSelectSession = useCallback((session: VNPlaySession) => {
+    setSelectedSession(session);
+    setCheckpointLabel('');
+    setRecoveryState(null);
+    setTurnStatus(null);
+  }, []);
+
   const handleCreateSession = useCallback(async (request: VNPlaySessionCreate) => {
     setIsCreating(true);
     setError(null);
@@ -121,6 +177,11 @@ export default function VNPlayWorkspace() {
       setSessions((previous) => [created, ...previous.filter((session) => session.id !== created.id)]);
       setSelectedSession(created);
       setEvents([]);
+      setBranches([]);
+      setCheckpoints([]);
+      setRecoveryState(null);
+      setTurnStatus(null);
+      setCheckpointLabel('');
       setModeFilter('all');
       setIsDialogOpen(false);
     } catch (createError) {
@@ -130,23 +191,43 @@ export default function VNPlayWorkspace() {
     }
   }, []);
 
-  const reloadSelectedSession = useCallback(async (sessionId: number) => {
-    const [nextSession, nextEvents] = await Promise.all([
+  const refreshSelectedSession = useCallback(async (sessionId: number) => {
+    const [nextSession, nextEvents, nextBranches, nextCheckpoints] = await Promise.all([
       getVNPlaySession(sessionId),
       listVNPlayEvents(sessionId),
+      listVNPlayBranches(sessionId),
+      listVNPlayCheckpoints(sessionId),
     ]);
     setSelectedSession(nextSession);
     setSessions((previous) =>
       previous.map((session) => (session.id === nextSession.id ? nextSession : session))
     );
     setEvents(nextEvents);
+    setBranches(nextBranches);
+    setCheckpoints(nextCheckpoints);
     return nextSession;
   }, []);
+
+  const selectedMode = selectedSession ? sessionModeLabel(selectedSession.mode) : null;
+  const sceneState: VNPlaySceneState | null =
+    selectedSession?.scene_state ?? selectedSession?.current_scene ?? null;
+  const sceneVersion = sceneState?.scene_version ?? selectedSession?.scene_version ?? 0;
+  const choices = (sceneState?.visible_choices ?? []).filter(isVNPlayChoice);
 
   const handleTurn = useCallback(async (response: VNPlayTurnResponse) => {
     if (!selectedSession) return;
 
     setTurnStatus(response.status);
+    if (RECOVERABLE_TURN_STATUSES.has(response.status)) {
+      setRecoveryState({
+        detail: response.error_message ?? response.error_code ?? response.status,
+        kind: 'retry_available',
+        message: 'The last turn did not complete. Retry it with a fresh idempotency key.',
+        title: 'Turn can be retried',
+      });
+    } else {
+      setRecoveryState(null);
+    }
     const responseEvents = response.events ?? [];
     if (responseEvents.length > 0) {
       setEvents((previous) => {
@@ -164,6 +245,11 @@ export default function VNPlayWorkspace() {
       setSessions((previous) =>
         previous.map((session) => (session.id === response.session?.id ? response.session : session))
       );
+      try {
+        await refreshSelectedSession(response.session.id);
+      } catch {
+        // Keep response-derived state when the follow-up refresh is unavailable.
+      }
       return;
     }
 
@@ -193,7 +279,7 @@ export default function VNPlayWorkspace() {
     }
 
     try {
-      await reloadSelectedSession(selectedSession.id);
+      await refreshSelectedSession(selectedSession.id);
       if (responseEvents.length > 0) {
         setEvents((previous) => {
           const byId = new Map(previous.map((event) => [event.id, event]));
@@ -206,33 +292,113 @@ export default function VNPlayWorkspace() {
     } catch {
       // Keep response-derived state when the follow-up refresh is unavailable.
     }
-  }, [reloadSelectedSession, selectedSession]);
+  }, [refreshSelectedSession, selectedSession]);
 
   const handleTurnError = useCallback(async (turnError: unknown) => {
-    const status = typeof turnError === 'object' && turnError !== null && 'status' in turnError
-      ? Number((turnError as { status?: number }).status)
-      : undefined;
-    const detail = turnError instanceof Error ? turnError.message : String(turnError);
+    const { detail, status } = describeTurnError(turnError);
     const isConflict = status === 409 || /stale_scene_version|turn_in_progress/i.test(detail);
 
     if (isConflict && selectedSession) {
-      setTurnStatus(/turn_in_progress/i.test(detail) ? 'turn_in_progress' : 'stale_scene_version');
+      const kind: RecoveryKind = /turn_in_progress/i.test(detail)
+        ? 'turn_in_progress'
+        : 'stale_scene_version';
+      setTurnStatus(kind);
+      setRecoveryState({
+        detail,
+        kind,
+        message: kind === 'turn_in_progress'
+          ? 'A turn is already running for this session. Poll the session before submitting another action.'
+          : 'The scene changed on the server. Reload the session before resubmitting.',
+        title: kind === 'turn_in_progress' ? 'Turn is still in progress' : 'Scene changed on the server',
+      });
       try {
-        await reloadSelectedSession(selectedSession.id);
+        await refreshSelectedSession(selectedSession.id);
       } catch {
         setError(detail);
       }
       return;
     }
 
+    if (selectedSession) {
+      setRecoveryState({
+        detail,
+        kind: 'retry_available',
+        message: 'The last turn failed before completion. Retry it with a fresh idempotency key.',
+        title: 'Turn can be retried',
+      });
+    }
     setError(detail);
-  }, [reloadSelectedSession, selectedSession]);
+  }, [refreshSelectedSession, selectedSession]);
 
-  const selectedMode = selectedSession ? sessionModeLabel(selectedSession.mode) : null;
-  const sceneState: VNPlaySceneState | null =
-    selectedSession?.scene_state ?? selectedSession?.current_scene ?? null;
-  const sceneVersion = sceneState?.scene_version ?? selectedSession?.scene_version ?? 0;
-  const choices = (sceneState?.visible_choices ?? []).filter(isVNPlayChoice);
+  const handleCreateCheckpoint = useCallback(async () => {
+    if (!selectedSession) return;
+    const label = checkpointLabel.trim() || `Scene ${sceneVersion}`;
+    setIsCreatingCheckpoint(true);
+    setError(null);
+    try {
+      await createVNPlayCheckpoint(selectedSession.id, {
+        label,
+        scene_version: sceneVersion,
+      });
+      setCheckpointLabel('');
+      await refreshSelectedSession(selectedSession.id);
+    } catch (checkpointError) {
+      setError(checkpointError instanceof Error ? checkpointError.message : 'Failed to create checkpoint');
+    } finally {
+      setIsCreatingCheckpoint(false);
+    }
+  }, [checkpointLabel, refreshSelectedSession, sceneVersion, selectedSession]);
+
+  const handleRestoreCheckpoint = useCallback(async (checkpointId: number) => {
+    if (!selectedSession) return;
+    setRestoringCheckpointId(checkpointId);
+    setError(null);
+    try {
+      await restoreVNPlaySession(selectedSession.id, {
+        checkpoint_id: checkpointId,
+        idempotency_key: idempotencyKey('restore'),
+      });
+      setRecoveryState(null);
+      await refreshSelectedSession(selectedSession.id);
+    } catch (restoreError) {
+      setError(restoreError instanceof Error ? restoreError.message : 'Failed to restore checkpoint');
+    } finally {
+      setRestoringCheckpointId(null);
+    }
+  }, [refreshSelectedSession, selectedSession]);
+
+  const handleRetryLastTurn = useCallback(async () => {
+    if (!selectedSession) return;
+    setRecoveryAction('retry_available');
+    setError(null);
+    try {
+      const response = await retryLastVNPlayTurn(selectedSession.id, {
+        client_scene_version: sceneVersion,
+        idempotency_key: idempotencyKey('retry'),
+      });
+      await handleTurn(response);
+    } catch (retryError) {
+      setError(retryError instanceof Error ? retryError.message : 'Failed to retry turn');
+    } finally {
+      setRecoveryAction(null);
+    }
+  }, [handleTurn, sceneVersion, selectedSession]);
+
+  const handleRecoveryRefresh = useCallback(async (kind: RecoveryKind) => {
+    if (!selectedSession) return;
+    setRecoveryAction(kind);
+    setError(null);
+    try {
+      await refreshSelectedSession(selectedSession.id);
+      if (kind !== 'retry_available') {
+        setRecoveryState(null);
+      }
+    } catch (refreshError) {
+      setError(refreshError instanceof Error ? refreshError.message : 'Failed to refresh session');
+    } finally {
+      setRecoveryAction(null);
+    }
+  }, [refreshSelectedSession, selectedSession]);
 
   return (
     <main className="min-h-screen bg-bg text-text">
@@ -264,7 +430,43 @@ export default function VNPlayWorkspace() {
             {error}
           </div>
         )}
-        {turnStatus && turnStatus !== 'completed' && (
+        {recoveryState && (
+          <div className="grid gap-3 rounded-md border border-warn/30 bg-warn/10 px-3 py-3 text-sm text-warn">
+            <div>
+              <p className="font-medium">{recoveryState.title}</p>
+              <p>{recoveryState.message}</p>
+              {recoveryState.detail && (
+                <p className="mt-1 text-xs opacity-80">{recoveryState.detail}</p>
+              )}
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {recoveryState.kind === 'retry_available' ? (
+                <Button
+                  className="gap-2"
+                  loading={recoveryAction === 'retry_available'}
+                  onClick={() => void handleRetryLastTurn()}
+                  type="button"
+                  variant="secondary"
+                >
+                  <RotateCcw aria-hidden className="h-4 w-4" />
+                  Retry last turn
+                </Button>
+              ) : (
+                <Button
+                  className="gap-2"
+                  loading={recoveryAction === recoveryState.kind}
+                  onClick={() => void handleRecoveryRefresh(recoveryState.kind)}
+                  type="button"
+                  variant="secondary"
+                >
+                  <RefreshCw aria-hidden className="h-4 w-4" />
+                  {recoveryState.kind === 'turn_in_progress' ? 'Poll session' : 'Reload session'}
+                </Button>
+              )}
+            </div>
+          </div>
+        )}
+        {!recoveryState && turnStatus && turnStatus !== 'completed' && (
           <div className="rounded-md border border-warn/30 bg-warn/10 px-3 py-2 text-sm text-warn">
             {turnStatus}
           </div>
@@ -284,7 +486,7 @@ export default function VNPlayWorkspace() {
             selectedSessionId={selectedSession?.id}
             sessions={filteredSessions}
             onModeFilterChange={setModeFilter}
-            onSelectSession={setSelectedSession}
+            onSelectSession={handleSelectSession}
           />
 
           <section className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(300px,380px)]">
@@ -321,7 +523,18 @@ export default function VNPlayWorkspace() {
             </div>
 
             {selectedSession && sceneState ? (
-              <SceneInspector sceneState={sceneState} session={selectedSession} />
+              <SceneInspector
+                branches={branches}
+                checkpointLabel={checkpointLabel}
+                checkpoints={checkpoints}
+                isCreatingCheckpoint={isCreatingCheckpoint}
+                restoringCheckpointId={restoringCheckpointId}
+                sceneState={sceneState}
+                session={selectedSession}
+                onCheckpointLabelChange={setCheckpointLabel}
+                onCreateCheckpoint={handleCreateCheckpoint}
+                onRestoreCheckpoint={handleRestoreCheckpoint}
+              />
             ) : (
               <aside className="rounded-md border border-border bg-surface p-4">
                 <h2 className="mb-4 text-lg font-semibold">Runtime inspector</h2>

--- a/apps/tldw-frontend/e2e/smoke/vn-play.spec.ts
+++ b/apps/tldw-frontend/e2e/smoke/vn-play.spec.ts
@@ -18,6 +18,16 @@ test.describe('VN play smoke', () => {
     });
 
     const events: Array<Record<string, unknown>> = [];
+    const branches: Array<Record<string, unknown>> = [
+      {
+        id: 1,
+        session_id: 1,
+        owner_user_id: 42,
+        branch_label: 'Smoke path',
+        status: 'active',
+      },
+    ];
+    const checkpoints: Array<Record<string, unknown>> = [];
     let session: Record<string, unknown> | null = null;
 
     await page.route(/\/api\/v1\/health(?:\/.*)?$/, async (route) => {
@@ -73,6 +83,31 @@ test.describe('VN play smoke', () => {
         return;
       }
 
+      if (method === 'GET' && path === '/sessions/1/branches') {
+        await fulfillJson(route, 200, branches);
+        return;
+      }
+
+      if (method === 'GET' && path === '/sessions/1/checkpoints') {
+        await fulfillJson(route, 200, checkpoints);
+        return;
+      }
+
+      if (method === 'POST' && path === '/sessions/1/checkpoint') {
+        const body = request.postDataJSON() as Record<string, unknown>;
+        const checkpoint = {
+          id: checkpoints.length + 1,
+          session_id: 1,
+          owner_user_id: 42,
+          label: body.label,
+          scene_version: body.scene_version ?? (session?.scene_version as number | undefined) ?? 0,
+          scene_state_snapshot: session?.scene_state ?? { scene_version: 0 },
+        };
+        checkpoints.push(checkpoint);
+        await fulfillJson(route, 201, checkpoint);
+        return;
+      }
+
       if (method === 'POST' && path === '/sessions/1/turn') {
         const modelTurn = {
           id: 2,
@@ -119,6 +154,11 @@ test.describe('VN play smoke', () => {
     await page.getByRole('button', { name: 'Create session' }).click();
 
     await expect(page.getByText('Selected session: Smoke Story')).toBeVisible();
+    await expect(page.getByText('Smoke path')).toBeVisible();
+    await page.getByLabel('Checkpoint label').fill('Before door');
+    await page.getByRole('button', { name: 'Create checkpoint' }).click();
+    await expect(page.getByRole('button', { name: 'Restore checkpoint Before door' })).toBeVisible();
+
     await page.getByRole('button', { name: 'Open the door' }).click();
 
     await expect(page.getByText('The door opens onto the archive.')).toBeVisible();

--- a/backlog/tasks/task-151 - Add-VN-Play-recovery-and-branch-controls.md
+++ b/backlog/tasks/task-151 - Add-VN-Play-recovery-and-branch-controls.md
@@ -1,0 +1,72 @@
+---
+id: TASK-151
+title: Add VN Play recovery and branch controls
+status: Done
+assignee: []
+created_date: '2026-05-09 04:39'
+updated_date: '2026-05-09 05:01'
+labels:
+  - vn-play
+  - frontend
+  - recovery
+  - webui
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1401'
+  - 'https://github.com/rmusser01/tldw_server/issues/1391'
+  - 'https://github.com/rmusser01/tldw_server/pull/1404'
+documentation:
+  - >-
+    Docs/superpowers/plans/2026-05-09-vn-play-recovery-controls-implementation-plan.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement issue #1401: make VN Play session recovery and branching controls first-class in the WebUI. The backend already exposes checkpoint, restore, retry-last-turn, events, session, and branch endpoints; this task should wire them into the existing VN Play workspace with explicit recovery states and focused frontend coverage.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Selected sessions load and display checkpoint and branch metadata in the runtime inspector
+- [x] #2 Users can create a checkpoint from the current scene and see the refreshed checkpoint list
+- [x] #3 Users can restore a checkpoint and the selected session, scene state, events, checkpoints, and branches refresh coherently
+- [x] #4 Users can retry the last recoverable failed/interrupted turn with a fresh idempotency key without duplicating the original action
+- [x] #5 stale_scene_version and turn_in_progress conflicts show explicit recovery UI with reload/poll actions instead of generic errors
+- [x] #6 Focused frontend tests cover checkpoint create, checkpoint restore, retry-last-turn, branch/checkpoint loading, and conflict-state recovery behavior
+- [x] #7 Smoke/E2E coverage is updated where feasible, or exact environment blockers are documented
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Plan saved at Docs/superpowers/plans/2026-05-09-vn-play-recovery-controls-implementation-plan.md. Scope is frontend-first: load branch/checkpoint metadata, add checkpoint create/restore UX, add retry/stale/in-progress recovery controls, and verify focused VN Play tests plus smoke coverage where feasible.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented branch/checkpoint metadata loading, checkpoint create/restore controls, retry-last-turn recovery, stale_scene_version reload recovery, and turn_in_progress polling recovery in the VN Play WebUI.
+Verification: bunx vitest run __tests__/vn-play/VNPlayWorkspace.test.tsx __tests__/vn-play/vnPlayApi.test.ts __tests__/vn-play/SceneStage.test.tsx -> 3 files / 15 tests passed.
+Verification: TLDW_WEB_URL=http://localhost:18081 TLDW_WEB_CMD="bun run dev -- -p 18081" bunx playwright test e2e/smoke/vn-play.spec.ts --reporter=line -> 1 passed.
+Verification: bunx eslint components/vn-play/VNPlayWorkspace.tsx components/vn-play/SceneInspector.tsx __tests__/vn-play/VNPlayWorkspace.test.tsx e2e/smoke/vn-play.spec.ts -> 0 errors/warnings.
+Verification: git diff --check -> passed.
+Bandit: skipped because this task touched only frontend TypeScript/TSX and docs/task metadata, no Python paths.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added VN Play WebUI recovery controls and branch/checkpoint inspection. The workspace now refreshes session, events, branches, and checkpoints together; the runtime inspector can create and restore checkpoints; recoverable turn failures expose retry/reload/poll actions with fresh idempotency keys. Focused Vitest, ESLint, git diff --check, and an isolated-port Playwright smoke test all pass.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Load VN Play branch and checkpoint metadata through the selected-session refresh path and show it in the runtime inspector.
- Add checkpoint create/restore controls that refresh session, events, branches, and checkpoints from the backend.
- Add recoverable turn UI for retry-last-turn, stale scene reload, and turn-in-progress polling.

## Verification
- `bunx vitest run __tests__/vn-play/VNPlayWorkspace.test.tsx __tests__/vn-play/vnPlayApi.test.ts __tests__/vn-play/SceneStage.test.tsx` -> 3 files / 15 tests passed
- `bunx eslint components/vn-play/VNPlayWorkspace.tsx components/vn-play/SceneInspector.tsx __tests__/vn-play/VNPlayWorkspace.test.tsx e2e/smoke/vn-play.spec.ts` -> 0 errors/warnings
- `TLDW_WEB_URL=http://localhost:18081 TLDW_WEB_CMD="bun run dev -- -p 18081" bunx playwright test e2e/smoke/vn-play.spec.ts --reporter=line` -> 1 passed
- `git diff --check` / `git diff --check HEAD~1..HEAD` -> passed

## Tracking
Closes #1401
Refs #1391
Backlog: TASK-151

## Merge Gate
Draft PR. Before merge, the human requester needs to add a human-written Change summary explaining what changed and why, per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.