### PR TITLE
Design personal Persona Visual pack library

### DIFF
--- a/Docs/superpowers/specs/2026-05-09-persona-visual-personal-library-design.md
+++ b/Docs/superpowers/specs/2026-05-09-persona-visual-personal-library-design.md
@@ -71,18 +71,20 @@ Add a new table owned by the ChaChaNotes persona store:
 CREATE TABLE persona_visual_library_items (
   id TEXT PRIMARY KEY,
   user_id TEXT NOT NULL,
-  source_persona_id TEXT NOT NULL,
-  source_pack_id TEXT NOT NULL,
+  source_persona_id TEXT,
+  source_pack_id TEXT,
   title TEXT NOT NULL,
   notes TEXT,
   tags_json TEXT NOT NULL DEFAULT '[]',
+  source_persona_name_snapshot TEXT,
+  source_pack_title_snapshot TEXT,
   source_pack_version INTEGER,
   created_at DATETIME NOT NULL,
   last_modified DATETIME NOT NULL,
   deleted BOOLEAN NOT NULL DEFAULT 0,
   version INTEGER NOT NULL DEFAULT 1,
-  FOREIGN KEY(source_persona_id) REFERENCES persona_profiles(id),
-  FOREIGN KEY(source_pack_id) REFERENCES persona_visual_packs(id)
+  FOREIGN KEY(source_persona_id) REFERENCES persona_profiles(id) ON DELETE SET NULL,
+  FOREIGN KEY(source_pack_id) REFERENCES persona_visual_packs(id) ON DELETE SET NULL
 );
 ```
 
@@ -90,8 +92,9 @@ Indexes:
 
 1. `(user_id, deleted, last_modified)` for library listing.
 2. A unique active-entry index for `(user_id, source_persona_id,
-   source_pack_id)` where `deleted = false`, or the closest existing backend
-   equivalent, to prevent duplicate saved entries for the same live pack.
+   source_pack_id)` where `deleted = false` and both source references are not
+   null, or the closest existing backend equivalent, to prevent duplicate saved
+   entries for the same live pack.
 3. Optional `(user_id, title)` for simple filtering once the UI adds search.
 
 `source_pack_version` records the pack version when the item was saved. Because
@@ -99,6 +102,12 @@ the first slice is reference-backed, applying the item uses the current source
 pack state, not a snapshot. If the source pack version has changed since save,
 the API should surface `source_changed: true` so the UI can show a small status
 label.
+
+`source_persona_id` and `source_pack_id` are nullable so hard deletes or future
+maintenance operations do not delete or block the library entry. The snapshot
+name/title fields preserve enough display metadata to show stale entries and let
+users remove them. `source_available` is derived at read time from whether the
+source IDs are present and still resolve to non-deleted same-user records.
 
 ## Library Item Shape
 
@@ -115,6 +124,8 @@ API responses should include:
   "source_available": true,
   "source_persona_name": "Research Buddy",
   "source_pack_title": "Warm desk assistant",
+  "source_persona_name_snapshot": "Research Buddy",
+  "source_pack_title_snapshot": "Warm desk assistant",
   "title": "Warm desk assistant",
   "notes": "Good default for focused research sessions.",
   "tags": ["research", "calm"],
@@ -131,7 +142,9 @@ already scoped to the authenticated/current user.
 If the source persona or pack was deleted, the item can still be listed with
 `source_available: false`, but "Use for persona" must be disabled and the
 backend must reject the apply request. This keeps users able to remove stale
-library entries.
+library entries. Display fields should prefer live source persona/pack names when
+available and fall back to the stored snapshot values when the source no longer
+resolves.
 
 ## Backend API
 
@@ -242,7 +255,8 @@ The migration must be additive:
 2. Existing duplicate, import, export, activation, and MCP paths do not need to
    know about library entries.
 3. Deleting a source pack should not cascade-delete library entries in V1. It
-   should make entries unavailable so users can see and remove stale references.
+   should set source references to null or otherwise make entries unavailable so
+   users can see and remove stale references.
 4. Future archive-backed snapshots can add a nullable snapshot/archive pointer
    to library entries or introduce a parallel item type without changing the
    source-pack reference behavior.

