### PR TITLE
Remove dayjs from DataTables date cell

### DIFF
--- a/Docs/Design/WebUI_Dependency_Audit.md
+++ b/Docs/Design/WebUI_Dependency_Audit.md
@@ -107,7 +107,7 @@ This audit does not remove packages or rewrite runtime code.
 | `cytoscape` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 6 | apps/packages/ui/src/components/Notes/NotesGraphModal.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesGraphModal.stage2.graph-view.test.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage21.accessibility-modal-focus.test.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage22.accessibility-regression.test.tsx | shared UI, shared UI tests | graph/rendering | `keep` | Low; import/config/package-script evidence in current WebUI or shared UI paths. | No immediate reduction; keep current behavior. | none |
 | `cytoscape-dagre` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 6 | apps/packages/ui/src/components/Notes/NotesGraphModal.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesGraphModal.stage2.graph-view.test.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage21.accessibility-modal-focus.test.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage22.accessibility-regression.test.tsx | shared UI, shared UI tests | graph/rendering | `keep` | Low; import/config/package-script evidence in current WebUI or shared UI paths. | No immediate reduction; keep current behavior. | none |
 | `d3-dsv` | `web:dependencies`, `extension:dependencies` | 0 | none found | web app, extension impact declaration only | parser/conversion | `investigate-lockfile` | Medium; no import/config/package-script evidence, but package sits in parser/conversion behavior. Confirm direct-vs-transitive ownership and CSV/DSV coverage before removal. | Potential install/bundle reduction if direct declaration proves unused. | Lockfile/parser-domain investigation slice. |
-| `dayjs` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 7 | apps/packages/ui/src/components/Media/FilterPanel.tsx, apps/packages/ui/src/components/Option/Collections/ReadingList/ReadingItemsList.tsx, apps/packages/ui/src/components/Option/DataTables/EditableCell.tsx, apps/packages/ui/src/components/Option/Items/ItemsWorkspace.tsx | shared UI | frontend/runtime | `defer-design` | Medium; remaining shared UI imports are Ant Design DatePicker/DateRangePicker value surfaces that currently exchange `Dayjs` values and types. | No immediate dependency reduction until shared UI date-picker value contracts are redesigned or isolated. | Date-picker contract design before manifest removal. |
+| `dayjs` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 6 | apps/packages/ui/src/components/Media/FilterPanel.tsx, apps/packages/ui/src/components/Option/Collections/ReadingList/ReadingItemsList.tsx, apps/packages/ui/src/components/Option/Items/ItemsWorkspace.tsx, apps/packages/ui/src/components/Option/KanbanPlayground/CardDetailPanel.tsx | shared UI | frontend/runtime | `defer-design` | Medium; remaining shared UI imports are Ant Design DatePicker/DateRangePicker value surfaces plus an Items published-date display use co-located with the Items date-filter contract. | No immediate dependency reduction until shared UI date-picker value contracts are redesigned or isolated and the final co-located display use is migrated. | Date-picker contract design before manifest removal. |
 | `dexie` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 6 | apps/packages/ui/src/db/dexie/chat.ts, apps/packages/ui/src/db/dexie/schema.ts, apps/packages/ui/src/hooks/document-workspace/__tests__/offlineQueue.test.ts, apps/packages/ui/src/hooks/document-workspace/offlineQueue.ts | shared UI, shared UI tests, web tests, web app | state/data | `keep` | Low; import/config/package-script evidence in current WebUI or shared UI paths. | No immediate reduction; keep current behavior. | none |
 | `dexie-react-hooks` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 1 | apps/packages/ui/src/components/Sidepanel/Chat/TtsClipsDrawer.tsx | shared UI | state/data | `keep` | Low; import/config/package-script evidence in current WebUI or shared UI paths. | No immediate reduction; keep current behavior. | none |
 | `dompurify` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 11 | apps/packages/ui/src/components/Common/CodeBlock.tsx, apps/packages/ui/src/components/Notes/NotesStudioDiagramCard.tsx, apps/packages/ui/src/components/Notes/export-utils.ts, apps/packages/ui/src/components/Option/Collections/ReadingList/ReadingItemDetail.tsx | shared UI | security/sanitization | `keep` | Low; import/config/package-script evidence in current WebUI or shared UI paths. | No immediate reduction; keep current behavior. | none |
