### PR TITLE
Clarify Persona Visual pack ownership

### DIFF
--- a/Docs/Code_Documentation/Persona_Visual_Packs.md
+++ b/Docs/Code_Documentation/Persona_Visual_Packs.md
@@ -52,8 +52,8 @@ Import is staged:
    persona.
 2. The preview reports bundle metadata, warnings, conflicts, and the proposed
    commit plan.
-3. Commit import creates or updates a reviewed pack for the persona after the
-   preview succeeds.
+3. Commit import creates a reviewed draft pack for the persona after the preview
+   succeeds.
 
 Committed imports remain reviewable and do not automatically activate. Users
 still choose when a valid pack should become the active pack.

--- a/Docs/Code_Documentation/Persona_Visual_Packs.md
+++ b/Docs/Code_Documentation/Persona_Visual_Packs.md
@@ -1,0 +1,92 @@
+# Persona Visual Packs
+
+Persona Visual Packs are the user-owned 2D asset packs used by Persona Buddy and
+Persona Live. They are authored and reviewed from Persona Garden, then rendered
+by the floating Buddy shell when a pack is explicitly activated.
+
+This document describes the current ownership, activation, import/export, and
+review semantics. It is intentionally scoped to Persona/Buddy visual packs, not
+VN or CYOA asset-pack/runtime behavior.
+
+## Ownership Model
+
+Persona Visual Pack assets are user-owned. A pack is attached to one persona by
+default, and the asset rows, generated-file references, manifest, and pack
+metadata stay scoped to that persona unless a future workflow explicitly
+duplicates or shares them.
+
+This default attachment keeps the user's visual assistant identity tied to the
+Persona profile rather than creating a separate avatar identity. The current
+system does not publish packs to a shared library and does not automatically
+reuse assets across personas.
+
+## Active Versus Available Packs
+
+A persona can have multiple available visual packs. Draft packs, imported packs,
+and reviewed generated candidates can all remain available for editing and
+review without changing the live assistant.
+
+The active pack is the one Persona Buddy renders now. Activation is explicit and
+pack-level: a user must activate a valid pack before Persona Buddy switches to
+it. Generated or imported assets do not become live just because a job finished.
+
+Deactivation clears the active visual pack for that persona while leaving
+available packs in place for later editing or activation.
+
+## Manifest-Backed Pack Format
+
+Packs are stored as manifests with referenced assets. The V1 renderer uses
+sprite/frame data, state mappings, fallbacks, authored triggers, and animation
+timing in the manifest while storing raster files through generated-file storage.
+
+The manifest-backed format is the compatibility boundary for future portability
+work. It keeps today's pack attached to one persona while leaving room for later
+duplicate-to-persona, import/export, and shared-library workflows without
+changing the core pack format.
+
+## Import Preview And Commit
+
+Import is staged:
+
+1. The import preview validates a portable pack archive before it changes this
+   persona.
+2. The preview reports bundle metadata, warnings, conflicts, and the proposed
+   commit plan.
+3. Commit import creates or updates a reviewed pack for the persona after the
+   preview succeeds.
+
+Committed imports remain reviewable and do not automatically activate. Users
+still choose when a valid pack should become the active pack.
+
+## Generated Candidates And Review
+
+Image generation runs through background Jobs and produces generated candidates.
+Those generated candidates stay in review until accepted or rejected.
+
+Accepting a candidate updates the selected pack's manifest/assets according to
+the review action. It does not make the pack active by itself. Rejection leaves
+the active pack untouched.
+
+Generation readiness diagnostics in the editor explain whether the worker,
+queue, image provider, selected backend, and default backend are ready before a
+user queues a generation job.
+
+## Export Archives And Future Portability
+
+Export downloads a portable archive for the selected pack. Export does not
+publish to a shared library and does not detach ownership from the source user or
+persona.
+
+The archive is meant to preserve enough manifest and asset information for
+backup and later import. Future duplicate-to-persona or shared-library flows can
+reuse this shape, but those behaviors should stay explicit user actions.
+
+## Scope: Persona/Buddy, Not VN/CYOA
+
+Persona Visual Packs are for Persona Buddy and Persona Live. The VN asset-pack
+portability work provided a useful background-job and review precedent, but this
+feature is not VN gameplay, not VN Play rendering, and not CYOA scene state.
+
+Do not route Persona Visual Packs through VN runtime assumptions. Persona Buddy
+renders the active pack from the selected persona context; VN and CYOA modules
+have separate asset models, review surfaces, and runtime semantics.

--- a/Docs/Code_Documentation/index.md
+++ b/Docs/Code_Documentation/index.md
@@ -39,6 +39,7 @@ Use the links below to jump to common areas, or the sidebar to browse all topics
 
 ## Voice Assistant
 - Voice Assistant Module: VoiceAssistant_Module.md
+- Persona Visual Packs: Persona_Visual_Packs.md
 
 ## Evaluations
 - Evaluations Developer Guide: Evaluations_Developer_Guide.md

