### PR TITLE
Allow RecoveryCallout adapters in product-state guard

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -5445,17 +5445,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "local-recovery-banner:src/components/Sidepanel/Chat/ConnectionBanner.tsx:ConnectionBanner",
-    "path": "src/components/Sidepanel/Chat/ConnectionBanner.tsx",
-    "rule": "local-recovery-banner",
-    "subject": "ConnectionBanner",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing local ConnectionBanner recovery banner before the guard.",
-    "replacement": "RecoveryCallout or StatePanel",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/recipe-configs/EmbeddingsModelSelectionConfig.tsx:Alert",
     "path": "src/components/Option/Evaluations/tabs/recipe-configs/EmbeddingsModelSelectionConfig.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/scripts/design-system-product-state-rules.mjs
+++ b/apps/packages/ui/scripts/design-system-product-state-rules.mjs
@@ -399,6 +399,7 @@ function collectCanonicalDesignSystemUsage(sourceFile, fileSubject) {
   const imports = {
     emptyState: new Set(),
     loadingState: new Set(),
+    recoveryState: new Set(),
     badge: new Set(),
     stateRegistry: new Set()
   }
@@ -434,6 +435,12 @@ function collectCanonicalDesignSystemUsage(sourceFile, fileSubject) {
         if (isCanonicalComponentImport && importedName === "LoadingState") {
           imports.loadingState.add(element.name.text)
         }
+        if (
+          isCanonicalComponentImport &&
+          (importedName === "RecoveryCallout" || importedName === "StatePanel")
+        ) {
+          imports.recoveryState.add(element.name.text)
+        }
         if (isCanonicalComponentImport && importedName === "Badge") {
           imports.badge.add(element.name.text)
         }
@@ -460,6 +467,13 @@ function collectCanonicalDesignSystemUsage(sourceFile, fileSubject) {
     if (
       isCanonicalComponentImport &&
       importClause?.name &&
+      /\/(?:RecoveryCallout|StatePanel)$/.test(importPath)
+    ) {
+      imports.recoveryState.add(importClause.name.text)
+    }
+    if (
+      isCanonicalComponentImport &&
+      importClause?.name &&
       /\/Badge$/.test(importPath)
     ) {
       imports.badge.add(importClause.name.text)
@@ -478,6 +492,11 @@ function collectCanonicalDesignSystemUsage(sourceFile, fileSubject) {
   )
 
   return {
+    recoveryStateOwners: collectReturnedJsxTreeTagOwners(
+      sourceFile,
+      imports.recoveryState,
+      fileSubject
+    ),
     emptyStateOwners: collectJsxTagOwners(
       sourceFile,
       imports.emptyState,
@@ -545,7 +564,10 @@ function pushLocalComponentFinding(
     return
   }
 
-  if (RECOVERY_COMPONENT_PATTERN.test(subject)) {
+  if (
+    RECOVERY_COMPONENT_PATTERN.test(subject) &&
+    !canonicalUsage.recoveryStateOwners?.has(subject)
+  ) {
     pushFinding(findings, {
       relativePath,
       rule: "local-recovery-banner",

--- a/apps/packages/ui/scripts/design-system-product-state-rules.mjs
+++ b/apps/packages/ui/scripts/design-system-product-state-rules.mjs
@@ -492,7 +492,7 @@ function collectCanonicalDesignSystemUsage(sourceFile, fileSubject) {
   )
 
   return {
-    recoveryStateOwners: collectReturnedJsxTreeTagOwners(
+    recoveryStateOwners: collectReturnedJsxBoundaryTagOwners(
       sourceFile,
       imports.recoveryState,
       fileSubject
@@ -757,6 +757,34 @@ function collectReturnedJsxTreeTagOwners(sourceFile, localNames, fallbackOwner) 
   return owners
 }
 
+function collectReturnedJsxBoundaryTagOwners(sourceFile, localNames, fallbackOwner) {
+  const owners = new Set()
+
+  if (!localNames || localNames.size === 0) {
+    return owners
+  }
+
+  walk(sourceFile, (node) => {
+    if (!isFunctionLikeNode(node)) {
+      return
+    }
+
+    const ownerName = returnedJsxOwnerName(node, fallbackOwner)
+    if (!ownerName) {
+      return
+    }
+
+    const returnsMatchingTag = collectOwnReturnExpressions(node).some(
+      (expression) => returnedExpressionHasJsxBoundaryTag(expression, localNames)
+    )
+    if (returnsMatchingTag) {
+      owners.add(ownerName)
+    }
+  })
+
+  return owners
+}
+
 function returnedJsxOwnerName(functionNode, fallbackOwner) {
   if (functionNode.name && ts.isIdentifier(functionNode.name)) {
     return functionNode.name.text
@@ -903,6 +931,56 @@ function returnedExpressionContainsJsxTag(expression, localNames) {
 
   visit(unwrapped)
   return found
+}
+
+function returnedExpressionHasJsxBoundaryTag(expression, localNames) {
+  const unwrapped = unwrapReturnedExpression(expression)
+
+  if (ts.isConditionalExpression(unwrapped)) {
+    return (
+      returnedExpressionHasJsxBoundaryTag(unwrapped.whenTrue, localNames) ||
+      returnedExpressionHasJsxBoundaryTag(unwrapped.whenFalse, localNames)
+    )
+  }
+
+  if (jsxNodeMatchesTag(unwrapped, localNames)) {
+    return true
+  }
+
+  const children = substantiveJsxChildren(unwrapped)
+  return children.length === 1 && jsxNodeMatchesTag(children[0], localNames)
+}
+
+function jsxNodeMatchesTag(node, localNames) {
+  if (ts.isJsxSelfClosingElement(node)) {
+    const localName = jsxTagName(node.tagName)
+    return Boolean(localName && localNames.has(localName))
+  }
+
+  if (ts.isJsxElement(node)) {
+    const localName = jsxTagName(node.openingElement.tagName)
+    return Boolean(localName && localNames.has(localName))
+  }
+
+  return false
+}
+
+function substantiveJsxChildren(node) {
+  if (!ts.isJsxElement(node) && !ts.isJsxFragment(node)) {
+    return []
+  }
+
+  return node.children.filter((child) => {
+    if (ts.isJsxText(child)) {
+      return child.text.trim().length > 0
+    }
+
+    if (ts.isJsxExpression(child)) {
+      return Boolean(child.expression)
+    }
+
+    return true
+  })
 }
 
 function isReturnedCollectionRenderCallback(functionNode) {

--- a/apps/packages/ui/src/design-system/__tests__/product-state-guard.test.ts
+++ b/apps/packages/ui/src/design-system/__tests__/product-state-guard.test.ts
@@ -41,6 +41,58 @@ describe("design-system product-state guard rules", () => {
     )
   })
 
+  it("allows recovery-banner adapters that return RecoveryCallout", () => {
+    const findings = analyze(
+      "src/components/Sidepanel/Chat/ConnectionBanner.tsx",
+      `
+        import { RecoveryCallout } from "@/components/ui/state"
+
+        export function ConnectionBanner() {
+          return (
+            <RecoveryCallout
+              state="unavailable"
+              title="Can't reach your tldw server"
+              primaryAction={{ label: "Retry", onClick: () => undefined }}
+            />
+          )
+        }
+      `
+    )
+
+    expect(findings).not.toContainEqual(
+      expect.objectContaining({
+        rule: "local-recovery-banner",
+        subject: "ConnectionBanner"
+      })
+    )
+  })
+
+  it("allows recovery-banner adapters that return StatePanel", () => {
+    const findings = analyze(
+      "src/components/Common/BackendErrorBanner.tsx",
+      `
+        import { StatePanel } from "@/components/ui/state"
+
+        export function BackendErrorBanner() {
+          return (
+            <StatePanel
+              state="error"
+              title="Backend error"
+              primaryAction={{ label: "Retry", onClick: () => undefined }}
+            />
+          )
+        }
+      `
+    )
+
+    expect(findings).not.toContainEqual(
+      expect.objectContaining({
+        rule: "local-recovery-banner",
+        subject: "BackendErrorBanner"
+      })
+    )
+  })
+
   it("flags local empty, loading, and status wrappers", () => {
     const findings = [
       ...analyze(

--- a/apps/packages/ui/src/design-system/__tests__/product-state-guard.test.ts
+++ b/apps/packages/ui/src/design-system/__tests__/product-state-guard.test.ts
@@ -97,6 +97,34 @@ describe("design-system product-state guard rules", () => {
     )
   })
 
+  it("flags mixed bespoke recovery markup with a nested RecoveryCallout", () => {
+    const findings = analyze(
+      "src/components/Common/MixedRecoveryBanner.tsx",
+      `
+        import { RecoveryCallout } from "@/components/ui/state"
+
+        export function MixedRecoveryBanner() {
+          return (
+            <div className="rounded border p-3">
+              <p>Disconnected from backend</p>
+              <RecoveryCallout
+                state="unavailable"
+                title="Can't reach your tldw server"
+              />
+            </div>
+          )
+        }
+      `
+    )
+
+    expect(findings).toContainEqual(
+      expect.objectContaining({
+        rule: "local-recovery-banner",
+        subject: "MixedRecoveryBanner"
+      })
+    )
+  })
+
   it("flags local empty, loading, and status wrappers", () => {
     const findings = [
       ...analyze(

--- a/apps/packages/ui/src/design-system/__tests__/product-state-guard.test.ts
+++ b/apps/packages/ui/src/design-system/__tests__/product-state-guard.test.ts
@@ -41,7 +41,7 @@ describe("design-system product-state guard rules", () => {
     )
   })
 
-  it("allows recovery-banner adapters that return RecoveryCallout", () => {
+  it("allows recovery-banner adapters that return a wrapper containing RecoveryCallout", () => {
     const findings = analyze(
       "src/components/Sidepanel/Chat/ConnectionBanner.tsx",
       `
@@ -49,11 +49,13 @@ describe("design-system product-state guard rules", () => {
 
         export function ConnectionBanner() {
           return (
-            <RecoveryCallout
-              state="unavailable"
-              title="Can't reach your tldw server"
-              primaryAction={{ label: "Retry", onClick: () => undefined }}
-            />
+            <div className="px-3 py-2">
+              <RecoveryCallout
+                state="unavailable"
+                title="Can't reach your tldw server"
+                primaryAction={{ label: "Retry", onClick: () => undefined }}
+              />
+            </div>
           )
         }
       `
@@ -67,7 +69,7 @@ describe("design-system product-state guard rules", () => {
     )
   })
 
-  it("allows recovery-banner adapters that return StatePanel", () => {
+  it("allows recovery-banner adapters that return a wrapper containing StatePanel", () => {
     const findings = analyze(
       "src/components/Common/BackendErrorBanner.tsx",
       `
@@ -75,11 +77,13 @@ describe("design-system product-state guard rules", () => {
 
         export function BackendErrorBanner() {
           return (
-            <StatePanel
-              state="error"
-              title="Backend error"
-              primaryAction={{ label: "Retry", onClick: () => undefined }}
-            />
+            <section aria-label="Backend recovery">
+              <StatePanel
+                state="error"
+                title="Backend error"
+                primaryAction={{ label: "Retry", onClick: () => undefined }}
+              />
+            </section>
           )
         }
       `

--- a/backlog/tasks/task-45.32 - Allow-RecoveryCallout-adapters-in-product-state-guard.md
+++ b/backlog/tasks/task-45.32 - Allow-RecoveryCallout-adapters-in-product-state-guard.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - Codex
 created_date: '2026-05-09 21:11'
-updated_date: '2026-05-09 21:16'
+updated_date: '2026-05-09 21:31'
 labels:
   - design-system
   - ui
@@ -41,16 +41,22 @@ priority: medium
 Implemented recovery adapter recognition in the product-state guard by collecting returned JSX-tree owners for canonical RecoveryCallout and StatePanel imports. Added focused tests that prove canonical adapters are allowed while bespoke recovery banners remain findings. Removed the now-stale Sidepanel ConnectionBanner local-recovery-banner baseline entry.
 
 Verification: RED run of bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot failed the two new canonical adapter tests with local-recovery-banner findings. GREEN/final run passed 51/51 tests. bun run verify:design-system-state passed with Baseline exceptions: 510 and local-recovery-banner: 3. node --check apps/packages/ui/scripts/design-system-product-state-rules.mjs passed. git diff --check passed. bunx tsc --noEmit --pretty false exited 2 with 236 lines of pre-existing unrelated UI type errors; touched-file filter for design-system-product-state-rules, product-state-guard, design-system-product-state-baseline, task-45.32, RecoveryCallout, StatePanel, and ConnectionBanner returned no diagnostics. Bandit skipped because touched implementation/test/config files are UI JS/TS/JSON/Markdown only, with no Python execution surface. No standalone docs update was needed; the executable guard tests and baseline update document the rule behavior.
+
+PR #1451 review follow-up: Qodo identified that the canonical recovery adapter tests only covered direct primitive returns, while the production motivating ConnectionBanner returns a wrapper element containing RecoveryCallout. Reopening the task to update tests so returned-JSX-tree scanning is covered explicitly before pushing a review-fix commit.
+
+PR #1451 review fix implemented: updated the canonical recovery adapter tests so both RecoveryCallout and StatePanel are nested inside returned wrapper elements. This directly covers collectReturnedJsxTreeTagOwners behavior and matches the real Sidepanel ConnectionBanner shape.
+
+Review-fix verification: bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed 51/51. bun run verify:design-system-state passed with Baseline exceptions: 510 and local-recovery-banner: 3. node --check apps/packages/ui/scripts/design-system-product-state-rules.mjs passed. git diff --check passed. bunx tsc --noEmit --pretty false still exits 2 on 236 lines of existing unrelated UI type errors, with no touched-file filter hits.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Change summary: taught the design-system product-state guard to treat components that return shared RecoveryCallout or StatePanel as canonical recovery adapters, added regression tests for both canonical adapter forms, preserved detection for bespoke local recovery banners, and removed the stale Sidepanel ConnectionBanner baseline exception now that the guard recognizes it correctly.
+Change summary: taught the product-state guard to recognize canonical RecoveryCallout and StatePanel recovery adapters, removed the stale ConnectionBanner baseline entry, and updated the adapter tests after review so the canonical primitives are nested inside returned wrapper elements.
 
-Why: the prior guard flagged every recovery-banner-named component even when it was only a compatibility adapter around a canonical primitive. That kept migrated components in the debt baseline and made stale-baseline cleanup unreliable. The new check mirrors the existing returned-loading-primitive approach and keeps the allowance limited to returned canonical recovery UI.
+Why: the production motivating adapter wraps RecoveryCallout in layout markup, so the regression test needs to prove the returned-JSX-tree scan stays intact rather than only proving direct root primitive returns.
 
-Verification: focused guard suite passed 51/51, design-system verifier passed with 510 baseline exceptions and 3 remaining local-recovery-banner entries, JS syntax check passed, git diff whitespace check passed, and a full UI type-check produced only unrelated existing diagnostics with no touched-file hits. Bandit is not applicable for this UI-only JS/TS/JSON/Markdown change.
+Verification: focused guard suite passed 51/51, design-system verifier passed with 510 baseline exceptions and 3 remaining local-recovery-banner entries, JS syntax check passed, git diff whitespace check passed, and full UI type-check still reports only unrelated existing diagnostics with no touched-file hits. Bandit remains not applicable for this UI-only JS/TS/JSON/Markdown change.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.32 - Allow-RecoveryCallout-adapters-in-product-state-guard.md
+++ b/backlog/tasks/task-45.32 - Allow-RecoveryCallout-adapters-in-product-state-guard.md
@@ -1,0 +1,64 @@
+---
+id: TASK-45.32
+title: Allow RecoveryCallout adapters in product-state guard
+status: Done
+assignee:
+  - Codex
+created_date: '2026-05-09 21:11'
+updated_date: '2026-05-09 21:16'
+labels:
+  - design-system
+  - ui
+  - product-state
+  - guard
+dependencies: []
+references:
+  - apps/packages/ui/scripts/design-system-product-state-rules.mjs
+  - apps/packages/ui/src/design-system/__tests__/product-state-guard.test.ts
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+  - apps/packages/ui/src/components/Sidepanel/Chat/ConnectionBanner.tsx
+parent_task_id: TASK-45
+priority: medium
+---
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The product-state guard does not flag local recovery-banner adapters that return the shared RecoveryCallout or StatePanel primitive.
+- [x] #2 The guard still flags local recovery-banner components that render bespoke recovery UI.
+- [x] #3 The Sidepanel ConnectionBanner local-recovery-banner baseline exception is removed because it already renders the shared RecoveryCallout.
+- [x] #4 Focused guard tests and design-system verification cover the new recovery adapter allowance and stale-baseline cleanup.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing guard tests for recovery-banner adapters: allow a component returning RecoveryCallout/StatePanel while continuing to flag bespoke recovery banners. 2. Update canonical usage collection and local recovery-banner finding logic to recognize returned RecoveryCallout/StatePanel owners. 3. Remove the Sidepanel ConnectionBanner baseline entry that becomes stale under the updated rule. 4. Run focused product-state guard tests, design-system verifier, git diff --check, and a touched-scope type/filter check; document Bandit skip for UI JS/TS/JSON-only changes.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented recovery adapter recognition in the product-state guard by collecting returned JSX-tree owners for canonical RecoveryCallout and StatePanel imports. Added focused tests that prove canonical adapters are allowed while bespoke recovery banners remain findings. Removed the now-stale Sidepanel ConnectionBanner local-recovery-banner baseline entry.
+
+Verification: RED run of bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot failed the two new canonical adapter tests with local-recovery-banner findings. GREEN/final run passed 51/51 tests. bun run verify:design-system-state passed with Baseline exceptions: 510 and local-recovery-banner: 3. node --check apps/packages/ui/scripts/design-system-product-state-rules.mjs passed. git diff --check passed. bunx tsc --noEmit --pretty false exited 2 with 236 lines of pre-existing unrelated UI type errors; touched-file filter for design-system-product-state-rules, product-state-guard, design-system-product-state-baseline, task-45.32, RecoveryCallout, StatePanel, and ConnectionBanner returned no diagnostics. Bandit skipped because touched implementation/test/config files are UI JS/TS/JSON/Markdown only, with no Python execution surface. No standalone docs update was needed; the executable guard tests and baseline update document the rule behavior.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Change summary: taught the design-system product-state guard to treat components that return shared RecoveryCallout or StatePanel as canonical recovery adapters, added regression tests for both canonical adapter forms, preserved detection for bespoke local recovery banners, and removed the stale Sidepanel ConnectionBanner baseline exception now that the guard recognizes it correctly.
+
+Why: the prior guard flagged every recovery-banner-named component even when it was only a compatibility adapter around a canonical primitive. That kept migrated components in the debt baseline and made stale-baseline cleanup unreliable. The new check mirrors the existing returned-loading-primitive approach and keeps the allowance limited to returned canonical recovery UI.
+
+Verification: focused guard suite passed 51/51, design-system verifier passed with 510 baseline exceptions and 3 remaining local-recovery-banner entries, JS syntax check passed, git diff whitespace check passed, and a full UI type-check produced only unrelated existing diagnostics with no touched-file hits. Bandit is not applicable for this UI-only JS/TS/JSON/Markdown change.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.32 - Allow-RecoveryCallout-adapters-in-product-state-guard.md
+++ b/backlog/tasks/task-45.32 - Allow-RecoveryCallout-adapters-in-product-state-guard.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - Codex
 created_date: '2026-05-09 21:11'
-updated_date: '2026-05-09 21:31'
+updated_date: '2026-05-09 21:35'
 labels:
   - design-system
   - ui
@@ -47,16 +47,22 @@ PR #1451 review follow-up: Qodo identified that the canonical recovery adapter t
 PR #1451 review fix implemented: updated the canonical recovery adapter tests so both RecoveryCallout and StatePanel are nested inside returned wrapper elements. This directly covers collectReturnedJsxTreeTagOwners behavior and matches the real Sidepanel ConnectionBanner shape.
 
 Review-fix verification: bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed 51/51. bun run verify:design-system-state passed with Baseline exceptions: 510 and local-recovery-banner: 3. node --check apps/packages/ui/scripts/design-system-product-state-rules.mjs passed. git diff --check passed. bunx tsc --noEmit --pretty false still exits 2 on 236 lines of existing unrelated UI type errors, with no touched-file filter hits.
+
+PR #1451 second review follow-up: CodeRabbit identified the recovery exemption is still too broad for mixed bespoke recovery UI plus nested canonical primitives. Reopening task to add a mixed recovery regression test and tighten recovery owner collection so only direct canonical returns or one-wrapper canonical adapter returns are exempted.
+
+Second PR #1451 review fix implemented: added a mixed bespoke recovery markup regression test that fails under the old tree-wide recovery exemption, then replaced the recovery owner collection with a boundary helper. Recovery adapters are now exempt only when the returned JSX is the canonical primitive itself or a single returned wrapper whose only substantive child is RecoveryCallout/StatePanel. Mixed bespoke markup plus nested canonical recovery UI remains flagged as local-recovery-banner.
+
+Second review-fix verification: RED run of bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot failed the mixed recovery test because findings were empty. GREEN/final run passed 52/52. bun run verify:design-system-state passed with Baseline exceptions: 510 and local-recovery-banner: 3. node --check apps/packages/ui/scripts/design-system-product-state-rules.mjs passed. git diff --check passed. bunx tsc --noEmit --pretty false still exits 2 on 236 lines of unrelated existing UI type errors, with no touched-file filter hits.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Change summary: taught the product-state guard to recognize canonical RecoveryCallout and StatePanel recovery adapters, removed the stale ConnectionBanner baseline entry, and updated the adapter tests after review so the canonical primitives are nested inside returned wrapper elements.
+Change summary: taught the product-state guard to recognize canonical RecoveryCallout and StatePanel recovery adapters, removed the stale ConnectionBanner baseline entry, updated the adapter tests so canonical primitives are nested inside returned wrapper elements, and tightened the recovery exemption after review so mixed bespoke recovery markup plus a nested canonical primitive is still flagged.
 
-Why: the production motivating adapter wraps RecoveryCallout in layout markup, so the regression test needs to prove the returned-JSX-tree scan stays intact rather than only proving direct root primitive returns.
+Why: the production motivating adapter wraps RecoveryCallout in layout markup, but a tree-wide scan was too permissive. The final recovery rule allows direct canonical returns or one-wrapper canonical adapters while preserving detection for components that still render custom recovery UI alongside the canonical primitive.
 
-Verification: focused guard suite passed 51/51, design-system verifier passed with 510 baseline exceptions and 3 remaining local-recovery-banner entries, JS syntax check passed, git diff whitespace check passed, and full UI type-check still reports only unrelated existing diagnostics with no touched-file hits. Bandit remains not applicable for this UI-only JS/TS/JSON/Markdown change.
+Verification: focused guard suite passed 52/52 after a red/green mixed-recovery regression, design-system verifier passed with 510 baseline exceptions and 3 remaining local-recovery-banner entries, JS syntax check passed, git diff whitespace check passed, and full UI type-check still reports only unrelated existing diagnostics with no touched-file hits. Bandit remains not applicable for this UI-only JS/TS/JSON/Markdown change.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary
- Allow the product-state guard to recognize recovery-banner adapters that return canonical RecoveryCallout or StatePanel primitives.
- Add focused guard tests for RecoveryCallout and StatePanel adapter allowances while preserving bespoke recovery-banner detection.
- Remove the stale Sidepanel ConnectionBanner local-recovery-banner baseline entry and record the work in Backlog TASK-45.32.

## Verification
- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot: 51/51 passed
- bun run verify:design-system-state: passed; baseline exceptions 510; local-recovery-banner 3
- node --check apps/packages/ui/scripts/design-system-product-state-rules.mjs: passed
- git diff --check: passed
- bunx tsc --noEmit --pretty false: exits 2 on existing unrelated UI type errors; touched-file filter returned no diagnostics for this slice
- Bandit skipped: UI-only JS/TS/JSON/Markdown changes with no Python execution surface

## Merge note
AI-authored PR: per repo policy, a human-written Change summary is still required before merge.