### PR TITLE
Remove dayjs from Kanban due date editor

### DIFF
--- a/Docs/Design/WebUI_Dependency_Audit.md
+++ b/Docs/Design/WebUI_Dependency_Audit.md
@@ -238,7 +238,10 @@ This audit does not remove packages or rewrite runtime code.
   `datetime-local` input plus local ISO parse/format helpers. The shared UI
   `dayjs` import count dropped from 6 to 5 while leaving the package declared
   for media, reading list, and items date-control value-contract surfaces plus
-  the co-located Items published-date display use.
+  the co-located Items published-date display use. Expected impact for this
+  narrow slice was one active package-import surface removed and no direct
+  manifest, lockfile, install-size, or bundle-size reduction until the
+  remaining `dayjs` surfaces are migrated.
 
 ### Quick Cleanup Candidates
 
@@ -466,7 +469,16 @@ ownership checks, or complex-domain packages that should stay on the
   date-time helper, then passed after the helper/input implementation. The
   focused suite covers local `datetime-local` formatting, clearing, invalid
   input handling, changed due-date ISO saves, cleared `null` saves, and
-  preserving an unchanged existing due date when saving unrelated fields.
+  preserving an unchanged existing due date when saving unrelated fields. PR
+  review follow-up added a same-drawer-session regression test that first
+  failed because a title-only save resent `due_date` after an earlier due-date
+  save, then passed after the async save/reset fix; the focused suite now
+  passes with 9 tests.
+- 2026-05-09 TASK-171 WebUI build verification:
+  `NEXT_PUBLIC_API_URL=http://127.0.0.1:8000 bun run compile` from
+  `apps/tldw-frontend` exited 0. Next compiled successfully, generated 138
+  static pages, and `verify-shared-token-sync.mjs` reported OK for the
+  generated CSS.
 - Bandit: skipped for TASK-144 because the slice changed documentation and
   Backlog metadata only; no Python files were modified.
 - Bandit: skipped for TASK-147 because the slice changed TypeScript,

--- a/Docs/Design/WebUI_Dependency_Audit.md
+++ b/Docs/Design/WebUI_Dependency_Audit.md
@@ -107,7 +107,7 @@ This audit does not remove packages or rewrite runtime code.
 | `cytoscape` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 6 | apps/packages/ui/src/components/Notes/NotesGraphModal.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesGraphModal.stage2.graph-view.test.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage21.accessibility-modal-focus.test.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage22.accessibility-regression.test.tsx | shared UI, shared UI tests | graph/rendering | `keep` | Low; import/config/package-script evidence in current WebUI or shared UI paths. | No immediate reduction; keep current behavior. | none |
 | `cytoscape-dagre` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 6 | apps/packages/ui/src/components/Notes/NotesGraphModal.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesGraphModal.stage2.graph-view.test.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage21.accessibility-modal-focus.test.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage22.accessibility-regression.test.tsx | shared UI, shared UI tests | graph/rendering | `keep` | Low; import/config/package-script evidence in current WebUI or shared UI paths. | No immediate reduction; keep current behavior. | none |
 | `d3-dsv` | `web:dependencies`, `extension:dependencies` | 0 | none found | web app, extension impact declaration only | parser/conversion | `investigate-lockfile` | Medium; no import/config/package-script evidence, but package sits in parser/conversion behavior. Confirm direct-vs-transitive ownership and CSV/DSV coverage before removal. | Potential install/bundle reduction if direct declaration proves unused. | Lockfile/parser-domain investigation slice. |
-| `dayjs` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 6 | apps/packages/ui/src/components/Media/FilterPanel.tsx, apps/packages/ui/src/components/Option/Collections/ReadingList/ReadingItemsList.tsx, apps/packages/ui/src/components/Option/Items/ItemsWorkspace.tsx, apps/packages/ui/src/components/Option/KanbanPlayground/CardDetailPanel.tsx | shared UI | frontend/runtime | `defer-design` | Medium; remaining shared UI imports are Ant Design DatePicker/DateRangePicker value surfaces plus an Items published-date display use co-located with the Items date-filter contract. | No immediate dependency reduction until shared UI date-picker value contracts are redesigned or isolated and the final co-located display use is migrated. | Date-picker contract design before manifest removal. |
+| `dayjs` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 5 | apps/packages/ui/src/components/Media/FilterPanel.tsx, apps/packages/ui/src/components/Option/Collections/ReadingList/ReadingItemsList.tsx, apps/packages/ui/src/components/Option/Items/ItemsWorkspace.tsx | shared UI | frontend/runtime | `defer-design` | Medium; remaining shared UI imports are Ant Design DatePicker/DateRangePicker value surfaces plus an Items published-date display use co-located with the Items date-filter contract. | No immediate dependency reduction until shared UI date-picker value contracts are redesigned or isolated and the final co-located display use is migrated. | Date-picker contract design before manifest removal. |
 | `dexie` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 6 | apps/packages/ui/src/db/dexie/chat.ts, apps/packages/ui/src/db/dexie/schema.ts, apps/packages/ui/src/hooks/document-workspace/__tests__/offlineQueue.test.ts, apps/packages/ui/src/hooks/document-workspace/offlineQueue.ts | shared UI, shared UI tests, web tests, web app | state/data | `keep` | Low; import/config/package-script evidence in current WebUI or shared UI paths. | No immediate reduction; keep current behavior. | none |
 | `dexie-react-hooks` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 1 | apps/packages/ui/src/components/Sidepanel/Chat/TtsClipsDrawer.tsx | shared UI | state/data | `keep` | Low; import/config/package-script evidence in current WebUI or shared UI paths. | No immediate reduction; keep current behavior. | none |
 | `dompurify` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 11 | apps/packages/ui/src/components/Common/CodeBlock.tsx, apps/packages/ui/src/components/Notes/NotesStudioDiagramCard.tsx, apps/packages/ui/src/components/Notes/export-utils.ts, apps/packages/ui/src/components/Option/Collections/ReadingList/ReadingItemDetail.tsx | shared UI | security/sanitization | `keep` | Low; import/config/package-script evidence in current WebUI or shared UI paths. | No immediate reduction; keep current behavior. | none |
