### PR TITLE
Add Persona/Buddy visual pack diagnostics

### DIFF
--- a/Docs/superpowers/plans/2026-05-09-persona-buddy-visual-diagnostics.md
+++ b/Docs/superpowers/plans/2026-05-09-persona-buddy-visual-diagnostics.md
@@ -1,0 +1,59 @@
+# Persona Buddy Visual Diagnostics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Persona/Buddy visual-pack failures visible and actionable while preserving the existing text fallback.
+
+**Architecture:** Add one small UI diagnostics helper that classifies visual-pack health from load state, pack metadata, assets, manifest, and renderer errors. Use that model in the Buddy runtime for compact diagnostics and in Persona Visuals for a fuller health summary.
+
+**Tech Stack:** React, TypeScript, Vitest, Testing Library, existing Persona/Buddy UI services.
+
+---
+
+### Task 1: Shared Diagnostics Helper
+
+**Files:**
+- Create: `apps/packages/ui/src/components/Common/PersonaBuddy/personaVisualDiagnostics.ts`
+- Test: `apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/personaVisualDiagnostics.test.ts`
+
+- [ ] Write failing tests for no active pack, load failure, unsupported renderer, missing manifest, missing assets, missing animation, and missing asset render failures.
+- [ ] Run the diagnostics test and confirm it fails because the helper does not exist.
+- [ ] Implement the minimal helper with stable reason codes, severity, title, message, and optional action label.
+- [ ] Re-run the diagnostics test and confirm it passes.
+
+### Task 2: Buddy Runtime Diagnostics
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellHost.tsx`
+- Modify: `apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellDock.tsx`
+- Modify: `apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellPopover.tsx`
+- Test: `apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx`
+- Test: `apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/SpriteFrameRenderer.test.tsx`
+
+- [ ] Write failing Buddy runtime tests for active-pack load failure and renderer missing-asset diagnostics.
+- [ ] Run the Buddy tests and confirm the new assertions fail.
+- [ ] Track load status/errors in `BuddyShellHost` and pass diagnostics to `BuddyShellDock`.
+- [ ] Use `SpriteFrameRenderer.onRenderError` to report render failures without disabling fallback rendering.
+- [ ] Show compact diagnostics in the dock/popover with an existing Visuals workflow link when a persona id is available.
+- [ ] Re-run Buddy tests and confirm they pass.
+
+### Task 3: Persona Visuals Editor Health Summary
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx`
+- Test: `apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx`
+
+- [ ] Write failing editor tests for selected-pack health summary output.
+- [ ] Run the editor test and confirm the new assertions fail.
+- [ ] Render the shared diagnostics summary near the selected pack/validation area.
+- [ ] Re-run the editor test and confirm it passes.
+
+### Task 4: Verification And Closeout
+
+**Files:**
+- Update: Backlog task `TASK-175`
+
+- [ ] Run targeted Vitest commands for the diagnostics, Buddy, renderer, and VisualPackEditor tests.
+- [ ] Run any practical TypeScript/lint check for the touched UI package.
+- [ ] Document Bandit as not applicable if no Python files are touched.
+- [ ] Update Backlog acceptance criteria and final notes.

--- a/apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellDock.tsx
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellDock.tsx
@@ -11,7 +11,11 @@ import type {
 } from "@/types/persona-visuals"
 
 import { BuddyShellPopover } from "./BuddyShellPopover"
