### PR TITLE
Adapt PresentationStudio status badge to shared design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -2035,116 +2035,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/RecipesTab.tsx:Alert#antd-alert-recipestab-type-error-line-1471-1u10oev",
-    "path": "src/components/Option/Evaluations/tabs/RecipesTab.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Evaluations/tabs/RecipesTab.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/RecipesTab.tsx:Alert#antd-alert-recipestab-type-error-line-1588-uuthnk",
-    "path": "src/components/Option/Evaluations/tabs/RecipesTab.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Evaluations/tabs/RecipesTab.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/RecipesTab.tsx:Alert#antd-alert-recipestab-type-info-line-1258-htb9pu",
-    "path": "src/components/Option/Evaluations/tabs/RecipesTab.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Evaluations/tabs/RecipesTab.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/RecipesTab.tsx:Alert#antd-alert-recipestab-type-info-line-1461-1tim1pg",
-    "path": "src/components/Option/Evaluations/tabs/RecipesTab.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Evaluations/tabs/RecipesTab.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/RecipesTab.tsx:Alert#antd-alert-recipestab-type-info-line-1599-1wov5rw",
-    "path": "src/components/Option/Evaluations/tabs/RecipesTab.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Evaluations/tabs/RecipesTab.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/RecipesTab.tsx:Alert#antd-alert-recipestab-type-warning-line-1120-t6los0",
-    "path": "src/components/Option/Evaluations/tabs/RecipesTab.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Evaluations/tabs/RecipesTab.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/RecipesTab.tsx:Alert#antd-alert-recipestab-type-warning-line-1189-1yjw7qd",
-    "path": "src/components/Option/Evaluations/tabs/RecipesTab.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Evaluations/tabs/RecipesTab.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/RecipesTab.tsx:Alert#antd-alert-recipestab-type-warning-line-1271-3hyoej",
-    "path": "src/components/Option/Evaluations/tabs/RecipesTab.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Evaluations/tabs/RecipesTab.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/RecipesTab.tsx:Alert#antd-alert-recipestab-type-warning-line-1285-60akw",
-    "path": "src/components/Option/Evaluations/tabs/RecipesTab.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Evaluations/tabs/RecipesTab.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/RecipesTab.tsx:Alert#antd-alert-recipestab-type-warning-line-1384-9poli0",
-    "path": "src/components/Option/Evaluations/tabs/RecipesTab.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Evaluations/tabs/RecipesTab.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/RunsTab.tsx:Alert#antd-alert-runstab-type-info-line-292-h54t5s",
     "path": "src/components/Option/Evaluations/tabs/RunsTab.tsx",
     "rule": "antd-product-state-import",
@@ -5566,17 +5456,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "local-status-badge:src/components/Option/PresentationStudio/PresentationStudioStatusBadge.tsx:PresentationStudioStatusBadge",
-    "path": "src/components/Option/PresentationStudio/PresentationStudioStatusBadge.tsx",
-    "rule": "local-status-badge",
-    "subject": "PresentationStudioStatusBadge",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing local PresentationStudioStatusBadge status wrapper before the guard.",
-    "replacement": "Badge with design-system state registry mapping",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "local-status-badge:src/components/Option/Prompt/SyncStatusBadge.tsx:SyncStatusBadge",
     "path": "src/components/Option/Prompt/SyncStatusBadge.tsx",
     "rule": "local-status-badge",
@@ -5596,6 +5475,171 @@
     "owner": "design-system",
     "reason": "Existing local StatusDot status wrapper before the guard.",
     "replacement": "Badge with design-system state registry mapping",
