### PR TITLE
Migrate ConnectionProblemBanner to RecoveryCallout

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -5456,17 +5456,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "local-recovery-banner:src/components/Common/ConnectionProblemBanner.tsx:ConnectionProblemBanner",
-    "path": "src/components/Common/ConnectionProblemBanner.tsx",
-    "rule": "local-recovery-banner",
-    "subject": "ConnectionProblemBanner",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing local ConnectionProblemBanner recovery banner before the guard.",
-    "replacement": "RecoveryCallout or StatePanel",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/recipe-configs/EmbeddingsModelSelectionConfig.tsx:Alert",
     "path": "src/components/Option/Evaluations/tabs/recipe-configs/EmbeddingsModelSelectionConfig.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Common/ConnectionProblemBanner.tsx
+++ b/apps/packages/ui/src/components/Common/ConnectionProblemBanner.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import FeatureEmptyState from "@/components/Common/FeatureEmptyState"
+import { RecoveryCallout, type StateAction } from "@/components/ui/state"
 
 type ConnectionProblemBannerProps = {
   badgeLabel?: React.ReactNode
@@ -44,33 +44,56 @@ const ConnectionProblemBanner: React.FC<ConnectionProblemBannerProps> = ({
   ) : (
     title
   )
+  const primaryAction: StateAction | undefined = primaryActionLabel
+    ? {
+        label: primaryActionLabel,
+        onClick: onPrimaryAction,
+        disabled: primaryDisabled,
+        ariaLabel:
+          typeof primaryActionLabel === "string" ? primaryActionLabel : undefined
+      }
+    : undefined
+  const secondaryActions: StateAction[] = []
+
+  if (retryActionLabel && onRetry) {
+    secondaryActions.push({
+      label: retryActionLabel,
+      onClick: onRetry,
+      disabled: retryDisabled,
+      ariaLabel:
+        typeof retryActionLabel === "string" ? retryActionLabel : undefined
+    })
+  }
+
+  if (secondaryActionLabel) {
+    secondaryActions.push({
+      label: secondaryActionLabel,
+      onClick: onSecondaryAction,
+      disabled: secondaryDisabled,
+      ariaLabel:
+        typeof secondaryActionLabel === "string"
+          ? secondaryActionLabel
+          : undefined
+    })
+  }
 
   return (
-    <div className={className}>
-      <FeatureEmptyState
-        title={composedTitle}
-        description={description}
-        examples={examples}
-        primaryActionLabel={primaryActionLabel}
-        onPrimaryAction={onPrimaryAction}
-        secondaryActionLabel={secondaryActionLabel}
-        onSecondaryAction={onSecondaryAction}
-        primaryDisabled={primaryDisabled}
-        secondaryDisabled={secondaryDisabled}
-      />
-      {retryActionLabel && onRetry && (
-        <div className="mt-2 flex justify-start text-xs">
-          <button
-            type="button"
-            onClick={onRetry}
-            disabled={retryDisabled}
-            className="inline-flex items-center gap-1 text-primary hover:text-primary disabled:opacity-60 disabled:cursor-not-allowed disabled:hover:text-primary"
-          >
-            {retryActionLabel}
-          </button>
-        </div>
-      )}
-    </div>
+    <RecoveryCallout
+      state="unavailable"
+      title={composedTitle}
+      message={description}
+      primaryAction={primaryAction}
+      secondaryActions={secondaryActions}
+      className={className}
+    >
+      {examples && examples.length > 0 ? (
+        <ul className="list-disc space-y-1 pl-4 text-sm text-text-muted">
+          {examples.map((example, index) => (
+            <li key={index}>{example}</li>
+          ))}
+        </ul>
+      ) : null}
+    </RecoveryCallout>
   )
 }
 

--- a/apps/packages/ui/src/components/Common/__tests__/ConnectionProblemBanner.test.tsx
+++ b/apps/packages/ui/src/components/Common/__tests__/ConnectionProblemBanner.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import ConnectionProblemBanner from "../ConnectionProblemBanner"
+
+describe("ConnectionProblemBanner", () => {
+  it("renders connection recovery through the shared RecoveryCallout primitive", () => {
+    const onPrimaryAction = vi.fn()
+    const onSecondaryAction = vi.fn()
+    const onRetry = vi.fn()
+
+    render(
+      <ConnectionProblemBanner
+        badgeLabel="Not connected"
+        title="Connect to use Notes"
+        description="This view needs a connected server."
+        examples={["Add your server URL.", "Check your API key."]}
+        primaryActionLabel="Set up server"
+        onPrimaryAction={onPrimaryAction}
+        secondaryActionLabel="Health & diagnostics"
+        onSecondaryAction={onSecondaryAction}
+        retryActionLabel="Retry connection"
+        onRetry={onRetry}
+      />
+    )
+
+    const banner = screen.getByText("Connect to use Notes").closest("section")
+
+    expect(banner).toHaveAttribute("data-ds-component", "RecoveryCallout")
+    expect(screen.getByText("Unavailable")).toBeInTheDocument()
+    expect(screen.getByText("Not connected")).toBeInTheDocument()
+    expect(screen.getByText("This view needs a connected server.")).toBeInTheDocument()
+    expect(screen.getByText("Add your server URL.")).toBeInTheDocument()
+    expect(screen.getByText("Check your API key.")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Set up server" }))
+    fireEvent.click(screen.getByRole("button", { name: "Health & diagnostics" }))
+    fireEvent.click(screen.getByRole("button", { name: "Retry connection" }))
+
+    expect(onPrimaryAction).toHaveBeenCalledTimes(1)
+    expect(onSecondaryAction).toHaveBeenCalledTimes(1)
+    expect(onRetry).toHaveBeenCalledTimes(1)
+  })
+
+  it("keeps the retry action disabled when retrying is unavailable", () => {
+    render(
+      <ConnectionProblemBanner
+        title="Connect to use Review"
+        primaryActionLabel="Open Settings"
+        retryActionLabel="Retry connection"
+        onRetry={vi.fn()}
+        retryDisabled
+      />
+    )
+
+    expect(screen.getByRole("button", { name: "Retry connection" })).toBeDisabled()
+  })
+})

--- a/apps/packages/ui/src/components/ui/state/StatePanel.tsx
+++ b/apps/packages/ui/src/components/ui/state/StatePanel.tsx
@@ -15,7 +15,7 @@ export interface StatePanelProps {
   title: React.ReactNode
   message?: React.ReactNode
   diagnostics?: StatePanelDiagnostic[]
-  primaryAction: StateAction
+  primaryAction?: StateAction
   secondaryActions?: StateAction[]
   className?: string
   children?: React.ReactNode

--- a/backlog/tasks/task-45.35 - Migrate-ConnectionProblemBanner-to-RecoveryCallout.md
+++ b/backlog/tasks/task-45.35 - Migrate-ConnectionProblemBanner-to-RecoveryCallout.md
@@ -1,0 +1,66 @@
+---
+id: TASK-45.35
+title: Migrate ConnectionProblemBanner to RecoveryCallout
+status: Done
+assignee: []
+created_date: '2026-05-10 00:50'
+updated_date: '2026-05-10 00:55'
+labels:
+  - design-system
+  - ui
+  - product-state
+  - recovery
+  - common
+dependencies: []
+references:
+  - apps/packages/ui/src/components/Common/ConnectionProblemBanner.tsx
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+parent_task_id: TASK-45
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate the remaining ConnectionProblemBanner local-recovery-banner debt to the canonical RecoveryCallout product-state primitive while preserving copy, optional details, action labels, and call-site behavior across common recovery surfaces.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 ConnectionProblemBanner renders through RecoveryCallout with a matching recovery state and keeps the existing user-facing title/message/details content.
+- [x] #2 Focused tests cover retry/settings actions and optional details rendering through the canonical primitive.
+- [x] #3 The ConnectionProblemBanner local-recovery-banner baseline entry is removed and the design-system verifier passes with no remaining local-recovery-banner debt.
+- [x] #4 Verification records focused tests, product-state guard tests, design-system verifier, syntax/whitespace checks, and known TypeScript/Bandit status.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused tests that expect ConnectionProblemBanner to render the RecoveryCallout primitive while preserving actions and optional detail text. 2. Migrate the component to RecoveryCallout action semantics without changing its public props. 3. Remove the local-recovery-banner baseline exception. 4. Run focused tests, product-state guard tests, design-system verifier, git diff check, and touched-file TypeScript filtering.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented ConnectionProblemBanner through RecoveryCallout with state=unavailable, preserving badge/title composition, description text, examples, primary action, secondary action, retry action, disabled retry state, and className forwarding. StatePanel primaryAction is now optional to match ActionGroup runtime semantics and allow canonical recovery surfaces that only have secondary actions.
+
+Removed the ConnectionProblemBanner local-recovery-banner baseline exception. The design-system verifier now reports 511 allowed legacy exceptions and no local-recovery-banner bucket.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated ConnectionProblemBanner from FeatureEmptyState plus custom retry markup to the canonical RecoveryCallout product-state primitive. This removes the final local-recovery-banner baseline exception while preserving the component public props used by Notes, Flashcards, Quiz, and Review recovery surfaces.
+
+Verification: bunx vitest run src/components/Common/__tests__/ConnectionProblemBanner.test.tsx --reporter=dot passed 2 tests; bunx vitest run src/components/ui/state/__tests__/state-primitives.test.tsx --reporter=dot passed 7 tests; bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed 52 tests; bun run verify:design-system-state passed with 511 allowed legacy exceptions and no local-recovery-banner bucket; git diff --check passed. bunx tsc --noEmit --pretty false exited 2 on existing repo-wide TypeScript test debt, with no filtered output for ConnectionProblemBanner, StatePanel, RecoveryCallout, ActionGroup, baseline, product-state guard, or TASK-45.35. Bandit skipped because this is UI-only TS/TSX/JSON/Backlog work.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Change summary

Migrates `ConnectionProblemBanner` from `FeatureEmptyState` plus custom retry markup to the canonical `RecoveryCallout` product-state primitive with `state="unavailable"`. The public props used by Notes, Flashcards, Quiz, and Review are preserved: badge/title composition, description text, examples, primary action, secondary action, retry action, disabled retry state, and `className` forwarding.

`StatePanel` now accepts an optional `primaryAction`, matching the existing `ActionGroup` behavior and allowing canonical recovery surfaces that only expose secondary actions. The stale `ConnectionProblemBanner` baseline entry is removed, which clears the final `local-recovery-banner` bucket from the design-system verifier.

## Verification

- `bunx vitest run src/components/Common/__tests__/ConnectionProblemBanner.test.tsx --reporter=dot` passed 2 tests
- `bunx vitest run src/components/ui/state/__tests__/state-primitives.test.tsx --reporter=dot` passed 7 tests
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed 52 tests
- `bun run verify:design-system-state` passed with 511 allowed legacy exceptions and no `local-recovery-banner` bucket
- `git diff --check` passed
- `bunx tsc --noEmit --pretty false` still exits 2 on existing repo-wide TypeScript test debt; filtered output had no hits for `ConnectionProblemBanner`, `StatePanel`, `RecoveryCallout`, `ActionGroup`, baseline, product-state guard, or `TASK-45.35`
- Bandit skipped because this is UI-only TS/TSX/JSON/Backlog work

Backlog: `TASK-45.35`