### PR TITLE
Add Persona visual import conflict choices

### DIFF
--- a/Docs/Code_Documentation/Persona_Visual_Packs.md
+++ b/Docs/Code_Documentation/Persona_Visual_Packs.md
@@ -95,11 +95,22 @@ Import is staged:
    persona.
 2. The preview reports bundle metadata, warnings, conflicts, and the proposed
    commit plan.
-3. Commit import creates a reviewed draft pack for the persona after the preview
-   succeeds.
+3. Commit import creates or replaces a reviewed draft pack for the persona
+   after the preview succeeds and the user has selected any required conflict
+   choice.
 
 Committed imports remain reviewable and do not automatically activate. Users
 still choose when a valid pack should become the active pack.
+
+V1 conflict detection is intentionally conservative. When the target persona
+already has a pack with the incoming title, preview records
+`target_pack_title_match` conflicts. Active conflicts only allow
+`create_new`; draft-like conflicts (`draft`, `review`, or `failed`) also allow
+`replace_draft`. Replace-draft commits are preview-backed: the request must
+name a reviewed replaceable pack id, the selected target pack must still belong
+to the same user and target persona, and the imported replacement is created as
+a fresh draft before the selected old draft is soft-deleted with its assets.
+Active packs are never replaced or activated by import commit.
 
 ## Generated Candidates And Review
 

--- a/Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md
+++ b/Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md
@@ -84,7 +84,7 @@ providers, shared/cross-device libraries, and future renderer adapters.
 
 ## 5. Current Implementation Snapshot
 
-As of 2026-05-09:
+As of 2026-05-10:
 
 1. The durable implementation from PR #1393 is merged into `dev`.
 2. The closeout documentation and E2E verification from PR #1400 is merged into
@@ -133,6 +133,9 @@ Implemented foundations include:
     existing visual packs, listing available/source-changed/unavailable entries,
     editing/removing entries, and using an available entry to create a target
     persona draft through duplicate semantics.
+17. Import preview conflict choices for target title matches, including
+    create-new-draft and reviewed draft replacement while preserving separate
+    activation.
 
 ---
 
@@ -205,7 +208,7 @@ The Visuals tab should support:
 6. generated candidate review.
 7. export job queue, status refresh, and authenticated archive download.
 8. import-preview upload, status refresh, preview summary, conflicts, warnings,
-   proposed plan, and commit flow.
+   proposed plan, explicit conflict choices, and commit flow.
 9. explicit activation and deactivation.
 
 ### 8.3 Floating Buddy Runtime
@@ -463,8 +466,9 @@ The portability model should stay aligned with PR #1135:
 4. Import starts with a review-only preview.
 5. Preview reports summary, validation warnings, conflicts, proposed plan, quota
    estimate, required choices, and target warnings.
-6. Import commit is explicit and should create a draft pack unless a future
-   product decision allows direct replacement.
+6. Import commit is explicit. It creates a new draft by default, and may
+   replace a reviewed draft-like target pack when preview reported that pack as
+   replaceable.
 7. Activation remains separate from import commit.
 
 Current and future portability/library work:
