### PR TITLE
Improve Persona Visuals first-run empty state

### DIFF
--- a/Docs/superpowers/plans/2026-05-09-persona-visual-empty-state-plan.md
+++ b/Docs/superpowers/plans/2026-05-09-persona-visual-empty-state-plan.md
@@ -1,0 +1,77 @@
+# Persona Visual Empty State Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Improve the Persona Garden Visuals no-pack state so first-time users understand how to start the existing Persona Buddy visual-pack workflow.
+
+**Architecture:** Keep this as a focused frontend hardening slice in `VisualPackEditor`. The empty state stays inside the existing Visuals tab and points to the already-present draft creation flow without adding backend APIs or duplicate editor controls.
+
+**Tech Stack:** React, TypeScript, Vitest, Testing Library, existing Persona Garden UI primitives.
+
+---
+
+### Task 1: Add First-Run Empty-State Coverage
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx`
+
+- [x] **Step 1: Write the failing test**
+
+Add assertions to the existing no-pack test for copy that says the selected persona's Buddy has no visual pack yet, that users should create a draft pack first, and that upload/import/generation/activation happen after a draft exists.
+
+- [x] **Step 2: Run the focused test**
+
+Run: `bunx vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx`
+Expected: FAIL because the current empty state only renders `No visual packs yet.`
+
+### Task 2: Implement Empty-State Copy
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx`
+
+- [x] **Step 1: Replace passive empty copy**
+
+Update the `persona-visual-pack-empty` block to include concise Persona Buddy / Persona Live framing, the draft-first action, and follow-on workflow summary.
+
+- [x] **Step 2: Keep controls scoped**
+
+Do not expose upload, import, generation, activation, or manifest controls when `selectedPack` is absent; those remain behind the existing selected-pack branch.
+
+- [x] **Step 3: Run focused tests**
+
+Run: `bunx vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx`
+Expected: PASS.
+
+### Task 3: Verify Related Frontend Behavior
+
+**Files:**
+- Verify: `apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx`
+- Verify: `apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx`
+- Verify: `apps/packages/ui/src/utils/__tests__/persona-garden-route.test.ts`
+
+- [x] **Step 1: Run related tests**
+
+Run: `bunx vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx src/utils/__tests__/persona-garden-route.test.ts`
+Expected: PASS.
+
+- [x] **Step 2: Run diff hygiene**
+
+Run: `git diff --check`
+Expected: no output and exit 0.
+
+### Task 4: Closeout
+
+**Files:**
+- Modify: `backlog/tasks/task-164 - Harden-Persona-Visuals-first-run-empty-state.md`
+
+- [x] **Step 1: Record verification in Backlog**
+
+Check acceptance criteria, record red/green verification, and note Bandit is not applicable for this frontend-only slice.
+
+- [x] **Step 2: Commit**
+
+Run:
+```bash
+git add apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx Docs/superpowers/plans/2026-05-09-persona-visual-empty-state-plan.md "backlog/tasks/task-164 - Harden-Persona-Visuals-first-run-empty-state.md"
+git commit -m "fix: improve persona visuals empty state"
+```

--- a/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
@@ -1056,8 +1056,8 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
               Create a draft visual pack first.
             </div>
             <div className="mt-1">
-              After a draft exists, upload frames, map states, import packs,
-              queue generation, review candidates, and activate a valid pack.
+              After a draft exists, upload frames, map states, import or export
+              packs, queue generation, review candidates, and activate a valid pack.
             </div>
           </div>
         ) : null}

