### PR TITLE
Harden VZ Linux helper-generation session recovery

### DIFF
--- a/backlog/tasks/task-160 - Harden-vz_linux-helper-generation-session-recovery.md
+++ b/backlog/tasks/task-160 - Harden-vz_linux-helper-generation-session-recovery.md
@@ -4,7 +4,7 @@ title: Harden vz_linux helper-generation session recovery
 status: In Progress
 assignee: []
 created_date: '2026-05-09 05:34'
-updated_date: '2026-05-09 16:23'
+updated_date: '2026-05-09 18:43'
 labels:
   - sandbox
   - vz_linux
@@ -71,6 +71,10 @@ Persisted helper_instance_id/helper_started_at across VZ session-control store i
 Hardened VZLinuxRunner reuse so same-generation healthy VMs are reused, generation/status/metadata drift reprovisions, and helper unavailable/protocol mismatch fail closed without deleting or overwriting session-control state.
 
 Verification: swift test --filter 'PingTests|HelperServiceVMTests' passed; pytest test_vz_linux_runner.py test_vz_linux_session_control_store.py test_store_sqlite_migrations.py passed; Bandit touched Python scope wrote /tmp/bandit_vz_helper_generation.json with 0 findings.
+
+PR 1420 review pass plan: add runner docstrings and metadata None guard; move optional nonempty string normalization to a shared Sandbox helper; make Postgres session-control column migrations fail fast with contextual logging; run focused tests and Bandit before pushing.
+
+PR 1420 review verification: focused pytest passed with 27 passed and 2 skipped; git diff --check passed; Bandit review scope wrote /tmp/bandit_vz_helper_generation_review.json with 0 findings.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-160 - Harden-vz_linux-helper-generation-session-recovery.md
+++ b/backlog/tasks/task-160 - Harden-vz_linux-helper-generation-session-recovery.md
@@ -4,6 +4,7 @@ title: Harden vz_linux helper-generation session recovery
 status: In Progress
 assignee: []
 created_date: '2026-05-09 05:34'
+updated_date: '2026-05-09 16:23'
 labels:
   - sandbox
   - vz_linux
@@ -35,22 +36,12 @@ Add the next narrow sandbox recovery slice after PR #1406: make vz_linux session
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A design spec defines the helper-generation/session-control recovery contract and explicitly reviews lifecycle ownership and scope risks before implementation.
-- [ ] #2 vz_linux session reuse can distinguish healthy same-helper reuse from stale control state after helper identity or generation drift.
-- [ ] #3 Stale generation metadata is cleared or replaced before provisioning a fresh VM, without deleting session-control rows on helper unavailable or helper protocol mismatch.
-- [ ] #4 Focused host-independent tests cover healthy reuse, generation mismatch recovery, helper-unavailable fail-closed behavior, and protocol-mismatch fail-closed behavior.
-- [ ] #5 Operator docs and host-gated smoke expectations are updated only where needed to explain the new recovery signal and limitations.
+- [x] #1 A design spec defines the helper-generation/session-control recovery contract and explicitly reviews lifecycle ownership and scope risks before implementation.
+- [x] #2 vz_linux session reuse can distinguish healthy same-helper reuse from stale control state after helper identity or generation drift.
+- [x] #3 Stale generation metadata is cleared or replaced before provisioning a fresh VM, without deleting session-control rows on helper unavailable or helper protocol mismatch.
+- [x] #4 Focused host-independent tests cover healthy reuse, generation mismatch recovery, helper-unavailable fail-closed behavior, and protocol-mismatch fail-closed behavior.
+- [x] #5 Operator docs and host-gated smoke expectations are updated only where needed to explain the new recovery signal and limitations.
 <!-- AC:END -->
-
-## Definition of Done
-<!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
-<!-- DOD:END -->
 
 ## Implementation Plan
 
@@ -72,4 +63,28 @@ Add the next narrow sandbox recovery slice after PR #1406: make vz_linux session
 - PR review fixes: plan now normalizes whitespace-only helper generation values to `None` and explicitly requires `MacOSVirtualizationHelperProtocolError` in the runner's controlled failure exception tuple.
 - Current evidence: helper ping/status has no generation signal, and persisted VZ session control stores only VM/template/workspace readiness.
 - Design decision: helper generation must be helper-owned rather than Python-synthesized; Python should preserve session-control rows when helper availability/protocol truth is ambiguous.
+
+Implemented helper-owned generation details in Swift helper responses and PROTOCOL.md.
+
+Persisted helper_instance_id/helper_started_at across VZ session-control store interfaces, in-memory, SQLite, Postgres, SQLite migrations, and orchestrator facade.
+
+Hardened VZLinuxRunner reuse so same-generation healthy VMs are reused, generation/status/metadata drift reprovisions, and helper unavailable/protocol mismatch fail closed without deleting or overwriting session-control state.
+
+Verification: swift test --filter 'PingTests|HelperServiceVMTests' passed; pytest test_vz_linux_runner.py test_vz_linux_session_control_store.py test_store_sqlite_migrations.py passed; Bandit touched Python scope wrote /tmp/bandit_vz_helper_generation.json with 0 findings.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented helper-generation-aware vz_linux session recovery. The Swift helper now emits per-process helper generation details, VZ session-control persistence stores them, and VZLinuxRunner reuses session VMs only when live helper metadata and generation match while preserving rows on helper unavailable/protocol mismatch. Focused Swift/Python tests, README operator notes, SQLite migration coverage, and Bandit verification were completed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/Sandbox/README.md
+++ b/tldw_Server_API/app/core/Sandbox/README.md
@@ -108,7 +108,14 @@ Current limitations:
 - `seatbelt` discovery may be `available=True` while `strict_deny_all_supported=False`; deny-all is a best-effort host policy claim, not a VM-grade guarantee.
 - `seatbelt` control files and isolated `HOME`/temp dirs live outside the writable workspace and are removed after each run.
 - `seatbelt` real execution still depends on deprecated `sandbox-exec` and may be blocked by an enclosing sandbox even on macOS hosts.
-- `vz_linux` supports session VM reuse through persisted VZ session-control metadata; `vz_macos` does not.
+- `vz_linux` supports session VM reuse through persisted VZ session-control
+  metadata; `vz_macos` does not. Reuse is generation-aware: the Swift helper
+  reports a per-process `helper_instance_id` and `helper_started_at`, Python
+  persists those values with the session-control row, and a later run reuses the
+  VM only when live helper status, ownership/session metadata, and helper
+  generation still agree. Helper unavailable or protocol mismatch fails closed
+  and preserves the row; reachable stale VM truth or generation drift clears the
+  row before provisioning a fresh VM.
 - `vz_linux` admin diagnostics include reconciliation data comparing persisted VZ session-control rows against live helper VM state.
 - `vz_linux` admin diagnostics also include a read-only image-store block that correlates persisted run manifests and dry-run GC classifications with reconciliation/helper state.
 - `vz_linux` also exposes `GET /api/v1/sandbox/admin/macos-image-store/cleanup-plan` for read-only GC action planning and `POST /api/v1/sandbox/admin/macos-image-store/cleanup` for explicit admin cleanup, which defaults to `dry_run=true`; unfiltered mutating cleanup requires `confirm_all=true`.

