### PR TITLE
Adapt Sidepanel StatusDot to design-system state registry

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -5456,17 +5456,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "local-status-badge:src/components/Sidepanel/Chat/StatusDot.tsx:StatusDot",
-    "path": "src/components/Sidepanel/Chat/StatusDot.tsx",
-    "rule": "local-status-badge",
-    "subject": "StatusDot",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing local StatusDot status wrapper before the guard.",
-    "replacement": "Badge with design-system state registry mapping",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/recipe-configs/EmbeddingsModelSelectionConfig.tsx:Alert",
     "path": "src/components/Option/Evaluations/tabs/recipe-configs/EmbeddingsModelSelectionConfig.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Sidepanel/Chat/StatusDot.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/StatusDot.tsx
@@ -11,6 +11,33 @@ import {
   getBadgeVariantForDesignSystemSeverity,
   type BadgeVariant
 } from "@/components/ui/primitives"
+import type { ConnectionUxState } from "@/types/connection"
+
+const stateKeyForConnectionUxState = (
+  uxState: ConnectionUxState
+): DesignSystemStateKey => {
+  switch (uxState) {
+    case "testing":
+      return "retrying"
+    case "connected_ok":
+    case "demo_mode":
+      return "ready"
+    case "connected_degraded":
+      return "degraded"
+    case "error_auth":
+      return "auth_required"
+    case "error_unreachable":
+      return "unavailable"
+    case "unconfigured":
+    case "configuring_url":
+    case "configuring_auth":
+      return "setup_required"
+    default: {
+      const exhaustive: never = uxState
+      return exhaustive
+    }
+  }
+}
 
 /**
  * Compact connection status indicator with icon and color for accessibility.
@@ -24,7 +51,7 @@ import {
  */
 export const StatusDot = () => {
   const { t } = useTranslation(["sidepanel"])
-  const { mode, isConnectedUx, isChecking, isConfigOrError } =
+  const { uxState, mode, isConnectedUx, isChecking, isConfigOrError } =
     useConnectionUxState()
   const { checkOnce } = useConnectionActions()
 
@@ -47,6 +74,12 @@ export const StatusDot = () => {
         "Connected to your tldw server"
       )
     }
