### PR TITLE
Gate character-chat onboarding actions after auth

### DIFF
--- a/apps/packages/ui/src/routes/__tests__/core-route-identity.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/core-route-identity.test.tsx
@@ -219,7 +219,7 @@ describe("core route identity guardrails", () => {
     expect(toggleDarkModeMock).toHaveBeenCalledTimes(1)
   })
 
-  it("surfaces a character-chat first-run lane from preserved route intent", async () => {
+  it("preserves character-chat first-run context without pre-auth action lane", async () => {
     currentLocation = {
       pathname: "/",
       search:
@@ -234,17 +234,21 @@ describe("core route identity guardrails", () => {
     expect(
       screen.getByText("Finish setup, then continue creating and chatting with characters.")
     ).toBeInTheDocument()
-    expect(screen.getByTestId("character-chat-onboarding-lane")).toBeInTheDocument()
     expect(
-      screen.getByRole("button", { name: "Create character" })
-    ).toBeInTheDocument()
+      screen.queryByTestId("character-chat-onboarding-lane")
+    ).not.toBeInTheDocument()
     expect(
-      screen.getByRole("button", { name: "Import character" })
-    ).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: "Choose model" })).toBeInTheDocument()
+      screen.queryByRole("button", { name: "Create character" })
+    ).not.toBeInTheDocument()
     expect(
-      screen.getByRole("button", { name: "Start character chat" })
-    ).toBeInTheDocument()
+      screen.queryByRole("button", { name: "Import character" })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "Choose model" })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "Start character chat" })
+    ).not.toBeInTheDocument()
     expect(await screen.findByTestId("onboarding-wizard")).toBeInTheDocument()
   })
 

--- a/apps/packages/ui/src/routes/option-index.tsx
+++ b/apps/packages/ui/src/routes/option-index.tsx
@@ -3,7 +3,6 @@ import { Moon, Sun } from "lucide-react"
 import { useLocation, useNavigate } from "react-router-dom"
 
 import { PageAssistLoader } from "@/components/Common/PageAssistLoader"
-import { CharacterChatOnboardingLane } from "@/components/Option/Onboarding/CharacterChatOnboardingLane"
 import {
   useConnectionActions,
   useConnectionState,
@@ -15,7 +14,6 @@ import { useDarkMode } from "@/hooks/useDarkmode"
 import OptionLayout from "~/components/Layouts/Layout"
 import { isHostedTldwDeployment } from "@/services/tldw/deployment-mode"
 import {
-  buildCharacterOnboardingRoute,
   CHARACTER_CHAT_ONBOARDING_INTENT,
   getOnboardingReturnToFromSearch,
   resolveOnboardingEntryIntent
@@ -117,32 +115,6 @@ const OptionIndex = () => {
     const onboardingDescription = isCharacterChatOnboarding
       ? "Finish setup, then continue creating and chatting with characters."
       : "Start here to connect your server or try local demo mode."
-    const navigateToCharacterCreate = () => {
-      if (!hasCompletedFirstRun) return
-      navigate(
-        buildCharacterOnboardingRoute({
-          returnTo: onboardingReturnTo,
-          action: "create"
-        })
-      )
-    }
-    const navigateToCharacterImport = () => {
-      if (!hasCompletedFirstRun) return
-      navigate(
-        buildCharacterOnboardingRoute({
-          returnTo: onboardingReturnTo,
-          action: "import"
-        })
-      )
-    }
-    const navigateToModelSettings = () => {
-      if (!hasCompletedFirstRun) return
-      navigate("/settings/model?from=character-chat-onboarding")
-    }
-    const navigateToCharacterChat = () => {
-      if (!hasCompletedFirstRun) return
-      navigate("/chat?from=character-chat-onboarding")
-    }
     return (
       <OptionLayout hideHeader hideSidebar>
         <div className="mx-auto mb-4 w-full max-w-3xl rounded-lg border border-border bg-surface px-4 py-3">
@@ -170,16 +142,6 @@ const OptionIndex = () => {
               )}
             </button>
           </div>
-          {isCharacterChatOnboarding && (
-            <CharacterChatOnboardingLane
-              className="mt-3"
-              actionsDisabled
-              onCreateCharacter={navigateToCharacterCreate}
-              onImportCharacter={navigateToCharacterImport}
-              onChooseModel={navigateToModelSettings}
-              onStartCharacterChat={navigateToCharacterChat}
-            />
-          )}
         </div>
         <React.Suspense
           fallback={

--- a/apps/packages/ui/src/utils/__tests__/onboarding-route-intent.test.ts
+++ b/apps/packages/ui/src/utils/__tests__/onboarding-route-intent.test.ts
@@ -38,4 +38,13 @@ describe("onboarding route intent", () => {
       })
     ).toBe("/characters/library?sort=name&from=onboarding&import=true")
   })
+
+  it("preserves existing characters query context when adding onboarding actions", () => {
+    expect(
+      buildCharacterOnboardingRoute({
+        returnTo: "/characters?from=header-select",
+        action: "create"
+      })
+    ).toBe("/characters?from=header-select&create=true")
+  })
 })

