### PR TITLE
test(sandbox): document VZ crash reboot recovery

### DIFF
--- a/Docs/Sandbox/macos-runtime-operator-notes.md
+++ b/Docs/Sandbox/macos-runtime-operator-notes.md
@@ -306,6 +306,55 @@ the VM is owned by this `tldw` `vz_linux` sandbox control plane. Operators shoul
 inspect the dry-run plan first. Helper unavailable or protocol mismatch
 conditions fail closed and block mutating repair.
 
+## Helper Crash, Restart, And Host Reboot Recovery
+
+`vz_linux` recovery is generation-aware and helper-truth-driven. Persisted
+session-control rows are useful control-plane state, but they are not proof that
+a warm VM still exists. A row should be reused only when the current helper can
+prove live VM health, `tldw/vz_linux` ownership, matching session metadata, and
+matching helper generation.
+
+If the helper crashes or is manually stopped and has not been restored:
+
+- `vz_linux` runs that require helper truth fail closed.
+- persisted session-control rows are preserved.
+- `/api/v1/sandbox/admin/macos-diagnostics` reports recovery as unavailable.
+- mutating reconciliation repair is blocked because helper truth is unavailable.
+- the operator should restore helper readiness before retrying runs or repair.
+
+If the helper is restarted directly or by a future launchd-managed workflow:
+
+- treat the replacement helper as a new helper generation.
+- run `tools/macos-vz-helper/scripts/vz-helperctl.py status` or `check` to
+  verify socket, pid, log-directory, entitlements, ping, and protocol state.
+- re-run macOS sandbox diagnostics.
+- inspect `reconciliation` and `recovery_summary` before mutating anything.
+- retrying a same-session run may clear stale control state and provision a
+  fresh VM after reachable helper truth proves the old row is stale.
+- if stale inactive rows remain, run
+  `POST /api/v1/sandbox/admin/macos-reconciliation/repair` in dry-run mode
+  before applying a mutating repair.
+
+After a host reboot, assume helper process identity, helper in-memory VM state,
+virtiofs state, and guest-agent readiness were lost until proven otherwise.
+Durable image-store manifests and persisted session-control rows may still
+exist, but they are provenance, not live VM proof. The recommended manual
+procedure is:
+
+1. Start or verify the helper through the managed operator workflow.
+2. Run `vz-helperctl.py status` and confirm protocol-compatible helper ping.
+3. Run `/api/v1/sandbox/admin/macos-diagnostics`.
+4. Inspect stale, unhealthy, skipped-active, and orphan classifications.
+5. Run reconciliation repair in dry-run mode if stale inactive rows are
+   reported.
+6. Apply mutating repair only after reviewing the dry-run plan.
+7. Run the real host smoke to verify fresh ephemeral execution and same-session
+   behavior.
+
+Diagnostics, startup warnings, and host smoke must not delete session-control
+rows or terminate VMs automatically. Host reboot is an operator procedure today,
+not a scheduled CI action or hidden startup repair path.
+
 Startup now also records bounded reconciliation/helper warnings during process
 boot through the shared startup warning framework. That startup path is
 read-only and never performs repair or VM termination. The current sandbox

--- a/Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
+++ b/Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
@@ -110,6 +110,14 @@ session-control row and restart only the helper process owned by the smoke
 harness restart lease. They then verify the next same-session command provisions
 a fresh VM and completes. Scheduled runs must not enable these drills by default.
 
+Host reboot and launchd-managed restart are not part of the current host-gated
+CI contract. Maintainers validating those paths should treat them as manual
+operator procedures: restore or verify helper readiness first, inspect
+`/api/v1/sandbox/admin/macos-diagnostics`, run reconciliation repair in dry-run
+mode before any mutation, and then run the real host smoke. A host reboot drill
+must not be added to scheduled CI until a dedicated prepared runner can tolerate
+disruptive reboot testing and preserve helper/stdout/serial logs reliably.
+
 ## Expected Skips And Non-Blocking Conditions
 
 These are expected and should not block ordinary PRs:
