### PR TITLE
Expose Persona Visuals import commit controls

### DIFF
--- a/Docs/superpowers/plans/2026-05-09-persona-visual-import-commit-controls-plan.md
+++ b/Docs/superpowers/plans/2026-05-09-persona-visual-import-commit-controls-plan.md
@@ -1,0 +1,98 @@
+# Persona Visual Import Commit Controls Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose the existing Persona Visuals import-commit backend flow in the Persona Garden Visuals editor.
+
+**Architecture:** Keep the work frontend-scoped and reuse the existing PR #1135-aligned backend/API contract. Add typed service helpers for commit start/status, then surface commit and refresh controls inside the existing `VisualPackEditor` portability panel without auto-activating imported packs.
+
+**Tech Stack:** React, TypeScript, Ant Design, Vitest, Testing Library, existing `tldwClient.fetchWithAuth`.
+
+---
+
+### Task 1: Add Failing Frontend Coverage
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx`
+
+- [x] **Step 1: Extend the import-preview test**
+
+Add assertions that a completed import preview exposes `persona-visual-import-commit-button`, clicking it POSTs to `/api/v1/persona/profiles/persona-1/visual-packs/import-previews/preview-1/commit`, and the request body uses `trust_mode: "untrusted_import"` and `target_mode: "create_new"`.
+
+- [x] **Step 2: Add commit status assertions**
+
+Mock `GET /api/v1/persona/profiles/persona-1/visual-packs/imports/import-job-1` and assert the editor renders `persona-visual-import-commit-status`, stage, and job id, with a refresh button that updates completed state.
+
+- [x] **Step 3: Verify RED**
+
+Run: `cd apps/packages/ui && bunx vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx`
+
+Expected: FAIL because commit controls/service helpers do not exist in the editor yet.
+
+### Task 2: Add Service Types and Helpers
+
+**Files:**
+- Modify: `apps/packages/ui/src/types/persona-visuals.ts`
+- Modify: `apps/packages/ui/src/services/persona-visuals.ts`
+
+- [x] **Step 1: Add import commit types**
+
+Add `PersonaVisualImportCommitRequest` and `PersonaVisualImportCommitStartResponse` matching the backend schema. Reuse `PersonaVisualPortabilityJobResponse` for status polling.
+
+- [x] **Step 2: Add service helpers**
+
+Add `startPersonaVisualImportCommit(personaId, previewId, payload)` and `getPersonaVisualImportCommitStatus(personaId, jobId)`.
+
+- [x] **Step 3: Keep endpoint shape exact**
+
+POST path: `/visual-packs/import-previews/{preview_id}/commit`.
+
+GET path: `/visual-packs/imports/{job_id}`.
+
+### Task 3: Surface Commit Controls in VisualPackEditor
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx`
+
+- [x] **Step 1: Add local commit job state**
+
+Track `importCommitJob`, `committingImport`, and `refreshingImportCommit`. Reset commit job state when persona/pack changes or a new preview starts.
+
+- [x] **Step 2: Add handlers**
+
+Add `handleStartImportCommit` using default payload `{ trust_mode: "untrusted_import", target_mode: "create_new" }`, and `handleRefreshImportCommit` using the commit job id.
+
+- [x] **Step 3: Gate commit action**
+
+Show and enable commit only when `fullImportPreview?.status === "completed"`. Keep the preview review-only until the user explicitly clicks commit.
+
+- [x] **Step 4: Refresh packs after completion**
+
+When a refreshed import-commit status is completed and includes `pack_id`, call `loadPacks()` so the new draft appears. Do not call activate.
+
+### Task 4: Verify and Close Out
+
+**Files:**
+- Modify: `backlog/tasks/task-126.8 - Expose-persona-visual-import-commit-controls-in-editor.md`
+
+- [x] **Step 1: Run focused tests**
+
+Run: `cd apps/packages/ui && bunx vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx`
+
+Expected: PASS.
+
+- [x] **Step 2: Run related Persona Visuals/Buddy tests**
+
+Run: `cd apps/packages/ui && bunx vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx src/utils/__tests__/persona-garden-route.test.ts`
+
+Expected: PASS.
+
+- [x] **Step 3: Run hygiene checks**
+
+Run: `git diff --check`
+
+Expected: no output, exit 0.
+
+- [x] **Step 4: Update Backlog and commit**
+
+Record RED/GREEN verification, mark acceptance criteria complete, then commit and open a PR for issue #1422.

--- a/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
@@ -354,13 +354,13 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
     [draftManifest]
   )
 