--- a/tldw_Server_API/app/core/Sandbox/orchestrator.py
+++ b/tldw_Server_API/app/core/Sandbox/orchestrator.py
@@ -22,6 +22,7 @@ from .models import RunPhase, RunSpec, RunStatus, RuntimeType, Session, SessionS
 from .policy import SandboxPolicy, SandboxPolicyConfig
 from .store import IdempotencyConflict as StoreIdemConflict
 from .store import get_store
+from .utils import coerce_optional_nonempty_string
 
 _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS = (
     AssertionError,
@@ -43,13 +44,6 @@ _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS = (
 )
 
 _OWNER_ONLY_DIR_MODE = stat.S_IRWXU
-
-
-def _coerce_optional_nonempty_string(value: Any) -> str | None:
-    if value is None:
-        return None
-    text = str(value).strip()
-    return text or None
 
 
 class IdempotencyConflict(Exception):
@@ -1435,8 +1429,8 @@ class SandboxOrchestrator:
             template_id=(str(template_id) if template_id is not None else None),
             workspace_mount=(str(workspace_mount) if workspace_mount is not None else None),
             agent_ready=bool(agent_ready),
-            helper_instance_id=_coerce_optional_nonempty_string(helper_instance_id),
-            helper_started_at=_coerce_optional_nonempty_string(helper_started_at),
+            helper_instance_id=coerce_optional_nonempty_string(helper_instance_id),
+            helper_started_at=coerce_optional_nonempty_string(helper_started_at),
         )
 
     def get_vz_session_control(self, session_id: str) -> dict[str, Any] | None:

--- a/tldw_Server_API/app/core/Sandbox/orchestrator.py
+++ b/tldw_Server_API/app/core/Sandbox/orchestrator.py
@@ -45,6 +45,13 @@ _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS = (
 _OWNER_ONLY_DIR_MODE = stat.S_IRWXU
 
 
+def _coerce_optional_nonempty_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
 class IdempotencyConflict(Exception):
     def __init__(self, original_id: str, key: str | None = None, prior_created_at: str | None = None, message: str = "Idempotency conflict") -> None:
         super().__init__(message)
@@ -1418,6 +1425,8 @@ class SandboxOrchestrator:
         template_id: str | None,
         workspace_mount: str | None,
         agent_ready: bool,
+        helper_instance_id: str | None = None,
+        helper_started_at: str | None = None,
     ) -> None:
         self._store.put_vz_session_control(
             session_id=str(session_id),
@@ -1426,6 +1435,8 @@ class SandboxOrchestrator:
             template_id=(str(template_id) if template_id is not None else None),
             workspace_mount=(str(workspace_mount) if workspace_mount is not None else None),
             agent_ready=bool(agent_ready),
+            helper_instance_id=_coerce_optional_nonempty_string(helper_instance_id),
+            helper_started_at=_coerce_optional_nonempty_string(helper_started_at),
         )
 
     def get_vz_session_control(self, session_id: str) -> dict[str, Any] | None:

--- a/tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py
@@ -31,6 +31,7 @@ _VZ_LINUX_RUNNER_NONCRITICAL_EXCEPTIONS = (
     RuntimeError,
     TypeError,
     ValueError,
+    MacOSVirtualizationHelperProtocolError,
     MacOSVirtualizationHelperUnavailable,
 )
 _OUTPUT_COUNTER_KEYS = frozenset(
@@ -252,6 +253,56 @@ class VZLinuxRunner(VZBaseRunner):
                 counters[key] = value
         return counters
 
+    @staticmethod
+    def _normalize_optional_text(value: Any) -> str | None:
+        if value is None:
+            return None
+        text = str(value).strip()
+        return text or None
+
+    @classmethod
+    def _helper_generation_from_details(cls, details: dict[str, Any] | None) -> tuple[str | None, str | None]:
+        if not isinstance(details, dict):
+            return None, None
+        return (
+            cls._normalize_optional_text(details.get("helper_instance_id")),
+            cls._normalize_optional_text(details.get("helper_started_at")),
+        )
+
+    @classmethod
+    def _session_status_reusable(
+        cls,
+        *,
+        status: Any,
+        session_control: dict[str, Any],
+        session_id: str | None,
+    ) -> bool:
+        if not bool(getattr(status, "healthy", False)):
+            return False
+
+        metadata = getattr(status, "metadata", None)
+        owner = str(getattr(metadata, "owner", "") or "").strip()
+        runtime = str(getattr(metadata, "runtime", "") or "").strip()
+        if owner != "tldw" or runtime != RuntimeType.vz_linux.value:
+            return False
+
+        requested_session_id = str(session_id or "").strip()
+        live_session_id = str(getattr(metadata, "session_id", "") or "").strip()
+        if live_session_id and live_session_id != requested_session_id:
+            return False
+
+        stored_instance = cls._normalize_optional_text(session_control.get("helper_instance_id"))
+        stored_started_at = cls._normalize_optional_text(session_control.get("helper_started_at"))
+        live_instance, live_started_at = cls._helper_generation_from_details(getattr(status, "details", None))
+        if stored_instance and stored_started_at and live_instance and live_started_at:
+            return stored_instance == live_instance and stored_started_at == live_started_at
+
+        return bool(
+            requested_session_id
+            and live_session_id == requested_session_id
+            and bool(getattr(metadata, "session_mode", False))
+        )
+
     def _load_session_control(self, session_id: str | None) -> dict[str, Any] | None:
         sid = str(session_id or "").strip()
         if not sid or self._session_control_store is None:
@@ -269,6 +320,8 @@ class VZLinuxRunner(VZBaseRunner):
         vm_id: str,
         template_id: str | None,
         workspace_mount: str | None,
+        helper_instance_id: str | None = None,
+        helper_started_at: str | None = None,
     ) -> None:
         sid = str(session_id or "").strip()
         if not sid or self._session_control_store is None:
@@ -283,6 +336,8 @@ class VZLinuxRunner(VZBaseRunner):
             template_id=(str(template_id) if template_id is not None else None),
             workspace_mount=(str(workspace_mount) if workspace_mount is not None else None),
             agent_ready=True,
+            helper_instance_id=self._normalize_optional_text(helper_instance_id),
+            helper_started_at=self._normalize_optional_text(helper_started_at),
         )
 
     def _delete_session_control(self, session_id: str | None) -> None:
@@ -410,8 +465,12 @@ class VZLinuxRunner(VZBaseRunner):
                 try:
                     status = helper.get_vm_status(candidate_vm_id)
                 except (MacOSVirtualizationHelperUnavailable, MacOSVirtualizationHelperProtocolError):
