### PR TITLE
Remove dayjs from flashcard date labels

### DIFF
--- a/Docs/Design/WebUI_Dependency_Audit.md
+++ b/Docs/Design/WebUI_Dependency_Audit.md
@@ -224,7 +224,7 @@ This audit does not remove packages or rewrite runtime code.
   Flashcards Review/Manage display formatting and Ant Design `Dayjs`
   value-contract surfaces.
 - TASK-164 removed `dayjs` relative/absolute display formatting from
-  Flashcards ReviewTab and ManageTab by extending the shared native Date
+  Flashcards ReviewTab and ManageTab by extending the shared native Date/Intl
   helpers used by FlashcardEditDrawer. The shared UI `dayjs` import count
   dropped from 11 to 7 while leaving the package declared for Ant Design
   `Dayjs` value-contract surfaces.
@@ -423,6 +423,8 @@ ownership checks, or complex-domain packages that should stay on the
   the existing warning baseline, and `git diff --check` passed. The shared UI
   TypeScript check still fails on existing repo-wide test/service baseline
   errors outside this slice.
+- 2026-05-09 TASK-164 review follow-up: replaced manual English weekday/month
+  arrays in the long Flashcards date label helper with `Intl.DateTimeFormat`.
 - Bandit: skipped for TASK-144 because the slice changed documentation and
   Backlog metadata only; no Python files were modified.
 - Bandit: skipped for TASK-147 because the slice changed TypeScript,

--- a/Docs/Design/WebUI_Dependency_Audit.md
+++ b/Docs/Design/WebUI_Dependency_Audit.md
@@ -107,7 +107,7 @@ This audit does not remove packages or rewrite runtime code.
 | `cytoscape` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 6 | apps/packages/ui/src/components/Notes/NotesGraphModal.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesGraphModal.stage2.graph-view.test.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage21.accessibility-modal-focus.test.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage22.accessibility-regression.test.tsx | shared UI, shared UI tests | graph/rendering | `keep` | Low; import/config/package-script evidence in current WebUI or shared UI paths. | No immediate reduction; keep current behavior. | none |
 | `cytoscape-dagre` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 6 | apps/packages/ui/src/components/Notes/NotesGraphModal.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesGraphModal.stage2.graph-view.test.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage21.accessibility-modal-focus.test.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage22.accessibility-regression.test.tsx | shared UI, shared UI tests | graph/rendering | `keep` | Low; import/config/package-script evidence in current WebUI or shared UI paths. | No immediate reduction; keep current behavior. | none |
 | `d3-dsv` | `web:dependencies`, `extension:dependencies` | 0 | none found | web app, extension impact declaration only | parser/conversion | `investigate-lockfile` | Medium; no import/config/package-script evidence, but package sits in parser/conversion behavior. Confirm direct-vs-transitive ownership and CSV/DSV coverage before removal. | Potential install/bundle reduction if direct declaration proves unused. | Lockfile/parser-domain investigation slice. |
-| `dayjs` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 11 | apps/packages/ui/src/components/Flashcards/tabs/ReviewTab.tsx, apps/packages/ui/src/components/Flashcards/tabs/ManageTab.tsx, apps/packages/ui/src/components/Media/FilterPanel.tsx, apps/packages/ui/src/components/Option/DataTables/EditableCell.tsx | shared UI | frontend/runtime | `defer-design` | Medium; some display formatting can move to native `Intl` or small local helpers, but several Ant Design DatePicker/DateRangePicker surfaces currently exchange `Dayjs` values and types. | No immediate dependency reduction until shared UI date-picker value contracts are redesigned or isolated. | Continue display-formatting replacement slices before date-picker design. |
+| `dayjs` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 7 | apps/packages/ui/src/components/Media/FilterPanel.tsx, apps/packages/ui/src/components/Option/Collections/ReadingList/ReadingItemsList.tsx, apps/packages/ui/src/components/Option/DataTables/EditableCell.tsx, apps/packages/ui/src/components/Option/Items/ItemsWorkspace.tsx | shared UI | frontend/runtime | `defer-design` | Medium; remaining shared UI imports are Ant Design DatePicker/DateRangePicker value surfaces that currently exchange `Dayjs` values and types. | No immediate dependency reduction until shared UI date-picker value contracts are redesigned or isolated. | Date-picker contract design before manifest removal. |
 | `dexie` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 6 | apps/packages/ui/src/db/dexie/chat.ts, apps/packages/ui/src/db/dexie/schema.ts, apps/packages/ui/src/hooks/document-workspace/__tests__/offlineQueue.test.ts, apps/packages/ui/src/hooks/document-workspace/offlineQueue.ts | shared UI, shared UI tests, web tests, web app | state/data | `keep` | Low; import/config/package-script evidence in current WebUI or shared UI paths. | No immediate reduction; keep current behavior. | none |
 | `dexie-react-hooks` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 1 | apps/packages/ui/src/components/Sidepanel/Chat/TtsClipsDrawer.tsx | shared UI | state/data | `keep` | Low; import/config/package-script evidence in current WebUI or shared UI paths. | No immediate reduction; keep current behavior. | none |
 | `dompurify` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 11 | apps/packages/ui/src/components/Common/CodeBlock.tsx, apps/packages/ui/src/components/Notes/NotesStudioDiagramCard.tsx, apps/packages/ui/src/components/Notes/export-utils.ts, apps/packages/ui/src/components/Option/Collections/ReadingList/ReadingItemDetail.tsx | shared UI | security/sanitization | `keep` | Low; import/config/package-script evidence in current WebUI or shared UI paths. | No immediate reduction; keep current behavior. | none |