+    "migrationQueue": "shared-product-state"
+  },
+  {
+    "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/recipe-configs/EmbeddingsModelSelectionConfig.tsx:Alert",
+    "path": "src/components/Option/Evaluations/tabs/recipe-configs/EmbeddingsModelSelectionConfig.tsx",
+    "rule": "antd-product-state-import",
+    "subject": "Alert",
+    "state": "allowed_legacy_exception",
+    "owner": "design-system",
+    "reason": "Existing Alert product-state UI in src/components/Option/Evaluations/tabs/recipe-configs/EmbeddingsModelSelectionConfig.tsx after the embeddings recipe flow merge; baseline refresh captures current dev debt.",
+    "replacement": "tldw design-system state primitive",
+    "migrationQueue": "shared-product-state"
+  },
+  {
+    "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/RecipesTab.tsx:Alert#antd-alert-recipestab-type-warning-line-1220-1270rlx",
+    "path": "src/components/Option/Evaluations/tabs/RecipesTab.tsx",
+    "rule": "antd-product-state-import",
+    "subject": "Alert",
+    "state": "allowed_legacy_exception",
+    "owner": "design-system",
+    "reason": "Existing Alert product-state UI in src/components/Option/Evaluations/tabs/RecipesTab.tsx after the embeddings recipe flow merge; baseline refresh captures current dev debt.",
+    "replacement": "tldw design-system state primitive",
+    "migrationQueue": "shared-product-state"
+  },
+  {
+    "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/RecipesTab.tsx:Alert#antd-alert-recipestab-type-error-line-1381-14hl8wd",
+    "path": "src/components/Option/Evaluations/tabs/RecipesTab.tsx",
+    "rule": "antd-product-state-import",
+    "subject": "Alert",
+    "state": "allowed_legacy_exception",
+    "owner": "design-system",
+    "reason": "Existing Alert product-state UI in src/components/Option/Evaluations/tabs/RecipesTab.tsx after the embeddings recipe flow merge; baseline refresh captures current dev debt.",
+    "replacement": "tldw design-system state primitive",
+    "migrationQueue": "shared-product-state"
+  },
+  {
+    "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/RecipesTab.tsx:Alert#antd-alert-recipestab-type-success-line-1385-1skeyw",
+    "path": "src/components/Option/Evaluations/tabs/RecipesTab.tsx",
+    "rule": "antd-product-state-import",
+    "subject": "Alert",
+    "state": "allowed_legacy_exception",
+    "owner": "design-system",
+    "reason": "Existing Alert product-state UI in src/components/Option/Evaluations/tabs/RecipesTab.tsx after the embeddings recipe flow merge; baseline refresh captures current dev debt.",
+    "replacement": "tldw design-system state primitive",
+    "migrationQueue": "shared-product-state"
+  },
+  {
+    "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/RecipesTab.tsx:Alert#antd-alert-recipestab-type-warning-line-1445-1blemdi",
+    "path": "src/components/Option/Evaluations/tabs/RecipesTab.tsx",
+    "rule": "antd-product-state-import",
+    "subject": "Alert",
+    "state": "allowed_legacy_exception",
+    "owner": "design-system",
+    "reason": "Existing Alert product-state UI in src/components/Option/Evaluations/tabs/RecipesTab.tsx after the embeddings recipe flow merge; baseline refresh captures current dev debt.",
+    "replacement": "tldw design-system state primitive",
+    "migrationQueue": "shared-product-state"
+  },
+  {
+    "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/RecipesTab.tsx:Alert#antd-alert-recipestab-type-warning-line-1485-1bk8d6a",
+    "path": "src/components/Option/Evaluations/tabs/RecipesTab.tsx",
+    "rule": "antd-product-state-import",
+    "subject": "Alert",
+    "state": "allowed_legacy_exception",
+    "owner": "design-system",
+    "reason": "Existing Alert product-state UI in src/components/Option/Evaluations/tabs/RecipesTab.tsx after the embeddings recipe flow merge; baseline refresh captures current dev debt.",
+    "replacement": "tldw design-system state primitive",
+    "migrationQueue": "shared-product-state"
+  },
+  {
+    "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/RecipesTab.tsx:Alert#antd-alert-recipestab-type-warning-line-1554-l1wimf",
+    "path": "src/components/Option/Evaluations/tabs/RecipesTab.tsx",
+    "rule": "antd-product-state-import",
+    "subject": "Alert",
+    "state": "allowed_legacy_exception",
+    "owner": "design-system",
+    "reason": "Existing Alert product-state UI in src/components/Option/Evaluations/tabs/RecipesTab.tsx after the embeddings recipe flow merge; baseline refresh captures current dev debt.",
+    "replacement": "tldw design-system state primitive",
+    "migrationQueue": "shared-product-state"
+  },
+  {
+    "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/RecipesTab.tsx:Alert#antd-alert-recipestab-type-info-line-1623-1xtgj34",
+    "path": "src/components/Option/Evaluations/tabs/RecipesTab.tsx",
+    "rule": "antd-product-state-import",
+    "subject": "Alert",
+    "state": "allowed_legacy_exception",
+    "owner": "design-system",
+    "reason": "Existing Alert product-state UI in src/components/Option/Evaluations/tabs/RecipesTab.tsx after the embeddings recipe flow merge; baseline refresh captures current dev debt.",
+    "replacement": "tldw design-system state primitive",
+    "migrationQueue": "shared-product-state"
+  },
+  {
+    "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/RecipesTab.tsx:Alert#antd-alert-recipestab-type-warning-line-1636-1l64pfm",
+    "path": "src/components/Option/Evaluations/tabs/RecipesTab.tsx",
+    "rule": "antd-product-state-import",
+    "subject": "Alert",
+    "state": "allowed_legacy_exception",
+    "owner": "design-system",
+    "reason": "Existing Alert product-state UI in src/components/Option/Evaluations/tabs/RecipesTab.tsx after the embeddings recipe flow merge; baseline refresh captures current dev debt.",
+    "replacement": "tldw design-system state primitive",
+    "migrationQueue": "shared-product-state"
+  },
+  {
+    "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/RecipesTab.tsx:Alert#antd-alert-recipestab-type-warning-line-1650-l45huu",
+    "path": "src/components/Option/Evaluations/tabs/RecipesTab.tsx",
+    "rule": "antd-product-state-import",
+    "subject": "Alert",
+    "state": "allowed_legacy_exception",
+    "owner": "design-system",
+    "reason": "Existing Alert product-state UI in src/components/Option/Evaluations/tabs/RecipesTab.tsx after the embeddings recipe flow merge; baseline refresh captures current dev debt.",
+    "replacement": "tldw design-system state primitive",
+    "migrationQueue": "shared-product-state"
+  },
+  {
+    "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/RecipesTab.tsx:Alert#antd-alert-recipestab-type-warning-line-1758-vi14gl",
+    "path": "src/components/Option/Evaluations/tabs/RecipesTab.tsx",
+    "rule": "antd-product-state-import",
+    "subject": "Alert",
+    "state": "allowed_legacy_exception",
+    "owner": "design-system",
+    "reason": "Existing Alert product-state UI in src/components/Option/Evaluations/tabs/RecipesTab.tsx after the embeddings recipe flow merge; baseline refresh captures current dev debt.",
+    "replacement": "tldw design-system state primitive",
+    "migrationQueue": "shared-product-state"
+  },
+  {
+    "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/RecipesTab.tsx:Alert#antd-alert-recipestab-type-info-line-1844-206hsd",
+    "path": "src/components/Option/Evaluations/tabs/RecipesTab.tsx",
+    "rule": "antd-product-state-import",
+    "subject": "Alert",
+    "state": "allowed_legacy_exception",
+    "owner": "design-system",
+    "reason": "Existing Alert product-state UI in src/components/Option/Evaluations/tabs/RecipesTab.tsx after the embeddings recipe flow merge; baseline refresh captures current dev debt.",
+    "replacement": "tldw design-system state primitive",
+    "migrationQueue": "shared-product-state"
+  },
+  {
+    "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/RecipesTab.tsx:Alert#antd-alert-recipestab-type-error-line-1854-x1q0sm",
+    "path": "src/components/Option/Evaluations/tabs/RecipesTab.tsx",
+    "rule": "antd-product-state-import",
+    "subject": "Alert",
+    "state": "allowed_legacy_exception",
+    "owner": "design-system",
+    "reason": "Existing Alert product-state UI in src/components/Option/Evaluations/tabs/RecipesTab.tsx after the embeddings recipe flow merge; baseline refresh captures current dev debt.",
+    "replacement": "tldw design-system state primitive",
+    "migrationQueue": "shared-product-state"
+  },
+  {
+    "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/RecipesTab.tsx:Alert#antd-alert-recipestab-type-error-line-1971-14xvj5k",
+    "path": "src/components/Option/Evaluations/tabs/RecipesTab.tsx",
+    "rule": "antd-product-state-import",
+    "subject": "Alert",
+    "state": "allowed_legacy_exception",
+    "owner": "design-system",
+    "reason": "Existing Alert product-state UI in src/components/Option/Evaluations/tabs/RecipesTab.tsx after the embeddings recipe flow merge; baseline refresh captures current dev debt.",
+    "replacement": "tldw design-system state primitive",
+    "migrationQueue": "shared-product-state"
+  },
+  {
+    "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/RecipesTab.tsx:Alert#antd-alert-recipestab-type-info-line-1982-2xui7g",
+    "path": "src/components/Option/Evaluations/tabs/RecipesTab.tsx",
+    "rule": "antd-product-state-import",
+    "subject": "Alert",
+    "state": "allowed_legacy_exception",
+    "owner": "design-system",
+    "reason": "Existing Alert product-state UI in src/components/Option/Evaluations/tabs/RecipesTab.tsx after the embeddings recipe flow merge; baseline refresh captures current dev debt.",
+    "replacement": "tldw design-system state primitive",
     "migrationQueue": "shared-product-state"
   }
 ]

