### PR TITLE
Add backend VN Play setup options API

### DIFF
--- a/Docs/API-related/VN_PLAY_API.md
+++ b/Docs/API-related/VN_PLAY_API.md
@@ -19,6 +19,7 @@ Linked chat is read-only in V1. `linked_chat_id` may be stored as session contex
 
 | Method | Path | Purpose |
 | --- | --- | --- |
+| `GET` | `/setup-options` | Return backend-computed character and asset pack setup selectors. |
 | `POST` | `/sessions` | Create a Freeform or Story session. |
 | `GET` | `/sessions` | List the current user's non-deleted sessions. |
 | `GET` | `/sessions/{session_id}` | Get one session with current scene state. |
@@ -31,6 +32,36 @@ Linked chat is read-only in V1. `linked_chat_id` may be stored as session contex
 | `GET` | `/sessions/{session_id}/checkpoints` | List checkpoints. |
 | `POST` | `/sessions/{session_id}/restore` | Restore a checkpoint. |
 | `GET` | `/sessions/{session_id}/branches` | List branch metadata. |
+
+## Setup Options
+
+`GET /setup-options` returns a bounded, selector-safe setup contract for WebUI and custom frontend session creation. The backend owns character option shaping, VN asset pack readiness fanout, compatibility classification, content-rating warnings, trust provenance, warning severity, and empty-state hints.
+
+Example:
+
+```bash
+curl "http://127.0.0.1:8000/api/v1/vn-play/setup-options?mode=story&selected_character_id=42&content_rating=general" \
+  -H "X-API-KEY: $SINGLE_USER_API_KEY"
+```
+
+Supported query parameters:
+
+- `mode`: optional `freeform` or `story`.
+- `character_query` / `pack_query`: optional selector search text.
+- `character_limit` / `pack_limit`: bounded page sizes, default `25`, maximum `100`.
+- `character_offset` / `pack_offset`: zero-based selector offsets.
+- `selected_character_id`: optional active character; included as `selected_character` even when outside the current character page.
+- `content_rating`: intended session content rating, default `general`.
+
+The response includes:
+
+- `characters`: selector-safe character rows with `id`, `name`, `description_preview`, `tags`, `favorite`, `deleted`, and `has_image`; full prompts and image bytes are not embedded.
+- `asset_packs`: bounded pack rows with readiness, compatibility, trust, warning summary, and `recommended` metadata.
+- `pagination`: separate character and pack pagination metadata. Pack readiness is computed only for returned pack rows.
+- `empty_states`: scoped hints such as `no_characters`, `no_asset_packs`, `no_ready_packs`, `no_compatible_packs`, or `selected_character_not_found`.
+- `defaults`: optional unambiguous defaults for frontend convenience.
+
+High-risk warning summaries require frontend acknowledgement before submit, but V1 keeps `POST /sessions` compatible and does not enforce setup acknowledgement server-side. Clients that accept high-risk warnings should persist acknowledgement metadata in `settings.setup_acknowledgements`.
 
 ## Create A Session
 

