### PR TITLE
Add Persona Visuals generation readiness

### DIFF
--- a/Docs/superpowers/plans/2026-05-09-persona-visual-generation-readiness-plan.md
+++ b/Docs/superpowers/plans/2026-05-09-persona-visual-generation-readiness-plan.md
@@ -1,0 +1,88 @@
+# Persona Visual Generation Readiness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Persona/Buddy visual asset generation readiness visible and actionable before users enqueue background generation jobs.
+
+**Architecture:** Add a small pack-scoped readiness endpoint that reports the persona visual worker flag and configured image generation backends. The WebUI consumes that readiness signal, classifies it into user-facing states, and disables enqueue when Jobs or image provider setup cannot support generation.
+
+**Tech Stack:** FastAPI, Pydantic, Jobs, image generation adapter registry, React, Vitest, Testing Library.
+
+---
+
+## File Structure
+
+- Modify `tldw_Server_API/app/api/v1/schemas/persona.py` to add `PersonaVisualGenerationReadinessResponse`.
+- Modify `tldw_Server_API/app/api/v1/endpoints/persona.py` to add a pack-scoped readiness endpoint beside `generation-jobs`.
+- Modify `tldw_Server_API/tests/Persona/test_persona_visuals_api.py` to cover disabled worker and available backend readiness responses.
+- Modify `apps/packages/ui/src/types/persona-visuals.ts` to add the readiness response type.
+- Modify `apps/packages/ui/src/services/persona-visuals.ts` to add `getPersonaVisualGenerationReadiness`.
+- Create `apps/packages/ui/src/components/PersonaGarden/personaVisualGenerationReadiness.ts` for the UI classifier.
+- Create `apps/packages/ui/src/components/PersonaGarden/__tests__/personaVisualGenerationReadiness.test.ts` for classifier coverage.
+- Modify `apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx` to load readiness, render setup state, and gate enqueue.
+- Modify `apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx` to cover gated and ready enqueue flows.
+- Update `backlog/tasks/task-180 - Improve-Persona-Visuals-generation-setup-and-unavailable-provider-states.md` with verification and final status.
+
+## Stage 1: Backend Readiness Contract
+
+**Goal:** Expose current generation setup without enqueuing a job.
+
+**Success Criteria:** The endpoint distinguishes Jobs worker enablement from image backend availability and remains scoped to the persona/pack owner.
+
+**Tests:** `test_visual_generation_readiness_reports_disabled_worker_and_missing_provider` and `test_visual_generation_readiness_reports_available_backend`.
+
+**Status:** Complete
+
+- [x] Add failing API tests in `tldw_Server_API/tests/Persona/test_persona_visuals_api.py`.
+- [x] Run the two new tests and verify they fail because the endpoint/schema do not exist.
+- [x] Add `PersonaVisualGenerationReadinessResponse`.
+- [x] Add `GET /profiles/{persona_id}/visual-packs/{pack_id}/generation-readiness`.
+- [x] Re-run the two API tests and verify they pass.
+
+## Stage 2: Frontend Readiness Classifier
+
+**Goal:** Keep setup-state rules testable outside the large editor component.
+
+**Success Criteria:** Classifier returns separate messages for worker disabled, no image providers, missing default backend, unavailable requested backend, loading, error, and ready states.
+
+**Tests:** `personaVisualGenerationReadiness.test.ts`.
+
+**Status:** Complete
+
+- [x] Add failing classifier tests.
+- [x] Run classifier tests and verify they fail because the helper does not exist.
+- [x] Implement the minimal classifier helper.
+- [x] Re-run classifier tests and verify they pass.
+
+## Stage 3: VisualPackEditor Gating
+
+**Goal:** Show setup/unavailable states before enqueue and preserve ready enqueue plus review.
+
+**Success Criteria:** The Queue button is disabled for known unavailable readiness states, copy separates Jobs/backend from image provider/model setup, and the existing ready enqueue/review test continues to pass.
+
+**Tests:** `VisualPackEditor.test.tsx` focused cases.
+
+**Status:** Complete
+
+- [x] Add failing editor tests for disabled worker and missing provider states.
+- [x] Update the existing enqueue test to mock ready readiness.
+- [x] Run editor tests and verify the new tests fail before implementation.
+- [x] Wire readiness loading into `VisualPackEditor.tsx`.
+- [x] Render readiness state near generation controls and disable enqueue when classified unavailable.
+- [x] Re-run editor tests and verify they pass.
+
+## Stage 4: Verification and PR Packaging
+
+**Goal:** Leave the branch reviewable and tied back to issue `#1431`.
+
+**Success Criteria:** Focused frontend/backend tests pass, Bandit is run on touched backend files, Backlog task is updated, and a PR is opened against `dev`.
+
+**Tests:** Focused Vitest, focused pytest, Bandit touched scope.
+
+**Status:** Complete
+
+- [x] Run focused Vitest for Persona Visuals editor/classifier/diagnostics tests.
+- [x] Run focused pytest for Persona visual API readiness tests.
+- [x] Run Bandit on touched backend files.
+- [x] Update Backlog acceptance criteria and verification notes.
+- [ ] Commit, push, and open the PR linked to `#1431`.

--- a/Docs/superpowers/plans/2026-05-09-persona-visual-generation-readiness-plan.md
+++ b/Docs/superpowers/plans/2026-05-09-persona-visual-generation-readiness-plan.md
@@ -85,4 +85,4 @@
 - [x] Run focused pytest for Persona visual API readiness tests.
 - [x] Run Bandit on touched backend files.
 - [x] Update Backlog acceptance criteria and verification notes.
-- [ ] Commit, push, and open the PR linked to `#1431`.
+- [x] Commit, push, and open the PR linked to `#1431`.

--- a/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
@@ -21,6 +21,7 @@ import {
   createPersonaVisualPack,
   deactivatePersonaVisualPack,
   downloadPersonaVisualPackExportArchive,
+  getPersonaVisualGenerationReadiness,
   getPersonaVisualImportCommitStatus,
   getPersonaVisualImportPreview,
   getPersonaVisualPackExportJob,
@@ -41,6 +42,7 @@ import type {
   PersonaVisualCandidate,
   PersonaVisualImportCommitStartResponse,
   PersonaVisualFrame,
+  PersonaVisualGenerationReadinessResponse,
   PersonaVisualImportPreviewResponse,
   PersonaVisualImportPreviewStartResponse,
   PersonaVisualManifest,
@@ -55,6 +57,10 @@ import {
   getPrimaryPersonaVisualDiagnostic,
   type PersonaVisualDiagnostic
 } from "../Common/PersonaBuddy/personaVisualDiagnostics"
+import {
+  classifyPersonaVisualGenerationReadiness,
+  type PersonaVisualGenerationReadinessView
+} from "./personaVisualGenerationReadiness"
 
 type VisualPackEditorProps = {
   selectedPersonaId: string
@@ -68,6 +74,94 @@ type TriggerDraft = {
   state: PersonaVisualStateId
   durationMs: string
   priority: string
+}
+
+const getGenerationReadinessCopy = (
+  view: PersonaVisualGenerationReadinessView,
+  t: (key: string, options?: { defaultValue?: string }) => string
+): { title: string; message: string; toneClassName: string } => {
+  switch (view.status) {
+    case "ready":
+      return {
+        title: t("sidepanel:personaGarden.visuals.generationReadyTitle", {
+          defaultValue: "Generation is ready."
+        }),
+        message: t("sidepanel:personaGarden.visuals.generationReadyMessage", {
+          defaultValue:
+            "Queued assets will appear here for review before they can be applied."
+        }),
+        toneClassName: "border-success/30 bg-success/5 text-success"
+      }
+    case "jobs_unavailable":
+      return {
+        title: t("sidepanel:personaGarden.visuals.generationWorkerUnavailableTitle", {
+          defaultValue: "Generation worker is not enabled."
+        }),
+        message: t("sidepanel:personaGarden.visuals.generationWorkerUnavailableMessage", {
+          defaultValue:
+            "Enable PERSONA_VISUAL_GENERATION_WORKER_ENABLED before queueing Persona Buddy visual generation jobs."
+        }),
+        toneClassName: "border-warning/40 bg-warning/10 text-warning"
+      }
+    case "image_provider_unavailable":
+      return {
+        title: t("sidepanel:personaGarden.visuals.generationProviderUnavailableTitle", {
+          defaultValue: "No image generation provider is configured."
+        }),
+        message: t("sidepanel:personaGarden.visuals.generationProviderUnavailableMessage", {
+          defaultValue:
+            "Enable an image backend before queueing a Persona Buddy visual generation job."
+        }),
+        toneClassName: "border-warning/40 bg-warning/10 text-warning"
+      }
+    case "backend_unavailable":
+      return {
+        title: t("sidepanel:personaGarden.visuals.generationBackendUnavailableTitle", {
+          defaultValue: "Selected image backend is unavailable."
+        }),
+        message: t("sidepanel:personaGarden.visuals.generationBackendUnavailableMessage", {
+          defaultValue:
+            "Use an enabled backend name or leave the field blank to use the default backend."
+        }),
+        toneClassName: "border-warning/40 bg-warning/10 text-warning"
+      }
+    case "default_backend_unavailable":
+      return {
+        title: t("sidepanel:personaGarden.visuals.generationDefaultBackendUnavailableTitle", {
+          defaultValue: "No default image backend is selected."
+        }),
+        message: t("sidepanel:personaGarden.visuals.generationDefaultBackendUnavailableMessage", {
+          defaultValue:
+            "Enter one enabled backend name before queueing this generation job."
+        }),
+        toneClassName: "border-warning/40 bg-warning/10 text-warning"
+      }
+    case "error":
+      return {
+        title: t("sidepanel:personaGarden.visuals.generationReadinessErrorTitle", {
+          defaultValue: "Generation readiness could not be checked."
+        }),
+        message:
+          view.errorMessage ||
+          t("sidepanel:personaGarden.visuals.generationReadinessErrorMessage", {
+            defaultValue:
+              "Refresh the visual pack before queueing a generation job."
+          }),
+        toneClassName: "border-danger/30 bg-danger/5 text-danger"
+      }
+    case "loading":
+    default:
+      return {
+        title: t("sidepanel:personaGarden.visuals.generationReadinessLoadingTitle", {
+          defaultValue: "Checking generation readiness."
+        }),
+        message: t("sidepanel:personaGarden.visuals.generationReadinessLoadingMessage", {
+          defaultValue:
+            "Persona Buddy visual generation will be available after setup checks finish."
+        }),
+        toneClassName: "border-border bg-bg text-text-muted"
+      }
+  }
 }
 
 const REQUIRED_VISUAL_STATES: PersonaVisualStateId[] = [
@@ -332,6 +426,12 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
   const [generationTargetState, setGenerationTargetState] =
     React.useState<PersonaVisualStateId>("thinking")
   const [generationBackend, setGenerationBackend] = React.useState("")
+  const [generationReadiness, setGenerationReadiness] =
+    React.useState<PersonaVisualGenerationReadinessResponse | null>(null)
+  const [generationReadinessLoading, setGenerationReadinessLoading] =
+    React.useState(false)
+  const [generationReadinessError, setGenerationReadinessError] =
+    React.useState<string | null>(null)
   const [enqueueingGeneration, setEnqueueingGeneration] = React.useState(false)
   const [reviewingCandidateId, setReviewingCandidateId] = React.useState("")
   const [error, setError] = React.useState<string | null>(null)
@@ -370,6 +470,18 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
           })
         : null,
     [draftManifest, selectedPack]
+  )
+  const generationReadinessView = React.useMemo(
+    () =>
+      classifyPersonaVisualGenerationReadiness(generationReadiness, generationBackend, {
+        isLoading: generationReadinessLoading,
+        errorMessage: generationReadinessError
+      }),
+    [generationBackend, generationReadiness, generationReadinessError, generationReadinessLoading]
+  )
+  const generationReadinessCopy = React.useMemo(
+    () => getGenerationReadinessCopy(generationReadinessView, t),
+    [generationReadinessView, t]
   )
 
   const loadPacks = React.useCallback(async (): Promise<boolean> => {
@@ -436,6 +548,34 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
     }
   }, [isActive, selectedPersonaId, selectedPack?.id])
 