@@ -122,6 +130,8 @@ These are expected and should not block ordinary PRs:
 - local developer machines without a prepared bundle/helper environment
 - failure-drill coverage skipped because manual dispatch did not set
   `include_failure_drills=true`
+- host reboot or launchd-managed restart validation handled through a manual
+  operator procedure rather than the workflow
 
 A manual run that fails before VM execution because the runner is missing the
 configured bundle path is an operator setup failure, not a sandbox runtime

--- a/backlog/tasks/task-196 - Document-VZ-Linux-crash-reboot-operator-follow-up-and-fill-portable-tests.md
+++ b/backlog/tasks/task-196 - Document-VZ-Linux-crash-reboot-operator-follow-up-and-fill-portable-tests.md
@@ -1,0 +1,61 @@
+---
+id: TASK-196
+title: Document VZ Linux crash reboot operator follow-up and fill portable tests
+status: Done
+assignee: []
+created_date: '2026-05-09 22:04'
+updated_date: '2026-05-09 22:07'
+labels:
+  - sandbox
+  - vz_linux
+  - recovery
+  - docs
+  - tests
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1459'
+  - 'https://github.com/rmusser01/tldw_server/pull/1464'
+documentation:
+  - Docs/Sandbox/macos-runtime-operator-notes.md
+  - Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
+  - tldw_Server_API/tests/sandbox/test_vz_linux_runner.py
+  - tldw_Server_API/tests/sandbox/test_vz_reconciliation.py
+  - tldw_Server_API/tests/sandbox/test_admin_macos_reconciliation_repair.py
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add the first follow-up implementation slice for the VZ Linux crash/reboot posture: update operator-facing docs for helper crash/restart/host reboot procedures and add only missing portable tests for preserve-versus-clear behavior. Keep scope host-independent and do not add launchd automation, reboot CI, networking changes, guest protocol changes, or generic repair automation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Operator docs explain helper crash/manual restart and host reboot procedure without implying automatic repair
+- [x] #2 Portable tests cover any missing session-control preserve-versus-clear or repair-blocking behavior identified by current-code audit
+- [x] #3 No host-gated destructive behavior or launchd bootstrap/kickstart implementation is added
+- [x] #4 Verification records focused pytest and docs hygiene checks
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Current-code audit: existing VZ runner tests already covered helper unavailable/protocol mismatch preservation, absent status replacement, unhealthy replacement, and helper-generation mismatch replacement. Added missing portable coverage for reachable helper truth with owner/runtime/session metadata mismatch; the new test passed without production changes. Added operator docs for helper crash/manual stop, direct or future launchd-managed restart, host reboot procedure, and host-gated CI exclusions. Verification: python -m pytest tldw_Server_API/tests/sandbox/test_vz_linux_runner.py -q passed (27 passed); git diff --check passed; Bandit on touched test file with baseline test-file B101/B108 skips returned 0 findings; rg verified crash/reboot doc anchors.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Updated macOS sandbox operator docs and host-gated CI policy to document helper crash/restart and host reboot recovery procedure without implying automatic repair. Added portable VZ runner coverage proving reachable helper status with mismatched owner/runtime/session metadata clears stale session-control state and provisions a fresh VM. No production code or host-gated destructive behavior was changed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-196 - Document-VZ-Linux-crash-reboot-operator-follow-up-and-fill-portable-tests.md
+++ b/backlog/tasks/task-196 - Document-VZ-Linux-crash-reboot-operator-follow-up-and-fill-portable-tests.md
@@ -4,7 +4,7 @@ title: Document VZ Linux crash reboot operator follow-up and fill portable tests
 status: Done
 assignee: []
 created_date: '2026-05-09 22:04'
-updated_date: '2026-05-09 22:07'
+updated_date: '2026-05-10 00:01'
 labels:
   - sandbox
   - vz_linux