-                    status = None
-                if bool(getattr(status, "healthy", False)):
+                    raise
+                if status is not None and self._session_status_reusable(
+                    status=status,
+                    session_control=session_control,
+                    session_id=spec.session_id,
+                ):
                     vm_id = candidate_vm_id
                     template_ref = str(session_control.get("template_id") or "").strip() or spec.base_image
                     should_terminate_vm = False
@@ -482,6 +541,8 @@ class VZLinuxRunner(VZBaseRunner):
                         vm_id=vm.vm_id,
                         template_id=template_ref,
                         workspace_mount=workspace,
+                        helper_instance_id=vm.details.get("helper_instance_id") if isinstance(vm.details, dict) else None,
+                        helper_started_at=vm.details.get("helper_started_at") if isinstance(vm.details, dict) else None,
                     )
             self._register_active_run(run_id, vm_id, workspace if created_workspace else None)
 

--- a/tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py
@@ -22,6 +22,7 @@ from ..models import RunPhase, RunSpec, RunStatus, RuntimeType
 from ..policy import SandboxPolicyConfig
 from ..runtime_capabilities import RuntimePreflightResult
 from ..streams import get_hub
+from ..utils import coerce_optional_nonempty_string
 from .resource_limits import log_limit_counters
 from .vz_common import _VZ_NONCRITICAL_EXCEPTIONS, VZBaseRunner, vz_host_facts
 
@@ -253,20 +254,14 @@ class VZLinuxRunner(VZBaseRunner):
                 counters[key] = value
         return counters
 
-    @staticmethod
-    def _normalize_optional_text(value: Any) -> str | None:
-        if value is None:
-            return None
-        text = str(value).strip()
-        return text or None
-
     @classmethod
     def _helper_generation_from_details(cls, details: dict[str, Any] | None) -> tuple[str | None, str | None]:
+        """Extract helper-generation identifiers from helper response details."""
         if not isinstance(details, dict):
             return None, None
         return (
-            cls._normalize_optional_text(details.get("helper_instance_id")),
-            cls._normalize_optional_text(details.get("helper_started_at")),
+            coerce_optional_nonempty_string(details.get("helper_instance_id")),
+            coerce_optional_nonempty_string(details.get("helper_started_at")),
         )
 
     @classmethod
@@ -277,10 +272,13 @@ class VZLinuxRunner(VZBaseRunner):
         session_control: dict[str, Any],
         session_id: str | None,
     ) -> bool:
+        """Return true only when live VM metadata proves safe same-session reuse."""
         if not bool(getattr(status, "healthy", False)):
             return False
 
         metadata = getattr(status, "metadata", None)
+        if metadata is None:
+            return False
         owner = str(getattr(metadata, "owner", "") or "").strip()
         runtime = str(getattr(metadata, "runtime", "") or "").strip()
         if owner != "tldw" or runtime != RuntimeType.vz_linux.value:
@@ -291,8 +289,8 @@ class VZLinuxRunner(VZBaseRunner):
         if live_session_id and live_session_id != requested_session_id:
             return False
 
-        stored_instance = cls._normalize_optional_text(session_control.get("helper_instance_id"))
-        stored_started_at = cls._normalize_optional_text(session_control.get("helper_started_at"))
+        stored_instance = coerce_optional_nonempty_string(session_control.get("helper_instance_id"))
+        stored_started_at = coerce_optional_nonempty_string(session_control.get("helper_started_at"))
         live_instance, live_started_at = cls._helper_generation_from_details(getattr(status, "details", None))
         if stored_instance and stored_started_at and live_instance and live_started_at:
             return stored_instance == live_instance and stored_started_at == live_started_at
@@ -336,8 +334,8 @@ class VZLinuxRunner(VZBaseRunner):
             template_id=(str(template_id) if template_id is not None else None),
             workspace_mount=(str(workspace_mount) if workspace_mount is not None else None),
             agent_ready=True,
-            helper_instance_id=self._normalize_optional_text(helper_instance_id),
-            helper_started_at=self._normalize_optional_text(helper_started_at),
+            helper_instance_id=coerce_optional_nonempty_string(helper_instance_id),
+            helper_started_at=coerce_optional_nonempty_string(helper_started_at),
         )
 
     def _delete_session_control(self, session_id: str | None) -> None:

--- a/tldw_Server_API/app/core/Sandbox/store.py
+++ b/tldw_Server_API/app/core/Sandbox/store.py
@@ -56,6 +56,14 @@ def _coerce_optional_iso_datetime(value: Any) -> str | None:
     return text
 
 
+def _coerce_optional_nonempty_string(value: Any) -> str | None:
+    """Normalize optional metadata strings and avoid persisting empty placeholders."""
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
 def _parse_optional_iso_datetime(value: Any) -> datetime | None:
     """Parse ISO datetime text defensively; return None on empty/invalid input."""
     text = _coerce_optional_iso_datetime(value)
@@ -214,6 +222,8 @@ class SandboxStore:
         template_id: str | None,
         workspace_mount: str | None,
         agent_ready: bool,
+        helper_instance_id: str | None = None,
+        helper_started_at: str | None = None,
     ) -> None:
         raise NotImplementedError
 
@@ -719,6 +729,8 @@ class InMemoryStore(SandboxStore):
         template_id: str | None,
         workspace_mount: str | None,
         agent_ready: bool,
+        helper_instance_id: str | None = None,
+        helper_started_at: str | None = None,
     ) -> None:
         now_ts = time.time()
         with self._lock:
@@ -731,6 +743,8 @@ class InMemoryStore(SandboxStore):
                 "template_id": (str(template_id) if template_id is not None else None),
                 "workspace_mount": (str(workspace_mount) if workspace_mount is not None else None),
                 "agent_ready": bool(agent_ready),
+                "helper_instance_id": _coerce_optional_nonempty_string(helper_instance_id),
+                "helper_started_at": _coerce_optional_nonempty_string(helper_started_at),
                 "created_at": float(created_at),
                 "updated_at": float(now_ts),
             }
@@ -1137,6 +1151,8 @@ class SQLiteStore(SandboxStore):
                     template_id TEXT,
                     workspace_mount TEXT,
                     agent_ready INTEGER,
+                    helper_instance_id TEXT,
+                    helper_started_at TEXT,
                     created_at REAL,
                     updated_at REAL
                 );
@@ -1196,6 +1212,8 @@ class SQLiteStore(SandboxStore):
             _ensure_sqlite_column("sandbox_acp_sessions", "workspace_id", "TEXT")
             _ensure_sqlite_column("sandbox_acp_sessions", "workspace_group_id", "TEXT")
             _ensure_sqlite_column("sandbox_acp_sessions", "scope_snapshot_id", "TEXT")
