### PR TITLE
Add Persona Visual duplicate-to-persona draft flow

### DIFF
--- a/Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md
+++ b/Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md
@@ -431,7 +431,8 @@ The portability model should stay aligned with PR #1135:
 
 Future work may add:
 
-1. duplicate to another persona.
+1. duplicate to another persona. First implementation target: same-user draft
+   duplication (#1450).
 2. shared user library.
 3. cross-device sync.
 4. signed community packs.
@@ -495,7 +496,8 @@ Completed Product Hardening includes:
 Phase 3 is optional future product work, not required for the current
 Persona/Buddy visual-pack baseline:
 
-1. Duplicate pack to another persona.
+1. Duplicate pack to another persona. First implementation target: same-user
+   draft duplication (#1450).
 2. Personal shared visual-pack library.
 3. Import/export polish and conflict choices.
 4. External MCP-compatible visual providers.
@@ -593,3 +595,4 @@ E2E:
 7. Issue #1410: Expose Persona Buddy visual packs in live assistant.
 8. PR #1447 / issue #1429: Persona visual pack ownership/help copy.
 9. Issue #1428: Completed Persona/Buddy visual-pack Product Hardening tracker.
+10. Issue #1450: Same-user Persona Visual pack duplicate-to-persona draft flow.

--- a/Docs/superpowers/plans/2026-05-09-persona-visual-duplicate-to-persona-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-09-persona-visual-duplicate-to-persona-implementation-plan.md
@@ -1,0 +1,1566 @@
+# Persona Visual Pack Duplicate-To-Persona Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a same-user Persona Visual workflow that duplicates one persona's visual pack to a different persona as a draft with copied manifest-referenced assets.
+
+**Architecture:** Keep duplication inside the Persona Visual service and expose it through one synchronous API route that returns the existing `PersonaVisualPackResponse`. Promote manifest asset collection/remapping into a shared helper so import and duplicate use the same traversal. Extend the DB layer narrowly for same-user cross-persona lineage and safe status transitions without weakening normal pack creation.
+
+**Tech Stack:** FastAPI, Pydantic, SQLite-backed `CharactersRAGDB`, `PersonaVisualService`, Next/React shared UI package, Vitest, Pytest, Bandit.
+
+---
+
+## Spec And Tracking
+
+- Spec: `Docs/superpowers/specs/2026-05-09-persona-visual-duplicate-to-persona-design.md`
+- Backlog: `TASK-193`
+- GitHub: #1449, #1450
+
+Key decisions from the spec:
+
+- Duplicate only to a different same-user persona.
+- Return `PersonaVisualPackResponse`; do not expose `asset_id_map`.
+- Do not add idempotency keys in V1.
+- Copy only manifest-referenced source assets.
+- Never activate or archive source or target active packs.
+- Keep this in Persona/Buddy visual-pack scope, not VN/CYOA.
+
+Design-review refinements before implementation:
+
+- Normalize a provided duplicate title after trimming; if it becomes empty, fall back to `Copy of {source title}` before calling the DB layer.
+- Treat missing source files and checksum mismatches as stored-state conflicts at the API boundary, not ordinary user validation failures.
+- Verify failed duplicate attempts do not activate anything and remove any copied files. A failed target pack may remain with status `failed`; do not expose it as a usable draft.
+- Keep the duplicate target list scoped to active catalog personas in the UI, while the backend remains the authority for same-user target validation.
+
+## File Structure
+
+Backend:
+
+- Create: `tldw_Server_API/app/core/Persona/visual_manifest_assets.py`
+  - Owns manifest asset ID collection and remapping.
+- Modify: `tldw_Server_API/app/core/Persona/visual_portability/importer.py`
+  - Uses shared remapping helper instead of private helper.
+- Modify: `tldw_Server_API/app/core/DB_Management/chacha/persona_state_store.py`
+  - Allows explicit same-user cross-persona `parent_pack_id` validation for duplicate creation.
+  - Adds a narrow status-update helper for failed-to-draft transitions.
+- Modify: `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`
+  - Exports any new persona visual DB helper names.
+- Modify: `tldw_Server_API/app/core/Persona/visual_service.py`
+  - Adds duplicate orchestration, preflight, safe storage path resolution, and cleanup.
+- Modify: `tldw_Server_API/app/api/v1/schemas/persona.py`
+  - Adds duplicate request schema.
+- Modify: `tldw_Server_API/app/api/v1/endpoints/persona.py`
+  - Adds duplicate endpoint and error mapping.
+
+Backend tests:
+
+- Create: `tldw_Server_API/tests/Persona/test_persona_visual_manifest_assets.py`
+- Modify: `tldw_Server_API/tests/Persona/test_persona_visual_service.py`
+- Modify: `tldw_Server_API/tests/Persona/test_persona_visuals_api.py`
+
+Frontend:
+
+- Modify: `apps/packages/ui/src/types/persona-visuals.ts`
+  - Adds duplicate request and target persona types.
+- Modify: `apps/packages/ui/src/services/persona-visuals.ts`
+  - Adds duplicate API call and target persona listing helper.
+- Modify: `apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx`
+  - Adds duplicate UI state/action/card and success handoff behavior.
+- Modify: `apps/packages/ui/src/routes/sidepanel-persona.tsx`
+  - Passes a callback that switches to the target persona's Visuals tab.
+
+Frontend tests:
+
+- Modify: `apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx`
+
+Docs:
+
+- Modify: `Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md`
+  - Mark duplicate-to-persona as implemented once the implementation lands.
+
+---
+
+### Task 1: Share Manifest Asset Helpers
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Persona/visual_manifest_assets.py`
+- Modify: `tldw_Server_API/app/core/Persona/visual_portability/importer.py`
+- Test: `tldw_Server_API/tests/Persona/test_persona_visual_manifest_assets.py`
+
+- [ ] **Step 1: Write failing tests for asset collection and remapping**
+
+Create `tldw_Server_API/tests/Persona/test_persona_visual_manifest_assets.py`:
+
+```python
+from copy import deepcopy
+
+from tldw_Server_API.app.core.Persona.visual_manifest_assets import (
+    collect_visual_manifest_asset_ids,
+    remap_visual_manifest_assets,
+)
+
+
+def test_collect_visual_manifest_asset_ids_reads_all_supported_references() -> None:
+    manifest = {
+        "manifest_version": 1,
+        "renderer_type": "sprite_frames",
+        "states": {"idle": {"animation_id": "idle"}},
+        "animations": {
+            "idle": {
+                "frames": [{"asset_id": "asset-frame"}],
+                "asset_ids": ["asset-sheet"],
+                "preview_asset_id": "asset-preview",
+            }
+        },
+    }
+
+    assert collect_visual_manifest_asset_ids(manifest) == {
+        "asset-frame",
+        "asset-sheet",
+        "asset-preview",
+    }
+
+
+def test_remap_visual_manifest_assets_returns_copy_with_supported_references_remapped() -> None:
+    manifest = {
+        "manifest_version": 1,
+        "renderer_type": "sprite_frames",
+        "states": {"idle": {"animation_id": "idle"}},
+        "animations": {
+            "idle": {
+                "frames": [{"asset_id": "source-a"}, {"asset_id": "source-b"}],
+                "asset_ids": ["source-a", "source-c"],
+                "preview_asset_id": "source-b",
+            }
+        },
+    }
+    original = deepcopy(manifest)
+
+    remapped = remap_visual_manifest_assets(
+        manifest,
+        {"source-a": "target-a", "source-b": "target-b"},
+    )
+
+    assert manifest == original
+    animation = remapped["animations"]["idle"]
+    assert animation["frames"] == [
+        {"asset_id": "target-a"},
+        {"asset_id": "target-b"},
+    ]
+    assert animation["asset_ids"] == ["target-a", "source-c"]
+    assert animation["preview_asset_id"] == "target-b"
+```
+
+- [ ] **Step 2: Run the new tests and verify they fail**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_manifest_assets.py -q
+```
+
+Expected: import failure because `visual_manifest_assets.py` does not exist.
+
+- [ ] **Step 3: Implement the shared helper**
+
+Create `tldw_Server_API/app/core/Persona/visual_manifest_assets.py`:
+
+```python
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+
+def collect_visual_manifest_asset_ids(manifest: dict[str, Any]) -> set[str]:
+    asset_ids: set[str] = set()
+    animations = manifest.get("animations")
+    if not isinstance(animations, dict):
+        return asset_ids
+    for animation in animations.values():
+        if not isinstance(animation, dict):
+            continue
+        frames = animation.get("frames")
+        if isinstance(frames, list):
+            for frame in frames:
+                if isinstance(frame, dict):
+                    asset_id = str(frame.get("asset_id") or "").strip()
+                    if asset_id:
+                        asset_ids.add(asset_id)
+        listed_asset_ids = animation.get("asset_ids")
+        if isinstance(listed_asset_ids, list):
+            for asset_id in listed_asset_ids:
+                normalized = str(asset_id or "").strip()
+                if normalized:
+                    asset_ids.add(normalized)
+        preview_asset_id = str(animation.get("preview_asset_id") or "").strip()
+        if preview_asset_id:
+            asset_ids.add(preview_asset_id)
+    return asset_ids
+
+
+def remap_visual_manifest_assets(
+    manifest: dict[str, Any],
+    asset_id_map: dict[str, str],
+) -> dict[str, Any]:
+    remapped = deepcopy(manifest)
+    animations = remapped.get("animations")
+    if not isinstance(animations, dict):
+        return remapped
+    for animation in animations.values():
+        if not isinstance(animation, dict):
+            continue
+        frames = animation.get("frames")
+        if isinstance(frames, list):
+            for frame in frames:
+                if not isinstance(frame, dict):
+                    continue
+                asset_id = str(frame.get("asset_id") or "")
+                if asset_id in asset_id_map:
+                    frame["asset_id"] = asset_id_map[asset_id]
+        asset_ids = animation.get("asset_ids")
+        if isinstance(asset_ids, list):
+            animation["asset_ids"] = [
+                asset_id_map.get(str(asset_id), asset_id)
+                for asset_id in asset_ids
+            ]
+        preview_asset_id = str(animation.get("preview_asset_id") or "")
+        if preview_asset_id in asset_id_map:
+            animation["preview_asset_id"] = asset_id_map[preview_asset_id]
+    return remapped
+```
+
+- [ ] **Step 4: Update importer to use the shared helper**
+
+In `tldw_Server_API/app/core/Persona/visual_portability/importer.py`:
+
+```python
+from tldw_Server_API.app.core.Persona.visual_manifest_assets import (
+    remap_visual_manifest_assets,
+)
+```
+
+Replace:
+
+```python
+remapped_manifest = _remap_visual_manifest_assets(visual_manifest, id_maps["assets"])
+```
+
+with:
+
+```python
+remapped_manifest = remap_visual_manifest_assets(visual_manifest, id_maps["assets"])
+```
+
+Then remove the private `_remap_visual_manifest_assets()` function and the now-unused `deepcopy` import from `importer.py`.
+
+- [ ] **Step 5: Run helper and import regression tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_manifest_assets.py tldw_Server_API/tests/Persona/test_persona_visuals_api.py -q
+```
+
+Expected: helper tests pass and existing import/export API tests still pass.
+
+- [ ] **Step 6: Commit helper extraction**
+
+```bash
+git add tldw_Server_API/app/core/Persona/visual_manifest_assets.py \
+  tldw_Server_API/app/core/Persona/visual_portability/importer.py \
+  tldw_Server_API/tests/Persona/test_persona_visual_manifest_assets.py
+git commit -m "Extract persona visual manifest asset helpers"
+```
+
+---
+
+### Task 2: Add Narrow DB Support For Duplicate Lineage
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/DB_Management/chacha/persona_state_store.py`
+- Modify: `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`
+- Test: `tldw_Server_API/tests/Persona/test_persona_visual_service.py`
+
+- [ ] **Step 1: Write service-level failing tests for cross-persona parent creation and status transition**
+
+Append focused expectations to the duplicate service tests in Task 3, or temporarily add this failing test to `tldw_Server_API/tests/Persona/test_persona_visual_service.py`:
+
+```python
+def test_db_allows_explicit_cross_persona_parent_for_duplicate_path(db_instance: CharactersRAGDB) -> None:
+    user_id = "user-1"
+    source_persona_id = db_instance.create_persona_profile({"user_id": user_id, "name": "Source"})
+    target_persona_id = db_instance.create_persona_profile({"user_id": user_id, "name": "Target"})
+    source_pack = db_instance.create_persona_visual_pack(
+        persona_id=source_persona_id,
+        user_id=user_id,
+        title="Source Pack",
+    )
+
+    target_pack = db_instance.create_persona_visual_pack(
+        persona_id=target_persona_id,
+        user_id=user_id,
+        title="Duplicate",
+        parent_pack_id=source_pack["id"],
+        parent_persona_id=source_persona_id,
+        status="failed",
+        provenance="mixed",
+    )
+    updated = db_instance.update_persona_visual_pack_status(
+        pack_id=target_pack["id"],
+        persona_id=target_persona_id,
+        user_id=user_id,
+        status="draft",
+        expected_version=target_pack["version"],
+    )
+
+    assert updated["parent_pack_id"] == source_pack["id"]
+    assert updated["status"] == "draft"
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_service.py::test_db_allows_explicit_cross_persona_parent_for_duplicate_path -q
+```
+
+Expected: failure because `parent_persona_id` and `update_persona_visual_pack_status()` do not exist.
+
+- [ ] **Step 3: Extend pack creation with explicit parent persona**
+
+In `create_persona_visual_pack()` in `tldw_Server_API/app/core/DB_Management/chacha/persona_state_store.py`, add an optional keyword after `parent_pack_id`:
+
+```python
+parent_persona_id: str | None = None,
+```
+
+Change parent validation to:
+
+```python
+if parent_pack_id:
+    self._require_persona_visual_pack_owner(
+        conn,
+        pack_id=str(parent_pack_id),
+        persona_id=str(parent_persona_id or persona_id),
+        user_id=user_id,
+    )
+```
+
+Do not change existing callers; the default remains same-persona validation.
+
+- [ ] **Step 4: Add status-update helper**
+
+In `persona_state_store.py`, near `update_persona_visual_pack_manifest()`, add:
+
+```python
+def update_persona_visual_pack_status(
+    self,
+    *,
+    pack_id: str,
+    persona_id: str,
+    user_id: str,
+    status: str,
+    expected_version: int | None = None,
+) -> dict[str, Any] | None:
+    status_value = self._normalize_persona_visual_enum(
+        status,
+        allowed=self._ALLOWED_PERSONA_VISUAL_PACK_STATUSES,
+        field_name="status",
+    )
+    if status_value == "active":
+        raise InputError("Use activate_persona_visual_pack for active status transitions.")
+    now = self._get_current_utc_timestamp_iso()
+    bool_cast = bool if self.backend_type == BackendType.POSTGRESQL else int
+    params: list[Any] = [
+        status_value,
+        None,
+        now,
+        pack_id,
+        user_id,
+        persona_id,
+        bool_cast(False),
+    ]
+    where_sql = "id = ? AND user_id = ? AND persona_id = ? AND deleted = ?"
+    if expected_version is not None:
+        where_sql += " AND version = ?"
+        params.append(int(expected_version))
+    query = (
+        "UPDATE persona_visual_packs "
+        "SET status = ?, active_at = ?, last_modified = ?, version = version + 1 "
+        f"WHERE {where_sql}"  # nosec B608
+    )
+    with self.transaction() as conn:
+        self._require_active_persona_profile_owner(conn, persona_id=persona_id, user_id=user_id)
+        self._require_persona_visual_pack_owner(
+            conn,
+            pack_id=pack_id,
+            persona_id=persona_id,
+            user_id=user_id,
+        )
+        prepared_query, prepared_params = self._prepare_backend_statement(query, tuple(params))
+        cursor = conn.execute(prepared_query, prepared_params or ())
+        if cursor.rowcount == 0 and expected_version is not None:
+            raise ConflictError(
+                "Persona visual pack version mismatch.",
+                entity="persona_visual_packs",
+                entity_id=pack_id,
+            )
+    return self.get_persona_visual_pack(pack_id=pack_id, persona_id=persona_id, user_id=user_id)
+```
+
+- [ ] **Step 5: Export the helper**
+
+In `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`, add `update_persona_visual_pack_status` to the persona visual method export list near `update_persona_visual_pack_manifest`.
+
+- [ ] **Step 6: Run the DB-focused test**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_service.py::test_db_allows_explicit_cross_persona_parent_for_duplicate_path -q
+```
+
+Expected: pass.
+
+- [ ] **Step 7: Commit DB support**
+
+```bash
+git add tldw_Server_API/app/core/DB_Management/chacha/persona_state_store.py \
+  tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py \
+  tldw_Server_API/tests/Persona/test_persona_visual_service.py
+git commit -m "Support persona visual duplicate lineage"
+```
+
+---
+
+### Task 3: Implement PersonaVisualService Duplication
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Persona/visual_service.py`
+- Test: `tldw_Server_API/tests/Persona/test_persona_visual_service.py`
+
+- [ ] **Step 1: Write failing service test for successful duplicate**
+
+Add to `tldw_Server_API/tests/Persona/test_persona_visual_service.py`:
+
+```python
+def _manifest_with_all_reference_shapes(asset_a: str, asset_b: str) -> dict[str, object]:
+    return {
+        "manifest_version": 1,
+        "renderer_type": "sprite_frames",
+        "states": {
+            "idle": {"animation_id": "idle"},
+            "listening": {"animation_id": "idle"},
+            "thinking": {"animation_id": "idle"},
+            "speaking": {"animation_id": "idle"},
+            "error": {"animation_id": "idle"},
+        },
+        "animations": {
+            "idle": {
+                "frames": [
+                    {"asset_id": asset_a, "duration_ms": 100},
+                    {"asset_id": asset_b, "duration_ms": 100},
+                ],
+                "asset_ids": [asset_a],
+                "preview_asset_id": asset_b,
+                "frame_rate": 2,
+            }
+        },
+    }
+
+
+def test_duplicate_pack_to_persona_copies_referenced_assets_and_remaps_manifest(
+    service: PersonaVisualService,
+    db_instance: CharactersRAGDB,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_visuals_dir(monkeypatch, tmp_path / "visuals")
+    user_id = "user-1"
+    source_persona_id = db_instance.create_persona_profile({"user_id": user_id, "name": "Source"})
+    target_persona_id = db_instance.create_persona_profile({"user_id": user_id, "name": "Target"})
+    source_pack = db_instance.create_persona_visual_pack(
+        persona_id=source_persona_id,
+        user_id=user_id,
+        title="Source Pack",
+    )
+    asset_a = service.create_asset_from_upload(
+        persona_id=source_persona_id,
+        user_id=user_id,
+        pack_id=source_pack["id"],
+        content=_png_bytes(width=2, height=2),
+        mime_type="image/png",
+        original_filename="idle-a.png",
+        asset_role="frame",
+    )
+    asset_b = service.create_asset_from_upload(
+        persona_id=source_persona_id,
+        user_id=user_id,
+        pack_id=source_pack["id"],
+        content=_png_bytes(width=3, height=3),
+        mime_type="image/png",
+        original_filename="idle-b.png",
+        asset_role="preview",
+    )
+    unused = service.create_asset_from_upload(
+        persona_id=source_persona_id,
+        user_id=user_id,
+        pack_id=source_pack["id"],
+        content=_png_bytes(width=4, height=4),
+        mime_type="image/png",
+        original_filename="unused.png",
+        asset_role="generated_candidate",
+    )
+    updated_source = db_instance.update_persona_visual_pack_manifest(
+        pack_id=source_pack["id"],
+        persona_id=source_persona_id,
+        user_id=user_id,
+        manifest=_manifest_with_all_reference_shapes(asset_a["id"], asset_b["id"]),
+        expected_version=source_pack["version"],
+    )
+
+    duplicated = service.duplicate_pack_to_persona(
+        source_persona_id=source_persona_id,
+        user_id=user_id,
+        pack_id=updated_source["id"],
+        target_persona_id=target_persona_id,
+        title="Target Draft",
+    )
+
+    assert duplicated["status"] == "draft"
+    assert duplicated["persona_id"] == target_persona_id
+    assert duplicated["parent_pack_id"] == source_pack["id"]
+    copied_assets = db_instance.list_persona_visual_assets(
+        pack_id=duplicated["id"],
+        persona_id=target_persona_id,
+        user_id=user_id,
+    )
+    assert len(copied_assets) == 2
+    copied_ids = {asset["id"] for asset in copied_assets}
+    assert asset_a["id"] not in copied_ids
+    assert asset_b["id"] not in copied_ids
+    assert unused["checksum_sha256"] not in {asset["checksum_sha256"] for asset in copied_assets}
+    assert all(f"persona_visuals/{target_persona_id}/{duplicated['id']}/" in asset["storage_key"] for asset in copied_assets)
+    remapped_animation = duplicated["manifest"]["animations"]["idle"]
+    assert {frame["asset_id"] for frame in remapped_animation["frames"]} == copied_ids
+    assert set(remapped_animation["asset_ids"]).issubset(copied_ids)
+    assert remapped_animation["preview_asset_id"] in copied_ids
+```
+
+- [ ] **Step 2: Write failing service tests for V1 guardrails**
+
+Add tests for same-persona, missing manifest asset row, and missing source file:
+
+```python
+def test_duplicate_pack_rejects_same_persona_target(service: PersonaVisualService, db_instance: CharactersRAGDB) -> None:
+    persona_id, pack = _create_pack(db_instance)
+
+    with pytest.raises(PersonaVisualServiceError) as exc_info:
+        service.duplicate_pack_to_persona(
+            source_persona_id=persona_id,
+            user_id="user-1",
+            pack_id=pack["id"],
+            target_persona_id=persona_id,
+        )
+
+    assert exc_info.value.code == "same_persona_target_unsupported"
+```
+
+For missing file, create an asset, update the manifest to reference it, remove `Path(asset["storage_path"])`, and assert `source_asset_missing`.
+
+For missing row, update the manifest to reference `"does-not-exist"` and assert `invalid_manifest`.
+
+For checksum mismatch, mutate the stored source file bytes after upload and assert `source_asset_checksum_mismatch`.
+
+For partial failure cleanup, induce an exception after the first copied file is created, then assert copied files under the target pack storage directory were removed and no target pack was promoted to `draft` or `active`.
+
+- [ ] **Step 3: Run service duplicate tests and verify they fail**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_service.py -q
+```
+
+Expected: failures because `duplicate_pack_to_persona()` does not exist.
+
+- [ ] **Step 4: Add source asset path resolution helper**
+
+In `PersonaVisualService`, add a private helper based on the exporter pattern:
+
+```python
+def _asset_storage_path(self, *, user_id: str, storage_key: str) -> Path:
+    prefix = f"{VISUAL_STORAGE_PREFIX}/"
+    relative_key = storage_key[len(prefix):] if storage_key.startswith(prefix) else storage_key
+    relative_path = Path(*Path(relative_key).parts)
+    if relative_path.is_absolute() or ".." in relative_path.parts:
+        raise PersonaVisualServiceError(
+            "invalid_storage_path",
+            "Persona visual storage path escapes the user visual directory.",
+        )
+    base = DatabasePaths.get_user_persona_visuals_dir(user_id).resolve(strict=False)
+    target_path = (base / relative_path).resolve(strict=False)
+    if not target_path.is_relative_to(base):
+        raise PersonaVisualServiceError(
+            "invalid_storage_path",
+            "Persona visual storage path escapes the user visual directory.",
+        )
+    return target_path
+```
+
+If using `Path(*Path(relative_key).parts)` proves awkward with normalized keys, import and reuse `_safe_relative_storage_path()` from the exporter only if it does not create an import cycle. Otherwise keep the helper local.
+
+- [ ] **Step 5: Add duplicate orchestration**
+
+In `PersonaVisualService`, implement:
+
+```python
+def duplicate_pack_to_persona(
+    self,
+    *,
+    source_persona_id: str,
+    user_id: str,
+    pack_id: str,
+    target_persona_id: str,
+    title: str | None = None,
+) -> dict[str, Any]:
+    if str(source_persona_id) == str(target_persona_id):
+        raise PersonaVisualServiceError(
+            "same_persona_target_unsupported",
+            "Persona visual packs can only be duplicated to a different persona in V1.",
+        )
+
+    source_pack = self._db.get_persona_visual_pack(
+        pack_id=pack_id,
+        persona_id=source_persona_id,
+        user_id=user_id,
+    )
+    if not source_pack:
+        raise PersonaVisualServiceError("pack_not_found", "Persona visual pack not found for user.")
+
+    target_persona = self._db.get_persona_profile(
+        persona_id=target_persona_id,
+        user_id=user_id,
+    )
+    if not target_persona:
+        raise PersonaVisualServiceError(
+            "target_persona_not_found",
+            "Target persona not found for user.",
+            details={"target_persona_id": target_persona_id},
+        )
+
+    source_manifest = source_pack.get("manifest") if isinstance(source_pack.get("manifest"), dict) else {}
+    source_assets = self._db.list_persona_visual_assets(
+        pack_id=pack_id,
+        persona_id=source_persona_id,
+        user_id=user_id,
+    )
+    source_assets_by_id = {str(asset["id"]): asset for asset in source_assets}
+    referenced_asset_ids = collect_visual_manifest_asset_ids(source_manifest)
+    missing_asset_ids = sorted(referenced_asset_ids - set(source_assets_by_id))
+    if missing_asset_ids:
+        raise PersonaVisualServiceError(
+            "invalid_manifest",
+            "Persona visual manifest references assets that are not in the source pack.",
+            details={"asset_ids": missing_asset_ids},
+        )
+
+    # Preflight bytes and checksums before creating target records.
+    preflight_assets = []
+    for asset_id in sorted(referenced_asset_ids):
+        asset = source_assets_by_id[asset_id]
+        source_path = self._asset_storage_path(
+            user_id=user_id,
+            storage_key=str(asset.get("storage_key") or ""),
+        )
+        if not source_path.is_file():
+            raise PersonaVisualServiceError(
+                "source_asset_missing",
+                "Persona visual source asset file is missing.",
+                details={"asset_id": asset_id},
+            )
+        content = source_path.read_bytes()
+        checksum = hashlib.sha256(content).hexdigest()
+        if checksum != str(asset.get("checksum_sha256") or ""):
+            raise PersonaVisualServiceError(
+                "source_asset_checksum_mismatch",
+                "Persona visual source asset checksum does not match metadata.",
+                details={"asset_id": asset_id},
+            )
+        preflight_assets.append((asset, content))
+
+    title_value = str(title or "").strip()
+    if not title_value:
+        title_value = f"Copy of {source_pack['title']}"
+
+    target_pack = self._db.create_persona_visual_pack(
+        persona_id=target_persona_id,
+        user_id=user_id,
+        title=title_value,
+        renderer_type=str(source_pack.get("renderer_type") or "sprite_frames"),
+        status="failed",
+        parent_pack_id=pack_id,
+        parent_persona_id=source_persona_id,
+        provenance="mixed",
+        manifest={
+            "manifest_version": 1,
+            "renderer_type": str(source_pack.get("renderer_type") or "sprite_frames"),
+            "states": {},
+            "animations": {},
+        },
+    )
+    copied_file_paths: list[Path] = []
+    try:
+        asset_id_map: dict[str, str] = {}
+        copied_assets: list[dict[str, Any]] = []
+        for source_asset, content in preflight_assets:
+            copied = self.create_asset_from_upload(
+                persona_id=target_persona_id,
+                user_id=user_id,
+                pack_id=str(target_pack["id"]),
+                content=content,
+                mime_type=str(source_asset.get("mime_type") or "application/octet-stream"),
+                original_filename=source_asset.get("original_filename"),
+                asset_role=str(source_asset.get("asset_role") or "frame"),
+                provenance="mixed",
+            )
+            if copied.get("storage_path"):
+                copied_file_paths.append(Path(str(copied["storage_path"])))
+            asset_id_map[str(source_asset["id"])] = str(copied["id"])
+            copied_assets.append(copied)
+
+        remapped_manifest = remap_visual_manifest_assets(source_manifest, asset_id_map)
+        validation = validate_visual_manifest(
+            remapped_manifest,
+            available_asset_ids={str(asset["id"]) for asset in copied_assets},
+            available_asset_dimensions={
+                str(asset["id"]): (int(asset["width"]), int(asset["height"]))
+                for asset in copied_assets
+                if asset.get("width") is not None and asset.get("height") is not None
+            },
+            require_activatable=False,
+        )
+        updated_pack = self._db.update_persona_visual_pack_manifest(
+            pack_id=str(target_pack["id"]),
+            persona_id=target_persona_id,
+            user_id=user_id,
+            manifest=validation.manifest,
+            expected_version=int(target_pack["version"]),
+        )
+        finalized = self._db.update_persona_visual_pack_status(
+            pack_id=str(target_pack["id"]),
+            persona_id=target_persona_id,
+            user_id=user_id,
+            status="draft",
+            expected_version=int(updated_pack["version"]),
+        )
+    except Exception:
+        for path in copied_file_paths:
+            path.unlink(missing_ok=True)
+        raise
+
+    assets = self._db.list_persona_visual_assets(
+        pack_id=str(target_pack["id"]),
+        persona_id=target_persona_id,
+        user_id=user_id,
+    )
+    finalized["assets"] = assets
+    finalized["assets_by_id"] = {str(asset["id"]): asset for asset in assets}
+    return finalized
+```
+
+Adjust exact calls if `get_persona_profile()` uses a different signature; use the existing profile owner helper pattern from the endpoint if needed.
+
+- [ ] **Step 6: Convert manifest validation errors**
+
+Wrap `validate_visual_manifest()` in the duplicate path:
+
+```python
+try:
+    validation = validate_visual_manifest(...)
+except PersonaVisualManifestError as exc:
+    raise PersonaVisualServiceError(
+        "invalid_manifest",
+        str(exc),
+        details={"pack_id": pack_id},
+    ) from exc
+```
+
+- [ ] **Step 7: Run service tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_service.py -q
+```
+
+Expected: pass.
+
+- [ ] **Step 8: Commit service duplicate behavior**
+
+```bash
+git add tldw_Server_API/app/core/Persona/visual_service.py \
+  tldw_Server_API/tests/Persona/test_persona_visual_service.py
+git commit -m "Add persona visual pack duplication service"
+```
+
+---
+
+### Task 4: Add Duplicate API Contract
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/schemas/persona.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/persona.py`
+- Test: `tldw_Server_API/tests/Persona/test_persona_visuals_api.py`
+
+- [ ] **Step 1: Write failing API tests**
+
+In `tldw_Server_API/tests/Persona/test_persona_visuals_api.py`, add:
+
+```python
+def test_duplicate_visual_pack_to_another_persona_creates_draft(persona_db: CharactersRAGDB) -> None:
+    with _client_for_user(1, persona_db) as client:
+        source_persona_id = _create_persona(client, name="Source Persona")
+        target_persona_id = _create_persona(client, name="Target Persona")
+        source_pack = _create_visual_pack(client, source_persona_id, title="Source Visuals")
+        asset = _upload_png(client, source_persona_id, source_pack["id"])
+        manifest_response = client.patch(
+            f"/api/v1/persona/profiles/{source_persona_id}/visual-packs/{source_pack['id']}/manifest",
+            json={"manifest": _valid_manifest(asset["id"]), "expected_version": source_pack["version"]},
+        )
+        assert manifest_response.status_code == 200, manifest_response.text
+
+        response = client.post(
+            f"/api/v1/persona/profiles/{source_persona_id}/visual-packs/{source_pack['id']}/duplicate",
+            json={"target_persona_id": target_persona_id, "title": "Target Draft"},
+        )
+
+        assert response.status_code == 201, response.text
+        payload = response.json()
+        assert payload["title"] == "Target Draft"
+        assert payload["persona_id"] == target_persona_id
+        assert payload["status"] == "draft"
+        assert payload["parent_pack_id"] == source_pack["id"]
+        assert "asset_id_map" not in payload
+        assert len(payload["assets"]) == 1
+        assert payload["assets"][0]["id"] != asset["id"]
+```
+
+Add negative tests:
+
+```python
+def test_duplicate_visual_pack_rejects_same_persona_target(persona_db: CharactersRAGDB) -> None:
+    with _client_for_user(1, persona_db) as client:
+        persona_id = _create_persona(client, name="Source Persona")
+        source_pack = _create_visual_pack(client, persona_id, title="Source Visuals")
+
+        response = client.post(
+            f"/api/v1/persona/profiles/{persona_id}/visual-packs/{source_pack['id']}/duplicate",
+            json={"target_persona_id": persona_id},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"]["code"] == "same_persona_target_unsupported"
+```
+
+Also test unauthorized target by creating a target persona under a different user DB/client and expecting `404` with `target_persona_not_found`.
+
+- [ ] **Step 2: Run API tests and verify they fail**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Persona/test_persona_visuals_api.py -q
+```
+
+Expected: duplicate endpoint returns 404 because route does not exist.
+
+- [ ] **Step 3: Add request schema**
+
+In `tldw_Server_API/app/api/v1/schemas/persona.py` near `PersonaVisualPackCreate`:
+
+```python
+class PersonaVisualPackDuplicateRequest(BaseModel):
+    target_persona_id: str = Field(min_length=1, max_length=128)
+    title: str | None = Field(default=None, min_length=1, max_length=200)
+
+    @field_validator("target_persona_id")
+    @classmethod
+    def normalize_target_persona_id(cls, value: str) -> str:
+        normalized = str(value or "").strip()
+        if not normalized:
+            raise ValueError("target_persona_id is required")
+        return normalized
+```
+
+- [ ] **Step 4: Import the schema in the endpoint**
+
+Add `PersonaVisualPackDuplicateRequest` to the existing imports from `tldw_Server_API.app.api.v1.schemas.persona`.
+
+- [ ] **Step 5: Extend service error mapping**
+
+In `_persona_visual_service_error_to_http()`:
+
+```python
+if exc.code in {
+    "pack_not_found",
+    "asset_not_found",
+    "candidate_not_found",
+    "target_persona_not_found",
+}:
+    status_code = status.HTTP_404_NOT_FOUND
+```
+
+Map stale stored-source conditions to conflict:
+
+```python
+elif exc.code in {"source_asset_missing", "source_asset_checksum_mismatch"}:
+    status_code = status.HTTP_409_CONFLICT
+```
+
+Leave `same_persona_target_unsupported` and `invalid_manifest` as `400`.
+
+- [ ] **Step 6: Add duplicate endpoint**
+
+Place after `get_persona_visual_pack()` or before asset upload in `persona.py`:
+
+```python
+@router.post(
+    "/profiles/{persona_id}/visual-packs/{pack_id}/duplicate",
+    response_model=PersonaVisualPackResponse,
+    tags=["persona"],
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(check_rate_limit)],
+)
+async def duplicate_persona_visual_pack(
+    persona_id: str,
+    pack_id: str,
+    payload: PersonaVisualPackDuplicateRequest,
+    _current_user: User = Depends(get_request_user),
+    visual_service: PersonaVisualService = Depends(get_persona_visual_service),
+) -> PersonaVisualPackResponse:
+    """Duplicate a persona visual pack to another same-user persona as a draft."""
+    if not is_persona_enabled():
+        raise HTTPException(status_code=404, detail="Persona disabled")
+    user_id = _require_current_user_id(_current_user)
+    try:
+        duplicated = await _run_persona_db_call(
+            visual_service.duplicate_pack_to_persona,
+            source_persona_id=persona_id,
+            user_id=user_id,
+            pack_id=pack_id,
+            target_persona_id=payload.target_persona_id,
+            title=payload.title,
+        )
+        assets = list(duplicated.get("assets") or [])
+        return _persona_visual_pack_to_response(duplicated, assets=assets)
+    except PersonaVisualServiceError as exc:
+        raise _persona_visual_service_error_to_http(exc) from exc
+    except (InputError, ConflictError, CharactersRAGDBError) as exc:
+        raise _to_http_exception(exc, action="duplicate persona visual pack") from exc
+```
+
+- [ ] **Step 7: Run API tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Persona/test_persona_visuals_api.py -q
+```
+
+Expected: pass.
+
+- [ ] **Step 8: Commit API contract**
+
+```bash
+git add tldw_Server_API/app/api/v1/schemas/persona.py \
+  tldw_Server_API/app/api/v1/endpoints/persona.py \
+  tldw_Server_API/tests/Persona/test_persona_visuals_api.py
+git commit -m "Expose persona visual pack duplication API"
+```
+
+---
+
+### Task 5: Add Frontend Service And Types
+
+**Files:**
+- Modify: `apps/packages/ui/src/types/persona-visuals.ts`
+- Modify: `apps/packages/ui/src/services/persona-visuals.ts`
+- Test indirectly in: `apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx`
+
+- [ ] **Step 1: Add frontend types**
+
+In `apps/packages/ui/src/types/persona-visuals.ts`:
+
+```ts
+export interface PersonaVisualPackDuplicateRequest {
+  target_persona_id: string
+  title?: string | null
+}
+
+export interface PersonaVisualDuplicateTarget {
+  id: string
+  name?: string | null
+}
+```
+
+- [ ] **Step 2: Add API helper imports**
+
+In `apps/packages/ui/src/services/persona-visuals.ts`, import the new types:
+
+```ts
+  PersonaVisualDuplicateTarget,
+  PersonaVisualPackDuplicateRequest,
+```
+
+- [ ] **Step 3: Add duplicate API helper**
+
+In `persona-visuals.ts`:
+
+```ts
+export async function duplicatePersonaVisualPack(
+  sourcePersonaId: string,
+  packId: string,
+  payload: PersonaVisualPackDuplicateRequest
+): Promise<PersonaVisualPack> {
+  return fetchPersonaVisualJson<PersonaVisualPack>(
+    packPath(sourcePersonaId, packId, "/duplicate"),
+    {
+      method: "POST",
+      body: payload
+    }
+  )
+}
+```
+
+- [ ] **Step 4: Add duplicate target listing helper**
+
+Use the same fetch wrapper so existing `fetchWithAuth` test mocks keep working:
+
+```ts
+export async function listPersonaVisualDuplicateTargets(): Promise<
+  PersonaVisualDuplicateTarget[]
+> {
+  const payload = await fetchPersonaVisualJson<unknown>("/api/v1/persona/catalog")
+  if (!Array.isArray(payload)) return []
+  return payload
+    .map((item) => {
+      if (!item || typeof item !== "object") return null
+      const candidate = item as { id?: unknown; name?: unknown }
+      const id = String(candidate.id || "").trim()
+      if (!id) return null
+      return {
+        id,
+        name:
+          typeof candidate.name === "string" && candidate.name.trim()
+            ? candidate.name
+            : null
+      }
+    })
+    .filter((item): item is PersonaVisualDuplicateTarget => item !== null)
+}
+```
+
+- [ ] **Step 5: Run TypeScript-focused frontend test file after UI task**
+
+Defer execution until Task 6 adds UI consumers:
+
+```bash
+cd apps/tldw-frontend
+bunx vitest run ../packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+```
+
+Expected after Task 6: pass.
+
+---
+
+### Task 6: Add VisualPackEditor Duplicate UI
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx`
+- Modify: `apps/packages/ui/src/routes/sidepanel-persona.tsx`
+- Test: `apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx`
+
+- [ ] **Step 1: Write failing UI test for duplicate flow**
+
+In `VisualPackEditor.test.tsx`, add a test near import/export tests:
+
+```tsx
+it("duplicates a visual pack to another persona as a draft", async () => {
+  const sourcePack = {
+    id: "pack-1",
+    persona_id: "persona-1",
+    title: "Animated pack",
+    renderer_type: "sprite_frames",
+    status: "active",
+    manifest: structuredClone(baseManifest),
+    assets: visualAssets,
+    version: 3
+  }
+  const duplicatedPack = {
+    ...sourcePack,
+    id: "pack-duplicate",
+    persona_id: "persona-2",
+    title: "Research Buddy copy",
+    status: "draft",
+    parent_pack_id: "pack-1",
+    assets: [{ ...visualAssets[0], id: "asset-copy", pack_id: "pack-duplicate", persona_id: "persona-2" }]
+  }
+  const openTarget = vi.fn()
+
+  mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string; body?: any }) => {
+    const method = init?.method || "GET"
+    if (path === "/api/v1/persona/profiles/persona-1/visual-packs" && method === "GET") {
+      return okResponse([sourcePack])
+    }
+    if (
+      path === "/api/v1/persona/profiles/persona-1/visual-packs/pack-1/generated-candidates" &&
+      method === "GET"
+    ) {
+      return okResponse({ candidates: [] })
+    }
+    if (path === "/api/v1/persona/catalog" && method === "GET") {
+      return okResponse([
+        { id: "persona-1", name: "Source Persona" },
+        { id: "persona-2", name: "Research Buddy" }
+      ])
+    }
+    if (
+      path === "/api/v1/persona/profiles/persona-1/visual-packs/pack-1/duplicate" &&
+      method === "POST"
+    ) {
+      expect(parseJsonBody(init?.body)).toEqual({
+        target_persona_id: "persona-2",
+        title: "Research Buddy copy"
+      })
+      return okResponse(duplicatedPack)
+    }
+    return Promise.resolve({
+      ok: false,
+      status: 404,
+      error: `Unhandled path: ${path}`,
+      json: async () => ({})
+    })
+  })
+
+  render(
+    <VisualPackEditor
+      selectedPersonaId="persona-1"
+      selectedPersonaName="Source Persona"
+      isActive
+      onOpenPersonaVisuals={openTarget}
+    />
+  )
+
+  await waitFor(() =>
+    expect(screen.getByTestId("persona-visual-pack-status")).toHaveTextContent("active")
+  )
+  await waitFor(() =>
+    expect(screen.getByTestId("persona-visual-duplicate-target-select")).toHaveTextContent(
+      "Research Buddy"
+    )
+  )
+  expect(screen.getByTestId("persona-visual-duplicate-target-select")).not.toHaveTextContent(
+    "Source Persona"
+  )
+
+  fireEvent.change(screen.getByTestId("persona-visual-duplicate-title-input"), {
+    target: { value: "Research Buddy copy" }
+  })
+  fireEvent.change(screen.getByTestId("persona-visual-duplicate-target-select"), {
+    target: { value: "persona-2" }
+  })
+  fireEvent.click(screen.getByTestId("persona-visual-duplicate-button"))
+
+  await waitFor(() =>
+    expect(screen.getByText(/Duplicated as a draft for Research Buddy/)).toBeInTheDocument()
+  )
+  fireEvent.click(screen.getByTestId("persona-visual-duplicate-open-target"))
+  expect(openTarget).toHaveBeenCalledWith("persona-2")
+})
+```
+
+- [ ] **Step 2: Run the UI test and verify it fails**
+
+Run:
+
+```bash
+cd apps/tldw-frontend
+bunx vitest run ../packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+```
+
+Expected: type/test failure because duplicate UI does not exist.
+
+- [ ] **Step 3: Extend `VisualPackEditorProps`**
+
+In `VisualPackEditor.tsx`:
+
+```ts
+type VisualPackEditorProps = {
+  selectedPersonaId: string
+  selectedPersonaName: string
+  isActive?: boolean
+  onOpenPersonaVisuals?: (personaId: string) => void
+}
+```
+
+Destructure `onOpenPersonaVisuals`.
+
+- [ ] **Step 4: Import duplicate helpers and icon**
+
+Add `Copy` from `lucide-react`.
+
+Add service imports:
+
+```ts
+  duplicatePersonaVisualPack,
+  listPersonaVisualDuplicateTargets,
+```
+
+Add type import:
+
+```ts
+  PersonaVisualDuplicateTarget,
+```
+
+- [ ] **Step 5: Add duplicate state**
+
+Near other import/export state:
+
+```ts
+const [duplicateTargets, setDuplicateTargets] = React.useState<PersonaVisualDuplicateTarget[]>([])
+const [duplicateTargetsLoading, setDuplicateTargetsLoading] = React.useState(false)
+const [duplicateTargetId, setDuplicateTargetId] = React.useState("")
+const [duplicateTitle, setDuplicateTitle] = React.useState("")
+const [duplicatingPack, setDuplicatingPack] = React.useState(false)
+const [lastDuplicatedPersonaId, setLastDuplicatedPersonaId] = React.useState("")
+```
+
+Add memo:
+
+```ts
+const availableDuplicateTargets = React.useMemo(
+  () => duplicateTargets.filter((target) => target.id !== selectedPersonaId),
+  [duplicateTargets, selectedPersonaId]
+)
+const selectedDuplicateTarget = availableDuplicateTargets.find(
+  (target) => target.id === duplicateTargetId
+) ?? null
+```
+
+- [ ] **Step 6: Load duplicate targets**
+
+Add a callback/effect similar to `loadPacks()`:
+
+```ts
+const loadDuplicateTargets = React.useCallback(async () => {
+  if (!isActive || !selectedPersonaId || !selectedPack) return
+  setDuplicateTargetsLoading(true)
+  try {
+    const targets = await listPersonaVisualDuplicateTargets()
+    const available = targets.filter((target) => target.id !== selectedPersonaId)
+    setDuplicateTargets(targets)
+    setDuplicateTargetId((current) =>
+      current && available.some((target) => target.id === current)
+        ? current
+        : available[0]?.id ?? ""
+    )
+  } catch (loadError) {
+    setError(
+      loadError instanceof Error
+        ? loadError.message
+        : "Failed to load persona duplicate targets."
+    )
+  } finally {
+    setDuplicateTargetsLoading(false)
+  }
+}, [isActive, selectedPersonaId, selectedPack?.id])
+```
+
+Run it in an effect:
+
+```ts
+React.useEffect(() => {
+  void loadDuplicateTargets()
+}, [loadDuplicateTargets])
+```
+
+When `selectedPack` changes, initialize the title:
+
+```ts
+React.useEffect(() => {
+  setDuplicateTitle(selectedPack ? `Copy of ${selectedPack.title}` : "")
+  setLastDuplicatedPersonaId("")
+}, [selectedPack?.id])
+```
+
+- [ ] **Step 7: Add duplicate handler**
+
+```ts
+const handleDuplicatePack = async () => {
+  if (!selectedPersonaId || !selectedPack || !duplicateTargetId) return
+  setDuplicatingPack(true)
+  setError(null)
+  try {
+    const duplicated = await duplicatePersonaVisualPack(
+      selectedPersonaId,
+      selectedPack.id,
+      {
+        target_persona_id: duplicateTargetId,
+        title: duplicateTitle.trim() || `Copy of ${selectedPack.title}`
+      }
+    )
+    setLastDuplicatedPersonaId(duplicated.persona_id)
+    const targetName =
+      selectedDuplicateTarget?.name || selectedDuplicateTarget?.id || duplicated.persona_id
+    setStatusMessage(
+      t("sidepanel:personaGarden.visuals.duplicatedDraft", {
+        defaultValue: `Duplicated as a draft for ${targetName}. Review and activate it from that persona's Visuals tab.`
+      })
+    )
+  } catch (duplicateError) {
+    setError(
+      duplicateError instanceof Error
+        ? duplicateError.message
+        : t("sidepanel:personaGarden.visuals.duplicateError", {
+            defaultValue: "Failed to duplicate visual pack."
+          })
+    )
+  } finally {
+    setDuplicatingPack(false)
+  }
+}
+```
+
+- [ ] **Step 8: Add duplicate card in the Portability section**
+
+Change the portability grid to allow three cards:
+
+```tsx
+<div className="mt-3 grid gap-3 xl:grid-cols-3">
+```
+
+Add a new card before export or after import:
+
+```tsx
+<div className="rounded border border-border bg-bg p-2">
+  <div className="flex flex-wrap items-center justify-between gap-2">
+    <Typography.Text strong>Duplicate to persona</Typography.Text>
+    <Tag>creates draft</Tag>
+  </div>
+  <div className="mt-1 text-xs text-text-muted">
+    Copy this pack to another persona. It stays a draft until reviewed and activated.
+  </div>
+  <div className="mt-2 grid gap-2">
+    <label className="text-xs text-text-muted">
+      <span className="mb-1 block">Target persona</span>
+      <select
+        data-testid="persona-visual-duplicate-target-select"
+        className="w-full rounded border border-border bg-bg px-2 py-1 text-sm text-text"
+        value={duplicateTargetId}
+        disabled={duplicateTargetsLoading || !availableDuplicateTargets.length}
+        onChange={(event) => setDuplicateTargetId(event.target.value)}
+      >
+        {availableDuplicateTargets.map((target) => (
+          <option key={target.id} value={target.id}>
+            {target.name || target.id}
+          </option>
+        ))}
+      </select>
+    </label>
+    <label className="text-xs text-text-muted">
+      <span className="mb-1 block">Draft title</span>
+      <input
+        data-testid="persona-visual-duplicate-title-input"
+        className="w-full rounded border border-border bg-bg px-2 py-1 text-sm text-text"
+        value={duplicateTitle}
+        onChange={(event) => setDuplicateTitle(event.target.value)}
+      />
+    </label>
+    <Button
+      data-testid="persona-visual-duplicate-button"
+      size="small"
+      icon={<Copy className="h-3.5 w-3.5" />}
+      loading={duplicatingPack}
+      disabled={!duplicateTargetId || !selectedPack}
+      onClick={() => void handleDuplicatePack()}
+    >
+      Duplicate as draft
+    </Button>
+    {lastDuplicatedPersonaId && onOpenPersonaVisuals ? (
+      <Button
+        data-testid="persona-visual-duplicate-open-target"
+        size="small"
+        type="link"
+        onClick={() => onOpenPersonaVisuals(lastDuplicatedPersonaId)}
+      >
+        Open target Visuals
+      </Button>
+    ) : null}
+  </div>
+  {!availableDuplicateTargets.length ? (
+    <div className="mt-2 text-xs text-text-muted">
+      Add another persona before duplicating this pack.
+    </div>
+  ) : null}
+</div>
+```
+
+- [ ] **Step 9: Wire sidepanel persona switching**
+
+In `apps/packages/ui/src/routes/sidepanel-persona.tsx`, pass:
+
+```tsx
+onOpenPersonaVisuals={(personaId) => {
+  setSelectedPersonaId(personaId)
+  setActiveTab("visuals")
+}}
+```
+
+to `LazyVisualPackEditor`.
+
+- [ ] **Step 10: Run UI tests**
+
+Run:
+
+```bash
+cd apps/tldw-frontend
+bunx vitest run ../packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+```
+
+Expected: pass.
+
+- [ ] **Step 11: Commit frontend duplicate UI**
+
+```bash
+git add apps/packages/ui/src/types/persona-visuals.ts \
+  apps/packages/ui/src/services/persona-visuals.ts \
+  apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx \
+  apps/packages/ui/src/routes/sidepanel-persona.tsx \
+  apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+git commit -m "Add persona visual duplicate UI"
+```
+
+---
+
+### Task 7: Update Product Documentation And Final Verification
+
+**Files:**
+- Modify: `Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md`
+- Modify: `backlog/tasks/task-193 - Write-persona-visual-pack-duplicate-implementation-plan.md` only if executing this plan later in the same branch
+
+- [ ] **Step 1: Update PRD Phase 3 status**
+
+In `Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md`, update the Phase 3 list item:
+
+```markdown
+1. Duplicate pack to another persona. Initial same-user draft duplication is implemented by #1450.
+```
+
+If this implementation is not merged yet, phrase it as:
+
+```markdown
+1. Duplicate pack to another persona. First implementation target: same-user draft duplication (#1450).
+```
+
+- [ ] **Step 2: Run backend focused tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_manifest_assets.py tldw_Server_API/tests/Persona/test_persona_visual_service.py tldw_Server_API/tests/Persona/test_persona_visuals_api.py -q
+```
+
+Expected: pass.
+
+- [ ] **Step 3: Run frontend focused tests**
+
+Run:
+
+```bash
+cd apps/tldw-frontend
+bunx vitest run ../packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+```
+
+Expected: pass.
+
+- [ ] **Step 4: Run Bandit on touched backend code**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m bandit -r \
+  tldw_Server_API/app/core/Persona/visual_manifest_assets.py \
+  tldw_Server_API/app/core/Persona/visual_service.py \
+  tldw_Server_API/app/core/Persona/visual_portability/importer.py \
+  tldw_Server_API/app/api/v1/endpoints/persona.py \
+  tldw_Server_API/app/api/v1/schemas/persona.py \
+  tldw_Server_API/app/core/DB_Management/chacha/persona_state_store.py \
+  -f json -o /tmp/bandit_persona_visual_duplicate.json
+```
+
+Expected: no new high or medium findings in touched code. If Bandit is not installed in the environment, document the blocker and do not claim it passed.
+
+- [ ] **Step 5: Run whitespace check**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output.
+
+- [ ] **Step 6: Review changed files**
+
+Run:
+
+```bash
+git status --short
+git diff --stat
+```
+
+Expected: only planned files changed.
+
+- [ ] **Step 7: Commit docs and verification notes**
+
+```bash
+git add Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md
+git commit -m "Document persona visual duplicate workflow"
+```
+
+If the implementation tasks were not already committed task-by-task, commit all remaining implementation files with a single message:
+
+```bash
+git add tldw_Server_API apps/packages/ui Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md
+git commit -m "Implement persona visual pack duplication"
+```
+
+---
+
+## Final Acceptance Checklist
+
+- [ ] Backend duplicate service copies only manifest-referenced assets.
+- [ ] Public duplicate endpoint returns `PersonaVisualPackResponse`.
+- [ ] Same-persona duplicate is rejected.
+- [ ] Target draft is not activated automatically.
+- [ ] Source and target active packs are unchanged.
+- [ ] UI excludes the current persona from duplicate targets.
+- [ ] UI communicates that duplicates are drafts for review.
+- [ ] Tests pass:
+  - `python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_manifest_assets.py tldw_Server_API/tests/Persona/test_persona_visual_service.py tldw_Server_API/tests/Persona/test_persona_visuals_api.py -q`
+  - `cd apps/tldw-frontend && bunx vitest run ../packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx`
+- [ ] Bandit run is recorded or blocker documented.
+- [ ] `git diff --check` passes.

--- a/Docs/superpowers/plans/2026-05-09-persona-visual-duplicate-to-persona-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-09-persona-visual-duplicate-to-persona-implementation-plan.md
@@ -1459,7 +1459,7 @@ git commit -m "Add persona visual duplicate UI"
 - Modify: `Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md`
 - Modify: `backlog/tasks/task-193 - Write-persona-visual-pack-duplicate-implementation-plan.md` only if executing this plan later in the same branch
 
-- [ ] **Step 1: Update PRD Phase 3 status**
+- [x] **Step 1: Update PRD Phase 3 status**
 
 In `Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md`, update the Phase 3 list item:
 
@@ -1473,7 +1473,7 @@ If this implementation is not merged yet, phrase it as:
 1. Duplicate pack to another persona. First implementation target: same-user draft duplication (#1450).
 ```
 
-- [ ] **Step 2: Run backend focused tests**
+- [x] **Step 2: Run backend focused tests**
 
 Run:
 
@@ -1484,7 +1484,7 @@ python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_manifest_asse
 
 Expected: pass.
 
-- [ ] **Step 3: Run frontend focused tests**
+- [x] **Step 3: Run frontend focused tests**
 
 Run:
 
@@ -1495,7 +1495,7 @@ bunx vitest run ../packages/ui/src/components/PersonaGarden/__tests__/VisualPack
 
 Expected: pass.
 
-- [ ] **Step 4: Run Bandit on touched backend code**
+- [x] **Step 4: Run Bandit on touched backend code**
 
 Run:
 
@@ -1513,7 +1513,7 @@ python -m bandit -r \
 
 Expected: no new high or medium findings in touched code. If Bandit is not installed in the environment, document the blocker and do not claim it passed.
 
-- [ ] **Step 5: Run whitespace check**
+- [x] **Step 5: Run whitespace check**
 
 Run:
 
@@ -1523,7 +1523,7 @@ git diff --check
 
 Expected: no output.
 
-- [ ] **Step 6: Review changed files**
+- [x] **Step 6: Review changed files**
 
 Run:
 
@@ -1534,7 +1534,7 @@ git diff --stat
 
 Expected: only planned files changed.
 
-- [ ] **Step 7: Commit docs and verification notes**
+- [x] **Step 7: Commit docs and verification notes**
 
 ```bash
 git add Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md
@@ -1552,15 +1552,15 @@ git commit -m "Implement persona visual pack duplication"
 
 ## Final Acceptance Checklist
 
-- [ ] Backend duplicate service copies only manifest-referenced assets.
-- [ ] Public duplicate endpoint returns `PersonaVisualPackResponse`.
-- [ ] Same-persona duplicate is rejected.
-- [ ] Target draft is not activated automatically.
-- [ ] Source and target active packs are unchanged.
-- [ ] UI excludes the current persona from duplicate targets.
-- [ ] UI communicates that duplicates are drafts for review.
-- [ ] Tests pass:
+- [x] Backend duplicate service copies only manifest-referenced assets.
+- [x] Public duplicate endpoint returns `PersonaVisualPackResponse`.
+- [x] Same-persona duplicate is rejected.
+- [x] Target draft is not activated automatically.
+- [x] Source and target active packs are unchanged.
+- [x] UI excludes the current persona from duplicate targets.
+- [x] UI communicates that duplicates are drafts for review.
+- [x] Tests pass:
   - `python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_manifest_assets.py tldw_Server_API/tests/Persona/test_persona_visual_service.py tldw_Server_API/tests/Persona/test_persona_visuals_api.py -q`
   - `cd apps/tldw-frontend && bunx vitest run ../packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx`
-- [ ] Bandit run is recorded or blocker documented.
-- [ ] `git diff --check` passes.
+- [x] Bandit run is recorded or blocker documented.
+- [x] `git diff --check` passes.

--- a/Docs/superpowers/plans/2026-05-09-persona-visual-duplicate-to-persona-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-09-persona-visual-duplicate-to-persona-implementation-plan.md
@@ -445,7 +445,7 @@ git commit -m "Support persona visual duplicate lineage"
 - Modify: `tldw_Server_API/app/core/Persona/visual_service.py`
 - Test: `tldw_Server_API/tests/Persona/test_persona_visual_service.py`
 
-- [ ] **Step 1: Write failing service test for successful duplicate**
+- [x] **Step 1: Write failing service test for successful duplicate**
 
 Add to `tldw_Server_API/tests/Persona/test_persona_visual_service.py`:
 
@@ -553,7 +553,7 @@ def test_duplicate_pack_to_persona_copies_referenced_assets_and_remaps_manifest(
     assert remapped_animation["preview_asset_id"] in copied_ids
 ```
 
-- [ ] **Step 2: Write failing service tests for V1 guardrails**
+- [x] **Step 2: Write failing service tests for V1 guardrails**
 
 Add tests for same-persona, missing manifest asset row, and missing source file:
 
@@ -580,7 +580,7 @@ For checksum mismatch, mutate the stored source file bytes after upload and asse
 
 For partial failure cleanup, induce an exception after the first copied file is created, then assert copied files under the target pack storage directory were removed and no target pack was promoted to `draft` or `active`.
 
-- [ ] **Step 3: Run service duplicate tests and verify they fail**
+- [x] **Step 3: Run service duplicate tests and verify they fail**
 
 Run:
 
@@ -591,7 +591,7 @@ python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_service.py -q
 
 Expected: failures because `duplicate_pack_to_persona()` does not exist.
 
-- [ ] **Step 4: Add source asset path resolution helper**
+- [x] **Step 4: Add source asset path resolution helper**
 
 In `PersonaVisualService`, add a private helper based on the exporter pattern:
 
@@ -617,7 +617,7 @@ def _asset_storage_path(self, *, user_id: str, storage_key: str) -> Path:
 
 If using `Path(*Path(relative_key).parts)` proves awkward with normalized keys, import and reuse `_safe_relative_storage_path()` from the exporter only if it does not create an import cycle. Otherwise keep the helper local.
 
-- [ ] **Step 5: Add duplicate orchestration**
+- [x] **Step 5: Add duplicate orchestration**
 
 In `PersonaVisualService`, implement:
 
@@ -778,7 +778,7 @@ def duplicate_pack_to_persona(
 
 Adjust exact calls if `get_persona_profile()` uses a different signature; use the existing profile owner helper pattern from the endpoint if needed.
 
-- [ ] **Step 6: Convert manifest validation errors**
+- [x] **Step 6: Convert manifest validation errors**
 
 Wrap `validate_visual_manifest()` in the duplicate path:
 
@@ -793,7 +793,7 @@ except PersonaVisualManifestError as exc:
     ) from exc
 ```
 
-- [ ] **Step 7: Run service tests**
+- [x] **Step 7: Run service tests**
 
 Run:
 
@@ -804,7 +804,7 @@ python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_service.py -q
 
 Expected: pass.
 
-- [ ] **Step 8: Commit service duplicate behavior**
+- [x] **Step 8: Commit service duplicate behavior**
 
 ```bash
 git add tldw_Server_API/app/core/Persona/visual_service.py \

--- a/Docs/superpowers/plans/2026-05-09-persona-visual-duplicate-to-persona-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-09-persona-visual-duplicate-to-persona-implementation-plan.md
@@ -87,7 +87,7 @@ Docs:
 - Modify: `tldw_Server_API/app/core/Persona/visual_portability/importer.py`
 - Test: `tldw_Server_API/tests/Persona/test_persona_visual_manifest_assets.py`
 
-- [ ] **Step 1: Write failing tests for asset collection and remapping**
+- [x] **Step 1: Write failing tests for asset collection and remapping**
 
 Create `tldw_Server_API/tests/Persona/test_persona_visual_manifest_assets.py`:
 
@@ -151,7 +151,7 @@ def test_remap_visual_manifest_assets_returns_copy_with_supported_references_rem
     assert animation["preview_asset_id"] == "target-b"
 ```
 
-- [ ] **Step 2: Run the new tests and verify they fail**
+- [x] **Step 2: Run the new tests and verify they fail**
 
 Run:
 
@@ -162,7 +162,7 @@ python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_manifest_asse
 
 Expected: import failure because `visual_manifest_assets.py` does not exist.
 
-- [ ] **Step 3: Implement the shared helper**
+- [x] **Step 3: Implement the shared helper**
 
 Create `tldw_Server_API/app/core/Persona/visual_manifest_assets.py`:
 
@@ -231,7 +231,7 @@ def remap_visual_manifest_assets(
     return remapped
 ```
 
-- [ ] **Step 4: Update importer to use the shared helper**
+- [x] **Step 4: Update importer to use the shared helper**
 
 In `tldw_Server_API/app/core/Persona/visual_portability/importer.py`:
 
@@ -255,7 +255,7 @@ remapped_manifest = remap_visual_manifest_assets(visual_manifest, id_maps["asset
 
 Then remove the private `_remap_visual_manifest_assets()` function and the now-unused `deepcopy` import from `importer.py`.
 
-- [ ] **Step 5: Run helper and import regression tests**
+- [x] **Step 5: Run helper and import regression tests**
 
 Run:
 
@@ -266,7 +266,7 @@ python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_manifest_asse
 
 Expected: helper tests pass and existing import/export API tests still pass.
 
-- [ ] **Step 6: Commit helper extraction**
+- [x] **Step 6: Commit helper extraction**
 
 ```bash
 git add tldw_Server_API/app/core/Persona/visual_manifest_assets.py \

--- a/Docs/superpowers/plans/2026-05-09-persona-visual-duplicate-to-persona-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-09-persona-visual-duplicate-to-persona-implementation-plan.md
@@ -998,7 +998,7 @@ git commit -m "Expose persona visual pack duplication API"
 - Modify: `apps/packages/ui/src/services/persona-visuals.ts`
 - Test indirectly in: `apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx`
 
-- [ ] **Step 1: Add frontend types**
+- [x] **Step 1: Add frontend types**
 
 In `apps/packages/ui/src/types/persona-visuals.ts`:
 
@@ -1014,7 +1014,7 @@ export interface PersonaVisualDuplicateTarget {
 }
 ```
 
-- [ ] **Step 2: Add API helper imports**
+- [x] **Step 2: Add API helper imports**
 
 In `apps/packages/ui/src/services/persona-visuals.ts`, import the new types:
 
@@ -1023,7 +1023,7 @@ In `apps/packages/ui/src/services/persona-visuals.ts`, import the new types:
   PersonaVisualPackDuplicateRequest,
 ```
 
-- [ ] **Step 3: Add duplicate API helper**
+- [x] **Step 3: Add duplicate API helper**
 
 In `persona-visuals.ts`:
 
@@ -1043,7 +1043,7 @@ export async function duplicatePersonaVisualPack(
 }
 ```
 
-- [ ] **Step 4: Add duplicate target listing helper**
+- [x] **Step 4: Add duplicate target listing helper**
 
 Use the same fetch wrapper so existing `fetchWithAuth` test mocks keep working:
 
@@ -1071,7 +1071,7 @@ export async function listPersonaVisualDuplicateTargets(): Promise<
 }
 ```
 
-- [ ] **Step 5: Run TypeScript-focused frontend test file after UI task**
+- [x] **Step 5: Run TypeScript-focused frontend test file after UI task**
 
 Defer execution until Task 6 adds UI consumers:
 
@@ -1091,7 +1091,7 @@ Expected after Task 6: pass.
 - Modify: `apps/packages/ui/src/routes/sidepanel-persona.tsx`
 - Test: `apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx`
 
-- [ ] **Step 1: Write failing UI test for duplicate flow**
+- [x] **Step 1: Write failing UI test for duplicate flow**
 
 In `VisualPackEditor.test.tsx`, add a test near import/export tests:
 
@@ -1190,7 +1190,7 @@ it("duplicates a visual pack to another persona as a draft", async () => {
 })
 ```
 
-- [ ] **Step 2: Run the UI test and verify it fails**
+- [x] **Step 2: Run the UI test and verify it fails**
 
 Run:
 
@@ -1201,7 +1201,7 @@ bunx vitest run ../packages/ui/src/components/PersonaGarden/__tests__/VisualPack
 
 Expected: type/test failure because duplicate UI does not exist.
 
-- [ ] **Step 3: Extend `VisualPackEditorProps`**
+- [x] **Step 3: Extend `VisualPackEditorProps`**
 
 In `VisualPackEditor.tsx`:
 
@@ -1216,7 +1216,7 @@ type VisualPackEditorProps = {
 
 Destructure `onOpenPersonaVisuals`.
 
-- [ ] **Step 4: Import duplicate helpers and icon**
+- [x] **Step 4: Import duplicate helpers and icon**
 
 Add `Copy` from `lucide-react`.
 
@@ -1233,7 +1233,7 @@ Add type import:
   PersonaVisualDuplicateTarget,
 ```
 
-- [ ] **Step 5: Add duplicate state**
+- [x] **Step 5: Add duplicate state**
 
 Near other import/export state:
 
@@ -1258,7 +1258,7 @@ const selectedDuplicateTarget = availableDuplicateTargets.find(
 ) ?? null
 ```
 
-- [ ] **Step 6: Load duplicate targets**
+- [x] **Step 6: Load duplicate targets**
 
 Add a callback/effect similar to `loadPacks()`:
 
@@ -1304,7 +1304,7 @@ React.useEffect(() => {
 }, [selectedPack?.id])
 ```
 
-- [ ] **Step 7: Add duplicate handler**
+- [x] **Step 7: Add duplicate handler**
 
 ```ts
 const handleDuplicatePack = async () => {
@@ -1342,7 +1342,7 @@ const handleDuplicatePack = async () => {
 }
 ```
 
-- [ ] **Step 8: Add duplicate card in the Portability section**
+- [x] **Step 8: Add duplicate card in the Portability section**
 
 Change the portability grid to allow three cards:
 
@@ -1416,7 +1416,7 @@ Add a new card before export or after import:
 </div>
 ```
 
-- [ ] **Step 9: Wire sidepanel persona switching**
+- [x] **Step 9: Wire sidepanel persona switching**
 
 In `apps/packages/ui/src/routes/sidepanel-persona.tsx`, pass:
 
@@ -1429,7 +1429,7 @@ onOpenPersonaVisuals={(personaId) => {
 
 to `LazyVisualPackEditor`.
 
-- [ ] **Step 10: Run UI tests**
+- [x] **Step 10: Run UI tests**
 
 Run:
 
@@ -1440,7 +1440,7 @@ bunx vitest run ../packages/ui/src/components/PersonaGarden/__tests__/VisualPack
 
 Expected: pass.
 
-- [ ] **Step 11: Commit frontend duplicate UI**
+- [x] **Step 11: Commit frontend duplicate UI**
 
 ```bash
 git add apps/packages/ui/src/types/persona-visuals.ts \

--- a/Docs/superpowers/plans/2026-05-09-persona-visual-duplicate-to-persona-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-09-persona-visual-duplicate-to-persona-implementation-plan.md
@@ -821,7 +821,7 @@ git commit -m "Add persona visual pack duplication service"
 - Modify: `tldw_Server_API/app/api/v1/endpoints/persona.py`
 - Test: `tldw_Server_API/tests/Persona/test_persona_visuals_api.py`
 
-- [ ] **Step 1: Write failing API tests**
+- [x] **Step 1: Write failing API tests**
 
 In `tldw_Server_API/tests/Persona/test_persona_visuals_api.py`, add:
 
@@ -873,7 +873,7 @@ def test_duplicate_visual_pack_rejects_same_persona_target(persona_db: Character
 
 Also test unauthorized target by creating a target persona under a different user DB/client and expecting `404` with `target_persona_not_found`.
 
-- [ ] **Step 2: Run API tests and verify they fail**
+- [x] **Step 2: Run API tests and verify they fail**
 
 Run:
 
@@ -884,7 +884,7 @@ python -m pytest tldw_Server_API/tests/Persona/test_persona_visuals_api.py -q
 
 Expected: duplicate endpoint returns 404 because route does not exist.
 
-- [ ] **Step 3: Add request schema**
+- [x] **Step 3: Add request schema**
 
 In `tldw_Server_API/app/api/v1/schemas/persona.py` near `PersonaVisualPackCreate`:
 
@@ -902,11 +902,11 @@ class PersonaVisualPackDuplicateRequest(BaseModel):
         return normalized
 ```
 
-- [ ] **Step 4: Import the schema in the endpoint**
+- [x] **Step 4: Import the schema in the endpoint**
 
 Add `PersonaVisualPackDuplicateRequest` to the existing imports from `tldw_Server_API.app.api.v1.schemas.persona`.
 
-- [ ] **Step 5: Extend service error mapping**
+- [x] **Step 5: Extend service error mapping**
 
 In `_persona_visual_service_error_to_http()`:
 
@@ -929,7 +929,7 @@ elif exc.code in {"source_asset_missing", "source_asset_checksum_mismatch"}:
 
 Leave `same_persona_target_unsupported` and `invalid_manifest` as `400`.
 
-- [ ] **Step 6: Add duplicate endpoint**
+- [x] **Step 6: Add duplicate endpoint**
 
 Place after `get_persona_visual_pack()` or before asset upload in `persona.py`:
 
@@ -969,7 +969,7 @@ async def duplicate_persona_visual_pack(
         raise _to_http_exception(exc, action="duplicate persona visual pack") from exc
 ```
 
-- [ ] **Step 7: Run API tests**
+- [x] **Step 7: Run API tests**
 
 Run:
 
@@ -980,7 +980,7 @@ python -m pytest tldw_Server_API/tests/Persona/test_persona_visuals_api.py -q
 
 Expected: pass.
 
-- [ ] **Step 8: Commit API contract**
+- [x] **Step 8: Commit API contract**
 
 ```bash
 git add tldw_Server_API/app/api/v1/schemas/persona.py \

--- a/Docs/superpowers/plans/2026-05-09-persona-visual-duplicate-to-persona-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-09-persona-visual-duplicate-to-persona-implementation-plan.md
@@ -284,7 +284,7 @@ git commit -m "Extract persona visual manifest asset helpers"
 - Modify: `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`
 - Test: `tldw_Server_API/tests/Persona/test_persona_visual_service.py`
 
-- [ ] **Step 1: Write service-level failing tests for cross-persona parent creation and status transition**
+- [x] **Step 1: Write service-level failing tests for cross-persona parent creation and status transition**
 
 Append focused expectations to the duplicate service tests in Task 3, or temporarily add this failing test to `tldw_Server_API/tests/Persona/test_persona_visual_service.py`:
 
@@ -320,7 +320,7 @@ def test_db_allows_explicit_cross_persona_parent_for_duplicate_path(db_instance:
     assert updated["status"] == "draft"
 ```
 
-- [ ] **Step 2: Run the focused test and verify it fails**
+- [x] **Step 2: Run the focused test and verify it fails**
 
 Run:
 
@@ -331,7 +331,7 @@ python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_service.py::t
 
 Expected: failure because `parent_persona_id` and `update_persona_visual_pack_status()` do not exist.
 
-- [ ] **Step 3: Extend pack creation with explicit parent persona**
+- [x] **Step 3: Extend pack creation with explicit parent persona**
 
 In `create_persona_visual_pack()` in `tldw_Server_API/app/core/DB_Management/chacha/persona_state_store.py`, add an optional keyword after `parent_pack_id`:
 
@@ -353,7 +353,7 @@ if parent_pack_id:
 
 Do not change existing callers; the default remains same-persona validation.
 
-- [ ] **Step 4: Add status-update helper**
+- [x] **Step 4: Add status-update helper**
 
 In `persona_state_store.py`, near `update_persona_visual_pack_manifest()`, add:
 
@@ -413,11 +413,11 @@ def update_persona_visual_pack_status(
     return self.get_persona_visual_pack(pack_id=pack_id, persona_id=persona_id, user_id=user_id)
 ```
 
-- [ ] **Step 5: Export the helper**
+- [x] **Step 5: Export the helper**
 
 In `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`, add `update_persona_visual_pack_status` to the persona visual method export list near `update_persona_visual_pack_manifest`.
 
-- [ ] **Step 6: Run the DB-focused test**
+- [x] **Step 6: Run the DB-focused test**
 
 Run:
 
@@ -428,7 +428,7 @@ python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_service.py::t
 
 Expected: pass.
 
-- [ ] **Step 7: Commit DB support**
+- [x] **Step 7: Commit DB support**
 
 ```bash
 git add tldw_Server_API/app/core/DB_Management/chacha/persona_state_store.py \

--- a/Docs/superpowers/specs/2026-05-09-persona-visual-duplicate-to-persona-design.md
+++ b/Docs/superpowers/specs/2026-05-09-persona-visual-duplicate-to-persona-design.md
@@ -48,6 +48,8 @@ turning the first duplicate action into a background import/export archive flow.
 - Do not build a general archive import/export replacement.
 - Do not copy generated candidates unless they are already accepted pack assets.
 - Do not support same-persona "make a draft copy" duplication in V1.
+- Do not add idempotency keys in V1; duplicate is a synchronous command and a
+  repeated submit creates another draft.
 
 ## Existing Context
 
@@ -99,7 +101,7 @@ The service should:
    `user_id`.
 2. Validate target persona ownership by `target_persona_id` and `user_id`.
 3. Create a target draft pack with a copied or user-provided title.
-4. Copy each source pack asset that participates as a pack asset into the target
+4. Copy each source asset referenced by the source manifest into the target
    storage path.
 5. Create target asset rows with new IDs and copied metadata.
 6. Build an old-asset-ID to new-asset-ID map.
@@ -157,24 +159,18 @@ Response:
 
 ```json
 {
-  "pack": {
-    "id": "new_pack_id",
-    "persona_id": "persona_target",
-    "status": "draft",
-    "parent_pack_id": "source_pack_id",
-    "assets": []
-  },
-  "source_pack_id": "source_pack_id",
-  "target_persona_id": "persona_target",
-  "asset_id_map": {
-    "old_asset_id": "new_asset_id"
-  }
+  "id": "new_pack_id",
+  "persona_id": "persona_target",
+  "status": "draft",
+  "parent_pack_id": "source_pack_id",
+  "assets": []
 }
 ```
 
-The response can omit `asset_id_map` if the existing API response style prefers
-not to expose implementation details. The service should still return or log the
-map internally for tests and diagnostics.
+Use the existing `PersonaVisualPackResponse` shape. Do not expose
+`asset_id_map` in the public response. The service may return the map internally
+for tests and diagnostics, but client code should rely on the returned pack and
+its remapped manifest/assets.
 
 The endpoint should require normal persona auth and use the current authenticated
 user. It must not accept a source or target user ID from the client.
@@ -205,11 +201,25 @@ same persona. The implementation should either:
 The implementation should not weaken the default pack-creation path. Ordinary
 pack creation should still avoid arbitrary parent references.
 
-## Asset Copying
+## Asset Selection and Copying
 
-The duplicate should physically copy bytes into the target pack's storage path.
-The implementation can do this by reading the source asset file, then passing
-the bytes back through `PersonaVisualService.create_asset_from_upload()` with:
+The duplicate should copy only source assets referenced by the source manifest.
+This prevents unaccepted generated candidates, stale uploads, and rejected review
+artifacts from leaking into the target pack. The duplicate service should collect
+source asset IDs from:
+
+- `animations.*.frames[].asset_id`
+- `animations.*.asset_ids[]`
+- `animations.*.preview_asset_id`
+
+If the source manifest references an asset ID that does not belong to the source
+pack, the duplicate should fail with `invalid_manifest` before creating target
+records.
+
+Referenced source assets should be physically copied into the target pack's
+storage path. The implementation can do this by reading the source asset file,
+then passing the bytes back through `PersonaVisualService.create_asset_from_upload()`
+with:
 
 - `persona_id`: target persona
 - `pack_id`: target pack
@@ -219,10 +229,12 @@ the bytes back through `PersonaVisualService.create_asset_from_upload()` with:
 - `provenance`: `mixed`
 
 This reuses upload image validation, checksum calculation, safe storage-target
-construction, and DB asset creation. If this is too strict for already-accepted
-legacy assets, the implementation may add a service-private copy helper that
-performs checksum and path validation without re-decoding unnecessarily, but it
-must keep the same storage safety properties.
+construction, and DB asset creation. The implementation should preflight source
+manifest validity, referenced asset membership, source asset file existence, and
+source asset checksums before creating target records. If using
+`create_asset_from_upload()` makes all-or-nothing cleanup difficult, add a
+service-private copy helper that preserves the same image validation and storage
+safety properties while keeping target metadata creation atomic.
 
 Source asset path resolution should follow the exporter pattern:
 
@@ -231,11 +243,11 @@ Source asset path resolution should follow the exporter pattern:
 - Reject paths that escape that base.
 - Treat missing files as a failed duplicate, not as a partial success.
 
-If any asset copy or manifest update fails after creating the target draft, the
-service should clean up created target asset files where practical and leave no
-active-pack changes. A failed draft pack should either be deleted/rolled back by
-the transaction boundary or marked `failed` only if the existing DB pattern makes
-full rollback impractical.
+If any asset copy or manifest update fails after target files are written, the
+service should remove created target asset files where practical and leave no
+active-pack changes. The preferred outcome is no visible target draft. If the
+existing DB layer makes full rollback impractical, the service must mark the
+target pack `failed` rather than leaving a partial `draft`.
 
 ## Manifest Remapping
 
@@ -293,6 +305,8 @@ Expected failures:
   `same_persona_target_unsupported`
 - source pack has no assets: allowed only if the manifest validates as a draft
   without assets; otherwise return a validation error
+- source manifest references unowned or missing asset rows: `400` with
+  `invalid_manifest`
 - source asset file missing: conflict or validation error with a stable code
   such as `source_asset_missing`
 - source asset checksum mismatch: conflict or validation error with a stable
@@ -311,8 +325,10 @@ Backend service tests should cover:
 - source and target asset checksums match
 - manifest references are remapped for `frames`, `asset_ids`, and
   `preview_asset_id`
+- unreferenced source assets and unaccepted generated candidates are not copied
 - source active pack and target active pack remain unchanged
 - same-persona duplicate is rejected with the stable V1 error code
+- missing source asset rows or files fail before a usable target draft appears
 - missing source file fails without activating anything
 - cross-user target/source access fails
 
@@ -349,10 +365,9 @@ Implementation docs should explicitly preserve the distinction between:
 
 ## Open Questions for Implementation Planning
 
-1. Should the duplicate response expose `asset_id_map`, or should that remain an
-   internal service/test detail?
-2. Should duplicate use a request idempotency key in V1, or is a normal
-   synchronous action acceptable for the first slice?
+No product-level open questions remain for the first implementation plan.
+Implementation planning may still choose the exact private helper boundaries for
+asset copy atomicity.
 
 ## Success Criteria
 

--- a/Docs/superpowers/specs/2026-05-09-persona-visual-duplicate-to-persona-design.md
+++ b/Docs/superpowers/specs/2026-05-09-persona-visual-duplicate-to-persona-design.md
@@ -1,0 +1,363 @@
+# Persona Visual Pack Duplicate-To-Persona Design
+
+Date: 2026-05-09
+Status: Approved by spec review; pending user review
+Owner: Codex brainstorming pass
+Backlog: TASK-192
+GitHub: #1449, #1450
+
+## Summary
+
+Add a focused Persona/Buddy visual-pack workflow that lets a user duplicate an
+existing Persona Visual pack from one of their personas to another of their
+personas as a draft.
+
+The duplicate is a real pack attached to the target persona. It owns its own
+asset rows and copied asset files, has a remapped manifest that references the
+new asset IDs, and is not activated automatically. The source pack, source
+persona, target persona active pack, and existing import/export behavior remain
+unchanged.
+
+This is Phase 3 library/reuse groundwork from the Persona Live Visual Packs
+PRD. It should reuse the existing Persona Visual portability model where useful,
+especially asset-byte copying and manifest asset-reference remapping, without
+turning the first duplicate action into a background import/export archive flow.
+
+## Goals
+
+- Let users reuse an existing Persona Visual pack on another same-user persona.
+- Preserve the one-persona-default attachment model by creating a distinct
+  target pack with distinct target asset records.
+- Copy asset bytes into the target persona/pack storage path so the duplicate
+  does not depend on source-pack storage cleanup behavior.
+- Remap all manifest asset references to the duplicated asset IDs.
+- Create the duplicate as `draft` and require normal review/activation.
+- Preserve same-user lineage from the duplicate back to the source pack.
+- Keep the workflow in Persona Garden/Visuals and Buddy/persona language.
+- Provide enough backend, frontend, error, and test coverage for a small
+  implementation PR.
+
+## Non-Goals
+
+- Do not support cross-user sharing.
+- Do not add a public marketplace or shared library browser.
+- Do not auto-activate the duplicated pack.
+- Do not add Live2D renderer support or change renderer contracts.
+- Do not add VN/CYOA asset-pack behavior or UI.
+- Do not expose external MCP-compatible visual providers.
+- Do not build a general archive import/export replacement.
+- Do not copy generated candidates unless they are already accepted pack assets.
+- Do not support same-persona "make a draft copy" duplication in V1.
+
+## Existing Context
+
+Current Persona Visual support already includes:
+
+- Persona-scoped visual packs and assets in the ChaChaNotes persona data layer.
+- `PersonaVisualService` for upload validation, file placement, candidate
+  review, activation, and active-pack validation.
+- API routes under
+  `/api/v1/persona/profiles/{persona_id}/visual-packs`.
+- Frontend services/types in `apps/packages/ui/src/services/persona-visuals.ts`
+  and `apps/packages/ui/src/types/persona-visuals.ts`.
+- A Persona Garden Visual Pack editor in
+  `apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx`.
+- Buddy shell rendering and diagnostics in
+  `apps/packages/ui/src/components/Common/PersonaBuddy/`.
+- Import/export Jobs for `.tldw-persona-vpack` archives, including an import
+  commit path that creates draft packs and remaps asset references.
+
+Important current details:
+
+- `persona_visual_packs.parent_pack_id` already exists.
+- Pack creation currently validates `parent_pack_id` as same persona and same
+  user.
+- Allowed visual provenance values are `uploaded`, `generated`, `imported`,
+  and `mixed`.
+- Existing import commit code copies asset bytes through
+  `PersonaVisualService.create_asset_from_upload()` and remaps manifest fields:
+  `frames[].asset_id`, `asset_ids[]`, and `preview_asset_id`.
+- Existing exporter resolves `persona_visuals/...` storage keys under
+  `DatabasePaths.get_user_persona_visuals_dir(user_id)` and guards path escape.
+
+## User-Confirmed Product Rules
+
+1. Duplicates should use the physical-copy model, not metadata-only shared
+   storage keys.
+2. Duplicates should preserve same-user cross-persona lineage where possible.
+3. The first implementation target is duplicate-to-persona as draft.
+4. This remains Persona/Buddy visual-pack work, not VN/CYOA runtime work.
+
+## Recommended Approach
+
+Implement a synchronous same-user duplicate operation in the Persona Visual
+service and expose it through one API route from the source pack.
+
+The service should:
+
+1. Validate source pack ownership by `source_persona_id`, `pack_id`, and
+   `user_id`.
+2. Validate target persona ownership by `target_persona_id` and `user_id`.
+3. Create a target draft pack with a copied or user-provided title.
+4. Copy each source pack asset that participates as a pack asset into the target
+   storage path.
+5. Create target asset rows with new IDs and copied metadata.
+6. Build an old-asset-ID to new-asset-ID map.
+7. Remap the source visual manifest through that map.
+8. Validate the remapped manifest with `require_activatable=False`.
+9. Save the remapped manifest on the target draft pack.
+10. Return the target draft pack with assets.
+
+This approach is recommended because it keeps the user model simple: a duplicated
+pack is now the target persona's pack and is independent from the source pack.
+It costs more disk space than shared storage keys, but avoids cleanup coupling,
+cross-persona storage paths, and surprising breakage if the source pack is later
+deleted or repaired.
+
+## Alternatives Considered
+
+### Shared Storage-Key Copy
+
+The service could create new target pack and asset rows while keeping the source
+asset `storage_key` values.
+
+This is smaller on disk, but it breaks the "attached to one persona by default"
+mental model. It also means the target persona's pack depends on files stored in
+the source persona/pack directory, which makes future deletion, repair, and
+export diagnostics harder.
+
+### Export/Import Loopback
+
+The UI could export a pack archive and immediately import it into another
+persona through existing Jobs.
+
+This reuses the portability stack most completely, but it is too heavy for an
+in-app duplicate action. It would introduce staging archives, asynchronous job
+state, and import-preview language for a workflow that should feel like copying
+a draft.
+
+## API Design
+
+Add a route under the source pack:
+
+```text
+POST /api/v1/persona/profiles/{source_persona_id}/visual-packs/{pack_id}/duplicate
+```
+
+Request body:
+
+```json
+{
+  "target_persona_id": "persona_target",
+  "title": "Optional copied title"
+}
+```
+
+Response:
+
+```json
+{
+  "pack": {
+    "id": "new_pack_id",
+    "persona_id": "persona_target",
+    "status": "draft",
+    "parent_pack_id": "source_pack_id",
+    "assets": []
+  },
+  "source_pack_id": "source_pack_id",
+  "target_persona_id": "persona_target",
+  "asset_id_map": {
+    "old_asset_id": "new_asset_id"
+  }
+}
+```
+
+The response can omit `asset_id_map` if the existing API response style prefers
+not to expose implementation details. The service should still return or log the
+map internally for tests and diagnostics.
+
+The endpoint should require normal persona auth and use the current authenticated
+user. It must not accept a source or target user ID from the client.
+
+## Persistence and Lineage
+
+The duplicate should create a new `persona_visual_packs` row:
+
+- `persona_id`: target persona
+- `user_id`: current user
+- `status`: `draft`
+- `renderer_type`: copied from source
+- `manifest_version`: copied from validated remapped manifest
+- `manifest_json`: remapped source manifest
+- `parent_pack_id`: source pack ID when same-user cross-persona parent lineage
+  is allowed
+- `revision_number`: `1`
+- `provenance`: `mixed`
+
+Current `create_persona_visual_pack()` validates `parent_pack_id` against the
+same persona. The implementation should either:
+
+1. add a narrow DB helper/path for duplicate creation that validates the parent
+   pack as same user while allowing a different persona, or
+2. extend parent validation with an explicit same-user cross-persona mode that is
+   only used by the duplicate service.
+
+The implementation should not weaken the default pack-creation path. Ordinary
+pack creation should still avoid arbitrary parent references.
+
+## Asset Copying
+
+The duplicate should physically copy bytes into the target pack's storage path.
+The implementation can do this by reading the source asset file, then passing
+the bytes back through `PersonaVisualService.create_asset_from_upload()` with:
+
+- `persona_id`: target persona
+- `pack_id`: target pack
+- `asset_role`: copied source role
+- `mime_type`: copied source MIME type
+- `original_filename`: copied source original filename
+- `provenance`: `mixed`
+
+This reuses upload image validation, checksum calculation, safe storage-target
+construction, and DB asset creation. If this is too strict for already-accepted
+legacy assets, the implementation may add a service-private copy helper that
+performs checksum and path validation without re-decoding unnecessarily, but it
+must keep the same storage safety properties.
+
+Source asset path resolution should follow the exporter pattern:
+
+- Strip the `persona_visuals/` prefix if present.
+- Resolve under `DatabasePaths.get_user_persona_visuals_dir(user_id)`.
+- Reject paths that escape that base.
+- Treat missing files as a failed duplicate, not as a partial success.
+
+If any asset copy or manifest update fails after creating the target draft, the
+service should clean up created target asset files where practical and leave no
+active-pack changes. A failed draft pack should either be deleted/rolled back by
+the transaction boundary or marked `failed` only if the existing DB pattern makes
+full rollback impractical.
+
+## Manifest Remapping
+
+The duplicate must remap every source asset ID referenced by the manifest to its
+new target asset ID. At minimum this includes the existing import-remap fields:
+
+- `animations.*.frames[].asset_id`
+- `animations.*.asset_ids[]`
+- `animations.*.preview_asset_id`
+
+The implementation should avoid duplicating this traversal logic. The current
+import helper `_remap_visual_manifest_assets()` can be promoted to a shared
+module under `tldw_Server_API/app/core/Persona/` or
+`visual_portability/` if that keeps dependencies clean.
+
+After remapping, validate the manifest with:
+
+- all target asset IDs as `available_asset_ids`
+- target asset dimensions as `available_asset_dimensions`
+- `require_activatable=False`
+
+The duplicate is a draft, so it may be incomplete, but it must not reference
+missing source asset IDs after remap.
+
+## Frontend Workflow
+
+Add a small duplicate affordance in the Visual Pack editor. The preferred shape
+is a command near existing export/import pack actions:
+
+- "Duplicate to persona"
+- target persona selector that excludes the source persona
+- optional title field defaulting to `Copy of {source title}`
+- confirmation copy that says the result is a draft and will not replace the
+  target persona's active pack
+
+On success:
+
+- show the target draft pack title/status
+- refresh pack data
+- if the editor can switch personas cleanly, move the user to the target persona
+  and select the new draft pack
+- otherwise provide a clear link/action to open the target persona's Visuals
+  editor
+
+The UI copy should avoid library/marketplace language in this slice. It should
+say this copies a pack to another of the user's personas for review.
+
+## Error Handling
+
+Expected failures:
+
+- source pack not found or not owned by user: `404`
+- target persona not found or not owned by user: `404`
+- target persona equals source persona: `400` with a stable code such as
+  `same_persona_target_unsupported`
+- source pack has no assets: allowed only if the manifest validates as a draft
+  without assets; otherwise return a validation error
+- source asset file missing: conflict or validation error with a stable code
+  such as `source_asset_missing`
+- source asset checksum mismatch: conflict or validation error with a stable
+  code such as `source_asset_checksum_mismatch`
+- remapped manifest invalid: `400` with `invalid_manifest`
+
+The operation must never archive or activate packs as part of failure handling.
+
+## Testing
+
+Backend service tests should cover:
+
+- duplicate creates a target draft pack for another same-user persona
+- target asset IDs differ from source asset IDs
+- target storage keys point at the target persona/pack path
+- source and target asset checksums match
+- manifest references are remapped for `frames`, `asset_ids`, and
+  `preview_asset_id`
+- source active pack and target active pack remain unchanged
+- same-persona duplicate is rejected with the stable V1 error code
+- missing source file fails without activating anything
+- cross-user target/source access fails
+
+API tests should cover:
+
+- successful duplicate response shape
+- `404` for missing source pack
+- `404` for missing or unauthorized target persona
+- error mapping for invalid source assets or manifests
+
+Frontend tests should cover:
+
+- duplicate action opens target selection
+- submit calls the duplicate service with source persona, source pack, and
+  target persona
+- source persona is not offered as a target
+- success state communicates draft/review status
+- active-pack copy does not say it replaces the target active pack
+
+No E2E browser flow is required for the first implementation unless the UI
+change materially alters navigation.
+
+## Documentation
+
+Update the Persona Live Visual Packs PRD or the relevant WebUI help copy to note
+that Phase 3 duplicate-to-persona is implemented once the code lands.
+
+Implementation docs should explicitly preserve the distinction between:
+
+- duplicate-to-persona: same-user local copy into a target draft
+- import/export: archive-based portability
+- shared library: future work
+- external providers: future MCP-compatible work
+
+## Open Questions for Implementation Planning
+
+1. Should the duplicate response expose `asset_id_map`, or should that remain an
+   internal service/test detail?
+2. Should duplicate use a request idempotency key in V1, or is a normal
+   synchronous action acceptable for the first slice?
+
+## Success Criteria
+
+- The spec can be converted into a small implementation plan without revisiting
+  the product model.
+- The implementation can be reviewed as one focused PR.
+- The duplicate workflow advances Persona/Buddy visual-pack reuse without
+  introducing shared-library or marketplace semantics early.

--- a/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
@@ -4,6 +4,7 @@ import {
   ArrowDown,
   ArrowUp,
   CheckCircle2,
+  Copy,
   Download,
   FileSearch,
   Plus,
@@ -21,11 +22,13 @@ import {
   createPersonaVisualPack,
   deactivatePersonaVisualPack,
   downloadPersonaVisualPackExportArchive,
+  duplicatePersonaVisualPack,
   getPersonaVisualGenerationReadiness,
   getPersonaVisualImportCommitStatus,
   getPersonaVisualImportPreview,
   getPersonaVisualPackExportJob,
   listPersonaVisualCandidates,
+  listPersonaVisualDuplicateTargets,
   listPersonaVisualPacks,
   PersonaVisualApiError,
   reviewPersonaVisualCandidate,
@@ -40,6 +43,7 @@ import type {
   PersonaVisualAssetRole,
   PersonaVisualAuthoredTrigger,
   PersonaVisualCandidate,
+  PersonaVisualDuplicateTarget,
   PersonaVisualImportCommitStartResponse,
   PersonaVisualFrame,
   PersonaVisualGenerationReadinessResponse,
@@ -66,6 +70,7 @@ type VisualPackEditorProps = {
   selectedPersonaId: string
   selectedPersonaName: string
   isActive?: boolean
+  onOpenPersonaVisuals?: (personaId: string) => void
 }
 
 type TriggerDraft = {
@@ -402,7 +407,8 @@ const replaceAnimation = (
 export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
   selectedPersonaId,
   selectedPersonaName,
-  isActive = false
+  isActive = false,
+  onOpenPersonaVisuals
 }) => {
   const { t } = useTranslation(["sidepanel", "common"])
   const loadingLabel = t("common:loading", getDesignSystemState("loading").label)
@@ -431,6 +437,14 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
   const [importCommitJob, setImportCommitJob] = React.useState<
     PersonaVisualImportCommitStartResponse | PersonaVisualPortabilityJobResponse | null
   >(null)
+  const [duplicateTargets, setDuplicateTargets] = React.useState<
+    PersonaVisualDuplicateTarget[]
+  >([])
+  const [duplicateTargetsLoading, setDuplicateTargetsLoading] = React.useState(false)
+  const [duplicateTargetId, setDuplicateTargetId] = React.useState("")
+  const [duplicateTitle, setDuplicateTitle] = React.useState("")
+  const [duplicatingPack, setDuplicatingPack] = React.useState(false)
+  const [lastDuplicatedPersonaId, setLastDuplicatedPersonaId] = React.useState("")
   const [previewingImport, setPreviewingImport] = React.useState(false)
   const [refreshingImportPreview, setRefreshingImportPreview] = React.useState(false)
   const [committingImport, setCommittingImport] = React.useState(false)
@@ -464,6 +478,12 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
 
   const selectedPack =
     packs.find((pack) => pack.id === selectedPackId) ?? packs[0] ?? null
+  const availableDuplicateTargets = React.useMemo(
+    () => duplicateTargets.filter((target) => target.id !== selectedPersonaId),
+    [duplicateTargets, selectedPersonaId]
+  )
+  const selectedDuplicateTarget =
+    availableDuplicateTargets.find((target) => target.id === duplicateTargetId) ?? null
   const assets = React.useMemo(() => getPackAssets(selectedPack), [selectedPack])
   const animationIds = React.useMemo(
     () => getAnimationIds(draftManifest),
@@ -605,6 +625,35 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
     }
   }, [isActive, selectedPersonaId, selectedPack?.id])
 
+  const loadDuplicateTargets = React.useCallback(async () => {
+    if (!isActive || !selectedPersonaId || !selectedPack) {
+      setDuplicateTargets([])
+      setDuplicateTargetId("")
+      return
+    }
+    setDuplicateTargetsLoading(true)
+    try {
+      const targets = await listPersonaVisualDuplicateTargets()
+      const available = targets.filter((target) => target.id !== selectedPersonaId)
+      setDuplicateTargets(targets)
+      setDuplicateTargetId((current) =>
+        current && available.some((target) => target.id === current)
+          ? current
+          : available[0]?.id ?? ""
+      )
+    } catch (loadError) {
+      setDuplicateTargets([])
+      setDuplicateTargetId("")
+      setError(
+        loadError instanceof Error
+          ? loadError.message
+          : "Failed to load persona duplicate targets."
+      )
+    } finally {
+      setDuplicateTargetsLoading(false)
+    }
+  }, [isActive, selectedPersonaId, selectedPack?.id])
+
   React.useEffect(() => {
     void loadPacks()
   }, [loadPacks])
@@ -616,6 +665,10 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
   React.useEffect(() => {
     void loadGenerationReadiness()
   }, [loadGenerationReadiness])
+
+  React.useEffect(() => {
+    void loadDuplicateTargets()
+  }, [loadDuplicateTargets])
 
   React.useEffect(() => {
     if (!selectedPack) {
@@ -645,8 +698,14 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
     setImportPreview(null)
     setImportCommitJob(null)
     setSelectedImportPreviewFile(null)
+    setLastDuplicatedPersonaId("")
     if (importPreviewInputRef.current) importPreviewInputRef.current.value = ""
   }, [selectedPersonaId, selectedPack?.id])
+
+  React.useEffect(() => {
+    setDuplicateTitle(selectedPack ? `Copy of ${selectedPack.title}` : "")
+    setLastDuplicatedPersonaId("")
+  }, [selectedPack?.id])
 
   const updateManifest = React.useCallback(
     (updater: (manifest: PersonaVisualManifest) => PersonaVisualManifest) => {
@@ -784,6 +843,42 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
       )
     } finally {
       setDownloadingExport(false)
+    }
+  }
+
+  const handleDuplicatePack = async () => {
+    if (!selectedPersonaId || !selectedPack || !duplicateTargetId) return
+    setDuplicatingPack(true)
+    setError(null)
+    try {
+      const duplicated = await duplicatePersonaVisualPack(
+        selectedPersonaId,
+        selectedPack.id,
+        {
+          target_persona_id: duplicateTargetId,
+          title: duplicateTitle.trim() || `Copy of ${selectedPack.title}`
+        }
+      )
+      setLastDuplicatedPersonaId(duplicated.persona_id)
+      const targetName =
+        selectedDuplicateTarget?.name ||
+        selectedDuplicateTarget?.id ||
+        duplicated.persona_id
+      setStatusMessage(
+        t("sidepanel:personaGarden.visuals.duplicatedDraft", {
+          defaultValue: `Duplicated as a draft for ${targetName}. Review and activate it from that persona's Visuals tab.`
+        })
+      )
+    } catch (duplicateError) {
+      setError(
+        duplicateError instanceof Error
+          ? duplicateError.message
+          : t("sidepanel:personaGarden.visuals.duplicateError", {
+              defaultValue: "Failed to duplicate visual pack."
+            })
+      )
+    } finally {
+      setDuplicatingPack(false)
     }
   }
 
@@ -1490,7 +1585,72 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
                 })}
               </div>
             </div>