@@ -42,6 +42,8 @@ Add the first follow-up implementation slice for the VZ Linux crash/reboot postu
 
 <!-- SECTION:NOTES:BEGIN -->
 Current-code audit: existing VZ runner tests already covered helper unavailable/protocol mismatch preservation, absent status replacement, unhealthy replacement, and helper-generation mismatch replacement. Added missing portable coverage for reachable helper truth with owner/runtime/session metadata mismatch; the new test passed without production changes. Added operator docs for helper crash/manual stop, direct or future launchd-managed restart, host reboot procedure, and host-gated CI exclusions. Verification: python -m pytest tldw_Server_API/tests/sandbox/test_vz_linux_runner.py -q passed (27 passed); git diff --check passed; Bandit on touched test file with baseline test-file B101/B108 skips returned 0 findings; rg verified crash/reboot doc anchors.
+
+Review fix: addressed Qodo type-hint finding by annotating the new metadata-mismatch test fixture parameters and nested store `**kwargs`.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/tldw_Server_API/tests/sandbox/test_vz_linux_runner.py
+++ b/tldw_Server_API/tests/sandbox/test_vz_linux_runner.py
@@ -4,6 +4,8 @@ import json
 import shutil
 from pathlib import Path
 
+import pytest
+
 import tldw_Server_API.app.core.Sandbox.runners.vz_common as vz_common
 import tldw_Server_API.app.core.Sandbox.runners.vz_linux_runner as vz_linux_module
 from tldw_Server_API.app.core.Sandbox.image_store import SandboxImageStore
