### PR TITLE
Add manual VZ helper restart recovery drill

### DIFF
--- a/Docs/Sandbox/macos-runtime-operator-notes.md
+++ b/Docs/Sandbox/macos-runtime-operator-notes.md
@@ -413,6 +413,22 @@ helper daemon for real `vz_linux` E2E, verifies ephemeral execution, verifies
 same-session VM reuse, verifies recovery diagnostics plus dry-run
 reconciliation repair planning, and stops the helper on exit.
 
+Manual failure drills are opt-in and remain disabled for default smoke and
+scheduled host-gated runs. To include them, pass:
+
+```bash
+tools/macos-vz-helper/scripts/vz-helperctl.py smoke \
+  --bundle /path/to/canonical/bundle \
+  --entitlements /path/to/helper.entitlements \
+  --include-failure-drills
+```
+
+The manual drills currently cover a drill-owned stale session VM after
+helper-side VM termination and stale session-control VM state after the smoke
+harness stops and restarts its helper process through a private restart lease.
+They do not cover host reboot, launchd bootstrap/load behavior, broad helper
+crash classes, networking changes, or destructive repair generalization.
+
 The recovery smoke is non-destructive. It seeds an isolated test-store stale VZ
 session-control row, verifies `/api/v1/sandbox/admin/macos-diagnostics` style
 reconciliation and `recovery_summary` output through the service layer, then

--- a/Docs/Sandbox/sandbox-runtime-capability-inventory.md
+++ b/Docs/Sandbox/sandbox-runtime-capability-inventory.md
@@ -295,7 +295,7 @@ for `untrusted` workloads.
 | Gap | Runtime(s) | Follow-up phase |
 | --- | --- | --- |
 | Additional real allowlist implementations remain limited beyond Docker granular enforcement. | all except unsupported paths | Future |
-| Host-gated recovery smoke covers `vz_linux` diagnostics and dry-run repair planning, but destructive repair, host reboot, and helper crash recovery remain manual/operator-verified. | all | Phase 4 |
+| Host-gated recovery smoke covers `vz_linux` diagnostics, dry-run repair planning, drill-owned stale VM termination, and one manual smoke-owned helper restart drill; destructive repair, host reboot, launchd restart, and broader helper crash recovery remain manual/operator-verified. | all | Phase 4 |
 | Recovery/repair ownership exists only for `vz_linux`. | all except `vz_linux` | Phase 4 |
 | No single CI job proves real execution for every runtime; the portable capability gate covers capability contracts only. | all | Phase 5 |
 

--- a/Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
+++ b/Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
@@ -105,9 +105,10 @@ session controls, or run image-store cleanup.
 Manual failure drills are separate from the default smoke. When a maintainer
 starts the workflow with `include_failure_drills=true`, the delegated smoke
 script runs additional tests that may invalidate VMs created by those tests. The
-current drill terminates only the session VM recorded by the drill's own
-session-control row, then verifies the next same-session command provisions a
-fresh VM and completes. Scheduled runs must not enable these drills by default.
+current drills terminate only the session VM recorded by the drill's own
+session-control row and restart only the helper process owned by the smoke
+harness restart lease. They then verify the next same-session command provisions
+a fresh VM and completes. Scheduled runs must not enable these drills by default.
 
 ## Expected Skips And Non-Blocking Conditions
 
@@ -142,6 +143,9 @@ prepared host and fails one of the accepted runtime guarantees:
   helper/template readiness passes
 - a manually requested failure drill cannot replace a drill-owned stale session
   VM after helper-side termination
+- a manually requested helper restart drill cannot replace stale session-control
+  VM state after the helper process is stopped and restarted through the smoke
+  harness restart lease
 - cleanup leaves the helper process or accepted socket path behind
 - helper protocol mismatch is introduced without a matching compatibility plan
 - artifacts/logs are not uploaded when the job fails