--- a/Docs/superpowers/specs/2026-05-09-persona-visual-personal-library-design.md
+++ b/Docs/superpowers/specs/2026-05-09-persona-visual-personal-library-design.md
@@ -1,0 +1,302 @@
+# Persona Visual Personal Library Design
+
+## Status
+
+Design for GitHub issue #1468 under epic #1449.
+
+This design covers the first personal library layer for Persona/Buddy visual
+packs. It builds on PR #1467, which added same-user duplicate-to-persona as a
+reviewed draft workflow.
+
+## Problem
+
+Persona Visual Packs are currently attached to one persona by default. Users can
+export a pack, import an archive, or duplicate one pack directly to another
+persona, but there is no durable personal catalog of reusable packs. That makes
+reuse depend on remembering which persona has the pack and navigating into that
+persona first.
+
+The next slice should make reuse discoverable without turning Persona Garden
+into a public marketplace or introducing a second asset ownership model.
+
+## Goals
+
+1. Let a user save an existing Persona Visual pack into a personal library.
+2. Let the user browse saved reusable packs across their own personas.
+3. Let the user apply a saved library entry to another same-user persona as a
+   draft through the existing duplicate-to-persona semantics.
+4. Preserve explicit review and activation. Saving or using a library entry must
+   never silently change an active Buddy renderer.
+5. Keep the library user-scoped and persona-aware so future import/export,
+   duplication, or shared-library work can extend the format without rewriting
+   the core pack model.
+
+## Non-Goals
+
+1. No cross-user publishing.
+2. No shared community marketplace.
+3. No organization-wide library.
+4. No archive-backed snapshots in the first slice.
+5. No asset deduplication or detached asset ownership model.
+6. No automatic activation after applying a library entry.
+7. No Live2D, external visual provider, VN Play, or CYOA runtime work.
+
+## Recommended Approach
+
+Use a reference-backed personal library.
+
+A library entry is user-owned metadata pointing at an existing user-owned
+`persona_visual_packs` row. The source pack remains attached to its original
+persona. The library entry does not copy files, create a new manifest, or claim a
+separate ownership boundary.
+
+When the user chooses "Use for persona," the backend loads the referenced source
+pack and calls the same duplication workflow used by PR #1467. The result is a
+draft pack on the target persona. The target persona's active pack is unchanged.
+
+This approach is intentionally smaller than a full reusable asset store:
+
+1. It gives users the product affordance they need now: "I saved this pack for
+   reuse."
+2. It keeps all asset validation, checksum checks, manifest remapping, and
+   draft creation in one existing path.
+3. It leaves room for a later archive-backed snapshot or shared library without
+   changing `persona_visual_packs` or asset storage in this first slice.
+
+## Data Model
+
+Add a new table owned by the ChaChaNotes persona store:
+
+```sql
+CREATE TABLE persona_visual_library_items (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  source_persona_id TEXT NOT NULL,
+  source_pack_id TEXT NOT NULL,
+  title TEXT NOT NULL,
+  notes TEXT,
+  tags_json TEXT NOT NULL DEFAULT '[]',
+  source_pack_version INTEGER,
+  created_at DATETIME NOT NULL,
+  last_modified DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT 0,
+  version INTEGER NOT NULL DEFAULT 1,
+  FOREIGN KEY(source_persona_id) REFERENCES persona_profiles(id),
+  FOREIGN KEY(source_pack_id) REFERENCES persona_visual_packs(id)
+);
+```
+
+Indexes:
+
+1. `(user_id, deleted, last_modified)` for library listing.
+2. A unique active-entry index for `(user_id, source_persona_id,
+   source_pack_id)` where `deleted = false`, or the closest existing backend
+   equivalent, to prevent duplicate saved entries for the same live pack.
+3. Optional `(user_id, title)` for simple filtering once the UI adds search.
+
+`source_pack_version` records the pack version when the item was saved. Because
+the first slice is reference-backed, applying the item uses the current source
+pack state, not a snapshot. If the source pack version has changed since save,
+the API should surface `source_changed: true` so the UI can show a small status
+label.
+
+## Library Item Shape
+
+API responses should include:
+
+```json
+{
+  "id": "library-item-id",
+  "source_persona_id": "persona-a",
+  "source_pack_id": "pack-a",
+  "source_pack_version": 3,
+  "source_current_version": 5,
+  "source_changed": true,
+  "source_available": true,
+  "source_persona_name": "Research Buddy",
+  "source_pack_title": "Warm desk assistant",
+  "title": "Warm desk assistant",
+  "notes": "Good default for focused research sessions.",
+  "tags": ["research", "calm"],
+  "created_at": "...",
+  "last_modified": "...",
+  "version": 1
+}
+```
+
+`user_id` should remain an ownership field in persistence and service logic. The
+API does not need to echo it back to the WebUI because all returned entries are
+already scoped to the authenticated/current user.
+
+If the source persona or pack was deleted, the item can still be listed with
+`source_available: false`, but "Use for persona" must be disabled and the
+backend must reject the apply request. This keeps users able to remove stale
+library entries.
+
+## Backend API
+
+Add endpoints under the existing persona API namespace:
+
+1. `GET /api/v1/persona/visual-library`
+   - Lists current user's non-deleted library entries.
+   - Supports later query parameters such as `q`, `tag`, `limit`, and `offset`,
+     but V1 can ship with pagination only if existing endpoint patterns require
+     it.
+
+2. `POST /api/v1/persona/profiles/{persona_id}/visual-packs/{pack_id}/library`
+   - Saves a pack to the user's personal library.
+   - Requires the source persona and pack to belong to the current user.
+   - If the pack is already saved, return the existing entry or update the
+     metadata depending on request body. The recommended V1 behavior is an
+     idempotent upsert keyed by user/source persona/source pack.
+
+3. `PATCH /api/v1/persona/visual-library/{item_id}`
+   - Updates library metadata only: title, notes, tags.
+   - Does not mutate the source pack or assets.
+
+4. `DELETE /api/v1/persona/visual-library/{item_id}`
+   - Soft-deletes the library entry.
+   - Does not delete the source pack or assets.
+
+5. `POST /api/v1/persona/visual-library/{item_id}/use`
+   - Request body: `target_persona_id`, optional `title`.
+   - Validates that the library item belongs to the current user.
+   - Validates that the referenced source persona and pack still exist and
+     belong to the current user.
+   - Calls `PersonaVisualService.duplicate_pack_to_persona(...)`.
+   - Returns the created `PersonaVisualPackResponse`.
+
+The `use` endpoint should preserve the existing V1 rule that duplicate-to-persona
+targets a different persona. If same-persona reuse becomes important later, that
+should be a separate product decision because it changes the semantics from
+"reuse across personas" to "clone a draft into the same persona."
+
+## Backend Service Boundary
+
+Add a small service layer beside `PersonaVisualService`, for example
+`PersonaVisualLibraryService`.
+
+Responsibilities:
+
+1. Normalize library metadata.
+2. Own idempotent save/upsert behavior.
+3. Compose library rows with source persona/pack display metadata.
+4. Enforce item ownership before update/delete/use.
+5. Delegate actual pack copy to `PersonaVisualService.duplicate_pack_to_persona`.
+
+Do not duplicate manifest remapping, asset copying, checksum validation, or draft
+status logic in the library service.
+
+## WebUI Flow
+
+Add library affordances in the existing Visuals editor rather than introducing a
+new top-level marketplace page.
+
+V1 UI:
+
+1. In the selected pack header or portability area, add "Save to library."
+2. Show saved state for the selected pack:
+   - unsaved
+   - saved
+   - source changed since save
+3. Add a "Personal library" panel in the Visuals tab. It lists saved entries with
+   title, source persona, source pack, tags, and source availability.
+4. Each entry supports:
+   - "Use for persona" with a target persona select.
+   - "Edit details" for title, notes, tags.
+   - "Remove from library."
+5. "Use for persona" creates a draft and shows the same handoff affordance as PR
+   #1467: open the target persona's Visuals tab.
+
+The copy should stay explicit:
+
+1. "Save to library" means save this pack as reusable.
+2. "Use for persona" means create a draft copy for another persona.
+3. "Activate" remains a separate action on the target persona.
+
+## Error Handling
+
+Stable service/API error codes should include:
+
+1. `library_item_not_found`
+2. `source_pack_not_found`
+3. `source_pack_unavailable`
+4. `target_persona_not_found`
+5. `same_persona_target_unsupported`
+6. `invalid_library_metadata`
+7. `library_item_conflict`
+
+HTTP mapping:
+
+1. 404 for missing item/source/target not owned by user.
+2. 409 for stale or unavailable source pack states.
+3. 422 for malformed title, notes, tags, or target payload.
+
+Source-unavailable entries should still be removable from the library.
+
+## Migration Compatibility
+
+The migration must be additive:
+
+1. Existing `persona_visual_packs` rows remain unchanged.
+2. Existing duplicate, import, export, activation, and MCP paths do not need to
+   know about library entries.
+3. Deleting a source pack should not cascade-delete library entries in V1. It
+   should make entries unavailable so users can see and remove stale references.
+4. Future archive-backed snapshots can add a nullable snapshot/archive pointer
+   to library entries or introduce a parallel item type without changing the
+   source-pack reference behavior.
+
+## Testing
+
+Backend unit/integration tests:
+
+1. Saving a pack creates a user-owned library entry.
+2. Saving the same pack twice is idempotent or updates metadata according to the
+   chosen upsert behavior.
+3. Listing entries includes source persona and pack display metadata.
+4. Deleted source pack/persona entries list as unavailable and cannot be used.
+5. Updating/removing a library entry affects only the entry, not the source pack.
+6. Using a library entry creates a draft on the target persona via duplicate
+   semantics and preserves active pack state on both personas.
+7. Cross-user access to entries, source packs, and targets is rejected.
+
+Frontend tests:
+
+1. VisualPackEditor renders save-to-library state for selected pack.
+2. Personal library panel lists entries and unavailable states.
+3. Use-for-persona sends the expected target payload and shows draft handoff.
+4. Remove entry updates the panel without deleting the pack.
+5. Source-changed and source-unavailable copy is visible when returned by API.
+
+Security checks:
+
+1. Run Bandit on touched backend modules.
+2. Confirm no library endpoint exposes entries across users.
+3. Confirm delete is soft-delete of library metadata only.
+
+## Documentation Updates
+
+Update:
+
+1. `Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md`
+   - Mark personal library as the next Phase 3 slice.
+   - Clarify reference-backed V1 behavior and non-goals.
+2. `Docs/Code_Documentation/Persona_Visual_Packs.md`
+   - Add a "Personal Library" section.
+   - Explain that save-to-library is metadata only in V1.
+   - Explain that use-for-persona creates a draft via duplicate semantics.
+
+## Rollout
+
+Recommended implementation order:
+
+1. DB/schema helpers and tests for library item persistence.
+2. Library service tests and implementation.
+3. API schemas/endpoints and integration tests.
+4. Frontend service/types and VisualPackEditor library panel tests.
+5. Documentation updates and final focused verification.
+
+This should be one focused feature PR if kept to reference-backed V1 behavior.
+If archive snapshots, shared libraries, or same-persona cloning are added, split
+them into separate issues and PRs.