@@ -709,6 +711,132 @@ def test_vz_linux_session_reuse_generation_mismatch_recreates_vm(monkeypatch, tm
     assert stored and stored[0]["vm_id"] == "vm-new-generation"
     assert stored[0]["helper_instance_id"] == "helper-new"
     assert stored[0]["helper_started_at"] == "2026-05-09T01:00:00Z"
+
+
+@pytest.mark.parametrize(
+    ("metadata", "case_name"),
+    [
+        (
+            HelperVMMetadata(
+                owner="other",
+                runtime="vz_linux",
+                session_id="sess-metadata-mismatch",
+                session_mode=True,
+            ),
+            "owner",
+        ),
+        (
+            HelperVMMetadata(
+                owner="tldw",
+                runtime="vz_macos",
+                session_id="sess-metadata-mismatch",
+                session_mode=True,
+            ),
+            "runtime",
+        ),
+        (
+            HelperVMMetadata(
+                owner="tldw",
+                runtime="vz_linux",
+                session_id="other-session",
+                session_mode=True,
+            ),
+            "session",
+        ),
+    ],
+)
+def test_vz_linux_session_reuse_metadata_mismatch_recreates_vm(
+    monkeypatch,
+    tmp_path,
+    metadata: HelperVMMetadata,
+    case_name: str,
+) -> None:
+    monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_FAKE_EXEC", raising=False)
+    calls: list[str] = []
+    deleted: list[str] = []
+    stored: list[dict[str, object]] = []
+
+    class _Store:
+        def get_vz_session_control(self, session_id: str) -> dict[str, object]:
+            assert session_id == "sess-metadata-mismatch"
+            return {
+                "runtime": "vz_linux",
+                "vm_id": f"vm-stale-{case_name}",
+                "template_id": "vz_linux:existing",
+                "workspace_mount": str(tmp_path),
+                "agent_ready": True,
+                "helper_instance_id": "helper-a",
+                "helper_started_at": "2026-05-09T00:00:00Z",
+            }
+
+        def delete_vz_session_control(self, session_id: str) -> bool:
+            deleted.append(session_id)
+            return True
+
+        def put_vz_session_control(self, **kwargs) -> None:
+            stored.append(dict(kwargs))
+
+    class _FakeHelper:
+        def get_vm_status(self, vm_id: str) -> HelperVMStatusReply:
+            calls.append("get_vm_status")
+            return HelperVMStatusReply(
+                protocol_version="1",
+                helper_version="0.1.0",
+                vm_id=vm_id,
+                state="running",
+                healthy=True,
+                metadata=metadata,
+                details={
+                    "helper_instance_id": "helper-a",
+                    "helper_started_at": "2026-05-09T00:00:00Z",
+                },
+            )
+
+        def validate_template(self, request: dict[str, object]) -> dict[str, object]:
+            calls.append("validate_template")
+            return {
+                "template_id": "vz_linux:new-template",
+                "ready": True,
+                "reasons": [],
+            }
+
+        def create_vm(self, request: dict[str, object]) -> HelperVMReply:
+            calls.append("create_vm")
+            assert request["session_id"] == "sess-metadata-mismatch"
+            assert request["session_mode"] is True
+            return HelperVMReply(
+                vm_id=f"vm-new-{case_name}",
+                state="created",
+                details={
+                    "helper_instance_id": "helper-a",
+                    "helper_started_at": "2026-05-09T00:00:00Z",
+                },
+            )
+
+        def exec_guest(self, *, vm_id: str, request: dict[str, object]) -> HelperExecReply:
+            calls.append("exec_guest")
+            assert vm_id == f"vm-new-{case_name}"
+            return HelperExecReply(exit_code=0, stdout=b"recreated\n")
+
+    monkeypatch.setattr(vz_linux_module.VZLinuxRunner, "helper_client_cls", _FakeHelper)
+
+    status = VZLinuxRunner(session_control_store=_Store()).start_run(
+        run_id=f"vz-run-metadata-mismatch-{case_name}",
+        spec=RunSpec(
+            session_id="sess-metadata-mismatch",
+            runtime=RuntimeType.vz_linux,
+            base_image="ubuntu-24.04",
+            command=["/bin/echo", "ok"],
+            network_policy="deny_all",
+        ),
+        session_workspace=str(tmp_path),
+    )
+
+    assert status.phase == RunPhase.completed
+    assert status.exit_code == 0
+    assert calls == ["get_vm_status", "validate_template", "create_vm", "exec_guest"]
+    assert deleted == ["sess-metadata-mismatch"]
+    assert stored and stored[0]["vm_id"] == f"vm-new-{case_name}"
 
 
 def test_vz_linux_session_reuse_helper_unavailable_fails_closed(monkeypatch, tmp_path) -> None:

--- a/tldw_Server_API/tests/sandbox/test_vz_linux_runner.py
+++ b/tldw_Server_API/tests/sandbox/test_vz_linux_runner.py
@@ -746,8 +746,8 @@ def test_vz_linux_session_reuse_generation_mismatch_recreates_vm(monkeypatch, tm
     ],
 )
 def test_vz_linux_session_reuse_metadata_mismatch_recreates_vm(
-    monkeypatch,
-    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
     metadata: HelperVMMetadata,
     case_name: str,
 ) -> None:
@@ -773,7 +773,7 @@ def test_vz_linux_session_reuse_metadata_mismatch_recreates_vm(
             deleted.append(session_id)
             return True
 
-        def put_vz_session_control(self, **kwargs) -> None:
+        def put_vz_session_control(self, **kwargs: object) -> None:
             stored.append(dict(kwargs))
 
     class _FakeHelper:


### PR DESCRIPTION
## Summary
- Documents operator handling for VZ Linux helper crash/manual stop, direct or future launchd-managed restart, and host reboot recovery.
- Clarifies that host reboot and launchd-managed restart are manual procedures, not scheduled host-gated CI coverage.
- Adds portable VZ runner coverage for reachable helper truth with mismatched owner/runtime/session metadata replacing stale session-control state.

## Verification
- python -m pytest tldw_Server_API/tests/sandbox/test_vz_linux_runner.py -q
- git diff --check
- python -m bandit -r tldw_Server_API/tests/sandbox/test_vz_linux_runner.py -s B101,B108 -f json -o /tmp/bandit_vz_crash_reboot_operator_followup.json
- rg docs anchor checks for helper crash/reboot/manual operator procedure

## Change summary
Human-authored change summary pending.