### PR TITLE
Remove dayjs from FlashcardEditDrawer scheduling labels

### DIFF
--- a/Docs/Design/WebUI_Dependency_Audit.md
+++ b/Docs/Design/WebUI_Dependency_Audit.md
@@ -107,7 +107,7 @@ This audit does not remove packages or rewrite runtime code.
 | `cytoscape` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 6 | apps/packages/ui/src/components/Notes/NotesGraphModal.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesGraphModal.stage2.graph-view.test.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage21.accessibility-modal-focus.test.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage22.accessibility-regression.test.tsx | shared UI, shared UI tests | graph/rendering | `keep` | Low; import/config/package-script evidence in current WebUI or shared UI paths. | No immediate reduction; keep current behavior. | none |
 | `cytoscape-dagre` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 6 | apps/packages/ui/src/components/Notes/NotesGraphModal.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesGraphModal.stage2.graph-view.test.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage21.accessibility-modal-focus.test.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage22.accessibility-regression.test.tsx | shared UI, shared UI tests | graph/rendering | `keep` | Low; import/config/package-script evidence in current WebUI or shared UI paths. | No immediate reduction; keep current behavior. | none |
 | `d3-dsv` | `web:dependencies`, `extension:dependencies` | 0 | none found | web app, extension impact declaration only | parser/conversion | `investigate-lockfile` | Medium; no import/config/package-script evidence, but package sits in parser/conversion behavior. Confirm direct-vs-transitive ownership and CSV/DSV coverage before removal. | Potential install/bundle reduction if direct declaration proves unused. | Lockfile/parser-domain investigation slice. |
-| `dayjs` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 15 | apps/packages/ui/src/components/Flashcards/components/FlashcardEditDrawer.tsx, apps/packages/ui/src/components/Media/FilterPanel.tsx, apps/packages/ui/src/components/Option/DataTables/EditableCell.tsx, apps/packages/ui/src/components/Option/KanbanPlayground/CardDetailPanel.tsx | shared UI, shared UI tests | frontend/runtime | `defer-design` | Medium; some display formatting can move to native `Intl` or small local helpers, but several Ant Design DatePicker/DateRangePicker surfaces currently exchange `Dayjs` values and types. | No immediate dependency reduction until shared UI date-picker value contracts are redesigned or isolated. | Continue display-formatting replacement slices before date-picker design. |
+| `dayjs` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 11 | apps/packages/ui/src/components/Flashcards/tabs/ReviewTab.tsx, apps/packages/ui/src/components/Flashcards/tabs/ManageTab.tsx, apps/packages/ui/src/components/Media/FilterPanel.tsx, apps/packages/ui/src/components/Option/DataTables/EditableCell.tsx | shared UI | frontend/runtime | `defer-design` | Medium; some display formatting can move to native `Intl` or small local helpers, but several Ant Design DatePicker/DateRangePicker surfaces currently exchange `Dayjs` values and types. | No immediate dependency reduction until shared UI date-picker value contracts are redesigned or isolated. | Continue display-formatting replacement slices before date-picker design. |
 | `dexie` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 6 | apps/packages/ui/src/db/dexie/chat.ts, apps/packages/ui/src/db/dexie/schema.ts, apps/packages/ui/src/hooks/document-workspace/__tests__/offlineQueue.test.ts, apps/packages/ui/src/hooks/document-workspace/offlineQueue.ts | shared UI, shared UI tests, web tests, web app | state/data | `keep` | Low; import/config/package-script evidence in current WebUI or shared UI paths. | No immediate reduction; keep current behavior. | none |
 | `dexie-react-hooks` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 1 | apps/packages/ui/src/components/Sidepanel/Chat/TtsClipsDrawer.tsx | shared UI | state/data | `keep` | Low; import/config/package-script evidence in current WebUI or shared UI paths. | No immediate reduction; keep current behavior. | none |
 | `dompurify` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 11 | apps/packages/ui/src/components/Common/CodeBlock.tsx, apps/packages/ui/src/components/Notes/NotesStudioDiagramCard.tsx, apps/packages/ui/src/components/Notes/export-utils.ts, apps/packages/ui/src/components/Option/Collections/ReadingList/ReadingItemDetail.tsx | shared UI | security/sanitization | `keep` | Low; import/config/package-script evidence in current WebUI or shared UI paths. | No immediate reduction; keep current behavior. | none |
@@ -214,9 +214,15 @@ This audit does not remove packages or rewrite runtime code.
   Design `Dayjs` value-contract surfaces.
 - TASK-153 removed `dayjs` time formatting from the display-only Models
   last-refreshed label by replacing `dayjs(...).format("HH:mm")` with a small
-  native `Intl.DateTimeFormat` helper. The shared UI `dayjs` import count
+  native Date helper. The shared UI `dayjs` import count
   dropped from 17 to 15 while leaving the package declared for remaining
   Flashcards display formatting and Ant Design `Dayjs` value-contract surfaces.
+- TASK-158 removed `dayjs` scheduling metadata formatting from the display-only
+  FlashcardEditDrawer due/last-reviewed labels by replacing absolute and
+  relative labels with native Date helpers. The shared UI `dayjs` import count
+  dropped from 15 to 11 while leaving the package declared for remaining
+  Flashcards Review/Manage display formatting and Ant Design `Dayjs`
+  value-contract surfaces.
 
 ### Quick Cleanup Candidates
 
@@ -387,6 +393,18 @@ ownership checks, or complex-domain packages that should stay on the
   The PR review follow-up removed the filesystem-based source guard from the
   Vitest unit test; dependency regression coverage for this slice is recorded
   through the exact Models-tree package-import scan instead.