--- a/Docs/superpowers/plans/2026-05-09-vz-linux-helper-restart-recovery-drill-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-09-vz-linux-helper-restart-recovery-drill-implementation-plan.md
@@ -1,0 +1,817 @@
+# VZ Linux Helper Restart Recovery Drill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a manual host-gated `vz_linux` helper restart recovery drill that proves stale same-session VM control state is cleared after the macOS helper process is restarted.
+
+**Architecture:** Keep `run-host-e2e-smoke.sh` as the lower-level helper lifecycle owner and add a private restart lease only when failure drills are enabled. The real-host pytest drill uses that lease to stop the current helper, start a replacement helper on the same socket, update the pid file for shell cleanup, then run a second same-session command and assert a new VM is used. `vz-helperctl.py smoke` remains the preferred operator wrapper and must forward `--include-failure-drills`.
+
+**Tech Stack:** Bash, Python 3.11, pytest, macOS AF_UNIX sockets, existing `MacOSVirtualizationHelperClient`, existing sandbox service/session APIs.
+
+---
+
+## Scope Check
+
+This is one focused PR. It touches one operator shell script, one operator wrapper, one real-host pytest module, focused tests, and operator docs. It must not add launchd management, host reboot automation, network changes, helper protocol changes, or broad repair mutation.
+
+## File Map
+
+- Modify: `tools/vz-linux-image/scripts/run-host-e2e-smoke.sh`
+  - Owns lower-level helper lifecycle and restart lease env for failure drills.
+- Modify: `tools/vz-linux-image/tests/test_host_e2e_smoke_script.py`
+  - Verifies dry-run lease visibility, default non-visibility, and cleanup of replacement helper PID.
+- Modify: `tools/macos-vz-helper/scripts/vz-helperctl.py`
+  - Adds `smoke --include-failure-drills` pass-through to the lower-level script.
+- Modify: `tools/macos-vz-helper/tests/test_vz_helperctl.py`
+  - Verifies wrapper dry-run pass-through.
+- Modify: `tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py`
+  - Adds restart-lease validation helpers and the real host-gated helper restart drill.
+- Modify: `Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md`
+  - Adds helper restart recovery as a manual failure-drill criterion.
+- Modify: `Docs/Sandbox/macos-runtime-operator-notes.md`
+  - Documents that manual failure drills now cover stale VM termination and helper restart recovery.
+- Optional Modify: `Docs/Sandbox/sandbox-runtime-capability-inventory.md`
+  - Only if the current gaps language needs to distinguish helper restart drill coverage from host reboot/destructive repair gaps.
+- Modify: `backlog/tasks/task-150 - Add-manual-VZ-Linux-helper-restart-recovery-drill.md`
+  - Track implementation notes and verification.
+
+## Task 1: Add Smoke Script Restart Lease
+
+**Files:**
+- Modify: `tools/vz-linux-image/scripts/run-host-e2e-smoke.sh`
+- Modify: `tools/vz-linux-image/tests/test_host_e2e_smoke_script.py`
+
+- [ ] **Step 1: Write failing dry-run tests for restart lease env**
+
+Add to `tools/vz-linux-image/tests/test_host_e2e_smoke_script.py`:
+
+```python
+def test_host_e2e_smoke_script_default_dry_run_omits_restart_lease(tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    (bundle / "kernel").write_bytes(b"kernel")
+    (bundle / "rootfs.img").write_bytes(b"rootfs")
+    helper = tmp_path / "macos-vz-helper"
+
+    result = _run_smoke_script(
+        "--dry-run",
+        "--bundle",
+        str(bundle),
+        "--helper",
+        str(helper),
+        "--python",
+        sys.executable,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "TLDW_SANDBOX_VZ_LINUX_E2E_HELPER_RESTART_ALLOWED" not in result.stdout
+    assert "TLDW_SANDBOX_VZ_LINUX_E2E_HELPER_PID_FILE" not in result.stdout
+
+
+def test_host_e2e_smoke_script_failure_drill_dry_run_includes_restart_lease(tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    (bundle / "kernel").write_bytes(b"kernel")
+    (bundle / "rootfs.img").write_bytes(b"rootfs")
+    helper = tmp_path / "macos-vz-helper"
+
+    result = _run_smoke_script(
+        "--dry-run",
+        "--include-failure-drills",
+        "--bundle",
+        str(bundle),
+        "--helper",
+        str(helper),
+        "--python",
+        sys.executable,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "TLDW_SANDBOX_VZ_LINUX_E2E_HELPER_RESTART_ALLOWED=1" in result.stdout
+    assert "TLDW_SANDBOX_VZ_LINUX_E2E_HELPER_PID_FILE=" in result.stdout
+    assert "/helper.pid" in result.stdout
+    assert f"TLDW_SANDBOX_MACOS_HELPER_BINARY={helper}" in result.stdout
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tools/vz-linux-image/tests/test_host_e2e_smoke_script.py::test_host_e2e_smoke_script_default_dry_run_omits_restart_lease \
+  tools/vz-linux-image/tests/test_host_e2e_smoke_script.py::test_host_e2e_smoke_script_failure_drill_dry_run_includes_restart_lease \
+  -q
+```
+
+Expected: first test passes or remains neutral; second test fails because restart lease env is not printed.
+
+- [ ] **Step 3: Implement minimal restart lease env**
+
+In `run-host-e2e-smoke.sh`:
+
+```bash
+HELPER_PID=""
+HELPER_PID_FILE=""
+
+helper_pid_file_path() {
+  local socket_dir
+  socket_dir="$(dirname "${SOCKET_PATH}")"
+  printf '%s/helper.pid' "${socket_dir}"
+}
+
+record_helper_pid() {
+  if [[ "${DRY_RUN}" -eq 1 ]]; then
+    return 0
+  fi
+  HELPER_PID_FILE="$(helper_pid_file_path)"
+  printf '%s\n' "${HELPER_PID}" > "${HELPER_PID_FILE}"
+  chmod 600 "${HELPER_PID_FILE}" 2>/dev/null || true
+}
+```
+
+After `HELPER_PID="$!"` in `start_helper_for_real_e2e`, call `record_helper_pid`.
+
+Change `run_real_vz_linux_failure_drills` to:
+
+```bash
+run_real_vz_linux_failure_drills() {
+  local helper_pid_file
+  helper_pid_file="$(helper_pid_file_path)"
+  run_cmd env \
+    TEST_MODE=0 \
+    TLDW_SANDBOX_VZ_LINUX_E2E=1 \
+    TLDW_SANDBOX_VZ_LINUX_E2E_BASE_IMAGE="${BUNDLE_PATH}" \
+    TLDW_SANDBOX_MACOS_HELPER_SOCKET="${SOCKET_PATH}" \
+    TLDW_SANDBOX_MACOS_HELPER_BINARY="${HELPER_PATH}" \
+    TLDW_SANDBOX_VZ_LINUX_SERIAL_LOG_DIR="${SERIAL_LOG_DIR}" \
+    TLDW_SANDBOX_VZ_LINUX_E2E_HELPER_RESTART_ALLOWED=1 \
+    TLDW_SANDBOX_VZ_LINUX_E2E_HELPER_PID_FILE="${helper_pid_file}" \
+    SANDBOX_ENABLE_EXECUTION=1 \
+    SANDBOX_BACKGROUND_EXECUTION=0 \
+    "${PYTHON_BIN}" -m pytest \
+    "${REPO_ROOT}/tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py" \
+    -m vz_linux_host_failure_drill -q -rs
+}
+```
+
+Keep `run_real_vz_linux_pytest` unchanged for baseline smoke so restart lease env is not present by default.
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tools/vz-linux-image/tests/test_host_e2e_smoke_script.py::test_host_e2e_smoke_script_default_dry_run_omits_restart_lease \
+  tools/vz-linux-image/tests/test_host_e2e_smoke_script.py::test_host_e2e_smoke_script_failure_drill_dry_run_includes_restart_lease \
+  -q
+```
+
+Expected: both pass.
+
+- [ ] **Step 5: Write failing cleanup test for replacement helper PID**
+
+Add a test that proves cleanup follows the updated pid file:
+
+```python
+def test_host_e2e_smoke_script_cleanup_uses_replacement_helper_pid(tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    (bundle / "kernel").write_bytes(b"kernel")
+    (bundle / "rootfs.img").write_bytes(b"rootfs")
+    tmp_dir = tmp_path / "tmp"
+    tmp_dir.mkdir()
+    marker = tmp_path / "replacement_pid.txt"
+    fake_python = tmp_path / "fake-python"
+    fake_helper = tmp_path / "fake-helper"
+    fake_python.write_text(
+        "#!/usr/bin/env python3\n"
+        "import os, subprocess, sys, time\n"
+        "if sys.argv[1:3] != ['-m', 'pytest']:\n"
+        "    sys.exit(2)\n"
+        "if 'vz_linux_host_failure_drill' in sys.argv:\n"
+        "    pid_file = os.environ['TLDW_SANDBOX_VZ_LINUX_E2E_HELPER_PID_FILE']\n"
+        "    marker = os.environ['TLDW_TEST_REPLACEMENT_PID_MARKER']\n"
+        "    proc = subprocess.Popen([os.environ['TLDW_SANDBOX_MACOS_HELPER_BINARY']])\n"
+        "    open(pid_file, 'w', encoding='utf-8').write(str(proc.pid) + '\\n')\n"
+        "    open(marker, 'w', encoding='utf-8').write(str(proc.pid) + '\\n')\n"
+        "sys.exit(0)\n",
+        encoding="utf-8",
+    )
+    fake_helper.write_text(
+        "#!/usr/bin/env python3\n"
+        "import signal, sys, time\n"
+        "signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))\n"
+        "while True:\n"
+        "    time.sleep(0.1)\n",
+        encoding="utf-8",
+    )
+    fake_python.chmod(0o755)
+    fake_helper.chmod(0o755)
+
+    result = _run_smoke_script(
+        "--bundle", str(bundle),
+        "--helper", str(fake_helper),
+        "--python", str(fake_python),
+        "--skip-build",
+        "--skip-sign",
+        "--include-failure-drills",
+        env_overrides={
+            "TMPDIR": str(tmp_dir),
+            "TLDW_HOST_E2E_SMOKE_SKIP_SOCKET_WAIT": "1",
+            "TLDW_TEST_REPLACEMENT_PID_MARKER": str(marker),
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    replacement_pid = int(marker.read_text(encoding="utf-8").strip())
+    with pytest.raises(ProcessLookupError):
+        os.kill(replacement_pid, 0)
+```
+
+If `os.kill(pid, 0)` behavior is platform-sensitive in this environment, adjust the assertion to poll briefly and still require `ProcessLookupError` as the success condition.
+
+- [ ] **Step 6: Run cleanup test to verify RED**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tools/vz-linux-image/tests/test_host_e2e_smoke_script.py::test_host_e2e_smoke_script_cleanup_uses_replacement_helper_pid \
+  -q
+```
+
+Expected: FAIL because cleanup only tracks the original shell `HELPER_PID`.
+
+- [ ] **Step 7: Implement cleanup pid-file handoff**
+
+In `cleanup`, prefer the current pid file:
+
+```bash
+current_helper_pid() {
+  local candidate=""
+  local pid_file="${HELPER_PID_FILE:-$(helper_pid_file_path)}"
+  if [[ -f "${pid_file}" && ! -L "${pid_file}" ]]; then
+    candidate="$(tr -d '[:space:]' < "${pid_file}" 2>/dev/null || true)"
+    if [[ "${candidate}" =~ ^[1-9][0-9]*$ ]]; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+  fi
+  printf '%s\n' "${HELPER_PID}"
+}
+
+cleanup() {
+  local pid
+  pid="$(current_helper_pid)"
+  if [[ -n "${pid}" ]] && kill -0 "${pid}" 2>/dev/null; then
+    kill "${pid}" 2>/dev/null || true
+    wait "${pid}" 2>/dev/null || true
+  fi
+  if [[ -S "${SOCKET_PATH}" ]]; then
+    rm -f "${SOCKET_PATH}"
+  fi
+}
+```
+
+Keep pid-file deletion out of cleanup for this PR unless a test proves it is needed; the runtime directory is already temporary and useful for failure logs.
+
+- [ ] **Step 8: Run script tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tools/vz-linux-image/tests/test_host_e2e_smoke_script.py -q
+bash -n tools/vz-linux-image/scripts/run-host-e2e-smoke.sh
+```
+
+Expected: existing script tests pass with the expected skip; bash syntax check exits 0.
+
+- [ ] **Step 9: Commit Task 1**
+
+```bash
+git add tools/vz-linux-image/scripts/run-host-e2e-smoke.sh \
+  tools/vz-linux-image/tests/test_host_e2e_smoke_script.py
+git commit -m "test(sandbox): add VZ helper restart lease wiring"
+```
+
+## Task 2: Forward Failure Drills Through `vz-helperctl smoke`
+
+**Files:**
+- Modify: `tools/macos-vz-helper/scripts/vz-helperctl.py`
+- Modify: `tools/macos-vz-helper/tests/test_vz_helperctl.py`
+
+- [ ] **Step 1: Write failing wrapper pass-through test**
+
+Add near existing smoke dry-run tests:
+
+```python
+def test_smoke_dry_run_forwards_failure_drills(tmp_path, capsys):
+    helperctl = load_helperctl()
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+
+    code = helperctl.main([
+        "smoke",
+        "--dry-run",
+        "--bundle",
+        str(bundle),
+        "--include-failure-drills",
+    ])
+
+    captured = capsys.readouterr()
+    CASE.assertEqual(code, 0)
+    CASE.assertIn("--include-failure-drills", captured.out)
+```
+
+- [ ] **Step 2: Run test to verify RED**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tools/macos-vz-helper/tests/test_vz_helperctl.py::test_smoke_dry_run_forwards_failure_drills -q
+```
+
+Expected: FAIL because the parser does not accept the flag.
+
+- [ ] **Step 3: Implement pass-through**
+
+In `smoke_helper`, add parameter:
+
+```python
+include_failure_drills: bool = False,
+```
+
+Append:
+
+```python
+if include_failure_drills:
+    argv.append("--include-failure-drills")
+```
+
+In `_smoke_command`, pass `include_failure_drills=args.include_failure_drills`.
+
+In `build_parser`, add:
+
+```python
+smoke.add_argument("--include-failure-drills", action="store_true")
+```
+
+- [ ] **Step 4: Run wrapper tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tools/macos-vz-helper/tests/test_vz_helperctl.py::test_smoke_dry_run_forwards_failure_drills \
+  tools/macos-vz-helper/tests/test_vz_helperctl.py::test_smoke_dry_run_delegates_to_host_smoke_script \
+  tools/macos-vz-helper/tests/test_vz_helperctl.py::test_helperctl_executable_smoke_dry_run_works \
+  -q
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit Task 2**
+
+```bash
+git add tools/macos-vz-helper/scripts/vz-helperctl.py \
+  tools/macos-vz-helper/tests/test_vz_helperctl.py
+git commit -m "feat(sandbox): forward helper failure drills from helperctl"
+```
+
+## Task 3: Add Real-Host Helper Restart Drill
+
+**Files:**
+- Modify: `tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py`
+
+- [ ] **Step 1: Add helper restart lease model and validation tests**
+
+Add imports:
+
+```python
+import dataclasses
+import signal
+import socket
+import subprocess
+import time
+```
+
+Add helper types/functions near `_require_vz_linux_real_host_e2e`:
+
+```python
+@dataclasses.dataclass(frozen=True)
+class _HelperRestartLease:
+    helper_path: Path
+    socket_path: Path
+    serial_log_dir: Path
+    pid_file: Path
+
+
+def _require_helper_restart_lease() -> _HelperRestartLease:
+    if not is_truthy(os.getenv("TLDW_SANDBOX_VZ_LINUX_E2E_HELPER_RESTART_ALLOWED")):
+        pytest.skip("Set TLDW_SANDBOX_VZ_LINUX_E2E_HELPER_RESTART_ALLOWED=1 to enable helper restart drill")
+    helper_text = str(os.getenv("TLDW_SANDBOX_MACOS_HELPER_BINARY") or "").strip()
+    socket_text = str(os.getenv("TLDW_SANDBOX_MACOS_HELPER_SOCKET") or "").strip()
+    serial_log_text = str(os.getenv("TLDW_SANDBOX_VZ_LINUX_SERIAL_LOG_DIR") or "").strip()
+    pid_file_text = str(os.getenv("TLDW_SANDBOX_VZ_LINUX_E2E_HELPER_PID_FILE") or "").strip()
+    if not helper_text or not socket_text or not serial_log_text or not pid_file_text:
+        pytest.skip("helper restart drill requires helper binary, socket, serial log dir, and pid file env")
+    return _HelperRestartLease(
+        helper_path=Path(helper_text).expanduser(),
+        socket_path=Path(socket_text).expanduser(),
+        serial_log_dir=Path(serial_log_text).expanduser(),
+        pid_file=Path(pid_file_text).expanduser(),
+    )
+```
+
+Add unit tests:
+
+```python
+def test_helper_restart_lease_requires_explicit_opt_in(monkeypatch) -> None:
+    monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_E2E_HELPER_RESTART_ALLOWED", raising=False)
+    with pytest.raises(pytest.skip.Exception, match="HELPER_RESTART_ALLOWED"):
+        _require_helper_restart_lease()
+
+
+def test_helper_restart_pid_file_rejects_symlink(tmp_path: Path) -> None:
+    helper = tmp_path / "macos-vz-helper"
+    helper.write_text("#!/bin/sh\n", encoding="utf-8")
+    helper.chmod(0o755)
+    runtime_dir = tmp_path / "runtime"
+    runtime_dir.mkdir(mode=0o700)
+    target = runtime_dir / "target.pid"
+    target.write_text("1234\n", encoding="utf-8")
+    pid_file = runtime_dir / "helper.pid"
+    pid_file.symlink_to(target)
+    lease = _HelperRestartLease(helper, runtime_dir / "helper.sock", runtime_dir / "serial", pid_file)
+
+    with pytest.raises(pytest.fail.Exception, match="pid file"):
+        _read_valid_restart_pid(lease, process_lookup=lambda _pid: str(helper))
+```
+
+The second test requires `_read_valid_restart_pid` to be defined in the next step.
+
+- [ ] **Step 2: Run validation tests to verify RED**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py::test_helper_restart_lease_requires_explicit_opt_in \
+  tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py::test_helper_restart_pid_file_rejects_symlink \
+  -q
+```
+
+Expected: opt-in test may pass once helper exists; symlink test fails because `_read_valid_restart_pid` does not exist.
+
+- [ ] **Step 3: Implement pid/process validation helpers**
+
+Add:
+
+```python
+def _lookup_process_command(pid: int) -> str | None:
+    completed = subprocess.run(
+        ["ps", "-p", str(pid), "-o", "command="],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        return None
+    command = completed.stdout.strip()
+    return command or None
+
+
+def _read_valid_restart_pid(
+    lease: _HelperRestartLease,
+    *,
+    process_lookup=_lookup_process_command,
+) -> int:
+    socket_dir = lease.socket_path.parent.resolve()
+    try:
+        pid_parent = lease.pid_file.parent.resolve()
+    except OSError as exc:
+        pytest.fail(f"helper restart pid file parent is invalid: {exc}")
+    if pid_parent != socket_dir:
+        pytest.fail("helper restart pid file must be inside the private socket directory")
+    try:
+        stat_result = lease.pid_file.lstat()
+    except OSError as exc:
+        pytest.fail(f"helper restart pid file is unavailable: {exc}")
+    if not lease.pid_file.is_file() or lease.pid_file.is_symlink():
+        pytest.fail("helper restart pid file must be a regular non-symlink file")
+    if stat_result.st_mode & 0o077:
+        pytest.fail("helper restart pid file must be owner-only")
+    raw_pid = lease.pid_file.read_text(encoding="utf-8").strip()
+    if not raw_pid.isdigit() or int(raw_pid) <= 0:
+        pytest.fail("helper restart pid file does not contain a positive PID")
+    pid = int(raw_pid)
+    command = process_lookup(pid)
+    if command is None:
+        pytest.skip("helper process exited before restart drill could stop it")
+    if str(lease.helper_path) not in command and lease.helper_path.name not in command:
+        pytest.fail("helper restart pid file points at a non-helper process")
+    return pid
+```
+
+- [ ] **Step 4: Run validation tests to verify GREEN**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py::test_helper_restart_lease_requires_explicit_opt_in \
+  tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py::test_helper_restart_pid_file_rejects_symlink \
+  -q
+```
+
+Expected: both pass.
+
+- [ ] **Step 5: Add restart helper function with unit guards**
+
+Add helper:
+
+```python
+def _wait_for_helper_socket_unavailable(socket_path: Path, timeout_sec: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout_sec
+    while time.monotonic() < deadline:
+        if not socket_path.exists():
+            return
+        try:
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+                client.settimeout(0.2)
+                client.connect(str(socket_path))
+        except OSError:
+            return
+        time.sleep(0.05)
+    pytest.fail(f"helper socket remained available after helper stop: {socket_path}")
+
+
+def _wait_for_helper_ping(helper, timeout_sec: float = 10.0) -> None:
+    deadline = time.monotonic() + timeout_sec
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            helper.ping()
+            return
+        except Exception as exc:  # intentionally broad for test harness readiness polling
+            last_error = exc
+            time.sleep(0.1)
+    pytest.fail(f"replacement helper did not answer ping: {last_error}")
+```
+
+Add `_restart_helper_for_drill` that:
+
+- reads the valid old pid
+- sends SIGTERM with `os.kill(pid, signal.SIGTERM)`
+- waits for old socket unavailable
+- starts replacement via `subprocess.Popen([str(lease.helper_path)], env=env, stdout=..., stderr=...)`
+- writes replacement pid to lease pid file with `0o600`
+- waits for ping
+- returns replacement process
+
+Use `TLDW_SANDBOX_MACOS_HELPER_SOCKET`, `TLDW_SANDBOX_VZ_LINUX_SERIAL_LOG_DIR`, and existing protocol env if needed.
+
+- [ ] **Step 6: Add real helper restart drill test**
+
+Add:
+
+```python
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS host only")
+@pytest.mark.vz_linux_host_failure_drill
+def test_vz_linux_real_session_recreates_vm_after_helper_restart(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    base_image = _require_vz_linux_real_host_e2e(monkeypatch, tmp_path)
+    lease = _require_helper_restart_lease()
+    monkeypatch.delenv("TEST_MODE", raising=False)
+    monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_FAKE_EXEC", raising=False)
+    monkeypatch.delenv("TLDW_SANDBOX_MACOS_HELPER_READY", raising=False)
+    monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_TEMPLATE_READY", raising=False)
+    monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_AVAILABLE", raising=False)
+
+    service = SandboxService()
+    helper = VZLinuxRunner.helper_client_cls()
+    session_id: str | None = None
+    destroyed = False
+    try:
+        session = service.create_session(
+            user_id="e2e-user",
+            spec=SessionSpec(runtime=RuntimeType.vz_linux, base_image=base_image, network_policy="deny_all"),
+            spec_version="1.0",
+            idem_key=None,
+            raw_body={"spec_version": "1.0", "runtime": "vz_linux", "base_image": base_image},
+        )
+        session_id = session.id
+        first = service.start_run_scaffold(
+            user_id="e2e-user",
+            spec=RunSpec(
+                session_id=session.id,
+                runtime=RuntimeType.vz_linux,
+                base_image=base_image,
+                command=["/bin/echo", "restart-drill-first"],
+                network_policy="deny_all",
+            ),
+            spec_version="1.0",
+            idem_key=None,
+            raw_body={"session_id": session.id, "runtime": "vz_linux"},
+        )
+        control_after_first = service._orch.get_vz_session_control(session.id)
+        _expect(first.phase == RunPhase.completed, f"Expected first run completed, got {first.phase!r}")
+        _expect(isinstance(control_after_first, dict), "Expected VZ session control after first run")
+        first_vm_id = str(control_after_first.get("vm_id") or "").strip()
+        _expect(bool(first_vm_id), f"Expected first VM id, got {control_after_first!r}")
+        _expect(helper.get_vm_status(first_vm_id).healthy, f"Expected first VM healthy before restart: {first_vm_id!r}")
+
+        _restart_helper_for_drill(lease)
+        helper_after_restart = VZLinuxRunner.helper_client_cls()
+        status_after_restart = helper_after_restart.get_vm_status(first_vm_id)
+        _expect(not bool(status_after_restart.healthy), f"Expected old VM stale after helper restart: {status_after_restart!r}")
+
+        second = service.start_run_scaffold(
+            user_id="e2e-user",
+            spec=RunSpec(
+                session_id=session.id,
+                runtime=RuntimeType.vz_linux,
+                base_image=base_image,
+                command=["/bin/echo", "restart-drill-second"],
+                network_policy="deny_all",
+            ),
+            spec_version="1.0",
+            idem_key=None,
+            raw_body={"session_id": session.id, "runtime": "vz_linux"},
+        )
+        control_after_second = service._orch.get_vz_session_control(session.id)
+        _expect(second.phase == RunPhase.completed, f"Expected second run completed, got {second.phase!r}")
+        _expect(isinstance(control_after_second, dict), "Expected VZ session control after second run")
+        second_vm_id = str(control_after_second.get("vm_id") or "").strip()
+        _expect(bool(second_vm_id), f"Expected second VM id, got {control_after_second!r}")
+        _expect(second_vm_id != first_vm_id, f"Expected helper restart to force fresh VM, got {first_vm_id!r}")
+        _expect(service.destroy_session(session.id) is True, "Expected session destruction to succeed")
+        destroyed = True
+    finally:
+        if session_id and not destroyed:
+            service.destroy_session(session_id)
+```
+
+Adjust exact helper implementation if `HelperVMStatusReply` field access differs; existing tests use `getattr(..., "healthy", False)` if needed.
+
+- [ ] **Step 7: Run host-gated marker locally to verify guarded skip**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py \
+  -m vz_linux_host_failure_drill -q -rs
+```
+
+Expected locally without real env: selected failure drills skip with clear opt-in/base-image reasons, not collection errors.
+
+- [ ] **Step 8: Commit Task 3**
+
+```bash
+git add tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py
+git commit -m "test(sandbox): add VZ helper restart recovery drill"
+```
+
+## Task 4: Update Operator Docs And Policy
+
+**Files:**
+- Modify: `Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md`
+- Modify: `Docs/Sandbox/macos-runtime-operator-notes.md`
+- Optional Modify: `Docs/Sandbox/sandbox-runtime-capability-inventory.md`
+- Modify: `backlog/tasks/task-150 - Add-manual-VZ-Linux-helper-restart-recovery-drill.md`
+
+- [ ] **Step 1: Update failure criteria policy**
+
+In `Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md`, extend blocking regression criteria:
+
+```markdown
+- a manually requested helper restart drill cannot replace stale session-control
+  VM state after the helper process is stopped and restarted through the smoke
+  harness restart lease
+```
+
+- [ ] **Step 2: Update operator notes**
+
+In `Docs/Sandbox/macos-runtime-operator-notes.md`, update Real Host E2E Smoke to say failure drills include:
+
+- stale session VM after helper-side termination
+- helper restart recovery through the smoke harness restart lease
+
+Keep host reboot and launchd restart listed as manual/operator-only gaps.
+
+- [ ] **Step 3: Update inventory only if wording is stale**
+
+If `Docs/Sandbox/sandbox-runtime-capability-inventory.md` still says helper crash/restart remains wholly manual after this PR, narrow it to host reboot/destructive repair/stale socket/stuck readiness. Do not claim broad helper crash coverage beyond this explicit restart drill.
+
+- [ ] **Step 4: Update Backlog task notes**
+
+Record touched files, verification commands, host-gated skip status, and any unrun real VM drill reason.
+
+- [ ] **Step 5: Commit Task 4**
+
+```bash
+git add Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md \
+  Docs/Sandbox/macos-runtime-operator-notes.md \
+  Docs/Sandbox/sandbox-runtime-capability-inventory.md \
+  "backlog/tasks/task-150 - Add-manual-VZ-Linux-helper-restart-recovery-drill.md"
+git commit -m "docs(sandbox): document helper restart recovery drill"
+```
+
+If inventory is not changed, omit it from `git add`.
+
+## Task 5: Final Verification And PR Prep
+
+**Files:**
+- All touched files from Tasks 1-4.
+
+- [ ] **Step 1: Run focused Python/shell tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tools/vz-linux-image/tests/test_host_e2e_smoke_script.py \
+  tools/macos-vz-helper/tests/test_vz_helperctl.py \
+  tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py \
+  -m "not vz_linux_host_smoke and not vz_linux_host_failure_drill" \
+  -q
+bash -n tools/vz-linux-image/scripts/run-host-e2e-smoke.sh
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile \
+  tools/macos-vz-helper/scripts/vz-helperctl.py \
+  tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py
+```
+
+Expected: focused tests pass, shell syntax exits 0, py_compile exits 0.
+
+- [ ] **Step 2: Run host-gated drill selection locally**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py \
+  -m vz_linux_host_failure_drill -q -rs
+```
+
+Expected without prepared real-host env: skips with clear reasons. On a prepared Apple silicon host, run the full operator command:
+
+```bash
+tools/macos-vz-helper/scripts/vz-helperctl.py smoke \
+  --bundle /path/to/canonical/bundle \
+  --entitlements /path/to/helper.entitlements \
+  --include-failure-drills
+```
+
+- [ ] **Step 3: Run Bandit and diff checks**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit \
+  -r tools/macos-vz-helper/scripts/vz-helperctl.py \
+     tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py \
+  -s B101 -f json -o /tmp/bandit_vz_helper_restart_recovery.json
+git diff --check
+```
+
+Expected: Bandit reports zero new findings after excluding pytest `assert` noise; diff check has no output.
+
+- [ ] **Step 4: Rebase and inspect final diff**
+
+Run:
+
+```bash
+git fetch origin dev
+git rebase origin/dev
+git diff --stat origin/dev...HEAD
+git log --oneline origin/dev..HEAD
+```
+
+Expected: clean rebase, diff limited to planned files.
+
+- [ ] **Step 5: Update Backlog final summary**
+
+Set TASK-150 acceptance criteria and DoD checked only after verification passes. Include any real-host drill that was skipped locally because a prepared host or bundle was not available.
+
+- [ ] **Step 6: Push and create/update PR**
+
+```bash
+git push -u origin codex/sandbox-helper-restart-recovery-drills
+gh pr create --base dev --head codex/sandbox-helper-restart-recovery-drills \
+  --title "Add manual VZ helper restart recovery drill" \
+  --body-file /tmp/vz-helper-restart-recovery-pr.md
+```
+
+PR body must include:
+
+- summary of manual helper restart drill and restart lease
+- host-independent tests run
+- host-gated drill status and exact prepared-host command
+- explicit note that host reboot, launchd bootstrap, networking, and broad repair generalization remain out of scope

--- a/Docs/superpowers/specs/2026-05-09-vz-linux-helper-restart-recovery-drill-design.md
+++ b/Docs/superpowers/specs/2026-05-09-vz-linux-helper-restart-recovery-drill-design.md
@@ -1,0 +1,272 @@
+# VZ Linux Helper Restart Recovery Drill Design
+
+**Date:** 2026-05-09
+**Status:** Approved slice; awaiting implementation-plan review
+**Backlog:** TASK-150
+**Scope:** Host-gated `vz_linux` failure-drill path, lower-level smoke script lifecycle handoff, real-host pytest coverage, and operator policy docs.
+
+## Summary
+
+PR #1397 added a manual failure-drill path that proves a `vz_linux` session can
+recover when its helper-owned VM is terminated behind the sandbox service's
+back. The next narrow recovery drill should validate the adjacent failure mode:
+the helper process is stopped and restarted after a session VM exists, leaving
+the sandbox service with stale session-control metadata that points at helper
+state the replacement helper cannot know about.
+
+This slice should stay manual-only and host-gated. It should add one helper
+restart drill that creates a real `vz_linux` session, runs a command, restarts
+the helper process through an explicit test lease from the smoke script, runs a
+second command in the same session, and asserts the runner clears stale control
+state and provisions or recovers cleanly.
+
+## Current Baseline
+
+- `run-host-e2e-smoke.sh` owns the lower-level helper lifecycle for real host
+  smoke: build/sign, runtime path preparation, direct helper start, socket wait,
+  real pytest smoke, optional failure drills, and cleanup on exit.
+- `vz-helperctl.py smoke` delegates to the lower-level smoke script with managed
+  defaults, but the lower-level script still starts the helper directly.
+- Real-host pytest currently validates ephemeral execution, same-session reuse,
+  recovery diagnostics/dry-run repair, and stale VM replacement after
+  helper-side VM termination.
+- The sandbox roadmap still lists helper crash/restart, host reboot, stale
+  socket, stuck boot/readiness, and guest-agent mismatch recovery as remaining
+  Phase 1/Phase 4 work.
+
+## Goals
+
+- Add one manual helper restart drill under the existing failure-drill path.
+- Preserve normal host smoke and scheduled host-gated CI defaults.
+- Exercise the real service/runner path, not a fake helper or synthetic control
+  row.
+- Keep helper lifecycle ownership explicit and local to the smoke harness.
+- Add host-independent tests for script/workflow/operator contract changes.
+- Document the new accepted host-gated failure mode and remaining gaps.
+
+## Non-Goals
+
+- Do not add host reboot automation.
+- Do not add `launchctl bootstrap`, `bootout`, `kickstart`, install, or
+  uninstall behavior.
+- Do not refactor the entire lower-level smoke script to use `vz-helperctl
+  start`/`stop`.
+- Do not change helper protocol, VM boot, guest-agent, networking, image-store,
+  or sandbox public API behavior.
+- Do not run helper restart drills in scheduled smoke by default.
+- Do not generalize repair mutation beyond the existing ownership-checked
+  `vz_linux` surfaces.
+
+## Approach Options
+
+### Option A: Smoke Script Restart Lease
+
+Keep `run-host-e2e-smoke.sh` as the helper lifecycle owner. When failure drills
+are enabled, it writes the current helper PID to a private pid file and passes a
+small set of drill-only environment variables to pytest:
+
+- helper PID file path
+- helper binary path
+- helper socket path
+- serial/helper log directory
+- an explicit `TLDW_SANDBOX_VZ_LINUX_E2E_HELPER_RESTART_ALLOWED=1` opt-in
+
+The pytest drill may terminate the current helper PID, wait for the socket to go
+away, start the same helper binary with the same socket and serial log
+environment, update the pid file with the replacement helper PID, wait for
+helper ping/template readiness, then continue with the second same-session run.
+The script cleanup reads the pid file on exit so it terminates whichever helper
+instance is current.
+
+This is the recommended path for this PR. It is narrow, keeps the lower-level
+smoke harness responsible for process cleanup, and avoids making the
+implementation depend on `launchd` or a broader helperctl lifecycle refactor.
+
+### Option B: Convert Smoke To `vz-helperctl start`/`stop`
+
+Make the lower-level smoke script start and stop the helper through
+`vz-helperctl.py` and use its pid file as the restart handoff. This is cleaner
+long term, but it changes the baseline helper lifecycle for every host smoke
+run. It also needs a careful compatibility story for custom `--serial-log-dir`
+values because `vz-helperctl start` derives serial logs from `--log-dir/serial`.
+
+This should remain a later lifecycle-unification PR unless the restart lease
+proves too brittle.
+
+### Option C: Launchd Or Host-Reboot Drill
+
+Use launchd restart or host reboot to prove recovery. This would be closer to a
+real operator outage, but it is too destructive and too slow for the next
+reviewable slice. It also requires host-level state and runner orchestration
+that the current manual host-gated workflow intentionally avoids.
+
+## Chosen Design
+
+Use Option A. Extend the lower-level smoke script with a private helper pid file
+and restart lease only when failure drills are enabled. The default smoke path
+should still start the helper, wait for the socket, run baseline smoke, and
+cleanup exactly as it does now.
+
+The helper restart drill should live in
+`tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py` under the existing
+`vz_linux_host_failure_drill` marker. It should require the current real-host
+opt-in variables plus the helper restart lease variables. If the drill is run
+directly without the lease, it should skip with a clear reason instead of trying
+to infer process ownership.
+
+## Drill Contract
+
+1. Configure the isolated SQLite sandbox store and temporary sandbox root using
+   the existing real-host E2E setup.
+2. Create a `vz_linux` sandbox session with the canonical bundle.
+3. Run a first command and assert it completes.
+4. Capture the persisted VZ session-control VM ID.
+5. Confirm helper status reports that VM as healthy before restart.
+6. Terminate the helper process from the pid file and wait until the old helper
+   socket is unavailable.
+7. Start the same helper binary with the same socket path and serial log
+   environment.
+8. Update the pid file to the replacement helper PID before running the second
+   command.
+9. Wait for helper ping and template validation to pass.
+10. Run a second command in the same sandbox session.
+11. Assert the command completes and the session-control VM ID changed, proving
+    stale helper-owned VM state was not reused.
+12. Destroy the sandbox session in `finally`.
+
+The drill should treat restart setup failures as clear skips or failures based
+on ownership:
+
+- missing lease variables: skip, because direct pytest runs cannot safely manage
+  the external helper process
+- original helper already exited before the drill can stop it: skip with a
+  prepared-host/lifecycle reason
+- replacement helper cannot create the accepted socket or answer ping: fail the
+  drill, because that is the failure mode being tested
+- second run aborts instead of provisioning a fresh VM: fail the drill
+
+## Smoke Script Changes
+
+`run-host-e2e-smoke.sh` should gain internal state for a helper pid file under
+the private runtime directory. For normal smoke, this can be implementation
+detail only. For failure drills, `run_real_vz_linux_failure_drills` should pass:
+
+```text
+TLDW_SANDBOX_VZ_LINUX_E2E_HELPER_RESTART_ALLOWED=1
+TLDW_SANDBOX_VZ_LINUX_E2E_HELPER_PID_FILE=<private-runtime-dir>/helper.pid
+TLDW_SANDBOX_MACOS_HELPER_BINARY=<helper-path>
+TLDW_SANDBOX_MACOS_HELPER_SOCKET=<socket-path>
+TLDW_SANDBOX_VZ_LINUX_SERIAL_LOG_DIR=<serial-log-dir>
+```
+
+Cleanup should read the pid file if present and prefer that PID over the
+original shell variable. This lets a pytest-managed replacement helper remain
+visible to the script's existing cleanup trap.
+
+Dry-run output should make the restart lease visible only when failure drills
+are included. Default dry-run output without failure drills should not advertise
+restart behavior.
+
+## Workflow Shape
+
+No new workflow trigger is needed. The existing manual
+`include_failure_drills` input remains the gate. Scheduled runs continue to run
+baseline smoke only.
+
+The host-gated workflow contract tests should be updated only if script
+arguments or documented accepted failure criteria change. Do not add PR or push
+triggers.
+
+## Safety Constraints
+
+- Restart management is available only under the real-host E2E opt-in plus
+  failure-drill opt-in.
+- The drill must use a private runtime directory and owner-only serial/log/pid
+  paths.
+- The drill must only act on the helper PID supplied by the smoke script's
+  private pid file.
+- The replacement helper must use the exact accepted socket path; no fallback
+  socket path is allowed.
+- The test should not terminate arbitrary helper processes discovered through
+  `ps`, socket probing, or broad name matching.
+- The sandbox session must be destroyed in `finally`.
+- The smoke script cleanup must tolerate the original helper already being gone
+  and the replacement helper being the current process to stop.
+
+## Host-Independent Test Strategy
+
+Script tests should cover:
+
+- failure-drill dry-run output includes the restart lease environment when
+  failure drills are requested
+- default dry-run output does not include helper restart lease variables
+- cleanup selects a replacement helper PID from the pid file when present
+- fake-helper real-run mode can update the helper pid file without leaking the
+  runtime directory or logs
+
+Real-host pytest guard tests should cover:
+
+- helper restart drill skips when real-host opt-in is missing
+- helper restart drill skips when restart lease opt-in is missing
+- restart helper helper functions reject missing or non-private pid/log/socket
+  inputs where practical
+
+Real-host verification remains:
+
+```bash
+tools/macos-vz-helper/scripts/vz-helperctl.py smoke \
+  --bundle /path/to/canonical/bundle \
+  --entitlements /path/to/helper.entitlements \
+  --include-failure-drills
+```
+
+If `vz-helperctl.py smoke` does not yet forward `--include-failure-drills`, this
+PR should add that pass-through so the documented operator entrypoint can run
+the manual drills.
+
+## Documentation Updates
+
+Update:
+
+- `Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md` to include helper
+  restart replacement as a manual failure-drill criterion.
+- `Docs/Sandbox/macos-runtime-operator-notes.md` to describe that manual
+  failure drills now include stale VM termination and helper restart recovery,
+  while host reboot and launchd restart remain manual/operator-only gaps.
+- `Docs/Sandbox/sandbox-runtime-capability-inventory.md` only if the current
+  gaps text needs to distinguish helper restart drill coverage from still-manual
+  host reboot/destructive repair coverage.
+
+## Design Review Notes
+
+- **Potential problem:** Restarting the helper inside pytest can hide ownership
+  from the shell cleanup trap.
+  **Mitigation:** Require a script-owned pid file and make cleanup read the
+  latest pid from that file.
+- **Potential problem:** Refactoring all smoke startup through `vz-helperctl
+  start` would be cleaner but broad.
+  **Mitigation:** Keep this PR to the restart lease and leave full lifecycle
+  unification as a later PR.
+- **Potential problem:** Pytest order could matter if one failure drill leaves
+  the helper in a different state.
+  **Mitigation:** The helper restart drill must leave a healthy replacement
+  helper running and update the pid file, so subsequent drills and script
+  cleanup see the current helper.
+- **Potential problem:** A replacement helper may start but not own the old VM.
+  **Mitigation:** That is the intended condition; the second same-session run
+  should see missing/unhealthy helper truth and provision a fresh VM.
+- **Potential problem:** Direct pytest invocation could kill a developer's
+  manually started helper.
+  **Mitigation:** The restart drill skips without the explicit restart lease
+  variables supplied by the smoke script.
+
+## Open Follow-Ups
+
+- Convert the lower-level smoke script to `vz-helperctl start`/`stop` after the
+  restart lease path proves stable.
+- Add stale socket and stuck-readiness drills as separate manual failure-drill
+  slices.
+- Add host reboot recovery documentation or a manual operator playbook before
+  attempting automated reboot coverage.
+- Promote selected failure drills to scheduled host-gated runs only after
+  repeated prepared-host success.

--- a/Docs/superpowers/specs/2026-05-09-vz-linux-helper-restart-recovery-drill-design.md
+++ b/Docs/superpowers/specs/2026-05-09-vz-linux-helper-restart-recovery-drill-design.md
@@ -81,6 +81,8 @@ instance is current.
 This is the recommended path for this PR. It is narrow, keeps the lower-level
 smoke harness responsible for process cleanup, and avoids making the
 implementation depend on `launchd` or a broader helperctl lifecycle refactor.
+The main tradeoff is that the first implementation needs a careful pid-file
+lease contract rather than relying on `vz-helperctl`'s richer lifecycle checks.
 
 ### Option B: Convert Smoke To `vz-helperctl start`/`stop`
 
@@ -122,17 +124,25 @@ to infer process ownership.
 3. Run a first command and assert it completes.
 4. Capture the persisted VZ session-control VM ID.
 5. Confirm helper status reports that VM as healthy before restart.
-6. Terminate the helper process from the pid file and wait until the old helper
-   socket is unavailable.
-7. Start the same helper binary with the same socket path and serial log
+6. Validate the pid file is a regular file inside the private socket directory,
+   contains a positive PID, and points at a process that appears to be the
+   configured helper binary.
+7. Terminate the helper process from the pid file and wait with a bounded
+   timeout until the process exits and the old helper socket is unavailable or
+   no longer accepts connections.
+8. Start the same helper binary with the same socket path and serial log
    environment.
-8. Update the pid file to the replacement helper PID before running the second
+9. Redirect replacement helper stdout/stderr to restart-specific files under
+   the private serial/log directory.
+10. Update the pid file to the replacement helper PID before running the second
    command.
-9. Wait for helper ping and template validation to pass.
-10. Run a second command in the same sandbox session.
-11. Assert the command completes and the session-control VM ID changed, proving
+11. Wait for helper ping and template validation to pass.
+12. Treat the old VM ID as stale by confirming the replacement helper does not
+   report it as healthy before the second run.
+13. Run a second command in the same sandbox session.
+14. Assert the command completes and the session-control VM ID changed, proving
     stale helper-owned VM state was not reused.
-12. Destroy the sandbox session in `finally`.
+15. Destroy the sandbox session in `finally`.
 
 The drill should treat restart setup failures as clear skips or failures based
 on ownership:
@@ -141,6 +151,11 @@ on ownership:
   the external helper process
 - original helper already exited before the drill can stop it: skip with a
   prepared-host/lifecycle reason
+- pid file is missing, symlinked, non-regular, outside the private socket
+  directory, or points at a non-helper process: fail closed before sending any
+  signal
+- original helper does not exit within the bounded stop timeout: fail the drill
+  and leave cleanup to the shell trap
 - replacement helper cannot create the accepted socket or answer ping: fail the
   drill, because that is the failure mode being tested
 - second run aborts instead of provisioning a fresh VM: fail the drill
@@ -148,12 +163,13 @@ on ownership:
 ## Smoke Script Changes
 
 `run-host-e2e-smoke.sh` should gain internal state for a helper pid file under
-the private runtime directory. For normal smoke, this can be implementation
-detail only. For failure drills, `run_real_vz_linux_failure_drills` should pass:
+the accepted private socket directory. For the default path this is
+implementation detail only. For failure drills,
+`run_real_vz_linux_failure_drills` should pass:
 
 ```text
 TLDW_SANDBOX_VZ_LINUX_E2E_HELPER_RESTART_ALLOWED=1
-TLDW_SANDBOX_VZ_LINUX_E2E_HELPER_PID_FILE=<private-runtime-dir>/helper.pid
+TLDW_SANDBOX_VZ_LINUX_E2E_HELPER_PID_FILE=<private-socket-dir>/helper.pid
 TLDW_SANDBOX_MACOS_HELPER_BINARY=<helper-path>
 TLDW_SANDBOX_MACOS_HELPER_SOCKET=<socket-path>
 TLDW_SANDBOX_VZ_LINUX_SERIAL_LOG_DIR=<serial-log-dir>
@@ -166,6 +182,10 @@ visible to the script's existing cleanup trap.
 Dry-run output should make the restart lease visible only when failure drills
 are included. Default dry-run output without failure drills should not advertise
 restart behavior.
+
+The script should not let a caller choose an arbitrary restart pid-file path in
+this PR. Deriving the path from the already-validated private socket directory
+keeps the trust boundary simple and avoids adding another file-safety surface.
 
 ## Workflow Shape
 
@@ -185,8 +205,15 @@ triggers.
   paths.
 - The drill must only act on the helper PID supplied by the smoke script's
   private pid file.
+- The pid file must live under the private socket directory and must be checked
+  with `lstat`/regular-file validation before use.
+- The drill must verify the PID still refers to the expected helper binary
+  before sending a signal. If that cannot be established, it must fail closed.
 - The replacement helper must use the exact accepted socket path; no fallback
   socket path is allowed.
+- The pytest drill should not remove arbitrary socket paths. If stale socket
+  cleanup is required, it must only act on a real socket under the private
+  socket directory or rely on the helper's existing socket safety behavior.
 - The test should not terminate arbitrary helper processes discovered through
   `ps`, socket probing, or broad name matching.
 - The sandbox session must be destroyed in `finally`.
@@ -203,6 +230,8 @@ Script tests should cover:
 - cleanup selects a replacement helper PID from the pid file when present
 - fake-helper real-run mode can update the helper pid file without leaking the
   runtime directory or logs
+- `vz-helperctl.py smoke --dry-run --include-failure-drills` forwards the flag
+  to the lower-level smoke script
 
 Real-host pytest guard tests should cover:
 
@@ -210,6 +239,8 @@ Real-host pytest guard tests should cover:
 - helper restart drill skips when restart lease opt-in is missing
 - restart helper helper functions reject missing or non-private pid/log/socket
   inputs where practical
+- restart helper helper functions reject pid-file symlinks, non-regular files,
+  non-positive PIDs, and obvious process-command mismatches before signaling
 
 Real-host verification remains:
 
@@ -223,6 +254,9 @@ tools/macos-vz-helper/scripts/vz-helperctl.py smoke \
 If `vz-helperctl.py smoke` does not yet forward `--include-failure-drills`, this
 PR should add that pass-through so the documented operator entrypoint can run
 the manual drills.
+
+Add a focused `vz-helperctl.py smoke --dry-run --include-failure-drills` test so
+the managed wrapper and lower-level script do not drift.
 
 ## Documentation Updates
 
@@ -259,6 +293,24 @@ Update:
   manually started helper.
   **Mitigation:** The restart drill skips without the explicit restart lease
   variables supplied by the smoke script.
+- **Potential problem:** A stale or malicious pid file could point at an
+  unrelated local process.
+  **Mitigation:** Keep the pid file under the private socket directory, reject
+  symlinks/non-regular files/non-positive PIDs, and verify the process command
+  appears to match the configured helper before sending a signal.
+- **Potential problem:** The old helper process exits but leaves a stale socket
+  filesystem entry.
+  **Mitigation:** The drill should wait for connection failure rather than only
+  file disappearance, and it should not unlink non-socket or non-private paths.
+  Stale socket deletion remains constrained to the private socket directory and
+  existing helper safety rules.
+- **Potential problem:** Killing the helper could leave an old VM resource
+  outside the replacement helper's in-memory registry.
+  **Mitigation:** The drill records the old VM ID, verifies replacement helper
+  truth reports it unhealthy/missing where possible, asserts the second run uses
+  a new VM ID, and relies on the helper-process exit to release
+  Virtualization.framework-owned VM objects. Broader orphan detection remains a
+  separate reconciliation/host-reboot slice.
 
 ## Open Follow-Ups
 

--- a/backlog/tasks/task-150 - Add-manual-VZ-Linux-helper-restart-recovery-drill.md
+++ b/backlog/tasks/task-150 - Add-manual-VZ-Linux-helper-restart-recovery-drill.md
@@ -1,0 +1,66 @@
+---
+id: TASK-150
+title: Add manual VZ Linux helper restart recovery drill
+status: In Progress
+assignee: []
+created_date: '2026-05-09 04:26'
+updated_date: '2026-05-09 04:29'
+labels:
+  - sandbox
+  - vz_linux
+  - host-gated
+  - recovery
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1397'
+  - .github/workflows/vz-linux-host-gated.yml
+  - tools/vz-linux-image/scripts/run-host-e2e-smoke.sh
+  - tools/macos-vz-helper/scripts/vz-helperctl.py
+  - tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py
+documentation:
+  - Docs/Sandbox/sandbox-architecture-doctrine.md
+  - Docs/Sandbox/sandbox-runtime-capability-inventory.md
+  - Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
+  - Docs/Sandbox/macos-runtime-operator-notes.md
+  - Docs/superpowers/specs/2026-05-02-sandbox-module-roadmap-design.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add the next narrow host-gated recovery slice for vz_linux: a manual-only drill that validates session recovery behavior when the macOS VZ helper is stopped and restarted after a session VM has been created. This follows PR #1397's stale-VM termination drill and the sandbox roadmap's Phase 1/Phase 4 recovery goals. Scope must stay operator-first and host-gated; do not add host reboot automation, launchd bootstrap/install behavior, networking changes, or broad repair generalization in this task.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A design spec is added for the manual helper restart recovery drill and reviewed for scope risks before implementation.
+- [ ] #2 The drill remains opt-in through the existing failure-drill path and is never enabled by default for scheduled or normal host smoke runs.
+- [ ] #3 The planned drill validates that a same-session command after helper stop/start does not reuse stale control state and can provision or recover cleanly.
+- [ ] #4 The plan defines how helper lifecycle ownership is handled without adding host reboot automation, launchd bootstrap/install behavior, networking changes, or broad repair generalization.
+- [ ] #5 Focused host-independent tests and host-gated verification expectations are specified for the implementation slice.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Design-first slice. Write a focused helper restart recovery drill spec, review it for lifecycle ownership and host-gated safety risks, record verification, then ask for human review before implementation planning.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Created design spec: Docs/superpowers/specs/2026-05-09-vz-linux-helper-restart-recovery-drill-design.md. Key design decision: keep the lower-level smoke script as helper lifecycle owner and add an explicit restart lease/pid-file for manual failure drills instead of refactoring all smoke startup through vz-helperctl in this PR.
+
+Design self-review completed. Reviewed the spec for lifecycle ownership, private pid-file cleanup, direct pytest safety, default scheduled CI behavior, and scope creep. The design intentionally avoids host reboot automation, launchd bootstrap/install, networking changes, and broad repair generalization. Bandit is not applicable for this design-only checkpoint.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-150 - Add-manual-VZ-Linux-helper-restart-recovery-drill.md
+++ b/backlog/tasks/task-150 - Add-manual-VZ-Linux-helper-restart-recovery-drill.md
@@ -4,7 +4,7 @@ title: Add manual VZ Linux helper restart recovery drill
 status: In Progress
 assignee: []
 created_date: '2026-05-09 04:26'
-updated_date: '2026-05-09 04:35'
+updated_date: '2026-05-09 04:43'
 labels:
   - sandbox
   - vz_linux
@@ -23,6 +23,8 @@ documentation:
   - Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
   - Docs/Sandbox/macos-runtime-operator-notes.md
   - Docs/superpowers/specs/2026-05-02-sandbox-module-roadmap-design.md
+  - >-
+    Docs/superpowers/plans/2026-05-09-vz-linux-helper-restart-recovery-drill-implementation-plan.md
 priority: medium
 ---
 
@@ -55,6 +57,8 @@ Created design spec: Docs/superpowers/specs/2026-05-09-vz-linux-helper-restart-r
 Design self-review completed. Reviewed the spec for lifecycle ownership, private pid-file cleanup, direct pytest safety, default scheduled CI behavior, and scope creep. The design intentionally avoids host reboot automation, launchd bootstrap/install, networking changes, and broad repair generalization. Bandit is not applicable for this design-only checkpoint.
 
 Design hardening review found implementation-risk gaps and patched the spec before planning: pid-file lease must live under the private socket directory, use lstat/regular-file and positive-PID validation, verify process command matches the helper before signaling, bound helper-stop waits, avoid arbitrary socket deletion, add wrapper pass-through coverage for vz-helperctl smoke --include-failure-drills, and document the old-VM/orphan assumption as a separate follow-up risk.
+
+Implementation plan added at Docs/superpowers/plans/2026-05-09-vz-linux-helper-restart-recovery-drill-implementation-plan.md. Pre-execution plan review patched three implementation hazards before coding: require ProcessLookupError for replacement helper cleanup checks, include the signal import for SIGTERM, and validate env strings before constructing Path objects so missing helper lease env cannot collapse to the current directory.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-150 - Add-manual-VZ-Linux-helper-restart-recovery-drill.md
+++ b/backlog/tasks/task-150 - Add-manual-VZ-Linux-helper-restart-recovery-drill.md
@@ -4,7 +4,7 @@ title: Add manual VZ Linux helper restart recovery drill
 status: In Progress
 assignee: []
 created_date: '2026-05-09 04:26'
-updated_date: '2026-05-09 04:43'
+updated_date: '2026-05-09 05:02'
 labels:
   - sandbox
   - vz_linux
@@ -59,6 +59,8 @@ Design self-review completed. Reviewed the spec for lifecycle ownership, private
 Design hardening review found implementation-risk gaps and patched the spec before planning: pid-file lease must live under the private socket directory, use lstat/regular-file and positive-PID validation, verify process command matches the helper before signaling, bound helper-stop waits, avoid arbitrary socket deletion, add wrapper pass-through coverage for vz-helperctl smoke --include-failure-drills, and document the old-VM/orphan assumption as a separate follow-up risk.
 
 Implementation plan added at Docs/superpowers/plans/2026-05-09-vz-linux-helper-restart-recovery-drill-implementation-plan.md. Pre-execution plan review patched three implementation hazards before coding: require ProcessLookupError for replacement helper cleanup checks, include the signal import for SIGTERM, and validate env strings before constructing Path objects so missing helper lease env cannot collapse to the current directory.
+
+Implementation completed: smoke script now grants an opt-in restart lease only for manual failure drills, helperctl forwards --include-failure-drills, real-host pytest validates private PID-file restart ownership and adds a helper restart recovery drill, and operator docs now distinguish this manual helper restart coverage from host reboot, launchd, networking, and broad repair gaps.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-150 - Add-manual-VZ-Linux-helper-restart-recovery-drill.md
+++ b/backlog/tasks/task-150 - Add-manual-VZ-Linux-helper-restart-recovery-drill.md
@@ -4,7 +4,7 @@ title: Add manual VZ Linux helper restart recovery drill
 status: In Progress
 assignee: []
 created_date: '2026-05-09 04:26'
-updated_date: '2026-05-09 04:29'
+updated_date: '2026-05-09 04:35'
 labels:
   - sandbox
   - vz_linux
@@ -53,6 +53,8 @@ Design-first slice. Write a focused helper restart recovery drill spec, review i
 Created design spec: Docs/superpowers/specs/2026-05-09-vz-linux-helper-restart-recovery-drill-design.md. Key design decision: keep the lower-level smoke script as helper lifecycle owner and add an explicit restart lease/pid-file for manual failure drills instead of refactoring all smoke startup through vz-helperctl in this PR.
 
 Design self-review completed. Reviewed the spec for lifecycle ownership, private pid-file cleanup, direct pytest safety, default scheduled CI behavior, and scope creep. The design intentionally avoids host reboot automation, launchd bootstrap/install, networking changes, and broad repair generalization. Bandit is not applicable for this design-only checkpoint.
+
+Design hardening review found implementation-risk gaps and patched the spec before planning: pid-file lease must live under the private socket directory, use lstat/regular-file and positive-PID validation, verify process command matches the helper before signaling, bound helper-stop waits, avoid arbitrary socket deletion, add wrapper pass-through coverage for vz-helperctl smoke --include-failure-drills, and document the old-VM/orphan assumption as a separate follow-up risk.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-153 - Add-manual-VZ-Linux-helper-restart-recovery-drill.md
+++ b/backlog/tasks/task-153 - Add-manual-VZ-Linux-helper-restart-recovery-drill.md
@@ -1,10 +1,10 @@
 ---
-id: TASK-150
+id: TASK-153
 title: Add manual VZ Linux helper restart recovery drill
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-09 04:26'
-updated_date: '2026-05-09 05:02'
+updated_date: '2026-05-09 05:05'
 labels:
   - sandbox
   - vz_linux
@@ -36,11 +36,11 @@ Add the next narrow host-gated recovery slice for vz_linux: a manual-only drill 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A design spec is added for the manual helper restart recovery drill and reviewed for scope risks before implementation.
-- [ ] #2 The drill remains opt-in through the existing failure-drill path and is never enabled by default for scheduled or normal host smoke runs.
-- [ ] #3 The planned drill validates that a same-session command after helper stop/start does not reuse stale control state and can provision or recover cleanly.
-- [ ] #4 The plan defines how helper lifecycle ownership is handled without adding host reboot automation, launchd bootstrap/install behavior, networking changes, or broad repair generalization.
-- [ ] #5 Focused host-independent tests and host-gated verification expectations are specified for the implementation slice.
+- [x] #1 A design spec is added for the manual helper restart recovery drill and reviewed for scope risks before implementation.
+- [x] #2 The drill remains opt-in through the existing failure-drill path and is never enabled by default for scheduled or normal host smoke runs.
+- [x] #3 The planned drill validates that a same-session command after helper stop/start does not reuse stale control state and can provision or recover cleanly.
+- [x] #4 The plan defines how helper lifecycle ownership is handled without adding host reboot automation, launchd bootstrap/install behavior, networking changes, or broad repair generalization.
+- [x] #5 Focused host-independent tests and host-gated verification expectations are specified for the implementation slice.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -61,14 +61,22 @@ Design hardening review found implementation-risk gaps and patched the spec befo
 Implementation plan added at Docs/superpowers/plans/2026-05-09-vz-linux-helper-restart-recovery-drill-implementation-plan.md. Pre-execution plan review patched three implementation hazards before coding: require ProcessLookupError for replacement helper cleanup checks, include the signal import for SIGTERM, and validate env strings before constructing Path objects so missing helper lease env cannot collapse to the current directory.
 
 Implementation completed: smoke script now grants an opt-in restart lease only for manual failure drills, helperctl forwards --include-failure-drills, real-host pytest validates private PID-file restart ownership and adds a helper restart recovery drill, and operator docs now distinguish this manual helper restart coverage from host reboot, launchd, networking, and broad repair gaps.
+
+Verification after rebase on origin/dev: focused pytest suite passed with 108 passed, 2 skipped, 5 deselected; bash -n passed for run-host-e2e-smoke.sh; py_compile passed for vz-helperctl.py and test_vz_linux_real_host_e2e.py; host-gated failure-drill selection skipped 2 tests because TLDW_SANDBOX_VZ_LINUX_E2E was not set; Bandit report /tmp/bandit_vz_helper_restart_recovery.json had zero findings after skipping pytest assert noise with -s B101; git diff --check was clean.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added a manual-only VZ Linux helper restart recovery drill. The smoke harness now exposes a private restart lease only for opt-in failure drills, helperctl forwards --include-failure-drills, pytest validates restart PID ownership and same-session stale VM replacement after helper restart, and docs clarify this covers the smoke-owned helper restart path but not host reboot, launchd, networking, or broad repair automation. Host-independent verification passed; real VZ execution remains host-gated and skipped locally without TLDW_SANDBOX_VZ_LINUX_E2E.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-153 - Add-manual-VZ-Linux-helper-restart-recovery-drill.md
+++ b/backlog/tasks/task-153 - Add-manual-VZ-Linux-helper-restart-recovery-drill.md
@@ -4,7 +4,7 @@ title: Add manual VZ Linux helper restart recovery drill
 status: Done
 assignee: []
 created_date: '2026-05-09 04:26'
-updated_date: '2026-05-09 05:05'
+updated_date: '2026-05-09 05:27'
 labels:
   - sandbox
   - vz_linux
@@ -47,6 +47,8 @@ Add the next narrow host-gated recovery slice for vz_linux: a manual-only drill 
 
 <!-- SECTION:PLAN:BEGIN -->
 Design-first slice. Write a focused helper restart recovery drill spec, review it for lifecycle ownership and host-gated safety risks, record verification, then ask for human review before implementation planning.
+
+Review-fix pass for PR #1406: verify each open Qodo/Gemini item against current code; add regression tests for dry-run/early-exit cleanup safety, socket-timeout waiting, SIGTERM disappearance race, and PID-file permission creation where practical; then implement minimal fixes for still-valid issues and re-run focused plus touched-scope verification.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -63,12 +65,16 @@ Implementation plan added at Docs/superpowers/plans/2026-05-09-vz-linux-helper-r
 Implementation completed: smoke script now grants an opt-in restart lease only for manual failure drills, helperctl forwards --include-failure-drills, real-host pytest validates private PID-file restart ownership and adds a helper restart recovery drill, and operator docs now distinguish this manual helper restart coverage from host reboot, launchd, networking, and broad repair gaps.
 
 Verification after rebase on origin/dev: focused pytest suite passed with 108 passed, 2 skipped, 5 deselected; bash -n passed for run-host-e2e-smoke.sh; py_compile passed for vz-helperctl.py and test_vz_linux_real_host_e2e.py; host-gated failure-drill selection skipped 2 tests because TLDW_SANDBOX_VZ_LINUX_E2E was not set; Bandit report /tmp/bandit_vz_helper_restart_recovery.json had zero findings after skipping pytest assert noise with -s B101; git diff --check was clean.
+
+PR review fix pass completed for Qodo/Gemini comments. Added regression coverage proving dry-run and early validation failures do not kill a pre-existing helper.pid process, socket timeouts keep waiting for helper shutdown, and ProcessLookupError during SIGTERM becomes a clear skip. Hardened smoke cleanup so it only trusts pid files recorded by this invocation, created shell pid files under umask 077, wrote replacement helper pid files with os.open/fchmod 0600, removed the redundant symlink check after lstat, wrapped long skip strings, added missing test type hints, and documented the restart helpers.
+
+Review-fix verification: the new red tests failed before the fix and passed after; touched host-independent suite passed with 112 passed, 2 skipped, 5 deselected; bash -n, py_compile, git diff --check passed; host-gated failure-drill selection skipped 2 tests without TLDW_SANDBOX_VZ_LINUX_E2E; Bandit first pass only reported existing test-harness B404/B603/B108 baseline findings, and the test-file baseline-skipped report /tmp/bandit_vz_helper_restart_recovery_review_skips.json had zero findings.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added a manual-only VZ Linux helper restart recovery drill. The smoke harness now exposes a private restart lease only for opt-in failure drills, helperctl forwards --include-failure-drills, pytest validates restart PID ownership and same-session stale VM replacement after helper restart, and docs clarify this covers the smoke-owned helper restart path but not host reboot, launchd, networking, or broad repair automation. Host-independent verification passed; real VZ execution remains host-gated and skipped locally without TLDW_SANDBOX_VZ_LINUX_E2E.
+Added a manual-only VZ Linux helper restart recovery drill. The smoke harness now exposes a private restart lease only for opt-in failure drills, helperctl forwards --include-failure-drills, pytest validates restart PID ownership and same-session stale VM replacement after helper restart, and docs clarify this covers the smoke-owned helper restart path but not host reboot, launchd, networking, or broad repair automation. Review fixes hardened dry-run/early-exit cleanup ownership, pid-file permissions, socket-timeout waiting, and SIGTERM race handling. Host-independent verification passed; real VZ execution remains host-gated and skipped locally without TLDW_SANDBOX_VZ_LINUX_E2E.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py
+++ b/tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+import errno
 import os
 import platform
 import signal
@@ -105,13 +106,19 @@ class _HelperRestartLease:
 
 def _require_helper_restart_lease() -> _HelperRestartLease:
     if not is_truthy(os.getenv("TLDW_SANDBOX_VZ_LINUX_E2E_HELPER_RESTART_ALLOWED")):
-        pytest.skip("Set TLDW_SANDBOX_VZ_LINUX_E2E_HELPER_RESTART_ALLOWED=1 to enable helper restart drill")
+        pytest.skip(
+            "Set TLDW_SANDBOX_VZ_LINUX_E2E_HELPER_RESTART_ALLOWED=1 "
+            "to enable helper restart drill"
+        )
     helper_text = str(os.getenv("TLDW_SANDBOX_MACOS_HELPER_BINARY") or "").strip()
     socket_text = str(os.getenv("TLDW_SANDBOX_MACOS_HELPER_SOCKET") or "").strip()
     serial_log_text = str(os.getenv("TLDW_SANDBOX_VZ_LINUX_SERIAL_LOG_DIR") or "").strip()
     pid_file_text = str(os.getenv("TLDW_SANDBOX_VZ_LINUX_E2E_HELPER_PID_FILE") or "").strip()
     if not helper_text or not socket_text or not serial_log_text or not pid_file_text:
-        pytest.skip("helper restart drill requires helper binary, socket, serial log dir, and pid file env")
+        pytest.skip(
+            "helper restart drill requires helper binary, socket, serial log dir, "
+            "and pid file env"
+        )
     return _HelperRestartLease(
         helper_path=Path(helper_text).expanduser(),
         socket_path=Path(socket_text).expanduser(),
@@ -138,6 +145,7 @@ def _read_valid_restart_pid(
     *,
     process_lookup=_lookup_process_command,
 ) -> int:
+    """Return a validated helper PID from the private restart-lease pid file."""
     socket_dir = lease.socket_path.parent.resolve()
     try:
         pid_parent = lease.pid_file.parent.resolve()
@@ -149,7 +157,7 @@ def _read_valid_restart_pid(
         stat_result = lease.pid_file.lstat()
     except OSError as exc:
         pytest.fail(f"helper restart pid file is unavailable: {exc}")
-    if not stat.S_ISREG(stat_result.st_mode) or lease.pid_file.is_symlink():
+    if not stat.S_ISREG(stat_result.st_mode):
         pytest.fail("helper restart pid file must be a regular non-symlink file")
     if stat_result.st_mode & 0o077:
         pytest.fail("helper restart pid file must be owner-only")
@@ -169,7 +177,11 @@ def _read_valid_restart_pid(
 
 
 def _wait_for_helper_socket_unavailable(socket_path: Path, timeout_sec: float = 5.0) -> None:
+    """Wait until the helper socket is missing or refuses connections."""
+    unavailable_errnos = {errno.ENOENT, errno.ECONNREFUSED, errno.ENOTSOCK}
+    retry_errnos = {errno.EAGAIN, errno.EWOULDBLOCK, errno.ETIMEDOUT}
     deadline = time.monotonic() + timeout_sec
+    last_error: OSError | None = None
     while time.monotonic() < deadline:
         if not socket_path.exists():
             return
@@ -177,13 +189,26 @@ def _wait_for_helper_socket_unavailable(socket_path: Path, timeout_sec: float = 
             with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
                 client.settimeout(0.2)
                 client.connect(str(socket_path))
-        except OSError:
+        except socket.timeout as exc:
+            last_error = exc
+        except (FileNotFoundError, ConnectionRefusedError):
             return
+        except OSError as exc:
+            if exc.errno in unavailable_errnos:
+                return
+            last_error = exc
+            if exc.errno not in retry_errnos:
+                time.sleep(0.05)
+                continue
         time.sleep(0.05)
-    pytest.fail(f"helper socket remained available after helper stop: {socket_path}")
+    pytest.fail(
+        f"helper socket remained available after helper stop: {socket_path}; "
+        f"last_error={last_error!r}"
+    )
 
 
 def _wait_for_helper_ping(helper, timeout_sec: float = 10.0) -> None:
+    """Poll the replacement helper until it answers ping or the startup budget expires."""
     deadline = time.monotonic() + timeout_sec
     last_error: Exception | None = None
     while time.monotonic() < deadline:
@@ -196,6 +221,22 @@ def _wait_for_helper_ping(helper, timeout_sec: float = 10.0) -> None:
     pytest.fail(f"replacement helper did not answer ping: {last_error}")
 
 
+def _write_restart_pid_file(pid_file: Path, pid: int) -> None:
+    """Write the replacement helper PID with owner-only permissions from creation."""
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = os.open(pid_file, flags, 0o600)
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            fd = -1
+            handle.write(f"{pid}\n")
+    finally:
+        if fd >= 0:
+            os.close(fd)
+
+
 def _restart_helper_for_drill(
     lease: _HelperRestartLease,
     *,
@@ -203,8 +244,12 @@ def _restart_helper_for_drill(
     process_lookup=_lookup_process_command,
     startup_timeout_sec: float = 10.0,
 ) -> subprocess.Popen[str]:
+    """Stop the smoke-owned helper and start a replacement on the same socket."""
     old_pid = _read_valid_restart_pid(lease, process_lookup=process_lookup)
-    os.kill(old_pid, signal.SIGTERM)
+    try:
+        os.kill(old_pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pytest.skip("helper process exited before restart drill could stop it")
     _wait_for_helper_socket_unavailable(lease.socket_path)
 
     env = os.environ.copy()
@@ -219,8 +264,7 @@ def _restart_helper_for_drill(
             stdout=stdout,
             stderr=stderr,
         )
-    lease.pid_file.write_text(f"{replacement.pid}\n", encoding="utf-8")
-    lease.pid_file.chmod(0o600)
+    _write_restart_pid_file(lease.pid_file, replacement.pid)
     try:
         _wait_for_helper_ping(helper_client_factory(), timeout_sec=startup_timeout_sec)
     except Exception:
@@ -295,7 +339,7 @@ def test_vz_linux_real_host_e2e_requires_helper_ping(monkeypatch, tmp_path: Path
         _require_vz_linux_real_host_e2e(monkeypatch, tmp_path)
 
 
-def test_helper_restart_lease_requires_explicit_opt_in(monkeypatch) -> None:
+def test_helper_restart_lease_requires_explicit_opt_in(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_E2E_HELPER_RESTART_ALLOWED", raising=False)
 
     with pytest.raises(pytest.skip.Exception, match="HELPER_RESTART_ALLOWED"):
@@ -313,10 +357,71 @@ def test_helper_restart_pid_file_rejects_symlink(tmp_path: Path) -> None:
     target.chmod(0o600)
     pid_file = runtime_dir / "helper.pid"
     pid_file.symlink_to(target)
-    lease = _HelperRestartLease(helper, runtime_dir / "helper.sock", runtime_dir / "serial", pid_file)
+    lease = _HelperRestartLease(
+        helper,
+        runtime_dir / "helper.sock",
+        runtime_dir / "serial",
+        pid_file,
+    )
 
     with pytest.raises(pytest.fail.Exception, match="pid file"):
         _read_valid_restart_pid(lease, process_lookup=lambda _pid: str(helper))
+
+
+def test_wait_for_helper_socket_unavailable_retries_socket_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    socket_path = tmp_path / "helper.sock"
+    socket_path.write_text("", encoding="utf-8")
+    attempts: list[str] = []
+
+    class _FakeSocket:
+        def __enter__(self) -> "_FakeSocket":
+            return self
+
+        def __exit__(self, *_exc: object) -> None:
+            return None
+
+        def settimeout(self, _timeout: float) -> None:
+            return None
+
+        def connect(self, path: str) -> None:
+            attempts.append(path)
+            if len(attempts) == 1:
+                raise socket.timeout("transient timeout")
+            raise ConnectionRefusedError("helper socket unavailable")
+
+    monkeypatch.setattr(socket, "socket", lambda *_args, **_kwargs: _FakeSocket())
+
+    _wait_for_helper_socket_unavailable(socket_path, timeout_sec=1.0)
+
+    assert attempts == [str(socket_path), str(socket_path)]
+
+
+def test_restart_helper_for_drill_skips_when_pid_exits_before_signal(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    helper = tmp_path / "macos-vz-helper"
+    helper.write_text("#!/bin/sh\n", encoding="utf-8")
+    helper.chmod(0o755)
+    runtime_dir = tmp_path / "runtime"
+    runtime_dir.mkdir(mode=0o700)
+    serial_log_dir = runtime_dir / "serial"
+    serial_log_dir.mkdir(mode=0o700)
+    pid_file = runtime_dir / "helper.pid"
+    pid_file.write_text("1234\n", encoding="utf-8")
+    pid_file.chmod(0o600)
+    lease = _HelperRestartLease(helper, runtime_dir / "helper.sock", serial_log_dir, pid_file)
+
+    def _raise_process_lookup_error(_pid: int, _signal_number: int) -> None:
+        raise ProcessLookupError("process exited")
+
+    monkeypatch.setattr(os, "kill", _raise_process_lookup_error)
+
+    with pytest.raises(pytest.skip.Exception, match="helper process exited"):
+        _restart_helper_for_drill(lease, process_lookup=lambda _pid: str(helper))
 
 
 def test_restart_helper_for_drill_replaces_pid_file_and_stops_old_helper(tmp_path: Path) -> None:

--- a/tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py
+++ b/tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py
@@ -6,7 +6,7 @@ import platform
 import signal
 import socket
 import stat
-import subprocess
+import subprocess  # nosec B404
 import sys
 import time
 from pathlib import Path
@@ -121,7 +121,7 @@ def _require_helper_restart_lease() -> _HelperRestartLease:
 
 
 def _lookup_process_command(pid: int) -> str | None:
-    completed = subprocess.run(  # nosec B603,B607
+    completed = subprocess.run(  # nosec B603, B607
         ["ps", "-p", str(pid), "-o", "command="],
         check=False,
         capture_output=True,

--- a/tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py
+++ b/tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+import dataclasses
 import os
 import platform
+import signal
+import socket
+import stat
+import subprocess
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -89,6 +95,146 @@ def _require_vz_linux_real_host_e2e(monkeypatch, tmp_path: Path) -> str:
     return base_image
 
 
+@dataclasses.dataclass(frozen=True)
+class _HelperRestartLease:
+    helper_path: Path
+    socket_path: Path
+    serial_log_dir: Path
+    pid_file: Path
+
+
+def _require_helper_restart_lease() -> _HelperRestartLease:
+    if not is_truthy(os.getenv("TLDW_SANDBOX_VZ_LINUX_E2E_HELPER_RESTART_ALLOWED")):
+        pytest.skip("Set TLDW_SANDBOX_VZ_LINUX_E2E_HELPER_RESTART_ALLOWED=1 to enable helper restart drill")
+    helper_text = str(os.getenv("TLDW_SANDBOX_MACOS_HELPER_BINARY") or "").strip()
+    socket_text = str(os.getenv("TLDW_SANDBOX_MACOS_HELPER_SOCKET") or "").strip()
+    serial_log_text = str(os.getenv("TLDW_SANDBOX_VZ_LINUX_SERIAL_LOG_DIR") or "").strip()
+    pid_file_text = str(os.getenv("TLDW_SANDBOX_VZ_LINUX_E2E_HELPER_PID_FILE") or "").strip()
+    if not helper_text or not socket_text or not serial_log_text or not pid_file_text:
+        pytest.skip("helper restart drill requires helper binary, socket, serial log dir, and pid file env")
+    return _HelperRestartLease(
+        helper_path=Path(helper_text).expanduser(),
+        socket_path=Path(socket_text).expanduser(),
+        serial_log_dir=Path(serial_log_text).expanduser(),
+        pid_file=Path(pid_file_text).expanduser(),
+    )
+
+
+def _lookup_process_command(pid: int) -> str | None:
+    completed = subprocess.run(  # nosec B603,B607
+        ["ps", "-p", str(pid), "-o", "command="],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        return None
+    command = completed.stdout.strip()
+    return command or None
+
+
+def _read_valid_restart_pid(
+    lease: _HelperRestartLease,
+    *,
+    process_lookup=_lookup_process_command,
+) -> int:
+    socket_dir = lease.socket_path.parent.resolve()
+    try:
+        pid_parent = lease.pid_file.parent.resolve()
+    except OSError as exc:
+        pytest.fail(f"helper restart pid file parent is invalid: {exc}")
+    if pid_parent != socket_dir:
+        pytest.fail("helper restart pid file must be inside the private socket directory")
+    try:
+        stat_result = lease.pid_file.lstat()
+    except OSError as exc:
+        pytest.fail(f"helper restart pid file is unavailable: {exc}")
+    if not stat.S_ISREG(stat_result.st_mode) or lease.pid_file.is_symlink():
+        pytest.fail("helper restart pid file must be a regular non-symlink file")
+    if stat_result.st_mode & 0o077:
+        pytest.fail("helper restart pid file must be owner-only")
+    try:
+        raw_pid = lease.pid_file.read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        pytest.fail(f"helper restart pid file could not be read: {exc}")
+    if not raw_pid.isdigit() or int(raw_pid) <= 0:
+        pytest.fail("helper restart pid file does not contain a positive PID")
+    pid = int(raw_pid)
+    command = process_lookup(pid)
+    if command is None:
+        pytest.skip("helper process exited before restart drill could stop it")
+    if str(lease.helper_path) not in command and lease.helper_path.name not in command:
+        pytest.fail("helper restart pid file points at a non-helper process")
+    return pid
+
+
+def _wait_for_helper_socket_unavailable(socket_path: Path, timeout_sec: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout_sec
+    while time.monotonic() < deadline:
+        if not socket_path.exists():
+            return
+        try:
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+                client.settimeout(0.2)
+                client.connect(str(socket_path))
+        except OSError:
+            return
+        time.sleep(0.05)
+    pytest.fail(f"helper socket remained available after helper stop: {socket_path}")
+
+
+def _wait_for_helper_ping(helper, timeout_sec: float = 10.0) -> None:
+    deadline = time.monotonic() + timeout_sec
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            helper.ping()
+            return
+        except Exception as exc:
+            last_error = exc
+            time.sleep(0.1)
+    pytest.fail(f"replacement helper did not answer ping: {last_error}")
+
+
+def _restart_helper_for_drill(
+    lease: _HelperRestartLease,
+    *,
+    helper_client_factory=VZLinuxRunner.helper_client_cls,
+    process_lookup=_lookup_process_command,
+    startup_timeout_sec: float = 10.0,
+) -> subprocess.Popen[str]:
+    old_pid = _read_valid_restart_pid(lease, process_lookup=process_lookup)
+    os.kill(old_pid, signal.SIGTERM)
+    _wait_for_helper_socket_unavailable(lease.socket_path)
+
+    env = os.environ.copy()
+    env["TLDW_SANDBOX_MACOS_HELPER_SOCKET"] = str(lease.socket_path)
+    env["TLDW_SANDBOX_VZ_LINUX_SERIAL_LOG_DIR"] = str(lease.serial_log_dir)
+    stdout_path = lease.serial_log_dir / "helper.restart.stdout.log"
+    stderr_path = lease.serial_log_dir / "helper.restart.stderr.log"
+    with stdout_path.open("ab") as stdout, stderr_path.open("ab") as stderr:
+        replacement = subprocess.Popen(  # nosec B603
+            [str(lease.helper_path)],
+            env=env,
+            stdout=stdout,
+            stderr=stderr,
+        )
+    lease.pid_file.write_text(f"{replacement.pid}\n", encoding="utf-8")
+    lease.pid_file.chmod(0o600)
+    try:
+        _wait_for_helper_ping(helper_client_factory(), timeout_sec=startup_timeout_sec)
+    except Exception:
+        if replacement.poll() is None:
+            replacement.terminate()
+            try:
+                replacement.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                replacement.kill()
+                replacement.wait(timeout=5)
+        raise
+    return replacement
+
+
 def test_vz_linux_real_host_e2e_requires_opt_in(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr(sys, "platform", "darwin")
     monkeypatch.setattr(platform, "machine", lambda: "arm64")
@@ -147,6 +293,90 @@ def test_vz_linux_real_host_e2e_requires_helper_ping(monkeypatch, tmp_path: Path
 
     with pytest.raises(pytest.skip.Exception, match="helper unavailable for ping"):
         _require_vz_linux_real_host_e2e(monkeypatch, tmp_path)
+
+
+def test_helper_restart_lease_requires_explicit_opt_in(monkeypatch) -> None:
+    monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_E2E_HELPER_RESTART_ALLOWED", raising=False)
+
+    with pytest.raises(pytest.skip.Exception, match="HELPER_RESTART_ALLOWED"):
+        _require_helper_restart_lease()
+
+
+def test_helper_restart_pid_file_rejects_symlink(tmp_path: Path) -> None:
+    helper = tmp_path / "macos-vz-helper"
+    helper.write_text("#!/bin/sh\n", encoding="utf-8")
+    helper.chmod(0o755)
+    runtime_dir = tmp_path / "runtime"
+    runtime_dir.mkdir(mode=0o700)
+    target = runtime_dir / "target.pid"
+    target.write_text("1234\n", encoding="utf-8")
+    target.chmod(0o600)
+    pid_file = runtime_dir / "helper.pid"
+    pid_file.symlink_to(target)
+    lease = _HelperRestartLease(helper, runtime_dir / "helper.sock", runtime_dir / "serial", pid_file)
+
+    with pytest.raises(pytest.fail.Exception, match="pid file"):
+        _read_valid_restart_pid(lease, process_lookup=lambda _pid: str(helper))
+
+
+def test_restart_helper_for_drill_replaces_pid_file_and_stops_old_helper(tmp_path: Path) -> None:
+    helper = tmp_path / "macos-vz-helper"
+    helper.write_text(
+        "#!/usr/bin/env python3\n"
+        "import signal\n"
+        "import sys\n"
+        "import time\n"
+        "signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))\n"
+        "while True:\n"
+        "    time.sleep(0.1)\n",
+        encoding="utf-8",
+    )
+    helper.chmod(0o755)
+    runtime_dir = tmp_path / "runtime"
+    runtime_dir.mkdir(mode=0o700)
+    serial_log_dir = runtime_dir / "serial"
+    serial_log_dir.mkdir(mode=0o700)
+    pid_file = runtime_dir / "helper.pid"
+    old_proc = subprocess.Popen(  # nosec B603
+        [str(helper)],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    pid_file.write_text(f"{old_proc.pid}\n", encoding="utf-8")
+    pid_file.chmod(0o600)
+    lease = _HelperRestartLease(helper, runtime_dir / "helper.sock", serial_log_dir, pid_file)
+
+    class _PingHelper:
+        def ping(self) -> HelperPingReply:
+            return HelperPingReply(
+                protocol_version="1",
+                helper_version="test-mode",
+                status="ok",
+                details={"transport": "fake"},
+            )
+
+    replacement_proc: subprocess.Popen[str] | None = None
+    try:
+        replacement_proc = _restart_helper_for_drill(
+            lease,
+            helper_client_factory=_PingHelper,
+            process_lookup=lambda _pid: str(helper),
+            startup_timeout_sec=1.0,
+        )
+        _expect(replacement_proc.poll() is None, "Expected replacement helper to remain running")
+        _expect(
+            int(pid_file.read_text(encoding="utf-8").strip()) == replacement_proc.pid,
+            "Expected restart helper to update pid file to replacement process",
+        )
+        old_proc.wait(timeout=5)
+    finally:
+        if replacement_proc is not None and replacement_proc.poll() is None:
+            replacement_proc.terminate()
+            replacement_proc.wait(timeout=5)
+        if old_proc.poll() is None:
+            old_proc.terminate()
+            old_proc.wait(timeout=5)
 
 
 @pytest.mark.skipif(sys.platform != "darwin", reason="macOS host only")
@@ -432,6 +662,109 @@ def test_vz_linux_real_session_recreates_vm_after_helper_termination(
         _expect(
             second_vm_id != first_vm_id,
             f"Expected stale VM replacement after helper termination, got {first_vm_id!r}",
+        )
+
+        _expect(service.destroy_session(session.id) is True, "Expected session destruction to succeed")
+        destroyed = True
+        _expect(service._orch.get_vz_session_control(session.id) is None, "Expected VZ session control cleanup")
+    finally:
+        if session_id and not destroyed:
+            service.destroy_session(session_id)
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS host only")
+@pytest.mark.vz_linux_host_failure_drill
+def test_vz_linux_real_session_recreates_vm_after_helper_restart(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Verify stale session VM control is replaced after helper process restart."""
+    base_image = _require_vz_linux_real_host_e2e(monkeypatch, tmp_path)
+    lease = _require_helper_restart_lease()
+    monkeypatch.delenv("TEST_MODE", raising=False)
+    monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_FAKE_EXEC", raising=False)
+    monkeypatch.delenv("TLDW_SANDBOX_MACOS_HELPER_READY", raising=False)
+    monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_TEMPLATE_READY", raising=False)
+    monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_AVAILABLE", raising=False)
+
+    service = SandboxService()
+    helper = VZLinuxRunner.helper_client_cls()
+    session_id: str | None = None
+    destroyed = False
+    try:
+        session = service.create_session(
+            user_id="e2e-user",
+            spec=SessionSpec(
+                runtime=RuntimeType.vz_linux,
+                base_image=base_image,
+                network_policy="deny_all",
+            ),
+            spec_version="1.0",
+            idem_key=None,
+            raw_body={"spec_version": "1.0", "runtime": "vz_linux", "base_image": base_image},
+        )
+        session_id = session.id
+
+        first = service.start_run_scaffold(
+            user_id="e2e-user",
+            spec=RunSpec(
+                session_id=session.id,
+                runtime=RuntimeType.vz_linux,
+                base_image=base_image,
+                command=["/bin/echo", "restart-drill-first"],
+                network_policy="deny_all",
+            ),
+            spec_version="1.0",
+            idem_key=None,
+            raw_body={
+                "session_id": session.id,
+                "runtime": "vz_linux",
+                "command": ["/bin/echo", "restart-drill-first"],
+            },
+        )
+        control_after_first = service._orch.get_vz_session_control(session.id)
+        _expect(first.phase == RunPhase.completed, f"Expected first run completed, got {first.phase!r}")
+        _expect(isinstance(control_after_first, dict), "Expected VZ session control after first run")
+        first_vm_id = str(control_after_first.get("vm_id") or "").strip() if control_after_first else ""
+        _expect(bool(first_vm_id), f"Expected first VM id, got {control_after_first!r}")
+        _expect(
+            bool(getattr(helper.get_vm_status(first_vm_id), "healthy", False)),
+            f"Expected first VM healthy before restart: {first_vm_id!r}",
+        )
+
+        _restart_helper_for_drill(lease)
+        helper_after_restart = VZLinuxRunner.helper_client_cls()
+        status_after_restart = helper_after_restart.get_vm_status(first_vm_id)
+        _expect(
+            not bool(getattr(status_after_restart, "healthy", False)),
+            f"Expected old VM stale after helper restart: {status_after_restart!r}",
+        )
+
+        second = service.start_run_scaffold(
+            user_id="e2e-user",
+            spec=RunSpec(
+                session_id=session.id,
+                runtime=RuntimeType.vz_linux,
+                base_image=base_image,
+                command=["/bin/echo", "restart-drill-second"],
+                network_policy="deny_all",
+            ),
+            spec_version="1.0",
+            idem_key=None,
+            raw_body={
+                "session_id": session.id,
+                "runtime": "vz_linux",
+                "command": ["/bin/echo", "restart-drill-second"],
+            },
+        )
+        control_after_second = service._orch.get_vz_session_control(session.id)
+        _expect(second.phase == RunPhase.completed, f"Expected second run completed, got {second.phase!r}")
+        _expect(isinstance(control_after_second, dict), "Expected VZ session control after second run")
+        second_vm_id = str(control_after_second.get("vm_id") or "").strip() if control_after_second else ""
+        _expect(bool(second_vm_id), f"Expected second VM id, got {control_after_second!r}")
+        _expect(
+            second_vm_id != first_vm_id,
+            f"Expected helper restart to force fresh VM, got {first_vm_id!r}",
         )
 
         _expect(service.destroy_session(session.id) is True, "Expected session destruction to succeed")

--- a/tools/macos-vz-helper/Tests/test_vz_helperctl.py
+++ b/tools/macos-vz-helper/Tests/test_vz_helperctl.py
@@ -2079,7 +2079,10 @@ def test_smoke_dry_run_delegates_to_host_smoke_script(tmp_path, capsys):
     CASE.assertIn(f"--serial-log-dir {serial_log_dir}", captured.out)
 
 
-def test_smoke_dry_run_forwards_failure_drills(tmp_path, capsys):
+def test_smoke_dry_run_forwards_failure_drills(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     helperctl = load_helperctl()
     bundle = tmp_path / "bundle"
     bundle.mkdir()

--- a/tools/macos-vz-helper/Tests/test_vz_helperctl.py
+++ b/tools/macos-vz-helper/Tests/test_vz_helperctl.py
@@ -2076,6 +2076,26 @@ def test_smoke_dry_run_delegates_to_host_smoke_script(tmp_path, capsys):
     CASE.assertIn(f"--serial-log-dir {serial_log_dir}", captured.out)
 
 
+def test_smoke_dry_run_forwards_failure_drills(tmp_path, capsys):
+    helperctl = load_helperctl()
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+
+    code = helperctl.main(
+        [
+            "smoke",
+            "--dry-run",
+            "--bundle",
+            str(bundle),
+            "--include-failure-drills",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    CASE.assertEqual(code, 0)
+    CASE.assertIn("--include-failure-drills", captured.out)
+
+
 def test_helperctl_executable_smoke_dry_run_works(tmp_path):
     bundle = tmp_path / "bundle"
     bundle.mkdir()

--- a/tools/macos-vz-helper/Tests/test_vz_helperctl.py
+++ b/tools/macos-vz-helper/Tests/test_vz_helperctl.py
@@ -2015,6 +2015,7 @@ def test_stop_helper_removes_owned_socket_after_process_exit(tmp_path):
     helper.write_text("#!/bin/sh\n", encoding="utf-8")
     pid_file.parent.mkdir(mode=0o700)
     pid_file.write_text("1234\n", encoding="utf-8")
+    killed = []
     removed = []
     lookups = []
 
@@ -2029,11 +2030,13 @@ def test_stop_helper_removes_owned_socket_after_process_exit(tmp_path):
         pid_file,
         socket_path=socket_path,
         process_lookup=process_lookup,
+        process_killer=lambda pid: killed.append(pid),
         socket_identity_reader=lambda path: identity,
         socket_remover=lambda path, owned_identity: removed.append((path, owned_identity)),
     )
 
     CASE.assertEqual(result, helperctl.CheckResult(ok=True))
+    CASE.assertEqual(killed, [1234])
     CASE.assertEqual(removed, [(socket_path, identity)])
 
 

--- a/tools/macos-vz-helper/scripts/vz-helperctl.py
+++ b/tools/macos-vz-helper/scripts/vz-helperctl.py
@@ -28,15 +28,18 @@ DEFAULT_HELPER = HELPER_PACKAGE_DIR / ".build" / "debug" / "macos-vz-helper"
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-try:
-    from tldw_Server_API.app.core.Sandbox.macos_virtualization.helper_client import (
-        EXPECTED_HELPER_PROTOCOL_VERSION,
-    )
-except ModuleNotFoundError as exc:
-    missing_name = str(exc.name or "")
-    if missing_name != "tldw_Server_API" and not missing_name.startswith("tldw_Server_API."):
-        raise
+if sys.version_info < (3, 10):
     EXPECTED_HELPER_PROTOCOL_VERSION = "1"
+else:
+    try:
+        from tldw_Server_API.app.core.Sandbox.macos_virtualization.helper_client import (
+            EXPECTED_HELPER_PROTOCOL_VERSION,
+        )
+    except ModuleNotFoundError as exc:
+        missing_name = str(exc.name or "")
+        if missing_name != "tldw_Server_API" and not missing_name.startswith("tldw_Server_API."):
+            raise
+        EXPECTED_HELPER_PROTOCOL_VERSION = "1"
 
 
 INVALID_LIFECYCLE_LOCK_GRACE_SEC = 1.0
@@ -325,6 +328,7 @@ def smoke_helper(
     helper_path: Path | None = None,
     entitlements_path: Path | None = None,
     python_path: Path | None = None,
+    include_failure_drills: bool = False,
     dry_run: bool = False,
 ) -> CheckResult:
     argv = [str(host_smoke_script_path()), "--bundle", str(bundle_path)]
@@ -338,6 +342,8 @@ def smoke_helper(
         argv.extend(["--entitlements", str(entitlements_path)])
     if python_path is not None:
         argv.extend(["--python", str(python_path)])
+    if include_failure_drills:
+        argv.append("--include-failure-drills")
     if dry_run:
         argv.append("--dry-run")
     code = run_command(argv, dry_run=dry_run)
@@ -1379,6 +1385,7 @@ def _smoke_command(args: argparse.Namespace) -> int:
         helper_path=Path(args.helper_path) if args.helper_path else DEFAULT_HELPER,
         entitlements_path=Path(args.entitlements) if args.entitlements else None,
         python_path=Path(args.python) if args.python else None,
+        include_failure_drills=args.include_failure_drills,
         dry_run=args.dry_run,
     )
     if not result.ok:
@@ -1449,6 +1456,7 @@ def build_parser() -> argparse.ArgumentParser:
     smoke.add_argument("--helper", "--helper-path", dest="helper_path")
     smoke.add_argument("--entitlements")
     smoke.add_argument("--python")
+    smoke.add_argument("--include-failure-drills", action="store_true")
     smoke.add_argument("--dry-run", action="store_true")
     smoke.set_defaults(func=_smoke_command)
 

--- a/tools/vz-linux-image/scripts/run-host-e2e-smoke.sh
+++ b/tools/vz-linux-image/scripts/run-host-e2e-smoke.sh
@@ -76,6 +76,12 @@ die() {
 }
 
 cleanup() {
+  if [[ "${DRY_RUN}" -eq 1 ]]; then
+    return 0
+  fi
+  if [[ -z "${HELPER_PID}" && -z "${HELPER_PID_FILE}" ]]; then
+    return 0
+  fi
   local pid
   pid="$(current_helper_pid)"
   if [[ -n "${pid}" ]] && kill -0 "${pid}" 2>/dev/null; then
@@ -289,16 +295,17 @@ record_helper_pid() {
   if [[ "${DRY_RUN}" -eq 1 ]]; then
     return 0
   fi
-  HELPER_PID_FILE="$(helper_pid_file_path)"
-  printf '%s\n' "${HELPER_PID}" > "${HELPER_PID_FILE}"
-  chmod 600 "${HELPER_PID_FILE}" 2>/dev/null || true
+  local pid_file
+  pid_file="$(helper_pid_file_path)"
+  (umask 077; printf '%s\n' "${HELPER_PID}" > "${pid_file}")
+  chmod 600 "${pid_file}" 2>/dev/null || true
+  HELPER_PID_FILE="${pid_file}"
 }
 
 current_helper_pid() {
   local candidate=""
-  local pid_file="${HELPER_PID_FILE:-$(helper_pid_file_path)}"
-  if [[ -f "${pid_file}" && ! -L "${pid_file}" ]]; then
-    candidate="$(tr -d '[:space:]' < "${pid_file}" 2>/dev/null || true)"
+  if [[ -n "${HELPER_PID_FILE}" && -f "${HELPER_PID_FILE}" && ! -L "${HELPER_PID_FILE}" ]]; then
+    candidate="$(tr -d '[:space:]' < "${HELPER_PID_FILE}" 2>/dev/null || true)"
     if [[ "${candidate}" =~ ^[1-9][0-9]*$ ]]; then
       printf '%s\n' "${candidate}"
       return 0

--- a/tools/vz-linux-image/scripts/run-host-e2e-smoke.sh
+++ b/tools/vz-linux-image/scripts/run-host-e2e-smoke.sh
@@ -17,6 +17,7 @@ SKIP_BUILD=0
 SKIP_SIGN=0
 INCLUDE_FAILURE_DRILLS=0
 HELPER_PID=""
+HELPER_PID_FILE=""
 
 usage() {
   cat <<'EOF'
@@ -75,9 +76,11 @@ die() {
 }
 
 cleanup() {
-  if [[ -n "${HELPER_PID}" ]] && kill -0 "${HELPER_PID}" 2>/dev/null; then
-    kill "${HELPER_PID}" 2>/dev/null || true
-    wait "${HELPER_PID}" 2>/dev/null || true
+  local pid
+  pid="$(current_helper_pid)"
+  if [[ -n "${pid}" ]] && kill -0 "${pid}" 2>/dev/null; then
+    kill "${pid}" 2>/dev/null || true
+    wait "${pid}" 2>/dev/null || true
   fi
   if [[ -S "${SOCKET_PATH}" ]]; then
     rm -f "${SOCKET_PATH}"
@@ -276,6 +279,34 @@ prepare_runtime_paths() {
   prepare_private_serial_log_dir
 }
 
+helper_pid_file_path() {
+  local socket_dir
+  socket_dir="$(dirname "${SOCKET_PATH}")"
+  printf '%s/helper.pid' "${socket_dir}"
+}
+
+record_helper_pid() {
+  if [[ "${DRY_RUN}" -eq 1 ]]; then
+    return 0
+  fi
+  HELPER_PID_FILE="$(helper_pid_file_path)"
+  printf '%s\n' "${HELPER_PID}" > "${HELPER_PID_FILE}"
+  chmod 600 "${HELPER_PID_FILE}" 2>/dev/null || true
+}
+
+current_helper_pid() {
+  local candidate=""
+  local pid_file="${HELPER_PID_FILE:-$(helper_pid_file_path)}"
+  if [[ -f "${pid_file}" && ! -L "${pid_file}" ]]; then
+    candidate="$(tr -d '[:space:]' < "${pid_file}" 2>/dev/null || true)"
+    if [[ "${candidate}" =~ ^[1-9][0-9]*$ ]]; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+  fi
+  printf '%s\n' "${HELPER_PID}"
+}
+
 run_helper_daemon_smoke() {
   run_cmd env \
     TLDW_SANDBOX_MACOS_HELPER_DAEMON_SMOKE=1 \
@@ -306,6 +337,7 @@ start_helper_for_real_e2e() {
     > "${SERIAL_LOG_DIR}/helper.stdout.log" \
     2> "${SERIAL_LOG_DIR}/helper.stderr.log" &
   HELPER_PID="$!"
+  record_helper_pid
 }
 
 wait_for_helper_socket() {
@@ -347,7 +379,22 @@ run_real_vz_linux_host_smoke() {
 }
 
 run_real_vz_linux_failure_drills() {
-  run_real_vz_linux_pytest -m vz_linux_host_failure_drill -q -rs
+  local helper_pid_file
+  helper_pid_file="$(helper_pid_file_path)"
+  run_cmd env \
+    TEST_MODE=0 \
+    TLDW_SANDBOX_VZ_LINUX_E2E=1 \
+    TLDW_SANDBOX_VZ_LINUX_E2E_BASE_IMAGE="${BUNDLE_PATH}" \
+    TLDW_SANDBOX_MACOS_HELPER_SOCKET="${SOCKET_PATH}" \
+    TLDW_SANDBOX_MACOS_HELPER_BINARY="${HELPER_PATH}" \
+    TLDW_SANDBOX_VZ_LINUX_SERIAL_LOG_DIR="${SERIAL_LOG_DIR}" \
+    TLDW_SANDBOX_VZ_LINUX_E2E_HELPER_RESTART_ALLOWED=1 \
+    TLDW_SANDBOX_VZ_LINUX_E2E_HELPER_PID_FILE="${helper_pid_file}" \
+    SANDBOX_ENABLE_EXECUTION=1 \
+    SANDBOX_BACKGROUND_EXECUTION=0 \
+    "${PYTHON_BIN}" -m pytest \
+    "${REPO_ROOT}/tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py" \
+    -m vz_linux_host_failure_drill -q -rs
 }
 
 if [[ "${DRY_RUN}" -eq 1 ]]; then

--- a/tools/vz-linux-image/tests/test_host_e2e_smoke_script.py
+++ b/tools/vz-linux-image/tests/test_host_e2e_smoke_script.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import re
+import signal
 import socket
 import subprocess
 import sys
@@ -107,6 +108,53 @@ def test_host_e2e_smoke_script_dry_run_includes_failure_drills_when_requested(tm
     assert result.returncode == 0, result.stderr
     assert "-m vz_linux_host_smoke" in result.stdout
     assert "-m vz_linux_host_failure_drill" in result.stdout
+
+
+def test_host_e2e_smoke_script_default_dry_run_omits_restart_lease(tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    (bundle / "kernel").write_bytes(b"kernel")
+    (bundle / "rootfs.img").write_bytes(b"rootfs")
+    helper = tmp_path / "macos-vz-helper"
+
+    result = _run_smoke_script(
+        "--dry-run",
+        "--bundle",
+        str(bundle),
+        "--helper",
+        str(helper),
+        "--python",
+        sys.executable,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "TLDW_SANDBOX_VZ_LINUX_E2E_HELPER_RESTART_ALLOWED" not in result.stdout
+    assert "TLDW_SANDBOX_VZ_LINUX_E2E_HELPER_PID_FILE" not in result.stdout
+
+
+def test_host_e2e_smoke_script_failure_drill_dry_run_includes_restart_lease(tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    (bundle / "kernel").write_bytes(b"kernel")
+    (bundle / "rootfs.img").write_bytes(b"rootfs")
+    helper = tmp_path / "macos-vz-helper"
+
+    result = _run_smoke_script(
+        "--dry-run",
+        "--include-failure-drills",
+        "--bundle",
+        str(bundle),
+        "--helper",
+        str(helper),
+        "--python",
+        sys.executable,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "TLDW_SANDBOX_VZ_LINUX_E2E_HELPER_RESTART_ALLOWED=1" in result.stdout
+    assert "TLDW_SANDBOX_VZ_LINUX_E2E_HELPER_PID_FILE=" in result.stdout
+    assert "/helper.pid" in result.stdout
+    assert f"TLDW_SANDBOX_MACOS_HELPER_BINARY={helper}" in result.stdout
 
 
 def test_host_e2e_smoke_script_default_socket_uses_private_runtime_dir(tmp_path: Path) -> None:
@@ -369,3 +417,79 @@ def test_host_e2e_smoke_script_refuses_regular_file_socket_path(tmp_path: Path) 
     assert result.returncode != 0
     assert "helper socket path already exists and is not a UNIX socket" in result.stderr
     assert socket_path.read_text(encoding="utf-8") == "do not delete"
+
+
+def test_host_e2e_smoke_script_cleanup_uses_replacement_helper_pid(tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    (bundle / "kernel").write_bytes(b"kernel")
+    (bundle / "rootfs.img").write_bytes(b"rootfs")
+    tmp_dir = tmp_path / "tmp"
+    tmp_dir.mkdir()
+    marker = tmp_path / "replacement_pid.txt"
+    fake_python = tmp_path / "fake-python"
+    fake_helper = tmp_path / "fake-helper"
+    fake_python.write_text(
+        "#!/usr/bin/env python3\n"
+        "import os\n"
+        "import subprocess\n"
+        "import sys\n"
+        "if sys.argv[1:3] != ['-m', 'pytest']:\n"
+        "    sys.exit(2)\n"
+        "if 'vz_linux_host_failure_drill' in sys.argv:\n"
+        "    pid_file = os.environ['TLDW_SANDBOX_VZ_LINUX_E2E_HELPER_PID_FILE']\n"
+        "    marker = os.environ['TLDW_TEST_REPLACEMENT_PID_MARKER']\n"
+        "    proc = subprocess.Popen(\n"
+        "        [os.environ['TLDW_SANDBOX_MACOS_HELPER_BINARY']],\n"
+        "        stdin=subprocess.DEVNULL,\n"
+        "        stdout=subprocess.DEVNULL,\n"
+        "        stderr=subprocess.DEVNULL,\n"
+        "    )\n"
+        "    with open(pid_file, 'w', encoding='utf-8') as handle:\n"
+        "        handle.write(str(proc.pid) + '\\n')\n"
+        "    os.chmod(pid_file, 0o600)\n"
+        "    with open(marker, 'w', encoding='utf-8') as handle:\n"
+        "        handle.write(str(proc.pid) + '\\n')\n"
+        "sys.exit(0)\n",
+        encoding="utf-8",
+    )
+    fake_helper.write_text(
+        "#!/usr/bin/env python3\n"
+        "import signal\n"
+        "import sys\n"
+        "import time\n"
+        "signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))\n"
+        "while True:\n"
+        "    time.sleep(0.1)\n",
+        encoding="utf-8",
+    )
+    fake_python.chmod(0o755)
+    fake_helper.chmod(0o755)
+
+    result = _run_smoke_script(
+        "--bundle",
+        str(bundle),
+        "--helper",
+        str(fake_helper),
+        "--python",
+        str(fake_python),
+        "--skip-build",
+        "--skip-sign",
+        "--include-failure-drills",
+        env_overrides={
+            "TMPDIR": str(tmp_dir),
+            "TLDW_HOST_E2E_SMOKE_SKIP_SOCKET_WAIT": "1",
+            "TLDW_TEST_REPLACEMENT_PID_MARKER": str(marker),
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    replacement_pid = int(marker.read_text(encoding="utf-8").strip())
+    try:
+        with pytest.raises(ProcessLookupError):
+            os.kill(replacement_pid, 0)
+    finally:
+        try:
+            os.kill(replacement_pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass

--- a/tools/vz-linux-image/tests/test_host_e2e_smoke_script.py
+++ b/tools/vz-linux-image/tests/test_host_e2e_smoke_script.py
@@ -157,6 +157,96 @@ def test_host_e2e_smoke_script_failure_drill_dry_run_includes_restart_lease(tmp_
     assert f"TLDW_SANDBOX_MACOS_HELPER_BINARY={helper}" in result.stdout
 
 
+def test_host_e2e_smoke_script_dry_run_does_not_kill_existing_pid_file_process(
+    tmp_path: Path,
+) -> None:
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    (bundle / "kernel").write_bytes(b"kernel")
+    (bundle / "rootfs.img").write_bytes(b"rootfs")
+    socket_dir = tmp_path / "runtime"
+    socket_dir.mkdir(mode=0o700)
+    pid_file = socket_dir / "helper.pid"
+    helper = tmp_path / "macos-vz-helper"
+    helper.write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+    helper.chmod(0o755)
+    proc = subprocess.Popen(  # nosec B603
+        [sys.executable, "-c", "import time; time.sleep(60)"],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    try:
+        pid_file.write_text(f"{proc.pid}\n", encoding="utf-8")
+        pid_file.chmod(0o600)
+
+        result = _run_smoke_script(
+            "--dry-run",
+            "--bundle",
+            str(bundle),
+            "--helper",
+            str(helper),
+            "--socket",
+            str(socket_dir / "helper.sock"),
+            "--python",
+            sys.executable,
+        )
+
+        assert result.returncode == 0, result.stderr
+        with pytest.raises(subprocess.TimeoutExpired):
+            proc.wait(timeout=0.2)
+    finally:
+        if proc.poll() is None:
+            proc.terminate()
+            proc.wait(timeout=5)
+
+
+def test_host_e2e_smoke_script_validation_failure_does_not_kill_existing_pid_file_process(
+    tmp_path: Path,
+) -> None:
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    socket_dir = tmp_path / "runtime"
+    socket_dir.mkdir(mode=0o700)
+    pid_file = socket_dir / "helper.pid"
+    helper = tmp_path / "macos-vz-helper"
+    helper.write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+    helper.chmod(0o755)
+    proc = subprocess.Popen(  # nosec B603
+        [sys.executable, "-c", "import time; time.sleep(60)"],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    try:
+        pid_file.write_text(f"{proc.pid}\n", encoding="utf-8")
+        pid_file.chmod(0o600)
+
+        result = _run_smoke_script(
+            "--bundle",
+            str(bundle),
+            "--helper",
+            str(helper),
+            "--socket",
+            str(socket_dir / "helper.sock"),
+            "--python",
+            sys.executable,
+            "--skip-build",
+            "--skip-sign",
+        )
+
+        assert result.returncode != 0
+        assert "bundle missing kernel" in result.stderr
+        with pytest.raises(subprocess.TimeoutExpired):
+            proc.wait(timeout=0.2)
+    finally:
+        if proc.poll() is None:
+            proc.terminate()
+            proc.wait(timeout=5)
+
+
 def test_host_e2e_smoke_script_default_socket_uses_private_runtime_dir(tmp_path: Path) -> None:
     bundle = tmp_path / "bundle"
     bundle.mkdir()


### PR DESCRIPTION
## Summary
- Adds an opt-in smoke-harness restart lease for manual VZ Linux failure drills so pytest can stop/restart the smoke-owned helper safely.
- Adds `vz-helperctl.py smoke --include-failure-drills` pass-through and real-host pytest coverage that proves same-session stale VM state is replaced after helper restart.
- Updates operator docs and the sandbox runtime inventory to distinguish this manual helper restart drill from host reboot, launchd, networking, and broad repair automation.

## Test Plan
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tools/vz-linux-image/tests/test_host_e2e_smoke_script.py tools/macos-vz-helper/Tests/test_vz_helperctl.py tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py -m "not vz_linux_host_smoke and not vz_linux_host_failure_drill" -q`
- `bash -n tools/vz-linux-image/scripts/run-host-e2e-smoke.sh`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile tools/macos-vz-helper/scripts/vz-helperctl.py tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py -m vz_linux_host_failure_drill -q -rs` skipped locally because `TLDW_SANDBOX_VZ_LINUX_E2E` is not set
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tools/macos-vz-helper/scripts/vz-helperctl.py tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py -s B101 -f json -o /tmp/bandit_vz_helper_restart_recovery.json`
- `git diff --check`

## Out of Scope
- Host reboot recovery
- launchd bootstrap/load behavior
- networking policy changes
- broad helper crash recovery or destructive repair generalization

## Change Summary
Human-authored change summary still required before merge per repo policy.