### PR TITLE
Migrate chat queue blocked label to state registry

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -4994,17 +4994,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "canonical-state-label:src/components/Common/ChatQueuePanel.tsx:Blocked",
-    "path": "src/components/Common/ChatQueuePanel.tsx",
-    "rule": "canonical-state-label",
-    "subject": "Blocked",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing hardcoded \"Blocked\" state label in src/components/Common/ChatQueuePanel.tsx before the guard.",
-    "replacement": "getDesignSystemState(...)",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "canonical-state-label:src/components/Common/PromptSelect.tsx:Loading",
     "path": "src/components/Common/PromptSelect.tsx",
     "rule": "canonical-state-label",

--- a/apps/packages/ui/src/components/Common/ChatQueuePanel.tsx
+++ b/apps/packages/ui/src/components/Common/ChatQueuePanel.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import type { TFunction } from "i18next"
 import { useTranslation } from "react-i18next"
 
+import { getDesignSystemState } from "@/design-system"
 import type { QueuedRequest } from "@/utils/chat-request-queue"
 
 type ChatQueuePanelProps = {
@@ -17,6 +18,8 @@ type ChatQueuePanelProps = {
   onOpenDiagnostics?: () => void
   forceRunDisabledReason?: string | null
 }
+
+const BLOCKED_STATE_LABEL = getDesignSystemState("blocked").label
 
 const formatBlockedReason = (
   blockedReason: string | null,
@@ -36,7 +39,7 @@ const formatBlockedReason = (
     default:
       return blockedReason
         ? blockedReason
-        : t("playground:composer.queue.blocked", "Blocked")
+        : t("playground:composer.queue.blocked", BLOCKED_STATE_LABEL)
   }
 }
 

--- a/apps/packages/ui/src/components/Common/__tests__/ChatQueuePanel.test.tsx
+++ b/apps/packages/ui/src/components/Common/__tests__/ChatQueuePanel.test.tsx
@@ -24,6 +24,13 @@ vi.mock("react-i18next", () => ({
   })
 }))
 
