### PR TITLE
Remove dayjs from Media FilterPanel date range

### DIFF
--- a/Docs/Design/WebUI_Dependency_Audit.md
+++ b/Docs/Design/WebUI_Dependency_Audit.md
@@ -107,7 +107,7 @@ This audit does not remove packages or rewrite runtime code.
 | `cytoscape` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 6 | apps/packages/ui/src/components/Notes/NotesGraphModal.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesGraphModal.stage2.graph-view.test.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage21.accessibility-modal-focus.test.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage22.accessibility-regression.test.tsx | shared UI, shared UI tests | graph/rendering | `keep` | Low; import/config/package-script evidence in current WebUI or shared UI paths. | No immediate reduction; keep current behavior. | none |
 | `cytoscape-dagre` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 6 | apps/packages/ui/src/components/Notes/NotesGraphModal.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesGraphModal.stage2.graph-view.test.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage21.accessibility-modal-focus.test.tsx, apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage22.accessibility-regression.test.tsx | shared UI, shared UI tests | graph/rendering | `keep` | Low; import/config/package-script evidence in current WebUI or shared UI paths. | No immediate reduction; keep current behavior. | none |
 | `d3-dsv` | `web:dependencies`, `extension:dependencies` | 0 | none found | web app, extension impact declaration only | parser/conversion | `investigate-lockfile` | Medium; no import/config/package-script evidence, but package sits in parser/conversion behavior. Confirm direct-vs-transitive ownership and CSV/DSV coverage before removal. | Potential install/bundle reduction if direct declaration proves unused. | Lockfile/parser-domain investigation slice. |
-| `dayjs` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 5 | apps/packages/ui/src/components/Media/FilterPanel.tsx, apps/packages/ui/src/components/Option/Collections/ReadingList/ReadingItemsList.tsx, apps/packages/ui/src/components/Option/Items/ItemsWorkspace.tsx | shared UI | frontend/runtime | `defer-design` | Medium; remaining shared UI imports are Ant Design DatePicker/DateRangePicker value surfaces plus an Items published-date display use co-located with the Items date-filter contract. | No immediate dependency reduction until shared UI date-picker value contracts are redesigned or isolated and the final co-located display use is migrated. | Date-picker contract design before manifest removal. |
+| `dayjs` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 4 | apps/packages/ui/src/components/Option/Collections/ReadingList/ReadingItemsList.tsx, apps/packages/ui/src/components/Option/Items/ItemsWorkspace.tsx | shared UI | frontend/runtime | `defer-design` | Medium; remaining shared UI imports are Ant Design RangePicker value surfaces plus an Items published-date display use co-located with the Items date-filter contract. | No immediate dependency reduction until shared UI date-picker value contracts are redesigned or isolated and the final co-located display use is migrated. | Date-picker contract design before manifest removal. |
 | `dexie` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 6 | apps/packages/ui/src/db/dexie/chat.ts, apps/packages/ui/src/db/dexie/schema.ts, apps/packages/ui/src/hooks/document-workspace/__tests__/offlineQueue.test.ts, apps/packages/ui/src/hooks/document-workspace/offlineQueue.ts | shared UI, shared UI tests, web tests, web app | state/data | `keep` | Low; import/config/package-script evidence in current WebUI or shared UI paths. | No immediate reduction; keep current behavior. | none |
 | `dexie-react-hooks` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 1 | apps/packages/ui/src/components/Sidepanel/Chat/TtsClipsDrawer.tsx | shared UI | state/data | `keep` | Low; import/config/package-script evidence in current WebUI or shared UI paths. | No immediate reduction; keep current behavior. | none |
 | `dompurify` | `web:dependencies`, `shared-ui:peerDependencies`, `extension:dependencies` | 11 | apps/packages/ui/src/components/Common/CodeBlock.tsx, apps/packages/ui/src/components/Notes/NotesStudioDiagramCard.tsx, apps/packages/ui/src/components/Notes/export-utils.ts, apps/packages/ui/src/components/Option/Collections/ReadingList/ReadingItemDetail.tsx | shared UI | security/sanitization | `keep` | Low; import/config/package-script evidence in current WebUI or shared UI paths. | No immediate reduction; keep current behavior. | none |
@@ -242,6 +242,15 @@ This audit does not remove packages or rewrite runtime code.
   narrow slice was one active package-import surface removed and no direct
   manifest, lockfile, install-size, or bundle-size reduction until the
   remaining `dayjs` surfaces are migrated.
+- TASK-176 removed `dayjs` from the Media FilterPanel date-range filter by
+  replacing the Ant Design RangePicker/Dayjs state path with native date
+  inputs plus local `YYYY-MM-DD` parse/format helpers. The shared UI `dayjs`
+  import count dropped from 5 to 4 while leaving the package declared for
+  ReadingList and Items date-control value-contract surfaces plus the
+  co-located Items published-date display use. Expected impact for this narrow
+  slice was one active package-import surface removed and no direct manifest,
+  lockfile, install-size, or bundle-size reduction until the remaining
+  `dayjs` surfaces are migrated.
 
 ### Quick Cleanup Candidates
 