--- a/Docs/superpowers/plans/2026-05-09-vn-play-setup-options-backend-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-09-vn-play-setup-options-backend-implementation-plan.md
@@ -1,0 +1,86 @@
+# VN Play Setup Options Backend Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a backend setup-options API so VN Play session setup is usable by the WebUI and custom frontends without duplicating setup rules client-side.
+
+**Architecture:** Keep setup logic inside the API server. Add Pydantic setup response schemas, bounded VN asset pack repository/service helpers, and a focused `core/VN_Play/setup_options.py` composer used by `GET /api/v1/vn-play/setup-options`. PR #1409 remains a frontend reference for UX scenarios, but this implementation centralizes readiness, compatibility, trust, and warning decisions in the backend.
+
+**Tech Stack:** FastAPI, Pydantic, SQLite via `CharactersRAGDB`, existing `VNAssetPackService`, pytest `TestClient`, Bandit.
+
+---
+
+## References
+
+- Spec: `Docs/superpowers/specs/2026-05-09-vn-play-setup-options-design.md`
+- Backlog: `TASK-158`
+- UX reference only: `https://github.com/rmusser01/tldw_server/pull/1409`
+
+## Task 1: RED Backend API Contract Tests
+
+**Files:**
+- Modify: `tldw_Server_API/tests/VN_Play/test_vn_play_api.py`
+
+- [x] Add failing tests for:
+  - `GET /api/v1/vn-play/setup-options` returns selector-safe character metadata, selected character, pack warning summary, and pagination.
+  - `selected_character` is preserved when outside the current character page.
+  - readiness is evaluated only for returned pack rows.
+  - untrusted completed import provenance emits `pack_untrusted_import`.
+  - per-pack readiness failures degrade to `readiness_unavailable`.
+- [x] Run:
+  `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/VN_Play/test_vn_play_api.py -q`
+- [x] Expected: new tests fail because `/setup-options` does not exist yet.
+
+Status: Complete. RED run failed with seven expected 404s for the missing setup-options route; later GREEN run passed 14 VN Play API tests.
+
+## Task 2: Bounded Pack And Provenance Repository Helpers
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/DB_Management/VNAssetPacks_DB.py`
+- Modify: `tldw_Server_API/app/core/VN_Assets/service.py`
+- Modify: `tldw_Server_API/tests/VN_Assets/test_vn_asset_packs_db.py`
+
+- [x] Add failing repository tests for bounded setup pack listing and latest completed import provenance lookup.
+- [x] Implement `list_packs_for_setup(owner_user_id, query, limit, offset)` with SQL-level filtering and `LIMIT limit + 1`.
+- [x] Implement `latest_completed_import_provenance_by_pack_ids(owner_user_id, pack_ids)` with one query over the returned pack IDs.
+- [x] Add a thin `VNAssetPackService.list_packs_for_setup` wrapper.
+- [x] Run:
+  `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/VN_Assets/test_vn_asset_packs_db.py -q`
+
+Status: Complete. RED run failed on the missing setup helpers and exposed an existing multi-hop matrix dependency failure; GREEN run passed 10 VN Assets DB tests after fixing both.
+
+## Task 3: Schemas, Composer, And Endpoint
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/schemas/vn_play_schemas.py`
+- Create: `tldw_Server_API/app/core/VN_Play/setup_options.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/vn_play.py`
+
+- [x] Add setup response schemas matching the approved spec: top-level `characters`, `selected_character`, `asset_packs`, `defaults`, `pagination`, `empty_states`, and `generated_at`.
+- [x] Build selector-safe character options from `query_character_cards`/`get_character_card_by_id` without exposing image bytes.
+- [x] Build bounded pack options from returned pack rows only; compute readiness, compatibility, content-rating warnings, and trust provenance warning summaries.
+- [x] Add `GET /setup-options` to the VN Play router using the existing per-user `ChaChaNotes.db` dependency.
+- [x] Run:
+  `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/VN_Play/test_vn_play_api.py -q`
+
+Status: Complete. GREEN run passed 14 VN Play API tests.
+
+## Task 4: Documentation And Closeout
+
+**Files:**
+- Modify: `Docs/API-related/VN_PLAY_API.md` if the endpoint is documented there.
+- Modify: `backlog/tasks/task-158 - Implement-backend-VN-Play-setup-options-API.md`
+
+- [x] Document the backend endpoint or record why existing docs do not cover VN Play endpoint details.
+- [x] Run focused backend tests:
+  `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/VN_Play/test_vn_play_api.py tldw_Server_API/tests/VN_Assets/test_vn_asset_packs_db.py -q`
+- [x] Run Bandit on touched backend files.
+- [x] Run `git diff --check`.
+- [x] Update `TASK-158` with verification and final summary.
+
+Status: Complete. Final verification:
+
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/VN_Play/test_vn_play_api.py tldw_Server_API/tests/VN_Assets/test_vn_asset_packs_db.py -q` passed 24 tests.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/VN_Play/setup_options.py tldw_Server_API/app/api/v1/endpoints/vn_play.py tldw_Server_API/app/api/v1/schemas/vn_play_schemas.py tldw_Server_API/app/core/DB_Management/VNAssetPacks_DB.py tldw_Server_API/app/core/VN_Assets/service.py -f json -o /tmp/bandit_vn_setup_options_prod.json` exited 0.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/tests/VN_Play/test_vn_play_api.py tldw_Server_API/tests/VN_Assets/test_vn_asset_packs_db.py -s B101 -f json -o /tmp/bandit_vn_setup_options_tests.json` exited 0.
+- `git diff --check` exited 0.

--- a/Docs/superpowers/specs/2026-05-09-vn-play-setup-options-design.md
+++ b/Docs/superpowers/specs/2026-05-09-vn-play-setup-options-design.md
@@ -1,0 +1,552 @@
+# VN Play Setup Options Design
+
+Status: Draft
+Date: 2026-05-09
+Owner: Core/WebUI maintainers
+Scope: Usable VN Play session creation with backend-computed setup options
+Tracking: https://github.com/rmusser01/tldw_server/issues/1407
+
+## Summary
+
+Add a backend setup-options endpoint for VN Play session creation. The endpoint
+aggregates minimal character selector data, bounded VN asset pack selector data,
+pack readiness, compatibility, trust provenance, content-rating notes, and warning
+severity into one contract the WebUI can render directly.
+
+The first implementation keeps `POST /api/v1/vn-play/sessions` compatible with the
+existing `VNPlaySessionCreate` contract. Setup options are advisory and
+user-facing. The WebUI should warn but allow problematic asset pack choices, with
+an explicit acknowledgement step only for high-risk warnings.
+
+## Goals
+
+- Let users create VN Play sessions without knowing raw character or asset pack
+  database IDs.
+- Centralize setup compatibility and readiness logic in the backend instead of
+  duplicating it in the frontend.
+- Preserve the existing session creation payload shape.
+- Keep unready or incompatible packs visible and selectable, with clear reasons.
+- Require WebUI acknowledgement for high-risk setup warnings.
+- Keep setup queries bounded so users with many characters or packs do not trigger
+  unbounded readiness evaluation.
+- Provide empty and failure states that direct users to character creation, asset
+  pack review, import, or manual ID fallback.
+- Preserve the selected character label even when pagination or search would
+  otherwise omit it from the current character page.
+
+## Non-Goals
+
+- No realtime image generation.
+- No new VN turn/runtime mechanics.
+- No story branch graph authoring.
+- No large VN asset pack editor redesign.
+- No backend hard block for warned setup choices in V1.
+- No full character response or image payload embedded in the setup-options
+  response.
+
+## Existing Project Context
+
+The current `/vn-play` setup dialog uses numeric `primary_character_id` and
+`vn_asset_pack_id` fields. This is functional for early development, but not
+usable as the normal entry point.
+
+Relevant existing surfaces:
+
+- `GET /api/v1/characters/` and `GET /api/v1/characters/query` return character
+  records.
+- `GET /api/v1/vn-assets/packs` lists VN asset packs.
+- `GET /api/v1/vn-assets/packs/{pack_id}/readiness` evaluates runtime readiness.
+- `POST /api/v1/vn-play/sessions` already creates a session with
+  `primary_character_id`, `vn_asset_pack_id`, mode, title, rating, linked chat,
+  trust level, and settings.
+
+The new setup endpoint should reuse the same per-user `ChaChaNotes.db` boundary
+as characters, VN assets, and VN Play. It should not read or serve image bytes.
+
+Current VN asset pack list helpers return all non-deleted packs. This design
+requires adding a paginated/searchable repository or service method for setup
+options before computing readiness. A compliant implementation must not fetch all
+packs into Python and then slice the result.
+
+## Design Choices
+
+### Backend Aggregated Setup Contract
+
+Use a new endpoint:
+
+```text
+GET /api/v1/vn-play/setup-options
+```
+
+This endpoint returns selector data and compatibility/readiness summaries in one
+response. The frontend should not independently decide whether a pack is
+compatible or high risk.
+
+### Warn But Allow
+
+VN Play setup should not hide or permanently block problematic packs. Users may
+choose an incompatible or unready pack after seeing the issue. This matters for
+self-hosted experimentation, imported packs, and partially prepared assets.
+
+The WebUI may still make the recommended path easier by sorting compatible ready
+packs first and visually de-emphasizing high-risk choices.
+
+### High-Risk Acknowledgement
+
+High-risk warnings require an explicit WebUI acknowledgement before submit. This
+is a UX guard, not a new backend policy gate in V1.
+
+The frontend can store acknowledgement metadata in the existing session
+`settings` object, for example:
+
+```json
+{
+  "setup_acknowledgements": {
+    "warning_codes": ["pack_character_mismatch"],
+    "acknowledged_at": "2026-05-09T00:00:00Z"
+  }
+}
+```
+
+The backend should accept the normal session creation payload without requiring
+this metadata.
+
+The WebUI must persist acknowledgement metadata whenever a session is created
+after accepting high-risk setup warnings. The metadata should include the warning
+codes and enough snapshot context to debug the decision later, such as selected
+character ID, selected pack ID, readiness status, and timestamp. This is still not
+a backend gate in V1; API clients that bypass setup-options remain compatible.
+
+### Minimal Character Metadata
+
+The setup response should expose only selector-safe character fields:
+
+- `id`
+- `name`
+- `description_preview`
+- `tags`
+- `favorite`, defaulting to false if not cheaply available
+- `deleted`, defaulting to false because normal setup should exclude deleted
+  characters
+- `has_image`
+
+Do not embed full prompts, greetings, full image base64, or private character
+payload fields in the setup response.
+
+### Bounded Summary Mode
+
+The endpoint returns bounded pages for characters and asset packs. It computes
+readiness and warnings only for the returned pack page.
+
+Default limits should be conservative, for example:
+
+- `character_limit=25`
+- `pack_limit=25`
+- maximum `character_limit=100`
+- maximum `pack_limit=100`
+
+The response includes separate pagination metadata for characters and asset
+packs. This avoids one large selector call becoming a slow readiness sweep.
+
+Pack filtering, sorting, limit, and offset must happen at the repository/service
+query boundary. The implementation can use a `LIMIT pack_limit + 1` query to
+derive `has_more`, or return an exact total if the repository can do that cheaply.
+Readiness fanout happens only for the final returned pack rows.
+
+## API Contract
+
+### Query Parameters
+
+```text
+GET /api/v1/vn-play/setup-options
+  ?mode=story
+  &character_query=mira
+  &pack_query=library
+  &character_limit=25
+  &character_offset=0
+  &pack_limit=25
+  &pack_offset=0
+  &selected_character_id=42
+  &content_rating=general
+```
+
+Parameters:
+
+- `mode`: optional `freeform` or `story`; used for defaults and future mode
+  specific warnings.
+- `character_query`: optional search text for character selector pages.
+- `pack_query`: optional search text for asset pack selector pages.
+- `character_limit` / `character_offset`: bounded character pagination.
+- `pack_limit` / `pack_offset`: bounded pack pagination.
+- `selected_character_id`: optional current character selection. When present,
+  pack compatibility and sort hints should be computed against this character.
+- `content_rating`: optional intended session content rating. When present,
+  content-rating mismatch warnings should be computed against this rating.
+
+### Response Shape
+
+```json
+{
+  "characters": [
+    {
+      "id": 42,
+      "name": "Mira",
+      "description_preview": "Archivist with a careful eye...",
+      "tags": ["sci-fi", "guide"],
+      "favorite": true,
+      "deleted": false,
+      "has_image": true
+    }
+  ],
+  "selected_character": {
+    "id": 42,
+    "name": "Mira",
+    "description_preview": "Archivist with a careful eye...",
+    "tags": ["sci-fi", "guide"],
+    "favorite": true,
+    "deleted": false,
+    "has_image": true
+  },
+  "asset_packs": [
+    {
+      "id": 7,
+      "title": "Mira - Archive Pack",
+      "primary_character_id": 42,
+      "content_rating": "general",
+      "status": "ready",
+      "trust_level": "local",
+      "trust_source": "local_pack",
+      "ready": true,
+      "readiness_status": "ready",
+      "readiness_warnings": [],
+      "readiness_errors": [],
+      "compatibility": {
+        "status": "compatible",
+        "reason_codes": []
+      },
+      "warning_summary": {
+        "highest_severity": "info",
+        "requires_acknowledgement": false,
+        "warnings": []
+      },
+      "recommended": true
+    }
+  ],
+  "defaults": {
+    "mode": "story",
+    "character_id": 42,
+    "asset_pack_id": 7,
+    "content_rating": "general"
+  },
+  "pagination": {
+    "characters": {
+      "limit": 25,
+      "offset": 0,
+      "has_more": false,
+      "total": null
+    },
+    "asset_packs": {
+      "limit": 25,
+      "offset": 0,
+      "has_more": true,
+      "total": null
+    }
+  },
+  "empty_states": [
+    {
+      "code": "no_compatible_packs",
+      "scope": "page",
+      "message": "No compatible packs were found in this page of results."
+    }
+  ],
+  "generated_at": "2026-05-09T00:00:00Z"
+}
+```
+
+### Pagination Object
+
+Character and pack pagination metadata should use the same object shape:
+
+- `limit`: effective bounded page size after applying server maximums.
+- `offset`: effective zero-based offset.
+- `has_more`: true when another page is known to exist.
+- `total`: exact total for the current selector query when cheap to compute,
+  otherwise null.
+
+When `total` is null, the implementation should still derive `has_more` from a
+bounded overfetch such as `LIMIT limit + 1`. It must not mark `has_more=false`
+just because the total count was skipped.
+
+### Warning Object
+
+Warnings should be typed and stable enough for frontend tests:
+
+```json
+{
+  "code": "pack_character_mismatch",
+  "severity": "high_risk",
+  "message": "This pack was generated for a different primary character.",
+  "requires_acknowledgement": true
+}
+```
+
+Allowed severities:
+
+- `info`
+- `warning`
+- `high_risk`
+
+Initial warning codes:
+
+- `pack_character_mismatch`: pack primary character differs from selected
+  character. High risk.
+- `pack_not_ready`: pack readiness is not ready. High risk.
+- `pack_has_readiness_errors`: readiness response contains errors. High risk.
+- `pack_missing_required_assets`: required runtime assets are missing or lack
+  approved variants. High risk.
+- `content_rating_mismatch`: pack rating differs from intended session rating.
+  High risk when the pack rating is more permissive or unknown; warning otherwise.
+- `pack_untrusted_import`: pack was last committed from an untrusted import
+  flow. Warning.
+- `pack_deleted_or_archived`: pack is hidden from normal use. High risk.
+- `readiness_unavailable`: readiness could not be computed for this pack. Warning.
+
+Implementation may add warning codes later, but existing codes must remain stable
+once shipped.
+
+### Content Rating Comparison
+
+Use a small ordered baseline for known labels:
+
+```text
+general < suggestive < mature < violent
+```
+
+Custom, missing, or unknown labels cannot be reliably ordered. If the pack rating
+differs from the requested session rating and either side is unknown, emit
+`content_rating_mismatch` as high risk. If both labels are known and the pack
+rating is more permissive than the requested session rating, emit high risk. If
+the pack rating is less permissive than the requested session rating, emit a
+warning.
+
+### Compatibility Status
+
+Compatibility is scoped to the selected character when one is provided:
+
+- `compatible`: pack primary character matches selected character.
+- `different_character`: pack primary character differs.
+- `unknown`: no selected character or missing metadata.
+
+Compatibility does not decide whether the pack can be submitted. It only drives
+warning severity, sort order, and acknowledgement behavior.
+
+### Trust Provenance
+
+V1 asset pack rows do not store a dedicated trust field. Setup options should
+derive `trust_level` as follows:
+
+- `local`: no completed import journal is associated with the pack for this user.
+- `trusted_restore`: the latest completed import journal for the pack used
+  `trust_mode=trusted_restore`.
+- `untrusted_import`: the latest completed import journal for the pack used
+  `trust_mode=untrusted_import`.
+- `unknown`: provenance lookup failed or the pack predates provenance data in a
+  way the service cannot classify.
+
+The source should be reported in `trust_source`:
+
+- `local_pack`
+- `latest_import_journal`
+- `unknown`
+
+The latest completed import journal means the newest committed import journal row
+for the same owner boundary and target pack ID. Failed, canceled, preview-only, or
+missing-target import rows must not affect trust classification.
+
+If this derivation is too expensive to perform per returned pack page, the
+implementation should add a small repository helper that returns latest completed
+import provenance for the returned pack IDs in one query. It should not do one
+unbounded journal scan per pack.
+
+### Defaults
+
+Defaults are optional. The backend should suggest a default only when the choice is
+unambiguous:
+
+1. Prefer selected character when `selected_character_id` is valid.
+2. Otherwise prefer one non-deleted favorite character when exactly one exists in
+   the returned page.
+3. Prefer a ready compatible pack for the selected/default character.
+4. If multiple equivalent safe packs exist, omit `asset_pack_id`.
+
+The frontend must tolerate absent defaults.
+
+When `selected_character_id` is supplied and resolves to an active character, the
+response must include `selected_character` even if that character is outside the
+current `characters` page or does not match `character_query`. If it does not
+resolve, `selected_character` is null and setup options should include a scoped
+empty/error hint such as `selected_character_not_found`.
+
+### Sorting
+
+Within the returned pack page, the backend should order rows for setup usefulness:
+
+1. compatible and ready packs
+2. compatible but warned packs
+3. unknown-compatibility packs
+4. different-character or high-risk packs
+
+This sort order is only for presentation. It must not hide warned packs.
+
+## Backend Implementation Notes
+
+Add setup-option schemas to `vn_play_schemas.py`, keeping them separate from
+session creation models:
+
+- `VNPlaySetupOptionsResponse`
+- `VNPlaySetupCharacterOption`
+- `VNPlaySetupAssetPackOption`
+- `VNPlaySetupWarning`
+- `VNPlaySetupCompatibility`
+- `VNPlaySetupPagination`
+- `VNPlaySetupDefaults`
+- `VNPlaySetupEmptyState`
+
+Add endpoint logic to `vn_play.py` near session creation routes:
+
+```text
+GET /setup-options
+```
+
+Recommended service boundary:
+
+- Add a small setup helper under `core/VN_Play/` if the endpoint logic grows past
+  straightforward aggregation.
+- Reuse existing `VNAssetPackService` or repository methods where available for
+  pack readiness. Do not call internal HTTP endpoints.
+- Add paginated/searchable VN asset pack listing at the repository/service layer
+  before readiness fanout. Do not use the existing all-packs list as the setup
+  source of truth.
+- Add a bulk provenance lookup for latest completed import journal rows by
+  returned pack IDs if trust warnings are implemented in V1.
+- Reuse character DB query/list helpers rather than duplicating SQL in the
+  endpoint module. Character setup queries should never request `image_base64`.
+
+Readiness fanout must stay bounded to the returned pack page. If readiness fails
+for one pack, the endpoint should include that pack with a
+`readiness_unavailable` warning rather than failing the entire setup-options
+request.
+
+## Frontend Implementation Notes
+
+Update `NewSessionDialog` to load setup options when opened.
+
+Recommended component split:
+
+- Keep `NewSessionDialog` as the orchestration component.
+- Add small internal selector helpers only if needed:
+  - character selector
+  - asset pack selector
+  - warning acknowledgement panel
+
+Behavior:
+
+1. Load setup options on open.
+2. Render named character options.
+3. Render named asset pack options with readiness and warning badges.
+4. Re-fetch setup options when search text, pagination, selected character, mode,
+   or content rating changes.
+5. If selected pack warning summary requires acknowledgement, disable create until
+   the acknowledgement checkbox is checked.
+6. Submit the existing `VNPlaySessionCreate` payload shape.
+7. Include acknowledgement metadata under `settings` whenever high-risk warnings
+   were accepted.
+8. If setup-options fails, show an error and reveal manual ID fields as a fallback.
+
+When `selected_character` is present, the frontend should use it as the selected
+label even if that row is not present in the current `characters` page.
+
+The fallback preserves the current raw-ID capability but should not be the default
+path.
+
+## Empty And Error States
+
+The endpoint can return empty state hints:
+
+- `no_characters`: user has no available characters.
+- `no_asset_packs`: user has no VN asset packs.
+- `no_ready_packs`: packs exist but none are runtime-ready in the relevant result
+  scope.
+- `no_compatible_packs`: packs exist but none match the selected character in the
+  relevant result scope.
+- `selected_character_not_found`: supplied `selected_character_id` does not
+  resolve to an active character for this user.
+
+Each empty state must include a `scope`:
+
+- `global`: true for the user's complete dataset.
+- `filter`: true for the current query/filter but not necessarily global.
+- `page`: true only for the returned page.
+
+If the backend cannot cheaply prove a global condition, it must return `filter` or
+`page` rather than implying there are no matching records anywhere.
+
+The frontend should link users toward existing character creation/import and VN
+asset pack creation/review/import surfaces when possible.
+
+## Testing
+
+Backend tests:
+
+- setup options returns bounded character and pack pages.
+- pack list filtering and pagination happen before readiness fanout.
+- ready compatible pack returns no high-risk warnings.
+- different-character pack returns `pack_character_mismatch`.
+- selected character outside the current page still appears in
+  `selected_character`.
+- unready pack returns high-risk readiness warnings but remains in `asset_packs`.
+- untrusted import provenance emits `pack_untrusted_import` when provenance is
+  available.
+- per-pack readiness failure degrades to `readiness_unavailable` instead of
+  failing the whole endpoint.
+- pagination metadata is correct and readiness is evaluated only for returned
+  packs.
+- empty-state scope is page/filter/global accurate.
+
+Frontend tests:
+
+- dialog renders selector labels instead of raw ID fields when setup options load.
+- selected character changes asset pack warning state.
+- high-risk pack selection requires acknowledgement before create.
+- warning-but-allow flow still submits after acknowledgement.
+- accepted high-risk warnings are persisted into the session creation `settings`
+  payload.
+- setup-options failure exposes manual ID fallback.
+- create payload remains compatible with `VNPlaySessionCreate`.
+
+Verification should run focused VN Play backend tests, focused VN Play frontend
+tests, `git diff --check`, and Bandit only if Python code is implemented in the
+later implementation task. This design-only task does not require Bandit.
+
+## Rollout And Compatibility
+
+This is additive. Existing API consumers can continue posting raw IDs to
+`POST /api/v1/vn-play/sessions`.
+
+The WebUI should prefer setup-options but keep manual fallback. If the endpoint is
+unavailable because a user is running an older backend, the current manual flow
+still works.
+
+## Risks
+
+- Readiness evaluation can become expensive if pack limits are too high. Keep
+  bounded defaults and maximums, and apply them before readiness fanout.
+- Character query and asset pack query may have different performance profiles.
+  Keep pagination independent.
+- Warning severity can drift between frontend and backend if the frontend embeds
+  its own rules. Treat backend warning objects as authoritative.
+- High-risk acknowledgement is a WebUI guard only in V1. API clients can still
+  create warned sessions directly.
+- Trust provenance is derived from import journal state in V1 rather than a
+  pack-level trust column. If that proves too costly or ambiguous, defer trust
+  warnings until pack-level provenance is persisted.

--- a/backlog/tasks/task-155 - Write-VN-Play-setup-options-design-spec.md
+++ b/backlog/tasks/task-155 - Write-VN-Play-setup-options-design-spec.md
@@ -1,0 +1,56 @@
+---
+id: TASK-155
+title: Write VN Play setup options design spec
+status: Done
+assignee: []
+created_date: '2026-05-09 05:17'
+updated_date: '2026-05-09 05:27'
+labels:
+  - vn-play
+  - design
+  - webui
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1407'
+  - 'https://github.com/rmusser01/tldw_server/issues/1391'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Write and commit the design spec for GitHub issue #1407. The spec must define a backend setup-options endpoint for VN Play session setup, warn-but-allow asset pack selection, high-risk acknowledgement behavior, minimal character selector metadata, bounded pack/readiness pagination, frontend fallback/manual ID behavior, and implementation/testing guidance. This task only covers the design/spec artifact, not implementation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Spec document is created under Docs/superpowers/specs with decisions from issue #1407
+- [x] #2 Spec defines setup-options API contract, warning severities, acknowledgement rules, pagination, frontend data flow, error states, and tests
+- [x] #3 Spec is reviewed for obvious correctness issues and committed on the design branch
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Created Docs/superpowers/specs/2026-05-09-vn-play-setup-options-design.md. Local review tightened naming for readiness_warnings/readiness_errors, content-rating comparison severity, pack sorting, and no image_base64 character queries. Verification: git diff --check produced no output. Spec-review subagent was not dispatched because this Codex session only permits subagents when the user explicitly requests them; performed local self-review instead.
+
+Reopened for design-review fixes requested after initial spec commit. Addressing bounded pack pagination, acknowledgement persistence, trust warning source, selected-character pagination, and page-scoped empty-state semantics.
+
+Review fixes applied: setup spec now requires repository/service-level bounded pack pagination before readiness fanout, persisted WebUI acknowledgement metadata for accepted high-risk warnings, import-journal-derived trust provenance, selected_character preservation across pagination/search, scoped empty states, and consistent pagination metadata.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Wrote and tightened the VN Play setup-options design spec for issue #1407. The spec now defines the aggregate setup endpoint, bounded selector pagination before readiness fanout, minimal character and selected_character metadata, warning severities, high-risk acknowledgement persistence, import-journal trust provenance, scoped empty/error states, frontend fallback behavior, rollout compatibility, risks, and backend/frontend test expectations. Verification: git diff --check passed. Bandit is not applicable because this task only changes markdown/task metadata.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-158 - Implement-backend-VN-Play-setup-options-API.md
+++ b/backlog/tasks/task-158 - Implement-backend-VN-Play-setup-options-API.md
@@ -1,0 +1,61 @@
+---
+id: TASK-158
+title: Implement backend VN Play setup-options API
+status: Done
+assignee: []
+created_date: '2026-05-09 05:38'
+updated_date: '2026-05-09 05:53'
+labels:
+  - vn-play
+  - api
+  - webui
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1407'
+  - 'https://github.com/rmusser01/tldw_server/issues/1391'
+  - 'https://github.com/rmusser01/tldw_server/pull/1409'
+documentation:
+  - Docs/superpowers/specs/2026-05-09-vn-play-setup-options-design.md
+  - >-
+    Docs/superpowers/plans/2026-05-09-vn-play-setup-options-backend-implementation-plan.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the backend-first VN Play setup-options API described in the design spec so the API server can stand alone and custom frontends can create VN Play sessions without duplicating character, pack readiness, compatibility, trust, and warning logic. PR #1409 is frontend-only and should be treated as a UX/reference path rather than the architecture to copy.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Backend exposes a bounded GET /api/v1/vn-play/setup-options endpoint with selector-safe character data, selected_character preservation, asset pack readiness/compatibility/warning summaries, pagination metadata, defaults, scoped empty states, and no image bytes.
+- [x] #2 Asset pack listing for setup options applies query, sort, limit, and offset at the repository/service boundary before readiness fanout; readiness is evaluated only for returned pack rows.
+- [x] #3 Trust provenance and pack_untrusted_import warnings are derived from completed import journal metadata when available, and degrade safely when provenance cannot be classified.
+- [x] #4 Focused backend tests cover endpoint contract, bounded readiness behavior, selected_character pagination behavior, warning severity/acknowledgement metadata, scoped empty states, and safe fallback when per-pack readiness fails.
+- [x] #5 A follow-up frontend integration path is documented so PR #1409 or a successor can consume the backend contract instead of client-side duplicating setup rules.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Direction confirmed: prefer a backend setup-options API over PR #1409's frontend-only selector logic so custom frontends and standalone API deployments can reuse server-authoritative setup rules. Created backend implementation plan Docs/superpowers/plans/2026-05-09-vn-play-setup-options-backend-implementation-plan.md.
+
+Implemented backend-first setup-options endpoint, bounded pack listing/provenance helpers, response schemas, composer, API docs, and focused backend coverage. Verification: pytest VN_Play+VN_Assets 24 passed; Bandit production scope exit 0; Bandit touched tests with B101 skipped exit 0; git diff --check exit 0.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added server-authoritative VN Play setup options so custom frontends can query selector-safe characters, selected-character preservation, bounded asset pack readiness, compatibility, trust provenance, warning summaries, defaults, pagination, and empty-state hints from the API. Pack setup listing now filters and paginates at the repository boundary before readiness fanout, import provenance is derived from latest completed journals, and lookup/readiness failures degrade safely. Documented the endpoint as the integration target for PR #1409 or a successor frontend slice.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-163 - Address-PR-1413-review-comments.md
+++ b/backlog/tasks/task-163 - Address-PR-1413-review-comments.md
@@ -1,0 +1,61 @@
+---
+id: TASK-163
+title: Address PR 1413 review comments
+status: Done
+assignee: []
+created_date: '2026-05-09 15:33'
+updated_date: '2026-05-09 15:38'
+labels:
+  - vn-play
+  - api
+  - review
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1413'
+  - 'https://github.com/rmusser01/tldw_server/issues/1407'
+documentation:
+  - Docs/superpowers/specs/2026-05-09-vn-play-setup-options-design.md
+  - >-
+    Docs/superpowers/plans/2026-05-09-vn-play-setup-options-backend-implementation-plan.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the actionable PR #1413 review threads on the backend-first VN Play setup-options API while preserving the API-owned setup contract for standalone/custom frontends.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Setup helper functions include concise docstrings for key behavior and constraints.
+- [x] #2 Character setup selectors use a lightweight query that avoids loading image BLOBs and unrelated large prompt fields.
+- [x] #3 Pack setup listing avoids per-pack slot scans for fields unused by setup-options.
+- [x] #4 Missing-required-assets warnings use structured readiness data instead of brittle substring heuristics.
+- [x] #5 Description preview truncation respects the configured maximum length.
+- [x] #6 Focused tests and Bandit verification are rerun and recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Addressed PR #1413 review threads: added setup helper docstrings; added lightweight character setup selector queries that compute has_image without image BLOB materialization; skipped planned_output_count slot scans for setup pack listing; replaced missing-required warning substring matching with structured readiness error-code detection; fixed preview truncation to keep the final string within max_length.
+
+Verification: pytest tldw_Server_API/tests/VN_Play/test_vn_play_api.py tldw_Server_API/tests/VN_Assets/test_vn_asset_packs_db.py -q passed with 28 tests; Bandit production touched scope wrote /tmp/bandit_vn_setup_options_review_prod.json with exit 0; Bandit touched test scope with B101 skipped wrote /tmp/bandit_vn_setup_options_review_tests.json with exit 0; git diff --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Resolved all five actionable PR #1413 review threads by moving setup character selection to lightweight DB queries, avoiding setup-time planned-count slot scans, making missing-required warnings structured, fixing preview truncation, and adding docstrings plus regression coverage.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/vn_play.py
+++ b/tldw_Server_API/app/api/v1/endpoints/vn_play.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import asdict
-from typing import Any
+from typing import Any, cast
 
-from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
 from tldw_Server_API.app.api.v1.schemas.vn_play_schemas import (
@@ -16,9 +16,11 @@ from tldw_Server_API.app.api.v1.schemas.vn_play_schemas import (
     VNPlayRestoreRequest,
     VNPlayRetryTurnRequest,
     VNPlaySceneStateResponse,
+    VNPlayMode,
     VNPlaySessionCreate,
     VNPlaySessionResponse,
     VNPlaySessionUpdate,
+    VNPlaySetupOptionsResponse,
     VNPlayTurnRequest,
     VNPlayTurnResponse,
 )
@@ -31,6 +33,11 @@ from tldw_Server_API.app.core.VN_Play.constants import (
     ERROR_TURN_IN_PROGRESS,
     TURN_STATUS_MODEL_FAILED,
     TURN_STATUS_PARSE_FAILED,
+)
+from tldw_Server_API.app.core.VN_Play.setup_options import (
+    DEFAULT_SETUP_LIMIT,
+    MAX_SETUP_LIMIT,
+    build_vn_play_setup_options,
 )
 from tldw_Server_API.app.core.VN_Play.service import (
     VNPlayConflictError,
@@ -54,15 +61,49 @@ def _service(
     db: CharactersRAGDB = Depends(get_chacha_db_for_user),
     current_user: User = Depends(get_request_user),
 ) -> VNPlayService:
+    owner_user_id = _owner_user_id(current_user)
+    return VNPlayService(
+        repo=VNPlayRepository.initialized(db),
+        owner_user_id=owner_user_id,
+    )
+
+
+def _owner_user_id(current_user: User) -> int:
     owner_user_id = current_user.id_int
     if owner_user_id is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="invalid_user_id",
         )
-    return VNPlayService(
-        repo=VNPlayRepository.initialized(db),
-        owner_user_id=owner_user_id,
+    return owner_user_id
+
+
+@router.get("/setup-options", response_model=VNPlaySetupOptionsResponse)
+def setup_options(
+    mode: str | None = Query(default=None, pattern="^(freeform|story)$"),
+    character_query: str | None = Query(default=None, max_length=200),
+    pack_query: str | None = Query(default=None, max_length=200),
+    character_limit: int = Query(default=DEFAULT_SETUP_LIMIT, ge=1, le=MAX_SETUP_LIMIT),
+    character_offset: int = Query(default=0, ge=0),
+    pack_limit: int = Query(default=DEFAULT_SETUP_LIMIT, ge=1, le=MAX_SETUP_LIMIT),
+    pack_offset: int = Query(default=0, ge=0),
+    selected_character_id: int | None = Query(default=None, ge=1),
+    content_rating: str | None = Query(default="general", min_length=1, max_length=100),
+    db: CharactersRAGDB = Depends(get_chacha_db_for_user),
+    current_user: User = Depends(get_request_user),
+) -> VNPlaySetupOptionsResponse:
+    return build_vn_play_setup_options(
+        db=db,
+        owner_user_id=_owner_user_id(current_user),
+        mode=cast(VNPlayMode | None, mode),
+        character_query=character_query,
+        pack_query=pack_query,
+        character_limit=character_limit,
+        character_offset=character_offset,
+        pack_limit=pack_limit,
+        pack_offset=pack_offset,
+        selected_character_id=selected_character_id,
+        content_rating=content_rating,
     )
 
 

--- a/tldw_Server_API/app/api/v1/schemas/vn_play_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/vn_play_schemas.py
@@ -16,6 +16,11 @@ VNPlayMode = Literal["freeform", "story"]
 VNPlaySessionStatus = Literal["active", "paused", "completed", "archived", "failed"]
 VNPlayTrustLevel = Literal["local", "trusted_restore", "untrusted_import", "mixed"]
 VNPlayLinkedChatMode = Literal["read_only_context"]
+VNPlaySetupTrustLevel = Literal["local", "trusted_restore", "untrusted_import", "unknown"]
+VNPlaySetupTrustSource = Literal["local_pack", "latest_import_journal", "unknown"]
+VNPlaySetupWarningSeverity = Literal["info", "warning", "high_risk"]
+VNPlaySetupCompatibilityStatus = Literal["compatible", "different_character", "unknown"]
+VNPlaySetupEmptyStateScope = Literal["global", "filter", "page"]
 VNPlayTurnStatus = Literal[
     "pending",
     "model_calling",
@@ -152,6 +157,106 @@ class VNPlaySessionResponse(BaseModel):
     deleted: bool = False
 
 
+class VNPlaySetupCharacterOption(BaseModel):
+    """Selector-safe character metadata for VN Play setup."""
+
+    id: StrictInt
+    name: StrictStr
+    description_preview: str | None = None
+    tags: list[str] = Field(default_factory=list)
+    favorite: StrictBool = False
+    deleted: StrictBool = False
+    has_image: StrictBool = False
+
+
+class VNPlaySetupCompatibility(BaseModel):
+    """Compatibility summary between a setup character and asset pack."""
+
+    status: VNPlaySetupCompatibilityStatus
+    reason_codes: list[str] = Field(default_factory=list)
+
+
+class VNPlaySetupWarning(BaseModel):
+    """Stable setup warning for frontend acknowledgement flows."""
+
+    code: StrictStr
+    severity: VNPlaySetupWarningSeverity
+    message: StrictStr
+    requires_acknowledgement: StrictBool = False
+
+
+class VNPlaySetupWarningSummary(BaseModel):
+    """Aggregate warning metadata for one setup option."""
+
+    highest_severity: VNPlaySetupWarningSeverity = "info"
+    requires_acknowledgement: StrictBool = False
+    warnings: list[VNPlaySetupWarning] = Field(default_factory=list)
+
+
+class VNPlaySetupAssetPackOption(BaseModel):
+    """Asset pack setup option with backend-computed readiness and warnings."""
+
+    id: StrictInt
+    title: StrictStr
+    primary_character_id: StrictInt
+    content_rating: StrictStr
+    status: StrictStr
+    trust_level: VNPlaySetupTrustLevel
+    trust_source: VNPlaySetupTrustSource
+    ready: StrictBool
+    readiness_status: StrictStr
+    readiness_warnings: list[str] = Field(default_factory=list)
+    readiness_errors: list[str] = Field(default_factory=list)
+    compatibility: VNPlaySetupCompatibility
+    warning_summary: VNPlaySetupWarningSummary
+    recommended: StrictBool = False
+
+
+class VNPlaySetupDefaults(BaseModel):
+    """Optional unambiguous defaults for creating a VN Play session."""
+
+    mode: VNPlayMode | None = None
+    character_id: int | None = None
+    asset_pack_id: int | None = None
+    content_rating: str | None = None
+
+
+class VNPlaySetupPagination(BaseModel):
+    """Pagination metadata for setup option selectors."""
+
+    limit: StrictInt = Field(..., ge=1)
+    offset: StrictInt = Field(..., ge=0)
+    has_more: StrictBool
+    total: int | None = Field(default=None, ge=0)
+
+
+class VNPlaySetupEmptyState(BaseModel):
+    """Scoped empty state hint for setup clients."""
+
+    code: StrictStr
+    scope: VNPlaySetupEmptyStateScope
+    message: StrictStr
+
+
+class VNPlaySetupPaginationSet(BaseModel):
+    """Pagination metadata for both setup selectors."""
+
+    characters: VNPlaySetupPagination
+    asset_packs: VNPlaySetupPagination
+
+
+class VNPlaySetupOptionsResponse(BaseModel):
+    """Aggregated VN Play setup options for API and custom frontend clients."""
+
+    characters: list[VNPlaySetupCharacterOption] = Field(default_factory=list)
+    selected_character: VNPlaySetupCharacterOption | None = None
+    asset_packs: list[VNPlaySetupAssetPackOption] = Field(default_factory=list)
+    defaults: VNPlaySetupDefaults = Field(default_factory=VNPlaySetupDefaults)
+    pagination: VNPlaySetupPaginationSet
+    empty_states: list[VNPlaySetupEmptyState] = Field(default_factory=list)
+    generated_at: StrictStr
+
+
 class VNPlayTurnRequest(BaseModel):
     """Request body for advancing a VN Play session by one turn."""
 
@@ -265,6 +370,20 @@ __all__ = [
     "VNPlaySessionCreate",
     "VNPlaySessionResponse",
     "VNPlaySessionUpdate",
+    "VNPlaySetupAssetPackOption",
+    "VNPlaySetupCharacterOption",
+    "VNPlaySetupCompatibility",
+    "VNPlaySetupDefaults",
+    "VNPlaySetupEmptyState",
+    "VNPlaySetupEmptyStateScope",
+    "VNPlaySetupOptionsResponse",
+    "VNPlaySetupPagination",
+    "VNPlaySetupPaginationSet",
+    "VNPlaySetupTrustLevel",
+    "VNPlaySetupTrustSource",
+    "VNPlaySetupWarning",
+    "VNPlaySetupWarningSeverity",
+    "VNPlaySetupWarningSummary",
     "VNPlayTurnRequest",
     "VNPlayTurnResponse",
     "VNPlayEventType",

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -23604,6 +23604,8 @@ for _character_store_method in (
     "get_character_card_by_name",
     "list_character_cards",
     "query_character_cards",
+    "query_character_setup_options",
+    "get_character_setup_option_by_id",
     "_normalize_character_tags_for_operation",
     "_apply_character_tag_operation_to_list",
     "manage_character_tags",

--- a/tldw_Server_API/app/core/DB_Management/VNAssetPacks_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/VNAssetPacks_DB.py
@@ -222,6 +222,8 @@ CREATE INDEX IF NOT EXISTS idx_vn_pack_import_journal_job_id
     ON vn_pack_import_journal(job_id);
 CREATE INDEX IF NOT EXISTS idx_vn_pack_import_journal_status
     ON vn_pack_import_journal(status);
+CREATE INDEX IF NOT EXISTS idx_vn_pack_import_journal_target_pack_id
+    ON vn_pack_import_journal(target_pack_id);
 CREATE INDEX IF NOT EXISTS idx_vn_pack_import_journal_fingerprint
     ON vn_pack_import_journal(canonical_payload_fingerprint);
 """
@@ -766,6 +768,82 @@ class VNAssetPacksRepository:
             )
         return [dict(row) for row in cursor.fetchall()]
 
+    def list_packs_for_setup(
+        self,
+        *,
+        owner_user_id: int,
+        query: str | None = None,
+        limit: int = 25,
+        offset: int = 0,
+    ) -> tuple[list[dict[str, Any]], bool]:
+        """Return one bounded setup page before readiness fanout."""
+        self._ensure_schema_initialized()
+        normalized_limit = max(1, int(limit))
+        normalized_offset = max(0, int(offset))
+
+        filters = ["deleted = 0", "owner_user_id = ?"]
+        params: list[Any] = [owner_user_id]
+        normalized_query = (query or "").strip().lower()
+        if normalized_query:
+            like_value = f"%{normalized_query}%"
+            filters.append(
+                "("
+                "LOWER(COALESCE(title, '')) LIKE ? OR "
+                "LOWER(COALESCE(description, '')) LIKE ?"
+                ")"
+            )
+            params.extend([like_value, like_value])
+
+        params.extend([normalized_limit + 1, normalized_offset])
+        where_clause = " AND ".join(filters)
+        cursor = self.db.execute_query(
+            f"""
+            SELECT * FROM vn_asset_packs
+            WHERE {where_clause}
+            ORDER BY id ASC
+            LIMIT ? OFFSET ?
+            """,  # nosec B608
+            tuple(params),
+        )
+        rows = [dict(row) for row in cursor.fetchall()]
+        return rows[:normalized_limit], len(rows) > normalized_limit
+
+    def latest_completed_import_provenance_by_pack_ids(
+        self,
+        *,
+        owner_user_id: int,
+        pack_ids: list[int],
+    ) -> dict[int, dict[str, Any]]:
+        """Return latest completed import journal rows for the requested packs."""
+        self._ensure_schema_initialized()
+        normalized_pack_ids = sorted({int(pack_id) for pack_id in pack_ids})
+        if not normalized_pack_ids:
+            return {}
+
+        placeholders = ",".join("?" for _ in normalized_pack_ids)
+        cursor = self.db.execute_query(
+            f"""
+            SELECT * FROM vn_pack_import_journal
+            WHERE owner_user_id = ?
+              AND status = 'completed'
+              AND target_pack_id IN ({placeholders})
+            ORDER BY
+              target_pack_id ASC,
+              COALESCE(completed_at, updated_at, created_at) DESC,
+              id DESC
+            """,  # nosec B608
+            (owner_user_id, *normalized_pack_ids),
+        )
+        provenance: dict[int, dict[str, Any]] = {}
+        for row in cursor.fetchall():
+            journal = dict(row)
+            target_pack_id = journal.get("target_pack_id")
+            if target_pack_id is None:
+                continue
+            pack_id = int(target_pack_id)
+            provenance.setdefault(pack_id, journal)
+        return provenance
+
     def update_pack(self, pack_id: int, fields: Mapping[str, Any]) -> dict[str, Any] | None:
         self._ensure_schema_initialized()
         json_fields = {
@@ -892,19 +970,29 @@ class VNAssetPacksRepository:
                 slot_ids_by_key[str(spec["slot_key"])] = slot_id
                 created_slot_ids.append(slot_id)
 
-            for spec in pending_dependent_specs:
-                parent_slot_key = str(spec["depends_on_slot_key"])
-                depends_on_slot_id = slot_ids_by_key.get(parent_slot_key)
-                if depends_on_slot_id is None:
+            while pending_dependent_specs:
+                unresolved_specs: list[Mapping[str, Any]] = []
+                resolved_count = 0
+                for spec in pending_dependent_specs:
+                    parent_slot_key = str(spec["depends_on_slot_key"])
+                    depends_on_slot_id = slot_ids_by_key.get(parent_slot_key)
+                    if depends_on_slot_id is None:
+                        unresolved_specs.append(spec)
+                        continue
+                    slot_kwargs = _slot_insert_kwargs(spec)
+                    slot_kwargs["depends_on_slot_id"] = depends_on_slot_id
+                    slot_id = self._insert_slot_row(
+                        conn,
+                        pack_id=pack_id,
+                        **slot_kwargs,
+                    )
+                    slot_ids_by_key[str(spec["slot_key"])] = slot_id
+                    created_slot_ids.append(slot_id)
+                    resolved_count += 1
+
+                if resolved_count == 0:
                     raise ValueError("dependent_slot_not_found")
-                slot_kwargs = _slot_insert_kwargs(spec)
-                slot_kwargs["depends_on_slot_id"] = depends_on_slot_id
-                slot_id = self._insert_slot_row(
-                    conn,
-                    pack_id=pack_id,
-                    **slot_kwargs,
-                )
-                created_slot_ids.append(slot_id)
+                pending_dependent_specs = unresolved_specs
 
         return [
             slot

--- a/tldw_Server_API/app/core/DB_Management/chacha/character_store.py
+++ b/tldw_Server_API/app/core/DB_Management/chacha/character_store.py
@@ -508,6 +508,111 @@ class CharacterStore:
             logger.error(f"Database error querying character cards: {e}")
             raise
 
+    def query_character_setup_options(
+        self,
+        *,
+        query: str | None = None,
+        include_deleted: bool = False,
+        limit: int = 25,
+        offset: int = 0,
+    ) -> tuple[list[dict[str, Any]], int]:
+        """
+        Query lightweight character selector rows for setup screens.
+
+        The returned rows intentionally omit image BLOBs and large prompt fields.
+        ``has_image`` is computed in SQL so callers can render image affordances
+        without materializing the stored image bytes.
+        """
+        normalized_limit = max(1, int(limit))
+        normalized_offset = max(0, int(offset))
+        normalized_query = (query or "").strip().lower()
+        params: list[Any] = []
+        filters: list[str] = []
+        deleted_false = "FALSE" if self._db.backend_type == BackendType.POSTGRESQL else "0"
+
+        if normalized_query:
+            like_value = f"%{normalized_query}%"
+            filters.append(
+                "("
+                "LOWER(COALESCE(cc.name, '')) LIKE ? OR "
+                "LOWER(COALESCE(cc.description, '')) LIKE ? OR "
+                "LOWER(COALESCE(cc.personality, '')) LIKE ? OR "
+                "LOWER(COALESCE(cc.scenario, '')) LIKE ? OR "
+                "LOWER(COALESCE(cc.system_prompt, '')) LIKE ?"
+                ")"
+            )
+            params.extend([like_value, like_value, like_value, like_value, like_value])
+
+        deleted_filter = "1=1" if include_deleted else f"cc.deleted = {deleted_false}"
+        base_query = f"FROM character_cards cc WHERE {deleted_filter}"  # nosec B608
+        if filters:
+            base_query += " AND " + " AND ".join(filters)
+
+        total_query = f"SELECT COUNT(1) AS total {base_query}"  # nosec B608
+        data_query = (
+            "SELECT "
+            "cc.id, cc.name, cc.description, cc.tags, cc.extensions, cc.deleted, "
+            "CASE WHEN cc.image IS NOT NULL THEN 1 ELSE 0 END AS has_image "
+            f"{base_query} "
+            "ORDER BY LOWER(COALESCE(cc.name, '')) ASC, cc.id ASC "
+            "LIMIT ? OFFSET ?"
+        )
+
+        try:
+            total_cursor = self._db.execute_query(total_query, tuple(params))
+            total_row = total_cursor.fetchone()
+            if total_row is None:
+                total = 0
+            elif isinstance(total_row, dict):
+                total = int(total_row.get("total", 0))
+            else:
+                try:
+                    total = int(total_row["total"])  # sqlite Row / adapter row
+                except _CHACHA_NONCRITICAL_EXCEPTIONS:
+                    total = int(total_row[0]) if len(total_row) > 0 else 0
+
+            data_params = [*params, normalized_limit, normalized_offset]
+            data_cursor = self._db.execute_query(data_query, tuple(data_params))
+            rows = data_cursor.fetchall()
+            return [
+                self._db._deserialize_row_fields(row, self._db._CHARACTER_CARD_JSON_FIELDS)
+                for row in rows
+                if row
+            ], total
+        except CharactersRAGDBError as e:
+            logger.error(f"Database error querying character setup options: {e}")
+            raise
+
+    def get_character_setup_option_by_id(
+        self,
+        character_id: int,
+        *,
+        include_deleted: bool = False,
+    ) -> dict[str, Any] | None:
+        """
+        Retrieve one lightweight character selector row by ID.
+
+        This mirrors ``get_character_card_by_id`` ownership/deleted semantics
+        while omitting image bytes and prompt-heavy columns for setup-option
+        callers that only need selector-safe metadata.
+        """
+        query = (
+            "SELECT "
+            "id, name, description, tags, extensions, deleted, "
+            "CASE WHEN image IS NOT NULL THEN 1 ELSE 0 END AS has_image "
+            "FROM character_cards WHERE id = ?"
+        )
+        params: tuple[Any, ...] = (character_id,)
+        if not include_deleted:
+            query += f" AND deleted = {self._deleted_literal(False)}"
+        try:
+            cursor = self._db.execute_query(query, params)
+            row = cursor.fetchone()
+            return self._db._deserialize_row_fields(row, self._db._CHARACTER_CARD_JSON_FIELDS)
+        except CharactersRAGDBError as e:
+            logger.error(f"Database error fetching character setup option ID {character_id}: {e}")
+            raise
+
     # ------------------------------------------------------------------
     # Tag normalisation helpers
     # ------------------------------------------------------------------

--- a/tldw_Server_API/app/core/VN_Assets/service.py
+++ b/tldw_Server_API/app/core/VN_Assets/service.py
@@ -132,6 +132,21 @@ class VNAssetPackService:
             for pack in self.repo.list_packs(owner_user_id=self.owner_user_id)
         ]
 
+    def list_packs_for_setup(
+        self,
+        *,
+        query: str | None = None,
+        limit: int = 25,
+        offset: int = 0,
+    ) -> tuple[list[VNAssetPackResponse], bool]:
+        rows, has_more = self.repo.list_packs_for_setup(
+            owner_user_id=self.owner_user_id,
+            query=query,
+            limit=limit,
+            offset=offset,
+        )
+        return [self._pack_response(pack) for pack in rows], has_more
+
     def get_pack(self, pack_id: int) -> VNAssetPackResponse:
         return self._pack_response(self._require_pack(pack_id))
 

--- a/tldw_Server_API/app/core/VN_Assets/service.py
+++ b/tldw_Server_API/app/core/VN_Assets/service.py
@@ -145,7 +145,10 @@ class VNAssetPackService:
             limit=limit,
             offset=offset,
         )
-        return [self._pack_response(pack) for pack in rows], has_more
+        return [
+            self._pack_response(pack, include_planned_output_count=False)
+            for pack in rows
+        ], has_more
 
     def get_pack(self, pack_id: int) -> VNAssetPackResponse:
         return self._pack_response(self._require_pack(pack_id))
@@ -829,7 +832,12 @@ class VNAssetPackService:
             current_slot = self._require_slot_in_pack(pack_id, current_id)
             current_id = current_slot["depends_on_slot_id"]
 
-    def _pack_response(self, row: Mapping[str, Any]) -> VNAssetPackResponse:
+    def _pack_response(
+        self,
+        row: Mapping[str, Any],
+        *,
+        include_planned_output_count: bool = True,
+    ) -> VNAssetPackResponse:
         pack_id = int(row["id"])
         return VNAssetPackResponse(
             id=pack_id,
@@ -848,7 +856,11 @@ class VNAssetPackService:
             default_dimensions=_loads_optional_json(row["default_dimensions_json"]),
             style_lock=_loads_optional_json(row["style_lock_json"]),
             generation_budget=_loads_optional_json(row["generation_budget_json"]),
-            planned_output_count=self._planned_output_count(pack_id),
+            planned_output_count=(
+                self._planned_output_count(pack_id)
+                if include_planned_output_count
+                else 0
+            ),
             created_at=row["created_at"],
             updated_at=row["updated_at"],
             version=int(row["version"]),

--- a/tldw_Server_API/app/core/VN_Play/setup_options.py
+++ b/tldw_Server_API/app/core/VN_Play/setup_options.py
@@ -1,0 +1,538 @@
+"""Backend aggregation for VN Play session setup options."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+from loguru import logger
+
+from tldw_Server_API.app.api.v1.schemas.vn_asset_schemas import (
+    VNAssetPackResponse,
+    VNAssetReadinessResponse,
+)
+from tldw_Server_API.app.api.v1.schemas.vn_play_schemas import (
+    VNPlayMode,
+    VNPlaySetupAssetPackOption,
+    VNPlaySetupCharacterOption,
+    VNPlaySetupCompatibility,
+    VNPlaySetupDefaults,
+    VNPlaySetupEmptyState,
+    VNPlaySetupOptionsResponse,
+    VNPlaySetupPagination,
+    VNPlaySetupPaginationSet,
+    VNPlaySetupTrustLevel,
+    VNPlaySetupTrustSource,
+    VNPlaySetupWarning,
+    VNPlaySetupWarningSeverity,
+    VNPlaySetupWarningSummary,
+)
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+from tldw_Server_API.app.core.VN_Assets.service import VNAssetPackService
+
+DEFAULT_SETUP_LIMIT = 25
+MAX_SETUP_LIMIT = 100
+CONTENT_RATING_ORDER = {
+    "general": 0,
+    "suggestive": 1,
+    "mature": 2,
+    "violent": 3,
+}
+SEVERITY_ORDER: dict[VNPlaySetupWarningSeverity, int] = {
+    "info": 0,
+    "warning": 1,
+    "high_risk": 2,
+}
+WARNING_MESSAGES = {
+    "pack_character_mismatch": "This pack was generated for a different primary character.",
+    "pack_not_ready": "This pack is not runtime-ready yet.",
+    "pack_has_readiness_errors": "This pack has readiness errors.",
+    "pack_missing_required_assets": "This pack is missing required runtime assets.",
+    "content_rating_mismatch": "This pack content rating differs from the requested session rating.",
+    "pack_untrusted_import": "This pack was last committed from an untrusted import.",
+    "pack_deleted_or_archived": "This pack is hidden from normal use.",
+    "readiness_unavailable": "Readiness could not be computed for this pack.",
+}
+
+
+def build_vn_play_setup_options(
+    *,
+    db: CharactersRAGDB,
+    owner_user_id: int,
+    mode: VNPlayMode | None = None,
+    character_query: str | None = None,
+    pack_query: str | None = None,
+    character_limit: int = DEFAULT_SETUP_LIMIT,
+    character_offset: int = 0,
+    pack_limit: int = DEFAULT_SETUP_LIMIT,
+    pack_offset: int = 0,
+    selected_character_id: int | None = None,
+    content_rating: str | None = "general",
+) -> VNPlaySetupOptionsResponse:
+    """Return setup selectors with server-computed pack readiness and warnings."""
+    character_limit = _bounded_limit(character_limit)
+    pack_limit = _bounded_limit(pack_limit)
+    character_offset = max(0, int(character_offset))
+    pack_offset = max(0, int(pack_offset))
+    requested_rating = _normalized_rating(content_rating or "general")
+
+    character_rows, character_total = db.query_character_cards(
+        query=character_query,
+        include_deleted=False,
+        sort_by="name",
+        sort_order="asc",
+        limit=character_limit,
+        offset=character_offset,
+    )
+    characters = [_character_option(row) for row in character_rows]
+
+    selected_character = _selected_character_option(db, selected_character_id)
+    asset_service = VNAssetPackService(db, owner_user_id=owner_user_id)
+    pack_rows, pack_has_more = asset_service.list_packs_for_setup(
+        query=pack_query,
+        limit=pack_limit,
+        offset=pack_offset,
+    )
+    provenance_by_pack_id, provenance_lookup_failed = _latest_import_provenance(
+        asset_service,
+        pack_rows,
+    )
+
+    asset_packs = [
+        _asset_pack_option(
+            asset_service=asset_service,
+            pack=pack,
+            selected_character=selected_character,
+            requested_rating=requested_rating,
+            provenance=provenance_by_pack_id.get(pack.id),
+            provenance_lookup_failed=provenance_lookup_failed,
+        )
+        for pack in pack_rows
+    ]
+    asset_packs = _sort_pack_options(asset_packs)
+
+    return VNPlaySetupOptionsResponse(
+        characters=characters,
+        selected_character=selected_character,
+        asset_packs=asset_packs,
+        defaults=_setup_defaults(
+            mode=mode,
+            content_rating=requested_rating,
+            selected_character=selected_character,
+            characters=characters,
+            asset_packs=asset_packs,
+        ),
+        pagination=VNPlaySetupPaginationSet(
+            characters=VNPlaySetupPagination(
+                limit=character_limit,
+                offset=character_offset,
+                has_more=(character_offset + len(characters)) < character_total,
+                total=character_total,
+            ),
+            asset_packs=VNPlaySetupPagination(
+                limit=pack_limit,
+                offset=pack_offset,
+                has_more=pack_has_more,
+                total=None,
+            ),
+        ),
+        empty_states=_empty_states(
+            characters=characters,
+            character_total=character_total,
+            character_query=character_query,
+            character_offset=character_offset,
+            asset_packs=asset_packs,
+            pack_query=pack_query,
+            pack_offset=pack_offset,
+            selected_character_id=selected_character_id,
+            selected_character=selected_character,
+        ),
+        generated_at=_utc_now_iso(),
+    )
+
+
+def _bounded_limit(value: int) -> int:
+    return max(1, min(MAX_SETUP_LIMIT, int(value)))
+
+
+def _selected_character_option(
+    db: CharactersRAGDB,
+    selected_character_id: int | None,
+) -> VNPlaySetupCharacterOption | None:
+    if selected_character_id is None:
+        return None
+    row = db.get_character_card_by_id(int(selected_character_id))
+    if row is None:
+        return None
+    return _character_option(row)
+
+
+def _character_option(row: dict[str, Any]) -> VNPlaySetupCharacterOption:
+    return VNPlaySetupCharacterOption(
+        id=int(row["id"]),
+        name=str(row.get("name") or f"Character {row['id']}"),
+        description_preview=_preview_text(row.get("description")),
+        tags=_string_list(row.get("tags")),
+        favorite=_character_favorite(row.get("extensions")),
+        deleted=bool(row.get("deleted", False)),
+        has_image=bool(row.get("image") or row.get("image_base64")),
+    )
+
+
+def _asset_pack_option(
+    *,
+    asset_service: VNAssetPackService,
+    pack: VNAssetPackResponse,
+    selected_character: VNPlaySetupCharacterOption | None,
+    requested_rating: str,
+    provenance: dict[str, Any] | None,
+    provenance_lookup_failed: bool,
+) -> VNPlaySetupAssetPackOption:
+    readiness = _readiness_for_pack(asset_service, pack.id)
+    warnings: list[VNPlaySetupWarning] = []
+    if readiness is None:
+        ready = False
+        readiness_status = "unknown"
+        readiness_warnings: list[str] = []
+        readiness_errors: list[str] = []
+        warnings.append(_warning("readiness_unavailable", "warning"))
+    else:
+        ready = bool(readiness.ready)
+        readiness_status = str(readiness.status)
+        readiness_warnings = [str(item) for item in readiness.warnings]
+        readiness_errors = [str(item) for item in readiness.errors]
+        if not ready:
+            warnings.append(_warning("pack_not_ready", "high_risk"))
+        if readiness_errors:
+            warnings.append(_warning("pack_has_readiness_errors", "high_risk"))
+        if _missing_required_assets(readiness_status, readiness_warnings, readiness_errors):
+            warnings.append(_warning("pack_missing_required_assets", "high_risk"))
+
+    compatibility = _compatibility(pack, selected_character)
+    if compatibility.status == "different_character":
+        warnings.append(_warning("pack_character_mismatch", "high_risk"))
+
+    rating_warning = _content_rating_warning(pack.content_rating, requested_rating)
+    if rating_warning is not None:
+        warnings.append(rating_warning)
+
+    trust_level, trust_source = _trust_for_provenance(
+        provenance,
+        lookup_failed=provenance_lookup_failed,
+    )
+    if trust_level == "untrusted_import":
+        warnings.append(_warning("pack_untrusted_import", "warning"))
+
+    if pack.deleted or str(pack.status).lower() in {"archived", "deleted", "hidden"}:
+        warnings.append(_warning("pack_deleted_or_archived", "high_risk"))
+
+    warning_summary = _warning_summary(warnings)
+    recommended = (
+        ready
+        and compatibility.status in {"compatible", "unknown"}
+        and not warning_summary.requires_acknowledgement
+    )
+    return VNPlaySetupAssetPackOption(
+        id=pack.id,
+        title=pack.title,
+        primary_character_id=pack.primary_character_id,
+        content_rating=pack.content_rating,
+        status=pack.status,
+        trust_level=trust_level,
+        trust_source=trust_source,
+        ready=ready,
+        readiness_status=readiness_status,
+        readiness_warnings=readiness_warnings,
+        readiness_errors=readiness_errors,
+        compatibility=compatibility,
+        warning_summary=warning_summary,
+        recommended=recommended,
+    )
+
+
+def _latest_import_provenance(
+    asset_service: VNAssetPackService,
+    packs: list[VNAssetPackResponse],
+) -> tuple[dict[int, dict[str, Any]], bool]:
+    pack_ids = [pack.id for pack in packs]
+    if not pack_ids:
+        return {}, False
+    try:
+        return (
+            asset_service.repo.latest_completed_import_provenance_by_pack_ids(
+                owner_user_id=asset_service.owner_user_id,
+                pack_ids=pack_ids,
+            ),
+            False,
+        )
+    except Exception as exc:
+        logger.warning("Failed to derive VN setup import provenance: {}", exc)
+        return {}, True
+
+
+def _readiness_for_pack(
+    asset_service: VNAssetPackService,
+    pack_id: int,
+) -> VNAssetReadinessResponse | None:
+    try:
+        return asset_service.get_readiness(pack_id)
+    except Exception as exc:
+        logger.warning("Failed to compute VN setup readiness for pack {}: {}", pack_id, exc)
+        return None
+
+
+def _compatibility(
+    pack: VNAssetPackResponse,
+    selected_character: VNPlaySetupCharacterOption | None,
+) -> VNPlaySetupCompatibility:
+    if selected_character is None:
+        return VNPlaySetupCompatibility(status="unknown", reason_codes=["no_selected_character"])
+    if pack.primary_character_id == selected_character.id:
+        return VNPlaySetupCompatibility(status="compatible", reason_codes=[])
+    return VNPlaySetupCompatibility(
+        status="different_character",
+        reason_codes=["pack_character_mismatch"],
+    )
+
+
+def _content_rating_warning(
+    pack_rating: str | None,
+    requested_rating: str | None,
+) -> VNPlaySetupWarning | None:
+    normalized_pack = _normalized_rating(pack_rating)
+    normalized_requested = _normalized_rating(requested_rating)
+    if normalized_pack == normalized_requested:
+        return None
+
+    pack_rank = CONTENT_RATING_ORDER.get(normalized_pack)
+    requested_rank = CONTENT_RATING_ORDER.get(normalized_requested)
+    severity: VNPlaySetupWarningSeverity
+    if pack_rank is None or requested_rank is None or pack_rank > requested_rank:
+        severity = "high_risk"
+    else:
+        severity = "warning"
+    return _warning("content_rating_mismatch", severity)
+
+
+def _trust_for_provenance(
+    provenance: dict[str, Any] | None,
+    *,
+    lookup_failed: bool,
+) -> tuple[VNPlaySetupTrustLevel, VNPlaySetupTrustSource]:
+    if lookup_failed:
+        return "unknown", "unknown"
+    if provenance is None:
+        return "local", "local_pack"
+    trust_mode = str(provenance.get("trust_mode") or "").strip()
+    if trust_mode in {"trusted_restore", "untrusted_import"}:
+        return trust_mode, "latest_import_journal"
+    return "unknown", "unknown"
+
+
+def _warning(
+    code: str,
+    severity: VNPlaySetupWarningSeverity,
+) -> VNPlaySetupWarning:
+    return VNPlaySetupWarning(
+        code=code,
+        severity=severity,
+        message=WARNING_MESSAGES.get(code, code),
+        requires_acknowledgement=severity == "high_risk",
+    )
+
+
+def _warning_summary(
+    warnings: list[VNPlaySetupWarning],
+) -> VNPlaySetupWarningSummary:
+    if not warnings:
+        return VNPlaySetupWarningSummary()
+    highest = max(warnings, key=lambda warning: SEVERITY_ORDER[warning.severity]).severity
+    return VNPlaySetupWarningSummary(
+        highest_severity=highest,
+        requires_acknowledgement=any(warning.requires_acknowledgement for warning in warnings),
+        warnings=warnings,
+    )
+
+
+def _setup_defaults(
+    *,
+    mode: VNPlayMode | None,
+    content_rating: str,
+    selected_character: VNPlaySetupCharacterOption | None,
+    characters: list[VNPlaySetupCharacterOption],
+    asset_packs: list[VNPlaySetupAssetPackOption],
+) -> VNPlaySetupDefaults:
+    default_character_id = selected_character.id if selected_character is not None else None
+    if default_character_id is None and len(characters) == 1:
+        default_character_id = characters[0].id
+
+    recommended_pack_ids = [pack.id for pack in asset_packs if pack.recommended]
+    default_pack_id = recommended_pack_ids[0] if len(recommended_pack_ids) == 1 else None
+    return VNPlaySetupDefaults(
+        mode=mode,
+        character_id=default_character_id,
+        asset_pack_id=default_pack_id,
+        content_rating=content_rating,
+    )
+
+
+def _empty_states(
+    *,
+    characters: list[VNPlaySetupCharacterOption],
+    character_total: int,
+    character_query: str | None,
+    character_offset: int,
+    asset_packs: list[VNPlaySetupAssetPackOption],
+    pack_query: str | None,
+    pack_offset: int,
+    selected_character_id: int | None,
+    selected_character: VNPlaySetupCharacterOption | None,
+) -> list[VNPlaySetupEmptyState]:
+    states: list[VNPlaySetupEmptyState] = []
+    if character_total == 0:
+        states.append(
+            VNPlaySetupEmptyState(
+                code="no_characters",
+                scope="filter" if _has_query(character_query) else "global",
+                message="No available characters were found.",
+            )
+        )
+    elif not characters and character_offset > 0:
+        states.append(
+            VNPlaySetupEmptyState(
+                code="no_characters",
+                scope="page",
+                message="No characters were found on this page.",
+            )
+        )
+
+    if selected_character_id is not None and selected_character is None:
+        states.append(
+            VNPlaySetupEmptyState(
+                code="selected_character_not_found",
+                scope="global",
+                message="The selected character is not available.",
+            )
+        )
+
+    if not asset_packs:
+        if pack_offset > 0:
+            scope = "page"
+        elif _has_query(pack_query):
+            scope = "filter"
+        else:
+            scope = "global"
+        states.append(
+            VNPlaySetupEmptyState(
+                code="no_asset_packs",
+                scope=scope,
+                message="No VN asset packs were found.",
+            )
+        )
+        return states
+
+    if not any(pack.ready for pack in asset_packs):
+        states.append(
+            VNPlaySetupEmptyState(
+                code="no_ready_packs",
+                scope="page",
+                message="No ready packs were found in this page of results.",
+            )
+        )
+    if selected_character is not None and not any(
+        pack.compatibility.status == "compatible" for pack in asset_packs
+    ):
+        states.append(
+            VNPlaySetupEmptyState(
+                code="no_compatible_packs",
+                scope="page",
+                message="No compatible packs were found in this page of results.",
+            )
+        )
+    return states
+
+
+def _sort_pack_options(
+    packs: list[VNPlaySetupAssetPackOption],
+) -> list[VNPlaySetupAssetPackOption]:
+    def sort_key(indexed_pack: tuple[int, VNPlaySetupAssetPackOption]) -> tuple[int, int]:
+        index, pack = indexed_pack
+        if pack.recommended:
+            group = 0
+        elif pack.compatibility.status == "compatible":
+            group = 1
+        elif pack.compatibility.status == "unknown":
+            group = 2
+        else:
+            group = 3
+        return group, index
+
+    return [pack for _, pack in sorted(enumerate(packs), key=sort_key)]
+
+
+def _missing_required_assets(
+    readiness_status: str,
+    readiness_warnings: list[str],
+    readiness_errors: list[str],
+) -> bool:
+    haystack = " ".join([readiness_status, *readiness_warnings, *readiness_errors]).lower()
+    return "missing" in haystack and "required" in haystack
+
+
+def _normalized_rating(value: str | None) -> str:
+    normalized = (value or "general").strip().lower()
+    return normalized or "general"
+
+
+def _preview_text(value: Any, *, max_length: int = 160) -> str | None:
+    if value is None:
+        return None
+    text = " ".join(str(value).split())
+    if not text:
+        return None
+    if len(text) <= max_length:
+        return text
+    return text[: max_length - 1].rstrip() + "..."
+
+
+def _string_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    raw_values: list[Any]
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+            raw_values = parsed if isinstance(parsed, list) else [value]
+        except (TypeError, ValueError, json.JSONDecodeError):
+            raw_values = [value]
+    elif isinstance(value, (list, tuple, set)):
+        raw_values = list(value)
+    else:
+        raw_values = [value]
+    return [tag for item in raw_values if (tag := str(item).strip())]
+
+
+def _character_favorite(extensions: Any) -> bool:
+    if extensions is None:
+        return False
+    parsed = extensions
+    if isinstance(extensions, str):
+        try:
+            parsed = json.loads(extensions)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return False
+    if not isinstance(parsed, dict):
+        return False
+    nested = parsed.get("tldw")
+    if isinstance(nested, dict) and nested.get("favorite") is not None:
+        return bool(nested.get("favorite"))
+    return bool(parsed.get("favorite", False))
+
+
+def _has_query(value: str | None) -> bool:
+    return bool((value or "").strip())
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")

--- a/tldw_Server_API/app/core/VN_Play/setup_options.py
+++ b/tldw_Server_API/app/core/VN_Play/setup_options.py
@@ -39,6 +39,13 @@ CONTENT_RATING_ORDER = {
     "mature": 2,
     "violent": 3,
 }
+REQUIRED_ASSET_READINESS_ERROR_CODES = {
+    "missing_required_asset",
+    "missing_required_assets",
+    "missing_required_runtime_asset",
+    "missing_required_slot",
+    "required_slot_not_ready",
+}
 SEVERITY_ORDER: dict[VNPlaySetupWarningSeverity, int] = {
     "info": 0,
     "warning": 1,
@@ -77,11 +84,9 @@ def build_vn_play_setup_options(
     pack_offset = max(0, int(pack_offset))
     requested_rating = _normalized_rating(content_rating or "general")
 
-    character_rows, character_total = db.query_character_cards(
+    character_rows, character_total = db.query_character_setup_options(
         query=character_query,
         include_deleted=False,
-        sort_by="name",
-        sort_order="asc",
         limit=character_limit,
         offset=character_offset,
     )
@@ -153,6 +158,7 @@ def build_vn_play_setup_options(
 
 
 def _bounded_limit(value: int) -> int:
+    """Clamp client-provided setup page sizes to the supported API bounds."""
     return max(1, min(MAX_SETUP_LIMIT, int(value)))
 
 
@@ -160,15 +166,22 @@ def _selected_character_option(
     db: CharactersRAGDB,
     selected_character_id: int | None,
 ) -> VNPlaySetupCharacterOption | None:
+    """Return the selected character selector row even when it is off-page."""
     if selected_character_id is None:
         return None
-    row = db.get_character_card_by_id(int(selected_character_id))
+    row = db.get_character_setup_option_by_id(int(selected_character_id))
     if row is None:
         return None
     return _character_option(row)
 
 
 def _character_option(row: dict[str, Any]) -> VNPlaySetupCharacterOption:
+    """Serialize a lightweight character row into selector-safe API shape."""
+    has_image = (
+        bool(row.get("has_image"))
+        if "has_image" in row
+        else bool(row.get("image") or row.get("image_base64"))
+    )
     return VNPlaySetupCharacterOption(
         id=int(row["id"]),
         name=str(row.get("name") or f"Character {row['id']}"),
@@ -176,7 +189,7 @@ def _character_option(row: dict[str, Any]) -> VNPlaySetupCharacterOption:
         tags=_string_list(row.get("tags")),
         favorite=_character_favorite(row.get("extensions")),
         deleted=bool(row.get("deleted", False)),
-        has_image=bool(row.get("image") or row.get("image_base64")),
+        has_image=has_image,
     )
 
 
@@ -189,6 +202,7 @@ def _asset_pack_option(
     provenance: dict[str, Any] | None,
     provenance_lookup_failed: bool,
 ) -> VNPlaySetupAssetPackOption:
+    """Serialize pack setup state with readiness, compatibility, and warnings."""
     readiness = _readiness_for_pack(asset_service, pack.id)
     warnings: list[VNPlaySetupWarning] = []
     if readiness is None:
@@ -206,7 +220,7 @@ def _asset_pack_option(
             warnings.append(_warning("pack_not_ready", "high_risk"))
         if readiness_errors:
             warnings.append(_warning("pack_has_readiness_errors", "high_risk"))
-        if _missing_required_assets(readiness_status, readiness_warnings, readiness_errors):
+        if _missing_required_assets(readiness_errors):
             warnings.append(_warning("pack_missing_required_assets", "high_risk"))
 
     compatibility = _compatibility(pack, selected_character)
@@ -255,6 +269,7 @@ def _latest_import_provenance(
     asset_service: VNAssetPackService,
     packs: list[VNAssetPackResponse],
 ) -> tuple[dict[int, dict[str, Any]], bool]:
+    """Return latest completed import provenance for listed packs when available."""
     pack_ids = [pack.id for pack in packs]
     if not pack_ids:
         return {}, False
@@ -275,6 +290,7 @@ def _readiness_for_pack(
     asset_service: VNAssetPackService,
     pack_id: int,
 ) -> VNAssetReadinessResponse | None:
+    """Return pack readiness, degrading to ``None`` when the check fails."""
     try:
         return asset_service.get_readiness(pack_id)
     except Exception as exc:
@@ -286,6 +302,7 @@ def _compatibility(
     pack: VNAssetPackResponse,
     selected_character: VNPlaySetupCharacterOption | None,
 ) -> VNPlaySetupCompatibility:
+    """Derive selected-character compatibility for one asset pack."""
     if selected_character is None:
         return VNPlaySetupCompatibility(status="unknown", reason_codes=["no_selected_character"])
     if pack.primary_character_id == selected_character.id:
@@ -300,6 +317,7 @@ def _content_rating_warning(
     pack_rating: str | None,
     requested_rating: str | None,
 ) -> VNPlaySetupWarning | None:
+    """Return a warning when pack and requested content ratings differ."""
     normalized_pack = _normalized_rating(pack_rating)
     normalized_requested = _normalized_rating(requested_rating)
     if normalized_pack == normalized_requested:
@@ -320,6 +338,7 @@ def _trust_for_provenance(
     *,
     lookup_failed: bool,
 ) -> tuple[VNPlaySetupTrustLevel, VNPlaySetupTrustSource]:
+    """Map import-journal provenance into setup trust level and source labels."""
     if lookup_failed:
         return "unknown", "unknown"
     if provenance is None:
@@ -334,6 +353,7 @@ def _warning(
     code: str,
     severity: VNPlaySetupWarningSeverity,
 ) -> VNPlaySetupWarning:
+    """Build a warning payload with acknowledgement semantics from severity."""
     return VNPlaySetupWarning(
         code=code,
         severity=severity,
@@ -345,6 +365,7 @@ def _warning(
 def _warning_summary(
     warnings: list[VNPlaySetupWarning],
 ) -> VNPlaySetupWarningSummary:
+    """Summarize warning severity and acknowledgement requirements."""
     if not warnings:
         return VNPlaySetupWarningSummary()
     highest = max(warnings, key=lambda warning: SEVERITY_ORDER[warning.severity]).severity
@@ -363,6 +384,7 @@ def _setup_defaults(
     characters: list[VNPlaySetupCharacterOption],
     asset_packs: list[VNPlaySetupAssetPackOption],
 ) -> VNPlaySetupDefaults:
+    """Choose conservative setup defaults from selected and recommended options."""
     default_character_id = selected_character.id if selected_character is not None else None
     if default_character_id is None and len(characters) == 1:
         default_character_id = characters[0].id
@@ -389,6 +411,7 @@ def _empty_states(
     selected_character_id: int | None,
     selected_character: VNPlaySetupCharacterOption | None,
 ) -> list[VNPlaySetupEmptyState]:
+    """Build scoped empty-state hints for selector pages and filters."""
     states: list[VNPlaySetupEmptyState] = []
     if character_total == 0:
         states.append(
@@ -456,6 +479,7 @@ def _empty_states(
 def _sort_pack_options(
     packs: list[VNPlaySetupAssetPackOption],
 ) -> list[VNPlaySetupAssetPackOption]:
+    """Sort packs with recommended and compatible options first without reordering ties."""
     def sort_key(indexed_pack: tuple[int, VNPlaySetupAssetPackOption]) -> tuple[int, int]:
         index, pack = indexed_pack
         if pack.recommended:
@@ -471,21 +495,23 @@ def _sort_pack_options(
     return [pack for _, pack in sorted(enumerate(packs), key=sort_key)]
 
 
-def _missing_required_assets(
-    readiness_status: str,
-    readiness_warnings: list[str],
-    readiness_errors: list[str],
-) -> bool:
-    haystack = " ".join([readiness_status, *readiness_warnings, *readiness_errors]).lower()
-    return "missing" in haystack and "required" in haystack
+def _missing_required_assets(readiness_errors: list[str]) -> bool:
+    """Return true only for structured missing-required readiness error codes."""
+    for error in readiness_errors:
+        code = str(error).split(":", 1)[0].strip().lower()
+        if code in REQUIRED_ASSET_READINESS_ERROR_CODES:
+            return True
+    return False
 
 
 def _normalized_rating(value: str | None) -> str:
+    """Normalize empty or mixed-case content ratings for comparisons."""
     normalized = (value or "general").strip().lower()
     return normalized or "general"
 
 
 def _preview_text(value: Any, *, max_length: int = 160) -> str | None:
+    """Return compact preview text whose final length stays within ``max_length``."""
     if value is None:
         return None
     text = " ".join(str(value).split())
@@ -493,10 +519,13 @@ def _preview_text(value: Any, *, max_length: int = 160) -> str | None:
         return None
     if len(text) <= max_length:
         return text
-    return text[: max_length - 1].rstrip() + "..."
+    if max_length <= 3:
+        return text[:max_length]
+    return text[: max_length - 3].rstrip() + "..."
 
 
 def _string_list(value: Any) -> list[str]:
+    """Normalize stored JSON, iterable, or scalar tag values into strings."""
     if value is None:
         return []
     raw_values: list[Any]
@@ -514,6 +543,7 @@ def _string_list(value: Any) -> list[str]:
 
 
 def _character_favorite(extensions: Any) -> bool:
+    """Extract the setup favorite flag from known extension locations."""
     if extensions is None:
         return False
     parsed = extensions
@@ -531,8 +561,10 @@ def _character_favorite(extensions: Any) -> bool:
 
 
 def _has_query(value: str | None) -> bool:
+    """Return whether a query parameter contains non-whitespace text."""
     return bool((value or "").strip())
 
 
 def _utc_now_iso() -> str:
+    """Return the current UTC timestamp in API-friendly ISO-8601 form."""
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")

--- a/tldw_Server_API/tests/VN_Assets/test_vn_asset_packs_db.py
+++ b/tldw_Server_API/tests/VN_Assets/test_vn_asset_packs_db.py
@@ -137,3 +137,129 @@ def test_matrix_slot_creation_supports_multi_hop_dependencies(chacha_db: Charact
     slots_by_key = {slot["slot_key"]: slot for slot in slots}
     assert slots_by_key["depth.interior"]["depends_on_slot_id"] == slots_by_key["background.interior"]["id"]
     assert slots_by_key["trim.depth.interior"]["depends_on_slot_id"] == slots_by_key["depth.interior"]["id"]
+
+
+def test_list_packs_for_setup_applies_owner_query_and_bounded_pagination(
+    chacha_db: CharactersRAGDB,
+) -> None:
+    character_id = chacha_db.add_character_card({"name": "VN Primary"})
+    repo = VNAssetPacksRepository.initialized(chacha_db)
+    repo.create_pack(
+        owner_user_id=42,
+        primary_character_id=character_id,
+        title="Archive Alpha",
+        description="Station archive pack.",
+    )
+    repo.create_pack(
+        owner_user_id=42,
+        primary_character_id=character_id,
+        title="Archive Beta",
+        description="Secondary archive pack.",
+    )
+    repo.create_pack(
+        owner_user_id=7,
+        primary_character_id=character_id,
+        title="Archive Other Owner",
+    )
+
+    rows, has_more = repo.list_packs_for_setup(
+        owner_user_id=42,
+        query="archive",
+        limit=1,
+        offset=0,
+    )
+
+    assert [row["title"] for row in rows] == ["Archive Alpha"]
+    assert has_more is True
+
+    next_rows, next_has_more = repo.list_packs_for_setup(
+        owner_user_id=42,
+        query="archive",
+        limit=1,
+        offset=1,
+    )
+
+    assert [row["title"] for row in next_rows] == ["Archive Beta"]
+    assert next_has_more is False
+
+
+def test_latest_completed_import_provenance_by_pack_ids_uses_latest_completed_row(
+    chacha_db: CharactersRAGDB,
+) -> None:
+    character_id = chacha_db.add_character_card({"name": "VN Primary"})
+    repo = VNAssetPacksRepository.initialized(chacha_db)
+    pack = repo.create_pack(
+        owner_user_id=42,
+        primary_character_id=character_id,
+        title="Imported Pack",
+    )
+    other_pack = repo.create_pack(
+        owner_user_id=7,
+        primary_character_id=character_id,
+        title="Other Owner Pack",
+    )
+    preview = repo.create_import_preview(
+        owner_user_id=42,
+        job_id="preview-job",
+        status="completed",
+        archive_path="test-artifacts/preview.vnpack",
+    )
+    repo.create_import_journal(
+        owner_user_id=42,
+        preview_id=int(preview["id"]),
+        job_id="older-completed",
+        status="completed",
+        stage="completed",
+        trust_mode="trusted_restore",
+        target_mode="create_new",
+        target_pack_id=int(pack["id"]),
+        completed_at="2026-05-08T00:00:00Z",
+    )
+    repo.create_import_journal(
+        owner_user_id=42,
+        preview_id=int(preview["id"]),
+        job_id="failed-newer",
+        status="failed",
+        stage="failed",
+        trust_mode="trusted_restore",
+        target_mode="create_new",
+        target_pack_id=int(pack["id"]),
+        completed_at="2026-05-10T00:00:00Z",
+    )
+    repo.create_import_journal(
+        owner_user_id=42,
+        preview_id=int(preview["id"]),
+        job_id="newer-completed",
+        status="completed",
+        stage="completed",
+        trust_mode="untrusted_import",
+        target_mode="create_new",
+        target_pack_id=int(pack["id"]),
+        completed_at="2026-05-09T00:00:00Z",
+    )
+    other_preview = repo.create_import_preview(
+        owner_user_id=7,
+        job_id="other-preview",
+        status="completed",
+        archive_path="test-artifacts/other.vnpack",
+    )
+    repo.create_import_journal(
+        owner_user_id=7,
+        preview_id=int(other_preview["id"]),
+        job_id="other-owner",
+        status="completed",
+        stage="completed",
+        trust_mode="trusted_restore",
+        target_mode="create_new",
+        target_pack_id=int(other_pack["id"]),
+        completed_at="2026-05-10T00:00:00Z",
+    )
+
+    provenance = repo.latest_completed_import_provenance_by_pack_ids(
+        owner_user_id=42,
+        pack_ids=[int(pack["id"]), int(other_pack["id"])],
+    )
+
+    assert set(provenance) == {int(pack["id"])}
+    assert provenance[int(pack["id"])]["job_id"] == "newer-completed"
+    assert provenance[int(pack["id"])]["trust_mode"] == "untrusted_import"

--- a/tldw_Server_API/tests/VN_Play/test_vn_play_api.py
+++ b/tldw_Server_API/tests/VN_Play/test_vn_play_api.py
@@ -10,6 +10,7 @@ from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_
 from tldw_Server_API.app.api.v1.endpoints.vn_play import router as vn_play_router
 from tldw_Server_API.app.api.v1.schemas.vn_asset_schemas import (
     VNAssetPackCreate,
+    VNAssetReadinessResponse,
     VNAssetReviewRequest,
 )
 from tldw_Server_API.app.api.v1.schemas.vn_play_schemas import (
@@ -214,6 +215,106 @@ def test_setup_options_returns_selector_safe_character_and_pack(
     assert "image_base64" not in body["characters"][0]
 
 
+def test_setup_options_uses_lightweight_character_selector_queries(
+    client: TestClient,
+    chacha_db: CharactersRAGDB,
+    character_id: int,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _create_pack(
+        chacha_db,
+        owner_user_id=42,
+        character_id=character_id,
+    )
+
+    def fail_full_character_query(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("setup options should not load full character rows")
+
+    def query_selector_rows(
+        self: CharactersRAGDB,
+        *,
+        query: str | None = None,
+        include_deleted: bool = False,
+        limit: int = 25,
+        offset: int = 0,
+    ) -> tuple[list[dict[str, Any]], int]:
+        return (
+            [
+                {
+                    "id": character_id,
+                    "name": "Mira",
+                    "description": "A careful archivist.",
+                    "tags": ["guide", "archive"],
+                    "extensions": {"tldw": {"favorite": True}},
+                    "deleted": False,
+                    "has_image": True,
+                }
+            ],
+            1,
+        )
+
+    def get_selector_row(
+        self: CharactersRAGDB,
+        selected_character_id: int,
+        *,
+        include_deleted: bool = False,
+    ) -> dict[str, Any] | None:
+        assert selected_character_id == character_id
+        return {
+            "id": character_id,
+            "name": "Mira",
+            "description": "A careful archivist.",
+            "tags": ["guide", "archive"],
+            "extensions": {"tldw": {"favorite": True}},
+            "deleted": False,
+            "has_image": True,
+        }
+
+    monkeypatch.setattr(CharactersRAGDB, "query_character_cards", fail_full_character_query)
+    monkeypatch.setattr(CharactersRAGDB, "get_character_card_by_id", fail_full_character_query)
+    monkeypatch.setattr(
+        CharactersRAGDB,
+        "query_character_setup_options",
+        query_selector_rows,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        CharactersRAGDB,
+        "get_character_setup_option_by_id",
+        get_selector_row,
+        raising=False,
+    )
+
+    response = client.get(
+        f"/api/v1/vn-play/setup-options?selected_character_id={character_id}"
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["selected_character"]["has_image"] is True
+    assert body["characters"][0]["favorite"] is True
+
+
+def test_setup_options_description_preview_respects_max_length(
+    client: TestClient,
+    chacha_db: CharactersRAGDB,
+    character_id: int,
+) -> None:
+    long_description = " ".join(["archivist"] * 40)
+    chacha_db.update_character_card(
+        character_id,
+        {"description": long_description},
+        expected_version=1,
+    )
+
+    response = client.get("/api/v1/vn-play/setup-options")
+
+    assert response.status_code == 200
+    description_preview = response.json()["characters"][0]["description_preview"]
+    assert description_preview.endswith("...")
+    assert len(description_preview) <= 160
+
+
 def test_setup_options_preserves_selected_character_outside_page(
     client: TestClient,
     chacha_db: CharactersRAGDB,
@@ -387,6 +488,104 @@ def test_setup_options_evaluates_readiness_only_for_returned_pack_page(
     assert second_pack_id not in readiness_calls
     assert readiness_calls == [first_pack_id]
     assert body["pagination"]["asset_packs"]["has_more"] is True
+
+
+def test_setup_options_pack_listing_does_not_compute_planned_output_count(
+    client: TestClient,
+    chacha_db: CharactersRAGDB,
+    character_id: int,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _create_pack(
+        chacha_db,
+        owner_user_id=42,
+        character_id=character_id,
+    )
+
+    def fail_planned_output_count(self: VNAssetPackService, pack_id: int) -> int:
+        raise AssertionError("setup pack listing should not scan slots for planned counts")
+
+    monkeypatch.setattr(
+        VNAssetPackService,
+        "_planned_output_count",
+        fail_planned_output_count,
+    )
+
+    response = client.get(
+        f"/api/v1/vn-play/setup-options?selected_character_id={character_id}"
+    )
+
+    assert response.status_code == 200
+    assert response.json()["asset_packs"][0]["title"] == "Mira - Archive Pack"
+
+
+def test_setup_options_missing_required_assets_warning_uses_structured_errors(
+    client: TestClient,
+    chacha_db: CharactersRAGDB,
+    character_id: int,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _create_pack(
+        chacha_db,
+        owner_user_id=42,
+        character_id=character_id,
+    )
+
+    def readiness_with_false_positive_text(
+        self: VNAssetPackService,
+        pack_id: int,
+    ) -> VNAssetReadinessResponse:
+        return VNAssetReadinessResponse(
+            ready=True,
+            status="ready",
+            warnings=["Required assets are present, none are missing."],
+            errors=[],
+        )
+
+    monkeypatch.setattr(
+        VNAssetPackService,
+        "get_readiness",
+        readiness_with_false_positive_text,
+    )
+
+    response = client.get(
+        f"/api/v1/vn-play/setup-options?selected_character_id={character_id}"
+    )
+
+    assert response.status_code == 200
+    warning_codes = {
+        warning["code"]
+        for warning in response.json()["asset_packs"][0]["warning_summary"]["warnings"]
+    }
+    assert "pack_missing_required_assets" not in warning_codes
+
+    def readiness_with_structured_missing_required_slot(
+        self: VNAssetPackService,
+        pack_id: int,
+    ) -> VNAssetReadinessResponse:
+        return VNAssetReadinessResponse(
+            ready=False,
+            status="not_ready",
+            warnings=[],
+            errors=["required_slot_not_ready:123"],
+        )
+
+    monkeypatch.setattr(
+        VNAssetPackService,
+        "get_readiness",
+        readiness_with_structured_missing_required_slot,
+    )
+
+    structured_response = client.get(
+        f"/api/v1/vn-play/setup-options?selected_character_id={character_id}"
+    )
+
+    assert structured_response.status_code == 200
+    structured_warning_codes = {
+        warning["code"]
+        for warning in structured_response.json()["asset_packs"][0]["warning_summary"]["warnings"]
+    }
+    assert "pack_missing_required_assets" in structured_warning_codes
 
 
 def test_setup_options_degrades_when_pack_readiness_fails(

--- a/tldw_Server_API/tests/VN_Play/test_vn_play_api.py
+++ b/tldw_Server_API/tests/VN_Play/test_vn_play_api.py
@@ -1,4 +1,5 @@
 from collections.abc import Generator, Iterator
+from typing import Any
 
 import pytest
 from fastapi import FastAPI
@@ -7,12 +8,18 @@ from pydantic import ValidationError
 
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
 from tldw_Server_API.app.api.v1.endpoints.vn_play import router as vn_play_router
+from tldw_Server_API.app.api.v1.schemas.vn_asset_schemas import (
+    VNAssetPackCreate,
+    VNAssetReviewRequest,
+)
 from tldw_Server_API.app.api.v1.schemas.vn_play_schemas import (
     VNPlaySessionCreate,
     VNPlayTurnRequest,
 )
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+from tldw_Server_API.app.core.DB_Management.VNAssetPacks_DB import VNAssetPacksRepository
+from tldw_Server_API.app.core.VN_Assets.service import VNAssetPackService
 
 
 @pytest.fixture
@@ -24,12 +31,16 @@ def chacha_db(tmp_path) -> Generator[CharactersRAGDB, None, None]:
 
 @pytest.fixture
 def character_id(chacha_db: CharactersRAGDB) -> int:
+    existing_characters, _ = chacha_db.query_character_cards(limit=100)
+    for character in existing_characters:
+        chacha_db.soft_delete_character_card(int(character["id"]), int(character["version"]))
     return chacha_db.add_character_card(
         {
             "name": "Mira",
             "description": "A careful archivist.",
             "personality": "Patient and exacting.",
             "scenario": "Cataloging an orbital library.",
+            "image": "data:image/png;base64,abc123",
         }
     )
 
@@ -70,6 +81,58 @@ def session_id(client: TestClient, character_id: int, ready_pack_id: int) -> int
     )
     assert response.status_code == 201
     return int(response.json()["id"])
+
+
+def _add_character(
+    chacha_db: CharactersRAGDB,
+    *,
+    name: str,
+    description: str = "A careful archivist.",
+) -> int:
+    character_id = chacha_db.add_character_card(
+        {
+            "name": name,
+            "description": description,
+            "personality": "Patient and exacting.",
+            "scenario": "Cataloging an orbital library.",
+            "tags": ["guide", "archive"],
+            "image": "data:image/png;base64,abc123",
+        }
+    )
+    assert character_id is not None
+    return int(character_id)
+
+
+def _create_pack(
+    chacha_db: CharactersRAGDB,
+    *,
+    owner_user_id: int,
+    character_id: int,
+    title: str = "Mira - Archive Pack",
+    content_rating: str = "general",
+    ready: bool = True,
+) -> int:
+    service = VNAssetPackService(chacha_db, owner_user_id=owner_user_id)
+    pack = service.create_pack(
+        VNAssetPackCreate(
+            title=title,
+            primary_character_id=character_id,
+            content_rating=content_rating,
+        )
+    )
+    slots = service.apply_matrix(pack.id, "starter", {"variant_count": 1})
+    if ready:
+        repo = VNAssetPacksRepository.initialized(chacha_db)
+        for index, slot in enumerate(slots, start=1):
+            item = repo.create_item(
+                pack_id=pack.id,
+                slot_id=slot.id,
+                variant_index=0,
+                generated_file_id=1000 + index,
+                mime_type="image/png",
+            )
+            service.review_item(item["id"], VNAssetReviewRequest(review_status="approved"))
+    return pack.id
 
 
 def test_turn_request_requires_exactly_one_input_field() -> None:
@@ -119,6 +182,260 @@ def test_create_session_endpoint_returns_scene_state(
     body = response.json()
     assert body["mode"] == "freeform"
     assert body["scene_state"]["scene_version"] == 0
+
+
+def test_setup_options_returns_selector_safe_character_and_pack(
+    client: TestClient,
+    chacha_db: CharactersRAGDB,
+    character_id: int,
+) -> None:
+    _create_pack(
+        chacha_db,
+        owner_user_id=42,
+        character_id=character_id,
+    )
+
+    response = client.get(
+        f"/api/v1/vn-play/setup-options?selected_character_id={character_id}"
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["selected_character"]["id"] == character_id
+    assert body["selected_character"]["has_image"] is True
+    assert body["characters"][0]["name"] == "Mira"
+    assert body["asset_packs"][0]["title"] == "Mira - Archive Pack"
+    assert body["asset_packs"][0]["ready"] is True
+    assert body["asset_packs"][0]["compatibility"]["status"] == "compatible"
+    assert body["asset_packs"][0]["warning_summary"]["requires_acknowledgement"] is False
+    assert body["pagination"]["characters"]["limit"] == 25
+    assert body["pagination"]["asset_packs"]["limit"] == 25
+    assert "image" not in body["characters"][0]
+    assert "image_base64" not in body["characters"][0]
+
+
+def test_setup_options_preserves_selected_character_outside_page(
+    client: TestClient,
+    chacha_db: CharactersRAGDB,
+    character_id: int,
+) -> None:
+    selected_character_id = _add_character(
+        chacha_db,
+        name="Zara",
+        description="A pilot who knows the archive station.",
+    )
+
+    response = client.get(
+        "/api/v1/vn-play/setup-options"
+        f"?character_limit=1&character_offset=0&selected_character_id={selected_character_id}"
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    page_character_ids = {item["id"] for item in body["characters"]}
+    assert body["selected_character"]["id"] == selected_character_id
+    assert selected_character_id not in page_character_ids
+    assert character_id in page_character_ids
+
+
+def test_setup_options_warns_for_unready_and_incompatible_packs(
+    client: TestClient,
+    chacha_db: CharactersRAGDB,
+    character_id: int,
+) -> None:
+    other_character_id = _add_character(chacha_db, name="Zara")
+    _create_pack(
+        chacha_db,
+        owner_user_id=42,
+        character_id=other_character_id,
+        title="Zara Draft Pack",
+        content_rating="mature",
+        ready=False,
+    )
+
+    response = client.get(
+        "/api/v1/vn-play/setup-options"
+        f"?selected_character_id={character_id}&content_rating=general"
+    )
+
+    assert response.status_code == 200
+    pack = response.json()["asset_packs"][0]
+    warning_codes = {warning["code"] for warning in pack["warning_summary"]["warnings"]}
+    assert pack["ready"] is False
+    assert pack["compatibility"]["status"] == "different_character"
+    assert pack["warning_summary"]["requires_acknowledgement"] is True
+    assert "pack_character_mismatch" in warning_codes
+    assert "pack_not_ready" in warning_codes
+    assert "content_rating_mismatch" in warning_codes
+
+
+def test_setup_options_marks_untrusted_import_provenance(
+    client: TestClient,
+    chacha_db: CharactersRAGDB,
+    character_id: int,
+) -> None:
+    pack_id = _create_pack(
+        chacha_db,
+        owner_user_id=42,
+        character_id=character_id,
+    )
+    repo = VNAssetPacksRepository.initialized(chacha_db)
+    preview = repo.create_import_preview(
+        owner_user_id=42,
+        job_id="preview-job",
+        status="completed",
+        archive_path="test-artifacts/preview.vnpack",
+    )
+    repo.create_import_journal(
+        owner_user_id=42,
+        preview_id=int(preview["id"]),
+        job_id="import-job",
+        status="completed",
+        stage="completed",
+        trust_mode="untrusted_import",
+        target_mode="create_new",
+        target_pack_id=pack_id,
+        completed_at="2026-05-09T00:00:00Z",
+    )
+
+    response = client.get(
+        f"/api/v1/vn-play/setup-options?selected_character_id={character_id}"
+    )
+
+    assert response.status_code == 200
+    pack = response.json()["asset_packs"][0]
+    warning_codes = {warning["code"] for warning in pack["warning_summary"]["warnings"]}
+    assert pack["trust_level"] == "untrusted_import"
+    assert pack["trust_source"] == "latest_import_journal"
+    assert "pack_untrusted_import" in warning_codes
+
+
+def test_setup_options_degrades_to_unknown_when_provenance_lookup_fails(
+    client: TestClient,
+    chacha_db: CharactersRAGDB,
+    character_id: int,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _create_pack(
+        chacha_db,
+        owner_user_id=42,
+        character_id=character_id,
+    )
+
+    def failing_provenance_lookup(
+        self: VNAssetPacksRepository,
+        *,
+        owner_user_id: int,
+        pack_ids: list[int],
+    ) -> dict[int, dict[str, Any]]:
+        raise RuntimeError("journal lookup unavailable")
+
+    monkeypatch.setattr(
+        VNAssetPacksRepository,
+        "latest_completed_import_provenance_by_pack_ids",
+        failing_provenance_lookup,
+    )
+
+    response = client.get(
+        f"/api/v1/vn-play/setup-options?selected_character_id={character_id}"
+    )
+
+    assert response.status_code == 200
+    pack = response.json()["asset_packs"][0]
+    assert pack["trust_level"] == "unknown"
+    assert pack["trust_source"] == "unknown"
+
+
+def test_setup_options_evaluates_readiness_only_for_returned_pack_page(
+    client: TestClient,
+    chacha_db: CharactersRAGDB,
+    character_id: int,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first_pack_id = _create_pack(
+        chacha_db,
+        owner_user_id=42,
+        character_id=character_id,
+        title="Mira - First Pack",
+    )
+    second_pack_id = _create_pack(
+        chacha_db,
+        owner_user_id=42,
+        character_id=character_id,
+        title="Mira - Second Pack",
+    )
+    original_get_readiness = VNAssetPackService.get_readiness
+    readiness_calls: list[int] = []
+
+    def tracking_get_readiness(
+        self: VNAssetPackService,
+        pack_id: int,
+    ) -> Any:
+        readiness_calls.append(pack_id)
+        return original_get_readiness(self, pack_id)
+
+    monkeypatch.setattr(VNAssetPackService, "get_readiness", tracking_get_readiness)
+
+    response = client.get(
+        "/api/v1/vn-play/setup-options"
+        f"?selected_character_id={character_id}&pack_limit=1"
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert [pack["id"] for pack in body["asset_packs"]] == [first_pack_id]
+    assert second_pack_id not in readiness_calls
+    assert readiness_calls == [first_pack_id]
+    assert body["pagination"]["asset_packs"]["has_more"] is True
+
+
+def test_setup_options_degrades_when_pack_readiness_fails(
+    client: TestClient,
+    chacha_db: CharactersRAGDB,
+    character_id: int,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _create_pack(
+        chacha_db,
+        owner_user_id=42,
+        character_id=character_id,
+        title="Mira - Fragile Pack",
+    )
+
+    def failing_get_readiness(
+        self: VNAssetPackService,
+        pack_id: int,
+    ) -> Any:
+        raise RuntimeError("readiness backend unavailable")
+
+    monkeypatch.setattr(VNAssetPackService, "get_readiness", failing_get_readiness)
+
+    response = client.get(
+        f"/api/v1/vn-play/setup-options?selected_character_id={character_id}"
+    )
+
+    assert response.status_code == 200
+    pack = response.json()["asset_packs"][0]
+    warning_codes = {warning["code"] for warning in pack["warning_summary"]["warnings"]}
+    assert pack["ready"] is False
+    assert pack["readiness_status"] == "unknown"
+    assert "readiness_unavailable" in warning_codes
+
+
+def test_setup_options_returns_global_empty_states_for_empty_user(
+    client: TestClient,
+    chacha_db: CharactersRAGDB,
+) -> None:
+    characters, _ = chacha_db.query_character_cards(limit=100)
+    for character in characters:
+        chacha_db.soft_delete_character_card(int(character["id"]), int(character["version"]))
+
+    response = client.get("/api/v1/vn-play/setup-options")
+
+    assert response.status_code == 200
+    empty_states = {state["code"]: state for state in response.json()["empty_states"]}
+    assert empty_states["no_characters"]["scope"] == "global"
+    assert empty_states["no_asset_packs"]["scope"] == "global"
 
 
 def test_turn_endpoint_rejects_stale_scene_version(


### PR DESCRIPTION
## Summary
- Adds backend `GET /api/v1/vn-play/setup-options` for VN Play character and asset-pack setup pages, selected entity lookup, defaults, compatibility warnings, readiness/provenance summaries, pagination, and empty states.
- Extends the VN asset pack repository/service with owner-scoped setup listing and latest completed import provenance helpers.
- Fixes multi-hop VN asset slot dependency creation so dependency ordering is resolved iteratively.
- Documents the API contract and design plan so custom frontends can consume server-derived setup state instead of reimplementing setup/readiness logic.

## Why
- Keeps VN Play setup behavior backend-owned, so the API server remains useful without the bundled frontend.
- Lets PR #1409-style UI work render against a stable endpoint instead of coupling client code to pack readiness, import provenance, warning rules, or database details.

## Test Plan
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/VN_Play/test_vn_play_api.py tldw_Server_API/tests/VN_Assets/test_vn_asset_packs_db.py -q` -> 24 passed, 5 warnings.
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/VN_Play/setup_options.py tldw_Server_API/app/api/v1/endpoints/vn_play.py tldw_Server_API/app/api/v1/schemas/vn_play_schemas.py tldw_Server_API/app/core/DB_Management/VNAssetPacks_DB.py tldw_Server_API/app/core/VN_Assets/service.py -f json -o /tmp/bandit_vn_setup_options_prod.json` -> no failed findings.
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/tests/VN_Play/test_vn_play_api.py tldw_Server_API/tests/VN_Assets/test_vn_asset_packs_db.py -s B101 -f json -o /tmp/bandit_vn_setup_options_tests.json` -> no failed findings.
- `git diff --check` -> clean.

## Notes
- Refs #1407.
- PR #1409 can be updated to consume this API or treated as a frontend reference path.
- AI-authored PR: per repo policy, a maintainer-owned Change summary is still required before merge.