### PR TITLE
Add managed VZ helper restart drill

### DIFF
--- a/Docs/Sandbox/macos-runtime-operator-notes.md
+++ b/Docs/Sandbox/macos-runtime-operator-notes.md
@@ -462,6 +462,20 @@ helper daemon for real `vz_linux` E2E, verifies ephemeral execution, verifies
 same-session VM reuse, verifies recovery diagnostics plus dry-run
 reconciliation repair planning, and stops the helper on exit.
 
+`restart-drill` is a narrower local helper lifecycle check. Use it after
+starting the helper through `vz-helperctl.py start` when you need to prove that
+the managed pid-file/socket workflow can stop the helper, start a replacement
+on the same paths, and reach healthy status again. It refuses absent or
+unmanaged helpers, preserves existing helper logs under the configured log
+directory, and does not run guest commands, mutate reconciliation state, manage
+launchd, or validate host reboot behavior.
+
+```bash
+tools/macos-vz-helper/scripts/vz-helperctl.py start
+tools/macos-vz-helper/scripts/vz-helperctl.py restart-drill
+tools/macos-vz-helper/scripts/vz-helperctl.py stop
+```
+
 Manual failure drills are opt-in and remain disabled for default smoke and
 scheduled host-gated runs. To include them, pass:
 

--- a/Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
+++ b/Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
@@ -118,6 +118,14 @@ mode before any mutation, and then run the real host smoke. A host reboot drill
 must not be added to scheduled CI until a dedicated prepared runner can tolerate
 disruptive reboot testing and preserve helper/stdout/serial logs reliably.
 
+For a non-launchd helper lifecycle check, maintainers can run
+`tools/macos-vz-helper/scripts/vz-helperctl.py restart-drill` against a helper
+that was started through `vz-helperctl.py start`. That drill is local and
+operator-owned: it validates managed helper status, stops the pid-file-owned
+process, starts a replacement on the same socket/log paths, and validates
+status again. It is not a substitute for launchd bootstrap/bootout testing or a
+host reboot drill.
+
 ## Expected Skips And Non-Blocking Conditions
 
 These are expected and should not block ordinary PRs:
@@ -130,6 +138,8 @@ These are expected and should not block ordinary PRs:
 - local developer machines without a prepared bundle/helper environment
 - failure-drill coverage skipped because manual dispatch did not set
   `include_failure_drills=true`
+- managed helper `restart-drill` skipped because no helper was started through
+  the local `vz-helperctl.py start` workflow
 - host reboot or launchd-managed restart validation handled through a manual
   operator procedure rather than the workflow
 