@@ -223,6 +223,11 @@ This audit does not remove packages or rewrite runtime code.
   dropped from 15 to 11 while leaving the package declared for remaining
   Flashcards Review/Manage display formatting and Ant Design `Dayjs`
   value-contract surfaces.
+- TASK-164 removed `dayjs` relative/absolute display formatting from
+  Flashcards ReviewTab and ManageTab by extending the shared native Date
+  helpers used by FlashcardEditDrawer. The shared UI `dayjs` import count
+  dropped from 11 to 7 while leaving the package declared for Ant Design
+  `Dayjs` value-contract surfaces.
 
 ### Quick Cleanup Candidates
 
@@ -234,19 +239,17 @@ ownership checks, or complex-domain packages that should stay on the
 
 ### Replacement Candidates
 
-1. `dayjs`: continue replacing selected display-only formatting with native
-   `Intl.DateTimeFormat`, `Intl.RelativeTimeFormat`, and small local helpers.
-   Do not attempt a direct dependency removal until Ant Design date-picker
-   surfaces that pass or type `Dayjs` values are redesigned or isolated.
+1. `dayjs`: remaining shared UI imports are Ant Design date-control value
+   surfaces. Do not attempt a direct dependency removal until those surfaces
+   that pass or type `Dayjs` values are redesigned or isolated.
 
 ### Deferred Design Candidates
 
 - Icon-stack consolidation: `lucide-react`, `@heroicons/react`, `@ant-design/icons`, and `react-icons` are active visible UI dependencies and should be handled with a visual/design pass.
-- Date/time consolidation: `dayjs` has simple display-formatting call sites
-  that can likely move to native `Intl`, but current shared UI also uses
-  `Dayjs` values with Ant Design date controls in media, reading list, items,
-  data table, and kanban surfaces. Treat this as a compatibility/design slice,
-  not a quick manifest cleanup.
+- Date/time consolidation: current shared UI uses `Dayjs` values with Ant
+  Design date controls in media, reading list, items, data table, and kanban
+  surfaces. Treat this as a compatibility/design slice, not a quick manifest
+  cleanup.
 - PDF, ePub, document rendering, rich text editor, Mermaid, KaTeX, markdown, parser, graph/layout, OCR, tokenizer, schema, Monaco, Tiptap, and archive packages with active evidence are kept or deferred rather than replaced with hand-rolled browser code. Remaining zero-evidence complex declarations should keep using the `investigate-lockfile` path before any manifest edit.
 - DnD package declarations with no direct import evidence, such as `@dnd-kit/abstract` and `@dnd-kit/dom`, are retained after TASK-134 because the current lockfile still routes active DnD packages through the DnD abstract/dom graph.
 