+            _ensure_sqlite_column("sandbox_vz_sessions", "helper_instance_id", "TEXT")
+            _ensure_sqlite_column("sandbox_vz_sessions", "helper_started_at", "TEXT")
 
     def _fp(self, body: dict[str, Any]) -> str:
         """
@@ -1870,20 +1888,25 @@ class SQLiteStore(SandboxStore):
         template_id: str | None,
         workspace_mount: str | None,
         agent_ready: bool,
+        helper_instance_id: str | None = None,
+        helper_started_at: str | None = None,
     ) -> None:
         now_ts = time.time()
         with self._lock, self._conn() as con:
             con.execute(
                 (
                     "INSERT INTO sandbox_vz_sessions("
-                    "id,runtime,vm_id,template_id,workspace_mount,agent_ready,created_at,updated_at"
-                    ") VALUES (?,?,?,?,?,?,?,?) "
+                    "id,runtime,vm_id,template_id,workspace_mount,agent_ready,"
+                    "helper_instance_id,helper_started_at,created_at,updated_at"
+                    ") VALUES (?,?,?,?,?,?,?,?,?,?) "
                     "ON CONFLICT(id) DO UPDATE SET "
                     "runtime=excluded.runtime,"
                     "vm_id=excluded.vm_id,"
                     "template_id=excluded.template_id,"
                     "workspace_mount=excluded.workspace_mount,"
                     "agent_ready=excluded.agent_ready,"
+                    "helper_instance_id=excluded.helper_instance_id,"
+                    "helper_started_at=excluded.helper_started_at,"
                     "updated_at=excluded.updated_at"
                 ),
                 (
@@ -1893,6 +1916,8 @@ class SQLiteStore(SandboxStore):
                     (str(template_id) if template_id is not None else None),
                     (str(workspace_mount) if workspace_mount is not None else None),
                     1 if agent_ready else 0,
+                    _coerce_optional_nonempty_string(helper_instance_id),
+                    _coerce_optional_nonempty_string(helper_started_at),
                     float(now_ts),
                     float(now_ts),
                 ),
@@ -1902,7 +1927,8 @@ class SQLiteStore(SandboxStore):
         with self._lock, self._conn() as con:
             cur = con.execute(
                 (
-                    "SELECT id,runtime,vm_id,template_id,workspace_mount,agent_ready,created_at,updated_at "
+                    "SELECT id,runtime,vm_id,template_id,workspace_mount,agent_ready,"
+                    "helper_instance_id,helper_started_at,created_at,updated_at "
                     "FROM sandbox_vz_sessions WHERE id=?"
                 ),
                 (str(session_id),),
@@ -1926,7 +1952,8 @@ class SQLiteStore(SandboxStore):
     def list_vz_session_controls(self) -> list[dict[str, Any]]:
         with self._lock, self._conn() as con:
             cur = con.execute(
-                "SELECT id,runtime,vm_id,template_id,workspace_mount,agent_ready,created_at,updated_at "
+                "SELECT id,runtime,vm_id,template_id,workspace_mount,agent_ready,"
+                "helper_instance_id,helper_started_at,created_at,updated_at "
                 "FROM sandbox_vz_sessions ORDER BY id"
             )
             rows = [dict(row) for row in cur.fetchall() or []]
@@ -2394,6 +2421,8 @@ class PostgresStore(SandboxStore):
                         template_id TEXT,
                         workspace_mount TEXT,
                         agent_ready BOOLEAN,
+                        helper_instance_id TEXT,
+                        helper_started_at TEXT,
                         created_at DOUBLE PRECISION,
                         updated_at DOUBLE PRECISION
                     );
@@ -2475,6 +2504,8 @@ class PostgresStore(SandboxStore):
             _ensure_column("sandbox_acp_sessions", "workspace_id", "TEXT")
             _ensure_column("sandbox_acp_sessions", "workspace_group_id", "TEXT")
             _ensure_column("sandbox_acp_sessions", "scope_snapshot_id", "TEXT")
+            _ensure_column("sandbox_vz_sessions", "helper_instance_id", "TEXT")
+            _ensure_column("sandbox_vz_sessions", "helper_started_at", "TEXT")
 
     def _fp(self, body: dict[str, Any]) -> str:
         try:
@@ -3155,6 +3186,8 @@ class PostgresStore(SandboxStore):
         template_id: str | None,
         workspace_mount: str | None,
         agent_ready: bool,
+        helper_instance_id: str | None = None,
+        helper_started_at: str | None = None,
     ) -> None:
         now_ts = time.time()
         with self._lock, self._conn() as con:
@@ -3162,15 +3195,18 @@ class PostgresStore(SandboxStore):
                 cur.execute(
                     """
                     INSERT INTO sandbox_vz_sessions(
-                        id,runtime,vm_id,template_id,workspace_mount,agent_ready,created_at,updated_at
+                        id,runtime,vm_id,template_id,workspace_mount,agent_ready,
+                        helper_instance_id,helper_started_at,created_at,updated_at
                     )
-                    VALUES (%s,%s,%s,%s,%s,%s,%s,%s)
+                    VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
                     ON CONFLICT (id) DO UPDATE SET
                         runtime=EXCLUDED.runtime,
                         vm_id=EXCLUDED.vm_id,
                         template_id=EXCLUDED.template_id,
                         workspace_mount=EXCLUDED.workspace_mount,
                         agent_ready=EXCLUDED.agent_ready,