--- a/Docs/superpowers/plans/2026-05-09-persona-visual-ownership-copy-plan.md
+++ b/Docs/superpowers/plans/2026-05-09-persona-visual-ownership-copy-plan.md
@@ -96,7 +96,7 @@
 
 **Tests:** Focused Vitest, docs grep, diff hygiene. Bandit is not required if only docs and TSX copy/tests are touched; record the skip reason.
 
-**Status:** In Progress
+**Status:** Complete
 
 - [x] Run focused Vitest:
   `./node_modules/.bin/vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx`
@@ -105,6 +105,7 @@
 - [x] Run diff hygiene:
   `git diff --check`
 - [x] Update TASK-189 acceptance criteria, notes, verification, and final summary.
-- [ ] Commit with:
+- [x] Commit with:
   `git commit -m "docs: clarify persona visual pack ownership"`
-- [ ] Push and open a PR against `dev` linked to #1429.
+- [x] Push and open a PR against `dev` linked to #1429:
+  https://github.com/rmusser01/tldw_server/pull/1447

--- a/Docs/superpowers/plans/2026-05-09-persona-visual-ownership-copy-plan.md
+++ b/Docs/superpowers/plans/2026-05-09-persona-visual-ownership-copy-plan.md
@@ -1,0 +1,110 @@
+# Persona Visual Ownership Copy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Clarify Persona/Buddy visual-pack ownership, activation, import/export, and review semantics in the WebUI and docs.
+
+**Architecture:** Keep the implementation copy/docs only. Add a compact explanatory block and stage-specific helper copy to the existing `VisualPackEditor`, cover the visible language with focused Vitest assertions, and add a docs page that repeats the same product model without changing runtime behavior.
+
+**Tech Stack:** React, Ant Design/Tailwind utility classes already used by the editor, Vitest, Testing Library, Markdown docs.
+
+---
+
+## File Structure
+
+- Modify `apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx`
+  - Add compact ownership/activation help copy near the pack selector/header.
+  - Add import/export/review helper copy in existing editor sections.
+- Modify `apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx`
+  - Add focused assertions for ownership, active pack, import/export, and generated-candidate review copy.
+- Create `Docs/Code_Documentation/Persona_Visual_Packs.md`
+  - Document the ownership model, active pack semantics, import preview/commit, export archive, and generated candidate review.
+- Modify `backlog/tasks/task-189 - Document-Persona-Visuals-pack-ownership-and-activation-semantics.md`
+  - Track implementation notes, verification, and final summary.
+
+## Stage 1: WebUI Ownership Copy
+
+**Goal:** Make the core product model visible in the Persona Visuals editor.
+
+**Success Criteria:** Users can see that assets are user-owned, attached to one persona by default, manifest-backed, and that active pack means the Buddy renderer uses it now.
+
+**Tests:** `VisualPackEditor.test.tsx` copy assertion.
+
+**Status:** Not Started
+
+- [ ] Add a failing test in `apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx` that renders an active pack and expects:
+  - `Assets are user-owned`
+  - `attached to Garden Helper by default`
+  - `stored as manifests`
+  - `The active pack is the one Persona Buddy renders now`
+- [ ] Run:
+  `./node_modules/.bin/vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx -t "explains visual pack ownership"`
+  Expected: FAIL because the copy does not exist yet.
+- [ ] Update `VisualPackEditor.tsx` near the pack header/selector with the compact ownership help block.
+- [ ] Re-run the focused test.
+  Expected: PASS.
+
+## Stage 2: Import/Export And Review Copy
+
+**Goal:** Clarify staged workflows without changing behavior.
+
+**Success Criteria:** Existing import/export/generation sections distinguish preview from commit, export from shared library publication, and generated-candidate review from immediate activation.
+
+**Tests:** `VisualPackEditor.test.tsx` copy assertion.
+
+**Status:** Not Started
+
+- [ ] Add a failing test in `VisualPackEditor.test.tsx` that expects visible helper copy for:
+  - import preview validates a portable archive before changing this persona
+  - commit import creates or updates a reviewed pack
+  - export downloads a portable archive and does not publish to a shared library
+  - generated candidates stay in review until accepted
+- [ ] Run:
+  `./node_modules/.bin/vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx -t "clarifies import export and generated candidate review"`
+  Expected: FAIL because the copy does not exist yet.
+- [ ] Add the helper copy to the existing import/export/generated-candidate sections in `VisualPackEditor.tsx`.
+- [ ] Re-run the focused test.
+  Expected: PASS.
+
+## Stage 3: Documentation
+
+**Goal:** Preserve the same product model outside the editor.
+
+**Success Criteria:** Docs explain Persona/Buddy visual-pack ownership and explicitly say this is not VN/CYOA asset-pack behavior.
+
+**Tests:** docs grep check.
+
+**Status:** Not Started
+
+- [ ] Create `Docs/Code_Documentation/Persona_Visual_Packs.md` with sections:
+  - Ownership model
+  - Active versus available packs
+  - Manifest-backed pack format
+  - Import preview and commit
+  - Generated candidates and review
+  - Export archives and future portability
+  - Scope: Persona/Buddy, not VN/CYOA
+- [ ] Run:
+  `rg -n "user-owned|attached to one persona|manifest|active pack|import preview|generated candidates|not VN|CYOA" Docs/Code_Documentation/Persona_Visual_Packs.md`
+  Expected: all required phrases are present.
+
+## Stage 4: Verification And Packaging
+
+**Goal:** Leave the branch reviewable and tied back to issue #1429.
+
+**Success Criteria:** Focused UI tests pass, docs checks pass, Backlog task is updated, and the branch is ready for PR.
+
+**Tests:** Focused Vitest, docs grep, diff hygiene. Bandit is not required if only docs and TSX copy/tests are touched; record the skip reason.
+
+**Status:** Not Started
+
+- [ ] Run focused Vitest:
+  `./node_modules/.bin/vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx`
+- [ ] Run docs grep:
+  `rg -n "user-owned|attached to one persona|manifest|active pack|import preview|generated candidates|not VN|CYOA" Docs/Code_Documentation/Persona_Visual_Packs.md`
+- [ ] Run diff hygiene:
+  `git diff --check`
+- [ ] Update TASK-189 acceptance criteria, notes, verification, and final summary.
+- [ ] Commit with:
+  `git commit -m "docs: clarify persona visual pack ownership"`
+- [ ] Push and open a PR against `dev` linked to #1429.

