### PR TITLE
Migrate WorkspaceStatusStrip ready label to state registry

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -5093,17 +5093,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "canonical-state-label:src/components/Option/ChatWorkspace/WorkspaceStatusStrip.tsx:Ready",
-    "path": "src/components/Option/ChatWorkspace/WorkspaceStatusStrip.tsx",
-    "rule": "canonical-state-label",
-    "subject": "Ready",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing hardcoded \"Ready\" state label in src/components/Option/ChatWorkspace/WorkspaceStatusStrip.tsx before the guard.",
-    "replacement": "getDesignSystemState(...)",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "canonical-state-label:src/components/Option/CompanionHome/CompanionHomePage.tsx:Setup required#label-setup-required-companionhomepage-line-119-ne2x8o",
     "path": "src/components/Option/CompanionHome/CompanionHomePage.tsx",
     "rule": "canonical-state-label",

--- a/apps/packages/ui/src/components/Option/ChatWorkspace/WorkspaceStatusStrip.tsx
+++ b/apps/packages/ui/src/components/Option/ChatWorkspace/WorkspaceStatusStrip.tsx
@@ -1,3 +1,5 @@
+import { getDesignSystemState } from "@/design-system"
+
 export type WorkspaceStatusStripProps = {
   backendAvailable: boolean
   streaming: boolean
@@ -6,6 +8,8 @@ export type WorkspaceStatusStripProps = {
 
 const statusPillClass =
   "inline-flex min-h-[24px] items-center rounded-md border border-border bg-surface px-2 text-xs font-medium text-text"
+
+const READY_STATE_LABEL = getDesignSystemState("ready").label
 
 export const WorkspaceStatusStrip = ({
   backendAvailable,
@@ -16,7 +20,7 @@ export const WorkspaceStatusStrip = ({
     ? "Server unavailable"
     : streaming
       ? "Streaming"
-      : "Ready"
+      : READY_STATE_LABEL
 
   return (
     <footer

--- a/apps/packages/ui/src/components/Option/ChatWorkspace/__tests__/WorkspaceStatusStrip.test.tsx
+++ b/apps/packages/ui/src/components/Option/ChatWorkspace/__tests__/WorkspaceStatusStrip.test.tsx
@@ -1,12 +1,30 @@
 import { render, screen } from "@testing-library/react"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import { WorkspaceStatusStrip } from "../WorkspaceStatusStrip"
+
+vi.mock("@/design-system", async (importActual) => {
+  const actual = await importActual<typeof import("@/design-system")>()
+
+  return {
+    ...actual,
+    getDesignSystemState: vi.fn(
+      (key: Parameters<typeof actual.getDesignSystemState>[0]) => {
+        const state = actual.getDesignSystemState(key)
+
+        return {
+          ...state,
+          label: key === "ready" ? "Ready via registry" : state.label
+        }
+      }
+    )
+  }
+})
 
 describe("WorkspaceStatusStrip", () => {
   it("renders ready and keyboard hint state", () => {
     render(<WorkspaceStatusStrip backendAvailable streaming={false} stagedSourceCount={0} />)
 
-    expect(screen.getByText("Ready")).toBeInTheDocument()
+    expect(screen.getByText("Ready via registry")).toBeInTheDocument()
     expect(screen.getByText("Ctrl+K command")).toBeInTheDocument()
     expect(screen.getByText("Ctrl+Enter send")).toBeInTheDocument()
   })

--- a/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
@@ -450,6 +450,11 @@ const replaceAnimation = (
   }
 })
 
+const sourceBadgeClass =
+  "inline-flex min-h-[22px] items-center rounded border px-1.5 py-0.5 text-xs font-medium"
+const sourceAvailableBadgeClass = `${sourceBadgeClass} border-state-ready/30 bg-state-ready/10 text-state-ready`
+const sourceUnavailableBadgeClass = `${sourceBadgeClass} border-state-unavailable/30 bg-state-unavailable/10 text-state-unavailable`
+
 export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
   selectedPersonaId,
   selectedPersonaName,
@@ -1616,9 +1621,9 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
           </div>
           <div className="flex flex-wrap gap-1">
             {item.source_available ? (
-              <Tag color="green">available</Tag>
+              <span className={sourceAvailableBadgeClass}>available</span>
             ) : (
-              <Tag color="red">unavailable</Tag>
+              <span className={sourceUnavailableBadgeClass}>unavailable</span>
             )}
             {item.source_changed ? <Tag color="orange">source changed</Tag> : null}
             {item.tags.map((tag) => (

--- a/backlog/tasks/task-210 - Migrate-WorkspaceStatusStrip-ready-label-to-design-system-state-registry.md
+++ b/backlog/tasks/task-210 - Migrate-WorkspaceStatusStrip-ready-label-to-design-system-state-registry.md
@@ -1,0 +1,58 @@
+---
+id: TASK-210
+title: Migrate WorkspaceStatusStrip ready label to design-system state registry
+status: Done
+assignee: []
+created_date: '2026-05-10 02:28'
+updated_date: '2026-05-10 02:34'
+labels:
+  - design-system
+  - frontend
+  - product-state
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replace the WorkspaceStatusStrip runtime ready label with the canonical design-system ready state label and remove the matching product-state baseline exception.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 WorkspaceStatusStrip uses getDesignSystemState('ready').label for the backend-available idle runtime label.
+- [x] #2 Focused tests prove the ready fallback reads from the design-system state registry rather than a hardcoded literal.
+- [x] #3 The canonical-state-label baseline entry for WorkspaceStatusStrip is removed and the design-system product-state verifier passes.
+- [x] #4 Pre-existing unbaselined PersonaGarden visual-library availability status is migrated off AntD Tag so the product-state verifier has no blocked findings.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused RED test proving WorkspaceStatusStrip ready status reads from getDesignSystemState('ready').label. 2. Replace the WorkspaceStatusStrip hardcoded Ready runtime label with the design-system state registry label. 3. Remove the matching canonical-state-label baseline exception. 4. Clear the pre-existing VisualPackEditor product-state verifier blocker by replacing availability AntD Tags with token-backed spans. 5. Run focused tests, product-state guard, verifier, diff check, and broad tsc touched-file filtering.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented WorkspaceStatusStrip ready status through getDesignSystemState('ready').label and added a partial design-system mock in its focused test. Removed canonical-state-label baseline entry for src/components/Option/ChatWorkspace/WorkspaceStatusStrip.tsx:Ready. While running verify:design-system-state, found a pre-existing blocked finding on src/components/PersonaGarden/VisualPackEditor.tsx caused by AntD Tag availability badges. Replaced those availability badges with token-backed spans preserving the visible lowercase copy. Bandit skipped because touched code is UI TypeScript/JSON/Backlog markdown with no Python execution surface.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated WorkspaceStatusStrip ready label to the design-system state registry and removed its product-state baseline exception. Also cleared a pre-existing unbaselined VisualPackEditor availability Tag blocker so the product-state verifier is green. Verification: RED WorkspaceStatusStrip Vitest failed on mocked registry label before implementation; GREEN WorkspaceStatusStrip Vitest passed 3/3; VisualPackEditor focused test passed 20/20; product-state guard passed 52/52; verify:design-system-state passed with baseline exceptions now 507 total and 39 canonical-state-label; git diff --check passed; broad UI tsc still fails on existing unrelated repo-wide debt with no touched-file matches.
+
+PR: https://github.com/rmusser01/tldw_server/pull/1491
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Route WorkspaceStatusStrip ready status through getDesignSystemState("ready").label
- Add focused coverage proving the ready status uses the design-system state registry
- Remove the matching canonical-state-label baseline exception and record TASK-210
- Clear a pre-existing unbaselined VisualPackEditor availability Tag verifier blocker with token-backed spans

## Verification
- RED: bunx vitest run src/components/Option/ChatWorkspace/__tests__/WorkspaceStatusStrip.test.tsx --reporter=dot failed because the component still rendered "Ready"
- GREEN: bunx vitest run src/components/Option/ChatWorkspace/__tests__/WorkspaceStatusStrip.test.tsx --reporter=dot passed 3/3
- bunx vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx --reporter=dot passed 20/20
- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed 52/52
- bun run verify:design-system-state passed; baseline exceptions now 507 total, 39 canonical-state-label
- git diff --check passed
- bunx tsc --noEmit --pretty false still exits 2 on existing unrelated UI test/type debt; filtered output had no touched-file matches

## Notes
- Bandit skipped: touched files are UI TypeScript, JSON baseline, and Backlog markdown only.
- Per AI-generated PR policy, a human-authored Change summary is still needed before merge.