-  const loadPacks = React.useCallback(async () => {
+  const loadPacks = React.useCallback(async (): Promise<boolean> => {
     if (!isActive || !selectedPersonaId) {
       setPacks([])
       setSelectedPackId("")
       setDraftManifest(DEFAULT_MANIFEST)
       setCandidates([])
-      return
+      return false
     }
     setLoading(true)
     setError(null)
@@ -378,6 +378,7 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
         setDraftManifest(DEFAULT_MANIFEST)
         setSelectedAnimationId("")
       }
+      return true
     } catch (loadError) {
       setPacks([])
       setSelectedPackId("")
@@ -385,8 +386,9 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
       setError(
         loadError instanceof Error
           ? loadError.message
-          : "Failed to load visual packs."
+            : "Failed to load visual packs."
       )
+      return false
     } finally {
       setLoading(false)
     }
@@ -680,10 +682,14 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
       )
       setImportCommitJob(job)
       if (job.status === "completed" && job.pack_id) {
-        await loadPacks()
-        setStatusMessage(
-          "Import commit completed. Review and activate the new draft when ready."
-        )
+        const refreshed = await loadPacks()
+        if (refreshed) {
+          setStatusMessage(
+            "Import commit completed. Review and activate the new draft when ready."
+          )
+        } else {
+          setStatusMessage(null)
+        }
       }
     } catch (refreshError) {
       setError(

--- a/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
@@ -21,12 +21,14 @@ import {
   createPersonaVisualPack,
   deactivatePersonaVisualPack,
   downloadPersonaVisualPackExportArchive,
+  getPersonaVisualImportCommitStatus,
   getPersonaVisualImportPreview,
   getPersonaVisualPackExportJob,
   listPersonaVisualCandidates,
   listPersonaVisualPacks,
   PersonaVisualApiError,
   reviewPersonaVisualCandidate,
+  startPersonaVisualImportCommit,
   startPersonaVisualPackExport,
   updatePersonaVisualManifest,
   uploadPersonaVisualAsset
@@ -37,6 +39,7 @@ import type {
   PersonaVisualAssetRole,
   PersonaVisualAuthoredTrigger,
   PersonaVisualCandidate,
+  PersonaVisualImportCommitStartResponse,
   PersonaVisualFrame,
   PersonaVisualImportPreviewResponse,
   PersonaVisualImportPreviewStartResponse,
@@ -298,8 +301,13 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
   const [importPreview, setImportPreview] = React.useState<
     PersonaVisualImportPreviewStartResponse | PersonaVisualImportPreviewResponse | null
   >(null)
+  const [importCommitJob, setImportCommitJob] = React.useState<
+    PersonaVisualImportCommitStartResponse | PersonaVisualPortabilityJobResponse | null
+  >(null)
   const [previewingImport, setPreviewingImport] = React.useState(false)
   const [refreshingImportPreview, setRefreshingImportPreview] = React.useState(false)
+  const [committingImport, setCommittingImport] = React.useState(false)
+  const [refreshingImportCommit, setRefreshingImportCommit] = React.useState(false)
   const [triggerDraft, setTriggerDraft] =
     React.useState<TriggerDraft>(DEFAULT_TRIGGER_DRAFT)
   const [loading, setLoading] = React.useState(false)
@@ -436,6 +444,7 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
   React.useEffect(() => {
     setExportJob(null)
     setImportPreview(null)
+    setImportCommitJob(null)
     setSelectedImportPreviewFile(null)
     if (importPreviewInputRef.current) importPreviewInputRef.current.value = ""
   }, [selectedPersonaId, selectedPack?.id])
@@ -589,6 +598,7 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
         selectedImportPreviewFile
       )
       setImportPreview(preview)
+      setImportCommitJob(null)
       setSelectedImportPreviewFile(null)
       if (importPreviewInputRef.current) importPreviewInputRef.current.value = ""
       setStatusMessage("Import preview queued.")
@@ -621,6 +631,62 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
       )
     } finally {
       setRefreshingImportPreview(false)
+    }
+  }
+
+  const handleStartImportCommit = async () => {
+    if (!selectedPersonaId || !fullImportPreview?.preview_id) return
+    if (fullImportPreview.status !== "completed") return
+    setCommittingImport(true)
+    setError(null)
+    try {
+      const job = await startPersonaVisualImportCommit(
+        selectedPersonaId,
+        fullImportPreview.preview_id,
+        {
+          trust_mode: "untrusted_import",
+          target_mode: "create_new"
+        }
+      )
+      setImportCommitJob(job)
+      setStatusMessage(
+        "Import commit queued. Imported packs remain drafts until activated."
+      )
+    } catch (commitError) {
+      setError(
+        commitError instanceof Error
+          ? commitError.message
+          : "Failed to queue visual pack import commit."
+      )
+    } finally {
+      setCommittingImport(false)
+    }
+  }
+
+  const handleRefreshImportCommit = async () => {
+    if (!selectedPersonaId || !importCommitJob?.job_id) return
+    setRefreshingImportCommit(true)
+    setError(null)
+    try {
+      const job = await getPersonaVisualImportCommitStatus(
+        selectedPersonaId,
+        importCommitJob.job_id
+      )
+      setImportCommitJob(job)
+      if (job.status === "completed" && job.pack_id) {
+        await loadPacks()
+        setStatusMessage(
+          "Import commit completed. Review and activate the new draft when ready."
+        )
+      }
+    } catch (refreshError) {
+      setError(
+        refreshError instanceof Error
+          ? refreshError.message
+          : "Failed to refresh visual pack import commit."
+      )
+    } finally {
+      setRefreshingImportCommit(false)
     }
   }
 
@@ -982,6 +1048,7 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
     : []
   const importPreviewConflicts = fullImportPreview?.conflicts || []
   const importPreviewPlan = fullImportPreview?.proposed_plan || null