+- 2026-05-09 TASK-158 active-code scan: exact shared UI package-import scan
+  found 11 remaining `dayjs` import lines after removing both runtime imports
+  from `apps/packages/ui/src/components/Flashcards/components/FlashcardEditDrawer.tsx`
+  and both test imports from the scheduling metadata test. Remaining
+  Flashcards imports are in ReviewTab and ManageTab display formatting; the
+  other remaining imports are Ant Design `Dayjs` value/type surfaces in media,
+  reading list, items, data table, and kanban code.
+- 2026-05-09 TASK-158 verification: `bunx vitest run
+  src/components/Flashcards/utils/__tests__/date-display.test.ts
+  src/components/Flashcards/components/__tests__/FlashcardEditDrawer.scheduling-metadata.test.tsx`
+  from `apps/packages/ui` passed after first failing on the missing native
+  date-display helper.
 - Bandit: skipped for TASK-144 because the slice changed documentation and
   Backlog metadata only; no Python files were modified.
 - Bandit: skipped for TASK-147 because the slice changed TypeScript,
@@ -394,6 +412,8 @@ ownership checks, or complex-domain packages that should stay on the
 - Bandit: skipped for TASK-149 because the slice changed TypeScript,
   documentation, and Backlog metadata only; no Python files were modified.
 - Bandit: skipped for TASK-153 because the slice changed TypeScript,
+  documentation, and Backlog metadata only; no Python files were modified.
+- Bandit: skipped for TASK-158 because the slice changed TypeScript,
   documentation, and Backlog metadata only; no Python files were modified.
 
 ## Known Skips And Blockers

--- a/apps/packages/ui/src/components/Flashcards/components/FlashcardEditDrawer.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/FlashcardEditDrawer.tsx
@@ -13,12 +13,11 @@ import {
   Typography
 } from "antd"
 import type { TextAreaRef } from "antd/es/input/TextArea"
-import dayjs from "dayjs"
-import relativeTime from "dayjs/plugin/relativeTime"
 import { useTranslation } from "react-i18next"
 import { useAntdMessage } from "@/hooks/useAntdMessage"
 import { useDebouncedFormField } from "../hooks"
 import { FLASHCARDS_DRAWER_WIDTH_PX } from "../constants"