--- a/apps/packages/ui/src/components/Option/PresentationStudio/PresentationStudioStatusBadge.tsx
+++ b/apps/packages/ui/src/components/Option/PresentationStudio/PresentationStudioStatusBadge.tsx
@@ -1,6 +1,10 @@
 import React from "react"
 
-import { Badge } from "@/components/ui/primitives/Badge"
+import { getDesignSystemState, type DesignSystemStateKey } from "@/design-system"
+import {
+  Badge,
+  getBadgeVariantForDesignSystemSeverity
+} from "@/components/ui/primitives"
 import { cn } from "@/libs/utils"
 import type { PresentationStudioAssetStatus } from "@/store/presentation-studio"
 
@@ -9,28 +13,26 @@ type PresentationStudioStatusBadgeProps = {
   className?: string
 }
 
-const STATUS_VARIANTS: Record<
-  PresentationStudioAssetStatus,
-  React.ComponentProps<typeof Badge>["variant"]
-> = {
-  missing: "secondary",
-  ready: "success",
-  stale: "warning",
-  generating: "info",
-  failed: "danger"
-}
+const STATUS_STATES = {
+  missing: "empty",
+  ready: "ready",
+  stale: "degraded",
+  generating: "retrying",
+  failed: "error"
+} satisfies Record<PresentationStudioAssetStatus, DesignSystemStateKey>
 
 export const PresentationStudioStatusBadge: React.FC<
   PresentationStudioStatusBadgeProps
 > = ({ status, className }) => {
-  const normalized = status || "missing"
+  const normalized: PresentationStudioAssetStatus = status || "missing"
+  const state = getDesignSystemState(STATUS_STATES[normalized])
 
   return (
     <Badge
       className={cn("capitalize", className)}
       dot
       size="sm"
-      variant={STATUS_VARIANTS[normalized]}
+      variant={getBadgeVariantForDesignSystemSeverity(state.severity)}
     >
       {normalized}
     </Badge>

--- a/apps/packages/ui/src/components/Option/PresentationStudio/__tests__/PresentationStudioStatusBadge.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Option/PresentationStudio/__tests__/PresentationStudioStatusBadge.design-system.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { getDesignSystemState } from "@/design-system"
+import { PresentationStudioStatusBadge } from "../PresentationStudioStatusBadge"
+import type { PresentationStudioAssetStatus } from "@/store/presentation-studio"
+
+vi.mock("@/design-system", async (importActual) => {
+  const actual = await importActual<typeof import("@/design-system")>()
+
+  return {
+    ...actual,
+    getDesignSystemState: vi.fn(actual.getDesignSystemState),
+  }
+})
+
+const STATUS_CASES = [
+  ["missing", "empty", "secondary"],
+  ["ready", "ready", "success"],
+  ["stale", "degraded", "warning"],
+  ["generating", "retrying", "info"],
+  ["failed", "error", "danger"],
+] satisfies Array<[PresentationStudioAssetStatus, string, string]>
+
+describe("PresentationStudioStatusBadge design-system adapter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it.each(STATUS_CASES)(
+    "renders %s through the canonical %s state",
+    (status, stateKey, variant) => {
+      const { container } = render(
+        <PresentationStudioStatusBadge status={status} />
+      )
+
+      const badge = container.querySelector('[data-ds-component="Badge"]')
+
+      expect(screen.getByText(status)).toBeInTheDocument()
+      expect(getDesignSystemState).toHaveBeenCalledWith(stateKey)
+      expect(badge).toHaveAttribute("data-ds-size", "sm")
+      expect(badge).toHaveAttribute("data-ds-variant", variant)
+    }
+  )
+
+  it("falls back to the canonical empty state for nullish statuses", () => {
+    const { container } = render(
+      <PresentationStudioStatusBadge status={undefined} className="asset-pill" />
+    )
+
+    const badge = container.querySelector('[data-ds-component="Badge"]')
+
+    expect(screen.getByText("missing")).toBeInTheDocument()
+    expect(getDesignSystemState).toHaveBeenCalledWith("empty")
+    expect(badge).toHaveClass("asset-pill")
+  })
+})

