### PR TITLE
Wire VN Play setup dialog to backend options

### DIFF
--- a/Docs/superpowers/plans/2026-05-09-vn-play-setup-options-webui-integration-plan.md
+++ b/Docs/superpowers/plans/2026-05-09-vn-play-setup-options-webui-integration-plan.md
@@ -1,0 +1,23 @@
+## Stage 1: Frontend Contract
+**Goal**: Add typed WebUI support for `GET /api/v1/vn-play/setup-options`.
+**Success Criteria**: `listVNPlaySetupOptions()` serializes query parameters and returns the backend setup response shape.
+**Tests**: `apps/tldw-frontend/__tests__/vn-play/vnPlayApi.test.ts`.
+**Status**: Complete
+
+## Stage 2: Dialog Integration
+**Goal**: Move `NewSessionDialog` from client-side character, pack, and readiness fan-out to the backend setup-options contract.
+**Success Criteria**: The dialog renders backend-derived defaults, labels, warnings, compatibility, trust, and empty states while preserving the existing create-session payload.
+**Tests**: `apps/tldw-frontend/__tests__/vn-play/VNPlayWorkspace.test.tsx`.
+**Status**: Complete
+
+## Stage 3: Smoke Coverage
+**Goal**: Keep the VN Play smoke route aligned with the setup-options API.
+**Success Criteria**: The smoke test mocks `/vn-play/setup-options` and no longer needs setup-only character/pack/readiness routes.
+**Tests**: `apps/tldw-frontend/e2e/smoke/vn-play.spec.ts`.
+**Status**: Complete
+
+## Stage 4: Verification
+**Goal**: Validate the focused WebUI slice and record results.
+**Success Criteria**: Focused unit tests, lint/diff checks, and applicable security checks complete or have documented skips.
+**Tests**: Focused Vitest, ESLint, `git diff --check`, and Bandit only if backend Python files are touched.
+**Status**: Complete

