### PR TITLE
Remove dayjs from Models refresh time

### DIFF
--- a/Docs/Design/WebUI_Dependency_Audit.md
+++ b/Docs/Design/WebUI_Dependency_Audit.md
@@ -107,7 +107,7 @@ This audit does not remove packages or rewrite runtime code.
 | `cytoscape` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 6 | apps/packages/ui/src/components/Notes/NotesGraphModal.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesGraphModal.stage2.graph-view.test.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage21.accessibility-modal-focus.test.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage22.accessibility-regression.test.tsx | shared UI, shared UI tests | graph/rendering | `keep` | Low; import/config/package-script evidence in current WebUI or shared UI paths. | No immediate reduction; keep current behavior. | none |
 | `cytoscape-dagre` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 6 | apps/packages/ui/src/components/Notes/NotesGraphModal.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesGraphModal.stage2.graph-view.test.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage21.accessibility-modal-focus.test.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage22.accessibility-regression.test.tsx | shared UI, shared UI tests | graph/rendering | `keep` | Low; import/config/package-script evidence in current WebUI or shared UI paths. | No immediate reduction; keep current behavior. | none |
 | `d3-dsv` | `web:dependencies`, `extension:dependencies` | 0 | none found | web app, extension impact declaration only | parser/conversion | `investigate-lockfile` | Medium; no import/config/package-script evidence, but package sits in parser/conversion behavior. Confirm direct-vs-transitive ownership and CSV/DSV coverage before removal. | Potential install/bundle reduction if direct declaration proves unused. | Lockfile/parser-domain investigation slice. |
-| `dayjs` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 17 | apps/packages/ui/src/components/Flashcards/components/FlashcardEditDrawer.tsx, apps/packages/ui/src/components/Media/FilterPanel.tsx, apps/packages/ui/src/components/Option/DataTables/EditableCell.tsx, apps/packages/ui/src/components/Option/KanbanPlayground/CardDetailPanel.tsx | shared UI, shared UI tests | frontend/runtime | `defer-design` | Medium; some display formatting can move to native `Intl` or small local helpers, but several Ant Design DatePicker/DateRangePicker surfaces currently exchange `Dayjs` values and types. | No immediate dependency reduction until shared UI date-picker value contracts are redesigned or isolated. | Continue display-formatting replacement slices before date-picker design. |
+| `dayjs` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 15 | apps/packages/ui/src/components/Flashcards/components/FlashcardEditDrawer.tsx, apps/packages/ui/src/components/Media/FilterPanel.tsx, apps/packages/ui/src/components/Option/DataTables/EditableCell.tsx, apps/packages/ui/src/components/Option/KanbanPlayground/CardDetailPanel.tsx | shared UI, shared UI tests | frontend/runtime | `defer-design` | Medium; some display formatting can move to native `Intl` or small local helpers, but several Ant Design DatePicker/DateRangePicker surfaces currently exchange `Dayjs` values and types. | No immediate dependency reduction until shared UI date-picker value contracts are redesigned or isolated. | Continue display-formatting replacement slices before date-picker design. |
 | `dexie` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 6 | apps/packages/ui/src/db/dexie/chat.ts, apps/packages/ui/src/db/dexie/schema.ts, apps/packages/ui/src/hooks/document-workspace/__tests__/offlineQueue.test.ts, apps/packages/ui/src/hooks/document-workspace/offlineQueue.ts | shared UI, shared UI tests, web tests, web app | state/data | `keep` | Low; import/config/package-script evidence in current WebUI or shared UI paths. | No immediate reduction; keep current behavior. | none |
 | `dexie-react-hooks` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 1 | apps/packages/ui/src/components/Sidepanel/Chat/TtsClipsDrawer.tsx | shared UI | state/data | `keep` | Low; import/config/package-script evidence in current WebUI or shared UI paths. | No immediate reduction; keep current behavior. | none |
 | `dompurify` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 11 | apps/packages/ui/src/components/Common/CodeBlock.tsx, apps/packages/ui/src/components/Notes/NotesStudioDiagramCard.tsx, apps/packages/ui/src/components/Notes/export-utils.ts, apps/packages/ui/src/components/Option/Collections/ReadingList/ReadingItemDetail.tsx | shared UI | security/sanitization | `keep` | Low; import/config/package-script evidence in current WebUI or shared UI paths. | No immediate reduction; keep current behavior. | none |