-import { SpriteFrameRenderer } from "./SpriteFrameRenderer"
+import type { PersonaVisualDiagnostic } from "./personaVisualDiagnostics"
+import {
+  SpriteFrameRenderer,
+  type PersonaVisualRenderError
+} from "./SpriteFrameRenderer"
 
 type BuddyShellDockProps = {
   buddySummary: PersonaBuddySummary
@@ -20,6 +24,8 @@ type BuddyShellDockProps = {
   isDormant?: boolean
   visualPack?: PersonaVisualPack | null
   visualState?: PersonaVisualStateId
+  visualDiagnostic?: PersonaVisualDiagnostic | null
+  onVisualRenderError?: (error: PersonaVisualRenderError) => void
   position: PersonaBuddyShellPosition
   onToggle: () => void
   onDragHandlePointerDown: (event: React.PointerEvent<HTMLDivElement>) => void
@@ -47,6 +53,8 @@ export const BuddyShellDock: React.FC<BuddyShellDockProps> = ({
   isDormant = false,
   visualPack = null,
   visualState = "idle",
+  visualDiagnostic = null,
+  onVisualRenderError,
   position,
   onToggle,
   onDragHandlePointerDown,
@@ -94,6 +102,7 @@ export const BuddyShellDock: React.FC<BuddyShellDockProps> = ({
               state={visualState}
               fallbackLabel={buddySummary.persona_name}
               className="max-h-10 max-w-10 object-contain"
+              onRenderError={onVisualRenderError}
             />
           </div>
         ) : null}
@@ -110,8 +119,23 @@ export const BuddyShellDock: React.FC<BuddyShellDockProps> = ({
         </div>
       </button>
 
+      {visualDiagnostic ? (
+        <div
+          data-testid="persona-buddy-visual-diagnostic"
+          data-severity={visualDiagnostic.severity}
+          className="max-w-[220px] rounded-lg border border-border bg-bg/95 px-3 py-2 text-xs leading-5 text-text-muted shadow-sm backdrop-blur"
+        >
+          <div className="font-medium text-text">{visualDiagnostic.title}</div>
+          <div>{visualDiagnostic.message}</div>
+        </div>
+      ) : null}
+
       {isOpen && !isDormant ? (
-        <BuddyShellPopover buddySummary={buddySummary} personaId={personaId} />
+        <BuddyShellPopover
+          buddySummary={buddySummary}
+          personaId={personaId}
+          visualDiagnostic={visualDiagnostic}
+        />
       ) : null}
     </div>
   )

--- a/apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellDock.tsx
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellDock.tsx
@@ -5,13 +5,16 @@ import type {
 } from "@/store/persona-buddy-shell"
 import type { PersonaBuddySummary } from "@/types/persona-buddy"
 import type {
-  PersonaVisualAsset,
   PersonaVisualPack,
   PersonaVisualStateId
 } from "@/types/persona-visuals"
 
 import { BuddyShellPopover } from "./BuddyShellPopover"
-import type { PersonaVisualDiagnostic } from "./personaVisualDiagnostics"
+import {
+  getAssetsById,
+  getPersonaVisualDiagnosticToneClassName,
+  type PersonaVisualDiagnostic
+} from "./personaVisualDiagnostics"
 import {
   SpriteFrameRenderer,
   type PersonaVisualRenderError
@@ -25,25 +28,11 @@ type BuddyShellDockProps = {
   visualPack?: PersonaVisualPack | null
   visualState?: PersonaVisualStateId
   visualDiagnostic?: PersonaVisualDiagnostic | null
-  onVisualRenderError?: (error: PersonaVisualRenderError) => void
+  onVisualRenderError?: (error: PersonaVisualRenderError | null) => void
   position: PersonaBuddyShellPosition
   onToggle: () => void
   onDragHandlePointerDown: (event: React.PointerEvent<HTMLDivElement>) => void
   dockRef: React.RefObject<HTMLDivElement | null>
-}
-
-const getPersonaVisualAssetsById = (
-  visualPack: PersonaVisualPack | null | undefined
-): Record<string, PersonaVisualAsset> => {
-  if (!visualPack) return {}
-  if (visualPack.assets_by_id && Object.keys(visualPack.assets_by_id).length > 0) {
-    return visualPack.assets_by_id
-  }
-  const assets: Record<string, PersonaVisualAsset> = {}
-  for (const asset of visualPack.assets || []) {
-    if (asset?.id) assets[asset.id] = asset
-  }
-  return assets
 }
 
 export const BuddyShellDock: React.FC<BuddyShellDockProps> = ({
@@ -60,7 +49,7 @@ export const BuddyShellDock: React.FC<BuddyShellDockProps> = ({
   onDragHandlePointerDown,
   dockRef
 }) => {
-  const assetsById = getPersonaVisualAssetsById(visualPack)
+  const assetsById = getAssetsById(visualPack)
   const canRenderVisualPack =
     !isDormant &&
     visualPack?.renderer_type === "sprite_frames" &&
@@ -123,9 +112,9 @@ export const BuddyShellDock: React.FC<BuddyShellDockProps> = ({
         <div
           data-testid="persona-buddy-visual-diagnostic"
           data-severity={visualDiagnostic.severity}
-          className="max-w-[220px] rounded-lg border border-border bg-bg/95 px-3 py-2 text-xs leading-5 text-text-muted shadow-sm backdrop-blur"
+          className={`max-w-[220px] rounded-lg border px-3 py-2 text-xs leading-5 shadow-sm backdrop-blur ${getPersonaVisualDiagnosticToneClassName(visualDiagnostic.severity)}`}
         >
-          <div className="font-medium text-text">{visualDiagnostic.title}</div>
+          <div className="font-medium text-inherit">{visualDiagnostic.title}</div>
           <div>{visualDiagnostic.message}</div>
         </div>
       ) : null}

--- a/apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellHost.tsx
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellHost.tsx
@@ -24,6 +24,11 @@ import type { PersonaVisualPack } from "@/types/persona-visuals"
 
 import { useBuddyShellRenderContext } from "./BuddyShellRenderContext"
 import { BuddyShellDock } from "./BuddyShellDock"
+import {
+  getPrimaryPersonaVisualDiagnostic,
+  type PersonaVisualDiagnostic,
+  type PersonaVisualDiagnosticCode
+} from "./personaVisualDiagnostics"
 import { resolvePersonaVisualState } from "./personaVisualState"
 
 type BuddyShellHostProps = {
@@ -148,6 +153,13 @@ const resolveActivePersonaSelection = ({
 
 const hasVisualPackAssetMap = (pack: PersonaVisualPack | null): boolean =>
   Boolean(pack?.assets_by_id && Object.keys(pack.assets_by_id).length > 0)
+
+type PersonaVisualPackLoadStatus = "idle" | "loading" | "loaded" | "error"
+
+type PersonaVisualRenderErrorState = {
+  key: string
+  error: PersonaVisualDiagnosticCode
+}
 
 type BuddyShellHostInnerProps = {
   root: "web" | "sidepanel"
@@ -279,6 +291,12 @@ const BuddyShellHostInner: React.FC<BuddyShellHostInnerProps> = ({
     [renderContext, selectedAssistant]
   )
   const [visualPack, setVisualPack] = React.useState<PersonaVisualPack | null>(null)
+  const [visualPackLoadStatus, setVisualPackLoadStatus] =
+    React.useState<PersonaVisualPackLoadStatus>("idle")
+  const [visualPackLoadError, setVisualPackLoadError] =
+    React.useState<unknown>(null)
+  const [visualRenderError, setVisualRenderError] =
+    React.useState<PersonaVisualRenderErrorState | null>(null)
   const runtimeOverride = usePersonaVisualRuntimeStore((state) => state.override)
   const clearExpiredVisualOverride = usePersonaVisualRuntimeStore(
     (state) => state.clearExpired
@@ -295,11 +313,15 @@ const BuddyShellHostInner: React.FC<BuddyShellHostInnerProps> = ({
     const activePersonaId = String(resolvedPersona.activePersonaId || "").trim()
     if (!resolvedPersona.hasTargetPersona || !activePersonaId) {
       setVisualPack(null)
+      setVisualPackLoadStatus("idle")
+      setVisualPackLoadError(null)
       return undefined
     }
 
     let cancelled = false
     setVisualPack(null)
+    setVisualPackLoadStatus("loading")
+    setVisualPackLoadError(null)
     ;(async () => {
       try {
         const response = await listPersonaVisualPacks(activePersonaId)
@@ -312,10 +334,13 @@ const BuddyShellHostInner: React.FC<BuddyShellHostInnerProps> = ({
         }
         if (!cancelled) {
           setVisualPack(activePack)
+          setVisualPackLoadStatus("loaded")
         }
-      } catch {
+      } catch (error) {
         if (!cancelled) {
           setVisualPack(null)
+          setVisualPackLoadStatus("error")
+          setVisualPackLoadError(error)
         }
       }
     })()
@@ -348,6 +373,29 @@ const BuddyShellHostInner: React.FC<BuddyShellHostInnerProps> = ({
       authoredTriggers: visualPack?.manifest?.authored_triggers,
       mcpRuntimeReason: applicableRuntimeOverride?.reason
     })
+  const visualRenderKey = `${resolvedPersona.activePersonaId || ""}:${
+    visualPack?.id || ""
+  }:${visualState}`
+  const activeVisualRenderError =
+    visualRenderError?.key === visualRenderKey ? visualRenderError.error : null
+  const handleVisualRenderError = React.useCallback(
+    (error: PersonaVisualDiagnosticCode) => {
+      setVisualRenderError({
+        key: visualRenderKey,
+        error
+      })
+    },
+    [visualRenderKey]
+  )
+  const visualDiagnostic: PersonaVisualDiagnostic | null =
+    getPrimaryPersonaVisualDiagnostic({
+      pack: visualPack,
+      visualState,
+      loadStatus: visualPackLoadStatus,
+      loadError: visualPackLoadError,
+      renderError: activeVisualRenderError,
+      includeNoActivePack: visualPackLoadStatus === "loaded"
+    })
   const portalRoot = ensurePortalRoot()
 
   if (!resolvedPersona.hasTargetPersona) {
@@ -376,6 +424,8 @@ const BuddyShellHostInner: React.FC<BuddyShellHostInnerProps> = ({
       isDormant={isDormant}
       visualPack={visualPack}
       visualState={visualState}
+      visualDiagnostic={visualDiagnostic}
+      onVisualRenderError={handleVisualRenderError}
       position={position}
       onToggle={() => setOpen(!isOpen)}
       onDragHandlePointerDown={handleDragHandlePointerDown}

--- a/apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellHost.tsx
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellHost.tsx
@@ -379,11 +379,14 @@ const BuddyShellHostInner: React.FC<BuddyShellHostInnerProps> = ({
   const activeVisualRenderError =
     visualRenderError?.key === visualRenderKey ? visualRenderError.error : null
   const handleVisualRenderError = React.useCallback(
-    (error: PersonaVisualDiagnosticCode) => {
-      setVisualRenderError({
-        key: visualRenderKey,
-        error
-      })
+    (error: PersonaVisualDiagnosticCode | null) => {
+      if (!error) {
+        setVisualRenderError((current) =>
+          current?.key === visualRenderKey ? null : current
+        )
+        return
+      }
+      setVisualRenderError({ key: visualRenderKey, error })
     },
     [visualRenderKey]
   )

--- a/apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellPopover.tsx
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellPopover.tsx
@@ -6,7 +6,10 @@ import { Link } from "react-router-dom"
 import type { PersonaBuddySummary } from "@/types/persona-buddy"
 import { buildPersonaGardenRoute } from "@/utils/persona-garden-route"
 
-import type { PersonaVisualDiagnostic } from "./personaVisualDiagnostics"
+import {
+  getPersonaVisualDiagnosticToneClassName,
+  type PersonaVisualDiagnostic
+} from "./personaVisualDiagnostics"
 
 type BuddyShellPopoverProps = {
   buddySummary: PersonaBuddySummary
@@ -48,9 +51,9 @@ export const BuddyShellPopover: React.FC<BuddyShellPopoverProps> = ({
         <div
           data-testid="persona-buddy-visual-diagnostic-detail"
           data-severity={visualDiagnostic.severity}
-          className="mt-3 rounded-lg border border-border bg-surface px-2.5 py-2 text-xs leading-5 text-text-muted"
+          className={`mt-3 rounded-lg border px-2.5 py-2 text-xs leading-5 ${getPersonaVisualDiagnosticToneClassName(visualDiagnostic.severity)}`}
         >
-          <div className="font-medium text-text">{visualDiagnostic.title}</div>
+          <div className="font-medium text-inherit">{visualDiagnostic.title}</div>
           <div>{visualDiagnostic.message}</div>
         </div>
       ) : null}

--- a/apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellPopover.tsx
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellPopover.tsx
@@ -6,14 +6,18 @@ import { Link } from "react-router-dom"
 import type { PersonaBuddySummary } from "@/types/persona-buddy"
 import { buildPersonaGardenRoute } from "@/utils/persona-garden-route"
 
+import type { PersonaVisualDiagnostic } from "./personaVisualDiagnostics"
+
 type BuddyShellPopoverProps = {
   buddySummary: PersonaBuddySummary
   personaId?: string | null
+  visualDiagnostic?: PersonaVisualDiagnostic | null
 }
 
 export const BuddyShellPopover: React.FC<BuddyShellPopoverProps> = ({
   buddySummary,
-  personaId = null
+  personaId = null,
+  visualDiagnostic = null
 }) => {
   const { t } = useTranslation("common")
   const normalizedPersonaId = String(personaId ?? "").trim()
@@ -38,6 +42,16 @@ export const BuddyShellPopover: React.FC<BuddyShellPopoverProps> = ({
       {buddySummary.role_summary ? (
         <div className="mt-1 text-xs leading-5 text-text-muted">
           {buddySummary.role_summary}
+        </div>
+      ) : null}
+      {visualDiagnostic ? (
+        <div
+          data-testid="persona-buddy-visual-diagnostic-detail"
+          data-severity={visualDiagnostic.severity}
+          className="mt-3 rounded-lg border border-border bg-surface px-2.5 py-2 text-xs leading-5 text-text-muted"
+        >
+          <div className="font-medium text-text">{visualDiagnostic.title}</div>
+          <div>{visualDiagnostic.message}</div>
         </div>
       ) : null}
       {visualsRoute ? (

--- a/apps/packages/ui/src/components/Common/PersonaBuddy/SpriteFrameRenderer.tsx
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/SpriteFrameRenderer.tsx
@@ -8,6 +8,8 @@ import type {
   PersonaVisualStateId
 } from "@/types/persona-visuals"
 
+import { normalizeFrames } from "./personaVisualDiagnostics"
+
 export type PersonaVisualRenderError =
   | "missing_animation"
   | "missing_asset"
@@ -19,7 +21,7 @@ export type SpriteFrameRendererProps = {
   state: PersonaVisualStateId
   fallbackLabel: string
   className?: string
-  onRenderError?: (error: PersonaVisualRenderError) => void
+  onRenderError?: (error: PersonaVisualRenderError | null) => void
 }
 
 type ResolvedAnimation = {
@@ -27,17 +29,7 @@ type ResolvedAnimation = {
   animationId: string
 }
 
-export const normalizePersonaVisualFrames = (
-  animation: PersonaVisualAnimation | null | undefined
-): PersonaVisualFrame[] => {
-  if (!animation) return []
-  if (Array.isArray(animation.frames) && animation.frames.length > 0) {
-    return animation.frames.filter((frame) => Boolean(frame?.asset_id))
-  }
-  return (animation.asset_ids || [])
-    .filter((assetId) => Boolean(String(assetId || "").trim()))
-    .map((assetId) => ({ asset_id: String(assetId) }))
-}
+export const normalizePersonaVisualFrames = normalizeFrames
 
 export const resolveAnimationForState = (
   manifest: PersonaVisualManifest,
@@ -141,6 +133,35 @@ const renderFrame = ({
   )
 }
 
+const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === "number" && Number.isFinite(value)
+
+const hasUnsupportedRegion = (
+  frame: PersonaVisualFrame,
+  asset: PersonaVisualAsset
+): boolean => {
+  if (!frame.region) return false
+  const { x, y, width, height } = frame.region
+  if (
+    !isFiniteNumber(x) ||
+    !isFiniteNumber(y) ||
+    !isFiniteNumber(width) ||
+    !isFiniteNumber(height)
+  ) {
+    return true
+  }
+  if (x < 0 || y < 0 || width <= 0 || height <= 0) {
+    return true
+  }
+  if (isFiniteNumber(asset.width) && x + width > asset.width) {
+    return true
+  }
+  if (isFiniteNumber(asset.height) && y + height > asset.height) {
+    return true
+  }
+  return false
+}
+
 export const SpriteFrameRenderer: React.FC<SpriteFrameRendererProps> = ({
   manifest,
   assets,
@@ -183,10 +204,12 @@ export const SpriteFrameRenderer: React.FC<SpriteFrameRendererProps> = ({
     ? "missing_animation"
     : !asset
       ? "missing_asset"
-      : null
+      : hasUnsupportedRegion(frame, asset)
+        ? "unsupported_region"
+        : null
 
   React.useEffect(() => {
-    if (error) onRenderError?.(error)
+    onRenderError?.(error)
   }, [error, onRenderError])
 
   if (error || !frame || !asset) {

--- a/apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx
@@ -604,6 +604,48 @@ describe("BuddyShellHost", () => {
       expect(visualMocks.listPersonaVisualPacks).toHaveBeenCalledWith("persona-1")
     })
     expect(screen.getByTestId("persona-buddy-dock")).toHaveTextContent("Persona persona-1")
+    expect(screen.getByTestId("persona-buddy-visual-diagnostic")).toHaveTextContent(
+      "Visual pack did not load"
+    )
+    expect(screen.getByTestId("persona-buddy-visual-diagnostic")).toHaveTextContent(
+      "offline"
+    )
     expect(screen.queryByTestId("persona-visual-frame")).not.toBeInTheDocument()
+  })
+
+  it("reports missing visual assets while preserving the buddy text fallback", async () => {
+    const visualPack = buildVisualPack("persona-1")
+    visualMocks.listPersonaVisualPacks.mockResolvedValue({
+      packs: [visualPack],
+      active_pack: {
+        ...visualPack,
+        assets_by_id: {
+          "idle-asset": visualPack.assets_by_id["idle-asset"]
+        }
+      }
+    })
+
+    renderHost({
+      context: {
+        surface_id: "persona-garden",
+        surface_active: true,
+        active_persona_id: "persona-1",
+        position_bucket: "sidepanel-desktop",
+        persona_source: "route-local",
+        buddy_summary: buildBuddySummary("persona-1"),
+        active_tool_status: "Running notes.search"
+      },
+      root: "sidepanel"
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("persona-buddy-visual-diagnostic")).toHaveTextContent(
+        "Visual asset is missing"
+      )
+    })
+    expect(screen.getByTestId("persona-buddy-dock")).toHaveTextContent("Persona persona-1")
+    expect(screen.getByTestId("persona-buddy-visual-diagnostic")).toHaveTextContent(
+      "tool-asset"
+    )
   })
 })

--- a/apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/SpriteFrameRenderer.test.tsx
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/SpriteFrameRenderer.test.tsx
@@ -207,4 +207,59 @@ describe("SpriteFrameRenderer", () => {
     expect(screen.getByText("Buddy")).toBeInTheDocument()
     expect(onRenderError).toHaveBeenCalledWith("missing_asset")
   })
+
+  it("clears onRenderError when a previous render failure becomes renderable", () => {
+    const onRenderError = vi.fn()
+    const view = render(
+      <SpriteFrameRenderer
+        manifest={baseManifest()}
+        assets={{}}
+        state="idle"
+        fallbackLabel="Buddy"
+        onRenderError={onRenderError}
+      />
+    )
+
+    expect(onRenderError).toHaveBeenLastCalledWith("missing_asset")
+
+    view.rerender(
+      <SpriteFrameRenderer
+        manifest={baseManifest()}
+        assets={assets}
+        state="idle"
+        fallbackLabel="Buddy"
+        onRenderError={onRenderError}
+      />
+    )
+
+    expect(onRenderError).toHaveBeenLastCalledWith(null)
+    expect(currentFrame()).toHaveAttribute("src", expect.stringContaining("/assets/idle-1.png"))
+  })
+
+  it("reports unsupported regions before trying to render them", () => {
+    const onRenderError = vi.fn()
+    render(
+      <SpriteFrameRenderer
+        manifest={baseManifest({
+          animations: {
+            idle: {
+              frames: [
+                {
+                  asset_id: "idle-1",
+                  region: { x: 0, y: 0, width: 0, height: 32 }
+                }
+              ]
+            }
+          }
+        })}
+        assets={assets}
+        state="idle"
+        fallbackLabel="Buddy"
+        onRenderError={onRenderError}
+      />
+    )
+
+    expect(screen.getByText("Buddy")).toBeInTheDocument()
+    expect(onRenderError).toHaveBeenCalledWith("unsupported_region")
+  })
 })

--- a/apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/SpriteFrameRenderer.test.tsx
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/SpriteFrameRenderer.test.tsx
@@ -191,4 +191,20 @@ describe("SpriteFrameRenderer", () => {
     expect(screen.getByText("Buddy")).toBeInTheDocument()
     expect(onRenderError).toHaveBeenCalledWith("missing_animation")
   })
+
+  it("calls onRenderError when the resolved frame asset is missing", () => {
+    const onRenderError = vi.fn()
+    render(
+      <SpriteFrameRenderer
+        manifest={baseManifest()}
+        assets={{}}
+        state="idle"
+        fallbackLabel="Buddy"
+        onRenderError={onRenderError}
+      />
+    )
+
+    expect(screen.getByText("Buddy")).toBeInTheDocument()
+    expect(onRenderError).toHaveBeenCalledWith("missing_asset")
+  })
 })

--- a/apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/personaVisualDiagnostics.test.ts
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/personaVisualDiagnostics.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest"
+
+import type { PersonaVisualPack } from "@/types/persona-visuals"
+
+import {
+  getPrimaryPersonaVisualDiagnostic,
+  resolvePersonaVisualDiagnostics
+} from "../personaVisualDiagnostics"
+
+const buildPack = (
+  overrides: Partial<PersonaVisualPack> = {}
+): PersonaVisualPack => ({
+  id: "pack-1",
+  persona_id: "persona-1",
+  title: "Reliable buddy",
+  renderer_type: "sprite_frames",
+  status: "active",
+  manifest: {
+    manifest_version: 1,
+    renderer_type: "sprite_frames",
+    states: {
+      idle: { animation_id: "idle" },
+      tool_running: { animation_id: "tool" }
+    },
+    animations: {
+      idle: {
+        frames: [{ asset_id: "idle-asset", duration_ms: 100 }]
+      },
+      tool: {
+        frames: [{ asset_id: "tool-asset", duration_ms: 100 }]
+      }
+    },
+    fallbacks: {
+      thinking: ["idle"]
+    }
+  },
+  assets_by_id: {
+    "idle-asset": {
+      id: "idle-asset",
+      asset_role: "frame",
+      url: "/assets/idle.png",
+      mime_type: "image/png"
+    },
+    "tool-asset": {
+      id: "tool-asset",
+      asset_role: "frame",
+      url: "/assets/tool.png",
+      mime_type: "image/png"
+    }
+  },
+  ...overrides
+})
+
+describe("resolvePersonaVisualDiagnostics", () => {
+  it("reports no active pack when requested", () => {
+    expect(
+      resolvePersonaVisualDiagnostics({
+        pack: null,
+        includeNoActivePack: true
+      })
+    ).toEqual([
+      expect.objectContaining({
+        code: "no_active_pack",
+        severity: "info"
+      })
+    ])
+  })
+
+  it("reports active pack load failures", () => {
+    expect(
+      getPrimaryPersonaVisualDiagnostic({
+        loadStatus: "error",
+        loadError: new Error("offline"),
+        pack: null
+      })
+    ).toEqual(
+      expect.objectContaining({
+        code: "load_failed",
+        severity: "warning",
+        message: expect.stringContaining("offline")
+      })
+    )
+  })
+
+  it("reports unsupported renderer types", () => {
+    expect(
+      getPrimaryPersonaVisualDiagnostic({
+        pack: buildPack({ renderer_type: "live2d" })
+      })
+    ).toEqual(
+      expect.objectContaining({
+        code: "unsupported_renderer",
+        severity: "warning"
+      })
+    )
+  })
+
+  it("reports missing manifests", () => {
+    expect(
+      getPrimaryPersonaVisualDiagnostic({
+        pack: buildPack({ manifest: null as unknown as PersonaVisualPack["manifest"] })
+      })
+    ).toEqual(
+      expect.objectContaining({
+        code: "missing_manifest",
+        severity: "error"
+      })
+    )
+  })
+
+  it("reports missing asset maps", () => {
+    expect(
+      getPrimaryPersonaVisualDiagnostic({
+        pack: buildPack({ assets_by_id: {}, assets: [] })
+      })
+    ).toEqual(
+      expect.objectContaining({
+        code: "missing_assets",
+        severity: "error"
+      })
+    )
+  })
+
+  it("reports missing animations for the requested state", () => {
+    expect(
+      getPrimaryPersonaVisualDiagnostic({
+        pack: buildPack({
+          manifest: {
+            ...buildPack().manifest,
+            states: {},
+            fallbacks: {}
+          }
+        }),
+        visualState: "thinking"
+      })
+    ).toEqual(
+      expect.objectContaining({
+        code: "missing_animation",
+        severity: "error"
+      })
+    )
+  })
+
+  it("reports missing assets referenced by resolved animations", () => {
+    expect(
+      getPrimaryPersonaVisualDiagnostic({
+        pack: buildPack({
+          assets_by_id: {
+            "idle-asset": {
+              id: "idle-asset",
+              asset_role: "frame",
+              url: "/assets/idle.png",
+              mime_type: "image/png"
+            }
+          }
+        }),
+        visualState: "tool_running"
+      })
+    ).toEqual(
+      expect.objectContaining({
+        code: "missing_asset",
+        severity: "error",
+        message: expect.stringContaining("tool-asset")
+      })
+    )
+  })
+
+  it("returns no diagnostics for a renderable sprite-frame pack", () => {
+    expect(resolvePersonaVisualDiagnostics({ pack: buildPack() })).toEqual([])
+  })
+})

--- a/apps/packages/ui/src/components/Common/PersonaBuddy/personaVisualDiagnostics.ts
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/personaVisualDiagnostics.ts
@@ -1,0 +1,221 @@
+import type {
+  PersonaVisualAnimation,
+  PersonaVisualAsset,
+  PersonaVisualFrame,
+  PersonaVisualPack,
+  PersonaVisualStateId
+} from "@/types/persona-visuals"
+
+export type PersonaVisualDiagnosticCode =
+  | "load_failed"
+  | "no_active_pack"
+  | "unsupported_renderer"
+  | "missing_manifest"
+  | "missing_assets"
+  | "missing_animation"
+  | "missing_asset"
+  | "unsupported_region"
+
+export type PersonaVisualDiagnosticSeverity = "info" | "warning" | "error"
+
+export type PersonaVisualDiagnostic = {
+  code: PersonaVisualDiagnosticCode
+  severity: PersonaVisualDiagnosticSeverity
+  title: string
+  message: string
+  actionLabel?: string
+}
+
+export type PersonaVisualDiagnosticsInput = {
+  pack?: PersonaVisualPack | null
+  visualState?: PersonaVisualStateId
+  loadStatus?: "idle" | "loading" | "loaded" | "error"
+  loadError?: unknown
+  renderError?: PersonaVisualDiagnosticCode | null
+  includeNoActivePack?: boolean
+}
+
+type ResolvedAnimation = {
+  animation: PersonaVisualAnimation
+  animationId: string
+}
+
+const SUPPORTED_RUNTIME_RENDERERS = new Set(["sprite_frames"])
+
+const createDiagnostic = (
+  code: PersonaVisualDiagnosticCode,
+  severity: PersonaVisualDiagnosticSeverity,
+  title: string,
+  message: string,
+  actionLabel = "Open Visuals"
+): PersonaVisualDiagnostic => ({
+  code,
+  severity,
+  title,
+  message,
+  actionLabel
+})
+
+const getErrorMessage = (error: unknown): string => {
+  if (error instanceof Error && error.message.trim()) return error.message.trim()
+  if (typeof error === "string" && error.trim()) return error.trim()
+  return "The active visual pack could not be loaded."
+}
+
+const getAssetsById = (
+  pack: PersonaVisualPack | null | undefined
+): Record<string, PersonaVisualAsset> => {
+  if (!pack) return {}
+  if (pack.assets_by_id && Object.keys(pack.assets_by_id).length > 0) {
+    return pack.assets_by_id
+  }
+  const assets: Record<string, PersonaVisualAsset> = {}
+  for (const asset of pack.assets || []) {
+    if (asset?.id) assets[asset.id] = asset
+  }
+  return assets
+}
+
+const normalizeFrames = (
+  animation: PersonaVisualAnimation | null | undefined
+): PersonaVisualFrame[] => {
+  if (!animation) return []
+  if (Array.isArray(animation.frames) && animation.frames.length > 0) {
+    return animation.frames.filter((frame) => Boolean(frame?.asset_id))
+  }
+  return (animation.asset_ids || [])
+    .filter((assetId) => Boolean(String(assetId || "").trim()))
+    .map((assetId) => ({ asset_id: String(assetId) }))
+}
+
+const resolveAnimationForState = (
+  pack: PersonaVisualPack,
+  visualState: PersonaVisualStateId
+): ResolvedAnimation | null => {
+  const manifest = pack.manifest
+  const stateOrder = [
+    visualState,
+    ...(manifest.fallbacks?.[visualState] || []),
+    ...(visualState === "idle" ? [] : ["idle" as PersonaVisualStateId])
+  ]
+
+  for (const state of stateOrder) {
+    const animationId = manifest.states?.[state]?.animation_id
+    if (!animationId) continue
+    const animation = manifest.animations?.[animationId]
+    if (animation) return { animation, animationId }
+  }
+  return null
+}
+
+export const resolvePersonaVisualDiagnostics = ({
+  pack = null,
+  visualState = "idle",
+  loadStatus = "idle",
+  loadError = null,
+  renderError = null,
+  includeNoActivePack = false
+}: PersonaVisualDiagnosticsInput = {}): PersonaVisualDiagnostic[] => {
+  if (loadStatus === "error") {
+    return [
+      createDiagnostic(
+        "load_failed",
+        "warning",
+        "Visual pack did not load",
+        getErrorMessage(loadError)
+      )
+    ]
+  }
+
+  if (!pack) {
+    return includeNoActivePack
+      ? [
+          createDiagnostic(
+            "no_active_pack",
+            "info",
+            "No active visual pack",
+            "This persona is using the text Buddy fallback until a visual pack is activated."
+          )
+        ]
+      : []
+  }
+
+  if (!SUPPORTED_RUNTIME_RENDERERS.has(pack.renderer_type)) {
+    return [
+      createDiagnostic(
+        "unsupported_renderer",
+        "warning",
+        "Visual renderer is not supported here",
+        `The Buddy runtime cannot render ${pack.renderer_type} packs yet.`
+      )
+    ]
+  }
+
+  if (!pack.manifest) {
+    return [
+      createDiagnostic(
+        "missing_manifest",
+        "error",
+        "Visual pack manifest is missing",
+        "The active visual pack needs a manifest before Buddy can render it."
+      )
+    ]
+  }
+
+  const assetsById = getAssetsById(pack)
+  if (Object.keys(assetsById).length === 0) {
+    return [
+      createDiagnostic(
+        "missing_assets",
+        "error",
+        "Visual pack has no assets",
+        "The active visual pack references no uploaded assets."
+      )
+    ]
+  }
+
+  const resolved = resolveAnimationForState(pack, visualState)
+  const frames = normalizeFrames(resolved?.animation)
+  if (!resolved || frames.length === 0 || renderError === "missing_animation") {
+    return [
+      createDiagnostic(
+        "missing_animation",
+        "error",
+        "Visual animation is missing",
+        `No renderable animation was found for the ${visualState} state.`
+      )
+    ]
+  }
+
+  const missingFrame = frames.find((frame) => !assetsById[frame.asset_id])
+  if (missingFrame || renderError === "missing_asset") {
+    const assetId = missingFrame?.asset_id
+    return [
+      createDiagnostic(
+        "missing_asset",
+        "error",
+        "Visual asset is missing",
+        assetId
+          ? `The ${resolved.animationId} animation references missing asset ${assetId}.`
+          : `The ${resolved.animationId} animation references an asset Buddy cannot load.`
+      )
+    ]
+  }
+
+  if (renderError === "unsupported_region") {
+    return [
+      createDiagnostic(
+        "unsupported_region",
+        "warning",
+        "Visual frame region is unsupported",
+        "Buddy fell back because this frame uses an unsupported sprite region."
+      )
+    ]
+  }
+
+  return []
+}
+
+export const getPrimaryPersonaVisualDiagnostic = (
+  input: PersonaVisualDiagnosticsInput = {}
+): PersonaVisualDiagnostic | null => resolvePersonaVisualDiagnostics(input)[0] ?? null

--- a/apps/packages/ui/src/components/Common/PersonaBuddy/personaVisualDiagnostics.ts
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/personaVisualDiagnostics.ts
@@ -62,7 +62,7 @@ const getErrorMessage = (error: unknown): string => {
   return "The active visual pack could not be loaded."
 }
 
-const getAssetsById = (
+export const getAssetsById = (
   pack: PersonaVisualPack | null | undefined
 ): Record<string, PersonaVisualAsset> => {
   if (!pack) return {}
@@ -76,7 +76,7 @@ const getAssetsById = (
   return assets
 }
 
-const normalizeFrames = (
+export const normalizeFrames = (
   animation: PersonaVisualAnimation | null | undefined
 ): PersonaVisualFrame[] => {
   if (!animation) return []
@@ -86,6 +86,18 @@ const normalizeFrames = (
   return (animation.asset_ids || [])
     .filter((assetId) => Boolean(String(assetId || "").trim()))
     .map((assetId) => ({ asset_id: String(assetId) }))
+}
+
+export const getPersonaVisualDiagnosticToneClassName = (
+  severity: PersonaVisualDiagnosticSeverity
+): string => {
+  if (severity === "error") {
+    return "border-danger/30 bg-danger/10 text-danger"
+  }
+  if (severity === "warning") {
+    return "border-warn/30 bg-warn/10 text-warn"
+  }
+  return "border-primary/30 bg-primary/10 text-primary"
 }
 
 const resolveAnimationForState = (

--- a/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
@@ -50,6 +50,10 @@ import type {
   PersonaVisualStateId
 } from "@/types/persona-visuals"
 import { getDesignSystemState } from "@/design-system"
+import {
+  getPrimaryPersonaVisualDiagnostic,
+  type PersonaVisualDiagnostic
+} from "../Common/PersonaBuddy/personaVisualDiagnostics"
 
 type VisualPackEditorProps = {
   selectedPersonaId: string
@@ -352,6 +356,19 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
   const validationErrors = React.useMemo(
     () => validateManifestForActivation(draftManifest),
     [draftManifest]
+  )
+  const packHealthDiagnostic: PersonaVisualDiagnostic | null = React.useMemo(
+    () =>
+      selectedPack
+        ? getPrimaryPersonaVisualDiagnostic({
+            pack: {
+              ...selectedPack,
+              manifest: draftManifest
+            },
+            visualState: "idle"
+          })
+        : null,
+    [draftManifest, selectedPack]
   )
 
   const loadPacks = React.useCallback(async (): Promise<boolean> => {
@@ -1155,6 +1172,18 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
             </Tag>
             <span className="font-medium text-text">{selectedPack.title}</span>
             <span className="text-text-muted">{`v${selectedPack.version ?? 1}`}</span>
+          </div>
+        ) : null}
+        {packHealthDiagnostic ? (
+          <div
+            data-testid="persona-visual-pack-health"
+            data-severity={packHealthDiagnostic.severity}
+            className="mt-3 rounded-md border border-border bg-bg px-3 py-2 text-xs leading-5 text-text-muted"
+          >
+            <div className="font-medium text-text">
+              {packHealthDiagnostic.title}
+            </div>
+            <div>{packHealthDiagnostic.message}</div>
           </div>
         ) : null}
       </div>

--- a/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
@@ -51,6 +51,7 @@ import type {
 } from "@/types/persona-visuals"
 import { getDesignSystemState } from "@/design-system"
 import {
+  getPersonaVisualDiagnosticToneClassName,
   getPrimaryPersonaVisualDiagnostic,
   type PersonaVisualDiagnostic
 } from "../Common/PersonaBuddy/personaVisualDiagnostics"
@@ -1178,9 +1179,9 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
           <div
             data-testid="persona-visual-pack-health"
             data-severity={packHealthDiagnostic.severity}
-            className="mt-3 rounded-md border border-border bg-bg px-3 py-2 text-xs leading-5 text-text-muted"
+            className={`mt-3 rounded-md border px-3 py-2 text-xs leading-5 ${getPersonaVisualDiagnosticToneClassName(packHealthDiagnostic.severity)}`}
           >
-            <div className="font-medium text-text">
+            <div className="font-medium text-inherit">
               {packHealthDiagnostic.title}
             </div>
             <div>{packHealthDiagnostic.message}</div>

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
@@ -203,6 +203,50 @@ describe("VisualPackEditor", () => {
     )
   })
 
+  it("shows selected pack health diagnostics from the shared visual pack classifier", async () => {
+    const pack = {
+      id: "pack-1",
+      persona_id: "persona-1",
+      title: "Animated pack",
+      renderer_type: "sprite_frames",
+      status: "active",
+      manifest: structuredClone(baseManifest),
+      assets: [visualAssets[0]],
+      version: 3
+    }
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string }) => {
+      const method = init?.method || "GET"
+      if (path === "/api/v1/persona/profiles/persona-1/visual-packs" && method === "GET") {
+        return okResponse([pack])
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/pack-1/generated-candidates" &&
+        method === "GET"
+      ) {
+        return okResponse({ candidates: [] })
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        error: `Unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(
+      <VisualPackEditor
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Garden Helper"
+        isActive
+      />
+    )
+
+    const health = await screen.findByTestId("persona-visual-pack-health")
+    expect(health).toHaveTextContent("Visual asset is missing")
+    expect(health).toHaveTextContent("asset-b")
+  })
+
   it("loads pack list, creates a draft pack, and uploads the selected asset role", async () => {
     let packs: any[] = []
     const uploadedAssets: any[] = []

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
@@ -245,6 +245,8 @@ describe("VisualPackEditor", () => {
     const health = await screen.findByTestId("persona-visual-pack-health")
     expect(health).toHaveTextContent("Visual asset is missing")
     expect(health).toHaveTextContent("asset-b")
+    expect(health).toHaveClass("border-danger/30")
+    expect(health).toHaveClass("text-danger")
   })
 
   it("loads pack list, creates a draft pack, and uploads the selected asset role", async () => {

--- a/backlog/tasks/task-177 - Address-PR-1433-Persona-Buddy-visual-diagnostics-review-comments.md
+++ b/backlog/tasks/task-177 - Address-PR-1433-Persona-Buddy-visual-diagnostics-review-comments.md
@@ -1,0 +1,72 @@
+---
+id: TASK-177
+title: Address PR 1433 Persona/Buddy visual diagnostics review comments
+status: Done
+assignee:
+  - Codex
+created_date: '2026-05-09 18:54'
+updated_date: '2026-05-09 18:59'
+labels:
+  - WebUI
+  - Persona
+  - Buddy
+  - review
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1433'
+  - 'https://github.com/rmusser01/tldw_server/issues/1430'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix actionable review feedback on PR #1433 for the Persona/Buddy visual pack diagnostics slice. Review surface contains Gemini suggestions to export/reuse diagnostics helpers, address unreachable unsupported_region handling, and style health summaries by severity, plus a Qodo correctness bug where renderer errors can remain latched after a later successful render.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 SpriteFrameRenderer can clear prior render diagnostics when rendering becomes healthy again.
+- [x] #2 BuddyShellHost clears stale visual render errors for the current render key without hiding valid current errors.
+- [x] #3 Shared diagnostics helpers are exported and reused by Buddy runtime/renderer where practical.
+- [x] #4 The unsupported_region diagnostic path is either reachable from renderer validation or removed/commented with clear rationale.
+- [x] #5 Persona Visuals editor health summary styling reflects diagnostic severity.
+- [x] #6 Focused tests cover stale render-error recovery plus the review-fix behavior.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Review-fix plan:
+1. Add/adjust tests first for stale render diagnostics recovery, severity styling, and shared helper reuse behavior where observable.
+2. Export `getAssetsById` and `normalizeFrames` from `personaVisualDiagnostics.ts`; import them in `BuddyShellDock` and `SpriteFrameRenderer` to remove duplicate asset/frame normalization.
+3. Change `SpriteFrameRenderer.onRenderError` to accept `PersonaVisualRenderError | null` and emit null when a frame becomes renderable.
+4. Update `BuddyShellHost` to clear current-key render errors when the renderer reports null, while preserving keyed error behavior for current failures.
+5. Make `unsupported_region` reachable by validating sprite regions before rendering, returning the fallback and callback when region geometry is invalid.
+6. Apply severity-specific styling in Buddy and Persona Visuals diagnostics boxes.
+7. Run focused Vitest coverage and diff checks, then push the review-fix commit and resolve/comment on the review threads.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented PR #1433 review fixes in .worktrees/persona-buddy-visual-diagnostics: exported and reused visual diagnostics helpers, made SpriteFrameRenderer emit null on healthy renders, cleared BuddyShellHost current-key render errors on success, added sprite-region validation for unsupported_region, and applied severity tone classes to Buddy/Persona Visuals diagnostic boxes.
+
+Verification: apps/packages/ui targeted Vitest passed for SpriteFrameRenderer.test.tsx and VisualPackEditor.test.tsx (19 tests); broader focused Vitest passed for personaVisualDiagnostics.test.ts, BuddyShellHost.test.tsx, SpriteFrameRenderer.test.tsx, and VisualPackEditor.test.tsx (45 tests). git diff --check passed. Full UI tsc still fails on existing unrelated baseline errors; filtered tsc output for PersonaBuddy/VisualPackEditor/SpriteFrameRenderer/BuddyShell paths was empty. Bandit not applicable because this review-fix touched frontend TypeScript/TSX only.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed the actionable PR #1433 review feedback for Persona/Buddy visual diagnostics. SpriteFrameRenderer now reports unsupported sprite regions and emits a null success signal so BuddyShellHost can clear stale current-key render diagnostics. Shared visual diagnostics helpers are exported and reused by the Buddy dock/renderer, and diagnostic UI surfaces now use severity-specific tone classes. Added regression coverage for stale render recovery, unsupported regions, and Persona Visuals health severity styling.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Adds a shared Persona Visuals diagnostics classifier for active-pack load failures, unsupported renderers, missing manifests/assets, and missing animations.
- Surfaces compact diagnostics in the Buddy runtime while preserving the text fallback and Visuals workflow link.
- Reuses the same diagnostics in the Persona Visuals editor selected-pack health panel.

## Test Plan
- ./node_modules/.bin/vitest run src/components/Common/PersonaBuddy/__tests__/personaVisualDiagnostics.test.ts src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx src/components/Common/PersonaBuddy/__tests__/SpriteFrameRenderer.test.tsx src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
- git diff --check
- ./node_modules/.bin/tsc -p tsconfig.json --noEmit --pretty false 2>&1 | rg "PersonaBuddy|VisualPackEditor|personaVisualDiagnostics"

## Notes
- Closes #1430.
- Full UI package `tsc -p tsconfig.json --noEmit` still reports existing repo-wide baseline errors outside this touched Persona/Buddy slice.
- AI-generated PR merge gate: human Change summary still required before this PR is merge-ready.