+    if (uxState === "error_unreachable") {
+      return t(
+        "sidepanel:header.connection.failed",
+        "Connection failed. Click to retry."
+      )
+    }
     if (isConfigOrError) {
       return t(
         "sidepanel:header.connection.unconfigured",
@@ -61,7 +94,10 @@ export const StatusDot = () => {
 
   const handleClick = () => {
     if (isChecking) return
-    if (!isConnectedUx && !isConfigOrError) {
+    if (
+      uxState === "error_unreachable" ||
+      (!isConnectedUx && !isConfigOrError)
+    ) {
       // Retry connection
       void checkOnce()
     }
@@ -84,12 +120,7 @@ export const StatusDot = () => {
     )
   }
 
-  const connectionStateKey: DesignSystemStateKey = (() => {
-    if (isChecking) return "retrying"
-    if (isConnectedUx) return "ready"
-    if (isConfigOrError) return "setup_required"
-    return "unavailable"
-  })()
+  const connectionStateKey = stateKeyForConnectionUxState(uxState)
   const connectionState = getDesignSystemState(connectionStateKey)
   const badgeVariant: BadgeVariant =
     isConnectedUx && mode === "demo"

--- a/apps/packages/ui/src/components/Sidepanel/Chat/StatusDot.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/StatusDot.tsx
@@ -5,7 +5,12 @@ import {
   useConnectionActions,
   useConnectionUxState
 } from "@/hooks/useConnectionState"
-import { Badge, type BadgeVariant } from "@/components/ui/primitives"
+import { getDesignSystemState, type DesignSystemStateKey } from "@/design-system"
+import {
+  Badge,
+  getBadgeVariantForDesignSystemSeverity,
+  type BadgeVariant
+} from "@/components/ui/primitives"
 
 /**
  * Compact connection status indicator with icon and color for accessibility.
@@ -79,13 +84,17 @@ export const StatusDot = () => {
     )
   }
 
-  const badgeVariant: BadgeVariant = (() => {
-    if (isChecking) return "warning"
-    if (isConnectedUx && mode === "demo") return "demo"
-    if (isConnectedUx) return "success"
-    if (isConfigOrError) return "warning"
-    return "danger"
+  const connectionStateKey: DesignSystemStateKey = (() => {
+    if (isChecking) return "retrying"
+    if (isConnectedUx) return "ready"
+    if (isConfigOrError) return "setup_required"
+    return "unavailable"
   })()
+  const connectionState = getDesignSystemState(connectionStateKey)
+  const badgeVariant: BadgeVariant =
+    isConnectedUx && mode === "demo"
+      ? "demo"
+      : getBadgeVariantForDesignSystemSeverity(connectionState.severity)
 
   return (
     <Tooltip title={tooltip}>

--- a/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/StatusBadges.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/StatusBadges.design-system.test.tsx
@@ -3,18 +3,36 @@ import React from "react"
 import { fireEvent, render, screen } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-import { getDesignSystemState } from "@/design-system"
+import {
+  getDesignSystemState,
+  type DesignSystemStateKey
+} from "@/design-system"
+import type { ConnectionState, ConnectionUxState } from "@/types/connection"
 import { SaveStatusIcon } from "../SaveStatusIcon"
 import { StatusDot } from "../StatusDot"
 
+type ConnectionUxHookState = {
+  uxState: ConnectionUxState
+  mode: ConnectionState["mode"]
+  errorKind: ConnectionState["errorKind"]
+  configStep: ConnectionState["configStep"]
+  hasCompletedFirstRun: boolean
+  isConnectedUx: boolean
+  isChecking: boolean
+  isConfigOrError: boolean
+}
+
 const connectionState = vi.hoisted(() => ({
   ux: {
-    uxState: "connected",
-    mode: "full",
+    uxState: "connected_ok",
+    mode: "normal",
+    errorKind: "none",
+    configStep: "none",
+    hasCompletedFirstRun: true,
     isConnectedUx: true,
     isChecking: false,
     isConfigOrError: false
-  },
+  } as ConnectionUxHookState,
   checkOnce: vi.fn()
 }))
 
@@ -52,87 +70,127 @@ vi.mock("@/hooks/useAntdNotification", () => ({
   useAntdNotification: () => notificationMock
 }))
 
+const connectedUxStates: ConnectionUxState[] = [
+  "connected_ok",
+  "connected_degraded",
+  "demo_mode"
+]
+
+const configOrErrorUxStates: ConnectionUxState[] = [
+  "unconfigured",
+  "configuring_url",
+  "configuring_auth",
+  "error_unreachable",
+  "error_auth"
+]
+
+const makeConnectionUxState = ({
+  uxState,
+  mode = uxState === "demo_mode" ? "demo" : "normal",
+  errorKind = uxState === "error_auth"
+    ? "auth"
+    : uxState === "error_unreachable"
+      ? "unreachable"
+      : uxState === "connected_degraded"
+        ? "partial"
+        : "none",
+  configStep = uxState === "configuring_url"
+    ? "url"
+    : uxState === "configuring_auth"
+      ? "auth"
+      : "none",
+  hasCompletedFirstRun = true
+}: {
+  uxState: ConnectionUxState
+  mode?: ConnectionState["mode"]
+  errorKind?: ConnectionState["errorKind"]
+  configStep?: ConnectionState["configStep"]
+  hasCompletedFirstRun?: boolean
+}): ConnectionUxHookState => ({
+  uxState,
+  mode,
+  errorKind,
+  configStep,
+  hasCompletedFirstRun,
+  isConnectedUx: connectedUxStates.includes(uxState),
+  isChecking: uxState === "testing",
+  isConfigOrError: configOrErrorUxStates.includes(uxState)
+})
+
+const statusDotCases = [
+  [
+    "connected",
+    makeConnectionUxState({ uxState: "connected_ok" }),
+    "ready",
+    "success",
+    "Connected to your tldw server"
+  ],
+  [
+    "degraded connection",
+    makeConnectionUxState({ uxState: "connected_degraded" }),
+    "degraded",
+    "warning",
+    "Connected to your tldw server"
+  ],
+  [
+    "checking",
+    makeConnectionUxState({ uxState: "testing" }),
+    "retrying",
+    "info",
+    "Checking connection to your tldw server…"
+  ],
+  [
+    "demo",
+    makeConnectionUxState({ uxState: "demo_mode" }),
+    "ready",
+    "demo",
+    "Demo mode: explore with a sample workspace."
+  ],
+  [
+    "unconfigured setup",
+    makeConnectionUxState({ uxState: "unconfigured" }),
+    "setup_required",
+    "warning",
+    "Not connected. Open Settings to configure."
+  ],
+  [
+    "configuring auth setup",
+    makeConnectionUxState({ uxState: "configuring_auth" }),
+    "setup_required",
+    "warning",
+    "Not connected. Open Settings to configure."
+  ],
+  [
+    "auth error",
+    makeConnectionUxState({ uxState: "error_auth" }),
+    "auth_required",
+    "warning",
+    "Not connected. Open Settings to configure."
+  ],
+  [
+    "unreachable error",
+    makeConnectionUxState({ uxState: "error_unreachable" }),
+    "unavailable",
+    "danger",
+    "Connection failed. Click to retry."
+  ]
+] satisfies Array<[
+  string,
+  ConnectionUxHookState,
+  DesignSystemStateKey,
+  string,
+  string
+]>
+
 describe("Chat status design-system badges", () => {
   beforeEach(() => {
-    connectionState.ux = {
-      uxState: "connected",
-      mode: "full",
-      isConnectedUx: true,
-      isChecking: false,
-      isConfigOrError: false
-    }
+    connectionState.ux = makeConnectionUxState({ uxState: "connected_ok" })
     connectionState.checkOnce.mockReset()
     notificationMock.warning.mockReset()
     vi.clearAllMocks()
   })
 
-  it.each([
-    [
-      "connected",
-      {
-        uxState: "connected",
-        mode: "full",
-        isConnectedUx: true,
-        isChecking: false,
-        isConfigOrError: false
-      },
-      "ready",
-      "success",
-      "Connected to your tldw server"
-    ],
-    [
-      "checking",
-      {
-        uxState: "checking",
-        mode: "full",
-        isConnectedUx: false,
-        isChecking: true,
-        isConfigOrError: false
-      },
-      "retrying",
-      "info",
-      "Checking connection to your tldw server…"
-    ],
-    [
-      "demo",
-      {
-        uxState: "connected",
-        mode: "demo",
-        isConnectedUx: true,
-        isChecking: false,
-        isConfigOrError: false
-      },
-      "ready",
-      "demo",
-      "Demo mode: explore with a sample workspace."
-    ],
-    [
-      "setup issue",
-      {
-        uxState: "error_config",
-        mode: "full",
-        isConnectedUx: false,
-        isChecking: false,
-        isConfigOrError: true
-      },
-      "setup_required",
-      "warning",
-      "Not connected. Open Settings to configure."
-    ],
-    [
-      "retryable failure",
-      {
-        uxState: "failed",
-        mode: "full",
-        isConnectedUx: false,
-        isChecking: false,
-        isConfigOrError: false
-      },
-      "unavailable",
-      "danger",
-      "Connection failed. Click to retry."
-    ]
-  ])(
+  it.each(statusDotCases)(
     "renders %s connection status through the design-system state registry",
     (_label, uxState, stateKey, variant, accessibleName) => {
       connectionState.ux = uxState
@@ -152,13 +210,7 @@ describe("Chat status design-system badges", () => {
   )
 
   it("preserves retry behavior for retryable connection failures", () => {
-    connectionState.ux = {
-      uxState: "failed",
-      mode: "full",
-      isConnectedUx: false,
-      isChecking: false,
-      isConfigOrError: false
-    }
+    connectionState.ux = makeConnectionUxState({ uxState: "error_unreachable" })
 
     render(<StatusDot />)
 
@@ -172,13 +224,7 @@ describe("Chat status design-system badges", () => {
   })
 
   it("disables retry while checking the connection", () => {
-    connectionState.ux = {
-      uxState: "checking",
-      mode: "full",
-      isConnectedUx: false,
-      isChecking: true,
-      isConfigOrError: false
-    }
+    connectionState.ux = makeConnectionUxState({ uxState: "testing" })
 
     render(<StatusDot />)
 
@@ -215,13 +261,7 @@ describe("Chat status design-system badges", () => {
   })
 
   it("keeps configured-but-unavailable status colors aligned with the Badge variant", () => {
-    connectionState.ux = {
-      uxState: "error_config",
-      mode: "full",
-      isConnectedUx: false,
-      isChecking: false,
-      isConfigOrError: true
-    }
+    connectionState.ux = makeConnectionUxState({ uxState: "configuring_url" })
 
     render(<StatusDot />)
 

--- a/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/StatusBadges.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/StatusBadges.design-system.test.tsx
@@ -3,6 +3,7 @@ import React from "react"
 import { fireEvent, render, screen } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import { getDesignSystemState } from "@/design-system"
 import { SaveStatusIcon } from "../SaveStatusIcon"
 import { StatusDot } from "../StatusDot"
 
@@ -31,6 +32,15 @@ vi.mock("antd", () => ({
   Tooltip: ({ children }: { children?: React.ReactNode }) => <>{children}</>
 }))
 
+vi.mock("@/design-system", async (importActual) => {
+  const actual = await importActual<typeof import("@/design-system")>()
+
+  return {
+    ...actual,
+    getDesignSystemState: vi.fn(actual.getDesignSystemState)
+  }
+})
+
 vi.mock("@/hooks/useConnectionState", () => ({
   useConnectionUxState: () => connectionState.ux,
   useConnectionActions: () => ({
@@ -53,9 +63,95 @@ describe("Chat status design-system badges", () => {
     }
     connectionState.checkOnce.mockReset()
     notificationMock.warning.mockReset()
+    vi.clearAllMocks()
   })
 
-  it("renders the connection status through the shared Badge while preserving retry behavior", () => {
+  it.each([
+    [
+      "connected",
+      {
+        uxState: "connected",
+        mode: "full",
+        isConnectedUx: true,
+        isChecking: false,
+        isConfigOrError: false
+      },
+      "ready",
+      "success",
+      "Connected to your tldw server"
+    ],
+    [
+      "checking",
+      {
+        uxState: "checking",
+        mode: "full",
+        isConnectedUx: false,
+        isChecking: true,
+        isConfigOrError: false
+      },
+      "retrying",
+      "info",
+      "Checking connection to your tldw server…"
+    ],
+    [
+      "demo",
+      {
+        uxState: "connected",
+        mode: "demo",
+        isConnectedUx: true,
+        isChecking: false,
+        isConfigOrError: false
+      },
+      "ready",
+      "demo",
+      "Demo mode: explore with a sample workspace."
+    ],
+    [
+      "setup issue",
+      {
+        uxState: "error_config",
+        mode: "full",
+        isConnectedUx: false,
+        isChecking: false,
+        isConfigOrError: true
+      },
+      "setup_required",
+      "warning",
+      "Not connected. Open Settings to configure."
+    ],
+    [
+      "retryable failure",
+      {
+        uxState: "failed",
+        mode: "full",
+        isConnectedUx: false,
+        isChecking: false,
+        isConfigOrError: false
+      },
+      "unavailable",
+      "danger",
+      "Connection failed. Click to retry."
+    ]
+  ])(
+    "renders %s connection status through the design-system state registry",
+    (_label, uxState, stateKey, variant, accessibleName) => {
+      connectionState.ux = uxState
+
+      render(<StatusDot />)
+
+      const statusButton = screen.getByTestId("status-dot")
+      const badge = screen.getByTestId("status-dot-badge")
+
+      expect(getDesignSystemState).toHaveBeenCalledWith(stateKey)
+      expect(statusButton).toHaveAccessibleName(accessibleName)
+      expect(badge).toHaveAttribute("data-ds-component", "Badge")
+      expect(badge).toHaveAttribute("data-ds-variant", variant)
+      expect(badge.querySelector(".sr-only")).toBeNull()
+      expect(badge.querySelector("svg")).toHaveClass("text-current")
+    }
+  )
+
+  it("preserves retry behavior for retryable connection failures", () => {
     connectionState.ux = {
       uxState: "failed",
       mode: "full",
@@ -67,16 +163,32 @@ describe("Chat status design-system badges", () => {
     render(<StatusDot />)
 
     const statusButton = screen.getByTestId("status-dot")
-    const badge = screen.getByTestId("status-dot-badge")
 
     expect(statusButton).toHaveAccessibleName("Connection failed. Click to retry.")
-    expect(badge).toHaveAttribute("data-ds-component", "Badge")
-    expect(badge.querySelector(".sr-only")).toBeNull()
-    expect(badge.querySelector("svg")).toHaveClass("text-current")
 
     fireEvent.click(statusButton)
 
     expect(connectionState.checkOnce).toHaveBeenCalledTimes(1)
+  })
+
+  it("disables retry while checking the connection", () => {
+    connectionState.ux = {
+      uxState: "checking",
+      mode: "full",
+      isConnectedUx: false,
+      isChecking: true,
+      isConfigOrError: false
+    }
+
+    render(<StatusDot />)
+
+    const statusButton = screen.getByTestId("status-dot")
+
+    expect(statusButton).toBeDisabled()
+
+    fireEvent.click(statusButton)
+
+    expect(connectionState.checkOnce).not.toHaveBeenCalled()
   })
 
   it("renders the chat save status through the shared Badge while preserving the action", () => {

--- a/backlog/tasks/task-45.31 - Adapt-Sidepanel-StatusDot-to-design-system-state-registry.md
+++ b/backlog/tasks/task-45.31 - Adapt-Sidepanel-StatusDot-to-design-system-state-registry.md
@@ -1,0 +1,69 @@
+---
+id: TASK-45.31
+title: Adapt Sidepanel StatusDot to design-system state registry
+status: Done
+assignee:
+  - Codex
+created_date: '2026-05-09 20:08'
+updated_date: '2026-05-09 20:17'
+labels:
+  - design-system
+  - ui
+  - product-state
+dependencies: []
+references:
+  - apps/packages/ui/src/components/Sidepanel/Chat/StatusDot.tsx
+  - >-
+    apps/packages/ui/src/components/Sidepanel/Chat/__tests__/StatusBadges.design-system.test.tsx
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+documentation:
+  - Docs/Design/tldw_web_design_system_contract.md
+parent_task_id: TASK-45
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate the remaining Sidepanel Chat StatusDot local-status-badge adapter so connection status variants resolve through getDesignSystemState before selecting the shared Badge variant, while preserving icon-only rendering, tooltip labels, retry behavior, disabled checking state, and demo visual treatment.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 StatusDot resolves connection statuses through getDesignSystemState before choosing shared Badge severity styling.
+- [x] #2 Icon-only Badge rendering preserves tooltip/accessibility text, retry click behavior, disabled checking behavior, and demo visual treatment.
+- [x] #3 Focused tests cover connected, checking, demo, config/error, failed/retry, and state-registry mapping.
+- [x] #4 The design-system product-state baseline no longer contains the Sidepanel StatusDot local-status-badge exception.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Extend the existing StatusBadges design-system tests to assert StatusDot state-registry calls and Badge variants for connected, checking, demo, config/error, and failed states, plus retry/disabled behavior.
+2. Watch the focused test fail before implementation.
+3. Update StatusDot to map UX connection states to canonical design-system state keys and derive Badge variants through getBadgeVariantForDesignSystemSeverity, preserving demo as the explicit demo variant.
+4. Remove the Sidepanel StatusDot local-status-badge baseline exception.
+5. Run focused tests, product-state guard tests, design-system verifier, git diff --check, and a touched-file TypeScript filter; document Bandit skip for UI-only TS/JSON changes.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verification: focused StatusBadges design-system test passed 9/9; product-state guard test passed 49/49; verify:design-system-state passed with 511 baseline exceptions and no StatusDot local-status-badge entry; git diff --check passed. Full UI tsc exited 2 on existing repo-wide test typing debt; /tmp/tldw_ui_tsc_sidepanel_status_dot.txt has 236 lines and no diagnostics matching StatusDot, StatusBadges, or design-system-product-state-baseline. Bandit skipped because touched files are TS/TSX/JSON UI files only.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated Sidepanel StatusDot to resolve connection status through the design-system state registry before deriving Badge severity variants, while preserving icon-only rendering, accessible labels, retry behavior, disabled checking behavior, and the explicit demo variant. Added focused coverage for connected, checking, demo, setup/config error, and retryable failure states, and removed the obsolete StatusDot local-status-badge baseline exception.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.31.1 - Address-PR-1444-StatusDot-review-comments.md
+++ b/backlog/tasks/task-45.31.1 - Address-PR-1444-StatusDot-review-comments.md
@@ -1,0 +1,57 @@
+---
+id: TASK-45.31.1
+title: Address PR 1444 StatusDot review comments
+status: Done
+assignee:
+  - Codex
+created_date: '2026-05-09 20:59'
+updated_date: '2026-05-09 21:04'
+labels:
+  - design-system
+  - ui
+  - product-state
+  - review-fix
+dependencies: []
+references:
+  - apps/packages/ui/src/components/Sidepanel/Chat/StatusDot.tsx
+  - >-
+    apps/packages/ui/src/components/Sidepanel/Chat/__tests__/StatusBadges.design-system.test.tsx
+  - apps/packages/ui/src/hooks/useConnectionState.ts
+parent_task_id: TASK-45.31
+priority: medium
+---
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 StatusDot maps real connection UX states to specific design-system keys including connected_degraded, error_auth, error_unreachable, setup/configuring, testing, and demo/ready.
+- [x] #2 StatusDot tests use realistic uxState and mode values from the connection state model.
+- [x] #3 Review-fix verification covers the focused StatusBadges suite, product-state guard tests, design-system verifier, diff check, and touched-file TypeScript filter.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Update the StatusDot tests first to use real ConnectionUxState/mode fixtures and assert degraded/auth/unreachable mappings. 2. Watch the focused test fail against the current implementation. 3. Update StatusDot to destructure uxState and map it to canonical design-system keys before deriving Badge severity variants, preserving demo override and retry behavior. 4. Run focused tests plus guard/verifier/diff/type-filter checks, then push the review-fix commit and resolve or reply to the PR threads.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Review fixes: verified the PR threads pointed to real issues. StatusDot now maps uxState directly: connected_degraded -> degraded, error_auth -> auth_required, error_unreachable -> unavailable, testing -> retrying, setup/configuring -> setup_required, and demo/connected_ok -> ready. Test fixtures now use real ConnectionUxState and mode values instead of synthetic failed/full states. Red run before implementation failed 4 tests on degraded/auth/unreachable/retry; green run passed 12/12. Additional verification: product-state guard test passed 49/49; verify:design-system-state passed with 511 baseline exceptions; git diff --check passed; UI tsc still exits 2 on existing repo-wide typing debt with 236 lines and no touched-file diagnostics. Bandit skipped because touched files are TS/TSX and Backlog markdown only.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed PR #1444 review feedback by switching StatusDot from boolean-collapse mapping to real uxState-based canonical design-system keys, including degraded, auth-required, unavailable, retrying, setup-required, and ready states. Reworked StatusBadges tests to use realistic connection UX fixtures and added coverage for degraded, auth, unreachable, setup/configuring, testing, demo, and retry behavior.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- route Sidepanel Chat StatusDot connection states through getDesignSystemState before deriving Badge severity variants
- preserve icon-only Badge rendering, accessibility labels, retry behavior, disabled checking state, and the explicit demo variant
- remove the obsolete StatusDot local-status-badge baseline exception and add Backlog task TASK-45.31

## Tests
- bunx vitest run src/components/Sidepanel/Chat/__tests__/StatusBadges.design-system.test.tsx --reporter=dot
- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot
- bun run verify:design-system-state
- git diff --check
- bunx tsc --noEmit --pretty false > /tmp/tldw_ui_tsc_sidepanel_status_dot.txt 2>&1 (exits 2 on existing repo-wide test typing debt; no touched-file diagnostics for StatusDot, StatusBadges, or the baseline file)

## Notes
- Bandit skipped: touched files are UI TS/TSX/JSON only.
- Per the AI-generated PR merge gate, the human Change summary still needs to be supplied by the maintainer before merge.