--- a/Docs/superpowers/plans/2026-05-09-persona-visual-ownership-copy-plan.md
+++ b/Docs/superpowers/plans/2026-05-09-persona-visual-ownership-copy-plan.md
@@ -30,18 +30,18 @@
 
 **Tests:** `VisualPackEditor.test.tsx` copy assertion.
 
-**Status:** Not Started
+**Status:** Complete
 
-- [ ] Add a failing test in `apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx` that renders an active pack and expects:
+- [x] Add a failing test in `apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx` that renders an active pack and expects:
   - `Assets are user-owned`
   - `attached to Garden Helper by default`
   - `stored as manifests`
   - `The active pack is the one Persona Buddy renders now`
-- [ ] Run:
+- [x] Run:
   `./node_modules/.bin/vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx -t "explains visual pack ownership"`
   Expected: FAIL because the copy does not exist yet.
-- [ ] Update `VisualPackEditor.tsx` near the pack header/selector with the compact ownership help block.
-- [ ] Re-run the focused test.
+- [x] Update `VisualPackEditor.tsx` near the pack header/selector with the compact ownership help block.
+- [x] Re-run the focused test.
   Expected: PASS.
 
 ## Stage 2: Import/Export And Review Copy
@@ -52,18 +52,18 @@
 
 **Tests:** `VisualPackEditor.test.tsx` copy assertion.
 
-**Status:** Not Started
+**Status:** Complete
 
-- [ ] Add a failing test in `VisualPackEditor.test.tsx` that expects visible helper copy for:
+- [x] Add a failing test in `VisualPackEditor.test.tsx` that expects visible helper copy for:
   - import preview validates a portable archive before changing this persona
   - commit import creates or updates a reviewed pack
   - export downloads a portable archive and does not publish to a shared library
   - generated candidates stay in review until accepted
-- [ ] Run:
+- [x] Run:
   `./node_modules/.bin/vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx -t "clarifies import export and generated candidate review"`
   Expected: FAIL because the copy does not exist yet.
-- [ ] Add the helper copy to the existing import/export/generated-candidate sections in `VisualPackEditor.tsx`.
-- [ ] Re-run the focused test.
+- [x] Add the helper copy to the existing import/export/generated-candidate sections in `VisualPackEditor.tsx`.
+- [x] Re-run the focused test.
   Expected: PASS.
 
 ## Stage 3: Documentation
@@ -74,9 +74,9 @@
 
 **Tests:** docs grep check.
 
-**Status:** Not Started
+**Status:** Complete
 
-- [ ] Create `Docs/Code_Documentation/Persona_Visual_Packs.md` with sections:
+- [x] Create `Docs/Code_Documentation/Persona_Visual_Packs.md` with sections:
   - Ownership model
   - Active versus available packs
   - Manifest-backed pack format
@@ -84,7 +84,7 @@
   - Generated candidates and review
   - Export archives and future portability
   - Scope: Persona/Buddy, not VN/CYOA
-- [ ] Run:
+- [x] Run:
   `rg -n "user-owned|attached to one persona|manifest|active pack|import preview|generated candidates|not VN|CYOA" Docs/Code_Documentation/Persona_Visual_Packs.md`
   Expected: all required phrases are present.
 
@@ -96,15 +96,15 @@
 
 **Tests:** Focused Vitest, docs grep, diff hygiene. Bandit is not required if only docs and TSX copy/tests are touched; record the skip reason.
 
-**Status:** Not Started
+**Status:** In Progress
 
-- [ ] Run focused Vitest:
+- [x] Run focused Vitest:
   `./node_modules/.bin/vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx`
-- [ ] Run docs grep:
+- [x] Run docs grep:
   `rg -n "user-owned|attached to one persona|manifest|active pack|import preview|generated candidates|not VN|CYOA" Docs/Code_Documentation/Persona_Visual_Packs.md`
