### PR TITLE
Add Persona Garden visual-pack reuse affordances

### DIFF
--- a/Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md
+++ b/Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md
@@ -42,9 +42,10 @@ leaving the Persona workflow.
 The implementation now covers the core data model, renderer, API, editor, Jobs
 flow, MCP module, E2E runtime behavior, Buddy entry point, diagnostics, setup
 states, ownership/help copy, duplicate-to-persona drafts, and a reference-backed
-personal pack library. The remaining product gap is optional Phase 3
-externalization: richer import/export conflict choices, external visual
-providers, shared/cross-device libraries, and future renderer adapters.
+personal pack library, import conflict choices, and reusable Persona Garden
+affordances. The remaining product gap is optional Phase 3 externalization:
+external visual providers, shared/cross-device libraries, and future renderer
+adapters.
 
 ---
 
@@ -136,6 +137,10 @@ Implemented foundations include:
 17. Import preview conflict choices for target title matches, including
     create-new-draft and reviewed draft replacement while preserving separate
     activation.
+18. Persona Garden reusable visual-pack decision surface that routes create
+    draft, personal library, import archive preview, and duplicate-to-persona
+    actions into the existing controls while preserving draft/review-before-
+    activation semantics.
 
 ---
 

--- a/Docs/superpowers/plans/2026-05-10-persona-garden-visual-reuse-affordances.md
+++ b/Docs/superpowers/plans/2026-05-10-persona-garden-visual-reuse-affordances.md
@@ -1,0 +1,122 @@
+# Persona Garden Visual Reuse Affordances Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Persona Garden visual-pack reuse decision surface that makes existing draft, library, duplicate, and import workflows discoverable without adding a parallel management model.
+
+**Architecture:** Keep backend/API contracts unchanged. Add one focused React presentational component for the reuse affordance surface and wire it into `VisualPackEditor` with callbacks to the existing create, library, duplicate, and import controls. Preserve user-owned, persona-attached, draft/review-before-activation language.
+
+**Tech Stack:** React, TypeScript, Ant Design buttons/tags, lucide-react icons, Vitest, Testing Library.
+
+---
+
+### Task 1: Add Reuse Decision Surface Tests
+
+**Files:**
+- Create: `apps/packages/ui/src/components/PersonaGarden/VisualPackReusePanel.tsx`
+- Test: `apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackReusePanel.test.tsx`
+
+- [x] **Step 1: Write failing tests for available actions**
+
+Test that the panel renders the four reuse paths:
+- Create a new draft pack.
+- Use a personal library pack.
+- Import a portable archive for preview.
+- Duplicate the selected pack to another persona as a draft.
+
+Expected assertions:
+- Copy includes `draft`, `review`, and `activate` semantics.
+- Copy does not include `marketplace`, `shared with other users`, `VN`, or `CYOA`.
+- Clicking enabled actions invokes their callback props.
+
+- [x] **Step 2: Write failing tests for disabled and empty states**
+
+Test that duplicate is disabled when no selected pack or no other persona target exists, and that the empty library state still routes to the library area instead of hiding the workflow.
+
+- [x] **Step 3: Run focused panel tests to verify RED**
+
+Run:
+`cd apps/packages/ui && bunx vitest run src/components/PersonaGarden/__tests__/VisualPackReusePanel.test.tsx`
+
+Expected: FAIL because `VisualPackReusePanel` does not exist yet.
+
+### Task 2: Implement Panel Component
+
+**Files:**
+- Create: `apps/packages/ui/src/components/PersonaGarden/VisualPackReusePanel.tsx`
+
+- [x] **Step 1: Implement typed props and four actions**
+
+Props:
+- `selectedPersonaName`
+- `hasSelectedPack`
+- `libraryItemCount`
+- `hasDuplicateTargets`
+- `duplicateTargetsLoading`
+- `onCreateDraft`
+- `onOpenLibrary`
+- `onOpenImport`
+- `onOpenDuplicate`
+
+Render compact action buttons with icons and state notes. Disable duplicate when there is no selected pack, no target persona, or targets are loading.
+
+- [x] **Step 2: Run panel tests to verify GREEN**
+
+Run:
+`cd apps/packages/ui && bunx vitest run src/components/PersonaGarden/__tests__/VisualPackReusePanel.test.tsx`
+
+Expected: PASS.
+
+### Task 3: Wire Panel Into VisualPackEditor
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx`
+- Test: `apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx`
+
+- [x] **Step 1: Add failing integration tests**
+
+Add tests that:
+- The panel appears in the Persona Garden Visuals tab.
+- The create action focuses the draft title input.
+- The library action focuses or scrolls to the personal library panel.
+- The import action opens the existing import file input.
+- The duplicate action focuses the existing duplicate target select and remains disabled until a pack and target persona exist.
+
+- [x] **Step 2: Wire callbacks through existing refs**
+
+Use existing handlers and DOM controls:
+- Add refs for draft title, library panel, duplicate target select.
+- Reuse existing `importPreviewInputRef`.
+- Implement callbacks that focus/scroll or click existing controls only; do not add new API calls.
+
+- [x] **Step 3: Run editor tests to verify GREEN**
+
+Run:
+`cd apps/packages/ui && bunx vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx`
+
+Expected: PASS.
+
+### Task 4: Documentation, Backlog, and Verification
+
+**Files:**
+- Modify: `Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md`
+- Modify: `backlog/tasks/task-214 - Implement-Persona-Garden-reusable-visual-pack-affordances.md`
+
+- [x] **Step 1: Update the PRD implementation snapshot**
+
+Add a concise entry that Persona Garden now exposes the reusable visual-pack decision surface backed by existing draft, library, duplicate, and import flows.
+
+- [x] **Step 2: Run focused verification**
+
+Run:
+`cd apps/packages/ui && bunx vitest run src/components/PersonaGarden/__tests__/VisualPackReusePanel.test.tsx src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx`
+
+Expected: PASS.
+
+- [x] **Step 3: Record Bandit applicability**
+
+This slice touches TypeScript/Markdown only. Record that Python Bandit is not applicable unless Python files are added later.
+
+- [x] **Step 4: Update Backlog task**
+
+Check acceptance criteria and add verification notes.

--- a/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
@@ -77,6 +77,7 @@ import {
   classifyPersonaVisualGenerationReadiness,
   type PersonaVisualGenerationReadinessView
 } from "./personaVisualGenerationReadiness"
+import { VisualPackReusePanel } from "./VisualPackReusePanel"
 
 type VisualPackEditorProps = {
   selectedPersonaId: string
@@ -577,6 +578,9 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
   const [statusMessage, setStatusMessage] = React.useState<string | null>(null)
   const fileInputRef = React.useRef<HTMLInputElement | null>(null)
   const importPreviewInputRef = React.useRef<HTMLInputElement | null>(null)
+  const draftTitleInputRef = React.useRef<HTMLInputElement | null>(null)
+  const duplicateTargetSelectRef = React.useRef<HTMLSelectElement | null>(null)
+  const libraryPanelRef = React.useRef<HTMLDivElement | null>(null)
   const generationReadinessRequestIdRef = React.useRef(0)
   const duplicateTargetsRequestIdRef = React.useRef(0)
   const libraryRequestIdRef = React.useRef(0)
@@ -891,6 +895,26 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
     },
     []
   )
+
+  const focusDraftTitleInput = React.useCallback(() => {
+    draftTitleInputRef.current?.focus()
+  }, [])
+
+  const focusLibraryPanel = React.useCallback(() => {
+    libraryPanelRef.current?.scrollIntoView?.({ block: "start" })
+    libraryPanelRef.current?.focus()
+  }, [])
+
+  const openImportArchivePicker = React.useCallback(() => {
+    importPreviewInputRef.current?.scrollIntoView?.({ block: "center" })
+    importPreviewInputRef.current?.click()
+    importPreviewInputRef.current?.focus()
+  }, [])
+
+  const focusDuplicateControls = React.useCallback(() => {
+    duplicateTargetSelectRef.current?.scrollIntoView?.({ block: "center" })
+    duplicateTargetSelectRef.current?.focus()
+  }, [])
 
   const handleCreateDraft = async () => {
     const title = draftTitle.trim()
@@ -1892,6 +1916,7 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
           <label className="text-xs text-text-muted">
             <span className="mb-1 block">New draft title</span>
             <input
+              ref={draftTitleInputRef}
               data-testid="persona-visual-pack-title-input"
               className="w-full rounded border border-border bg-bg px-2 py-1 text-sm text-text"
               value={draftTitle}
@@ -1994,6 +2019,19 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
         ) : null}
       </div>
 
+      <VisualPackReusePanel
+        selectedPersonaName={selectedPersonaName || selectedPersonaId}
+        hasSelectedPack={Boolean(selectedPack)}
+        canImport={Boolean(selectedPack)}
+        libraryItemCount={libraryItems.length}
+        hasDuplicateTargets={availableDuplicateTargets.length > 0}
+        duplicateTargetsLoading={duplicateTargetsLoading}
+        onCreateDraft={focusDraftTitleInput}
+        onOpenLibrary={focusLibraryPanel}
+        onOpenImport={openImportArchivePicker}
+        onOpenDuplicate={focusDuplicateControls}
+      />
+
       {error ? (
         <div className="rounded-md border border-danger/30 bg-danger/10 p-2 text-xs text-danger">
           {error}
@@ -2006,7 +2044,9 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
       ) : null}
 
       <div
+        ref={libraryPanelRef}
         data-testid="persona-visual-library-panel"
+        tabIndex={-1}
         className="rounded-lg border border-border bg-surface p-3"
       >
         <div className="flex flex-wrap items-start justify-between gap-2">
@@ -2140,6 +2180,7 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
                   <label className="text-xs text-text-muted">
                     <span className="mb-1 block">Target persona</span>
                     <select
+                      ref={duplicateTargetSelectRef}
                       data-testid="persona-visual-duplicate-target-select"
                       className="w-full rounded border border-border bg-bg px-2 py-1 text-sm text-text"
                       value={duplicateTargetId}

--- a/apps/packages/ui/src/components/PersonaGarden/VisualPackReusePanel.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualPackReusePanel.tsx
@@ -1,0 +1,163 @@
+import React from "react"
+import { Button, Tag } from "antd"
+import { BookOpen, Copy, FileSearch, Plus } from "lucide-react"
+
+export type VisualPackReusePanelProps = {
+  selectedPersonaName: string
+  hasSelectedPack: boolean
+  canImport?: boolean
+  libraryItemCount: number
+  hasDuplicateTargets: boolean
+  duplicateTargetsLoading: boolean
+  onCreateDraft: () => void
+  onOpenLibrary: () => void
+  onOpenImport: () => void
+  onOpenDuplicate: () => void
+}
+
+const formatLibraryCount = (count: number): string => {
+  if (count <= 0) return "No saved visual packs yet"
+  if (count === 1) return "1 saved visual pack"
+  return `${count} saved visual packs`
+}
+
+const getDuplicateStatus = ({
+  duplicateTargetsLoading,
+  hasDuplicateTargets,
+  hasSelectedPack
+}: Pick<
+  VisualPackReusePanelProps,
+  "duplicateTargetsLoading" | "hasDuplicateTargets" | "hasSelectedPack"
+>): string => {
+  if (duplicateTargetsLoading) return "Loading persona targets."
+  if (!hasSelectedPack) return "Select a pack before duplicating."
+  if (!hasDuplicateTargets) return "Add another persona before duplicating."
+  return "Copy the selected pack as a draft for another persona."
+}
+
+export const VisualPackReusePanel: React.FC<VisualPackReusePanelProps> = ({
+  selectedPersonaName,
+  hasSelectedPack,
+  canImport = true,
+  libraryItemCount,
+  hasDuplicateTargets,
+  duplicateTargetsLoading,
+  onCreateDraft,
+  onOpenLibrary,
+  onOpenImport,
+  onOpenDuplicate
+}) => {
+  const duplicateDisabled =
+    duplicateTargetsLoading || !hasSelectedPack || !hasDuplicateTargets
+
+  return (
+    <div
+      data-testid="persona-visual-reuse-panel"
+      className="rounded-lg border border-border bg-surface p-3"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="text-[11px] font-semibold uppercase tracking-wide text-text-subtle">
+            Reuse visual packs
+          </div>
+          <div className="mt-1 text-sm font-medium text-text">
+            {selectedPersonaName}
+          </div>
+          <div className="mt-1 max-w-3xl text-xs leading-5 text-text-muted">
+            Assets are user-owned and attached to this persona by default. Each
+            path creates or opens a draft for review; activate it only after the
+            pack is ready.
+          </div>
+        </div>
+        <Tag color="blue">draft first</Tag>
+      </div>
+
+      <div className="mt-3 grid gap-2 md:grid-cols-2 xl:grid-cols-4">
+        <div className="rounded border border-border bg-bg p-2">
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-xs font-medium text-text">Start fresh</span>
+            <Tag>draft</Tag>
+          </div>
+          <div className="mt-1 min-h-[2.5rem] text-xs leading-5 text-text-muted">
+            Create an empty draft pack for new poses, animations, and state
+            mappings.
+          </div>
+          <Button
+            className="mt-2 w-full justify-center"
+            size="small"
+            icon={<Plus className="h-3.5 w-3.5" />}
+            onClick={onCreateDraft}
+          >
+            Create draft
+          </Button>
+        </div>
+
+        <div className="rounded border border-border bg-bg p-2">
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-xs font-medium text-text">Personal library</span>
+            <Tag>reference</Tag>
+          </div>
+          <div className="mt-1 min-h-[2.5rem] text-xs leading-5 text-text-muted">
+            {formatLibraryCount(libraryItemCount)}. Use one to create a reviewed
+            draft for the target persona.
+          </div>
+          <Button
+            className="mt-2 w-full justify-center"
+            size="small"
+            icon={<BookOpen className="h-3.5 w-3.5" />}
+            onClick={onOpenLibrary}
+          >
+            Use personal library
+          </Button>
+        </div>
+
+        <div className="rounded border border-border bg-bg p-2">
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-xs font-medium text-text">Portable archive</span>
+            <Tag>preview</Tag>
+          </div>
+          <div className="mt-1 min-h-[2.5rem] text-xs leading-5 text-text-muted">
+            {canImport
+              ? "Import an archive through preview, choose conflicts, then commit as a draft."
+              : "Select or create a draft before using import preview controls."}
+          </div>
+          <Button
+            className="mt-2 w-full justify-center"
+            size="small"
+            icon={<FileSearch className="h-3.5 w-3.5" />}
+            disabled={!canImport}
+            onClick={onOpenImport}
+          >
+            Import archive
+          </Button>
+        </div>
+
+        <div className="rounded border border-border bg-bg p-2">
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-xs font-medium text-text">Another persona</span>
+            <Tag>copy</Tag>
+          </div>
+          <div className="mt-1 min-h-[2.5rem] text-xs leading-5 text-text-muted">
+            {getDuplicateStatus({
+              duplicateTargetsLoading,
+              hasDuplicateTargets,
+              hasSelectedPack
+            })}
+          </div>
+          <Button
+            className="mt-2 w-full justify-center"
+            size="small"
+            icon={<Copy className="h-3.5 w-3.5" />}
+            disabled={duplicateDisabled}
+            loading={duplicateTargetsLoading}
+            onClick={onOpenDuplicate}
+          >
+            Duplicate to persona
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default VisualPackReusePanel

--- a/apps/packages/ui/src/components/PersonaGarden/VisualPackReusePanel.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualPackReusePanel.tsx
@@ -15,10 +15,20 @@ export type VisualPackReusePanelProps = {
   onOpenDuplicate: () => void
 }
 
-const formatLibraryCount = (count: number): string => {
-  if (count <= 0) return "No saved visual packs yet"
+const formatLibraryStatus = (count: number): string => {
+  if (count <= 0) {
+    return [
+      "No saved visual packs yet.",
+      "Save a pack here first, or create/import a draft before adding it to the library."
+    ].join(" ")
+  }
   if (count === 1) return "1 saved visual pack"
   return `${count} saved visual packs`
+}
+
+const getLibraryDescription = (count: number): string => {
+  if (count <= 0) return formatLibraryStatus(count)
+  return `${formatLibraryStatus(count)}. Use one to create a reviewed draft for the target persona.`
 }
 
 const getDuplicateStatus = ({
@@ -98,8 +108,7 @@ export const VisualPackReusePanel: React.FC<VisualPackReusePanelProps> = ({
             <Tag>reference</Tag>
           </div>
           <div className="mt-1 min-h-[2.5rem] text-xs leading-5 text-text-muted">
-            {formatLibraryCount(libraryItemCount)}. Use one to create a reviewed
-            draft for the target persona.
+            {getLibraryDescription(libraryItemCount)}
           </div>
           <Button
             className="mt-2 w-full justify-center"

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
@@ -520,6 +520,8 @@ describe("VisualPackEditor", () => {
 
     const reusePanel = await screen.findByTestId("persona-visual-reuse-panel")
     expect(reusePanel).toHaveTextContent("No saved visual packs yet")
+    expect(reusePanel).toHaveTextContent("Save a pack here first")
+    expect(reusePanel).not.toHaveTextContent("Use one to create")
     expect(reusePanel).toHaveTextContent("Select a pack before duplicating")
     expect(
       within(reusePanel).getByRole("button", { name: /duplicate to persona/i })

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
@@ -386,6 +386,150 @@ describe("VisualPackEditor", () => {
     )
   })
 
+  it("surfaces reusable visual-pack routes through existing editor controls", async () => {
+    const clickFileInput = vi
+      .spyOn(HTMLInputElement.prototype, "click")
+      .mockImplementation(() => undefined)
+    const pack = {
+      id: "pack-1",
+      persona_id: "persona-1",
+      title: "Animated pack",
+      renderer_type: "sprite_frames",
+      status: "draft",
+      manifest: structuredClone(baseManifest),
+      assets: visualAssets,
+      version: 3
+    }
+    const libraryItem = {
+      id: "library-1",
+      user_id: "user-1",
+      source_persona_id: "persona-1",
+      source_pack_id: "pack-1",
+      title: "Saved animated pack",
+      notes: "Reusable idle and speaking poses.",
+      tags: ["idle"],
+      source_persona_name: "Source Persona",
+      source_pack_title: "Animated pack",
+      source_pack_version: 3,
+      source_current_version: 3,
+      source_available: true,
+      source_changed: false,
+      created_at: "2026-05-09T00:00:00Z",
+      last_modified: "2026-05-09T00:00:00Z",
+      version: 2
+    }
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string }) => {
+      const method = init?.method || "GET"
+      if (path === "/api/v1/persona/profiles/persona-1/visual-packs" && method === "GET") {
+        return okResponse([pack])
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/pack-1/generated-candidates" &&
+        method === "GET"
+      ) {
+        return okResponse({ candidates: [] })
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/pack-1/generation-readiness" &&
+        method === "GET"
+      ) {
+        return okResponse(readyGenerationReadiness)
+      }
+      if (path === "/api/v1/persona/catalog" && method === "GET") {
+        return okResponse([
+          { id: "persona-1", name: "Source Persona" },
+          { id: "persona-2", name: "Research Buddy" }
+        ])
+      }
+      if (path === "/api/v1/persona/visual-library" && method === "GET") {
+        return okResponse({ items: [libraryItem] })
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        error: `Unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(
+      <VisualPackEditor
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Source Persona"
+        isActive
+      />
+    )
+
+    const reusePanel = await screen.findByTestId("persona-visual-reuse-panel")
+    expect(reusePanel).toHaveTextContent("Reuse visual packs")
+    expect(reusePanel).toHaveTextContent("user-owned")
+    expect(reusePanel).not.toHaveTextContent(/marketplace/i)
+    expect(reusePanel).not.toHaveTextContent(/\bVN\b/)
+    expect(reusePanel).not.toHaveTextContent(/CYOA/i)
+
+    fireEvent.click(within(reusePanel).getByRole("button", { name: /create draft/i }))
+    expect(screen.getByTestId("persona-visual-pack-title-input")).toHaveFocus()
+
+    fireEvent.click(
+      within(reusePanel).getByRole("button", { name: /use personal library/i })
+    )
+    expect(screen.getByTestId("persona-visual-library-panel")).toHaveFocus()
+
+    await waitFor(() =>
+      expect(
+        within(reusePanel).getByRole("button", { name: /duplicate to persona/i })
+      ).toBeEnabled()
+    )
+    fireEvent.click(
+      within(reusePanel).getByRole("button", { name: /duplicate to persona/i })
+    )
+    expect(screen.getByTestId("persona-visual-duplicate-target-select")).toHaveFocus()
+
+    fireEvent.click(within(reusePanel).getByRole("button", { name: /import archive/i }))
+    expect(clickFileInput).toHaveBeenCalled()
+  })
+
+  it("keeps duplicate reuse unavailable until a pack and another persona exist", async () => {
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string }) => {
+      const method = init?.method || "GET"
+      if (path === "/api/v1/persona/profiles/persona-1/visual-packs" && method === "GET") {
+        return okResponse([])
+      }
+      if (path === "/api/v1/persona/catalog" && method === "GET") {
+        return okResponse([{ id: "persona-1", name: "Solo Persona" }])
+      }
+      if (path === "/api/v1/persona/visual-library" && method === "GET") {
+        return okResponse({ items: [] })
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        error: `Unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(
+      <VisualPackEditor
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Solo Persona"
+        isActive
+      />
+    )
+
+    const reusePanel = await screen.findByTestId("persona-visual-reuse-panel")
+    expect(reusePanel).toHaveTextContent("No saved visual packs yet")
+    expect(reusePanel).toHaveTextContent("Select a pack before duplicating")
+    expect(
+      within(reusePanel).getByRole("button", { name: /duplicate to persona/i })
+    ).toBeDisabled()
+    expect(within(reusePanel).getByRole("button", { name: /import archive/i })).toBeDisabled()
+    expect(
+      within(reusePanel).getByRole("button", { name: /use personal library/i })
+    ).toBeEnabled()
+  })
+
   it("loads pack list, creates a draft pack, and uploads the selected asset role", async () => {
     let packs: any[] = []
     const uploadedAssets: any[] = []

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackReusePanel.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackReusePanel.test.tsx
@@ -1,0 +1,118 @@
+import React from "react"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { VisualPackReusePanel } from "../VisualPackReusePanel"
+
+const baseProps = {
+  selectedPersonaName: "Research Buddy",
+  hasSelectedPack: true,
+  libraryItemCount: 2,
+  hasDuplicateTargets: true,
+  duplicateTargetsLoading: false,
+  onCreateDraft: vi.fn(),
+  onOpenLibrary: vi.fn(),
+  onOpenImport: vi.fn(),
+  onOpenDuplicate: vi.fn()
+}
+
+describe("VisualPackReusePanel", () => {
+  it("routes user-owned visual pack reuse actions through existing flows", () => {
+    const onCreateDraft = vi.fn()
+    const onOpenLibrary = vi.fn()
+    const onOpenImport = vi.fn()
+    const onOpenDuplicate = vi.fn()
+
+    render(
+      <VisualPackReusePanel
+        {...baseProps}
+        onCreateDraft={onCreateDraft}
+        onOpenLibrary={onOpenLibrary}
+        onOpenImport={onOpenImport}
+        onOpenDuplicate={onOpenDuplicate}
+      />
+    )
+
+    const panel = screen.getByTestId("persona-visual-reuse-panel")
+    expect(panel).toHaveTextContent("Research Buddy")
+    expect(panel).toHaveTextContent("user-owned")
+    expect(panel).toHaveTextContent("draft")
+    expect(panel).toHaveTextContent("review")
+    expect(panel).toHaveTextContent("activate")
+    expect(panel).not.toHaveTextContent(/marketplace/i)
+    expect(panel).not.toHaveTextContent(/shared with other users/i)
+    expect(panel).not.toHaveTextContent(/\bVN\b/)
+    expect(panel).not.toHaveTextContent(/CYOA/i)
+
+    fireEvent.click(screen.getByRole("button", { name: /create draft/i }))
+    fireEvent.click(screen.getByRole("button", { name: /use personal library/i }))
+    fireEvent.click(screen.getByRole("button", { name: /import archive/i }))
+    fireEvent.click(screen.getByRole("button", { name: /duplicate to persona/i }))
+
+    expect(onCreateDraft).toHaveBeenCalledTimes(1)
+    expect(onOpenLibrary).toHaveBeenCalledTimes(1)
+    expect(onOpenImport).toHaveBeenCalledTimes(1)
+    expect(onOpenDuplicate).toHaveBeenCalledTimes(1)
+  })
+
+  it("keeps unavailable duplicate flows disabled while leaving library discovery open", () => {
+    const onOpenLibrary = vi.fn()
+    const onOpenDuplicate = vi.fn()
+
+    const { rerender } = render(
+      <VisualPackReusePanel
+        {...baseProps}
+        hasSelectedPack={false}
+        libraryItemCount={0}
+        hasDuplicateTargets={false}
+        onOpenLibrary={onOpenLibrary}
+        onOpenDuplicate={onOpenDuplicate}
+      />
+    )
+
+    expect(screen.getByTestId("persona-visual-reuse-panel")).toHaveTextContent(
+      "No saved visual packs yet"
+    )
+    fireEvent.click(screen.getByRole("button", { name: /use personal library/i }))
+    expect(onOpenLibrary).toHaveBeenCalledTimes(1)
+
+    const duplicateButton = screen.getByRole("button", {
+      name: /duplicate to persona/i
+    })
+    expect(duplicateButton).toBeDisabled()
+    expect(screen.getByTestId("persona-visual-reuse-panel")).toHaveTextContent(
+      "Select a pack before duplicating"
+    )
+    fireEvent.click(duplicateButton)
+    expect(onOpenDuplicate).not.toHaveBeenCalled()
+
+    rerender(
+      <VisualPackReusePanel
+        {...baseProps}
+        hasSelectedPack
+        hasDuplicateTargets={false}
+        duplicateTargetsLoading={false}
+        onOpenLibrary={onOpenLibrary}
+        onOpenDuplicate={onOpenDuplicate}
+      />
+    )
+
+    expect(screen.getByRole("button", { name: /duplicate to persona/i })).toBeDisabled()
+    expect(screen.getByTestId("persona-visual-reuse-panel")).toHaveTextContent(
+      "Add another persona before duplicating"
+    )
+
+    rerender(
+      <VisualPackReusePanel
+        {...baseProps}
+        hasSelectedPack
+        hasDuplicateTargets={false}
+        duplicateTargetsLoading
+        onOpenLibrary={onOpenLibrary}
+        onOpenDuplicate={onOpenDuplicate}
+      />
+    )
+
+    expect(screen.getByRole("button", { name: /duplicate to persona/i })).toBeDisabled()
+  })
+})

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackReusePanel.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackReusePanel.test.tsx
@@ -73,6 +73,12 @@ describe("VisualPackReusePanel", () => {
     expect(screen.getByTestId("persona-visual-reuse-panel")).toHaveTextContent(
       "No saved visual packs yet"
     )
+    expect(screen.getByTestId("persona-visual-reuse-panel")).toHaveTextContent(
+      "Save a pack here first"
+    )
+    expect(screen.getByTestId("persona-visual-reuse-panel")).not.toHaveTextContent(
+      "Use one to create"
+    )
     fireEvent.click(screen.getByRole("button", { name: /use personal library/i }))
     expect(onOpenLibrary).toHaveBeenCalledTimes(1)
 

--- a/backlog/tasks/task-214 - Implement-Persona-Garden-reusable-visual-pack-affordances.md
+++ b/backlog/tasks/task-214 - Implement-Persona-Garden-reusable-visual-pack-affordances.md
@@ -1,0 +1,56 @@
+---
+id: TASK-214
+title: Implement Persona Garden reusable visual-pack affordances
+status: Done
+assignee: []
+created_date: '2026-05-10 03:06'
+updated_date: '2026-05-10 03:24'
+labels:
+  - persona
+  - webui
+  - visual-packs
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1493'
+documentation:
+  - Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md
+  - Docs/Code_Documentation/Persona_Visual_Packs.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement GitHub issue #1493 as the next Phase 3 Persona/Buddy visual-pack reuse slice. Add a focused Persona Garden WebUI decision surface that helps users choose existing reuse workflows (duplicate from another persona, use from personal library, import with conflict choices) without changing backend ownership semantics, implying marketplace behavior, or automatically activating packs. Keep the work scoped to existing APIs and shared UI patterns.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Persona Garden exposes a clear visual-pack reuse entry point backed by existing duplicate, library, and import flows.
+- [x] #2 The UI presents draft/review-before-activation semantics in available/disabled/empty states without marketplace or cross-user wording.
+- [x] #3 Reuse actions route through existing client/API contracts without introducing a parallel visual-pack management model.
+- [x] #4 Focused shared-UI tests cover action availability, state copy, and routing callbacks for the new decision surface.
+- [x] #5 Docs or code comments are updated only where needed to explain the new Persona/Buddy affordance behavior.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented a Persona Garden Visual Pack reuse decision panel backed by existing editor controls. Added focused panel and editor integration tests for create-draft focus routing, personal-library routing, import archive routing, duplicate target routing, disabled duplicate/import empty states, and no marketplace/VN/CYOA wording. Verification: bun run test src/components/PersonaGarden/__tests__/VisualPackReusePanel.test.tsx src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx passed with 25 tests. Bandit: not applicable because this slice touches TypeScript and Markdown only.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added a reusable Persona Garden decision surface for Buddy/persona visual packs. The surface makes create draft, personal library, import archive, and duplicate-to-persona flows discoverable while delegating to existing controls and preserving draft/review-before-activation semantics. Updated the Persona Live Visual Packs PRD snapshot and added focused Vitest coverage.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-214 - Implement-Persona-Garden-reusable-visual-pack-affordances.md
+++ b/backlog/tasks/task-214 - Implement-Persona-Garden-reusable-visual-pack-affordances.md
@@ -4,7 +4,7 @@ title: Implement Persona Garden reusable visual-pack affordances
 status: Done
 assignee: []
 created_date: '2026-05-10 03:06'
-updated_date: '2026-05-10 03:24'
+updated_date: '2026-05-10 04:06'
 labels:
   - persona
   - webui
@@ -37,12 +37,16 @@ Implement GitHub issue #1493 as the next Phase 3 Persona/Buddy visual-pack reuse
 
 <!-- SECTION:NOTES:BEGIN -->
 Implemented a Persona Garden Visual Pack reuse decision panel backed by existing editor controls. Added focused panel and editor integration tests for create-draft focus routing, personal-library routing, import archive routing, duplicate target routing, disabled duplicate/import empty states, and no marketplace/VN/CYOA wording. Verification: bun run test src/components/PersonaGarden/__tests__/VisualPackReusePanel.test.tsx src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx passed with 25 tests. Bandit: not applicable because this slice touches TypeScript and Markdown only.
+
+Review-fix pass for PR #1494: Qodo reported one actionable requirement gap in VisualPackReusePanel empty library copy. Reopening task for the review fix before editing files.
+
+Review fix applied for PR #1494: adjusted the empty personal-library copy to avoid the contradictory 'Use one...' follow-up when there are no saved packs. Added regression assertions in VisualPackReusePanel and VisualPackEditor tests. Verification: bun run test src/components/PersonaGarden/__tests__/VisualPackReusePanel.test.tsx src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx passed with 25 tests; git diff --check passed. Bandit remains not applicable for TypeScript/Markdown-only changes.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added a reusable Persona Garden decision surface for Buddy/persona visual packs. The surface makes create draft, personal library, import archive, and duplicate-to-persona flows discoverable while delegating to existing controls and preserving draft/review-before-activation semantics. Updated the Persona Live Visual Packs PRD snapshot and added focused Vitest coverage.
+Added the Persona Garden visual-pack reuse surface and addressed PR #1494 review feedback by making the empty library state give valid next-step guidance instead of implying an item can be used when none exist. Focused Vitest coverage passes.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary

- Adds a Persona Garden reuse decision panel for Buddy/persona visual packs.
- Wires create draft, personal library, import archive, and duplicate-to-persona actions into the existing VisualPackEditor controls without new backend contracts.
- Updates the Persona Live Visual Packs PRD snapshot and Backlog task for issue #1493.

## Test Plan

- [x] `bun run test src/components/PersonaGarden/__tests__/VisualPackReusePanel.test.tsx src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx`
- [x] `git diff --check --cached`
- [x] Bandit not applicable: touched files are TypeScript and Markdown only.

## Change Summary

Human-authored change summary required before merge per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

Closes #1493