--- a/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
@@ -1046,9 +1046,19 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
         {!loading && !packs.length ? (
           <div
             data-testid="persona-visual-pack-empty"
-            className="mt-3 rounded border border-dashed border-border bg-bg px-3 py-2 text-xs text-text-muted"
+            className="mt-3 rounded border border-dashed border-border bg-bg px-3 py-3 text-xs text-text-muted"
           >
-            No visual packs yet.
+            <div className="font-medium text-text">
+              {selectedPersonaName || selectedPersonaId}
+              {"'s Persona Buddy does not have a visual pack yet."}
+            </div>
+            <div className="mt-1">
+              Create a draft visual pack first.
+            </div>
+            <div className="mt-1">
+              After a draft exists, upload frames, map states, import packs,
+              queue generation, review candidates, and activate a valid pack.
+            </div>
           </div>
         ) : null}
         {selectedPack ? (

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
@@ -270,7 +270,7 @@ describe("VisualPackEditor", () => {
     )
     expect(emptyState).toHaveTextContent("Create a draft visual pack first.")
     expect(emptyState).toHaveTextContent(
-      "After a draft exists, upload frames, map states, import packs, queue generation, review candidates, and activate a valid pack."
+      "After a draft exists, upload frames, map states, import or export packs, queue generation, review candidates, and activate a valid pack."
     )
     expect(emptyState).not.toHaveTextContent("VN")
     expect(emptyState).not.toHaveTextContent("CYOA")

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
@@ -264,7 +264,16 @@ describe("VisualPackEditor", () => {
       />
     )
 
-    expect(await screen.findByTestId("persona-visual-pack-empty")).toBeInTheDocument()
+    const emptyState = await screen.findByTestId("persona-visual-pack-empty")
+    expect(emptyState).toHaveTextContent(
+      "Garden Helper's Persona Buddy does not have a visual pack yet."
+    )
+    expect(emptyState).toHaveTextContent("Create a draft visual pack first.")
+    expect(emptyState).toHaveTextContent(
+      "After a draft exists, upload frames, map states, import packs, queue generation, review candidates, and activate a valid pack."
+    )
+    expect(emptyState).not.toHaveTextContent("VN")
+    expect(emptyState).not.toHaveTextContent("CYOA")
     fireEvent.change(screen.getByTestId("persona-visual-pack-title-input"), {
       target: { value: "First pack" }
     })

--- a/backlog/tasks/task-164 - Harden-Persona-Visuals-first-run-empty-state.md
+++ b/backlog/tasks/task-164 - Harden-Persona-Visuals-first-run-empty-state.md
@@ -1,0 +1,61 @@
+---
+id: TASK-164
+title: Harden Persona Visuals first-run empty state
+status: Done
+assignee: []
+created_date: '2026-05-09 15:39'
+updated_date: '2026-05-09 15:47'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1415'
+  - 'https://github.com/rmusser01/tldw_server/pull/1416'
+documentation:
+  - Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md
+  - Docs/superpowers/plans/2026-05-09-persona-visual-empty-state-plan.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Improve the Persona Garden Visuals no-pack empty state from a passive message into a concise, action-oriented first-run guide for the existing Persona Buddy visual-pack workflow. This should remain centered on Persona Buddy/Persona Live and explain that users start by creating a draft pack, then upload assets, map visual states, import/export packs, queue generation where configured, review results, and explicitly activate a valid pack.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 VisualPackEditor no-pack state explains the first action is creating a draft visual pack for the selected persona.
+- [x] #2 No-pack state references the existing follow-on workflows without exposing controls that require a selected pack.
+- [x] #3 No-pack state keeps Persona Buddy/Persona Live framing and does not mention VN/CYOA surfaces.
+- [x] #4 Focused VisualPackEditor tests cover the no-pack first-run copy and existing draft creation flow still works.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added implementation plan at Docs/superpowers/plans/2026-05-09-persona-visual-empty-state-plan.md.
+
+RED: bunx vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx failed because the empty state still rendered only "No visual packs yet."
+GREEN: bunx vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx passed with 7 tests after the empty-state copy update.
+RELATED VERIFICATION: bunx vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx src/utils/__tests__/persona-garden-route.test.ts passed with 31 tests.
+HYGIENE: git diff --check passed.
+BANDIT: not applicable; touched code is frontend TypeScript plus Backlog/plan metadata only.
+
+Opened draft PR #1416 for the Persona Visuals first-run empty-state slice.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Improved the Persona Garden Visuals no-pack empty state so it frames the workflow around the selected persona's Persona Buddy, names draft creation as the first action, and explains that upload, state mapping, import, generation, review, and activation follow after a draft exists. Existing draft creation and asset upload flow remains covered by the focused VisualPackEditor test.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-164.1 - Address-PR-1416-export-workflow-review-gap.md
+++ b/backlog/tasks/task-164.1 - Address-PR-1416-export-workflow-review-gap.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-164.1
 title: 'Address PR #1416 export workflow review gap'
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-09 16:00'
-updated_date: '2026-05-09 16:01'
+updated_date: '2026-05-09 16:06'
 labels: []
 dependencies: []
 references:
@@ -20,7 +20,7 @@ priority: medium
 <!-- AC:BEGIN -->
 - [x] #1 Persona Visuals no-pack empty state explicitly includes export/import review as a post-draft workflow.
 - [x] #2 Focused VisualPackEditor test fails before the copy change and passes after implementation.
-- [ ] #3 PR review thread is resolved after verification and push.
+- [x] #3 PR review thread is resolved after verification and push.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -35,14 +35,24 @@ RELATED VERIFICATION: bunx vitest run src/components/PersonaGarden/__tests__/Vis
 HYGIENE: git diff --check passed.
 
 BANDIT: not applicable; touched code is frontend TypeScript plus Backlog metadata only.
+
+REVIEW: Resolved GitHub review thread PRRT_kwDOL1aGf86A1J9- after pushing commit 7634fd9b7.
+
+PR CHECKS: Rechecked PR #1416 after push; checks were pending/skipping with no failed checks in the latest output.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed the PR #1416 review gap by updating the Persona Visuals no-pack empty state to mention import or export packs as a post-draft workflow. Added/updated the focused VisualPackEditor assertion, verified the RED/GREEN cycle and related Persona Visuals/Buddy route tests, pushed the fix, and resolved the Qodo review thread.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
+- [x] #1 Acceptance criteria completed
 - [x] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
+- [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-164.1 - Address-PR-1416-export-workflow-review-gap.md
+++ b/backlog/tasks/task-164.1 - Address-PR-1416-export-workflow-review-gap.md
@@ -1,0 +1,48 @@
+---
+id: TASK-164.1
+title: 'Address PR #1416 export workflow review gap'
+status: In Progress
+assignee: []
+created_date: '2026-05-09 16:00'
+updated_date: '2026-05-09 16:01'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1416#discussion_r3213384370'
+  - 'https://github.com/rmusser01/tldw_server/pull/1416'
+documentation:
+  - Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md
+parent_task_id: TASK-164
+priority: medium
+---
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Persona Visuals no-pack empty state explicitly includes export/import review as a post-draft workflow.
+- [x] #2 Focused VisualPackEditor test fails before the copy change and passes after implementation.
+- [ ] #3 PR review thread is resolved after verification and push.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+RED: bunx vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx failed with the expected missing export wording in persona-visual-pack-empty.
+
+GREEN: bunx vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx passed with 7 tests after adding import/export copy.
+
+RELATED VERIFICATION: bunx vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx src/utils/__tests__/persona-garden-route.test.ts passed with 31 tests.
+
+HYGIENE: git diff --check passed.
+
+BANDIT: not applicable; touched code is frontend TypeScript plus Backlog metadata only.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Change summary

This PR continues the Persona Live Visual Packs Phase 2 hardening work by improving the Persona Garden Visuals no-pack empty state. The previous state only said "No visual packs yet." The new copy frames the state around the selected persona's Persona Buddy, tells the user to create a draft visual pack first, and names the existing follow-on workflows that become available after a draft exists.

Why this approach:
- Reuses the existing VisualPackEditor flow instead of adding duplicate controls.
- Keeps the work centered on Persona Buddy / Persona Live, not VN or CYOA surfaces.
- Keeps upload, import, generation, review, and activation controls behind the existing selected-pack branch.

Closes #1415.

Backlog: TASK-164

## Verification

- RED: `bunx vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx` failed because the empty state still rendered only `No visual packs yet.`
- GREEN: `bunx vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx` passed with 7 tests.
- RELATED: `bunx vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx src/utils/__tests__/persona-garden-route.test.ts` passed with 31 tests.
- `git diff --check` passed.
- Bandit not applicable: frontend TypeScript plus Backlog/plan metadata only.

## Merge note

Draft until a human-owned change summary is confirmed for the AI-generated PR merge gate.