### PR TITLE
Adapt Agent DiffViewer status badges

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -5566,17 +5566,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "local-status-badge:src/components/Agent/DiffViewer.tsx:FileStatusBadge",
-    "path": "src/components/Agent/DiffViewer.tsx",
-    "rule": "local-status-badge",
-    "subject": "FileStatusBadge",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing local FileStatusBadge status wrapper before the guard.",
-    "replacement": "Badge with design-system state registry mapping",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "local-status-badge:src/components/Agent/SessionHistoryPanel.tsx:StatusBadge",
     "path": "src/components/Agent/SessionHistoryPanel.tsx",
     "rule": "local-status-badge",

--- a/apps/packages/ui/src/components/Agent/DiffViewer.tsx
+++ b/apps/packages/ui/src/components/Agent/DiffViewer.tsx
@@ -17,7 +17,7 @@ import {
 } from "lucide-react"
 import { message } from "antd"
 import { getDesignSystemState, type DesignSystemStateKey } from "@/design-system"
-import { Badge, type BadgeVariant } from "@/components/ui/primitives"
+import { Badge, getBadgeVariantForDesignSystemSeverity } from "@/components/ui/primitives"
 
 export interface DiffHunk {
   id: string
@@ -208,28 +208,24 @@ function getFilePath(diff: FileDiff): string {
 const FILE_STATUS_CONFIG = {
   new: {
     label: "NEW",
+    srLabel: "New file",
     stateKey: "ready"
   },
   deleted: {
     label: "DEL",
+    srLabel: "Deleted file",
     stateKey: "error"
   },
   renamed: {
     label: "RENAME",
+    srLabel: "Renamed file",
     stateKey: "empty"
   }
 } satisfies Record<string, {
   label: string
+  srLabel: string
   stateKey: DesignSystemStateKey
 }>
-
-const SEVERITY_BADGE_VARIANTS = {
-  success: "success",
-  error: "danger",
-  warning: "warning",
-  info: "info",
-  neutral: "secondary",
-} satisfies Record<ReturnType<typeof getDesignSystemState>["severity"], BadgeVariant>
 
 const FileStatusBadge: FC<{ diff: FileDiff }> = ({ diff }) => {
   const config = diff.isNew
@@ -248,10 +244,10 @@ const FileStatusBadge: FC<{ diff: FileDiff }> = ({ diff }) => {
 
   return (
     <Badge
-      variant={SEVERITY_BADGE_VARIANTS[state.severity]}
+      variant={getBadgeVariantForDesignSystemSeverity(state.severity)}
       size="md"
       pill={false}
-      srLabel={state.label}
+      srLabel={config.srLabel}
     >
       {config.label}
     </Badge>

--- a/apps/packages/ui/src/components/Agent/DiffViewer.tsx
+++ b/apps/packages/ui/src/components/Agent/DiffViewer.tsx
@@ -16,6 +16,8 @@ import {
   CheckCheck
 } from "lucide-react"
 import { message } from "antd"
+import { getDesignSystemState, type DesignSystemStateKey } from "@/design-system"
+import { Badge, type BadgeVariant } from "@/components/ui/primitives"
 
 export interface DiffHunk {
   id: string
@@ -203,29 +205,57 @@ function getFilePath(diff: FileDiff): string {
 /**
  * Get file status badge
  */
+const FILE_STATUS_CONFIG = {
+  new: {
+    label: "NEW",
+    stateKey: "ready"
+  },
+  deleted: {
+    label: "DEL",
+    stateKey: "error"
+  },
+  renamed: {
+    label: "RENAME",
+    stateKey: "empty"
+  }
+} satisfies Record<string, {
+  label: string
+  stateKey: DesignSystemStateKey
+}>
+
+const SEVERITY_BADGE_VARIANTS = {
+  success: "success",
+  error: "danger",
+  warning: "warning",
+  info: "info",
+  neutral: "secondary",
+} satisfies Record<ReturnType<typeof getDesignSystemState>["severity"], BadgeVariant>
+
 const FileStatusBadge: FC<{ diff: FileDiff }> = ({ diff }) => {
-  if (diff.isNew) {
-    return (
-      <span className="rounded bg-success/10 px-1.5 py-0.5 text-xs font-medium text-success">
-        NEW
-      </span>
-    )
+  const config = diff.isNew
+    ? FILE_STATUS_CONFIG.new
+    : diff.isDeleted
+      ? FILE_STATUS_CONFIG.deleted
+      : diff.isRenamed
+        ? FILE_STATUS_CONFIG.renamed
+        : null
+
+  if (!config) {
+    return null
   }
-  if (diff.isDeleted) {
-    return (
-      <span className="rounded bg-danger/10 px-1.5 py-0.5 text-xs font-medium text-danger">
-        DEL
-      </span>
-    )
-  }
-  if (diff.isRenamed) {
-    return (
-      <span className="rounded bg-primary/10 px-1.5 py-0.5 text-xs font-medium text-primary">
-        RENAME
-      </span>
-    )
-  }
-  return null
+
+  const state = getDesignSystemState(config.stateKey)
+
+  return (
+    <Badge
+      variant={SEVERITY_BADGE_VARIANTS[state.severity]}
+      size="md"
+      pill={false}
+      srLabel={state.label}
+    >
+      {config.label}
+    </Badge>
+  )
 }
 
 /**

--- a/apps/packages/ui/src/components/Agent/__tests__/DiffViewer.file-status-badge.test.tsx
+++ b/apps/packages/ui/src/components/Agent/__tests__/DiffViewer.file-status-badge.test.tsx
@@ -1,0 +1,77 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { DiffViewer, type FileDiff } from "../DiffViewer"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key
+  })
+}))
+
+const makeDiff = (overrides: Partial<FileDiff>): FileDiff => ({
+  id: overrides.id ?? "file-1",
+  oldPath: overrides.oldPath ?? "src/example.ts",
+  newPath: overrides.newPath ?? "src/example.ts",
+  hunks: [
+    {
+      id: `${overrides.id ?? "file-1"}-hunk-1`,
+      oldStart: 1,
+      oldCount: 1,
+      newStart: 1,
+      newCount: 1,
+      lines: [
+        {
+          type: "header",
+          content: "@@ -1 +1 @@"
+        }
+      ]
+    }
+  ],
+  ...overrides
+})
+
+const badgeFor = (label: string) => {
+  const badge = screen.getByText(label).closest('[data-ds-component="Badge"]')
+  expect(badge).not.toBeNull()
+  return badge
+}
+
+describe("DiffViewer file status badges", () => {
+  it("renders file status labels through the shared Badge primitive", () => {
+    render(
+      <DiffViewer
+        diffs={[
+          makeDiff({
+            id: "new-file",
+            oldPath: "/dev/null",
+            newPath: "src/new.ts",
+            isNew: true
+          }),
+          makeDiff({
+            id: "deleted-file",
+            oldPath: "src/deleted.ts",
+            newPath: "/dev/null",
+            isDeleted: true
+          }),
+          makeDiff({
+            id: "renamed-file",
+            oldPath: "src/old-name.ts",
+            newPath: "src/new-name.ts",
+            isRenamed: true
+          }),
+          makeDiff({
+            id: "modified-file",
+            oldPath: "src/modified.ts",
+            newPath: "src/modified.ts"
+          })
+        ]}
+      />
+    )
+
+    expect(badgeFor("NEW")).toHaveAttribute("data-ds-variant", "success")
+    expect(badgeFor("DEL")).toHaveAttribute("data-ds-variant", "danger")
+    expect(badgeFor("RENAME")).toHaveAttribute("data-ds-variant", "secondary")
+    expect(screen.queryByText("MOD")).not.toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/components/Agent/__tests__/DiffViewer.file-status-badge.test.tsx
+++ b/apps/packages/ui/src/components/Agent/__tests__/DiffViewer.file-status-badge.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render, screen } from "@testing-library/react"
+import { render, screen, within } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 import { DiffViewer, type FileDiff } from "../DiffViewer"
 
@@ -32,8 +32,10 @@ const makeDiff = (overrides: Partial<FileDiff>): FileDiff => ({
 })
 
 const badgeFor = (label: string) => {
-  const badge = screen.getByText(label).closest('[data-ds-component="Badge"]')
-  expect(badge).not.toBeNull()
+  const badge = screen.getByText(label).closest<HTMLElement>('[data-ds-component="Badge"]')
+  if (!badge) {
+    throw new Error(`Expected ${label} to render inside a Badge`)
+  }
   return badge
 }
 
@@ -73,5 +75,39 @@ describe("DiffViewer file status badges", () => {
     expect(badgeFor("DEL")).toHaveAttribute("data-ds-variant", "danger")
     expect(badgeFor("RENAME")).toHaveAttribute("data-ds-variant", "secondary")
     expect(screen.queryByText("MOD")).not.toBeInTheDocument()
+  })
+
+  it("uses file-operation screen reader labels for status badges", () => {
+    render(
+      <DiffViewer
+        diffs={[
+          makeDiff({
+            id: "new-file",
+            oldPath: "/dev/null",
+            newPath: "src/new.ts",
+            isNew: true
+          }),
+          makeDiff({
+            id: "deleted-file",
+            oldPath: "src/deleted.ts",
+            newPath: "/dev/null",
+            isDeleted: true
+          }),
+          makeDiff({
+            id: "renamed-file",
+            oldPath: "src/old-name.ts",
+            newPath: "src/new-name.ts",
+            isRenamed: true
+          })
+        ]}
+      />
+    )
+
+    expect(within(badgeFor("NEW")).getByText("New file")).toHaveClass("sr-only")
+    expect(within(badgeFor("DEL")).getByText("Deleted file")).toHaveClass("sr-only")
+    expect(within(badgeFor("RENAME")).getByText("Renamed file")).toHaveClass("sr-only")
+    expect(screen.queryByText("Ready")).not.toBeInTheDocument()
+    expect(screen.queryByText("Error")).not.toBeInTheDocument()
+    expect(screen.queryByText("Empty")).not.toBeInTheDocument()
   })
 })

--- a/apps/packages/ui/src/components/Common/StatusBadge.tsx
+++ b/apps/packages/ui/src/components/Common/StatusBadge.tsx
@@ -1,6 +1,10 @@
 import React from "react"
 import { getDesignSystemState, type DesignSystemStateKey } from "@/design-system"
-import { Badge, type BadgeVariant } from "@/components/ui/primitives"
+import {
+  Badge,
+  getBadgeVariantForDesignSystemSeverity,
+  type BadgeVariant
+} from "@/components/ui/primitives"
 
 export interface StatusBadgeProps {
   variant: "demo" | "warning" | "error"
@@ -13,21 +17,15 @@ const VARIANT_STATES: Record<StatusBadgeProps["variant"], DesignSystemStateKey> 
   error: "error",
 }
 
-const SEVERITY_BADGE_VARIANTS = {
-  success: "success",
-  error: "danger",
-  warning: "warning",
-  info: "info",
-  neutral: "secondary",
-} satisfies Record<ReturnType<typeof getDesignSystemState>["severity"], BadgeVariant>
-
 export const StatusBadge: React.FC<StatusBadgeProps> = ({
   variant,
   children
 }) => {
   const state = getDesignSystemState(VARIANT_STATES[variant])
   const badgeVariant: BadgeVariant =
-    variant === "demo" ? "demo" : SEVERITY_BADGE_VARIANTS[state.severity]
+    variant === "demo"
+      ? "demo"
+      : getBadgeVariantForDesignSystemSeverity(state.severity)
 
   return (
     <Badge

--- a/apps/packages/ui/src/components/ui/primitives/badgeUtils.ts
+++ b/apps/packages/ui/src/components/ui/primitives/badgeUtils.ts
@@ -1,0 +1,16 @@
+import type { DesignSystemSeverity } from "@/design-system"
+import type { BadgeVariant } from "./Badge"
+
+export const DESIGN_SYSTEM_SEVERITY_BADGE_VARIANTS = {
+  success: "success",
+  error: "danger",
+  warning: "warning",
+  info: "info",
+  neutral: "secondary",
+} satisfies Record<DesignSystemSeverity, BadgeVariant>
+
+export function getBadgeVariantForDesignSystemSeverity(
+  severity: DesignSystemSeverity
+): BadgeVariant {
+  return DESIGN_SYSTEM_SEVERITY_BADGE_VARIANTS[severity]
+}

--- a/apps/packages/ui/src/components/ui/primitives/index.ts
+++ b/apps/packages/ui/src/components/ui/primitives/index.ts
@@ -3,3 +3,7 @@ export type { AlertProps, AlertVariant } from "./Alert"
 
 export { Badge } from "./Badge"
 export type { BadgeProps, BadgeVariant, BadgeSize } from "./Badge"
+export {
+  DESIGN_SYSTEM_SEVERITY_BADGE_VARIANTS,
+  getBadgeVariantForDesignSystemSeverity
+} from "./badgeUtils"

--- a/backlog/tasks/task-45.25 - Adapt-Agent-DiffViewer-file-status-badges-to-shared-Badge.md
+++ b/backlog/tasks/task-45.25 - Adapt-Agent-DiffViewer-file-status-badges-to-shared-Badge.md
@@ -1,0 +1,64 @@
+---
+id: TASK-45.25
+title: Adapt Agent DiffViewer file status badges to shared Badge
+status: Done
+assignee: []
+created_date: '2026-05-09 05:21'
+updated_date: '2026-05-09 05:25'
+labels:
+  - design-system
+  - webui
+  - guard
+dependencies: []
+references:
+  - apps/packages/ui/src/components/Agent/DiffViewer.tsx
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+parent_task_id: TASK-45
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate Agent DiffViewer FileStatusBadge from local span styling to the shared design-system Badge primitive with explicit canonical state mapping, preserving visible file status labels and removing its local-status-badge baseline exception.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 DiffViewer file status labels for new, deleted, and renamed files render through the shared Badge primitive
+- [x] #2 File status badge variants are selected from design-system state registry mappings
+- [x] #3 The local-status-badge baseline exception for src/components/Agent/DiffViewer.tsx is removed without new unbaselined findings
+- [x] #4 Focused DiffViewer tests, product-state guard tests, design-system verifier, diff checks, and touched-file TypeScript filter are recorded
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Started after verifying PR #1403 merged into dev at 739b1a2b52b71132e4339bf4ac69621488977c36. New isolated worktree: .worktrees/design-system-agent-file-status-badge on branch codex/design-system-agent-file-status-badge. Remaining local-status-badge baseline entries include Agent/DiffViewer, Agent/SessionHistoryPanel, Layouts/ConnectionStatus, PresentationStudioStatusBadge, SyncStatusBadge, and Sidepanel/Chat StatusDot; this slice targets Agent/DiffViewer only.
+
+Red evidence: bunx vitest run src/components/Agent/__tests__/DiffViewer.file-status-badge.test.tsx --reporter=dot failed after dependency bootstrap because NEW was not inside data-ds-component="Badge".
+
+Implementation: FileStatusBadge now maps new/deleted/renamed file statuses to canonical design-system states, selects shared Badge variants from state severity, preserves visible labels NEW/DEL/RENAME, and removes the Agent/DiffViewer local-status-badge baseline exception.
+
+Verification: bunx vitest run src/components/Agent/__tests__/DiffViewer.file-status-badge.test.tsx --reporter=dot passed 1/1; bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed 46/46; bun run verify:design-system-state passed with baseline exceptions 511 and local-status-badge 5; git diff --check passed.
+
+TypeScript caveat: bunx tsc --noEmit --pretty false still fails on existing repo-wide frontend baseline errors, but filtering the output for DiffViewer, DiffViewer.file-status-badge, and design-system-product-state-baseline returned no touched-file errors.
+
+Bandit: skipped because this slice only changes TypeScript/TSX, JSON, and Backlog metadata.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Adapted Agent DiffViewer FileStatusBadge to the shared Badge primitive with design-system state mapping and removed its local-status-badge baseline exception. Focused tests, product-state guard tests, design-system verifier, and diff checks passed; full tsc remains blocked by unrelated baseline errors.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.25.1 - Address-PR-1408-DiffViewer-badge-review-comments.md
+++ b/backlog/tasks/task-45.25.1 - Address-PR-1408-DiffViewer-badge-review-comments.md
@@ -1,0 +1,63 @@
+---
+id: TASK-45.25.1
+title: Address PR 1408 DiffViewer badge review comments
+status: Done
+assignee: []
+created_date: '2026-05-09 06:15'
+updated_date: '2026-05-09 06:20'
+labels:
+  - design-system
+  - webui
+  - review
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1408'
+  - apps/packages/ui/src/components/Agent/DiffViewer.tsx
+  - apps/packages/ui/src/components/Common/StatusBadge.tsx
+parent_task_id: TASK-45.25
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Follow-up review-fix task for PR #1408. Resolve the accessibility review comments on Agent DiffViewer file status badge screen-reader labels and address the maintainability feedback about duplicated severity-to-Badge variant mapping where it can be handled within this review slice.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 File status badges expose screen-reader text that describes the file operation rather than the canonical design-system state label
+- [x] #2 DiffViewer does not introduce a new local severity-to-Badge variant mapping when a shared helper can provide the mapping
+- [x] #3 Focused DiffViewer badge test covers visible variants and accessible file-status labels
+- [x] #4 Focused tests, design-system guard/verifier, diff check, and touched-file TypeScript filter are recorded
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Review sweep for PR #1408 found three unresolved inline threads from Gemini, Qodo, and CodeRabbit on the same accessibility bug: DiffViewer FileStatusBadge exposed canonical state labels such as Ready/Error/Empty as Badge srLabel. Qodo also raised a PR-level maintainability issue that DiffViewer introduced another local design-system severity to Badge variant mapping.
+
+Red evidence: bunx vitest run src/components/Agent/__tests__/DiffViewer.file-status-badge.test.tsx --reporter=dot failed because NEW still contained hidden text Ready instead of New file.
+
+Implementation: Added file-operation srLabel values to FILE_STATUS_CONFIG, changed DiffViewer to pass config.srLabel to Badge, added getBadgeVariantForDesignSystemSeverity in components/ui/primitives/badgeUtils.ts, exported it from primitives, and updated both DiffViewer and Common/StatusBadge to use the shared helper instead of local severity mappings.
+
+Verification: bunx vitest run src/components/Agent/__tests__/DiffViewer.file-status-badge.test.tsx src/components/Common/__tests__/StatusBadge.design-system.test.tsx --reporter=dot passed 5/5; bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed 46/46; bun run verify:design-system-state passed with baseline exceptions 511 and local-status-badge 5; git diff --check passed. Full bunx tsc --noEmit --pretty false still fails on existing repo-wide frontend baseline errors, but the touched-file TypeScript filter returned no matches after fixing the DiffViewer test helper typing issue.
+
+Bandit: skipped because this review-fix slice changes TypeScript/TSX and Backlog metadata only.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Resolved PR #1408 review feedback by replacing generic design-system srLabel text on DiffViewer file status badges with file-operation labels and by extracting the design-system severity to Badge variant mapping into a shared primitive helper reused by DiffViewer and Common StatusBadge. Focused tests, product-state guard tests, design-system verifier, diff check, and touched-file TypeScript filter passed; full frontend tsc remains blocked by unrelated baseline errors.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Codex summary
- Migrates Agent DiffViewer `FileStatusBadge` from local span styling to the shared design-system `Badge` primitive.
- Maps new/deleted/renamed file states through `getDesignSystemState(...)` before selecting Badge variants.
- Adds focused DiffViewer coverage for shared Badge rendering and removes the DiffViewer `local-status-badge` baseline exception.
- Adds Backlog task `TASK-45.25` with verification evidence.

## Verification
- `bunx vitest run src/components/Agent/__tests__/DiffViewer.file-status-badge.test.tsx --reporter=dot` passed 1/1.
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed 46/46.
- `bun run verify:design-system-state` passed; summary reports baseline exceptions 511 and `local-status-badge` 5.
- `git diff --check` passed.
- `bunx tsc --noEmit --pretty false` still fails on the existing repo-wide frontend baseline; a filtered tsc pass for touched files produced no errors.

## Merge note
Per the AI-generated PR policy, this PR still needs a human-authored Change summary before merge.