-- [ ] Run diff hygiene:
+- [x] Run diff hygiene:
   `git diff --check`
-- [ ] Update TASK-189 acceptance criteria, notes, verification, and final summary.
+- [x] Update TASK-189 acceptance criteria, notes, verification, and final summary.
 - [ ] Commit with:
   `git commit -m "docs: clarify persona visual pack ownership"`
 - [ ] Push and open a PR against `dev` linked to #1429.

--- a/Docs/superpowers/specs/2026-05-09-persona-visual-ownership-copy-design.md
+++ b/Docs/superpowers/specs/2026-05-09-persona-visual-ownership-copy-design.md
@@ -1,0 +1,135 @@
+# Persona Visual Ownership Copy Design
+
+Date: 2026-05-09
+Status: Approved for implementation planning
+Owner: Codex brainstorming pass
+Backlog: TASK-189
+GitHub: #1429
+
+## Summary
+
+This lightweight PRD/spec clarifies the product language for Persona/Buddy visual packs.
+
+The existing Persona Visuals implementation already supports persona-scoped packs, manifest-backed assets, activation, import preview/commit, export, generation readiness, and generated-candidate review. The remaining gap is explanatory: users need to understand what a pack belongs to, what "active" means, and why imported or generated visual assets still pass through review before the Buddy renderer uses them.
+
+This sprint adds concise UI and docs copy. It does not add duplicate-to-persona, shared visual libraries, marketplace behavior, or VN/CYOA semantics.
+
+## Problem
+
+Persona Visuals now has several product concepts that are technically correct but easy to misread:
+
+- A pack is attached to one persona by default, but the manifest format is intentionally portable.
+- "Active" means the Persona Buddy renderer uses that pack now; inactive packs still exist and can be edited.
+- Import preview is inspection and validation, not a commit.
+- Import commit creates or updates a pack only after the review step.
+- Generated candidates are not applied until accepted.
+- Export creates a portable archive, not a shared library entry.
+
+Without explicit copy, a user can reasonably infer that assets are global, that an imported pack immediately becomes active, or that generation bypasses review.
+
+## Goals
+
+- Explain that Persona Visuals assets are user-owned.
+- Explain that visual packs are attached to the selected persona by default.
+- Explain that packs are manifest-based so future duplicate, import/export, and shared-library workflows can reuse the same format.
+- Clarify active pack versus available/editable pack behavior.
+- Clarify import preview, import commit, export archive, and generated-candidate review semantics.
+- Keep the copy concise and aligned with existing Persona/Buddy terminology.
+
+## Non-Goals
+
+- Do not implement duplicate-to-persona.
+- Do not implement shared visual libraries.
+- Do not implement marketplace or public sharing behavior.
+- Do not change storage ownership, RBAC, or backend data models.
+- Do not change Persona Visuals pack activation behavior.
+- Do not change generated-candidate review behavior.
+- Do not mix this with VN Play, CYOA, or story scene asset semantics.
+
+## Users And Jobs
+
+Primary user: a local/self-hosted user configuring the visible Persona Buddy for a selected persona.
+
+User jobs:
+
+- "Help me understand where this visual pack will be used."
+- "Let me safely import or generate assets without accidentally replacing my active Buddy."
+- "Let me tell the difference between a pack that exists and the pack currently being rendered."
+- "Let me understand why the pack format is portable even though the current pack belongs to this persona."
+
+## Product Model
+
+Use these exact model statements across UI/docs:
+
+- Assets are user-owned.
+- A visual pack is attached to one persona by default.
+- A pack is stored as a manifest plus referenced assets.
+- The active pack is the pack currently used by the Persona Buddy renderer.
+- Other packs remain available for editing, export, activation, or archival.
+- Imported packs and generated candidates require review before they affect the active Buddy.
+- Portable pack archives preserve the manifest format for import/export and future duplicate/shared-library workflows.
+
+Avoid these implications:
+
+- Do not imply that a pack is global today.
+- Do not imply that import preview mutates the active Buddy.
+- Do not imply that import commit automatically activates a pack unless the existing implementation actually does so.
+- Do not imply that shared libraries exist today.
+- Do not imply that VN/CYOA asset packs use this same product surface.
+
+## UI Design
+
+Add one compact help block near the top of `VisualPackEditor`, close to the pack selector/header.
+
+Recommended title:
+
+> How Persona Visual packs work
+
+Recommended body:
+
+> Assets are user-owned and this pack is attached to {personaName} by default. Packs are stored as manifests with referenced assets, so they can be edited, exported, imported, and later duplicated or shared without changing the core format. The active pack is the one Persona Buddy renders now; other packs stay available for editing or review.
+
+The copy can be split into two short paragraphs if the existing layout reads better that way.
+
+### Import/Export Copy
+
+Near import preview/commit controls, use language that distinguishes stages:
+
+- Import preview validates a portable pack archive before it changes this persona.
+- Commit import creates or updates a reviewed pack for this persona.
+- Export downloads a portable archive for this pack; it does not publish it to a shared library.
+
+### Generation Review Copy
+
+Near generated candidates, use language that preserves the review model:
+
+- Generated candidates stay in review until accepted.
+- Accepting a candidate updates this pack's manifest/assets; activation remains the explicit pack-level action.
+
+## Documentation Design
+
+Add or update a Persona/Buddy visual-pack documentation section. The doc should repeat the same product model and scope statements:
+
+- Persona/Buddy visual packs only.
+- User-owned assets.
+- One-persona attachment by default.
+- Manifest-backed pack structure.
+- Active versus available packs.
+- Import preview/commit/review.
+- Generated-candidate review.
+- Export as portable archive, not shared library.
+- Future duplicate/shared-library workflows are format-compatible but not implemented in this sprint.
+
+The doc should link or point operators toward the existing Persona Visuals editor behavior, not introduce a parallel workflow.
+
+## Acceptance Criteria
+
+- The Persona Visuals editor contains concise copy explaining user-owned assets and default persona attachment.
+- The editor copy explains active pack versus available/editable pack behavior.
+- The editor copy clarifies import preview/commit, export archive, and generated-candidate review semantics.
+- Docs contain the same model language and explicitly exclude VN/CYOA scope.
+- Focused tests or docs checks protect the visible copy from accidental removal.
+
+## Open Questions
+
+None. The work is intentionally copy/docs/test scoped.