+import { formatFlashcardTimestampWithRelative } from "../utils/date-display"
 import { normalizeFlashcardTemplateFields } from "../utils/template-helpers"
 import { normalizeOptionalFlashcardTags } from "../utils/tag-normalization"
 import {
@@ -40,7 +39,6 @@ import { MarkdownWithBoundary } from "./MarkdownWithBoundary"
 import type { Flashcard, FlashcardUpdate, Deck } from "@/services/flashcards"
 
 const { Text } = Typography
-dayjs.extend(relativeTime)
 const CLOZE_PATTERN = /\{\{c\d+::[\s\S]+?\}\}/
 
 type FlashcardModelType = Flashcard["model_type"]
@@ -111,6 +109,14 @@ export const FlashcardEditDrawer: React.FC<FlashcardEditDrawerProps> = ({
   const sourceMeta = React.useMemo(
     () => (card ? getFlashcardSourceMeta(card) : null),
     [card]
+  )
+  const dueAtDisplay = React.useMemo(
+    () => formatFlashcardTimestampWithRelative(card?.due_at),
+    [card?.due_at]
+  )
+  const lastReviewedDisplay = React.useMemo(
+    () => formatFlashcardTimestampWithRelative(card?.last_reviewed_at),
+    [card?.last_reviewed_at]
   )
 
   const templateHelperText = React.useMemo(() => {
@@ -496,11 +502,11 @@ export const FlashcardEditDrawer: React.FC<FlashcardEditDrawerProps> = ({
                   {t("option:flashcards.dueAt", { defaultValue: "Due at" })}
                 </Text>
                 <Text>
-                  {card.due_at
+                  {dueAtDisplay
                     ? t("option:flashcards.timestampWithRelative", {
                         defaultValue: "{{absolute}} ({{relative}})",
-                        absolute: dayjs(card.due_at).format("YYYY-MM-DD HH:mm"),
-                        relative: dayjs(card.due_at).fromNow()
+                        absolute: dueAtDisplay.absolute,
+                        relative: dueAtDisplay.relative
                       })
                     : t("option:flashcards.notScheduled", {
                         defaultValue: "Not scheduled"
@@ -512,11 +518,11 @@ export const FlashcardEditDrawer: React.FC<FlashcardEditDrawerProps> = ({
                   {t("option:flashcards.lastReviewed", { defaultValue: "Last reviewed" })}
                 </Text>
                 <Text>
-                  {card.last_reviewed_at
+                  {lastReviewedDisplay
                     ? t("option:flashcards.timestampWithRelative", {
                         defaultValue: "{{absolute}} ({{relative}})",
-                        absolute: dayjs(card.last_reviewed_at).format("YYYY-MM-DD HH:mm"),
-                        relative: dayjs(card.last_reviewed_at).fromNow()
+                        absolute: lastReviewedDisplay.absolute,
+                        relative: lastReviewedDisplay.relative
                       })
                     : t("option:flashcards.neverReviewed", {
                         defaultValue: "Never"

--- a/apps/packages/ui/src/components/Flashcards/components/FlashcardEditDrawer.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/FlashcardEditDrawer.tsx
@@ -110,13 +110,9 @@ export const FlashcardEditDrawer: React.FC<FlashcardEditDrawerProps> = ({
     () => (card ? getFlashcardSourceMeta(card) : null),
     [card]
   )
-  const dueAtDisplay = React.useMemo(
-    () => formatFlashcardTimestampWithRelative(card?.due_at),
-    [card?.due_at]
-  )
-  const lastReviewedDisplay = React.useMemo(
-    () => formatFlashcardTimestampWithRelative(card?.last_reviewed_at),
-    [card?.last_reviewed_at]
+  const dueAtDisplay = formatFlashcardTimestampWithRelative(card?.due_at)
+  const lastReviewedDisplay = formatFlashcardTimestampWithRelative(
+    card?.last_reviewed_at
   )
 
   const templateHelperText = React.useMemo(() => {

--- a/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardEditDrawer.scheduling-metadata.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardEditDrawer.scheduling-metadata.test.tsx
@@ -133,9 +133,15 @@ describe("FlashcardEditDrawer scheduling metadata panel", () => {
     expect(screen.getByText("Relearns")).toBeInTheDocument()
     expect(screen.getByText("2")).toBeInTheDocument()
 
-    const expectedDueAbsolute = formatFlashcardAbsoluteDateTime(dueAt) ?? ""
+    const expectedDueAbsolute = formatFlashcardAbsoluteDateTime(dueAt)
     const expectedLastReviewedAbsolute =
-      formatFlashcardAbsoluteDateTime(lastReviewedAt) ?? ""
+      formatFlashcardAbsoluteDateTime(lastReviewedAt)
+    expect(expectedDueAbsolute).not.toBeNull()
+    expect(expectedLastReviewedAbsolute).not.toBeNull()
+    if (expectedDueAbsolute == null || expectedLastReviewedAbsolute == null) {
+      throw new Error("Expected valid scheduling timestamp labels")
+    }
+
     expect(
       screen.getByText((content) => content.includes(expectedDueAbsolute))
     ).toBeInTheDocument()

--- a/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardEditDrawer.scheduling-metadata.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardEditDrawer.scheduling-metadata.test.tsx
@@ -1,13 +1,10 @@
-import dayjs from "dayjs"
-import relativeTime from "dayjs/plugin/relativeTime"
 import { render, screen } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 import { FlashcardEditDrawer } from "../FlashcardEditDrawer"
 import { FLASHCARDS_DRAWER_WIDTH_PX } from "../../constants"
 import type { Flashcard } from "@/services/flashcards"
 import { DEFAULT_SCHEDULER_SETTINGS_ENVELOPE } from "../../utils/scheduler-settings"
-
-dayjs.extend(relativeTime)
+import { formatFlashcardAbsoluteDateTime } from "../../utils/date-display"
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -119,6 +116,7 @@ describe("FlashcardEditDrawer scheduling metadata panel", () => {
             client_id: "1",
             version: 1,
             scheduler_type: "sm2_plus",
+            review_prompt_side: "front",
             scheduler_settings: DEFAULT_SCHEDULER_SETTINGS_ENVELOPE
           }
         ]}
@@ -135,8 +133,9 @@ describe("FlashcardEditDrawer scheduling metadata panel", () => {
     expect(screen.getByText("Relearns")).toBeInTheDocument()
     expect(screen.getByText("2")).toBeInTheDocument()
 
-    const expectedDueAbsolute = dayjs(dueAt).format("YYYY-MM-DD HH:mm")
-    const expectedLastReviewedAbsolute = dayjs(lastReviewedAt).format("YYYY-MM-DD HH:mm")
+    const expectedDueAbsolute = formatFlashcardAbsoluteDateTime(dueAt) ?? ""
+    const expectedLastReviewedAbsolute =
+      formatFlashcardAbsoluteDateTime(lastReviewedAt) ?? ""
     expect(
       screen.getByText((content) => content.includes(expectedDueAbsolute))
     ).toBeInTheDocument()

--- a/apps/packages/ui/src/components/Flashcards/utils/__tests__/date-display.test.ts
+++ b/apps/packages/ui/src/components/Flashcards/utils/__tests__/date-display.test.ts
@@ -28,6 +28,14 @@ describe("flashcard date display utilities", () => {
     [
       new Date(2000, 0, 1, 0, 0).getTime(),
       new Date(2000, 0, 1, 0, 0).getTime()
+    ],
+    [
+      new Date(1960, 0, 1, 0, 0).getTime() / 1000,
+      new Date(1960, 0, 1, 0, 0).getTime()
+    ],
+    [
+      new Date(1960, 0, 1, 0, 0).getTime(),
+      new Date(1960, 0, 1, 0, 0).getTime()
     ]
   ])("parses %s to %s", (value, expected) => {
     expect(parseFlashcardTimestamp(value)).toBe(expected)

--- a/apps/packages/ui/src/components/Flashcards/utils/__tests__/date-display.test.ts
+++ b/apps/packages/ui/src/components/Flashcards/utils/__tests__/date-display.test.ts
@@ -21,6 +21,14 @@ describe("flashcard date display utilities", () => {
     ["invalid-date", null],
     [null, null],
     ["2026-02-18T09:00:00Z", Date.parse("2026-02-18T09:00:00Z")],
+    [
+      Date.parse("2026-02-18T09:00:00Z") / 1000,
+      Date.parse("2026-02-18T09:00:00Z")
+    ],
+    [
+      new Date(2000, 0, 1, 0, 0).getTime(),
+      new Date(2000, 0, 1, 0, 0).getTime()
+    ]
   ])("parses %s to %s", (value, expected) => {
     expect(parseFlashcardTimestamp(value)).toBe(expected)
   })
@@ -62,6 +70,17 @@ describe("flashcard date display utilities", () => {
       absolute: "2026-02-18 09:00",
       relative: "3 hours ago",
       timestamp: new Date(2026, 1, 18, 9, 0).getTime()
+    })
+  })
+
+  it("combines pre-2001 millisecond timestamps without reinterpreting them as seconds", () => {
+    const timestamp = new Date(2000, 0, 1, 0, 0).getTime()
+    const nowMs = new Date(2000, 0, 2, 0, 0).getTime()
+
+    expect(formatFlashcardTimestampWithRelative(timestamp, { nowMs })).toEqual({
+      absolute: "2000-01-01 00:00",
+      relative: "a day ago",
+      timestamp
     })
   })
 })

--- a/apps/packages/ui/src/components/Flashcards/utils/__tests__/date-display.test.ts
+++ b/apps/packages/ui/src/components/Flashcards/utils/__tests__/date-display.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest"
+import {
+  formatFlashcardAbsoluteDateTime,
+  formatFlashcardRelativeTime,
+  formatFlashcardTimestampWithRelative,
+  parseFlashcardTimestamp
+} from "../date-display"
+
+const STABLE_NOW_MS = new Date(2026, 1, 18, 12, 0).getTime()
+const beforeStableNow = (deltaMs: number): string =>
+  new Date(STABLE_NOW_MS - deltaMs).toISOString()
+
+describe("flashcard date display utilities", () => {
+  it("formats local absolute timestamps as YYYY-MM-DD HH:mm", () => {
+    const value = new Date(2026, 1, 20, 9, 5).toISOString()
+
+    expect(formatFlashcardAbsoluteDateTime(value)).toBe("2026-02-20 09:05")
+  })
+
+  it.each([
+    ["invalid-date", null],
+    [null, null],
+    ["2026-02-18T09:00:00Z", Date.parse("2026-02-18T09:00:00Z")],
+  ])("parses %s to %s", (value, expected) => {
+    expect(parseFlashcardTimestamp(value)).toBe(expected)
+  })
+
+  it.each([
+    ["2026-02-18T11:59:30", "a few seconds ago"],
+    ["2026-02-18T11:59:00", "a minute ago"],
+    ["2026-02-18T11:58:00", "2 minutes ago"],
+    ["2026-02-18T09:00:00", "3 hours ago"],
+    ["2026-02-17T12:00:00", "a day ago"],
+    ["2026-02-19T12:00:00", "in a day"],
+  ])("formats %s with dayjs-compatible relative text", (value, expected) => {
+    expect(formatFlashcardRelativeTime(value, { nowMs: STABLE_NOW_MS })).toBe(
+      expected
+    )
+  })
+
+  it.each([
+    [beforeStableNow(89_500), "a minute ago"],
+    [beforeStableNow(90_000), "2 minutes ago"],
+    [beforeStableNow(89.5 * 60_000), "an hour ago"],
+    [beforeStableNow(90 * 60_000), "2 hours ago"],
+    [beforeStableNow(35.5 * 60 * 60_000), "a day ago"],
+    [beforeStableNow(36 * 60 * 60_000), "2 days ago"],
+    [beforeStableNow(540 * 24 * 60 * 60_000), "a year ago"],
+    [beforeStableNow(550 * 24 * 60 * 60_000), "2 years ago"],
+  ])("formats rounding boundary %s as %s", (value, expected) => {
+    expect(formatFlashcardRelativeTime(value, { nowMs: STABLE_NOW_MS })).toBe(
+      expected
+    )
+  })
+
+  it("combines absolute and relative labels for valid timestamps", () => {
+    expect(
+      formatFlashcardTimestampWithRelative("2026-02-18T09:00:00", {
+        nowMs: STABLE_NOW_MS
+      })
+    ).toEqual({
+      absolute: "2026-02-18 09:00",
+      relative: "3 hours ago",
+      timestamp: new Date(2026, 1, 18, 9, 0).getTime()
+    })
+  })
+})

--- a/apps/packages/ui/src/components/Flashcards/utils/date-display.ts
+++ b/apps/packages/ui/src/components/Flashcards/utils/date-display.ts
@@ -1,0 +1,109 @@
+const SECONDS_TO_MS = 1000
+const SECOND_TIMESTAMP_CUTOFF = 1_000_000_000_000
+const MINUTES_TO_MS = 60 * SECONDS_TO_MS
+const HOURS_TO_MS = 60 * MINUTES_TO_MS
+const DAYS_TO_MS = 24 * HOURS_TO_MS
+const MONTHS_TO_MS = 30 * DAYS_TO_MS
+const YEARS_TO_MS = 365 * DAYS_TO_MS
+
+export interface FlashcardTimestampDisplay {
+  absolute: string
+  relative: string
+  timestamp: number
+}
+
+export const parseFlashcardTimestamp = (value: unknown): number | null => {
+  if (value == null) return null
+  if (value instanceof Date) {
+    const timestamp = value.getTime()
+    return Number.isFinite(timestamp) ? timestamp : null
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value < SECOND_TIMESTAMP_CUTOFF ? value * SECONDS_TO_MS : value
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim()
+    if (!trimmed) return null
+    const timestamp = Date.parse(trimmed)
+    return Number.isFinite(timestamp) ? timestamp : null
+  }
+  return null
+}
+
+const padDatePart = (value: number): string => value.toString().padStart(2, "0")
+
+export const formatFlashcardAbsoluteDateTime = (value: unknown): string | null => {
+  const timestamp = parseFlashcardTimestamp(value)
+  if (timestamp == null) return null
+
+  const date = new Date(timestamp)
+  const year = date.getFullYear()
+  const month = padDatePart(date.getMonth() + 1)
+  const day = padDatePart(date.getDate())
+  const hours = padDatePart(date.getHours())
+  const minutes = padDatePart(date.getMinutes())
+
+  return `${year}-${month}-${day} ${hours}:${minutes}`
+}
+
+export const formatFlashcardRelativeTime = (
+  value: unknown,
+  options?: { nowMs?: number }
+): string | null => {
+  const timestamp = parseFlashcardTimestamp(value)
+  if (timestamp == null) return null
+
+  const nowMs =
+    typeof options?.nowMs === "number" && Number.isFinite(options.nowMs)
+      ? options.nowMs
+      : Date.now()
+  const diffMs = timestamp - nowMs
+  const absMs = Math.abs(diffMs)
+  const suffixRelative = (label: string): string =>
+    diffMs > 0 ? `in ${label}` : `${label} ago`
+  const unitRelative = (count: number, singular: string, pluralUnit: string): string =>
+    suffixRelative(count === 1 ? singular : `${count} ${pluralUnit}`)
+
+  if (absMs < 45 * SECONDS_TO_MS) return suffixRelative("a few seconds")
+  if (absMs < 90 * SECONDS_TO_MS) return suffixRelative("a minute")
+
+  if (absMs < 45 * MINUTES_TO_MS) {
+    return unitRelative(Math.round(absMs / MINUTES_TO_MS), "a minute", "minutes")
+  }
+  if (absMs < 90 * MINUTES_TO_MS) return suffixRelative("an hour")
+
+  if (absMs < 22 * HOURS_TO_MS) {
+    return unitRelative(Math.round(absMs / HOURS_TO_MS), "an hour", "hours")
+  }
+  if (absMs < 36 * HOURS_TO_MS) return suffixRelative("a day")
+
+  if (absMs < 26 * DAYS_TO_MS) {
+    return unitRelative(Math.round(absMs / DAYS_TO_MS), "a day", "days")
+  }
+  if (absMs < 46 * DAYS_TO_MS) return suffixRelative("a month")
+
+  const months = Math.round(absMs / MONTHS_TO_MS)
+  if (months < 11) return unitRelative(months, "a month", "months")
+  if (months < 18) return suffixRelative("a year")
+
+  const years = Math.round(absMs / YEARS_TO_MS)
+  return unitRelative(years, "a year", "years")
+}
+
+export const formatFlashcardTimestampWithRelative = (
+  value: unknown,
+  options?: { nowMs?: number }
+): FlashcardTimestampDisplay | null => {
+  const timestamp = parseFlashcardTimestamp(value)
+  if (timestamp == null) return null
+
+  const absolute = formatFlashcardAbsoluteDateTime(timestamp)
+  const relative = formatFlashcardRelativeTime(timestamp, options)
+  if (!absolute || !relative) return null
+
+  return {
+    absolute,
+    relative,
+    timestamp
+  }
+}

--- a/apps/packages/ui/src/components/Flashcards/utils/date-display.ts
+++ b/apps/packages/ui/src/components/Flashcards/utils/date-display.ts
@@ -20,7 +20,9 @@ export const parseFlashcardTimestamp = (value: unknown): number | null => {
     return Number.isFinite(timestamp) ? timestamp : null
   }
   if (typeof value === "number" && Number.isFinite(value)) {
-    return value < SECOND_TIMESTAMP_CUTOFF ? value * SECONDS_TO_MS : value
+    return Math.abs(value) < SECOND_TIMESTAMP_CUTOFF
+      ? value * SECONDS_TO_MS
+      : value
   }
   if (typeof value === "string") {
     const trimmed = value.trim()

--- a/apps/packages/ui/src/components/Flashcards/utils/date-display.ts
+++ b/apps/packages/ui/src/components/Flashcards/utils/date-display.ts
@@ -1,5 +1,6 @@
 const SECONDS_TO_MS = 1000
-const SECOND_TIMESTAMP_CUTOFF = 1_000_000_000_000
+// Epoch seconds remain below this until 2286; millisecond timestamps exceed it after 1970.
+const SECOND_TIMESTAMP_CUTOFF = 10_000_000_000
 const MINUTES_TO_MS = 60 * SECONDS_TO_MS
 const HOURS_TO_MS = 60 * MINUTES_TO_MS
 const DAYS_TO_MS = 24 * HOURS_TO_MS
@@ -32,10 +33,7 @@ export const parseFlashcardTimestamp = (value: unknown): number | null => {
 
 const padDatePart = (value: number): string => value.toString().padStart(2, "0")
 
-export const formatFlashcardAbsoluteDateTime = (value: unknown): string | null => {
-  const timestamp = parseFlashcardTimestamp(value)
-  if (timestamp == null) return null
-
+const formatFlashcardAbsoluteDateTimeFromMs = (timestamp: number): string => {
   const date = new Date(timestamp)
   const year = date.getFullYear()
   const month = padDatePart(date.getMonth() + 1)
@@ -46,13 +44,15 @@ export const formatFlashcardAbsoluteDateTime = (value: unknown): string | null =
   return `${year}-${month}-${day} ${hours}:${minutes}`
 }
 
-export const formatFlashcardRelativeTime = (
-  value: unknown,
-  options?: { nowMs?: number }
-): string | null => {
+export const formatFlashcardAbsoluteDateTime = (value: unknown): string | null => {
   const timestamp = parseFlashcardTimestamp(value)
-  if (timestamp == null) return null
+  return timestamp == null ? null : formatFlashcardAbsoluteDateTimeFromMs(timestamp)
+}
 
+const formatFlashcardRelativeTimeFromMs = (
+  timestamp: number,
+  options?: { nowMs?: number }
+): string => {
   const nowMs =
     typeof options?.nowMs === "number" && Number.isFinite(options.nowMs)
       ? options.nowMs
@@ -90,6 +90,14 @@ export const formatFlashcardRelativeTime = (
   return unitRelative(years, "a year", "years")
 }
 
+export const formatFlashcardRelativeTime = (
+  value: unknown,
+  options?: { nowMs?: number }
+): string | null => {
+  const timestamp = parseFlashcardTimestamp(value)
+  return timestamp == null ? null : formatFlashcardRelativeTimeFromMs(timestamp, options)
+}
+
 export const formatFlashcardTimestampWithRelative = (
   value: unknown,
   options?: { nowMs?: number }
@@ -97,13 +105,9 @@ export const formatFlashcardTimestampWithRelative = (
   const timestamp = parseFlashcardTimestamp(value)
   if (timestamp == null) return null
 
-  const absolute = formatFlashcardAbsoluteDateTime(timestamp)
-  const relative = formatFlashcardRelativeTime(timestamp, options)
-  if (!absolute || !relative) return null
-
   return {
-    absolute,
-    relative,
+    absolute: formatFlashcardAbsoluteDateTimeFromMs(timestamp),
+    relative: formatFlashcardRelativeTimeFromMs(timestamp, options),
     timestamp
   }
 }

--- a/backlog/tasks/task-158 - Remove-dayjs-from-FlashcardEditDrawer-scheduling-metadata-labels.md
+++ b/backlog/tasks/task-158 - Remove-dayjs-from-FlashcardEditDrawer-scheduling-metadata-labels.md
@@ -1,0 +1,64 @@
+---
+id: TASK-158
+title: Remove dayjs from FlashcardEditDrawer scheduling metadata labels
+status: In Progress
+assignee: []
+created_date: '2026-05-09 05:33'
+updated_date: '2026-05-09 05:42'
+labels:
+  - webui
+  - dependencies
+  - cleanup
+  - dayjs
+  - flashcards
+dependencies:
+  - TASK-153
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1346'
+documentation:
+  - Docs/Design/WebUI_Dependency_Audit.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue issue #1346 by replacing the display-only dayjs usage in FlashcardEditDrawer scheduling metadata labels with native date/time helpers. Scope is limited to the edit drawer's read-only due/last-reviewed labels and their existing tests; leave ReviewTab, ManageTab, and Ant Design Dayjs value-contract surfaces for separate slices.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 FlashcardEditDrawer no longer imports dayjs or dayjs/plugin/relativeTime for scheduling metadata display.
+- [x] #2 Due-at and last-reviewed labels preserve the existing absolute YYYY-MM-DD HH:mm shape and a relative label for valid timestamps using native helpers.
+- [x] #3 Existing FlashcardEditDrawer scheduling metadata coverage is updated to assert native-helper output without importing dayjs in the test.
+- [x] #4 The WebUI dependency audit records the reduced shared UI dayjs import count and the remaining Flashcards/Ant Design surfaces.
+- [x] #5 Focused Vitest, exact Flashcards dayjs import scan, frontend lint or focused lint rationale, git diff hygiene, and Bandit skip/run rationale are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+<!-- SECTION:PLAN:BEGIN -->
+1. Add native date-formatting expectations to the existing FlashcardEditDrawer scheduling metadata test and verify the red failure while the helper does not exist.
+2. Implement small Flashcards date display helpers for absolute YYYY-MM-DD HH:mm and relative due/last-reviewed labels.
+3. Replace FlashcardEditDrawer dayjs usage and remove test-side dayjs imports.
+4. Update the dependency audit and task notes with the new import count, verification, and remaining dayjs surfaces.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented native Flashcards date-display helpers for parsing timestamps, local YYYY-MM-DD HH:mm labels, and dayjs-compatible relative labels. Replaced FlashcardEditDrawer scheduling metadata dayjs usage with the helper and removed dayjs imports from the scheduling metadata test.
+
+TDD red: focused Vitest failed on missing ../../utils/date-display and ../date-display imports before implementation. Green: bunx vitest run src/components/Flashcards/utils/__tests__/date-display.test.ts src/components/Flashcards/components/__tests__/FlashcardEditDrawer.scheduling-metadata.test.tsx passed with 2 files and 20 tests.
+
+Verification: exact shared UI dayjs package-import scan now reports 11 remaining import lines; exact scan over Flashcards/components and Flashcards/utils returns no dayjs package imports. git diff --check passed. bun run lint in apps/tldw-frontend exited 0 with the existing 131-warning baseline. UI package tsc still exits 2 on the existing repo-wide baseline, but a filtered tsc diagnostic check for date-display and FlashcardEditDrawer.scheduling-metadata returned no touched-file diagnostics after adding review_prompt_side to the local test fixture. Bandit skipped because only TypeScript, documentation, and Backlog files changed.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-158 - Remove-dayjs-from-FlashcardEditDrawer-scheduling-metadata-labels.md
+++ b/backlog/tasks/task-158 - Remove-dayjs-from-FlashcardEditDrawer-scheduling-metadata-labels.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-158
 title: Remove dayjs from FlashcardEditDrawer scheduling metadata labels
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-09 05:33'
-updated_date: '2026-05-09 05:42'
+updated_date: '2026-05-09 05:44'
 labels:
   - webui
   - dependencies
@@ -15,6 +15,7 @@ dependencies:
   - TASK-153
 references:
   - 'https://github.com/rmusser01/tldw_server/issues/1346'
+  - 'https://github.com/rmusser01/tldw_server/pull/1411'
 documentation:
   - Docs/Design/WebUI_Dependency_Audit.md
 priority: medium
@@ -53,12 +54,18 @@ TDD red: focused Vitest failed on missing ../../utils/date-display and ../date-d
 Verification: exact shared UI dayjs package-import scan now reports 11 remaining import lines; exact scan over Flashcards/components and Flashcards/utils returns no dayjs package imports. git diff --check passed. bun run lint in apps/tldw-frontend exited 0 with the existing 131-warning baseline. UI package tsc still exits 2 on the existing repo-wide baseline, but a filtered tsc diagnostic check for date-display and FlashcardEditDrawer.scheduling-metadata returned no touched-file diagnostics after adding review_prompt_side to the local test fixture. Bandit skipped because only TypeScript, documentation, and Backlog files changed.
 <!-- SECTION:NOTES:END -->
 
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Removed dayjs from FlashcardEditDrawer scheduling metadata labels by adding native Flashcards date-display helpers for local YYYY-MM-DD HH:mm and dayjs-compatible relative labels, rewiring the drawer to use them, updating scheduling metadata tests to avoid dayjs imports, and refreshing the WebUI dependency audit from 15 to 11 remaining shared UI dayjs package-import lines. Opened PR #1411 against dev.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [x] #1 Acceptance criteria completed
 - [x] #2 Tests or verification recorded
 - [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
+- [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-162 - Address-PR-1411-date-display-review-comments.md
+++ b/backlog/tasks/task-162 - Address-PR-1411-date-display-review-comments.md
@@ -1,0 +1,58 @@
+---
+id: TASK-162
+title: Address PR 1411 date-display review comments
+status: In Progress
+assignee:
+  - codex
+created_date: '2026-05-09 06:15'
+updated_date: '2026-05-09 06:22'
+labels:
+  - webui
+  - dependencies
+  - cleanup
+  - dayjs
+  - flashcards
+  - review-fix
+dependencies:
+  - TASK-158
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1411'
+  - 'https://github.com/rmusser01/tldw_server/pull/1411#discussion_r3212561415'
+  - 'https://github.com/rmusser01/tldw_server/pull/1411#discussion_r3212561417'
+documentation:
+  - Docs/Design/WebUI_Dependency_Audit.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address actionable review feedback on PR #1411 for the FlashcardEditDrawer dayjs cleanup. Scope is limited to fixing the scheduling metadata test's vacuous timestamp assertion and hardening Flashcards date-display numeric timestamp parsing/combined formatting so millisecond timestamps before 2001 are not reinterpreted as seconds.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 FlashcardEditDrawer scheduling metadata test no longer falls back to an empty expected timestamp string before includes() assertions.
+- [x] #2 Flashcards date-display helpers correctly treat pre-2001 millisecond timestamps as milliseconds and avoid re-parsing an already-normalized timestamp in the combined absolute/relative helper.
+- [x] #3 Focused date-display and FlashcardEditDrawer scheduling metadata tests cover the review regressions and pass.
+- [ ] #4 PR #1411 actionable review threads are replied to and resolved after the fix is pushed.
+- [x] #5 Diff hygiene, focused import scan, lint or baseline rationale, and Bandit skip/run rationale are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Fixed the review feedback by removing the FlashcardEditDrawer scheduling metadata test's empty-string fallback, asserting formatter outputs are non-null before includes() assertions, lowering the numeric epoch-seconds cutoff to 10_000_000_000, and formatting combined absolute/relative labels from the already-normalized millisecond timestamp.
+
+Verification so far: red Vitest run failed on the new pre-2001 millisecond timestamp regression before implementation; after the fix, `bunx vitest run src/components/Flashcards/utils/__tests__/date-display.test.ts src/components/Flashcards/components/__tests__/FlashcardEditDrawer.scheduling-metadata.test.tsx` passed with 2 files and 23 tests. `git diff --check` passed. Flashcards component/utils dayjs import scan returned no matches; broader shared-ui dayjs scan remains the known 11-line baseline. `bun run lint` in apps/tldw-frontend exited 0 with the existing 131-warning baseline. Full apps/packages/ui TypeScript check still exits 2 on unrelated baseline diagnostics; filtered diagnostics for `date-display` and `FlashcardEditDrawer.scheduling-metadata` returned no matches. Bandit is not applicable because this review fix touches TypeScript/frontend test files and a Backlog task file, not Python code.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-162 - Address-PR-1411-date-display-review-comments.md
+++ b/backlog/tasks/task-162 - Address-PR-1411-date-display-review-comments.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-162
 title: Address PR 1411 date-display review comments
-status: In Progress
+status: Done
 assignee:
   - codex
 created_date: '2026-05-09 06:15'
-updated_date: '2026-05-09 06:31'
+updated_date: '2026-05-09 06:33'
 labels:
   - webui
   - dependencies
@@ -35,7 +35,7 @@ Address actionable review feedback on PR #1411 for the FlashcardEditDrawer dayjs
 - [x] #1 FlashcardEditDrawer scheduling metadata test no longer falls back to an empty expected timestamp string before includes() assertions.
 - [x] #2 Flashcards date-display helpers correctly treat pre-2001 millisecond timestamps as milliseconds and avoid re-parsing an already-normalized timestamp in the combined absolute/relative helper.
 - [x] #3 Focused date-display and FlashcardEditDrawer scheduling metadata tests cover the review regressions and pass.
-- [ ] #4 PR #1411 actionable review threads are replied to and resolved after the fix is pushed.
+- [x] #4 PR #1411 actionable review threads are replied to and resolved after the fix is pushed.
 - [x] #5 Diff hygiene, focused import scan, lint or baseline rationale, and Bandit skip/run rationale are recorded.
 <!-- AC:END -->
 
@@ -49,12 +49,20 @@ Verification so far: red Vitest run failed on the new pre-2001 millisecond times
 Additional CodeRabbit review pass: removed `React.useMemo` around `dueAtDisplay` and `lastReviewedDisplay` so relative labels are recomputed on render, changed numeric timestamp detection to compare `Math.abs(value)` against the seconds cutoff, and added regression coverage for pre-1970 numeric second and millisecond timestamps. Verification after this pass: red Vitest failed for the new pre-1970 millisecond case before implementation; after the fix, focused Vitest passed with 2 files and 25 tests, `git diff --check` passed, Flashcards component/utils dayjs scan returned no matches, broader shared-ui dayjs scan remains the known 11-line baseline, `bun run lint` exited 0 with the existing 131-warning baseline, and the narrow TypeScript diagnostic filter for `date-display`, `FlashcardEditDrawer.tsx`, and `FlashcardEditDrawer.scheduling-metadata` returned no matches.
 <!-- SECTION:NOTES:END -->
 
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed all actionable PR #1411 review comments on the FlashcardEditDrawer native date cleanup. The scheduling metadata test no longer uses an empty-string fallback before `includes()` assertions; it asserts formatted labels are non-null and fails early if formatting returns null. The shared date-display helper now uses a safer 10_000_000_000 epoch-seconds cutoff, compares numeric timestamp magnitude with `Math.abs`, and formats combined absolute/relative labels from the already-normalized millisecond timestamp instead of re-parsing. `FlashcardEditDrawer` also computes relative display labels directly on render instead of memoizing output from a helper that depends on `Date.now()`.
+
+Regression coverage now includes numeric epoch seconds, pre-2001 millisecond timestamps, pre-1970 epoch seconds, and pre-1970 millisecond timestamps. Verification: the new pre-2001 and pre-1970 millisecond regressions failed before implementation, then the focused Vitest suite passed with 2 files and 25 tests. `git diff --check` passed. The Flashcards component/utils dayjs import scan returned no matches; the broader shared-ui scan remains at the known 11-line baseline outside this slice. `bun run lint` in `apps/tldw-frontend` exited 0 with the existing 131-warning baseline. Full `apps/packages/ui` TypeScript still exits 2 on unrelated baseline diagnostics, while the narrow diagnostic filter for touched files returned no matches. Bandit was not run because this task touched TypeScript/frontend tests and Backlog metadata only, not Python code. Qodo and CodeRabbit actionable review threads were replied to and resolved after the final push.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [x] #1 Acceptance criteria completed
 - [x] #2 Tests or verification recorded
 - [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
+- [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-162 - Address-PR-1411-date-display-review-comments.md
+++ b/backlog/tasks/task-162 - Address-PR-1411-date-display-review-comments.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - codex
 created_date: '2026-05-09 06:15'
-updated_date: '2026-05-09 06:22'
+updated_date: '2026-05-09 06:31'
 labels:
   - webui
   - dependencies
@@ -45,6 +45,8 @@ Address actionable review feedback on PR #1411 for the FlashcardEditDrawer dayjs
 Fixed the review feedback by removing the FlashcardEditDrawer scheduling metadata test's empty-string fallback, asserting formatter outputs are non-null before includes() assertions, lowering the numeric epoch-seconds cutoff to 10_000_000_000, and formatting combined absolute/relative labels from the already-normalized millisecond timestamp.
 
 Verification so far: red Vitest run failed on the new pre-2001 millisecond timestamp regression before implementation; after the fix, `bunx vitest run src/components/Flashcards/utils/__tests__/date-display.test.ts src/components/Flashcards/components/__tests__/FlashcardEditDrawer.scheduling-metadata.test.tsx` passed with 2 files and 23 tests. `git diff --check` passed. Flashcards component/utils dayjs import scan returned no matches; broader shared-ui dayjs scan remains the known 11-line baseline. `bun run lint` in apps/tldw-frontend exited 0 with the existing 131-warning baseline. Full apps/packages/ui TypeScript check still exits 2 on unrelated baseline diagnostics; filtered diagnostics for `date-display` and `FlashcardEditDrawer.scheduling-metadata` returned no matches. Bandit is not applicable because this review fix touches TypeScript/frontend test files and a Backlog task file, not Python code.
+
+Additional CodeRabbit review pass: removed `React.useMemo` around `dueAtDisplay` and `lastReviewedDisplay` so relative labels are recomputed on render, changed numeric timestamp detection to compare `Math.abs(value)` against the seconds cutoff, and added regression coverage for pre-1970 numeric second and millisecond timestamps. Verification after this pass: red Vitest failed for the new pre-1970 millisecond case before implementation; after the fix, focused Vitest passed with 2 files and 25 tests, `git diff --check` passed, Flashcards component/utils dayjs scan returned no matches, broader shared-ui dayjs scan remains the known 11-line baseline, `bun run lint` exited 0 with the existing 131-warning baseline, and the narrow TypeScript diagnostic filter for `date-display`, `FlashcardEditDrawer.tsx`, and `FlashcardEditDrawer.scheduling-metadata` returned no matches.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary
- Replace FlashcardEditDrawer scheduling metadata `dayjs` formatting with native date-display helpers.
- Add focused helper coverage for local `YYYY-MM-DD HH:mm` labels and dayjs-compatible relative labels.
- Update the WebUI dependency audit to record the shared UI `dayjs` import count dropping from 15 to 11.

## Change summary
This PR continues issue #1346 with the smallest remaining Flashcards display-only surface. The edit drawer only needs read-only due and last-reviewed labels, so local Date helpers preserve the visible absolute timestamp shape and representative relative wording without keeping `dayjs` in the drawer or its scheduling metadata test. ReviewTab, ManageTab, and Ant Design `Dayjs` value-contract surfaces stay out of scope because they need separate display-flow or date-picker contract handling.

## Test plan
- Red: `bunx vitest run src/components/Flashcards/utils/__tests__/date-display.test.ts src/components/Flashcards/components/__tests__/FlashcardEditDrawer.scheduling-metadata.test.tsx` failed on missing `date-display` helper before implementation.
- Green: `bunx vitest run src/components/Flashcards/utils/__tests__/date-display.test.ts src/components/Flashcards/components/__tests__/FlashcardEditDrawer.scheduling-metadata.test.tsx` passed with 2 files and 20 tests.
- Exact shared UI dayjs package-import scan reports 11 remaining import lines.
- Exact scan over `apps/packages/ui/src/components/Flashcards/components` and `apps/packages/ui/src/components/Flashcards/utils` returns no dayjs package imports.
- `git diff --check` passed.
- `bun run lint` in `apps/tldw-frontend` exited 0 with the existing 131-warning baseline.
- `bunx tsc -p tsconfig.json --noEmit` in `apps/packages/ui` still exits 2 on existing repo-wide baseline errors; filtered diagnostics for `date-display` and `FlashcardEditDrawer.scheduling-metadata` returned no touched-file diagnostics.

Bandit skipped: no Python files changed.