### PR TITLE
Migrate Knowledge QA recovery banner to RecoveryCallout

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -5423,17 +5423,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "local-recovery-banner:src/components/Option/KnowledgeQA/panels/LowQualityRecoveryBanner.tsx:LowQualityRecoveryBanner",
-    "path": "src/components/Option/KnowledgeQA/panels/LowQualityRecoveryBanner.tsx",
-    "rule": "local-recovery-banner",
-    "subject": "LowQualityRecoveryBanner",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing local LowQualityRecoveryBanner recovery banner before the guard.",
-    "replacement": "RecoveryCallout or StatePanel",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "local-recovery-banner:src/components/Option/Playground/PlaygroundChatErrorBanner.tsx:PlaygroundChatErrorBanner",
     "path": "src/components/Option/Playground/PlaygroundChatErrorBanner.tsx",
     "rule": "local-recovery-banner",

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/LowQualityRecoveryBanner.test.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/LowQualityRecoveryBanner.test.tsx
@@ -30,16 +30,26 @@ describe("LowQualityRecoveryBanner", () => {
     ).toHaveAttribute("data-ds-component", "RecoveryCallout")
   })
 
+  it("announces the conditionally mounted recovery guidance as a polite status", () => {
+    render(<LowQualityRecoveryBanner {...defaultProps} />)
+    const status = screen.getByRole("status")
+
+    expect(status).toHaveAttribute("aria-live", "polite")
+    expect(status).toHaveAttribute("aria-atomic", "true")
+    expect(status).toHaveTextContent(/sources may not closely match/i)
+  })
+
   it("calls onEnableWeb when web button clicked", () => {
     render(<LowQualityRecoveryBanner {...defaultProps} />)
     fireEvent.click(screen.getByRole("button", { name: /include web/i }))
     expect(defaultProps.onEnableWeb).toHaveBeenCalled()
   })
 