--- a/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
@@ -1361,18 +1361,20 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
             className="mt-3 rounded-md border border-border bg-bg px-3 py-2 text-xs leading-5 text-text-muted"
           >
             <div className="font-medium text-text">
-              How Persona Visual packs work
+              {t("sidepanel:personaGarden.visuals.ownershipTitle", {
+                defaultValue: "How Persona Visual packs work"
+              })}
             </div>
             <div className="mt-1">
-              Assets are user-owned and attached to{" "}
-              {selectedPersonaName || selectedPersonaId} by default. Packs are
-              stored as manifests with referenced assets, so they can be edited,
-              exported, imported, and later duplicated or shared without changing
-              the core format.
+              {t("sidepanel:personaGarden.visuals.ownershipDescription", {
+                defaultValue: `Assets are user-owned and attached to ${selectedPersonaName || selectedPersonaId} by default. Packs are stored as manifests with referenced assets, so they can be edited, exported, imported, and later duplicated or shared without changing the core format.`
+              })}
             </div>
             <div className="mt-1">
-              The active pack is the one Persona Buddy renders now; other packs
-              stay available for editing or review.
+              {t("sidepanel:personaGarden.visuals.activePackDescription", {
+                defaultValue:
+                  "The active pack is the one Persona Buddy renders now; other packs stay available for editing or review."
+              })}
             </div>
           </div>
         ) : null}
@@ -1470,15 +1472,22 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
               className="mt-2 rounded-md border border-border bg-bg px-3 py-2 text-xs leading-5 text-text-muted"
             >
               <div>
-                Import preview validates a portable pack archive before it changes
-                this persona.
+                {t("sidepanel:personaGarden.visuals.importPreviewHelp", {
+                  defaultValue:
+                    "Import preview validates a portable pack archive before it changes this persona."
+                })}
               </div>
               <div>
-                Commit import creates or updates a reviewed pack for this persona.
+                {t("sidepanel:personaGarden.visuals.importCommitHelp", {
+                  defaultValue:
+                    "Commit import creates a reviewed draft pack for this persona."
+                })}
               </div>
               <div>
-                Export downloads a portable archive and does not publish to a shared
-                library.
+                {t("sidepanel:personaGarden.visuals.exportHelp", {
+                  defaultValue:
+                    "Export downloads a portable archive and does not publish to a shared library."
+                })}
               </div>
             </div>
             <div className="mt-3 grid gap-3 lg:grid-cols-2">
@@ -2093,9 +2102,10 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
               data-testid="persona-visual-generation-review-copy"
               className="mt-2 text-xs leading-5 text-text-muted"
             >
-              Generated candidates stay in review until accepted. Accepting a
-              candidate updates this pack's manifest and assets; activation remains
-              the explicit pack-level action.
+              {t("sidepanel:personaGarden.visuals.generationReviewHelp", {
+                defaultValue:
+                  "Generated candidates stay in review until accepted. Accepting a candidate updates this pack's manifest and assets; activation remains the explicit pack-level action."
+              })}
             </div>
             <div className="mt-3 grid gap-2 md:grid-cols-[minmax(180px,1fr)_150px_minmax(120px,160px)_auto]">
               <label className="text-xs text-text-muted">

--- a/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
@@ -1355,6 +1355,27 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
             <span className="text-text-muted">{`v${selectedPack.version ?? 1}`}</span>
           </div>
         ) : null}