--- a/Docs/superpowers/plans/2026-05-10-vz-helper-managed-restart-drill.md
+++ b/Docs/superpowers/plans/2026-05-10-vz-helper-managed-restart-drill.md
@@ -1,0 +1,77 @@
+# VZ Helper Managed Restart Drill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an operator-owned `vz-helperctl.py restart-drill` command that validates managed helper stop/start/status recovery without launchd or host reboot automation.
+
+**Architecture:** Keep the drill inside the existing `vz-helperctl.py` lifecycle wrapper so it reuses current socket, pid-file, log-directory, serial-directory, ping, and protocol checks. The drill only acts on helpers controlled by the managed pid-file path; unmanaged launchd/helper crash classes remain documented manual procedures.
+
+**Tech Stack:** Python 3 CLI, existing `tools/macos-vz-helper/Tests/test_vz_helperctl.py` pytest coverage, existing sandbox operator docs.
+
+---
+
+### Task 1: Add Portable Restart-Drill Behavior
+
+**Files:**
+- Modify: `tools/macos-vz-helper/scripts/vz-helperctl.py`
+- Test: `tools/macos-vz-helper/Tests/test_vz_helperctl.py`
+
+- [x] **Step 1: Write failing tests for the drill helper**
+
+Add tests proving a running managed helper is stopped, started, and status-checked after restart; an absent helper fails without mutation; and start failure is reported without running post-status.
+
+- [x] **Step 2: Verify red**
+
+Run: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -k 'restart_drill' -q`
+
+Expected: failures because restart-drill behavior does not exist yet.
+
+- [x] **Step 3: Implement the minimal restart-drill helper**
+
+Add a focused function that collects pre-status, requires `process=helper_pid_running` and successful `ping`, calls `stop_helper`, calls `start_helper`, then collects post-status and reports a final `restart_drill` result.
+
+- [x] **Step 4: Verify green**
+
+Run the same focused pytest command and confirm all restart-drill tests pass.
+
+### Task 2: Add CLI Entry Point And Docs
+
+**Files:**
+- Modify: `tools/macos-vz-helper/scripts/vz-helperctl.py`
+- Modify: `tools/macos-vz-helper/README.md`
+- Modify: `Docs/Sandbox/macos-runtime-operator-notes.md`
+- Modify: `Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md`
+- Test: `tools/macos-vz-helper/Tests/test_vz_helperctl.py`
+
+- [x] **Step 1: Write failing CLI test**
+
+Add coverage that `restart-drill` accepts the same helper/socket/pid/log/entitlement options as status/start/stop, passes them into the drill helper, and supports JSON output.
+
+- [x] **Step 2: Verify red**
+
+Run the focused restart-drill pytest selection and confirm the CLI test fails because the subcommand is not wired.
+
+- [x] **Step 3: Implement CLI and document operator usage**
+
+Add the `restart-drill` parser, print named results through existing `_print_results`, return non-zero when any result fails, and update docs to position it before launchd or host reboot validation.
+
+- [x] **Step 4: Verify focused tests**
+
+Run: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -q`
+
+### Task 3: Final Verification And Task Closeout
+
+**Files:**
+- Modify: `backlog/tasks/task-206 - Add-managed-VZ-helper-restart-status-drill.md`
+
+- [x] **Step 1: Run static and security checks**
+
+Run `git diff --check` and Bandit on the touched helper script/tests with `B101` skipped for tests.
+
+- [x] **Step 2: Update TASK-206**
+
+Check completed acceptance criteria, record verification, and add a final summary.
+
+- [x] **Step 3: Commit**
+
+Stage the plan, implementation, docs, tests, and task file. Commit with a message such as `feat(sandbox): add VZ helper restart drill`.

--- a/backlog/tasks/task-206 - Add-managed-VZ-helper-restart-status-drill.md
+++ b/backlog/tasks/task-206 - Add-managed-VZ-helper-restart-status-drill.md
@@ -4,7 +4,7 @@ title: Add managed VZ helper restart/status drill
 status: Done
 assignee: []
 created_date: '2026-05-10 00:55'
-updated_date: '2026-05-10 01:04'
+updated_date: '2026-05-10 01:19'
 labels:
   - sandbox
   - vz-linux
@@ -42,12 +42,18 @@ Plan: Docs/superpowers/plans/2026-05-10-vz-helper-managed-restart-drill.md
 Verification: pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -q => 93 passed, 1 skipped; git diff --check => pass; Bandit production script => 0 findings; Bandit test file with baseline test skips B101/B108/B404/B603 => 0 findings.
 
 Known skips/blockers: no real VZ VM restart drill was run in this portable slice; real host lifecycle validation remains operator-gated.