@@ -228,6 +228,11 @@ This audit does not remove packages or rewrite runtime code.
   helpers used by FlashcardEditDrawer. The shared UI `dayjs` import count
   dropped from 11 to 7 while leaving the package declared for Ant Design
   `Dayjs` value-contract surfaces.
+- TASK-168 removed `dayjs` from the DataTables EditableCell date display and
+  edit path by replacing display formatting with native Date handling and the
+  Ant Design DatePicker editor with a native date input. The shared UI `dayjs`
+  import count dropped from 7 to 6 while leaving the package declared for
+  remaining date-control value-contract surfaces.
 
 ### Quick Cleanup Candidates
 
@@ -240,16 +245,16 @@ ownership checks, or complex-domain packages that should stay on the
 ### Replacement Candidates
 
 1. `dayjs`: remaining shared UI imports are Ant Design date-control value
-   surfaces. Do not attempt a direct dependency removal until those surfaces
-   that pass or type `Dayjs` values are redesigned or isolated.
+   surfaces plus a co-located Items published-date display use. Do not attempt
+   a direct dependency removal until the surfaces that pass or type `Dayjs`
+   values are redesigned or isolated and the final display use is migrated.
 
 ### Deferred Design Candidates
 
 - Icon-stack consolidation: `lucide-react`, `@heroicons/react`, `@ant-design/icons`, and `react-icons` are active visible UI dependencies and should be handled with a visual/design pass.
 - Date/time consolidation: current shared UI uses `Dayjs` values with Ant
-  Design date controls in media, reading list, items, data table, and kanban
-  surfaces. Treat this as a compatibility/design slice, not a quick manifest
-  cleanup.
+  Design date controls in media, reading list, items, and kanban surfaces.
+  Treat this as a compatibility/design slice, not a quick manifest cleanup.
 - PDF, ePub, document rendering, rich text editor, Mermaid, KaTeX, markdown, parser, graph/layout, OCR, tokenizer, schema, Monaco, Tiptap, and archive packages with active evidence are kept or deferred rather than replaced with hand-rolled browser code. Remaining zero-evidence complex declarations should keep using the `investigate-lockfile` path before any manifest edit.
 - DnD package declarations with no direct import evidence, such as `@dnd-kit/abstract` and `@dnd-kit/dom`, are retained after TASK-134 because the current lockfile still routes active DnD packages through the DnD abstract/dom graph.
 
@@ -425,6 +430,20 @@ ownership checks, or complex-domain packages that should stay on the
   errors outside this slice.
 - 2026-05-09 TASK-164 review follow-up: replaced manual English weekday/month
   arrays in the long Flashcards date label helper with `Intl.DateTimeFormat`.
+- 2026-05-09 TASK-168 active-code scan: exact shared UI package-import scan
+  found 6 remaining `dayjs` import lines after removing the runtime import from
+  `apps/packages/ui/src/components/Option/DataTables/EditableCell.tsx`.
+  Remaining imports are in media, reading list, items, and kanban date-control
+  surfaces plus the co-located Items published-date display use.
+- 2026-05-09 TASK-168 verification: `bunx vitest run
+  src/components/Option/DataTables/__tests__/EditableCell.date.test.tsx
+  --maxWorkers=1` from `apps/packages/ui` first failed on the existing invalid
+  date rendering and Ant Design DatePicker editor, then passed after the native
+  date helper/input implementation. `bun run lint` from `apps/tldw-frontend`
+  passed with the existing 131-warning baseline, and `git diff --check` passed.
+  Full `apps/packages/ui` TypeScript still exits 2 on existing repo-wide
+  baseline errors outside this slice; filtering those diagnostics for
+  `EditableCell` and `DataTables` returned no matches.
 - Bandit: skipped for TASK-144 because the slice changed documentation and
   Backlog metadata only; no Python files were modified.
 - Bandit: skipped for TASK-147 because the slice changed TypeScript,
@@ -436,6 +455,8 @@ ownership checks, or complex-domain packages that should stay on the
 - Bandit: skipped for TASK-158 because the slice changed TypeScript,
   documentation, and Backlog metadata only; no Python files were modified.
 - Bandit: skipped for TASK-164 because the slice changed TypeScript,