@@ -254,10 +263,10 @@ ownership checks, or complex-domain packages that should stay on the
 ### Replacement Candidates
 
 1. `dayjs`: remaining shared UI imports are Ant Design date-control value
-   surfaces in media, reading list, and items plus a co-located Items
-   published-date display use. Do not attempt a direct dependency removal until
-   the surfaces that pass or type `Dayjs` values are redesigned or isolated and
-   the final display use is migrated.
+   surfaces in reading list and items plus a co-located Items published-date
+   display use. Do not attempt a direct dependency removal until the surfaces
+   that pass or type `Dayjs` values are redesigned or isolated and the final
+   display use is migrated.
 
 ### Deferred Design Candidates
 
@@ -479,6 +488,32 @@ ownership checks, or complex-domain packages that should stay on the
   `apps/tldw-frontend` exited 0. Next compiled successfully, generated 138
   static pages, and `verify-shared-token-sync.mjs` reported OK for the
   generated CSS.
+- 2026-05-09 TASK-176 active-code scan: exact shared UI package-import scan
+  found 4 remaining `dayjs` import lines after removing the combined
+  runtime/type import from
+  `apps/packages/ui/src/components/Media/FilterPanel.tsx`. Remaining imports
+  are in ReadingList and Items date-control surfaces plus the co-located Items
+  published-date display use.
+- 2026-05-09 TASK-176 focused verification: `bunx vitest run
+  src/components/Media/__tests__/FilterPanel.test.tsx
+  src/components/Media/__tests__/FilterPanel.dayjs-imports.test.ts
+  --maxWorkers=1` from `apps/packages/ui` first failed on the missing native
+  labeled date inputs and five remaining `dayjs` imports, then passed after the
+  helper/input implementation. The focused suite covers native date input
+  display values, local start/end day-boundary ISO emission, independent
+  clearing, and the remaining import scan expectation.
+- 2026-05-09 TASK-176 WebUI build/lint verification:
+  `NEXT_PUBLIC_API_URL=http://127.0.0.1:8000 bun run compile` from
+  `apps/tldw-frontend` exited 0. Next compiled successfully, generated 138
+  static pages, and `verify-shared-token-sync.mjs` reported OK for the
+  generated CSS. `bun run lint` from `apps/tldw-frontend` exited 0 with the
+  existing 131-warning baseline.
+- 2026-05-09 TASK-176 TypeScript/diff verification:
+  `node_modules/.bin/tsc --noEmit --project tsconfig.json --pretty false` from
+  `apps/tldw-frontend` still exits 1 on existing baseline errors in
+  `EmbeddingsModelSelectionConfig.tsx` and `lib/api/vnPlay.ts`; filtering the
+  log for `FilterPanel`, `components/Media`, `Media/__tests__`, task-176, and
+  `WebUI_Dependency_Audit` returned no matches. `git diff --check` exited 0.
 - Bandit: skipped for TASK-144 because the slice changed documentation and
   Backlog metadata only; no Python files were modified.
 - Bandit: skipped for TASK-147 because the slice changed TypeScript,
@@ -494,6 +529,8 @@ ownership checks, or complex-domain packages that should stay on the
 - Bandit: skipped for TASK-168 because the slice changed TypeScript,
   documentation, and Backlog metadata only; no Python files were modified.
 - Bandit: skipped for TASK-171 because the slice changed TypeScript,
+  documentation, and Backlog metadata only; no Python files were modified.
+- Bandit: skipped for TASK-176 because the slice changed TypeScript,
   documentation, and Backlog metadata only; no Python files were modified.
 
 ## Known Skips And Blockers

--- a/apps/packages/ui/src/components/Media/FilterPanel.tsx
+++ b/apps/packages/ui/src/components/Media/FilterPanel.tsx
@@ -1,7 +1,6 @@
 import { ChevronDown, Filter, Plus, Star, Trash2 } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