+        {selectedPack ? (
+          <div
+            data-testid="persona-visual-ownership-copy"
+            className="mt-3 rounded-md border border-border bg-bg px-3 py-2 text-xs leading-5 text-text-muted"
+          >
+            <div className="font-medium text-text">
+              How Persona Visual packs work
+            </div>
+            <div className="mt-1">
+              Assets are user-owned and attached to{" "}
+              {selectedPersonaName || selectedPersonaId} by default. Packs are
+              stored as manifests with referenced assets, so they can be edited,
+              exported, imported, and later duplicated or shared without changing
+              the core format.
+            </div>
+            <div className="mt-1">
+              The active pack is the one Persona Buddy renders now; other packs
+              stay available for editing or review.
+            </div>
+          </div>
+        ) : null}
         {packHealthDiagnostic ? (
           <div
             data-testid="persona-visual-pack-health"
@@ -1443,6 +1464,22 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
           <div className="rounded-lg border border-border bg-surface p-3">
             <div className="text-[11px] font-semibold uppercase tracking-wide text-text-subtle">
               Portability
+            </div>
+            <div
+              data-testid="persona-visual-portability-copy"
+              className="mt-2 rounded-md border border-border bg-bg px-3 py-2 text-xs leading-5 text-text-muted"
+            >
+              <div>
+                Import preview validates a portable pack archive before it changes
+                this persona.
+              </div>
+              <div>
+                Commit import creates or updates a reviewed pack for this persona.
+              </div>
+              <div>
+                Export downloads a portable archive and does not publish to a shared
+                library.
+              </div>
             </div>
             <div className="mt-3 grid gap-3 lg:grid-cols-2">
               <div className="rounded border border-border bg-bg p-2">
@@ -2051,6 +2088,14 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
               <Button size="small" onClick={() => void loadCandidates()}>
                 {candidatesLoading ? loadingLabel : refreshLabel}
               </Button>
+            </div>
+            <div
+              data-testid="persona-visual-generation-review-copy"
+              className="mt-2 text-xs leading-5 text-text-muted"
+            >
+              Generated candidates stay in review until accepted. Accepting a
+              candidate updates this pack's manifest and assets; activation remains
+              the explicit pack-level action.
             </div>
             <div className="mt-3 grid gap-2 md:grid-cols-[minmax(180px,1fr)_150px_minmax(120px,160px)_auto]">
               <label className="text-xs text-text-muted">

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
@@ -269,6 +269,121 @@ describe("VisualPackEditor", () => {
     expect(health).toHaveClass("text-danger")
   })
 
+  it("explains visual pack ownership and active pack semantics", async () => {
+    const pack = {
+      id: "pack-1",
+      persona_id: "persona-1",
+      title: "Animated pack",
+      renderer_type: "sprite_frames",
+      status: "active",
+      manifest: structuredClone(baseManifest),
+      assets: visualAssets,
+      version: 3
+    }
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string }) => {
+      const method = init?.method || "GET"
+      if (path === "/api/v1/persona/profiles/persona-1/visual-packs" && method === "GET") {
+        return okResponse([pack])
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/pack-1/generated-candidates" &&
+        method === "GET"
+      ) {
+        return okResponse({ candidates: [] })
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/pack-1/generation-readiness" &&
+        method === "GET"
+      ) {
+        return okResponse(readyGenerationReadiness)
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        error: `Unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(
+      <VisualPackEditor
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Garden Helper"
+        isActive
+      />
+    )
+
+    const ownership = await screen.findByTestId("persona-visual-ownership-copy")
+    expect(ownership).toHaveTextContent("Assets are user-owned")
+    expect(ownership).toHaveTextContent("attached to Garden Helper by default")
+    expect(ownership).toHaveTextContent("stored as manifests")
+    expect(ownership).toHaveTextContent(
+      "The active pack is the one Persona Buddy renders now"
+    )
+  })
+
+  it("clarifies import export and generated candidate review semantics", async () => {
+    const pack = {
+      id: "pack-1",
+      persona_id: "persona-1",
+      title: "Animated pack",
+      renderer_type: "sprite_frames",
+      status: "draft",
+      manifest: structuredClone(baseManifest),
+      assets: visualAssets,
+      version: 3
+    }
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string }) => {
+      const method = init?.method || "GET"
+      if (path === "/api/v1/persona/profiles/persona-1/visual-packs" && method === "GET") {
+        return okResponse([pack])
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/pack-1/generated-candidates" &&
+        method === "GET"
+      ) {
+        return okResponse({ candidates: [] })
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/pack-1/generation-readiness" &&
+        method === "GET"
+      ) {
+        return okResponse(readyGenerationReadiness)
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        error: `Unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(
+      <VisualPackEditor
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Garden Helper"
+        isActive
+      />
+    )
+
+    const portability = await screen.findByTestId("persona-visual-portability-copy")
+    expect(portability).toHaveTextContent(
+      "Import preview validates a portable pack archive before it changes this persona"
+    )
+    expect(portability).toHaveTextContent(
+      "Commit import creates or updates a reviewed pack"
+    )
+    expect(portability).toHaveTextContent(
+      "Export downloads a portable archive and does not publish to a shared library"
+    )
+
+    expect(screen.getByTestId("persona-visual-generation-review-copy")).toHaveTextContent(
+      "Generated candidates stay in review until accepted"
+    )
+  })
+
   it("loads pack list, creates a draft pack, and uploads the selected asset role", async () => {
     let packs: any[] = []
     const uploadedAssets: any[] = []

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
@@ -263,8 +263,10 @@ describe("VisualPackEditor", () => {
     )
 
     const health = await screen.findByTestId("persona-visual-pack-health")
-    expect(health).toHaveTextContent("Visual asset is missing")
-    expect(health).toHaveTextContent("asset-b")
+    await waitFor(() => {
+      expect(health).toHaveTextContent("Visual asset is missing")
+      expect(health).toHaveTextContent("asset-b")
+    })
     expect(health).toHaveClass("border-danger/30")
     expect(health).toHaveClass("text-danger")
   })
@@ -373,7 +375,7 @@ describe("VisualPackEditor", () => {
       "Import preview validates a portable pack archive before it changes this persona"
     )
     expect(portability).toHaveTextContent(
-      "Commit import creates or updates a reviewed pack"
+      "Commit import creates a reviewed draft pack"
     )
     expect(portability).toHaveTextContent(
       "Export downloads a portable archive and does not publish to a shared library"

--- a/backlog/tasks/task-189 - Document-Persona-Visuals-pack-ownership-and-activation-semantics.md
+++ b/backlog/tasks/task-189 - Document-Persona-Visuals-pack-ownership-and-activation-semantics.md
@@ -4,7 +4,7 @@ title: Document Persona Visuals pack ownership and activation semantics
 status: Done
 assignee: []
 created_date: '2026-05-09 20:13'
-updated_date: '2026-05-09 20:27'
+updated_date: '2026-05-09 20:41'
 labels:
   - WebUI
   - Persona
@@ -44,6 +44,8 @@ Use the lightweight PRD/spec in `Docs/superpowers/specs/2026-05-09-persona-visua
 Created from GitHub issue #1429 after PR #1439 merged and tracker #1428 was updated. This task is intentionally scoped to Persona/Buddy visual-pack ownership, activation, import/commit/review, and docs copy. It must not implement duplicate-to-persona, shared libraries, marketplaces, or VN/CYOA behavior.
 
 Implemented Persona Visuals editor ownership copy, portability copy, generated-candidate review copy, and Persona Visual Packs code documentation. Verification: focused Vitest passed, docs grep passed, git diff --check passed. Bandit skipped because this change only touches TSX copy/tests and Markdown documentation; no Python code was changed.
+
+PR opened for review: https://github.com/rmusser01/tldw_server/pull/1447. The PR body links issue #1429 for closeout on merge and keeps the human-authored Change summary placeholder required by the AI-generated PR merge policy.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-189 - Document-Persona-Visuals-pack-ownership-and-activation-semantics.md
+++ b/backlog/tasks/task-189 - Document-Persona-Visuals-pack-ownership-and-activation-semantics.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-189
 title: Document Persona Visuals pack ownership and activation semantics
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-09 20:13'
-updated_date: '2026-05-09 20:16'
+updated_date: '2026-05-09 20:27'
 labels:
   - WebUI
   - Persona
@@ -25,11 +25,11 @@ Implement GitHub issue #1429 for the Persona/Buddy visual-pack system. Add conci
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Persona Visuals editor explains user-owned assets and default persona attachment without implying shared-library behavior exists today
-- [ ] #2 Persona Visuals editor clarifies active pack versus available/editable pack behavior
-- [ ] #3 Import preview/commit and generated-candidate review copy clarify that imported or generated assets are reviewed before use
-- [ ] #4 Docs contain the same ownership and manifest-pack model language and explicitly scope it to Persona/Buddy visual packs not VN/CYOA work
-- [ ] #5 Focused UI tests or documentation checks cover the new visible copy
+- [x] #1 Persona Visuals editor explains user-owned assets and default persona attachment without implying shared-library behavior exists today
+- [x] #2 Persona Visuals editor clarifies active pack versus available/editable pack behavior
+- [x] #3 Import preview/commit and generated-candidate review copy clarify that imported or generated assets are reviewed before use
+- [x] #4 Docs contain the same ownership and manifest-pack model language and explicitly scope it to Persona/Buddy visual packs not VN/CYOA work
+- [x] #5 Focused UI tests or documentation checks cover the new visible copy
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -42,14 +42,22 @@ Use the lightweight PRD/spec in `Docs/superpowers/specs/2026-05-09-persona-visua
 
 <!-- SECTION:NOTES:BEGIN -->
 Created from GitHub issue #1429 after PR #1439 merged and tracker #1428 was updated. This task is intentionally scoped to Persona/Buddy visual-pack ownership, activation, import/commit/review, and docs copy. It must not implement duplicate-to-persona, shared libraries, marketplaces, or VN/CYOA behavior.
+
+Implemented Persona Visuals editor ownership copy, portability copy, generated-candidate review copy, and Persona Visual Packs code documentation. Verification: focused Vitest passed, docs grep passed, git diff --check passed. Bandit skipped because this change only touches TSX copy/tests and Markdown documentation; no Python code was changed.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Clarified Persona/Buddy visual-pack ownership and activation semantics in the WebUI and docs: assets are user-owned, attached to one persona by default, manifest-backed, explicitly activated, and staged through import preview/commit or generated-candidate review before use.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-189 - Document-Persona-Visuals-pack-ownership-and-activation-semantics.md
+++ b/backlog/tasks/task-189 - Document-Persona-Visuals-pack-ownership-and-activation-semantics.md
@@ -1,0 +1,55 @@
+---
+id: TASK-189
+title: Document Persona Visuals pack ownership and activation semantics
+status: In Progress
+assignee: []
+created_date: '2026-05-09 20:13'
+updated_date: '2026-05-09 20:16'
+labels:
+  - WebUI
+  - Persona
+  - Buddy
+  - visual-packs
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1428'
+  - 'https://github.com/rmusser01/tldw_server/issues/1429'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement GitHub issue #1429 for the Persona/Buddy visual-pack system. Add concise product/docs/UI copy that explains assets are user-owned, attached to one persona by default, and stored as manifest-based packs so future duplicate-to-persona, import/export, and shared-library workflows can reuse the format. Clarify active pack versus available pack behavior and keep import/commit/review semantics understandable without adding new duplicate/shared-library/marketplace behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Persona Visuals editor explains user-owned assets and default persona attachment without implying shared-library behavior exists today
+- [ ] #2 Persona Visuals editor clarifies active pack versus available/editable pack behavior
+- [ ] #3 Import preview/commit and generated-candidate review copy clarify that imported or generated assets are reviewed before use
+- [ ] #4 Docs contain the same ownership and manifest-pack model language and explicitly scope it to Persona/Buddy visual packs not VN/CYOA work
+- [ ] #5 Focused UI tests or documentation checks cover the new visible copy
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Use the lightweight PRD/spec in `Docs/superpowers/specs/2026-05-09-persona-visual-ownership-copy-design.md` and the implementation plan in `Docs/superpowers/plans/2026-05-09-persona-visual-ownership-copy-plan.md`.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Created from GitHub issue #1429 after PR #1439 merged and tracker #1428 was updated. This task is intentionally scoped to Persona/Buddy visual-pack ownership, activation, import/commit/review, and docs copy. It must not implement duplicate-to-persona, shared libraries, marketplaces, or VN/CYOA behavior.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-189 - Document-Persona-Visuals-pack-ownership-and-activation-semantics.md
+++ b/backlog/tasks/task-189 - Document-Persona-Visuals-pack-ownership-and-activation-semantics.md
@@ -4,7 +4,7 @@ title: Document Persona Visuals pack ownership and activation semantics
 status: Done
 assignee: []
 created_date: '2026-05-09 20:13'
-updated_date: '2026-05-09 20:41'
+updated_date: '2026-05-09 20:51'
 labels:
   - WebUI
   - Persona
@@ -46,6 +46,12 @@ Created from GitHub issue #1429 after PR #1439 merged and tracker #1428 was upda
 Implemented Persona Visuals editor ownership copy, portability copy, generated-candidate review copy, and Persona Visual Packs code documentation. Verification: focused Vitest passed, docs grep passed, git diff --check passed. Bandit skipped because this change only touches TSX copy/tests and Markdown documentation; no Python code was changed.
 
 PR opened for review: https://github.com/rmusser01/tldw_server/pull/1447. The PR body links issue #1429 for closeout on merge and keeps the human-authored Change summary placeholder required by the AI-generated PR merge policy.
+
+Review fix plan for PR #1447: wrap the newly added VisualPackEditor helper copy in existing sidepanel i18n t() calls; correct import-commit wording from creates-or-updates to reviewed draft/new draft to match target_mode=create_new; update the copy assertions and Persona Visual Packs docs to match; re-run focused Vitest, docs grep, diff hygiene, and record results.
+
+PR review fixes completed: new VisualPackEditor helper copy now uses sidepanel i18n t() calls; import commit wording now says it creates a reviewed draft pack to match target_mode=create_new; docs and tests were updated. Verification: focused Vitest passed, docs grep passed, git diff --check passed. Bandit remains skipped because only TSX copy/tests and Markdown docs changed.
+
+Additional test reliability cleanup: the existing health diagnostic assertion now waits for the selected pack manifest to settle before checking the missing-asset diagnostic, avoiding the transient default-manifest state observed during final verification. Re-run verification passed after this cleanup.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary


### PR DESCRIPTION
## Summary

- Adds Persona Visuals editor copy that explains user-owned assets, default persona attachment, manifest-backed packs, and active-pack rendering semantics.
- Adds portability and generated-candidate review helper copy for import preview, import commit, export, and generation review flows.
- Adds `Docs/Code_Documentation/Persona_Visual_Packs.md` and links it from the code-doc index.

## Test Plan

- `./node_modules/.bin/vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx`
- `rg -n "user-owned|attached to one persona|manifest|active pack|import preview|generated candidates|not VN|CYOA" Docs/Code_Documentation/Persona_Visual_Packs.md`
- `git diff --check`

## Change Summary

Pending human requester summary before merge per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

Closes #1429.