@@ -472,9 +476,11 @@ Current and future portability/library work:
 1. Duplicate to another persona creates a same-user draft copy (#1450).
 2. Personal visual-pack library V1 stores user-scoped references to existing
    source packs and creates target drafts through duplicate semantics (#1468).
-3. Future shared user libraries should be layered on top of the manifest-backed
+3. Import/export conflict choices support target title-match review and
+   draft-only replacement (#1490).
+4. Future shared user libraries should be layered on top of the manifest-backed
    pack format rather than replacing it.
-4. Future cross-device sync, signed community packs, and external
+5. Future cross-device sync, signed community packs, and external
    MCP-compatible pack providers remain out of scope for V1.
 
 ---
@@ -539,7 +545,8 @@ baseline. The first reference-backed V1 slices are now covered:
    (#1450).
 2. Personal visual-pack library: complete for user-owned, reference-backed
    save/list/edit/remove/use in Persona Garden (#1468).
-3. Import/export polish and conflict choices remain future work.
+3. Import/export conflict choices: complete for preview-backed target title
+   conflicts, create-new draft commits, and reviewed draft replacement (#1490).
 4. Shared/cross-device libraries remain future work.
 5. External MCP-compatible visual providers remain future work.
 6. Live2D or other renderer adapter remains future work after the sprite/frame
@@ -640,3 +647,4 @@ E2E:
 9. Issue #1428: Completed Persona/Buddy visual-pack Product Hardening tracker.
 10. Issue #1450: Same-user Persona Visual pack duplicate-to-persona draft flow.
 11. Issue #1468: Personal Persona Visual pack library foundation.
+12. Issue #1490: Persona visual-pack import conflict choices.

--- a/Docs/superpowers/plans/2026-05-10-persona-visual-import-conflicts.md
+++ b/Docs/superpowers/plans/2026-05-10-persona-visual-import-conflicts.md
@@ -1,0 +1,74 @@
+# Persona Visual Import Conflict Choices Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add explicit Persona/Buddy visual-pack import conflict choices while preserving review-before-commit and separate activation.
+
+**Architecture:** Extend the existing job-backed Persona Visual portability pipeline. Preview will report target-persona pack conflicts and allowed choices; commit will require an explicit target choice when conflicts are present and will only create or replace draft-like packs, never active packs.
+
+**Tech Stack:** FastAPI/Pydantic, ChaChaNotes SQLite persona store, Persona Visual portability Jobs, React/AntD Persona Garden, Vitest, pytest.
+
+---
+
+### Task 1: Backend Preview Conflict Contract
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Persona/visual_portability/preview.py`
+- Modify: `tldw_Server_API/app/core/Persona/visual_jobs_worker.py`
+- Test: `tldw_Server_API/tests/Persona/test_persona_visual_portability.py`
+- Test: `tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py`
+
+- [x] Add a failing previewer test where the target persona already has an active pack and a draft pack with the same incoming pack title; expect conflict entries, allowed choices, and required commit choice metadata.
+- [x] Run the focused pytest test and confirm it fails because preview conflicts are empty.
+- [x] Implement preview conflict building from target-persona pack summaries supplied by the worker, including stable `conflict_id`, `type`, `severity`, `message`, `pack_id`, `pack_title`, `pack_status`, and `allowed_choices`.
+- [x] Update the preview worker to load same-user target persona packs and pass them into the previewer.
+- [x] Run the focused backend preview/worker tests and confirm they pass.
+
+### Task 2: Backend Commit Choice Enforcement
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/schemas/persona.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/persona.py`
+- Modify: `tldw_Server_API/app/core/Persona/visual_jobs.py`
+- Modify: `tldw_Server_API/app/core/Persona/visual_jobs_worker.py`
+- Modify: `tldw_Server_API/app/core/Persona/visual_portability/importer.py`
+- Test: `tldw_Server_API/tests/Persona/test_persona_visual_portability.py`
+- Test: `tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py`
+- Test: `tldw_Server_API/tests/Persona/test_persona_visual_jobs.py`
+- Test: `tldw_Server_API/tests/Persona/test_persona_visuals_api.py`
+
+- [x] Add failing tests proving a commit with preview conflicts is rejected unless the request includes an explicit conflict choice.
+- [x] Add failing tests for `replace_draft` with a target draft pack id and title override.
+- [x] Extend commit request/payload schema with `target_mode: create_new | replace_draft`, optional `title`, and optional `target_pack_id`.
+- [x] Enforce that `replace_draft` can only target a same-user pack on the target persona with a non-active status; reject active packs and missing packs.
+- [x] Keep imported packs draft-only and leave active packs unchanged.
+- [x] Run focused backend tests and confirm they pass.
+
+### Task 3: Persona Garden Conflict UX
+
+**Files:**
+- Modify: `apps/packages/ui/src/types/persona-visuals.ts`
+- Modify: `apps/packages/ui/src/services/persona-visuals.ts`
+- Modify: `apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx`
+- Test: `apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx`
+
+- [x] Add a Vitest case where preview conflicts show actionable import choices and disable commit until the user chooses a conflict policy.
+- [x] Add a Vitest case where choosing `replace draft` posts `target_mode`, `target_pack_id`, and optional title to the commit endpoint.
+- [x] Add typed conflict/choice metadata to the frontend Persona Visual models.
+- [x] Update the import panel to show conflicts as Persona/Buddy visual-pack choices, with `create new draft` and safe `replace draft` controls.
+- [x] Keep copy clear that import commit creates or replaces a draft and activation remains separate.
+- [x] Run the focused VisualPackEditor Vitest suite and confirm it passes.
+
+### Task 4: Docs And Verification
+
+**Files:**
+- Modify: `Docs/Code_Documentation/Persona_Visual_Packs.md`
+- Modify: `Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md`
+- Modify: `backlog/tasks/task-208 - Implement-Persona-visual-pack-import-conflict-choices.md`
+
+- [x] Update code docs and PRD portability notes with the V1 conflict choices and non-goals.
+- [ ] Run `git diff --check`.
+- [ ] Run focused pytest suites.
+- [ ] Run focused Vitest suite.
+- [ ] Run Bandit on touched backend production files.
+- [ ] Update TASK-208 acceptance criteria, DoD, verification notes, and final summary.

--- a/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
@@ -56,8 +56,11 @@ import type {
   PersonaVisualImportCommitStartResponse,
   PersonaVisualFrame,
   PersonaVisualGenerationReadinessResponse,
+  PersonaVisualImportConflict,
   PersonaVisualImportPreviewResponse,
   PersonaVisualImportPreviewStartResponse,
+  PersonaVisualImportRequiredChoice,
+  PersonaVisualImportTargetMode,
   PersonaVisualManifest,
   PersonaVisualPack,
   PersonaVisualPackExportResponse,
@@ -329,6 +332,42 @@ const isFullImportPreview = (
 ): preview is PersonaVisualImportPreviewResponse =>
   Boolean(preview && "bundle_summary" in preview)
 
+const getImportTargetChoice = (
+  preview: PersonaVisualImportPreviewResponse | null
+): PersonaVisualImportRequiredChoice | null =>
+  preview?.required_choices.find(
+    (choice) => choice.choice_id === "import_target_mode"
+  ) || null
+
+const getAllowedImportTargetModes = (
+  choice: PersonaVisualImportRequiredChoice | null
+): PersonaVisualImportTargetMode[] => {
+  const modes = choice?.allowed_target_modes || []
+  return modes.length ? modes : ["create_new"]
+}
+
+const getReplaceableImportConflicts = (
+  conflicts: PersonaVisualImportConflict[]
+): PersonaVisualImportConflict[] =>
+  conflicts.filter(
+    (conflict) =>
+      Boolean(conflict.pack_id) &&
+      (conflict.allowed_choices || []).includes("replace_draft")
+  )
+
+const getImportConflictLabel = (conflict: PersonaVisualImportConflict): string => {
+  const title = conflict.pack_title || conflict.pack_id || "Draft pack"
+  const status = conflict.pack_status ? ` (${conflict.pack_status})` : ""
+  return `${title}${status}`
+}
+
+const getDefaultImportDraftTitle = (
+  preview: PersonaVisualImportPreviewResponse | null
+): string => {
+  const title = preview?.bundle_summary?.pack_title
+  return typeof title === "string" ? title : ""
+}
+
 const formatImportPreviewSummary = (
   preview: PersonaVisualImportPreviewStartResponse | PersonaVisualImportPreviewResponse
 ): string => {
@@ -480,6 +519,10 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
   const [importPreview, setImportPreview] = React.useState<
     PersonaVisualImportPreviewStartResponse | PersonaVisualImportPreviewResponse | null
   >(null)
+  const [importTargetMode, setImportTargetMode] =
+    React.useState<PersonaVisualImportTargetMode | "">("create_new")
+  const [importReplacePackId, setImportReplacePackId] = React.useState("")
+  const [importDraftTitle, setImportDraftTitle] = React.useState("")
   const [importCommitJob, setImportCommitJob] = React.useState<
     PersonaVisualImportCommitStartResponse | PersonaVisualPortabilityJobResponse | null
   >(null)
@@ -1148,6 +1191,9 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
       )
       setImportPreview(preview)
       setImportCommitJob(null)
+      setImportTargetMode("create_new")
+      setImportReplacePackId("")
+      setImportDraftTitle("")
       setSelectedImportPreviewFile(null)
       if (importPreviewInputRef.current) importPreviewInputRef.current.value = ""
       setStatusMessage("Import preview queued.")
@@ -1186,15 +1232,21 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
   const handleStartImportCommit = async () => {
     if (!selectedPersonaId || !fullImportPreview?.preview_id) return
     if (fullImportPreview.status !== "completed") return
+    if (importConflictChoiceRequired && !importTargetMode) return
     setCommittingImport(true)
     setError(null)
     try {
+      const targetMode = importTargetMode || "create_new"
+      const title = importDraftTitle.trim()
       const job = await startPersonaVisualImportCommit(
         selectedPersonaId,
         fullImportPreview.preview_id,
         {
           trust_mode: "untrusted_import",
-          target_mode: "create_new"
+          target_mode: targetMode,
+          target_pack_id:
+            targetMode === "replace_draft" ? importReplacePackId : null,
+          title: title || null
         }
       )
       setImportCommitJob(job)
@@ -1766,15 +1818,37 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
     : []
   const importPreviewConflicts = fullImportPreview?.conflicts || []
   const importPreviewPlan = fullImportPreview?.proposed_plan || null
+  const importTargetChoice = getImportTargetChoice(fullImportPreview)
+  const importAllowedTargetModes = getAllowedImportTargetModes(importTargetChoice)
+  const replaceableImportConflicts = getReplaceableImportConflicts(importPreviewConflicts)
+  const importConflictChoiceRequired = Boolean(importTargetChoice)
+  const importConflictChoiceValid =
+    !importConflictChoiceRequired ||
+    importTargetMode === "create_new" ||
+    Boolean(importReplacePackId)
   const canCommitImportPreview = fullImportPreview?.status === "completed"
   const importCommitStatus = importCommitJob?.status || null
   const importCommitIsTerminal = importCommitStatus
     ? IMPORT_COMMIT_TERMINAL_STATUSES.has(importCommitStatus)
     : false
   const canStartImportCommit =
-    !importCommitJob?.job_id || importCommitStatus === "failed"
+    importConflictChoiceValid &&
+    (!importCommitJob?.job_id || importCommitStatus === "failed")
   const canRefreshImportCommit =
     Boolean(importCommitJob?.job_id) && !importCommitIsTerminal
+
+  React.useEffect(() => {
+    if (!fullImportPreview) {
+      setImportTargetMode("create_new")
+      setImportReplacePackId("")
+      setImportDraftTitle("")
+      return
+    }
+    const choice = getImportTargetChoice(fullImportPreview)
+    setImportTargetMode(choice ? "" : "create_new")
+    setImportReplacePackId("")
+    setImportDraftTitle(getDefaultImportDraftTitle(fullImportPreview))
+  }, [fullImportPreview?.preview_id])
 
   return (
     <div className="space-y-3" data-testid="persona-visual-pack-editor">
@@ -2248,6 +2322,76 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
                         <div className="mt-1 text-text-muted">
                           Commit creates a new draft pack. Activation remains separate.
                         </div>
+                        {importConflictChoiceRequired ? (
+                          <div
+                            data-testid="persona-visual-import-conflict-choice"
+                            className="mt-2 grid gap-2 md:grid-cols-[minmax(140px,180px)_minmax(180px,1fr)_minmax(180px,1fr)]"
+                          >
+                            <label className="text-xs text-text-muted">
+                              <span className="mb-1 block">Target mode</span>
+                              <select
+                                data-testid="persona-visual-import-target-mode"
+                                className="w-full rounded border border-border bg-bg px-2 py-1 text-sm text-text"
+                                value={importTargetMode}
+                                onChange={(event) => {
+                                  const nextMode = event.target
+                                    .value as PersonaVisualImportTargetMode | ""
+                                  setImportTargetMode(nextMode)
+                                  if (nextMode !== "replace_draft") {
+                                    setImportReplacePackId("")
+                                  } else if (!importReplacePackId) {
+                                    setImportReplacePackId(
+                                      replaceableImportConflicts[0]?.pack_id || ""
+                                    )
+                                  }
+                                }}
+                              >
+                                <option value="">Choose</option>
+                                {importAllowedTargetModes.map((mode) => (
+                                  <option key={mode} value={mode}>
+                                    {mode === "replace_draft"
+                                      ? "Replace draft"
+                                      : "Create new draft"}
+                                  </option>
+                                ))}
+                              </select>
+                            </label>
+                            {importTargetMode === "replace_draft" ? (
+                              <label className="text-xs text-text-muted">
+                                <span className="mb-1 block">Draft</span>
+                                <select
+                                  data-testid="persona-visual-import-replace-pack"
+                                  className="w-full rounded border border-border bg-bg px-2 py-1 text-sm text-text"
+                                  value={importReplacePackId}
+                                  onChange={(event) =>
+                                    setImportReplacePackId(event.target.value)
+                                  }
+                                >
+                                  <option value="">Select draft</option>
+                                  {replaceableImportConflicts.map((conflict) => (
+                                    <option
+                                      key={conflict.pack_id}
+                                      value={conflict.pack_id}
+                                    >
+                                      {getImportConflictLabel(conflict)}
+                                    </option>
+                                  ))}
+                                </select>
+                              </label>
+                            ) : null}
+                            <label className="text-xs text-text-muted">
+                              <span className="mb-1 block">Draft title</span>
+                              <input
+                                data-testid="persona-visual-import-draft-title"
+                                className="w-full rounded border border-border bg-bg px-2 py-1 text-sm text-text"
+                                value={importDraftTitle}
+                                onChange={(event) =>
+                                  setImportDraftTitle(event.target.value)
+                                }
+                              />
+                            </label>
+                          </div>
+                        ) : null}
                         <div className="mt-2 flex flex-wrap items-center gap-2">
                           <Button
                             data-testid="persona-visual-import-commit-button"

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
@@ -1978,6 +1978,172 @@ describe("VisualPackEditor", () => {
     ).toBe(false)
   })
 
+  it("sends explicit replace-draft choices for conflicted visual imports", async () => {
+    const pack = {
+      id: "pack-1",
+      persona_id: "persona-1",
+      title: "Animated pack",
+      renderer_type: "sprite_frames",
+      status: "draft",
+      manifest: structuredClone(baseManifest),
+      assets: visualAssets,
+      version: 3
+    }
+    let commitPayload: any = null
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string; body?: any }) => {
+      const method = init?.method || "GET"
+      if (path === "/api/v1/persona/profiles/persona-1/visual-packs" && method === "GET") {
+        return okResponse([pack])
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/pack-1/generated-candidates" &&
+        method === "GET"
+      ) {
+        return okResponse({ candidates: [] })
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/import-previews" &&
+        method === "POST"
+      ) {
+        return okResponse({
+          preview_id: "preview-1",
+          job_id: "preview-job-1",
+          portability_job_id: "portability-preview-1",
+          operation: "import_preview",
+          target_persona_id: "persona-1",
+          status: "queued",
+          stage: "queued"
+        })
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/import-previews/preview-1" &&
+        method === "GET"
+      ) {
+        return okResponse({
+          preview_id: "preview-1",
+          job_id: "preview-job-1",
+          portability_job_id: "portability-preview-1",
+          operation: "import_preview",
+          target_persona_id: "persona-1",
+          status: "completed",
+          visual_status: "completed",
+          stage: "completed",
+          archive_sha256: "sha-preview",
+          canonical_payload_fingerprint: "fingerprint-preview",
+          schema_version: "persona_visual_pack.v1",
+          bundle_summary: {
+            pack_title: "Imported Visuals",
+            asset_count: 2,
+            assets_with_bytes: 2
+          },
+          validation_warnings: [],
+          conflicts: [
+            {
+              conflict_id: "target_pack_title_match:draft-pack-1",
+              type: "target_pack_title_match",
+              message: "Target persona already has a draft visual pack named Imported Visuals.",
+              pack_id: "draft-pack-1",
+              pack_title: "Imported Visuals",
+              pack_status: "draft",
+              allowed_choices: ["create_new", "replace_draft"]
+            }
+          ],
+          proposed_plan: {
+            target_mode: "create_new",
+            target_modes: ["create_new", "replace_draft"],
+            replaceable_pack_ids: ["draft-pack-1"]
+          },
+          quota_estimate: { asset_bytes: 512 },
+          required_choices: [
+            {
+              choice_id: "import_target_mode",
+              reason: "target_pack_conflicts",
+              default_target_mode: "create_new",
+              allowed_target_modes: ["create_new", "replace_draft"],
+              replaceable_pack_ids: ["draft-pack-1"]
+            }
+          ],
+          target_warnings: []
+        })
+      }
+      if (
+        path ===
+          "/api/v1/persona/profiles/persona-1/visual-packs/import-previews/preview-1/commit" &&
+        method === "POST"
+      ) {
+        commitPayload = parseJsonBody(init?.body)
+        return okResponse({
+          job_id: "import-job-1",
+          portability_job_id: "portability-import-1",
+          operation: "import_commit",
+          preview_id: "preview-1",
+          target_persona_id: "persona-1",
+          status: "queued",
+          stage: "queued"
+        })
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        error: `Unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(
+      <VisualPackEditor
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Garden Helper"
+        isActive
+      />
+    )
+
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-pack-status")).toHaveTextContent(
+        "draft"
+      )
+    )
+    const archive = new File(["portable archive"], "portable.tldw-persona-vpack", {
+      type: "application/octet-stream"
+    })
+    fireEvent.change(screen.getByTestId("persona-visual-import-preview-input"), {
+      target: { files: [archive] }
+    })
+    fireEvent.click(screen.getByTestId("persona-visual-import-preview-button"))
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-import-preview-status")).toHaveTextContent(
+        "queued"
+      )
+    )
+    fireEvent.click(screen.getByTestId("persona-visual-import-preview-refresh-button"))
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-import-conflict-choice")).toBeInTheDocument()
+    )
+    expect(screen.getByTestId("persona-visual-import-commit-button")).toBeDisabled()
+
+    fireEvent.change(screen.getByTestId("persona-visual-import-target-mode"), {
+      target: { value: "replace_draft" }
+    })
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-import-replace-pack")).toHaveValue(
+        "draft-pack-1"
+      )
+    )
+    fireEvent.change(screen.getByTestId("persona-visual-import-draft-title"), {
+      target: { value: "Replacement Visuals" }
+    })
+    fireEvent.click(screen.getByTestId("persona-visual-import-commit-button"))
+
+    await waitFor(() => expect(commitPayload).not.toBeNull())
+    expect(commitPayload).toMatchObject({
+      trust_mode: "untrusted_import",
+      target_mode: "replace_draft",
+      target_pack_id: "draft-pack-1",
+      title: "Replacement Visuals"
+    })
+  })
+
   it("allows failed import commit jobs to be retried", async () => {
     const pack = {
       id: "pack-1",

--- a/apps/packages/ui/src/types/persona-visuals.ts
+++ b/apps/packages/ui/src/types/persona-visuals.ts
@@ -283,6 +283,27 @@ export interface PersonaVisualImportPreviewStartResponse {
   stage: string
 }
 
+export type PersonaVisualImportTargetMode = "create_new" | "replace_draft"
+
+export interface PersonaVisualImportConflict {
+  conflict_id?: string
+  type?: string
+  severity?: string
+  message?: string
+  pack_id?: string
+  pack_title?: string
+  pack_status?: string
+  allowed_choices?: PersonaVisualImportTargetMode[]
+}
+
+export interface PersonaVisualImportRequiredChoice {
+  choice_id: string
+  reason?: string
+  default_target_mode?: PersonaVisualImportTargetMode
+  allowed_target_modes?: PersonaVisualImportTargetMode[]
+  replaceable_pack_ids?: string[]
+}
+
 export interface PersonaVisualImportPreviewResponse {
   preview_id: string
   job_id: string
@@ -297,10 +318,10 @@ export interface PersonaVisualImportPreviewResponse {
   schema_version?: string | null
   bundle_summary: Record<string, unknown>
   validation_warnings: unknown[]
-  conflicts: unknown[]
+  conflicts: PersonaVisualImportConflict[]
   proposed_plan: Record<string, unknown>
   quota_estimate: Record<string, unknown>
-  required_choices: unknown[]
+  required_choices: PersonaVisualImportRequiredChoice[]
   target_warnings: unknown[]
   error_code?: string | null
   error_message?: string | null
@@ -310,7 +331,9 @@ export interface PersonaVisualImportPreviewResponse {
 export interface PersonaVisualImportCommitRequest {
   request_id?: string | null
   trust_mode?: "trusted_restore" | "untrusted_import"
-  target_mode?: "create_new"
+  target_mode?: PersonaVisualImportTargetMode
+  target_pack_id?: string | null
+  title?: string | null
 }
 
 export interface PersonaVisualImportCommitStartResponse {

--- a/backlog/tasks/task-208 - Implement-Persona-visual-pack-import-conflict-choices.md
+++ b/backlog/tasks/task-208 - Implement-Persona-visual-pack-import-conflict-choices.md
@@ -4,7 +4,7 @@ title: Implement Persona visual-pack import conflict choices
 status: Done
 assignee: []
 created_date: '2026-05-10 02:04'
-updated_date: '2026-05-10 02:34'
+updated_date: '2026-05-10 02:54'
 labels:
   - persona
   - webui
@@ -43,12 +43,16 @@ Plan: Docs/superpowers/plans/2026-05-10-persona-visual-import-conflicts.md. V1 a
 
 <!-- SECTION:NOTES:BEGIN -->
 Implemented preview-backed Persona visual import conflict choices for target title matches. Backend preview reports allowed choices; commit requires explicit target mode for conflicted previews; replace_draft is limited to reviewed draft/review/failed target packs and leaves active packs unchanged. Persona Garden now shows conflict choices and disables commit until a user selects a policy. Verification: pytest persona visual portability/worker/jobs/API suite passed with 57 tests; VisualPackEditor Vitest passed with 21 tests; git diff --check passed; Bandit on touched backend production files wrote /tmp/bandit_persona_visual_import_conflicts.json with zero findings.
+
+PR #1492 review pass started. Actionable review items: missing helper docstrings, import-commit idempotency should include conflict-choice fields, import commit should gate on revalidated conflicts, and replace_draft failure should not leave an extra imported draft.
+
+PR #1492 review fixes implemented: added helper docstrings, expanded import-commit idempotency to include trust/target/title/conflict-choice intent, switched commit conflict gating to the revalidated current target state, and made replace_draft deletion guarded by target status/version with cleanup of the newly imported pack on replacement failure. Verification: focused red tests failed before the fix, then passed; persona visual focused suite passed (59 tests); git diff --check passed; Bandit on touched production files reported zero findings.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added V1 Persona/Buddy visual-pack import conflict choices. Preview now reports target title-match conflicts with create-new and draft-only replace options; import commit rejects ambiguous conflict commits and supports reviewed draft replacement with optional title override while preserving separate activation. Persona Garden surfaces the choices and requires an explicit user selection before conflicted commits. Docs and focused backend/frontend tests were updated.
+Addressed PR #1492 review feedback for Persona visual import conflicts. Commit intent is now represented in idempotency keys, import commits use freshly revalidated conflicts for choice gating, replace_draft uses guarded soft-delete semantics and cleans up imported draft records if replacement fails, and the reviewed helpers now have docstrings. Verified with the persona visual focused pytest suite, git diff --check, and Bandit on touched production files.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-208 - Implement-Persona-visual-pack-import-conflict-choices.md
+++ b/backlog/tasks/task-208 - Implement-Persona-visual-pack-import-conflict-choices.md
@@ -1,0 +1,62 @@
+---
+id: TASK-208
+title: Implement Persona visual-pack import conflict choices
+status: Done
+assignee: []
+created_date: '2026-05-10 02:04'
+updated_date: '2026-05-10 02:34'
+labels:
+  - persona
+  - webui
+  - visual-packs
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1490'
+documentation:
+  - Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md
+  - Docs/Code_Documentation/Persona_Visual_Packs.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add the next Phase 3 Persona/Buddy visual-pack reuse slice tracked by GitHub issue #1490. Extend the existing manifest-backed import preview/commit workflow so target-persona conflicts produce explicit user choices while preserving draft review and no automatic activation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Import preview reports actionable conflicts and allowed commit choices for the target persona.
+- [x] #2 Import commit requires an explicit choice when conflicts are present and rejects ambiguous conflict commits.
+- [x] #3 Supported choices preserve review-before-commit behavior and leave active visual packs unchanged until a later explicit activation.
+- [x] #4 Persona Garden or Visual Pack editor UI presents the choices clearly without marketplace/shared-library framing.
+- [x] #5 Backend, frontend, documentation, and focused tests cover the selected V1 conflict choices.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Plan: Docs/superpowers/plans/2026-05-10-persona-visual-import-conflicts.md. V1 adds preview conflict metadata, explicit commit choices, draft-only replacement, Persona Garden controls, docs, and focused tests.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented preview-backed Persona visual import conflict choices for target title matches. Backend preview reports allowed choices; commit requires explicit target mode for conflicted previews; replace_draft is limited to reviewed draft/review/failed target packs and leaves active packs unchanged. Persona Garden now shows conflict choices and disables commit until a user selects a policy. Verification: pytest persona visual portability/worker/jobs/API suite passed with 57 tests; VisualPackEditor Vitest passed with 21 tests; git diff --check passed; Bandit on touched backend production files wrote /tmp/bandit_persona_visual_import_conflicts.json with zero findings.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added V1 Persona/Buddy visual-pack import conflict choices. Preview now reports target title-match conflicts with create-new and draft-only replace options; import commit rejects ambiguous conflict commits and supports reviewed draft replacement with optional title override while preserving separate activation. Persona Garden surfaces the choices and requires an explicit user selection before conflicted commits. Docs and focused backend/frontend tests were updated.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -2182,6 +2182,22 @@ def _persona_visual_json_field(row: dict[str, Any], key: str, default: Any) -> A
         return default
 
 
+def _persona_visual_replaceable_pack_ids(conflicts: Any) -> set[str]:
+    if not isinstance(conflicts, list):
+        return set()
+    replaceable: set[str] = set()
+    for conflict in conflicts:
+        if not isinstance(conflict, dict):
+            continue
+        allowed_choices = conflict.get("allowed_choices")
+        if not isinstance(allowed_choices, list) or "replace_draft" not in allowed_choices:
+            continue
+        pack_id = str(conflict.get("pack_id") or "").strip()
+        if pack_id:
+            replaceable.add(pack_id)
+    return replaceable
+
+
 def _persona_visual_job_for_portability(jobs_manager: JobManager, job_id: str) -> dict[str, Any] | None:
     try:
         return jobs_manager.get_job(int(job_id))
@@ -5007,6 +5023,30 @@ async def start_persona_visual_pack_import_commit(
                 status_code=status.HTTP_409_CONFLICT,
                 detail="import_preview_not_completed",
             )
+        conflicts = _persona_visual_json_field(preview, "conflicts_json", [])
+        replaceable_pack_ids = _persona_visual_replaceable_pack_ids(conflicts)
+        explicit_target_mode = "target_mode" in getattr(payload, "model_fields_set", set())
+        if conflicts and not explicit_target_mode:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="import_conflict_choice_required",
+            )
+        if payload.target_mode == "replace_draft":
+            if not payload.target_pack_id:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="target_pack_id_required",
+                )
+            if payload.target_pack_id not in replaceable_pack_ids:
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="import_target_pack_not_replaceable",
+                )
+        elif payload.target_pack_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="target_pack_id_requires_replace_draft",
+            )
 
         request_id = str(payload.request_id or uuid.uuid4().hex)
         job = await _run_persona_db_call(
@@ -5019,6 +5059,9 @@ async def start_persona_visual_pack_import_commit(
             target_persona_id=persona_id,
             trust_mode=payload.trust_mode,
             target_mode=payload.target_mode,
+            target_pack_id=payload.target_pack_id,
+            title=payload.title,
+            conflict_choice_explicit=bool(conflicts and explicit_target_mode),
         )
         job_id = str(job.get("id") or "")
         portability_job = await _run_persona_db_call(
@@ -5037,6 +5080,9 @@ async def start_persona_visual_pack_import_commit(
                 "request_id": request_id,
                 "trust_mode": payload.trust_mode,
                 "target_mode": payload.target_mode,
+                "target_pack_id": payload.target_pack_id,
+                "title": payload.title,
+                "conflict_choice_explicit": bool(conflicts and explicit_target_mode),
             },
         )
         return PersonaVisualImportCommitStartResponse(

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -2183,6 +2183,7 @@ def _persona_visual_json_field(row: dict[str, Any], key: str, default: Any) -> A
 
 
 def _persona_visual_replaceable_pack_ids(conflicts: Any) -> set[str]:
+    """Return target pack ids that preview conflicts allow replacing."""
     if not isinstance(conflicts, list):
         return set()
     replaceable: set[str] = set()

--- a/tldw_Server_API/app/api/v1/schemas/persona.py
+++ b/tldw_Server_API/app/api/v1/schemas/persona.py
@@ -363,7 +363,17 @@ class PersonaVisualImportPreviewResponse(BaseModel):
 class PersonaVisualImportCommitRequest(BaseModel):
     request_id: str | None = Field(default=None, max_length=120)
     trust_mode: Literal["trusted_restore", "untrusted_import"] = "untrusted_import"
-    target_mode: Literal["create_new"] = "create_new"
+    target_mode: Literal["create_new", "replace_draft"] = "create_new"
+    target_pack_id: str | None = Field(default=None, max_length=128)
+    title: str | None = Field(default=None, max_length=200)
+
+    @field_validator("request_id", "target_pack_id", "title", mode="before")
+    @classmethod
+    def _normalize_optional_text(cls, value: Any) -> Any:
+        if value is None:
+            return None
+        text = str(value).strip()
+        return text or None
 
 
 class PersonaVisualImportCommitStartResponse(BaseModel):

--- a/tldw_Server_API/app/core/DB_Management/chacha/persona_state_store.py
+++ b/tldw_Server_API/app/core/DB_Management/chacha/persona_state_store.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from collections.abc import Iterable
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any
 
@@ -2520,12 +2521,27 @@ class PersonaStateStore:
         pack_id: str,
         persona_id: str,
         user_id: str,
+        expected_version: int | None = None,
+        allowed_statuses: Iterable[str] | None = None,
     ) -> bool:
-        """Soft-delete a persona visual pack and all of its asset rows."""
+        """Soft-delete a persona visual pack and its assets with optional guards."""
         now = self._get_current_utc_timestamp_iso()
         bool_cast = bool if self.backend_type == BackendType.POSTGRESQL else int
         deleted_false = bool_cast(False)
         deleted_true = bool_cast(True)
+        allowed_status_values: tuple[str, ...] | None = None
+        if allowed_statuses is not None:
+            allowed_status_values = tuple(
+                self._normalize_persona_visual_enum(
+                    status,
+                    allowed=self._ALLOWED_PERSONA_VISUAL_PACK_STATUSES,
+                    field_name="pack status",
+                )
+                for status in allowed_statuses
+            )
+            if not allowed_status_values:
+                return False
+
         with self.transaction() as conn:
             self._require_active_persona_profile_owner(conn, persona_id=persona_id, user_id=user_id)
             self._require_persona_visual_pack_owner(
@@ -2534,6 +2550,36 @@ class PersonaStateStore:
                 persona_id=persona_id,
                 user_id=user_id,
             )
+            pack_where_sql = "id = ? AND user_id = ? AND persona_id = ? AND deleted = ?"
+            pack_params: list[Any] = [
+                deleted_true,
+                now,
+                pack_id,
+                user_id,
+                persona_id,
+                deleted_false,
+            ]
+            if expected_version is not None:
+                pack_where_sql += " AND version = ?"
+                pack_params.append(int(expected_version))
+            if allowed_status_values is not None:
+                placeholders = ", ".join("?" for _ in allowed_status_values)
+                pack_where_sql += f" AND status IN ({placeholders})"
+                pack_params.extend(allowed_status_values)
+
+            pack_query = (
+                "UPDATE persona_visual_packs "
+                "SET deleted = ?, active_at = NULL, last_modified = ?, version = version + 1 "
+                f"WHERE {pack_where_sql}"  # nosec B608
+            )
+            prepared_pack_query, prepared_pack_params = self._prepare_backend_statement(
+                pack_query,
+                tuple(pack_params),
+            )
+            cursor = conn.execute(prepared_pack_query, prepared_pack_params or ())
+            if cursor.rowcount == 0:
+                return False
+
             asset_query = (
                 "UPDATE persona_visual_assets "
                 "SET deleted = ?, last_modified = ?, version = version + 1 "
@@ -2552,26 +2598,7 @@ class PersonaStateStore:
                 asset_params,
             )
             conn.execute(prepared_asset_query, prepared_asset_params or ())
-
-            pack_query = (
-                "UPDATE persona_visual_packs "
-                "SET deleted = ?, active_at = NULL, last_modified = ?, version = version + 1 "
-                "WHERE id = ? AND user_id = ? AND persona_id = ? AND deleted = ?"
-            )
-            pack_params = (
-                deleted_true,
-                now,
-                pack_id,
-                user_id,
-                persona_id,
-                deleted_false,
-            )
-            prepared_pack_query, prepared_pack_params = self._prepare_backend_statement(
-                pack_query,
-                pack_params,
-            )
-            cursor = conn.execute(prepared_pack_query, prepared_pack_params or ())
-            return cursor.rowcount > 0
+            return True
 
     def _load_persona_visual_library_source(
         self,

--- a/tldw_Server_API/app/core/Persona/visual_jobs.py
+++ b/tldw_Server_API/app/core/Persona/visual_jobs.py
@@ -184,11 +184,28 @@ def visual_pack_import_commit_idempotency_key(
     user_id: str,
     preview_id: str,
     request_id: str,
+    trust_mode: str,
+    target_mode: str = "create_new",
+    target_pack_id: str | None = None,
+    title: str | None = None,
+    conflict_choice_explicit: bool = False,
 ) -> str:
-    return visual_pack_import_commit_group(
-        user_id=user_id,
-        preview_id=preview_id,
-        request_id=request_id,
+    commit_digest = hashlib.sha256(
+        json.dumps(
+            {
+                "conflict_choice_explicit": bool(conflict_choice_explicit),
+                "target_mode": str(target_mode or "create_new").strip(),
+                "target_pack_id": str(target_pack_id).strip() if target_pack_id else None,
+                "title": str(title).strip() if title else None,
+                "trust_mode": str(trust_mode).strip(),
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()[:16]
+    return (
+        f"{visual_pack_import_commit_group(user_id=user_id, preview_id=preview_id, request_id=request_id)}"
+        f":{commit_digest}"
     )
 
 
@@ -375,6 +392,11 @@ def create_visual_pack_import_commit_job(
             user_id=user_id,
             preview_id=preview_id,
             request_id=request_id,
+            trust_mode=trust_mode,
+            target_mode=target_mode,
+            target_pack_id=target_pack_id,
+            title=title,
+            conflict_choice_explicit=conflict_choice_explicit,
         ),
         max_retries=2,
     )

--- a/tldw_Server_API/app/core/Persona/visual_jobs.py
+++ b/tldw_Server_API/app/core/Persona/visual_jobs.py
@@ -85,8 +85,11 @@ def build_visual_pack_import_commit_payload(
     target_persona_id: str,
     trust_mode: str,
     target_mode: str = "create_new",
+    target_pack_id: str | None = None,
+    title: str | None = None,
+    conflict_choice_explicit: bool = False,
 ) -> dict[str, Any]:
-    return {
+    payload = {
         "user_id": str(user_id),
         "preview_id": str(preview_id),
         "portability_job_id": str(portability_job_id),
@@ -95,6 +98,13 @@ def build_visual_pack_import_commit_payload(
         "trust_mode": str(trust_mode),
         "target_mode": str(target_mode or "create_new"),
     }
+    if target_pack_id:
+        payload["target_pack_id"] = str(target_pack_id).strip()
+    if title:
+        payload["title"] = str(title).strip()
+    if conflict_choice_explicit:
+        payload["conflict_choice_explicit"] = True
+    return payload
 
 
 def visual_pack_export_group(
@@ -335,6 +345,9 @@ def create_visual_pack_import_commit_job(
     target_persona_id: str,
     trust_mode: str,
     target_mode: str = "create_new",
+    target_pack_id: str | None = None,
+    title: str | None = None,
+    conflict_choice_explicit: bool = False,
 ) -> dict[str, Any]:
     return jobs_manager.create_job(
         domain=PERSONA_VISUALS_DOMAIN,
@@ -348,6 +361,9 @@ def create_visual_pack_import_commit_job(
             target_persona_id=target_persona_id,
             trust_mode=trust_mode,
             target_mode=target_mode,
+            target_pack_id=target_pack_id,
+            title=title,
+            conflict_choice_explicit=conflict_choice_explicit,
         ),
         owner_user_id=str(user_id),
         batch_group=visual_pack_import_commit_group(

--- a/tldw_Server_API/app/core/Persona/visual_jobs_worker.py
+++ b/tldw_Server_API/app/core/Persona/visual_jobs_worker.py
@@ -340,12 +340,19 @@ class PersonaVisualPortabilityWorker:
             "target_persona_id",
             default=str(preview.get("target_persona_id") or ""),
         ) or None
+        target_packs = []
+        if target_persona_id:
+            target_packs = self._db.list_persona_visual_packs(
+                persona_id=target_persona_id,
+                user_id=user_id,
+            )
         try:
             result = await asyncio.to_thread(
                 lambda: PersonaVisualPackImportPreviewer().create_preview(
                     archive_path=archive_path,
                     owner_user_id=user_id,
                     target_persona_id=target_persona_id,
+                    target_packs=target_packs,
                     progress=_progress,
                 )
             )
@@ -427,6 +434,9 @@ class PersonaVisualPortabilityWorker:
         target_persona_id = _payload_text(payload, "target_persona_id")
         trust_mode = _payload_text(payload, "trust_mode", default="untrusted_import")
         target_mode = _payload_text(payload, "target_mode", default="create_new")
+        target_pack_id = _payload_text(payload, "target_pack_id", default="") or None
+        title = _payload_text(payload, "title", default="") or None
+        conflict_choice_explicit = bool(payload.get("conflict_choice_explicit"))
         if not user_id or not preview_id or not target_persona_id:
             raise ValueError("invalid_persona_visual_import_commit_payload")
 
@@ -471,6 +481,9 @@ class PersonaVisualPortabilityWorker:
                     target_persona_id=target_persona_id,
                     trust_mode=trust_mode,
                     target_mode=target_mode,
+                    target_pack_id=target_pack_id,
+                    title=title,
+                    conflict_choice_explicit=conflict_choice_explicit,
                     progress=_progress,
                 )
             )

--- a/tldw_Server_API/app/core/Persona/visual_portability/importer.py
+++ b/tldw_Server_API/app/core/Persona/visual_portability/importer.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import json
 import zipfile
+from collections.abc import Mapping
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -29,6 +31,9 @@ from tldw_Server_API.app.core.Persona.visual_service import PersonaVisualService
 from tldw_Server_API.app.core.Persona.visuals import validate_visual_manifest
 
 
+_REPLACEABLE_IMPORT_TARGET_STATUSES = frozenset({"draft", "review", "failed"})
+
+
 class PersonaVisualPackImporter:
     """Commit a completed persona visual pack preview into a new draft pack."""
 
@@ -51,9 +56,13 @@ class PersonaVisualPackImporter:
         target_persona_id: str,
         trust_mode: str,
         target_mode: str = "create_new",
+        target_pack_id: str | None = None,
+        title: str | None = None,
+        conflict_choice_explicit: bool = False,
         progress: Any | None = None,
     ) -> dict[str, Any]:
-        if target_mode != "create_new":
+        target_mode_value = str(target_mode or "create_new").strip()
+        if target_mode_value not in {"create_new", "replace_draft"}:
             raise ValueError("unsupported_import_target_mode")
         if trust_mode not in {TRUST_MODE_TRUSTED_RESTORE, TRUST_MODE_UNTRUSTED_IMPORT}:
             raise ValueError("unsupported_import_trust_mode")
@@ -61,13 +70,31 @@ class PersonaVisualPackImporter:
         preview = self.repo.get_import_preview(str(preview_id), owner_user_id=self.user_id)
         if preview is None:
             raise ValueError("import_preview_not_found")
+        preview_conflicts = _import_preview_json_field(preview, "conflicts_json", [])
+        if preview_conflicts and not conflict_choice_explicit:
+            raise ValueError("import_conflict_choice_required")
+        replacement_pack = None
+        if target_mode_value == "replace_draft":
+            replacement_pack = self._replacement_pack_or_error(
+                target_persona_id=target_persona_id,
+                target_pack_id=target_pack_id,
+                preview_conflicts=preview_conflicts,
+            )
+        elif target_pack_id:
+            raise ValueError("target_pack_id_requires_replace_draft")
+
         archive_path = Path(str(preview.get("archive_path") or ""))
         self._validate_preview_ready(preview=preview, archive_path=archive_path)
         self._progress(progress, "revalidating_preview", {"preview_id": str(preview_id)})
+        target_packs = self.db.list_persona_visual_packs(
+            persona_id=target_persona_id,
+            user_id=self.user_id,
+        )
         revalidated = PersonaVisualPackImportPreviewer().create_preview(
             archive_path=archive_path,
             owner_user_id=self.user_id,
             target_persona_id=target_persona_id,
+            target_packs=target_packs,
         )
         expected_fingerprint = str(preview.get("canonical_payload_fingerprint") or "")
         if expected_fingerprint and revalidated["canonical_payload_fingerprint"] != expected_fingerprint:
@@ -81,10 +108,11 @@ class PersonaVisualPackImporter:
             assets = _section_list(assets_payload, key="assets", path="metadata/assets.json")
 
             self._progress(progress, "creating_pack", {"target_persona_id": target_persona_id})
+            pack_title = _import_pack_title(title=title, pack=pack)
             created_pack = self.db.create_persona_visual_pack(
                 persona_id=target_persona_id,
                 user_id=self.user_id,
-                title=str(pack.get("title") or "Imported visual pack"),
+                title=pack_title,
                 renderer_type=str(pack.get("renderer_type") or "sprite_frames"),
                 manifest={
                     "manifest_version": 1,
@@ -143,6 +171,20 @@ class PersonaVisualPackImporter:
             manifest=validation.manifest,
             expected_version=int(created_pack["version"]),
         )
+        replaced_pack_id = None
+        if replacement_pack is not None:
+            replaced_pack_id = str(replacement_pack["id"])
+            self._progress(
+                progress,
+                "replacing_draft",
+                {"target_pack_id": replaced_pack_id, "pack_id": str(created_pack["id"])},
+            )
+            if not self.db.soft_delete_persona_visual_pack_with_assets(
+                pack_id=replaced_pack_id,
+                persona_id=target_persona_id,
+                user_id=self.user_id,
+            ):
+                raise ValueError("import_target_pack_not_found")
         self._progress(
             progress,
             "completed",
@@ -152,13 +194,39 @@ class PersonaVisualPackImporter:
             "status": "imported",
             "preview_id": str(preview_id),
             "pack_id": str(created_pack["id"]),
+            "target_mode": target_mode_value,
+            "replaced_pack_id": replaced_pack_id,
             "pack": updated_pack,
             "id_maps": id_maps,
             "created_records": {
                 "pack_id": str(created_pack["id"]),
                 "asset_ids": [str(asset["id"]) for asset in imported_assets],
+                "replaced_pack_id": replaced_pack_id,
             },
         }
+
+    def _replacement_pack_or_error(
+        self,
+        *,
+        target_persona_id: str,
+        target_pack_id: str | None,
+        preview_conflicts: Any,
+    ) -> dict[str, Any]:
+        target_pack_id_value = str(target_pack_id or "").strip()
+        if not target_pack_id_value:
+            raise ValueError("target_pack_id_required")
+        if target_pack_id_value not in _replaceable_pack_ids_from_conflicts(preview_conflicts):
+            raise ValueError("import_target_pack_not_replaceable")
+        replacement_pack = self.db.get_persona_visual_pack(
+            pack_id=target_pack_id_value,
+            persona_id=target_persona_id,
+            user_id=self.user_id,
+        )
+        if replacement_pack is None:
+            raise ValueError("import_target_pack_not_found")
+        if str(replacement_pack.get("status") or "") not in _REPLACEABLE_IMPORT_TARGET_STATUSES:
+            raise ValueError("import_target_pack_not_replaceable")
+        return replacement_pack
 
     def _validate_preview_ready(self, *, preview: dict[str, Any], archive_path: Path) -> None:
         if str(preview.get("status") or "") != "completed":
@@ -175,6 +243,43 @@ class PersonaVisualPackImporter:
     def _progress(self, progress: Any | None, stage: str, payload: dict[str, Any]) -> None:
         if progress is not None:
             progress(stage, payload)
+
+
+def _import_preview_json_field(row: Mapping[str, Any], key: str, default: Any) -> Any:
+    value = row.get(key)
+    if value in (None, ""):
+        return default
+    if isinstance(value, (dict, list)):
+        return value
+    try:
+        return json.loads(str(value))
+    except json.JSONDecodeError:
+        return default
+
+
+def _replaceable_pack_ids_from_conflicts(conflicts: Any) -> set[str]:
+    if not isinstance(conflicts, list):
+        return set()
+    replaceable: set[str] = set()
+    for conflict in conflicts:
+        if not isinstance(conflict, dict):
+            continue
+        allowed_choices = conflict.get("allowed_choices")
+        if not isinstance(allowed_choices, list) or "replace_draft" not in allowed_choices:
+            continue
+        pack_id = str(conflict.get("pack_id") or "").strip()
+        if pack_id:
+            replaceable.add(pack_id)
+    return replaceable
+
+
+def _import_pack_title(*, title: str | None, pack: Mapping[str, Any]) -> str:
+    title_value = str(title or "").strip()
+    if title_value:
+        return title_value
+    pack_title = str(pack.get("title") or "").strip()
+    return pack_title or "Imported visual pack"
+
 
 def _parse_datetime(value: Any) -> datetime | None:
     if not value:

--- a/tldw_Server_API/app/core/Persona/visual_portability/importer.py
+++ b/tldw_Server_API/app/core/Persona/visual_portability/importer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import zipfile
 from collections.abc import Mapping
@@ -70,17 +71,7 @@ class PersonaVisualPackImporter:
         preview = self.repo.get_import_preview(str(preview_id), owner_user_id=self.user_id)
         if preview is None:
             raise ValueError("import_preview_not_found")
-        preview_conflicts = _import_preview_json_field(preview, "conflicts_json", [])
-        if preview_conflicts and not conflict_choice_explicit:
-            raise ValueError("import_conflict_choice_required")
-        replacement_pack = None
-        if target_mode_value == "replace_draft":
-            replacement_pack = self._replacement_pack_or_error(
-                target_persona_id=target_persona_id,
-                target_pack_id=target_pack_id,
-                preview_conflicts=preview_conflicts,
-            )
-        elif target_pack_id:
+        if target_mode_value != "replace_draft" and target_pack_id:
             raise ValueError("target_pack_id_requires_replace_draft")
 
         archive_path = Path(str(preview.get("archive_path") or ""))
@@ -99,6 +90,17 @@ class PersonaVisualPackImporter:
         expected_fingerprint = str(preview.get("canonical_payload_fingerprint") or "")
         if expected_fingerprint and revalidated["canonical_payload_fingerprint"] != expected_fingerprint:
             raise ValueError("import_archive_fingerprint_changed")
+        revalidated_conflicts = revalidated.get("conflicts")
+        current_conflicts = revalidated_conflicts if isinstance(revalidated_conflicts, list) else []
+        if current_conflicts and not conflict_choice_explicit:
+            raise ValueError("import_conflict_choice_required")
+        replacement_pack = None
+        if target_mode_value == "replace_draft":
+            replacement_pack = self._replacement_pack_or_error(
+                target_persona_id=target_persona_id,
+                target_pack_id=target_pack_id,
+                preview_conflicts=current_conflicts,
+            )
 
         with zipfile.ZipFile(archive_path, "r") as archive:
             members = _archive_members_by_normalized_name(archive)
@@ -179,12 +181,26 @@ class PersonaVisualPackImporter:
                 "replacing_draft",
                 {"target_pack_id": replaced_pack_id, "pack_id": str(created_pack["id"])},
             )
-            if not self.db.soft_delete_persona_visual_pack_with_assets(
-                pack_id=replaced_pack_id,
-                persona_id=target_persona_id,
-                user_id=self.user_id,
-            ):
-                raise ValueError("import_target_pack_not_found")
+            try:
+                replaced = self.db.soft_delete_persona_visual_pack_with_assets(
+                    pack_id=replaced_pack_id,
+                    persona_id=target_persona_id,
+                    user_id=self.user_id,
+                    expected_version=int(replacement_pack["version"]),
+                    allowed_statuses=_REPLACEABLE_IMPORT_TARGET_STATUSES,
+                )
+            except Exception:
+                self._cleanup_created_pack(
+                    pack_id=str(created_pack["id"]),
+                    target_persona_id=target_persona_id,
+                )
+                raise
+            if not replaced:
+                self._cleanup_created_pack(
+                    pack_id=str(created_pack["id"]),
+                    target_persona_id=target_persona_id,
+                )
+                raise ValueError("import_target_pack_not_replaceable")
         self._progress(
             progress,
             "completed",
@@ -212,6 +228,7 @@ class PersonaVisualPackImporter:
         target_pack_id: str | None,
         preview_conflicts: Any,
     ) -> dict[str, Any]:
+        """Validate that the selected target pack is currently replaceable."""
         target_pack_id_value = str(target_pack_id or "").strip()
         if not target_pack_id_value:
             raise ValueError("target_pack_id_required")
@@ -227,6 +244,15 @@ class PersonaVisualPackImporter:
         if str(replacement_pack.get("status") or "") not in _REPLACEABLE_IMPORT_TARGET_STATUSES:
             raise ValueError("import_target_pack_not_replaceable")
         return replacement_pack
+
+    def _cleanup_created_pack(self, *, pack_id: str, target_persona_id: str) -> None:
+        """Best-effort cleanup for a newly imported pack after commit failure."""
+        with contextlib.suppress(Exception):
+            self.db.soft_delete_persona_visual_pack_with_assets(
+                pack_id=pack_id,
+                persona_id=target_persona_id,
+                user_id=self.user_id,
+            )
 
     def _validate_preview_ready(self, *, preview: dict[str, Any], archive_path: Path) -> None:
         if str(preview.get("status") or "") != "completed":
@@ -246,6 +272,7 @@ class PersonaVisualPackImporter:
 
 
 def _import_preview_json_field(row: Mapping[str, Any], key: str, default: Any) -> Any:
+    """Read a JSON-backed import preview column with a typed fallback."""
     value = row.get(key)
     if value in (None, ""):
         return default
@@ -258,6 +285,7 @@ def _import_preview_json_field(row: Mapping[str, Any], key: str, default: Any) -
 
 
 def _replaceable_pack_ids_from_conflicts(conflicts: Any) -> set[str]:
+    """Extract target pack ids that current conflict metadata allows replacing."""
     if not isinstance(conflicts, list):
         return set()
     replaceable: set[str] = set()
@@ -274,6 +302,7 @@ def _replaceable_pack_ids_from_conflicts(conflicts: Any) -> set[str]:
 
 
 def _import_pack_title(*, title: str | None, pack: Mapping[str, Any]) -> str:
+    """Resolve the imported pack title from the explicit override or archive metadata."""
     title_value = str(title or "").strip()
     if title_value:
         return title_value

--- a/tldw_Server_API/app/core/Persona/visual_portability/preview.py
+++ b/tldw_Server_API/app/core/Persona/visual_portability/preview.py
@@ -324,6 +324,7 @@ def _target_pack_conflicts(
     pack: Mapping[str, Any],
     target_packs: Sequence[Mapping[str, Any]] | None,
 ) -> list[dict[str, Any]]:
+    """Return title-match conflicts against the current target persona packs."""
     incoming_title = str(pack.get("title") or "").strip()
     if not incoming_title:
         return []
@@ -360,10 +361,11 @@ def _target_pack_conflicts(
 
 
 def _replaceable_pack_ids(conflicts: Sequence[Mapping[str, Any]]) -> list[str]:
+    """List conflict pack ids that can be selected for replace-draft import."""
     replaceable: list[str] = []
     for conflict in conflicts:
         allowed = conflict.get("allowed_choices")
-        if not isinstance(allowed, Sequence) or "replace_draft" not in allowed:
+        if not isinstance(allowed, (list, tuple, set)) or "replace_draft" not in allowed:
             continue
         pack_id = str(conflict.get("pack_id") or "").strip()
         if pack_id:

--- a/tldw_Server_API/app/core/Persona/visual_portability/preview.py
+++ b/tldw_Server_API/app/core/Persona/visual_portability/preview.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import zipfile
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -35,6 +35,7 @@ class PersonaVisualPackImportPreviewer:
         archive_path: Path,
         owner_user_id: str,
         target_persona_id: str | None = None,
+        target_packs: Sequence[Mapping[str, Any]] | None = None,
         progress: Callable[[str, dict[str, Any]], None] | None = None,
     ) -> dict[str, Any]:
         archive_path = Path(archive_path)
@@ -88,9 +89,16 @@ class PersonaVisualPackImportPreviewer:
 
         validation_warnings = _validation_warnings(assets)
         source_persona_id = str(pack.get("source_persona_id") or "")
+        conflicts = _target_pack_conflicts(pack=pack, target_packs=target_packs)
+        replaceable_pack_ids = _replaceable_pack_ids(conflicts)
+        target_modes = ["create_new"]
+        if replaceable_pack_ids:
+            target_modes.append("replace_draft")
         required_choices = _required_choices(
             source_persona_id=source_persona_id,
             target_persona_id=target_persona_id,
+            conflicts=conflicts,
+            replaceable_pack_ids=replaceable_pack_ids,
         )
         preview_fingerprint = _preview_fingerprint(
             manifest=manifest,
@@ -99,14 +107,17 @@ class PersonaVisualPackImportPreviewer:
         )
         proposed_plan = {
             "target_mode": "create_new",
+            "target_modes": target_modes,
             "trust_modes": [
                 TRUST_MODE_TRUSTED_RESTORE,
                 TRUST_MODE_UNTRUSTED_IMPORT,
             ],
             "default_trust_mode": TRUST_MODE_UNTRUSTED_IMPORT,
+            "default_target_mode": "create_new",
             "review_before_commit": True,
             "default_target_persona_id": target_persona_id or source_persona_id or None,
             "missing_asset_policy": "import_metadata_only_until_bytes_supplied",
+            "replaceable_pack_ids": replaceable_pack_ids,
             "update_identity_rules": {
                 "assets": [
                     "source_asset_id",
@@ -135,7 +146,7 @@ class PersonaVisualPackImportPreviewer:
             "schema_version": PERSONA_VISUAL_PACK_SCHEMA_VERSION,
             "bundle_summary": bundle_summary,
             "validation_warnings": validation_warnings,
-            "conflicts": [],
+            "conflicts": conflicts,
             "proposed_plan": proposed_plan,
             "quota_estimate": quota_estimate,
             "required_choices": required_choices,
@@ -305,14 +316,86 @@ def _validation_warnings(assets: list[Mapping[str, Any]]) -> list[str]:
     return warnings
 
 
+_REPLACEABLE_TARGET_PACK_STATUSES = frozenset({"draft", "review", "failed"})
+
+
+def _target_pack_conflicts(
+    *,
+    pack: Mapping[str, Any],
+    target_packs: Sequence[Mapping[str, Any]] | None,
+) -> list[dict[str, Any]]:
+    incoming_title = str(pack.get("title") or "").strip()
+    if not incoming_title:
+        return []
+
+    conflicts: list[dict[str, Any]] = []
+    for target_pack in target_packs or []:
+        target_title = str(target_pack.get("title") or "").strip()
+        if target_title.casefold() != incoming_title.casefold():
+            continue
+        pack_id = str(target_pack.get("id") or "").strip()
+        if not pack_id:
+            continue
+        pack_status = str(target_pack.get("status") or "").strip() or "unknown"
+        allowed_choices = ["create_new"]
+        if pack_status in _REPLACEABLE_TARGET_PACK_STATUSES:
+            allowed_choices.append("replace_draft")
+        conflicts.append(
+            {
+                "conflict_id": f"target_pack_title_match:{pack_id}",
+                "type": "target_pack_title_match",
+                "severity": "warning",
+                "message": (
+                    f"Target persona already has a {pack_status} visual pack "
+                    f"named {incoming_title}."
+                ),
+                "pack_id": pack_id,
+                "pack_title": target_title,
+                "pack_status": pack_status,
+                "allowed_choices": allowed_choices,
+            }
+        )
+
+    return sorted(conflicts, key=lambda conflict: str(conflict["conflict_id"]))
+
+
+def _replaceable_pack_ids(conflicts: Sequence[Mapping[str, Any]]) -> list[str]:
+    replaceable: list[str] = []
+    for conflict in conflicts:
+        allowed = conflict.get("allowed_choices")
+        if not isinstance(allowed, Sequence) or "replace_draft" not in allowed:
+            continue
+        pack_id = str(conflict.get("pack_id") or "").strip()
+        if pack_id:
+            replaceable.append(pack_id)
+    return replaceable
+
+
 def _required_choices(
     *,
     source_persona_id: str,
     target_persona_id: str | None,
+    conflicts: Sequence[Mapping[str, Any]],
+    replaceable_pack_ids: Sequence[str],
 ) -> list[dict[str, Any]]:
+    choices: list[dict[str, Any]] = []
     if target_persona_id:
-        return []
-    return [
+        if conflicts:
+            choices.append(
+                {
+                    "choice_id": "import_target_mode",
+                    "reason": "target_pack_conflicts",
+                    "default_target_mode": "create_new",
+                    "allowed_target_modes": (
+                        ["create_new", "replace_draft"]
+                        if replaceable_pack_ids
+                        else ["create_new"]
+                    ),
+                    "replaceable_pack_ids": list(replaceable_pack_ids),
+                }
+            )
+        return choices
+    choices.append(
         {
             "choice_id": "target_persona",
             "resource": "persona",
@@ -321,7 +404,8 @@ def _required_choices(
             "default_action": "import_to_source_persona",
             "required": True,
         }
-    ]
+    )
+    return choices
 
 
 def _target_warnings(

--- a/tldw_Server_API/tests/Persona/test_persona_visual_jobs.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_jobs.py
@@ -235,7 +235,9 @@ def test_create_persona_visual_pack_import_commit_job_uses_preview_group() -> No
         request_id="request-1",
         target_persona_id="persona-2",
         trust_mode="untrusted_import",
-        target_mode="create_new",
+        target_mode="replace_draft",
+        target_pack_id="draft-pack-1",
+        title="Replacement Pack",
     )
 
     expected_key = visual_pack_import_commit_idempotency_key(
@@ -254,7 +256,9 @@ def test_create_persona_visual_pack_import_commit_job_uses_preview_group() -> No
         "request_id": "request-1",
         "target_persona_id": "persona-2",
         "trust_mode": "untrusted_import",
-        "target_mode": "create_new",
+        "target_mode": "replace_draft",
+        "target_pack_id": "draft-pack-1",
+        "title": "Replacement Pack",
     }
 
 

--- a/tldw_Server_API/tests/Persona/test_persona_visual_jobs.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_jobs.py
@@ -244,11 +244,43 @@ def test_create_persona_visual_pack_import_commit_job_uses_preview_group() -> No
         user_id="user-1",
         preview_id="preview-1",
         request_id="request-1",
+        trust_mode="untrusted_import",
+        target_mode="replace_draft",
+        target_pack_id="draft-pack-1",
+        title="Replacement Pack",
+        conflict_choice_explicit=False,
     )
     assert job["queue"] == "default"
     assert job["job_type"] == PERSONA_VISUAL_PACK_IMPORT_COMMIT_JOB_TYPE
     assert job["batch_group"] == "persona_visuals:user:user-1:portability:import-commit:preview-1:request-1"
     assert job["idempotency_key"] == expected_key
+    assert expected_key != visual_pack_import_commit_idempotency_key(
+        user_id="user-1",
+        preview_id="preview-1",
+        request_id="request-1",
+        trust_mode="untrusted_import",
+        target_mode="create_new",
+    )
+    assert expected_key != visual_pack_import_commit_idempotency_key(
+        user_id="user-1",
+        preview_id="preview-1",
+        request_id="request-1",
+        trust_mode="untrusted_import",
+        target_mode="replace_draft",
+        target_pack_id="draft-pack-2",
+        title="Replacement Pack",
+        conflict_choice_explicit=False,
+    )
+    assert expected_key != visual_pack_import_commit_idempotency_key(
+        user_id="user-1",
+        preview_id="preview-1",
+        request_id="request-1",
+        trust_mode="untrusted_import",
+        target_mode="replace_draft",
+        target_pack_id="draft-pack-1",
+        title="Replacement Pack",
+        conflict_choice_explicit=True,
+    )
     assert manager.created[0]["payload"] == {
         "user_id": "user-1",
         "preview_id": "preview-1",

--- a/tldw_Server_API/tests/Persona/test_persona_visual_portability.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_portability.py
@@ -274,6 +274,82 @@ def test_import_preview_validates_archive_without_mutating_packs(
     assert db_instance.list_persona_visual_packs(persona_id=persona_id, user_id="user-1") == packs_before  # nosec B101
 
 
+def test_import_preview_reports_target_pack_conflicts_and_choices(
+    db_instance: CharactersRAGDB,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_persona_id, pack, _asset = _create_pack_with_asset(
+        db_instance,
+        visuals_root=tmp_path / "visuals",
+        monkeypatch=monkeypatch,
+    )
+    target_persona_id = db_instance.create_persona_profile(
+        {"user_id": "user-1", "name": "Target Persona"}
+    )
+    active_pack = db_instance.create_persona_visual_pack(
+        persona_id=target_persona_id,
+        user_id="user-1",
+        title="Portable Visuals",
+        status="active",
+        manifest={"manifest_version": 1, "renderer_type": "sprite_frames", "states": {}, "animations": {}},
+    )
+    draft_pack = db_instance.create_persona_visual_pack(
+        persona_id=target_persona_id,
+        user_id="user-1",
+        title="Portable Visuals",
+        status="draft",
+        manifest={"manifest_version": 1, "renderer_type": "sprite_frames", "states": {}, "animations": {}},
+    )
+    exporter = PersonaVisualPackExporter(
+        db=db_instance,
+        user_id="user-1",
+        staging_root=tmp_path / "exports",
+    )
+    result = exporter.export_pack(
+        persona_id=source_persona_id,
+        pack_id=str(pack["id"]),
+        options=PersonaVisualPackExportOptions(),
+    )
+
+    preview = PersonaVisualPackImportPreviewer().create_preview(
+        archive_path=result.archive_path,
+        owner_user_id="user-1",
+        target_persona_id=target_persona_id,
+        target_packs=db_instance.list_persona_visual_packs(
+            persona_id=target_persona_id,
+            user_id="user-1",
+        ),
+    )
+
+    conflict_ids = {conflict["conflict_id"] for conflict in preview["conflicts"]}
+    assert conflict_ids == {  # nosec B101
+        f"target_pack_title_match:{active_pack['id']}",
+        f"target_pack_title_match:{draft_pack['id']}",
+    }
+    active_conflict = next(
+        conflict for conflict in preview["conflicts"] if conflict["pack_id"] == active_pack["id"]
+    )
+    draft_conflict = next(
+        conflict for conflict in preview["conflicts"] if conflict["pack_id"] == draft_pack["id"]
+    )
+    assert active_conflict["pack_status"] == "active"  # nosec B101
+    assert active_conflict["allowed_choices"] == ["create_new"]  # nosec B101
+    assert draft_conflict["pack_status"] == "draft"  # nosec B101
+    assert draft_conflict["allowed_choices"] == ["create_new", "replace_draft"]  # nosec B101
+    assert preview["proposed_plan"]["target_modes"] == ["create_new", "replace_draft"]  # nosec B101
+    assert preview["proposed_plan"]["replaceable_pack_ids"] == [draft_pack["id"]]  # nosec B101
+    assert preview["required_choices"] == [  # nosec B101
+        {
+            "choice_id": "import_target_mode",
+            "reason": "target_pack_conflicts",
+            "default_target_mode": "create_new",
+            "allowed_target_modes": ["create_new", "replace_draft"],
+            "replaceable_pack_ids": [draft_pack["id"]],
+        }
+    ]
+
+
 def test_import_preview_reports_missing_asset_bytes_as_warning(
     db_instance: CharactersRAGDB,
     tmp_path: Path,

--- a/tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py
@@ -473,6 +473,10 @@ async def test_persona_visual_import_commit_worker_creates_pack_and_remaps_asset
         archive_path=export_result.archive_path,
         owner_user_id="user-1",
         target_persona_id=persona_id,
+        target_packs=db_instance.list_persona_visual_packs(
+            persona_id=persona_id,
+            user_id="user-1",
+        ),
     )
     repo = PersonaVisualPortabilityRepository.initialized(db_instance)
     preview = repo.create_import_preview(
@@ -486,7 +490,9 @@ async def test_persona_visual_import_commit_worker_creates_pack_and_remaps_asset
         schema_version=preview_result["schema_version"],
         target_persona_id=persona_id,
         bundle_summary=preview_result["bundle_summary"],
+        conflicts=preview_result["conflicts"],
         proposed_plan=preview_result["proposed_plan"],
+        required_choices=preview_result["required_choices"],
     )
     portability_job = repo.create_portability_job(
         owner_user_id="user-1",
@@ -512,6 +518,7 @@ async def test_persona_visual_import_commit_worker_creates_pack_and_remaps_asset
                 "target_persona_id": persona_id,
                 "trust_mode": "untrusted_import",
                 "target_mode": "create_new",
+                "conflict_choice_explicit": True,
             },
         }
     )
@@ -664,6 +671,222 @@ async def test_persona_visual_import_commit_worker_replaces_selected_draft_only(
     assert deleted_draft["deleted"] is True
     assert active_after is not None
     assert active_after["id"] == active_pack["id"]
+
+
+@pytest.mark.asyncio
+async def test_persona_visual_import_commit_worker_requires_choice_for_revalidated_conflicts(
+    db_instance: CharactersRAGDB,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.core.DB_Management.PersonaVisualPortability_DB import (
+        PersonaVisualPortabilityRepository,
+    )
+    from tldw_Server_API.app.core.Persona.visual_jobs_worker import (
+        PersonaVisualPortabilityWorker,
+    )
+
+    source_persona_id, source_pack, _source_asset = _create_pack_with_asset(
+        db_instance,
+        visuals_root=tmp_path / "visuals",
+        monkeypatch=monkeypatch,
+    )
+    target_persona_id = db_instance.create_persona_profile(
+        {"user_id": "user-1", "name": "Worker Conflict Target"}
+    )
+    export_result = PersonaVisualPackExporter(
+        db=db_instance,
+        user_id="user-1",
+        staging_root=tmp_path / "exports",
+    ).export_pack(
+        persona_id=source_persona_id,
+        pack_id=str(source_pack["id"]),
+        options=PersonaVisualPackExportOptions(),
+    )
+    preview_result = PersonaVisualPackImportPreviewer().create_preview(
+        archive_path=export_result.archive_path,
+        owner_user_id="user-1",
+        target_persona_id=target_persona_id,
+        target_packs=db_instance.list_persona_visual_packs(
+            persona_id=target_persona_id,
+            user_id="user-1",
+        ),
+    )
+    assert preview_result["conflicts"] == []
+    repo = PersonaVisualPortabilityRepository.initialized(db_instance)
+    preview = repo.create_import_preview(
+        owner_user_id="user-1",
+        job_id="job-preview-1",
+        status="completed",
+        stage="completed",
+        archive_path=str(export_result.archive_path),
+        archive_sha256=preview_result["archive_sha256"],
+        canonical_payload_fingerprint=preview_result["canonical_payload_fingerprint"],
+        schema_version=preview_result["schema_version"],
+        target_persona_id=target_persona_id,
+        bundle_summary=preview_result["bundle_summary"],
+        conflicts=preview_result["conflicts"],
+        proposed_plan=preview_result["proposed_plan"],
+        required_choices=preview_result["required_choices"],
+    )
+    target_draft = db_instance.create_persona_visual_pack(
+        persona_id=target_persona_id,
+        user_id="user-1",
+        title=str(source_pack["title"]),
+        manifest={"manifest_version": 1, "renderer_type": "sprite_frames", "states": {}, "animations": {}},
+    )
+    portability_job = repo.create_portability_job(
+        owner_user_id="user-1",
+        job_id="job-commit-1",
+        operation="import_commit",
+        status="queued",
+        stage="queued",
+        preview_id=str(preview["id"]),
+        persona_id=target_persona_id,
+    )
+    worker = PersonaVisualPortabilityWorker(db=db_instance, repo=repo)
+
+    with pytest.raises(ValueError, match="import_conflict_choice_required"):
+        await worker.handle_job_async(
+            {
+                "id": "job-commit-1",
+                "job_type": PERSONA_VISUAL_PACK_IMPORT_COMMIT_JOB_TYPE,
+                "owner_user_id": "user-1",
+                "payload": {
+                    "user_id": "user-1",
+                    "preview_id": str(preview["id"]),
+                    "portability_job_id": str(portability_job["id"]),
+                    "request_id": "req-commit",
+                    "target_persona_id": target_persona_id,
+                    "trust_mode": "untrusted_import",
+                    "target_mode": "create_new",
+                },
+            }
+        )
+
+    remaining_packs = db_instance.list_persona_visual_packs(
+        persona_id=target_persona_id,
+        user_id="user-1",
+    )
+    assert [pack["id"] for pack in remaining_packs] == [target_draft["id"]]
+
+
+@pytest.mark.asyncio
+async def test_persona_visual_import_commit_worker_cleans_imported_pack_when_replace_fails(
+    db_instance: CharactersRAGDB,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.core.DB_Management.PersonaVisualPortability_DB import (
+        PersonaVisualPortabilityRepository,
+    )
+    from tldw_Server_API.app.core.Persona.visual_jobs_worker import (
+        PersonaVisualPortabilityWorker,
+    )
+
+    source_persona_id, source_pack, _source_asset = _create_pack_with_asset(
+        db_instance,
+        visuals_root=tmp_path / "visuals",
+        monkeypatch=monkeypatch,
+    )
+    target_persona_id = db_instance.create_persona_profile(
+        {"user_id": "user-1", "name": "Worker Cleanup Target"}
+    )
+    active_pack = db_instance.create_persona_visual_pack(
+        persona_id=target_persona_id,
+        user_id="user-1",
+        title="Active Target Visuals",
+        manifest={"manifest_version": 1, "renderer_type": "sprite_frames", "states": {}, "animations": {}},
+        status="active",
+    )
+    target_draft = db_instance.create_persona_visual_pack(
+        persona_id=target_persona_id,
+        user_id="user-1",
+        title=str(source_pack["title"]),
+        manifest={"manifest_version": 1, "renderer_type": "sprite_frames", "states": {}, "animations": {}},
+    )
+    export_result = PersonaVisualPackExporter(
+        db=db_instance,
+        user_id="user-1",
+        staging_root=tmp_path / "exports",
+    ).export_pack(
+        persona_id=source_persona_id,
+        pack_id=str(source_pack["id"]),
+        options=PersonaVisualPackExportOptions(),
+    )
+    preview_result = PersonaVisualPackImportPreviewer().create_preview(
+        archive_path=export_result.archive_path,
+        owner_user_id="user-1",
+        target_persona_id=target_persona_id,
+        target_packs=db_instance.list_persona_visual_packs(
+            persona_id=target_persona_id,
+            user_id="user-1",
+        ),
+    )
+    repo = PersonaVisualPortabilityRepository.initialized(db_instance)
+    preview = repo.create_import_preview(
+        owner_user_id="user-1",
+        job_id="job-preview-1",
+        status="completed",
+        stage="completed",
+        archive_path=str(export_result.archive_path),
+        archive_sha256=preview_result["archive_sha256"],
+        canonical_payload_fingerprint=preview_result["canonical_payload_fingerprint"],
+        schema_version=preview_result["schema_version"],
+        target_persona_id=target_persona_id,
+        bundle_summary=preview_result["bundle_summary"],
+        conflicts=preview_result["conflicts"],
+        proposed_plan=preview_result["proposed_plan"],
+        required_choices=preview_result["required_choices"],
+    )
+    portability_job = repo.create_portability_job(
+        owner_user_id="user-1",
+        job_id="job-commit-1",
+        operation="import_commit",
+        status="queued",
+        stage="queued",
+        preview_id=str(preview["id"]),
+        persona_id=target_persona_id,
+    )
+    original_soft_delete = db_instance.soft_delete_persona_visual_pack_with_assets
+
+    def _fail_target_draft_delete(*, pack_id: str, persona_id: str, user_id: str, **kwargs: Any) -> bool:
+        if str(pack_id) == str(target_draft["id"]):
+            return False
+        return original_soft_delete(pack_id=pack_id, persona_id=persona_id, user_id=user_id, **kwargs)
+
+    monkeypatch.setattr(
+        db_instance,
+        "soft_delete_persona_visual_pack_with_assets",
+        _fail_target_draft_delete,
+    )
+    worker = PersonaVisualPortabilityWorker(db=db_instance, repo=repo)
+
+    with pytest.raises(ValueError, match="import_target_pack_not_replaceable"):
+        await worker.handle_job_async(
+            {
+                "id": "job-commit-1",
+                "job_type": PERSONA_VISUAL_PACK_IMPORT_COMMIT_JOB_TYPE,
+                "owner_user_id": "user-1",
+                "payload": {
+                    "user_id": "user-1",
+                    "preview_id": str(preview["id"]),
+                    "portability_job_id": str(portability_job["id"]),
+                    "request_id": "req-commit",
+                    "target_persona_id": target_persona_id,
+                    "trust_mode": "untrusted_import",
+                    "target_mode": "replace_draft",
+                    "target_pack_id": str(target_draft["id"]),
+                    "conflict_choice_explicit": True,
+                },
+            }
+        )
+
+    remaining_packs = db_instance.list_persona_visual_packs(
+        persona_id=target_persona_id,
+        user_id="user-1",
+    )
+    assert {pack["id"] for pack in remaining_packs} == {active_pack["id"], target_draft["id"]}
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py
@@ -344,6 +344,105 @@ async def test_persona_visual_import_preview_worker_updates_preview_without_muta
 
 
 @pytest.mark.asyncio
+async def test_persona_visual_import_preview_worker_persists_target_conflicts(
+    db_instance: CharactersRAGDB,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.core.DB_Management.PersonaVisualPortability_DB import (
+        PersonaVisualPortabilityRepository,
+    )
+    from tldw_Server_API.app.core.Persona.visual_jobs_worker import (
+        PersonaVisualPortabilityWorker,
+    )
+
+    source_persona_id, pack, _asset = _create_pack_with_asset(
+        db_instance,
+        visuals_root=tmp_path / "visuals",
+        monkeypatch=monkeypatch,
+    )
+    target_persona_id = db_instance.create_persona_profile(
+        {"user_id": "user-1", "name": "Import Target"}
+    )
+    target_draft = db_instance.create_persona_visual_pack(
+        persona_id=target_persona_id,
+        user_id="user-1",
+        title="Worker Visuals",
+        status="draft",
+        manifest={"manifest_version": 1, "renderer_type": "sprite_frames", "states": {}, "animations": {}},
+    )
+    export_result = PersonaVisualPackExporter(
+        db=db_instance,
+        user_id="user-1",
+        staging_root=tmp_path / "exports",
+    ).export_pack(
+        persona_id=source_persona_id,
+        pack_id=str(pack["id"]),
+        options=PersonaVisualPackExportOptions(),
+    )
+    repo = PersonaVisualPortabilityRepository.initialized(db_instance)
+    preview = repo.create_import_preview(
+        owner_user_id="user-1",
+        job_id="job-preview-conflicts",
+        status="queued",
+        archive_path=str(export_result.archive_path),
+        target_persona_id=target_persona_id,
+    )
+    portability_job = repo.create_portability_job(
+        owner_user_id="user-1",
+        job_id="job-preview-conflicts",
+        operation="import_preview",
+        status="queued",
+        stage="queued",
+        preview_id=str(preview["id"]),
+        archive_path=str(export_result.archive_path),
+    )
+    worker = PersonaVisualPortabilityWorker(db=db_instance, repo=repo)
+
+    await worker.handle_job_async(
+        {
+            "id": "job-preview-conflicts",
+            "job_type": PERSONA_VISUAL_PACK_IMPORT_PREVIEW_JOB_TYPE,
+            "owner_user_id": "user-1",
+            "payload": {
+                "user_id": "user-1",
+                "preview_id": str(preview["id"]),
+                "archive_path": str(export_result.archive_path),
+                "request_id": "req-worker-conflicts",
+                "target_persona_id": target_persona_id,
+            },
+        }
+    )
+
+    updated_preview = repo.get_import_preview(str(preview["id"]), owner_user_id="user-1")
+    updated_job = repo.get_portability_job(str(portability_job["id"]), owner_user_id="user-1")
+    assert updated_preview is not None
+    assert json.loads(updated_preview["conflicts_json"]) == [  # nosec B101
+        {
+            "conflict_id": f"target_pack_title_match:{target_draft['id']}",
+            "type": "target_pack_title_match",
+            "severity": "warning",
+            "message": "Target persona already has a draft visual pack named Worker Visuals.",
+            "pack_id": target_draft["id"],
+            "pack_title": "Worker Visuals",
+            "pack_status": "draft",
+            "allowed_choices": ["create_new", "replace_draft"],
+        }
+    ]
+    assert json.loads(updated_preview["required_choices_json"]) == [  # nosec B101
+        {
+            "choice_id": "import_target_mode",
+            "reason": "target_pack_conflicts",
+            "default_target_mode": "create_new",
+            "allowed_target_modes": ["create_new", "replace_draft"],
+            "replaceable_pack_ids": [target_draft["id"]],
+        }
+    ]
+    assert updated_job is not None
+    assert json.loads(updated_job["progress_json"])["pack_title"] == "Worker Visuals"
+
+
+@pytest.mark.asyncio
 async def test_persona_visual_import_commit_worker_creates_pack_and_remaps_assets(
     db_instance: CharactersRAGDB,
     tmp_path: Path,
@@ -439,6 +538,132 @@ async def test_persona_visual_import_commit_worker_creates_pack_and_remaps_asset
     assert updated_job["status"] == "completed"
     assert updated_job["stage"] == "completed"
     assert updated_job["pack_id"] == imported_pack["id"]
+
+
+@pytest.mark.asyncio
+async def test_persona_visual_import_commit_worker_replaces_selected_draft_only(
+    db_instance: CharactersRAGDB,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.core.DB_Management.PersonaVisualPortability_DB import (
+        PersonaVisualPortabilityRepository,
+    )
+    from tldw_Server_API.app.core.Persona.visual_jobs_worker import (
+        PersonaVisualPortabilityWorker,
+    )
+
+    source_persona_id, source_pack, _source_asset = _create_pack_with_asset(
+        db_instance,
+        visuals_root=tmp_path / "visuals",
+        monkeypatch=monkeypatch,
+    )
+    target_persona_id = db_instance.create_persona_profile(
+        {"user_id": "user-1", "name": "Worker Target Persona"}
+    )
+    active_pack = db_instance.create_persona_visual_pack(
+        persona_id=target_persona_id,
+        user_id="user-1",
+        title="Active Target Visuals",
+        manifest={"manifest_version": 1, "renderer_type": "sprite_frames", "states": {}, "animations": {}},
+        status="active",
+    )
+    target_draft = db_instance.create_persona_visual_pack(
+        persona_id=target_persona_id,
+        user_id="user-1",
+        title=str(source_pack["title"]),
+        manifest={"manifest_version": 1, "renderer_type": "sprite_frames", "states": {}, "animations": {}},
+    )
+    export_result = PersonaVisualPackExporter(
+        db=db_instance,
+        user_id="user-1",
+        staging_root=tmp_path / "exports",
+    ).export_pack(
+        persona_id=source_persona_id,
+        pack_id=str(source_pack["id"]),
+        options=PersonaVisualPackExportOptions(),
+    )
+    preview_result = PersonaVisualPackImportPreviewer().create_preview(
+        archive_path=export_result.archive_path,
+        owner_user_id="user-1",
+        target_persona_id=target_persona_id,
+        target_packs=db_instance.list_persona_visual_packs(
+            persona_id=target_persona_id,
+            user_id="user-1",
+        ),
+    )
+    repo = PersonaVisualPortabilityRepository.initialized(db_instance)
+    preview = repo.create_import_preview(
+        owner_user_id="user-1",
+        job_id="job-preview-1",
+        status="completed",
+        stage="completed",
+        archive_path=str(export_result.archive_path),
+        archive_sha256=preview_result["archive_sha256"],
+        canonical_payload_fingerprint=preview_result["canonical_payload_fingerprint"],
+        schema_version=preview_result["schema_version"],
+        target_persona_id=target_persona_id,
+        bundle_summary=preview_result["bundle_summary"],
+        conflicts=preview_result["conflicts"],
+        proposed_plan=preview_result["proposed_plan"],
+        required_choices=preview_result["required_choices"],
+    )
+    portability_job = repo.create_portability_job(
+        owner_user_id="user-1",
+        job_id="job-commit-1",
+        operation="import_commit",
+        status="queued",
+        stage="queued",
+        preview_id=str(preview["id"]),
+        persona_id=target_persona_id,
+    )
+    worker = PersonaVisualPortabilityWorker(db=db_instance, repo=repo)
+
+    result = await worker.handle_job_async(
+        {
+            "id": "job-commit-1",
+            "job_type": PERSONA_VISUAL_PACK_IMPORT_COMMIT_JOB_TYPE,
+            "owner_user_id": "user-1",
+            "payload": {
+                "user_id": "user-1",
+                "preview_id": str(preview["id"]),
+                "portability_job_id": str(portability_job["id"]),
+                "request_id": "req-commit",
+                "target_persona_id": target_persona_id,
+                "trust_mode": "untrusted_import",
+                "target_mode": "replace_draft",
+                "target_pack_id": str(target_draft["id"]),
+                "title": "Imported Replacement",
+                "conflict_choice_explicit": True,
+            },
+        }
+    )
+
+    imported_pack = db_instance.get_persona_visual_pack(
+        pack_id=result["pack_id"],
+        persona_id=target_persona_id,
+        user_id="user-1",
+    )
+    deleted_draft = db_instance.get_persona_visual_pack(
+        pack_id=str(target_draft["id"]),
+        persona_id=target_persona_id,
+        user_id="user-1",
+        include_deleted=True,
+    )
+    active_after = db_instance.get_active_persona_visual_pack(
+        persona_id=target_persona_id,
+        user_id="user-1",
+    )
+    assert result["status"] == "imported"
+    assert result["replaced_pack_id"] == target_draft["id"]
+    assert imported_pack is not None
+    assert imported_pack["id"] != target_draft["id"]
+    assert imported_pack["title"] == "Imported Replacement"
+    assert imported_pack["status"] == "draft"
+    assert deleted_draft is not None
+    assert deleted_draft["deleted"] is True
+    assert active_after is not None
+    assert active_after["id"] == active_pack["id"]
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
@@ -1259,6 +1259,116 @@ def test_start_import_commit_creates_jobs_backed_portability_row(
     assert row["persona_id"] == persona_id
 
 
+def test_start_import_commit_requires_explicit_target_mode_for_conflicts(
+    persona_db: CharactersRAGDB,
+    tmp_path: Path,
+) -> None:
+    from tldw_Server_API.app.core.DB_Management.PersonaVisualPortability_DB import (
+        PersonaVisualPortabilityRepository,
+    )
+
+    manager = FakeJobManager()
+    fastapi_app.dependency_overrides[persona_ep.get_persona_visual_job_manager] = lambda: manager
+    with _client_for_user(1, persona_db) as client:
+        persona_id = _create_persona(client, name="Conflicted Import Commit Persona")
+        draft_pack = _create_visual_pack(client, persona_id, title="Existing Draft")
+        archive_path = tmp_path / "commit-conflict.tldw-persona-vpack"
+        archive_path.write_bytes(b"portable visual archive")
+        repo = PersonaVisualPortabilityRepository.initialized(persona_db)
+        preview = repo.create_import_preview(
+            owner_user_id="1",
+            job_id="preview-job-1",
+            status="completed",
+            stage="completed",
+            archive_path=str(archive_path),
+            archive_sha256="a" * 64,
+            canonical_payload_fingerprint="b" * 64,
+            schema_version="tldw.persona_visual_pack.v1",
+            target_persona_id=persona_id,
+            conflicts=[
+                {
+                    "conflict_id": f"target_pack_title_match:{draft_pack['id']}",
+                    "type": "target_pack_title_match",
+                    "pack_id": draft_pack["id"],
+                    "pack_status": "draft",
+                    "allowed_choices": ["create_new", "replace_draft"],
+                }
+            ],
+        )
+
+        response = client.post(
+            f"/api/v1/persona/profiles/{persona_id}/visual-packs/import-previews/{preview['id']}/commit",
+            json={"trust_mode": "untrusted_import"},
+        )
+
+    assert response.status_code == 409, response.text
+    assert response.json()["detail"] == "import_conflict_choice_required"
+    assert manager.created == []
+
+
+def test_start_import_commit_allows_replace_draft_choice(
+    persona_db: CharactersRAGDB,
+    tmp_path: Path,
+) -> None:
+    from tldw_Server_API.app.core.DB_Management.PersonaVisualPortability_DB import (
+        PersonaVisualPortabilityRepository,
+    )
+    from tldw_Server_API.app.core.Persona.visual_jobs import (
+        PERSONA_VISUAL_PACK_IMPORT_COMMIT_JOB_TYPE,
+    )
+
+    manager = FakeJobManager()
+    fastapi_app.dependency_overrides[persona_ep.get_persona_visual_job_manager] = lambda: manager
+    with _client_for_user(1, persona_db) as client:
+        persona_id = _create_persona(client, name="Replace Draft Import Commit Persona")
+        draft_pack = _create_visual_pack(client, persona_id, title="Existing Draft")
+        archive_path = tmp_path / "commit-replace-draft.tldw-persona-vpack"
+        archive_path.write_bytes(b"portable visual archive")
+        repo = PersonaVisualPortabilityRepository.initialized(persona_db)
+        preview = repo.create_import_preview(
+            owner_user_id="1",
+            job_id="preview-job-1",
+            status="completed",
+            stage="completed",
+            archive_path=str(archive_path),
+            archive_sha256="a" * 64,
+            canonical_payload_fingerprint="b" * 64,
+            schema_version="tldw.persona_visual_pack.v1",
+            target_persona_id=persona_id,
+            conflicts=[
+                {
+                    "conflict_id": f"target_pack_title_match:{draft_pack['id']}",
+                    "type": "target_pack_title_match",
+                    "pack_id": draft_pack["id"],
+                    "pack_status": "draft",
+                    "allowed_choices": ["create_new", "replace_draft"],
+                }
+            ],
+        )
+
+        response = client.post(
+            f"/api/v1/persona/profiles/{persona_id}/visual-packs/import-previews/{preview['id']}/commit",
+            json={
+                "trust_mode": "untrusted_import",
+                "target_mode": "replace_draft",
+                "target_pack_id": draft_pack["id"],
+                "title": "Imported Replacement",
+            },
+        )
+
+    assert response.status_code == 202, response.text
+    assert manager.created[0]["job_type"] == PERSONA_VISUAL_PACK_IMPORT_COMMIT_JOB_TYPE
+    assert manager.created[0]["payload"]["target_mode"] == "replace_draft"
+    assert manager.created[0]["payload"]["target_pack_id"] == draft_pack["id"]
+    assert manager.created[0]["payload"]["title"] == "Imported Replacement"
+    assert manager.created[0]["payload"]["conflict_choice_explicit"] is True
+    row = repo.get_portability_job_by_job_id("9001", owner_user_id="1")
+    assert row is not None
+    assert row["operation"] == "import_commit"
+    assert row["preview_id"] == preview["id"]
+    assert row["persona_id"] == persona_id
+
+
 def test_import_commit_status_is_scoped(persona_db: CharactersRAGDB, tmp_path: Path) -> None:
     from tldw_Server_API.app.core.DB_Management.PersonaVisualPortability_DB import (
         PersonaVisualPortabilityRepository,


### PR DESCRIPTION
## Summary
- Adds preview-backed target title-match conflicts for Persona visual-pack imports, including allowed create-new and draft-only replace choices.
- Enforces explicit commit target choices for conflicted previews and supports reviewed draft replacement without touching active packs.
- Adds Persona Garden conflict-choice controls, docs, Backlog task record, and focused backend/frontend coverage.

## Verification
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_portability.py tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py tldw_Server_API/tests/Persona/test_persona_visual_jobs.py tldw_Server_API/tests/Persona/test_persona_visuals_api.py -q`
- `bun run test src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx`
- `git diff --check`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Persona/visual_portability/preview.py tldw_Server_API/app/core/Persona/visual_portability/importer.py tldw_Server_API/app/core/Persona/visual_jobs.py tldw_Server_API/app/core/Persona/visual_jobs_worker.py tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/app/api/v1/schemas/persona.py -f json -o /tmp/bandit_persona_visual_import_conflicts.json`

## Tracking
Closes #1490.

## Change summary
Maintainer follow-up required before merge: per repo policy, the final Change summary must be written by the human requester.