@@ -212,6 +212,11 @@ This audit does not remove packages or rewrite runtime code.
   shared UI `dayjs` import count dropped from 19 to 17 while leaving the
   package declared for remaining Flashcards/Models display formatting and Ant
   Design `Dayjs` value-contract surfaces.
+- TASK-153 removed `dayjs` time formatting from the display-only Models
+  last-refreshed label by replacing `dayjs(...).format("HH:mm")` with a small
+  native `Intl.DateTimeFormat` helper. The shared UI `dayjs` import count
+  dropped from 17 to 15 while leaving the package declared for remaining
+  Flashcards display formatting and Ant Design `Dayjs` value-contract surfaces.
 
 ### Quick Cleanup Candidates
 
@@ -370,11 +375,23 @@ ownership checks, or complex-domain packages that should stay on the
   src/components/Option/WorldBooks/__tests__/worldBookListUtils.test.ts` from
   `apps/packages/ui` passed after first failing on the dependency guard before
   implementation.
+- 2026-05-09 TASK-153 active-code scan: exact shared UI package-import scan
+  found 15 remaining `dayjs` import lines after removing both imports from
+  `apps/packages/ui/src/components/Option/Models/index.tsx`. Remaining imports
+  are concentrated in Flashcards relative-time/date displays and Ant Design
+  `Dayjs` value/type surfaces in media, reading list, items, data table, and
+  kanban code.
+- 2026-05-09 TASK-153 verification: `bunx vitest run
+  src/components/Option/Models/__tests__/modelsDisplayUtils.test.ts` from
+  `apps/packages/ui` passed after first failing on the missing native helper
+  and then failing on the dependency guard before implementation.
 - Bandit: skipped for TASK-144 because the slice changed documentation and
   Backlog metadata only; no Python files were modified.
 - Bandit: skipped for TASK-147 because the slice changed TypeScript,
   documentation, and Backlog metadata only; no Python files were modified.
 - Bandit: skipped for TASK-149 because the slice changed TypeScript,
+  documentation, and Backlog metadata only; no Python files were modified.
+- Bandit: skipped for TASK-153 because the slice changed TypeScript,
   documentation, and Backlog metadata only; no Python files were modified.
 
 ## Known Skips And Blockers

--- a/Docs/Design/WebUI_Dependency_Audit.md
+++ b/Docs/Design/WebUI_Dependency_Audit.md
@@ -383,8 +383,10 @@ ownership checks, or complex-domain packages that should stay on the
   kanban code.
 - 2026-05-09 TASK-153 verification: `bunx vitest run
   src/components/Option/Models/__tests__/modelsDisplayUtils.test.ts` from
-  `apps/packages/ui` passed after first failing on the missing native helper
-  and then failing on the dependency guard before implementation.
+  `apps/packages/ui` passed after first failing on the missing native helper.
+  The PR review follow-up removed the filesystem-based source guard from the
+  Vitest unit test; dependency regression coverage for this slice is recorded
+  through the exact Models-tree package-import scan instead.
 - Bandit: skipped for TASK-144 because the slice changed documentation and
   Backlog metadata only; no Python files were modified.
 - Bandit: skipped for TASK-147 because the slice changed TypeScript,

--- a/apps/packages/ui/src/components/Option/Models/__tests__/modelsDisplayUtils.test.ts
+++ b/apps/packages/ui/src/components/Option/Models/__tests__/modelsDisplayUtils.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+import { describe, expect, it } from "vitest"
+import { formatModelsLastRefreshedTime } from "../modelsDisplayUtils"
+
+describe("models display utilities", () => {
+  it.each([
+    [new Date(2026, 1, 18, 9, 5).getTime(), "09:05"],
+    [new Date(2026, 1, 18, 0, 7).getTime(), "00:07"],
+  ])("formats %s as a dayjs-compatible HH:mm time", (value, expected) => {
+    expect(formatModelsLastRefreshedTime(value)).toBe(expected)
+  })
+
+  it("does not depend on dayjs for last-refreshed display formatting", () => {
+    const testDir = dirname(fileURLToPath(import.meta.url))
+    const source = readFileSync(resolve(testDir, "../index.tsx"), "utf8")
+    const dayjsImportPattern = /^\s*import\s+(?:type\s+)?(?:.+?\s+from\s+)?["']dayjs(?:\/[^"']*)?["']/m
+
+    expect(source).not.toMatch(dayjsImportPattern)
+  })
+})

--- a/apps/packages/ui/src/components/Option/Models/__tests__/modelsDisplayUtils.test.ts
+++ b/apps/packages/ui/src/components/Option/Models/__tests__/modelsDisplayUtils.test.ts
@@ -1,7 +1,3 @@
-import { readFileSync } from "node:fs"
-import { dirname, resolve } from "node:path"
-import { fileURLToPath } from "node:url"
-
 import { describe, expect, it } from "vitest"
 import { formatModelsLastRefreshedTime } from "../modelsDisplayUtils"
 
@@ -11,13 +7,5 @@ describe("models display utilities", () => {
     [new Date(2026, 1, 18, 0, 7).getTime(), "00:07"],
   ])("formats %s as a dayjs-compatible HH:mm time", (value, expected) => {
     expect(formatModelsLastRefreshedTime(value)).toBe(expected)
-  })
-
-  it("does not depend on dayjs for last-refreshed display formatting", () => {
-    const testDir = dirname(fileURLToPath(import.meta.url))
-    const source = readFileSync(resolve(testDir, "../index.tsx"), "utf8")
-    const dayjsImportPattern = /^\s*import\s+(?:type\s+)?(?:.+?\s+from\s+)?["']dayjs(?:\/[^"']*)?["']/m
-
-    expect(source).not.toMatch(dayjsImportPattern)
   })
 })

--- a/apps/packages/ui/src/components/Option/Models/index.tsx
+++ b/apps/packages/ui/src/components/Option/Models/index.tsx
@@ -1,11 +1,10 @@
 import { Select, Spin } from "antd"
-import dayjs from "dayjs"
-import relativeTime from "dayjs/plugin/relativeTime"
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { browser } from "wxt/browser"
 import { AvailableModelsList } from "./AvailableModelsList"
+import { formatModelsLastRefreshedTime } from "./modelsDisplayUtils"
 import { useAntdNotification } from "@/hooks/useAntdNotification"
 import { tldwClient, tldwModels } from "@/services/tldw"
 import { useStorage } from "@plasmohq/storage/hook"
@@ -15,8 +14,6 @@ import {
   normalizeProviderKey
 } from "@/utils/provider-registry"
 import { isAutoModelId } from "@/utils/resolve-api-provider"
-
-dayjs.extend(relativeTime)
 
 interface RefreshResponse {
   ok: boolean
@@ -426,7 +423,7 @@ export const ModelsBody = () => {
                 <span className="text-xs text-text-subtle">
                   {t("settings:models.lastRefreshedAt", {
                     defaultValue: "Last checked at {{time}}",
-                    time: dayjs(lastRefreshedAt).format("HH:mm")
+                    time: formatModelsLastRefreshedTime(lastRefreshedAt)
                   })}
                 </span>
               )}

--- a/apps/packages/ui/src/components/Option/Models/modelsDisplayUtils.ts
+++ b/apps/packages/ui/src/components/Option/Models/modelsDisplayUtils.ts
@@ -1,8 +1,6 @@
-const LAST_REFRESHED_TIME_FORMATTER = new Intl.DateTimeFormat("en-GB", {
-  hour: "2-digit",
-  hourCycle: "h23",
-  minute: "2-digit"
-})
-
-export const formatModelsLastRefreshedTime = (timestamp: number): string =>
-  LAST_REFRESHED_TIME_FORMATTER.format(new Date(timestamp))
+export const formatModelsLastRefreshedTime = (timestamp: number): string => {
+  const date = new Date(timestamp)
+  const hours = date.getHours().toString().padStart(2, "0")
+  const minutes = date.getMinutes().toString().padStart(2, "0")
+  return `${hours}:${minutes}`
+}

--- a/apps/packages/ui/src/components/Option/Models/modelsDisplayUtils.ts
+++ b/apps/packages/ui/src/components/Option/Models/modelsDisplayUtils.ts
@@ -1,0 +1,8 @@
+const LAST_REFRESHED_TIME_FORMATTER = new Intl.DateTimeFormat("en-GB", {
+  hour: "2-digit",
+  hourCycle: "h23",
+  minute: "2-digit"
+})
+
+export const formatModelsLastRefreshedTime = (timestamp: number): string =>
+  LAST_REFRESHED_TIME_FORMATTER.format(new Date(timestamp))

--- a/backlog/tasks/task-153 - Remove-dayjs-from-Models-last-refreshed-display-formatting.md
+++ b/backlog/tasks/task-153 - Remove-dayjs-from-Models-last-refreshed-display-formatting.md
@@ -24,7 +24,7 @@ priority: medium
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Continue issue #1346 by replacing the display-only dayjs usage in apps/packages/ui/src/components/Option/Models/index.tsx with native Date/Intl formatting. Keep dayjs declared for remaining Flashcards display formatting and Ant Design Dayjs value-contract surfaces, and update the dependency audit with the reduced import count.
+Continue issue #1346 by replacing the display-only dayjs usage in apps/packages/ui/src/components/Option/Models/index.tsx with native Date formatting. Keep dayjs declared for remaining Flashcards display formatting and Ant Design Dayjs value-contract surfaces, and update the dependency audit with the reduced import count.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
@@ -37,8 +37,8 @@ Continue issue #1346 by replacing the display-only dayjs usage in apps/packages/
 
 ## Implementation Plan
 <!-- SECTION:PLAN:BEGIN -->
-1. Add a focused Models test/source guard that fails while index.tsx imports dayjs.
-2. Replace the last-refreshed formatter with a native Date/Intl helper.
+1. Add focused Models formatting coverage and verify dependency removal with an explicit import scan.
+2. Replace the last-refreshed formatter with a native Date helper.
 3. Update the dependency audit import count and completed follow-up notes.
 4. Run focused Vitest, import scans, lint/diff checks, and record Bandit rationale before commit/PR.
 <!-- SECTION:PLAN:END -->
@@ -55,9 +55,9 @@ Continue issue #1346 by replacing the display-only dayjs usage in apps/packages/
 
 ## Implementation Notes
 <!-- SECTION:NOTES:BEGIN -->
-TDD red checks: the focused Models display utility test first failed because modelsDisplayUtils did not exist, then failed on the dayjs import guard while Models/index.tsx still imported dayjs and dayjs/plugin/relativeTime.
+TDD red check: the focused Models display utility test first failed because modelsDisplayUtils did not exist. Dependency removal was verified separately with an exact package-import scan rather than a filesystem-reading unit-test guard.
 
-Implemented a native Intl.DateTimeFormat helper for the Models last-refreshed HH:mm label and wired Models/index.tsx to use it instead of dayjs.
+Implemented a native Date/getHours/getMinutes helper for the Models last-refreshed HH:mm label and wired Models/index.tsx to use it instead of dayjs.
 
 Updated the WebUI dependency audit to record the dayjs import count dropping from 17 to 15 and to keep remaining Flashcards display formatting plus Ant Design Dayjs value contracts explicit.
 
@@ -68,5 +68,5 @@ Opened PR #1405 against dev for this Models dayjs cleanup slice: https://github.
 
 ## Final Summary
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Removed dayjs from the Models last-refreshed display label by replacing dayjs formatting with a native Intl helper, added focused formatting and no-dayjs guard tests, and updated the dependency audit to show the remaining dayjs import count dropping from 17 to 15 while preserving the remaining Flashcards and Ant Design Dayjs blockers.
+Removed dayjs from the Models last-refreshed display label by replacing dayjs formatting with a native Date helper, added focused formatting tests, and updated the dependency audit to show the remaining dayjs import count dropping from 17 to 15 while preserving the remaining Flashcards and Ant Design Dayjs blockers.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-153 - Remove-dayjs-from-Models-last-refreshed-display-formatting.md
+++ b/backlog/tasks/task-153 - Remove-dayjs-from-Models-last-refreshed-display-formatting.md
@@ -1,0 +1,69 @@
+---
+id: TASK-153
+title: Remove dayjs from Models last-refreshed display formatting
+status: Done
+assignee: []
+created_date: '2026-05-09 04:59'
+updated_date: '2026-05-09 05:04'
+labels:
+  - webui
+  - dependencies
+  - cleanup
+  - dayjs
+dependencies:
+  - TASK-144
+  - TASK-149
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1346'
+documentation:
+  - Docs/Design/WebUI_Dependency_Audit.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue issue #1346 by replacing the display-only dayjs usage in apps/packages/ui/src/components/Option/Models/index.tsx with native Date/Intl formatting. Keep dayjs declared for remaining Flashcards display formatting and Ant Design Dayjs value-contract surfaces, and update the dependency audit with the reduced import count.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Focused tests or source guards cover the Models last-refreshed formatting behavior without relying on dayjs.
+- [x] #2 apps/packages/ui/src/components/Option/Models/index.tsx no longer imports dayjs or dayjs/plugin/relativeTime.
+- [x] #3 The WebUI dependency audit records the reduced dayjs import count and notes remaining blockers explicitly.
+- [x] #4 Focused Vitest, git diff hygiene, frontend lint, and Bandit skip/run rationale are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused Models test/source guard that fails while index.tsx imports dayjs.
+2. Replace the last-refreshed formatter with a native Date/Intl helper.
+3. Update the dependency audit import count and completed follow-up notes.
+4. Run focused Vitest, import scans, lint/diff checks, and record Bandit rationale before commit/PR.
+<!-- SECTION:PLAN:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Notes
+<!-- SECTION:NOTES:BEGIN -->
+TDD red checks: the focused Models display utility test first failed because modelsDisplayUtils did not exist, then failed on the dayjs import guard while Models/index.tsx still imported dayjs and dayjs/plugin/relativeTime.
+
+Implemented a native Intl.DateTimeFormat helper for the Models last-refreshed HH:mm label and wired Models/index.tsx to use it instead of dayjs.
+
+Updated the WebUI dependency audit to record the dayjs import count dropping from 17 to 15 and to keep remaining Flashcards display formatting plus Ant Design Dayjs value contracts explicit.
+
+Verification: bunx vitest run src/components/Option/Models/__tests__/modelsDisplayUtils.test.ts passed with 3 tests; bunx vitest run src/components/Option/Models/__tests__ passed with 2 files and 5 tests; git diff --check passed; exact dayjs package-import scan listed 15 remaining shared UI import lines; bun run lint in apps/tldw-frontend exited 0 with the existing 131 warnings baseline and no touched-file warnings; Bandit skipped because only TypeScript/test/docs/Backlog files changed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Removed dayjs from the Models last-refreshed display label by replacing dayjs formatting with a native Intl helper, added focused formatting and no-dayjs guard tests, and updated the dependency audit to show the remaining dayjs import count dropping from 17 to 15 while preserving the remaining Flashcards and Ant Design Dayjs blockers.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-153 - Remove-dayjs-from-Models-last-refreshed-display-formatting.md
+++ b/backlog/tasks/task-153 - Remove-dayjs-from-Models-last-refreshed-display-formatting.md
@@ -4,7 +4,7 @@ title: Remove dayjs from Models last-refreshed display formatting
 status: Done
 assignee: []
 created_date: '2026-05-09 04:59'
-updated_date: '2026-05-09 05:04'
+updated_date: '2026-05-09 05:09'
 labels:
   - webui
   - dependencies
@@ -15,6 +15,7 @@ dependencies:
   - TASK-149
 references:
   - 'https://github.com/rmusser01/tldw_server/issues/1346'
+  - 'https://github.com/rmusser01/tldw_server/pull/1405'
 documentation:
   - Docs/Design/WebUI_Dependency_Audit.md
 priority: medium
@@ -61,6 +62,8 @@ Implemented a native Intl.DateTimeFormat helper for the Models last-refreshed HH
 Updated the WebUI dependency audit to record the dayjs import count dropping from 17 to 15 and to keep remaining Flashcards display formatting plus Ant Design Dayjs value contracts explicit.
 
 Verification: bunx vitest run src/components/Option/Models/__tests__/modelsDisplayUtils.test.ts passed with 3 tests; bunx vitest run src/components/Option/Models/__tests__ passed with 2 files and 5 tests; git diff --check passed; exact dayjs package-import scan listed 15 remaining shared UI import lines; bun run lint in apps/tldw-frontend exited 0 with the existing 131 warnings baseline and no touched-file warnings; Bandit skipped because only TypeScript/test/docs/Backlog files changed.
+
+Opened PR #1405 against dev for this Models dayjs cleanup slice: https://github.com/rmusser01/tldw_server/pull/1405
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-157 - Address-PR-1405-review-comments-on-Models-dayjs-cleanup.md
+++ b/backlog/tasks/task-157 - Address-PR-1405-review-comments-on-Models-dayjs-cleanup.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-157
 title: Address PR 1405 review comments on Models dayjs cleanup
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-09 05:21'
-updated_date: '2026-05-09 05:23'
+updated_date: '2026-05-09 05:28'
 labels:
   - webui
   - dependencies
@@ -35,7 +35,7 @@ Address actionable review feedback on PR #1405 by making the Models last-refresh
 - [x] #2 The Models display utility test remains behavior-focused and no longer reads source files from disk to assert implementation details.
 - [x] #3 A focused import scan verifies the Models module tree does not contain dayjs package imports after removing the test guard.
 - [x] #4 Focused Vitest, git diff hygiene, frontend lint, and Bandit skip/run rationale are recorded.
-- [ ] #5 Actionable PR review threads are answered and resolved after the fix is pushed.
+- [x] #5 Actionable PR review threads are answered and resolved after the fix is pushed.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -46,16 +46,6 @@ Address actionable review feedback on PR #1405 by making the Models last-refresh
 4. Run focused tests, import scan, diff hygiene, lint, then push and resolve PR threads.
 <!-- SECTION:PLAN:END -->
 
-## Definition of Done
-<!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [x] #2 Tests or verification recorded
-- [x] #3 Documentation updated when relevant
-- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
-<!-- DOD:END -->
-
 ## Implementation Notes
 <!-- SECTION:NOTES:BEGIN -->
 Implemented the review fixes by replacing Intl.DateTimeFormat with deterministic Date#getHours/getMinutes string padding and by removing the filesystem-reading dayjs source guard from the Vitest unit test.
@@ -63,4 +53,22 @@ Implemented the review fixes by replacing Intl.DateTimeFormat with deterministic
 Dependency regression coverage for this review fix is handled by an explicit exact import scan over apps/packages/ui/src/components/Option/Models, which returned no output and exit 1 as expected for no dayjs imports.
 
 Verification: bunx vitest run src/components/Option/Models/__tests__ passed with 2 files and 4 tests; git diff --check passed; bun run lint in apps/tldw-frontend exited 0 with the existing 131 warnings baseline; Bandit skipped because only TypeScript/test/docs/Backlog files changed.
+
+PR #1405 review closeout: pushed commit 8231f31a1, updated the PR body to remove stale Intl/source-guard wording, observed both Qodo threads resolved/outdated after the pushed diff, replied to and resolved the remaining Gemini formatter thread at https://github.com/rmusser01/tldw_server/pull/1405#discussion_r3212532157.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed PR #1405 review feedback by replacing the Models last-refreshed Intl formatter with deterministic Date#getHours/getMinutes padding, removing the filesystem-based dayjs source guard from the Vitest test, moving dependency regression coverage to an explicit Models-tree dayjs import scan, updating stale audit/task wording, pushing commit 8231f31a1, refreshing the PR body, and resolving the remaining actionable review thread.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-157 - Address-PR-1405-review-comments-on-Models-dayjs-cleanup.md
+++ b/backlog/tasks/task-157 - Address-PR-1405-review-comments-on-Models-dayjs-cleanup.md
@@ -1,0 +1,66 @@
+---
+id: TASK-157
+title: Address PR 1405 review comments on Models dayjs cleanup
+status: In Progress
+assignee: []
+created_date: '2026-05-09 05:21'
+updated_date: '2026-05-09 05:23'
+labels:
+  - webui
+  - dependencies
+  - cleanup
+  - dayjs
+  - review-fix
+dependencies:
+  - TASK-153
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1405'
+  - 'https://github.com/rmusser01/tldw_server/pull/1405#discussion_r3212502676'
+  - 'https://github.com/rmusser01/tldw_server/pull/1405#discussion_r3212507990'
+  - 'https://github.com/rmusser01/tldw_server/pull/1405#discussion_r3212507994'
+documentation:
+  - Docs/Design/WebUI_Dependency_Audit.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address actionable review feedback on PR #1405 by making the Models last-refreshed formatter deterministic without Intl locale output and removing the filesystem-based dayjs source guard from the Vitest unit test. Keep dependency reduction verified with behavior-focused tests plus explicit import-scan verification.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Models time formatting uses deterministic Date/getHours/getMinutes string padding rather than locale-dependent Intl formatting.
+- [x] #2 The Models display utility test remains behavior-focused and no longer reads source files from disk to assert implementation details.
+- [x] #3 A focused import scan verifies the Models module tree does not contain dayjs package imports after removing the test guard.
+- [x] #4 Focused Vitest, git diff hygiene, frontend lint, and Bandit skip/run rationale are recorded.
+- [ ] #5 Actionable PR review threads are answered and resolved after the fix is pushed.
+<!-- AC:END -->
+
+## Implementation Plan
+<!-- SECTION:PLAN:BEGIN -->
+1. Replace the Models time formatter with deterministic getHours/getMinutes string padding.
+2. Remove the filesystem-based dayjs guard from the unit test while keeping behavior coverage.
+3. Update audit/task notes to move dependency verification to explicit import scans rather than unit-test source reads.
+4. Run focused tests, import scan, diff hygiene, lint, then push and resolve PR threads.
+<!-- SECTION:PLAN:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Notes
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the review fixes by replacing Intl.DateTimeFormat with deterministic Date#getHours/getMinutes string padding and by removing the filesystem-reading dayjs source guard from the Vitest unit test.
+
+Dependency regression coverage for this review fix is handled by an explicit exact import scan over apps/packages/ui/src/components/Option/Models, which returned no output and exit 1 as expected for no dayjs imports.
+
+Verification: bunx vitest run src/components/Option/Models/__tests__ passed with 2 files and 4 tests; git diff --check passed; bun run lint in apps/tldw-frontend exited 0 with the existing 131 warnings baseline; Bandit skipped because only TypeScript/test/docs/Backlog files changed.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## Summary
- Replace the Models page last-refreshed `dayjs(...).format("HH:mm")` call with deterministic native `Date#getHours()`/`getMinutes()` padding.
- Keep focused behavior coverage for the `HH:mm` formatter and remove the filesystem-reading unit-test source guard flagged in review.
- Update the WebUI dependency audit and Backlog tasks to record the remaining `dayjs` import count dropping from 17 to 15 and the PR review follow-up.
- Verify dependency regression coverage with a Models-tree import scan rather than source assertions inside Vitest.

## Change summary
This PR keeps issue #1346 cleanup moving by taking the smallest remaining display-only `dayjs` surface after the WorldBooks merge. The Models timestamp only needs local `HH:mm` display, so a small native `Date` helper preserves the visible behavior without pulling in `dayjs` or relying on locale-specific `Intl.DateTimeFormat` output. The review follow-up also keeps the unit test behavior-focused; package-regression coverage now lives in explicit import-scan verification over the Models module tree. The remaining `dayjs` work is left explicitly split between Flashcards display formatting and Ant Design `Dayjs` value-contract surfaces, because those are higher-risk than this label-only path.

## Test plan
- `bunx vitest run src/components/Option/Models/__tests__/modelsDisplayUtils.test.ts`
- `bunx vitest run src/components/Option/Models/__tests__`
- `git diff --check`
- Models-tree `dayjs` package-import scan: no matches, `rg` exit 1
- `bun run lint` in `apps/tldw-frontend` (0 errors, existing 131-warning baseline)

Bandit skipped: no Python files changed.