### PR TITLE
Add shared sandbox audit metadata contract

### DIFF
--- a/backlog/tasks/task-183 - Add-shared-sandbox-audit-metadata-contract.md
+++ b/backlog/tasks/task-183 - Add-shared-sandbox-audit-metadata-contract.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - Codex
 created_date: '2026-05-09 19:31'
-updated_date: '2026-05-09 19:42'
+updated_date: '2026-05-09 19:44'
 labels:
   - sandbox
   - security
@@ -57,12 +57,18 @@ User asked to continue after PR #1438 merged. Existing trust-level and runtime c
 Implemented shared run-completion audit metadata helper and wired endpoint/background service paths. Red check: focused audit test file failed on missing helper and missing spec argument. Green checks: python -m pytest tldw_Server_API/tests/sandbox/test_sandbox_run_limit_audit.py -q passed 4 tests; endpoint smoke test passed 1 test; py_compile passed for touched production modules; git diff --check passed; Bandit on touched production files reported 0 results and 0 errors at /tmp/bandit_sandbox_audit_metadata_contract.json.
 <!-- SECTION:NOTES:END -->
 
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented a shared sandbox run-completion audit metadata contract and wired it into both REST endpoint and background-service completion audit paths. The helper centralizes runtime, requested/effective runtime, trust/network policy, spec version, outcome, status reason, policy/image identifiers, and bounded limit metadata while omitting raw artifact paths, raw capture patterns, and host-path base image values. Focused tests cover path minimization and service metadata parity; verification passed for focused pytest, endpoint smoke, py_compile, git diff --check, and Bandit. PR: https://github.com/rmusser01/tldw_server/pull/1441
+<!-- SECTION:FINAL_SUMMARY:END -->
+
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [x] #1 Acceptance criteria completed
 - [x] #2 Tests or verification recorded
 - [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-183 - Add-shared-sandbox-audit-metadata-contract.md
+++ b/backlog/tasks/task-183 - Add-shared-sandbox-audit-metadata-contract.md
@@ -1,0 +1,68 @@
+---
+id: TASK-183
+title: Add shared sandbox audit metadata contract
+status: In Progress
+assignee:
+  - Codex
+created_date: '2026-05-09 19:31'
+updated_date: '2026-05-09 19:42'
+labels:
+  - sandbox
+  - security
+  - audit
+  - runtime-policy
+dependencies: []
+references:
+  - tldw_Server_API/app/core/Sandbox/service.py
+  - tldw_Server_API/app/api/v1/endpoints/sandbox.py
+  - tldw_Server_API/app/core/Sandbox/limits.py
+  - tldw_Server_API/tests/sandbox/test_sandbox_run_limit_audit.py
+documentation:
+  - Docs/Sandbox/sandbox-security-policy-matrix.md
+  - Docs/Sandbox/sandbox-architecture-doctrine.md
+  - Docs/superpowers/specs/2026-05-02-sandbox-module-roadmap-design.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue the sandbox module roadmap Phase 2 security-hardening work by making sandbox audit metadata contract-shaped instead of duplicating ad hoc dictionaries in endpoint and background-service paths. The slice should centralize safe run-completion metadata for lifecycle/policy/artifact-limit fields, keep path/secret minimization guarantees, and preserve existing audit event behavior. Do not broaden this into a generic audit subsystem rewrite or runtime execution changes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A shared sandbox audit metadata helper/schema exists for run completion metadata and is used by both endpoint and background-service run-completion audit paths.
+- [x] #2 The helper includes requested/effective runtime where available, trust/network/policy identifiers where available, spec version, exit/outcome fields, status reason where available, and existing bounded limit metadata without exposing raw artifact paths or environment values.
+- [x] #3 Focused tests cover metadata shape, path minimization, and parity between endpoint-style and background-service audit metadata construction.
+- [x] #4 Existing limit audit behavior remains compatible with current audit tests.
+- [x] #5 Documentation or inline contract notes connect the helper to the sandbox security policy matrix audit expectations.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Inspect the current endpoint and background-service sandbox run-completion audit metadata to identify overlapping fields and existing limit metadata behavior.
+2. Add focused failing tests in the sandbox audit test module for a shared safe metadata builder, including path minimization and endpoint/background parity.
+3. Implement a small shared helper under tldw_Server_API/app/core/Sandbox/ that builds run-completion audit metadata from RunStatus plus optional request/spec context.
+4. Replace the duplicated metadata dictionaries in SandboxService._audit_run_completion and the sandbox endpoint completion audit path with the helper while preserving existing event types/actions/results.
+5. Run focused pytest, py_compile or import checks as needed, git diff --check, and Bandit on touched Python paths; update acceptance criteria and final task notes with evidence.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+User asked to continue after PR #1438 merged. Existing trust-level and runtime capability contracts already cover the initially considered security-policy slice, so this task targets the remaining Phase 2 audit metadata contract gap from the sandbox security matrix.
+
+Implemented shared run-completion audit metadata helper and wired endpoint/background service paths. Red check: focused audit test file failed on missing helper and missing spec argument. Green checks: python -m pytest tldw_Server_API/tests/sandbox/test_sandbox_run_limit_audit.py -q passed 4 tests; endpoint smoke test passed 1 test; py_compile passed for touched production modules; git diff --check passed; Bandit on touched production files reported 0 results and 0 errors at /tmp/bandit_sandbox_audit_metadata_contract.json.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-183 - Add-shared-sandbox-audit-metadata-contract.md
+++ b/backlog/tasks/task-183 - Add-shared-sandbox-audit-metadata-contract.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - Codex
 created_date: '2026-05-09 19:31'
-updated_date: '2026-05-09 19:44'
+updated_date: '2026-05-09 19:58'
 labels:
   - sandbox
   - security
@@ -55,12 +55,18 @@ Continue the sandbox module roadmap Phase 2 security-hardening work by making sa
 User asked to continue after PR #1438 merged. Existing trust-level and runtime capability contracts already cover the initially considered security-policy slice, so this task targets the remaining Phase 2 audit metadata contract gap from the sandbox security matrix.
 
 Implemented shared run-completion audit metadata helper and wired endpoint/background service paths. Red check: focused audit test file failed on missing helper and missing spec argument. Green checks: python -m pytest tldw_Server_API/tests/sandbox/test_sandbox_run_limit_audit.py -q passed 4 tests; endpoint smoke test passed 1 test; py_compile passed for touched production modules; git diff --check passed; Bandit on touched production files reported 0 results and 0 errors at /tmp/bandit_sandbox_audit_metadata_contract.json.
+
+PR review follow-up verified against current branch. Plan: add focused regression tests and run them red; update audit metadata and call sites minimally; run focused pytest, endpoint smoke, py_compile, diff check, Bandit; update the task, commit, and push.
+
+PR review fixes applied and verified. Red check failed on Windows drive-relative base_image redaction and omitted requested_runtime. Green checks passed: audit pytest 8 passed, endpoint smoke 1 passed, py_compile passed for touched production modules, git diff --check passed, Bandit reported 0 results and 0 errors in /tmp/bandit_sandbox_audit_metadata_contract_review.json.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Implemented a shared sandbox run-completion audit metadata contract and wired it into both REST endpoint and background-service completion audit paths. The helper centralizes runtime, requested/effective runtime, trust/network policy, spec version, outcome, status reason, policy/image identifiers, and bounded limit metadata while omitting raw artifact paths, raw capture patterns, and host-path base image values. Focused tests cover path minimization and service metadata parity; verification passed for focused pytest, endpoint smoke, py_compile, git diff --check, and Bandit. PR: https://github.com/rmusser01/tldw_server/pull/1441
+
+PR review follow-up: added helper docstrings, redacted Windows drive-relative base_image values, preserved omitted requested_runtime as None, split the broad metadata contract test into focused cases, and removed redundant reason_code merges from endpoint/service call sites.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/api/v1/endpoints/sandbox.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sandbox.py
@@ -79,6 +79,7 @@ from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
 from tldw_Server_API.app.core.AuthNZ.settings import get_settings
 from tldw_Server_API.app.core.config import settings as app_settings
 from tldw_Server_API.app.core.Metrics import increment_counter, observe_histogram
+from tldw_Server_API.app.core.Sandbox.audit_metadata import build_run_completion_audit_metadata
 from tldw_Server_API.app.core.Sandbox.models import RunPhase, RunSpec, SessionSpec
 from tldw_Server_API.app.core.Sandbox.models import RuntimeType as CoreRuntimeType
 from tldw_Server_API.app.core.Sandbox.models import TrustLevel as CoreTrustLevel
@@ -1508,16 +1509,15 @@ async def start_run(
                         action="run",
                         result=("success" if outcome == "success" else outcome),
                         duration_ms=duration * 1000.0,
-                        metadata={
-                            "runtime": status.runtime.value if status.runtime else None,
-                            "base_image": status.base_image,
-                            "image_digest": status.image_digest,
-                            "policy_hash": status.policy_hash,
-                            "exit_code": status.exit_code,
-                            "spec_version": payload.spec_version,
-                            "capture_patterns": payload.capture_patterns or [],
-                            "reason_code": reason_code,
-                        },
+                        metadata=build_run_completion_audit_metadata(
+                            status=status,
+                            spec_version=payload.spec_version,
+                            requested_runtime=runtime,
+                            trust_level=spec.trust_level,
+                            network_policy=spec.network_policy,
+                            capture_patterns=spec.capture_patterns,
+                        )
+                        | ({"reason_code": reason_code} if reason_code is not None else {}),
                     )
             except _SANDBOX_NONCRITICAL_EXCEPTIONS as e:
                 logger.debug(f"sandbox audit(run.complete) failed: {e}")

--- a/tldw_Server_API/app/api/v1/endpoints/sandbox.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sandbox.py
@@ -1492,13 +1492,6 @@ async def start_run(
                         method=(request.method if request else "POST"),
                         session_id=payload.session_id,
                     )
-                    # Map reason_code for non-success outcomes
-                    reason_code = None
-                    try:
-                        if outcome in ("timeout", "failed"):
-                            reason_code = (status.message or None)
-                    except _SANDBOX_NONCRITICAL_EXCEPTIONS:
-                        reason_code = None
                     await audit_service.log_event(
                         event_type=AuditEventType.API_RESPONSE,
                         category=AuditEventCategory.API_CALL,
@@ -1517,7 +1510,6 @@ async def start_run(
                             network_policy=spec.network_policy,
                             capture_patterns=spec.capture_patterns,
                         )
-                        | ({"reason_code": reason_code} if reason_code is not None else {}),
                     )
             except _SANDBOX_NONCRITICAL_EXCEPTIONS as e:
                 logger.debug(f"sandbox audit(run.complete) failed: {e}")

--- a/tldw_Server_API/app/core/Sandbox/audit_metadata.py
+++ b/tldw_Server_API/app/core/Sandbox/audit_metadata.py
@@ -1,0 +1,132 @@
+"""Path-minimized audit metadata helpers for sandbox lifecycle events.
+
+The sandbox security policy matrix requires audit rows to explain runtime,
+policy, lifecycle, and artifact-limit decisions without leaking host paths,
+environment variables, or raw artifact paths. Keep that contract centralized
+here so endpoint and background execution paths do not drift.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from pathlib import PurePosixPath, PureWindowsPath
+from typing import Any
+
+from .limits import build_limit_audit_metadata
+from .models import RunPhase, RunStatus
+from .run_status_taxonomy import normalize_run_status_reason
+
+
+def _enum_value(value: object) -> str | None:
+    if value is None:
+        return None
+    raw = getattr(value, "value", value)
+    text = str(raw).strip()
+    return text or None
+
+
+def _run_completion_outcome(status: RunStatus) -> str:
+    phase = status.phase
+    phase_value = phase.value if isinstance(phase, RunPhase) else str(phase)
+    if phase == RunPhase.completed and (status.exit_code or 0) == 0:
+        return "success"
+    if phase == RunPhase.timed_out:
+        return "timeout"
+    if phase == RunPhase.killed:
+        return "killed"
+    if phase == RunPhase.failed:
+        return "failed"
+    return phase_value
+
+
+def _pathlike_base_image(base_image: str) -> bool:
+    text = base_image.strip()
+    if not text:
+        return False
+    if text.startswith(("/", "~", "./", "../")):
+        return True
+    if PureWindowsPath(text).is_absolute() or PurePosixPath(text).is_absolute():
+        return True
+    return False
+
+
+def _safe_base_image(base_image: str | None) -> tuple[str | None, str | None]:
+    text = str(base_image or "").strip()
+    if not text:
+        return None, None
+    if _pathlike_base_image(text):
+        return None, "host_path"
+    return text, "image_ref"
+
+
+def _capture_pattern_count(capture_patterns: Iterable[object] | None) -> int | None:
+    if capture_patterns is None:
+        return None
+    count = 0
+    for pattern in capture_patterns:
+        if str(pattern or "").strip():
+            count += 1
+    return count
+
+
+def build_run_completion_audit_metadata(
+    *,
+    status: RunStatus,
+    spec_version: str | None,
+    requested_runtime: object = None,
+    trust_level: object = None,
+    network_policy: object = None,
+    capture_patterns: Iterable[object] | None = None,
+) -> dict[str, Any]:
+    """Build the shared safe metadata contract for sandbox run completion.
+
+    Raw host paths and artifact paths are intentionally omitted. If a base image
+    looks like a host filesystem path, only its kind is recorded.
+    """
+
+    effective_runtime = _enum_value(status.runtime)
+    requested_runtime_value = _enum_value(requested_runtime) or effective_runtime
+    base_image, base_image_kind = _safe_base_image(status.base_image)
+    outcome = _run_completion_outcome(status)
+    status_reason_code = normalize_run_status_reason(
+        phase=status.phase,
+        message=status.message,
+        exit_code=status.exit_code,
+        resource_usage=(
+            status.resource_usage if isinstance(status.resource_usage, Mapping) else None
+        ),
+    )
+    reason_code = None
+    if outcome in {"timeout", "failed"}:
+        reason_code = status.message or None
+
+    metadata: dict[str, Any] = {
+        "runtime": effective_runtime,
+        "effective_runtime": effective_runtime,
+        "requested_runtime": requested_runtime_value,
+        "base_image": base_image,
+        "base_image_kind": base_image_kind,
+        "image_digest": status.image_digest,
+        "policy_hash": status.policy_hash,
+        "exit_code": status.exit_code,
+        "outcome": outcome,
+        "status_reason_code": status_reason_code,
+        "spec_version": spec_version or status.spec_version,
+        "reason_code": reason_code,
+    }
+
+    runtime_version = _enum_value(status.runtime_version)
+    if runtime_version is not None:
+        metadata["runtime_version"] = runtime_version
+    trust_level_value = _enum_value(trust_level)
+    if trust_level_value is not None:
+        metadata["trust_level"] = trust_level_value
+    network_policy_value = _enum_value(network_policy)
+    if network_policy_value is not None:
+        metadata["network_policy"] = network_policy_value
+    capture_count = _capture_pattern_count(capture_patterns)
+    if capture_count is not None:
+        metadata["capture_pattern_count"] = capture_count
+
+    metadata.update(build_limit_audit_metadata(status.resource_usage))
+    return metadata

--- a/tldw_Server_API/app/core/Sandbox/audit_metadata.py
+++ b/tldw_Server_API/app/core/Sandbox/audit_metadata.py
@@ -18,6 +18,8 @@ from .run_status_taxonomy import normalize_run_status_reason
 
 
 def _enum_value(value: object) -> str | None:
+    """Return a stripped string value for enums and scalar metadata fields."""
+
     if value is None:
         return None
     raw = getattr(value, "value", value)
@@ -26,6 +28,8 @@ def _enum_value(value: object) -> str | None:
 
 
 def _run_completion_outcome(status: RunStatus) -> str:
+    """Map a run status into the stable audit outcome vocabulary."""
+
     phase = status.phase
     phase_value = phase.value if isinstance(phase, RunPhase) else str(phase)
     if phase == RunPhase.completed and (status.exit_code or 0) == 0:
@@ -40,17 +44,24 @@ def _run_completion_outcome(status: RunStatus) -> str:
 
 
 def _pathlike_base_image(base_image: str) -> bool:
+    """Detect base image strings that look like local host filesystem paths."""
+
     text = base_image.strip()
     if not text:
         return False
     if text.startswith(("/", "~", "./", "../")):
         return True
-    if PureWindowsPath(text).is_absolute() or PurePosixPath(text).is_absolute():
+    windows_path = PureWindowsPath(text)
+    if windows_path.drive or "\\" in text:
+        return True
+    if windows_path.is_absolute() or PurePosixPath(text).is_absolute():
         return True
     return False
 
 
 def _safe_base_image(base_image: str | None) -> tuple[str | None, str | None]:
+    """Return a redacted-safe base image reference and its audit-visible kind."""
+
     text = str(base_image or "").strip()
     if not text:
         return None, None
@@ -60,6 +71,8 @@ def _safe_base_image(base_image: str | None) -> tuple[str | None, str | None]:
 
 
 def _capture_pattern_count(capture_patterns: Iterable[object] | None) -> int | None:
+    """Count non-empty capture patterns without recording their raw values."""
+
     if capture_patterns is None:
         return None
     count = 0
@@ -85,7 +98,7 @@ def build_run_completion_audit_metadata(
     """
 
     effective_runtime = _enum_value(status.runtime)
-    requested_runtime_value = _enum_value(requested_runtime) or effective_runtime
+    requested_runtime_value = _enum_value(requested_runtime)
     base_image, base_image_kind = _safe_base_image(status.base_image)
     outcome = _run_completion_outcome(status)
     status_reason_code = normalize_run_status_reason(

--- a/tldw_Server_API/app/core/Sandbox/service.py
+++ b/tldw_Server_API/app/core/Sandbox/service.py
@@ -28,6 +28,7 @@ from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.core.Metrics import increment_counter, observe_histogram
 from tldw_Server_API.app.core.testing import is_truthy
 
+from .audit_metadata import build_run_completion_audit_metadata
 from .image_store import ImageStoreValidationError, SandboxImageStore
 from .limits import build_limit_audit_metadata, limit_event_actions
 from .macos_diagnostics import collect_macos_diagnostics, probe_helper
@@ -1592,7 +1593,16 @@ class SandboxService:
             "reasons": reasons,
         }
 
-    def _audit_run_completion(self, *, user_id: str | int | None, run_id: str, status: RunStatus, spec_version: str, session_id: str | None) -> None:
+    def _audit_run_completion(
+        self,
+        *,
+        user_id: str | int | None,
+        run_id: str,
+        status: RunStatus,
+        spec_version: str,
+        session_id: str | None,
+        spec: RunSpec | None = None,
+    ) -> None:
         """Log a completion audit event in a fire-and-forget manner."""
         try:
             uid_int = None
@@ -1633,17 +1643,17 @@ class SandboxService:
                             reason_code = (status.message or None)
                     except _SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS:
                         reason_code = None
+                    metadata = build_run_completion_audit_metadata(
+                        status=status,
+                        spec_version=spec_version,
+                        requested_runtime=(spec.runtime if spec else None),
+                        trust_level=(spec.trust_level if spec else None),
+                        network_policy=(spec.network_policy if spec else None),
+                        capture_patterns=(spec.capture_patterns if spec else None),
+                    )
+                    if reason_code is not None:
+                        metadata["reason_code"] = reason_code
                     limit_metadata = build_limit_audit_metadata(status.resource_usage)
-                    metadata = {
-                        "runtime": status.runtime.value if status.runtime else None,
-                        "base_image": status.base_image,
-                        "image_digest": status.image_digest,
-                        "policy_hash": status.policy_hash,
-                        "exit_code": status.exit_code,
-                        "spec_version": spec_version,
-                        "reason_code": reason_code,
-                    }
-                    metadata.update(limit_metadata)
                     await svc.log_event(
                         event_type=AuditEventType.API_RESPONSE,
                         category=AuditEventCategory.API_CALL,
@@ -2039,7 +2049,7 @@ class SandboxService:
                             if not status.policy_hash:
                                 status.policy_hash = compute_policy_hash(self.policy.cfg)
                             # Audit completion
-                            self._audit_run_completion(user_id=user_id, run_id=status.id, status=status, spec_version=spec_version, session_id=spec.session_id)
+                            self._audit_run_completion(user_id=user_id, run_id=status.id, status=status, spec_version=spec_version, session_id=spec.session_id, spec=spec)
                         except _SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS as e:
                             logger.warning(f"Background docker execution failed: {e}")
                             self._mark_run_failed(status, reason="docker_failed")
@@ -2088,7 +2098,7 @@ class SandboxService:
                     self._orch.update_run(status.id, status)
                     # Audit completion (sync path)
                     with contextlib.suppress(_SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS):
-                        self._audit_run_completion(user_id=user_id, run_id=status.id, status=status, spec_version=spec_version, session_id=spec.session_id)
+                        self._audit_run_completion(user_id=user_id, run_id=status.id, status=status, spec_version=spec_version, session_id=spec.session_id, spec=spec)
             except _SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS as e:
                 logger.warning(f"Docker execution failed; marking run failed. Error: {e}")
                 self._mark_run_failed(status, reason="docker_failed")
@@ -2131,7 +2141,7 @@ class SandboxService:
                                 self._orch.store_artifacts(status.id, real.artifacts)
                             self._orch.update_run(status.id, status)
                             with contextlib.suppress(_SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS):
-                                self._audit_run_completion(user_id=user_id, run_id=status.id, status=status, spec_version=spec_version, session_id=spec.session_id)
+                                self._audit_run_completion(user_id=user_id, run_id=status.id, status=status, spec_version=spec_version, session_id=spec.session_id, spec=spec)
                         except _SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS as e:
                             logger.warning(f"Firecracker background execution failed: {e}")
                             self._mark_run_failed(status, reason="firecracker_failed")
@@ -2172,7 +2182,7 @@ class SandboxService:
                         self._orch.store_artifacts(status.id, real.artifacts)
                     self._orch.update_run(status.id, status)
                     with contextlib.suppress(_SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS):
-                        self._audit_run_completion(user_id=user_id, run_id=status.id, status=status, spec_version=spec_version, session_id=spec.session_id)
+                        self._audit_run_completion(user_id=user_id, run_id=status.id, status=status, spec_version=spec_version, session_id=spec.session_id, spec=spec)
             except _SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS as e:
                 logger.warning(f"Firecracker execution failed; marking run failed. Error: {e}")
                 try:
@@ -2222,7 +2232,7 @@ class SandboxService:
                                 self._orch.store_artifacts(status.id, real.artifacts)
                             self._orch.update_run(status.id, status)
                             with contextlib.suppress(_SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS):
-                                self._audit_run_completion(user_id=user_id, run_id=status.id, status=status, spec_version=spec_version, session_id=spec.session_id)
+                                self._audit_run_completion(user_id=user_id, run_id=status.id, status=status, spec_version=spec_version, session_id=spec.session_id, spec=spec)
                         except (SandboxPolicy.RuntimeUnavailable, SandboxPolicy.PolicyUnsupported) as e:
                             logger.warning(f"Lima execution preflight rejected run: {e}")
                             try:
@@ -2283,7 +2293,7 @@ class SandboxService:
                         self._orch.store_artifacts(status.id, real.artifacts)
                     self._orch.update_run(status.id, status)
                     with contextlib.suppress(_SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS):
-                        self._audit_run_completion(user_id=user_id, run_id=status.id, status=status, spec_version=spec_version, session_id=spec.session_id)
+                        self._audit_run_completion(user_id=user_id, run_id=status.id, status=status, spec_version=spec_version, session_id=spec.session_id, spec=spec)
             except _SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS as e:
                 logger.warning(f"Lima execution failed; marking run failed. Error: {e}")
                 try:

--- a/tldw_Server_API/app/core/Sandbox/service.py
+++ b/tldw_Server_API/app/core/Sandbox/service.py
@@ -1636,13 +1636,6 @@ class SandboxService:
                             dur_ms = max(0.0, (status.finished_at - status.started_at).total_seconds() * 1000.0)
                     except _SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS:
                         dur_ms = None
-                    # Include reason_code for non-success outcomes when available
-                    reason_code = None
-                    try:
-                        if outcome in ("timeout", "failed"):
-                            reason_code = (status.message or None)
-                    except _SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS:
-                        reason_code = None
                     metadata = build_run_completion_audit_metadata(
                         status=status,
                         spec_version=spec_version,
@@ -1651,8 +1644,6 @@ class SandboxService:
                         network_policy=(spec.network_policy if spec else None),
                         capture_patterns=(spec.capture_patterns if spec else None),
                     )
-                    if reason_code is not None:
-                        metadata["reason_code"] = reason_code
                     limit_metadata = build_limit_audit_metadata(status.resource_usage)
                     await svc.log_event(
                         event_type=AuditEventType.API_RESPONSE,

--- a/tldw_Server_API/tests/sandbox/test_sandbox_run_limit_audit.py
+++ b/tldw_Server_API/tests/sandbox/test_sandbox_run_limit_audit.py
@@ -12,7 +12,13 @@ from tldw_Server_API.app.core.Sandbox.limits import (
     build_limit_audit_metadata,
     limit_event_actions,
 )
-from tldw_Server_API.app.core.Sandbox.models import RunPhase, RunStatus, RuntimeType
+from tldw_Server_API.app.core.Sandbox.models import (
+    RunPhase,
+    RunSpec,
+    RunStatus,
+    RuntimeType,
+    TrustLevel,
+)
 from tldw_Server_API.app.core.Sandbox.service import SandboxService
 
 
@@ -45,6 +51,59 @@ def test_limit_event_actions_reports_only_affected_limits() -> None:
     assert limit_event_actions({"log_truncated": 1}) == ["log_truncated"]
     assert limit_event_actions({"artifact_files_skipped": 1}) == ["artifacts_limited"]
     assert limit_event_actions({"stdout_truncated": 0, "artifact_files_skipped": 0}) == []
+
+
+def test_build_run_completion_audit_metadata_contract_minimizes_paths() -> None:
+    from tldw_Server_API.app.core.Sandbox.audit_metadata import (
+        build_run_completion_audit_metadata,
+    )
+
+    started = datetime.utcnow()
+    status = RunStatus(
+        id="run-audit-contract",
+        phase=RunPhase.completed,
+        runtime=RuntimeType.vz_linux,
+        base_image="/Users/operator/private-rootfs.img",
+        policy_hash="policy-hash",
+        exit_code=0,
+        started_at=started,
+        finished_at=started,
+        resource_usage={
+            "output_limit_bytes": 5,
+            "stdout_truncated": 1,
+            "artifact_files_skipped": 1,
+            "artifact_skip_file_limit": 1,
+            "artifact_paths": ["/Users/operator/private-output.txt"],
+        },
+    )
+
+    metadata = build_run_completion_audit_metadata(
+        status=status,
+        spec_version="1.1",
+        requested_runtime=RuntimeType.vz_linux,
+        trust_level=TrustLevel.untrusted,
+        network_policy="deny_all",
+        capture_patterns=["reports/*.json", "logs/*.txt"],
+    )
+
+    assert metadata["runtime"] == "vz_linux"
+    assert metadata["effective_runtime"] == "vz_linux"
+    assert metadata["requested_runtime"] == "vz_linux"
+    assert metadata["trust_level"] == "untrusted"
+    assert metadata["network_policy"] == "deny_all"
+    assert metadata["policy_hash"] == "policy-hash"
+    assert metadata["spec_version"] == "1.1"
+    assert metadata["exit_code"] == 0
+    assert metadata["outcome"] == "success"
+    assert metadata["status_reason_code"] == "limits_applied"
+    assert metadata["output_truncated"] is True
+    assert metadata["artifact_skip_reasons"] == ["file_limit"]
+    assert metadata["capture_pattern_count"] == 2
+    assert metadata["base_image_kind"] == "host_path"
+    assert metadata["base_image"] is None
+    assert "artifact_paths" not in metadata
+    assert "capture_patterns" not in metadata
+    assert "/Users/operator" not in str(metadata)
 
 
 def test_sandbox_service_audits_aggregate_limit_events(monkeypatch) -> None:
@@ -84,6 +143,15 @@ def test_sandbox_service_audits_aggregate_limit_events(monkeypatch) -> None:
             "artifact_skip_total_limit": 1,
         },
     )
+    spec = RunSpec(
+        session_id="session-1",
+        runtime=RuntimeType.vz_linux,
+        base_image="vz_linux:test",
+        command=["echo", "ok"],
+        trust_level=TrustLevel.standard,
+        network_policy="deny_all",
+        capture_patterns=["reports/*.json"],
+    )
 
     SandboxService()._audit_run_completion(
         user_id=None,
@@ -91,10 +159,18 @@ def test_sandbox_service_audits_aggregate_limit_events(monkeypatch) -> None:
         status=status,
         spec_version="1.0",
         session_id="session-1",
+        spec=spec,
     )
 
     assert [event["action"] for event in events] == ["run", "output_truncated", "artifacts_limited"]
     completion_metadata = events[0]["metadata"]
+    assert completion_metadata["effective_runtime"] == "vz_linux"
+    assert completion_metadata["requested_runtime"] == "vz_linux"
+    assert completion_metadata["trust_level"] == "standard"
+    assert completion_metadata["network_policy"] == "deny_all"
+    assert completion_metadata["status_reason_code"] == "limits_applied"
+    assert completion_metadata["outcome"] == "success"
+    assert completion_metadata["capture_pattern_count"] == 1
     assert completion_metadata["output_truncated"] is True
     assert completion_metadata["artifact_skip_reasons"] == ["file_limit", "total_limit"]
     assert "artifact_paths" not in completion_metadata

--- a/tldw_Server_API/tests/sandbox/test_sandbox_run_limit_audit.py
+++ b/tldw_Server_API/tests/sandbox/test_sandbox_run_limit_audit.py
@@ -8,6 +8,9 @@ from tldw_Server_API.app.core.Audit.unified_audit_service import (
     AuditEventType,
     AuditSeverity,
 )
+from tldw_Server_API.app.core.Sandbox.audit_metadata import (
+    build_run_completion_audit_metadata,
+)
 from tldw_Server_API.app.core.Sandbox.limits import (
     build_limit_audit_metadata,
     limit_event_actions,
@@ -20,6 +23,25 @@ from tldw_Server_API.app.core.Sandbox.models import (
     TrustLevel,
 )
 from tldw_Server_API.app.core.Sandbox.service import SandboxService
+
+
+def _completed_status(
+    *,
+    base_image: str = "vz_linux:test",
+    resource_usage: dict[str, object] | None = None,
+) -> RunStatus:
+    started = datetime.utcnow()
+    return RunStatus(
+        id="run-audit-contract",
+        phase=RunPhase.completed,
+        runtime=RuntimeType.vz_linux,
+        base_image=base_image,
+        policy_hash="policy-hash",
+        exit_code=0,
+        started_at=started,
+        finished_at=started,
+        resource_usage=resource_usage or {},
+    )
 
 
 def test_build_limit_audit_metadata_is_aggregate_and_path_minimized() -> None:
@@ -53,27 +75,13 @@ def test_limit_event_actions_reports_only_affected_limits() -> None:
     assert limit_event_actions({"stdout_truncated": 0, "artifact_files_skipped": 0}) == []
 
 
-def test_build_run_completion_audit_metadata_contract_minimizes_paths() -> None:
-    from tldw_Server_API.app.core.Sandbox.audit_metadata import (
-        build_run_completion_audit_metadata,
-    )
-
-    started = datetime.utcnow()
-    status = RunStatus(
-        id="run-audit-contract",
-        phase=RunPhase.completed,
-        runtime=RuntimeType.vz_linux,
-        base_image="/Users/operator/private-rootfs.img",
-        policy_hash="policy-hash",
-        exit_code=0,
-        started_at=started,
-        finished_at=started,
+def test_build_run_completion_audit_metadata_includes_runtime_policy_context() -> None:
+    status = _completed_status(
         resource_usage={
             "output_limit_bytes": 5,
             "stdout_truncated": 1,
             "artifact_files_skipped": 1,
             "artifact_skip_file_limit": 1,
-            "artifact_paths": ["/Users/operator/private-output.txt"],
         },
     )
 
@@ -96,14 +104,75 @@ def test_build_run_completion_audit_metadata_contract_minimizes_paths() -> None:
     assert metadata["exit_code"] == 0
     assert metadata["outcome"] == "success"
     assert metadata["status_reason_code"] == "limits_applied"
+    assert metadata["capture_pattern_count"] == 2
+    assert "capture_patterns" not in metadata
+
+
+def test_build_run_completion_audit_metadata_includes_bounded_limit_metadata() -> None:
+    status = _completed_status(
+        resource_usage={
+            "output_limit_bytes": 5,
+            "stdout_truncated": 1,
+            "artifact_files_skipped": 1,
+            "artifact_skip_file_limit": 1,
+            "artifact_paths": ["/Users/operator/private-output.txt"],
+        },
+    )
+
+    metadata = build_run_completion_audit_metadata(
+        status=status,
+        spec_version="1.1",
+        requested_runtime=RuntimeType.vz_linux,
+        trust_level=TrustLevel.untrusted,
+        network_policy="deny_all",
+        capture_patterns=["reports/*.json", "logs/*.txt"],
+    )
+
     assert metadata["output_truncated"] is True
     assert metadata["artifact_skip_reasons"] == ["file_limit"]
-    assert metadata["capture_pattern_count"] == 2
+    assert "artifact_paths" not in metadata
+    assert "/Users/operator" not in str(metadata)
+
+
+def test_build_run_completion_audit_metadata_minimizes_posix_host_paths() -> None:
+    status = _completed_status(base_image="/Users/operator/private-rootfs.img")
+
+    metadata = build_run_completion_audit_metadata(
+        status=status,
+        spec_version="1.1",
+        requested_runtime=RuntimeType.vz_linux,
+    )
+
     assert metadata["base_image_kind"] == "host_path"
     assert metadata["base_image"] is None
-    assert "artifact_paths" not in metadata
-    assert "capture_patterns" not in metadata
     assert "/Users/operator" not in str(metadata)
+
+
+def test_build_run_completion_audit_metadata_minimizes_windows_drive_relative_paths() -> None:
+    status = _completed_status(base_image=r"C:Users\operator\private-rootfs.img")
+
+    metadata = build_run_completion_audit_metadata(
+        status=status,
+        spec_version="1.1",
+        requested_runtime=RuntimeType.vz_linux,
+    )
+
+    assert metadata["base_image_kind"] == "host_path"
+    assert metadata["base_image"] is None
+    assert "operator" not in str(metadata)
+
+
+def test_build_run_completion_audit_metadata_preserves_omitted_requested_runtime() -> None:
+    status = _completed_status()
+
+    metadata = build_run_completion_audit_metadata(
+        status=status,
+        spec_version="1.1",
+        requested_runtime=None,
+    )
+
+    assert metadata["effective_runtime"] == "vz_linux"
+    assert metadata["requested_runtime"] is None
 
 
 def test_sandbox_service_audits_aggregate_limit_events(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Adds a shared sandbox run-completion audit metadata helper for endpoint and background-service audit paths.
- Includes requested/effective runtime, trust/network policy context, spec/outcome/status reason fields, and existing bounded limit metadata.
- Minimizes sensitive exposure by omitting raw artifact paths, raw capture patterns, and host-path base image values.

## Test Plan
- [x] source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/sandbox/test_sandbox_run_limit_audit.py -q
- [x] source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/sandbox/test_sandbox_api.py::test_start_run_scaffold_returns_completed_with_metadata -q
- [x] source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m py_compile tldw_Server_API/app/core/Sandbox/audit_metadata.py tldw_Server_API/app/core/Sandbox/service.py tldw_Server_API/app/api/v1/endpoints/sandbox.py
- [x] git diff --check
- [x] source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Sandbox/audit_metadata.py tldw_Server_API/app/core/Sandbox/service.py tldw_Server_API/app/api/v1/endpoints/sandbox.py -f json -o /tmp/bandit_sandbox_audit_metadata_contract.json

## Notes
- Bandit reported 0 results and 0 errors.
- A human-authored Change summary is still required before merge per repo policy.