+
+Review fix pass: Qodo opened two still-valid threads on missing helper docstrings and overlong _prefixed_results signature.
+
+Review fix verification: pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -q => 93 passed, 1 skipped; git diff --check => pass; Bandit helper script => 0 findings; Bandit helper tests with baseline skips B101/B108/B404/B603 => 0 findings.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Added a managed vz-helperctl restart-drill command that verifies a helperctl-owned helper is running, stops it through the existing pid/socket lease, starts it again on the same managed paths, and verifies status afterward. Added portable unit coverage and operator documentation clarifying this is a local lifecycle drill, not launchd or host reboot automation.
+
+Review follow-up added docstrings for the new restart-drill helper functions and wrapped the overlong _prefixed_results signature.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-206 - Add-managed-VZ-helper-restart-status-drill.md
+++ b/backlog/tasks/task-206 - Add-managed-VZ-helper-restart-status-drill.md
@@ -1,0 +1,61 @@
+---
+id: TASK-206
+title: Add managed VZ helper restart/status drill
+status: Done
+assignee: []
+created_date: '2026-05-10 00:55'
+updated_date: '2026-05-10 01:04'
+labels:
+  - sandbox
+  - vz-linux
+  - operator-workflow
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1465'
+documentation:
+  - Docs/Sandbox/macos-runtime-operator-notes.md
+  - Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
+  - tools/macos-vz-helper/README.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add a focused operator-managed VZ helper lifecycle drill that exercises stop/start/status behavior through the existing vz-helperctl path without introducing launchd automation or host reboot mutation. This follows the VZ Linux crash/reboot recovery posture: helper lifecycle validation should be explicit, operator-owned, log-preserving, and safe to run before broader launchd or reboot drills.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A vz-helperctl-managed drill command or equivalent host-side script validates helper stop/start/status/ping flow without requiring pytest to own the helper process.
+- [x] #2 The drill uses the existing private socket pid log and serial-log directory hardening checks and does not weaken helper lifecycle safety contracts.
+- [x] #3 The drill has portable unit coverage for command construction and failure cleanup behavior without requiring a real Virtualization.framework host.
+- [x] #4 Operator documentation explains when to use the drill and clearly states that launchd-managed restart and host reboot remain manual future work.
+- [x] #5 Focused tests plus touched-scope security checks pass.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Plan: Docs/superpowers/plans/2026-05-10-vz-helper-managed-restart-drill.md
+
+Verification: pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -q => 93 passed, 1 skipped; git diff --check => pass; Bandit production script => 0 findings; Bandit test file with baseline test skips B101/B108/B404/B603 => 0 findings.
+
+Known skips/blockers: no real VZ VM restart drill was run in this portable slice; real host lifecycle validation remains operator-gated.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added a managed vz-helperctl restart-drill command that verifies a helperctl-owned helper is running, stops it through the existing pid/socket lease, starts it again on the same managed paths, and verifies status afterward. Added portable unit coverage and operator documentation clarifying this is a local lifecycle drill, not launchd or host reboot automation.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/Sandbox/README.md
+++ b/tldw_Server_API/app/core/Sandbox/README.md
@@ -140,7 +140,7 @@ Current limitations:
 - The generic admin startup warning endpoint is `GET /api/v1/admin/startup-warnings`.
   It exposes current-process warning records only; there is no
   cross-process aggregation or persistence in this slice.
-- `tools/macos-vz-helper/scripts/vz-helperctl.py` is the preferred operator helper lifecycle command for `check`, `build`, `sign`, `start`, `status`, `stop`, `plist`, and `smoke`; it can generate launchd plist scaffolding but does not install or load services automatically.
+- `tools/macos-vz-helper/scripts/vz-helperctl.py` is the preferred operator helper lifecycle command for `check`, `build`, `sign`, `start`, `status`, `restart-drill`, `stop`, `plist`, and `smoke`; it can generate launchd plist scaffolding but does not install or load services automatically.
 - helper-backed template validation now distinguishes canonical bundles from
   raw-disk compatibility mode through `boot_mode` and `validation_strength`.
 - `SandboxImageStore` persists template manifests under
@@ -174,6 +174,10 @@ Current limitations:
   or the host-gated workflow's `include_failure_drills` dispatch input. These
   drills are disabled by default and currently verify that a drill-owned stale
   session VM is replaced before the next same-session command completes.
+- Manual helper lifecycle restart checks can be run through
+  `tools/macos-vz-helper/scripts/vz-helperctl.py restart-drill` after the helper
+  has been started through the managed wrapper. This is a local operator drill,
+  not launchd automation or host reboot validation.
 - The host-gated CI acceptance policy for real `vz_linux` smoke lives in
   `Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md`. It defines
   manual/nightly gates, expected skips, artifact upload expectations, branch

--- a/tools/macos-vz-helper/README.md
+++ b/tools/macos-vz-helper/README.md
@@ -40,6 +40,7 @@ tools/macos-vz-helper/scripts/vz-helperctl.py check
 tools/macos-vz-helper/scripts/vz-helperctl.py build
 tools/macos-vz-helper/scripts/vz-helperctl.py start
 tools/macos-vz-helper/scripts/vz-helperctl.py status
