### PR TITLE
Migrate MediaLibraryStatsPanel unavailable label to state registry

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -5027,17 +5027,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "canonical-state-label:src/components/Media/MediaLibraryStatsPanel.tsx:Unavailable",
-    "path": "src/components/Media/MediaLibraryStatsPanel.tsx",
-    "rule": "canonical-state-label",
-    "subject": "Unavailable",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing hardcoded \"Unavailable\" state label in src/components/Media/MediaLibraryStatsPanel.tsx before the guard.",
-    "replacement": "getDesignSystemState(...)",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "canonical-state-label:src/components/Option/ACPPlayground/ACPSessionCreateModal.tsx:Ready",
     "path": "src/components/Option/ACPPlayground/ACPSessionCreateModal.tsx",
     "rule": "canonical-state-label",

--- a/apps/packages/ui/src/components/Media/MediaLibraryStatsPanel.tsx
+++ b/apps/packages/ui/src/components/Media/MediaLibraryStatsPanel.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ChevronDown } from 'lucide-react'
 import type { MediaResultItem } from '@/components/Media/types'
+import { getDesignSystemState } from '@/design-system'
 
 export type MediaLibraryStorageUsage = {
   loading: boolean
@@ -53,6 +54,8 @@ const formatInteger = (value: number): string => {
 const formatMegabytes = (value: number): string => {
   return `${value.toFixed(1)} MB`
 }
+
+const UNAVAILABLE_STATE_LABEL = getDesignSystemState('unavailable').label
 
 export const MediaLibraryStatsPanel: React.FC<MediaLibraryStatsPanelProps> = ({
   results,
@@ -217,7 +220,7 @@ export const MediaLibraryStatsPanel: React.FC<MediaLibraryStatsPanelProps> = ({
             ) : (
               <p className="m-0 text-text-muted" data-testid="media-library-stats-storage-empty">
                 {t('review:mediaPage.libraryStorageUnavailable', {
-                  defaultValue: 'Unavailable'
+                  defaultValue: UNAVAILABLE_STATE_LABEL
                 })}
               </p>
             )}

--- a/apps/packages/ui/src/components/Media/__tests__/MediaLibraryStatsPanel.test.tsx
+++ b/apps/packages/ui/src/components/Media/__tests__/MediaLibraryStatsPanel.test.tsx
@@ -21,6 +21,25 @@ vi.mock('react-i18next', () => ({
   })
 }))
 
+vi.mock('@/design-system', async (importActual) => {
+  const actual = await importActual<typeof import('@/design-system')>()
+
+  return {
+    ...actual,
+    getDesignSystemState: vi.fn(
+      (key: Parameters<typeof actual.getDesignSystemState>[0]) => {
+        const state = actual.getDesignSystemState(key)
+
+        return {
+          ...state,
+          label:
+            key === 'unavailable' ? 'Unavailable via registry' : state.label
+        }
+      }
+    )
+  }
+})
+
 describe('MediaLibraryStatsPanel', () => {
   it('renders visible totals, type distribution, words, and storage usage', () => {
     render(
@@ -153,5 +172,27 @@ describe('MediaLibraryStatsPanel', () => {
     fireEvent.click(toggle)
     expect(toggle).toHaveAttribute('aria-expanded', 'false')
     expect(screen.queryByTestId('media-library-stats-visible')).not.toBeInTheDocument()
+  })
+
+  it('renders unavailable storage state from the design-system registry', () => {
+    render(
+      <MediaLibraryStatsPanel
+        results={[]}
+        totalCount={0}
+        storageUsage={{
+          loading: false,
+          error: null,
+          totalMb: null,
+          quotaMb: null,
+          usagePercentage: null,
+          warning: null
+        }}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId('media-library-stats-toggle'))
+    expect(screen.getByTestId('media-library-stats-storage-empty')).toHaveTextContent(
+      'Unavailable via registry'
+    )
   })
 })

--- a/backlog/tasks/task-207 - Migrate-MediaLibraryStatsPanel-unavailable-label-to-design-system-state-registry.md
+++ b/backlog/tasks/task-207 - Migrate-MediaLibraryStatsPanel-unavailable-label-to-design-system-state-registry.md
@@ -1,0 +1,59 @@
+---
+id: TASK-207
+title: >-
+  Migrate MediaLibraryStatsPanel unavailable label to design-system state
+  registry
+status: Done
+assignee: []
+created_date: '2026-05-10 01:47'
+updated_date: '2026-05-10 01:58'
+labels:
+  - design-system
+  - frontend
+  - product-state
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replace the MediaLibraryStatsPanel storage unavailable fallback label with the canonical design-system unavailable state label and remove the matching product-state baseline exception.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 MediaLibraryStatsPanel storage unavailable fallback uses getDesignSystemState('unavailable').label as its default translation value.
+- [x] #2 Focused tests prove the unavailable fallback reads from the design-system state registry rather than a hardcoded literal.
+- [x] #3 The canonical-state-label baseline entry for MediaLibraryStatsPanel is removed and the design-system product-state verifier passes.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a regression test that mocks getDesignSystemState('unavailable') to a distinct label and asserts the storage unavailable fallback renders it. 2. Replace the MediaLibraryStatsPanel hardcoded unavailable default with the design-system state registry label. 3. Remove the matching canonical-state-label baseline exception and run focused verification.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented MediaLibraryStatsPanel unavailable fallback through getDesignSystemState('unavailable').label. Added focused test coverage using a partial design-system mock. Removed canonical-state-label baseline entry for src/components/Media/MediaLibraryStatsPanel.tsx:Unavailable. Bandit skipped because touched code is UI-only TypeScript/JSON/Backlog markdown with no Python execution surface.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated the MediaLibraryStatsPanel storage unavailable label to the design-system state registry and removed its product-state baseline exception. Verification: RED focused Vitest failed on the mocked registry label before implementation; GREEN focused Vitest passed 4/4; product-state guard passed 52/52; verify:design-system-state passed with baseline exceptions now 508 total and 40 canonical-state-label; git diff --check passed; broad UI tsc still fails on existing unrelated repo-wide debt with no touched-file matches.
+
+PR: https://github.com/rmusser01/tldw_server/pull/1489
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Route MediaLibraryStatsPanel storage unavailable fallback through getDesignSystemState("unavailable").label
- Add focused coverage proving the fallback uses the design-system state registry
- Remove the matching canonical-state-label baseline exception and record TASK-207

## Verification
- RED: bunx vitest run src/components/Media/__tests__/MediaLibraryStatsPanel.test.tsx --reporter=dot failed because the component still rendered "Unavailable"
- GREEN: bunx vitest run src/components/Media/__tests__/MediaLibraryStatsPanel.test.tsx --reporter=dot passed 4/4
- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed 52/52
- bun run verify:design-system-state passed; baseline exceptions now 508 total, 40 canonical-state-label
- git diff --check passed
- bunx tsc --noEmit --pretty false still exits 2 on existing unrelated UI test/type debt; filtered output had no touched-file matches

## Notes
- Bandit skipped: touched files are UI TypeScript, JSON baseline, and Backlog markdown only.
- Per AI-generated PR policy, a human-authored Change summary is still needed before merge.