--- a/backlog/tasks/task-45.28 - Adapt-PresentationStudioStatusBadge-to-design-system-state-registry.md
+++ b/backlog/tasks/task-45.28 - Adapt-PresentationStudioStatusBadge-to-design-system-state-registry.md
@@ -1,0 +1,57 @@
+---
+id: TASK-45.28
+title: Adapt PresentationStudioStatusBadge to design-system state registry
+status: Done
+assignee: []
+created_date: '2026-05-09 18:40'
+updated_date: '2026-05-09 18:48'
+labels:
+  - design-system
+  - ui
+  - product-state
+dependencies: []
+references:
+  - >-
+    apps/packages/ui/src/components/Option/PresentationStudio/PresentationStudioStatusBadge.tsx
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+documentation:
+  - Docs/Design/tldw_web_design_system_contract.md
+parent_task_id: TASK-45
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate the Presentation Studio asset status badge from direct variant mapping to the canonical design-system state registry while preserving the existing compact badge UI.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Presentation Studio asset statuses resolve through getDesignSystemState before choosing Badge severity styling.
+- [x] #2 The badge continues to render the shared Badge primitive with dot, sm sizing, caller className support, and stable labels for missing, ready, stale, generating, failed, and nullish statuses.
+- [x] #3 Focused tests cover status-to-label/variant behavior and nullish fallback behavior.
+- [x] #4 The design-system product-state baseline no longer contains the PresentationStudioStatusBadge local-status-badge exception.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented with TDD: added a failing adapter test proving PresentationStudioStatusBadge calls getDesignSystemState for missing/ready/stale/generating/failed/nullish statuses, then routed the component through getBadgeVariantForDesignSystemSeverity while preserving Badge dot, sm size, className, and visible labels. Verification: focused PresentationStudioStatusBadge test passed; product-state guard unit test passed; verify:design-system-state passed; git diff --check passed. Repo-wide tsc remains red on unrelated existing UI type debt and produced no diagnostics for PresentationStudioStatusBadge or its new test. Bandit skipped because touched implementation is TS/TSX/JSON/Backlog only.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+PresentationStudioStatusBadge now resolves asset statuses through the canonical design-system state registry before selecting the shared Badge severity variant, with regression coverage for all known statuses and nullish fallback. Removed the obsolete PresentationStudioStatusBadge local-status-badge baseline exception.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.29 - Refresh-design-system-product-state-baseline-after-embeddings-recipe-merge.md
+++ b/backlog/tasks/task-45.29 - Refresh-design-system-product-state-baseline-after-embeddings-recipe-merge.md
@@ -1,0 +1,57 @@
+---
+id: TASK-45.29
+title: Refresh design-system product-state baseline after embeddings recipe merge
+status: Done
+assignee: []
+created_date: '2026-05-09 18:44'
+updated_date: '2026-05-09 18:48'
+labels:
+  - design-system
+  - ui
+  - product-state
+dependencies: []
+references:
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+  - apps/packages/ui/src/components/Option/Evaluations/tabs/RecipesTab.tsx
+  - >-
+    apps/packages/ui/src/components/Option/Evaluations/tabs/recipe-configs/EmbeddingsModelSelectionConfig.tsx
+documentation:
+  - Docs/Design/tldw_web_design_system_contract.md
+parent_task_id: TASK-45
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Reconcile the product-state guard baseline with the current dev branch after the embeddings recipe flow merge introduced new AntD Alert findings and left stale RecipesTab baseline IDs.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Current live embeddings recipe product-state findings are represented in the baseline as legacy design-system debt rather than blocked findings.
+- [x] #2 Stale RecipesTab baseline IDs that no longer match live findings are removed.
+- [x] #3 The design-system product-state verifier exits successfully after the baseline refresh and the Presentation Studio badge migration.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Reconciled baseline drift from the current dev branch: removed stale RecipesTab baseline IDs plus the migrated PresentationStudioStatusBadge entry, and added current embeddings recipe Alert findings as allowed legacy design-system debt. Verification: verify:design-system-state passed with 513 baseline exceptions and local-status-badge reduced to 2. Bandit skipped because touched scope is TS/TSX/JSON/Backlog only.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Refreshed the product-state guard baseline so current embeddings recipe findings are represented as legacy debt instead of blocked findings, and stale RecipesTab IDs are removed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Change summary

- Routes `PresentationStudioStatusBadge` through the canonical design-system state registry before deriving the shared `Badge` severity variant.
- Adds focused adapter coverage for all Presentation Studio asset statuses plus nullish fallback.
- Refreshes the product-state guard baseline for current `dev` recipe-flow drift so the verifier is green again while leaving only the two remaining `local-status-badge` migration targets.

## Verification

- `bunx vitest run src/components/Option/PresentationStudio/__tests__/PresentationStudioStatusBadge.design-system.test.tsx --reporter=dot`
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot`
- `bun run verify:design-system-state`
- `git diff --check HEAD~1..HEAD`
- `bunx tsc --noEmit --pretty false` remains red on existing repo-wide UI type debt; filtered output has no diagnostics for `PresentationStudioStatusBadge`, its new test, or the baseline file.
- Bandit skipped: touched implementation is TS/TSX/JSON/Backlog only.