@@ -233,6 +233,12 @@ This audit does not remove packages or rewrite runtime code.
   Ant Design DatePicker editor with a native date input. The shared UI `dayjs`
   import count dropped from 7 to 6 while leaving the package declared for
   remaining date-control value-contract surfaces.
+- TASK-171 removed `dayjs` from the Kanban CardDetailPanel due-date editor by
+  replacing the Ant Design DatePicker/Dayjs state path with a native
+  `datetime-local` input plus local ISO parse/format helpers. The shared UI
+  `dayjs` import count dropped from 6 to 5 while leaving the package declared
+  for media, reading list, and items date-control value-contract surfaces plus
+  the co-located Items published-date display use.
 
 ### Quick Cleanup Candidates
 
@@ -245,15 +251,16 @@ ownership checks, or complex-domain packages that should stay on the
 ### Replacement Candidates
 
 1. `dayjs`: remaining shared UI imports are Ant Design date-control value
-   surfaces plus a co-located Items published-date display use. Do not attempt
-   a direct dependency removal until the surfaces that pass or type `Dayjs`
-   values are redesigned or isolated and the final display use is migrated.
+   surfaces in media, reading list, and items plus a co-located Items
+   published-date display use. Do not attempt a direct dependency removal until
+   the surfaces that pass or type `Dayjs` values are redesigned or isolated and
+   the final display use is migrated.
 
 ### Deferred Design Candidates
 
 - Icon-stack consolidation: `lucide-react`, `@heroicons/react`, `@ant-design/icons`, and `react-icons` are active visible UI dependencies and should be handled with a visual/design pass.
 - Date/time consolidation: current shared UI uses `Dayjs` values with Ant
-  Design date controls in media, reading list, items, and kanban surfaces.
+  Design date controls in media, reading list, and items surfaces.
   Treat this as a compatibility/design slice, not a quick manifest cleanup.
 - PDF, ePub, document rendering, rich text editor, Mermaid, KaTeX, markdown, parser, graph/layout, OCR, tokenizer, schema, Monaco, Tiptap, and archive packages with active evidence are kept or deferred rather than replaced with hand-rolled browser code. Remaining zero-evidence complex declarations should keep using the `investigate-lockfile` path before any manifest edit.
 - DnD package declarations with no direct import evidence, such as `@dnd-kit/abstract` and `@dnd-kit/dom`, are retained after TASK-134 because the current lockfile still routes active DnD packages through the DnD abstract/dom graph.
@@ -447,6 +454,19 @@ ownership checks, or complex-domain packages that should stay on the
   `apps/packages/ui` TypeScript still exits 2 on existing repo-wide baseline
   errors outside this slice; filtering those diagnostics for `EditableCell`
   and `DataTables` returned no matches.
+- 2026-05-09 TASK-171 active-code scan: exact shared UI package-import scan
+  found 5 remaining `dayjs` import lines after removing the runtime import from
+  `apps/packages/ui/src/components/Option/KanbanPlayground/CardDetailPanel.tsx`.
+  Remaining imports are in media, reading list, and items date-control surfaces
+  plus the co-located Items published-date display use.
+- 2026-05-09 TASK-171 verification: `bunx vitest run
+  src/components/Option/KanbanPlayground/__tests__/kanbanDateTime.test.ts
+  src/components/Option/KanbanPlayground/__tests__/CardDetailPanel.due-date.test.tsx
+  --maxWorkers=1` from `apps/packages/ui` first failed on the missing native
+  date-time helper, then passed after the helper/input implementation. The
+  focused suite covers local `datetime-local` formatting, clearing, invalid
+  input handling, changed due-date ISO saves, cleared `null` saves, and
+  preserving an unchanged existing due date when saving unrelated fields.
 - Bandit: skipped for TASK-144 because the slice changed documentation and
   Backlog metadata only; no Python files were modified.
 - Bandit: skipped for TASK-147 because the slice changed TypeScript,
