### PR TITLE
Make VN Play session setup selectable

### DIFF
--- a/Docs/superpowers/plans/2026-05-09-vn-play-session-setup-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-09-vn-play-session-setup-implementation-plan.md
@@ -1,0 +1,199 @@
+# VN Play Session Setup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make VN Play session creation usable from the WebUI by replacing raw character and asset-pack ID entry with named selectors, compatibility/readiness guidance, and a manual fallback when selector data cannot load.
+
+**Architecture:** Keep the change local to the existing VN Play frontend surface. Add a small character API wrapper beside the existing VN asset API wrapper, load character and VN asset-pack options inside `NewSessionDialog`, derive compatibility/readiness warnings client-side from existing pack fields and readiness endpoint responses, and preserve the existing `VNPlaySessionCreate` payload.
+
+**Tech Stack:** Next.js/React, Vitest + Testing Library, Playwright smoke test, existing `apiClient`, existing VN asset-pack API, existing characters endpoint.
+
+---
+
+## Stage 1: Selector Data Contracts
+**Goal:** Add the minimal WebUI character client/types needed by VN Play setup.
+**Success Criteria:** VN Play setup can request character summaries through a small API wrapper without importing the larger shared package client.
+**Tests:** Add focused API-wrapper coverage if an equivalent API test pattern exists; otherwise cover through mocked dialog behavior in Stage 2.
+**Status:** Complete
+
+**Files:**
+- Create: `apps/tldw-frontend/types/characters.ts`
+- Create: `apps/tldw-frontend/lib/api/characters.ts`
+- Modify: `apps/tldw-frontend/__tests__/vn-play/VNPlayWorkspace.test.tsx`
+
+- [ ] **Step 1: Write failing tests that mock character loading**
+
+Expected behavior:
+- Dialog calls `listCharacters()` when opened.
+- Character options expose `id`, `name`, `description`, `tags`, and `image_present` enough for display metadata.
+
+- [ ] **Step 2: Run focused Vitest and verify RED**
+
+Run:
+```bash
+cd apps/tldw-frontend
+bunx vitest run __tests__/vn-play/VNPlayWorkspace.test.tsx
+```
+Expected: failure because `@web/lib/api/characters` does not exist or is not called.
+
+- [ ] **Step 3: Add minimal character types and wrapper**
+
+Implementation notes:
+- Use `apiClient.get('/characters/', { params: { limit: 1000, offset: 0 } })`.
+- Accept both array and `{ items: [...] }` shaped responses to tolerate existing endpoint variants.
+- Do not add character authoring or editing behavior in this slice.
+
+- [ ] **Step 4: Run focused Vitest and verify GREEN for wrapper-driven behavior**
+
+Run:
+```bash
+cd apps/tldw-frontend
+bunx vitest run __tests__/vn-play/VNPlayWorkspace.test.tsx
+```
+
+## Stage 2: New Session Selectors and Payload
+**Goal:** Replace default raw-ID entry with character and compatible VN asset-pack selectors.
+**Success Criteria:** A user can open the dialog, select named records, and create the existing session payload using selected IDs.
+**Tests:** `VNPlayWorkspace.test.tsx` covers happy-path selector loading and create payload.
+**Status:** Complete
+
+**Files:**
+- Modify: `apps/tldw-frontend/components/vn-play/NewSessionDialog.tsx`
+- Modify: `apps/tldw-frontend/__tests__/vn-play/VNPlayWorkspace.test.tsx`
+
+- [ ] **Step 1: Write failing selector happy-path test**
+
+Expected behavior:
+- Character selector shows a named character.
+- VN asset-pack selector shows compatible packs for the selected character.
+- Submit sends `primary_character_id` and `vn_asset_pack_id` from selected records, not raw typed IDs.
+
+- [ ] **Step 2: Verify RED**
+
+Run:
+```bash
+cd apps/tldw-frontend
+bunx vitest run __tests__/vn-play/VNPlayWorkspace.test.tsx
+```
+
+- [ ] **Step 3: Implement selector loading and derived selection state**
+
+Implementation notes:
+- Load characters and packs when `open` becomes true.
+- Load readiness for listed packs with `getVNAssetReadiness(pack.id)`.
+- Auto-select the first character and then the first compatible ready pack where possible.
+- Preserve `linked_chat_id`, `content_rating`, `mode`, `title`, and the existing payload schema.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run:
+```bash
+cd apps/tldw-frontend
+bunx vitest run __tests__/vn-play/VNPlayWorkspace.test.tsx
+```
+
+## Stage 3: Readiness, Compatibility, and Empty-State Guidance
+**Goal:** Make unready, incompatible, draft, missing-byte, trust-level, and content-rating conditions visible before submit.
+**Success Criteria:** Incompatible or unready packs are hard to submit accidentally, and empty/error states tell the user what to fix next.
+**Tests:** `VNPlayWorkspace.test.tsx` covers incompatible pack warning, unready/readiness errors, empty selectors, and manual fallback when loading fails.
+**Status:** Complete
+
+**Files:**
+- Modify: `apps/tldw-frontend/components/vn-play/NewSessionDialog.tsx`
+- Modify: `apps/tldw-frontend/__tests__/vn-play/VNPlayWorkspace.test.tsx`
+
+- [ ] **Step 1: Write failing warning and empty-state tests**
+
+Expected behavior:
+- Packs for other characters show an incompatibility warning and cannot be submitted through selector mode.
+- Readiness warnings/errors are shown, including missing runtime assets.
+- Draft/unapproved status is called out before submit.
+- Content-rating mismatch is visible when pack rating differs from the session rating.
+- No characters or no packs show direct guidance to create/import characters or prepare/review packs.
+
+- [ ] **Step 2: Write failing manual-fallback test**
+
+Expected behavior:
+- If character or asset-pack selector loading fails, raw numeric ID inputs are available as a secondary fallback and still create the same payload.
+
+- [ ] **Step 3: Verify RED**
+
+Run:
+```bash
+cd apps/tldw-frontend
+bunx vitest run __tests__/vn-play/VNPlayWorkspace.test.tsx
+```
+
+- [ ] **Step 4: Implement warning, submit gating, empty states, and fallback mode**
+
+Implementation notes:
+- Selector mode should require a selected character, selected pack, character compatibility, and readiness.
+- Manual fallback should be shown automatically after selector load failure and should keep positive-integer validation.
+- Avoid adding new backend APIs in this slice.
+
+- [ ] **Step 5: Verify GREEN**
+
+Run:
+```bash
+cd apps/tldw-frontend
+bunx vitest run __tests__/vn-play/VNPlayWorkspace.test.tsx
+```
+
+## Stage 4: Smoke Coverage and Closeout
+**Goal:** Keep the browser smoke route aligned with selector-based setup and finish repository tracking.
+**Success Criteria:** Smoke test mocks characters, packs, and readiness, then creates a Story session through selectors.
+**Tests:** Vitest targeted suite, eslint touched frontend files, Playwright smoke if local browser setup is available.
+**Status:** Complete
+
+**Files:**
+- Modify: `apps/tldw-frontend/e2e/smoke/vn-play.spec.ts`
+- Modify: `backlog/tasks/task-157 - Make-VN-Play-session-setup-usable.md`
+- Modify: `Docs/superpowers/plans/2026-05-09-vn-play-session-setup-implementation-plan.md`
+
+- [ ] **Step 1: Update smoke test mocks and selectors**
+
+Expected behavior:
+- `GET /api/v1/characters/` returns at least one character.
+- `GET /api/v1/vn-assets/packs` returns at least one compatible pack.
+- `GET /api/v1/vn-assets/packs/:id/readiness` returns ready.
+- Test creates the session without filling raw IDs.
+
+- [ ] **Step 2: Run focused verification**
+
+Run:
+```bash
+cd apps/tldw-frontend
+bunx vitest run __tests__/vn-play/VNPlayWorkspace.test.tsx __tests__/vn-play/vnPlayApi.test.ts __tests__/vn-play/SceneStage.test.tsx __tests__/vn-play/vnPlayRuntime.test.ts
+bunx eslint components/vn-play/NewSessionDialog.tsx __tests__/vn-play/VNPlayWorkspace.test.tsx e2e/smoke/vn-play.spec.ts lib/api/characters.ts types/characters.ts
+```
+
+- [ ] **Step 3: Run Playwright smoke when environment permits**
+
+Run:
+```bash
+cd apps/tldw-frontend
+TLDW_WEB_URL=http://localhost:18081 TLDW_WEB_CMD='bun run dev -- -p 18081' bunx playwright test e2e/smoke/vn-play.spec.ts --reporter=line
+```
+
+- [ ] **Step 4: Update Backlog task and plan status**
+
+Expected:
+- Acceptance criteria checked if met.
+- Verification commands recorded.
+- Bandit documented as not applicable for frontend-only touched code.
+
+- [ ] **Step 5: Commit, push, and open PR for issue #1407**
+
+Run:
+```bash
+git status --short
+git add apps/tldw-frontend/components/vn-play/NewSessionDialog.tsx apps/tldw-frontend/__tests__/vn-play/VNPlayWorkspace.test.tsx apps/tldw-frontend/e2e/smoke/vn-play.spec.ts apps/tldw-frontend/lib/api/characters.ts apps/tldw-frontend/types/characters.ts Docs/superpowers/plans/2026-05-09-vn-play-session-setup-implementation-plan.md "backlog/tasks/task-157 - Make-VN-Play-session-setup-usable.md"
+git commit -m "feat: make vn play session setup selectable"
+git push -u origin codex/vn-play-session-setup-1407
+```
+
+---
+
+## Review Note
+
+The writing-plans skill normally asks for a plan-document-reviewer subagent. Current session policy only allows subagents when the user explicitly asks for subagent work, so this plan proceeds without dispatching a reviewer unless requested.