+  const canCommitImportPreview = fullImportPreview?.status === "completed"
 
   return (
     <div className="space-y-3" data-testid="persona-visual-pack-editor">
@@ -1265,6 +1332,58 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
                     {importPreviewPlan ? (
                       <div data-testid="persona-visual-import-preview-plan">
                         {stringifyPreviewValue(importPreviewPlan)}
+                      </div>
+                    ) : null}
+                    {canCommitImportPreview ? (
+                      <div className="mt-2 border-t border-border pt-2">
+                        <div className="flex flex-wrap items-center justify-between gap-2">
+                          <div className="font-medium text-text">
+                            Commit reviewed import
+                          </div>
+                          <Tag>creates draft</Tag>
+                        </div>
+                        <div className="mt-1 text-text-muted">
+                          Commit creates a new draft pack. Activation remains separate.
+                        </div>
+                        <div className="mt-2 flex flex-wrap items-center gap-2">
+                          <Button
+                            data-testid="persona-visual-import-commit-button"
+                            size="small"
+                            icon={<CheckCircle2 className="h-3.5 w-3.5" />}
+                            loading={committingImport}
+                            disabled={Boolean(importCommitJob?.job_id)}
+                            onClick={() => void handleStartImportCommit()}
+                          >
+                            Commit as draft
+                          </Button>
+                          <Button
+                            data-testid="persona-visual-import-commit-refresh-button"
+                            size="small"
+                            icon={<RefreshCw className="h-3.5 w-3.5" />}
+                            loading={refreshingImportCommit}
+                            disabled={!importCommitJob?.job_id}
+                            onClick={() => void handleRefreshImportCommit()}
+                          >
+                            Refresh commit
+                          </Button>
+                        </div>
+                        {importCommitJob ? (
+                          <div className="mt-2 flex flex-wrap items-center gap-2 text-text-muted">
+                            <Tag data-testid="persona-visual-import-commit-status">
+                              {importCommitJob.status}
+                            </Tag>
+                            <span data-testid="persona-visual-import-commit-stage">
+                              {importCommitJob.stage}
+                            </span>
+                            <span data-testid="persona-visual-import-commit-job-id">
+                              {importCommitJob.job_id}
+                            </span>
+                          </div>
+                        ) : (
+                          <div className="mt-2 text-text-muted">
+                            No import commit job.
+                          </div>
+                        )}
                       </div>
                     ) : null}
                   </div>

--- a/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
@@ -100,6 +100,12 @@ const TRIGGER_SOURCES: PersonaVisualAuthoredTrigger["source"][] = [
 ]
 
 const PORTABLE_VISUAL_PACK_EXTENSION = ".tldw-persona-vpack"
+const IMPORT_COMMIT_TERMINAL_STATUSES = new Set([
+  "completed",
+  "failed",
+  "cancelled",
+  "quarantined"
+])
 
 const DEFAULT_MANIFEST: PersonaVisualManifest = {
   manifest_version: 1,
@@ -1049,6 +1055,14 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
   const importPreviewConflicts = fullImportPreview?.conflicts || []
   const importPreviewPlan = fullImportPreview?.proposed_plan || null
   const canCommitImportPreview = fullImportPreview?.status === "completed"
+  const importCommitStatus = importCommitJob?.status || null
+  const importCommitIsTerminal = importCommitStatus
+    ? IMPORT_COMMIT_TERMINAL_STATUSES.has(importCommitStatus)
+    : false
+  const canStartImportCommit =
+    !importCommitJob?.job_id || importCommitStatus === "failed"
+  const canRefreshImportCommit =
+    Boolean(importCommitJob?.job_id) && !importCommitIsTerminal
 
   return (
     <div className="space-y-3" data-testid="persona-visual-pack-editor">
@@ -1351,7 +1365,7 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
                             size="small"
                             icon={<CheckCircle2 className="h-3.5 w-3.5" />}
                             loading={committingImport}
-                            disabled={Boolean(importCommitJob?.job_id)}
+                            disabled={!canStartImportCommit}
                             onClick={() => void handleStartImportCommit()}
                           >
                             Commit as draft
@@ -1361,7 +1375,7 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
                             size="small"
                             icon={<RefreshCw className="h-3.5 w-3.5" />}
                             loading={refreshingImportCommit}
-                            disabled={!importCommitJob?.job_id}
+                            disabled={!canRefreshImportCommit}
                             onClick={() => void handleRefreshImportCommit()}
                           >
                             Refresh commit

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
@@ -755,12 +755,23 @@ describe("VisualPackEditor", () => {
       assets: visualAssets,
       version: 3
     }
+    const importedPack = {
+      id: "pack-imported",
+      persona_id: "persona-1",
+      title: "Imported Visuals",
+      renderer_type: "sprite_frames",
+      status: "draft",
+      manifest: structuredClone(baseManifest),
+      assets: visualAssets,
+      version: 1
+    }
+    let importCommitted = false
 
     mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string; body?: any }) => {
       const method = init?.method || "GET"
       calls.push(`${method} ${path}`)
       if (path === "/api/v1/persona/profiles/persona-1/visual-packs" && method === "GET") {
-        return okResponse([pack])
+        return okResponse(importCommitted ? [pack, importedPack] : [pack])
       }
       if (
         path === "/api/v1/persona/profiles/persona-1/visual-packs/pack-1/generated-candidates" &&
@@ -811,6 +822,43 @@ describe("VisualPackEditor", () => {
           quota_estimate: { asset_bytes: 512 },
           required_choices: [],
           target_warnings: ["Review target persona before import"]
+        })
+      }
+      if (
+        path ===
+          "/api/v1/persona/profiles/persona-1/visual-packs/import-previews/preview-1/commit" &&
+        method === "POST"
+      ) {
+        expect(parseJsonBody(init?.body)).toMatchObject({
+          trust_mode: "untrusted_import",
+          target_mode: "create_new"
+        })
+        return okResponse({
+          job_id: "import-job-1",
+          portability_job_id: "portability-import-1",
+          operation: "import_commit",
+          preview_id: "preview-1",
+          target_persona_id: "persona-1",
+          status: "queued",
+          stage: "queued"
+        })
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/imports/import-job-1" &&
+        method === "GET"
+      ) {
+        importCommitted = true
+        return okResponse({
+          job_id: "import-job-1",
+          portability_job_id: "portability-import-1",
+          operation: "import_commit",
+          persona_id: "persona-1",
+          pack_id: "pack-imported",
+          status: "completed",
+          visual_status: "completed",
+          stage: "completed",
+          progress: { asset_count: 2 },
+          warnings: []
         })
       }
       return Promise.resolve({
@@ -867,6 +915,32 @@ describe("VisualPackEditor", () => {
     )
     expect(screen.getByTestId("persona-visual-import-preview-plan")).toHaveTextContent(
       "create_new"
+    )
+
+    expect(screen.getByTestId("persona-visual-import-commit-button")).toBeEnabled()
+    fireEvent.click(screen.getByTestId("persona-visual-import-commit-button"))
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-import-commit-status")).toHaveTextContent(
+        "queued"
+      )
+    )
+    expect(screen.getByTestId("persona-visual-import-commit-stage")).toHaveTextContent(
+      "queued"
+    )
+    expect(screen.getByTestId("persona-visual-import-commit-job-id")).toHaveTextContent(
+      "import-job-1"
+    )
+
+    fireEvent.click(screen.getByTestId("persona-visual-import-commit-refresh-button"))
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-import-commit-status")).toHaveTextContent(
+        "completed"
+      )
+    )
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-pack-select")).toHaveTextContent(
+        "Imported Visuals"
+      )
     )
     expect(
       calls.some((call) => call.includes("/activate") || call.includes("/manifest"))

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
@@ -1116,4 +1116,165 @@ describe("VisualPackEditor", () => {
       "queued"
     )
   })