-  it("calls onDismiss when close button clicked", () => {
+  it("calls onDismiss from the contextual dismiss action", () => {
     render(<LowQualityRecoveryBanner {...defaultProps} />)
-    fireEvent.click(screen.getByRole("button", { name: /dismiss/i }))
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss recovery suggestions" }))
     expect(defaultProps.onDismiss).toHaveBeenCalled()
+    expect(screen.getByText("Dismiss")).toBeInTheDocument()
   })
 
   it("calls onSelectSources when select sources clicked", () => {

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/LowQualityRecoveryBanner.test.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/LowQualityRecoveryBanner.test.tsx
@@ -21,6 +21,15 @@ describe("LowQualityRecoveryBanner", () => {
     ).toBeInTheDocument()
   })
 
+  it("renders through the shared RecoveryCallout primitive", () => {
+    render(<LowQualityRecoveryBanner {...defaultProps} />)
+    expect(
+      screen
+        .getByText(/sources may not closely match/i)
+        .closest("[data-ds-component]")
+    ).toHaveAttribute("data-ds-component", "RecoveryCallout")
+  })
+
   it("calls onEnableWeb when web button clicked", () => {
     render(<LowQualityRecoveryBanner {...defaultProps} />)
     fireEvent.click(screen.getByRole("button", { name: /include web/i }))

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/panels/LowQualityRecoveryBanner.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/panels/LowQualityRecoveryBanner.tsx
@@ -1,5 +1,6 @@
 import React from "react"
-import { Lightbulb, X, Globe, Search, Layers } from "lucide-react"
+import { Globe, Layers, Search, X } from "lucide-react"
+import { RecoveryCallout } from "@/components/ui/state"
 
 type LowQualityRecoveryBannerProps = {
   onRefine: () => void
@@ -25,56 +26,48 @@ export function LowQualityRecoveryBanner({
   selectSourcesLabel = "Select different sources",
 }: LowQualityRecoveryBannerProps) {
   return (
-    <div
-      className="rounded-lg border border-warn/20 bg-warn/5 p-4"
-      role="status"
-    >
-      <div className="flex items-start justify-between gap-2">
-        <div className="flex items-start gap-2">
-          <Lightbulb className="mt-0.5 h-4 w-4 shrink-0 text-warn" />
-          <div className="space-y-2">
-            <p className="text-sm font-semibold text-text">{title}</p>
-            <p className="text-[13px] leading-5 text-text-muted">{description}</p>
-            <div className="flex flex-wrap gap-2 pt-1">
-              <button
-                type="button"
-                onClick={onRefine}
-                className="inline-flex items-center gap-1 rounded-md border border-primary/40 bg-primary/10 px-2.5 py-1 text-xs font-medium text-primary hover:bg-primary/15 transition-colors"
-                aria-label={refineLabel}
-              >
-                <Search className="h-3 w-3" />
-                {refineLabel}
-              </button>
-              <button
-                type="button"
-                onClick={onEnableWeb}
-                className="inline-flex items-center gap-1 rounded-full border border-border bg-surface px-2.5 py-1 text-xs font-medium text-text-subtle hover:bg-hover hover:text-text transition-colors"
-                aria-label={enableWebLabel}
-              >
-                <Globe className="h-3 w-3" />
-                {enableWebLabel}
-              </button>
-              <button
-                type="button"
-                onClick={onSelectSources}
-                className="inline-flex items-center gap-1 rounded-full border border-border bg-surface px-2.5 py-1 text-xs font-medium text-text-subtle hover:bg-hover hover:text-text transition-colors"
-                aria-label={selectSourcesLabel}
-              >
-                <Layers className="h-3 w-3" />
-                {selectSourcesLabel}
-              </button>
-            </div>
-          </div>
-        </div>
-        <button
-          type="button"
-          onClick={onDismiss}
-          className="shrink-0 rounded-md p-1 text-text-muted hover:bg-hover hover:text-text transition-colors"
-          aria-label="Dismiss recovery suggestions"
-        >
-          <X className="h-3.5 w-3.5" />
-        </button>
-      </div>
-    </div>
+    <RecoveryCallout
+      state="degraded"
+      title={title}
+      message={description}
+      primaryAction={{
+        label: (
+          <span className="inline-flex items-center gap-1">
+            <Search className="h-3 w-3" />
+            {refineLabel}
+          </span>
+        ),
+        onClick: onRefine
+      }}
+      secondaryActions={[
+        {
+          label: (
+            <span className="inline-flex items-center gap-1">
+              <Globe className="h-3 w-3" />
+              {enableWebLabel}
+            </span>
+          ),
+          onClick: onEnableWeb
+        },
+        {
+          label: (
+            <span className="inline-flex items-center gap-1">
+              <Layers className="h-3 w-3" />
+              {selectSourcesLabel}
+            </span>
+          ),
+          onClick: onSelectSources
+        },
+        {
+          label: (
+            <span className="inline-flex items-center gap-1">
+              <X className="h-3 w-3" />
+              Dismiss
+            </span>
+          ),
+          onClick: onDismiss
+        }
+      ]}
+    />
   )
 }

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/panels/LowQualityRecoveryBanner.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/panels/LowQualityRecoveryBanner.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Globe, Layers, Search, X } from "lucide-react"
+import { Globe, Layers, Search, X, type LucideIcon } from "lucide-react"
 import { RecoveryCallout } from "@/components/ui/state"
 
 type LowQualityRecoveryBannerProps = {
@@ -12,6 +12,20 @@ type LowQualityRecoveryBannerProps = {
   refineLabel?: string
   enableWebLabel?: string
   selectSourcesLabel?: string
+}
+
+type ActionLabelProps = {
+  icon: LucideIcon
+  children: React.ReactNode
+}
+
+function ActionLabel({ icon: Icon, children }: ActionLabelProps) {
+  return (
+    <span className="inline-flex items-center gap-1">
+      <Icon className="h-3 w-3" />
+      {children}
+    </span>
+  )
 }
 
 export function LowQualityRecoveryBanner({
@@ -30,41 +44,25 @@ export function LowQualityRecoveryBanner({
       state="degraded"
       title={title}
       message={description}
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
       primaryAction={{
-        label: (
-          <span className="inline-flex items-center gap-1">
-            <Search className="h-3 w-3" />
-            {refineLabel}
-          </span>
-        ),
+        label: <ActionLabel icon={Search}>{refineLabel}</ActionLabel>,
         onClick: onRefine
       }}
       secondaryActions={[
         {
-          label: (
-            <span className="inline-flex items-center gap-1">
-              <Globe className="h-3 w-3" />
-              {enableWebLabel}
-            </span>
-          ),
+          label: <ActionLabel icon={Globe}>{enableWebLabel}</ActionLabel>,
           onClick: onEnableWeb
         },
         {
-          label: (
-            <span className="inline-flex items-center gap-1">
-              <Layers className="h-3 w-3" />
-              {selectSourcesLabel}
-            </span>
-          ),
+          label: <ActionLabel icon={Layers}>{selectSourcesLabel}</ActionLabel>,
           onClick: onSelectSources
         },
         {
-          label: (
-            <span className="inline-flex items-center gap-1">
-              <X className="h-3 w-3" />
-              Dismiss
-            </span>
-          ),
+          label: <ActionLabel icon={X}>Dismiss</ActionLabel>,
+          ariaLabel: "Dismiss recovery suggestions",
           onClick: onDismiss
         }
       ]}

--- a/apps/packages/ui/src/components/ui/state/ActionGroup.tsx
+++ b/apps/packages/ui/src/components/ui/state/ActionGroup.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/libs/utils";
 
 export interface StateAction {
   label: React.ReactNode;
+  ariaLabel?: string;
   onClick?: () => void;
   loading?: boolean;
   disabled?: boolean;
@@ -40,6 +41,7 @@ export function ActionGroup({
           onClick={primaryAction.onClick}
           loading={primaryAction.loading}
           disabled={primaryAction.disabled}
+          ariaLabel={primaryAction.ariaLabel}
           data-testid={primaryAction["data-testid"]}
         >
           {primaryAction.label}
@@ -53,6 +55,7 @@ export function ActionGroup({
           onClick={action.onClick}
           loading={action.loading}
           disabled={action.disabled || action.loading}
+          ariaLabel={action.ariaLabel}
           data-testid={action["data-testid"]}
         >
           {action.label}

--- a/apps/packages/ui/src/components/ui/state/StatePanel.tsx
+++ b/apps/packages/ui/src/components/ui/state/StatePanel.tsx
@@ -19,6 +19,9 @@ export interface StatePanelProps {
   secondaryActions?: StateAction[]
   className?: string
   children?: React.ReactNode
+  role?: React.AriaRole
+  "aria-live"?: React.AriaAttributes["aria-live"]
+  "aria-atomic"?: React.AriaAttributes["aria-atomic"]
   "data-testid"?: string
   "data-ds-component"?: string
 }
@@ -50,6 +53,9 @@ export function StatePanel({
   secondaryActions,
   className,
   children,
+  role,
+  "aria-live": ariaLive,
+  "aria-atomic": ariaAtomic,
   "data-testid": dataTestId,
   "data-ds-component": dataDesignSystemComponent = "StatePanel"
 }: StatePanelProps) {
@@ -60,6 +66,9 @@ export function StatePanel({
   return (
     <section
       className={cn("rounded-lg border bg-surface p-4 text-text shadow-sm", className)}
+      role={role}
+      aria-live={ariaLive}
+      aria-atomic={ariaAtomic}
       data-testid={dataTestId}
       data-ds-component={dataDesignSystemComponent}
     >

--- a/apps/packages/ui/src/components/ui/state/__tests__/state-primitives.test.tsx
+++ b/apps/packages/ui/src/components/ui/state/__tests__/state-primitives.test.tsx
@@ -60,6 +60,42 @@ describe("state primitives", () => {
     expect(action).toHaveAttribute("aria-busy", "true")
   })
 
+  it("allows actions to keep short labels with contextual accessible names", () => {
+    render(
+      <ActionGroup
+        secondaryActions={[
+          {
+            label: "Dismiss",
+            ariaLabel: "Dismiss recovery suggestions",
+            onClick: vi.fn()
+          }
+        ]}
+      />
+    )
+
+    expect(screen.getByRole("button", { name: "Dismiss recovery suggestions" })).toHaveTextContent(
+      "Dismiss"
+    )
+  })
+
+  it("forwards live-region semantics to state panels when requested", () => {
+    render(
+      <RecoveryCallout
+        state="degraded"
+        title="Sources may need refinement"
+        primaryAction={{ label: "Refine", onClick: vi.fn() }}
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+      />
+    )
+
+    const status = screen.getByRole("status")
+    expect(status).toHaveAttribute("aria-live", "polite")
+    expect(status).toHaveAttribute("aria-atomic", "true")
+    expect(status).toHaveAttribute("data-ds-component", "RecoveryCallout")
+  })
+
   it("provides semantic wrappers for permission and setup states", () => {
     render(
       <>

--- a/backlog/tasks/task-45.33 - Migrate-LowQualityRecoveryBanner-to-RecoveryCallout.md
+++ b/backlog/tasks/task-45.33 - Migrate-LowQualityRecoveryBanner-to-RecoveryCallout.md
@@ -1,0 +1,71 @@
+---
+id: TASK-45.33
+title: Migrate LowQualityRecoveryBanner to RecoveryCallout
+status: Done
+assignee: []
+created_date: '2026-05-09 21:49'
+updated_date: '2026-05-09 21:52'
+labels:
+  - design-system
+  - ui
+  - product-state
+  - recovery
+dependencies: []
+references:
+  - >-
+    apps/packages/ui/src/components/Option/KnowledgeQA/panels/LowQualityRecoveryBanner.tsx
+  - >-
+    apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/LowQualityRecoveryBanner.test.tsx
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+  - apps/packages/ui/scripts/design-system-product-state-rules.mjs
+parent_task_id: TASK-45
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate the Knowledge QA low-quality answer recovery banner from bespoke recovery markup to the shared design-system RecoveryCallout primitive. This should remove exactly one remaining local-recovery-banner baseline exception while preserving the existing recovery actions and dismissal behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 LowQualityRecoveryBanner renders the shared RecoveryCallout design-system primitive.
+- [x] #2 Existing refine, enable web, select sources, and dismiss interactions remain covered by focused tests.
+- [x] #3 The LowQualityRecoveryBanner local-recovery-banner baseline entry is removed and the design-system verifier passes with the remaining expected baseline debt.
+- [x] #4 Verification records focused component tests, product-state guard tests, design-system verifier, syntax/whitespace checks, and any known TypeScript/Bandit skips.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused failing test that LowQualityRecoveryBanner renders RecoveryCallout while preserving existing interaction tests. 2. Replace bespoke warning panel markup with RecoveryCallout plus shared action mapping and explicit dismiss control. 3. Remove the LowQualityRecoveryBanner local-recovery-banner baseline exception. 4. Run focused tests, product-state guard tests, design-system verifier, syntax/whitespace checks, and a touched-file TypeScript filter.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the LowQualityRecoveryBanner migration to the shared RecoveryCallout primitive. Added a focused test that first failed because no data-ds-component marker existed, then replaced the bespoke warning panel and custom buttons with RecoveryCallout primary/secondary actions while preserving refine, enable web, select sources, and dismiss callbacks. Removed the stale local-recovery-banner baseline entry for LowQualityRecoveryBanner.
+
+Verification: RED run of bunx vitest run src/components/Option/KnowledgeQA/__tests__/LowQualityRecoveryBanner.test.tsx --reporter=dot failed the new RecoveryCallout marker assertion because closest([data-ds-component]) returned null. GREEN/final run passed 6/6. bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed 52/52. bun run verify:design-system-state passed with Baseline exceptions: 509 and local-recovery-banner: 2. git diff --check passed. bunx tsc --noEmit --pretty false exited 2 with 236 lines of existing unrelated UI type errors; touched-file filter for LowQualityRecoveryBanner, design-system-product-state-baseline, product-state-guard, RecoveryCallout, and task-45.33 returned no diagnostics. Bandit skipped because touched files are UI TS/TSX, JSON baseline, and Markdown task metadata only.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Change summary: migrated Knowledge QA LowQualityRecoveryBanner from bespoke recovery panel markup to the shared RecoveryCallout primitive, added a focused RecoveryCallout marker test while keeping the existing interaction tests, and removed the stale LowQualityRecoveryBanner local-recovery-banner baseline exception.
+
+Why: this is one of the remaining local recovery-banner debt entries. Using RecoveryCallout aligns the component with the design-system state surface while preserving the existing recovery actions and dismissal behavior.
+
+Verification: focused LowQualityRecoveryBanner tests passed 6/6 after a red/green marker assertion, product-state guard tests passed 52/52, design-system verifier passed with 509 baseline exceptions and 2 remaining local-recovery-banner entries, git diff whitespace check passed, and the full UI type-check still only reports unrelated existing baseline diagnostics with no touched-file hits. Bandit is not applicable for this UI-only TS/TSX/JSON/Markdown change.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.33 - Migrate-LowQualityRecoveryBanner-to-RecoveryCallout.md
+++ b/backlog/tasks/task-45.33 - Migrate-LowQualityRecoveryBanner-to-RecoveryCallout.md
@@ -4,7 +4,7 @@ title: Migrate LowQualityRecoveryBanner to RecoveryCallout
 status: Done
 assignee: []
 created_date: '2026-05-09 21:49'
-updated_date: '2026-05-09 21:52'
+updated_date: '2026-05-10 00:06'
 labels:
   - design-system
   - ui
@@ -48,16 +48,20 @@ Migrate the Knowledge QA low-quality answer recovery banner from bespoke recover
 Implemented the LowQualityRecoveryBanner migration to the shared RecoveryCallout primitive. Added a focused test that first failed because no data-ds-component marker existed, then replaced the bespoke warning panel and custom buttons with RecoveryCallout primary/secondary actions while preserving refine, enable web, select sources, and dismiss callbacks. Removed the stale local-recovery-banner baseline entry for LowQualityRecoveryBanner.
 
 Verification: RED run of bunx vitest run src/components/Option/KnowledgeQA/__tests__/LowQualityRecoveryBanner.test.tsx --reporter=dot failed the new RecoveryCallout marker assertion because closest([data-ds-component]) returned null. GREEN/final run passed 6/6. bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed 52/52. bun run verify:design-system-state passed with Baseline exceptions: 509 and local-recovery-banner: 2. git diff --check passed. bunx tsc --noEmit --pretty false exited 2 with 236 lines of existing unrelated UI type errors; touched-file filter for LowQualityRecoveryBanner, design-system-product-state-baseline, product-state-guard, RecoveryCallout, and task-45.33 returned no diagnostics. Bandit skipped because touched files are UI TS/TSX, JSON baseline, and Markdown task metadata only.
+
+PR review follow-up: Qodo flagged that the RecoveryCallout migration dropped the prior live-region status semantics and the dismiss action's specific accessible name. Gemini also requested reducing repeated action-label markup. Reopening the task to address those review comments before re-verifying and pushing.
+
+Review fix implementation: added regression tests proving the RecoveryCallout banner exposes role=status with polite/atomic live-region semantics and that the dismiss action keeps the visible label "Dismiss" while exposing the accessible name "Dismiss recovery suggestions". Added StatePanel live-region passthrough props, StateAction ariaLabel passthrough through ActionGroup, and a local ActionLabel helper to remove repeated icon label markup.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Change summary: migrated Knowledge QA LowQualityRecoveryBanner from bespoke recovery panel markup to the shared RecoveryCallout primitive, added a focused RecoveryCallout marker test while keeping the existing interaction tests, and removed the stale LowQualityRecoveryBanner local-recovery-banner baseline exception.
+Change summary: migrated Knowledge QA LowQualityRecoveryBanner from bespoke recovery panel markup to the shared RecoveryCallout primitive, then addressed PR review accessibility regressions by restoring live-region status semantics and the contextual dismiss accessible name. The shared StatePanel now supports optional live-region passthrough props, ActionGroup supports per-action ariaLabel, and LowQualityRecoveryBanner uses a local ActionLabel helper for the repeated icon+label markup.
 
-Why: this is one of the remaining local recovery-banner debt entries. Using RecoveryCallout aligns the component with the design-system state surface while preserving the existing recovery actions and dismissal behavior.
+Why: the migration should reduce local recovery-banner debt without weakening the banner's previous accessibility behavior. Keeping these as optional primitive hooks preserves the design-system path while allowing conditionally mounted state UI to remain announceable and context-rich for assistive tech.
 
-Verification: focused LowQualityRecoveryBanner tests passed 6/6 after a red/green marker assertion, product-state guard tests passed 52/52, design-system verifier passed with 509 baseline exceptions and 2 remaining local-recovery-banner entries, git diff whitespace check passed, and the full UI type-check still only reports unrelated existing baseline diagnostics with no touched-file hits. Bandit is not applicable for this UI-only TS/TSX/JSON/Markdown change.
+Verification: RED review-regression tests failed before implementation for missing role=status and missing "Dismiss recovery suggestions" accessible name. Final focused LowQualityRecoveryBanner tests passed 7/7, state primitive tests passed 7/7, product-state guard tests passed 52/52, design-system verifier passed with 509 baseline exceptions and 2 remaining local-recovery-banner entries, git diff whitespace check passed, and full UI type-check still reports only unrelated existing baseline diagnostics with no touched-file hits for LowQualityRecoveryBanner, ActionGroup, StatePanel, RecoveryCallout, state-primitives, or task-45.33. Bandit is not applicable for this UI-only TS/TSX/Markdown change.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary
- Migrate `LowQualityRecoveryBanner` from bespoke recovery panel markup to the shared `RecoveryCallout` primitive.
- Preserve refine, enable web, select sources, and dismiss interactions through focused tests.
- Remove the stale `LowQualityRecoveryBanner` `local-recovery-banner` baseline exception and record TASK-45.33.

## Verification
- `bunx vitest run src/components/Option/KnowledgeQA/__tests__/LowQualityRecoveryBanner.test.tsx --reporter=dot`: 6/6 passed
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot`: 52/52 passed
- `bun run verify:design-system-state`: passed; baseline exceptions 509; local-recovery-banner 2
- `git diff --check`: passed
- `bunx tsc --noEmit --pretty false`: exits 2 on existing unrelated UI type errors; touched-file filter returned no diagnostics
- Bandit skipped: UI-only TS/TSX/JSON/Markdown changes with no Python execution surface

## Merge note
AI-authored PR: per repo policy, a human-written Change summary is still required before merge.