--- a/apps/tldw-frontend/__tests__/vn-play/VNPlayWorkspace.test.tsx
+++ b/apps/tldw-frontend/__tests__/vn-play/VNPlayWorkspace.test.tsx
@@ -1,8 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import type { VNAssetReadiness } from '@web/types/vn-assets';
-import type { VNPlayBranch, VNPlayCheckpoint, VNPlaySession } from '@web/types/vn-play';
+import type {
+  VNPlayBranch,
+  VNPlayCheckpoint,
+  VNPlaySession,
+  VNPlaySetupAssetPackOption,
+  VNPlaySetupOptionsResponse,
+} from '@web/types/vn-play';
 
 const mocks = vi.hoisted(() => ({
   createVNPlayCheckpoint: vi.fn(),
@@ -13,6 +18,7 @@ const mocks = vi.hoisted(() => ({
   listVNPlayCheckpoints: vi.fn(),
   listVNPlayEvents: vi.fn(),
   listVNPlaySessions: vi.fn(),
+  listVNPlaySetupOptions: vi.fn(),
   listCharacters: vi.fn(),
   listVNAssetPacks: vi.fn(),
   restoreVNPlaySession: vi.fn(),
@@ -28,6 +34,7 @@ vi.mock('@web/lib/api/vnPlay', () => ({
   listVNPlayCheckpoints: (...args: unknown[]) => mocks.listVNPlayCheckpoints(...args),
   listVNPlayEvents: (...args: unknown[]) => mocks.listVNPlayEvents(...args),
   listVNPlaySessions: (...args: unknown[]) => mocks.listVNPlaySessions(...args),
+  listVNPlaySetupOptions: (...args: unknown[]) => mocks.listVNPlaySetupOptions(...args),
   restoreVNPlaySession: (...args: unknown[]) => mocks.restoreVNPlaySession(...args),
   retryLastVNPlayTurn: (...args: unknown[]) => mocks.retryLastVNPlayTurn(...args),
   submitVNPlayTurn: (...args: unknown[]) => mocks.submitVNPlayTurn(...args),
@@ -67,6 +74,100 @@ const defaultPacks = [
   },
 ];
 
+const defaultSetupOptions: VNPlaySetupOptionsResponse = {
+  characters: [
+    {
+      id: 7,
+      name: 'Mira Vale',
+      description_preview: 'Archive guide',
+      tags: ['archive', 'story'],
+      favorite: false,
+      deleted: false,
+      has_image: true,
+    },
+  ],
+  selected_character: null,
+  asset_packs: [
+    {
+      id: 12,
+      title: 'Moonlit Archive Pack',
+      primary_character_id: 7,
+      content_rating: 'general',
+      status: 'approved',
+      trust_level: 'local',
+      trust_source: 'local_pack',
+      ready: true,
+      readiness_status: 'ready',
+      readiness_warnings: [],
+      readiness_errors: [],
+      compatibility: { status: 'compatible', reason_codes: [] },
+      warning_summary: {
+        highest_severity: 'info',
+        requires_acknowledgement: false,
+        warnings: [],
+      },
+      recommended: true,
+    },
+  ],
+  defaults: {
+    mode: 'freeform',
+    character_id: 7,
+    asset_pack_id: 12,
+    content_rating: 'general',
+  },
+  pagination: {
+    characters: { limit: 25, offset: 0, has_more: false, total: 1 },
+    asset_packs: { limit: 25, offset: 0, has_more: false, total: 1 },
+  },
+  empty_states: [],
+  generated_at: '2026-05-09T15:00:00Z',
+};
+
+function setupPack(overrides: Partial<VNPlaySetupAssetPackOption> = {}): VNPlaySetupAssetPackOption {
+  return {
+    ...defaultSetupOptions.asset_packs[0],
+    compatibility: {
+      ...defaultSetupOptions.asset_packs[0].compatibility,
+      ...overrides.compatibility,
+    },
+    warning_summary: {
+      ...defaultSetupOptions.asset_packs[0].warning_summary,
+      ...overrides.warning_summary,
+    },
+    ...overrides,
+  };
+}
+
+function setupOptions(
+  overrides: Partial<VNPlaySetupOptionsResponse> = {}
+): VNPlaySetupOptionsResponse {
+  const characters = overrides.characters ?? defaultSetupOptions.characters;
+  const assetPacks = overrides.asset_packs ?? defaultSetupOptions.asset_packs;
+  return {
+    ...defaultSetupOptions,
+    ...overrides,
+    characters,
+    asset_packs: assetPacks,
+    defaults: {
+      ...defaultSetupOptions.defaults,
+      ...overrides.defaults,
+    },
+    pagination: {
+      characters: {
+        ...defaultSetupOptions.pagination.characters,
+        total: characters.length,
+        has_more: false,
+      },
+      asset_packs: {
+        ...defaultSetupOptions.pagination.asset_packs,
+        total: assetPacks.length,
+        has_more: false,
+      },
+      ...overrides.pagination,
+    },
+  };
+}
+
 function createDeferred<T>() {
   let resolve!: (value: T) => void;
   let reject!: (reason?: unknown) => void;
@@ -75,15 +176,6 @@ function createDeferred<T>() {
     reject = nextReject;
   });
   return { promise, reject, resolve };
-}
-
-function readyReadiness(): VNAssetReadiness {
-  return {
-    ready: true,
-    status: 'ready',
-    warnings: [],
-    errors: [],
-  };
 }
 
 function mockVNPlayApi({
@@ -156,6 +248,7 @@ describe('VNPlayWorkspace', () => {
     mockVNPlayApi();
     mocks.listCharacters.mockResolvedValue(defaultCharacters);
     mocks.listVNAssetPacks.mockResolvedValue(defaultPacks);
+    mocks.listVNPlaySetupOptions.mockResolvedValue(setupOptions());
     mocks.getVNAssetReadiness.mockResolvedValue({
       ready: true,
       status: 'ready',
@@ -204,10 +297,11 @@ describe('VNPlayWorkspace', () => {
     expect(await screen.findByLabelText('Character')).toBeInTheDocument();
     expect(screen.getAllByText('Mira Vale').length).toBeGreaterThan(0);
     expect(screen.getByText(/Archive guide/)).toBeInTheDocument();
-    expect(screen.getByText(/archive, story/)).toBeInTheDocument();
+    expect(screen.getAllByText(/archive, story/).length).toBeGreaterThan(0);
     expect(screen.getByLabelText('VN asset pack')).toBeInTheDocument();
     expect(screen.getAllByText('Moonlit Archive Pack').length).toBeGreaterThan(0);
-    expect(screen.getByText(/Runtime-ready VN poses and backdrops/)).toBeInTheDocument();
+    expect(screen.getByText(/Trust level: local/)).toBeInTheDocument();
+    expect(screen.getByText(/Readiness: ready/)).toBeInTheDocument();
 
     await user.clear(screen.getByLabelText('Title'));
     await user.type(screen.getByLabelText('Title'), 'Moonlit Archive');
@@ -228,84 +322,113 @@ describe('VNPlayWorkspace', () => {
     expect(await screen.findByText('Moonlit Archive')).toBeInTheDocument();
   });
 
-  it('renders character and pack selectors before readiness checks finish', async () => {
+  it('uses backend setup options instead of client-side setup fan-out', async () => {
     const user = userEvent.setup();
-    const readiness = createDeferred<VNAssetReadiness>();
     mockVNPlayApi({ sessions: [] });
-    mocks.getVNAssetReadiness.mockReturnValue(readiness.promise);
 
     render(<VNPlayWorkspace />);
 
     await user.click(await screen.findByRole('button', { name: /new freeform/i }));
 
     expect(await screen.findByLabelText('Character')).toBeInTheDocument();
-    expect(screen.getAllByText('Mira Vale').length).toBeGreaterThan(0);
-    expect(screen.getByRole('option', { name: /Moonlit Archive Pack/i })).toBeInTheDocument();
-
-    readiness.resolve(readyReadiness());
+    expect(mocks.listVNPlaySetupOptions).toHaveBeenCalledWith({
+      content_rating: 'general',
+      mode: 'freeform',
+    });
+    expect(mocks.listCharacters).not.toHaveBeenCalled();
+    expect(mocks.listVNAssetPacks).not.toHaveBeenCalled();
+    expect(mocks.getVNAssetReadiness).not.toHaveBeenCalled();
   });
 
-  it('limits concurrent readiness checks while loading selector data', async () => {
+  it('does not refetch setup options when applying backend defaults', async () => {
     const user = userEvent.setup();
-    const packs = Array.from({ length: 6 }, (_, index) => ({
-      ...defaultPacks[0],
-      id: index + 1,
-      title: `Pack ${index + 1}`,
-    }));
-    const pendingReadiness = new Map<number, ReturnType<typeof createDeferred<VNAssetReadiness>>>();
-    let activeRequests = 0;
-    let maxActiveRequests = 0;
-
+    const firstSetup = createDeferred<VNPlaySetupOptionsResponse>();
     mockVNPlayApi({ sessions: [] });
-    mocks.listVNAssetPacks.mockResolvedValue(packs);
-    mocks.getVNAssetReadiness.mockImplementation((packId: number) => {
-      activeRequests += 1;
-      maxActiveRequests = Math.max(maxActiveRequests, activeRequests);
-      const readiness = createDeferred<VNAssetReadiness>();
-      pendingReadiness.set(packId, readiness);
-      return readiness.promise.finally(() => {
-        activeRequests -= 1;
-      });
-    });
+    mocks.listVNPlaySetupOptions.mockReturnValueOnce(firstSetup.promise);
 
     render(<VNPlayWorkspace />);
 
     await user.click(await screen.findByRole('button', { name: /new freeform/i }));
-    await waitFor(() => expect(mocks.getVNAssetReadiness).toHaveBeenCalledTimes(4));
-    expect(maxActiveRequests).toBeLessThanOrEqual(4);
+    expect(mocks.listVNPlaySetupOptions).toHaveBeenCalledTimes(1);
 
-    for (const readiness of pendingReadiness.values()) {
-      readiness.resolve(readyReadiness());
-    }
-    await waitFor(() => expect(mocks.getVNAssetReadiness).toHaveBeenCalledTimes(6));
-    for (const readiness of pendingReadiness.values()) {
-      readiness.resolve(readyReadiness());
-    }
-    await waitFor(() => expect(activeRequests).toBe(0));
-    expect(maxActiveRequests).toBeLessThanOrEqual(4);
+    firstSetup.resolve(setupOptions());
+    expect(await screen.findByLabelText('Character')).toBeInTheDocument();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mocks.listVNPlaySetupOptions).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders setup loading state before backend options resolve', async () => {
+    const user = userEvent.setup();
+    const setup = createDeferred<VNPlaySetupOptionsResponse>();
+    mockVNPlayApi({ sessions: [] });
+    mocks.listVNPlaySetupOptions.mockReturnValueOnce(setup.promise);
+
+    render(<VNPlayWorkspace />);
+
+    await user.click(await screen.findByRole('button', { name: /new freeform/i }));
+
+    expect(await screen.findByText(/Loading setup options/i)).toBeInTheDocument();
+    setup.resolve(setupOptions());
+    expect(await screen.findByLabelText('Character')).toBeInTheDocument();
+    expect(screen.getAllByText('Mira Vale').length).toBeGreaterThan(0);
+    expect(screen.getByRole('option', { name: /Moonlit Archive Pack/i })).toBeInTheDocument();
+  });
+
+  it('does not issue client-side readiness checks for setup packs', async () => {
+    const user = userEvent.setup();
+    const packs = Array.from({ length: 6 }, (_, index) => ({
+      ...setupPack(),
+      id: index + 1,
+      title: `Pack ${index + 1}`,
+    }));
+
+    mockVNPlayApi({ sessions: [] });
+    mocks.listVNPlaySetupOptions.mockResolvedValue(setupOptions({ asset_packs: packs }));
+
+    render(<VNPlayWorkspace />);
+
+    await user.click(await screen.findByRole('button', { name: /new freeform/i }));
+    expect(await screen.findByRole('option', { name: /Pack 1/i })).toBeInTheDocument();
+    expect(mocks.getVNAssetReadiness).not.toHaveBeenCalled();
   });
 
   it('marks incompatible asset packs as unavailable for the selected character', async () => {
     const user = userEvent.setup();
     mockVNPlayApi({ sessions: [] });
-    mocks.listVNAssetPacks.mockResolvedValue([
-      ...defaultPacks,
-      {
-        id: 13,
-        title: 'Rival Pack',
-        primary_character_id: 99,
-        status: 'approved',
-        content_rating: 'general',
-        planned_output_count: 6,
-      },
-    ]);
+    mocks.listVNPlaySetupOptions.mockResolvedValue(
+      setupOptions({
+        asset_packs: [
+          setupPack(),
+          setupPack({
+            id: 13,
+            title: 'Rival Pack',
+            primary_character_id: 99,
+            compatibility: { status: 'different_character', reason_codes: ['character_mismatch'] },
+            recommended: false,
+            warning_summary: {
+              highest_severity: 'high_risk',
+              requires_acknowledgement: true,
+              warnings: [
+                {
+                  code: 'pack_character_mismatch',
+                  severity: 'high_risk',
+                  message: 'Rival Pack is attached to character 99, not Mira Vale.',
+                  requires_acknowledgement: true,
+                },
+              ],
+            },
+          }),
+        ],
+      })
+    );
 
     render(<VNPlayWorkspace />);
 
     await user.click(await screen.findByRole('button', { name: /new story/i }));
 
     expect(await screen.findByRole('option', {
-      name: /Rival Pack.*incompatible with Mira Vale/i,
+      name: /Rival Pack.*different character/i,
     })).toBeDisabled();
     expect(screen.getByText(/Rival Pack is attached to character 99/i)).toBeInTheDocument();
   });
@@ -313,19 +436,40 @@ describe('VNPlayWorkspace', () => {
   it('shows readiness, draft, missing-byte, and content-rating warnings before submit', async () => {
     const user = userEvent.setup();
     mockVNPlayApi({ sessions: [] });
-    mocks.listVNAssetPacks.mockResolvedValue([
-      {
-        ...defaultPacks[0],
-        status: 'draft',
-        content_rating: 'mature',
-      },
-    ]);
-    mocks.getVNAssetReadiness.mockResolvedValue({
-      ready: false,
-      status: 'missing_assets',
-      warnings: ['2 required runtime assets are missing bytes'],
-      errors: ['sprite.primary has no approved file bytes'],
-    });
+    mocks.listVNPlaySetupOptions.mockResolvedValue(
+      setupOptions({
+        asset_packs: [
+          setupPack({
+            status: 'draft',
+            content_rating: 'mature',
+            ready: false,
+            readiness_status: 'missing_assets',
+            readiness_warnings: ['2 required runtime assets are missing bytes'],
+            readiness_errors: ['sprite.primary has no approved file bytes'],
+            recommended: false,
+            warning_summary: {
+              highest_severity: 'high_risk',
+              requires_acknowledgement: true,
+              warnings: [
+                {
+                  code: 'pack_status_draft',
+                  severity: 'high_risk',
+                  message: 'Pack status is draft; review or approve it before starting VN Play.',
+                  requires_acknowledgement: true,
+                },
+                {
+                  code: 'content_rating_mismatch',
+                  severity: 'warning',
+                  message: 'Pack content rating mature differs from session rating general.',
+                  requires_acknowledgement: false,
+                },
+              ],
+            },
+          }),
+        ],
+        defaults: { asset_pack_id: 12 },
+      })
+    );
 
     render(<VNPlayWorkspace />);
 
@@ -338,16 +482,85 @@ describe('VNPlayWorkspace', () => {
     expect(screen.getByRole('button', { name: 'Create session' })).toBeDisabled();
   });
 
+  it('allows acknowledged high-risk setup warnings to be submitted in session settings', async () => {
+    const user = userEvent.setup();
+    mockVNPlayApi({ sessions: [] });
+    mocks.listVNPlaySetupOptions.mockResolvedValue(
+      setupOptions({
+        asset_packs: [
+          setupPack({
+            title: 'Imported Archive Pack',
+            trust_level: 'untrusted_import',
+            trust_source: 'latest_import_journal',
+            ready: true,
+            readiness_status: 'ready',
+            recommended: false,
+            warning_summary: {
+              highest_severity: 'high_risk',
+              requires_acknowledgement: true,
+              warnings: [
+                {
+                  code: 'untrusted_import',
+                  severity: 'high_risk',
+                  message: 'Imported packs should be reviewed before VN Play.',
+                  requires_acknowledgement: true,
+                },
+              ],
+            },
+          }),
+        ],
+        defaults: { asset_pack_id: 12 },
+      })
+    );
+
+    render(<VNPlayWorkspace />);
+
+    await user.click(await screen.findByRole('button', { name: /new freeform/i }));
+
+    expect(await screen.findByRole('option', {
+      name: /Imported Archive Pack.*review required/i,
+    })).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Create session' })).toBeDisabled();
+
+    await user.click(screen.getByRole('checkbox', { name: /I understand and want to proceed/i }));
+    await user.clear(screen.getByLabelText('Title'));
+    await user.type(screen.getByLabelText('Title'), 'Acknowledged Import');
+    await user.click(screen.getByRole('button', { name: 'Create session' }));
+
+    await waitFor(() => {
+      expect(mocks.createVNPlaySession).toHaveBeenCalledWith({
+        mode: 'freeform',
+        title: 'Acknowledged Import',
+        primary_character_id: 7,
+        vn_asset_pack_id: 12,
+        linked_chat_id: null,
+        content_rating: 'general',
+        settings: {
+          setup_acknowledgements: [
+            {
+              asset_pack_id: 12,
+              warning_codes: ['untrusted_import'],
+              highest_severity: 'high_risk',
+            },
+          ],
+        },
+      });
+    });
+  });
+
   it('renders duplicate readiness warnings without duplicate React keys', async () => {
     const user = userEvent.setup();
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
     mockVNPlayApi({ sessions: [] });
-    mocks.getVNAssetReadiness.mockResolvedValue({
-      ready: true,
-      status: 'ready',
-      warnings: ['Review duplicate slot metadata', 'Review duplicate slot metadata'],
-      errors: [],
-    });
+    mocks.listVNPlaySetupOptions.mockResolvedValue(
+      setupOptions({
+        asset_packs: [
+          setupPack({
+            readiness_warnings: ['Review duplicate slot metadata', 'Review duplicate slot metadata'],
+          }),
+        ],
+      })
+    );
 
     try {
       render(<VNPlayWorkspace />);
@@ -365,15 +578,42 @@ describe('VNPlayWorkspace', () => {
     }
   });
 
-  it('keeps manual ID entry available when setup selectors fail to load', async () => {
+  it('resets all new-session form fields when reopened after manual fallback', async () => {
     const user = userEvent.setup();
     mockVNPlayApi({ sessions: [] });
-    mocks.listCharacters.mockRejectedValueOnce(new Error('characters offline'));
+    mocks.listVNPlaySetupOptions.mockRejectedValue(new Error('setup options offline'));
 
     render(<VNPlayWorkspace />);
 
     await user.click(await screen.findByRole('button', { name: /new freeform/i }));
-    expect(await screen.findByText(/Could not load setup selectors/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Could not load setup options/i)).toBeInTheDocument();
+    await user.clear(screen.getByLabelText('Title'));
+    await user.type(screen.getByLabelText('Title'), 'Dirty draft');
+    await user.clear(screen.getByLabelText('Primary character ID'));
+    await user.type(screen.getByLabelText('Primary character ID'), '17');
+    await user.clear(screen.getByLabelText('VN asset pack ID'));
+    await user.type(screen.getByLabelText('VN asset pack ID'), '21');
+    await user.type(screen.getByLabelText('Linked chat ID'), 'chat-to-clear');
+    await user.click(screen.getByRole('button', { name: 'Close' }));
+
+    await user.click(await screen.findByRole('button', { name: /new freeform/i }));
+
+    expect(await screen.findByText(/Could not load setup options/i)).toBeInTheDocument();
+    expect(screen.getByLabelText('Title')).toHaveValue('Untitled VN play session');
+    expect(screen.getByLabelText('Primary character ID')).toHaveValue('1');
+    expect(screen.getByLabelText('VN asset pack ID')).toHaveValue('1');
+    expect(screen.getByLabelText('Linked chat ID')).toHaveValue('');
+  });
+
+  it('keeps manual ID entry available when setup selectors fail to load', async () => {
+    const user = userEvent.setup();
+    mockVNPlayApi({ sessions: [] });
+    mocks.listVNPlaySetupOptions.mockRejectedValueOnce(new Error('setup options offline'));
+
+    render(<VNPlayWorkspace />);
+
+    await user.click(await screen.findByRole('button', { name: /new freeform/i }));
+    expect(await screen.findByText(/Could not load setup options/i)).toBeInTheDocument();
 
     await user.clear(screen.getByLabelText('Title'));
     await user.type(screen.getByLabelText('Title'), 'Manual Session');
@@ -398,17 +638,26 @@ describe('VNPlayWorkspace', () => {
   it('shows empty-state guidance when no character or runtime-ready pack exists', async () => {
     const user = userEvent.setup();
     mockVNPlayApi({ sessions: [] });
-    mocks.listCharacters.mockResolvedValue([]);
-    mocks.listVNAssetPacks.mockResolvedValue([]);
+    mocks.listVNPlaySetupOptions.mockResolvedValue(
+      setupOptions({
+        characters: [],
+        asset_packs: [],
+        defaults: { character_id: null, asset_pack_id: null },
+        empty_states: [
+          { code: 'no_characters', scope: 'global', message: 'No available characters were found.' },
+          { code: 'no_asset_packs', scope: 'global', message: 'No VN asset packs were found.' },
+        ],
+      })
+    );
 
     render(<VNPlayWorkspace />);
 
     await user.click(await screen.findByRole('button', { name: /new story/i }));
 
-    expect(await screen.findByText(/No characters available/i)).toBeInTheDocument();
-    expect(screen.getByText(/Create or import a character before starting VN Play/i)).toBeInTheDocument();
-    expect(screen.getByText(/No VN asset packs available/i)).toBeInTheDocument();
-    expect(screen.getByText(/Prepare or review a VN asset pack before starting VN Play/i)).toBeInTheDocument();
+    expect(await screen.findByText(/No available characters were found/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Open characters/i })).toHaveAttribute('href', '/characters');
+    expect(screen.getByText(/No VN asset packs were found/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Open VN asset packs/i })).toHaveAttribute('href', '/vn-assets');
     expect(screen.getByRole('button', { name: 'Create session' })).toBeDisabled();
   });
 

--- a/apps/tldw-frontend/__tests__/vn-play/vnPlayApi.test.ts
+++ b/apps/tldw-frontend/__tests__/vn-play/vnPlayApi.test.ts
@@ -22,6 +22,7 @@ import {
   listVNPlayCheckpoints,
   listVNPlayEvents,
   listVNPlaySessions,
+  listVNPlaySetupOptions,
   restoreVNPlaySession,
   retryLastVNPlayTurn,
   submitVNPlayTurn,
@@ -110,5 +111,37 @@ describe('vnPlay api client', () => {
       idempotency_key: 'restore-1',
     });
     expect(mocks.apiClient.get).toHaveBeenCalledWith('/vn-play/sessions/1/branches');
+  });
+
+  it('loads VN play setup options with server-side selector parameters', async () => {
+    mocks.apiClient.get.mockResolvedValueOnce({
+      characters: [],
+      asset_packs: [],
+      defaults: {},
+      empty_states: [],
+      generated_at: '2026-05-09T15:00:00Z',
+      pagination: {
+        characters: { limit: 25, offset: 0, has_more: false, total: 0 },
+        asset_packs: { limit: 25, offset: 0, has_more: false, total: 0 },
+      },
+    });
+
+    await listVNPlaySetupOptions({
+      mode: 'story',
+      selected_character_id: 7,
+      content_rating: 'mature',
+      character_query: 'mira',
+      pack_query: 'archive',
+    });
+
+    expect(mocks.apiClient.get).toHaveBeenCalledWith('/vn-play/setup-options', {
+      params: {
+        mode: 'story',
+        selected_character_id: 7,
+        content_rating: 'mature',
+        character_query: 'mira',
+        pack_query: 'archive',
+      },
+    });
   });
 });

--- a/apps/tldw-frontend/components/vn-play/NewSessionDialog.tsx
+++ b/apps/tldw-frontend/components/vn-play/NewSessionDialog.tsx
@@ -1,11 +1,15 @@
-import React, { FormEvent, useEffect, useMemo, useState } from 'react';
+import React, { FormEvent, useEffect, useMemo, useRef, useState } from 'react';
 import { Button } from '@web/components/ui/Button';
 import { Input } from '@web/components/ui/Input';
-import { listCharacters } from '@web/lib/api/characters';
-import { getVNAssetReadiness, listVNAssetPacks } from '@web/lib/api/vnAssets';
-import type { CharacterSummary } from '@web/types/characters';
-import type { VNAssetPack, VNAssetReadiness } from '@web/types/vn-assets';
-import type { VNPlayMode, VNPlaySessionCreate } from '@web/types/vn-play';
+import { listVNPlaySetupOptions } from '@web/lib/api/vnPlay';
+import type {
+  VNPlayMode,
+  VNPlaySessionCreate,
+  VNPlaySetupAssetPackOption,
+  VNPlaySetupCharacterOption,
+  VNPlaySetupEmptyState,
+  VNPlaySetupOptionsResponse,
+} from '@web/types/vn-play';
 
 export interface NewSessionDialogProps {
   initialMode: VNPlayMode;
@@ -16,153 +20,186 @@ export interface NewSessionDialogProps {
 }
 
 type SelectorMode = 'selectors' | 'manual';
-type ReadinessByPackId = Record<number, VNAssetReadiness>;
 
 const SELECT_CLASS =
   'mt-1 block w-full rounded-md border-border bg-bg shadow-sm focus:border-primary focus:ring-primary';
-const APPROVED_PACK_STATUSES = new Set(['approved', 'ready', 'runtime_ready', 'active']);
-const READINESS_REQUEST_BATCH_SIZE = 4;
+const EMPTY_ASSET_PACKS: VNPlaySetupAssetPackOption[] = [];
+const EMPTY_EMPTY_STATES: VNPlaySetupEmptyState[] = [];
 
 function parsePositiveInteger(value: string): number | null {
   const parsed = Number(value);
   return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
 }
 
-function characterName(character: CharacterSummary | null): string {
+function characterName(character: VNPlaySetupCharacterOption | null): string {
   return character?.name?.trim() || (character ? `Character ${character.id}` : 'selected character');
 }
 
-function formatTags(tags: CharacterSummary['tags']): string | null {
-  if (Array.isArray(tags)) {
-    const normalized = tags.map((tag) => tag.trim()).filter(Boolean);
-    return normalized.length ? normalized.join(', ') : null;
+function formatTags(tags: string[] | undefined): string | null {
+  const normalized = (tags ?? []).map((tag) => tag.trim()).filter(Boolean);
+  return normalized.length ? normalized.join(', ') : null;
+}
+
+function characterOptionLabel(character: VNPlaySetupCharacterOption): string {
+  const parts = [characterName(character), `#${character.id}`];
+  const tags = formatTags(character.tags);
+  if (tags) {
+    parts.push(tags);
   }
-
-  if (typeof tags === 'string') {
-    return tags.trim() || null;
-  }
-
-  return null;
-}
-
-function isApprovedPackStatus(status?: string | null): boolean {
-  if (!status) return true;
-  return APPROVED_PACK_STATUSES.has(status.toLowerCase());
-}
-
-function chooseBestPack(
-  packs: VNAssetPack[],
-  characterId: number | null,
-  readinessByPackId: ReadinessByPackId
-): VNAssetPack | null {
-  if (!characterId) return null;
-
-  const compatiblePacks = packs.filter((pack) => pack.primary_character_id === characterId);
-  return (
-    compatiblePacks.find((pack) => readinessByPackId[pack.id]?.ready && isApprovedPackStatus(pack.status)) ??
-    compatiblePacks[0] ??
-    null
-  );
-}
-
-async function loadReadinessForPacks(packs: VNAssetPack[]): Promise<ReadinessByPackId> {
-  const entries: Array<readonly [number, VNAssetReadiness]> = [];
-
-  for (let index = 0; index < packs.length; index += READINESS_REQUEST_BATCH_SIZE) {
-    const batch = packs.slice(index, index + READINESS_REQUEST_BATCH_SIZE);
-    const batchEntries = await Promise.all(
-      batch.map(async (pack) => {
-        try {
-          const readiness = await getVNAssetReadiness(pack.id);
-          return [pack.id, readiness] as const;
-        } catch (error) {
-          const message = error instanceof Error ? error.message : 'Readiness request failed';
-          return [
-            pack.id,
-            {
-              ready: false,
-              status: 'readiness_unavailable',
-              warnings: [],
-              errors: [`Could not load readiness for ${pack.title}: ${message}`],
-            },
-          ] as const;
-        }
-      })
-    );
-    entries.push(...batchEntries);
-  }
-
-  return entries.reduce<ReadinessByPackId>((accumulator, [packId, readiness]) => {
-    accumulator[packId] = readiness;
-    return accumulator;
-  }, {});
-}
-
-function buildPackOptionLabel(
-  pack: VNAssetPack,
-  selectedCharacter: CharacterSummary | null,
-  readiness?: VNAssetReadiness
-): string {
-  const parts = [pack.title];
-  if (selectedCharacter && pack.primary_character_id !== selectedCharacter.id) {
-    parts.push(`incompatible with ${characterName(selectedCharacter)}`);
-  } else if (readiness && !readiness.ready) {
-    parts.push('not ready');
+  if (character.favorite) {
+    parts.push('favorite');
   }
   return parts.join(' - ');
 }
 
-function buildSelectedPackWarnings({
-  contentRating,
-  pack,
-  readiness,
-  selectedCharacter,
-}: {
-  contentRating: string;
-  pack: VNAssetPack | null;
-  readiness?: VNAssetReadiness;
-  selectedCharacter: CharacterSummary | null;
-}): string[] {
-  if (!pack) return [];
+function humanizeValue(value: string): string {
+  return value.replace(/_/g, ' ');
+}
 
-  const warnings: string[] = [];
-  if (selectedCharacter && pack.primary_character_id !== selectedCharacter.id) {
-    warnings.push(`${pack.title} is attached to character ${pack.primary_character_id}, not ${characterName(selectedCharacter)}.`);
+function requiresPackAcknowledgement(pack: VNPlaySetupAssetPackOption | null): boolean {
+  return Boolean(pack?.warning_summary.requires_acknowledgement);
+}
+
+function acknowledgementWarningCodes(pack: VNPlaySetupAssetPackOption): string[] {
+  const requiredCodes = pack.warning_summary.warnings
+    .filter((warning) => warning.requires_acknowledgement)
+    .map((warning) => warning.code)
+    .filter(Boolean);
+
+  if (requiredCodes.length > 0) {
+    return requiredCodes;
   }
 
-  if (pack.status && !isApprovedPackStatus(pack.status)) {
-    warnings.push(`Pack status is ${pack.status}; review or approve it before starting VN Play.`);
-  }
+  return pack.warning_summary.warnings.map((warning) => warning.code).filter(Boolean);
+}
 
-  if (readiness) {
-    if (!readiness.ready) {
-      warnings.push(`Readiness status: ${readiness.status}.`);
-    }
-    warnings.push(...readiness.warnings);
-    warnings.push(...readiness.errors);
-  }
+function acknowledgementKey(pack: VNPlaySetupAssetPackOption | null): string {
+  if (!pack || !requiresPackAcknowledgement(pack)) return '';
+  return [pack.id, ...acknowledgementWarningCodes(pack)].join(':');
+}
 
-  if (
-    pack.content_rating &&
-    contentRating.trim() &&
-    pack.content_rating.toLowerCase() !== contentRating.trim().toLowerCase()
-  ) {
-    warnings.push(`Pack content rating ${pack.content_rating} differs from session rating ${contentRating.trim()}.`);
-  }
+function buildSetupAcknowledgement(pack: VNPlaySetupAssetPackOption) {
+  return {
+    asset_pack_id: pack.id,
+    warning_codes: acknowledgementWarningCodes(pack),
+    highest_severity: pack.warning_summary.highest_severity,
+  };
+}
 
-  return warnings;
+function packOptionLabel(pack: VNPlaySetupAssetPackOption): string {
+  const parts = [pack.title];
+  if (pack.recommended) {
+    parts.push('recommended');
+  }
+  if (pack.compatibility.status === 'different_character') {
+    parts.push('different character');
+  } else if (!pack.ready) {
+    parts.push('not ready');
+  } else if (requiresPackAcknowledgement(pack)) {
+    parts.push('review required');
+  }
+  return parts.join(' - ');
+}
+
+function setupCharacters(options: VNPlaySetupOptionsResponse | null): VNPlaySetupCharacterOption[] {
+  if (!options) return [];
+  const selected = options.selected_character;
+  if (!selected || options.characters.some((character) => character.id === selected.id)) {
+    return options.characters;
+  }
+  return [selected, ...options.characters];
+}
+
+function selectedCharacterFromOptions(
+  options: VNPlaySetupOptionsResponse | null,
+  selectedCharacterId: number | null
+): VNPlaySetupCharacterOption | null {
+  if (!options || !selectedCharacterId) return null;
+  if (options.selected_character?.id === selectedCharacterId) {
+    return options.selected_character;
+  }
+  return options.characters.find((character) => character.id === selectedCharacterId) ?? null;
+}
+
+function defaultCharacterId(
+  options: VNPlaySetupOptionsResponse,
+  currentCharacterId: number | null
+): number | null {
+  if (currentCharacterId && setupCharacters(options).some((character) => character.id === currentCharacterId)) {
+    return currentCharacterId;
+  }
+  return options.defaults.character_id ?? options.selected_character?.id ?? options.characters[0]?.id ?? null;
 }
 
 function hasBlockingPackIssue(
-  pack: VNAssetPack | null,
-  selectedCharacter: CharacterSummary | null,
-  readiness?: VNAssetReadiness
+  pack: VNPlaySetupAssetPackOption | null,
+  selectedCharacter: VNPlaySetupCharacterOption | null
 ): boolean {
   if (!pack || !selectedCharacter) return true;
-  if (pack.primary_character_id !== selectedCharacter.id) return true;
-  if (pack.status && !isApprovedPackStatus(pack.status)) return true;
-  if (!readiness?.ready) return true;
+  if (pack.compatibility.status === 'different_character') return true;
+  if (!pack.ready) return true;
   return false;
+}
+
+function defaultPackId(
+  options: VNPlaySetupOptionsResponse,
+  selectedCharacter: VNPlaySetupCharacterOption | null,
+  currentPackId: number | null
+): number | null {
+  const currentPack = currentPackId
+    ? options.asset_packs.find((pack) => pack.id === currentPackId) ?? null
+    : null;
+  if (currentPack && !hasBlockingPackIssue(currentPack, selectedCharacter)) {
+    return currentPack.id;
+  }
+  return (
+    options.defaults.asset_pack_id ??
+    options.asset_packs.find((pack) => pack.recommended)?.id ??
+    options.asset_packs.find((pack) => !hasBlockingPackIssue(pack, selectedCharacter))?.id ??
+    null
+  );
+}
+
+function packWarningMessages(pack: VNPlaySetupAssetPackOption | null): string[] {
+  if (!pack) return [];
+  const messages: string[] = [];
+  if (!pack.ready) {
+    messages.push(`Readiness status: ${pack.readiness_status}.`);
+  }
+  messages.push(...pack.readiness_warnings);
+  messages.push(...pack.readiness_errors);
+  messages.push(...pack.warning_summary.warnings.map((warning) => warning.message));
+  return messages.filter(Boolean);
+}
+
+function emptyStatesFor(
+  emptyStates: VNPlaySetupEmptyState[],
+  codes: string[]
+): VNPlaySetupEmptyState[] {
+  const codeSet = new Set(codes);
+  return emptyStates.filter((state) => codeSet.has(state.code));
+}
+
+function EmptyStateGuidance({
+  states,
+  workspaceHref,
+  workspaceLabel,
+}: {
+  states: VNPlaySetupEmptyState[];
+  workspaceHref: string;
+  workspaceLabel: string;
+}) {
+  if (states.length === 0) return null;
+  return (
+    <div className="mt-2 rounded-md border border-warn/30 bg-warn/10 px-3 py-2 text-sm text-warn">
+      {states.map((state) => (
+        <p key={`${state.code}-${state.scope}`}>{state.message}</p>
+      ))}
+      <a className="mt-1 inline-block underline" href={workspaceHref}>
+        Open {workspaceLabel}
+      </a>
+    </div>
+  );
 }
 
 export default function NewSessionDialog({
@@ -182,60 +219,78 @@ export default function NewSessionDialog({
   const [contentRating, setContentRating] = useState('general');
   const [formError, setFormError] = useState<string | null>(null);
   const [selectorMode, setSelectorMode] = useState<SelectorMode>('selectors');
-  const [characters, setCharacters] = useState<CharacterSummary[]>([]);
-  const [assetPacks, setAssetPacks] = useState<VNAssetPack[]>([]);
-  const [readinessByPackId, setReadinessByPackId] = useState<ReadinessByPackId>({});
+  const [setupOptions, setSetupOptions] = useState<VNPlaySetupOptionsResponse | null>(null);
   const [isLoadingSelectors, setIsLoadingSelectors] = useState(false);
   const [selectorError, setSelectorError] = useState<string | null>(null);
+  const [acknowledgedSetupWarnings, setAcknowledgedSetupWarnings] = useState(false);
+  const selectedPackIdRef = useRef(selectedPackId);
+  const applyingDefaultCharacterIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    selectedPackIdRef.current = selectedPackId;
+  }, [selectedPackId]);
 
   useEffect(() => {
     if (open) {
+      applyingDefaultCharacterIdRef.current = null;
       setMode(initialMode);
+      setTitle('Untitled VN play session');
+      setPrimaryCharacterId('1');
+      setVnAssetPackId('1');
+      setLinkedChatId('');
       setFormError(null);
       setSelectorError(null);
       setSelectorMode('selectors');
+      setSetupOptions(null);
+      setSelectedCharacterId('');
+      setSelectedPackId('');
+      setContentRating('general');
+      setAcknowledgedSetupWarnings(false);
     }
   }, [initialMode, open]);
 
   useEffect(() => {
-    if (!open) return;
+    if (!open || selectorMode !== 'selectors') return;
+    if (applyingDefaultCharacterIdRef.current === selectedCharacterId) {
+      applyingDefaultCharacterIdRef.current = null;
+      return;
+    }
 
     let cancelled = false;
 
-    async function loadSelectorData() {
+    async function loadSetupOptions() {
       setIsLoadingSelectors(true);
       try {
-        const [nextCharacters, nextPacks] = await Promise.all([
-          listCharacters(),
-          listVNAssetPacks(),
-        ]);
+        const selectedCharacterIdNumber = parsePositiveInteger(selectedCharacterId);
+        const nextOptions = await listVNPlaySetupOptions({
+          content_rating: contentRating.trim() || 'general',
+          mode,
+          ...(selectedCharacterIdNumber ? { selected_character_id: selectedCharacterIdNumber } : {}),
+        });
         if (cancelled) return;
 
-        const firstCharacter = nextCharacters[0] ?? null;
-        const nextCharacterId = firstCharacter ? String(firstCharacter.id) : '';
+        const nextCharacterId = defaultCharacterId(nextOptions, selectedCharacterIdNumber);
+        const nextSelectedCharacter = selectedCharacterFromOptions(nextOptions, nextCharacterId);
+        const nextPackId = defaultPackId(
+          nextOptions,
+          nextSelectedCharacter,
+          parsePositiveInteger(selectedPackIdRef.current)
+        );
+        const nextCharacterIdValue = nextCharacterId ? String(nextCharacterId) : '';
+        const nextPackIdValue = nextPackId ? String(nextPackId) : '';
 
-        setCharacters(nextCharacters);
-        setAssetPacks(nextPacks);
-        setReadinessByPackId({});
-        setSelectedCharacterId(nextCharacterId);
-        setSelectedPackId(chooseBestPack(nextPacks, firstCharacter?.id ?? null, {})?.id.toString() ?? '');
-        setIsLoadingSelectors(false);
-
-        const nextReadiness = await loadReadinessForPacks(nextPacks);
-        if (cancelled) return;
-
-        const bestPack = chooseBestPack(nextPacks, firstCharacter?.id ?? null, nextReadiness);
-
-        setReadinessByPackId(nextReadiness);
-        setSelectedPackId(bestPack ? String(bestPack.id) : '');
+        setSetupOptions(nextOptions);
+        if (nextCharacterIdValue !== selectedCharacterId) {
+          applyingDefaultCharacterIdRef.current = nextCharacterIdValue;
+          setSelectedCharacterId(nextCharacterIdValue);
+        }
+        setSelectedPackId(nextPackIdValue);
       } catch (error) {
         if (!cancelled) {
-          const message = error instanceof Error ? error.message : 'Failed to load setup selectors';
+          const message = error instanceof Error ? error.message : 'Failed to load setup options';
           setSelectorError(message);
           setSelectorMode('manual');
-          setCharacters([]);
-          setAssetPacks([]);
-          setReadinessByPackId({});
+          setSetupOptions(null);
         }
       } finally {
         if (!cancelled) {
@@ -244,62 +299,43 @@ export default function NewSessionDialog({
       }
     }
 
-    void loadSelectorData();
+    void loadSetupOptions();
     return () => {
       cancelled = true;
     };
-  }, [open]);
+  }, [contentRating, mode, open, selectedCharacterId, selectorMode]);
 
   const selectedCharacterIdNumber = parsePositiveInteger(selectedCharacterId);
   const selectedPackIdNumber = parsePositiveInteger(selectedPackId);
+  const characters = useMemo(() => setupCharacters(setupOptions), [setupOptions]);
+  const assetPacks = setupOptions?.asset_packs ?? EMPTY_ASSET_PACKS;
+  const emptyStates = setupOptions?.empty_states ?? EMPTY_EMPTY_STATES;
 
   const selectedCharacter = useMemo(
-    () => characters.find((character) => character.id === selectedCharacterIdNumber) ?? null,
-    [characters, selectedCharacterIdNumber]
+    () => selectedCharacterFromOptions(setupOptions, selectedCharacterIdNumber),
+    [setupOptions, selectedCharacterIdNumber]
   );
   const selectedPack = useMemo(
     () => assetPacks.find((pack) => pack.id === selectedPackIdNumber) ?? null,
     [assetPacks, selectedPackIdNumber]
   );
-  const selectedReadiness = selectedPack ? readinessByPackId[selectedPack.id] : undefined;
-
-  const orderedPacks = useMemo(() => {
-    if (!selectedCharacterIdNumber) return assetPacks;
-    return [...assetPacks].sort((left, right) => {
-      const leftCompatible = left.primary_character_id === selectedCharacterIdNumber;
-      const rightCompatible = right.primary_character_id === selectedCharacterIdNumber;
-      if (leftCompatible !== rightCompatible) {
-        return leftCompatible ? -1 : 1;
-      }
-      return left.title.localeCompare(right.title);
-    });
-  }, [assetPacks, selectedCharacterIdNumber]);
-
-  const incompatiblePacks = useMemo(() => {
-    if (!selectedCharacter) return [];
-    return assetPacks.filter((pack) => pack.primary_character_id !== selectedCharacter.id);
-  }, [assetPacks, selectedCharacter]);
-
-  const selectedPackWarnings = useMemo(
-    () =>
-      buildSelectedPackWarnings({
-        contentRating,
-        pack: selectedPack,
-        readiness: selectedReadiness,
-        selectedCharacter,
-      }),
-    [contentRating, selectedCharacter, selectedPack, selectedReadiness]
-  );
-
-  const selectorSubmitDisabled =
-    selectorMode === 'selectors' &&
-    (isLoadingSelectors || hasBlockingPackIssue(selectedPack, selectedCharacter, selectedReadiness));
+  const selectedPackAcknowledgementKey = useMemo(() => acknowledgementKey(selectedPack), [selectedPack]);
 
   useEffect(() => {
-    if (!open || selectorMode !== 'selectors') return;
-    const bestPack = chooseBestPack(assetPacks, selectedCharacterIdNumber, readinessByPackId);
-    setSelectedPackId(bestPack ? String(bestPack.id) : '');
-  }, [assetPacks, open, readinessByPackId, selectedCharacterIdNumber, selectorMode]);
+    setAcknowledgedSetupWarnings(false);
+  }, [selectedPackAcknowledgementKey]);
+
+  const selectedPackWarnings = useMemo(() => packWarningMessages(selectedPack), [selectedPack]);
+  const selectedPackRequiresAcknowledgement = requiresPackAcknowledgement(selectedPack);
+  const incompatiblePacks = useMemo(
+    () => assetPacks.filter((pack) => pack.compatibility.status === 'different_character'),
+    [assetPacks]
+  );
+  const selectorSubmitDisabled =
+    selectorMode === 'selectors' &&
+    (isLoadingSelectors ||
+      hasBlockingPackIssue(selectedPack, selectedCharacter) ||
+      (selectedPackRequiresAcknowledgement && !acknowledgedSetupWarnings));
 
   if (!open) return null;
 
@@ -317,23 +353,44 @@ export default function NewSessionDialog({
       return;
     }
 
-    if (!usingManualIds && hasBlockingPackIssue(selectedPack, selectedCharacter, selectedReadiness)) {
+    if (!usingManualIds && hasBlockingPackIssue(selectedPack, selectedCharacter)) {
       setFormError('Select a compatible runtime-ready character and asset pack.');
+      return;
+    }
+    if (!usingManualIds && selectedPackRequiresAcknowledgement && !acknowledgedSetupWarnings) {
+      setFormError('Acknowledge setup warnings before creating this session.');
       return;
     }
 
     setFormError(null);
-    await onCreateSession({
+    const request: VNPlaySessionCreate = {
       mode,
       title: trimmedTitle,
       primary_character_id: parsedPrimaryCharacterId,
       vn_asset_pack_id: parsedPackId,
       linked_chat_id: linkedChatId.trim() || null,
       content_rating: contentRating.trim() || 'general',
-    });
+    };
+
+    if (!usingManualIds && selectedPackRequiresAcknowledgement && acknowledgedSetupWarnings && selectedPack) {
+      request.settings = {
+        setup_acknowledgements: [buildSetupAcknowledgement(selectedPack)],
+      };
+    }
+
+    await onCreateSession(request);
   };
 
   const selectedCharacterTags = formatTags(selectedCharacter?.tags);
+  const characterEmptyStates = emptyStatesFor(emptyStates, [
+    'no_characters',
+    'selected_character_not_found',
+  ]);
+  const packEmptyStates = emptyStatesFor(emptyStates, [
+    'no_asset_packs',
+    'no_ready_packs',
+    'no_compatible_packs',
+  ]);
 
   return (
     <div className="rounded-md border border-border bg-surface p-4">
@@ -365,7 +422,7 @@ export default function NewSessionDialog({
           <>
             {selectorError && (
               <div className="rounded-md border border-warn/30 bg-warn/10 px-3 py-2 text-sm text-warn sm:col-span-2">
-                Could not load setup selectors. Manual ID entry is available for this session. {selectorError}
+                Could not load setup options. Manual ID entry is available for this session. {selectorError}
               </div>
             )}
             <Input
@@ -397,23 +454,24 @@ export default function NewSessionDialog({
                 <option value="">Select a character</option>
                 {characters.map((character) => (
                   <option key={character.id} value={character.id}>
-                    {characterName(character)}
+                    {characterOptionLabel(character)}
                   </option>
                 ))}
               </select>
               {isLoadingSelectors && <p className="mt-1 text-sm text-text-muted">Loading setup options...</p>}
-              {!isLoadingSelectors && characters.length === 0 && (
-                <div className="mt-2 rounded-md border border-warn/30 bg-warn/10 px-3 py-2 text-sm text-warn">
-                  <p className="font-medium">No characters available.</p>
-                  <p>Create or import a character before starting VN Play.</p>
-                </div>
+              {!isLoadingSelectors && (
+                <EmptyStateGuidance
+                  states={characterEmptyStates}
+                  workspaceHref="/characters"
+                  workspaceLabel="characters"
+                />
               )}
               {selectedCharacter && (
                 <div className="mt-2 rounded-md border border-border bg-bg px-3 py-2 text-sm text-text-muted">
                   <p className="font-medium text-text">{characterName(selectedCharacter)}</p>
-                  {selectedCharacter.description && <p>{selectedCharacter.description}</p>}
+                  {selectedCharacter.description_preview && <p>{selectedCharacter.description_preview}</p>}
                   {selectedCharacterTags && <p>{selectedCharacterTags}</p>}
-                  {selectedCharacter.image_present && <p>Image attached</p>}
+                  {selectedCharacter.has_image && <p>Image attached</p>}
                 </div>
               )}
             </div>
@@ -430,22 +488,22 @@ export default function NewSessionDialog({
                 onChange={(event) => setSelectedPackId(event.target.value)}
               >
                 <option value="">Select a runtime-ready pack</option>
-                {orderedPacks.map((pack) => {
-                  const readiness = readinessByPackId[pack.id];
-                  const compatible = selectedCharacter ? pack.primary_character_id === selectedCharacter.id : false;
-                  const disabled = !compatible || !readiness?.ready || !isApprovedPackStatus(pack.status);
-                  return (
-                    <option key={pack.id} disabled={disabled} value={pack.id}>
-                      {buildPackOptionLabel(pack, selectedCharacter, readiness)}
-                    </option>
-                  );
-                })}
+                {assetPacks.map((pack) => (
+                  <option
+                    key={pack.id}
+                    disabled={hasBlockingPackIssue(pack, selectedCharacter)}
+                    value={pack.id}
+                  >
+                    {packOptionLabel(pack)}
+                  </option>
+                ))}
               </select>
-              {!isLoadingSelectors && assetPacks.length === 0 && (
-                <div className="mt-2 rounded-md border border-warn/30 bg-warn/10 px-3 py-2 text-sm text-warn">
-                  <p className="font-medium">No VN asset packs available.</p>
-                  <p>Prepare or review a VN asset pack before starting VN Play.</p>
-                </div>
+              {!isLoadingSelectors && (
+                <EmptyStateGuidance
+                  states={packEmptyStates}
+                  workspaceHref="/vn-assets"
+                  workspaceLabel="VN asset packs"
+                />
               )}
               {!isLoadingSelectors && assetPacks.length > 0 && selectedCharacter && !selectedPack && (
                 <div className="mt-2 rounded-md border border-warn/30 bg-warn/10 px-3 py-2 text-sm text-warn">
@@ -455,9 +513,9 @@ export default function NewSessionDialog({
               {selectedPack && (
                 <div className="mt-2 rounded-md border border-border bg-bg px-3 py-2 text-sm text-text-muted">
                   <p className="font-medium text-text">{selectedPack.title}</p>
-                  {selectedPack.description && <p>{selectedPack.description}</p>}
                   <p>Pack content rating: {selectedPack.content_rating || 'general'}</p>
-                  <p>Trust level: new sessions start as local; review imported packs before use.</p>
+                  <p>Trust level: {humanizeValue(selectedPack.trust_level)}</p>
+                  <p>Readiness: {humanizeValue(selectedPack.readiness_status)}</p>
                 </div>
               )}
             </div>
@@ -466,11 +524,12 @@ export default function NewSessionDialog({
               <div className="rounded-md border border-warn/30 bg-warn/10 px-3 py-2 text-sm text-warn sm:col-span-2">
                 <p className="font-medium">Some packs are attached to other characters.</p>
                 <ul className="mt-1 list-disc space-y-1 pl-5">
-                  {incompatiblePacks.map((pack) => (
-                    <li key={pack.id}>
-                      {pack.title} is attached to character {pack.primary_character_id}, not {characterName(selectedCharacter)}.
-                    </li>
-                  ))}
+                  {incompatiblePacks.map((pack) => {
+                    const message =
+                      pack.warning_summary.warnings[0]?.message ??
+                      `${pack.title} is attached to character ${pack.primary_character_id}, not ${characterName(selectedCharacter)}.`;
+                    return <li key={pack.id}>{message}</li>;
+                  })}
                 </ul>
               </div>
             )}
@@ -484,6 +543,17 @@ export default function NewSessionDialog({
                   ))}
                 </ul>
               </div>
+            )}
+            {selectedPackRequiresAcknowledgement && (
+              <label className="flex items-start gap-2 rounded-md border border-warn/30 bg-warn/10 px-3 py-2 text-sm text-warn sm:col-span-2">
+                <input
+                  checked={acknowledgedSetupWarnings}
+                  className="mt-1"
+                  onChange={(event) => setAcknowledgedSetupWarnings(event.target.checked)}
+                  type="checkbox"
+                />
+                <span>I understand and want to proceed with these warnings.</span>
+              </label>
             )}
           </>
         )}

--- a/apps/tldw-frontend/e2e/smoke/vn-play.spec.ts
+++ b/apps/tldw-frontend/e2e/smoke/vn-play.spec.ts
@@ -32,65 +32,63 @@ test.describe('VN play smoke', () => {
       await fulfillJson(route, 200, [{ id: 'smoke-profile', name: 'Smoke profile' }]);
     });
 
-    await page.route(/\/api\/v1\/characters(?:\/query|\/)?(?:\?.*)?$/, async (route) => {
-      await fulfillJson(route, 200, {
-        items: [
-          {
-            id: 7,
-            version: 1,
-            name: 'Mira Vale',
-            description: 'Archive guide',
-            tags: ['archive', 'story'],
-            image_present: true,
-          },
-        ],
-        has_more: false,
-        next_offset: null,
-        page: 1,
-        page_size: 100,
-        total: 1,
-      });
-    });
-
-    await page.route(/\/api\/v1\/vn-assets(?:\/.*)?$/, async (route) => {
-      const request = route.request();
-      const url = new URL(request.url());
-      const method = request.method().toUpperCase();
-      const path = url.pathname.replace('/api/v1/vn-assets', '');
-
-      if (method === 'GET' && path === '/packs') {
-        await fulfillJson(route, 200, [
-          {
-            id: 12,
-            title: 'Moonlit Archive Pack',
-            primary_character_id: 7,
-            description: 'Runtime-ready VN poses and backdrops',
-            status: 'approved',
-            content_rating: 'general',
-            planned_output_count: 8,
-          },
-        ]);
-        return;
-      }
-
-      if (method === 'GET' && path === '/packs/12/readiness') {
-        await fulfillJson(route, 200, {
-          ready: true,
-          status: 'ready',
-          warnings: [],
-          errors: [],
-        });
-        return;
-      }
-
-      await fulfillJson(route, 404, { detail: `unhandled vn-assets mock route: ${method} ${path}` });
-    });
-
     await page.route(/\/api\/v1\/vn-play(?:\/.*)?$/, async (route) => {
       const request = route.request();
       const url = new URL(request.url());
       const method = request.method().toUpperCase();
       const path = url.pathname.replace('/api/v1/vn-play', '');
+
+      if (method === 'GET' && path === '/setup-options') {
+        await fulfillJson(route, 200, {
+          characters: [
+            {
+              id: 7,
+              name: 'Mira Vale',
+              description_preview: 'Archive guide',
+              tags: ['archive', 'story'],
+              favorite: false,
+              deleted: false,
+              has_image: true,
+            },
+          ],
+          selected_character: null,
+          asset_packs: [
+            {
+              id: 12,
+              title: 'Moonlit Archive Pack',
+              primary_character_id: 7,
+              content_rating: 'general',
+              status: 'approved',
+              trust_level: 'local',
+              trust_source: 'local_pack',
+              ready: true,
+              readiness_status: 'ready',
+              readiness_warnings: [],
+              readiness_errors: [],
+              compatibility: { status: 'compatible', reason_codes: [] },
+              warning_summary: {
+                highest_severity: 'info',
+                requires_acknowledgement: false,
+                warnings: [],
+              },
+              recommended: true,
+            },
+          ],
+          defaults: {
+            mode: 'story',
+            character_id: 7,
+            asset_pack_id: 12,
+            content_rating: 'general',
+          },
+          pagination: {
+            characters: { limit: 25, offset: 0, has_more: false, total: 1 },
+            asset_packs: { limit: 25, offset: 0, has_more: false, total: 1 },
+          },
+          empty_states: [],
+          generated_at: '2026-05-09T15:00:00Z',
+        });
+        return;
+      }
 
       if (method === 'GET' && path === '/sessions') {
         await fulfillJson(route, 200, session ? [session] : []);

--- a/apps/tldw-frontend/lib/api/vnPlay.ts
+++ b/apps/tldw-frontend/lib/api/vnPlay.ts
@@ -9,6 +9,8 @@ import type {
   VNPlaySession,
   VNPlaySessionCreate,
   VNPlaySessionUpdate,
+  VNPlaySetupOptionsQuery,
+  VNPlaySetupOptionsResponse,
   VNPlayTurnRequest,
   VNPlayTurnResponse,
 } from '@web/types/vn-play';
@@ -17,6 +19,12 @@ const VN_PLAY_BASE = '/vn-play';
 
 export function createVNPlaySession(request: VNPlaySessionCreate): Promise<VNPlaySession> {
   return apiClient.post(`${VN_PLAY_BASE}/sessions`, request);
+}
+
+export function listVNPlaySetupOptions(
+  query: VNPlaySetupOptionsQuery = {}
+): Promise<VNPlaySetupOptionsResponse> {
+  return apiClient.get(`${VN_PLAY_BASE}/setup-options`, { params: query });
 }
 
 export function listVNPlaySessions(): Promise<VNPlaySession[]> {

--- a/apps/tldw-frontend/types/vn-play.ts
+++ b/apps/tldw-frontend/types/vn-play.ts
@@ -2,6 +2,11 @@ export type VNPlayMode = 'freeform' | 'story';
 export type VNPlaySessionStatus = 'active' | 'paused' | 'completed' | 'archived' | 'failed';
 export type VNPlayTrustLevel = 'local' | 'trusted_restore' | 'untrusted_import' | 'mixed';
 export type VNPlayLinkedChatMode = 'read_only_context';
+export type VNPlaySetupTrustLevel = 'local' | 'trusted_restore' | 'untrusted_import' | 'unknown';
+export type VNPlaySetupTrustSource = 'local_pack' | 'latest_import_journal' | 'unknown';
+export type VNPlaySetupWarningSeverity = 'info' | 'warning' | 'high_risk';
+export type VNPlaySetupCompatibilityStatus = 'compatible' | 'different_character' | 'unknown';
+export type VNPlaySetupEmptyStateScope = 'global' | 'filter' | 'page';
 export type VNPlayTurnStatus =
   | 'pending'
   | 'model_calling'
@@ -88,6 +93,96 @@ export interface VNPlaySessionCreate {
   linked_chat_mode?: VNPlayLinkedChatMode;
   seed?: string | null;
   settings?: Record<string, unknown>;
+}
+
+export interface VNPlaySetupCharacterOption {
+  id: number;
+  name: string;
+  description_preview?: string | null;
+  tags: string[];
+  favorite: boolean;
+  deleted: boolean;
+  has_image: boolean;
+}
+
+export interface VNPlaySetupCompatibility {
+  status: VNPlaySetupCompatibilityStatus;
+  reason_codes: string[];
+}
+
+export interface VNPlaySetupWarning {
+  code: string;
+  severity: VNPlaySetupWarningSeverity;
+  message: string;
+  requires_acknowledgement: boolean;
+}
+
+export interface VNPlaySetupWarningSummary {
+  highest_severity: VNPlaySetupWarningSeverity;
+  requires_acknowledgement: boolean;
+  warnings: VNPlaySetupWarning[];
+}
+
+export interface VNPlaySetupAssetPackOption {
+  id: number;
+  title: string;
+  primary_character_id: number;
+  content_rating: string;
+  status: string;
+  trust_level: VNPlaySetupTrustLevel;
+  trust_source: VNPlaySetupTrustSource;
+  ready: boolean;
+  readiness_status: string;
+  readiness_warnings: string[];
+  readiness_errors: string[];
+  compatibility: VNPlaySetupCompatibility;
+  warning_summary: VNPlaySetupWarningSummary;
+  recommended: boolean;
+}
+
+export interface VNPlaySetupDefaults {
+  mode?: VNPlayMode | null;
+  character_id?: number | null;
+  asset_pack_id?: number | null;
+  content_rating?: string | null;
+}
+
+export interface VNPlaySetupPagination {
+  limit: number;
+  offset: number;
+  has_more: boolean;
+  total?: number | null;
+}
+
+export interface VNPlaySetupEmptyState {
+  code: string;
+  scope: VNPlaySetupEmptyStateScope;
+  message: string;
+}
+
+export interface VNPlaySetupOptionsResponse {
+  characters: VNPlaySetupCharacterOption[];
+  selected_character?: VNPlaySetupCharacterOption | null;
+  asset_packs: VNPlaySetupAssetPackOption[];
+  defaults: VNPlaySetupDefaults;
+  pagination: {
+    characters: VNPlaySetupPagination;
+    asset_packs: VNPlaySetupPagination;
+  };
+  empty_states: VNPlaySetupEmptyState[];
+  generated_at: string;
+}
+
+export interface VNPlaySetupOptionsQuery {
+  mode?: VNPlayMode;
+  character_query?: string;
+  pack_query?: string;
+  character_limit?: number;
+  character_offset?: number;
+  pack_limit?: number;
+  pack_offset?: number;
+  selected_character_id?: number;
+  content_rating?: string;
 }
 
 export type VNPlaySessionUpdate = Partial<

--- a/backlog/tasks/task-165 - Wire-VN-Play-setup-dialog-to-backend-setup-options.md
+++ b/backlog/tasks/task-165 - Wire-VN-Play-setup-dialog-to-backend-setup-options.md
@@ -1,0 +1,65 @@
+---
+id: TASK-165
+title: Wire VN Play setup dialog to backend setup options
+status: Done
+assignee:
+  - codex
+created_date: '2026-05-09 15:58'
+updated_date: '2026-05-09 17:00'
+labels:
+  - vn-play
+  - webui
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1407'
+  - 'https://github.com/rmusser01/tldw_server/pull/1413'
+  - 'https://github.com/rmusser01/tldw_server/pull/1419'
+documentation:
+  - Docs/API-related/VN_PLAY_API.md
+priority: medium
+---
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 VN Play new-session dialog loads character and asset-pack setup state from GET /api/v1/vn-play/setup-options instead of doing client-side readiness fan-out.
+- [x] #2 Character and pack selectors render backend-derived labels, defaults, compatibility, trust, warning, and empty-state data while preserving the existing VNPlaySessionCreate payload.
+- [x] #3 Manual ID entry remains available when the backend setup-options request fails.
+- [x] #4 Focused WebUI tests cover setup-options API usage, payload creation, warning rendering, fallback behavior, and the absence of per-pack readiness fan-out in the setup dialog.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add frontend VN Play setup-options TypeScript types and an API client wrapper in apps/tldw-frontend/lib/api/vnPlay.ts.
+2. Refactor NewSessionDialog to consume backend setup options, request updated options when selected character/content rating changes, and keep manual fallback for setup endpoint failures.
+3. Update VN Play component/API tests and smoke mocks to use /vn-play/setup-options instead of separate character/pack/readiness setup calls.
+4. Run focused frontend tests, lint/diff checks, and Bandit on touched backend-adjacent scope if backend files are touched.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verification: focused Vitest passed (2 files, 21 tests); ESLint passed on touched frontend files; git diff --check passed; Playwright smoke passed after approved local dev-server bind; Bandit skipped because this slice touched only frontend TypeScript/TSX, e2e mock, docs, and Backlog task files with no Python backend code.
+
+PR opened: https://github.com/rmusser01/tldw_server/pull/1419
+
+PR review pass: live review surface has five unresolved threads. Treating Gemini reset-state, Qodo warning acknowledgement, and Qodo duplicate setup-options refetch as actionable. Qodo listCharacters/listVNAssetPacks findings conflict with the chosen backend setup-options API direction and will be answered as non-actionable design mismatch.
+
+PR review fixes: reset all new-session form fields on reopen; added frontend acknowledgement for high-risk setup warnings and persisted settings.setup_acknowledgements on create; suppressed the extra setup-options request caused by applying backend default character IDs. Verification after review fixes: focused Vitest passed (2 files, 24 tests); ESLint passed on touched frontend files; git diff --check passed; Playwright VN Play smoke passed after approved local dev-server bind. Bandit remains skipped because no Python files are touched.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Wired the VN Play new-session dialog to the backend setup-options API and handled PR review feedback by adding form reset coverage, high-risk setup warning acknowledgement metadata, and deduping backend-default refetches. Non-actionable reviewer suggestions to restore listCharacters/listVNAssetPacks were kept out because this slice intentionally moved setup selection behind the backend setup-options API for custom frontend/API-server parity.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Add typed WebUI support for `GET /api/v1/vn-play/setup-options`.
- Refactor the VN Play new-session dialog to use backend-derived character/pack defaults, compatibility, trust, warning, and empty-state data instead of client-side readiness fan-out.
- Update focused VN Play tests and the smoke mock to exercise the backend setup-options contract while preserving manual ID fallback.

## Verification
- `bunx vitest run __tests__/vn-play/vnPlayApi.test.ts __tests__/vn-play/VNPlayWorkspace.test.tsx --reporter=verbose`
- `bunx eslint components/vn-play/NewSessionDialog.tsx __tests__/vn-play/VNPlayWorkspace.test.tsx __tests__/vn-play/vnPlayApi.test.ts e2e/smoke/vn-play.spec.ts lib/api/vnPlay.ts types/vn-play.ts`
- `git diff --check`
- `TLDW_WEB_URL=http://localhost:18081 TLDW_WEB_CMD='bun run dev -- -p 18081' bunx playwright test e2e/smoke/vn-play.spec.ts --reporter=line`

Bandit skipped: touched files are frontend TypeScript/TSX, e2e mock, docs, and Backlog task records only.

## Task
- Backlog: TASK-165
- Continues #1407

## Merge note
This AI-authored PR still needs the requester-owned change summary required by the project merge gate before merge.