--- a/backlog/tasks/task-201 - Design-personal-Persona-Visual-pack-library-foundation.md
+++ b/backlog/tasks/task-201 - Design-personal-Persona-Visual-pack-library-foundation.md
@@ -1,0 +1,60 @@
+---
+id: TASK-201
+title: Design personal Persona Visual pack library foundation
+status: Done
+assignee: []
+created_date: '2026-05-09 22:50'
+updated_date: '2026-05-09 22:52'
+labels:
+  - persona
+  - buddy
+  - webui
+  - design
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1449'
+  - 'https://github.com/rmusser01/tldw_server/issues/1468'
+  - 'https://github.com/rmusser01/tldw_server/issues/1450'
+  - 'https://github.com/rmusser01/tldw_server/pull/1467'
+documentation:
+  - Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md
+  - Docs/Code_Documentation/Persona_Visual_Packs.md
+  - Docs/superpowers/specs/2026-05-09-persona-visual-personal-library-design.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Design GitHub issue #1468: a user-scoped personal library layer for Persona/Buddy visual packs. The approved scope is reference-backed library entries that point at existing user-owned Persona Visual packs, preserve the source persona attachment, and use the existing duplicate-to-persona draft workflow when applying a saved pack to another persona. This is not VN/CYOA work, not a shared marketplace, not cross-user publishing, and not archive-backed snapshots in the first slice.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 GitHub issue #1468 is linked from epic #1449 as the next Persona/Buddy visual-pack workstream
+- [x] #2 Design spec defines the reference-backed library data model and ownership boundaries
+- [x] #3 Design spec defines API and WebUI flows for saving, listing, removing, and using a library entry for another persona as a draft
+- [x] #4 Design spec covers error handling, migration compatibility, tests, documentation updates, and explicit non-goals
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Design task complete. Created GitHub issue #1468 and updated epic #1449. Wrote Docs/superpowers/specs/2026-05-09-persona-visual-personal-library-design.md covering reference-backed library entries, user/persona ownership boundaries, API and WebUI flows, source-unavailable handling, migration compatibility, tests, docs, and non-goals. Verification: docs-only change; git diff --check will be run before commit; Bandit not applicable because no backend code changed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Designed the reference-backed personal Persona Visual pack library foundation for #1468. The spec keeps source packs attached to their original personas, saves user-scoped library metadata only, and applies saved entries to another persona by delegating to the existing duplicate-to-persona draft workflow. The design explicitly excludes cross-user sharing, marketplaces, archive snapshots, asset dedupe, automatic activation, VN/CYOA runtime work, and renderer/provider expansion.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-201 - Design-personal-Persona-Visual-pack-library-foundation.md
+++ b/backlog/tasks/task-201 - Design-personal-Persona-Visual-pack-library-foundation.md
@@ -4,7 +4,7 @@ title: Design personal Persona Visual pack library foundation
 status: Done
 assignee: []
 created_date: '2026-05-09 22:50'