-            <div className="mt-3 grid gap-3 lg:grid-cols-2">
+            <div className="mt-3 grid gap-3 xl:grid-cols-3">
+              <div className="rounded border border-border bg-bg p-2">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <Typography.Text strong>Duplicate to persona</Typography.Text>
+                  <Tag>creates draft</Tag>
+                </div>
+                <div className="mt-1 text-xs text-text-muted">
+                  Copy this pack to another persona. It stays a draft until reviewed and
+                  activated.
+                </div>
+                <div className="mt-2 grid gap-2">
+                  <label className="text-xs text-text-muted">
+                    <span className="mb-1 block">Target persona</span>
+                    <select
+                      data-testid="persona-visual-duplicate-target-select"
+                      className="w-full rounded border border-border bg-bg px-2 py-1 text-sm text-text"
+                      value={duplicateTargetId}
+                      disabled={
+                        duplicateTargetsLoading || !availableDuplicateTargets.length
+                      }
+                      onChange={(event) => setDuplicateTargetId(event.target.value)}
+                    >
+                      {availableDuplicateTargets.map((target) => (
+                        <option key={target.id} value={target.id}>
+                          {target.name || target.id}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <label className="text-xs text-text-muted">
+                    <span className="mb-1 block">Draft title</span>
+                    <input
+                      data-testid="persona-visual-duplicate-title-input"
+                      className="w-full rounded border border-border bg-bg px-2 py-1 text-sm text-text"
+                      value={duplicateTitle}
+                      onChange={(event) => setDuplicateTitle(event.target.value)}
+                    />
+                  </label>
+                  <Button
+                    data-testid="persona-visual-duplicate-button"
+                    size="small"
+                    icon={<Copy className="h-3.5 w-3.5" />}
+                    loading={duplicatingPack}
+                    disabled={!duplicateTargetId || !selectedPack}
+                    onClick={() => void handleDuplicatePack()}
+                  >
+                    Duplicate as draft
+                  </Button>
+                  {lastDuplicatedPersonaId && onOpenPersonaVisuals ? (
+                    <Button
+                      data-testid="persona-visual-duplicate-open-target"
+                      size="small"
+                      type="link"
+                      onClick={() => onOpenPersonaVisuals(lastDuplicatedPersonaId)}
+                    >
+                      Open target Visuals
+                    </Button>
+                  ) : null}
+                </div>
+                {!availableDuplicateTargets.length ? (
+                  <div className="mt-2 text-xs text-text-muted">
+                    Add another persona before duplicating this pack.
+                  </div>
+                ) : null}
+              </div>
+
               <div className="rounded border border-border bg-bg p-2">
                 <div className="flex flex-wrap items-center justify-between gap-2">
                   <Typography.Text strong>Export archive</Typography.Text>

--- a/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
@@ -475,6 +475,7 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
   const fileInputRef = React.useRef<HTMLInputElement | null>(null)
   const importPreviewInputRef = React.useRef<HTMLInputElement | null>(null)
   const generationReadinessRequestIdRef = React.useRef(0)
+  const duplicateTargetsRequestIdRef = React.useRef(0)
 
   const selectedPack =
     packs.find((pack) => pack.id === selectedPackId) ?? packs[0] ?? null
@@ -627,30 +628,36 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
 
   const loadDuplicateTargets = React.useCallback(async () => {
     if (!isActive || !selectedPersonaId || !selectedPack) {
+      duplicateTargetsRequestIdRef.current += 1
       setDuplicateTargets([])
       setDuplicateTargetId("")
+      setDuplicateTargetsLoading(false)
       return
     }
+    const requestId = duplicateTargetsRequestIdRef.current + 1
+    duplicateTargetsRequestIdRef.current = requestId
+    const isLatestRequest = () => duplicateTargetsRequestIdRef.current === requestId
+    setDuplicateTargets([])
+    setDuplicateTargetId("")
     setDuplicateTargetsLoading(true)
     try {
       const targets = await listPersonaVisualDuplicateTargets()
+      if (!isLatestRequest()) return
       const available = targets.filter((target) => target.id !== selectedPersonaId)
       setDuplicateTargets(targets)
-      setDuplicateTargetId((current) =>
-        current && available.some((target) => target.id === current)
-          ? current
-          : available[0]?.id ?? ""
-      )
+      setDuplicateTargetId(available[0]?.id ?? "")
     } catch (loadError) {
-      setDuplicateTargets([])
-      setDuplicateTargetId("")
-      setError(
-        loadError instanceof Error
-          ? loadError.message
-          : "Failed to load persona duplicate targets."
-      )
+      if (isLatestRequest()) {
+        setDuplicateTargets([])
+        setDuplicateTargetId("")
+        setError(
+          loadError instanceof Error
+            ? loadError.message
+            : "Failed to load persona duplicate targets."
+        )
+      }
     } finally {
-      setDuplicateTargetsLoading(false)
+      if (isLatestRequest()) setDuplicateTargetsLoading(false)
     }
   }, [isActive, selectedPersonaId, selectedPack?.id])
 

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
@@ -1035,6 +1035,114 @@ describe("VisualPackEditor", () => {
     )
   })
 
+  it("duplicates a visual pack to another persona as a draft", async () => {
+    const sourcePack = {
+      id: "pack-1",
+      persona_id: "persona-1",
+      title: "Animated pack",
+      renderer_type: "sprite_frames",
+      status: "active",
+      manifest: structuredClone(baseManifest),
+      assets: visualAssets,
+      version: 3
+    }
+    const duplicatedPack = {
+      ...sourcePack,
+      id: "pack-duplicate",
+      persona_id: "persona-2",
+      title: "Research Buddy copy",
+      status: "draft",
+      parent_pack_id: "pack-1",
+      assets: [
+        {
+          ...visualAssets[0],
+          id: "asset-copy",
+          pack_id: "pack-duplicate",
+          persona_id: "persona-2"
+        }
+      ]
+    }
+    const openTarget = vi.fn()
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string; body?: any }) => {
+      const method = init?.method || "GET"
+      if (path === "/api/v1/persona/profiles/persona-1/visual-packs" && method === "GET") {
+        return okResponse([sourcePack])
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/pack-1/generated-candidates" &&
+        method === "GET"
+      ) {
+        return okResponse({ candidates: [] })
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/pack-1/generation-readiness" &&
+        method === "GET"
+      ) {
+        return okResponse(readyGenerationReadiness)
+      }
+      if (path === "/api/v1/persona/catalog" && method === "GET") {
+        return okResponse([
+          { id: "persona-1", name: "Source Persona" },
+          { id: "persona-2", name: "Research Buddy" }
+        ])
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/pack-1/duplicate" &&
+        method === "POST"
+      ) {
+        expect(parseJsonBody(init?.body)).toEqual({
+          target_persona_id: "persona-2",
+          title: "Research Buddy copy"
+        })
+        return okResponse(duplicatedPack)
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        error: `Unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(
+      <VisualPackEditor
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Source Persona"
+        isActive
+        onOpenPersonaVisuals={openTarget}
+      />
+    )
+
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-pack-status")).toHaveTextContent(
+        "active"
+      )
+    )
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-duplicate-target-select")).toHaveTextContent(
+        "Research Buddy"
+      )
+    )
+    expect(screen.getByTestId("persona-visual-duplicate-target-select")).not.toHaveTextContent(
+      "Source Persona"
+    )
+
+    fireEvent.change(screen.getByTestId("persona-visual-duplicate-title-input"), {
+      target: { value: "Research Buddy copy" }
+    })
+    fireEvent.change(screen.getByTestId("persona-visual-duplicate-target-select"), {
+      target: { value: "persona-2" }
+    })
+    fireEvent.click(screen.getByTestId("persona-visual-duplicate-button"))
+
+    await waitFor(() =>
+      expect(screen.getByText(/Duplicated as a draft for Research Buddy/)).toBeInTheDocument()
+    )
+    fireEvent.click(screen.getByTestId("persona-visual-duplicate-open-target"))
+    expect(openTarget).toHaveBeenCalledWith("persona-2")
+  })
+
   it("queues, polls, and downloads visual pack exports through the authenticated client", async () => {
     const calls: string[] = []
     const pack = {

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
@@ -1035,6 +1035,133 @@ describe("VisualPackEditor", () => {
     )
   })
 
+  it("ignores stale duplicate target responses after switching personas", async () => {
+    const delayedPersonaOneTargets = deferredResponse<Awaited<ReturnType<typeof okResponse>>>()
+    const personaOnePack = {
+      id: "pack-1",
+      persona_id: "persona-1",
+      title: "Source pack",
+      renderer_type: "sprite_frames",
+      status: "draft",
+      manifest: structuredClone(baseManifest),
+      assets: visualAssets,
+      version: 3
+    }
+    const personaTwoPack = {
+      ...personaOnePack,
+      id: "pack-2",
+      persona_id: "persona-2",
+      title: "Target pack",
+      assets: visualAssets.map((asset) => ({
+        ...asset,
+        pack_id: "pack-2",
+        persona_id: "persona-2"
+      }))
+    }
+    let catalogCalls = 0
+    const calls: string[] = []
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string; body?: any }) => {
+      const method = init?.method || "GET"
+      calls.push(`${method} ${path}`)
+      if (path === "/api/v1/persona/profiles/persona-1/visual-packs" && method === "GET") {
+        return okResponse([personaOnePack])
+      }
+      if (path === "/api/v1/persona/profiles/persona-2/visual-packs" && method === "GET") {
+        return okResponse([personaTwoPack])
+      }
+      if (path.endsWith("/generated-candidates") && method === "GET") {
+        return okResponse({ candidates: [] })
+      }
+      if (path.endsWith("/generation-readiness") && method === "GET") {
+        return okResponse(readyGenerationReadiness)
+      }
+      if (path === "/api/v1/persona/catalog" && method === "GET") {
+        catalogCalls += 1
+        if (catalogCalls === 1) return delayedPersonaOneTargets.promise
+        return okResponse([
+          { id: "persona-1", name: "Source Persona" },
+          { id: "persona-2", name: "Target Persona" }
+        ])
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-2/visual-packs/pack-2/duplicate" &&
+        method === "POST"
+      ) {
+        expect(parseJsonBody(init?.body)).toEqual({
+          target_persona_id: "persona-1",
+          title: "Copy of Target pack"
+        })
+        return okResponse({
+          ...personaTwoPack,
+          id: "pack-copy",
+          persona_id: "persona-1",
+          status: "draft",
+          parent_pack_id: "pack-2"
+        })
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        error: `Unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    const { rerender } = render(
+      <VisualPackEditor
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Source Persona"
+        isActive
+      />
+    )
+
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-pack-select")).toHaveValue("pack-1")
+    )
+    await waitFor(() => expect(catalogCalls).toBe(1))
+
+    rerender(
+      <VisualPackEditor
+        selectedPersonaId="persona-2"
+        selectedPersonaName="Target Persona"
+        isActive
+      />
+    )
+
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-pack-select")).toHaveValue("pack-2")
+    )
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-duplicate-target-select")).toHaveValue(
+        "persona-1"
+      )
+    )
+
+    await act(async () => {
+      delayedPersonaOneTargets.resolve(
+        await okResponse([
+          { id: "persona-1", name: "Source Persona" },
+          { id: "persona-2", name: "Target Persona" }
+        ])
+      )
+      await delayedPersonaOneTargets.promise
+    })
+
+    expect(screen.getByTestId("persona-visual-duplicate-target-select")).toHaveValue(
+      "persona-1"
+    )
+    expect(screen.getByTestId("persona-visual-duplicate-target-select")).not.toHaveTextContent(
+      "Target Persona"
+    )
+    fireEvent.click(screen.getByTestId("persona-visual-duplicate-button"))
+    await waitFor(() =>
+      expect(calls).toContain(
+        "POST /api/v1/persona/profiles/persona-2/visual-packs/pack-2/duplicate"
+      )
+    )
+  })
+
   it("duplicates a visual pack to another persona as a draft", async () => {
     const sourcePack = {
       id: "pack-1",

--- a/apps/packages/ui/src/routes/sidepanel-persona.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-persona.tsx
@@ -1855,6 +1855,10 @@ const SidepanelPersona = ({
           selectedPersonaId={selectedPersonaId}
           selectedPersonaName={selectedPersonaName}
           isActive={activeTab === "visuals"}
+          onOpenPersonaVisuals={(personaId) => {
+            setSelectedPersonaId(personaId)
+            setActiveTab("visuals")
+          }}
         />,
         {
           includeSetupHandoff: false

--- a/apps/packages/ui/src/services/persona-visuals.ts
+++ b/apps/packages/ui/src/services/persona-visuals.ts
@@ -7,6 +7,7 @@ import type {
   PersonaVisualCandidateListResponse,
   PersonaVisualCandidateReviewRequest,
   PersonaVisualDeactivateResponse,
+  PersonaVisualDuplicateTarget,
   PersonaVisualGenerationJobResponse,
   PersonaVisualGenerationRequest,
   PersonaVisualGenerationReadinessResponse,
@@ -17,6 +18,7 @@ import type {
   PersonaVisualManifestUpdate,
   PersonaVisualPack,
   PersonaVisualPackCreate,
+  PersonaVisualPackDuplicateRequest,
   PersonaVisualPackExportRequest,
   PersonaVisualPackExportResponse,
   PersonaVisualPackListResponse,
@@ -144,6 +146,42 @@ export async function createPersonaVisualPack(
       body: payload
     }
   )
+}
+
+export async function duplicatePersonaVisualPack(
+  sourcePersonaId: string,
+  packId: string,
+  payload: PersonaVisualPackDuplicateRequest
+): Promise<PersonaVisualPack> {
+  return fetchPersonaVisualJson<PersonaVisualPack>(
+    packPath(sourcePersonaId, packId, "/duplicate"),
+    {
+      method: "POST",
+      body: payload
+    }
+  )
+}
+
+export async function listPersonaVisualDuplicateTargets(): Promise<
+  PersonaVisualDuplicateTarget[]
+> {
+  const payload = await fetchPersonaVisualJson<unknown>("/api/v1/persona/catalog")
+  if (!Array.isArray(payload)) return []
+  return payload
+    .map((item) => {
+      if (!item || typeof item !== "object") return null
+      const candidate = item as { id?: unknown; name?: unknown }
+      const id = String(candidate.id || "").trim()
+      if (!id) return null
+      return {
+        id,
+        name:
+          typeof candidate.name === "string" && candidate.name.trim()
+            ? candidate.name
+            : null
+      }
+    })
+    .filter((item): item is PersonaVisualDuplicateTarget => item !== null)
 }
 
 export async function updatePersonaVisualManifest(

--- a/apps/packages/ui/src/types/persona-visuals.ts
+++ b/apps/packages/ui/src/types/persona-visuals.ts
@@ -126,6 +126,16 @@ export interface PersonaVisualPackCreate {
   manifest?: Partial<PersonaVisualManifest> | Record<string, unknown>
 }
 
+export interface PersonaVisualPackDuplicateRequest {
+  target_persona_id: string
+  title?: string | null
+}
+
+export interface PersonaVisualDuplicateTarget {
+  id: string
+  name?: string | null
+}
+
 export interface PersonaVisualManifestUpdate {
   manifest: PersonaVisualManifest | Record<string, unknown>
   expected_version?: number | null

--- a/backlog/tasks/task-192 - Design-persona-visual-pack-duplicate-to-persona-workflow.md
+++ b/backlog/tasks/task-192 - Design-persona-visual-pack-duplicate-to-persona-workflow.md
@@ -1,0 +1,50 @@
+---
+id: TASK-192
+title: Design persona visual pack duplicate-to-persona workflow
+status: In Progress
+assignee: []
+created_date: '2026-05-09 21:18'
+updated_date: '2026-05-09 21:21'
+labels:
+  - persona
+  - buddy
+  - webui
+  - design
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1449'
+  - 'https://github.com/rmusser01/tldw_server/issues/1450'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create the design/spec for GitHub issue #1450: duplicate a Persona Visual pack from one persona to another same-user persona as a draft. The approved design direction is to physically copy asset bytes into the target persona/pack storage path, remap manifest asset references to newly created asset rows, leave source and active packs unchanged, and preserve same-user cross-persona lineage via parent_pack_id or an equivalent lineage field if implementation review finds parent_pack_id must remain same-persona only. This is Buddy/persona visual-pack work, not VN/CYOA runtime work.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Spec documents the same-user duplicate workflow and explicitly excludes cross-user sharing, marketplaces, VN/CYOA, Live2D renderer work, and auto-activation.
+- [x] #2 Spec covers backend API, service, persistence/lineage, manifest remapping, frontend workflow, error handling, and tests for a future implementation plan.
+- [x] #3 Spec aligns duplicate behavior with existing Persona Visual import/export asset-copy and manifest-remap patterns introduced for visual-pack portability.
+- [x] #4 Spec is reviewed before implementation planning begins.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Created draft spec at Docs/superpowers/specs/2026-05-09-persona-visual-duplicate-to-persona-design.md in worktree .worktrees/persona-visual-duplicate-spec on branch codex/persona-visual-duplicate-spec. Spec review subagent dispatched after whitespace check passed.
+
+Spec review iteration 1 found one blocking ambiguity: same-persona duplication was both allowed and left open. Resolved V1 to require a different target persona and reject same-persona duplicate with a stable error. Spec review iteration 2 approved. Verification: git diff --check passed. Bandit not run because this task only adds design/backlog markdown.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-192 - Design-persona-visual-pack-duplicate-to-persona-workflow.md
+++ b/backlog/tasks/task-192 - Design-persona-visual-pack-duplicate-to-persona-workflow.md
@@ -4,7 +4,7 @@ title: Design persona visual pack duplicate-to-persona workflow
 status: In Progress
 assignee: []
 created_date: '2026-05-09 21:18'
-updated_date: '2026-05-09 21:21'
+updated_date: '2026-05-09 21:26'
 labels:
   - persona
   - buddy
@@ -37,6 +37,8 @@ Create the design/spec for GitHub issue #1450: duplicate a Persona Visual pack f
 Created draft spec at Docs/superpowers/specs/2026-05-09-persona-visual-duplicate-to-persona-design.md in worktree .worktrees/persona-visual-duplicate-spec on branch codex/persona-visual-duplicate-spec. Spec review subagent dispatched after whitespace check passed.
 
 Spec review iteration 1 found one blocking ambiguity: same-persona duplication was both allowed and left open. Resolved V1 to require a different target persona and reject same-persona duplicate with a stable error. Spec review iteration 2 approved. Verification: git diff --check passed. Bandit not run because this task only adds design/backlog markdown.
+
+Design self-review before implementation planning found and patched three issues: public API response is now the existing PersonaVisualPackResponse with asset_id_map kept internal only; idempotency keys are explicitly out of V1; duplicate now copies only manifest-referenced assets so unaccepted generated candidates and stale uploads are not copied. Also tightened preflight/cleanup guidance for source asset membership, checksum, file existence, and partial target draft failures.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-193 - Write-persona-visual-pack-duplicate-implementation-plan.md
+++ b/backlog/tasks/task-193 - Write-persona-visual-pack-duplicate-implementation-plan.md
@@ -1,0 +1,61 @@
+---
+id: TASK-193
+title: Write persona visual pack duplicate implementation plan
+status: Done
+assignee: []
+created_date: '2026-05-09 21:30'
+updated_date: '2026-05-09 21:38'
+labels:
+  - persona
+  - buddy
+  - webui
+  - plan
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1449'
+  - 'https://github.com/rmusser01/tldw_server/issues/1450'
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-05-09-persona-visual-duplicate-to-persona-design.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Write an implementation plan for GitHub issue #1450: duplicate a Persona Visual pack from one same-user persona to a different same-user persona as a draft. The approved spec requires physical copying of manifest-referenced asset bytes into the target persona/pack storage path, remapping manifest asset IDs, preserving active packs, keeping the public response as PersonaVisualPackResponse, rejecting same-persona targets in V1, and keeping this Buddy/persona visual-pack work separate from VN/CYOA and shared-library work.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Plan decomposes backend DB/service/API, frontend UI/service/types, tests, and documentation into TDD-friendly steps.
+- [x] #2 Plan references exact files and commands needed for implementation and verification.
+- [x] #3 Plan preserves the tightened spec decisions: no public asset_id_map, no idempotency key, copy only manifest-referenced assets, reject same-persona target, and no auto-activation.
+- [x] #4 Plan is reviewed before implementation begins.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Created implementation plan at Docs/superpowers/plans/2026-05-09-persona-visual-duplicate-to-persona-implementation-plan.md. Self-review checked code paths for PersonaVisualService, persona_state_store, persona endpoint/schema, VisualPackEditor, sidepanel persona switching, and existing test commands. Patched the plan to make the proposed DB status helper reject active status so activation validation cannot be bypassed.
+
+Reviewed the plan against existing PersonaVisualService, persona_state_store, persona endpoint/schema, visual portability importer/exporter, VisualPackEditor, and sidepanel wiring. Patched the plan to normalize blank duplicate titles before DB creation, map missing/checksum-mismatched source assets to 409 conflict responses, and require failure-cleanup coverage so copied files are removed and no failed duplicate is exposed as a draft or active pack. Formal subagent review was not run in this turn.
+
+Verification: git diff --check passed for the plan and Backlog task updates. Bandit was not run because this task changed only Markdown planning/tracking files and no Python implementation code.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implementation plan written and reviewed for GitHub issue #1450. Plan covers backend helper extraction, DB lineage/status support, duplicate service orchestration, API contract, frontend service/types/UI, docs, focused tests, Bandit scope, and whitespace verification. Review patches tightened title normalization, source-state conflict mapping, and partial-failure cleanup expectations.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-194 - Implement-persona-visual-pack-duplicate-to-persona-workflow.md
+++ b/backlog/tasks/task-194 - Implement-persona-visual-pack-duplicate-to-persona-workflow.md
@@ -4,7 +4,7 @@ title: Implement persona visual pack duplicate-to-persona workflow
 status: In Progress
 assignee: []
 created_date: '2026-05-09 21:42'
-updated_date: '2026-05-09 22:13'
+updated_date: '2026-05-09 22:29'
 labels:
   - persona
   - buddy
@@ -52,6 +52,8 @@ Task 5/6 complete: added frontend duplicate request/target types, duplicate pack
 Task 7 verification complete: PRD Phase 3 now records same-user draft duplication as the first implementation target for #1450. Focused backend pytest => 45 passed, 5 warnings. Focused frontend Vitest => 16 passed. Bandit touched backend scope => zero findings, JSON at /tmp/bandit_persona_visual_duplicate.json. git diff --check passed. Changed-file review before docs commit showed only Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md remaining.
 
 Draft PR opened: https://github.com/rmusser01/tldw_server/pull/1467.
+
+PR review follow-up complete: normalized remap lookups to match collection, switched duplicate preflight to path plus streaming checksum instead of buffering all source bytes, soft-deleted failed duplicate packs and copied asset rows on partial failures, preserved source and target active packs in regression coverage, and guarded duplicate-target loading against stale responses. Verification: backend persona visual tests 46 passed, VisualPackEditor Vitest 17 passed, Bandit zero findings at /tmp/bandit_persona_visual_duplicate_review.json, git diff --check passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-194 - Implement-persona-visual-pack-duplicate-to-persona-workflow.md
+++ b/backlog/tasks/task-194 - Implement-persona-visual-pack-duplicate-to-persona-workflow.md
@@ -4,7 +4,7 @@ title: Implement persona visual pack duplicate-to-persona workflow
 status: In Progress
 assignee: []
 created_date: '2026-05-09 21:42'
-updated_date: '2026-05-09 21:44'
+updated_date: '2026-05-09 21:45'
 labels:
   - persona
   - buddy
@@ -39,6 +39,8 @@ Implement GitHub issue #1450: duplicate a Persona Visual pack from one same-user
 
 <!-- SECTION:NOTES:BEGIN -->
 Task 1 complete: added shared persona visual manifest asset collection/remapping helpers, migrated import commit remapping to the shared helper, and added focused helper tests. Red verification: missing visual_manifest_assets module produced ModuleNotFoundError; first pytest run also confirmed collection failure. Green verification: source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_manifest_assets.py tldw_Server_API/tests/Persona/test_persona_visuals_api.py -q => 28 passed, 5 warnings.
+
+Task 2 complete: added explicit parent_persona_id support for create_persona_visual_pack so same-user duplicate creation can validate a cross-persona parent pack, exported update_persona_visual_pack_status, and added a DB-focused regression for failed-to-draft duplicate lineage. Red verification: focused test failed with unexpected parent_persona_id keyword. Green verification: source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_service.py::test_db_allows_explicit_cross_persona_parent_for_duplicate_path -q => 1 passed, 5 warnings.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-194 - Implement-persona-visual-pack-duplicate-to-persona-workflow.md
+++ b/backlog/tasks/task-194 - Implement-persona-visual-pack-duplicate-to-persona-workflow.md
@@ -4,7 +4,7 @@ title: Implement persona visual pack duplicate-to-persona workflow
 status: In Progress
 assignee: []
 created_date: '2026-05-09 21:42'
-updated_date: '2026-05-09 21:48'
+updated_date: '2026-05-09 21:50'
 labels:
   - persona
   - buddy
@@ -43,6 +43,8 @@ Task 1 complete: added shared persona visual manifest asset collection/remapping
 Task 2 complete: added explicit parent_persona_id support for create_persona_visual_pack so same-user duplicate creation can validate a cross-persona parent pack, exported update_persona_visual_pack_status, and added a DB-focused regression for failed-to-draft duplicate lineage. Red verification: focused test failed with unexpected parent_persona_id keyword. Green verification: source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_service.py::test_db_allows_explicit_cross_persona_parent_for_duplicate_path -q => 1 passed, 5 warnings.
 
 Task 3 complete: implemented PersonaVisualService.duplicate_pack_to_persona with same-persona rejection, target persona ownership validation, manifest-referenced asset preflight, source file/checksum checks, physical asset copying through create_asset_from_upload, manifest remapping, failed-to-draft finalization, and copied-file cleanup on partial failures. Red verification: service tests failed because duplicate_pack_to_persona was missing. Green verification: source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_service.py -q => 14 passed, 5 warnings.
+
+Task 4 complete: added PersonaVisualPackDuplicateRequest, mapped target_persona_not_found to 404 and stale source asset states to 409, and exposed POST /profiles/{persona_id}/visual-packs/{pack_id}/duplicate returning PersonaVisualPackResponse. Red verification: API duplicate tests returned 404 Not Found before route wiring. Green verification: source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Persona/test_persona_visuals_api.py -q => 29 passed, 5 warnings.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-194 - Implement-persona-visual-pack-duplicate-to-persona-workflow.md
+++ b/backlog/tasks/task-194 - Implement-persona-visual-pack-duplicate-to-persona-workflow.md
@@ -4,7 +4,7 @@ title: Implement persona visual pack duplicate-to-persona workflow
 status: In Progress
 assignee: []
 created_date: '2026-05-09 21:42'
-updated_date: '2026-05-09 21:50'
+updated_date: '2026-05-09 22:07'
 labels:
   - persona
   - buddy
@@ -31,7 +31,7 @@ Implement GitHub issue #1450: duplicate a Persona Visual pack from one same-user
 <!-- AC:BEGIN -->
 - [ ] #1 Backend duplicate workflow copies only manifest-referenced assets and remaps the manifest.
 - [ ] #2 Public duplicate endpoint returns PersonaVisualPackResponse and enforces same-user different-persona scope.
-- [ ] #3 Frontend exposes duplicate-to-persona draft flow and excludes the current persona from targets.
+- [x] #3 Frontend exposes duplicate-to-persona draft flow and excludes the current persona from targets.
 - [ ] #4 Focused backend and frontend tests pass.
 <!-- AC:END -->
 
@@ -45,6 +45,8 @@ Task 2 complete: added explicit parent_persona_id support for create_persona_vis
 Task 3 complete: implemented PersonaVisualService.duplicate_pack_to_persona with same-persona rejection, target persona ownership validation, manifest-referenced asset preflight, source file/checksum checks, physical asset copying through create_asset_from_upload, manifest remapping, failed-to-draft finalization, and copied-file cleanup on partial failures. Red verification: service tests failed because duplicate_pack_to_persona was missing. Green verification: source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_service.py -q => 14 passed, 5 warnings.
 
 Task 4 complete: added PersonaVisualPackDuplicateRequest, mapped target_persona_not_found to 404 and stale source asset states to 409, and exposed POST /profiles/{persona_id}/visual-packs/{pack_id}/duplicate returning PersonaVisualPackResponse. Red verification: API duplicate tests returned 404 Not Found before route wiring. Green verification: source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Persona/test_persona_visuals_api.py -q => 29 passed, 5 warnings.
+
+Task 5/6 complete: added frontend duplicate request/target types, duplicate pack and target-list service helpers, VisualPackEditor duplicate-to-persona draft controls, and sidepanel target persona Visuals handoff. Red verification: focused Vitest failed because persona-visual-duplicate-target-select did not exist. Green verification: bunx vitest run ../packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx => 16 tests passed.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-194 - Implement-persona-visual-pack-duplicate-to-persona-workflow.md
+++ b/backlog/tasks/task-194 - Implement-persona-visual-pack-duplicate-to-persona-workflow.md
@@ -4,7 +4,7 @@ title: Implement persona visual pack duplicate-to-persona workflow
 status: In Progress
 assignee: []
 created_date: '2026-05-09 21:42'
-updated_date: '2026-05-09 22:07'
+updated_date: '2026-05-09 22:09'
 labels:
   - persona
   - buddy
@@ -29,10 +29,10 @@ Implement GitHub issue #1450: duplicate a Persona Visual pack from one same-user
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Backend duplicate workflow copies only manifest-referenced assets and remaps the manifest.
-- [ ] #2 Public duplicate endpoint returns PersonaVisualPackResponse and enforces same-user different-persona scope.
+- [x] #1 Backend duplicate workflow copies only manifest-referenced assets and remaps the manifest.
+- [x] #2 Public duplicate endpoint returns PersonaVisualPackResponse and enforces same-user different-persona scope.
 - [x] #3 Frontend exposes duplicate-to-persona draft flow and excludes the current persona from targets.
-- [ ] #4 Focused backend and frontend tests pass.
+- [x] #4 Focused backend and frontend tests pass.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -47,14 +47,22 @@ Task 3 complete: implemented PersonaVisualService.duplicate_pack_to_persona with
 Task 4 complete: added PersonaVisualPackDuplicateRequest, mapped target_persona_not_found to 404 and stale source asset states to 409, and exposed POST /profiles/{persona_id}/visual-packs/{pack_id}/duplicate returning PersonaVisualPackResponse. Red verification: API duplicate tests returned 404 Not Found before route wiring. Green verification: source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Persona/test_persona_visuals_api.py -q => 29 passed, 5 warnings.
 
 Task 5/6 complete: added frontend duplicate request/target types, duplicate pack and target-list service helpers, VisualPackEditor duplicate-to-persona draft controls, and sidepanel target persona Visuals handoff. Red verification: focused Vitest failed because persona-visual-duplicate-target-select did not exist. Green verification: bunx vitest run ../packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx => 16 tests passed.
+
+Task 7 verification complete: PRD Phase 3 now records same-user draft duplication as the first implementation target for #1450. Focused backend pytest => 45 passed, 5 warnings. Focused frontend Vitest => 16 passed. Bandit touched backend scope => zero findings, JSON at /tmp/bandit_persona_visual_duplicate.json. git diff --check passed. Changed-file review before docs commit showed only Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md remaining.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented same-user Persona Visual pack duplicate-to-persona as a draft workflow for #1450. Backend duplicates only manifest-referenced assets, remaps the manifest, rejects same-persona targets, validates same-user target scope, and keeps activation separate. API exposes POST /profiles/{persona_id}/visual-packs/{pack_id}/duplicate returning PersonaVisualPackResponse. Frontend adds duplicate-to-persona controls in the Visuals portability section, excludes the current persona from targets, and can switch directly to the target persona's Visuals tab after duplication. PRD and implementation plan were updated with verification results.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-194 - Implement-persona-visual-pack-duplicate-to-persona-workflow.md
+++ b/backlog/tasks/task-194 - Implement-persona-visual-pack-duplicate-to-persona-workflow.md
@@ -4,7 +4,7 @@ title: Implement persona visual pack duplicate-to-persona workflow
 status: In Progress
 assignee: []
 created_date: '2026-05-09 21:42'
-updated_date: '2026-05-09 22:09'
+updated_date: '2026-05-09 22:13'
 labels:
   - persona
   - buddy
@@ -13,6 +13,7 @@ dependencies: []
 references:
   - 'https://github.com/rmusser01/tldw_server/issues/1449'
   - 'https://github.com/rmusser01/tldw_server/issues/1450'
+  - 'https://github.com/rmusser01/tldw_server/pull/1467'
 documentation:
   - >-
     Docs/superpowers/specs/2026-05-09-persona-visual-duplicate-to-persona-design.md
@@ -49,6 +50,8 @@ Task 4 complete: added PersonaVisualPackDuplicateRequest, mapped target_persona_
 Task 5/6 complete: added frontend duplicate request/target types, duplicate pack and target-list service helpers, VisualPackEditor duplicate-to-persona draft controls, and sidepanel target persona Visuals handoff. Red verification: focused Vitest failed because persona-visual-duplicate-target-select did not exist. Green verification: bunx vitest run ../packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx => 16 tests passed.
 
 Task 7 verification complete: PRD Phase 3 now records same-user draft duplication as the first implementation target for #1450. Focused backend pytest => 45 passed, 5 warnings. Focused frontend Vitest => 16 passed. Bandit touched backend scope => zero findings, JSON at /tmp/bandit_persona_visual_duplicate.json. git diff --check passed. Changed-file review before docs commit showed only Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md remaining.
+
+Draft PR opened: https://github.com/rmusser01/tldw_server/pull/1467.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-194 - Implement-persona-visual-pack-duplicate-to-persona-workflow.md
+++ b/backlog/tasks/task-194 - Implement-persona-visual-pack-duplicate-to-persona-workflow.md
@@ -1,0 +1,52 @@
+---
+id: TASK-194
+title: Implement persona visual pack duplicate-to-persona workflow
+status: In Progress
+assignee: []
+created_date: '2026-05-09 21:42'
+updated_date: '2026-05-09 21:44'
+labels:
+  - persona
+  - buddy
+  - webui
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1449'
+  - 'https://github.com/rmusser01/tldw_server/issues/1450'
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-05-09-persona-visual-duplicate-to-persona-design.md
+  - >-
+    Docs/superpowers/plans/2026-05-09-persona-visual-duplicate-to-persona-implementation-plan.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement GitHub issue #1450: duplicate a Persona Visual pack from one same-user persona to a different same-user persona as a draft. Follow the approved plan and keep the work scoped to the Buddy/persona visual-pack system.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Backend duplicate workflow copies only manifest-referenced assets and remaps the manifest.
+- [ ] #2 Public duplicate endpoint returns PersonaVisualPackResponse and enforces same-user different-persona scope.
+- [ ] #3 Frontend exposes duplicate-to-persona draft flow and excludes the current persona from targets.
+- [ ] #4 Focused backend and frontend tests pass.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Task 1 complete: added shared persona visual manifest asset collection/remapping helpers, migrated import commit remapping to the shared helper, and added focused helper tests. Red verification: missing visual_manifest_assets module produced ModuleNotFoundError; first pytest run also confirmed collection failure. Green verification: source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_manifest_assets.py tldw_Server_API/tests/Persona/test_persona_visuals_api.py -q => 28 passed, 5 warnings.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-194 - Implement-persona-visual-pack-duplicate-to-persona-workflow.md
+++ b/backlog/tasks/task-194 - Implement-persona-visual-pack-duplicate-to-persona-workflow.md
@@ -4,7 +4,7 @@ title: Implement persona visual pack duplicate-to-persona workflow
 status: In Progress
 assignee: []
 created_date: '2026-05-09 21:42'
-updated_date: '2026-05-09 21:45'
+updated_date: '2026-05-09 21:48'
 labels:
   - persona
   - buddy
@@ -41,6 +41,8 @@ Implement GitHub issue #1450: duplicate a Persona Visual pack from one same-user
 Task 1 complete: added shared persona visual manifest asset collection/remapping helpers, migrated import commit remapping to the shared helper, and added focused helper tests. Red verification: missing visual_manifest_assets module produced ModuleNotFoundError; first pytest run also confirmed collection failure. Green verification: source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_manifest_assets.py tldw_Server_API/tests/Persona/test_persona_visuals_api.py -q => 28 passed, 5 warnings.
 
 Task 2 complete: added explicit parent_persona_id support for create_persona_visual_pack so same-user duplicate creation can validate a cross-persona parent pack, exported update_persona_visual_pack_status, and added a DB-focused regression for failed-to-draft duplicate lineage. Red verification: focused test failed with unexpected parent_persona_id keyword. Green verification: source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_service.py::test_db_allows_explicit_cross_persona_parent_for_duplicate_path -q => 1 passed, 5 warnings.
+
+Task 3 complete: implemented PersonaVisualService.duplicate_pack_to_persona with same-persona rejection, target persona ownership validation, manifest-referenced asset preflight, source file/checksum checks, physical asset copying through create_asset_from_upload, manifest remapping, failed-to-draft finalization, and copied-file cleanup on partial failures. Red verification: service tests failed because duplicate_pack_to_persona was missing. Green verification: source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_service.py -q => 14 passed, 5 warnings.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -94,6 +94,7 @@ from tldw_Server_API.app.api.v1.schemas.persona import (
     PersonaVisualPackExportRequest,
     PersonaVisualPackExportResponse,
     PersonaVisualPackCreate,
+    PersonaVisualPackDuplicateRequest,
     PersonaVisualPackResponse,
     PersonaVisualPortabilityJobResponse,
 )
@@ -2091,12 +2092,14 @@ def _persona_visual_generated_assets_for_candidate(
 
 def _persona_visual_service_error_to_http(exc: PersonaVisualServiceError) -> HTTPException:
     status_code = status.HTTP_400_BAD_REQUEST
-    if exc.code in {"pack_not_found", "asset_not_found", "candidate_not_found"}:
+    if exc.code in {"pack_not_found", "asset_not_found", "candidate_not_found", "target_persona_not_found"}:
         status_code = status.HTTP_404_NOT_FOUND
     elif exc.code in {"forbidden"}:
         status_code = status.HTTP_403_FORBIDDEN
     elif exc.code in {"upload_too_large"}:
         status_code = status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
+    elif exc.code in {"source_asset_missing", "source_asset_checksum_mismatch"}:
+        status_code = status.HTTP_409_CONFLICT
     return HTTPException(
         status_code=status_code,
         detail={"code": exc.code, "message": str(exc), "details": exc.details},
@@ -3785,6 +3788,41 @@ async def update_persona_visual_pack_manifest(
         raise
     except (InputError, ConflictError, CharactersRAGDBError) as exc:
         raise _to_http_exception(exc, action="update persona visual pack manifest") from exc
+
+
+@router.post(
+    "/profiles/{persona_id}/visual-packs/{pack_id}/duplicate",
+    response_model=PersonaVisualPackResponse,
+    tags=["persona"],
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(check_rate_limit)],
+)
+async def duplicate_persona_visual_pack(
+    persona_id: str,
+    pack_id: str,
+    payload: PersonaVisualPackDuplicateRequest,
+    _current_user: User = Depends(get_request_user),
+    visual_service: PersonaVisualService = Depends(get_persona_visual_service),
+) -> PersonaVisualPackResponse:
+    """Duplicate a persona visual pack to another same-user persona as a draft."""
+    if not is_persona_enabled():
+        raise HTTPException(status_code=404, detail="Persona disabled")
+    user_id = _require_current_user_id(_current_user)
+    try:
+        duplicated = await _run_persona_db_call(
+            visual_service.duplicate_pack_to_persona,
+            source_persona_id=persona_id,
+            user_id=user_id,
+            pack_id=pack_id,
+            target_persona_id=payload.target_persona_id,
+            title=payload.title,
+        )
+        assets = list(duplicated.get("assets") or [])
+        return _persona_visual_pack_to_response(duplicated, assets=assets)
+    except PersonaVisualServiceError as exc:
+        raise _persona_visual_service_error_to_http(exc) from exc
+    except (InputError, ConflictError, CharactersRAGDBError) as exc:
+        raise _to_http_exception(exc, action="duplicate persona visual pack") from exc
 
 
 @router.post(

--- a/tldw_Server_API/app/api/v1/schemas/persona.py
+++ b/tldw_Server_API/app/api/v1/schemas/persona.py
@@ -57,6 +57,27 @@ class PersonaVisualPackCreate(BaseModel):
     manifest: dict[str, Any] = Field(default_factory=dict)
 
 
+class PersonaVisualPackDuplicateRequest(BaseModel):
+    target_persona_id: str = Field(min_length=1, max_length=128)
+    title: str | None = Field(default=None, max_length=200)
+
+    @field_validator("target_persona_id")
+    @classmethod
+    def normalize_target_persona_id(cls, value: str) -> str:
+        normalized = str(value or "").strip()
+        if not normalized:
+            raise ValueError("target_persona_id is required")
+        return normalized
+
+    @field_validator("title")
+    @classmethod
+    def normalize_title(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = str(value).strip()
+        return normalized or None
+
+
 class PersonaVisualManifestUpdate(BaseModel):
     manifest: dict[str, Any] = Field(default_factory=dict)
     expected_version: int | None = Field(default=None, ge=1)

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -23793,6 +23793,7 @@ for _persona_state_store_method in (
     "deactivate_persona_visual_pack",
     "update_persona_visual_pack_manifest",
     "update_persona_visual_pack_status",
+    "soft_delete_persona_visual_pack_with_assets",
     "create_persona_visual_asset",
     "get_persona_visual_asset",
     "list_persona_visual_assets",

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -23792,6 +23792,7 @@ for _persona_state_store_method in (
     "activate_persona_visual_pack",
     "deactivate_persona_visual_pack",
     "update_persona_visual_pack_manifest",
+    "update_persona_visual_pack_status",
     "create_persona_visual_asset",
     "get_persona_visual_asset",
     "list_persona_visual_assets",

--- a/tldw_Server_API/app/core/DB_Management/chacha/persona_state_store.py
+++ b/tldw_Server_API/app/core/DB_Management/chacha/persona_state_store.py
@@ -2427,6 +2427,65 @@ class PersonaStateStore:
                 )
         return self.get_persona_visual_pack(pack_id=pack_id, persona_id=persona_id, user_id=user_id)
 
+    def soft_delete_persona_visual_pack_with_assets(
+        self,
+        *,
+        pack_id: str,
+        persona_id: str,
+        user_id: str,
+    ) -> bool:
+        """Soft-delete a persona visual pack and all of its asset rows."""
+        now = self._get_current_utc_timestamp_iso()
+        bool_cast = bool if self.backend_type == BackendType.POSTGRESQL else int
+        deleted_false = bool_cast(False)
+        deleted_true = bool_cast(True)
+        with self.transaction() as conn:
+            self._require_active_persona_profile_owner(conn, persona_id=persona_id, user_id=user_id)
+            self._require_persona_visual_pack_owner(
+                conn,
+                pack_id=pack_id,
+                persona_id=persona_id,
+                user_id=user_id,
+            )
+            asset_query = (
+                "UPDATE persona_visual_assets "
+                "SET deleted = ?, last_modified = ?, version = version + 1 "
+                "WHERE pack_id = ? AND user_id = ? AND persona_id = ? AND deleted = ?"
+            )
+            asset_params = (
+                deleted_true,
+                now,
+                pack_id,
+                user_id,
+                persona_id,
+                deleted_false,
+            )
+            prepared_asset_query, prepared_asset_params = self._prepare_backend_statement(
+                asset_query,
+                asset_params,
+            )
+            conn.execute(prepared_asset_query, prepared_asset_params or ())
+
+            pack_query = (
+                "UPDATE persona_visual_packs "
+                "SET deleted = ?, active_at = NULL, last_modified = ?, version = version + 1 "
+                "WHERE id = ? AND user_id = ? AND persona_id = ? AND deleted = ?"
+            )
+            pack_params = (
+                deleted_true,
+                now,
+                pack_id,
+                user_id,
+                persona_id,
+                deleted_false,
+            )
+            prepared_pack_query, prepared_pack_params = self._prepare_backend_statement(
+                pack_query,
+                pack_params,
+            )
+            cursor = conn.execute(prepared_pack_query, prepared_pack_params or ())
+            return cursor.rowcount > 0
+
     def create_persona_visual_asset(
         self,
         *,

--- a/tldw_Server_API/app/core/DB_Management/chacha/persona_state_store.py
+++ b/tldw_Server_API/app/core/DB_Management/chacha/persona_state_store.py
@@ -2002,6 +2002,7 @@ class PersonaStateStore:
         renderer_type: str = "sprite_frames",
         status: str = "draft",
         parent_pack_id: str | None = None,
+        parent_persona_id: str | None = None,
         revision_number: int = 1,
         provenance: str = "uploaded",
         pack_id: str | None = None,
@@ -2058,7 +2059,7 @@ class PersonaStateStore:
                 self._require_persona_visual_pack_owner(
                     conn,
                     pack_id=str(parent_pack_id),
-                    persona_id=persona_id,
+                    persona_id=str(parent_persona_id or persona_id),
                     user_id=user_id,
                 )
             if status_value == "active":
@@ -2352,6 +2353,60 @@ class PersonaStateStore:
         query = (
             "UPDATE persona_visual_packs "
             "SET manifest_json = ?, manifest_version = ?, last_modified = ?, version = version + 1 "
+            f"WHERE {where_sql}"  # nosec B608
+        )
+        with self.transaction() as conn:
+            self._require_active_persona_profile_owner(conn, persona_id=persona_id, user_id=user_id)
+            self._require_persona_visual_pack_owner(
+                conn,
+                pack_id=pack_id,
+                persona_id=persona_id,
+                user_id=user_id,
+            )
+            prepared_query, prepared_params = self._prepare_backend_statement(query, tuple(params))
+            cursor = conn.execute(prepared_query, prepared_params or ())
+            if cursor.rowcount == 0 and expected_version is not None:
+                raise ConflictError(  # noqa: TRY003
+                    "Persona visual pack version mismatch.",
+                    entity="persona_visual_packs",
+                    entity_id=pack_id,
+                )
+        return self.get_persona_visual_pack(pack_id=pack_id, persona_id=persona_id, user_id=user_id)
+
+    def update_persona_visual_pack_status(
+        self,
+        *,
+        pack_id: str,
+        persona_id: str,
+        user_id: str,
+        status: str,
+        expected_version: int | None = None,
+    ) -> dict[str, Any] | None:
+        status_value = self._normalize_persona_visual_enum(
+            status,
+            allowed=self._ALLOWED_PERSONA_VISUAL_PACK_STATUSES,
+            field_name="status",
+        )
+        if status_value == "active":
+            raise InputError("Use activate_persona_visual_pack for active status transitions.")  # noqa: TRY003
+        now = self._get_current_utc_timestamp_iso()
+        bool_cast = bool if self.backend_type == BackendType.POSTGRESQL else int
+        params: list[Any] = [
+            status_value,
+            None,
+            now,
+            pack_id,
+            user_id,
+            persona_id,
+            bool_cast(False),
+        ]
+        where_sql = "id = ? AND user_id = ? AND persona_id = ? AND deleted = ?"
+        if expected_version is not None:
+            where_sql += " AND version = ?"
+            params.append(int(expected_version))
+        query = (
+            "UPDATE persona_visual_packs "
+            "SET status = ?, active_at = ?, last_modified = ?, version = version + 1 "
             f"WHERE {where_sql}"  # nosec B608
         )
         with self.transaction() as conn:

--- a/tldw_Server_API/app/core/Persona/visual_manifest_assets.py
+++ b/tldw_Server_API/app/core/Persona/visual_manifest_assets.py
@@ -1,10 +1,21 @@
+"""Utilities for locating and rewriting Persona Visual manifest asset IDs."""
+
 from __future__ import annotations
 
 from copy import deepcopy
 from typing import Any
 
 
+def _remap_asset_id(asset_id: Any, asset_id_map: dict[str, str]) -> Any:
+    """Normalize an asset ID and substitute it when a duplicate mapping exists."""
+    normalized = str(asset_id or "").strip()
+    if normalized in asset_id_map:
+        return asset_id_map[normalized]
+    return normalized or asset_id
+
+
 def collect_visual_manifest_asset_ids(manifest: dict[str, Any]) -> set[str]:
+    """Return normalized asset IDs referenced by supported manifest fields."""
     asset_ids: set[str] = set()
     animations = manifest.get("animations")
     if not isinstance(animations, dict):
@@ -35,6 +46,7 @@ def remap_visual_manifest_assets(
     manifest: dict[str, Any],
     asset_id_map: dict[str, str],
 ) -> dict[str, Any]:
+    """Return a copy of a manifest with supported asset references remapped."""
     remapped = deepcopy(manifest)
     animations = remapped.get("animations")
     if not isinstance(animations, dict):
@@ -47,16 +59,18 @@ def remap_visual_manifest_assets(
             for frame in frames:
                 if not isinstance(frame, dict):
                     continue
-                asset_id = str(frame.get("asset_id") or "")
-                if asset_id in asset_id_map:
-                    frame["asset_id"] = asset_id_map[asset_id]
+                if "asset_id" not in frame:
+                    continue
+                frame["asset_id"] = _remap_asset_id(frame.get("asset_id"), asset_id_map)
         asset_ids = animation.get("asset_ids")
         if isinstance(asset_ids, list):
             animation["asset_ids"] = [
-                asset_id_map.get(str(asset_id), asset_id)
+                _remap_asset_id(asset_id, asset_id_map)
                 for asset_id in asset_ids
             ]
-        preview_asset_id = str(animation.get("preview_asset_id") or "")
-        if preview_asset_id in asset_id_map:
-            animation["preview_asset_id"] = asset_id_map[preview_asset_id]
+        if "preview_asset_id" in animation:
+            animation["preview_asset_id"] = _remap_asset_id(
+                animation.get("preview_asset_id"),
+                asset_id_map,
+            )
     return remapped

--- a/tldw_Server_API/app/core/Persona/visual_manifest_assets.py
+++ b/tldw_Server_API/app/core/Persona/visual_manifest_assets.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+
+def collect_visual_manifest_asset_ids(manifest: dict[str, Any]) -> set[str]:
+    asset_ids: set[str] = set()
+    animations = manifest.get("animations")
+    if not isinstance(animations, dict):
+        return asset_ids
+    for animation in animations.values():
+        if not isinstance(animation, dict):
+            continue
+        frames = animation.get("frames")
+        if isinstance(frames, list):
+            for frame in frames:
+                if isinstance(frame, dict):
+                    asset_id = str(frame.get("asset_id") or "").strip()
+                    if asset_id:
+                        asset_ids.add(asset_id)
+        listed_asset_ids = animation.get("asset_ids")
+        if isinstance(listed_asset_ids, list):
+            for asset_id in listed_asset_ids:
+                normalized = str(asset_id or "").strip()
+                if normalized:
+                    asset_ids.add(normalized)
+        preview_asset_id = str(animation.get("preview_asset_id") or "").strip()
+        if preview_asset_id:
+            asset_ids.add(preview_asset_id)
+    return asset_ids
+
+
+def remap_visual_manifest_assets(
+    manifest: dict[str, Any],
+    asset_id_map: dict[str, str],
+) -> dict[str, Any]:
+    remapped = deepcopy(manifest)
+    animations = remapped.get("animations")
+    if not isinstance(animations, dict):
+        return remapped
+    for animation in animations.values():
+        if not isinstance(animation, dict):
+            continue
+        frames = animation.get("frames")
+        if isinstance(frames, list):
+            for frame in frames:
+                if not isinstance(frame, dict):
+                    continue
+                asset_id = str(frame.get("asset_id") or "")
+                if asset_id in asset_id_map:
+                    frame["asset_id"] = asset_id_map[asset_id]
+        asset_ids = animation.get("asset_ids")
+        if isinstance(asset_ids, list):
+            animation["asset_ids"] = [
+                asset_id_map.get(str(asset_id), asset_id)
+                for asset_id in asset_ids
+            ]
+        preview_asset_id = str(animation.get("preview_asset_id") or "")
+        if preview_asset_id in asset_id_map:
+            animation["preview_asset_id"] = asset_id_map[preview_asset_id]
+    return remapped

--- a/tldw_Server_API/app/core/Persona/visual_portability/importer.py
+++ b/tldw_Server_API/app/core/Persona/visual_portability/importer.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import zipfile
-from copy import deepcopy
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -25,6 +24,7 @@ from tldw_Server_API.app.core.Persona.visual_portability.preview import (
     _section_list,
     _section_record,
 )
+from tldw_Server_API.app.core.Persona.visual_manifest_assets import remap_visual_manifest_assets
 from tldw_Server_API.app.core.Persona.visual_service import PersonaVisualService
 from tldw_Server_API.app.core.Persona.visuals import validate_visual_manifest
 
@@ -123,7 +123,7 @@ class PersonaVisualPackImporter:
                 imported_assets.append(imported)
 
         visual_manifest = pack.get("visual_manifest") if isinstance(pack.get("visual_manifest"), dict) else {}
-        remapped_manifest = _remap_visual_manifest_assets(visual_manifest, id_maps["assets"])
+        remapped_manifest = remap_visual_manifest_assets(visual_manifest, id_maps["assets"])
         asset_ids = {str(asset["id"]) for asset in imported_assets}
         asset_dimensions = {
             str(asset["id"]): (int(asset["width"]), int(asset["height"]))
@@ -175,38 +175,6 @@ class PersonaVisualPackImporter:
     def _progress(self, progress: Any | None, stage: str, payload: dict[str, Any]) -> None:
         if progress is not None:
             progress(stage, payload)
-
-
-def _remap_visual_manifest_assets(
-    manifest: dict[str, Any],
-    asset_id_map: dict[str, str],
-) -> dict[str, Any]:
-    remapped = deepcopy(manifest)
-    animations = remapped.get("animations")
-    if not isinstance(animations, dict):
-        return remapped
-    for animation in animations.values():
-        if not isinstance(animation, dict):
-            continue
-        frames = animation.get("frames")
-        if isinstance(frames, list):
-            for frame in frames:
-                if not isinstance(frame, dict):
-                    continue
-                asset_id = str(frame.get("asset_id") or "")
-                if asset_id in asset_id_map:
-                    frame["asset_id"] = asset_id_map[asset_id]
-        asset_ids = animation.get("asset_ids")
-        if isinstance(asset_ids, list):
-            animation["asset_ids"] = [
-                asset_id_map.get(str(asset_id), asset_id)
-                for asset_id in asset_ids
-            ]
-        preview_asset_id = str(animation.get("preview_asset_id") or "")
-        if preview_asset_id in asset_id_map:
-            animation["preview_asset_id"] = asset_id_map[preview_asset_id]
-    return remapped
-
 
 def _parse_datetime(value: Any) -> datetime | None:
     if not value:

--- a/tldw_Server_API/app/core/Persona/visual_service.py
+++ b/tldw_Server_API/app/core/Persona/visual_service.py
@@ -14,6 +14,10 @@ from tldw_Server_API.app.core.DB_Management.db_path_utils import (
     normalize_output_storage_filename,
 )
 from tldw_Server_API.app.core.exceptions import InvalidStoragePathError
+from tldw_Server_API.app.core.Persona.visual_manifest_assets import (
+    collect_visual_manifest_asset_ids,
+    remap_visual_manifest_assets,
+)
 from tldw_Server_API.app.core.Persona.visuals import (
     PersonaVisualManifestError,
     validate_visual_manifest,
@@ -222,6 +226,171 @@ class PersonaVisualService:
             persona_id=persona_id,
             user_id=user_id,
         )
+
+    def duplicate_pack_to_persona(
+        self,
+        *,
+        source_persona_id: str,
+        user_id: str,
+        pack_id: str,
+        target_persona_id: str,
+        title: str | None = None,
+    ) -> dict[str, Any]:
+        if str(source_persona_id) == str(target_persona_id):
+            raise PersonaVisualServiceError(
+                "same_persona_target_unsupported",
+                "Persona visual packs can only be duplicated to a different persona in V1.",
+            )
+
+        source_pack = self._db.get_persona_visual_pack(
+            pack_id=pack_id,
+            persona_id=source_persona_id,
+            user_id=user_id,
+        )
+        if not source_pack:
+            raise PersonaVisualServiceError(
+                "pack_not_found",
+                "Persona visual pack not found for user.",
+                details={"pack_id": pack_id},
+            )
+
+        target_persona = self._db.get_persona_profile(
+            target_persona_id,
+            user_id=user_id,
+        )
+        if not target_persona:
+            raise PersonaVisualServiceError(
+                "target_persona_not_found",
+                "Target persona not found for user.",
+                details={"target_persona_id": target_persona_id},
+            )
+
+        source_manifest = source_pack.get("manifest") if isinstance(source_pack.get("manifest"), dict) else {}
+        source_assets = self._db.list_persona_visual_assets(
+            pack_id=pack_id,
+            persona_id=source_persona_id,
+            user_id=user_id,
+        )
+        source_assets_by_id = {str(asset["id"]): asset for asset in source_assets}
+        referenced_asset_ids = collect_visual_manifest_asset_ids(source_manifest)
+        missing_asset_ids = sorted(referenced_asset_ids - set(source_assets_by_id))
+        if missing_asset_ids:
+            raise PersonaVisualServiceError(
+                "invalid_manifest",
+                "Persona visual manifest references assets that are not in the source pack.",
+                details={"asset_ids": missing_asset_ids},
+            )
+
+        preflight_assets: list[tuple[dict[str, Any], bytes]] = []
+        for asset_id in sorted(referenced_asset_ids):
+            asset = source_assets_by_id[asset_id]
+            source_path = self._asset_storage_path(
+                user_id=user_id,
+                storage_key=str(asset.get("storage_key") or ""),
+            )
+            if not source_path.is_file():
+                raise PersonaVisualServiceError(
+                    "source_asset_missing",
+                    "Persona visual source asset file is missing.",
+                    details={"asset_id": asset_id},
+                )
+            content = source_path.read_bytes()
+            checksum = hashlib.sha256(content).hexdigest()
+            if checksum != str(asset.get("checksum_sha256") or ""):
+                raise PersonaVisualServiceError(
+                    "source_asset_checksum_mismatch",
+                    "Persona visual source asset checksum does not match metadata.",
+                    details={"asset_id": asset_id},
+                )
+            preflight_assets.append((asset, content))
+
+        title_value = str(title or "").strip()
+        if not title_value:
+            title_value = f"Copy of {source_pack['title']}"
+        renderer_type = str(source_pack.get("renderer_type") or "sprite_frames")
+        target_pack = self._db.create_persona_visual_pack(
+            persona_id=target_persona_id,
+            user_id=user_id,
+            title=title_value,
+            renderer_type=renderer_type,
+            status="failed",
+            parent_pack_id=pack_id,
+            parent_persona_id=source_persona_id,
+            provenance="mixed",
+            manifest={
+                "manifest_version": 1,
+                "renderer_type": renderer_type,
+                "states": {},
+                "animations": {},
+            },
+        )
+        copied_file_paths: list[Path] = []
+        try:
+            asset_id_map: dict[str, str] = {}
+            copied_assets: list[dict[str, Any]] = []
+            for source_asset, content in preflight_assets:
+                copied = self.create_asset_from_upload(
+                    persona_id=target_persona_id,
+                    user_id=user_id,
+                    pack_id=str(target_pack["id"]),
+                    content=content,
+                    mime_type=str(source_asset.get("mime_type") or "application/octet-stream"),
+                    original_filename=source_asset.get("original_filename"),
+                    asset_role=str(source_asset.get("asset_role") or "frame"),
+                    provenance="mixed",
+                )
+                if copied.get("storage_path"):
+                    copied_file_paths.append(Path(str(copied["storage_path"])))
+                asset_id_map[str(source_asset["id"])] = str(copied["id"])
+                copied_assets.append(copied)
+
+            remapped_manifest = remap_visual_manifest_assets(source_manifest, asset_id_map)
+            asset_ids = {str(asset["id"]) for asset in copied_assets}
+            asset_dimensions = {
+                str(asset["id"]): (int(asset["width"]), int(asset["height"]))
+                for asset in copied_assets
+                if asset.get("width") is not None and asset.get("height") is not None
+            }
+            try:
+                validation = validate_visual_manifest(
+                    remapped_manifest,
+                    available_asset_ids=asset_ids,
+                    available_asset_dimensions=asset_dimensions,
+                    require_activatable=False,
+                )
+            except PersonaVisualManifestError as exc:
+                raise PersonaVisualServiceError(
+                    "invalid_manifest",
+                    str(exc),
+                    details={"pack_id": pack_id},
+                ) from exc
+            updated_pack = self._db.update_persona_visual_pack_manifest(
+                pack_id=str(target_pack["id"]),
+                persona_id=target_persona_id,
+                user_id=user_id,
+                manifest=validation.manifest,
+                expected_version=int(target_pack["version"]),
+            )
+            finalized = self._db.update_persona_visual_pack_status(
+                pack_id=str(target_pack["id"]),
+                persona_id=target_persona_id,
+                user_id=user_id,
+                status="draft",
+                expected_version=int(updated_pack["version"]),
+            )
+        except Exception:
+            for path in copied_file_paths:
+                path.unlink(missing_ok=True)
+            raise
+
+        assets = self._db.list_persona_visual_assets(
+            pack_id=str(target_pack["id"]),
+            persona_id=target_persona_id,
+            user_id=user_id,
+        )
+        finalized["assets"] = assets
+        finalized["assets_by_id"] = {str(asset["id"]): asset for asset in assets}
+        return finalized
 
     def list_candidates(
         self,
@@ -474,6 +643,24 @@ class PersonaVisualService:
             )
         storage_key = f"{VISUAL_STORAGE_PREFIX}/{safe_persona_id}/{safe_pack_id}/{safe_asset_name}"
         return storage_key, target_path
+
+    def _asset_storage_path(self, *, user_id: str, storage_key: str) -> Path:
+        prefix = f"{VISUAL_STORAGE_PREFIX}/"
+        relative_key = storage_key[len(prefix):] if storage_key.startswith(prefix) else storage_key
+        relative_path = Path(*Path(relative_key).parts)
+        if relative_path.is_absolute() or ".." in relative_path.parts:
+            raise PersonaVisualServiceError(
+                "invalid_storage_path",
+                "Persona visual storage path escapes the user visual directory.",
+            )
+        base = DatabasePaths.get_user_persona_visuals_dir(user_id).resolve(strict=False)
+        target_path = (base / relative_path).resolve(strict=False)
+        if not target_path.is_relative_to(base):
+            raise PersonaVisualServiceError(
+                "invalid_storage_path",
+                "Persona visual storage path escapes the user visual directory.",
+            )
+        return target_path
 
 
 __all__ = [

--- a/tldw_Server_API/app/core/Persona/visual_service.py
+++ b/tldw_Server_API/app/core/Persona/visual_service.py
@@ -7,6 +7,7 @@ from copy import deepcopy
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from loguru import logger
 from PIL import Image, UnidentifiedImageError
 
 from tldw_Server_API.app.core.DB_Management.db_path_utils import (
@@ -255,7 +256,7 @@ class PersonaVisualService:
             )
 
         target_persona = self._db.get_persona_profile(
-            target_persona_id,
+            persona_id=target_persona_id,
             user_id=user_id,
         )
         if not target_persona:
@@ -281,7 +282,7 @@ class PersonaVisualService:
                 details={"asset_ids": missing_asset_ids},
             )
 
-        preflight_assets: list[tuple[dict[str, Any], bytes]] = []
+        preflight_assets: list[tuple[dict[str, Any], Path]] = []
         for asset_id in sorted(referenced_asset_ids):
             asset = source_assets_by_id[asset_id]
             source_path = self._asset_storage_path(
@@ -294,15 +295,14 @@ class PersonaVisualService:
                     "Persona visual source asset file is missing.",
                     details={"asset_id": asset_id},
                 )
-            content = source_path.read_bytes()
-            checksum = hashlib.sha256(content).hexdigest()
+            checksum = self._sha256_file(source_path)
             if checksum != str(asset.get("checksum_sha256") or ""):
                 raise PersonaVisualServiceError(
                     "source_asset_checksum_mismatch",
                     "Persona visual source asset checksum does not match metadata.",
                     details={"asset_id": asset_id},
                 )
-            preflight_assets.append((asset, content))
+            preflight_assets.append((asset, source_path))
 
         title_value = str(title or "").strip()
         if not title_value:
@@ -328,12 +328,12 @@ class PersonaVisualService:
         try:
             asset_id_map: dict[str, str] = {}
             copied_assets: list[dict[str, Any]] = []
-            for source_asset, content in preflight_assets:
+            for source_asset, source_path in preflight_assets:
                 copied = self.create_asset_from_upload(
                     persona_id=target_persona_id,
                     user_id=user_id,
                     pack_id=str(target_pack["id"]),
-                    content=content,
+                    content=source_path.read_bytes(),
                     mime_type=str(source_asset.get("mime_type") or "application/octet-stream"),
                     original_filename=source_asset.get("original_filename"),
                     asset_role=str(source_asset.get("asset_role") or "frame"),
@@ -379,8 +379,27 @@ class PersonaVisualService:
                 expected_version=int(updated_pack["version"]),
             )
         except Exception:
+            try:
+                self._db.soft_delete_persona_visual_pack_with_assets(
+                    pack_id=str(target_pack["id"]),
+                    persona_id=target_persona_id,
+                    user_id=user_id,
+                )
+            except Exception as cleanup_error:  # pragma: no cover - defensive cleanup logging
+                logger.warning(
+                    "Failed to soft-delete partially duplicated persona visual pack {}: {}",
+                    target_pack.get("id"),
+                    cleanup_error,
+                )
             for path in copied_file_paths:
-                path.unlink(missing_ok=True)
+                try:
+                    path.unlink(missing_ok=True)
+                except OSError as cleanup_error:  # pragma: no cover - defensive cleanup logging
+                    logger.warning(
+                        "Failed to unlink partially duplicated persona visual asset {}: {}",
+                        path,
+                        cleanup_error,
+                    )
             raise
 
         assets = self._db.list_persona_visual_assets(
@@ -661,6 +680,15 @@ class PersonaVisualService:
                 "Persona visual storage path escapes the user visual directory.",
             )
         return target_path
+
+    @staticmethod
+    def _sha256_file(path: Path) -> str:
+        """Hash a source asset without keeping every duplicate asset in memory."""
+        digest = hashlib.sha256()
+        with path.open("rb") as file_obj:
+            for chunk in iter(lambda: file_obj.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
 
 
 __all__ = [

--- a/tldw_Server_API/tests/Persona/test_persona_visual_manifest_assets.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_manifest_assets.py
@@ -1,0 +1,57 @@
+from copy import deepcopy
+
+from tldw_Server_API.app.core.Persona.visual_manifest_assets import (
+    collect_visual_manifest_asset_ids,
+    remap_visual_manifest_assets,
+)
+
+
+def test_collect_visual_manifest_asset_ids_reads_all_supported_references() -> None:
+    manifest = {
+        "manifest_version": 1,
+        "renderer_type": "sprite_frames",
+        "states": {"idle": {"animation_id": "idle"}},
+        "animations": {
+            "idle": {
+                "frames": [{"asset_id": "asset-frame"}],
+                "asset_ids": ["asset-sheet"],
+                "preview_asset_id": "asset-preview",
+            }
+        },
+    }
+
+    assert collect_visual_manifest_asset_ids(manifest) == {
+        "asset-frame",
+        "asset-sheet",
+        "asset-preview",
+    }
+
+
+def test_remap_visual_manifest_assets_returns_copy_with_supported_references_remapped() -> None:
+    manifest = {
+        "manifest_version": 1,
+        "renderer_type": "sprite_frames",
+        "states": {"idle": {"animation_id": "idle"}},
+        "animations": {
+            "idle": {
+                "frames": [{"asset_id": "source-a"}, {"asset_id": "source-b"}],
+                "asset_ids": ["source-a", "source-c"],
+                "preview_asset_id": "source-b",
+            }
+        },
+    }
+    original = deepcopy(manifest)
+
+    remapped = remap_visual_manifest_assets(
+        manifest,
+        {"source-a": "target-a", "source-b": "target-b"},
+    )
+
+    assert manifest == original
+    animation = remapped["animations"]["idle"]
+    assert animation["frames"] == [
+        {"asset_id": "target-a"},
+        {"asset_id": "target-b"},
+    ]
+    assert animation["asset_ids"] == ["target-a", "source-c"]
+    assert animation["preview_asset_id"] == "target-b"

--- a/tldw_Server_API/tests/Persona/test_persona_visual_manifest_assets.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_manifest_assets.py
@@ -55,3 +55,27 @@ def test_remap_visual_manifest_assets_returns_copy_with_supported_references_rem
     ]
     assert animation["asset_ids"] == ["target-a", "source-c"]
     assert animation["preview_asset_id"] == "target-b"
+
+
+def test_remap_visual_manifest_assets_matches_collector_normalization() -> None:
+    manifest = {
+        "manifest_version": 1,
+        "renderer_type": "sprite_frames",
+        "states": {"idle": {"animation_id": "idle"}},
+        "animations": {
+            "idle": {
+                "frames": [{"asset_id": " source-a "}],
+                "asset_ids": [" source-a ", "source-b"],
+                "preview_asset_id": " source-a ",
+            }
+        },
+    }
+
+    assert collect_visual_manifest_asset_ids(manifest) == {"source-a", "source-b"}
+
+    remapped = remap_visual_manifest_assets(manifest, {"source-a": "target-a"})
+    animation = remapped["animations"]["idle"]
+
+    assert animation["frames"] == [{"asset_id": "target-a"}]
+    assert animation["asset_ids"] == ["target-a", "source-b"]
+    assert animation["preview_asset_id"] == "target-a"

--- a/tldw_Server_API/tests/Persona/test_persona_visual_service.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_service.py
@@ -188,6 +188,22 @@ def test_duplicate_pack_to_persona_copies_referenced_assets_and_remaps_manifest(
         manifest=_manifest_with_all_reference_shapes(asset_a["id"], asset_b["id"]),
         expected_version=source_pack["version"],
     )
+    db_instance.activate_persona_visual_pack(
+        persona_id=source_persona_id,
+        user_id=user_id,
+        pack_id=updated_source["id"],
+    )
+    target_active = db_instance.create_persona_visual_pack(
+        persona_id=target_persona_id,
+        user_id=user_id,
+        title="Existing Target Active",
+        status="draft",
+    )
+    db_instance.activate_persona_visual_pack(
+        persona_id=target_persona_id,
+        user_id=user_id,
+        pack_id=target_active["id"],
+    )
 
     duplicated = service.duplicate_pack_to_persona(
         source_persona_id=source_persona_id,
@@ -218,6 +234,14 @@ def test_duplicate_pack_to_persona_copies_referenced_assets_and_remaps_manifest(
     assert {frame["asset_id"] for frame in remapped_animation["frames"]} == copied_ids
     assert set(remapped_animation["asset_ids"]).issubset(copied_ids)
     assert remapped_animation["preview_asset_id"] in copied_ids
+    assert db_instance.get_active_persona_visual_pack(
+        persona_id=source_persona_id,
+        user_id=user_id,
+    )["id"] == updated_source["id"]
+    assert db_instance.get_active_persona_visual_pack(
+        persona_id=target_persona_id,
+        user_id=user_id,
+    )["id"] == target_active["id"]
 
 
 def test_duplicate_pack_rejects_same_persona_target(
@@ -424,16 +448,24 @@ def test_duplicate_pack_cleans_up_copied_files_after_partial_failure(
         persona_id=target_persona_id,
         user_id=user_id,
     )
-    assert [pack["status"] for pack in target_packs] == ["failed"]
-    copied_assets = db_instance.list_persona_visual_assets(
-        pack_id=target_packs[0]["id"],
+    assert target_packs == []
+    deleted_target_packs = db_instance.list_persona_visual_packs(
         persona_id=target_persona_id,
         user_id=user_id,
+        include_deleted=True,
     )
-    assert len(copied_assets) == 1
+    assert len(deleted_target_packs) == 1
+    assert deleted_target_packs[0]["status"] == "failed"
+    assert deleted_target_packs[0]["deleted"] is True
+    copied_asset_rows = db_instance.execute_query(
+        "SELECT deleted, storage_key FROM persona_visual_assets WHERE user_id = ? AND persona_id = ?",
+        (user_id, target_persona_id),
+    ).fetchall()
+    assert len(copied_asset_rows) == 1
+    assert bool(copied_asset_rows[0]["deleted"]) is True
     copied_path = service._asset_storage_path(
         user_id=user_id,
-        storage_key=str(copied_assets[0]["storage_key"]),
+        storage_key=str(copied_asset_rows[0]["storage_key"]),
     )
     assert not copied_path.exists()
     assert db_instance.get_active_persona_visual_pack(

--- a/tldw_Server_API/tests/Persona/test_persona_visual_service.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_service.py
@@ -83,6 +83,37 @@ def _create_pack(db: CharactersRAGDB, *, user_id: str = "user-1", title: str = "
     return persona_id, pack
 
 
+def test_db_allows_explicit_cross_persona_parent_for_duplicate_path(db_instance: CharactersRAGDB) -> None:
+    user_id = "user-1"
+    source_persona_id = db_instance.create_persona_profile({"user_id": user_id, "name": "Source"})
+    target_persona_id = db_instance.create_persona_profile({"user_id": user_id, "name": "Target"})
+    source_pack = db_instance.create_persona_visual_pack(
+        persona_id=source_persona_id,
+        user_id=user_id,
+        title="Source Pack",
+    )
+
+    target_pack = db_instance.create_persona_visual_pack(
+        persona_id=target_persona_id,
+        user_id=user_id,
+        title="Duplicate",
+        parent_pack_id=source_pack["id"],
+        parent_persona_id=source_persona_id,
+        status="failed",
+        provenance="mixed",
+    )
+    updated = db_instance.update_persona_visual_pack_status(
+        pack_id=target_pack["id"],
+        persona_id=target_persona_id,
+        user_id=user_id,
+        status="draft",
+        expected_version=target_pack["version"],
+    )
+
+    assert updated["parent_pack_id"] == source_pack["id"]
+    assert updated["status"] == "draft"
+
+
 def test_merge_candidate_patch_replaces_authored_trigger_by_id() -> None:
     merged = PersonaVisualService._merge_candidate_patch(
         {

--- a/tldw_Server_API/tests/Persona/test_persona_visual_service.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_service.py
@@ -114,6 +114,335 @@ def test_db_allows_explicit_cross_persona_parent_for_duplicate_path(db_instance:
     assert updated["status"] == "draft"
 
 
+def _manifest_with_all_reference_shapes(asset_a: str, asset_b: str) -> dict[str, object]:
+    return {
+        "manifest_version": 1,
+        "renderer_type": "sprite_frames",
+        "states": {
+            "idle": {"animation_id": "idle"},
+            "listening": {"animation_id": "idle"},
+            "thinking": {"animation_id": "idle"},
+            "speaking": {"animation_id": "idle"},
+            "error": {"animation_id": "idle"},
+        },
+        "animations": {
+            "idle": {
+                "frames": [
+                    {"asset_id": asset_a, "duration_ms": 100},
+                    {"asset_id": asset_b, "duration_ms": 100},
+                ],
+                "asset_ids": [asset_a],
+                "preview_asset_id": asset_b,
+                "frame_rate": 2,
+            }
+        },
+    }
+
+
+def test_duplicate_pack_to_persona_copies_referenced_assets_and_remaps_manifest(
+    service: PersonaVisualService,
+    db_instance: CharactersRAGDB,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_visuals_dir(monkeypatch, tmp_path / "visuals")
+    user_id = "user-1"
+    source_persona_id = db_instance.create_persona_profile({"user_id": user_id, "name": "Source"})
+    target_persona_id = db_instance.create_persona_profile({"user_id": user_id, "name": "Target"})
+    source_pack = db_instance.create_persona_visual_pack(
+        persona_id=source_persona_id,
+        user_id=user_id,
+        title="Source Pack",
+    )
+    asset_a = service.create_asset_from_upload(
+        persona_id=source_persona_id,
+        user_id=user_id,
+        pack_id=source_pack["id"],
+        content=_png_bytes(width=2, height=2),
+        mime_type="image/png",
+        original_filename="idle-a.png",
+        asset_role="frame",
+    )
+    asset_b = service.create_asset_from_upload(
+        persona_id=source_persona_id,
+        user_id=user_id,
+        pack_id=source_pack["id"],
+        content=_png_bytes(width=3, height=3),
+        mime_type="image/png",
+        original_filename="idle-b.png",
+        asset_role="preview",
+    )
+    unused = service.create_asset_from_upload(
+        persona_id=source_persona_id,
+        user_id=user_id,
+        pack_id=source_pack["id"],
+        content=_png_bytes(width=4, height=4),
+        mime_type="image/png",
+        original_filename="unused.png",
+        asset_role="generated_candidate",
+    )
+    updated_source = db_instance.update_persona_visual_pack_manifest(
+        pack_id=source_pack["id"],
+        persona_id=source_persona_id,
+        user_id=user_id,
+        manifest=_manifest_with_all_reference_shapes(asset_a["id"], asset_b["id"]),
+        expected_version=source_pack["version"],
+    )
+
+    duplicated = service.duplicate_pack_to_persona(
+        source_persona_id=source_persona_id,
+        user_id=user_id,
+        pack_id=updated_source["id"],
+        target_persona_id=target_persona_id,
+        title="Target Draft",
+    )
+
+    assert duplicated["status"] == "draft"
+    assert duplicated["persona_id"] == target_persona_id
+    assert duplicated["parent_pack_id"] == source_pack["id"]
+    copied_assets = db_instance.list_persona_visual_assets(
+        pack_id=duplicated["id"],
+        persona_id=target_persona_id,
+        user_id=user_id,
+    )
+    assert len(copied_assets) == 2
+    copied_ids = {asset["id"] for asset in copied_assets}
+    assert asset_a["id"] not in copied_ids
+    assert asset_b["id"] not in copied_ids
+    assert unused["checksum_sha256"] not in {asset["checksum_sha256"] for asset in copied_assets}
+    assert all(
+        f"persona_visuals/{target_persona_id}/{duplicated['id']}/" in asset["storage_key"]
+        for asset in copied_assets
+    )
+    remapped_animation = duplicated["manifest"]["animations"]["idle"]
+    assert {frame["asset_id"] for frame in remapped_animation["frames"]} == copied_ids
+    assert set(remapped_animation["asset_ids"]).issubset(copied_ids)
+    assert remapped_animation["preview_asset_id"] in copied_ids
+
+
+def test_duplicate_pack_rejects_same_persona_target(
+    service: PersonaVisualService,
+    db_instance: CharactersRAGDB,
+) -> None:
+    persona_id, pack = _create_pack(db_instance)
+
+    with pytest.raises(PersonaVisualServiceError) as exc_info:
+        service.duplicate_pack_to_persona(
+            source_persona_id=persona_id,
+            user_id="user-1",
+            pack_id=pack["id"],
+            target_persona_id=persona_id,
+        )
+
+    assert exc_info.value.code == "same_persona_target_unsupported"
+
+
+def test_duplicate_pack_rejects_missing_manifest_asset_row(
+    service: PersonaVisualService,
+    db_instance: CharactersRAGDB,
+) -> None:
+    user_id = "user-1"
+    source_persona_id = db_instance.create_persona_profile({"user_id": user_id, "name": "Source"})
+    target_persona_id = db_instance.create_persona_profile({"user_id": user_id, "name": "Target"})
+    source_pack = db_instance.create_persona_visual_pack(
+        persona_id=source_persona_id,
+        user_id=user_id,
+        title="Source Pack",
+    )
+    updated_source = db_instance.update_persona_visual_pack_manifest(
+        pack_id=source_pack["id"],
+        persona_id=source_persona_id,
+        user_id=user_id,
+        manifest=_valid_manifest("does-not-exist"),
+        expected_version=source_pack["version"],
+    )
+
+    with pytest.raises(PersonaVisualServiceError) as exc_info:
+        service.duplicate_pack_to_persona(
+            source_persona_id=source_persona_id,
+            user_id=user_id,
+            pack_id=updated_source["id"],
+            target_persona_id=target_persona_id,
+        )
+
+    assert exc_info.value.code == "invalid_manifest"
+
+
+def test_duplicate_pack_rejects_missing_source_asset_file(
+    service: PersonaVisualService,
+    db_instance: CharactersRAGDB,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_visuals_dir(monkeypatch, tmp_path / "visuals")
+    user_id = "user-1"
+    source_persona_id = db_instance.create_persona_profile({"user_id": user_id, "name": "Source"})
+    target_persona_id = db_instance.create_persona_profile({"user_id": user_id, "name": "Target"})
+    source_pack = db_instance.create_persona_visual_pack(
+        persona_id=source_persona_id,
+        user_id=user_id,
+        title="Source Pack",
+    )
+    asset = service.create_asset_from_upload(
+        persona_id=source_persona_id,
+        user_id=user_id,
+        pack_id=source_pack["id"],
+        content=_png_bytes(),
+        mime_type="image/png",
+        original_filename="idle.png",
+        asset_role="frame",
+    )
+    Path(asset["storage_path"]).unlink()
+    updated_source = db_instance.update_persona_visual_pack_manifest(
+        pack_id=source_pack["id"],
+        persona_id=source_persona_id,
+        user_id=user_id,
+        manifest=_valid_manifest(asset["id"]),
+        expected_version=source_pack["version"],
+    )
+
+    with pytest.raises(PersonaVisualServiceError) as exc_info:
+        service.duplicate_pack_to_persona(
+            source_persona_id=source_persona_id,
+            user_id=user_id,
+            pack_id=updated_source["id"],
+            target_persona_id=target_persona_id,
+        )
+
+    assert exc_info.value.code == "source_asset_missing"
+
+
+def test_duplicate_pack_rejects_source_asset_checksum_mismatch(
+    service: PersonaVisualService,
+    db_instance: CharactersRAGDB,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_visuals_dir(monkeypatch, tmp_path / "visuals")
+    user_id = "user-1"
+    source_persona_id = db_instance.create_persona_profile({"user_id": user_id, "name": "Source"})
+    target_persona_id = db_instance.create_persona_profile({"user_id": user_id, "name": "Target"})
+    source_pack = db_instance.create_persona_visual_pack(
+        persona_id=source_persona_id,
+        user_id=user_id,
+        title="Source Pack",
+    )
+    asset = service.create_asset_from_upload(
+        persona_id=source_persona_id,
+        user_id=user_id,
+        pack_id=source_pack["id"],
+        content=_png_bytes(),
+        mime_type="image/png",
+        original_filename="idle.png",
+        asset_role="frame",
+    )
+    Path(asset["storage_path"]).write_bytes(b"not the original image bytes")
+    updated_source = db_instance.update_persona_visual_pack_manifest(
+        pack_id=source_pack["id"],
+        persona_id=source_persona_id,
+        user_id=user_id,
+        manifest=_valid_manifest(asset["id"]),
+        expected_version=source_pack["version"],
+    )
+
+    with pytest.raises(PersonaVisualServiceError) as exc_info:
+        service.duplicate_pack_to_persona(
+            source_persona_id=source_persona_id,
+            user_id=user_id,
+            pack_id=updated_source["id"],
+            target_persona_id=target_persona_id,
+        )
+
+    assert exc_info.value.code == "source_asset_checksum_mismatch"
+
+
+def test_duplicate_pack_cleans_up_copied_files_after_partial_failure(
+    service: PersonaVisualService,
+    db_instance: CharactersRAGDB,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    visuals_root = tmp_path / "visuals"
+    _patch_visuals_dir(monkeypatch, visuals_root)
+    user_id = "user-1"
+    source_persona_id = db_instance.create_persona_profile({"user_id": user_id, "name": "Source"})
+    target_persona_id = db_instance.create_persona_profile({"user_id": user_id, "name": "Target"})
+    source_pack = db_instance.create_persona_visual_pack(
+        persona_id=source_persona_id,
+        user_id=user_id,
+        title="Source Pack",
+    )
+    asset_a = service.create_asset_from_upload(
+        persona_id=source_persona_id,
+        user_id=user_id,
+        pack_id=source_pack["id"],
+        content=_png_bytes(width=2, height=2),
+        mime_type="image/png",
+        original_filename="idle-a.png",
+        asset_role="frame",
+    )
+    asset_b = service.create_asset_from_upload(
+        persona_id=source_persona_id,
+        user_id=user_id,
+        pack_id=source_pack["id"],
+        content=_png_bytes(width=3, height=3),
+        mime_type="image/png",
+        original_filename="idle-b.png",
+        asset_role="preview",
+    )
+    updated_source = db_instance.update_persona_visual_pack_manifest(
+        pack_id=source_pack["id"],
+        persona_id=source_persona_id,
+        user_id=user_id,
+        manifest=_manifest_with_all_reference_shapes(asset_a["id"], asset_b["id"]),
+        expected_version=source_pack["version"],
+    )
+
+    original_create_asset = service.create_asset_from_upload
+    target_copy_count = 0
+
+    def _fail_after_first_target_copy(**kwargs: object) -> dict[str, object]:
+        nonlocal target_copy_count
+        if kwargs.get("persona_id") == target_persona_id:
+            target_copy_count += 1
+            if target_copy_count > 1:
+                raise PersonaVisualServiceError("copy_failed", "Injected copy failure.")
+        return original_create_asset(**kwargs)
+
+    monkeypatch.setattr(service, "create_asset_from_upload", _fail_after_first_target_copy)
+
+    with pytest.raises(PersonaVisualServiceError) as exc_info:
+        service.duplicate_pack_to_persona(
+            source_persona_id=source_persona_id,
+            user_id=user_id,
+            pack_id=updated_source["id"],
+            target_persona_id=target_persona_id,
+        )
+
+    assert exc_info.value.code == "copy_failed"
+    target_packs = db_instance.list_persona_visual_packs(
+        persona_id=target_persona_id,
+        user_id=user_id,
+    )
+    assert [pack["status"] for pack in target_packs] == ["failed"]
+    copied_assets = db_instance.list_persona_visual_assets(
+        pack_id=target_packs[0]["id"],
+        persona_id=target_persona_id,
+        user_id=user_id,
+    )
+    assert len(copied_assets) == 1
+    copied_path = service._asset_storage_path(
+        user_id=user_id,
+        storage_key=str(copied_assets[0]["storage_key"]),
+    )
+    assert not copied_path.exists()
+    assert db_instance.get_active_persona_visual_pack(
+        persona_id=target_persona_id,
+        user_id=user_id,
+    ) is None
+    assert visuals_root.exists()
+
+
 def test_merge_candidate_patch_replaces_authored_trigger_by_id() -> None:
     merged = PersonaVisualService._merge_candidate_patch(
         {

--- a/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
@@ -212,6 +212,64 @@ def test_create_list_and_activate_visual_pack(persona_db: CharactersRAGDB) -> No
         assert payload[0]["assets"][0]["id"] == asset["id"]
 
 
+def test_duplicate_visual_pack_to_another_persona_creates_draft(persona_db: CharactersRAGDB) -> None:
+    with _client_for_user(1, persona_db) as client:
+        source_persona_id = _create_persona(client, name="Source Persona")
+        target_persona_id = _create_persona(client, name="Target Persona")
+        source_pack = _create_visual_pack(client, source_persona_id, title="Source Visuals")
+        asset = _upload_png(client, source_persona_id, source_pack["id"])
+        manifest_response = client.patch(
+            f"/api/v1/persona/profiles/{source_persona_id}/visual-packs/{source_pack['id']}/manifest",
+            json={"manifest": _valid_manifest(asset["id"]), "expected_version": source_pack["version"]},
+        )
+        assert manifest_response.status_code == 200, manifest_response.text
+
+        response = client.post(
+            f"/api/v1/persona/profiles/{source_persona_id}/visual-packs/{source_pack['id']}/duplicate",
+            json={"target_persona_id": target_persona_id, "title": "Target Draft"},
+        )
+
+        assert response.status_code == 201, response.text
+        payload = response.json()
+        assert payload["title"] == "Target Draft"
+        assert payload["persona_id"] == target_persona_id
+        assert payload["status"] == "draft"
+        assert payload["parent_pack_id"] == source_pack["id"]
+        assert "asset_id_map" not in payload
+        assert len(payload["assets"]) == 1
+        assert payload["assets"][0]["id"] != asset["id"]
+
+
+def test_duplicate_visual_pack_rejects_same_persona_target(persona_db: CharactersRAGDB) -> None:
+    with _client_for_user(1, persona_db) as client:
+        persona_id = _create_persona(client, name="Source Persona")
+        source_pack = _create_visual_pack(client, persona_id, title="Source Visuals")
+
+        response = client.post(
+            f"/api/v1/persona/profiles/{persona_id}/visual-packs/{source_pack['id']}/duplicate",
+            json={"target_persona_id": persona_id},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"]["code"] == "same_persona_target_unsupported"
+
+
+def test_duplicate_visual_pack_rejects_other_user_target(persona_db: CharactersRAGDB) -> None:
+    with _client_for_user(2, persona_db) as other_client:
+        other_persona_id = _create_persona(other_client, name="Other User Target")
+    with _client_for_user(1, persona_db) as client:
+        source_persona_id = _create_persona(client, name="Source Persona")
+        source_pack = _create_visual_pack(client, source_persona_id, title="Source Visuals")
+
+        response = client.post(
+            f"/api/v1/persona/profiles/{source_persona_id}/visual-packs/{source_pack['id']}/duplicate",
+            json={"target_persona_id": other_persona_id},
+        )
+
+        assert response.status_code == 404
+        assert response.json()["detail"]["code"] == "target_persona_not_found"
+
+
 def test_upload_rejects_unsupported_mime_type(persona_db: CharactersRAGDB) -> None:
     with _client_for_user(1, persona_db) as client:
         persona_id = _create_persona(client, name="Visual Upload Persona")


### PR DESCRIPTION
## Summary
- Adds same-user Persona Visual pack duplication from one persona to another as a draft, copying only manifest-referenced assets and remapping the target manifest.
- Exposes `POST /api/v1/persona/profiles/{persona_id}/visual-packs/{pack_id}/duplicate` and wires the Visuals tab duplicate-to-persona UI with target persona handoff.
- Updates the Persona Live Visual Packs PRD, implementation plan, and Backlog task for #1450.

## Verification
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_manifest_assets.py tldw_Server_API/tests/Persona/test_persona_visual_service.py tldw_Server_API/tests/Persona/test_persona_visuals_api.py -q`
- `cd apps/tldw-frontend && bunx vitest run ../packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx`
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Persona/visual_manifest_assets.py tldw_Server_API/app/core/Persona/visual_service.py tldw_Server_API/app/core/Persona/visual_portability/importer.py tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/app/api/v1/schemas/persona.py tldw_Server_API/app/core/DB_Management/chacha/persona_state_store.py -f json -o /tmp/bandit_persona_visual_duplicate.json`
- `git diff --check`

## Change Summary
Human-authored change summary required before merge per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

Closes #1450.
Part of #1449.