@@ -405,6 +408,21 @@ ownership checks, or complex-domain packages that should stay on the
   src/components/Flashcards/components/__tests__/FlashcardEditDrawer.scheduling-metadata.test.tsx`
   from `apps/packages/ui` passed after first failing on the missing native
   date-display helper.
+- 2026-05-09 TASK-164 active-code scan: exact shared UI package-import scan
+  found 7 remaining `dayjs` import lines after removing both runtime imports
+  from `apps/packages/ui/src/components/Flashcards/tabs/ReviewTab.tsx` and
+  `apps/packages/ui/src/components/Flashcards/tabs/ManageTab.tsx`. Remaining
+  imports are Ant Design `Dayjs` value/type surfaces in media, reading list,
+  items, data table, and kanban code.
+- 2026-05-09 TASK-164 verification: `bunx vitest run
+  src/components/Flashcards/utils/__tests__/date-display.test.ts
+  src/components/Flashcards/tabs/__tests__/ManageTab.scheduling-metadata.test.tsx
+  src/components/Flashcards/tabs/__tests__/ReviewTab.create-cta.test.tsx` from
+  `apps/packages/ui` passed after first failing on the missing native
+  date-display helpers. `bun run lint` from `apps/tldw-frontend` passed with
+  the existing warning baseline, and `git diff --check` passed. The shared UI
+  TypeScript check still fails on existing repo-wide test/service baseline
+  errors outside this slice.
 - Bandit: skipped for TASK-144 because the slice changed documentation and
   Backlog metadata only; no Python files were modified.
 - Bandit: skipped for TASK-147 because the slice changed TypeScript,
@@ -414,6 +432,8 @@ ownership checks, or complex-domain packages that should stay on the
 - Bandit: skipped for TASK-153 because the slice changed TypeScript,
   documentation, and Backlog metadata only; no Python files were modified.
 - Bandit: skipped for TASK-158 because the slice changed TypeScript,
+  documentation, and Backlog metadata only; no Python files were modified.
+- Bandit: skipped for TASK-164 because the slice changed TypeScript,
   documentation, and Backlog metadata only; no Python files were modified.
 
 ## Known Skips And Blockers

--- a/apps/packages/ui/src/components/Flashcards/tabs/ManageTab.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/ManageTab.tsx
@@ -23,8 +23,6 @@ import {
   Typography
 } from "antd"
 import { Filter, Plus, LayoutList, List as ListIcon, Keyboard, Check, CheckCheck } from "lucide-react"
-import dayjs from "dayjs"
-import relativeTime from "dayjs/plugin/relativeTime"
 import { useTranslation } from "react-i18next"
 import { useConfirmDanger } from "@/components/Common/confirm-danger"
 import { useAntdMessage } from "@/hooks/useAntdMessage"
@@ -66,6 +64,11 @@ import {
   getDeckDescendantIds
 } from "../utils/deck-display"
 import {
+  formatFlashcardAbsoluteDateTime,
+  formatFlashcardRelativeTime,
+  isFlashcardTimestampBefore
+} from "../utils/date-display"
+import {
   formatFlashcardsUiErrorMessage,
   mapFlashcardsUiError
 } from "../utils/error-taxonomy"
@@ -80,8 +83,6 @@ import {
   type Flashcard,
   type FlashcardUpdate
 } from "@/services/flashcards"
-
-dayjs.extend(relativeTime)
 
 const { Text } = Typography
 
@@ -2047,6 +2048,15 @@ export const ManageTab: React.FC<ManageTabProps> = ({
             const compactSchedule = compactSchedulingLabels(item)
             const expandedSchedule = expandedSchedulingLabels(item)
             const sourceMeta = getFlashcardSourceMeta(item)
+            const dueRelativeLabel = item.due_at
+              ? formatFlashcardRelativeTime(item.due_at)
+              : null
+            const dueAbsoluteLabel = item.due_at
+              ? formatFlashcardAbsoluteDateTime(item.due_at)
+              : null
+            const isDue = item.due_at
+              ? isFlashcardTimestampBefore(item.due_at)
+              : false
             return (
             <List.Item
               data-testid={`flashcard-item-${item.uuid}`}
@@ -2088,7 +2098,7 @@ export const ManageTab: React.FC<ManageTabProps> = ({
                   title={
                     <div className="flex items-center gap-2">
                       {/* Due status indicator */}
-                      {item.due_at && dayjs(item.due_at).isBefore(dayjs()) && (
+                      {isDue && (
                         <Tooltip title={t("option:flashcards.dueNow", { defaultValue: "Due now" })}>
                           <span className="inline-block w-2 h-2 rounded-full bg-success" />
                         </Tooltip>
@@ -2112,7 +2122,7 @@ export const ManageTab: React.FC<ManageTabProps> = ({
                         )}
                         {item.due_at && (
                           <span className="text-text-subtle">
-                            {dayjs(item.due_at).fromNow()}
+                            {dueRelativeLabel ?? item.due_at}
                           </span>
                         )}
                         {sourceMeta && (
@@ -2229,8 +2239,8 @@ export const ManageTab: React.FC<ManageTabProps> = ({
                         {item.due_at && (
                           <Tag color="green">
                             {t("option:flashcards.due", { defaultValue: "Due" })}:{" "}
-                            {dayjs(item.due_at).fromNow()} (
-                            {dayjs(item.due_at).format("YYYY-MM-DD HH:mm")})
+                            {dueRelativeLabel ?? item.due_at} (
+                            {dueAbsoluteLabel ?? item.due_at})
                           </Tag>
                         )}
                         <Tooltip

--- a/apps/packages/ui/src/components/Flashcards/tabs/ReviewTab.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/ReviewTab.tsx
@@ -14,8 +14,6 @@ import {
   Typography
 } from "antd"
 import { X, Minus, Check, Star, Calendar, Undo2 } from "lucide-react"
-import dayjs from "dayjs"
-import relativeTime from "dayjs/plugin/relativeTime"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
 import { useAntdMessage } from "@/hooks/useAntdMessage"
@@ -51,6 +49,10 @@ import {
 } from "../components"
 import { RecentStudySessions } from "../components/RecentStudySessions"
 import { calculateIntervals } from "../utils/calculateIntervals"
+import {
+  formatFlashcardLongDateTime,
+  formatFlashcardRelativeTime
+} from "../utils/date-display"
 import { formatCardType } from "../utils/model-type-labels"
 import { FlashcardQueueStateBadge } from "../utils/queue-state-badges"
 import { buildReviewUndoState } from "../utils/review-undo"
@@ -71,8 +73,6 @@ import {
 } from "@/services/studySuggestions"
 import { buildQuizAssessmentRouteFromFlashcards } from "@/services/tldw/quiz-flashcards-handoff"
 import { useFlashcardsShortcutHintDensity } from "../hooks/useFlashcardsShortcutHintDensity"
-
-dayjs.extend(relativeTime)
 
 const { Text, Title } = Typography
 
@@ -213,6 +213,12 @@ export const ReviewTab: React.FC<ReviewTabProps> = ({
   const nextDueQuery = useNextDueQuery(reviewDeckId, directPathVisibilityOptions)
   const endReviewSessionMutation = useEndFlashcardReviewSessionMutation()
   const nextDueInfo = nextDueQuery.data
+  const nextDueRelativeLabel = nextDueInfo?.nextDueAt
+    ? formatFlashcardRelativeTime(nextDueInfo.nextDueAt)
+    : null
+  const nextDueAbsoluteLabel = nextDueInfo?.nextDueAt
+    ? formatFlashcardLongDateTime(nextDueInfo.nextDueAt)
+    : null
   const cramQueue = cramQueueQuery.data || []
   const cramQueueCard =
     reviewMode === "cram" && cramQueueIndex < cramQueue.length
@@ -543,11 +549,13 @@ export const ReviewTab: React.FC<ReviewTabProps> = ({
           }
         }, 10000) // 10 second undo window
 
-        const dueLabel = reviewResult.due_at
-          ? dayjs(reviewResult.due_at).fromNow()
-          : t("option:flashcards.nextReviewUnknown", {
-              defaultValue: "soon"
-            })
+        const dueLabel =
+          (reviewResult.due_at
+            ? formatFlashcardRelativeTime(reviewResult.due_at)
+            : null) ??
+          t("option:flashcards.nextReviewUnknown", {
+            defaultValue: "soon"
+          })
         const intervalLabel =
           reviewResult.interval_days === 1
             ? t("option:flashcards.intervalOneDay", { defaultValue: "1 day" })
@@ -1689,12 +1697,12 @@ export const ReviewTab: React.FC<ReviewTabProps> = ({
                             <Text strong>
                               {t("option:flashcards.nextDueAt", {
                                 defaultValue: "Next review: {{time}}",
-                                time: dayjs(nextDueInfo.nextDueAt).fromNow()
+                                time: nextDueRelativeLabel ?? nextDueInfo.nextDueAt
                               })}
                             </Text>
                           </div>
                           <Text type="secondary" className="text-xs mt-1 block">
-                            {dayjs(nextDueInfo.nextDueAt).format("dddd, MMMM D [at] h:mm A")}
+                            {nextDueAbsoluteLabel ?? nextDueInfo.nextDueAt}
                             {" · "}
                             {t("option:flashcards.nextDueCardCount", {
                               defaultValue: "{{count}} cards due",

--- a/apps/packages/ui/src/components/Flashcards/utils/__tests__/date-display.test.ts
+++ b/apps/packages/ui/src/components/Flashcards/utils/__tests__/date-display.test.ts
@@ -22,7 +22,7 @@ describe("flashcard date display utilities", () => {
   it("formats long local absolute timestamps for next-due labels", () => {
     const value = new Date(2026, 1, 18, 9, 5).toISOString()
 
-    expect(formatFlashcardLongDateTime(value)).toBe(
+    expect(formatFlashcardLongDateTime(value, { locale: "en-US" })).toBe(
       "Wednesday, February 18 at 9:05 AM"
     )
   })

--- a/apps/packages/ui/src/components/Flashcards/utils/__tests__/date-display.test.ts
+++ b/apps/packages/ui/src/components/Flashcards/utils/__tests__/date-display.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest"
 import {
   formatFlashcardAbsoluteDateTime,
+  formatFlashcardLongDateTime,
   formatFlashcardRelativeTime,
   formatFlashcardTimestampWithRelative,
+  isFlashcardTimestampBefore,
   parseFlashcardTimestamp
 } from "../date-display"
 
@@ -15,6 +17,14 @@ describe("flashcard date display utilities", () => {
     const value = new Date(2026, 1, 20, 9, 5).toISOString()
 
     expect(formatFlashcardAbsoluteDateTime(value)).toBe("2026-02-20 09:05")
+  })
+
+  it("formats long local absolute timestamps for next-due labels", () => {
+    const value = new Date(2026, 1, 18, 9, 5).toISOString()
+
+    expect(formatFlashcardLongDateTime(value)).toBe(
+      "Wednesday, February 18 at 9:05 AM"
+    )
   })
 
   it.each([
@@ -90,5 +100,14 @@ describe("flashcard date display utilities", () => {
       relative: "a day ago",
       timestamp
     })
+  })
+
+  it.each([
+    [new Date(2026, 1, 18, 11, 59).toISOString(), true],
+    [new Date(2026, 1, 18, 12, 0).toISOString(), false],
+    [new Date(2026, 1, 18, 12, 1).toISOString(), false],
+    ["invalid-date", false]
+  ])("checks whether %s is before the reference time", (value, expected) => {
+    expect(isFlashcardTimestampBefore(value, STABLE_NOW_MS)).toBe(expected)
   })
 })

--- a/apps/packages/ui/src/components/Flashcards/utils/date-display.ts
+++ b/apps/packages/ui/src/components/Flashcards/utils/date-display.ts
@@ -6,29 +6,9 @@ const HOURS_TO_MS = 60 * MINUTES_TO_MS
 const DAYS_TO_MS = 24 * HOURS_TO_MS
 const MONTHS_TO_MS = 30 * DAYS_TO_MS
 const YEARS_TO_MS = 365 * DAYS_TO_MS
-const WEEKDAYS = [
-  "Sunday",
-  "Monday",
-  "Tuesday",
-  "Wednesday",
-  "Thursday",
-  "Friday",
-  "Saturday"
-] as const
-const MONTHS = [
-  "January",
-  "February",
-  "March",
-  "April",
-  "May",
-  "June",
-  "July",
-  "August",
-  "September",
-  "October",
-  "November",
-  "December"
-] as const
+type FlashcardLongDateTimeOptions = {
+  locale?: string | string[]
+}
 
 export interface FlashcardTimestampDisplay {
   absolute: string
@@ -74,22 +54,25 @@ export const formatFlashcardAbsoluteDateTime = (value: unknown): string | null =
   return timestamp == null ? null : formatFlashcardAbsoluteDateTimeFromMs(timestamp)
 }
 
-const formatFlashcardLongDateTimeFromMs = (timestamp: number): string => {
-  const date = new Date(timestamp)
-  const weekday = WEEKDAYS[date.getDay()]
-  const month = MONTHS[date.getMonth()]
-  const day = date.getDate()
-  const hour24 = date.getHours()
-  const hour12 = hour24 % 12 || 12
-  const minutes = padDatePart(date.getMinutes())
-  const meridiem = hour24 < 12 ? "AM" : "PM"
-
-  return `${weekday}, ${month} ${day} at ${hour12}:${minutes} ${meridiem}`
+const formatFlashcardLongDateTimeFromMs = (
+  timestamp: number,
+  options?: FlashcardLongDateTimeOptions
+): string => {
+  return new Intl.DateTimeFormat(options?.locale, {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit"
+  }).format(new Date(timestamp))
 }
 
-export const formatFlashcardLongDateTime = (value: unknown): string | null => {
+export const formatFlashcardLongDateTime = (
+  value: unknown,
+  options?: FlashcardLongDateTimeOptions
+): string | null => {
   const timestamp = parseFlashcardTimestamp(value)
-  return timestamp == null ? null : formatFlashcardLongDateTimeFromMs(timestamp)
+  return timestamp == null ? null : formatFlashcardLongDateTimeFromMs(timestamp, options)
 }
 
 export const isFlashcardTimestampBefore = (

--- a/apps/packages/ui/src/components/Flashcards/utils/date-display.ts
+++ b/apps/packages/ui/src/components/Flashcards/utils/date-display.ts
@@ -6,6 +6,29 @@ const HOURS_TO_MS = 60 * MINUTES_TO_MS
 const DAYS_TO_MS = 24 * HOURS_TO_MS
 const MONTHS_TO_MS = 30 * DAYS_TO_MS
 const YEARS_TO_MS = 365 * DAYS_TO_MS
+const WEEKDAYS = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday"
+] as const
+const MONTHS = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December"
+] as const
 
 export interface FlashcardTimestampDisplay {
   absolute: string
@@ -49,6 +72,38 @@ const formatFlashcardAbsoluteDateTimeFromMs = (timestamp: number): string => {
 export const formatFlashcardAbsoluteDateTime = (value: unknown): string | null => {
   const timestamp = parseFlashcardTimestamp(value)
   return timestamp == null ? null : formatFlashcardAbsoluteDateTimeFromMs(timestamp)
+}
+
+const formatFlashcardLongDateTimeFromMs = (timestamp: number): string => {
+  const date = new Date(timestamp)
+  const weekday = WEEKDAYS[date.getDay()]
+  const month = MONTHS[date.getMonth()]
+  const day = date.getDate()
+  const hour24 = date.getHours()
+  const hour12 = hour24 % 12 || 12
+  const minutes = padDatePart(date.getMinutes())
+  const meridiem = hour24 < 12 ? "AM" : "PM"
+
+  return `${weekday}, ${month} ${day} at ${hour12}:${minutes} ${meridiem}`
+}
+
+export const formatFlashcardLongDateTime = (value: unknown): string | null => {
+  const timestamp = parseFlashcardTimestamp(value)
+  return timestamp == null ? null : formatFlashcardLongDateTimeFromMs(timestamp)
+}
+
+export const isFlashcardTimestampBefore = (
+  value: unknown,
+  referenceMs?: number
+): boolean => {
+  const timestamp = parseFlashcardTimestamp(value)
+  if (timestamp == null) return false
+  const reference =
+    typeof referenceMs === "number" && Number.isFinite(referenceMs)
+      ? referenceMs
+      : Date.now()
+
+  return timestamp < reference
 }
 
 const formatFlashcardRelativeTimeFromMs = (

--- a/backlog/tasks/task-164 - Remove-dayjs-from-Flashcards-Review-and-Manage-display-formatting.md
+++ b/backlog/tasks/task-164 - Remove-dayjs-from-Flashcards-Review-and-Manage-display-formatting.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - codex
 created_date: '2026-05-09 15:32'
-updated_date: '2026-05-09 15:49'
+updated_date: '2026-05-09 15:58'
 labels:
   - webui
   - dependencies
@@ -46,6 +46,7 @@ Continue GitHub issue #1346 after PR #1411 by replacing the remaining display-on
 3. Replace ReviewTab and ManageTab display-only dayjs calls with shared native helpers. [done]
 4. Update dependency audit and task metadata. [done]
 5. Run focused Vitest, import scans, lint, diff hygiene, and PR packaging. [done]
+6. Address PR #1417 review comments and rerun focused verification. [done]
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -72,6 +73,12 @@ Verification: `git diff --check` passed.
 TypeScript baseline: `bunx tsc -p tsconfig.json --noEmit --pretty false` from `apps/packages/ui` still exits 2 on existing repo-wide test/service type errors outside this slice; no errors were reported in touched ReviewTab, ManageTab, or date-display files in the observed output.
 
 Bandit skipped because this slice changed TypeScript, documentation, and Backlog metadata only; no Python files were modified.
+
+PR #1417 review pass: Gemini left two inline comments on `date-display.ts` asking to replace hardcoded weekday/month arrays and manual long-date assembly with `Intl.DateTimeFormat` to avoid locale-specific lookup tables. Verified as actionable for this codebase; applying a narrow helper change and preserving deterministic en-US coverage via test options.
+
+PR #1417 review fix implemented: replaced the manual long-date weekday/month arrays and 12-hour assembly with `Intl.DateTimeFormat`, with deterministic `en-US` test coverage for the prior display label.
+
+Post-review verification: focused Flashcards Vitest command passed again with 49 tests; exact Flashcards tabs `dayjs` scan returned no matches; broader shared UI `dayjs` scan remains 7 Ant Design value-contract surfaces; `git diff --check` passed; `bun run lint` still exits 0 with the existing 131-warning baseline; package TypeScript still exits 2 on existing repo-wide baseline errors outside this slice with no touched-file errors observed.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done
@@ -87,5 +94,5 @@ Bandit skipped because this slice changed TypeScript, documentation, and Backlog
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Removed the remaining display-only dayjs usage from Flashcards ReviewTab and ManageTab by extending the shared native date-display helpers with long absolute formatting and timestamp-before checks. The dependency audit now records the shared UI dayjs import count reduction from 11 to 7, with all remaining imports limited to Ant Design Dayjs value/type surfaces. Verification passed for focused Flashcards Vitest coverage, exact import scans, WebUI lint, and diff hygiene; the shared UI TypeScript command still fails on existing repo-wide baseline errors outside this slice, and Bandit was skipped because no Python files changed.
+Removed the remaining display-only dayjs usage from Flashcards ReviewTab and ManageTab by extending the shared native date-display helpers with long absolute formatting and timestamp-before checks. The PR review follow-up replaced manual English weekday/month arrays with `Intl.DateTimeFormat` while keeping deterministic en-US helper coverage. The dependency audit now records the shared UI dayjs import count reduction from 11 to 7, with all remaining imports limited to Ant Design Dayjs value/type surfaces. Verification passed for focused Flashcards Vitest coverage, exact import scans, WebUI lint, and diff hygiene; the shared UI TypeScript command still fails on existing repo-wide baseline errors outside this slice, and Bandit was skipped because no Python files changed.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-164 - Remove-dayjs-from-Flashcards-Review-and-Manage-display-formatting.md
+++ b/backlog/tasks/task-164 - Remove-dayjs-from-Flashcards-Review-and-Manage-display-formatting.md
@@ -1,0 +1,84 @@
+---
+id: TASK-164
+title: Remove dayjs from Flashcards Review and Manage display formatting
+status: In Progress
+assignee:
+  - codex
+created_date: '2026-05-09 15:32'
+updated_date: '2026-05-09 15:43'
+labels:
+  - webui
+  - dependencies
+  - cleanup
+  - dayjs
+  - flashcards
+dependencies:
+  - TASK-158
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1346'
+  - 'https://github.com/rmusser01/tldw_server/pull/1411'
+documentation:
+  - Docs/Design/WebUI_Dependency_Audit.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue GitHub issue #1346 after PR #1411 by replacing the remaining display-only dayjs usage in Flashcards ReviewTab and ManageTab with native date/time helpers. Scope is limited to review-result due labels, next-due labels, card-list due badges, and expanded due metadata. Leave Ant Design Dayjs value-contract surfaces outside Flashcards for separate design work.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Flashcards ReviewTab no longer imports dayjs or dayjs/plugin/relativeTime for review-result or next-due display labels.
+- [x] #2 Flashcards ManageTab no longer imports dayjs or dayjs/plugin/relativeTime for due-status and due label display formatting.
+- [x] #3 Native helper coverage preserves representative dayjs-compatible relative labels and absolute display labels used by ReviewTab and ManageTab.
+- [x] #4 The WebUI dependency audit records the shared UI dayjs import count reduction and remaining Ant Design Dayjs value-contract surfaces.
+- [x] #5 Focused Vitest, exact Flashcards tab dayjs import scan, broader shared UI dayjs import scan, lint or baseline rationale, git diff hygiene, and Bandit skip/run rationale are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Create isolated worktree from current origin/dev. [done]
+2. Add focused failing tests around shared Flashcards date-display helper coverage. [done]
+3. Replace ReviewTab and ManageTab display-only dayjs calls with shared native helpers. [done]
+4. Update dependency audit and task metadata. [done]
+5. Run focused Vitest, import scans, lint, diff hygiene, and PR packaging. [in progress]
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+PR #1411 was verified merged into dev at 2026-05-09T15:29:29Z. Current origin/dev audit shows 11 remaining shared UI dayjs import lines: ReviewTab and ManageTab display formatting plus Ant Design Dayjs value/type surfaces in Media, ReadingList, Items, DataTables, and Kanban. This task targets only the remaining Flashcards display-only imports.
+
+RED verified with `bunx vitest run src/components/Flashcards/utils/__tests__/date-display.test.ts` from `apps/packages/ui`: 5 failures because `formatFlashcardLongDateTime` and `isFlashcardTimestampBefore` were missing.
+
+Implemented native long absolute date formatting, timestamp-before checks, and replaced display-only `dayjs` calls in Flashcards ReviewTab and ManageTab.
+
+Focused helper test now passes and exact Flashcards tabs package-import scan returns no direct `dayjs` imports.
+
+Broader shared UI package-import scan now finds 7 remaining `dayjs` lines, all in Ant Design `Dayjs` value/type surfaces.
+
+Verification: `bunx vitest run src/components/Flashcards/utils/__tests__/date-display.test.ts src/components/Flashcards/tabs/__tests__/ManageTab.scheduling-metadata.test.tsx src/components/Flashcards/tabs/__tests__/ReviewTab.create-cta.test.tsx` passed with 49 tests.
+
+Verification: exact Flashcards tabs `dayjs` package-import scan returned no matches; broader shared UI scan returned 7 remaining matches in Ant Design value-contract surfaces.
+
+Verification: `bun run lint` from `apps/tldw-frontend` exited 0 with the existing 131-warning baseline and no touched-file lint errors.
+
+Verification: `git diff --check` passed.
+
+TypeScript baseline: `bunx tsc -p tsconfig.json --noEmit --pretty false` from `apps/packages/ui` still exits 2 on existing repo-wide test/service type errors outside this slice; no errors were reported in touched ReviewTab, ManageTab, or date-display files in the observed output.
+
+Bandit skipped because this slice changed TypeScript, documentation, and Backlog metadata only; no Python files were modified.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-164 - Remove-dayjs-from-Flashcards-Review-and-Manage-display-formatting.md
+++ b/backlog/tasks/task-164 - Remove-dayjs-from-Flashcards-Review-and-Manage-display-formatting.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-164
 title: Remove dayjs from Flashcards Review and Manage display formatting
-status: In Progress
+status: Done
 assignee:
   - codex
 created_date: '2026-05-09 15:32'
-updated_date: '2026-05-09 15:43'
+updated_date: '2026-05-09 15:49'
 labels:
   - webui
   - dependencies
@@ -17,6 +17,7 @@ dependencies:
 references:
   - 'https://github.com/rmusser01/tldw_server/issues/1346'
   - 'https://github.com/rmusser01/tldw_server/pull/1411'
+  - 'https://github.com/rmusser01/tldw_server/pull/1417'
 documentation:
   - Docs/Design/WebUI_Dependency_Audit.md
 priority: medium
@@ -44,7 +45,7 @@ Continue GitHub issue #1346 after PR #1411 by replacing the remaining display-on
 2. Add focused failing tests around shared Flashcards date-display helper coverage. [done]
 3. Replace ReviewTab and ManageTab display-only dayjs calls with shared native helpers. [done]
 4. Update dependency audit and task metadata. [done]
-5. Run focused Vitest, import scans, lint, diff hygiene, and PR packaging. [in progress]
+5. Run focused Vitest, import scans, lint, diff hygiene, and PR packaging. [done]
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -79,6 +80,12 @@ Bandit skipped because this slice changed TypeScript, documentation, and Backlog
 - [x] #2 Tests or verification recorded
 - [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Removed the remaining display-only dayjs usage from Flashcards ReviewTab and ManageTab by extending the shared native date-display helpers with long absolute formatting and timestamp-before checks. The dependency audit now records the shared UI dayjs import count reduction from 11 to 7, with all remaining imports limited to Ant Design Dayjs value/type surfaces. Verification passed for focused Flashcards Vitest coverage, exact import scans, WebUI lint, and diff hygiene; the shared UI TypeScript command still fails on existing repo-wide baseline errors outside this slice, and Bandit was skipped because no Python files changed.
+<!-- SECTION:FINAL_SUMMARY:END -->


### PR DESCRIPTION
## Summary
- replace Flashcards ReviewTab and ManageTab display-only dayjs usage with shared native date helpers
- add helper coverage for long absolute labels and due-before checks
- update the WebUI dependency audit and TASK-164 to record the dayjs import count drop from 11 to 7

## Verification
- bunx vitest run src/components/Flashcards/utils/__tests__/date-display.test.ts src/components/Flashcards/tabs/__tests__/ManageTab.scheduling-metadata.test.tsx src/components/Flashcards/tabs/__tests__/ReviewTab.create-cta.test.tsx
- exact Flashcards tabs dayjs package-import scan: no matches
- broader shared UI dayjs package-import scan: 7 remaining Ant Design Dayjs value/type surfaces
- bun run lint from apps/tldw-frontend: exits 0 with existing 131-warning baseline
- git diff --check
- bunx tsc -p tsconfig.json --noEmit --pretty false from apps/packages/ui: still exits 2 on existing repo-wide baseline errors outside this slice; no touched ReviewTab, ManageTab, or date-display errors observed
- Bandit skipped: no Python files changed

## Merge gate
- Human requester still needs to provide the required AI-generated PR Change summary before merge.