-updated_date: '2026-05-09 22:52'
+updated_date: '2026-05-09 23:04'
 labels:
   - persona
   - buddy
@@ -41,6 +41,8 @@ Design GitHub issue #1468: a user-scoped personal library layer for Persona/Budd
 
 <!-- SECTION:NOTES:BEGIN -->
 Design task complete. Created GitHub issue #1468 and updated epic #1449. Wrote Docs/superpowers/specs/2026-05-09-persona-visual-personal-library-design.md covering reference-backed library entries, user/persona ownership boundaries, API and WebUI flows, source-unavailable handling, migration compatibility, tests, docs, and non-goals. Verification: docs-only change; git diff --check will be run before commit; Bandit not applicable because no backend code changed.
+
+PR review follow-up: Qodo flagged that NOT NULL foreign keys conflicted with stale-entry behavior. Updated the design schema to use nullable source_persona_id/source_pack_id with ON DELETE SET NULL, added source persona/pack snapshot display fields, clarified source_available derivation, adjusted the unique active-entry index, and clarified migration behavior for deleted sources.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary


### PR DESCRIPTION
## Summary

- Creates GitHub issue #1468 for the personal Persona Visual pack library foundation and records the local Backlog task.
- Adds a design spec for a reference-backed, user-scoped personal library over existing Persona Visual packs.
- Defines the first implementation shape: save metadata only, keep source packs persona-attached, and apply entries by delegating to duplicate-to-persona draft semantics.

## Change summary

This is a design-only PR for the next Persona/Buddy visual-pack reuse slice under #1449. The spec chooses a reference-backed library because it is the smallest durable step after PR #1467: it gives users a reusable catalog without creating new asset storage, archive snapshots, or shared-library semantics. It keeps ownership user-scoped and persona-aware, and it reuses the existing duplicate-to-persona path for manifest remapping, asset copying, draft status, and activation safety.

## Verification

- `git diff --check`
- Docs-only change; Bandit not applicable.
