### PR TITLE
Adapt Prompt sync status badge to shared design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -5456,17 +5456,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "local-status-badge:src/components/Option/Prompt/SyncStatusBadge.tsx:SyncStatusBadge",
-    "path": "src/components/Option/Prompt/SyncStatusBadge.tsx",
-    "rule": "local-status-badge",
-    "subject": "SyncStatusBadge",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing local SyncStatusBadge status wrapper before the guard.",
-    "replacement": "Badge with design-system state registry mapping",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "local-status-badge:src/components/Sidepanel/Chat/StatusDot.tsx:StatusDot",
     "path": "src/components/Sidepanel/Chat/StatusDot.tsx",
     "rule": "local-status-badge",

--- a/apps/packages/ui/scripts/design-system-product-state-rules.mjs
+++ b/apps/packages/ui/scripts/design-system-product-state-rules.mjs
@@ -854,6 +854,9 @@ function returnedExpressionContainsJsxTag(expression, localNames) {
     }
 
     if (node !== unwrapped && isFunctionLikeNode(node)) {
+      if (isReturnedCollectionRenderCallback(node)) {
+        ts.forEachChild(node, visit)
+      }
       return
     }
 
@@ -878,6 +881,23 @@ function returnedExpressionContainsJsxTag(expression, localNames) {
 
   visit(unwrapped)
   return found
+}
+
+function isReturnedCollectionRenderCallback(functionNode) {
+  const parent = functionNode.parent
+
+  if (!parent || !ts.isCallExpression(parent)) {
+    return false
+  }
+
+  const isArgument = parent.arguments.some(
+    (argument) => argument === functionNode
+  )
+  if (!isArgument || !ts.isPropertyAccessExpression(parent.expression)) {
+    return false
+  }
+
+  return parent.expression.name.text === "map"
 }
 
 function unwrapReturnedExpression(expression) {

--- a/apps/packages/ui/scripts/design-system-product-state-rules.mjs
+++ b/apps/packages/ui/scripts/design-system-product-state-rules.mjs
@@ -471,7 +471,7 @@ function collectCanonicalDesignSystemUsage(sourceFile, fileSubject) {
     imports.stateRegistry,
     fileSubject
   )
-  const returnedBadgeOwners = collectReturnedJsxTagOwners(
+  const returnedBadgeOwners = collectReturnedJsxTreeTagOwners(
     sourceFile,
     imports.badge,
     fileSubject
@@ -707,6 +707,34 @@ function collectReturnedJsxTagOwners(sourceFile, localNames, fallbackOwner) {
   return owners
 }
 
+function collectReturnedJsxTreeTagOwners(sourceFile, localNames, fallbackOwner) {
+  const owners = new Set()
+
+  if (!localNames || localNames.size === 0) {
+    return owners
+  }
+
+  walk(sourceFile, (node) => {
+    if (!isFunctionLikeNode(node)) {
+      return
+    }
+
+    const ownerName = returnedJsxOwnerName(node, fallbackOwner)
+    if (!ownerName) {
+      return
+    }
+
+    const returnsMatchingTag = collectOwnReturnExpressions(node).some(
+      (expression) => returnedExpressionContainsJsxTag(expression, localNames)
+    )
+    if (returnsMatchingTag) {
+      owners.add(ownerName)
+    }
+  })
+
+  return owners
+}
+
 function returnedJsxOwnerName(functionNode, fallbackOwner) {
   if (functionNode.name && ts.isIdentifier(functionNode.name)) {
     return functionNode.name.text
@@ -806,6 +834,50 @@ function expressionDirectlyReturnsJsxTag(expression, localNames) {
   }
 
   return false
+}
+
+function returnedExpressionContainsJsxTag(expression, localNames) {
+  const unwrapped = unwrapReturnedExpression(expression)
+
+  if (ts.isConditionalExpression(unwrapped)) {
+    return (
+      returnedExpressionContainsJsxTag(unwrapped.whenTrue, localNames) ||
+      returnedExpressionContainsJsxTag(unwrapped.whenFalse, localNames)
+    )
+  }
+
+  let found = false
+
+  const visit = (node) => {
+    if (found) {
+      return
+    }
+
+    if (node !== unwrapped && isFunctionLikeNode(node)) {
+      return
+    }
+
+    if (ts.isJsxSelfClosingElement(node)) {
+      const localName = jsxTagName(node.tagName)
+      if (localName && localNames.has(localName)) {
+        found = true
+      }
+      return
+    }
+
+    if (ts.isJsxOpeningElement(node)) {
+      const localName = jsxTagName(node.tagName)
+      if (localName && localNames.has(localName)) {
+        found = true
+      }
+      return
+    }
+
+    ts.forEachChild(node, visit)
+  }
+
+  visit(unwrapped)
+  return found
 }
 
 function unwrapReturnedExpression(expression) {

--- a/apps/packages/ui/src/components/Option/Prompt/SyncStatusBadge.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/SyncStatusBadge.tsx
@@ -1,7 +1,9 @@
 import React from "react"
-import { Tag, Tooltip } from "antd"
-import { Cloud, CloudOff, AlertTriangle, RefreshCw, HardDrive } from "lucide-react"
+import { Tooltip } from "antd"
+import { Cloud, AlertTriangle, RefreshCw, HardDrive } from "lucide-react"
 import { useTranslation } from "react-i18next"
+import { getDesignSystemState, type DesignSystemStateKey } from "@/design-system"
+import { Badge, getBadgeVariantForDesignSystemSeverity } from "@/components/ui/primitives"
 import type { PromptSyncStatus, PromptSourceSystem } from "@/db/dexie/types"
 
 interface SyncStatusBadgeProps {
@@ -12,6 +14,13 @@ interface SyncStatusBadgeProps {
   compact?: boolean
   onClick?: () => void
   onRetry?: () => void
+}
+
+type SyncStatusConfig = {
+  icon: React.ReactNode
+  stateKey: DesignSystemStateKey
+  label: string
+  tooltip: string
 }
 
 export const SyncStatusBadge: React.FC<SyncStatusBadgeProps> = ({
@@ -41,12 +50,12 @@ export const SyncStatusBadge: React.FC<SyncStatusBadgeProps> = ({
     return t("common:daysAgo", "{{count}}d ago", { count: diffDays })
   }
 
-  const getStatusConfig = () => {
+  const getStatusConfig = (): SyncStatusConfig => {
     switch (syncStatus) {
       case "synced":
         return {
           icon: <Cloud className="size-3" />,
-          color: "green",
+          stateKey: "ready",
           label: t("settings:managePrompts.sync.synced", "Synced"),
           tooltip: t("settings:managePrompts.sync.syncedTooltip", "Synced with server{{time}}", {
             time: lastSyncedAt ? ` (${formatLastSync(lastSyncedAt)})` : ""
@@ -55,14 +64,14 @@ export const SyncStatusBadge: React.FC<SyncStatusBadgeProps> = ({
       case "pending":
         return {
           icon: <RefreshCw className="size-3" />,
-          color: "gold",
+          stateKey: "degraded",
           label: t("settings:managePrompts.sync.pending", "Pending"),
           tooltip: t("settings:managePrompts.sync.pendingTooltip", "Local changes not yet synced")
         }
       case "conflict":
         return {
           icon: <AlertTriangle className="size-3" />,
-          color: "red",
+          stateKey: "blocked",
           label: t("settings:managePrompts.sync.conflict", "Conflict"),
           tooltip: t("settings:managePrompts.sync.conflictTooltip", "Local and server versions differ")
         }
@@ -70,7 +79,7 @@ export const SyncStatusBadge: React.FC<SyncStatusBadgeProps> = ({
       default:
         return {
           icon: <HardDrive className="size-3" />,
-          color: "default",
+          stateKey: "empty",
           label: t("settings:managePrompts.sync.local", "Local"),
           tooltip: t("settings:managePrompts.sync.localTooltip", "Stored locally only")
         }
@@ -100,6 +109,8 @@ export const SyncStatusBadge: React.FC<SyncStatusBadgeProps> = ({
 
   const statusConfig = getStatusConfig()
   const sourceConfig = getSourceConfig()
+  const state = getDesignSystemState(statusConfig.stateKey)
+  const badgeVariant = getBadgeVariantForDesignSystemSeverity(state.severity)
   const showRetry = syncStatus === "pending" && typeof onRetry === "function"
 
   const retryButton = showRetry ? (
@@ -163,22 +174,23 @@ export const SyncStatusBadge: React.FC<SyncStatusBadgeProps> = ({
               defaultValue: "Resolve conflict"
             })}
           >
-            <Tag
-              color={statusConfig.color}
-              className="inline-flex items-center gap-1 text-xs cursor-pointer"
+            <Badge
+              className="cursor-pointer"
+              size="sm"
+              variant={badgeVariant}
             >
               {statusConfig.icon}
               {statusConfig.label}
-            </Tag>
+            </Badge>
           </button>
         ) : (
-          <Tag
-            color={statusConfig.color}
-            className="inline-flex items-center gap-1 text-xs"
+          <Badge
+            size="sm"
+            variant={badgeVariant}
           >
             {statusConfig.icon}
             {statusConfig.label}
-          </Tag>
+          </Badge>
         )}
       </Tooltip>
       {retryButton}

--- a/apps/packages/ui/src/components/Option/Prompt/SyncStatusBadge.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/SyncStatusBadge.tsx
@@ -109,8 +109,6 @@ export const SyncStatusBadge: React.FC<SyncStatusBadgeProps> = ({
 
   const statusConfig = getStatusConfig()
   const sourceConfig = getSourceConfig()
-  const state = getDesignSystemState(statusConfig.stateKey)
-  const badgeVariant = getBadgeVariantForDesignSystemSeverity(state.severity)
   const showRetry = syncStatus === "pending" && typeof onRetry === "function"
 
   const retryButton = showRetry ? (
@@ -158,6 +156,9 @@ export const SyncStatusBadge: React.FC<SyncStatusBadgeProps> = ({
       </Tooltip>
     )
   }
+
+  const state = getDesignSystemState(statusConfig.stateKey)
+  const badgeVariant = getBadgeVariantForDesignSystemSeverity(state.severity)
 
   return (
     <div className="inline-flex items-center gap-1">

--- a/apps/packages/ui/src/components/Option/Prompt/__tests__/SyncStatusBadge.test.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/__tests__/SyncStatusBadge.test.tsx
@@ -77,6 +77,19 @@ describe("SyncStatusBadge", () => {
     expect(badge).toHaveAttribute("data-ds-variant", "secondary")
   })
 
+  it("does not resolve design-system badge state for compact icon-only badges", () => {
+    const { container } = render(
+      <SyncStatusBadge
+        syncStatus="pending"
+        sourceSystem="workspace"
+        compact
+      />
+    )
+
+    expect(getDesignSystemState).not.toHaveBeenCalled()
+    expect(container.querySelector('[data-ds-component="Badge"]')).toBeNull()
+  })
+
   it("invokes onClick when rendered as compact interactive badge", async () => {
     const user = userEvent.setup()
     const onClick = vi.fn()

--- a/apps/packages/ui/src/components/Option/Prompt/__tests__/SyncStatusBadge.test.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/__tests__/SyncStatusBadge.test.tsx
@@ -1,8 +1,10 @@
 import React from "react"
-import { describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
+import { getDesignSystemState } from "@/design-system"
 import { SyncStatusBadge } from "../SyncStatusBadge"
+import type { PromptSyncStatus } from "@/db/dexie/types"
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -19,12 +21,62 @@ vi.mock("react-i18next", () => ({
   })
 }))
 
+vi.mock("@/design-system", async (importActual) => {
+  const actual = await importActual<typeof import("@/design-system")>()
+
+  return {
+    ...actual,
+    getDesignSystemState: vi.fn(actual.getDesignSystemState)
+  }
+})
+
 vi.mock("antd", () => ({
-  Tag: ({ children }: any) => <span>{children}</span>,
+  Tag: ({ children, color }: any) => (
+    <span data-testid="antd-tag" data-color={color}>
+      {children}
+    </span>
+  ),
   Tooltip: ({ children }: any) => <>{children}</>
 }))
 
+const STATUS_CASES = [
+  ["local", "Local", "empty", "secondary"],
+  ["synced", "Synced", "ready", "success"],
+  ["pending", "Pending", "degraded", "warning"],
+  ["conflict", "Conflict", "blocked", "danger"]
+] satisfies Array<[PromptSyncStatus, string, string, string]>
+
 describe("SyncStatusBadge", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it.each(STATUS_CASES)(
+    "renders %s through the canonical state registry",
+    (syncStatus, label, stateKey, variant) => {
+      const { container } = render(
+        <SyncStatusBadge syncStatus={syncStatus} sourceSystem="workspace" />
+      )
+
+      const badge = container.querySelector('[data-ds-component="Badge"]')
+
+      expect(screen.getByText(label)).toBeInTheDocument()
+      expect(getDesignSystemState).toHaveBeenCalledWith(stateKey)
+      expect(badge).toHaveAttribute("data-ds-size", "sm")
+      expect(badge).toHaveAttribute("data-ds-variant", variant)
+      expect(screen.queryByTestId("antd-tag")).not.toBeInTheDocument()
+    }
+  )
+
+  it("falls back to the canonical empty state for missing sync status", () => {
+    const { container } = render(<SyncStatusBadge sourceSystem="workspace" />)
+    const badge = container.querySelector('[data-ds-component="Badge"]')
+
+    expect(screen.getByText("Local")).toBeInTheDocument()
+    expect(getDesignSystemState).toHaveBeenCalledWith("empty")
+    expect(badge).toHaveAttribute("data-ds-variant", "secondary")
+  })
+
   it("invokes onClick when rendered as compact interactive badge", async () => {
     const user = userEvent.setup()
     const onClick = vi.fn()

--- a/apps/packages/ui/src/design-system/__tests__/product-state-guard.test.ts
+++ b/apps/packages/ui/src/design-system/__tests__/product-state-guard.test.ts
@@ -139,6 +139,62 @@ describe("design-system product-state guard rules", () => {
     )
   })
 
+  it("allows status-badge adapters that render Badge inside returned map callbacks", () => {
+    const findings = analyze(
+      "src/components/Common/StatusBadge.tsx",
+      `
+        import { getDesignSystemState } from "@/design-system"
+        import { Badge } from "@/components/ui/primitives"
+
+        export function StatusBadge({ items }) {
+          const state = getDesignSystemState("ready")
+
+          return (
+            <div>
+              {items.map((item) => (
+                <Badge key={item.id} variant="success">{state.label}</Badge>
+              ))}
+            </div>
+          )
+        }
+      `
+    )
+
+    expect(findings).not.toContainEqual(
+      expect.objectContaining({
+        rule: "local-status-badge",
+        subject: "StatusBadge"
+      })
+    )
+  })
+
+  it("still flags status-badge adapters when Badge appears only in an event handler", () => {
+    const findings = analyze(
+      "src/components/Common/StatusBadge.tsx",
+      `
+        import { getDesignSystemState } from "@/design-system"
+        import { Badge } from "@/components/ui/primitives"
+
+        export function StatusBadge() {
+          const state = getDesignSystemState("ready")
+
+          return (
+            <button onClick={() => <Badge variant="success">{state.label}</Badge>}>
+              Ready
+            </button>
+          )
+        }
+      `
+    )
+
+    expect(findings).toContainEqual(
+      expect.objectContaining({
+        rule: "local-status-badge",
+        subject: "StatusBadge"
+      })
+    )
+  })
+
   it("still flags status-badge adapters that return Badge without state registry mapping", () => {
     const findings = analyze(
       "src/components/Common/StatusBadge.tsx",

--- a/apps/packages/ui/src/design-system/__tests__/product-state-guard.test.ts
+++ b/apps/packages/ui/src/design-system/__tests__/product-state-guard.test.ts
@@ -109,6 +109,36 @@ describe("design-system product-state guard rules", () => {
     )
   })
 
+  it("allows status-badge adapters that return compound JSX with Badge and use the state registry", () => {
+    const findings = analyze(
+      "src/components/Option/Prompt/SyncStatusBadge.tsx",
+      `
+        import { getDesignSystemState } from "@/design-system"
+        import { Badge } from "@/components/ui/primitives"
+
+        export function SyncStatusBadge({ retry }) {
+          const state = getDesignSystemState("ready")
+
+          return (
+            <div>
+              <button>
+                <Badge variant="success">{state.label}</Badge>
+              </button>
+              {retry && <button>Retry</button>}
+            </div>
+          )
+        }
+      `
+    )
+
+    expect(findings).not.toContainEqual(
+      expect.objectContaining({
+        rule: "local-status-badge",
+        subject: "SyncStatusBadge"
+      })
+    )
+  })
+
   it("still flags status-badge adapters that return Badge without state registry mapping", () => {
     const findings = analyze(
       "src/components/Common/StatusBadge.tsx",

--- a/backlog/tasks/task-45.30 - Adapt-Prompt-SyncStatusBadge-to-design-system-state-registry.md
+++ b/backlog/tasks/task-45.30 - Adapt-Prompt-SyncStatusBadge-to-design-system-state-registry.md
@@ -1,0 +1,74 @@
+---
+id: TASK-45.30
+title: Adapt Prompt SyncStatusBadge to design-system state registry
+status: Done
+assignee:
+  - Codex
+created_date: '2026-05-09 18:58'
+updated_date: '2026-05-09 19:05'
+labels:
+  - design-system
+  - ui
+  - product-state
+dependencies: []
+references:
+  - apps/packages/ui/src/components/Option/Prompt/SyncStatusBadge.tsx
+  - >-
+    apps/packages/ui/src/components/Option/Prompt/__tests__/SyncStatusBadge.test.tsx
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+documentation:
+  - Docs/Design/tldw_web_design_system_contract.md
+parent_task_id: TASK-45
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate the Prompt workspace sync status badge away from local AntD Tag/color status UI and through the canonical design-system state registry while preserving existing retry, compact, tooltip, server ID, and conflict resolution behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Sync statuses resolve through getDesignSystemState before choosing shared Badge severity styling.
+- [x] #2 The full-size sync badge renders the shared Badge primitive instead of AntD Tag while preserving labels, icons, interactive click behavior, retry behavior, and server ID display.
+- [x] #3 Compact mode preserves the existing icon-only affordance and retry behavior without introducing a visible text badge.
+- [x] #4 Focused tests cover status-to-state/variant behavior, compact behavior, retry behavior, interactive behavior, and null/default local fallback.
+- [x] #5 The design-system product-state baseline no longer contains the SyncStatusBadge local-status-badge exception.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused SyncStatusBadge tests that prove each sync status resolves through getDesignSystemState, renders the shared Badge variant, and no longer renders AntD Tag in full-size mode.
+2. Migrate SyncStatusBadge full-size rendering from AntD Tag colors to the design-system state registry plus shared Badge severity variants, while preserving compact icon-only behavior, retry, interaction, tooltips, and server ID display.
+3. Remove the SyncStatusBadge local-status-badge baseline exception and verify the design-system product-state guard accepts the migration.
+4. Add guard coverage for compound status badge adapters so returned JSX trees that include shared Badge plus same-owner state registry mapping are accepted, while keeping LoadingState direct-return validation strict.
+5. Run focused component tests, guard tests, design-system verifier, whitespace diff check, and a UI typecheck attempt; document unrelated typecheck failures and Bandit skip for UI-only TS/JS changes.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the Prompt SyncStatusBadge migration via TDD. The new component tests first failed because getDesignSystemState was not called, then passed after the full-size AntD Tag path was replaced with shared Badge severity variants.
+
+The design-system verifier initially blocked local-status-badge for SyncStatusBadge because the guard only accepted status adapters whose direct return expression was Badge. Added a failing guard regression for compound returned JSX containing Badge plus same-owner state registry mapping, then changed only the status-badge detector to inspect returned JSX trees. LoadingState still uses the stricter direct-return detector.
+
+Verification: bunx vitest run src/components/Option/Prompt/__tests__/SyncStatusBadge.test.tsx --reporter=dot passed 11 tests; bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed 47 tests; bun run verify:design-system-state exited 0 with SyncStatusBadge removed from blocked/baselined findings; git diff --check exited 0. bunx tsc --noEmit --pretty false exited 2 with unrelated existing UI/test type errors and no touched-file matches in /tmp/tldw_ui_tsc_prompt_sync_status.txt. Bandit skipped because this slice only touches UI TypeScript/JavaScript and JSON baseline data.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated Prompt SyncStatusBadge full-size rendering from AntD Tag color props to the design-system state registry and shared Badge severity variants. Added focused component coverage for every sync status, default local fallback, compact behavior, retry, and interaction. Updated the product-state guard so status-badge adapters that return compound JSX are accepted when their returned UI contains the canonical Badge and the same owner calls getDesignSystemState, while retaining strict direct-return validation for LoadingState. Removed the SyncStatusBadge baseline exception.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.30 - Adapt-Prompt-SyncStatusBadge-to-design-system-state-registry.md
+++ b/backlog/tasks/task-45.30 - Adapt-Prompt-SyncStatusBadge-to-design-system-state-registry.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - Codex
 created_date: '2026-05-09 18:58'
-updated_date: '2026-05-09 19:05'
+updated_date: '2026-05-09 19:56'
 labels:
   - design-system
   - ui
@@ -55,12 +55,18 @@ Implemented the Prompt SyncStatusBadge migration via TDD. The new component test
 The design-system verifier initially blocked local-status-badge for SyncStatusBadge because the guard only accepted status adapters whose direct return expression was Badge. Added a failing guard regression for compound returned JSX containing Badge plus same-owner state registry mapping, then changed only the status-badge detector to inspect returned JSX trees. LoadingState still uses the stricter direct-return detector.
 
 Verification: bunx vitest run src/components/Option/Prompt/__tests__/SyncStatusBadge.test.tsx --reporter=dot passed 11 tests; bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed 47 tests; bun run verify:design-system-state exited 0 with SyncStatusBadge removed from blocked/baselined findings; git diff --check exited 0. bunx tsc --noEmit --pretty false exited 2 with unrelated existing UI/test type errors and no touched-file matches in /tmp/tldw_ui_tsc_prompt_sync_status.txt. Bandit skipped because this slice only touches UI TypeScript/JavaScript and JSON baseline data.
+
+PR review pass for #1437: Qodo requested avoiding unused state/variant derivation in compact mode. Gemini noted the status-badge guard does not detect Badge usage inside nested render callbacks such as map(), and suggested restoring inline-flex/items-center/gap-1 classes. Verified Badge already provides inline-flex items-center gap-1 globally, so that layout comment will be addressed with evidence rather than redundant classes. Plan: add failing tests for compact no registry call and map-rendered Badge detection, implement the minimal component/guard fixes, rerun focused verification, update PR, and resolve/reply to review threads.
+
+PR review fixes implemented. Added compact-mode coverage proving compact icon-only badges do not call getDesignSystemState or render Badge. Added guard coverage for returned map() render callbacks and an event-handler false-positive case. Moved state/variant derivation below the compact return and taught returnedExpressionContainsJsxTag to traverse map callbacks only.
+
+Review-fix verification: bunx vitest run src/components/Option/Prompt/__tests__/SyncStatusBadge.test.tsx --reporter=dot passed 12 tests; bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed 49 tests; bun run verify:design-system-state exited 0; git diff --check exited 0; bunx tsc --noEmit --pretty false exited 2 with the existing 236-line unrelated UI/test type debt and no matches for SyncStatusBadge, design-system-product-state-rules, or product-state-guard.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Migrated Prompt SyncStatusBadge full-size rendering from AntD Tag color props to the design-system state registry and shared Badge severity variants. Added focused component coverage for every sync status, default local fallback, compact behavior, retry, and interaction. Updated the product-state guard so status-badge adapters that return compound JSX are accepted when their returned UI contains the canonical Badge and the same owner calls getDesignSystemState, while retaining strict direct-return validation for LoadingState. Removed the SyncStatusBadge baseline exception.
+Migrated Prompt SyncStatusBadge full-size rendering from AntD Tag color props to the design-system state registry and shared Badge severity variants. Added focused component coverage for every sync status, default local fallback, compact behavior, retry, and interaction. Updated the product-state guard so status-badge adapters that return compound JSX are accepted when their returned UI contains the canonical Badge and the same owner calls getDesignSystemState, including returned map() render callbacks, while retaining strict direct-return validation for LoadingState and guarding against event-handler-only false positives. Removed the SyncStatusBadge baseline exception. PR review follow-up moved non-compact state/variant derivation below the compact return.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Change summary

- Routes `SyncStatusBadge` full-size status rendering through the canonical design-system state registry before deriving the shared `Badge` severity variant.
- Preserves compact icon-only mode, conflict click handling, retry affordance, server ID display, and existing prompt sync labels/tooltips.
- Adds focused SyncStatusBadge coverage for all sync statuses, default local fallback, compact mode, retry, and interaction behavior.
- Updates the product-state guard so compound status-badge adapters are accepted when their returned JSX tree contains the canonical `Badge` and the same owner calls `getDesignSystemState`, while keeping `LoadingState` direct-return validation strict.
- Removes the `SyncStatusBadge` `local-status-badge` baseline exception; only the remaining Sidepanel `StatusDot` status-badge exception remains.

## Verification

- `bunx vitest run src/components/Option/Prompt/__tests__/SyncStatusBadge.test.tsx --reporter=dot`
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot`
- `bun run verify:design-system-state`
- `git diff --check`
- `bunx tsc --noEmit --pretty false` exits 2 on existing repo-wide UI/test type debt; filtered output has no diagnostics for `SyncStatusBadge`, its test, the guard test, or the guard script.
- Bandit skipped: touched implementation is TS/TSX/MJS/JSON/Backlog only.