+                        helper_instance_id=EXCLUDED.helper_instance_id,
+                        helper_started_at=EXCLUDED.helper_started_at,
                         updated_at=EXCLUDED.updated_at
                     """,
                     (
@@ -3180,6 +3216,8 @@ class PostgresStore(SandboxStore):
                         (str(template_id) if template_id is not None else None),
                         (str(workspace_mount) if workspace_mount is not None else None),
                         bool(agent_ready),
+                        _coerce_optional_nonempty_string(helper_instance_id),
+                        _coerce_optional_nonempty_string(helper_started_at),
                         float(now_ts),
                         float(now_ts),
                     ),
@@ -3189,7 +3227,8 @@ class PostgresStore(SandboxStore):
         with self._lock, self._conn() as con, con.cursor() as cur:
             cur.execute(
                 (
-                    "SELECT id,runtime,vm_id,template_id,workspace_mount,agent_ready,created_at,updated_at "
+                    "SELECT id,runtime,vm_id,template_id,workspace_mount,agent_ready,"
+                    "helper_instance_id,helper_started_at,created_at,updated_at "
                     "FROM sandbox_vz_sessions WHERE id=%s"
                 ),
                 (str(session_id),),
@@ -3209,7 +3248,8 @@ class PostgresStore(SandboxStore):
     def list_vz_session_controls(self) -> list[dict[str, Any]]:
         with self._lock, self._conn() as con, con.cursor() as cur:
             cur.execute(
-                "SELECT id,runtime,vm_id,template_id,workspace_mount,agent_ready,created_at,updated_at "
+                "SELECT id,runtime,vm_id,template_id,workspace_mount,agent_ready,"
+                "helper_instance_id,helper_started_at,created_at,updated_at "
                 "FROM sandbox_vz_sessions ORDER BY id"
             )
             return [dict(row) for row in cur.fetchall() or [] if isinstance(row, dict)]

--- a/tldw_Server_API/app/core/Sandbox/store.py
+++ b/tldw_Server_API/app/core/Sandbox/store.py
@@ -18,6 +18,7 @@ from tldw_Server_API.app.core.DB_Management.sqlite_policy import (
 )
 
 from .models import RunPhase, RunStatus, RuntimeType
+from .utils import coerce_optional_nonempty_string
 
 _SANDBOX_STORE_NONCRITICAL_EXCEPTIONS = (
     AssertionError,
@@ -54,14 +55,6 @@ def _coerce_optional_iso_datetime(value: Any) -> str | None:
     if not text or text.lower() == "none":
         return None
     return text
-
-
-def _coerce_optional_nonempty_string(value: Any) -> str | None:
-    """Normalize optional metadata strings and avoid persisting empty placeholders."""
-    if value is None:
-        return None
-    text = str(value).strip()
-    return text or None
 
 
 def _parse_optional_iso_datetime(value: Any) -> datetime | None:
@@ -743,8 +736,8 @@ class InMemoryStore(SandboxStore):
                 "template_id": (str(template_id) if template_id is not None else None),
                 "workspace_mount": (str(workspace_mount) if workspace_mount is not None else None),
                 "agent_ready": bool(agent_ready),
-                "helper_instance_id": _coerce_optional_nonempty_string(helper_instance_id),
-                "helper_started_at": _coerce_optional_nonempty_string(helper_started_at),
+                "helper_instance_id": coerce_optional_nonempty_string(helper_instance_id),
+                "helper_started_at": coerce_optional_nonempty_string(helper_started_at),
                 "created_at": float(created_at),
                 "updated_at": float(now_ts),
             }
@@ -1916,8 +1909,8 @@ class SQLiteStore(SandboxStore):
                     (str(template_id) if template_id is not None else None),
                     (str(workspace_mount) if workspace_mount is not None else None),
                     1 if agent_ready else 0,
-                    _coerce_optional_nonempty_string(helper_instance_id),
-                    _coerce_optional_nonempty_string(helper_started_at),
+                    coerce_optional_nonempty_string(helper_instance_id),
+                    coerce_optional_nonempty_string(helper_started_at),
                     float(now_ts),
                     float(now_ts),
                 ),
@@ -2471,8 +2464,11 @@ class PostgresStore(SandboxStore):
                     if cur.fetchone():
                         return
                     cur.execute(f"ALTER TABLE {table} ADD COLUMN {col} {coltype}")
-                except _SANDBOX_STORE_NONCRITICAL_EXCEPTIONS:
-                    logger.debug(f"Postgres migration: could not add {table}.{col}")
+                except _SANDBOX_STORE_NONCRITICAL_EXCEPTIONS as exc:
+                    logger.exception(f"Postgres migration failed while adding {table}.{col}")
+                    raise ClusterStoreUnavailable(
+                        f"Postgres migration failed while adding required column {table}.{col}"
+                    ) from exc
 
             _ensure_column("sandbox_runs", "resource_usage", "JSONB")
             _ensure_column("sandbox_runs", "runtime_version", "TEXT")
@@ -3216,8 +3212,8 @@ class PostgresStore(SandboxStore):
                         (str(template_id) if template_id is not None else None),
                         (str(workspace_mount) if workspace_mount is not None else None),
                         bool(agent_ready),
-                        _coerce_optional_nonempty_string(helper_instance_id),
-                        _coerce_optional_nonempty_string(helper_started_at),
+                        coerce_optional_nonempty_string(helper_instance_id),
+                        coerce_optional_nonempty_string(helper_started_at),
                         float(now_ts),
                         float(now_ts),
                     ),

--- a/tldw_Server_API/app/core/Sandbox/utils.py
+++ b/tldw_Server_API/app/core/Sandbox/utils.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def coerce_optional_nonempty_string(value: Any) -> str | None:
+    """Normalize optional metadata strings and drop empty placeholders."""
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None

--- a/tldw_Server_API/tests/sandbox/test_store_postgres_migrations.py
+++ b/tldw_Server_API/tests/sandbox/test_store_postgres_migrations.py
@@ -9,6 +9,44 @@ from datetime import datetime, timezone
 import pytest
 
 
+class _FakePostgresCursor:
+    def __init__(self, *, failing_table: str, failing_column: str) -> None:
+        self.failing_table = failing_table
+        self.failing_column = failing_column
+        self._last_lookup: tuple[str, str] | None = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+    def execute(self, query: str, params: tuple[str, str] | None = None) -> None:
+        if "information_schema.columns" in query and params:
+            self._last_lookup = params
+            return
+        failing_alter = f"ALTER TABLE {self.failing_table} ADD COLUMN {self.failing_column}"
+        if failing_alter in query:
+            raise OSError("simulated migration failure")
+
+    def fetchone(self):
+        return None
+
+
+class _FakePostgresConnection:
+    def __init__(self, cursor: _FakePostgresCursor) -> None:
+        self._cursor = cursor
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+    def cursor(self) -> _FakePostgresCursor:
+        return self._cursor
+
+
 def _has_psycopg() -> bool:
 
 
@@ -17,6 +55,20 @@ def _has_psycopg() -> bool:
         return True
     except Exception:
         return False
+
+
+def test_postgres_store_init_fails_fast_when_required_column_migration_fails(monkeypatch) -> None:
+    from tldw_Server_API.app.core.Sandbox.store import ClusterStoreUnavailable, PostgresStore
+
+    cursor = _FakePostgresCursor(
+        failing_table="sandbox_vz_sessions",
+        failing_column="helper_instance_id",
+    )
+    store = PostgresStore.__new__(PostgresStore)
+    monkeypatch.setattr(store, "_conn", lambda: _FakePostgresConnection(cursor))
+
+    with pytest.raises(ClusterStoreUnavailable, match="sandbox_vz_sessions.helper_instance_id"):
+        store._init_db()
 
 
 @pytest.mark.integration

--- a/tldw_Server_API/tests/sandbox/test_store_sqlite_migrations.py
+++ b/tldw_Server_API/tests/sandbox/test_store_sqlite_migrations.py
@@ -27,6 +27,20 @@ def test_sqlite_store_migrations_add_new_columns(tmp_path) -> None:
         );
         """
     )
+    con.execute(
+        """
+        CREATE TABLE sandbox_vz_sessions (
+            id TEXT PRIMARY KEY,
+            runtime TEXT,
+            vm_id TEXT,
+            template_id TEXT,
+            workspace_mount TEXT,
+            agent_ready INTEGER,
+            created_at REAL,
+            updated_at REAL
+        );
+        """
+    )
     con.commit()
     con.close()
 
