### PR TITLE
Resolve VN Play visual directives into scene assets

### DIFF
--- a/Docs/API-related/VN_PLAY_API.md
+++ b/Docs/API-related/VN_PLAY_API.md
@@ -153,6 +153,8 @@ Every turn request must include:
 
 The runtime stores turn request keys before model work starts. If the same key and same request payload are submitted again, the stored turn status or completed response is replayed. If the same key is reused with a different payload, the API returns `409 idempotency_key_conflict`.
 
+Model `visual_directives` are resolved by the backend against the session's approved VN asset-pack manifest. Resolved assets update scene state and unresolved directives remain warning-only: the text/model turn can still complete, while the runtime records a rejection event with a stable reason such as `asset_not_found` or `manifest_unavailable`.
+
 Freeform turn:
 
 ```bash
@@ -248,6 +250,20 @@ Model or parse failures are recorded as turn/event state and returned as `502 mo
 - `session_restored`
 
 The current scene state includes background/depth item ids, active sprite item payloads, location, mood, time of day, weather, visible choices, transcript cursor, scene version, and warnings.
+
+When a session has resolved visual state, scene responses also include render-ready asset payloads:
+
+- `background`: approved background asset payload for `current_background_item_id`, including `item_id`, `slot_key`, `content_url`, labels, dimensions, and storage metadata where available.
+- `depth`: approved depth companion payload for `current_depth_item_id`, when present.
+- `active_sprites`: approved sprite asset payloads for the current character staging.
+
+Visual directive event behavior:
+
+- `visual_directive_requested`: appended for each model/runtime visual directive considered by the backend.
+- `visual_directive_applied`: appended when the directive resolves to an approved manifest item; replay uses this to restore background, depth, and sprite state.
+- `visual_directive_rejected`: appended when the directive cannot be resolved safely. The event payload includes `code=visual_directive_rejected`, `reason`, the original directive context, and `scene_version`.
+
+Custom frontends should prefer `scene_state.background`, `scene_state.depth`, and `scene_state.active_sprites` from VN Play responses instead of calling VN asset-pack internals directly for runtime rendering.
 
 ## Checkpoints And Restore
 

