### PR TITLE
Adapt Layouts ConnectionStatus dot to shared Badge

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -5566,17 +5566,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "local-status-badge:src/components/Layouts/ConnectionStatus.tsx:StatusDot",
-    "path": "src/components/Layouts/ConnectionStatus.tsx",
-    "rule": "local-status-badge",
-    "subject": "StatusDot",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing local StatusDot status wrapper before the guard.",
-    "replacement": "Badge with design-system state registry mapping",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "local-status-badge:src/components/Option/PresentationStudio/PresentationStudioStatusBadge.tsx:PresentationStudioStatusBadge",
     "path": "src/components/Option/PresentationStudio/PresentationStudioStatusBadge.tsx",
     "rule": "local-status-badge",

--- a/apps/packages/ui/src/components/Layouts/ConnectionStatus.tsx
+++ b/apps/packages/ui/src/components/Layouts/ConnectionStatus.tsx
@@ -3,13 +3,40 @@ import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
 import { useConnectionState } from "@/hooks/useConnectionState"
 import { ConnectionPhase } from "@/types/connection"
-import { getDesignSystemState, type DesignSystemStateKey } from "@/design-system"
+import {
+  getDesignSystemState,
+  type DesignSystemSeverity,
+  type DesignSystemStateKey
+} from "@/design-system"
 import {
   Badge,
   getBadgeVariantForDesignSystemSeverity
 } from "@/components/ui/primitives"
 
 type StatusKind = "unknown" | "ok" | "fail"