+tools/macos-vz-helper/scripts/vz-helperctl.py restart-drill
 tools/macos-vz-helper/scripts/vz-helperctl.py stop
 tools/macos-vz-helper/scripts/vz-helperctl.py plist
 ```
@@ -51,6 +52,12 @@ The command uses stable user-owned defaults under
 `plist` prints LaunchAgent scaffolding by default and does not create runtime
 directories unless `--create-dirs` is provided. It does not call `launchctl`,
 install services, or auto-upgrade helpers.
+
+`restart-drill` is an operator-managed lifecycle drill for helpers already
+started through `vz-helperctl.py start`. It verifies the current managed helper
+status, stops it through the pid-file/socket lease, starts a replacement on the
+same managed paths, and verifies status again. It does not manage launchd,
+reboot the host, or take ownership of helpers started outside this wrapper.
 
 For real host E2E smoke, prefer the managed wrapper:
 

--- a/tools/macos-vz-helper/Tests/test_vz_helperctl.py
+++ b/tools/macos-vz-helper/Tests/test_vz_helperctl.py
@@ -1,4 +1,5 @@
 import importlib.util
+import json
 import os
 import plistlib
 import socket
@@ -8,6 +9,7 @@ import tempfile
 import time
 from pathlib import Path
 from subprocess import CompletedProcess
+from typing import Any
 from unittest import TestCase
 
 import pytest
@@ -2038,6 +2040,161 @@ def test_stop_helper_removes_owned_socket_after_process_exit(tmp_path):
     CASE.assertEqual(result, helperctl.CheckResult(ok=True))
     CASE.assertEqual(killed, [1234])
     CASE.assertEqual(removed, [(socket_path, identity)])
+
+
+def test_restart_drill_stops_starts_and_reports_after_status(tmp_path: Path) -> None:
+    helperctl = load_helperctl()
+    helper = tmp_path / "macos-vz-helper"
+    socket_path = tmp_path / "runtime" / "helper.sock"
+    pid_file = tmp_path / "runtime" / "helper.pid"
+    log_dir = tmp_path / "logs"
+    calls: list[tuple[str, tuple[Any, ...]]] = []
+
+    def status_collector(*args: Any, **kwargs: Any) -> list[tuple[str, Any]]:
+        calls.append(("status", args))
+        return [
+            ("process", helperctl.CheckResult(ok=True, reason="helper_pid_running")),
+            ("ping", helperctl.CheckResult(ok=True)),
+        ]
+
+    def stopper(*args: Any, **kwargs: Any) -> Any:
+        calls.append(("stop", args))
+        return helperctl.CheckResult(ok=True)
+
+    def starter(*args: Any, **kwargs: Any) -> Any:
+        calls.append(("start", args))
+        return helperctl.CheckResult(ok=True)
+
+    results = helperctl.restart_helper_drill(
+        helper,
+        socket_path,
+        pid_file,
+        log_dir,
+        status_collector=status_collector,
+        stopper=stopper,
+        starter=starter,
+    )
+
+    CASE.assertEqual([call[0] for call in calls], ["status", "stop", "start", "status"])
+    CASE.assertIn(("stop", helperctl.CheckResult(ok=True)), results)
+    CASE.assertIn(("start", helperctl.CheckResult(ok=True)), results)
+    CASE.assertIn(("restart_drill", helperctl.CheckResult(ok=True)), results)
+
+
+def test_restart_drill_fails_without_running_managed_helper(tmp_path: Path) -> None:
+    helperctl = load_helperctl()
+    helper = tmp_path / "macos-vz-helper"
+    socket_path = tmp_path / "runtime" / "helper.sock"
+    pid_file = tmp_path / "runtime" / "helper.pid"
+    log_dir = tmp_path / "logs"
+
+    def status_collector(*args: Any, **kwargs: Any) -> list[tuple[str, Any]]:
+        return [
+            ("process", helperctl.CheckResult(ok=True, reason="helper_not_running")),
+            ("ping", helperctl.CheckResult(ok=True, reason="helper_not_running")),
+        ]
+
+    results = helperctl.restart_helper_drill(
+        helper,
+        socket_path,
+        pid_file,
+        log_dir,
+        status_collector=status_collector,
+        stopper=lambda *args, **kwargs: pytest.fail("restart drill should not stop absent helper"),
+        starter=lambda *args, **kwargs: pytest.fail("restart drill should not start absent helper"),
+    )
+
+    CASE.assertEqual(results[-1], ("restart_drill", helperctl.CheckResult(ok=False, reason="helper_not_running")))
+
+
+def test_restart_drill_reports_start_failure_without_post_status(tmp_path: Path) -> None:
+    helperctl = load_helperctl()
+    helper = tmp_path / "macos-vz-helper"
+    socket_path = tmp_path / "runtime" / "helper.sock"
+    pid_file = tmp_path / "runtime" / "helper.pid"
+    log_dir = tmp_path / "logs"
+    status_calls: list[tuple[Any, ...]] = []
+
+    def status_collector(*args: Any, **kwargs: Any) -> list[tuple[str, Any]]:
+        status_calls.append(args)
+        return [
+            ("process", helperctl.CheckResult(ok=True, reason="helper_pid_running")),
+            ("ping", helperctl.CheckResult(ok=True)),
+        ]
+
+    results = helperctl.restart_helper_drill(
+        helper,
+        socket_path,
+        pid_file,
+        log_dir,
+        status_collector=status_collector,
+        stopper=lambda *args, **kwargs: helperctl.CheckResult(ok=True),
+        starter=lambda *args, **kwargs: helperctl.CheckResult(ok=False, reason="helper_ping_failed"),
+    )
+
+    CASE.assertEqual(len(status_calls), 1)
+    CASE.assertIn(("start", helperctl.CheckResult(ok=False, reason="helper_ping_failed")), results)
+    CASE.assertEqual(results[-1], ("restart_drill", helperctl.CheckResult(ok=False, reason="helper_ping_failed")))
+
+
+def test_restart_drill_cli_passes_paths_and_prints_json(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    helperctl = load_helperctl()
+    helper = tmp_path / "macos-vz-helper"
+    socket_path = tmp_path / "runtime" / "helper.sock"
+    pid_file = tmp_path / "runtime" / "helper.pid"
+    log_dir = tmp_path / "logs"
+    entitlements = tmp_path / "helper.entitlements"
+    captured_paths: dict[str, Any] = {}
+
+    def fake_restart_drill(
+        helper_path: Path,
+        received_socket_path: Path,
+        received_pid_file: Path,
+        received_log_dir: Path,
+        **kwargs: Any,
+    ) -> list[tuple[str, Any]]:
+        captured_paths.update(
+            {
+                "helper": helper_path,
+                "socket": received_socket_path,
+                "pid_file": received_pid_file,
+                "log_dir": received_log_dir,
+                "entitlements": kwargs["entitlements_path"],
+            }
+        )
+        return [("restart_drill", helperctl.CheckResult(ok=True))]
+
+    monkeypatch.setattr(helperctl, "restart_helper_drill", fake_restart_drill)
+
+    code = helperctl.main(
+        [
+            "restart-drill",
+            "--helper",
+            str(helper),
+            "--socket",
+            str(socket_path),
+            "--pid-file",
+            str(pid_file),
+            "--log-dir",
+            str(log_dir),
+            "--entitlements",
+            str(entitlements),
+            "--json",
+        ]
+    )
+
+    output = json.loads(capsys.readouterr().out)
+    CASE.assertEqual(code, 0)
+    CASE.assertEqual(output[0]["name"], "restart_drill")
+    CASE.assertEqual(captured_paths["helper"], helper)
+    CASE.assertEqual(captured_paths["socket"], socket_path)
+    CASE.assertEqual(captured_paths["pid_file"], pid_file)
+    CASE.assertEqual(captured_paths["log_dir"], log_dir)
+    CASE.assertEqual(captured_paths["entitlements"], entitlements)
 
 
 def test_smoke_dry_run_delegates_to_host_smoke_script(tmp_path, capsys):

--- a/tools/macos-vz-helper/scripts/vz-helperctl.py
+++ b/tools/macos-vz-helper/scripts/vz-helperctl.py
@@ -1156,6 +1156,103 @@ def status_helper(
     return CheckResult(ok=True, reason="helper_not_running")
 
 
+def _prefixed_results(prefix: str, results: Iterable[tuple[str, CheckResult]]) -> list[tuple[str, CheckResult]]:
+    return [(f"{prefix}_{name}", result) for name, result in results]
+
+
+def _result_named(results: Iterable[tuple[str, CheckResult]], name: str) -> CheckResult | None:
+    for result_name, result in results:
+        if result_name == name:
+            return result
+    return None
+
+
+def _managed_helper_running_result(results: list[tuple[str, CheckResult]]) -> CheckResult:
+    for _, result in results:
+        if not result.ok:
+            return result
+
+    process_result = _result_named(results, "process")
+    if process_result is None:
+        return CheckResult(ok=False, reason="helper_status_missing_process")
+    if process_result.reason != "helper_pid_running":
+        return CheckResult(
+            ok=False,
+            reason=process_result.reason or "helper_not_running",
+            message=process_result.message,
+        )
+
+    ping_result = _result_named(results, "ping")
+    if ping_result is None:
+        return CheckResult(ok=False, reason="helper_status_missing_ping")
+    if not ping_result.ok:
+        return ping_result
+
+    return CheckResult(ok=True)
+
+
+def restart_helper_drill(
+    helper_path: Path,
+    socket_path: Path,
+    pid_file: Path,
+    log_dir: Path,
+    *,
+    plist_path: Path | None = None,
+    entitlements_path: Path | None = None,
+    dry_run: bool = False,
+    status_collector: Callable[..., list[tuple[str, CheckResult]]] = collect_status_results,
+    stopper: Callable[..., CheckResult] | None = None,
+    starter: Callable[..., CheckResult] = start_helper,
+) -> list[tuple[str, CheckResult]]:
+    """Run an operator-managed stop/start/status drill for a helperctl-owned helper."""
+    stopper_fn = stopper or stop_helper
+    results: list[tuple[str, CheckResult]] = []
+    before_status = status_collector(
+        helper_path,
+        socket_path,
+        pid_file,
+        log_dir,
+        plist_path=plist_path,
+        entitlements_path=entitlements_path,
+    )
+    results.extend(_prefixed_results("before", before_status))
+
+    before_gate = _managed_helper_running_result(before_status)
+    if not before_gate.ok:
+        results.append(("restart_drill", before_gate))
+        return results
+
+    if dry_run:
+        results.append(("stop", CheckResult(ok=True, reason="dry_run")))
+        results.append(("start", CheckResult(ok=True, reason="dry_run")))
+        results.append(("restart_drill", CheckResult(ok=True, reason="dry_run")))
+        return results
+
+    stop_result = stopper_fn(helper_path, pid_file, socket_path=socket_path)
+    results.append(("stop", stop_result))
+    if not stop_result.ok:
+        results.append(("restart_drill", stop_result))
+        return results
+
+    start_result = starter(helper_path, socket_path, pid_file, log_dir, dry_run=False)
+    results.append(("start", start_result))
+    if not start_result.ok:
+        results.append(("restart_drill", start_result))
+        return results
+
+    after_status = status_collector(
+        helper_path,
+        socket_path,
+        pid_file,
+        log_dir,
+        plist_path=plist_path,
+        entitlements_path=entitlements_path,
+    )
+    results.extend(_prefixed_results("after", after_status))
+    results.append(("restart_drill", _managed_helper_running_result(after_status)))
+    return results
+
+
 def stop_helper(
     helper_path: Path,
     pid_file: Path,
@@ -1346,6 +1443,21 @@ def _status_command(args: argparse.Namespace) -> int:
     return 0 if all(result.ok for _, result in results) else 1
 
 
+def _restart_drill_command(args: argparse.Namespace) -> int:
+    paths = default_paths()
+    results = restart_helper_drill(
+        Path(args.helper_path) if args.helper_path else DEFAULT_HELPER,
+        Path(args.socket_path) if args.socket_path else paths.socket_path,
+        Path(args.pid_file) if args.pid_file else paths.pid_file,
+        Path(args.log_dir) if args.log_dir else paths.log_dir,
+        plist_path=Path(args.plist_output) if args.plist_output else paths.plist_path,
+        entitlements_path=Path(args.entitlements) if args.entitlements else None,
+        dry_run=args.dry_run,
+    )
+    _print_results(results, as_json=args.json)
+    return 0 if all(result.ok for _, result in results) else 1
+
+
 def _start_command(args: argparse.Namespace) -> int:
     paths = default_paths()
     result = start_helper(
@@ -1434,6 +1546,20 @@ def build_parser() -> argparse.ArgumentParser:
     status.add_argument("--entitlements")
     status.add_argument("--json", action="store_true")
     status.set_defaults(func=_status_command)
+
+    restart_drill = subparsers.add_parser(
+        "restart-drill",
+        help="stop, start, and status-check a helperctl-managed helper",
+    )
+    restart_drill.add_argument("--helper", "--helper-path", dest="helper_path")
+    restart_drill.add_argument("--socket", "--socket-path", dest="socket_path")
+    restart_drill.add_argument("--pid-file")
+    restart_drill.add_argument("--log-dir")
+    restart_drill.add_argument("--plist-output")
+    restart_drill.add_argument("--entitlements")
+    restart_drill.add_argument("--dry-run", action="store_true")
+    restart_drill.add_argument("--json", action="store_true")
+    restart_drill.set_defaults(func=_restart_drill_command)
 
     start = subparsers.add_parser("start", help="start the helper")
     start.add_argument("--helper", "--helper-path", dest="helper_path")

--- a/tools/macos-vz-helper/scripts/vz-helperctl.py
+++ b/tools/macos-vz-helper/scripts/vz-helperctl.py
@@ -1156,11 +1156,16 @@ def status_helper(
     return CheckResult(ok=True, reason="helper_not_running")
 
 
-def _prefixed_results(prefix: str, results: Iterable[tuple[str, CheckResult]]) -> list[tuple[str, CheckResult]]:
+def _prefixed_results(
+    prefix: str,
+    results: Iterable[tuple[str, CheckResult]],
+) -> list[tuple[str, CheckResult]]:
+    """Namespace drill sub-results so pre/post status rows remain distinguishable."""
     return [(f"{prefix}_{name}", result) for name, result in results]
 
 
 def _result_named(results: Iterable[tuple[str, CheckResult]], name: str) -> CheckResult | None:
+    """Return the first result matching a lifecycle check name."""
     for result_name, result in results:
         if result_name == name:
             return result
@@ -1168,6 +1173,7 @@ def _result_named(results: Iterable[tuple[str, CheckResult]], name: str) -> Chec
 
 
 def _managed_helper_running_result(results: list[tuple[str, CheckResult]]) -> CheckResult:
+    """Validate that status output proves a managed helper process is pingable."""
     for _, result in results:
         if not result.ok:
             return result


### PR DESCRIPTION
## Summary
- Add `vz-helperctl.py restart-drill` to validate a helperctl-owned helper can stop, restart on the same managed paths, and report healthy status afterward.
- Reuse existing status, stop, start, socket, pid-file, log-directory, serial-log, ping, and entitlement validation paths rather than adding a parallel lifecycle mechanism.
- Document the drill as a local operator check, explicitly separate from launchd automation and host reboot validation.

## Test Plan
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -q`
- `git diff --check`
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit tools/macos-vz-helper/scripts/vz-helperctl.py -f json -o /tmp/bandit_vz_helper_restart_drill_script.json`
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit tools/macos-vz-helper/Tests/test_vz_helperctl.py -s B101,B108,B404,B603 -f json -o /tmp/bandit_vz_helper_restart_drill_tests.json`

## Notes
- No real VZ VM restart drill was run in this portable slice; real host lifecycle validation remains operator-gated.
- AI-generated PR merge gate applies: a human-written Change summary explaining what changed and why is still required before merge.