+  documentation, and Backlog metadata only; no Python files were modified.
+- Bandit: skipped for TASK-168 because the slice changed TypeScript,
   documentation, and Backlog metadata only; no Python files were modified.
 
 ## Known Skips And Blockers

--- a/Docs/Design/WebUI_Dependency_Audit.md
+++ b/Docs/Design/WebUI_Dependency_Audit.md
@@ -439,11 +439,14 @@ ownership checks, or complex-domain packages that should stay on the
   src/components/Option/DataTables/__tests__/EditableCell.date.test.tsx
   --maxWorkers=1` from `apps/packages/ui` first failed on the existing invalid
   date rendering and Ant Design DatePicker editor, then passed after the native
-  date helper/input implementation. `bun run lint` from `apps/tldw-frontend`
-  passed with the existing 131-warning baseline, and `git diff --check` passed.
-  Full `apps/packages/ui` TypeScript still exits 2 on existing repo-wide
-  baseline errors outside this slice; filtering those diagnostics for
-  `EditableCell` and `DataTables` returned no matches.
+  date helper/input implementation. PR review follow-up added regression
+  coverage for numeric timestamps, epoch zero, malformed date-prefix strings,
+  and change-then-blur single-commit behavior; the focused suite now passes
+  with 7 tests. `bun run lint` from `apps/tldw-frontend` passed with the
+  existing 131-warning baseline, and `git diff --check` passed. Full
+  `apps/packages/ui` TypeScript still exits 2 on existing repo-wide baseline
+  errors outside this slice; filtering those diagnostics for `EditableCell`
+  and `DataTables` returned no matches.
 - Bandit: skipped for TASK-144 because the slice changed documentation and
   Backlog metadata only; no Python files were modified.
 - Bandit: skipped for TASK-147 because the slice changed TypeScript,

--- a/apps/packages/ui/src/components/Option/DataTables/EditableCell.tsx
+++ b/apps/packages/ui/src/components/Option/DataTables/EditableCell.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef, useState } from "react"
-import { Checkbox, DatePicker, Input, InputNumber, Tag } from "antd"
-import dayjs from "dayjs"
+import { Checkbox, Input, InputNumber, Tag } from "antd"
 import type { ColumnType } from "@/types/data-tables"
 
 interface EditableCellProps {
@@ -13,6 +12,28 @@ interface EditableCellProps {
   onStartEdit: () => void
   onFinishEdit: (value: any) => void
   onCancelEdit: () => void
+}
+
+const DATE_ONLY_PATTERN = /^(\d{4})-(\d{2})-(\d{2})/
+
+const toDateOnlyString = (value: unknown): string | null => {
+  if (!value) return null
+
+  if (typeof value === "string") {
+    const dateOnlyMatch = value.match(DATE_ONLY_PATTERN)
+    if (dateOnlyMatch) {
+      const [, year, month, day] = dateOnlyMatch
+      return `${year}-${month}-${day}`
+    }
+  }
+
+  const date = value instanceof Date ? value : new Date(String(value))
+  if (Number.isNaN(date.getTime())) return null
+
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, "0")
+  const day = String(date.getDate()).padStart(2, "0")
+  return `${year}-${month}-${day}`
 }
 
 /**
@@ -100,11 +121,7 @@ export const EditableCell: React.FC<EditableCellProps> = ({
 
       case "date":
         if (value) {
-          try {
-            return dayjs(value).format("YYYY-MM-DD")
-          } catch {
-            return String(value)
-          }
+          return toDateOnlyString(value) ?? String(value)
         }
         return String(value)
 
@@ -155,19 +172,19 @@ export const EditableCell: React.FC<EditableCellProps> = ({
 
       case "date":
         return (
-          <DatePicker
+          <input
             ref={inputRef}
-            value={editValue ? dayjs(editValue) : null}
-            onChange={(date) => {
-              const newValue = date ? date.format("YYYY-MM-DD") : null
+            type="date"
+            aria-label={columnName}
+            value={toDateOnlyString(editValue) ?? ""}
+            onChange={(event) => {
+              const newValue = event.target.value || null
               setEditValue(newValue)
-              // DatePicker doesn't blur properly, so finish on change
               onFinishEdit(newValue)
             }}
             onKeyDown={handleKeyDown}
-            className="w-full"
-            size="small"
-            open
+            onBlur={handleBlur}
+            className="w-full rounded border border-border bg-background px-2 py-1 text-sm text-text focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
           />
         )
 

--- a/apps/packages/ui/src/components/Option/DataTables/EditableCell.tsx
+++ b/apps/packages/ui/src/components/Option/DataTables/EditableCell.tsx
@@ -16,18 +16,57 @@ interface EditableCellProps {
 
 const DATE_ONLY_PATTERN = /^(\d{4})-(\d{2})-(\d{2})/
 
+const hasDateValue = (value: unknown): boolean =>
+  value !== null && value !== undefined && value !== ""
+
+const isLeapYear = (year: number): boolean =>
+  year % 400 === 0 || (year % 4 === 0 && year % 100 !== 0)
+
+const isValidDateParts = (year: string, month: string, day: string): boolean => {
+  const numericYear = Number(year)
+  const numericMonth = Number(month)
+  const numericDay = Number(day)
+  const daysInMonth = [
+    31,
+    isLeapYear(numericYear) ? 29 : 28,
+    31,
+    30,
+    31,
+    30,
+    31,
+    31,
+    30,
+    31,
+    30,
+    31
+  ]
+
+  return (
+    numericMonth >= 1 &&
+    numericMonth <= 12 &&
+    numericDay >= 1 &&
+    numericDay <= daysInMonth[numericMonth - 1]
+  )
+}
+
 const toDateOnlyString = (value: unknown): string | null => {
-  if (!value) return null
+  if (!hasDateValue(value)) return null
 
   if (typeof value === "string") {
     const dateOnlyMatch = value.match(DATE_ONLY_PATTERN)
     if (dateOnlyMatch) {
       const [, year, month, day] = dateOnlyMatch
+      if (!isValidDateParts(year, month, day)) return null
       return `${year}-${month}-${day}`
     }
   }
 
-  const date = value instanceof Date ? value : new Date(String(value))
+  const date =
+    value instanceof Date
+      ? value
+      : typeof value === "number"
+        ? new Date(value)
+        : new Date(String(value))
   if (Number.isNaN(date.getTime())) return null
 
   const year = date.getFullYear()
@@ -120,7 +159,7 @@ export const EditableCell: React.FC<EditableCellProps> = ({
         )
 
       case "date":
-        if (value) {
+        if (hasDateValue(value)) {
           return toDateOnlyString(value) ?? String(value)
         }
         return String(value)
@@ -178,9 +217,7 @@ export const EditableCell: React.FC<EditableCellProps> = ({
             aria-label={columnName}
             value={toDateOnlyString(editValue) ?? ""}
             onChange={(event) => {
-              const newValue = event.target.value || null
-              setEditValue(newValue)
-              onFinishEdit(newValue)
+              setEditValue(event.target.value || null)
             }}
             onKeyDown={handleKeyDown}
             onBlur={handleBlur}

--- a/apps/packages/ui/src/components/Option/DataTables/__tests__/EditableCell.date.test.tsx
+++ b/apps/packages/ui/src/components/Option/DataTables/__tests__/EditableCell.date.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { EditableCell } from "../EditableCell"
+
+const renderDateCell = ({
+  value,
+  isEditing = false,
+  onFinishEdit = vi.fn()
+}: {
+  value: unknown
+  isEditing?: boolean
+  onFinishEdit?: (value: unknown) => void
+}) => {
+  const props = {
+    value,
+    columnType: "date" as const,
+    columnName: "Due date",
+    rowIndex: 0,
+    isEditing,
+    onStartEdit: vi.fn(),
+    onFinishEdit,
+    onCancelEdit: vi.fn()
+  }
+
+  return render(<EditableCell {...props} />)
+}
+
+describe("EditableCell date handling", () => {
+  it("renders valid date-like values as YYYY-MM-DD", () => {
+    renderDateCell({ value: "2026-04-03T12:34:56" })
+
+    expect(screen.getByText("2026-04-03")).toBeInTheDocument()
+  })
+
+  it("preserves invalid date values instead of rendering Invalid Date", () => {
+    renderDateCell({ value: "not-a-date" })
+
+    expect(screen.getByText("not-a-date")).toBeInTheDocument()
+    expect(screen.queryByText("Invalid Date")).not.toBeInTheDocument()
+  })
+
+  it("uses a native date input and emits YYYY-MM-DD changes", () => {
+    const onFinishEdit = vi.fn()
+    renderDateCell({
+      value: "2026-04-03T12:34:56",
+      isEditing: true,
+      onFinishEdit
+    })
+
+    const input = screen.getByLabelText("Due date") as HTMLInputElement
+    expect(input.type).toBe("date")
+    expect(input).toHaveValue("2026-04-03")
+
+    fireEvent.change(input, { target: { value: "2026-05-09" } })
+
+    expect(onFinishEdit).toHaveBeenCalledWith("2026-05-09")
+  })
+
+  it("emits null when the native date input is cleared", () => {
+    const onFinishEdit = vi.fn()
+    renderDateCell({
+      value: "2026-04-03",
+      isEditing: true,
+      onFinishEdit
+    })
+
+    fireEvent.change(screen.getByLabelText("Due date"), {
+      target: { value: "" }
+    })
+
+    expect(onFinishEdit).toHaveBeenCalledWith(null)
+  })
+})

--- a/apps/packages/ui/src/components/Option/DataTables/__tests__/EditableCell.date.test.tsx
+++ b/apps/packages/ui/src/components/Option/DataTables/__tests__/EditableCell.date.test.tsx
@@ -26,11 +26,33 @@ const renderDateCell = ({
   return render(<EditableCell {...props} />)
 }
 
+const toLocalDateLabel = (value: number) => {
+  const date = new Date(value)
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, "0")
+  const day = String(date.getDate()).padStart(2, "0")
+  return `${year}-${month}-${day}`
+}
+
 describe("EditableCell date handling", () => {
   it("renders valid date-like values as YYYY-MM-DD", () => {
     renderDateCell({ value: "2026-04-03T12:34:56" })
 
     expect(screen.getByText("2026-04-03")).toBeInTheDocument()
+  })
+
+  it("renders numeric timestamps as local YYYY-MM-DD dates", () => {
+    const timestamp = new Date(2026, 3, 3).getTime()
+
+    renderDateCell({ value: timestamp })
+
+    expect(screen.getByText(toLocalDateLabel(timestamp))).toBeInTheDocument()
+  })
+
+  it("treats zero as a valid epoch timestamp", () => {
+    renderDateCell({ value: 0 })
+
+    expect(screen.getByText(toLocalDateLabel(0))).toBeInTheDocument()
   })
 
   it("preserves invalid date values instead of rendering Invalid Date", () => {
@@ -40,7 +62,13 @@ describe("EditableCell date handling", () => {
     expect(screen.queryByText("Invalid Date")).not.toBeInTheDocument()
   })
 
-  it("uses a native date input and emits YYYY-MM-DD changes", () => {
+  it("preserves malformed date-prefix values instead of truncating them", () => {
+    renderDateCell({ value: "2026-99-99T12:34:56" })
+
+    expect(screen.getByText("2026-99-99T12:34:56")).toBeInTheDocument()
+  })
+
+  it("uses a native date input and emits one YYYY-MM-DD change on blur", () => {
     const onFinishEdit = vi.fn()
     renderDateCell({
       value: "2026-04-03T12:34:56",
@@ -53,11 +81,15 @@ describe("EditableCell date handling", () => {
     expect(input).toHaveValue("2026-04-03")
 
     fireEvent.change(input, { target: { value: "2026-05-09" } })
+    expect(onFinishEdit).not.toHaveBeenCalled()
 
+    fireEvent.blur(input)
+
+    expect(onFinishEdit).toHaveBeenCalledTimes(1)
     expect(onFinishEdit).toHaveBeenCalledWith("2026-05-09")
   })
 
-  it("emits null when the native date input is cleared", () => {
+  it("emits null when the native date input is cleared and blurred", () => {
     const onFinishEdit = vi.fn()
     renderDateCell({
       value: "2026-04-03",
@@ -68,6 +100,7 @@ describe("EditableCell date handling", () => {
     fireEvent.change(screen.getByLabelText("Due date"), {
       target: { value: "" }
     })
+    fireEvent.blur(screen.getByLabelText("Due date"))
 
     expect(onFinishEdit).toHaveBeenCalledWith(null)
   })

--- a/backlog/tasks/task-168 - Remove-dayjs-from-DataTables-EditableCell-date-handling.md
+++ b/backlog/tasks/task-168 - Remove-dayjs-from-DataTables-EditableCell-date-handling.md
@@ -1,10 +1,11 @@
 ---
 id: TASK-168
 title: Remove dayjs from DataTables EditableCell date handling
-status: In Progress
-assignee: []
+status: Done
+assignee:
+  - codex
 created_date: '2026-05-09 16:49'
-updated_date: '2026-05-09 16:55'
+updated_date: '2026-05-09 17:01'
 labels:
   - webui
   - dependencies
@@ -12,6 +13,7 @@ labels:
 dependencies: []
 references:
   - 'https://github.com/rmusser01/tldw_server/issues/1346'
+  - 'https://github.com/rmusser01/tldw_server/pull/1424'
 priority: medium
 ---
 
@@ -51,6 +53,8 @@ Exact shared UI dayjs package-import scan now reports 6 lines: Media/FilterPanel
 `git diff --check` exited 0. `bun run lint` from apps/tldw-frontend exited 0 with the existing 131-warning baseline. Full `./node_modules/.bin/tsc --noEmit --project tsconfig.json --pretty false` from apps/packages/ui exits 2 on existing repo-wide baseline diagnostics; filtering the same diagnostics for `EditableCell|DataTables` returned no matches.
 
 Bandit skipped because this slice touches TypeScript, tests, docs, and Backlog metadata only; no Python files changed.
+
+Opened PR #1424 against dev: https://github.com/rmusser01/tldw_server/pull/1424
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-168 - Remove-dayjs-from-DataTables-EditableCell-date-handling.md
+++ b/backlog/tasks/task-168 - Remove-dayjs-from-DataTables-EditableCell-date-handling.md
@@ -1,0 +1,70 @@
+---
+id: TASK-168
+title: Remove dayjs from DataTables EditableCell date handling
+status: In Progress
+assignee: []
+created_date: '2026-05-09 16:49'
+updated_date: '2026-05-09 16:55'
+labels:
+  - webui
+  - dependencies
+  - issue-1346
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1346'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue issue #1346 dependency cleanup by removing the remaining dayjs usage from the shared WebUI DataTables editable date-cell path. This is a narrow compatibility slice: keep the data-table date editing/display behavior intact while replacing dayjs parsing/formatting with platform-native date handling so the remaining Ant Design DatePicker/Dayjs value-contract surfaces can stay deferred to a separate design slice.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 EditableCell no longer imports or references dayjs for date display or editing.
+- [x] #2 Date cell display still renders valid date-like values as YYYY-MM-DD and preserves invalid raw values rather than throwing.
+- [x] #3 Date editing still emits YYYY-MM-DD for selected dates and null/empty for cleared values.
+- [x] #4 Focused tests cover display formatting, invalid values, and edit-change output for date cells.
+- [x] #5 Issue #1346 audit notes are updated to reflect the reduced dayjs import count and the remaining deferred DatePicker value-contract surfaces.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Replace the DataTables EditableCell date display/editing path with native date formatting and a native date input while leaving other column types untouched.
+2. Add focused Vitest coverage for valid date display, invalid raw values, native input output, and clearing behavior.
+3. Update the WebUI dependency audit for the reduced dayjs import count and remaining blockers.
+4. Run focused tests, exact dayjs import scan, lint/diff hygiene, and document the existing shared UI TypeScript baseline.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented in isolated worktree branch codex/webui-datatables-native-date-cell-1346. EditableCell now formats date cells via a local native Date helper and renders date edits with an accessible native input[type=date]. The test suite first failed against the old behavior: invalid values rendered as Invalid Date and edit mode exposed Ant Design DatePicker rather than the native input contract. After implementation, the focused tests pass. The audit now records shared UI dayjs package imports dropping from 7 to 6 and keeps the remaining Media, ReadingList, Items, and Kanban DatePicker/Dayjs surfaces deferred.
+
+Verification: `bunx vitest run src/components/Option/DataTables/__tests__/EditableCell.date.test.tsx --maxWorkers=1` failed before implementation on invalid date rendering and missing native date input; after implementation it passed with 4 tests.
+
+Exact shared UI dayjs package-import scan now reports 6 lines: Media/FilterPanel.tsx, ReadingItemsList.tsx type/runtime imports, ItemsWorkspace.tsx type/runtime imports, and KanbanPlayground/CardDetailPanel.tsx.
+
+`git diff --check` exited 0. `bun run lint` from apps/tldw-frontend exited 0 with the existing 131-warning baseline. Full `./node_modules/.bin/tsc --noEmit --project tsconfig.json --pretty false` from apps/packages/ui exits 2 on existing repo-wide baseline diagnostics; filtering the same diagnostics for `EditableCell|DataTables` returned no matches.
+
+Bandit skipped because this slice touches TypeScript, tests, docs, and Backlog metadata only; no Python files changed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Removed dayjs from the DataTables EditableCell date path by replacing display formatting with native Date handling and replacing the Ant Design DatePicker editor with an accessible native date input. Added focused EditableCell date tests and updated the WebUI dependency audit to record the shared UI dayjs import count dropping from 7 to 6 while keeping the remaining DatePicker/Dayjs surfaces deferred.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-168 - Remove-dayjs-from-DataTables-EditableCell-date-handling.md
+++ b/backlog/tasks/task-168 - Remove-dayjs-from-DataTables-EditableCell-date-handling.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - codex
 created_date: '2026-05-09 16:49'
-updated_date: '2026-05-09 17:01'
+updated_date: '2026-05-09 17:12'
 labels:
   - webui
   - dependencies
@@ -55,12 +55,16 @@ Exact shared UI dayjs package-import scan now reports 6 lines: Media/FilterPanel
 Bandit skipped because this slice touches TypeScript, tests, docs, and Backlog metadata only; no Python files changed.
 
 Opened PR #1424 against dev: https://github.com/rmusser01/tldw_server/pull/1424
+
+PR #1424 review follow-up: addressed Gemini/Qodo date-cell findings by removing the change-time finish call, relying on blur/Enter for date edit commits, handling numeric timestamps including 0, and validating date-prefix strings before truncation. Added regression coverage for numeric timestamps, epoch zero, malformed date-prefix values, and change-then-blur single-commit behavior.
+
+Review-fix verification: `bunx vitest run src/components/Option/DataTables/__tests__/EditableCell.date.test.tsx --maxWorkers=1` now passes with 7 tests. `git diff --check` exits 0. Exact shared UI dayjs package-import scan remains 6 expected lines. `bun run lint` from apps/tldw-frontend exits 0 with the existing 131-warning baseline. Filtered shared UI TypeScript diagnostics for `EditableCell|DataTables` returned no matches.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Removed dayjs from the DataTables EditableCell date path by replacing display formatting with native Date handling and replacing the Ant Design DatePicker editor with an accessible native date input. Added focused EditableCell date tests and updated the WebUI dependency audit to record the shared UI dayjs import count dropping from 7 to 6 while keeping the remaining DatePicker/Dayjs surfaces deferred.
+Removed dayjs from the DataTables EditableCell date path by replacing display formatting with native Date handling and replacing the Ant Design DatePicker editor with an accessible native date input. PR review follow-up removed change-time double commits, added numeric timestamp and malformed date-prefix handling, expanded focused tests to 7 cases, and kept the dependency audit at 6 remaining shared UI dayjs imports for deferred DatePicker/Dayjs surfaces.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary
- replace DataTables EditableCell date display/editing dayjs usage with native Date handling and an accessible `input[type=date]`
- add focused EditableCell date coverage for valid values, invalid raw values, numeric timestamps, epoch zero, malformed date prefixes, selected dates, cleared dates, and change-then-blur single commit behavior
- update the WebUI dependency audit and TASK-168 to record the shared UI dayjs import count drop from 7 to 6
- address Gemini/Qodo review feedback by removing change-time save commits and relying on blur/Enter for native date edits

## Verification
- `bunx vitest run src/components/Option/DataTables/__tests__/EditableCell.date.test.tsx --maxWorkers=1`
- exact shared UI dayjs package-import scan: 6 remaining lines in Media, ReadingList, Items, and Kanban surfaces
- `bun run lint` from `apps/tldw-frontend`: exits 0 with existing 131-warning baseline
- `git diff --check`
- `./node_modules/.bin/tsc --noEmit --project tsconfig.json --pretty false` from `apps/packages/ui`: still exits 2 on existing repo-wide baseline errors outside this slice; filtering diagnostics for `EditableCell|DataTables` returned no matches
- Bandit skipped: no Python files changed

## Merge gate
- Human requester still needs to provide the required AI-generated PR Change summary before merge.