@@ -60,4 +74,9 @@ def test_sqlite_store_migrations_add_new_columns(tmp_path) -> None:
     assert "workspace_id" in acp_cols
     assert "workspace_group_id" in acp_cols
     assert "scope_snapshot_id" in acp_cols
+
+    cur_vz = con2.execute("PRAGMA table_info(sandbox_vz_sessions)")
+    vz_cols = {row[1] for row in cur_vz.fetchall()}
+    assert "helper_instance_id" in vz_cols
+    assert "helper_started_at" in vz_cols
     con2.close()

--- a/tldw_Server_API/tests/sandbox/test_vz_linux_runner.py
+++ b/tldw_Server_API/tests/sandbox/test_vz_linux_runner.py
@@ -13,6 +13,7 @@ from tldw_Server_API.app.core.Sandbox.macos_virtualization.helper_client import 
 )
 from tldw_Server_API.app.core.Sandbox.macos_virtualization.models import (
     HelperExecReply,
+    HelperVMMetadata,
     HelperVMReply,
     HelperVMStatusReply,
 )
@@ -257,6 +258,8 @@ def test_vz_linux_image_store_does_not_persist_manifest_for_healthy_session_reus
                 "template_id": template_id,
                 "workspace_mount": str(tmp_path),
                 "agent_ready": True,
+                "helper_instance_id": "helper-a",
+                "helper_started_at": "2026-05-09T00:00:00Z",
             }
 
     class _FakeHelper:
@@ -267,6 +270,16 @@ def test_vz_linux_image_store_does_not_persist_manifest_for_healthy_session_reus
                 vm_id=vm_id,
                 state="running",
                 healthy=True,
+                metadata=HelperVMMetadata(
+                    owner="tldw",
+                    runtime="vz_linux",
+                    session_id="sess-store-reuse",
+                    session_mode=True,
+                ),
+                details={
+                    "helper_instance_id": "helper-a",
+                    "helper_started_at": "2026-05-09T00:00:00Z",
+                },
             )
 
         def validate_template(self, request: dict[str, object]) -> dict[str, object]:
@@ -542,6 +555,8 @@ def test_vz_linux_session_run_reuses_only_healthy_vm(monkeypatch, tmp_path) -> N
                 "template_id": "vz_linux:existing",
                 "workspace_mount": str(tmp_path),
                 "agent_ready": True,
+                "helper_instance_id": "helper-a",
+                "helper_started_at": "2026-05-09T00:00:00Z",
             }
 
         def delete_vz_session_control(self, session_id: str) -> bool:
@@ -559,6 +574,16 @@ def test_vz_linux_session_run_reuses_only_healthy_vm(monkeypatch, tmp_path) -> N
                 vm_id=vm_id,
                 state="running",
                 healthy=True,
+                metadata=HelperVMMetadata(
+                    owner="tldw",
+                    runtime="vz_linux",
+                    session_id="sess-1",
+                    session_mode=True,
+                ),
+                details={
+                    "helper_instance_id": "helper-a",
+                    "helper_started_at": "2026-05-09T00:00:00Z",
+                },
             )
 
         def validate_template(self, request: dict[str, object]) -> dict[str, object]:
@@ -590,7 +615,103 @@ def test_vz_linux_session_run_reuses_only_healthy_vm(monkeypatch, tmp_path) -> N
     assert calls == ["get_vm_status", "exec_guest"]
 
 
