### PR TITLE
Adapt Agent SessionHistoryPanel status badges

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -5566,17 +5566,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "local-status-badge:src/components/Agent/SessionHistoryPanel.tsx:StatusBadge",
-    "path": "src/components/Agent/SessionHistoryPanel.tsx",
-    "rule": "local-status-badge",
-    "subject": "StatusBadge",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing local StatusBadge status wrapper before the guard.",
-    "replacement": "Badge with design-system state registry mapping",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "local-status-badge:src/components/Layouts/ConnectionStatus.tsx:StatusDot",
     "path": "src/components/Layouts/ConnectionStatus.tsx",
     "rule": "local-status-badge",

--- a/apps/packages/ui/src/components/Agent/SessionHistoryPanel.tsx
+++ b/apps/packages/ui/src/components/Agent/SessionHistoryPanel.tsx
@@ -20,6 +20,8 @@ import {
 } from "lucide-react"
 import type { SessionMetadata } from "@/services/agent/storage"
 import type { AgentStatus } from "@/services/agent/types"
+import { getDesignSystemState, type DesignSystemStateKey } from "@/design-system"
+import { Badge, getBadgeVariantForDesignSystemSeverity } from "@/components/ui/primitives"
 import { formatRelativeTime } from "@/utils/dateFormatters"
 
 interface SessionHistoryPanelProps {
@@ -40,57 +42,64 @@ const StatusBadge: FC<{
     AgentStatus,
     {
       icon: FC<{ className?: string }>
-      color: string
+      stateKey: DesignSystemStateKey
       labelKey: string
       labelDefault: string
     }
   > = {
     idle: {
       icon: Clock,
-      color: "text-text-subtle bg-surface2",
+      stateKey: "empty",
       labelKey: "statusIdle",
       labelDefault: "Idle"
     },
     running: {
       icon: Loader2,
-      color: "text-primary bg-primary/10",
+      stateKey: "retrying",
       labelKey: "statusRunning",
       labelDefault: "Running"
     },
     waiting_approval: {
       icon: Pause,
-      color: "text-warn bg-warn/10",
+      stateKey: "degraded",
       labelKey: "statusPaused",
       labelDefault: "Paused"
     },
     complete: {
       icon: CheckCircle,
-      color: "text-success bg-success/10",
+      stateKey: "ready",
       labelKey: "statusComplete",
       labelDefault: "Complete"
     },
     error: {
       icon: XCircle,
-      color: "text-danger bg-danger/10",
+      stateKey: "error",
       labelKey: "statusError",
       labelDefault: "Error"
     },
     cancelled: {
       icon: AlertCircle,
-      color: "text-warn bg-warn/10",
+      stateKey: "degraded",
       labelKey: "statusCancelled",
       labelDefault: "Cancelled"
     }
   }
 
-  const { icon: Icon, color, labelKey, labelDefault } =
+  const { icon: Icon, stateKey, labelKey, labelDefault } =
     config[status] || config.idle
+  const state = getDesignSystemState(stateKey)
 
   return (
-    <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${color}`}>
-      <Icon className={`size-3 ${status === "running" ? "animate-spin" : ""}`} />
+    <Badge
+      variant={getBadgeVariantForDesignSystemSeverity(state.severity)}
+      size="md"
+    >
+      <Icon
+        aria-hidden="true"
+        className={`size-3 ${status === "running" ? "animate-spin" : ""}`}
+      />
       {t(labelKey, labelDefault)}
-    </span>
+    </Badge>
   )
 }
 

--- a/apps/packages/ui/src/components/Agent/__tests__/SessionHistoryPanel.status-badge.test.tsx
+++ b/apps/packages/ui/src/components/Agent/__tests__/SessionHistoryPanel.status-badge.test.tsx
@@ -1,0 +1,61 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { SessionHistoryPanel } from "../SessionHistoryPanel"
+import type { SessionMetadata } from "@/services/agent/storage"
+import type { AgentStatus } from "@/services/agent/types"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key
+  })
+}))
+
+const makeSession = (status: AgentStatus, index: number): SessionMetadata => ({
+  id: `session-${status}`,
+  workspaceId: "workspace-1",
+  task: `Task for ${status}`,
+  title: `${status} session`,
+  status,
+  currentStep: index + 1,
+  createdAt: `2026-05-09T15:${String(index).padStart(2, "0")}:00.000Z`,
+  updatedAt: `2026-05-09T16:${String(index).padStart(2, "0")}:00.000Z`,
+  messageCount: index + 2,
+  toolCallCount: index
+})
+
+const badgeFor = (label: string) => {
+  const badge = screen.getByText(label).closest<HTMLElement>('[data-ds-component="Badge"]')
+  if (!badge) {
+    throw new Error(`Expected ${label} to render inside a Badge`)
+  }
+  return badge
+}
+
+describe("SessionHistoryPanel status badges", () => {
+  it("renders agent status labels through shared Badge variants", () => {
+    render(
+      <SessionHistoryPanel
+        sessions={[
+          makeSession("idle", 0),
+          makeSession("running", 1),
+          makeSession("waiting_approval", 2),
+          makeSession("complete", 3),
+          makeSession("error", 4),
+          makeSession("cancelled", 5)
+        ]}
+        isLoading={false}
+        onRestore={vi.fn()}
+        onDelete={vi.fn()}
+        onClearAll={vi.fn()}
+      />
+    )
+
+    expect(badgeFor("Idle")).toHaveAttribute("data-ds-variant", "secondary")
+    expect(badgeFor("Running")).toHaveAttribute("data-ds-variant", "info")
+    expect(badgeFor("Paused")).toHaveAttribute("data-ds-variant", "warning")
+    expect(badgeFor("Complete")).toHaveAttribute("data-ds-variant", "success")
+    expect(badgeFor("Error")).toHaveAttribute("data-ds-variant", "danger")
+    expect(badgeFor("Cancelled")).toHaveAttribute("data-ds-variant", "warning")
+  })
+})

--- a/apps/packages/ui/src/components/Agent/__tests__/SessionHistoryPanel.status-badge.test.tsx
+++ b/apps/packages/ui/src/components/Agent/__tests__/SessionHistoryPanel.status-badge.test.tsx
@@ -1,13 +1,21 @@
 import React from "react"
 import { render, screen } from "@testing-library/react"
-import { describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { SessionHistoryPanel } from "../SessionHistoryPanel"
 import type { SessionMetadata } from "@/services/agent/storage"
 import type { AgentStatus } from "@/services/agent/types"
 
+type TranslationFallback = string | { defaultValue?: string }
+
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
-    t: (_key: string, fallback?: string) => fallback ?? _key
+    t: (key: string, fallback?: TranslationFallback) => {
+      if (typeof fallback === "string") {
+        return fallback
+      }
+
+      return fallback?.defaultValue ?? key
+    }
   })
 }))
 
@@ -33,6 +41,15 @@ const badgeFor = (label: string) => {
 }
 
 describe("SessionHistoryPanel status badges", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-05-09T17:30:00.000Z"))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it("renders agent status labels through shared Badge variants", () => {
     render(
       <SessionHistoryPanel

--- a/backlog/tasks/task-45.26 - Adapt-Agent-SessionHistoryPanel-status-badges-to-shared-Badge.md
+++ b/backlog/tasks/task-45.26 - Adapt-Agent-SessionHistoryPanel-status-badges-to-shared-Badge.md
@@ -1,0 +1,60 @@
+---
+id: TASK-45.26
+title: Adapt Agent SessionHistoryPanel status badges to shared Badge
+status: Done
+assignee: []
+created_date: '2026-05-09 15:37'
+updated_date: '2026-05-09 15:42'
+labels:
+  - design-system
+  - webui
+  - guard
+dependencies: []
+references:
+  - apps/packages/ui/src/components/Agent/SessionHistoryPanel.tsx
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+parent_task_id: TASK-45
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate Agent SessionHistoryPanel local StatusBadge from bespoke span styling to the shared design-system Badge primitive with explicit canonical state mapping, preserving localized labels and removing its local-status-badge baseline exception.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 SessionHistoryPanel agent statuses render through the shared Badge primitive
+- [x] #2 Agent status badge variants are selected from design-system state registry mappings while preserving existing visible labels and icons
+- [x] #3 The local-status-badge baseline exception for src/components/Agent/SessionHistoryPanel.tsx is removed without new unbaselined findings
+- [x] #4 Focused SessionHistoryPanel tests, product-state guard tests, design-system verifier, diff checks, and touched-file TypeScript filter are recorded
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Red evidence: bunx vitest run src/components/Agent/__tests__/SessionHistoryPanel.status-badge.test.tsx --reporter=dot failed because Idle was not rendered inside data-ds-component="Badge".
+
+Implementation: SessionHistoryPanel StatusBadge now maps AgentStatus values to canonical design-system state keys, selects shared Badge variants through getBadgeVariantForDesignSystemSeverity, preserves the translated visible labels and lucide status icons, marks icons aria-hidden, and removes the SessionHistoryPanel local-status-badge baseline exception. Running maps to retrying so it keeps an info/primary visual treatment while still using the canonical state registry.
+
+Verification: bunx vitest run src/components/Agent/__tests__/SessionHistoryPanel.status-badge.test.tsx --reporter=dot passed 1/1; bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed 46/46; bun run verify:design-system-state passed with baseline exceptions 510 and local-status-badge 4; git diff --check passed; touched-file TypeScript filter over bunx tsc --noEmit --pretty false returned no matches.
+
+Bandit: skipped because this slice only changes TypeScript/TSX, JSON, and Backlog metadata.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Adapted Agent SessionHistoryPanel StatusBadge to the shared Badge primitive with design-system state mapping and removed its local-status-badge baseline exception. Focused tests, product-state guard tests, design-system verifier, diff checks, and touched-file TypeScript filter passed; full frontend tsc remains covered by the existing repo-wide baseline caveat.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.26.1 - Address-PR-1418-SessionHistoryPanel-review-comments.md
+++ b/backlog/tasks/task-45.26.1 - Address-PR-1418-SessionHistoryPanel-review-comments.md
@@ -1,0 +1,60 @@
+---
+id: TASK-45.26.1
+title: Address PR 1418 SessionHistoryPanel review comments
+status: Done
+assignee: []
+created_date: '2026-05-09 15:58'
+updated_date: '2026-05-09 16:07'
+labels:
+  - design-system
+  - webui
+  - review
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1418'
+  - >-
+    apps/packages/ui/src/components/Agent/__tests__/SessionHistoryPanel.status-badge.test.tsx
+parent_task_id: TASK-45.26
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Follow-up review-fix task for PR #1418. Resolve the review feedback on SessionHistoryPanel status badge tests so the new coverage is deterministic and handles react-i18next translation signatures used by formatRelativeTime.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 SessionHistoryPanel status badge test freezes time or otherwise removes dependency on the live system clock
+- [x] #2 The react-i18next t() mock handles both string fallback and options.defaultValue fallback signatures
+- [x] #3 Focused SessionHistoryPanel test and design-system verifier/guard checks are rerun and recorded
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+2026-05-09: Reproduced Qodo finding with fake timers before fixing the i18n mock. The focused test failed with React's "Objects are not valid as a React child" error when formatRelativeTime passed { count, defaultValue } to t().
+
+2026-05-09: Fixed the test mock to return string fallbacks and options.defaultValue fallbacks. Kept vi.useFakeTimers()/vi.setSystemTime() around the test for deterministic relative-time rendering.
+
+Verification: bunx vitest run src/components/Agent/__tests__/SessionHistoryPanel.status-badge.test.tsx --reporter=dot -> 1 passed. bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot -> 46 passed. bun run verify:design-system-state -> passed with existing baseline exceptions. git diff --check -> passed. bunx tsc --noEmit --pretty false | rg touched files -> no touched-file diagnostics (rg exit 1/no matches).
+
+Bandit skip: touched files are TSX test code and Backlog metadata only; no Python runtime/security surface changed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed PR #1418 review feedback by stabilizing the SessionHistoryPanel status-badge test. The test now freezes system time and the react-i18next mock supports both string fallback and options.defaultValue fallback signatures used by formatRelativeTime, preventing React from receiving the translation options object as a child.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrate Agent SessionHistoryPanel local StatusBadge to the shared Badge primitive.
- Map AgentStatus values through canonical design-system state keys while preserving existing visible labels and icons.
- Remove the SessionHistoryPanel local-status-badge baseline exception and add focused coverage.

## Verification
- bunx vitest run src/components/Agent/__tests__/SessionHistoryPanel.status-badge.test.tsx --reporter=dot
- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot
- bun run verify:design-system-state
- git diff --check
- touched-file TypeScript filter over bunx tsc --noEmit --pretty false returned no matches

Full frontend tsc remains covered by the existing repo-wide baseline caveat.

Change summary: This adapts the remaining Agent SessionHistoryPanel status wrapper to the shared Badge primitive because the design-system guard is tracking local status badge wrappers as migration debt. The status-to-state mapping keeps the existing user-facing semantics and icon treatment while routing visual variants through the canonical state registry, which reduces local token drift and lets the baseline entry be removed.