+
+  it("does not show import completion success when pack refresh fails", async () => {
+    const pack = {
+      id: "pack-1",
+      persona_id: "persona-1",
+      title: "Animated pack",
+      renderer_type: "sprite_frames",
+      status: "draft",
+      manifest: structuredClone(baseManifest),
+      assets: visualAssets,
+      version: 3
+    }
+    let packListRequests = 0
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string; body?: any }) => {
+      const method = init?.method || "GET"
+      if (path === "/api/v1/persona/profiles/persona-1/visual-packs" && method === "GET") {
+        packListRequests += 1
+        if (packListRequests > 1) {
+          return Promise.resolve({
+            ok: false,
+            status: 503,
+            error: "Pack refresh failed",
+            json: async () => ({ detail: "Pack refresh failed" })
+          })
+        }
+        return okResponse([pack])
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/pack-1/generated-candidates" &&
+        method === "GET"
+      ) {
+        return okResponse({ candidates: [] })
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/import-previews" &&
+        method === "POST"
+      ) {
+        return okResponse({
+          preview_id: "preview-1",
+          job_id: "preview-job-1",
+          portability_job_id: "portability-preview-1",
+          operation: "import_preview",
+          target_persona_id: "persona-1",
+          status: "queued",
+          stage: "queued"
+        })
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/import-previews/preview-1" &&
+        method === "GET"
+      ) {
+        return okResponse({
+          preview_id: "preview-1",
+          job_id: "preview-job-1",
+          portability_job_id: "portability-preview-1",
+          operation: "import_preview",
+          target_persona_id: "persona-1",
+          status: "completed",
+          visual_status: "completed",
+          stage: "completed",
+          bundle_summary: {
+            pack_title: "Imported Visuals",
+            asset_count: 2,
+            assets_with_bytes: 2
+          },
+          validation_warnings: [],
+          conflicts: [],
+          proposed_plan: { target_mode: "create_new" },
+          quota_estimate: {},
+          required_choices: [],
+          target_warnings: []
+        })
+      }
+      if (
+        path ===
+          "/api/v1/persona/profiles/persona-1/visual-packs/import-previews/preview-1/commit" &&
+        method === "POST"
+      ) {
+        return okResponse({
+          job_id: "import-job-1",
+          portability_job_id: "portability-import-1",
+          operation: "import_commit",
+          preview_id: "preview-1",
+          target_persona_id: "persona-1",
+          status: "queued",
+          stage: "queued"
+        })
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/imports/import-job-1" &&
+        method === "GET"
+      ) {
+        return okResponse({
+          job_id: "import-job-1",
+          portability_job_id: "portability-import-1",
+          operation: "import_commit",
+          persona_id: "persona-1",
+          pack_id: "pack-imported",
+          status: "completed",
+          visual_status: "completed",
+          stage: "completed",
+          progress: { asset_count: 2 },
+          warnings: []
+        })
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        error: `Unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(
+      <VisualPackEditor
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Garden Helper"
+        isActive
+      />
+    )
+
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-pack-status")).toHaveTextContent(
+        "draft"
+      )
+    )
+    const archive = new File(["portable archive"], "portable.tldw-persona-vpack", {
+      type: "application/octet-stream"
+    })
+    fireEvent.change(screen.getByTestId("persona-visual-import-preview-input"), {
+      target: { files: [archive] }
+    })
+    fireEvent.click(screen.getByTestId("persona-visual-import-preview-button"))
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-import-preview-status")).toHaveTextContent(
+        "queued"
+      )
+    )
+
+    fireEvent.click(screen.getByTestId("persona-visual-import-preview-refresh-button"))
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-import-preview-status")).toHaveTextContent(
+        "completed"
+      )
+    )
+
+    fireEvent.click(screen.getByTestId("persona-visual-import-commit-button"))
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-import-commit-status")).toHaveTextContent(
+        "queued"
+      )
+    )
+    fireEvent.click(screen.getByTestId("persona-visual-import-commit-refresh-button"))
+    await waitFor(() => expect(screen.getByText("Pack refresh failed")).toBeInTheDocument())
+    expect(
+      screen.queryByText(
+        "Import commit completed. Review and activate the new draft when ready."
+      )
+    ).not.toBeInTheDocument()
+  })
 })

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
@@ -930,6 +930,7 @@ describe("VisualPackEditor", () => {
     expect(screen.getByTestId("persona-visual-import-commit-job-id")).toHaveTextContent(
       "import-job-1"
     )
+    expect(screen.getByTestId("persona-visual-import-commit-refresh-button")).toBeEnabled()
 
     fireEvent.click(screen.getByTestId("persona-visual-import-commit-refresh-button"))
     await waitFor(() =>
@@ -937,6 +938,7 @@ describe("VisualPackEditor", () => {
         "completed"
       )
     )
+    expect(screen.getByTestId("persona-visual-import-commit-refresh-button")).toBeDisabled()
     await waitFor(() =>
       expect(screen.getByTestId("persona-visual-pack-select")).toHaveTextContent(
         "Imported Visuals"
@@ -945,5 +947,173 @@ describe("VisualPackEditor", () => {
     expect(
       calls.some((call) => call.includes("/activate") || call.includes("/manifest"))
     ).toBe(false)
+  })
+
+  it("allows failed import commit jobs to be retried", async () => {
+    const pack = {
+      id: "pack-1",
+      persona_id: "persona-1",
+      title: "Animated pack",
+      renderer_type: "sprite_frames",
+      status: "draft",
+      manifest: structuredClone(baseManifest),
+      assets: visualAssets,
+      version: 3
+    }
+    let commitAttempts = 0
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string; body?: any }) => {
+      const method = init?.method || "GET"
+      if (path === "/api/v1/persona/profiles/persona-1/visual-packs" && method === "GET") {
+        return okResponse([pack])
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/pack-1/generated-candidates" &&
+        method === "GET"
+      ) {
+        return okResponse({ candidates: [] })
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/import-previews" &&
+        method === "POST"
+      ) {
+        return okResponse({
+          preview_id: "preview-1",
+          job_id: "preview-job-1",
+          portability_job_id: "portability-preview-1",
+          operation: "import_preview",
+          target_persona_id: "persona-1",
+          status: "queued",
+          stage: "queued"
+        })
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/import-previews/preview-1" &&
+        method === "GET"
+      ) {
+        return okResponse({
+          preview_id: "preview-1",
+          job_id: "preview-job-1",
+          portability_job_id: "portability-preview-1",
+          operation: "import_preview",
+          target_persona_id: "persona-1",
+          status: "completed",
+          visual_status: "completed",
+          stage: "completed",
+          bundle_summary: {
+            pack_title: "Imported Visuals",
+            asset_count: 2,
+            assets_with_bytes: 2
+          },
+          validation_warnings: [],
+          conflicts: [],
+          proposed_plan: { target_mode: "create_new" },
+          quota_estimate: {},
+          required_choices: [],
+          target_warnings: []
+        })
+      }
+      if (
+        path ===
+          "/api/v1/persona/profiles/persona-1/visual-packs/import-previews/preview-1/commit" &&
+        method === "POST"
+      ) {
+        commitAttempts += 1
+        expect(parseJsonBody(init?.body)).toMatchObject({
+          trust_mode: "untrusted_import",
+          target_mode: "create_new"
+        })
+        return okResponse({
+          job_id: `import-job-${commitAttempts}`,
+          portability_job_id: `portability-import-${commitAttempts}`,
+          operation: "import_commit",
+          preview_id: "preview-1",
+          target_persona_id: "persona-1",
+          status: "queued",
+          stage: "queued"
+        })
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/imports/import-job-1" &&
+        method === "GET"
+      ) {
+        return okResponse({
+          job_id: "import-job-1",
+          portability_job_id: "portability-import-1",
+          operation: "import_commit",
+          persona_id: "persona-1",
+          pack_id: null,
+          status: "failed",
+          visual_status: "failed",
+          stage: "failed",
+          error_message: "Archive failed validation"
+        })
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        error: `Unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(
+      <VisualPackEditor
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Garden Helper"
+        isActive
+      />
+    )
+
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-pack-status")).toHaveTextContent(
+        "draft"
+      )
+    )
+    const archive = new File(["portable archive"], "portable.tldw-persona-vpack", {
+      type: "application/octet-stream"
+    })
+    fireEvent.change(screen.getByTestId("persona-visual-import-preview-input"), {
+      target: { files: [archive] }
+    })
+    fireEvent.click(screen.getByTestId("persona-visual-import-preview-button"))
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-import-preview-status")).toHaveTextContent(
+        "queued"
+      )
+    )
+
+    fireEvent.click(screen.getByTestId("persona-visual-import-preview-refresh-button"))
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-import-preview-status")).toHaveTextContent(
+        "completed"
+      )
+    )
+
+    fireEvent.click(screen.getByTestId("persona-visual-import-commit-button"))
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-import-commit-status")).toHaveTextContent(
+        "queued"
+      )
+    )
+    fireEvent.click(screen.getByTestId("persona-visual-import-commit-refresh-button"))
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-import-commit-status")).toHaveTextContent(
+        "failed"
+      )
+    )
+    expect(screen.getByTestId("persona-visual-import-commit-refresh-button")).toBeDisabled()
+    expect(screen.getByTestId("persona-visual-import-commit-button")).toBeEnabled()
+
+    fireEvent.click(screen.getByTestId("persona-visual-import-commit-button"))
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-import-commit-job-id")).toHaveTextContent(
+        "import-job-2"
+      )
+    )
+    expect(commitAttempts).toBe(2)
+    expect(screen.getByTestId("persona-visual-import-commit-status")).toHaveTextContent(
+      "queued"
+    )
   })
 })