-def test_vz_linux_session_reuse_helper_unavailable_recreates_vm(monkeypatch, tmp_path) -> None:
+def test_vz_linux_session_reuse_generation_mismatch_recreates_vm(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_FAKE_EXEC", raising=False)
+    calls: list[str] = []
+    deleted: list[str] = []
+    stored: list[dict[str, object]] = []
+
+    class _Store:
+        def get_vz_session_control(self, session_id: str) -> dict[str, object]:
+            assert session_id == "sess-generation-mismatch"
+            return {
+                "runtime": "vz_linux",
+                "vm_id": "vm-stale-generation",
+                "template_id": "vz_linux:existing",
+                "workspace_mount": str(tmp_path),
+                "agent_ready": True,
+                "helper_instance_id": "helper-old",
+                "helper_started_at": "2026-05-09T00:00:00Z",
+            }
+
+        def delete_vz_session_control(self, session_id: str) -> bool:
+            deleted.append(session_id)
+            return True
+
+        def put_vz_session_control(self, **kwargs) -> None:
+            stored.append(dict(kwargs))
+
+    class _FakeHelper:
+        def get_vm_status(self, vm_id: str) -> HelperVMStatusReply:
+            calls.append("get_vm_status")
+            return HelperVMStatusReply(
+                protocol_version="1",
+                helper_version="0.1.0",
+                vm_id=vm_id,
+                state="running",
+                healthy=True,
+                metadata=HelperVMMetadata(
+                    owner="tldw",
+                    runtime="vz_linux",
+                    session_id="sess-generation-mismatch",
+                    session_mode=True,
+                ),
+                details={
+                    "helper_instance_id": "helper-new",
+                    "helper_started_at": "2026-05-09T01:00:00Z",
+                },
+            )
+
+        def validate_template(self, request: dict[str, object]) -> dict[str, object]:
+            calls.append("validate_template")
+            return {
+                "template_id": "vz_linux:new-template",
+                "ready": True,
+                "reasons": [],
+            }
+
+        def create_vm(self, request: dict[str, object]) -> HelperVMReply:
+            calls.append("create_vm")
+            assert request["session_id"] == "sess-generation-mismatch"
+            assert request["session_mode"] is True
+            return HelperVMReply(
+                vm_id="vm-new-generation",
+                state="created",
+                details={
+                    "helper_instance_id": "helper-new",
+                    "helper_started_at": "2026-05-09T01:00:00Z",
+                },
+            )
+
+        def exec_guest(self, *, vm_id: str, request: dict[str, object]) -> HelperExecReply:
+            calls.append("exec_guest")
+            assert vm_id == "vm-new-generation"
+            return HelperExecReply(exit_code=0, stdout=b"recreated\n")
+
+    monkeypatch.setattr(vz_linux_module.VZLinuxRunner, "helper_client_cls", _FakeHelper)
+
+    status = VZLinuxRunner(session_control_store=_Store()).start_run(
+        run_id="vz-run-generation-mismatch",
+        spec=RunSpec(
+            session_id="sess-generation-mismatch",
+            runtime=RuntimeType.vz_linux,
+            base_image="ubuntu-24.04",
+            command=["/bin/echo", "ok"],
+            network_policy="deny_all",
+        ),
+        session_workspace=str(tmp_path),
+    )
+
+    assert status.phase == RunPhase.completed
+    assert status.exit_code == 0
+    assert calls == ["get_vm_status", "validate_template", "create_vm", "exec_guest"]
+    assert deleted == ["sess-generation-mismatch"]
+    assert stored and stored[0]["vm_id"] == "vm-new-generation"
+    assert stored[0]["helper_instance_id"] == "helper-new"
+    assert stored[0]["helper_started_at"] == "2026-05-09T01:00:00Z"
+
+
+def test_vz_linux_session_reuse_helper_unavailable_fails_closed(monkeypatch, tmp_path) -> None:
     monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_FAKE_EXEC", raising=False)
     calls: list[str] = []
     deleted: list[str] = []
@@ -654,14 +775,15 @@ def test_vz_linux_session_reuse_helper_unavailable_recreates_vm(monkeypatch, tmp
         session_workspace=str(tmp_path),
     )
 
-    assert status.phase == RunPhase.completed
-    assert status.exit_code == 0
-    assert calls == ["get_vm_status", "validate_template", "create_vm", "exec_guest"]
-    assert deleted == ["sess-helper-unavailable"]
-    assert stored and stored[0]["vm_id"] == "vm-new"
+    assert status.phase == RunPhase.failed
+    assert status.exit_code is None
+    assert "macos_virtualization_helper_unavailable" in status.message
+    assert calls == ["get_vm_status"]
+    assert deleted == []
+    assert stored == []
 
 
-def test_vz_linux_session_reuse_protocol_mismatch_recreates_vm(monkeypatch, tmp_path) -> None:
+def test_vz_linux_session_reuse_protocol_mismatch_fails_closed(monkeypatch, tmp_path) -> None:
     monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_FAKE_EXEC", raising=False)
     calls: list[str] = []
     deleted: list[str] = []
@@ -725,11 +847,12 @@ def test_vz_linux_session_reuse_protocol_mismatch_recreates_vm(monkeypatch, tmp_
         session_workspace=str(tmp_path),
     )
 
-    assert status.phase == RunPhase.completed
-    assert status.exit_code == 0
-    assert calls == ["get_vm_status", "validate_template", "create_vm", "exec_guest"]
-    assert deleted == ["sess-protocol-mismatch"]
-    assert stored and stored[0]["vm_id"] == "vm-new"
+    assert status.phase == RunPhase.failed
+    assert status.exit_code is None
+    assert "macos_virtualization_helper_protocol_mismatch" in status.message
+    assert calls == ["get_vm_status"]
+    assert deleted == []
+    assert stored == []
 
 
 def test_vz_linux_session_reuse_absent_status_recreates_vm(monkeypatch, tmp_path) -> None:
@@ -775,7 +898,14 @@ def test_vz_linux_session_reuse_absent_status_recreates_vm(monkeypatch, tmp_path
             assert request["run_id"] == "vz-run-absent-status"
             assert request["session_id"] == "sess-absent-status"
             assert request["session_mode"] is True
-            return HelperVMReply(vm_id="vm-new", state="created")
+            return HelperVMReply(
+                vm_id="vm-new",
+                state="created",
+                details={
+                    "helper_instance_id": "helper-new",
+                    "helper_started_at": "2026-05-09T01:00:00Z",
+                },
+            )
 
         def exec_guest(self, *, vm_id: str, request: dict[str, object]) -> HelperExecReply:
             calls.append("exec_guest")
@@ -801,6 +931,8 @@ def test_vz_linux_session_reuse_absent_status_recreates_vm(monkeypatch, tmp_path
     assert calls == ["get_vm_status", "validate_template", "create_vm", "exec_guest"]
     assert deleted == ["sess-absent-status"]
     assert stored and stored[0]["vm_id"] == "vm-new"
+    assert stored[0]["helper_instance_id"] == "helper-new"
+    assert stored[0]["helper_started_at"] == "2026-05-09T01:00:00Z"
 
 
 def test_vz_linux_session_run_recreates_unhealthy_vm(monkeypatch, tmp_path) -> None:
@@ -854,7 +986,14 @@ def test_vz_linux_session_run_recreates_unhealthy_vm(monkeypatch, tmp_path) -> N
             assert request["session_id"] == "sess-2"
             assert request["session_mode"] is True
             assert request["template"] == "ubuntu-24.04"
-            return HelperVMReply(vm_id="vm-new", state="created")
+            return HelperVMReply(
+                vm_id="vm-new",
+                state="created",
+                details={
+                    "helper_instance_id": "helper-new",
+                    "helper_started_at": "2026-05-09T01:00:00Z",
+                },
+            )
 
         def exec_guest(self, *, vm_id: str, request: dict[str, object]) -> HelperExecReply:
             calls.append("exec_guest")
@@ -880,6 +1019,8 @@ def test_vz_linux_session_run_recreates_unhealthy_vm(monkeypatch, tmp_path) -> N
     assert deleted == ["sess-2"]
     assert stored and stored[0]["vm_id"] == "vm-new"
     assert stored[0]["template_id"] == "vz_linux:new-template"
+    assert stored[0]["helper_instance_id"] == "helper-new"
+    assert stored[0]["helper_started_at"] == "2026-05-09T01:00:00Z"
 
 
 def test_vz_linux_start_run_passes_log_cap_to_helper(monkeypatch, tmp_path) -> None:

--- a/tldw_Server_API/tests/sandbox/test_vz_linux_session_control_store.py
+++ b/tldw_Server_API/tests/sandbox/test_vz_linux_session_control_store.py
@@ -36,6 +36,8 @@ def test_store_persists_vz_linux_session_control_metadata(monkeypatch, tmp_path:
         template_id="vz_linux:ubuntu-24.04",
         workspace_mount="/tmp/ws",
         agent_ready=True,
+        helper_instance_id="helper-a",
+        helper_started_at="2026-05-09T00:00:00Z",
     )
 
     store_b = get_store()
@@ -46,5 +48,7 @@ def test_store_persists_vz_linux_session_control_metadata(monkeypatch, tmp_path:
     assert row["template_id"] == "vz_linux:ubuntu-24.04"
     assert row["workspace_mount"] == "/tmp/ws"
     assert row["agent_ready"] is True
+    assert row["helper_instance_id"] == "helper-a"
+    assert row["helper_started_at"] == "2026-05-09T00:00:00Z"
     assert store_b.delete_vz_session_control("sess-1") is True
     assert store_b.get_vz_session_control("sess-1") is None

--- a/tools/macos-vz-helper/PROTOCOL.md
+++ b/tools/macos-vz-helper/PROTOCOL.md
@@ -23,6 +23,11 @@ Every failure response should include:
 - `error_code`
 - `message`
 
+Successful `details` dictionaries may include helper-owned generation metadata:
+
+- `helper_instance_id`: per-helper-process UUID, changes after helper restart
+- `helper_started_at`: helper process start timestamp in ISO-8601 format
+
 ## Required Operations
 
 - `ping`
@@ -45,6 +50,8 @@ Every failure response should include:
   "helper_version": "0.1.0",
   "status": "ok",
   "details": {
+    "helper_instance_id": "77777777-7777-7777-7777-777777777777",
+    "helper_started_at": "2026-05-09T00:00:00Z",
     "transport": "unix"
   }
 }
@@ -91,6 +98,8 @@ Every failure response should include:
     "created_at": "2026-04-30T18:00:00Z"
   },
   "details": {
+    "helper_instance_id": "77777777-7777-7777-7777-777777777777",
+    "helper_started_at": "2026-05-09T00:00:00Z",
     "transport": "vsock",
     "network_policy": "deny_all",
     "guest_version": "1.0.0",
@@ -160,6 +169,8 @@ Response:
     "created_at": "2026-04-30T18:00:00Z"
   },
   "details": {
+    "helper_instance_id": "77777777-7777-7777-7777-777777777777",
+    "helper_started_at": "2026-05-09T00:00:00Z",
     "transport": "vsock",
     "network_policy": "deny_all",
     "guest_version": "1.0.0",

--- a/tools/macos-vz-helper/Sources/Server/HelperService.swift
+++ b/tools/macos-vz-helper/Sources/Server/HelperService.swift
@@ -26,6 +26,8 @@ final class HelperService {
 
     private let protocolVersion = "1"
     private let helperVersion = "0.1.0"
+    private let helperInstanceID: String
+    private let helperStartedAt: String
     private let hostFacts: HostFacts
     private let templateValidator: TemplateValidator
     private let registry: VMRegistry
@@ -36,8 +38,12 @@ final class HelperService {
         hostFacts: HostFacts = HostFacts(isMacOS: true, isAppleSilicon: true),
         templateValidator: TemplateValidator = TemplateValidator(),
         registry: VMRegistry = VMRegistry(),
-        vmManager: VZLinuxVMManager? = nil
+        vmManager: VZLinuxVMManager? = nil,
+        helperInstanceID: String = UUID().uuidString,
+        helperStartedAt: String = ISO8601DateFormatter().string(from: Date())
     ) {
+        self.helperInstanceID = helperInstanceID
+        self.helperStartedAt = helperStartedAt
         self.hostFacts = hostFacts
         self.templateValidator = templateValidator
         self.registry = registry
@@ -53,7 +59,7 @@ final class HelperService {
             executionMode: nil,
             transport: nil,
             reasons: [],
-            details: ["transport": "unix"],
+            details: withHelperGeneration(["transport": "unix"]),
             errorCode: nil,
             message: nil
         )
@@ -265,7 +271,22 @@ final class HelperService {
                 details["guest_capabilities"] = guestInfo.capabilities.joined(separator: ",")
             }
         }
-        return details
+        return withHelperGeneration(details)
+    }
+
+    private func helperGenerationDetails() -> [String: String] {
+        [
+            "helper_instance_id": helperInstanceID,
+            "helper_started_at": helperStartedAt,
+        ]
+    }
+
+    private func withHelperGeneration(_ details: [String: String]) -> [String: String] {
+        var merged = details
+        for (key, value) in helperGenerationDetails() {
+            merged[key] = value
+        }
+        return merged
     }
 
     private func validateExecGuestContract(

--- a/tools/macos-vz-helper/Tests/HelperServiceVMTests.swift
+++ b/tools/macos-vz-helper/Tests/HelperServiceVMTests.swift
@@ -11,7 +11,9 @@ import Testing
     let service = HelperService(
         hostFacts: HostFacts(isMacOS: true, isAppleSilicon: true),
         registry: registry,
-        vmManager: manager
+        vmManager: manager,
+        helperInstanceID: "helper-test-1",
+        helperStartedAt: "2026-05-09T00:00:00Z"
     )
 
     let response = try service.createVM(
@@ -24,6 +26,8 @@ import Testing
     #expect(response.vmID == "vm-service")
     #expect(response.state == "running")
     #expect(response.details["transport"] == "vsock")
+    #expect(response.details["helper_instance_id"] == "helper-test-1")
+    #expect(response.details["helper_started_at"] == "2026-05-09T00:00:00Z")
 }
 
 @Test func helperServiceSurfacesGuestAgentDetailsInCreateStatusAndList() throws {
@@ -42,7 +46,9 @@ import Testing
     let service = HelperService(
         hostFacts: HostFacts(isMacOS: true, isAppleSilicon: true),
         registry: registry,
-        vmManager: manager
+        vmManager: manager,
+        helperInstanceID: "helper-test-1",
+        helperStartedAt: "2026-05-09T00:00:00Z"
     )
 
     let response = try service.createVM(
@@ -55,6 +61,8 @@ import Testing
     let listed = service.listVMs().vms.first
 
     for details in [response.details, status?.details, listed?.details] {
+        #expect(details?["helper_instance_id"] == "helper-test-1")
+        #expect(details?["helper_started_at"] == "2026-05-09T00:00:00Z")
         #expect(details?["guest_version"] == "1.0.0")
         #expect(details?["guest_workspace_root"] == "/workspace")
         #expect(details?["guest_capabilities_known"] == "true")

--- a/tools/macos-vz-helper/Tests/PingTests.swift
+++ b/tools/macos-vz-helper/Tests/PingTests.swift
@@ -2,7 +2,10 @@ import Testing
 @testable import MacOSVZHelperDaemon
 
 @Test func pingIncludesProtocolAndHelperVersion() throws {
-    let service = HelperService()
+    let service = HelperService(
+        helperInstanceID: "helper-test-1",
+        helperStartedAt: "2026-05-09T00:00:00Z"
+    )
 
     let response = service.ping()
 
@@ -10,4 +13,6 @@ import Testing
     #expect(response.helperVersion == "0.1.0")
     #expect(response.status == "ok")
     #expect(response.details["transport"] == "unix")
+    #expect(response.details["helper_instance_id"] == "helper-test-1")
+    #expect(response.details["helper_started_at"] == "2026-05-09T00:00:00Z")
 }


### PR DESCRIPTION
## Change summary
TODO: Human-authored Change summary required before merge.

## Summary
- Add helper-owned generation metadata to ping and VM detail payloads.
- Persist helper generation on VZ Linux session-control rows across in-memory, SQLite, and Postgres stores.
- Harden same-session VM reuse so stale helper generations are reprovisioned while helper/protocol failures fail closed without deleting control state.

## Test Plan
- swift test --filter "PingTests|HelperServiceVMTests"
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_vz_linux_runner.py tldw_Server_API/tests/sandbox/test_vz_linux_session_control_store.py tldw_Server_API/tests/sandbox/test_store_sqlite_migrations.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py tldw_Server_API/app/core/Sandbox/store.py tldw_Server_API/app/core/Sandbox/orchestrator.py -f json -o /tmp/bandit_vz_helper_generation.json