-import dayjs, { type Dayjs } from 'dayjs'
-import { DatePicker, Select } from 'antd'
+import { Select } from 'antd'
 import { useTranslation } from 'react-i18next'
 import type {
   MediaBoostFields,
@@ -90,6 +89,50 @@ const getMediaTypeLabel = (type: string): string => {
     Url: 'URL'
   }
   return labelMap[normalized] || normalized
+}
+
+const DATE_INPUT_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/
+
+const formatDateInputValue = (value?: string | null): string => {
+  if (!value) return ''
+
+  const date = new Date(value)
+  if (!Number.isFinite(date.getTime())) return ''
+
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+const parseDateInputValue = (
+  value: string,
+  boundary: 'start' | 'end'
+): string | null => {
+  if (!value) return null
+
+  const match = DATE_INPUT_PATTERN.exec(value)
+  if (!match) return null
+
+  const [, yearText, monthText, dayText] = match
+  const year = Number(yearText)
+  const month = Number(monthText)
+  const day = Number(dayText)
+  const date =
+    boundary === 'start'
+      ? new Date(year, month - 1, day, 0, 0, 0, 0)
+      : new Date(year, month - 1, day, 23, 59, 59, 999)
+
+  if (
+    !Number.isFinite(date.getTime()) ||
+    date.getFullYear() !== year ||
+    date.getMonth() !== month - 1 ||
+    date.getDate() !== day
+  ) {
+    return null
+  }
+
+  return date.toISOString()
 }
 
 export function FilterPanel({
@@ -225,12 +268,8 @@ export function FilterPanel({
     ).length
   }, [excludeKeywordSearchText, keywordOptions])
 
-  const dateRangeValue = useMemo<[Dayjs | null, Dayjs | null]>(() => {
-    return [
-      dateRange?.startDate ? dayjs(dateRange.startDate) : null,
-      dateRange?.endDate ? dayjs(dateRange.endDate) : null
-    ]
-  }, [dateRange?.endDate, dateRange?.startDate])
+  const startDateInputValue = formatDateInputValue(dateRange?.startDate)
+  const endDateInputValue = formatDateInputValue(dateRange?.endDate)
 
   const toggleSection = (section: keyof typeof expandedSections) => {
     if (section === 'mediaTypes') {
@@ -284,6 +323,24 @@ export function FilterPanel({
     onBoostFieldsChange?.({
       ...boostFields,
       [field]: parsed
+    })
+  }
+
+  const handleDateInputChange = (
+    field: keyof MediaDateRange,
+    value: string
+  ) => {
+    if (!onDateRangeChange) return
+
+    onDateRangeChange({
+      startDate:
+        field === 'startDate'
+          ? parseDateInputValue(value, 'start')
+          : dateRange?.startDate ?? null,
+      endDate:
+        field === 'endDate'
+          ? parseDateInputValue(value, 'end')
+          : dateRange?.endDate ?? null
     })
   }
 
@@ -433,23 +490,34 @@ export function FilterPanel({
         <div className="text-sm text-text">
           {t('review:mediaPage.dateRange', { defaultValue: 'Date range' })}
         </div>
-        <DatePicker.RangePicker
-          className="w-full"
-          value={dateRangeValue}
-          allowClear
-          onChange={(dates: null | [Dayjs | null, Dayjs | null]) => {
-            if (!onDateRangeChange) return
-            if (!dates) {
-              onDateRangeChange({ startDate: null, endDate: null })
-              return
-            }
-            const [start, end] = dates
-            onDateRangeChange({
-              startDate: start ? start.startOf('day').toDate().toISOString() : null,
-              endDate: end ? end.endOf('day').toDate().toISOString() : null
-            })
-          }}
-        />
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+          <label className="space-y-1 text-xs text-textMuted">
+            <span>
+              {t('review:mediaPage.startDate', { defaultValue: 'Start date' })}
+            </span>
+            <input
+              type="date"
+              value={startDateInputValue}
+              onChange={(event) =>
+                handleDateInputChange('startDate', event.currentTarget.value)
+              }
+              className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-text focus:outline-none focus:ring-2 focus:ring-primary/40"
+            />
+          </label>
+          <label className="space-y-1 text-xs text-textMuted">
+            <span>
+              {t('review:mediaPage.endDate', { defaultValue: 'End date' })}
+            </span>
+            <input
+              type="date"
+              value={endDateInputValue}
+              onChange={(event) =>
+                handleDateInputChange('endDate', event.currentTarget.value)
+              }
+              className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-text focus:outline-none focus:ring-2 focus:ring-primary/40"
+            />
+          </label>
+        </div>
       </div>
 
       {searchMode === 'full_text' && (

--- a/apps/packages/ui/src/components/Media/FilterPanel.tsx
+++ b/apps/packages/ui/src/components/Media/FilterPanel.tsx
@@ -491,7 +491,7 @@ export function FilterPanel({
           {t('review:mediaPage.dateRange', { defaultValue: 'Date range' })}
         </div>
         <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-          <label className="space-y-1 text-xs text-textMuted">
+          <label className="space-y-1 text-xs text-text-muted">
             <span>
               {t('review:mediaPage.startDate', { defaultValue: 'Start date' })}
             </span>
@@ -504,7 +504,7 @@ export function FilterPanel({
               className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-text focus:outline-none focus:ring-2 focus:ring-primary/40"
             />
           </label>
-          <label className="space-y-1 text-xs text-textMuted">
+          <label className="space-y-1 text-xs text-text-muted">
             <span>
               {t('review:mediaPage.endDate', { defaultValue: 'End date' })}
             </span>

--- a/apps/packages/ui/src/components/Media/__tests__/FilterPanel.dayjs-imports.test.ts
+++ b/apps/packages/ui/src/components/Media/__tests__/FilterPanel.dayjs-imports.test.ts
@@ -1,0 +1,56 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const srcRoot = existsSync(join(process.cwd(), 'src'))
+  ? join(process.cwd(), 'src')
+  : join(process.cwd(), 'apps/packages/ui/src')
+const dayjsImportPattern =
+  /^\s*import\s+(?:type\s+)?(?:.+?\s+from\s+)?['"]dayjs(?:\/[^'"]*)?['"]/
+
+const collectSourceFiles = (directory: string): string[] => {
+  return readdirSync(directory).flatMap((entry) => {
+    const fullPath = join(directory, entry)
+    const stats = statSync(fullPath)
+
+    if (stats.isDirectory()) {
+      return collectSourceFiles(fullPath)
+    }
+
+    return /\.(ts|tsx)$/.test(entry) ? [fullPath] : []
+  })
+}
+
+const collectDayjsImports = (): string[] => {
+  return collectSourceFiles(srcRoot).flatMap((filePath) => {
+    const relativePath = relative(srcRoot, filePath)
+    return readFileSync(filePath, 'utf8')
+      .split(/\r?\n/)
+      .flatMap((line) => (dayjsImportPattern.test(line) ? [`${relativePath}:${line.trim()}`] : []))
+  })
+}
+
+describe('FilterPanel dayjs dependency cleanup', () => {
+  it('leaves only the deferred ReadingList and Items dayjs import surfaces', () => {
+    const dayjsImports = collectDayjsImports()
+    const importCountsByFile = dayjsImports.reduce<Record<string, number>>(
+      (counts, importMatch) => {
+        const [filePath] = importMatch.split(':')
+        counts[filePath] = (counts[filePath] ?? 0) + 1
+        return counts
+      },
+      {}
+    )
+
+    expect(dayjsImports).toHaveLength(4)
+    expect(importCountsByFile).toEqual({
+      'components/Option/Collections/ReadingList/ReadingItemsList.tsx': 2,
+      'components/Option/Items/ItemsWorkspace.tsx': 2
+    })
+    expect(dayjsImports).not.toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/^components\/Media\/FilterPanel\.tsx:/)
+      ])
+    )
+  })
+})

--- a/apps/packages/ui/src/components/Media/__tests__/FilterPanel.dayjs-imports.test.ts
+++ b/apps/packages/ui/src/components/Media/__tests__/FilterPanel.dayjs-imports.test.ts
@@ -1,10 +1,8 @@
-import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
-import { join, relative } from 'node:path'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative, resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
-const srcRoot = existsSync(join(process.cwd(), 'src'))
-  ? join(process.cwd(), 'src')
-  : join(process.cwd(), 'apps/packages/ui/src')
+const srcRoot = resolve(__dirname, '../../..')
 const dayjsImportPattern =
   /^\s*import\s+(?:type\s+)?(?:.+?\s+from\s+)?['"]dayjs(?:\/[^'"]*)?['"]/
 
@@ -23,7 +21,7 @@ const collectSourceFiles = (directory: string): string[] => {
 
 const collectDayjsImports = (): string[] => {
   return collectSourceFiles(srcRoot).flatMap((filePath) => {
-    const relativePath = relative(srcRoot, filePath)
+    const relativePath = relative(srcRoot, filePath).replace(/\\/g, '/')
     return readFileSync(filePath, 'utf8')
       .split(/\r?\n/)
       .flatMap((line) => (dayjsImportPattern.test(line) ? [`${relativePath}:${line.trim()}`] : []))

--- a/apps/packages/ui/src/components/Media/__tests__/FilterPanel.test.tsx
+++ b/apps/packages/ui/src/components/Media/__tests__/FilterPanel.test.tsx
@@ -1,6 +1,33 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ComponentProps } from 'react'
 import { FilterPanel } from '../FilterPanel'
+
+const isoForLocalDate = (
+  value: string,
+  boundary: 'start' | 'end'
+): string => {
+  const [year, month, day] = value.split('-').map(Number)
+  const date =
+    boundary === 'start'
+      ? new Date(year, month - 1, day, 0, 0, 0, 0)
+      : new Date(year, month - 1, day, 23, 59, 59, 999)
+  return date.toISOString()
+}
+
+const renderFilterPanel = (
+  props: Partial<ComponentProps<typeof FilterPanel>> = {}
+) =>
+  render(
+    <FilterPanel
+      mediaTypes={[]}
+      selectedMediaTypes={[]}
+      onMediaTypesChange={vi.fn()}
+      selectedKeywords={[]}
+      onKeywordsChange={vi.fn()}
+      {...props}
+    />
+  )
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -33,6 +60,121 @@ describe('FilterPanel', () => {
     expect(screen.getByText('Sort by')).toBeInTheDocument()
     expect(screen.getByText('Date range')).toBeInTheDocument()
     expect(screen.getByText('Exclude keywords')).toBeInTheDocument()
+  })
+
+  it('renders existing date range values in native date inputs', () => {
+    renderFilterPanel({
+      dateRange: {
+        startDate: '2026-01-02T12:00:00.000Z',
+        endDate: '2026-01-31T12:00:00.000Z'
+      },
+      onDateRangeChange: vi.fn()
+    })
+
+    const startDateInput = screen.getByLabelText('Start date') as HTMLInputElement
+    const endDateInput = screen.getByLabelText('End date') as HTMLInputElement
+
+    expect(startDateInput).toHaveAttribute('type', 'date')
+    expect(startDateInput).toHaveValue('2026-01-02')
+    expect(endDateInput).toHaveAttribute('type', 'date')
+    expect(endDateInput).toHaveValue('2026-01-31')
+  })
+
+  it('emits local day-boundary ISO values from native date input changes', () => {
+    const onDateRangeChange = vi.fn()
+    const existingStartDate = '2026-01-01T00:00:00.000Z'
+    const existingEndDate = '2026-01-31T23:59:59.999Z'
+
+    renderFilterPanel({
+      dateRange: {
+        startDate: existingStartDate,
+        endDate: existingEndDate
+      },
+      onDateRangeChange
+    })
+
+    fireEvent.change(screen.getByLabelText('Start date'), {
+      target: { value: '2026-02-03' }
+    })
+    fireEvent.change(screen.getByLabelText('End date'), {
+      target: { value: '2026-02-04' }
+    })
+
+    expect(onDateRangeChange).toHaveBeenNthCalledWith(1, {
+      startDate: isoForLocalDate('2026-02-03', 'start'),
+      endDate: existingEndDate
+    })
+    expect(onDateRangeChange).toHaveBeenNthCalledWith(2, {
+      startDate: existingStartDate,
+      endDate: isoForLocalDate('2026-02-04', 'end')
+    })
+  })
+
+  it('clears native date inputs independently and preserves the other boundary', () => {
+    const onDateRangeChange = vi.fn()
+    const existingStartDate = '2026-01-01T00:00:00.000Z'
+    const existingEndDate = '2026-01-31T23:59:59.999Z'
+    const { rerender } = renderFilterPanel({
+      dateRange: {
+        startDate: existingStartDate,
+        endDate: existingEndDate
+      },
+      onDateRangeChange
+    })
+
+    fireEvent.change(screen.getByLabelText('Start date'), {
+      target: { value: '' }
+    })
+    expect(onDateRangeChange).toHaveBeenLastCalledWith({
+      startDate: null,
+      endDate: existingEndDate
+    })
+
+    onDateRangeChange.mockClear()
+    rerender(
+      <FilterPanel
+        mediaTypes={[]}
+        selectedMediaTypes={[]}
+        onMediaTypesChange={vi.fn()}
+        selectedKeywords={[]}
+        onKeywordsChange={vi.fn()}
+        dateRange={{
+          startDate: existingStartDate,
+          endDate: existingEndDate
+        }}
+        onDateRangeChange={onDateRangeChange}
+      />
+    )
+    fireEvent.change(screen.getByLabelText('End date'), {
+      target: { value: '' }
+    })
+    expect(onDateRangeChange).toHaveBeenLastCalledWith({
+      startDate: existingStartDate,
+      endDate: null
+    })
+
+    onDateRangeChange.mockClear()
+    rerender(
+      <FilterPanel
+        mediaTypes={[]}
+        selectedMediaTypes={[]}
+        onMediaTypesChange={vi.fn()}
+        selectedKeywords={[]}
+        onKeywordsChange={vi.fn()}
+        dateRange={{
+          startDate: null,
+          endDate: existingEndDate
+        }}
+        onDateRangeChange={onDateRangeChange}
+      />
+    )
+    fireEvent.change(screen.getByLabelText('End date'), {
+      target: { value: '' }
+    })
+    expect(onDateRangeChange).toHaveBeenLastCalledWith({
+      startDate: null,
+      endDate: null
+    })
   })
 
   it('clear all resets include/exclude keywords, date range, and sort state', () => {

--- a/apps/packages/ui/src/components/Media/__tests__/FilterPanel.test.tsx
+++ b/apps/packages/ui/src/components/Media/__tests__/FilterPanel.test.tsx
@@ -65,8 +65,8 @@ describe('FilterPanel', () => {
   it('renders existing date range values in native date inputs', () => {
     renderFilterPanel({
       dateRange: {
-        startDate: '2026-01-02T12:00:00.000Z',
-        endDate: '2026-01-31T12:00:00.000Z'
+        startDate: isoForLocalDate('2026-01-02', 'start'),
+        endDate: isoForLocalDate('2026-01-31', 'end')
       },
       onDateRangeChange: vi.fn()
     })

--- a/backlog/tasks/task-176 - Remove-dayjs-from-Media-FilterPanel-date-range.md
+++ b/backlog/tasks/task-176 - Remove-dayjs-from-Media-FilterPanel-date-range.md
@@ -1,0 +1,88 @@
+---
+id: TASK-176
+title: Remove dayjs from Media FilterPanel date range
+status: Done
+assignee:
+  - codex
+created_date: '2026-05-09 18:46'
+updated_date: '2026-05-09 18:58'
+labels:
+  - webui
+  - dependencies
+  - issue-1346
+  - media
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1346'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue issue #1346 by replacing the shared UI Media FilterPanel date range control's dayjs/Ant Design RangePicker value path with native platform date inputs. Scope is limited to FilterPanel date-range state conversion, focused tests, the dependency audit, and task metadata. Leave ReadingList and Items Dayjs value-contract surfaces for later slices.
+
+Expected impact estimate for this narrow replacement: reduce active shared UI dayjs package-import lines from 5 to 4 and remove one RangePicker/Dayjs runtime filter surface from Media. No direct manifest, lockfile, install-size, or bundle-size reduction is expected until dayjs is removed from the remaining ReadingList and Items surfaces, and Ant Design still owns dayjs transitively.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 FilterPanel no longer imports or references dayjs or Ant Design DatePicker/RangePicker for media date range filtering.
+- [x] #2 The media date range editor uses native date inputs that display existing ISO start/end dates as YYYY-MM-DD values and allow clearing each side independently.
+- [x] #3 Changing dates emits start-of-day ISO for startDate and end-of-day ISO for endDate, while clearing both emits null values for both fields.
+- [x] #4 Focused tests cover displayed native date values, start/end conversion, independent clearing, and the remaining dayjs import scan expectation.
+- [x] #5 Issue #1346 audit notes are updated to reflect the reduced shared UI dayjs import count and remaining deferred ReadingList/Items DatePicker value-contract surfaces.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Create an isolated worktree from current origin/dev on branch codex/webui-media-native-date-range-1346.
+2. Mirror TASK-176 into the worktree so the task metadata travels with the PR branch.
+3. Write focused failing tests for the Media FilterPanel native date inputs: displayed YYYY-MM-DD values, start/end ISO conversion, independent clearing, and remaining dayjs import scan count.
+4. Replace FilterPanel's dayjs/AntD RangePicker path with native date inputs and small date conversion helpers that parse YYYY-MM-DD into local start/end day boundaries before ISO serialization.
+5. Update Docs/Design/WebUI_Dependency_Audit.md and TASK-176 notes/criteria to record the reduced shared UI dayjs import count and remaining ReadingList/Items surfaces.
+6. Run focused Vitest, dayjs import scan, WebUI compile/lint/targeted TypeScript filter, git diff --check, and Bandit skip note for JS-only touched scope before committing and opening a PR against dev.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verified PR #1427 merged into dev at a443c105a41431b8dea56074f1e9cf3418f948af on 2026-05-09T18:45:52Z.
+
+Corrected the expected import-line impact from 5->3 to 5->4 because ReadingList and Items each retain separate runtime and type dayjs imports after the Media slice.
+
+Implemented the Media FilterPanel date range replacement in branch codex/webui-media-native-date-range-1346: removed the combined dayjs/Dayjs import and Ant Design RangePicker usage from FilterPanel, added native labeled date inputs, and preserved local start/end day-boundary ISO emission plus independent clearing behavior.
+
+Focused red/green verification: `bunx vitest run src/components/Media/__tests__/FilterPanel.test.tsx src/components/Media/__tests__/FilterPanel.dayjs-imports.test.ts --maxWorkers=1` first failed on missing native labels and five remaining dayjs imports, then passed with 12 tests after implementation.
+
+Exact dayjs scan now returns four remaining shared UI import lines: ReadingItemsList.tsx runtime/type imports and ItemsWorkspace.tsx runtime/type imports. Media FilterPanel no longer appears in the direct dayjs import scan.
+
+WebUI compile passed: `NEXT_PUBLIC_API_URL=http://127.0.0.1:8000 bun run compile` generated 138 static pages and token sync reported OK. `bun run lint` exited 0 with the existing 131-warning baseline. `git diff --check` exited 0.
+
+TypeScript baseline note: `node_modules/.bin/tsc --noEmit --project tsconfig.json --pretty false` still exits 1 on existing EmbeddingsModelSelectionConfig.tsx and lib/api/vnPlay.ts errors; filtering /tmp/task176_tsc.log for FilterPanel, components/Media, Media/__tests__, task-176, and WebUI_Dependency_Audit returned no matches.
+
+Bandit skipped because this slice changed TypeScript, documentation, and Backlog metadata only; no Python files were modified.
+
+Correction after rerunning the TypeScript check post-test-harness tweak: `node_modules/.bin/tsc --noEmit --project tsconfig.json --pretty false` exits 1, not 2, on the existing EmbeddingsModelSelectionConfig.tsx and lib/api/vnPlay.ts baseline errors; the task-specific filter still returns no matches.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Replaced the Media FilterPanel date range control's dayjs/Ant Design RangePicker path with native labeled date inputs while preserving the existing controlled MediaDateRange contract. The new helpers format existing ISO values as YYYY-MM-DD, emit local start-of-day/end-of-day ISO values when edited, and preserve the opposite boundary when either side is cleared.
+
+Added focused component coverage for native date display, start/end conversion, and independent clearing, plus a static shared-UI dayjs import guard that now expects only the deferred ReadingList and Items surfaces. Updated the issue #1346 dependency audit to record the active shared UI dayjs import count dropping from 5 to 4 and to keep direct dependency removal deferred until ReadingList/Items are migrated.
+
+Verification: focused Vitest suite passed after the required red run, exact dayjs import scan returns only ReadingItemsList and ItemsWorkspace runtime/type imports, WebUI compile exited 0 and generated 138 static pages with token sync OK, WebUI lint exited 0 with the existing 131-warning baseline, git diff --check exited 0, and the TypeScript baseline still exits 1 on existing EmbeddingsModelSelectionConfig.tsx/lib/api/vnPlay.ts diagnostics with no task-scope matches. Bandit was skipped because no Python files changed.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-176 - Remove-dayjs-from-Media-FilterPanel-date-range.md
+++ b/backlog/tasks/task-176 - Remove-dayjs-from-Media-FilterPanel-date-range.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - codex
 created_date: '2026-05-09 18:46'
-updated_date: '2026-05-09 18:58'
+updated_date: '2026-05-09 19:00'
 labels:
   - webui
   - dependencies
@@ -14,6 +14,7 @@ labels:
 dependencies: []
 references:
   - 'https://github.com/rmusser01/tldw_server/issues/1346'
+  - 'https://github.com/rmusser01/tldw_server/pull/1436'
 priority: medium
 ---
 
@@ -65,6 +66,8 @@ TypeScript baseline note: `node_modules/.bin/tsc --noEmit --project tsconfig.jso
 Bandit skipped because this slice changed TypeScript, documentation, and Backlog metadata only; no Python files were modified.
 
 Correction after rerunning the TypeScript check post-test-harness tweak: `node_modules/.bin/tsc --noEmit --project tsconfig.json --pretty false` exits 1, not 2, on the existing EmbeddingsModelSelectionConfig.tsx and lib/api/vnPlay.ts baseline errors; the task-specific filter still returns no matches.
+
+Opened PR #1436 against dev: https://github.com/rmusser01/tldw_server/pull/1436
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-184 - Address-PR-1436-review-comments.md
+++ b/backlog/tasks/task-184 - Address-PR-1436-review-comments.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-184
 title: Address PR-1436 review comments
-status: In Progress
+status: Done
 assignee:
   - codex
 created_date: '2026-05-09 19:39'
-updated_date: '2026-05-09 19:40'
+updated_date: '2026-05-09 19:42'
 labels:
   - webui
   - dependencies
@@ -29,7 +29,7 @@ Address actionable reviewer comments on PR #1436 for the Media FilterPanel dayjs
 - [x] #2 The existing date-range display test uses timezone-stable local ISO fixtures instead of fixed UTC-noon strings.
 - [x] #3 FilterPanel.dayjs-imports.test.ts computes the scanned source root from the test file location and normalizes relative paths to forward slashes.
 - [x] #4 Focused Media FilterPanel tests pass and diff whitespace check passes after the review fixes.
-- [ ] #5 PR #1436 review threads for these findings are resolved or made outdated by the pushed fix commit.
+- [x] #5 PR #1436 review threads for these findings are resolved or made outdated by the pushed fix commit.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -56,6 +56,8 @@ Verification: focused Media FilterPanel Vitest suite passed with 12 tests; exact
 TypeScript baseline note: `node_modules/.bin/tsc --noEmit --project tsconfig.json --pretty false` still exits 2 on existing EmbeddingsModelSelectionConfig.tsx and lib/api/vnPlay.ts errors; filtering /tmp/task184_tsc.log for FilterPanel, components/Media, Media/__tests__, task-184, and task-176 returned no matches.
 
 Bandit skipped because this review-fix slice changed TypeScript/tests and Backlog metadata only; no Python files were modified.
+
+Resolved all six PR #1436 review threads after pushing a2a7761b4. Qodo's top-level review summary now reports Bugs (0), and CodeRabbit status is pass/skipped with no unresolved actionable inline threads. GitHub Actions checks are still pending, not failed.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done
@@ -64,6 +66,16 @@ Bandit skipped because this review-fix slice changed TypeScript/tests and Backlo
 - [x] #2 Tests or verification recorded
 - [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
+- [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed all actionable PR #1436 review findings. The review-fix commit changes the two Media FilterPanel native date labels to the existing text-text-muted token, makes the display-value fixture timezone-stable by using isoForLocalDate local-boundary ISO values, and makes the dayjs import scan deterministic by resolving the source root from the test file directory and normalizing relative path separators.
+
+Verification: focused Media FilterPanel Vitest suite passed with 12 tests, exact dayjs import scan still returns only the four deferred ReadingList/Items imports, text-textMuted scan returned no matches, WebUI lint exited 0 with the existing 131-warning baseline, git diff --check exited 0, and the TypeScript baseline still exits 2 on unrelated EmbeddingsModelSelectionConfig.tsx/lib/api/vnPlay.ts diagnostics with no task-scope matches. Bandit was skipped because no Python files changed.
+
+PR follow-up: pushed commit a2a7761b4 to PR #1436 and resolved all six review threads. Qodo now reports Bugs (0). GitHub Actions checks were still pending at last check, with no failed checks reported.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-184 - Address-PR-1436-review-comments.md
+++ b/backlog/tasks/task-184 - Address-PR-1436-review-comments.md
@@ -1,0 +1,69 @@
+---
+id: TASK-184
+title: Address PR-1436 review comments
+status: In Progress
+assignee:
+  - codex
+created_date: '2026-05-09 19:39'
+updated_date: '2026-05-09 19:40'
+labels:
+  - webui
+  - dependencies
+  - issue-1346
+  - review-fix
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1436'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address actionable reviewer comments on PR #1436 for the Media FilterPanel dayjs cleanup. Scope is limited to the muted-text Tailwind token typo, timezone-stable date fixture, deterministic dayjs import scan root/path normalization, verification, and resolving the addressed review threads.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 FilterPanel native date labels use the existing text-text-muted token instead of text-textMuted.
+- [x] #2 The existing date-range display test uses timezone-stable local ISO fixtures instead of fixed UTC-noon strings.
+- [x] #3 FilterPanel.dayjs-imports.test.ts computes the scanned source root from the test file location and normalizes relative paths to forward slashes.
+- [x] #4 Focused Media FilterPanel tests pass and diff whitespace check passes after the review fixes.
+- [ ] #5 PR #1436 review threads for these findings are resolved or made outdated by the pushed fix commit.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Mirror TASK-184 into the PR branch worktree before code edits.
+2. Verify the reviewer claims against local code and token naming.
+3. Patch FilterPanel labels from text-textMuted to text-text-muted.
+4. Patch the date display fixture to use isoForLocalDate for local-time deterministic ISO values.
+5. Patch the dayjs import scan test to derive srcRoot from the test file directory and normalize relative paths to forward slashes.
+6. Run the focused Media FilterPanel Vitest suite, exact dayjs import scan, WebUI lint, targeted TypeScript filter, and git diff --check.
+7. Commit and push the review fixes, then resolve or confirm outdated the addressed PR review threads and recheck PR status.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Inspected PR #1436 review surface. Actionable findings are: duplicated text-textMuted label-token comments, timezone-sensitive date display fixture, and process.cwd()/path-separator sensitivity in FilterPanel.dayjs-imports.test.ts. CodeRabbit status is passing; GitHub Actions checks are still pending.
+
+Implemented the three review fixes on PR #1436: replaced both text-textMuted classes with text-text-muted, changed the date display fixture to isoForLocalDate local-boundary fixtures, and made FilterPanel.dayjs-imports.test.ts derive srcRoot from __dirname with forward-slash relative path normalization.
+
+Verification: focused Media FilterPanel Vitest suite passed with 12 tests; exact dayjs import scan still returns only the four deferred ReadingList/Items imports; text-textMuted scan returned no matches; git diff --check exited 0; WebUI lint exited 0 with the existing 131-warning baseline.
+
+TypeScript baseline note: `node_modules/.bin/tsc --noEmit --project tsconfig.json --pretty false` still exits 2 on existing EmbeddingsModelSelectionConfig.tsx and lib/api/vnPlay.ts errors; filtering /tmp/task184_tsc.log for FilterPanel, components/Media, Media/__tests__, task-184, and task-176 returned no matches.
+
+Bandit skipped because this review-fix slice changed TypeScript/tests and Backlog metadata only; no Python files were modified.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Change summary

Maintainer-owned summary still required before merge under the AI-generated PR policy.

This PR removes the Media FilterPanel date range control's direct `dayjs`/Ant Design `RangePicker` path and replaces it with native labeled date inputs. The implementation keeps the existing `MediaDateRange` controlled prop contract: existing ISO values render as `YYYY-MM-DD`, edited starts emit local start-of-day ISO strings, edited ends emit local end-of-day ISO strings, and clearing either side preserves the other boundary.

## Why

Issue #1346 is trimming WebUI dependency usage before removing declarations. Media was the next narrow `dayjs` surface after the Kanban cleanup: it had a single combined runtime/type import and existing focused FilterPanel tests, while ReadingList and Items still need separate value-contract slices.

## Verification

- `bunx vitest run src/components/Media/__tests__/FilterPanel.test.tsx src/components/Media/__tests__/FilterPanel.dayjs-imports.test.ts --maxWorkers=1`
- `rg -n "^\\s*import\\s+(?:type\\s+)?(?:.+?\\s+from\\s+)?['\\\"]dayjs(?:/[^'\\\"]*)?['\\\"]" apps/packages/ui/src -g '*.ts' -g '*.tsx'`
- `NEXT_PUBLIC_API_URL=http://127.0.0.1:8000 bun run compile`
- `bun run lint` (exits 0 with existing 131-warning baseline)
- `node_modules/.bin/tsc --noEmit --project tsconfig.json --pretty false` (still exits 1 on existing `EmbeddingsModelSelectionConfig.tsx` and `lib/api/vnPlay.ts` baseline errors; task-scope filter returned no matches)
- `git diff --check`

Bandit skipped: no Python files changed.

## Follow-ups

- Remaining direct shared UI `dayjs` imports are in `ReadingItemsList.tsx` and `ItemsWorkspace.tsx`.