+vi.mock("@/design-system", () => ({
+  getDesignSystemState: vi.fn((key: string) => ({
+    key,
+    label: key === "blocked" ? "Blocked via registry" : key
+  }))
+}))
+
 describe("ChatQueuePanel", () => {
   it("shows a queue summary and lets the user edit a queued request", async () => {
     const user = userEvent.setup()
@@ -133,5 +140,54 @@ describe("ChatQueuePanel", () => {
     expect(
       screen.getAllByRole("button", { name: "Move down" })[0]
     ).toBeDisabled()
+  })
+
+  it("uses the design-system blocked label when no blocked reason is provided", () => {
+    const blocked = buildQueuedRequest({
+      promptText: "retry when the backend is ready",
+      status: "blocked"
+    })
+
+    render(
+      <ChatQueuePanel
+        queue={[blocked]}
+        isConnectionReady
+        isStreaming={false}
+        onRunNext={vi.fn()}
+        onRunNow={vi.fn()}
+        onDelete={vi.fn()}
+        onMove={vi.fn()}
+        onUpdate={vi.fn()}
+        onClearAll={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText("Blocked via registry")).toBeInTheDocument()
+  })
+
+  it("keeps custom blocked reasons unchanged", () => {
+    const blocked = buildQueuedRequest({
+      promptText: "retry after reviewing diagnostics",
+      status: "blocked",
+      blockedReason: "Review diagnostics before retrying"
+    })
+
+    render(
+      <ChatQueuePanel
+        queue={[blocked]}
+        isConnectionReady
+        isStreaming={false}
+        onRunNext={vi.fn()}
+        onRunNow={vi.fn()}
+        onDelete={vi.fn()}
+        onMove={vi.fn()}
+        onUpdate={vi.fn()}
+        onClearAll={vi.fn()}
+      />
+    )
+
+    expect(
+      screen.getByText("Review diagnostics before retrying")
+    ).toBeInTheDocument()
   })
 })

--- a/apps/packages/ui/src/components/Common/__tests__/ChatQueuePanel.test.tsx
+++ b/apps/packages/ui/src/components/Common/__tests__/ChatQueuePanel.test.tsx
@@ -24,12 +24,23 @@ vi.mock("react-i18next", () => ({
   })
 }))
 
-vi.mock("@/design-system", () => ({
-  getDesignSystemState: vi.fn((key: string) => ({
-    key,
-    label: key === "blocked" ? "Blocked via registry" : key
-  }))
-}))
+vi.mock("@/design-system", async (importActual) => {
+  const actual = await importActual<typeof import("@/design-system")>()
+
+  return {
+    ...actual,
+    getDesignSystemState: vi.fn(
+      (key: Parameters<typeof actual.getDesignSystemState>[0]) => {
+        const state = actual.getDesignSystemState(key)
+
+        return {
+          ...state,
+          label: key === "blocked" ? "Blocked via registry" : state.label
+        }
+      }
+    )
+  }
+})
 
 describe("ChatQueuePanel", () => {
   it("shows a queue summary and lets the user edit a queued request", async () => {

--- a/backlog/tasks/task-45.36 - Migrate-ChatQueuePanel-blocked-label-to-design-system-state-registry.md
+++ b/backlog/tasks/task-45.36 - Migrate-ChatQueuePanel-blocked-label-to-design-system-state-registry.md
@@ -1,0 +1,64 @@
+---
+id: TASK-45.36
+title: Migrate ChatQueuePanel blocked label to design-system state registry
+status: Done
+assignee:
+  - Codex
+created_date: '2026-05-10 01:22'
+updated_date: '2026-05-10 01:24'
+labels:
+  - design-system
+  - ui
+  - product-state
+  - chat
+  - queue
+dependencies: []
+references:
+  - apps/packages/ui/src/components/Common/ChatQueuePanel.tsx
+  - apps/packages/ui/src/components/Common/__tests__/ChatQueuePanel.test.tsx
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+parent_task_id: TASK-45
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Route the ChatQueuePanel generic blocked fallback label through the canonical design-system state registry instead of leaving the hardcoded product-state label as a baseline exception. This continues the design-system product-state migration under TASK-45 and keeps ChatQueuePanel translation override behavior intact while removing the matching guard baseline entry.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 ChatQueuePanel uses the design-system state registry for the generic blocked fallback label while preserving explicit blocked reasons and i18n fallback behavior.
+- [x] #2 Focused ChatQueuePanel tests cover the registry fallback path and a custom blocked reason path.
+- [x] #3 The ChatQueuePanel canonical-state-label baseline entry is removed and the design-system product-state verifier passes.
+- [x] #4 Verification notes include focused Vitest coverage, product-state guard coverage, product-state verifier, diff check, TypeScript touched-file status, and Bandit applicability.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused ChatQueuePanel regression test that proves the generic blocked fallback can come from the design-system state registry, while a custom blocked reason still renders unchanged. 2. Verify the new test fails before production changes. 3. Update ChatQueuePanel to use getDesignSystemState("blocked").label as the translation fallback for the generic blocked state only. 4. Remove the matching ChatQueuePanel canonical-state-label baseline exception. 5. Run focused ChatQueuePanel tests, product-state guard tests, bun run verify:design-system-state, git diff --check, and a touched-file TypeScript check; record Bandit as skipped if the touched scope remains UI-only TypeScript/JSON/Backlog.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implementation notes: Added RED coverage for the generic blocked fallback by mocking getDesignSystemState("blocked") to return a distinct label; the first focused run failed because ChatQueuePanel still rendered the hardcoded Blocked fallback. Updated ChatQueuePanel to use getDesignSystemState("blocked").label as the i18n fallback only when blockedReason is empty, preserving explicit blocked reasons. Removed canonical-state-label:src/components/Common/ChatQueuePanel.tsx:Blocked from the product-state baseline. Verification: focused ChatQueuePanel Vitest passed 5 tests; product-state guard Vitest passed 52 tests; bun run verify:design-system-state exited 0 with 510 baseline exceptions; git diff --check passed; repo-wide bunx tsc --noEmit --pretty false exited 2 on existing unrelated UI TypeScript debt, and rg found no touched-file/design-system matches in the tsc output. Bandit skipped because the touched scope is UI TypeScript, JSON, and Backlog markdown only.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated ChatQueuePanel's generic blocked fallback label to the design-system state registry and removed the corresponding baseline exception. Added focused tests proving the registry fallback is used when no blocked reason is present and custom blocked reasons still render unchanged. Verification passed for focused component coverage, product-state guard coverage, the design-system state verifier, and diff whitespace; repo-wide TypeScript still has unrelated existing failures with no touched-file matches. Bandit was not applicable to this UI-only TS/JSON/markdown slice.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.36 - Migrate-ChatQueuePanel-blocked-label-to-design-system-state-registry.md
+++ b/backlog/tasks/task-45.36 - Migrate-ChatQueuePanel-blocked-label-to-design-system-state-registry.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - Codex
 created_date: '2026-05-10 01:22'
-updated_date: '2026-05-10 01:24'
+updated_date: '2026-05-10 01:32'
 labels:
   - design-system
   - ui
@@ -45,12 +45,16 @@ Route the ChatQueuePanel generic blocked fallback label through the canonical de
 
 <!-- SECTION:NOTES:BEGIN -->
 Implementation notes: Added RED coverage for the generic blocked fallback by mocking getDesignSystemState("blocked") to return a distinct label; the first focused run failed because ChatQueuePanel still rendered the hardcoded Blocked fallback. Updated ChatQueuePanel to use getDesignSystemState("blocked").label as the i18n fallback only when blockedReason is empty, preserving explicit blocked reasons. Removed canonical-state-label:src/components/Common/ChatQueuePanel.tsx:Blocked from the product-state baseline. Verification: focused ChatQueuePanel Vitest passed 5 tests; product-state guard Vitest passed 52 tests; bun run verify:design-system-state exited 0 with 510 baseline exceptions; git diff --check passed; repo-wide bunx tsc --noEmit --pretty false exited 2 on existing unrelated UI TypeScript debt, and rg found no touched-file/design-system matches in the tsc output. Bandit skipped because the touched scope is UI TypeScript, JSON, and Backlog markdown only.
+
+PR review follow-up: Qodo reported that the ChatQueuePanel test replaced the full @/design-system module with a minimal mock. Verified the repo uses a safer partial-mock pattern in PresentationStudioStatusBadge.design-system.test.tsx, so this review item is valid and will be addressed by spreading actual design-system exports while overriding only getDesignSystemState.
+
+PR review follow-up completed: changed ChatQueuePanel.test.tsx to partial-mock @/design-system by spreading importActual exports and overriding only getDesignSystemState. Verification after the review fix: ChatQueuePanel Vitest passed 5 tests; product-state guard Vitest passed 52 tests; bun run verify:design-system-state exited 0 with 510 baseline exceptions; git diff --check passed; repo-wide bunx tsc --noEmit --pretty false still exits 2 on existing unrelated UI TypeScript debt, and rg found no touched-file/design-system matches in the review-fix tsc output. Bandit remains skipped because this PR touches UI TypeScript, JSON, and Backlog markdown only.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Migrated ChatQueuePanel's generic blocked fallback label to the design-system state registry and removed the corresponding baseline exception. Added focused tests proving the registry fallback is used when no blocked reason is present and custom blocked reasons still render unchanged. Verification passed for focused component coverage, product-state guard coverage, the design-system state verifier, and diff whitespace; repo-wide TypeScript still has unrelated existing failures with no touched-file matches. Bandit was not applicable to this UI-only TS/JSON/markdown slice.
+Migrated ChatQueuePanel's generic blocked fallback label to the design-system state registry and removed the corresponding baseline exception. Added focused tests proving the registry fallback is used when no blocked reason is present and custom blocked reasons still render unchanged. Addressed PR review feedback by converting the @/design-system test mock to a partial mock that preserves actual exports while overriding only getDesignSystemState. Verification passed for focused component coverage, product-state guard coverage, the design-system state verifier, and diff whitespace; repo-wide TypeScript still has unrelated existing failures with no touched-file matches. Bandit was not applicable to this UI-only TS/JSON/markdown slice.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary
- route ChatQueuePanel generic blocked fallback through `getDesignSystemState("blocked").label`
- keep explicit blocked reasons unchanged
- remove the matching product-state baseline exception and track the slice in `TASK-45.36`

## Verification
- `bunx vitest run src/components/Common/__tests__/ChatQueuePanel.test.tsx --reporter=dot`
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot`
- `bun run verify:design-system-state`
- `git diff --check`
- `bunx tsc --noEmit --pretty false` exits 2 on existing unrelated UI TypeScript debt; filtered output has no touched-file/design-system matches
- Bandit skipped: UI-only TS/TSX/JSON/Backlog markdown changes