--- a/apps/packages/ui/src/services/persona-visuals.ts
+++ b/apps/packages/ui/src/services/persona-visuals.ts
@@ -275,8 +275,12 @@ export async function downloadPersonaVisualPackExportArchive(
   if (data instanceof ArrayBuffer) {
     blobPart = data
   } else if (ArrayBuffer.isView(data)) {
-    const view = new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
-    blobPart = Uint8Array.from(view)
+    if (data.buffer instanceof ArrayBuffer) {
+      blobPart = new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
+    } else {
+      const view = new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
+      blobPart = Uint8Array.from(view)
+    }
   } else if (Array.isArray(data)) {
     blobPart = Uint8Array.from(data)
   }

--- a/apps/packages/ui/src/services/persona-visuals.ts
+++ b/apps/packages/ui/src/services/persona-visuals.ts
@@ -9,6 +9,8 @@ import type {
   PersonaVisualDeactivateResponse,
   PersonaVisualGenerationJobResponse,
   PersonaVisualGenerationRequest,
+  PersonaVisualImportCommitRequest,
+  PersonaVisualImportCommitStartResponse,
   PersonaVisualImportPreviewResponse,
   PersonaVisualImportPreviewStartResponse,
   PersonaVisualManifestUpdate,
@@ -273,7 +275,8 @@ export async function downloadPersonaVisualPackExportArchive(
   if (data instanceof ArrayBuffer) {
     blobPart = data
   } else if (ArrayBuffer.isView(data)) {
-    blobPart = data
+    const view = new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
+    blobPart = Uint8Array.from(view)
   } else if (Array.isArray(data)) {
     blobPart = Uint8Array.from(data)
   }
@@ -314,6 +317,35 @@ export async function getPersonaVisualImportPreview(
     personaVisualPath(
       personaId,
       `/visual-packs/import-previews/${encodeURIComponent(previewId)}`
+    )
+  )
+}
+
+export async function startPersonaVisualImportCommit(
+  personaId: string,
+  previewId: string,
+  payload: PersonaVisualImportCommitRequest = {}
+): Promise<PersonaVisualImportCommitStartResponse> {
+  return fetchPersonaVisualJson<PersonaVisualImportCommitStartResponse>(
+    personaVisualPath(
+      personaId,
+      `/visual-packs/import-previews/${encodeURIComponent(previewId)}/commit`
+    ),
+    {
+      method: "POST",
+      body: payload
+    }
+  )
+}
+
+export async function getPersonaVisualImportCommitStatus(
+  personaId: string,
+  jobId: string
+): Promise<PersonaVisualPortabilityJobResponse> {
+  return fetchPersonaVisualJson<PersonaVisualPortabilityJobResponse>(
+    personaVisualPath(
+      personaId,
+      `/visual-packs/imports/${encodeURIComponent(jobId)}`
     )
   )
 }

--- a/apps/packages/ui/src/types/persona-visuals.ts
+++ b/apps/packages/ui/src/types/persona-visuals.ts
@@ -35,7 +35,10 @@ export type PersonaVisualCandidateStatus =
   | "rejected"
   | "failed"
 
-export type PersonaVisualPortabilityOperation = "export" | "import_preview"
+export type PersonaVisualPortabilityOperation =
+  | "export"
+  | "import_preview"
+  | "import_commit"
 
 export interface PersonaVisualRegion {
   x: number
@@ -234,6 +237,22 @@ export interface PersonaVisualImportPreviewResponse {
   error_code?: string | null
   error_message?: string | null
   expires_at?: string | null
+}
+
+export interface PersonaVisualImportCommitRequest {
+  request_id?: string | null
+  trust_mode?: "trusted_restore" | "untrusted_import"
+  target_mode?: "create_new"
+}
+
+export interface PersonaVisualImportCommitStartResponse {
+  job_id: string
+  portability_job_id: string
+  operation: "import_commit"
+  preview_id: string
+  target_persona_id: string
+  status: string
+  stage: string
 }
 
 export interface PersonaVisualCandidateReviewRequest {

--- a/backlog/tasks/task-126.10 - Address-PR-1425-import-completion-refresh-messaging-review.md
+++ b/backlog/tasks/task-126.10 - Address-PR-1425-import-completion-refresh-messaging-review.md
@@ -1,0 +1,69 @@
+---
+id: TASK-126.10
+title: Address PR 1425 import completion refresh messaging review
+status: Done
+assignee: []
+created_date: '2026-05-09 17:11'
+updated_date: '2026-05-09 17:12'
+labels:
+  - persona
+  - visual-packs
+  - frontend
+  - review-fix
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1425'
+documentation:
+  - Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md
+parent_task_id: TASK-126
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Follow-up review-fix task for the CodeRabbit inline comment on PR #1425. Scope is limited to ensuring the import commit completion success message is shown only when the completed job pack refresh actually succeeds.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 VisualPackEditor only shows the import commit completed success message after loadPacks refresh succeeds.
+- [x] #2 VisualPackEditor avoids showing a false import-completed success message when the pack refresh fails.
+- [x] #3 Focused tests cover the failed pack-refresh behavior.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Review surface: CodeRabbit inline comment on PR #1425 flagged false success messaging when import commit completed but pack refresh failed.
+
+RED: bunx vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx failed because the completed success message remained visible after a mocked pack-refresh failure.
+
+GREEN: bunx vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx passed with 9 tests after loadPacks returned refresh success/failure and the import completion branch gated the success message.
+
+RELATED VERIFICATION: bunx vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx src/utils/__tests__/persona-garden-route.test.ts passed with 33 tests.
+
+HYGIENE: git diff --check passed.
+
+TSC: bunx tsc --noEmit --pretty false still exits 2 on existing repo-wide diagnostics; filtered /tmp/persona-visual-import-tsc-coderabbit.log showed no diagnostics for the touched VisualPackEditor, VisualPackEditor test, persona-visuals service, or persona-visuals types files.
+
+BANDIT: not applicable; touched production code is frontend TypeScript only. No docs change required for this review fix.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed the CodeRabbit import-completion messaging comment on PR #1425. loadPacks now returns whether the pack list refreshed, and the import commit completion branch only shows the completed success message when that refresh succeeds; failed refreshes leave the API error visible instead of reporting completion success. Added focused regression coverage for completed import commit plus pack-refresh failure.
+
+Verification: focused VisualPackEditor Vitest passed, related Persona Garden/Buddy route Vitest passed, git diff --check passed, and filtered tsc output showed no diagnostics for touched files. Full tsc still exits 2 on existing repo-wide diagnostics outside this slice. Bandit was not applicable because touched production code is frontend TypeScript.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-126.8 - Expose-persona-visual-import-commit-controls-in-editor.md
+++ b/backlog/tasks/task-126.8 - Expose-persona-visual-import-commit-controls-in-editor.md
@@ -1,0 +1,78 @@
+---
+id: TASK-126.8
+title: Expose persona visual import commit controls in editor
+status: Done
+assignee: []
+created_date: '2026-05-09 16:53'
+updated_date: '2026-05-09 17:02'
+labels:
+  - persona
+  - visual-packs
+  - portability
+  - frontend
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1422'
+  - 'https://github.com/rmusser01/tldw_server/pull/1135'
+documentation:
+  - Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md
+  - >-
+    Docs/superpowers/plans/2026-05-08-persona-visual-packs-implementation-plan.md
+  - >-
+    Docs/superpowers/plans/2026-05-09-persona-visual-import-commit-controls-plan.md
+parent_task_id: TASK-126
+priority: medium
+---
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 VisualPackEditor shows an explicit import commit action only after an import preview is completed.
+- [x] #2 Import commit starts the existing create_new import_commit job and keeps activation separate from commit.
+- [x] #3 VisualPackEditor shows import commit status/stage/job id and can refresh status.
+- [x] #4 Completed import commit refreshes pack state so the new draft can be selected or inspected.
+- [x] #5 Focused frontend tests cover commit start/status and completed pack refresh behavior.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Plan: Docs/superpowers/plans/2026-05-09-persona-visual-import-commit-controls-plan.md. Scope: frontend service/types plus VisualPackEditor controls for the existing import_commit backend flow. TDD target: VisualPackEditor focused import-preview/commit coverage first.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Created implementation plan at Docs/superpowers/plans/2026-05-09-persona-visual-import-commit-controls-plan.md.
+
+RED: bunx vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx first hit missing fresh-worktree dependencies; after bun install, the test failed as intended because persona-visual-import-commit-button was absent after a completed import preview.
+
+GREEN: bunx vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx passed with 7 tests after adding import commit service helpers and editor controls.
+
+RELATED VERIFICATION: bunx vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx src/utils/__tests__/persona-garden-route.test.ts passed with 31 tests.
+
+HYGIENE: git diff --check passed.
+
+BANDIT: not applicable; touched production code is frontend TypeScript plus plan/task metadata only.
+
+No known blockers. Bandit skipped as non-applicable for frontend TypeScript-only production changes.
+
+TSC: bunx tsc --noEmit --pretty false still exits 2 on existing repo-wide diagnostics; filtered /tmp/persona-visual-import-tsc.log shows no diagnostics for the touched VisualPackEditor, VisualPackEditor test, persona-visuals service, or persona-visuals types files after the ArrayBufferView BlobPart copy fix.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added typed Persona Visuals import-commit helpers and exposed commit-as-draft controls in VisualPackEditor after a completed import preview. The editor now starts the existing untrusted create_new import_commit flow, shows status/stage/job id, refreshes commit status, and reloads packs when the committed draft is available without activating it. Also tightened the touched Persona Visuals service export-download BlobPart handling so arbitrary ArrayBufferView responses are copied into a Blob-safe Uint8Array.
+
+Verification: focused/related Persona Garden and Buddy Vitest passed, git diff --check passed, and a filtered tsc log showed no diagnostics for the touched files. Full tsc still exits 2 on existing repo-wide diagnostics outside this slice. Bandit was not applicable because touched production code is frontend TypeScript.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-126.9 - Address-PR-1425-persona-visual-import-commit-review-comments.md
+++ b/backlog/tasks/task-126.9 - Address-PR-1425-persona-visual-import-commit-review-comments.md
@@ -1,0 +1,70 @@
+---
+id: TASK-126.9
+title: Address PR 1425 persona visual import commit review comments
+status: Done
+assignee: []
+created_date: '2026-05-09 17:07'
+updated_date: '2026-05-09 17:10'
+labels:
+  - persona
+  - visual-packs
+  - frontend
+  - review-fix
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1425'
+documentation:
+  - Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md
+parent_task_id: TASK-126
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Follow-up review-fix task for PR #1425. Scope is limited to the Gemini inline comments on Persona Visual import-commit controls: avoid unnecessary visual export buffer copies, allow retry after failed import commit jobs, and disable commit refresh after terminal statuses.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Persona Visual export download handling avoids unnecessary ArrayBufferView copy while remaining BlobPart-safe.
+- [x] #2 VisualPackEditor allows retrying an import commit after a failed commit job.
+- [x] #3 VisualPackEditor disables import commit refresh for terminal completed or failed commit jobs.
+- [x] #4 Focused tests cover failed retry and terminal refresh disabled behavior.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Review surface: three unresolved Gemini inline comments on PR #1425. Addressed buffer-copy optimization, failed import-commit retry, and terminal commit-refresh disabling.
+
+RED: bunx vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx failed on the new terminal refresh-disabled assertions before implementation.
+
+GREEN: bunx vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx passed with 8 tests after implementation.
+
+RELATED VERIFICATION: bunx vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx src/utils/__tests__/persona-garden-route.test.ts passed with 32 tests.
+
+HYGIENE: git diff --check passed.
+
+TSC: bunx tsc --noEmit --pretty false still exits 2 on existing repo-wide diagnostics; filtered /tmp/persona-visual-import-tsc-review.log showed no diagnostics for the touched VisualPackEditor, VisualPackEditor test, persona-visuals service, or persona-visuals types files.
+
+BANDIT: not applicable; touched production code is frontend TypeScript only. No docs change required for these review fixes.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed all three Gemini inline comments on PR #1425: Persona Visual export download now avoids copying ArrayBuffer-backed views while still copying SharedArrayBuffer-backed views into Blob-safe data, failed import commit jobs can be retried, and commit refresh is disabled after terminal commit statuses. Added focused regression coverage for completed/failed terminal refresh behavior and failed commit retry.
+
+Verification: focused VisualPackEditor Vitest passed, related Persona Garden/Buddy route Vitest passed, git diff --check passed, and filtered tsc output showed no diagnostics for touched files. Full tsc still exits 2 on existing repo-wide diagnostics outside this slice. Bandit was not applicable because touched production code is frontend TypeScript.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
Closes #1422

## Summary
- Adds typed Persona Visuals frontend helpers for the existing import-preview commit and import status endpoints.
- Shows an explicit commit-as-draft action after a completed import preview in VisualPackEditor.
- Polls import commit status and reloads packs when the committed draft is available, without activating it.
- Copies arbitrary ArrayBufferView export-download responses into a Blob-safe Uint8Array to clear a touched-file TypeScript diagnostic.

## Verification
- bunx vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx src/utils/__tests__/persona-garden-route.test.ts
- git diff --check
- bunx tsc --noEmit --pretty false still exits 2 on existing repo-wide diagnostics; filtered log shows no diagnostics for the touched VisualPackEditor, VisualPackEditor test, persona-visuals service, or persona-visuals types files.
- Bandit N/A: touched production code is frontend TypeScript.

## Merge Gate
- Human-written Change summary required before marking ready/merge per Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md.