--- a/apps/tldw-frontend/__tests__/vn-play/VNPlayWorkspace.test.tsx
+++ b/apps/tldw-frontend/__tests__/vn-play/VNPlayWorkspace.test.tsx
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { VNAssetReadiness } from '@web/types/vn-assets';
 import type { VNPlayBranch, VNPlayCheckpoint, VNPlaySession } from '@web/types/vn-play';
 
 const mocks = vi.hoisted(() => ({
@@ -65,6 +66,25 @@ const defaultPacks = [
     planned_output_count: 8,
   },
 ];
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+  return { promise, reject, resolve };
+}
+
+function readyReadiness(): VNAssetReadiness {
+  return {
+    ready: true,
+    status: 'ready',
+    warnings: [],
+    errors: [],
+  };
+}
 
 function mockVNPlayApi({
   branches = [],
@@ -208,6 +228,63 @@ describe('VNPlayWorkspace', () => {
     expect(await screen.findByText('Moonlit Archive')).toBeInTheDocument();
   });
 
+  it('renders character and pack selectors before readiness checks finish', async () => {
+    const user = userEvent.setup();
+    const readiness = createDeferred<VNAssetReadiness>();
+    mockVNPlayApi({ sessions: [] });
+    mocks.getVNAssetReadiness.mockReturnValue(readiness.promise);
+
+    render(<VNPlayWorkspace />);
+
+    await user.click(await screen.findByRole('button', { name: /new freeform/i }));
+
+    expect(await screen.findByLabelText('Character')).toBeInTheDocument();
+    expect(screen.getAllByText('Mira Vale').length).toBeGreaterThan(0);
+    expect(screen.getByRole('option', { name: /Moonlit Archive Pack/i })).toBeInTheDocument();
+
+    readiness.resolve(readyReadiness());
+  });
+
+  it('limits concurrent readiness checks while loading selector data', async () => {
+    const user = userEvent.setup();
+    const packs = Array.from({ length: 6 }, (_, index) => ({
+      ...defaultPacks[0],
+      id: index + 1,
+      title: `Pack ${index + 1}`,
+    }));
+    const pendingReadiness = new Map<number, ReturnType<typeof createDeferred<VNAssetReadiness>>>();
+    let activeRequests = 0;
+    let maxActiveRequests = 0;
+
+    mockVNPlayApi({ sessions: [] });
+    mocks.listVNAssetPacks.mockResolvedValue(packs);
+    mocks.getVNAssetReadiness.mockImplementation((packId: number) => {
+      activeRequests += 1;
+      maxActiveRequests = Math.max(maxActiveRequests, activeRequests);
+      const readiness = createDeferred<VNAssetReadiness>();
+      pendingReadiness.set(packId, readiness);
+      return readiness.promise.finally(() => {
+        activeRequests -= 1;
+      });
+    });
+
+    render(<VNPlayWorkspace />);
+
+    await user.click(await screen.findByRole('button', { name: /new freeform/i }));
+    await waitFor(() => expect(mocks.getVNAssetReadiness).toHaveBeenCalledTimes(4));
+    expect(maxActiveRequests).toBeLessThanOrEqual(4);
+
+    for (const readiness of pendingReadiness.values()) {
+      readiness.resolve(readyReadiness());
+    }
+    await waitFor(() => expect(mocks.getVNAssetReadiness).toHaveBeenCalledTimes(6));
+    for (const readiness of pendingReadiness.values()) {
+      readiness.resolve(readyReadiness());
+    }
+    await waitFor(() => expect(activeRequests).toBe(0));
+    expect(maxActiveRequests).toBeLessThanOrEqual(4);
+  });
+
   it('marks incompatible asset packs as unavailable for the selected character', async () => {
     const user = userEvent.setup();
     mockVNPlayApi({ sessions: [] });
@@ -259,6 +336,33 @@ describe('VNPlayWorkspace', () => {
     expect(screen.getByText(/sprite.primary has no approved file bytes/i)).toBeInTheDocument();
     expect(screen.getByText(/Pack content rating mature differs from session rating general/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Create session' })).toBeDisabled();
+  });
+
+  it('renders duplicate readiness warnings without duplicate React keys', async () => {
+    const user = userEvent.setup();
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    mockVNPlayApi({ sessions: [] });
+    mocks.getVNAssetReadiness.mockResolvedValue({
+      ready: true,
+      status: 'ready',
+      warnings: ['Review duplicate slot metadata', 'Review duplicate slot metadata'],
+      errors: [],
+    });
+
+    try {
+      render(<VNPlayWorkspace />);
+
+      await user.click(await screen.findByRole('button', { name: /new freeform/i }));
+
+      expect(await screen.findAllByText('Review duplicate slot metadata')).toHaveLength(2);
+      expect(
+        consoleErrorSpy.mock.calls.some((call) =>
+          call.some((value) => String(value).includes('Encountered two children with the same key'))
+        )
+      ).toBe(false);
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
   });
 
   it('keeps manual ID entry available when setup selectors fail to load', async () => {

--- a/apps/tldw-frontend/__tests__/vn-play/VNPlayWorkspace.test.tsx
+++ b/apps/tldw-frontend/__tests__/vn-play/VNPlayWorkspace.test.tsx
@@ -7,10 +7,13 @@ const mocks = vi.hoisted(() => ({
   createVNPlayCheckpoint: vi.fn(),
   createVNPlaySession: vi.fn(),
   getVNPlaySession: vi.fn(),
+  getVNAssetReadiness: vi.fn(),
   listVNPlayBranches: vi.fn(),
   listVNPlayCheckpoints: vi.fn(),
   listVNPlayEvents: vi.fn(),
   listVNPlaySessions: vi.fn(),
+  listCharacters: vi.fn(),
+  listVNAssetPacks: vi.fn(),
   restoreVNPlaySession: vi.fn(),
   retryLastVNPlayTurn: vi.fn(),
   submitVNPlayTurn: vi.fn(),
@@ -29,7 +32,39 @@ vi.mock('@web/lib/api/vnPlay', () => ({
   submitVNPlayTurn: (...args: unknown[]) => mocks.submitVNPlayTurn(...args),
 }));
 
+vi.mock('@web/lib/api/characters', () => ({
+  listCharacters: (...args: unknown[]) => mocks.listCharacters(...args),
+}));
+
+vi.mock('@web/lib/api/vnAssets', () => ({
+  getVNAssetReadiness: (...args: unknown[]) => mocks.getVNAssetReadiness(...args),
+  listVNAssetPacks: (...args: unknown[]) => mocks.listVNAssetPacks(...args),
+}));
+
 import VNPlayWorkspace from '@web/components/vn-play/VNPlayWorkspace';
+
+const defaultCharacters = [
+  {
+    id: 7,
+    version: 1,
+    name: 'Mira Vale',
+    description: 'Archive guide',
+    tags: ['archive', 'story'],
+    image_present: true,
+  },
+];
+
+const defaultPacks = [
+  {
+    id: 12,
+    title: 'Moonlit Archive Pack',
+    primary_character_id: 7,
+    description: 'Runtime-ready VN poses and backdrops',
+    status: 'approved',
+    content_rating: 'general',
+    planned_output_count: 8,
+  },
+];
 
 function mockVNPlayApi({
   branches = [],
@@ -99,6 +134,14 @@ describe('VNPlayWorkspace', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockVNPlayApi();
+    mocks.listCharacters.mockResolvedValue(defaultCharacters);
+    mocks.listVNAssetPacks.mockResolvedValue(defaultPacks);
+    mocks.getVNAssetReadiness.mockResolvedValue({
+      ready: true,
+      status: 'ready',
+      warnings: [],
+      errors: [],
+    });
   });
 
   it('renders freeform and story session actions', async () => {
@@ -131,19 +174,25 @@ describe('VNPlayWorkspace', () => {
     expect(screen.getByText('Selected session: Library')).toBeInTheDocument();
   });
 
-  it('creates a freeform session from the dialog', async () => {
+  it('creates a freeform session from named character and asset pack selectors', async () => {
     const user = userEvent.setup();
     mockVNPlayApi({ sessions: [] });
 
     render(<VNPlayWorkspace />);
 
     await user.click(await screen.findByRole('button', { name: /new freeform/i }));
+    expect(await screen.findByLabelText('Character')).toBeInTheDocument();
+    expect(screen.getAllByText('Mira Vale').length).toBeGreaterThan(0);
+    expect(screen.getByText(/Archive guide/)).toBeInTheDocument();
+    expect(screen.getByText(/archive, story/)).toBeInTheDocument();
+    expect(screen.getByLabelText('VN asset pack')).toBeInTheDocument();
+    expect(screen.getAllByText('Moonlit Archive Pack').length).toBeGreaterThan(0);
+    expect(screen.getByText(/Runtime-ready VN poses and backdrops/)).toBeInTheDocument();
+
     await user.clear(screen.getByLabelText('Title'));
     await user.type(screen.getByLabelText('Title'), 'Moonlit Archive');
-    await user.clear(screen.getByLabelText('Primary character ID'));
-    await user.type(screen.getByLabelText('Primary character ID'), '7');
-    await user.clear(screen.getByLabelText('VN asset pack ID'));
-    await user.type(screen.getByLabelText('VN asset pack ID'), '12');
+    await user.selectOptions(screen.getByLabelText('Character'), '7');
+    await user.selectOptions(screen.getByLabelText('VN asset pack'), '12');
     await user.click(screen.getByRole('button', { name: 'Create session' }));
 
     await waitFor(() => {
@@ -157,6 +206,106 @@ describe('VNPlayWorkspace', () => {
       });
     });
     expect(await screen.findByText('Moonlit Archive')).toBeInTheDocument();
+  });
+
+  it('marks incompatible asset packs as unavailable for the selected character', async () => {
+    const user = userEvent.setup();
+    mockVNPlayApi({ sessions: [] });
+    mocks.listVNAssetPacks.mockResolvedValue([
+      ...defaultPacks,
+      {
+        id: 13,
+        title: 'Rival Pack',
+        primary_character_id: 99,
+        status: 'approved',
+        content_rating: 'general',
+        planned_output_count: 6,
+      },
+    ]);
+
+    render(<VNPlayWorkspace />);
+
+    await user.click(await screen.findByRole('button', { name: /new story/i }));
+
+    expect(await screen.findByRole('option', {
+      name: /Rival Pack.*incompatible with Mira Vale/i,
+    })).toBeDisabled();
+    expect(screen.getByText(/Rival Pack is attached to character 99/i)).toBeInTheDocument();
+  });
+
+  it('shows readiness, draft, missing-byte, and content-rating warnings before submit', async () => {
+    const user = userEvent.setup();
+    mockVNPlayApi({ sessions: [] });
+    mocks.listVNAssetPacks.mockResolvedValue([
+      {
+        ...defaultPacks[0],
+        status: 'draft',
+        content_rating: 'mature',
+      },
+    ]);
+    mocks.getVNAssetReadiness.mockResolvedValue({
+      ready: false,
+      status: 'missing_assets',
+      warnings: ['2 required runtime assets are missing bytes'],
+      errors: ['sprite.primary has no approved file bytes'],
+    });
+
+    render(<VNPlayWorkspace />);
+
+    await user.click(await screen.findByRole('button', { name: /new freeform/i }));
+
+    expect(await screen.findByText(/Pack status is draft/i)).toBeInTheDocument();
+    expect(screen.getByText(/2 required runtime assets are missing bytes/i)).toBeInTheDocument();
+    expect(screen.getByText(/sprite.primary has no approved file bytes/i)).toBeInTheDocument();
+    expect(screen.getByText(/Pack content rating mature differs from session rating general/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Create session' })).toBeDisabled();
+  });
+
+  it('keeps manual ID entry available when setup selectors fail to load', async () => {
+    const user = userEvent.setup();
+    mockVNPlayApi({ sessions: [] });
+    mocks.listCharacters.mockRejectedValueOnce(new Error('characters offline'));
+
+    render(<VNPlayWorkspace />);
+
+    await user.click(await screen.findByRole('button', { name: /new freeform/i }));
+    expect(await screen.findByText(/Could not load setup selectors/i)).toBeInTheDocument();
+
+    await user.clear(screen.getByLabelText('Title'));
+    await user.type(screen.getByLabelText('Title'), 'Manual Session');
+    await user.clear(screen.getByLabelText('Primary character ID'));
+    await user.type(screen.getByLabelText('Primary character ID'), '17');
+    await user.clear(screen.getByLabelText('VN asset pack ID'));
+    await user.type(screen.getByLabelText('VN asset pack ID'), '21');
+    await user.click(screen.getByRole('button', { name: 'Create session' }));
+
+    await waitFor(() => {
+      expect(mocks.createVNPlaySession).toHaveBeenCalledWith({
+        mode: 'freeform',
+        title: 'Manual Session',
+        primary_character_id: 17,
+        vn_asset_pack_id: 21,
+        linked_chat_id: null,
+        content_rating: 'general',
+      });
+    });
+  });
+
+  it('shows empty-state guidance when no character or runtime-ready pack exists', async () => {
+    const user = userEvent.setup();
+    mockVNPlayApi({ sessions: [] });
+    mocks.listCharacters.mockResolvedValue([]);
+    mocks.listVNAssetPacks.mockResolvedValue([]);
+
+    render(<VNPlayWorkspace />);
+
+    await user.click(await screen.findByRole('button', { name: /new story/i }));
+
+    expect(await screen.findByText(/No characters available/i)).toBeInTheDocument();
+    expect(screen.getByText(/Create or import a character before starting VN Play/i)).toBeInTheDocument();
+    expect(screen.getByText(/No VN asset packs available/i)).toBeInTheDocument();
+    expect(screen.getByText(/Prepare or review a VN asset pack before starting VN Play/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Create session' })).toBeDisabled();
   });
 
   it('submits a freeform turn and renders the returned dialogue', async () => {

--- a/apps/tldw-frontend/__tests__/vn-play/charactersApi.test.ts
+++ b/apps/tldw-frontend/__tests__/vn-play/charactersApi.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  apiClient: {
+    get: vi.fn(),
+  },
+}));
+
+vi.mock('@web/lib/api', () => ({
+  apiClient: mocks.apiClient,
+}));
+
+import { listCharacters } from '@web/lib/api/characters';
+
+describe('characters api client', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('loads characters through the paginated query endpoint', async () => {
+    mocks.apiClient.get
+      .mockResolvedValueOnce({
+        items: [{ id: 1, name: 'Alpha' }],
+        has_more: true,
+        next_offset: 100,
+        page: 1,
+        page_size: 100,
+        total: 2,
+      })
+      .mockResolvedValueOnce({
+        items: [{ id: 2, name: 'Beta' }],
+        has_more: false,
+        next_offset: null,
+        page: 2,
+        page_size: 100,
+        total: 2,
+      });
+
+    const characters = await listCharacters();
+
+    expect(characters.map((character) => character.id)).toEqual([1, 2]);
+    expect(mocks.apiClient.get).toHaveBeenNthCalledWith(1, '/characters/query', {
+      params: {
+        include_image_base64: false,
+        page: 1,
+        page_size: 100,
+      },
+    });
+    expect(mocks.apiClient.get).toHaveBeenNthCalledWith(2, '/characters/query', {
+      params: {
+        include_image_base64: false,
+        page: 2,
+        page_size: 100,
+      },
+    });
+  });
+
+  it('passes search text through to the character query endpoint', async () => {
+    mocks.apiClient.get.mockResolvedValueOnce({
+      items: [{ id: 7, name: 'Mira Vale' }],
+      has_more: false,
+      next_offset: null,
+      page: 1,
+      page_size: 100,
+      total: 1,
+    });
+
+    await listCharacters({ query: 'mira' });
+
+    expect(mocks.apiClient.get).toHaveBeenCalledWith('/characters/query', {
+      params: {
+        include_image_base64: false,
+        page: 1,
+        page_size: 100,
+        query: 'mira',
+      },
+    });
+  });
+});

--- a/apps/tldw-frontend/components/vn-play/NewSessionDialog.tsx
+++ b/apps/tldw-frontend/components/vn-play/NewSessionDialog.tsx
@@ -21,6 +21,7 @@ type ReadinessByPackId = Record<number, VNAssetReadiness>;
 const SELECT_CLASS =
   'mt-1 block w-full rounded-md border-border bg-bg shadow-sm focus:border-primary focus:ring-primary';
 const APPROVED_PACK_STATUSES = new Set(['approved', 'ready', 'runtime_ready', 'active']);
+const READINESS_REQUEST_BATCH_SIZE = 4;
 
 function parsePositiveInteger(value: string): number | null {
   const parsed = Number(value);
@@ -65,25 +66,31 @@ function chooseBestPack(
 }
 
 async function loadReadinessForPacks(packs: VNAssetPack[]): Promise<ReadinessByPackId> {
-  const entries = await Promise.all(
-    packs.map(async (pack) => {
-      try {
-        const readiness = await getVNAssetReadiness(pack.id);
-        return [pack.id, readiness] as const;
-      } catch (error) {
-        const message = error instanceof Error ? error.message : 'Readiness request failed';
-        return [
-          pack.id,
-          {
-            ready: false,
-            status: 'readiness_unavailable',
-            warnings: [],
-            errors: [`Could not load readiness for ${pack.title}: ${message}`],
-          },
-        ] as const;
-      }
-    })
-  );
+  const entries: Array<readonly [number, VNAssetReadiness]> = [];
+
+  for (let index = 0; index < packs.length; index += READINESS_REQUEST_BATCH_SIZE) {
+    const batch = packs.slice(index, index + READINESS_REQUEST_BATCH_SIZE);
+    const batchEntries = await Promise.all(
+      batch.map(async (pack) => {
+        try {
+          const readiness = await getVNAssetReadiness(pack.id);
+          return [pack.id, readiness] as const;
+        } catch (error) {
+          const message = error instanceof Error ? error.message : 'Readiness request failed';
+          return [
+            pack.id,
+            {
+              ready: false,
+              status: 'readiness_unavailable',
+              warnings: [],
+              errors: [`Could not load readiness for ${pack.title}: ${message}`],
+            },
+          ] as const;
+        }
+      })
+    );
+    entries.push(...batchEntries);
+  }
 
   return entries.reduce<ReadinessByPackId>((accumulator, [packId, readiness]) => {
     accumulator[packId] = readiness;
@@ -202,17 +209,24 @@ export default function NewSessionDialog({
           listCharacters(),
           listVNAssetPacks(),
         ]);
-        const nextReadiness = await loadReadinessForPacks(nextPacks);
         if (cancelled) return;
 
         const firstCharacter = nextCharacters[0] ?? null;
         const nextCharacterId = firstCharacter ? String(firstCharacter.id) : '';
-        const bestPack = chooseBestPack(nextPacks, firstCharacter?.id ?? null, nextReadiness);
 
         setCharacters(nextCharacters);
         setAssetPacks(nextPacks);
-        setReadinessByPackId(nextReadiness);
+        setReadinessByPackId({});
         setSelectedCharacterId(nextCharacterId);
+        setSelectedPackId(chooseBestPack(nextPacks, firstCharacter?.id ?? null, {})?.id.toString() ?? '');
+        setIsLoadingSelectors(false);
+
+        const nextReadiness = await loadReadinessForPacks(nextPacks);
+        if (cancelled) return;
+
+        const bestPack = chooseBestPack(nextPacks, firstCharacter?.id ?? null, nextReadiness);
+
+        setReadinessByPackId(nextReadiness);
         setSelectedPackId(bestPack ? String(bestPack.id) : '');
       } catch (error) {
         if (!cancelled) {
@@ -465,8 +479,8 @@ export default function NewSessionDialog({
               <div className="rounded-md border border-warn/30 bg-warn/10 px-3 py-2 text-sm text-warn sm:col-span-2">
                 <p className="font-medium">Review pack readiness before starting.</p>
                 <ul className="mt-1 list-disc space-y-1 pl-5">
-                  {selectedPackWarnings.map((warning) => (
-                    <li key={warning}>{warning}</li>
+                  {selectedPackWarnings.map((warning, index) => (
+                    <li key={`${warning}-${index}`}>{warning}</li>
                   ))}
                 </ul>
               </div>

--- a/apps/tldw-frontend/components/vn-play/NewSessionDialog.tsx
+++ b/apps/tldw-frontend/components/vn-play/NewSessionDialog.tsx
@@ -1,6 +1,10 @@
-import React, { FormEvent, useEffect, useState } from 'react';
+import React, { FormEvent, useEffect, useMemo, useState } from 'react';
 import { Button } from '@web/components/ui/Button';
 import { Input } from '@web/components/ui/Input';
+import { listCharacters } from '@web/lib/api/characters';
+import { getVNAssetReadiness, listVNAssetPacks } from '@web/lib/api/vnAssets';
+import type { CharacterSummary } from '@web/types/characters';
+import type { VNAssetPack, VNAssetReadiness } from '@web/types/vn-assets';
 import type { VNPlayMode, VNPlaySessionCreate } from '@web/types/vn-play';
 
 export interface NewSessionDialogProps {
@@ -11,9 +15,147 @@ export interface NewSessionDialogProps {
   onCreateSession: (request: VNPlaySessionCreate) => Promise<void>;
 }
 
+type SelectorMode = 'selectors' | 'manual';
+type ReadinessByPackId = Record<number, VNAssetReadiness>;
+
+const SELECT_CLASS =
+  'mt-1 block w-full rounded-md border-border bg-bg shadow-sm focus:border-primary focus:ring-primary';
+const APPROVED_PACK_STATUSES = new Set(['approved', 'ready', 'runtime_ready', 'active']);
+
 function parsePositiveInteger(value: string): number | null {
   const parsed = Number(value);
   return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function characterName(character: CharacterSummary | null): string {
+  return character?.name?.trim() || (character ? `Character ${character.id}` : 'selected character');
+}
+
+function formatTags(tags: CharacterSummary['tags']): string | null {
+  if (Array.isArray(tags)) {
+    const normalized = tags.map((tag) => tag.trim()).filter(Boolean);
+    return normalized.length ? normalized.join(', ') : null;
+  }
+
+  if (typeof tags === 'string') {
+    return tags.trim() || null;
+  }
+
+  return null;
+}
+
+function isApprovedPackStatus(status?: string | null): boolean {
+  if (!status) return true;
+  return APPROVED_PACK_STATUSES.has(status.toLowerCase());
+}
+
+function chooseBestPack(
+  packs: VNAssetPack[],
+  characterId: number | null,
+  readinessByPackId: ReadinessByPackId
+): VNAssetPack | null {
+  if (!characterId) return null;
+
+  const compatiblePacks = packs.filter((pack) => pack.primary_character_id === characterId);
+  return (
+    compatiblePacks.find((pack) => readinessByPackId[pack.id]?.ready && isApprovedPackStatus(pack.status)) ??
+    compatiblePacks[0] ??
+    null
+  );
+}
+
+async function loadReadinessForPacks(packs: VNAssetPack[]): Promise<ReadinessByPackId> {
+  const entries = await Promise.all(
+    packs.map(async (pack) => {
+      try {
+        const readiness = await getVNAssetReadiness(pack.id);
+        return [pack.id, readiness] as const;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Readiness request failed';
+        return [
+          pack.id,
+          {
+            ready: false,
+            status: 'readiness_unavailable',
+            warnings: [],
+            errors: [`Could not load readiness for ${pack.title}: ${message}`],
+          },
+        ] as const;
+      }
+    })
+  );
+
+  return entries.reduce<ReadinessByPackId>((accumulator, [packId, readiness]) => {
+    accumulator[packId] = readiness;
+    return accumulator;
+  }, {});
+}
+
+function buildPackOptionLabel(
+  pack: VNAssetPack,
+  selectedCharacter: CharacterSummary | null,
+  readiness?: VNAssetReadiness
+): string {
+  const parts = [pack.title];
+  if (selectedCharacter && pack.primary_character_id !== selectedCharacter.id) {
+    parts.push(`incompatible with ${characterName(selectedCharacter)}`);
+  } else if (readiness && !readiness.ready) {
+    parts.push('not ready');
+  }
+  return parts.join(' - ');
+}
+
+function buildSelectedPackWarnings({
+  contentRating,
+  pack,
+  readiness,
+  selectedCharacter,
+}: {
+  contentRating: string;
+  pack: VNAssetPack | null;
+  readiness?: VNAssetReadiness;
+  selectedCharacter: CharacterSummary | null;
+}): string[] {
+  if (!pack) return [];
+
+  const warnings: string[] = [];
+  if (selectedCharacter && pack.primary_character_id !== selectedCharacter.id) {
+    warnings.push(`${pack.title} is attached to character ${pack.primary_character_id}, not ${characterName(selectedCharacter)}.`);
+  }
+
+  if (pack.status && !isApprovedPackStatus(pack.status)) {
+    warnings.push(`Pack status is ${pack.status}; review or approve it before starting VN Play.`);
+  }
+
+  if (readiness) {
+    if (!readiness.ready) {
+      warnings.push(`Readiness status: ${readiness.status}.`);
+    }
+    warnings.push(...readiness.warnings);
+    warnings.push(...readiness.errors);
+  }
+
+  if (
+    pack.content_rating &&
+    contentRating.trim() &&
+    pack.content_rating.toLowerCase() !== contentRating.trim().toLowerCase()
+  ) {
+    warnings.push(`Pack content rating ${pack.content_rating} differs from session rating ${contentRating.trim()}.`);
+  }
+
+  return warnings;
+}
+
+function hasBlockingPackIssue(
+  pack: VNAssetPack | null,
+  selectedCharacter: CharacterSummary | null,
+  readiness?: VNAssetReadiness
+): boolean {
+  if (!pack || !selectedCharacter) return true;
+  if (pack.primary_character_id !== selectedCharacter.id) return true;
+  if (pack.status && !isApprovedPackStatus(pack.status)) return true;
+  if (!readiness?.ready) return true;
+  return false;
 }
 
 export default function NewSessionDialog({
@@ -27,27 +169,142 @@ export default function NewSessionDialog({
   const [title, setTitle] = useState('Untitled VN play session');
   const [primaryCharacterId, setPrimaryCharacterId] = useState('1');
   const [vnAssetPackId, setVnAssetPackId] = useState('1');
+  const [selectedCharacterId, setSelectedCharacterId] = useState('');
+  const [selectedPackId, setSelectedPackId] = useState('');
   const [linkedChatId, setLinkedChatId] = useState('');
   const [contentRating, setContentRating] = useState('general');
   const [formError, setFormError] = useState<string | null>(null);
+  const [selectorMode, setSelectorMode] = useState<SelectorMode>('selectors');
+  const [characters, setCharacters] = useState<CharacterSummary[]>([]);
+  const [assetPacks, setAssetPacks] = useState<VNAssetPack[]>([]);
+  const [readinessByPackId, setReadinessByPackId] = useState<ReadinessByPackId>({});
+  const [isLoadingSelectors, setIsLoadingSelectors] = useState(false);
+  const [selectorError, setSelectorError] = useState<string | null>(null);
 
   useEffect(() => {
     if (open) {
       setMode(initialMode);
       setFormError(null);
+      setSelectorError(null);
+      setSelectorMode('selectors');
     }
   }, [initialMode, open]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    let cancelled = false;
+
+    async function loadSelectorData() {
+      setIsLoadingSelectors(true);
+      try {
+        const [nextCharacters, nextPacks] = await Promise.all([
+          listCharacters(),
+          listVNAssetPacks(),
+        ]);
+        const nextReadiness = await loadReadinessForPacks(nextPacks);
+        if (cancelled) return;
+
+        const firstCharacter = nextCharacters[0] ?? null;
+        const nextCharacterId = firstCharacter ? String(firstCharacter.id) : '';
+        const bestPack = chooseBestPack(nextPacks, firstCharacter?.id ?? null, nextReadiness);
+
+        setCharacters(nextCharacters);
+        setAssetPacks(nextPacks);
+        setReadinessByPackId(nextReadiness);
+        setSelectedCharacterId(nextCharacterId);
+        setSelectedPackId(bestPack ? String(bestPack.id) : '');
+      } catch (error) {
+        if (!cancelled) {
+          const message = error instanceof Error ? error.message : 'Failed to load setup selectors';
+          setSelectorError(message);
+          setSelectorMode('manual');
+          setCharacters([]);
+          setAssetPacks([]);
+          setReadinessByPackId({});
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoadingSelectors(false);
+        }
+      }
+    }
+
+    void loadSelectorData();
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  const selectedCharacterIdNumber = parsePositiveInteger(selectedCharacterId);
+  const selectedPackIdNumber = parsePositiveInteger(selectedPackId);
+
+  const selectedCharacter = useMemo(
+    () => characters.find((character) => character.id === selectedCharacterIdNumber) ?? null,
+    [characters, selectedCharacterIdNumber]
+  );
+  const selectedPack = useMemo(
+    () => assetPacks.find((pack) => pack.id === selectedPackIdNumber) ?? null,
+    [assetPacks, selectedPackIdNumber]
+  );
+  const selectedReadiness = selectedPack ? readinessByPackId[selectedPack.id] : undefined;
+
+  const orderedPacks = useMemo(() => {
+    if (!selectedCharacterIdNumber) return assetPacks;
+    return [...assetPacks].sort((left, right) => {
+      const leftCompatible = left.primary_character_id === selectedCharacterIdNumber;
+      const rightCompatible = right.primary_character_id === selectedCharacterIdNumber;
+      if (leftCompatible !== rightCompatible) {
+        return leftCompatible ? -1 : 1;
+      }
+      return left.title.localeCompare(right.title);
+    });
+  }, [assetPacks, selectedCharacterIdNumber]);
+
+  const incompatiblePacks = useMemo(() => {
+    if (!selectedCharacter) return [];
+    return assetPacks.filter((pack) => pack.primary_character_id !== selectedCharacter.id);
+  }, [assetPacks, selectedCharacter]);
+
+  const selectedPackWarnings = useMemo(
+    () =>
+      buildSelectedPackWarnings({
+        contentRating,
+        pack: selectedPack,
+        readiness: selectedReadiness,
+        selectedCharacter,
+      }),
+    [contentRating, selectedCharacter, selectedPack, selectedReadiness]
+  );
+
+  const selectorSubmitDisabled =
+    selectorMode === 'selectors' &&
+    (isLoadingSelectors || hasBlockingPackIssue(selectedPack, selectedCharacter, selectedReadiness));
+
+  useEffect(() => {
+    if (!open || selectorMode !== 'selectors') return;
+    const bestPack = chooseBestPack(assetPacks, selectedCharacterIdNumber, readinessByPackId);
+    setSelectedPackId(bestPack ? String(bestPack.id) : '');
+  }, [assetPacks, open, readinessByPackId, selectedCharacterIdNumber, selectorMode]);
 
   if (!open) return null;
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    const parsedPrimaryCharacterId = parsePositiveInteger(primaryCharacterId);
-    const parsedPackId = parsePositiveInteger(vnAssetPackId);
+    const usingManualIds = selectorMode === 'manual';
+    const parsedPrimaryCharacterId = usingManualIds
+      ? parsePositiveInteger(primaryCharacterId)
+      : selectedCharacterIdNumber;
+    const parsedPackId = usingManualIds ? parsePositiveInteger(vnAssetPackId) : selectedPackIdNumber;
     const trimmedTitle = title.trim();
 
     if (!trimmedTitle || !parsedPrimaryCharacterId || !parsedPackId) {
       setFormError('Enter a title, character ID, and asset pack ID.');
+      return;
+    }
+
+    if (!usingManualIds && hasBlockingPackIssue(selectedPack, selectedCharacter, selectedReadiness)) {
+      setFormError('Select a compatible runtime-ready character and asset pack.');
       return;
     }
 
@@ -61,6 +318,8 @@ export default function NewSessionDialog({
       content_rating: contentRating.trim() || 'general',
     });
   };
+
+  const selectedCharacterTags = formatTags(selectedCharacter?.tags);
 
   return (
     <div className="rounded-md border border-border bg-surface p-4">
@@ -78,7 +337,7 @@ export default function NewSessionDialog({
         <label className="block text-sm font-medium text-text">
           Mode
           <select
-            className="mt-1 block w-full rounded-md border-border bg-bg shadow-sm focus:border-primary focus:ring-primary"
+            className={SELECT_CLASS}
             value={mode}
             onChange={(event) => setMode(event.target.value as VNPlayMode)}
           >
@@ -87,18 +346,134 @@ export default function NewSessionDialog({
           </select>
         </label>
         <Input label="Title" value={title} onChange={(event) => setTitle(event.target.value)} />
-        <Input
-          inputMode="numeric"
-          label="Primary character ID"
-          value={primaryCharacterId}
-          onChange={(event) => setPrimaryCharacterId(event.target.value)}
-        />
-        <Input
-          inputMode="numeric"
-          label="VN asset pack ID"
-          value={vnAssetPackId}
-          onChange={(event) => setVnAssetPackId(event.target.value)}
-        />
+
+        {selectorMode === 'manual' ? (
+          <>
+            {selectorError && (
+              <div className="rounded-md border border-warn/30 bg-warn/10 px-3 py-2 text-sm text-warn sm:col-span-2">
+                Could not load setup selectors. Manual ID entry is available for this session. {selectorError}
+              </div>
+            )}
+            <Input
+              inputMode="numeric"
+              label="Primary character ID"
+              value={primaryCharacterId}
+              onChange={(event) => setPrimaryCharacterId(event.target.value)}
+            />
+            <Input
+              inputMode="numeric"
+              label="VN asset pack ID"
+              value={vnAssetPackId}
+              onChange={(event) => setVnAssetPackId(event.target.value)}
+            />
+          </>
+        ) : (
+          <>
+            <div>
+              <label htmlFor="new-session-character" className="mb-1 block text-sm font-medium text-text">
+                Character
+              </label>
+              <select
+                className={SELECT_CLASS}
+                disabled={isLoadingSelectors || characters.length === 0}
+                id="new-session-character"
+                value={selectedCharacterId}
+                onChange={(event) => setSelectedCharacterId(event.target.value)}
+              >
+                <option value="">Select a character</option>
+                {characters.map((character) => (
+                  <option key={character.id} value={character.id}>
+                    {characterName(character)}
+                  </option>
+                ))}
+              </select>
+              {isLoadingSelectors && <p className="mt-1 text-sm text-text-muted">Loading setup options...</p>}
+              {!isLoadingSelectors && characters.length === 0 && (
+                <div className="mt-2 rounded-md border border-warn/30 bg-warn/10 px-3 py-2 text-sm text-warn">
+                  <p className="font-medium">No characters available.</p>
+                  <p>Create or import a character before starting VN Play.</p>
+                </div>
+              )}
+              {selectedCharacter && (
+                <div className="mt-2 rounded-md border border-border bg-bg px-3 py-2 text-sm text-text-muted">
+                  <p className="font-medium text-text">{characterName(selectedCharacter)}</p>
+                  {selectedCharacter.description && <p>{selectedCharacter.description}</p>}
+                  {selectedCharacterTags && <p>{selectedCharacterTags}</p>}
+                  {selectedCharacter.image_present && <p>Image attached</p>}
+                </div>
+              )}
+            </div>
+
+            <div>
+              <label htmlFor="new-session-vn-asset-pack" className="mb-1 block text-sm font-medium text-text">
+                VN asset pack
+              </label>
+              <select
+                className={SELECT_CLASS}
+                disabled={isLoadingSelectors || assetPacks.length === 0 || !selectedCharacter}
+                id="new-session-vn-asset-pack"
+                value={selectedPackId}
+                onChange={(event) => setSelectedPackId(event.target.value)}
+              >
+                <option value="">Select a runtime-ready pack</option>
+                {orderedPacks.map((pack) => {
+                  const readiness = readinessByPackId[pack.id];
+                  const compatible = selectedCharacter ? pack.primary_character_id === selectedCharacter.id : false;
+                  const disabled = !compatible || !readiness?.ready || !isApprovedPackStatus(pack.status);
+                  return (
+                    <option key={pack.id} disabled={disabled} value={pack.id}>
+                      {buildPackOptionLabel(pack, selectedCharacter, readiness)}
+                    </option>
+                  );
+                })}
+              </select>
+              {!isLoadingSelectors && assetPacks.length === 0 && (
+                <div className="mt-2 rounded-md border border-warn/30 bg-warn/10 px-3 py-2 text-sm text-warn">
+                  <p className="font-medium">No VN asset packs available.</p>
+                  <p>Prepare or review a VN asset pack before starting VN Play.</p>
+                </div>
+              )}
+              {!isLoadingSelectors && assetPacks.length > 0 && selectedCharacter && !selectedPack && (
+                <div className="mt-2 rounded-md border border-warn/30 bg-warn/10 px-3 py-2 text-sm text-warn">
+                  No compatible runtime-ready VN asset pack is available for {characterName(selectedCharacter)}.
+                </div>
+              )}
+              {selectedPack && (
+                <div className="mt-2 rounded-md border border-border bg-bg px-3 py-2 text-sm text-text-muted">
+                  <p className="font-medium text-text">{selectedPack.title}</p>
+                  {selectedPack.description && <p>{selectedPack.description}</p>}
+                  <p>Pack content rating: {selectedPack.content_rating || 'general'}</p>
+                  <p>Trust level: new sessions start as local; review imported packs before use.</p>
+                </div>
+              )}
+            </div>
+
+            {incompatiblePacks.length > 0 && selectedCharacter && (
+              <div className="rounded-md border border-warn/30 bg-warn/10 px-3 py-2 text-sm text-warn sm:col-span-2">
+                <p className="font-medium">Some packs are attached to other characters.</p>
+                <ul className="mt-1 list-disc space-y-1 pl-5">
+                  {incompatiblePacks.map((pack) => (
+                    <li key={pack.id}>
+                      {pack.title} is attached to character {pack.primary_character_id}, not {characterName(selectedCharacter)}.
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {selectedPackWarnings.length > 0 && (
+              <div className="rounded-md border border-warn/30 bg-warn/10 px-3 py-2 text-sm text-warn sm:col-span-2">
+                <p className="font-medium">Review pack readiness before starting.</p>
+                <ul className="mt-1 list-disc space-y-1 pl-5">
+                  {selectedPackWarnings.map((warning) => (
+                    <li key={warning}>{warning}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </>
+        )}
+
         <Input
           label="Linked chat ID"
           placeholder="Optional"
@@ -121,7 +496,7 @@ export default function NewSessionDialog({
           <Button onClick={onClose} type="button" variant="secondary">
             Cancel
           </Button>
-          <Button loading={isCreating} type="submit">
+          <Button disabled={selectorSubmitDisabled} loading={isCreating} type="submit">
             Create session
           </Button>
         </div>

--- a/apps/tldw-frontend/e2e/smoke/vn-play.spec.ts
+++ b/apps/tldw-frontend/e2e/smoke/vn-play.spec.ts
@@ -32,6 +32,53 @@ test.describe('VN play smoke', () => {
       await fulfillJson(route, 200, [{ id: 'smoke-profile', name: 'Smoke profile' }]);
     });
 
+    await page.route(/\/api\/v1\/characters\/?(?:\?.*)?$/, async (route) => {
+      await fulfillJson(route, 200, [
+        {
+          id: 7,
+          version: 1,
+          name: 'Mira Vale',
+          description: 'Archive guide',
+          tags: ['archive', 'story'],
+          image_present: true,
+        },
+      ]);
+    });
+
+    await page.route(/\/api\/v1\/vn-assets(?:\/.*)?$/, async (route) => {
+      const request = route.request();
+      const url = new URL(request.url());
+      const method = request.method().toUpperCase();
+      const path = url.pathname.replace('/api/v1/vn-assets', '');
+
+      if (method === 'GET' && path === '/packs') {
+        await fulfillJson(route, 200, [
+          {
+            id: 12,
+            title: 'Moonlit Archive Pack',
+            primary_character_id: 7,
+            description: 'Runtime-ready VN poses and backdrops',
+            status: 'approved',
+            content_rating: 'general',
+            planned_output_count: 8,
+          },
+        ]);
+        return;
+      }
+
+      if (method === 'GET' && path === '/packs/12/readiness') {
+        await fulfillJson(route, 200, {
+          ready: true,
+          status: 'ready',
+          warnings: [],
+          errors: [],
+        });
+        return;
+      }
+
+      await fulfillJson(route, 404, { detail: `unhandled vn-assets mock route: ${method} ${path}` });
+    });
+
     await page.route(/\/api\/v1\/vn-play(?:\/.*)?$/, async (route) => {
       const request = route.request();
       const url = new URL(request.url());
@@ -114,8 +161,9 @@ test.describe('VN play smoke', () => {
     await expect(page.getByRole('heading', { name: 'VN play' })).toBeVisible();
     await page.getByRole('button', { name: 'New Story' }).click();
     await page.getByLabel('Title').fill('Smoke Story');
-    await page.getByLabel('Primary character ID').fill('7');
-    await page.getByLabel('VN asset pack ID').fill('12');
+    await expect(page.getByLabel('Character', { exact: true })).toBeVisible();
+    await page.getByLabel('Character', { exact: true }).selectOption('7');
+    await page.getByLabel('VN asset pack', { exact: true }).selectOption('12');
     await page.getByRole('button', { name: 'Create session' }).click();
 
     await expect(page.getByText('Selected session: Smoke Story')).toBeVisible();

--- a/apps/tldw-frontend/e2e/smoke/vn-play.spec.ts
+++ b/apps/tldw-frontend/e2e/smoke/vn-play.spec.ts
@@ -32,17 +32,24 @@ test.describe('VN play smoke', () => {
       await fulfillJson(route, 200, [{ id: 'smoke-profile', name: 'Smoke profile' }]);
     });
 
-    await page.route(/\/api\/v1\/characters\/?(?:\?.*)?$/, async (route) => {
-      await fulfillJson(route, 200, [
-        {
-          id: 7,
-          version: 1,
-          name: 'Mira Vale',
-          description: 'Archive guide',
-          tags: ['archive', 'story'],
-          image_present: true,
-        },
-      ]);
+    await page.route(/\/api\/v1\/characters(?:\/query|\/)?(?:\?.*)?$/, async (route) => {
+      await fulfillJson(route, 200, {
+        items: [
+          {
+            id: 7,
+            version: 1,
+            name: 'Mira Vale',
+            description: 'Archive guide',
+            tags: ['archive', 'story'],
+            image_present: true,
+          },
+        ],
+        has_more: false,
+        next_offset: null,
+        page: 1,
+        page_size: 100,
+        total: 1,
+      });
     });
 
     await page.route(/\/api\/v1\/vn-assets(?:\/.*)?$/, async (route) => {

--- a/apps/tldw-frontend/lib/api/characters.ts
+++ b/apps/tldw-frontend/lib/api/characters.ts
@@ -1,0 +1,22 @@
+import { apiClient } from '@web/lib/api';
+import type { CharacterListResponse, CharacterSummary } from '@web/types/characters';
+
+const CHARACTERS_BASE = '/characters';
+
+function normalizeCharacterList(response: CharacterListResponse): CharacterSummary[] {
+  if (Array.isArray(response)) {
+    return response;
+  }
+
+  return Array.isArray(response.items) ? response.items : [];
+}
+
+export async function listCharacters(): Promise<CharacterSummary[]> {
+  const response = await apiClient.get<CharacterListResponse>(`${CHARACTERS_BASE}/`, {
+    params: {
+      limit: 1000,
+      offset: 0,
+    },
+  });
+  return normalizeCharacterList(response);
+}

--- a/apps/tldw-frontend/lib/api/characters.ts
+++ b/apps/tldw-frontend/lib/api/characters.ts
@@ -1,7 +1,13 @@
 import { apiClient } from '@web/lib/api';
-import type { CharacterListResponse, CharacterSummary } from '@web/types/characters';
+import type { CharacterListQueryResponse, CharacterListResponse, CharacterSummary } from '@web/types/characters';
 
 const CHARACTERS_BASE = '/characters';
+const CHARACTER_QUERY_PAGE_SIZE = 100;
+
+export interface ListCharactersOptions {
+  query?: string;
+  pageSize?: number;
+}
 
 function normalizeCharacterList(response: CharacterListResponse): CharacterSummary[] {
   if (Array.isArray(response)) {
@@ -11,12 +17,34 @@ function normalizeCharacterList(response: CharacterListResponse): CharacterSumma
   return Array.isArray(response.items) ? response.items : [];
 }
 
-export async function listCharacters(): Promise<CharacterSummary[]> {
-  const response = await apiClient.get<CharacterListResponse>(`${CHARACTERS_BASE}/`, {
-    params: {
-      limit: 1000,
-      offset: 0,
-    },
-  });
-  return normalizeCharacterList(response);
+function normalizePageSize(pageSize?: number): number {
+  if (!Number.isFinite(pageSize)) return CHARACTER_QUERY_PAGE_SIZE;
+  return Math.min(Math.max(Math.trunc(pageSize ?? CHARACTER_QUERY_PAGE_SIZE), 1), CHARACTER_QUERY_PAGE_SIZE);
+}
+
+export async function listCharacters(options: ListCharactersOptions = {}): Promise<CharacterSummary[]> {
+  const pageSize = normalizePageSize(options.pageSize);
+  const query = options.query?.trim();
+  const characters: CharacterSummary[] = [];
+  let page = 1;
+
+  while (true) {
+    const response = await apiClient.get<CharacterListQueryResponse>(`${CHARACTERS_BASE}/query`, {
+      params: {
+        include_image_base64: false,
+        page,
+        page_size: pageSize,
+        ...(query ? { query } : {}),
+      },
+    });
+    const pageItems = normalizeCharacterList(response);
+    characters.push(...pageItems);
+
+    if (!response.has_more || pageItems.length === 0) {
+      break;
+    }
+    page += 1;
+  }
+
+  return characters;
 }

--- a/apps/tldw-frontend/types/characters.ts
+++ b/apps/tldw-frontend/types/characters.ts
@@ -1,0 +1,20 @@
+export interface CharacterSummary {
+  id: number;
+  version?: number;
+  name?: string | null;
+  description?: string | null;
+  tags?: string[] | string | null;
+  creator?: string | null;
+  image_present?: boolean;
+}
+
+export interface CharacterListQueryResponse {
+  items?: CharacterSummary[];
+  total?: number;
+  page?: number;
+  page_size?: number;
+  has_more?: boolean;
+  next_offset?: number | null;
+}
+
+export type CharacterListResponse = CharacterSummary[] | CharacterListQueryResponse;

--- a/backlog/tasks/task-157 - Make-VN-Play-session-setup-usable.md
+++ b/backlog/tasks/task-157 - Make-VN-Play-session-setup-usable.md
@@ -1,0 +1,75 @@
+---
+id: TASK-157
+title: Make VN Play session setup usable
+status: In Progress
+assignee: []
+created_date: '2026-05-09 05:15'
+labels:
+  - vn-play
+  - frontend
+  - webui
+  - setup
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1407'
+  - 'https://github.com/rmusser01/tldw_server/issues/1391'
+documentation:
+  - Docs/API-related/VN_PLAY_API.md
+  - Docs/superpowers/plans/2026-05-09-vn-play-session-setup-implementation-plan.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement issue #1407: replace raw VN Play session setup IDs with data-driven character and VN asset-pack selection in the WebUI. Users should be able to start Freeform or Story/CYOA sessions by choosing named records, seeing compatibility/readiness/trust/content-rating warnings before submit, and falling back to manual ID entry only when selector data cannot load.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 New VN Play session dialog loads and displays selectable characters with identifying metadata
+- [x] #2 Dialog loads VN asset packs and annotates or filters them by selected character compatibility
+- [x] #3 Ready/approved compatible packs can be selected and create the existing VNPlaySessionCreate payload without raw ID typing
+- [x] #4 Unready, draft, missing-byte, incompatible, trust-level, and content-rating conditions show explicit guidance before session creation
+- [x] #5 When character or asset-pack selectors fail to load, manual ID entry remains available as a secondary fallback
+- [x] #6 Empty states guide users toward character creation/import or VN asset pack preparation/review
+- [x] #7 Focused frontend tests cover selector loading, compatibility behavior, warning states, fallback/manual entry, and create-session payloads
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Implement in four stages: add minimal character API/types; replace raw IDs with selector-driven session creation; add readiness/compatibility/content-rating/empty-state/manual-fallback behavior; update smoke coverage and closeout verification.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Created implementation plan Docs/superpowers/plans/2026-05-09-vn-play-session-setup-implementation-plan.md for issue #1407. The Backlog ID was moved to TASK-157 to avoid colliding with an existing TASK-155 in the main checkout.
+
+Implemented a selector-driven VN Play session setup dialog, a minimal WebUI characters API wrapper/types, readiness and compatibility warning states, manual ID fallback on selector load failure, empty-state guidance, and selector-aware VN Play smoke mocks.
+
+Verification recorded:
+- RED: `bunx vitest run __tests__/vn-play/VNPlayWorkspace.test.tsx` failed 5 selector/warning/fallback tests before implementation.
+- GREEN: `bunx vitest run __tests__/vn-play/VNPlayWorkspace.test.tsx __tests__/vn-play/vnPlayApi.test.ts __tests__/vn-play/SceneStage.test.tsx __tests__/vn-play/vnPlayRuntime.test.ts` passed 4 files / 21 tests.
+- Lint: `bunx eslint components/vn-play/NewSessionDialog.tsx __tests__/vn-play/VNPlayWorkspace.test.tsx e2e/smoke/vn-play.spec.ts lib/api/characters.ts types/characters.ts` exited 0.
+- Smoke: `TLDW_WEB_URL=http://localhost:18081 TLDW_WEB_CMD='bun run dev -- -p 18081' bunx playwright test e2e/smoke/vn-play.spec.ts --reporter=line` passed 1 test after rerunning outside the sandbox for port binding.
+- Whitespace: `git diff --check` exited 0.
+- Bandit: not applicable; touched production code is frontend TypeScript/React only.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Made VN Play session setup selectable from named character and VN asset-pack records while preserving the existing create-session payload. The dialog now loads characters, packs, and pack readiness; prefers compatible ready packs; disables incompatible/unready/draft selections; shows readiness, trust, and content-rating guidance; falls back to manual numeric IDs when selector loading fails; and updates the smoke test to cover the selector flow.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-157 - Make-VN-Play-session-setup-usable.md
+++ b/backlog/tasks/task-157 - Make-VN-Play-session-setup-usable.md
@@ -13,6 +13,7 @@ dependencies: []
 references:
   - 'https://github.com/rmusser01/tldw_server/issues/1407'
   - 'https://github.com/rmusser01/tldw_server/issues/1391'
+  - 'https://github.com/rmusser01/tldw_server/pull/1409'
 documentation:
   - Docs/API-related/VN_PLAY_API.md
   - Docs/superpowers/plans/2026-05-09-vn-play-session-setup-implementation-plan.md
@@ -48,6 +49,8 @@ Implement in four stages: add minimal character API/types; replace raw IDs with 
 Created implementation plan Docs/superpowers/plans/2026-05-09-vn-play-session-setup-implementation-plan.md for issue #1407. The Backlog ID was moved to TASK-157 to avoid colliding with an existing TASK-155 in the main checkout.
 
 Implemented a selector-driven VN Play session setup dialog, a minimal WebUI characters API wrapper/types, readiness and compatibility warning states, manual ID fallback on selector load failure, empty-state guidance, and selector-aware VN Play smoke mocks.
+
+Opened draft PR #1409 for review.
 
 Verification recorded:
 - RED: `bunx vitest run __tests__/vn-play/VNPlayWorkspace.test.tsx` failed 5 selector/warning/fallback tests before implementation.

--- a/backlog/tasks/task-157 - Make-VN-Play-session-setup-usable.md
+++ b/backlog/tasks/task-157 - Make-VN-Play-session-setup-usable.md
@@ -4,6 +4,7 @@ title: Make VN Play session setup usable
 status: In Progress
 assignee: []
 created_date: '2026-05-09 05:15'
+updated_date: '2026-05-09 06:03'
 labels:
   - vn-play
   - frontend
@@ -16,7 +17,8 @@ references:
   - 'https://github.com/rmusser01/tldw_server/pull/1409'
 documentation:
   - Docs/API-related/VN_PLAY_API.md
-  - Docs/superpowers/plans/2026-05-09-vn-play-session-setup-implementation-plan.md
+  - >-
+    Docs/superpowers/plans/2026-05-09-vn-play-session-setup-implementation-plan.md
 priority: medium
 ---
 
@@ -59,7 +61,15 @@ Verification recorded:
 - Smoke: `TLDW_WEB_URL=http://localhost:18081 TLDW_WEB_CMD='bun run dev -- -p 18081' bunx playwright test e2e/smoke/vn-play.spec.ts --reporter=line` passed 1 test after rerunning outside the sandbox for port binding.
 - Whitespace: `git diff --check` exited 0.
 - Bandit: not applicable; touched production code is frontend TypeScript/React only.
+
+PR #1409 review follow-up: verified unresolved review threads, then added regressions and fixes for paginated character loading via /characters/query, bounded VN asset readiness request fan-out, rendering selectors before readiness completes, and duplicate readiness-warning React keys. Verification: red run failed 5 expected tests before fixes; final focused vitest passed 5 files / 26 tests; touched-file ESLint exited 0; git diff --check exited 0; VN Play smoke passed 1 test outside the sandbox after port binding was denied inside the sandbox. Bandit remains not applicable because touched production code is frontend TypeScript/React only.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Made VN Play session setup selectable from named character and VN asset-pack records while preserving the existing create-session payload. The dialog now loads characters, packs, and pack readiness; prefers compatible ready packs; disables incompatible/unready/draft selections; shows readiness, trust, and content-rating guidance; falls back to manual numeric IDs when selector loading fails; and updates the smoke test to cover the selector flow.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
@@ -70,9 +80,3 @@ Verification recorded:
 - [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->
-
-## Final Summary
-
-<!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Made VN Play session setup selectable from named character and VN asset-pack records while preserving the existing create-session payload. The dialog now loads characters, packs, and pack readiness; prefers compatible ready packs; disables incompatible/unready/draft selections; shows readiness, trust, and content-rating guidance; falls back to manual numeric IDs when selector loading fails; and updates the smoke test to cover the selector flow.
-<!-- SECTION:FINAL_SUMMARY:END -->


### PR DESCRIPTION
Closes #1407
Parent effort: #1391

## Summary
- Added a minimal WebUI character API wrapper and local character summary types for VN Play setup.
- Replaced raw default character/asset-pack IDs in the VN Play new-session dialog with character and VN asset-pack selectors.
- Added compatibility, readiness, draft, missing-byte, trust-level, content-rating, empty-state, and selector-load-failure guidance while preserving the existing `VNPlaySessionCreate` payload.
- Updated VN Play component tests and the VN Play smoke test to exercise selector-based session creation.

## Verification
- `bunx vitest run __tests__/vn-play/VNPlayWorkspace.test.tsx __tests__/vn-play/vnPlayApi.test.ts __tests__/vn-play/SceneStage.test.tsx __tests__/vn-play/vnPlayRuntime.test.ts`
- `bunx eslint components/vn-play/NewSessionDialog.tsx __tests__/vn-play/VNPlayWorkspace.test.tsx e2e/smoke/vn-play.spec.ts lib/api/characters.ts types/characters.ts`
- `git diff --check`
- `TLDW_WEB_URL=http://localhost:18081 TLDW_WEB_CMD='bun run dev -- -p 18081' bunx playwright test e2e/smoke/vn-play.spec.ts --reporter=line`

## Human Change Summary Required
This draft PR is materially AI-authored. Per repository policy, a human-written Change summary explaining both what changed and why these implementation choices were made is still required before merge.