+  const loadGenerationReadiness = React.useCallback(async () => {
+    const packId = selectedPack?.id || ""
+    if (!isActive || !selectedPersonaId || !packId) {
+      setGenerationReadiness(null)
+      setGenerationReadinessError(null)
+      setGenerationReadinessLoading(false)
+      return
+    }
+    setGenerationReadinessLoading(true)
+    setGenerationReadinessError(null)
+    try {
+      const response = await getPersonaVisualGenerationReadiness(
+        selectedPersonaId,
+        packId
+      )
+      setGenerationReadiness(response)
+    } catch (loadError) {
+      setGenerationReadiness(null)
+      setGenerationReadinessError(
+        loadError instanceof Error
+          ? loadError.message
+          : "Failed to check generation readiness."
+      )
+    } finally {
+      setGenerationReadinessLoading(false)
+    }
+  }, [isActive, selectedPersonaId, selectedPack?.id])
+
   React.useEffect(() => {
     void loadPacks()
   }, [loadPacks])
@@ -443,6 +583,10 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
   React.useEffect(() => {
     void loadCandidates()
   }, [loadCandidates])
+
+  React.useEffect(() => {
+    void loadGenerationReadiness()
+  }, [loadGenerationReadiness])
 
   React.useEffect(() => {
     if (!selectedPack) {
@@ -822,7 +966,14 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
   }
 
   const handleEnqueueGeneration = async () => {
-    if (!selectedPersonaId || !selectedPack || !generationPrompt.trim()) return
+    if (
+      !selectedPersonaId ||
+      !selectedPack ||
+      !generationPrompt.trim() ||
+      !generationReadinessView.canQueue
+    ) {
+      return
+    }
     setEnqueueingGeneration(true)
     setError(null)
     try {
@@ -1902,10 +2053,19 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
               <label className="text-xs text-text-muted">
                 <span className="mb-1 block">Backend</span>
                 <input
+                  data-testid="persona-visual-generation-backend-input"
                   className="w-full rounded border border-border bg-bg px-2 py-1 text-sm text-text"
                   value={generationBackend}
                   onChange={(event) => setGenerationBackend(event.target.value)}
+                  list="persona-visual-generation-backends"
                 />
+                {generationReadinessView.enabledBackends.length ? (
+                  <datalist id="persona-visual-generation-backends">
+                    {generationReadinessView.enabledBackends.map((backend) => (
+                      <option key={backend} value={backend} />
+                    ))}
+                  </datalist>
+                ) : null}
               </label>
               <Button
                 data-testid="persona-visual-generation-enqueue-button"
@@ -1913,11 +2073,28 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
                 size="small"
                 type="primary"
                 loading={enqueueingGeneration}
-                disabled={!generationPrompt.trim()}
+                disabled={!generationPrompt.trim() || !generationReadinessView.canQueue}
                 onClick={() => void handleEnqueueGeneration()}
               >
                 Queue
               </Button>
+            </div>
+            <div
+              data-testid="persona-visual-generation-readiness"
+              className={`mt-3 rounded border px-3 py-2 text-xs ${generationReadinessCopy.toneClassName}`}
+            >
+              <div className="font-medium">{generationReadinessCopy.title}</div>
+              <div className="mt-1 text-current/80">{generationReadinessCopy.message}</div>
+              {generationReadinessView.queue ? (
+                <div className="mt-1 text-current/70">
+                  Jobs queue: {generationReadinessView.queue}
+                </div>
+              ) : null}
+              {generationReadinessView.enabledBackends.length ? (
+                <div className="mt-1 text-current/70">
+                  Enabled image backends: {generationReadinessView.enabledBackends.join(", ")}
+                </div>
+              ) : null}
             </div>
             <div className="mt-3 space-y-2">
               {candidates.length ? (

--- a/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
@@ -125,6 +125,17 @@ const getGenerationReadinessCopy = (
         }),
         toneClassName: "border-warning/40 bg-warning/10 text-warning"
       }
+    case "dependency_check_failed":
+      return {
+        title: t("sidepanel:personaGarden.visuals.generationDependencyCheckFailedTitle", {
+          defaultValue: "Generation readiness check failed."
+        }),
+        message: t("sidepanel:personaGarden.visuals.generationDependencyCheckFailedMessage", {
+          defaultValue:
+            "Check the server logs and image generation configuration before queueing a Persona Buddy visual generation job."
+        }),
+        toneClassName: "border-destructive/40 bg-destructive/10 text-destructive"
+      }
     case "backend_unavailable":
       return {
         title: t("sidepanel:personaGarden.visuals.generationBackendUnavailableTitle", {

--- a/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
@@ -114,6 +114,17 @@ const getGenerationReadinessCopy = (
         }),
         toneClassName: "border-warning/40 bg-warning/10 text-warning"
       }
+    case "image_adapter_unavailable":
+      return {
+        title: t("sidepanel:personaGarden.visuals.generationAdapterUnavailableTitle", {
+          defaultValue: "Configured image backend cannot be started."
+        }),
+        message: t("sidepanel:personaGarden.visuals.generationAdapterUnavailableMessage", {
+          defaultValue:
+            "Check the selected image backend installation and credentials before queueing a Persona Buddy visual generation job."
+        }),
+        toneClassName: "border-warning/40 bg-warning/10 text-warning"
+      }
     case "backend_unavailable":
       return {
         title: t("sidepanel:personaGarden.visuals.generationBackendUnavailableTitle", {
@@ -438,6 +449,7 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
   const [statusMessage, setStatusMessage] = React.useState<string | null>(null)
   const fileInputRef = React.useRef<HTMLInputElement | null>(null)
   const importPreviewInputRef = React.useRef<HTMLInputElement | null>(null)
+  const generationReadinessRequestIdRef = React.useRef(0)
 
   const selectedPack =
     packs.find((pack) => pack.id === selectedPackId) ?? packs[0] ?? null
@@ -551,11 +563,15 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
   const loadGenerationReadiness = React.useCallback(async () => {
     const packId = selectedPack?.id || ""
     if (!isActive || !selectedPersonaId || !packId) {
+      generationReadinessRequestIdRef.current += 1
       setGenerationReadiness(null)
       setGenerationReadinessError(null)
       setGenerationReadinessLoading(false)
       return
     }
+    const requestId = generationReadinessRequestIdRef.current + 1
+    generationReadinessRequestIdRef.current = requestId
+    const isLatestRequest = () => generationReadinessRequestIdRef.current === requestId
     setGenerationReadinessLoading(true)
     setGenerationReadinessError(null)
     try {
@@ -563,16 +579,18 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
         selectedPersonaId,
         packId
       )
-      setGenerationReadiness(response)
+      if (isLatestRequest()) setGenerationReadiness(response)
     } catch (loadError) {
-      setGenerationReadiness(null)
-      setGenerationReadinessError(
-        loadError instanceof Error
-          ? loadError.message
-          : "Failed to check generation readiness."
-      )
+      if (isLatestRequest()) {
+        setGenerationReadiness(null)
+        setGenerationReadinessError(
+          loadError instanceof Error
+            ? loadError.message
+            : "Failed to check generation readiness."
+        )
+      }
     } finally {
-      setGenerationReadinessLoading(false)
+      if (isLatestRequest()) setGenerationReadinessLoading(false)
     }
   }, [isActive, selectedPersonaId, selectedPack?.id])
 

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react"
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const mocks = vi.hoisted(() => ({
@@ -47,6 +47,14 @@ const okBinaryResponse = (payload: ArrayBuffer) =>
     data: payload,
     json: async () => payload
   })
+
+const deferredResponse = <T,>() => {
+  let resolve: (value: T) => void = () => undefined
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve
+  })
+  return { promise, resolve }
+}
 
 const parseJsonBody = (body: unknown): any => {
   if (typeof body === "string") return JSON.parse(body)
@@ -815,6 +823,98 @@ describe("VisualPackEditor", () => {
     expect(screen.getByTestId("persona-visual-generation-enqueue-button")).toBeDisabled()
     expect(calls).not.toContain(
       "POST /api/v1/persona/profiles/persona-1/visual-packs/pack-1/generation-jobs"
+    )
+  })
+
+  it("ignores stale generation readiness responses after switching packs", async () => {
+    const delayedPackOneReadiness = deferredResponse<Awaited<ReturnType<typeof okResponse>>>()
+    const packOne = {
+      id: "pack-1",
+      persona_id: "persona-1",
+      title: "Animated pack",
+      renderer_type: "sprite_frames",
+      status: "draft",
+      manifest: structuredClone(baseManifest),
+      assets: visualAssets,
+      version: 3
+    }
+    const packTwo = {
+      ...packOne,
+      id: "pack-2",
+      title: "Second pack",
+      manifest: structuredClone(baseManifest)
+    }
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string }) => {
+      const method = init?.method || "GET"
+      if (path === "/api/v1/persona/profiles/persona-1/visual-packs" && method === "GET") {
+        return okResponse([packOne, packTwo])
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/pack-1/generated-candidates" &&
+        method === "GET"
+      ) {
+        return okResponse({ candidates: [] })
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/pack-2/generated-candidates" &&
+        method === "GET"
+      ) {
+        return okResponse({ candidates: [] })
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/pack-1/generation-readiness" &&
+        method === "GET"
+      ) {
+        return delayedPackOneReadiness.promise
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/pack-2/generation-readiness" &&
+        method === "GET"
+      ) {
+        return okResponse({
+          ...readyGenerationReadiness,
+          available: false,
+          image_backend_available: false,
+          default_backend: null,
+          enabled_backends: [],
+          reasons: ["image_backend_unavailable"]
+        })
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        error: `Unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(
+      <VisualPackEditor
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Garden Helper"
+        isActive
+      />
+    )
+
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-pack-select")).toHaveValue("pack-1")
+    )
+    fireEvent.change(screen.getByTestId("persona-visual-pack-select"), {
+      target: { value: "pack-2" }
+    })
+
+    const readiness = await screen.findByTestId("persona-visual-generation-readiness")
+    expect(readiness).toHaveTextContent("No image generation provider is configured.")
+
+    await act(async () => {
+      delayedPackOneReadiness.resolve(await okResponse(readyGenerationReadiness))
+      await delayedPackOneReadiness.promise
+    })
+
+    expect(screen.getByTestId("persona-visual-pack-select")).toHaveValue("pack-2")
+    expect(screen.getByTestId("persona-visual-generation-readiness")).toHaveTextContent(
+      "No image generation provider is configured."
     )
   })
 

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
@@ -109,6 +109,18 @@ const visualAssets = [
   }
 ]
 
+const readyGenerationReadiness = {
+  available: true,
+  worker_enabled: true,
+  queue: "generation",
+  image_backend_available: true,
+  default_backend: "openrouter",
+  requested_backend: null,
+  requested_backend_available: null,
+  enabled_backends: ["openrouter"],
+  reasons: []
+}
+
 describe("VisualPackEditor", () => {
   beforeEach(() => {
     vi.restoreAllMocks()
@@ -606,6 +618,12 @@ describe("VisualPackEditor", () => {
         return okResponse({ candidates: [candidate] })
       }
       if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/pack-1/generation-readiness" &&
+        method === "GET"
+      ) {
+        return okResponse(readyGenerationReadiness)
+      }
+      if (
         path === "/api/v1/persona/profiles/persona-1/visual-packs/pack-1/generation-jobs" &&
         method === "POST"
       ) {
@@ -663,6 +681,140 @@ describe("VisualPackEditor", () => {
           call.includes("/visual-packs/pack-1/candidates/candidate-1/review")
         )
       ).toHaveLength(2)
+    )
+  })
+
+  it("disables visual generation when the Jobs worker is unavailable", async () => {
+    const calls: string[] = []
+    const pack = {
+      id: "pack-1",
+      persona_id: "persona-1",
+      title: "Animated pack",
+      renderer_type: "sprite_frames",
+      status: "draft",
+      manifest: structuredClone(baseManifest),
+      assets: visualAssets,
+      version: 3
+    }
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string }) => {
+      const method = init?.method || "GET"
+      calls.push(`${method} ${path}`)
+      if (path === "/api/v1/persona/profiles/persona-1/visual-packs" && method === "GET") {
+        return okResponse([pack])
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/pack-1/generated-candidates" &&
+        method === "GET"
+      ) {
+        return okResponse({ candidates: [] })
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/pack-1/generation-readiness" &&
+        method === "GET"
+      ) {
+        return okResponse({
+          ...readyGenerationReadiness,
+          available: false,
+          worker_enabled: false,
+          reasons: ["jobs_worker_disabled"]
+        })
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        error: `Unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(
+      <VisualPackEditor
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Garden Helper"
+        isActive
+      />
+    )
+
+    const readiness = await screen.findByTestId("persona-visual-generation-readiness")
+    expect(readiness).toHaveTextContent("Generation worker is not enabled.")
+    expect(readiness).toHaveTextContent("Jobs queue: generation")
+
+    fireEvent.change(screen.getByTestId("persona-visual-generation-prompt-input"), {
+      target: { value: "make an idle pose" }
+    })
+
+    expect(screen.getByTestId("persona-visual-generation-enqueue-button")).toBeDisabled()
+    expect(calls).not.toContain(
+      "POST /api/v1/persona/profiles/persona-1/visual-packs/pack-1/generation-jobs"
+    )
+  })
+
+  it("disables visual generation when no image provider is configured", async () => {
+    const calls: string[] = []
+    const pack = {
+      id: "pack-1",
+      persona_id: "persona-1",
+      title: "Animated pack",
+      renderer_type: "sprite_frames",
+      status: "draft",
+      manifest: structuredClone(baseManifest),
+      assets: visualAssets,
+      version: 3
+    }
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string }) => {
+      const method = init?.method || "GET"
+      calls.push(`${method} ${path}`)
+      if (path === "/api/v1/persona/profiles/persona-1/visual-packs" && method === "GET") {
+        return okResponse([pack])
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/pack-1/generated-candidates" &&
+        method === "GET"
+      ) {
+        return okResponse({ candidates: [] })
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/pack-1/generation-readiness" &&
+        method === "GET"
+      ) {
+        return okResponse({
+          ...readyGenerationReadiness,
+          available: false,
+          image_backend_available: false,
+          default_backend: null,
+          enabled_backends: [],
+          reasons: ["image_backend_unavailable"]
+        })
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        error: `Unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(
+      <VisualPackEditor
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Garden Helper"
+        isActive
+      />
+    )
+
+    const readiness = await screen.findByTestId("persona-visual-generation-readiness")
+    expect(readiness).toHaveTextContent("No image generation provider is configured.")
+    expect(readiness).toHaveTextContent("Enable an image backend before queueing a Persona Buddy visual generation job.")
+
+    fireEvent.change(screen.getByTestId("persona-visual-generation-prompt-input"), {
+      target: { value: "make an idle pose" }
+    })
+
+    expect(screen.getByTestId("persona-visual-generation-enqueue-button")).toBeDisabled()
+    expect(calls).not.toContain(
+      "POST /api/v1/persona/profiles/persona-1/visual-packs/pack-1/generation-jobs"
     )
   })
 

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/personaVisualGenerationReadiness.test.ts
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/personaVisualGenerationReadiness.test.ts
@@ -76,6 +76,20 @@ describe("classifyPersonaVisualGenerationReadiness", () => {
     expect(view.canQueue).toBe(false)
   })
 
+  it("blocks resolved backends whose adapter cannot be started", () => {
+    const view = classifyPersonaVisualGenerationReadiness(
+      readiness({
+        available: false,
+        image_backend_available: false,
+        reasons: ["image_adapter_unavailable"]
+      }),
+      ""
+    )
+
+    expect(view.status).toBe("image_adapter_unavailable")
+    expect(view.canQueue).toBe(false)
+  })
+
   it("allows queueing when the user selects an enabled backend even without a default", () => {
     const base = readiness({
       available: false,

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/personaVisualGenerationReadiness.test.ts
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/personaVisualGenerationReadiness.test.ts
@@ -90,6 +90,22 @@ describe("classifyPersonaVisualGenerationReadiness", () => {
     expect(view.canQueue).toBe(false)
   })
 
+  it("reports readiness dependency failures separately from provider setup", () => {
+    const view = classifyPersonaVisualGenerationReadiness(
+      readiness({
+        available: false,
+        image_backend_available: false,
+        default_backend: null,
+        enabled_backends: [],
+        reasons: ["dependency_check_failed"]
+      }),
+      ""
+    )
+
+    expect(view.status).toBe("dependency_check_failed")
+    expect(view.canQueue).toBe(false)
+  })
+
   it("allows queueing when the user selects an enabled backend even without a default", () => {
     const base = readiness({
       available: false,

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/personaVisualGenerationReadiness.test.ts
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/personaVisualGenerationReadiness.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  classifyPersonaVisualGenerationReadiness,
+  type PersonaVisualGenerationReadinessView
+} from "../personaVisualGenerationReadiness"
+import type { PersonaVisualGenerationReadinessResponse } from "@/types/persona-visuals"
+
+const readiness = (
+  overrides: Partial<PersonaVisualGenerationReadinessResponse> = {}
+): PersonaVisualGenerationReadinessResponse => ({
+  available: true,
+  worker_enabled: true,
+  queue: "generation",
+  image_backend_available: true,
+  default_backend: "openrouter",
+  requested_backend: null,
+  requested_backend_available: null,
+  enabled_backends: ["openrouter", "novita"],
+  reasons: [],
+  ...overrides
+})
+
+describe("classifyPersonaVisualGenerationReadiness", () => {
+  it("blocks queueing while readiness is loading", () => {
+    const view = classifyPersonaVisualGenerationReadiness(null, "", {
+      isLoading: true
+    })
+
+    expect(view).toMatchObject<Partial<PersonaVisualGenerationReadinessView>>({
+      status: "loading",
+      canQueue: false,
+      blocking: true
+    })
+  })
+
+  it("distinguishes Jobs worker unavailability from provider setup", () => {
+    const view = classifyPersonaVisualGenerationReadiness(
+      readiness({
+        available: false,
+        worker_enabled: false,
+        reasons: ["jobs_worker_disabled"]
+      }),
+      ""
+    )
+
+    expect(view.status).toBe("jobs_unavailable")
+    expect(view.canQueue).toBe(false)
+    expect(view.blocking).toBe(true)
+  })
+
+  it("reports missing image providers separately from Jobs readiness", () => {
+    const view = classifyPersonaVisualGenerationReadiness(
+      readiness({
+        available: false,
+        image_backend_available: false,
+        default_backend: null,
+        enabled_backends: [],
+        reasons: ["image_backend_unavailable"]
+      }),
+      ""
+    )
+
+    expect(view.status).toBe("image_provider_unavailable")
+    expect(view.canQueue).toBe(false)
+  })
+
+  it("blocks unavailable typed backends before enqueue", () => {
+    const view = classifyPersonaVisualGenerationReadiness(
+      readiness(),
+      "missing-provider"
+    )
+
+    expect(view.status).toBe("backend_unavailable")
+    expect(view.selectedBackend).toBe("missing-provider")
+    expect(view.canQueue).toBe(false)
+  })
+
+  it("allows queueing when the user selects an enabled backend even without a default", () => {
+    const base = readiness({
+      available: false,
+      image_backend_available: false,
+      default_backend: null,
+      enabled_backends: ["novita"],
+      reasons: ["default_backend_unavailable"]
+    })
+
+    expect(classifyPersonaVisualGenerationReadiness(base, "")).toMatchObject({
+      status: "default_backend_unavailable",
+      canQueue: false
+    })
+    expect(classifyPersonaVisualGenerationReadiness(base, "novita")).toMatchObject({
+      status: "ready",
+      canQueue: true,
+      selectedBackend: "novita"
+    })
+  })
+})

--- a/apps/packages/ui/src/components/PersonaGarden/personaVisualGenerationReadiness.ts
+++ b/apps/packages/ui/src/components/PersonaGarden/personaVisualGenerationReadiness.ts
@@ -6,6 +6,7 @@ export type PersonaVisualGenerationReadinessStatus =
   | "ready"
   | "jobs_unavailable"
   | "image_provider_unavailable"
+  | "image_adapter_unavailable"
   | "backend_unavailable"
   | "default_backend_unavailable"
 
@@ -99,6 +100,18 @@ export function classifyPersonaVisualGenerationReadiness(
   if (!selectedBackend && !defaultBackend) {
     return {
       status: "default_backend_unavailable",
+      canQueue: false,
+      blocking: true,
+      selectedBackend,
+      defaultBackend,
+      enabledBackends,
+      queue: readiness.queue
+    }
+  }
+
+  if (readiness.reasons.includes("image_adapter_unavailable")) {
+    return {
+      status: "image_adapter_unavailable",
       canQueue: false,
       blocking: true,
       selectedBackend,

--- a/apps/packages/ui/src/components/PersonaGarden/personaVisualGenerationReadiness.ts
+++ b/apps/packages/ui/src/components/PersonaGarden/personaVisualGenerationReadiness.ts
@@ -7,6 +7,7 @@ export type PersonaVisualGenerationReadinessStatus =
   | "jobs_unavailable"
   | "image_provider_unavailable"
   | "image_adapter_unavailable"
+  | "dependency_check_failed"
   | "backend_unavailable"
   | "default_backend_unavailable"
 
@@ -64,6 +65,18 @@ export function classifyPersonaVisualGenerationReadiness(
   if (!readiness.worker_enabled || readiness.reasons.includes("jobs_worker_disabled")) {
     return {
       status: "jobs_unavailable",
+      canQueue: false,
+      blocking: true,
+      selectedBackend,
+      defaultBackend,
+      enabledBackends,
+      queue: readiness.queue
+    }
+  }
+
+  if (readiness.reasons.includes("dependency_check_failed")) {
+    return {
+      status: "dependency_check_failed",
       canQueue: false,
       blocking: true,
       selectedBackend,

--- a/apps/packages/ui/src/components/PersonaGarden/personaVisualGenerationReadiness.ts
+++ b/apps/packages/ui/src/components/PersonaGarden/personaVisualGenerationReadiness.ts
@@ -1,0 +1,120 @@
+import type { PersonaVisualGenerationReadinessResponse } from "@/types/persona-visuals"
+
+export type PersonaVisualGenerationReadinessStatus =
+  | "loading"
+  | "error"
+  | "ready"
+  | "jobs_unavailable"
+  | "image_provider_unavailable"
+  | "backend_unavailable"
+  | "default_backend_unavailable"
+
+export interface PersonaVisualGenerationReadinessView {
+  status: PersonaVisualGenerationReadinessStatus
+  canQueue: boolean
+  blocking: boolean
+  selectedBackend?: string | null
+  defaultBackend?: string | null
+  enabledBackends: string[]
+  queue?: string | null
+  errorMessage?: string | null
+}
+
+export function classifyPersonaVisualGenerationReadiness(
+  readiness: PersonaVisualGenerationReadinessResponse | null,
+  backendInput: string,
+  options: { isLoading?: boolean; errorMessage?: string | null } = {}
+): PersonaVisualGenerationReadinessView {
+  const selectedBackend = backendInput.trim() || null
+  if (options.isLoading) {
+    return {
+      status: "loading",
+      canQueue: false,
+      blocking: true,
+      selectedBackend,
+      enabledBackends: []
+    }
+  }
+  if (options.errorMessage) {
+    return {
+      status: "error",
+      canQueue: false,
+      blocking: true,
+      selectedBackend,
+      enabledBackends: [],
+      errorMessage: options.errorMessage
+    }
+  }
+  if (!readiness) {
+    return {
+      status: "loading",
+      canQueue: false,
+      blocking: true,
+      selectedBackend,
+      enabledBackends: []
+    }
+  }
+
+  const enabledBackends = readiness.enabled_backends || []
+  const defaultBackend = readiness.default_backend || null
+  const selectedBackendAvailable =
+    selectedBackend === null || enabledBackends.includes(selectedBackend)
+
+  if (!readiness.worker_enabled || readiness.reasons.includes("jobs_worker_disabled")) {
+    return {
+      status: "jobs_unavailable",
+      canQueue: false,
+      blocking: true,
+      selectedBackend,
+      defaultBackend,
+      enabledBackends,
+      queue: readiness.queue
+    }
+  }
+
+  if (enabledBackends.length === 0 || readiness.reasons.includes("image_backend_unavailable")) {
+    return {
+      status: "image_provider_unavailable",
+      canQueue: false,
+      blocking: true,
+      selectedBackend,
+      defaultBackend,
+      enabledBackends,
+      queue: readiness.queue
+    }
+  }
+
+  if (selectedBackend && !selectedBackendAvailable) {
+    return {
+      status: "backend_unavailable",
+      canQueue: false,
+      blocking: true,
+      selectedBackend,
+      defaultBackend,
+      enabledBackends,
+      queue: readiness.queue
+    }
+  }
+
+  if (!selectedBackend && !defaultBackend) {
+    return {
+      status: "default_backend_unavailable",
+      canQueue: false,
+      blocking: true,
+      selectedBackend,
+      defaultBackend,
+      enabledBackends,
+      queue: readiness.queue
+    }
+  }
+
+  return {
+    status: "ready",
+    canQueue: true,
+    blocking: false,
+    selectedBackend: selectedBackend || defaultBackend,
+    defaultBackend,
+    enabledBackends,
+    queue: readiness.queue
+  }
+}

--- a/apps/packages/ui/src/services/persona-visuals.ts
+++ b/apps/packages/ui/src/services/persona-visuals.ts
@@ -9,6 +9,7 @@ import type {
   PersonaVisualDeactivateResponse,
   PersonaVisualGenerationJobResponse,
   PersonaVisualGenerationRequest,
+  PersonaVisualGenerationReadinessResponse,
   PersonaVisualImportCommitRequest,
   PersonaVisualImportCommitStartResponse,
   PersonaVisualImportPreviewResponse,
@@ -221,6 +222,19 @@ export async function createPersonaVisualGenerationJob(
       method: "POST",
       body: payload
     }
+  )
+}
+
+export async function getPersonaVisualGenerationReadiness(
+  personaId: string,
+  packId: string,
+  backend?: string | null
+): Promise<PersonaVisualGenerationReadinessResponse> {
+  const query = backend?.trim()
+    ? `?backend=${encodeURIComponent(backend.trim())}`
+    : ""
+  return fetchPersonaVisualJson<PersonaVisualGenerationReadinessResponse>(
+    packPath(personaId, packId, `/generation-readiness${query}`)
   )
 }
 

--- a/apps/packages/ui/src/types/persona-visuals.ts
+++ b/apps/packages/ui/src/types/persona-visuals.ts
@@ -168,6 +168,18 @@ export interface PersonaVisualGenerationJobResponse {
   status?: string | null
 }
 
+export interface PersonaVisualGenerationReadinessResponse {
+  available: boolean
+  worker_enabled: boolean
+  queue: string
+  image_backend_available: boolean
+  default_backend?: string | null
+  requested_backend?: string | null
+  requested_backend_available?: boolean | null
+  enabled_backends: string[]
+  reasons: string[]
+}
+
 export interface PersonaVisualPackExportRequest {
   request_id?: string | null
   strict?: boolean

--- a/backlog/tasks/task-180 - Improve-Persona-Visuals-generation-setup-and-unavailable-provider-states.md
+++ b/backlog/tasks/task-180 - Improve-Persona-Visuals-generation-setup-and-unavailable-provider-states.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-180
 title: Improve Persona Visuals generation setup and unavailable-provider states
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-09 19:16'
-updated_date: '2026-05-09 19:26'
+updated_date: '2026-05-09 19:29'
 labels:
   - WebUI
   - Persona
@@ -14,6 +14,7 @@ dependencies: []
 references:
   - 'https://github.com/rmusser01/tldw_server/issues/1428'
   - 'https://github.com/rmusser01/tldw_server/issues/1431'
+  - 'https://github.com/rmusser01/tldw_server/pull/1439'
 priority: medium
 ---
 
@@ -51,12 +52,18 @@ Implemented the Persona Visuals generation readiness slice for issue #1431 in wo
 Verification: Vitest focused Persona visual suite passed (VisualPackEditor, personaVisualGenerationReadiness, personaVisualDiagnostics, SpriteFrameRenderer): 34 tests passed. Pytest Persona visual API suite passed: 24 tests passed. Bandit on touched backend endpoint/schema files reported zero findings. Package-wide tsc currently fails on existing unrelated baseline errors; grep of tsc output for touched files found no errors in VisualPackEditor/persona-visuals/personaVisualGenerationReadiness.
 <!-- SECTION:NOTES:END -->
 
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented PR #1439 for issue #1431. The slice adds a pack-scoped Persona Visuals generation readiness API, WebUI service/types, a tested readiness classifier, and VisualPackEditor setup-state rendering/gating for disabled Jobs worker and missing image provider states. Generation enqueue remains available when readiness is available, and generated candidates still go through the review workflow. Verification recorded in implementation notes; package-wide TypeScript still has unrelated baseline failures, with no errors found in the touched Persona Visuals files.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [x] #1 Acceptance criteria completed
 - [x] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
+- [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-180 - Improve-Persona-Visuals-generation-setup-and-unavailable-provider-states.md
+++ b/backlog/tasks/task-180 - Improve-Persona-Visuals-generation-setup-and-unavailable-provider-states.md
@@ -4,7 +4,7 @@ title: Improve Persona Visuals generation setup and unavailable-provider states
 status: Done
 assignee: []
 created_date: '2026-05-09 19:16'
-updated_date: '2026-05-09 19:42'
+updated_date: '2026-05-09 19:51'
 labels:
   - WebUI
   - Persona
@@ -54,12 +54,14 @@ Verification: Vitest focused Persona visual suite passed (VisualPackEditor, pers
 PR review follow-up: addressed Qodo and Gemini comments by checking adapter instantiation in the readiness endpoint, adding the requested Python docstrings, adding adapter-failure regression coverage, and guarding VisualPackEditor readiness loads against stale async responses after rapid pack switches.
 
 Review verification: Vitest focused Persona visual suite passed (VisualPackEditor, personaVisualGenerationReadiness, personaVisualDiagnostics, SpriteFrameRenderer): 36 tests passed. Pytest Persona visual API suite passed: 25 tests passed. Bandit on touched backend endpoint/schema files reported zero findings. git diff --check passed. The package-wide TypeScript baseline still reports an unrelated PersonaGarden/MCPExternalCatalog.tsx error; touched Persona Visuals files were clean in the grep-filtered output.
+
+Second review follow-up: addressed CodeRabbit's fail-closed readiness comment by returning a deterministic non-sensitive `dependency_check_failed` readiness payload when image generation registry checks fail, and by classifying that reason separately in the WebUI instead of presenting it as a missing provider.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented PR #1439 for issue #1431 and addressed follow-up review comments. The slice adds a pack-scoped Persona Visuals generation readiness API, WebUI service/types, a tested readiness classifier, VisualPackEditor setup-state rendering/gating, adapter-instantiation preflight, and stale-readiness request protection. Generation enqueue remains available when readiness is available, and generated candidates still go through the review workflow. Verification recorded in implementation notes; package-wide TypeScript still has unrelated baseline failures, with no errors found in the touched Persona Visuals files.
+Implemented PR #1439 for issue #1431 and addressed follow-up review comments. The slice adds a pack-scoped Persona Visuals generation readiness API, WebUI service/types, a tested readiness classifier, VisualPackEditor setup-state rendering/gating, adapter-instantiation preflight, fail-closed dependency-check handling, and stale-readiness request protection. Generation enqueue remains available when readiness is available, and generated candidates still go through the review workflow. Verification recorded in implementation notes; package-wide TypeScript still has unrelated baseline failures, with no errors found in the touched Persona Visuals files.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-180 - Improve-Persona-Visuals-generation-setup-and-unavailable-provider-states.md
+++ b/backlog/tasks/task-180 - Improve-Persona-Visuals-generation-setup-and-unavailable-provider-states.md
@@ -4,7 +4,7 @@ title: Improve Persona Visuals generation setup and unavailable-provider states
 status: Done
 assignee: []
 created_date: '2026-05-09 19:16'
-updated_date: '2026-05-09 19:29'
+updated_date: '2026-05-09 19:42'
 labels:
   - WebUI
   - Persona
@@ -50,12 +50,16 @@ Implement GitHub issue #1431 for the Persona/Buddy visual-pack system. Make asse
 Implemented the Persona Visuals generation readiness slice for issue #1431 in worktree .worktrees/persona-visual-generation-readiness. Added a pack-scoped backend readiness endpoint, WebUI service/type support, a tested readiness classifier, and VisualPackEditor setup-state rendering/gating for disabled Jobs worker and missing image provider states.
 
 Verification: Vitest focused Persona visual suite passed (VisualPackEditor, personaVisualGenerationReadiness, personaVisualDiagnostics, SpriteFrameRenderer): 34 tests passed. Pytest Persona visual API suite passed: 24 tests passed. Bandit on touched backend endpoint/schema files reported zero findings. Package-wide tsc currently fails on existing unrelated baseline errors; grep of tsc output for touched files found no errors in VisualPackEditor/persona-visuals/personaVisualGenerationReadiness.
+
+PR review follow-up: addressed Qodo and Gemini comments by checking adapter instantiation in the readiness endpoint, adding the requested Python docstrings, adding adapter-failure regression coverage, and guarding VisualPackEditor readiness loads against stale async responses after rapid pack switches.
+
+Review verification: Vitest focused Persona visual suite passed (VisualPackEditor, personaVisualGenerationReadiness, personaVisualDiagnostics, SpriteFrameRenderer): 36 tests passed. Pytest Persona visual API suite passed: 25 tests passed. Bandit on touched backend endpoint/schema files reported zero findings. git diff --check passed. The package-wide TypeScript baseline still reports an unrelated PersonaGarden/MCPExternalCatalog.tsx error; touched Persona Visuals files were clean in the grep-filtered output.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented PR #1439 for issue #1431. The slice adds a pack-scoped Persona Visuals generation readiness API, WebUI service/types, a tested readiness classifier, and VisualPackEditor setup-state rendering/gating for disabled Jobs worker and missing image provider states. Generation enqueue remains available when readiness is available, and generated candidates still go through the review workflow. Verification recorded in implementation notes; package-wide TypeScript still has unrelated baseline failures, with no errors found in the touched Persona Visuals files.
+Implemented PR #1439 for issue #1431 and addressed follow-up review comments. The slice adds a pack-scoped Persona Visuals generation readiness API, WebUI service/types, a tested readiness classifier, VisualPackEditor setup-state rendering/gating, adapter-instantiation preflight, and stale-readiness request protection. Generation enqueue remains available when readiness is available, and generated candidates still go through the review workflow. Verification recorded in implementation notes; package-wide TypeScript still has unrelated baseline failures, with no errors found in the touched Persona Visuals files.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-180 - Improve-Persona-Visuals-generation-setup-and-unavailable-provider-states.md
+++ b/backlog/tasks/task-180 - Improve-Persona-Visuals-generation-setup-and-unavailable-provider-states.md
@@ -1,0 +1,62 @@
+---
+id: TASK-180
+title: Improve Persona Visuals generation setup and unavailable-provider states
+status: In Progress
+assignee: []
+created_date: '2026-05-09 19:16'
+updated_date: '2026-05-09 19:26'
+labels:
+  - WebUI
+  - Persona
+  - Buddy
+  - visual-packs
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1428'
+  - 'https://github.com/rmusser01/tldw_server/issues/1431'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement GitHub issue #1431 for the Persona/Buddy visual-pack system. Make asset generation readiness obvious before users start background jobs by distinguishing provider/model unavailability from Jobs/backend unavailability, preventing or clearly gating generation actions that cannot succeed, and preserving the generated-asset review workflow.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Persona Visuals editor shows clear setup/unavailable states when generation provider/backend configuration is missing or disabled.
+- [x] #2 Jobs/backend unavailability is distinguished from image provider/model unavailability in user-facing copy and gating.
+- [x] #3 Generation actions that cannot succeed are disabled or clearly guarded without bypassing the review-step workflow.
+- [x] #4 Focused UI/service tests cover disabled and missing-provider generation readiness states.
+- [x] #5 Existing persona visual generation job enqueue and review candidate flows continue to work when readiness is available.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Create an isolated branch/worktree from latest origin/dev for issue #1431.
+2. Inspect existing persona visual generation service/API/editor code to find the current readiness signal and generation action path.
+3. Add failing focused tests for missing provider/backend readiness and action gating in the Persona Visuals editor/service boundary.
+4. Implement a minimal frontend readiness classifier and wire it into VisualPackEditor generation controls without changing provider implementations.
+5. Preserve the existing generation job enqueue and candidate review flow for ready states.
+6. Run focused Vitest/service tests, diff hygiene, and applicable static checks; update Backlog, commit, push, and open/update PR.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the Persona Visuals generation readiness slice for issue #1431 in worktree .worktrees/persona-visual-generation-readiness. Added a pack-scoped backend readiness endpoint, WebUI service/type support, a tested readiness classifier, and VisualPackEditor setup-state rendering/gating for disabled Jobs worker and missing image provider states.
+
+Verification: Vitest focused Persona visual suite passed (VisualPackEditor, personaVisualGenerationReadiness, personaVisualDiagnostics, SpriteFrameRenderer): 34 tests passed. Pytest Persona visual API suite passed: 24 tests passed. Bandit on touched backend endpoint/schema files reported zero findings. Package-wide tsc currently fails on existing unrelated baseline errors; grep of tsc output for touched files found no errors in VisualPackEditor/persona-visuals/personaVisualGenerationReadiness.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -1919,31 +1919,42 @@ def _build_persona_visual_generation_readiness(
     queue name, backend resolution, and adapter instantiation.
     """
 
-    registry = get_image_generation_registry()
-    enabled_backends = registry.list_backend_names(include_disabled=False)
-    default_backend = registry.resolve_backend(None)
     requested_backend = str(backend or "").strip() or None
-    resolved_backend = registry.resolve_backend(requested_backend) if requested_backend else default_backend
-    requested_backend_available = None
-    adapter_available = False
-    if resolved_backend:
-        adapter_available = registry.get_adapter(resolved_backend) is not None
-    if requested_backend is not None:
-        requested_backend_available = adapter_available
-
     worker_enabled = env_flag_enabled("PERSONA_VISUAL_GENERATION_WORKER_ENABLED")
-    image_backend_available = adapter_available
-    reasons: list[str] = []
-    if not worker_enabled:
-        reasons.append("jobs_worker_disabled")
-    if requested_backend and resolved_backend is None:
-        reasons.append("requested_backend_unavailable")
-    elif resolved_backend and not adapter_available:
-        reasons.append("image_adapter_unavailable")
-    elif not requested_backend and not enabled_backends:
-        reasons.append("image_backend_unavailable")
-    elif not requested_backend and default_backend is None:
-        reasons.append("default_backend_unavailable")
+    try:
+        registry = get_image_generation_registry()
+        enabled_backends = registry.list_backend_names(include_disabled=False)
+        default_backend = registry.resolve_backend(None)
+        resolved_backend = registry.resolve_backend(requested_backend) if requested_backend else default_backend
+        requested_backend_available = None
+        adapter_available = False
+        if resolved_backend:
+            adapter_available = registry.get_adapter(resolved_backend) is not None
+        if requested_backend is not None:
+            requested_backend_available = adapter_available
+
+        image_backend_available = adapter_available
+        reasons: list[str] = []
+        if not worker_enabled:
+            reasons.append("jobs_worker_disabled")
+        if requested_backend and resolved_backend is None:
+            reasons.append("requested_backend_unavailable")
+        elif resolved_backend and not adapter_available:
+            reasons.append("image_adapter_unavailable")
+        elif not requested_backend and not enabled_backends:
+            reasons.append("image_backend_unavailable")
+        elif not requested_backend and default_backend is None:
+            reasons.append("default_backend_unavailable")
+    except Exception:
+        logger.exception("Persona visual generation readiness dependency check failed")
+        enabled_backends = []
+        default_backend = None
+        requested_backend_available = False if requested_backend is not None else None
+        image_backend_available = False
+        reasons = []
+        if not worker_enabled:
+            reasons.append("jobs_worker_disabled")
+        reasons.append("dependency_check_failed")
 
     return PersonaVisualGenerationReadinessResponse(
         available=worker_enabled and image_backend_available,

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -85,6 +85,7 @@ from tldw_Server_API.app.api.v1.schemas.persona import (
     PersonaVisualDeactivateResponse,
     PersonaVisualGenerationJobResponse,
     PersonaVisualGenerationRequest,
+    PersonaVisualGenerationReadinessResponse,
     PersonaVisualImportCommitRequest,
     PersonaVisualImportCommitStartResponse,
     PersonaVisualImportPreviewResponse,
@@ -127,6 +128,9 @@ from tldw_Server_API.app.core.feature_flags import (
     is_persona_enabled,
 )
 from tldw_Server_API.app.core.http_client import RetryPolicy, afetch
+from tldw_Server_API.app.core.Image_Generation.adapter_registry import (
+    get_registry as get_image_generation_registry,
+)
 from tldw_Server_API.app.core.MCP_unified import MCPRequest, get_mcp_server
 from tldw_Server_API.app.core.MCP_unified.auth.jwt_manager import get_jwt_manager
 from tldw_Server_API.app.core.MCP_unified.persona_scope import normalize_persona_scope_payload
@@ -141,6 +145,7 @@ from tldw_Server_API.app.core.Persona.visual_jobs import (
     create_visual_pack_export_job,
     create_visual_pack_import_commit_job,
     create_visual_pack_import_preview_job,
+    persona_visual_generation_queue,
 )
 from tldw_Server_API.app.core.Persona.visual_portability.archive import (
     DEFAULT_MAX_ARCHIVE_SIZE_BYTES,
@@ -209,6 +214,7 @@ from tldw_Server_API.app.core.Personalization.companion_activity import (
 from tldw_Server_API.app.core.Personalization.companion_context import load_companion_context
 from tldw_Server_API.app.core.Skills.context_integration import handle_skill_tool_call
 from tldw_Server_API.app.core.Streaming.streams import WebSocketStream
+from tldw_Server_API.app.core.testing import env_flag_enabled
 from tldw_Server_API.app.core.VoiceAssistant import (
     ActionType as VoiceActionTypeInternal,
 )
@@ -1901,6 +1907,44 @@ def get_persona_visual_service(
     db: CharactersRAGDB = Depends(get_chacha_db_for_user),
 ) -> PersonaVisualService:
     return PersonaVisualService(db)
+
+
+def _build_persona_visual_generation_readiness(
+    *,
+    backend: str | None,
+) -> PersonaVisualGenerationReadinessResponse:
+    registry = get_image_generation_registry()
+    enabled_backends = registry.list_backend_names(include_disabled=False)
+    default_backend = registry.resolve_backend(None)
+    requested_backend = str(backend or "").strip() or None
+    resolved_backend = registry.resolve_backend(requested_backend) if requested_backend else default_backend
+    requested_backend_available = None
+    if requested_backend is not None:
+        requested_backend_available = resolved_backend is not None
+
+    worker_enabled = env_flag_enabled("PERSONA_VISUAL_GENERATION_WORKER_ENABLED")
+    image_backend_available = resolved_backend is not None
+    reasons: list[str] = []
+    if not worker_enabled:
+        reasons.append("jobs_worker_disabled")
+    if requested_backend and resolved_backend is None:
+        reasons.append("requested_backend_unavailable")
+    elif not requested_backend and not enabled_backends:
+        reasons.append("image_backend_unavailable")
+    elif not requested_backend and default_backend is None:
+        reasons.append("default_backend_unavailable")
+
+    return PersonaVisualGenerationReadinessResponse(
+        available=worker_enabled and image_backend_available,
+        worker_enabled=worker_enabled,
+        queue=persona_visual_generation_queue(),
+        image_backend_available=image_backend_available,
+        default_backend=default_backend,
+        requested_backend=requested_backend,
+        requested_backend_available=requested_backend_available,
+        enabled_backends=enabled_backends,
+        reasons=reasons,
+    )
 
 
 def _persona_visual_override_payload_from_tool_result(
@@ -3970,6 +4014,46 @@ async def get_persona_visual_generated_candidate(
         raise
     except (InputError, ConflictError, CharactersRAGDBError) as exc:
         raise _to_http_exception(exc, action="get persona visual candidate") from exc
+
+
+@router.get(
+    "/profiles/{persona_id}/visual-packs/{pack_id}/generation-readiness",
+    response_model=PersonaVisualGenerationReadinessResponse,
+    tags=["persona"],
+    status_code=status.HTTP_200_OK,
+    dependencies=[Depends(check_rate_limit)],
+)
+async def get_persona_visual_generation_readiness(
+    persona_id: str,
+    pack_id: str,
+    backend: str | None = Query(default=None, max_length=80),
+    _current_user: User = Depends(get_request_user),
+    db: CharactersRAGDB = Depends(get_chacha_db_for_user),
+) -> PersonaVisualGenerationReadinessResponse:
+    """Report whether visual generation can be queued for this pack."""
+    if not is_persona_enabled():
+        raise HTTPException(status_code=404, detail="Persona disabled")
+    user_id = _require_current_user_id(_current_user)
+    try:
+        await _get_persona_profile_or_404(
+            db,
+            persona_id=persona_id,
+            user_id=user_id,
+            include_deleted=False,
+        )
+        pack = await _run_persona_db_call(
+            db.get_persona_visual_pack,
+            pack_id=pack_id,
+            persona_id=persona_id,
+            user_id=user_id,
+        )
+        if pack is None:
+            raise HTTPException(status_code=404, detail="Persona visual pack not found")
+        return _build_persona_visual_generation_readiness(backend=backend)
+    except HTTPException:
+        raise
+    except (InputError, ConflictError, CharactersRAGDBError) as exc:
+        raise _to_http_exception(exc, action="get persona visual generation readiness") from exc
 
 
 @router.post(

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -1913,22 +1913,33 @@ def _build_persona_visual_generation_readiness(
     *,
     backend: str | None,
 ) -> PersonaVisualGenerationReadinessResponse:
+    """Build the generation preflight response without enqueueing a job.
+
+    The checks mirror the worker's first failure points: optional worker flag,
+    queue name, backend resolution, and adapter instantiation.
+    """
+
     registry = get_image_generation_registry()
     enabled_backends = registry.list_backend_names(include_disabled=False)
     default_backend = registry.resolve_backend(None)
     requested_backend = str(backend or "").strip() or None
     resolved_backend = registry.resolve_backend(requested_backend) if requested_backend else default_backend
     requested_backend_available = None
+    adapter_available = False
+    if resolved_backend:
+        adapter_available = registry.get_adapter(resolved_backend) is not None
     if requested_backend is not None:
-        requested_backend_available = resolved_backend is not None
+        requested_backend_available = adapter_available
 
     worker_enabled = env_flag_enabled("PERSONA_VISUAL_GENERATION_WORKER_ENABLED")
-    image_backend_available = resolved_backend is not None
+    image_backend_available = adapter_available
     reasons: list[str] = []
     if not worker_enabled:
         reasons.append("jobs_worker_disabled")
     if requested_backend and resolved_backend is None:
         reasons.append("requested_backend_unavailable")
+    elif resolved_backend and not adapter_available:
+        reasons.append("image_adapter_unavailable")
     elif not requested_backend and not enabled_backends:
         reasons.append("image_backend_unavailable")
     elif not requested_backend and default_backend is None:

--- a/tldw_Server_API/app/api/v1/schemas/persona.py
+++ b/tldw_Server_API/app/api/v1/schemas/persona.py
@@ -118,6 +118,13 @@ class PersonaVisualGenerationJobResponse(BaseModel):
 
 
 class PersonaVisualGenerationReadinessResponse(BaseModel):
+    """Preflight state for queueing Persona visual generation jobs.
+
+    ``available`` is true only when the Jobs worker is enabled and the
+    selected or default image backend can resolve to an instantiable adapter.
+    ``reasons`` contains machine-readable blockers for setup UI copy.
+    """
+
     available: bool
     worker_enabled: bool
     queue: str

--- a/tldw_Server_API/app/api/v1/schemas/persona.py
+++ b/tldw_Server_API/app/api/v1/schemas/persona.py
@@ -117,6 +117,18 @@ class PersonaVisualGenerationJobResponse(BaseModel):
     status: str | None = None
 
 
+class PersonaVisualGenerationReadinessResponse(BaseModel):
+    available: bool
+    worker_enabled: bool
+    queue: str
+    image_backend_available: bool
+    default_backend: str | None = None
+    requested_backend: str | None = None
+    requested_backend_available: bool | None = None
+    enabled_backends: list[str] = Field(default_factory=list)
+    reasons: list[str] = Field(default_factory=list)
+
+
 class PersonaVisualPackExportRequest(BaseModel):
     request_id: str | None = Field(default=None, max_length=120)
     strict: bool = False

--- a/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
@@ -153,6 +153,26 @@ class FakeJobManager:
         return True
 
 
+class FakeImageRegistry:
+    def __init__(
+        self,
+        *,
+        enabled_backends: list[str] | None = None,
+        default_backend: str | None = None,
+    ) -> None:
+        self.enabled_backends = enabled_backends or []
+        self.default_backend = default_backend
+
+    def list_backend_names(self, *, include_disabled: bool = False) -> list[str]:
+        return list(self.enabled_backends)
+
+    def resolve_backend(self, requested: str | None) -> str | None:
+        name = (requested or self.default_backend or "").strip()
+        if not name or name not in self.enabled_backends:
+            return None
+        return name
+
+
 def test_create_list_and_activate_visual_pack(persona_db: CharactersRAGDB) -> None:
     with _client_for_user(1, persona_db) as client:
         persona_id = _create_persona(client, name="Visual API Persona")
@@ -372,6 +392,106 @@ def test_create_generation_job_rejects_other_user_pack(persona_db: CharactersRAG
 
     assert response.status_code == 404
     assert manager.created == []
+
+
+def test_visual_generation_readiness_reports_disabled_worker(
+    persona_db: CharactersRAGDB,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("PERSONA_VISUAL_GENERATION_WORKER_ENABLED", raising=False)
+    monkeypatch.setenv("PERSONA_VISUAL_GENERATION_JOBS_QUEUE", "persona-generation")
+    monkeypatch.setattr(
+        persona_ep,
+        "get_image_generation_registry",
+        lambda: FakeImageRegistry(
+            enabled_backends=["openrouter"],
+            default_backend="openrouter",
+        ),
+        raising=False,
+    )
+
+    with _client_for_user(1, persona_db) as client:
+        persona_id = _create_persona(client, name="Readiness Worker Persona")
+        pack = _create_visual_pack(client, persona_id)
+
+        response = client.get(
+            f"/api/v1/persona/profiles/{persona_id}/visual-packs/{pack['id']}/generation-readiness"
+        )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["available"] is False
+    assert payload["worker_enabled"] is False
+    assert payload["queue"] == "persona-generation"
+    assert payload["image_backend_available"] is True
+    assert payload["default_backend"] == "openrouter"
+    assert payload["enabled_backends"] == ["openrouter"]
+    assert payload["reasons"] == ["jobs_worker_disabled"]
+
+
+def test_visual_generation_readiness_reports_missing_image_provider(
+    persona_db: CharactersRAGDB,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PERSONA_VISUAL_GENERATION_WORKER_ENABLED", "1")
+    monkeypatch.setattr(
+        persona_ep,
+        "get_image_generation_registry",
+        lambda: FakeImageRegistry(enabled_backends=[], default_backend=None),
+        raising=False,
+    )
+
+    with _client_for_user(1, persona_db) as client:
+        persona_id = _create_persona(client, name="Readiness Provider Persona")
+        pack = _create_visual_pack(client, persona_id)
+
+        response = client.get(
+            f"/api/v1/persona/profiles/{persona_id}/visual-packs/{pack['id']}/generation-readiness"
+        )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["available"] is False
+    assert payload["worker_enabled"] is True
+    assert payload["image_backend_available"] is False
+    assert payload["default_backend"] is None
+    assert payload["enabled_backends"] == []
+    assert payload["reasons"] == ["image_backend_unavailable"]
+
+
+def test_visual_generation_readiness_reports_available_backend(
+    persona_db: CharactersRAGDB,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PERSONA_VISUAL_GENERATION_WORKER_ENABLED", "true")
+    monkeypatch.setattr(
+        persona_ep,
+        "get_image_generation_registry",
+        lambda: FakeImageRegistry(
+            enabled_backends=["openrouter", "novita"],
+            default_backend="openrouter",
+        ),
+        raising=False,
+    )
+
+    with _client_for_user(1, persona_db) as client:
+        persona_id = _create_persona(client, name="Readiness Ready Persona")
+        pack = _create_visual_pack(client, persona_id)
+
+        response = client.get(
+            f"/api/v1/persona/profiles/{persona_id}/visual-packs/{pack['id']}/generation-readiness?backend=novita"
+        )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["available"] is True
+    assert payload["worker_enabled"] is True
+    assert payload["image_backend_available"] is True
+    assert payload["default_backend"] == "openrouter"
+    assert payload["requested_backend"] == "novita"
+    assert payload["requested_backend_available"] is True
+    assert payload["enabled_backends"] == ["openrouter", "novita"]
+    assert payload["reasons"] == []
 
 
 def test_start_visual_pack_export_creates_portability_job(persona_db: CharactersRAGDB) -> None:

--- a/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
@@ -162,15 +162,19 @@ class FakeImageRegistry:
         enabled_backends: list[str] | None = None,
         default_backend: str | None = None,
         adapter_available: bool = True,
+        raise_on_resolve: bool = False,
     ) -> None:
         self.enabled_backends = enabled_backends or []
         self.default_backend = default_backend
         self.adapter_available = adapter_available
+        self.raise_on_resolve = raise_on_resolve
 
     def list_backend_names(self, *, include_disabled: bool = False) -> list[str]:
         return list(self.enabled_backends)
 
     def resolve_backend(self, requested: str | None) -> str | None:
+        if self.raise_on_resolve:
+            raise RuntimeError("backend resolution failed")
         name = (requested or self.default_backend or "").strip()
         if not name or name not in self.enabled_backends:
             return None
@@ -535,6 +539,44 @@ def test_visual_generation_readiness_reports_adapter_unavailable(
     assert payload["default_backend"] == "openrouter"
     assert payload["enabled_backends"] == ["openrouter"]
     assert payload["reasons"] == ["image_adapter_unavailable"]
+
+
+def test_visual_generation_readiness_fails_closed_when_dependency_check_errors(
+    persona_db: CharactersRAGDB,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PERSONA_VISUAL_GENERATION_WORKER_ENABLED", "true")
+    monkeypatch.setenv("PERSONA_VISUAL_GENERATION_JOBS_QUEUE", "persona-generation")
+    monkeypatch.setattr(
+        persona_ep,
+        "get_image_generation_registry",
+        lambda: FakeImageRegistry(
+            enabled_backends=["openrouter"],
+            default_backend="openrouter",
+            raise_on_resolve=True,
+        ),
+        raising=False,
+    )
+
+    with _client_for_user(1, persona_db) as client:
+        persona_id = _create_persona(client, name="Readiness Dependency Persona")
+        pack = _create_visual_pack(client, persona_id)
+
+        response = client.get(
+            f"/api/v1/persona/profiles/{persona_id}/visual-packs/{pack['id']}/generation-readiness?backend=openrouter"
+        )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["available"] is False
+    assert payload["worker_enabled"] is True
+    assert payload["queue"] == "persona-generation"
+    assert payload["image_backend_available"] is False
+    assert payload["default_backend"] is None
+    assert payload["requested_backend"] == "openrouter"
+    assert payload["requested_backend_available"] is False
+    assert payload["enabled_backends"] == []
+    assert payload["reasons"] == ["dependency_check_failed"]
 
 
 def test_start_visual_pack_export_creates_portability_job(persona_db: CharactersRAGDB) -> None:

--- a/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
@@ -154,14 +154,18 @@ class FakeJobManager:
 
 
 class FakeImageRegistry:
+    """Small image registry double for persona visual readiness tests."""
+
     def __init__(
         self,
         *,
         enabled_backends: list[str] | None = None,
         default_backend: str | None = None,
+        adapter_available: bool = True,
     ) -> None:
         self.enabled_backends = enabled_backends or []
         self.default_backend = default_backend
+        self.adapter_available = adapter_available
 
     def list_backend_names(self, *, include_disabled: bool = False) -> list[str]:
         return list(self.enabled_backends)
@@ -171,6 +175,11 @@ class FakeImageRegistry:
         if not name or name not in self.enabled_backends:
             return None
         return name
+
+    def get_adapter(self, name: str):
+        if name not in self.enabled_backends or not self.adapter_available:
+            return None
+        return object()
 
 
 def test_create_list_and_activate_visual_pack(persona_db: CharactersRAGDB) -> None:
@@ -492,6 +501,40 @@ def test_visual_generation_readiness_reports_available_backend(
     assert payload["requested_backend_available"] is True
     assert payload["enabled_backends"] == ["openrouter", "novita"]
     assert payload["reasons"] == []
+
+
+def test_visual_generation_readiness_reports_adapter_unavailable(
+    persona_db: CharactersRAGDB,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PERSONA_VISUAL_GENERATION_WORKER_ENABLED", "true")
+    monkeypatch.setattr(
+        persona_ep,
+        "get_image_generation_registry",
+        lambda: FakeImageRegistry(
+            enabled_backends=["openrouter"],
+            default_backend="openrouter",
+            adapter_available=False,
+        ),
+        raising=False,
+    )
+
+    with _client_for_user(1, persona_db) as client:
+        persona_id = _create_persona(client, name="Readiness Adapter Persona")
+        pack = _create_visual_pack(client, persona_id)
+
+        response = client.get(
+            f"/api/v1/persona/profiles/{persona_id}/visual-packs/{pack['id']}/generation-readiness"
+        )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["available"] is False
+    assert payload["worker_enabled"] is True
+    assert payload["image_backend_available"] is False
+    assert payload["default_backend"] == "openrouter"
+    assert payload["enabled_backends"] == ["openrouter"]
+    assert payload["reasons"] == ["image_adapter_unavailable"]
 
 
 def test_start_visual_pack_export_creates_portability_job(persona_db: CharactersRAGDB) -> None:


### PR DESCRIPTION
## Summary
- add a pack-scoped Persona Visuals generation readiness endpoint that reports Jobs worker state, queue, enabled image backends, default/requested backend availability, and reason codes
- add WebUI service/types plus a tested readiness classifier for Persona Buddy visual generation setup states
- render readiness in VisualPackEditor and disable enqueue when the Jobs worker or image provider setup cannot support generation, while preserving generated-candidate review flow

## Verification
- `./node_modules/.bin/vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx src/components/PersonaGarden/__tests__/personaVisualGenerationReadiness.test.ts src/components/Common/PersonaBuddy/__tests__/personaVisualDiagnostics.test.ts src/components/Common/PersonaBuddy/__tests__/SpriteFrameRenderer.test.tsx` (34 passed)
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_visuals_api.py -q` (24 passed)
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/app/api/v1/schemas/persona.py -f json -o /tmp/bandit_persona_visual_generation_readiness.json` (0 findings)
- `git diff --check`

## Notes
- Package-wide `./node_modules/.bin/tsc --noEmit --project tsconfig.json --pretty false` still fails on existing unrelated baseline errors. Grepping that output for `PersonaGarden|persona-visuals|VisualPackEditor|personaVisualGenerationReadiness` found no errors in the files touched by this PR; the only PersonaGarden hit was existing `MCPExternalCatalog.tsx`.
- AI-authored PR merge gate still requires a human-owned Change summary before merge.

Closes #1431