+
+const SEVERITY_STYLES = {
+  success: {
+    bg: "border-success/30 bg-success/10",
+    text: "text-success"
+  },
+  error: {
+    bg: "border-danger/30 bg-danger/10",
+    text: "text-danger"
+  },
+  warning: {
+    bg: "border-warn/30 bg-warn/10",
+    text: "text-warn"
+  },
+  info: {
+    bg: "border-primary/30 bg-primary/10",
+    text: "text-primary"
+  },
+  neutral: {
+    bg: "border-border bg-surface2",
+    text: "text-text-muted"
+  }
+} satisfies Record<DesignSystemSeverity, { bg: string; text: string }>
 
 interface ConnectionStatusProps {
   /** Custom click handler (defaults to navigating to /settings/health) */
@@ -82,21 +109,9 @@ export function ConnectionStatus({
     }
   }
 
-  const statusBgClass = {
-    success: "border-success/30 bg-success/10",
-    error: "border-danger/30 bg-danger/10",
-    warning: "border-warn/30 bg-warn/10",
-    info: "border-primary/30 bg-primary/10",
-    neutral: "border-border bg-surface2"
-  }[coreState.severity]
-
-  const statusTextClass = {
-    success: "text-success",
-    error: "text-danger",
-    warning: "text-warn",
-    info: "text-primary",
-    neutral: "text-text-muted"
-  }[coreState.severity]
+  const severityStyles = SEVERITY_STYLES[coreState.severity]
+  const statusBgClass = severityStyles.bg
+  const statusTextClass = severityStyles.text
 
   return (
     <button

--- a/apps/packages/ui/src/components/Layouts/ConnectionStatus.tsx
+++ b/apps/packages/ui/src/components/Layouts/ConnectionStatus.tsx
@@ -3,6 +3,11 @@ import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
 import { useConnectionState } from "@/hooks/useConnectionState"
 import { ConnectionPhase } from "@/types/connection"
+import { getDesignSystemState, type DesignSystemStateKey } from "@/design-system"
+import {
+  Badge,
+  getBadgeVariantForDesignSystemSeverity
+} from "@/components/ui/primitives"
 
 type StatusKind = "unknown" | "ok" | "fail"
 
@@ -37,6 +42,22 @@ export function ConnectionStatus({
           ? "fail"
           : "unknown"
 
+  const stateKeyForCoreStatus = (status: StatusKind): DesignSystemStateKey => {
+    if (phase === ConnectionPhase.UNCONFIGURED) {
+      return "setup_required"
+    }
+    if (status === "ok") {
+      return "ready"
+    }
+    if (status === "fail") {
+      return "unavailable"
+    }
+    return "retrying"
+  }
+
+  const coreStateKey = stateKeyForCoreStatus(coreStatus)
+  const coreState = getDesignSystemState(coreStateKey)
+
   const statusLabelForCore = (status: StatusKind): string => {
     if (phase === ConnectionPhase.UNCONFIGURED) {
       return t(
@@ -61,19 +82,21 @@ export function ConnectionStatus({
     }
   }
 
-  const statusBgClass =
-    coreStatus === "ok"
-      ? "border-success/30 bg-success/10"
-      : coreStatus === "fail"
-        ? "border-danger/30 bg-danger/10"
-        : "border-border bg-surface2"
+  const statusBgClass = {
+    success: "border-success/30 bg-success/10",
+    error: "border-danger/30 bg-danger/10",
+    warning: "border-warn/30 bg-warn/10",
+    info: "border-primary/30 bg-primary/10",
+    neutral: "border-border bg-surface2"
+  }[coreState.severity]
 
-  const statusTextClass =
-    coreStatus === "ok"
-      ? "text-success"
-      : coreStatus === "fail"
-        ? "text-danger"
-        : "text-text-muted"
+  const statusTextClass = {
+    success: "text-success",
+    error: "text-danger",
+    warning: "text-warn",
+    info: "text-primary",
+    neutral: "text-text-muted"
+  }[coreState.severity]
 
   return (
     <button
@@ -105,7 +128,7 @@ export function ConnectionStatus({
         )
       }
     >
-      <StatusDot status={coreStatus} />
+      <StatusDot status={coreStatus} stateKey={coreStateKey} />
       {showLabel && (
         <span className={statusTextClass}>
           {statusLabelForCore(coreStatus)}
@@ -118,19 +141,31 @@ export function ConnectionStatus({
 /**
  * Simple status dot indicator with animation for unknown state
  */
-export function StatusDot({ status }: { status: StatusKind }) {
+export function StatusDot({
+  status,
+  stateKey
+}: {
+  status: StatusKind
+  stateKey: DesignSystemStateKey
+}) {
+  const state = getDesignSystemState(stateKey)
+
   return (
-    <span
-      data-testid="connection-status-dot"
-      aria-hidden
-      className={`inline-block h-2 w-2 rounded-full ${
-        status === "ok"
-          ? "bg-success"
-          : status === "fail"
-            ? "bg-danger"
-            : "bg-text-subtle animate-pulse"
-      }`}
-    />
+    <Badge
+      data-testid="connection-status-dot-badge"
+      variant={getBadgeVariantForDesignSystemSeverity(state.severity)}
+      size="sm"
+      outline
+      className="gap-0 px-1 py-1 leading-none"
+    >
+      <span
+        data-testid="connection-status-dot"
+        aria-hidden
+        className={`inline-block h-2 w-2 rounded-full bg-current ${
+          status === "unknown" ? "animate-pulse" : ""
+        }`}
+      />
+    </Badge>
   )
 }
 

--- a/apps/packages/ui/src/components/Layouts/__tests__/ConnectionStatus.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Layouts/__tests__/ConnectionStatus.design-system.test.tsx
@@ -1,0 +1,109 @@
+import React from "react"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { ConnectionStatus } from "../ConnectionStatus"
+
+type TranslationOptions = {
+  defaultValue?: string
+  [key: string]: unknown
+}
+
+const connectionState = vi.hoisted(() => ({
+  state: {
+    phase: "connected",
+    isConnected: true
+  }
+}))
+
+const navigateMock = vi.hoisted(() => vi.fn())
+
+const translate = (
+  key: string,
+  fallback?: string | TranslationOptions,
+  interpolation?: Record<string, unknown>
+) => {
+  const defaultValue =
+    typeof fallback === "string" ? fallback : fallback?.defaultValue ?? key
+  const values = typeof fallback === "object" ? fallback : interpolation
+
+  if (!values) {
+    return defaultValue
+  }
+
+  return Object.entries(values).reduce((copy, [name, value]) => {
+    return copy.replaceAll(`{{${name}}}`, String(value))
+  }, defaultValue)
+}
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: translate
+  })
+}))
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>()
+  return {
+    ...actual,
+    useNavigate: () => navigateMock
+  }
+})
+
+vi.mock("@/hooks/useConnectionState", () => ({
+  useConnectionState: () => connectionState.state
+}))
+
+describe("ConnectionStatus design-system badge", () => {
+  beforeEach(() => {
+    connectionState.state = {
+      phase: "connected",
+      isConnected: true
+    }
+    navigateMock.mockReset()
+  })
+
+  it.each([
+    ["connected", "connected", true, "success", "Server: Online"],
+    ["checking", "searching", false, "info", "Server: Checking..."],
+    ["unconfigured", "unconfigured", false, "warning", "Server: Not configured"],
+    ["offline", "error", false, "danger", "Server: Offline"]
+  ])(
+    "renders %s status through the shared Badge primitive",
+    (_name, phase, isConnected, expectedVariant, label) => {
+      connectionState.state = {
+        phase,
+        isConnected
+      }
+
+      render(<ConnectionStatus />)
+
+      const badge = screen.getByTestId("connection-status-dot-badge")
+
+      expect(badge).toHaveAttribute("data-ds-component", "Badge")
+      expect(badge).toHaveAttribute("data-ds-variant", expectedVariant)
+      expect(
+        badge.querySelector('[data-testid="connection-status-dot"]')
+      ).toBeInTheDocument()
+      expect(screen.getByText(label)).toBeInTheDocument()
+    }
+  )
+
+  it("preserves the custom click handler override", () => {
+    const onClick = vi.fn()
+
+    render(<ConnectionStatus onClick={onClick} />)
+
+    fireEvent.click(screen.getByTestId("connection-status"))
+
+    expect(onClick).toHaveBeenCalledTimes(1)
+    expect(navigateMock).not.toHaveBeenCalled()
+  })
+
+  it("opens health diagnostics when no click handler is provided", () => {
+    render(<ConnectionStatus />)
+
+    fireEvent.click(screen.getByTestId("connection-status"))
+
+    expect(navigateMock).toHaveBeenCalledWith("/settings/health")
+  })
+})

--- a/backlog/tasks/task-45.27 - Adapt-Layouts-ConnectionStatus-dot-to-shared-Badge.md
+++ b/backlog/tasks/task-45.27 - Adapt-Layouts-ConnectionStatus-dot-to-shared-Badge.md
@@ -1,0 +1,59 @@
+---
+id: TASK-45.27
+title: Adapt Layouts ConnectionStatus dot to shared Badge
+status: Done
+assignee: []
+created_date: '2026-05-09 16:46'
+updated_date: '2026-05-09 16:50'
+labels:
+  - design-system
+  - webui
+dependencies: []
+references:
+  - apps/packages/ui/src/components/Layouts/ConnectionStatus.tsx
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+parent_task_id: TASK-45
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate the Layouts ConnectionStatus local StatusDot product-state indicator to the shared Badge primitive and design-system state registry. This targets the remaining local-status-badge baseline entry for src/components/Layouts/ConnectionStatus.tsx without changing navigation or health-diagnostics behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 ConnectionStatus renders its status indicator through the shared Badge primitive while preserving the existing clickable health diagnostics button behavior
+- [x] #2 StatusKind values map through getDesignSystemState before selecting Badge variants
+- [x] #3 The local-status-badge baseline exception for src/components/Layouts/ConnectionStatus.tsx is removed without introducing new guard findings
+- [x] #4 Focused component coverage and design-system guard verification are recorded
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+2026-05-09: Added a focused red test for Layouts/ConnectionStatus requiring the dot indicator to render through data-ds-component="Badge" across connected, checking, unconfigured, and offline states while preserving custom click handling and default /settings/health navigation. Initial run failed because the existing indicator was a raw span with no connection-status-dot-badge element.
+
+2026-05-09: Migrated StatusDot to return the shared Badge primitive. ConnectionStatus now maps core connection status through getDesignSystemState using ready, retrying, setup_required, and unavailable before selecting Badge variants. Removed the ConnectionStatus local-status-badge baseline exception.
+
+Verification: bunx vitest run src/components/Layouts/__tests__/ConnectionStatus.design-system.test.tsx --reporter=dot -> 6 passed. bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot -> 46 passed. bun run verify:design-system-state -> passed; baseline exceptions 509 and local-status-badge 3. git diff --check -> passed. bunx tsc --noEmit --pretty false | rg touched files -> no touched-file diagnostics (rg exit 1/no matches).
+
+Bandit skip: touched runtime/test files are TypeScript/TSX plus JSON Backlog metadata; no Python security surface changed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated Layouts ConnectionStatus status dot to the shared Badge primitive and design-system state registry. The component now derives canonical state keys for connected, checking, unconfigured, and offline server states, renders the compact dot inside a Badge, keeps diagnostics click behavior intact, and removes the obsolete baseline exception.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.27.1 - Address-PR-1423-ConnectionStatus-review-comments.md
+++ b/backlog/tasks/task-45.27.1 - Address-PR-1423-ConnectionStatus-review-comments.md
@@ -1,0 +1,57 @@
+---
+id: TASK-45.27.1
+title: Address PR 1423 ConnectionStatus review comments
+status: Done
+assignee: []
+created_date: '2026-05-09 17:10'
+updated_date: '2026-05-09 17:11'
+labels:
+  - design-system
+  - webui
+  - review
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1423'
+  - apps/packages/ui/src/components/Layouts/ConnectionStatus.tsx
+parent_task_id: TASK-45.27
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Follow-up review-fix task for PR #1423. Resolve the Gemini review comment on ConnectionStatus by consolidating severity class mappings outside the component render path while preserving behavior and design-system guard compliance.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 ConnectionStatus uses a module-level severity style mapping instead of recreating style objects during render
+- [x] #2 Connected, checking, unconfigured, and offline badge rendering remains covered by the focused ConnectionStatus design-system test
+- [x] #3 Design-system guard verification and touched-file checks are rerun and recorded
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+2026-05-09: Addressed Gemini review comment by moving severity class mapping to a module-level SEVERITY_STYLES constant typed with DesignSystemSeverity and replacing two render-time lookup objects with a single severityStyles lookup.
+
+Verification: bunx vitest run src/components/Layouts/__tests__/ConnectionStatus.design-system.test.tsx --reporter=dot -> 6 passed. bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot -> 46 passed. bun run verify:design-system-state -> passed; baseline exceptions remain 509 and local-status-badge remains 3. git diff --check -> passed. bunx tsc --noEmit --pretty false | rg touched files -> no touched-file diagnostics (rg exit 1/no matches).
+
+Bandit skip: touched runtime/test files are TypeScript/TSX plus Backlog metadata only; no Python security surface changed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed PR #1423 Gemini feedback by consolidating ConnectionStatus severity class mappings into a module-level constant and using one render-time lookup. Behavior and design-system guard coverage remain unchanged.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrates `ConnectionStatus` status-dot rendering to the shared `Badge` primitive with design-system state mapping.
- Maps connected/checking/unconfigured/offline states through `getDesignSystemState` before selecting badge variants.
- Removes the obsolete `ConnectionStatus` local-status-badge baseline entry and records TASK-45.27.

## Verification
- `bunx vitest run src/components/Layouts/__tests__/ConnectionStatus.design-system.test.tsx --reporter=dot`
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot`
- `bun run verify:design-system-state`
- `git diff --check`
- `bunx tsc --noEmit --pretty false 2>&1 | rg touched files` -> no touched-file diagnostics

## Notes
- Bandit skipped: touched files are TypeScript/TSX, JSON, and Backlog metadata only.