--- a/Docs/superpowers/plans/2026-05-09-vn-play-visual-directives-runtime-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-09-vn-play-visual-directives-runtime-implementation-plan.md
@@ -1,0 +1,358 @@
+# VN Play Visual Directives Runtime Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve VN Play turn `visual_directives` against approved VN asset packs and return scene-ready visual payloads from `/api/v1/vn-play`.
+
+**Architecture:** Keep VN Play backend-authoritative for visual state. The durable scene state remains compact and replayable using approved asset IDs plus sprite payload JSON; API responses enrich that state from the approved manifest so custom frontends do not need to call VN asset-pack internals. Directive failures append audit events and warnings without failing the narrative turn.
+
+**Tech Stack:** FastAPI, Pydantic, SQLite-backed ChaChaNotes repositories, VNAssetPackService manifest builder, pytest.
+
+---
+
+## File Structure
+
+- Modify `tldw_Server_API/app/core/VN_Play/assets.py`
+  - Normalize manifest collection names and directive asset type aliases (`background`/`backgrounds`, `sprite`/`sprites`, `depth`/`depth_companion`/`depth_companions`, `cg`/`cgs`).
+  - Keep deterministic approved-only resolution in the existing resolver.
+- Modify `tldw_Server_API/app/core/VN_Play/state.py`
+  - Replay `visual_directive_applied` events into `current_background_item_id`, `current_depth_item_id`, and `active_sprite_items`.
+  - Replay rejected directives as warnings with stable reason codes.
+- Modify `tldw_Server_API/app/core/VN_Play/service.py`
+  - Build the approved VN asset manifest from the session pack during turn completion.
+  - Append requested/applied/rejected visual directive events.
+  - Merge applied directives into the `scene_state_changed` payload before persisting state.
+  - Add a response enrichment helper for `background`, `depth`, and `active_sprites` in API-facing scene state payloads.
+  - Treat missing pack/manifest resolver failures as non-fatal warnings once the narrative turn has been accepted.
+- Modify `tldw_Server_API/app/api/v1/endpoints/vn_play.py`
+  - Return enriched scene state from session and turn responses.
+- Modify `tldw_Server_API/app/api/v1/schemas/vn_play_schemas.py`
+  - Add permissive optional `background`, `depth`, and `active_sprites` fields to `VNPlaySceneStateResponse`.
+- Modify `Docs/API-related/VN_PLAY_API.md`
+  - Document directive application/rejection events and scene asset payload shape.
+- Add/modify tests:
+  - `tldw_Server_API/tests/VN_Play/test_vn_play_assets.py`
+  - `tldw_Server_API/tests/VN_Play/test_vn_play_state.py`
+  - `tldw_Server_API/tests/VN_Play/test_vn_play_turns.py`
+  - `tldw_Server_API/tests/VN_Play/test_vn_play_api.py`
+
+## Baseline
+
+- Existing focused suite passed before changes:
+  - ` /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/VN_Play -q`
+  - Result: `39 passed, 5 warnings`
+
+---
+
+### Task 1: Normalize Manifest Asset Resolution
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/VN_Play/assets.py`
+- Test: `tldw_Server_API/tests/VN_Play/test_vn_play_assets.py`
+
+- [x] **Step 1: Write failing resolver alias tests**
+
+Add tests showing a runtime manifest with plural collections resolves singular directives:
+
+```python
+def test_resolver_supports_manifest_collection_aliases() -> None:
+    manifest = {
+        "assets": {
+            "backgrounds": [
+                {
+                    "item_id": 10,
+                    "slot_key": "background.library",
+                    "asset_type": "background",
+                    "labels": {"location": "library"},
+                    "review_status": "approved",
+                    "content_url": "/api/v1/vn-assets/packs/1/items/10/content",
+                }
+            ],
+            "sprites": [
+                {
+                    "item_id": 20,
+                    "slot_key": "sprite.happy",
+                    "asset_type": "sprite",
+                    "labels": {"emotion": "happy"},
+                    "review_status": "approved",
+                    "content_url": "/api/v1/vn-assets/packs/1/items/20/content",
+                }
+            ],
+        }
+    }
+
+    background = resolve_visual_directive(
+        manifest,
+        {"asset_type": "background", "labels": {"location": "library"}},
+        seed="seed",
+    )
+    sprite = resolve_visual_directive(
+        manifest,
+        {"asset_type": "sprite", "labels": {"emotion": "happy"}},
+        seed="seed",
+    )
+
+    assert background.applied is True
+    assert background.item["item_id"] == 10
+    assert sprite.applied is True
+    assert sprite.item["item_id"] == 20
+```
+
+- [x] **Step 2: Verify RED**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/VN_Play/test_vn_play_assets.py::test_resolver_supports_manifest_collection_aliases -q
+```
+
+Expected: FAIL because `assets.py` looks up the directive `asset_type` literally.
+
+- [x] **Step 3: Implement alias normalization**
+
+Add a private alias helper and route `_iter_manifest_items()` through it:
+
+```python
+_ASSET_TYPE_COLLECTION_ALIASES = {
+    "background": ("backgrounds", "background"),
+    "backgrounds": ("backgrounds", "background"),
+    "sprite": ("sprites", "sprite"),
+    "sprites": ("sprites", "sprite"),
+    "depth": ("depth_companions", "depth_companion"),
+    "depth_companion": ("depth_companions", "depth_companion"),
+    "depth_companions": ("depth_companions", "depth_companion"),
+    "cg": ("cgs", "cg"),
+    "cgs": ("cgs", "cg"),
+}
+```
+
+Keep legacy tests with singular `assets["sprite"]` passing by checking both collection aliases and direct keys.
+
+- [x] **Step 4: Verify GREEN**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/VN_Play/test_vn_play_assets.py -q
+```
+
+Expected: PASS.
+
+---
+
+### Task 2: Replay Applied Visual Directive Events
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/VN_Play/state.py`
+- Test: `tldw_Server_API/tests/VN_Play/test_vn_play_state.py`
+
+- [x] **Step 1: Write failing replay tests**
+
+Add tests showing applied visual directives update scene state:
+
+```python
+def test_replay_applies_visual_directive_assets() -> None:
+    state = derive_scene_state(
+        [
+            {
+                "event_type": "visual_directive_applied",
+                "event_payload": {
+                    "asset_type": "background",
+                    "item": {"item_id": 101, "content_url": "/content/bg"},
+                    "scene_version": 1,
+                },
+            },
+            {
+                "event_type": "visual_directive_applied",
+                "event_payload": {
+                    "asset_type": "sprite",
+                    "item": {"item_id": 201, "content_url": "/content/sprite"},
+                    "scene_version": 1,
+                },
+            },
+        ]
+    )
+
+    assert state.current_background_item_id == 101
+    assert state.active_sprite_items == [{"item_id": 201, "content_url": "/content/sprite"}]
+    assert state.scene_version == 1
+```
+
+- [x] **Step 2: Verify RED**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/VN_Play/test_vn_play_state.py::test_replay_applies_visual_directive_assets -q
+```
+
+Expected: FAIL because `visual_directive_applied` is ignored.
+
+- [x] **Step 3: Implement replay support**
+
+Import `EVENT_VISUAL_DIRECTIVE_APPLIED` and add `_apply_visual_directive_applied()`. For V1:
+- background sets `current_background_item_id`.
+- depth/depth_companion sets `current_depth_item_id`.
+- sprite appends the resolved item payload to `active_sprite_items`.
+- rejected directives keep existing warning behavior.
+
+- [x] **Step 4: Verify GREEN**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/VN_Play/test_vn_play_state.py -q
+```
+
+Expected: PASS.
+
+---
+
+### Task 3: Apply Directives During Turn Completion
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/VN_Play/service.py`
+- Test: `tldw_Server_API/tests/VN_Play/test_vn_play_turns.py`
+
+- [x] **Step 1: Write failing service tests**
+
+Add a custom adapter returning visual directives and fixture helpers that create an approved VN asset pack in the same ChaCha DB:
+
+```python
+class VisualDirectiveAdapter:
+    async def generate_turn(self, context):
+        return TurnResult(
+            narrative_text="The library appears.",
+            dialogue=[{"speaker": "Narrator", "text": "The library appears."}],
+            visual_directives=[
+                {"asset_type": "background", "labels": {"location": "library"}},
+                {"asset_type": "sprite", "labels": {"emotion": "happy"}},
+            ],
+            scene_updates={"location_key": "library"},
+        )
+```
+
+Assertions:
+- response events include `visual_directive_requested` and `visual_directive_applied`.
+- persisted scene state has `current_background_item_id` and `active_sprite_items`.
+- repeated submit with the same idempotency key replays the same response.
+
+- [x] **Step 2: Verify RED**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/VN_Play/test_vn_play_turns.py::test_turn_applies_visual_directives_to_scene_state -q
+```
+
+Expected: FAIL because service currently stores model `visual_directives` but does not resolve or apply them.
+
+- [x] **Step 3: Implement directive application**
+
+In `VNPlayService._complete_turn()`:
+- Pass the accepted `session` into `_complete_turn()` from `submit_turn()`.
+- Build the approved manifest with `VNAssetPackService(self.repo.db, owner_user_id=self.owner_user_id).build_manifest(session.vn_asset_pack_id)`.
+- Resolve `result.visual_directives` with `resolve_scene_directives()`.
+- Append `visual_directive_requested` for each directive.
+- Append `visual_directive_applied` with resolved item payloads.
+- Append `visual_directive_rejected` with stable `reason` for misses.
+- Merge applied background/depth/sprite results into `scene_payload` before `scene_state_changed`.
+- If manifest loading or directive resolution raises unexpectedly, append rejected events or warnings with `reason=manifest_unavailable` or `reason=resolver_error`, keep the narrative/model turn, and include those warnings in the returned `VNPlayTurnResponse`.
+
+- [x] **Step 4: Verify GREEN**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/VN_Play/test_vn_play_turns.py -q
+```
+
+Expected: PASS.
+
+---
+
+### Task 4: Enrich API Scene State Responses
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/schemas/vn_play_schemas.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/vn_play.py`
+- Test: `tldw_Server_API/tests/VN_Play/test_vn_play_api.py`
+
+- [x] **Step 1: Write failing API response test**
+
+Add a test that creates an approved pack, submits a turn with a visual directive adapter, and verifies `GET /sessions/{id}` or the turn response includes:
+
+```python
+assert body["scene_state"]["background"]["content_url"].endswith("/items/<id>/content")
+assert body["scene_state"]["active_sprites"][0]["content_url"].endswith("/items/<id>/content")
+```
+
+- [x] **Step 2: Verify RED**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/VN_Play/test_vn_play_api.py::test_turn_response_includes_resolved_scene_assets -q
+```
+
+Expected: FAIL because `VNPlaySceneStateResponse` has no `background`, `depth`, or `active_sprites` fields.
+
+- [x] **Step 3: Implement API enrichment**
+
+- Add optional `background`, `depth`, and `active_sprites` fields to `VNPlaySceneStateResponse`.
+- Add a service helper such as `get_enriched_scene_state(session_id)` that loads the session, reads repository scene state, builds the approved manifest for the session pack, and enriches current item IDs into payload objects. If the manifest cannot load, return the durable scene state plus warnings rather than failing `GET /sessions/{id}`.
+- Use enriched state in `_session_response()` and `_turn_response()`.
+
+- [x] **Step 4: Verify GREEN**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/VN_Play/test_vn_play_api.py -q
+```
+
+Expected: PASS.
+
+---
+
+### Task 5: Documentation And Full Verification
+
+**Files:**
+- Modify: `Docs/API-related/VN_PLAY_API.md`
+- Modify: `backlog/tasks/task-172 - Resolve-VN-Play-visual-directives-into-scene-assets.md`
+
+- [x] **Step 1: Update API docs**
+
+Document:
+- `visual_directive_requested`
+- `visual_directive_applied`
+- `visual_directive_rejected`
+- `scene_state.background`
+- `scene_state.depth`
+- `scene_state.active_sprites`
+- Warning-only behavior for unresolved directives.
+
+- [x] **Step 2: Run focused backend tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/VN_Play -q
+```
+
+Expected: PASS.
+
+- [x] **Step 3: Run API docs/schema-adjacent checks**
+
+Run:
+
+```bash
+git diff --check
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/VN_Play tldw_Server_API/app/api/v1/endpoints/vn_play.py tldw_Server_API/app/api/v1/schemas/vn_play_schemas.py -f json -o /tmp/bandit_vn_play_visual_directives.json
+```
+
+Expected: PASS or only pre-existing/non-touched findings with notes.
+
+- [x] **Step 4: Update Backlog task**
+
+Check acceptance criteria and DoD, record verification commands and known skips, and add a final summary.

--- a/backlog/tasks/task-172 - Resolve-VN-Play-visual-directives-into-scene-assets.md
+++ b/backlog/tasks/task-172 - Resolve-VN-Play-visual-directives-into-scene-assets.md
@@ -1,0 +1,83 @@
+---
+id: TASK-172
+title: Resolve VN Play visual directives into scene assets
+status: Done
+assignee: []
+created_date: '2026-05-09 17:48'
+labels:
+  - vn-play
+  - backend
+  - api
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1432'
+  - 'https://github.com/rmusser01/tldw_server/issues/1426'
+  - 'https://github.com/rmusser01/tldw_server/issues/1391'
+documentation:
+  - Docs/API-related/VN_PLAY_API.md
+  - Docs/API-related/VN_ASSET_PACKS_API.md
+  - Docs/superpowers/specs/2026-05-01-vn-play-runtime-design.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement GitHub issue #1426: make VN Play turn completion resolve model/runtime visual directives against the approved VN asset pack manifest and expose backend-owned scene asset payloads for custom frontends and the bundled WebUI. Keep the backend as source of truth for approved-only filtering, generated-file content URLs, deterministic variants, warnings, and auditable events.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A VN Play turn with valid visual directives updates returned scene state with approved renderable asset payloads.
+- [x] #2 Rejected or unresolved directives append auditable rejection events and stable scene warnings without failing the text turn.
+- [x] #3 Scene replay and checkpoint restore preserve resolved background depth and sprite state.
+- [x] #4 Custom frontends can consume visual state from VN Play API responses without calling VN asset-pack internals directly.
+- [x] #5 Backend tests cover successful resolution missing assets unapproved assets deterministic variants replay/checkpoint behavior and API response shape.
+- [x] #6 Existing turn idempotency stale-scene and in-progress behavior remain unchanged.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Plan file: Docs/superpowers/plans/2026-05-09-vn-play-visual-directives-runtime-implementation-plan.md
+
+1. Normalize VN Play visual resolver asset-type aliases so approved runtime manifests resolve singular and plural directive forms.
+2. Replay visual_directive_applied events into durable scene state IDs and sprite item payloads.
+3. Apply model visual directives during turn completion by appending requested/applied/rejected events and merging applied assets into scene_state_changed payloads.
+4. Enrich VN Play API scene responses with background depth and active_sprites payloads from the approved manifest.
+5. Update API docs and run focused VN Play tests, diff checks, and Bandit on touched backend code.
+<!-- SECTION:PLAN:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Added approved-manifest alias support for singular/plural VN Play visual directive asset types.
+- Added turn-time directive resolution that records requested/applied/rejected events and keeps accepted narrative turns completed when visual resolution fails.
+- Added scene replay and API enrichment so frontends can render `background`, `depth`, and `active_sprites` from VN Play responses.
+- Rejected directives are warning-only and auditable; resolver exceptions are converted into `resolver_error` rejection warnings.
+- Enriched `active_sprites` is derived from the current approved manifest and does not fall back to stale sprite payloads when an item is no longer approved.
+<!-- SECTION:NOTES:END -->
+
+## Verification
+
+<!-- SECTION:VERIFICATION:BEGIN -->
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/VN_Play -q` - `47 passed, 5 warnings`
+- `git diff --check` - passed
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/VN_Play tldw_Server_API/app/api/v1/endpoints/vn_play.py tldw_Server_API/app/api/v1/schemas/vn_play_schemas.py -f json -o /tmp/bandit_vn_play_visual_directives.json` - passed with 0 findings
+<!-- SECTION:VERIFICATION:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Resolved VN Play visual directives against approved VN asset-pack manifests during turn completion. The backend now emits requested applied and rejected visual directive events, persists replayable scene asset state, enriches VN Play API scene responses with render-ready approved asset payloads, keeps visual misses warning-only, and documents the runtime contract for custom frontends.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-172 - Resolve-VN-Play-visual-directives-into-scene-assets.md
+++ b/backlog/tasks/task-172 - Resolve-VN-Play-visual-directives-into-scene-assets.md
@@ -66,6 +66,8 @@ Plan file: Docs/superpowers/plans/2026-05-09-vn-play-visual-directives-runtime-i
 - Added scene replay and API enrichment so frontends can render `background`, `depth`, and `active_sprites` from VN Play responses.
 - Rejected directives are warning-only and auditable; resolver exceptions are converted into `resolver_error` rejection warnings.
 - Enriched `active_sprites` is derived from the current approved manifest and does not fall back to stale sprite payloads when an item is no longer approved.
+- Reopened for PR #1432 review fixes covering annotation cleanup, safe warning payloads, approved-only sprite enrichment, and manifest build reuse.
+- Addressed PR #1432 review comments by adding type hints to new test adapters/helpers, simplifying manifest alias key de-duping, logging full visual-resolution exceptions server-side while returning only `error_type`, making enriched sprite payloads approved-manifest-only, and reusing the manifest within a service request lifecycle.
 <!-- SECTION:NOTES:END -->
 
 ## Verification
@@ -74,10 +76,19 @@ Plan file: Docs/superpowers/plans/2026-05-09-vn-play-visual-directives-runtime-i
 - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/VN_Play -q` - `47 passed, 5 warnings`
 - `git diff --check` - passed
 - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/VN_Play tldw_Server_API/app/api/v1/endpoints/vn_play.py tldw_Server_API/app/api/v1/schemas/vn_play_schemas.py -f json -o /tmp/bandit_vn_play_visual_directives.json` - passed with 0 findings
+- Review-fix targeted tests:
+  - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/VN_Play/test_vn_play_turns.py::test_turn_records_resolver_error_without_failing_text_turn tldw_Server_API/tests/VN_Play/test_vn_play_turns.py::test_scene_enrichment_reuses_turn_manifest_cache tldw_Server_API/tests/VN_Play/test_vn_play_turns.py::test_scene_enrichment_omits_sprites_missing_from_approved_manifest tldw_Server_API/tests/VN_Play/test_vn_play_turns.py::test_scene_enrichment_warning_uses_safe_error_type -q` - `4 passed, 5 warnings`
+  - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/VN_Play/test_vn_play_assets.py::test_resolver_supports_manifest_collection_aliases tldw_Server_API/tests/VN_Play/test_vn_play_api.py::test_session_response_includes_resolved_scene_assets -q` - `2 passed, 5 warnings`
+- Review-fix full verification:
+  - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/VN_Play -q` - `49 passed, 5 warnings`
+  - `git diff --check` - passed
+  - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/VN_Play tldw_Server_API/app/api/v1/endpoints/vn_play.py tldw_Server_API/app/api/v1/schemas/vn_play_schemas.py -f json -o /tmp/bandit_vn_play_visual_directives_review_fixes.json` - passed with 0 findings
 <!-- SECTION:VERIFICATION:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Resolved VN Play visual directives against approved VN asset-pack manifests during turn completion. The backend now emits requested applied and rejected visual directive events, persists replayable scene asset state, enriches VN Play API scene responses with render-ready approved asset payloads, keeps visual misses warning-only, and documents the runtime contract for custom frontends.
+
+Review follow-up tightened the implementation by keeping frontend warning payloads non-sensitive, logging full exception details server-side, enforcing approved-only sprite enrichment, reusing the manifest within the request-scoped service, and adding missing type annotations on new tests.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/vn_play.py
+++ b/tldw_Server_API/app/api/v1/endpoints/vn_play.py
@@ -303,10 +303,7 @@ def _turn_response(
 
 
 def _scene_state(service: VNPlayService, session_id: int) -> dict[str, Any] | None:
-    return service.repo.get_scene_state(
-        session_id,
-        owner_user_id=service.owner_user_id,
-    )
+    return service.get_enriched_scene_state(session_id)
 
 
 def _http_error_for_service_exception(exc: Exception) -> HTTPException:

--- a/tldw_Server_API/app/api/v1/schemas/vn_play_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/vn_play_schemas.py
@@ -112,6 +112,9 @@ class VNPlaySceneStateResponse(BaseModel):
     session_id: StrictInt
     owner_user_id: StrictInt
     last_event_id: int | None = None
+    background: dict[str, Any] | None = None
+    depth: dict[str, Any] | None = None
+    active_sprites: list[dict[str, Any]] = Field(default_factory=list)
     current_background_item_id: int | None = None
     current_depth_item_id: int | None = None
     active_sprite_items: list[dict[str, Any]] = Field(default_factory=list)

--- a/tldw_Server_API/app/core/VN_Play/assets.py
+++ b/tldw_Server_API/app/core/VN_Play/assets.py
@@ -9,6 +9,19 @@ from typing import Any
 from tldw_Server_API.app.core.VN_Play.models import VisualDirectiveResolution
 
 
+_ASSET_TYPE_COLLECTION_ALIASES: dict[str, tuple[str, ...]] = {
+    "background": ("backgrounds", "background"),
+    "backgrounds": ("backgrounds", "background"),
+    "sprite": ("sprites", "sprite"),
+    "sprites": ("sprites", "sprite"),
+    "depth": ("depth_companions", "depth_companion", "depth"),
+    "depth_companion": ("depth_companions", "depth_companion", "depth"),
+    "depth_companions": ("depth_companions", "depth_companion", "depth"),
+    "cg": ("cgs", "cg"),
+    "cgs": ("cgs", "cg"),
+}
+
+
 def resolve_visual_directive(
     manifest: Mapping[str, Any],
     directive: Mapping[str, Any],
@@ -60,14 +73,30 @@ def _iter_manifest_items(
     if not isinstance(assets, Mapping):
         return []
 
-    if isinstance(asset_type, str) and asset_type:
-        items = assets.get(asset_type, [])
-        return _list_of_dicts(items)
+    collection_keys = _collection_keys_for_asset_type(asset_type)
+    if collection_keys is not None:
+        items: list[dict[str, Any]] = []
+        for collection_key in collection_keys:
+            items.extend(_list_of_dicts(assets.get(collection_key, [])))
+        return items
 
     all_items: list[dict[str, Any]] = []
     for items in assets.values():
         all_items.extend(_list_of_dicts(items))
     return all_items
+
+
+def _collection_keys_for_asset_type(asset_type: Any) -> list[str] | None:
+    if not isinstance(asset_type, str) or not asset_type.strip():
+        return None
+
+    normalized = asset_type.strip().lower()
+    aliases = _ASSET_TYPE_COLLECTION_ALIASES.get(normalized, (asset_type,))
+    keys: list[str] = []
+    for key in (*aliases, asset_type):
+        if key not in keys:
+            keys.append(key)
+    return keys
 
 
 def _is_approved_item(item: Mapping[str, Any]) -> bool:

--- a/tldw_Server_API/app/core/VN_Play/assets.py
+++ b/tldw_Server_API/app/core/VN_Play/assets.py
@@ -92,11 +92,7 @@ def _collection_keys_for_asset_type(asset_type: Any) -> list[str] | None:
 
     normalized = asset_type.strip().lower()
     aliases = _ASSET_TYPE_COLLECTION_ALIASES.get(normalized, (asset_type,))
-    keys: list[str] = []
-    for key in (*aliases, asset_type):
-        if key not in keys:
-            keys.append(key)
-    return keys
+    return list(dict.fromkeys((*aliases, asset_type)))
 
 
 def _is_approved_item(item: Mapping[str, Any]) -> bool:

--- a/tldw_Server_API/app/core/VN_Play/service.py
+++ b/tldw_Server_API/app/core/VN_Play/service.py
@@ -8,6 +8,8 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any, Protocol
 
+from loguru import logger
+
 from tldw_Server_API.app.core.DB_Management.VNPlay_DB import VNPlayRepository
 from tldw_Server_API.app.core.VN_Assets.service import VNAssetPackService
 from tldw_Server_API.app.core.VN_Play.assets import resolve_scene_directives
@@ -189,6 +191,7 @@ class VNPlayService:
         self.repo = repo
         self.owner_user_id = owner_user_id
         self.adapter = adapter or DeterministicVNPlayTurnAdapter()
+        self._manifest_cache: dict[int, dict[str, Any]] = {}
 
     def create_session(
         self,
@@ -392,12 +395,14 @@ class VNPlayService:
 
         enriched = dict(state)
         try:
-            manifest_response = VNAssetPackService(
-                self.repo.db,
-                owner_user_id=self.owner_user_id,
-            ).build_manifest(session.vn_asset_pack_id)
-            manifest = manifest_response.model_dump()
+            manifest = self._build_pack_manifest(session.vn_asset_pack_id)
         except Exception as exc:
+            logger.exception(
+                "Failed to enrich VN Play scene state from VN asset manifest: "
+                "session_id={}, pack_id={}",
+                session_id,
+                session.vn_asset_pack_id,
+            )
             _append_enrichment_warning(enriched, exc)
             return enriched
 
@@ -415,8 +420,6 @@ class VNPlayService:
             item_id = sprite.get("item_id")
             if isinstance(item_id, int) and item_id in items_by_id:
                 active_sprites.append(items_by_id[item_id])
-            elif not isinstance(item_id, int):
-                active_sprites.append(sprite)
         enriched["active_sprites"] = active_sprites
         return enriched
 
@@ -695,13 +698,15 @@ class VNPlayService:
         default_rejection_reason = "manifest_unavailable"
 
         try:
-            manifest_response = VNAssetPackService(
-                self.repo.db,
-                owner_user_id=self.owner_user_id,
-            ).build_manifest(session.vn_asset_pack_id)
-            manifest = manifest_response.model_dump()
+            manifest = self._build_pack_manifest(session.vn_asset_pack_id)
         except Exception as exc:
-            manifest_error = str(exc) or exc.__class__.__name__
+            logger.exception(
+                "Failed to build VN asset manifest for VN Play visual directives: "
+                "session_id={}, pack_id={}",
+                session_id,
+                session.vn_asset_pack_id,
+            )
+            manifest_error = exc.__class__.__name__
 
         if manifest is not None:
             try:
@@ -711,7 +716,12 @@ class VNPlayService:
                     seed=session.seed or f"session-{session_id}",
                 )
             except Exception as exc:
-                manifest_error = str(exc) or exc.__class__.__name__
+                logger.exception(
+                    "Failed to resolve VN Play visual directives: session_id={}, pack_id={}",
+                    session_id,
+                    session.vn_asset_pack_id,
+                )
+                manifest_error = exc.__class__.__name__
                 default_rejection_reason = "resolver_error"
                 resolutions = []
         else:
@@ -769,7 +779,7 @@ class VNPlayService:
                 directive_payload,
                 reason=reason,
                 scene_version=scene_version,
-                error=manifest_error,
+                error_type=manifest_error,
             )
             warnings.append(warning)
             events.append(
@@ -789,6 +799,17 @@ class VNPlayService:
         if sprite_items:
             scene_updates["active_sprite_items"] = sprite_items
         return events, scene_updates, warnings
+
+    def _build_pack_manifest(self, pack_id: int) -> dict[str, Any]:
+        manifest = self._manifest_cache.get(pack_id)
+        if manifest is None:
+            manifest_response = VNAssetPackService(
+                self.repo.db,
+                owner_user_id=self.owner_user_id,
+            ).build_manifest(pack_id)
+            manifest = manifest_response.model_dump()
+            self._manifest_cache[pack_id] = manifest
+        return manifest
 
     def _mark_turn_failed(
         self,
@@ -924,7 +945,7 @@ def _visual_directive_warning(
     *,
     reason: str,
     scene_version: int,
-    error: str | None = None,
+    error_type: str | None = None,
 ) -> dict[str, Any]:
     warning: dict[str, Any] = {
         "code": "visual_directive_rejected",
@@ -937,8 +958,8 @@ def _visual_directive_warning(
     slot_key = directive.get("slot_key")
     if isinstance(slot_key, str):
         warning["slot_key"] = slot_key
-    if error:
-        warning["error"] = error
+    if error_type:
+        warning["error_type"] = error_type
     return warning
 
 
@@ -962,7 +983,7 @@ def _append_enrichment_warning(state: dict[str, Any], exc: Exception) -> None:
         {
             "code": "scene_asset_enrichment_failed",
             "reason": "manifest_unavailable",
-            "error": str(exc) or exc.__class__.__name__,
+            "error_type": exc.__class__.__name__,
         }
     )
     state["warnings"] = warnings

--- a/tldw_Server_API/app/core/VN_Play/service.py
+++ b/tldw_Server_API/app/core/VN_Play/service.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass, field
 from typing import Any, Protocol
 
 from tldw_Server_API.app.core.DB_Management.VNPlay_DB import VNPlayRepository
+from tldw_Server_API.app.core.VN_Assets.service import VNAssetPackService
+from tldw_Server_API.app.core.VN_Play.assets import resolve_scene_directives
 from tldw_Server_API.app.core.VN_Play.constants import (
     ERROR_IDEMPOTENCY_KEY_CONFLICT,
     ERROR_STALE_SCENE_VERSION,
@@ -22,6 +24,9 @@ from tldw_Server_API.app.core.VN_Play.constants import (
     EVENT_TURN_COMPLETED,
     EVENT_TURN_FAILED,
     EVENT_TURN_STARTED,
+    EVENT_VISUAL_DIRECTIVE_APPLIED,
+    EVENT_VISUAL_DIRECTIVE_REJECTED,
+    EVENT_VISUAL_DIRECTIVE_REQUESTED,
     EVENT_USER_TURN,
     EVENT_MODEL_TURN_PARSE_FAILED,
     TURN_STATUS_ABANDONED,
@@ -341,6 +346,7 @@ class VNPlayService:
             raise VNPlayTurnError(TURN_STATUS_MODEL_FAILED) from exc
 
         return self._complete_turn(
+            session=session,
             session_id=session_id,
             turn_request_id=int(turn_request["id"]),
             prior_events=turn_events,
@@ -374,6 +380,45 @@ class VNPlayService:
     def list_events(self, session_id: int) -> list[dict[str, Any]]:
         self.get_session(session_id)
         return self.repo.list_events(session_id)
+
+    def get_enriched_scene_state(self, session_id: int) -> dict[str, Any] | None:
+        session = self.get_session(session_id)
+        state = self.repo.get_scene_state(
+            session_id,
+            owner_user_id=self.owner_user_id,
+        )
+        if state is None:
+            return None
+
+        enriched = dict(state)
+        try:
+            manifest_response = VNAssetPackService(
+                self.repo.db,
+                owner_user_id=self.owner_user_id,
+            ).build_manifest(session.vn_asset_pack_id)
+            manifest = manifest_response.model_dump()
+        except Exception as exc:
+            _append_enrichment_warning(enriched, exc)
+            return enriched
+
+        items_by_id = _manifest_items_by_id(manifest)
+        background_id = enriched.get("current_background_item_id")
+        if isinstance(background_id, int):
+            enriched["background"] = items_by_id.get(background_id)
+
+        depth_id = enriched.get("current_depth_item_id")
+        if isinstance(depth_id, int):
+            enriched["depth"] = items_by_id.get(depth_id)
+
+        active_sprites: list[dict[str, Any]] = []
+        for sprite in _list_of_dicts(enriched.get("active_sprite_items")):
+            item_id = sprite.get("item_id")
+            if isinstance(item_id, int) and item_id in items_by_id:
+                active_sprites.append(items_by_id[item_id])
+            elif not isinstance(item_id, int):
+                active_sprites.append(sprite)
+        enriched["active_sprites"] = active_sprites
+        return enriched
 
     def create_checkpoint(self, session_id: int, *, label: str) -> dict[str, Any]:
         self.get_session(session_id)
@@ -528,6 +573,7 @@ class VNPlayService:
     def _complete_turn(
         self,
         *,
+        session: VNPlaySession,
         session_id: int,
         turn_request_id: int,
         prior_events: Sequence[Mapping[str, Any]],
@@ -551,6 +597,15 @@ class VNPlayService:
         new_events: list[dict[str, Any]] = [dict(event) for event in prior_events]
         new_events.append(model_turn)
 
+        visual_events, visual_scene_updates, visual_warnings = self._apply_visual_directives(
+            session=session,
+            session_id=session_id,
+            turn_request_id=turn_request_id,
+            directives=result.visual_directives,
+            scene_version=next_scene_version,
+        )
+        new_events.extend(visual_events)
+
         if result.choices:
             choice_presented = self.repo.append_event(
                 session_id=session_id,
@@ -566,7 +621,9 @@ class VNPlayService:
             new_events.append(choice_presented)
 
         scene_payload = dict(result.scene_updates)
+        scene_payload.update(visual_scene_updates)
         scene_payload["scene_version"] = next_scene_version
+        all_warnings = [*result.warnings, *visual_warnings]
         if result.warnings:
             scene_payload["warnings"] = result.warnings
         scene_state_changed = self.repo.append_event(
@@ -604,7 +661,7 @@ class VNPlayService:
             status=TURN_STATUS_COMPLETED,
             scene_version=next_scene_version,
             events=new_events,
-            warnings=result.warnings,
+            warnings=all_warnings,
         )
         self.repo.update_turn_request(
             turn_request_id,
@@ -616,6 +673,122 @@ class VNPlayService:
             owner_user_id=self.owner_user_id,
         )
         return response
+
+    def _apply_visual_directives(
+        self,
+        *,
+        session: VNPlaySession,
+        session_id: int,
+        turn_request_id: int,
+        directives: Sequence[Mapping[str, Any]],
+        scene_version: int,
+    ) -> tuple[list[dict[str, Any]], dict[str, Any], list[dict[str, Any]]]:
+        if not directives:
+            return [], {}, []
+
+        events: list[dict[str, Any]] = []
+        warnings: list[dict[str, Any]] = []
+        scene_updates: dict[str, Any] = {}
+        sprite_items: list[dict[str, Any]] = []
+        manifest: Mapping[str, Any] | None = None
+        manifest_error: str | None = None
+        default_rejection_reason = "manifest_unavailable"
+
+        try:
+            manifest_response = VNAssetPackService(
+                self.repo.db,
+                owner_user_id=self.owner_user_id,
+            ).build_manifest(session.vn_asset_pack_id)
+            manifest = manifest_response.model_dump()
+        except Exception as exc:
+            manifest_error = str(exc) or exc.__class__.__name__
+
+        if manifest is not None:
+            try:
+                resolutions = resolve_scene_directives(
+                    manifest,
+                    directives,
+                    seed=session.seed or f"session-{session_id}",
+                )
+            except Exception as exc:
+                manifest_error = str(exc) or exc.__class__.__name__
+                default_rejection_reason = "resolver_error"
+                resolutions = []
+        else:
+            resolutions = []
+
+        for index, directive in enumerate(directives):
+            directive_payload = dict(directive)
+            events.append(
+                self.repo.append_event(
+                    session_id=session_id,
+                    owner_user_id=self.owner_user_id,
+                    event_type=EVENT_VISUAL_DIRECTIVE_REQUESTED,
+                    event_payload={
+                        "turn_request_id": turn_request_id,
+                        "directive": directive_payload,
+                        "scene_version": scene_version,
+                    },
+                    source="runtime",
+                )
+            )
+
+            resolution = resolutions[index] if index < len(resolutions) else None
+            if resolution is not None and resolution.applied and resolution.item is not None:
+                item = dict(resolution.item)
+                asset_type = _visual_asset_type(directive_payload, item)
+                events.append(
+                    self.repo.append_event(
+                        session_id=session_id,
+                        owner_user_id=self.owner_user_id,
+                        event_type=EVENT_VISUAL_DIRECTIVE_APPLIED,
+                        event_payload={
+                            "turn_request_id": turn_request_id,
+                            "asset_type": asset_type,
+                            "directive": directive_payload,
+                            "item": item,
+                            "scene_version": scene_version,
+                        },
+                        source="runtime",
+                    )
+                )
+                _merge_visual_item_scene_update(
+                    scene_updates,
+                    sprite_items,
+                    asset_type=asset_type,
+                    item=item,
+                )
+                continue
+
+            reason = (
+                resolution.reason
+                if resolution is not None and resolution.reason
+                else default_rejection_reason
+            )
+            warning = _visual_directive_warning(
+                directive_payload,
+                reason=reason,
+                scene_version=scene_version,
+                error=manifest_error,
+            )
+            warnings.append(warning)
+            events.append(
+                self.repo.append_event(
+                    session_id=session_id,
+                    owner_user_id=self.owner_user_id,
+                    event_type=EVENT_VISUAL_DIRECTIVE_REJECTED,
+                    event_payload={
+                        "turn_request_id": turn_request_id,
+                        "directive": directive_payload,
+                        **warning,
+                    },
+                    source="runtime",
+                )
+            )
+
+        if sprite_items:
+            scene_updates["active_sprite_items"] = sprite_items
+        return events, scene_updates, warnings
 
     def _mark_turn_failed(
         self,
@@ -706,6 +879,93 @@ def _normalize_input_payload(
     if choice_id is not None:
         return {"choice_id": choice_id}
     return {"custom_action": dict(custom_action or {})}
+
+
+def _visual_asset_type(
+    directive: Mapping[str, Any],
+    item: Mapping[str, Any],
+) -> str:
+    raw_asset_type = directive.get("asset_type") or item.get("asset_type")
+    if not isinstance(raw_asset_type, str):
+        return ""
+    normalized = raw_asset_type.strip().lower()
+    if normalized in {"background", "backgrounds"}:
+        return "background"
+    if normalized in {"depth", "depth_companion", "depth_companions"}:
+        return "depth_companion"
+    if normalized in {"sprite", "sprites"}:
+        return "sprite"
+    if normalized in {"cg", "cgs"}:
+        return "cg"
+    return normalized
+
+
+def _merge_visual_item_scene_update(
+    scene_updates: dict[str, Any],
+    sprite_items: list[dict[str, Any]],
+    *,
+    asset_type: str,
+    item: Mapping[str, Any],
+) -> None:
+    item_id = item.get("item_id")
+    if asset_type == "background" and isinstance(item_id, int):
+        scene_updates["current_background_item_id"] = item_id
+        depth_item_id = item.get("depth_companion_item_id")
+        if isinstance(depth_item_id, int):
+            scene_updates["current_depth_item_id"] = depth_item_id
+    elif asset_type == "depth_companion" and isinstance(item_id, int):
+        scene_updates["current_depth_item_id"] = item_id
+    elif asset_type == "sprite":
+        sprite_items.append(dict(item))
+
+
+def _visual_directive_warning(
+    directive: Mapping[str, Any],
+    *,
+    reason: str,
+    scene_version: int,
+    error: str | None = None,
+) -> dict[str, Any]:
+    warning: dict[str, Any] = {
+        "code": "visual_directive_rejected",
+        "reason": reason,
+        "scene_version": scene_version,
+    }
+    asset_type = directive.get("asset_type")
+    if isinstance(asset_type, str):
+        warning["asset_type"] = asset_type
+    slot_key = directive.get("slot_key")
+    if isinstance(slot_key, str):
+        warning["slot_key"] = slot_key
+    if error:
+        warning["error"] = error
+    return warning
+
+
+def _manifest_items_by_id(manifest: Mapping[str, Any]) -> dict[int, dict[str, Any]]:
+    assets = manifest.get("assets")
+    if not isinstance(assets, Mapping):
+        return {}
+
+    items_by_id: dict[int, dict[str, Any]] = {}
+    for collection in assets.values():
+        for item in _list_of_dicts(collection):
+            item_id = item.get("item_id")
+            if isinstance(item_id, int):
+                items_by_id[item_id] = item
+    return items_by_id
+
+
+def _append_enrichment_warning(state: dict[str, Any], exc: Exception) -> None:
+    warnings = list(state.get("warnings") or [])
+    warnings.append(
+        {
+            "code": "scene_asset_enrichment_failed",
+            "reason": "manifest_unavailable",
+            "error": str(exc) or exc.__class__.__name__,
+        }
+    )
+    state["warnings"] = warnings
 
 
 def _payload_hash(payload: Mapping[str, Any]) -> str:

--- a/tldw_Server_API/app/core/VN_Play/state.py
+++ b/tldw_Server_API/app/core/VN_Play/state.py
@@ -14,6 +14,7 @@ from tldw_Server_API.app.core.VN_Play.constants import (
     EVENT_SESSION_RESTORED,
     EVENT_SESSION_STARTED,
     EVENT_TURN_FAILED,
+    EVENT_VISUAL_DIRECTIVE_APPLIED,
     EVENT_VISUAL_DIRECTIVE_REJECTED,
 )
 from tldw_Server_API.app.core.VN_Play.models import SceneState
@@ -41,6 +42,8 @@ def derive_scene_state(events: Iterable[Mapping[str, Any]]) -> SceneState:
             if isinstance(snapshot, Mapping):
                 _apply_scene_snapshot(state, snapshot)
             _apply_scene_version(state, payload)
+        elif event_type == EVENT_VISUAL_DIRECTIVE_APPLIED:
+            _apply_visual_directive_applied(state, payload)
         elif event_type == EVENT_VISUAL_DIRECTIVE_REJECTED:
             state.warnings.append(_warning_from_payload("visual_directive_rejected", payload))
             _apply_scene_version(state, payload)
@@ -99,6 +102,25 @@ def _apply_choice_presented(state: SceneState, payload: Mapping[str, Any]) -> No
     _apply_scene_version(state, payload)
 
 
+def _apply_visual_directive_applied(state: SceneState, payload: Mapping[str, Any]) -> None:
+    item = payload.get("item")
+    if not isinstance(item, Mapping):
+        _apply_scene_version(state, payload)
+        return
+
+    item_payload = dict(item)
+    item_id = item_payload.get("item_id")
+    asset_type = _asset_type_from_payload(payload, item_payload)
+    if asset_type == "background" and isinstance(item_id, int):
+        state.current_background_item_id = item_id
+    elif asset_type == "depth_companion" and isinstance(item_id, int):
+        state.current_depth_item_id = item_id
+    elif asset_type == "sprite":
+        state.active_sprite_items.append(item_payload)
+
+    _apply_scene_version(state, payload)
+
+
 def _apply_scene_snapshot(state: SceneState, snapshot: Mapping[str, Any]) -> None:
     _apply_int_field(
         state,
@@ -124,6 +146,23 @@ def _apply_scene_snapshot(state: SceneState, snapshot: Mapping[str, Any]) -> Non
     _apply_int_field(state, "transcript_cursor", snapshot, "transcript_cursor")
     _append_payload_warnings(state, snapshot, replace=True)
     _apply_scene_version(state, snapshot)
+
+
+def _asset_type_from_payload(
+    payload: Mapping[str, Any],
+    item_payload: Mapping[str, Any],
+) -> str:
+    raw_asset_type = payload.get("asset_type") or item_payload.get("asset_type")
+    if not isinstance(raw_asset_type, str):
+        return ""
+    normalized = raw_asset_type.strip().lower()
+    if normalized in {"background", "backgrounds"}:
+        return "background"
+    if normalized in {"depth", "depth_companion", "depth_companions"}:
+        return "depth_companion"
+    if normalized in {"sprite", "sprites"}:
+        return "sprite"
+    return normalized
 
 
 def _apply_text_field(state: SceneState, field_name: str, payload: Mapping[str, Any]) -> None:

--- a/tldw_Server_API/tests/VN_Play/test_vn_play_api.py
+++ b/tldw_Server_API/tests/VN_Play/test_vn_play_api.py
@@ -23,7 +23,7 @@ from tldw_Server_API.app.core.DB_Management.VNAssetPacks_DB import VNAssetPacksR
 from tldw_Server_API.app.core.DB_Management.VNPlay_DB import VNPlayRepository
 from tldw_Server_API.app.core.VN_Assets.service import VNAssetPackService
 from tldw_Server_API.app.core.VN_Play.models import TurnResult
-from tldw_Server_API.app.core.VN_Play.service import VNPlayService
+from tldw_Server_API.app.core.VN_Play.service import VNPlayService, VNPlayTurnContext
 
 
 @pytest.fixture
@@ -140,7 +140,7 @@ def _create_pack(
 
 
 class _VisualDirectiveAdapter:
-    async def generate_turn(self, context):
+    async def generate_turn(self, context: VNPlayTurnContext) -> TurnResult:
         return TurnResult(
             narrative_text="The library appears.",
             dialogue=[{"speaker": "Narrator", "text": "The library appears."}],

--- a/tldw_Server_API/tests/VN_Play/test_vn_play_api.py
+++ b/tldw_Server_API/tests/VN_Play/test_vn_play_api.py
@@ -20,7 +20,10 @@ from tldw_Server_API.app.api.v1.schemas.vn_play_schemas import (
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 from tldw_Server_API.app.core.DB_Management.VNAssetPacks_DB import VNAssetPacksRepository
+from tldw_Server_API.app.core.DB_Management.VNPlay_DB import VNPlayRepository
 from tldw_Server_API.app.core.VN_Assets.service import VNAssetPackService
+from tldw_Server_API.app.core.VN_Play.models import TurnResult
+from tldw_Server_API.app.core.VN_Play.service import VNPlayService
 
 
 @pytest.fixture
@@ -136,6 +139,61 @@ def _create_pack(
     return pack.id
 
 
+class _VisualDirectiveAdapter:
+    async def generate_turn(self, context):
+        return TurnResult(
+            narrative_text="The library appears.",
+            dialogue=[{"speaker": "Narrator", "text": "The library appears."}],
+            visual_directives=[
+                {"asset_type": "background", "labels": {"location": "library"}},
+                {"asset_type": "sprite", "labels": {"emotion": "happy"}},
+            ],
+            scene_updates={"location_key": "library"},
+        )
+
+
+def _create_visual_pack(chacha_db: CharactersRAGDB) -> tuple[int, int, int, int]:
+    character_id = _add_character(chacha_db, name="Visual Mira")
+    repo = VNAssetPacksRepository.initialized(chacha_db)
+    pack = repo.create_pack(
+        owner_user_id=42,
+        primary_character_id=character_id,
+        title="Visual Mira - Archive Pack",
+    )
+    background_slot = repo.create_slot(
+        pack_id=int(pack["id"]),
+        asset_type="background",
+        slot_key="background.library",
+        labels={"location": "library"},
+    )
+    sprite_slot = repo.create_slot(
+        pack_id=int(pack["id"]),
+        asset_type="sprite",
+        slot_key="sprite.happy",
+        labels={"emotion": "happy"},
+    )
+    background_item = repo.create_item(
+        pack_id=int(pack["id"]),
+        slot_id=int(background_slot["id"]),
+        generated_file_id=2001,
+        mime_type="image/png",
+        review_status="approved",
+    )
+    sprite_item = repo.create_item(
+        pack_id=int(pack["id"]),
+        slot_id=int(sprite_slot["id"]),
+        generated_file_id=2002,
+        mime_type="image/png",
+        review_status="approved",
+    )
+    return (
+        character_id,
+        int(pack["id"]),
+        int(background_item["id"]),
+        int(sprite_item["id"]),
+    )
+
+
 def test_turn_request_requires_exactly_one_input_field() -> None:
     VNPlayTurnRequest(input_text="hello", client_scene_version=0, idempotency_key="k")
 
@@ -183,6 +241,45 @@ def test_create_session_endpoint_returns_scene_state(
     body = response.json()
     assert body["mode"] == "freeform"
     assert body["scene_state"]["scene_version"] == 0
+
+
+@pytest.mark.asyncio
+async def test_session_response_includes_resolved_scene_assets(
+    client: TestClient,
+    chacha_db: CharactersRAGDB,
+) -> None:
+    character_id, pack_id, background_item_id, sprite_item_id = _create_visual_pack(chacha_db)
+    service = VNPlayService(
+        repo=VNPlayRepository.initialized(chacha_db),
+        owner_user_id=42,
+        adapter=_VisualDirectiveAdapter(),
+    )
+    session = service.create_session(
+        mode="freeform",
+        title="Visual library",
+        primary_character_id=character_id,
+        vn_asset_pack_id=pack_id,
+        seed="seed-1",
+    )
+    await service.submit_turn(
+        session.id,
+        input_text="Look around",
+        client_scene_version=0,
+        idempotency_key="visual-api-turn-1",
+    )
+
+    response = client.get(f"/api/v1/vn-play/sessions/{session.id}")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["scene_state"]["background"]["item_id"] == background_item_id
+    assert body["scene_state"]["background"]["content_url"].endswith(
+        f"/items/{background_item_id}/content"
+    )
+    assert body["scene_state"]["active_sprites"][0]["item_id"] == sprite_item_id
+    assert body["scene_state"]["active_sprites"][0]["content_url"].endswith(
+        f"/items/{sprite_item_id}/content"
+    )
 
 
 def test_setup_options_returns_selector_safe_character_and_pack(

--- a/tldw_Server_API/tests/VN_Play/test_vn_play_assets.py
+++ b/tldw_Server_API/tests/VN_Play/test_vn_play_assets.py
@@ -31,6 +31,49 @@ def test_resolver_prefers_preferred_approved_item() -> None:
     assert resolved.item["item_id"] == 2
 
 
+def test_resolver_supports_manifest_collection_aliases() -> None:
+    manifest = {
+        "assets": {
+            "backgrounds": [
+                {
+                    "item_id": 10,
+                    "slot_key": "background.library",
+                    "asset_type": "background",
+                    "labels": {"location": "library"},
+                    "review_status": "approved",
+                    "content_url": "/api/v1/vn-assets/packs/1/items/10/content",
+                }
+            ],
+            "sprites": [
+                {
+                    "item_id": 20,
+                    "slot_key": "sprite.happy",
+                    "asset_type": "sprite",
+                    "labels": {"emotion": "happy"},
+                    "review_status": "approved",
+                    "content_url": "/api/v1/vn-assets/packs/1/items/20/content",
+                }
+            ],
+        }
+    }
+
+    background = resolve_visual_directive(
+        manifest,
+        {"asset_type": "background", "labels": {"location": "library"}},
+        seed="seed",
+    )
+    sprite = resolve_visual_directive(
+        manifest,
+        {"asset_type": "sprite", "labels": {"emotion": "happy"}},
+        seed="seed",
+    )
+
+    assert background.applied is True
+    assert background.item["item_id"] == 10
+    assert sprite.applied is True
+    assert sprite.item["item_id"] == 20
+
+
 def test_resolver_rejects_unmatched_directive() -> None:
     resolved = resolve_visual_directive(
         {"assets": {"sprite": []}},
@@ -56,3 +99,41 @@ def test_resolver_ignores_explicitly_unapproved_items() -> None:
 
     assert resolved.applied is True
     assert resolved.item["item_id"] == 2
+
+
+def test_resolver_variant_selection_is_seed_stable() -> None:
+    manifest = {
+        "assets": {
+            "sprites": [
+                {
+                    "item_id": 1,
+                    "slot_key": "sprite.happy",
+                    "labels": {"emotion": "happy"},
+                    "review_status": "approved",
+                    "variant_index": 0,
+                },
+                {
+                    "item_id": 2,
+                    "slot_key": "sprite.happy",
+                    "labels": {"emotion": "happy"},
+                    "review_status": "approved",
+                    "variant_index": 1,
+                },
+            ]
+        }
+    }
+
+    first = resolve_visual_directive(
+        manifest,
+        {"asset_type": "sprite", "labels": {"emotion": "happy"}},
+        seed="stable-seed",
+    )
+    second = resolve_visual_directive(
+        manifest,
+        {"asset_type": "sprite", "labels": {"emotion": "happy"}},
+        seed="stable-seed",
+    )
+
+    assert first.applied is True
+    assert second.applied is True
+    assert first.item["item_id"] == second.item["item_id"]

--- a/tldw_Server_API/tests/VN_Play/test_vn_play_state.py
+++ b/tldw_Server_API/tests/VN_Play/test_vn_play_state.py
@@ -35,6 +35,35 @@ def test_replay_keeps_warning_for_rejected_visual_directive() -> None:
     assert state.warnings[0]["reason"] == "asset_not_found"
 
 
+def test_replay_applies_visual_directive_assets() -> None:
+    state = derive_scene_state(
+        [
+            {
+                "event_type": "visual_directive_applied",
+                "event_payload": {
+                    "asset_type": "background",
+                    "item": {"item_id": 101, "content_url": "/content/bg"},
+                    "scene_version": 1,
+                },
+            },
+            {
+                "event_type": "visual_directive_applied",
+                "event_payload": {
+                    "asset_type": "sprite",
+                    "item": {"item_id": 201, "content_url": "/content/sprite"},
+                    "scene_version": 1,
+                },
+            },
+        ]
+    )
+
+    assert state.current_background_item_id == 101
+    assert state.active_sprite_items == [
+        {"item_id": 201, "content_url": "/content/sprite"}
+    ]
+    assert state.scene_version == 1
+
+
 def test_replay_replaces_visible_choices_after_selection() -> None:
     state = derive_scene_state(
         [
@@ -75,6 +104,8 @@ def test_replay_restores_snapshot_state() -> None:
                 "event_payload": {
                     "scene_state_snapshot": {
                         "current_background_item_id": 202,
+                        "current_depth_item_id": 203,
+                        "active_sprite_items": [{"item_id": 301, "content_url": "/sprite"}],
                         "location_key": "garden",
                         "visible_choices": [{"id": "inspect", "label": "Inspect"}],
                         "scene_version": 7,
@@ -85,6 +116,8 @@ def test_replay_restores_snapshot_state() -> None:
     )
 
     assert state.current_background_item_id == 202
+    assert state.current_depth_item_id == 203
+    assert state.active_sprite_items == [{"item_id": 301, "content_url": "/sprite"}]
     assert state.location_key == "garden"
     assert state.visible_choices == [{"id": "inspect", "label": "Inspect"}]
     assert state.scene_version == 7

--- a/tldw_Server_API/tests/VN_Play/test_vn_play_turns.py
+++ b/tldw_Server_API/tests/VN_Play/test_vn_play_turns.py
@@ -3,9 +3,10 @@ from collections.abc import Generator
 import pytest
 
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+from tldw_Server_API.app.core.DB_Management.VNAssetPacks_DB import VNAssetPacksRepository
 from tldw_Server_API.app.core.DB_Management.VNPlay_DB import VNPlayRepository
 from tldw_Server_API.app.core.VN_Play import adapters as vn_play_adapters
-from tldw_Server_API.app.core.VN_Play.models import SceneState
+from tldw_Server_API.app.core.VN_Play.models import SceneState, TurnResult
 from tldw_Server_API.app.core.VN_Play.parser import VNPlayParseError, parse_model_turn
 from tldw_Server_API.app.core.VN_Play.service import (
     DeterministicVNPlayTurnAdapter,
@@ -73,6 +74,80 @@ def make_turn_context(mode: str = "freeform") -> VNPlayTurnContext:
     )
 
 
+class VisualDirectiveAdapter:
+    async def generate_turn(self, context):
+        return TurnResult(
+            narrative_text="The library appears.",
+            dialogue=[{"speaker": "Narrator", "text": "The library appears."}],
+            visual_directives=[
+                {"asset_type": "background", "labels": {"location": "library"}},
+                {"asset_type": "sprite", "labels": {"emotion": "happy"}},
+            ],
+            scene_updates={"location_key": "library"},
+        )
+
+
+class MissingVisualDirectiveAdapter:
+    async def generate_turn(self, context):
+        return TurnResult(
+            narrative_text="The library remains quiet.",
+            dialogue=[{"speaker": "Narrator", "text": "The library remains quiet."}],
+            visual_directives=[
+                {"asset_type": "sprite", "labels": {"emotion": "angry"}},
+            ],
+            scene_updates={"location_key": "library"},
+        )
+
+
+def create_visual_pack(chacha_db: CharactersRAGDB) -> tuple[int, int, int, int]:
+    character_id = chacha_db.add_character_card(
+        {
+            "name": "Mira",
+            "description": "A careful archivist.",
+            "personality": "Patient and exacting.",
+            "scenario": "Cataloging an orbital library.",
+        }
+    )
+    repo = VNAssetPacksRepository.initialized(chacha_db)
+    pack = repo.create_pack(
+        owner_user_id=42,
+        primary_character_id=int(character_id),
+        title="Mira - Archive Pack",
+    )
+    background_slot = repo.create_slot(
+        pack_id=int(pack["id"]),
+        asset_type="background",
+        slot_key="background.library",
+        labels={"location": "library"},
+    )
+    sprite_slot = repo.create_slot(
+        pack_id=int(pack["id"]),
+        asset_type="sprite",
+        slot_key="sprite.happy",
+        labels={"emotion": "happy"},
+    )
+    background_item = repo.create_item(
+        pack_id=int(pack["id"]),
+        slot_id=int(background_slot["id"]),
+        generated_file_id=1001,
+        mime_type="image/png",
+        review_status="approved",
+    )
+    sprite_item = repo.create_item(
+        pack_id=int(pack["id"]),
+        slot_id=int(sprite_slot["id"]),
+        generated_file_id=1002,
+        mime_type="image/png",
+        review_status="approved",
+    )
+    return (
+        int(character_id),
+        int(pack["id"]),
+        int(background_item["id"]),
+        int(sprite_item["id"]),
+    )
+
+
 @pytest.fixture
 def ready_session(service: VNPlayService):
     return service.create_session(
@@ -119,6 +194,168 @@ async def test_duplicate_completed_turn_returns_stored_response(
 
     assert second.turn_request_id == first.turn_request_id
     assert second.events == first.events
+
+
+@pytest.mark.asyncio
+async def test_turn_applies_visual_directives_to_scene_state(
+    chacha_db: CharactersRAGDB,
+) -> None:
+    character_id, pack_id, background_item_id, sprite_item_id = create_visual_pack(chacha_db)
+    service = VNPlayService(
+        repo=VNPlayRepository.initialized(chacha_db),
+        owner_user_id=42,
+        adapter=VisualDirectiveAdapter(),
+    )
+    session = service.create_session(
+        mode="freeform",
+        title="Library night",
+        primary_character_id=character_id,
+        vn_asset_pack_id=pack_id,
+        seed="seed-1",
+    )
+
+    first = await service.submit_turn(
+        session.id,
+        input_text="Look around",
+        client_scene_version=0,
+        idempotency_key="visual-turn-1",
+    )
+
+    event_types = [event["event_type"] for event in first.events]
+    assert "visual_directive_requested" in event_types
+    assert event_types.count("visual_directive_applied") == 2
+    state = service.repo.get_scene_state(session.id, owner_user_id=42)
+    assert state is not None
+    assert state["current_background_item_id"] == background_item_id
+    assert state["active_sprite_items"][0]["item_id"] == sprite_item_id
+
+    second = await service.submit_turn(
+        session.id,
+        input_text="Look around",
+        client_scene_version=0,
+        idempotency_key="visual-turn-1",
+    )
+    assert second.events == first.events
+
+
+@pytest.mark.asyncio
+async def test_turn_rejects_unresolved_visual_directive_without_failing_text_turn(
+    chacha_db: CharactersRAGDB,
+) -> None:
+    character_id, pack_id, _, _ = create_visual_pack(chacha_db)
+    service = VNPlayService(
+        repo=VNPlayRepository.initialized(chacha_db),
+        owner_user_id=42,
+        adapter=MissingVisualDirectiveAdapter(),
+    )
+    session = service.create_session(
+        mode="freeform",
+        title="Library night",
+        primary_character_id=character_id,
+        vn_asset_pack_id=pack_id,
+        seed="seed-1",
+    )
+
+    response = await service.submit_turn(
+        session.id,
+        input_text="Look around",
+        client_scene_version=0,
+        idempotency_key="missing-visual-turn-1",
+    )
+
+    event_types = [event["event_type"] for event in response.events]
+    assert response.status == "completed"
+    assert "model_turn" in event_types
+    assert "visual_directive_rejected" in event_types
+    assert response.warnings[0]["reason"] == "asset_not_found"
+    state = service.repo.get_scene_state(session.id, owner_user_id=42)
+    assert state is not None
+    assert state["warnings"][0]["reason"] == "asset_not_found"
+    assert len(state["warnings"]) == 1
+    assert service.get_session(session.id).active_turn_request_id is None
+
+
+@pytest.mark.asyncio
+async def test_turn_records_resolver_error_without_failing_text_turn(
+    chacha_db: CharactersRAGDB,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    character_id, pack_id, _, _ = create_visual_pack(chacha_db)
+    service = VNPlayService(
+        repo=VNPlayRepository.initialized(chacha_db),
+        owner_user_id=42,
+        adapter=VisualDirectiveAdapter(),
+    )
+    session = service.create_session(
+        mode="freeform",
+        title="Library night",
+        primary_character_id=character_id,
+        vn_asset_pack_id=pack_id,
+        seed="seed-1",
+    )
+
+    def fail_resolution(*args, **kwargs):
+        raise RuntimeError("resolver exploded")
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.VN_Play.service.resolve_scene_directives",
+        fail_resolution,
+    )
+
+    response = await service.submit_turn(
+        session.id,
+        input_text="Look around",
+        client_scene_version=0,
+        idempotency_key="resolver-error-turn-1",
+    )
+
+    rejected_events = [
+        event
+        for event in response.events
+        if event["event_type"] == "visual_directive_rejected"
+    ]
+    assert response.status == "completed"
+    assert len(rejected_events) == 2
+    assert rejected_events[0]["event_payload"]["reason"] == "resolver_error"
+    assert rejected_events[0]["event_payload"]["directive"]["asset_type"] == "background"
+    assert response.warnings[0]["error"] == "resolver exploded"
+    assert service.get_session(session.id).active_turn_request_id is None
+
+
+@pytest.mark.asyncio
+async def test_scene_enrichment_omits_sprites_missing_from_approved_manifest(
+    chacha_db: CharactersRAGDB,
+) -> None:
+    character_id, pack_id, _, sprite_item_id = create_visual_pack(chacha_db)
+    service = VNPlayService(
+        repo=VNPlayRepository.initialized(chacha_db),
+        owner_user_id=42,
+        adapter=VisualDirectiveAdapter(),
+    )
+    session = service.create_session(
+        mode="freeform",
+        title="Library night",
+        primary_character_id=character_id,
+        vn_asset_pack_id=pack_id,
+        seed="seed-1",
+    )
+    await service.submit_turn(
+        session.id,
+        input_text="Look around",
+        client_scene_version=0,
+        idempotency_key="approved-visual-turn-1",
+    )
+
+    VNAssetPacksRepository.initialized(chacha_db).update_item_review(
+        sprite_item_id,
+        review_status="rejected",
+    )
+
+    state = service.get_enriched_scene_state(session.id)
+
+    assert state is not None
+    assert state["active_sprite_items"][0]["item_id"] == sprite_item_id
+    assert state["active_sprites"] == []
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/VN_Play/test_vn_play_turns.py
+++ b/tldw_Server_API/tests/VN_Play/test_vn_play_turns.py
@@ -1,12 +1,18 @@
-from collections.abc import Generator
+from collections.abc import Generator, Mapping, Sequence
+from typing import Any
 
 import pytest
 
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 from tldw_Server_API.app.core.DB_Management.VNAssetPacks_DB import VNAssetPacksRepository
 from tldw_Server_API.app.core.DB_Management.VNPlay_DB import VNPlayRepository
+from tldw_Server_API.app.core.VN_Assets.service import VNAssetPackService
 from tldw_Server_API.app.core.VN_Play import adapters as vn_play_adapters
-from tldw_Server_API.app.core.VN_Play.models import SceneState, TurnResult
+from tldw_Server_API.app.core.VN_Play.models import (
+    SceneState,
+    TurnResult,
+    VisualDirectiveResolution,
+)
 from tldw_Server_API.app.core.VN_Play.parser import VNPlayParseError, parse_model_turn
 from tldw_Server_API.app.core.VN_Play.service import (
     DeterministicVNPlayTurnAdapter,
@@ -38,7 +44,7 @@ def service(chacha_db: CharactersRAGDB) -> VNPlayService:
 @pytest.fixture
 def service_with_failing_adapter(chacha_db: CharactersRAGDB) -> VNPlayService:
     class FailingAdapter:
-        async def generate_turn(self, context):
+        async def generate_turn(self, context: VNPlayTurnContext) -> TurnResult:
             raise RuntimeError("provider unavailable")
 
     repo = VNPlayRepository.initialized(chacha_db)
@@ -75,7 +81,7 @@ def make_turn_context(mode: str = "freeform") -> VNPlayTurnContext:
 
 
 class VisualDirectiveAdapter:
-    async def generate_turn(self, context):
+    async def generate_turn(self, context: VNPlayTurnContext) -> TurnResult:
         return TurnResult(
             narrative_text="The library appears.",
             dialogue=[{"speaker": "Narrator", "text": "The library appears."}],
@@ -88,7 +94,7 @@ class VisualDirectiveAdapter:
 
 
 class MissingVisualDirectiveAdapter:
-    async def generate_turn(self, context):
+    async def generate_turn(self, context: VNPlayTurnContext) -> TurnResult:
         return TurnResult(
             narrative_text="The library remains quiet.",
             dialogue=[{"speaker": "Narrator", "text": "The library remains quiet."}],
@@ -294,7 +300,12 @@ async def test_turn_records_resolver_error_without_failing_text_turn(
         seed="seed-1",
     )
 
-    def fail_resolution(*args, **kwargs):
+    def fail_resolution(
+        manifest: Mapping[str, Any],
+        directives: Sequence[Mapping[str, Any]],
+        *,
+        seed: str,
+    ) -> list[VisualDirectiveResolution]:
         raise RuntimeError("resolver exploded")
 
     monkeypatch.setattr(
@@ -318,8 +329,52 @@ async def test_turn_records_resolver_error_without_failing_text_turn(
     assert len(rejected_events) == 2
     assert rejected_events[0]["event_payload"]["reason"] == "resolver_error"
     assert rejected_events[0]["event_payload"]["directive"]["asset_type"] == "background"
-    assert response.warnings[0]["error"] == "resolver exploded"
+    assert response.warnings[0]["error_type"] == "RuntimeError"
+    assert "error" not in response.warnings[0]
     assert service.get_session(session.id).active_turn_request_id is None
+
+
+@pytest.mark.asyncio
+async def test_scene_enrichment_reuses_turn_manifest_cache(
+    chacha_db: CharactersRAGDB,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    character_id, pack_id, _, _ = create_visual_pack(chacha_db)
+    service = VNPlayService(
+        repo=VNPlayRepository.initialized(chacha_db),
+        owner_user_id=42,
+        adapter=VisualDirectiveAdapter(),
+    )
+    session = service.create_session(
+        mode="freeform",
+        title="Library night",
+        primary_character_id=character_id,
+        vn_asset_pack_id=pack_id,
+        seed="seed-1",
+    )
+    build_calls: list[int] = []
+    original_build_manifest = VNAssetPackService.build_manifest
+
+    def counted_build_manifest(
+        self: VNAssetPackService,
+        requested_pack_id: int,
+    ) -> Any:
+        build_calls.append(requested_pack_id)
+        return original_build_manifest(self, requested_pack_id)
+
+    monkeypatch.setattr(VNAssetPackService, "build_manifest", counted_build_manifest)
+
+    await service.submit_turn(
+        session.id,
+        input_text="Look around",
+        client_scene_version=0,
+        idempotency_key="cached-manifest-turn-1",
+    )
+    state = service.get_enriched_scene_state(session.id)
+
+    assert state is not None
+    assert state["background"] is not None
+    assert build_calls == [pack_id]
 
 
 @pytest.mark.asyncio
@@ -351,11 +406,47 @@ async def test_scene_enrichment_omits_sprites_missing_from_approved_manifest(
         review_status="rejected",
     )
 
-    state = service.get_enriched_scene_state(session.id)
+    fresh_service = VNPlayService(
+        repo=VNPlayRepository.initialized(chacha_db),
+        owner_user_id=42,
+        adapter=VisualDirectiveAdapter(),
+    )
+    state = fresh_service.get_enriched_scene_state(session.id)
 
     assert state is not None
     assert state["active_sprite_items"][0]["item_id"] == sprite_item_id
     assert state["active_sprites"] == []
+
+
+def test_scene_enrichment_warning_uses_safe_error_type(
+    chacha_db: CharactersRAGDB,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    character_id, pack_id, _, _ = create_visual_pack(chacha_db)
+    service = VNPlayService(
+        repo=VNPlayRepository.initialized(chacha_db),
+        owner_user_id=42,
+        adapter=VisualDirectiveAdapter(),
+    )
+    session = service.create_session(
+        mode="freeform",
+        title="Library night",
+        primary_character_id=character_id,
+        vn_asset_pack_id=pack_id,
+        seed="seed-1",
+    )
+
+    def fail_manifest(self: VNAssetPackService, requested_pack_id: int) -> object:
+        raise RuntimeError("/private/path/secret.db")
+
+    monkeypatch.setattr(VNAssetPackService, "build_manifest", fail_manifest)
+
+    state = service.get_enriched_scene_state(session.id)
+
+    assert state is not None
+    assert state["warnings"][0]["reason"] == "manifest_unavailable"
+    assert state["warnings"][0]["error_type"] == "RuntimeError"
+    assert "error" not in state["warnings"][0]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Resolve VN Play model visual_directives against the approved VN asset-pack manifest during turn completion.
- Emit requested/applied/rejected visual directive events and keep unresolved directives warning-only.
- Enrich VN Play scene_state responses with backend-owned background/depth/active_sprites payloads for custom frontends.

## Tests
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/VN_Play -q`
- `git diff --cached --check`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/VN_Play tldw_Server_API/app/api/v1/endpoints/vn_play.py tldw_Server_API/app/api/v1/schemas/vn_play_schemas.py -f json -o /tmp/bandit_vn_play_visual_directives.json`

Refs #1426

## Merge note
Human-authored Change summary required before merge per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.