--- a/apps/packages/ui/src/utils/onboarding-route-intent.ts
+++ b/apps/packages/ui/src/utils/onboarding-route-intent.ts
@@ -11,8 +11,19 @@ type LocationLike = {
 
 const SAFE_URL_ORIGIN = "https://tldw.local"
 
-const isCharactersRoute = (path: string | null | undefined): boolean =>
-  path === "/characters" || Boolean(path?.startsWith("/characters/"))
+const getRoutePathname = (path: string | null | undefined): string => {
+  if (!path) return ""
+  try {
+    return new URL(path, SAFE_URL_ORIGIN).pathname
+  } catch {
+    return path.split(/[?#]/, 1)[0] ?? ""
+  }
+}
+
+const isCharactersRoute = (path: string | null | undefined): boolean => {
+  const pathname = getRoutePathname(path)
+  return pathname === "/characters" || pathname.startsWith("/characters/")
+}
 
 export const getSafeOnboardingReturnTo = (
   value: string | null | undefined

--- a/backlog/tasks/task-202 - Gate-character-chat-onboarding-actions-behind-completed-authentication.md
+++ b/backlog/tasks/task-202 - Gate-character-chat-onboarding-actions-behind-completed-authentication.md
@@ -1,0 +1,55 @@
+---
+id: TASK-202
+title: Gate character-chat onboarding actions behind completed authentication
+status: Done
+assignee: []
+created_date: '2026-05-09 22:56'
+updated_date: '2026-05-09 23:02'
+labels:
+  - webui
+  - ux
+  - character-chat
+  - auth
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Ensure route-aware character-chat onboarding actions are only visible after the user has entered credentials and the onboarding connection flow has completed authentication and authorization. The first-run credential/setup screen may remain route-aware in title/copy, but it must not expose character-chat actions before auth succeeds.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A first-run user with character-chat route intent does not see the character-chat onboarding action lane before completing credentials and connection validation.
+- [x] #2 After the onboarding connection flow reaches its authenticated success state with character-chat route intent, the character-chat action lane remains visible and actionable.
+- [x] #3 The route intent return path still sends character-chat users to the intended destination after completing onboarding.
+- [x] #4 Focused frontend tests cover the pre-auth negative case and the post-auth success case.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implementation: removed the disabled character-chat action lane from the unauthenticated first-run OptionIndex shell; kept route-aware title/copy; left the active lane in the OnboardingConnectForm authenticated success screen. Also fixed returnTo route recognition so /characters?... query paths preserve their existing source context when adding create/import action flags.
+
+Verification: bunx vitest run src/routes/__tests__/core-route-identity.test.tsx src/components/Option/Onboarding/__tests__/OnboardingConnectForm.success-screen.guard.test.tsx src/utils/__tests__/onboarding-route-intent.test.ts --maxWorkers=1 --no-file-parallelism passed 15/15; git diff --check passed; Chromium browser check of first-run character-chat route after readiness timeout reported laneCount=0 headingCount=1 credentialFields=2 and saved output/playwright/character-chat-first-run-pre-auth-no-lane-dismissed.png.
+
+Bandit: skipped because touched implementation/test files are TypeScript frontend files, not Python.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Gated the character-chat onboarding actions behind completed onboarding auth by removing the pre-auth disabled lane from the first-run route shell while preserving route-aware setup copy. Added regression coverage for the pre-auth negative case, preserved the post-auth success action lane, and fixed character return-path parsing so /characters query routes continue to their original context after auth.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-202 - Gate-character-chat-onboarding-actions-behind-completed-authentication.md
+++ b/backlog/tasks/task-202 - Gate-character-chat-onboarding-actions-behind-completed-authentication.md
@@ -4,7 +4,7 @@ title: Gate character-chat onboarding actions behind completed authentication
 status: Done
 assignee: []
 created_date: '2026-05-09 22:56'
-updated_date: '2026-05-09 23:02'
+updated_date: '2026-05-09 23:04'
 labels:
   - webui
   - ux
@@ -36,6 +36,8 @@ Implementation: removed the disabled character-chat action lane from the unauthe
 Verification: bunx vitest run src/routes/__tests__/core-route-identity.test.tsx src/components/Option/Onboarding/__tests__/OnboardingConnectForm.success-screen.guard.test.tsx src/utils/__tests__/onboarding-route-intent.test.ts --maxWorkers=1 --no-file-parallelism passed 15/15; git diff --check passed; Chromium browser check of first-run character-chat route after readiness timeout reported laneCount=0 headingCount=1 credentialFields=2 and saved output/playwright/character-chat-first-run-pre-auth-no-lane-dismissed.png.
 
 Bandit: skipped because touched implementation/test files are TypeScript frontend files, not Python.
+
+PR: https://github.com/rmusser01/tldw_server/pull/1470
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary


### PR DESCRIPTION
## Summary
- Remove the disabled character-chat action lane from the unauthenticated first-run shell while keeping route-aware setup copy.
- Keep the active character-chat action lane on the authenticated onboarding success screen.
- Preserve /characters return paths that already include query context when adding create/import onboarding actions.

## Verification
- bunx vitest run src/routes/__tests__/core-route-identity.test.tsx src/components/Option/Onboarding/__tests__/OnboardingConnectForm.success-screen.guard.test.tsx src/utils/__tests__/onboarding-route-intent.test.ts --maxWorkers=1 --no-file-parallelism
- git diff --check
- Chromium check: first-run character-chat route after readiness timeout reported laneCount=0, headingCount=1, credentialFields=2; screenshot saved under output/playwright/character-chat-first-run-pre-auth-no-lane-dismissed.png

## Merge note
This PR is draft because the project AI-generated PR policy requires a human-written Change summary before it is merge-ready.