@@ -460,6 +480,8 @@ ownership checks, or complex-domain packages that should stay on the
 - Bandit: skipped for TASK-164 because the slice changed TypeScript,
   documentation, and Backlog metadata only; no Python files were modified.
 - Bandit: skipped for TASK-168 because the slice changed TypeScript,
+  documentation, and Backlog metadata only; no Python files were modified.
+- Bandit: skipped for TASK-171 because the slice changed TypeScript,
   documentation, and Backlog metadata only; no Python files were modified.
 
 ## Known Skips And Blockers

--- a/apps/packages/ui/src/components/Option/KanbanPlayground/BoardView.tsx
+++ b/apps/packages/ui/src/components/Option/KanbanPlayground/BoardView.tsx
@@ -398,8 +398,11 @@ export const BoardView = ({
 
   // Save card from detail panel
   const handleSaveCard = useCallback(
-    (cardId: number, data: CardUpdate) => {
-      updateCardMutation.mutate({ cardId, data })
+    async (cardId: number, data: CardUpdate) => {
+      const updatedCard = await updateCardMutation.mutateAsync({ cardId, data })
+      setSelectedCard((current) =>
+        current?.id === updatedCard.id ? updatedCard : current
+      )
     },
     [updateCardMutation]
   )

--- a/apps/packages/ui/src/components/Option/KanbanPlayground/CardDetailPanel.tsx
+++ b/apps/packages/ui/src/components/Option/KanbanPlayground/CardDetailPanel.tsx
@@ -26,7 +26,7 @@ interface CardDetailPanelProps {
   lists: ListWithCards[]
   open: boolean
   onClose: () => void
-  onSave: (cardId: number, data: CardUpdate) => void
+  onSave: (cardId: number, data: CardUpdate) => void | Promise<void>
   onDelete: (cardId: number) => void
   onArchive?: (cardId: number, cardTitle: string) => void
   onMove: (cardId: number, targetListId: number) => void
@@ -112,7 +112,7 @@ export const CardDetailPanel = ({
     }
   }, [card])
 
-  const handleSave = () => {
+  const handleSave = async () => {
     if (!card) return
 
     const updates: CardUpdate = {}
@@ -126,11 +126,16 @@ export const CardDetailPanel = ({
     }
     if (priority !== (card.priority ?? null)) updates.priority = priority
 
-    // Only save if there are changes
-    if (Object.keys(updates).length > 0) {
-      onSave(card.id, updates)
+    try {
+      // Only save if there are changes
+      if (Object.keys(updates).length > 0) {
+        await onSave(card.id, updates)
+      }
+    } catch {
+      return
     }
 
+    setDueDateTouched(false)
     setIsDirty(false)
   }
 
@@ -190,7 +195,7 @@ export const CardDetailPanel = ({
       }
       open={open}
       onClose={onClose}
-      size={400}
+      styles={{ wrapper: { width: 400 } }}
       footer={
         <div className="flex justify-end gap-2">
           <Button onClick={onClose}>Cancel</Button>

--- a/apps/packages/ui/src/components/Option/KanbanPlayground/CardDetailPanel.tsx
+++ b/apps/packages/ui/src/components/Option/KanbanPlayground/CardDetailPanel.tsx
@@ -3,7 +3,6 @@ import {
   Drawer,
   Input,
   Select,
-  DatePicker,
   Button,
   Popconfirm,
   Space,
@@ -11,12 +10,15 @@ import {
 } from "antd"
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import { Trash2, Archive, Copy, Send } from "lucide-react"
-import dayjs from "dayjs"
 
 import type { Card, CardUpdate, ListWithCards, PriorityType, Comment } from "@/types/kanban"
 import { copyCard, listComments, createComment, generateClientId } from "@/services/kanban"
 import { LabelManager } from "./LabelManager"
 import { ChecklistSection } from "./ChecklistSection"
+import {
+  formatKanbanDateTimeLocalValue,
+  parseKanbanDateTimeLocalValue
+} from "./kanbanDateTime"
 
 interface CardDetailPanelProps {
   card: Card | null
@@ -55,7 +57,8 @@ export const CardDetailPanel = ({
   // Form state
   const [title, setTitle] = useState("")
   const [description, setDescription] = useState("")
-  const [dueDate, setDueDate] = useState<dayjs.Dayjs | null>(null)
+  const [dueDateInput, setDueDateInput] = useState("")
+  const [dueDateTouched, setDueDateTouched] = useState(false)
   const [priority, setPriority] = useState<PriorityType | null>(null)
   const [newComment, setNewComment] = useState("")
 
@@ -102,7 +105,8 @@ export const CardDetailPanel = ({
     if (card) {
       setTitle(card.title)
       setDescription(card.description || "")
-      setDueDate(card.due_date ? dayjs(card.due_date) : null)
+      setDueDateInput(formatKanbanDateTimeLocalValue(card.due_date))
+      setDueDateTouched(false)
       setPriority(card.priority || null)
       setIsDirty(false)
     }
@@ -117,21 +121,8 @@ export const CardDetailPanel = ({
     if (description !== (card.description ?? "")) {
       updates.description = description === "" ? null : description
     }
-    const newDueDate = dueDate?.toISOString() ?? null
-    const oldDueDate = card.due_date ?? null
-    let hasDateChanged = false
-    if (dueDate) {
-      if (!oldDueDate) {
-        hasDateChanged = true
-      } else {
-        const oldParsed = dayjs(oldDueDate)
-        hasDateChanged = !oldParsed.isValid() || !oldParsed.isSame(dueDate)
-      }
-    } else {
-      hasDateChanged = oldDueDate !== null
-    }
-    if (hasDateChanged) {
-      updates.due_date = newDueDate
+    if (dueDateTouched) {
+      updates.due_date = parseKanbanDateTimeLocalValue(dueDateInput)
     }
     if (priority !== (card.priority ?? null)) updates.priority = priority
 
@@ -199,7 +190,7 @@ export const CardDetailPanel = ({
       }
       open={open}
       onClose={onClose}
-      width={400}
+      size={400}
       footer={
         <div className="flex justify-end gap-2">
           <Button onClick={onClose}>Cancel</Button>
@@ -282,17 +273,22 @@ export const CardDetailPanel = ({
 
           {/* Due Date */}
           <div>
-            <label className="block text-sm font-medium mb-1">Due Date</label>
-            <DatePicker
-              value={dueDate}
-              onChange={(date) => {
-                setDueDate(date)
+            <label
+              className="block text-sm font-medium mb-1"
+              htmlFor="kanban-card-due-date"
+            >
+              Due Date
+            </label>
+            <input
+              id="kanban-card-due-date"
+              type="datetime-local"
+              value={dueDateInput}
+              onChange={(event) => {
+                setDueDateInput(event.target.value)
+                setDueDateTouched(true)
                 setIsDirty(true)
               }}
-              className="w-full"
-              showTime={{ format: "HH:mm" }}
-              format="YYYY-MM-DD HH:mm"
-              allowClear
+              className="w-full rounded border border-border bg-background px-2 py-1 text-sm text-text focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
             />
           </div>
 

--- a/apps/packages/ui/src/components/Option/KanbanPlayground/__tests__/CardDetailPanel.due-date.test.tsx
+++ b/apps/packages/ui/src/components/Option/KanbanPlayground/__tests__/CardDetailPanel.due-date.test.tsx
@@ -1,0 +1,169 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+
+import type { Card, ListWithCards } from "@/types/kanban"
+import { CardDetailPanel } from "../CardDetailPanel"
+import { formatKanbanDateTimeLocalValue } from "../kanbanDateTime"
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: vi.fn(),
+  useMutation: vi.fn(),
+  useQueryClient: vi.fn()
+}))
+
+vi.mock("@/services/kanban", () => ({
+  copyCard: vi.fn(),
+  listComments: vi.fn(),
+  createComment: vi.fn(),
+  generateClientId: vi.fn(() => "test-client-id")
+}))
+
+vi.mock("../LabelManager", () => ({
+  LabelManager: () => <div data-testid="label-manager" />
+}))
+
+vi.mock("../ChecklistSection", () => ({
+  ChecklistSection: () => <div data-testid="checklist-section" />
+}))
+
+const makeCard = (overrides: Partial<Card> = {}): Card => ({
+  id: 11,
+  uuid: "card-uuid",
+  title: "Initial title",
+  description: "Initial description",
+  board_id: 1,
+  list_id: 2,
+  client_id: "client-1",
+  position: 0,
+  due_date: new Date(2026, 3, 3, 12, 34).toISOString(),
+  due_complete: false,
+  priority: "medium",
+  archived: false,
+  created_at: "2026-04-01T10:00:00Z",
+  updated_at: "2026-04-02T10:00:00Z",
+  deleted: false,
+  version: 1,
+  labels: [],
+  ...overrides
+})
+
+const lists: ListWithCards[] = [
+  {
+    id: 2,
+    uuid: "list-uuid",
+    name: "Todo",
+    board_id: 1,
+    client_id: "list-client",
+    position: 0,
+    archived: false,
+    created_at: "2026-04-01T10:00:00Z",
+    updated_at: "2026-04-01T10:00:00Z",
+    deleted: false,
+    version: 1,
+    cards: []
+  }
+]
+
+const renderPanel = ({
+  card = makeCard(),
+  onSave = vi.fn()
+}: {
+  card?: Card
+  onSave?: (cardId: number, data: any) => void
+} = {}) => {
+  render(
+    <CardDetailPanel
+      card={card}
+      boardId={1}
+      lists={lists}
+      open
+      onClose={vi.fn()}
+      onSave={onSave}
+      onDelete={vi.fn()}
+      onMove={vi.fn()}
+    />
+  )
+  return { card, onSave }
+}
+
+describe("CardDetailPanel due-date editing", () => {
+  beforeAll(() => {
+    if (typeof window.matchMedia !== "function") {
+      Object.defineProperty(window, "matchMedia", {
+        writable: true,
+        value: vi.fn().mockImplementation((query: string) => ({
+          matches: false,
+          media: query,
+          onchange: null,
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          dispatchEvent: vi.fn()
+        }))
+      })
+    }
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useQueryClient).mockReturnValue({
+      invalidateQueries: vi.fn()
+    } as any)
+    vi.mocked(useQuery).mockReturnValue({
+      data: [],
+      isLoading: false
+    } as any)
+    vi.mocked(useMutation).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false
+    } as any)
+  })
+
+  it("renders the due date as a native datetime-local input", () => {
+    const { card } = renderPanel()
+
+    const input = screen.getByLabelText("Due Date") as HTMLInputElement
+
+    expect(input.type).toBe("datetime-local")
+    expect(input).toHaveValue(formatKanbanDateTimeLocalValue(card.due_date))
+  })
+
+  it("saves a changed due date as an ISO timestamp", () => {
+    const onSave = vi.fn()
+    const { card } = renderPanel({ onSave })
+    const input = screen.getByLabelText("Due Date")
+
+    fireEvent.change(input, { target: { value: "2026-05-09T14:45" } })
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }))
+
+    expect(onSave).toHaveBeenCalledWith(card.id, {
+      due_date: new Date(2026, 4, 9, 14, 45).toISOString()
+    })
+  })
+
+  it("saves a cleared due date as null", () => {
+    const onSave = vi.fn()
+    const { card } = renderPanel({ onSave })
+
+    fireEvent.change(screen.getByLabelText("Due Date"), {
+      target: { value: "" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }))
+
+    expect(onSave).toHaveBeenCalledWith(card.id, { due_date: null })
+  })
+
+  it("does not rewrite an unchanged due date when saving another field", () => {
+    const onSave = vi.fn()
+    const { card } = renderPanel({ onSave })
+
+    fireEvent.change(screen.getByPlaceholderText("Card title"), {
+      target: { value: "Updated title" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }))
+
+    expect(onSave).toHaveBeenCalledWith(card.id, { title: "Updated title" })
+  })
+})

--- a/apps/packages/ui/src/components/Option/KanbanPlayground/__tests__/CardDetailPanel.due-date.test.tsx
+++ b/apps/packages/ui/src/components/Option/KanbanPlayground/__tests__/CardDetailPanel.due-date.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 
@@ -165,5 +165,27 @@ describe("CardDetailPanel due-date editing", () => {
     fireEvent.click(screen.getByRole("button", { name: "Save Changes" }))
 
     expect(onSave).toHaveBeenCalledWith(card.id, { title: "Updated title" })
+  })
+
+  it("does not keep resending due date after a due-date save in the same drawer session", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined)
+    const { card } = renderPanel({ onSave })
+
+    fireEvent.change(screen.getByLabelText("Due Date"), {
+      target: { value: "2026-05-09T14:45" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }))
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1))
+
+    fireEvent.change(screen.getByPlaceholderText("Card title"), {
+      target: { value: "Updated title" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }))
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(2))
+    expect(onSave).toHaveBeenNthCalledWith(2, card.id, {
+      title: "Updated title"
+    })
   })
 })

--- a/apps/packages/ui/src/components/Option/KanbanPlayground/__tests__/kanbanDateTime.test.ts
+++ b/apps/packages/ui/src/components/Option/KanbanPlayground/__tests__/kanbanDateTime.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  formatKanbanDateTimeLocalValue,
+  parseKanbanDateTimeLocalValue
+} from "../kanbanDateTime"
+
+const localDateTimeValue = (date: Date) => {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, "0")
+  const day = String(date.getDate()).padStart(2, "0")
+  const hour = String(date.getHours()).padStart(2, "0")
+  const minute = String(date.getMinutes()).padStart(2, "0")
+  return `${year}-${month}-${day}T${hour}:${minute}`
+}
+
+describe("kanban date-time helpers", () => {
+  it("formats ISO due dates for native datetime-local inputs", () => {
+    const date = new Date(2026, 3, 3, 12, 34, 56)
+
+    expect(formatKanbanDateTimeLocalValue(date.toISOString())).toBe(
+      localDateTimeValue(date)
+    )
+  })
+
+  it("returns an empty input value for missing or invalid due dates", () => {
+    expect(formatKanbanDateTimeLocalValue(null)).toBe("")
+    expect(formatKanbanDateTimeLocalValue("not-a-date")).toBe("")
+  })
+
+  it("converts native datetime-local input values to ISO timestamps", () => {
+    expect(parseKanbanDateTimeLocalValue("2026-04-03T12:34")).toBe(
+      new Date(2026, 3, 3, 12, 34).toISOString()
+    )
+  })
+
+  it("returns null for cleared or invalid datetime-local input values", () => {
+    expect(parseKanbanDateTimeLocalValue("")).toBeNull()
+    expect(parseKanbanDateTimeLocalValue("not-a-date")).toBeNull()
+  })
+})

--- a/apps/packages/ui/src/components/Option/KanbanPlayground/kanbanDateTime.ts
+++ b/apps/packages/ui/src/components/Option/KanbanPlayground/kanbanDateTime.ts
@@ -1,0 +1,29 @@
+const padDateTimePart = (value: number): string => String(value).padStart(2, "0")
+
+export const formatKanbanDateTimeLocalValue = (
+  value: string | null | undefined
+): string => {
+  if (!value) return ""
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return ""
+
+  const year = date.getFullYear()
+  const month = padDateTimePart(date.getMonth() + 1)
+  const day = padDateTimePart(date.getDate())
+  const hour = padDateTimePart(date.getHours())
+  const minute = padDateTimePart(date.getMinutes())
+
+  return `${year}-${month}-${day}T${hour}:${minute}`
+}
+
+export const parseKanbanDateTimeLocalValue = (
+  value: string | null | undefined
+): string | null => {
+  if (!value) return null
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return null
+
+  return date.toISOString()
+}

--- a/backlog/tasks/task-171 - Remove-dayjs-from-Kanban-CardDetailPanel-due-date-editing.md
+++ b/backlog/tasks/task-171 - Remove-dayjs-from-Kanban-CardDetailPanel-due-date-editing.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-171
 title: Remove dayjs from Kanban CardDetailPanel due-date editing
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-09 17:46'
-updated_date: '2026-05-09 17:53'
+updated_date: '2026-05-09 17:55'
 labels:
   - webui
   - dependencies
@@ -13,6 +13,7 @@ labels:
 dependencies: []
 references:
   - 'https://github.com/rmusser01/tldw_server/issues/1346'
+  - 'https://github.com/rmusser01/tldw_server/pull/1427'
 priority: medium
 ---
 
@@ -54,12 +55,18 @@ bun run lint from apps/tldw-frontend exited 0 with the existing 131-warning base
 Bandit skipped for this task because the touched scope is TypeScript, tests, documentation, and Backlog metadata only; no Python files changed.
 <!-- SECTION:NOTES:END -->
 
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Removed the Kanban CardDetailPanel dependency on dayjs and Ant Design DatePicker for due-date editing. The panel now uses a native datetime-local input backed by small local ISO parse/format helpers, with an explicit touched flag so unchanged due dates are not rewritten when saving unrelated fields. Focused tests cover helper behavior plus changed, cleared, and unchanged due-date saves. The dependency audit now records the shared UI dayjs import count at 5 remaining lines, limited to Media, ReadingList, and Items surfaces. Verification passed with the focused Kanban Vitest suite, exact dayjs import scan, git diff --check, lint exiting 0 with the known warning baseline, and filtered touched-slice TypeScript diagnostics returning no matches. Bandit was skipped because this slice changed no Python files.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [x] #1 Acceptance criteria completed
 - [x] #2 Tests or verification recorded
 - [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
+- [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-171 - Remove-dayjs-from-Kanban-CardDetailPanel-due-date-editing.md
+++ b/backlog/tasks/task-171 - Remove-dayjs-from-Kanban-CardDetailPanel-due-date-editing.md
@@ -4,7 +4,7 @@ title: Remove dayjs from Kanban CardDetailPanel due-date editing
 status: Done
 assignee: []
 created_date: '2026-05-09 17:46'
-updated_date: '2026-05-09 17:55'
+updated_date: '2026-05-09 18:43'
 labels:
   - webui
   - dependencies
@@ -21,6 +21,8 @@ priority: medium
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
 Continue issue #1346 by replacing the shared WebUI Kanban card due-date editor's dayjs/Ant Design DatePicker path with native platform date-time handling. Scope is limited to CardDetailPanel due-date form state, parsing/formatting helpers, focused tests, and the dependency audit. Leave Media, ReadingList, and Items RangePicker Dayjs value-contract surfaces for later design slices.
+
+Expected impact estimate for this narrow replacement: reduce active shared UI dayjs package-import lines from 6 to 5 and remove one DatePicker/Dayjs runtime editing surface from Kanban. No direct manifest, lockfile, install-size, or bundle-size reduction is expected until dayjs is removed from the remaining Media, ReadingList, and Items surfaces, and Ant Design still owns dayjs transitively.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
@@ -39,26 +41,39 @@ Continue issue #1346 by replacing the shared WebUI Kanban card due-date editor's
 2. Replace CardDetailPanel dayjs/Ant Design DatePicker state with native datetime-local state and ISO parse/format helpers.
 3. Refresh the issue #1346 dependency audit to remove Kanban from remaining dayjs surfaces.
 4. Run focused Vitest, dayjs import scan, lint, diff check, touched-slice TypeScript diagnostics, and document the Bandit skip because no Python files changed.
+
+PR review follow-up plan for #1427:
+1. Add a focused regression test proving a due-date save followed by an unrelated title save does not resend due_date while the drawer stays open.
+2. Fix the touched-state reset behavior with the smallest local change that preserves existing CardDetailPanel/BoardView contracts.
+3. Replace numeric Drawer size with an AntD 6-compatible pixel-width pattern and update verification notes.
+4. Remove machine-specific local paths from Backlog notes, add the missing expected impact estimate, and run/record the WebUI build required by issue #1346.
+5. Re-run focused tests, import scan, lint/build/type-filter/diff checks, push, and resolve/reply to review threads.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Implemented native Kanban due-date editing with a local helper module. CardDetailPanel now stores the datetime-local string plus an explicit touched flag so unchanged existing due dates are not rewritten when saving unrelated card fields. Changed due dates are parsed as local datetime-local values and emitted as ISO strings; cleared values emit null. Replaced the deprecated Drawer width prop with numeric size after tests surfaced the AntD 6 warning, preserving the 400px panel sizing.
+Implemented native Kanban due-date editing with a local helper module. CardDetailPanel now stores the datetime-local string plus an explicit touched flag so unchanged existing due dates are not rewritten when saving unrelated card fields. Changed due dates are parsed as local datetime-local values and emitted as ISO strings; cleared values emit null.
 
-Verification run from /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/webui-kanban-native-due-date-1346: focused Vitest suite passed with 2 files and 8 tests after the native helper/input implementation; rerun after replacing Drawer width with size had no deprecation warnings.
+PR review follow-up: verified the stale touched-state finding by adding a regression test that first failed because a due-date save followed by a title save in the same open drawer resent due_date. Fixed it by allowing CardDetailPanel.onSave to return a promise, awaiting the parent update, resetting dueDateTouched only after save success, and having BoardView use mutateAsync plus setSelectedCard(updatedCard) so the open panel receives the saved card. Also replaced numeric Drawer size with the repo's AntD 6 pixel-width pattern, styles.wrapper.width, preserving the 400px drawer width without using the deprecated width prop.
 
-Exact shared UI dayjs package-import scan now reports 5 remaining import lines in Media FilterPanel, ReadingList ReadingItemsList, and Items ItemsWorkspace; Kanban CardDetailPanel is no longer in the scan.
+Verification run from the feature worktree (webui-kanban-native-due-date-1346): focused Vitest suite passed with 2 files and 9 tests after the review follow-up. The new stale touched-state regression first failed with the second save including due_date, then passed after the async save/reset fix.
 
-bun run lint from apps/tldw-frontend exited 0 with the existing 131-warning baseline. git diff --check exited 0. Filtered apps/packages/ui TypeScript diagnostics for CardDetailPanel, kanbanDateTime, and KanbanPlayground returned no matches.
+Exact shared UI dayjs package-import scan reports 5 remaining import lines in Media FilterPanel, ReadingList ReadingItemsList, and Items ItemsWorkspace; Kanban CardDetailPanel is no longer in the scan.
+
+WebUI build verification: NEXT_PUBLIC_API_URL=http://127.0.0.1:8000 bun run compile from apps/tldw-frontend exited 0. The build compiled successfully, generated 138 static pages, and the shared-token sync check reported OK for the generated CSS.
+
+bun run lint from apps/tldw-frontend exited 0 with the existing 131-warning baseline. git diff --check exited 0. Filtered apps/packages/ui TypeScript diagnostics for CardDetailPanel, BoardView, kanbanDateTime, and KanbanPlayground returned no matches.
 
 Bandit skipped for this task because the touched scope is TypeScript, tests, documentation, and Backlog metadata only; no Python files changed.
+
+Final review-fix verification: focused Kanban Vitest passed 2 files and 9 tests; git diff --check exited 0; exact dayjs import scan still reports only the 5 deferred Media/ReadingList/Items lines; bun run lint exited 0 with the existing 131-warning baseline; filtered TypeScript diagnostics for CardDetailPanel, BoardView, kanbanDateTime, and KanbanPlayground returned no matches. The WebUI compile was run after the code fixes and exited 0.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Removed the Kanban CardDetailPanel dependency on dayjs and Ant Design DatePicker for due-date editing. The panel now uses a native datetime-local input backed by small local ISO parse/format helpers, with an explicit touched flag so unchanged due dates are not rewritten when saving unrelated fields. Focused tests cover helper behavior plus changed, cleared, and unchanged due-date saves. The dependency audit now records the shared UI dayjs import count at 5 remaining lines, limited to Media, ReadingList, and Items surfaces. Verification passed with the focused Kanban Vitest suite, exact dayjs import scan, git diff --check, lint exiting 0 with the known warning baseline, and filtered touched-slice TypeScript diagnostics returning no matches. Bandit was skipped because this slice changed no Python files.
+Removed the Kanban CardDetailPanel dependency on dayjs and Ant Design DatePicker for due-date editing. The panel now uses a native datetime-local input backed by small local ISO parse/format helpers, with an explicit touched flag so unchanged due dates are not rewritten when saving unrelated fields. PR review follow-up fixed the stale touched-state case by awaiting the parent update, resetting dueDateTouched only after save success, and updating the selected card from the returned mutation result. The Drawer keeps its 400px pixel width through the existing AntD 6 styles.wrapper.width pattern. Focused tests cover helper behavior plus changed, cleared, unchanged, and same-session post-due-date-save behavior. The dependency audit records the shared UI dayjs import count at 5 remaining lines, limited to Media, ReadingList, and Items surfaces; no manifest/lockfile reduction is expected until those remaining surfaces are migrated. Verification passed with the focused Kanban Vitest suite, WebUI compile, exact dayjs import scan, git diff --check, lint exiting 0 with the known warning baseline, and filtered touched-slice TypeScript diagnostics returning no matches. Bandit was skipped because this slice changed no Python files.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-171 - Remove-dayjs-from-Kanban-CardDetailPanel-due-date-editing.md
+++ b/backlog/tasks/task-171 - Remove-dayjs-from-Kanban-CardDetailPanel-due-date-editing.md
@@ -1,0 +1,65 @@
+---
+id: TASK-171
+title: Remove dayjs from Kanban CardDetailPanel due-date editing
+status: In Progress
+assignee: []
+created_date: '2026-05-09 17:46'
+updated_date: '2026-05-09 17:53'
+labels:
+  - webui
+  - dependencies
+  - issue-1346
+  - kanban
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1346'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue issue #1346 by replacing the shared WebUI Kanban card due-date editor's dayjs/Ant Design DatePicker path with native platform date-time handling. Scope is limited to CardDetailPanel due-date form state, parsing/formatting helpers, focused tests, and the dependency audit. Leave Media, ReadingList, and Items RangePicker Dayjs value-contract surfaces for later design slices.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 CardDetailPanel no longer imports or references dayjs or Ant Design DatePicker for due-date editing.
+- [x] #2 The due-date editor uses a native datetime-local input that displays existing ISO due dates in local YYYY-MM-DDTHH:mm form and allows clearing the field.
+- [x] #3 Saving a changed due date emits an ISO timestamp, saving a cleared due date emits null, and saving unrelated fields does not rewrite an unchanged existing due date.
+- [x] #4 Focused tests cover native date-time formatting/parsing and changed/unchanged/cleared due-date update behavior.
+- [x] #5 Issue #1346 audit notes are updated to reflect the reduced shared UI dayjs import count and remaining deferred DatePicker value-contract surfaces.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused regression coverage for Kanban due-date helpers and CardDetailPanel changed/cleared/unchanged save behavior.
+2. Replace CardDetailPanel dayjs/Ant Design DatePicker state with native datetime-local state and ISO parse/format helpers.
+3. Refresh the issue #1346 dependency audit to remove Kanban from remaining dayjs surfaces.
+4. Run focused Vitest, dayjs import scan, lint, diff check, touched-slice TypeScript diagnostics, and document the Bandit skip because no Python files changed.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented native Kanban due-date editing with a local helper module. CardDetailPanel now stores the datetime-local string plus an explicit touched flag so unchanged existing due dates are not rewritten when saving unrelated card fields. Changed due dates are parsed as local datetime-local values and emitted as ISO strings; cleared values emit null. Replaced the deprecated Drawer width prop with numeric size after tests surfaced the AntD 6 warning, preserving the 400px panel sizing.
+
+Verification run from /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/webui-kanban-native-due-date-1346: focused Vitest suite passed with 2 files and 8 tests after the native helper/input implementation; rerun after replacing Drawer width with size had no deprecation warnings.
+
+Exact shared UI dayjs package-import scan now reports 5 remaining import lines in Media FilterPanel, ReadingList ReadingItemsList, and Items ItemsWorkspace; Kanban CardDetailPanel is no longer in the scan.
+
+bun run lint from apps/tldw-frontend exited 0 with the existing 131-warning baseline. git diff --check exited 0. Filtered apps/packages/ui TypeScript diagnostics for CardDetailPanel, kanbanDateTime, and KanbanPlayground returned no matches.
+
+Bandit skipped for this task because the touched scope is TypeScript, tests, documentation, and Backlog metadata only; no Python files changed.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary

- Replace Kanban CardDetailPanel's dayjs/Ant Design DatePicker due-date editor with a native `datetime-local` input and local ISO parse/format helpers.
- Preserve existing due dates when unrelated fields are saved by tracking whether the due-date input was touched.
- Update the issue #1346 dependency audit and Backlog task record to show the shared UI `dayjs` import count dropped from 6 to 5.

## Verification

- `bunx vitest run src/components/Option/KanbanPlayground/__tests__/kanbanDateTime.test.ts src/components/Option/KanbanPlayground/__tests__/CardDetailPanel.due-date.test.tsx --maxWorkers=1`
- `rg -n "^\\s*import\\s+(?:type\\s+)?(?:.+?\\s+from\\s+)?['\\\"]dayjs(?:/[^'\\\"]*)?['\\\"]" apps/packages/ui/src -g '*.ts' -g '*.tsx'`
- `bun run lint` from `apps/tldw-frontend` (exits 0 with the existing 131-warning baseline)
- `./node_modules/.bin/tsc --noEmit --project tsconfig.json --pretty false 2>&1 | rg "CardDetailPanel|kanbanDateTime|KanbanPlayground" || true`
- `git diff --check`

## Change summary

Human requester must write the final merge-gate summary here before merge, covering what changed and why this native input/touched-state design was chosen.

## Notes

- Bandit skipped: touched files are TypeScript, tests, documentation, and Backlog metadata only; no Python files changed.
