### PR TITLE
Add MCP Hub workflow shell

### DIFF
--- a/Docs/superpowers/specs/2026-05-10-mcp-hub-workflow-first-control-panel-design.md
+++ b/Docs/superpowers/specs/2026-05-10-mcp-hub-workflow-first-control-panel-design.md
@@ -19,7 +19,7 @@ The approved direction is the heavier workflow-first redesign. The new page shou
 - Governance
 - Audit
 
-The first implementation program should preserve existing child components and service contracts wherever possible. It should change the information architecture, routing state, workflow framing, readiness summaries, and first-use guidance before attempting deeper form rewrites.
+The overall implementation program should preserve existing child components and service contracts wherever possible. It should change the information architecture, routing state, workflow framing, readiness summaries, and first-use guidance before attempting deeper form rewrites.
 
 For PR sizing, split that program into at least two slices: Stage 1 ships the workflow shell, URL state, child-view grouping, audit drilldown mapping, and Setup-first default; Stage 2 adds readiness/status summaries and richer first-use empty-state guidance. Stage 1 may include static workflow descriptions or lightweight placeholders, but it should not require all readiness aggregation to land in the same PR.
 
@@ -112,7 +112,7 @@ Use five top-level workflows:
 
 | Workflow | User job | Existing child views |
 | --- | --- | --- |
-| Setup | Connect MCP servers, configure credentials, verify available tools | Tool Catalog, Servers & Credentials |
+| Setup | Connect MCP servers, configure credentials, verify available tools | Servers & Credentials, Tool Catalog |
 | Access | Define who can use tools and bind access to personas, groups, or defaults | Profiles, Assignments |
 | Workspaces | Define trusted local path and workspace boundaries | Path Scopes, Workspace Sets, Shared Workspaces |
 | Governance | Manage approvals, portable packs, and capability adapters | Approvals, Governance Packs, Capability Mappings |
@@ -196,6 +196,8 @@ Rules:
 - Query updates should use replace behavior for internal tab switching where possible, so navigation does not pollute browser history.
 - `/settings/mcp-hub` should continue to reach the same workflow shell through existing route behavior.
 
+Implementation constraint: shared WebUI/extension code should use the existing `react-router-dom` compatibility layer (`useSearchParams`, `useNavigate`, or a small helper built on those hooks) rather than direct `window.history` calls. The Next WebUI currently aliases `react-router-dom` to the extension shim, so route-state code must keep both surfaces on the same path.
+
 ### Legacy tab-key compatibility
 
 Audit findings and older tests already use tab/view keys such as `assignments`, `credentials`, and `workspace-sets`. Keep those keys as the canonical child view keys. The redesign should wrap them in workflows, not rename them.
@@ -236,7 +238,7 @@ Selected child view content:
   existing component
 ```
 
-The status strip should be a short operational summary, not a tutorial block. It should answer:
+The eventual status strip should be a short operational summary, not a tutorial block. It should answer:
 
 - What exists?
 - What is missing?
@@ -244,9 +246,11 @@ The status strip should be a short operational summary, not a tutorial block. It
 
 The existing dismissible explainer can remain, but it should be rewritten to reflect the workflow model and should not be the only source of first-use guidance.
 
+Stage 1 can omit dynamic readiness/status aggregation. If the first shell reserves visual space for status, keep it static and descriptive until the Stage 2 readiness model is implemented.
+
 ## Readiness Summary Model
 
-The first implementation should derive summary state on the frontend from existing endpoints. A later backend summary endpoint can be added only if the frontend implementation becomes too slow, inconsistent, or duplicated across components.
+The Stage 2 readiness implementation should derive summary state on the frontend from existing endpoints. A later backend summary endpoint can be added only if the frontend implementation becomes too slow, inconsistent, or duplicated across components.
 
 ### Setup readiness
 
@@ -480,6 +484,7 @@ Deliverables:
 - child component rendering by view key
 - old audit drilldown mapped through workflow/view
 - Setup-first default route
+- shared WebUI/extension route-state handling through the existing router shim
 
 Primary files:
 
@@ -527,7 +532,9 @@ These are intentionally outside the first shell slice.
 
 ### Unit and component tests
 
-Add or update focused tests under [apps/packages/ui/src/components/Option/MCPHub/__tests__](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/MCPHub/__tests__):
+Add or update focused tests under [apps/packages/ui/src/components/Option/MCPHub/__tests__](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/MCPHub/__tests__).
+
+Stage 1 expectations:
 
 - workflow config maps every current view key to exactly one workflow
 - default route lands on Setup / Servers & Credentials
@@ -536,6 +543,9 @@ Add or update focused tests under [apps/packages/ui/src/components/Option/MCPHub
 - selecting a child view updates selected view
 - audit `Open` maps a finding to the expected workflow and child view
 - explainer dismissal behavior still works
+
+Stage 2 readiness expectations:
+
 - readiness summary failure does not hide the selected child view
 
 ### Extension route parity
@@ -554,13 +564,14 @@ Required checks:
 Update [mcp-hub.spec.ts](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/tldw-frontend/e2e/workflows/tier-2-features/mcp-hub.spec.ts):
 
 - page loads with MCP Hub heading and workflow navigation
+- page-object helpers move from tab-only `switchToTab` locators to workflow/view selection helpers
 - each workflow can be selected
 - representative child views load and fire expected API calls:
   - Setup / Tool Catalog -> `GET /api/v1/mcp/hub/tool-registry`
   - Setup / Servers & Credentials -> `GET /api/v1/mcp/hub/external-servers`
   - Access / Profiles -> `GET /api/v1/mcp/hub/permission-profiles`
   - Access / Assignments -> `GET /api/v1/mcp/hub/policy-assignments`
-  - Audit -> `GET /api/v1/mcp/hub/governance-audit`
+  - Audit -> `GET /api/v1/mcp/hub/audit/findings`
 - audit drilldown opens the mapped workflow and child view
 
 ### Verification commands
@@ -569,7 +580,7 @@ Expected focused verification after implementation:
 
 ```bash
 cd apps/tldw-frontend
-bunx vitest run ../packages/ui/src/components/Option/MCPHub/__tests__/McpHubPage.test.tsx ../packages/ui/src/components/Option/MCPHub/__tests__/McpHubPage.ftux.test.tsx
+bunx vitest run ../packages/ui/src/components/Option/MCPHub/__tests__/McpHubWorkflowConfig.test.ts ../packages/ui/src/components/Option/MCPHub/__tests__/McpHubPage.test.tsx ../packages/ui/src/components/Option/MCPHub/__tests__/McpHubPage.ftux.test.tsx
 bunx vitest run ../packages/ui/src/routes/__tests__/mcp-hub-route.test.tsx ../../apps/tldw-frontend/__tests__/extension/route-registry.mcp-hub.test.tsx
 npx playwright test e2e/workflows/tier-2-features/mcp-hub.spec.ts --reporter=line
 ```

--- a/Docs/superpowers/specs/2026-05-10-mcp-hub-workflow-first-control-panel-design.md
+++ b/Docs/superpowers/specs/2026-05-10-mcp-hub-workflow-first-control-panel-design.md
@@ -1,0 +1,614 @@
+# MCP Hub Workflow-First Control Panel Design
+
+Date: 2026-05-10
+Status: Approved for planning
+Owner: Codex brainstorming session
+Backlog: TASK-211
+
+## Summary
+
+Redesign the MCP Hub control panel from an object-centric tab list into a workflow-first hub for WebUI and extension users.
+
+The current shared page in [McpHubPage.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/MCPHub/McpHubPage.tsx) exposes 11 peer tabs: Tool Catalog, Servers & Credentials, Profiles, Assignments, Approvals, Path Scopes, Capability Mappings, Workspace Sets, Shared Workspaces, Governance Packs, and Audit. Those are accurate backend concepts, but they ask users to already understand the MCP control plane before they can complete a basic task.
+
+The approved direction is the heavier workflow-first redesign. The new page should organize the same underlying capabilities around the jobs users are trying to complete:
+
+- Setup
+- Access
+- Workspaces
+- Governance
+- Audit
+
+The first implementation program should preserve existing child components and service contracts wherever possible. It should change the information architecture, routing state, workflow framing, readiness summaries, and first-use guidance before attempting deeper form rewrites.
+
+For PR sizing, split that program into at least two slices: Stage 1 ships the workflow shell, URL state, child-view grouping, audit drilldown mapping, and Setup-first default; Stage 2 adds readiness/status summaries and richer first-use empty-state guidance. Stage 1 may include static workflow descriptions or lightweight placeholders, but it should not require all readiness aggregation to land in the same PR.
+
+## Problem
+
+MCP Hub has grown into a capable control panel, but its navigation exposes storage and policy objects as equal choices. That creates avoidable cognitive load for both first-time users and admins.
+
+Current pain points:
+
+- P1: Navigation overload. Eleven peer tabs make the page feel like an admin database browser rather than a control panel.
+- P1: First-use dead end. The explainer says to start with Tool Catalog, but an empty catalog tells users to add a server elsewhere. The primary first-use action should be Add Managed Server.
+- P1: Cross-tab dependency blindness. Profiles depend on tools, assignments depend on profiles, workspace policies depend on scopes and workspace sets, and audit findings point back into all of them. The UI does not surface dependency readiness.
+- P2: Extension width risk. The flat tab row is fragile in extension/options layouts and becomes harder to scan as the surface grows.
+- P2: Object labels are too internal. Terms like Capability Mappings, Path Scopes, and Workspace Sets are correct, but they need workflow framing so users know when to use them.
+- P2: Remediation context is weak. Audit can open affected objects, but the destination views do not strongly carry why the user was sent there.
+
+From a senior UX/HCI perspective, the core issue is a mismatch between the system model and the user's task model. The backend model is object based; the user model is workflow based: connect tools, grant access, scope local workspaces, govern risk, and fix audit findings.
+
+## Goals
+
+- Replace the single 11-tab peer navigation with workflow-level navigation.
+- Preserve existing MCP Hub functionality in the first implementation slice.
+- Make first-time setup legible without requiring prior MCP Hub knowledge.
+- Make cross-object dependencies visible through readiness/status summaries.
+- Keep expert object-level editors available under their workflow groups.
+- Support WebUI and extension through the shared UI package.
+- Preserve audit drilldown behavior.
+- Preserve deep links and provide a compatibility path for old tab-key references.
+- Avoid backend changes in the first slice unless frontend aggregation is demonstrably insufficient.
+- Add focused test coverage for workflow navigation, deep links, audit drilldown, and extension parity.
+
+## Non-Goals
+
+- No new MCP Hub backend capabilities in the first workflow shell slice.
+- No replacement of the underlying permission, assignment, workspace, approval, governance pack, or audit service contracts.
+- No removal of existing object editors.
+- No live migration of stored MCP Hub policies.
+- No extension-only UI fork.
+- No visual redesign of every form in the first slice.
+- No automatic policy mutation from audit findings beyond the inline remediation actions that already exist.
+- No new backend summary endpoint unless the implementation proves that client-side aggregation is too slow, inconsistent, or too duplicative.
+
+## Current Repo Foundation
+
+### Shared route and page
+
+- [apps/tldw-frontend/pages/mcp-hub.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/tldw-frontend/pages/mcp-hub.tsx) dynamically imports the shared route.
+- [apps/packages/ui/src/routes/option-mcp-hub.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/routes/option-mcp-hub.tsx) renders `McpHubPage` inside the option layout.
+- [apps/tldw-frontend/extension/routes/option-mcp-hub.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/tldw-frontend/extension/routes/option-mcp-hub.tsx) renders the same shared `McpHubPage` through the extension route.
+- [apps/packages/ui/src/routes/option-settings-mcp-hub.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/routes/option-settings-mcp-hub.tsx) redirects `/settings/mcp-hub` to `/mcp-hub`.
+
+### Current MCP Hub component set
+
+The current components already map cleanly into workflow groups:
+
+- [ToolCatalogsTab.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/MCPHub/ToolCatalogsTab.tsx)
+- [ExternalServersTab.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/MCPHub/ExternalServersTab.tsx)
+- [PermissionProfilesTab.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/MCPHub/PermissionProfilesTab.tsx)
+- [PolicyAssignmentsTab.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/MCPHub/PolicyAssignmentsTab.tsx)
+- [PathScopesTab.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/MCPHub/PathScopesTab.tsx)
+- [WorkspaceSetsTab.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/MCPHub/WorkspaceSetsTab.tsx)
+- [SharedWorkspacesTab.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/MCPHub/SharedWorkspacesTab.tsx)
+- [ApprovalPoliciesTab.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/MCPHub/ApprovalPoliciesTab.tsx)
+- [GovernancePacksTab.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/MCPHub/GovernancePacksTab.tsx)
+- [CapabilityMappingsTab.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/MCPHub/CapabilityMappingsTab.tsx)
+- [GovernanceAuditTab.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/MCPHub/GovernanceAuditTab.tsx)
+
+### Service contract
+
+[mcp-hub.ts](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/services/tldw/mcp-hub.ts) already exposes typed client calls for:
+
+- tool registry summary
+- external servers and credential slots
+- permission profiles
+- policy assignments and overrides
+- approval policies
+- path scopes
+- workspace sets
+- shared workspaces
+- capability mappings
+- governance packs
+- governance audit findings
+- effective policy and external access summaries
+
+These endpoints are enough for the first workflow shell and readiness summaries.
+
+## Proposed Information Architecture
+
+Use five top-level workflows:
+
+| Workflow | User job | Existing child views |
+| --- | --- | --- |
+| Setup | Connect MCP servers, configure credentials, verify available tools | Tool Catalog, Servers & Credentials |
+| Access | Define who can use tools and bind access to personas, groups, or defaults | Profiles, Assignments |
+| Workspaces | Define trusted local path and workspace boundaries | Path Scopes, Workspace Sets, Shared Workspaces |
+| Governance | Manage approvals, portable packs, and capability adapters | Approvals, Governance Packs, Capability Mappings |
+| Audit | Find and remediate broken or risky MCP Hub configuration | Audit Findings |
+
+The workflow names should be the main navigation labels. Existing object names remain visible as child views inside each workflow. This keeps expert precision without forcing every user through the object model first.
+
+## Navigation And State Contract
+
+`McpHubPage` should own three related pieces of state:
+
+- `workflow`
+- `view`
+- `drillTarget`
+
+Suggested type names:
+
+```ts
+type McpHubWorkflowKey =
+  | "setup"
+  | "access"
+  | "workspaces"
+  | "governance"
+  | "audit"
+
+type McpHubViewKey =
+  | "tool-catalogs"
+  | "credentials"
+  | "profiles"
+  | "assignments"
+  | "path-scopes"
+  | "workspace-sets"
+  | "shared-workspaces"
+  | "approvals"
+  | "governance-packs"
+  | "capability-mappings"
+  | "audit"
+```
+
+Workflow/view mapping:
+
+```ts
+const MCP_HUB_WORKFLOWS = {
+  setup: ["credentials", "tool-catalogs"],
+  access: ["profiles", "assignments"],
+  workspaces: ["path-scopes", "workspace-sets", "shared-workspaces"],
+  governance: ["approvals", "governance-packs", "capability-mappings"],
+  audit: ["audit"]
+}
+```
+
+Recommended defaults:
+
+- Default workflow: `setup`
+- Default Setup view: `credentials`
+- Default Access view: `profiles`
+- Default Workspaces view: `path-scopes`
+- Default Governance view: `approvals`
+- Default Audit view: `audit`
+
+This intentionally changes the first-use default from Tool Catalog to Servers & Credentials. Tool Catalog stays available in Setup, but users without connected servers should first see the action that can create useful catalog data.
+
+### URL state
+
+Support query parameters:
+
+```text
+/mcp-hub?workflow=setup&view=credentials
+/mcp-hub?workflow=access&view=assignments
+/mcp-hub?workflow=workspaces&view=workspace-sets
+/mcp-hub?workflow=governance&view=governance-packs
+/mcp-hub?workflow=audit&view=audit
+```
+
+Rules:
+
+- If `workflow` is missing, default to `setup`.
+- If `view` is missing, use the workflow's default view.
+- If `view` belongs to a different workflow, prefer the view and derive its workflow.
+- If either query value is invalid, fall back to `setup/credentials`.
+- Query updates should use replace behavior for internal tab switching where possible, so navigation does not pollute browser history.
+- `/settings/mcp-hub` should continue to reach the same workflow shell through existing route behavior.
+
+### Legacy tab-key compatibility
+
+Audit findings and older tests already use tab/view keys such as `assignments`, `credentials`, and `workspace-sets`. Keep those keys as the canonical child view keys. The redesign should wrap them in workflows, not rename them.
+
+This compatibility requirement applies to internal view keys, audit `navigate_to.tab` payloads, and existing test/page-object terminology. The current MCP Hub page does not expose a documented `?tab=` URL contract. If implementation discovers real `/mcp-hub?tab=...` usage in code or tests, map it through the same view-to-workflow helper as a compatibility convenience; otherwise `workflow` and `view` are the new URL parameters.
+
+## Layout Design
+
+The new layout should have two navigation levels:
+
+1. Top-level workflow navigation: Setup, Access, Workspaces, Governance, Audit.
+2. Child view navigation inside the selected workflow.
+
+The layout should be compact and operational:
+
+- no marketing-style hero
+- no decorative cards
+- no nested cards for page sections
+- restrained status indicators
+- dense enough for admin use
+- responsive enough for extension widths
+
+Recommended structure:
+
+```text
+MCP Hub
+Manage external tool servers, access policy, workspace trust boundaries, and audit findings.
+
+[Setup] [Access] [Workspaces] [Governance] [Audit]
+
+Workflow status strip:
+  counts, warnings, next action
+
+Child views:
+  [Servers & Credentials] [Tool Catalog]
+
+Selected child view content:
+  existing component
+```
+
+The status strip should be a short operational summary, not a tutorial block. It should answer:
+
+- What exists?
+- What is missing?
+- What should I do next?
+
+The existing dismissible explainer can remain, but it should be rewritten to reflect the workflow model and should not be the only source of first-use guidance.
+
+## Readiness Summary Model
+
+The first implementation should derive summary state on the frontend from existing endpoints. A later backend summary endpoint can be added only if the frontend implementation becomes too slow, inconsistent, or duplicated across components.
+
+### Setup readiness
+
+Inputs:
+
+- `getToolRegistrySummary`
+- `listExternalServers`
+
+Summary fields:
+
+- managed server count
+- legacy server count
+- executable managed server count
+- servers with missing secrets or slot secrets
+- servers with invalid or blocked auth templates
+- registered tool count
+- high/medium/low risk tool counts
+
+Next action examples:
+
+- If no managed server exists: Add Managed Server.
+- If managed servers exist but secrets are missing: Configure Credentials.
+- If servers are executable but no tools are registered: Review Server Runtime or Tool Catalog.
+- If tools exist: Review Tool Catalog.
+
+### Access readiness
+
+Inputs:
+
+- `listPermissionProfiles`
+- `listPolicyAssignments`
+- `listExternalServers`
+- `listProfileCredentialBindings` for profiles included in the visible readiness check
+- optionally `getEffectivePolicy` for the current sample preview
+
+Summary fields:
+
+- active profile count
+- active assignment count
+- assignments with no profile
+- profiles with no credential binding where external servers require one, computed only after binding rows are fetched for the profiles being summarized
+- assignments with overrides
+
+Next action examples:
+
+- If no profiles exist: Create Profile.
+- If profiles exist but no assignments exist: Assign Profile.
+- If assignments exist with overrides: Review Overrides.
+
+### Workspaces readiness
+
+Inputs:
+
+- `listPathScopeObjects`
+- `listWorkspaceSetObjects`
+- `listSharedWorkspaces`
+
+Summary fields:
+
+- path scope count
+- workspace set count
+- shared workspace count
+- multi-root readiness warnings
+- unresolved workspace IDs
+- overlapping shared roots
+
+Next action examples:
+
+- If no path scopes exist: Create Path Scope.
+- If multi-root warnings exist: Review Workspace Warnings.
+- If shared-scope policies are needed and no shared workspaces exist: Add Shared Workspace.
+
+### Governance readiness
+
+Inputs:
+
+- `listApprovalPolicies`
+- `listGovernancePacks`
+- `listCapabilityAdapterMappings`
+
+Summary fields:
+
+- active approval policies
+- installed governance packs
+- active governance pack installs
+- capability mappings
+- unverified or failed source verification states where available
+
+Next action examples:
+
+- If no approval policy exists: Create Approval Policy.
+- If no governance pack exists: Preview Governance Pack.
+- If portable capability behavior is needed: Add Capability Mapping.
+
+### Audit readiness
+
+Inputs:
+
+- `listGovernanceAuditFindings`
+
+Summary fields:
+
+- total findings
+- error count
+- warning count
+- top related object count
+- available safe inline remediation count, if derivable through existing audit helpers
+
+Next action examples:
+
+- If errors exist: Review Errors.
+- If only warnings exist: Review Warnings.
+- If no findings exist: Export Clean Audit or continue monitoring.
+
+## First-Use Behavior
+
+First-time users should land in Setup with Servers & Credentials selected.
+
+Empty state requirements:
+
+- If no managed servers exist, show Add Managed Server as the primary action.
+- Tool Catalog should not be the first empty surface for a new user.
+- If only legacy servers exist, explain that they are read-only inventory until imported into MCP Hub and offer Import where the current component already supports it.
+- If servers exist but are not executable, the status strip should identify missing secrets or auth template issues before the user reaches Audit.
+
+The copy should be direct and operational. Avoid explaining MCP generally on every screen. Explain the specific missing prerequisite and the next action.
+
+## Audit Drilldown Behavior
+
+The existing audit flow passes `navigate_to` targets into `McpHubPage`, then switches to the matching tab and stores `drillTarget`. Preserve that behavior through workflow mapping.
+
+Mapping:
+
+| Audit target tab | Workflow | Child view |
+| --- | --- | --- |
+| `credentials` | setup | credentials |
+| `profiles` | access | profiles |
+| `assignments` | access | assignments |
+| `path-scopes` | workspaces | path-scopes |
+| `workspace-sets` | workspaces | workspace-sets |
+| `shared-workspaces` | workspaces | shared-workspaces |
+| `approvals` | governance | approvals |
+| `governance-packs` | governance | governance-packs |
+| `capability-mappings` | governance | capability-mappings |
+| `audit` | audit | audit |
+
+Stage 1 requirements:
+
+- `GovernanceAuditTab` continues to call `onOpen(target)`.
+- `McpHubPage` resolves `target.tab` to workflow and view.
+- The target child component receives the same `drillTarget` shape it expects today.
+- If the destination object cannot be found, the child component should keep its existing behavior and the page-level shell should not throw.
+
+Stage 3 can add richer audit-origin context after the shell is stable. That later context may show messages such as "Opened from audit: missing credential slot on Docs Managed." Stage 1 only needs to preserve the existing open-and-focus behavior through the new workflow/view mapping.
+
+## Component Architecture
+
+Stage 1 shell components:
+
+- `McpHubPage`
+  - owns URL-backed workflow/view state
+  - owns drill target state
+  - renders workflow navigation
+  - renders child view navigation
+  - renders selected child component
+
+- `mcpHubWorkflowConfig.ts`
+  - exports workflow metadata
+  - exports view-to-workflow mapping
+  - exports default view per workflow
+  - exports validation helpers for query parameters
+
+- `McpHubWorkflowNav`
+  - renders top-level workflow nav
+  - exposes selected workflow through ARIA-compatible tabs or segmented controls
+  - remains responsive in extension widths
+
+- `McpHubViewNav`
+  - renders child views for the active workflow
+  - reuses existing view labels
+
+Stage 2 readiness components:
+
+- `useMcpHubReadiness`
+  - aggregates existing service calls
+  - returns per-workflow summary data
+  - exposes loading and error states per workflow
+  - avoids blocking child view rendering on summary fetch failures
+
+- `McpHubWorkflowStatus`
+  - renders counts, warnings, and next action for the active workflow
+  - links or buttons navigate to the relevant child view
+
+The Stage 1 shell should avoid modifying the internals of large child components unless required for drilldown or Setup-first action wiring. Stage 2 introduces readiness aggregation and workflow status once the shell and URL contract are stable.
+
+## Error Handling
+
+Readiness summary failures should not make the page unusable.
+
+Rules:
+
+- Child views remain the source of truth for detailed errors.
+- Summary fetch failures render a compact warning in the workflow status strip.
+- If one summary endpoint fails, other summaries should still render where available.
+- Invalid URL query values fall back to `setup/credentials`.
+- Audit drilldown to an unknown view falls back to Audit and records no drill target.
+- Summary actions should be disabled or hidden only when their destination is not available.
+
+## Accessibility And Responsive Requirements
+
+- Top-level workflow navigation must be keyboard reachable.
+- Child navigation must expose selected state.
+- Workflow and child view labels must remain readable at extension option widths.
+- Status strip actions must have visible text labels.
+- Do not rely on color alone for readiness severity.
+- Audit drilldown context should be announced as visible text, not only as color or icon state.
+- Existing `data-testid` hooks should either remain stable or receive compatibility replacements for E2E tests.
+
+## Implementation Sequence
+
+### Stage 1: Workflow shell and routing
+
+Goal: Replace the flat tab row with workflow and child view navigation while keeping current child components.
+
+Deliverables:
+
+- workflow config module
+- query parsing and URL sync
+- top-level workflow nav
+- child view nav
+- child component rendering by view key
+- old audit drilldown mapped through workflow/view
+- Setup-first default route
+
+Primary files:
+
+- [McpHubPage.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/MCPHub/McpHubPage.tsx)
+- new workflow config/component files under [MCPHub](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/MCPHub)
+- [mcp-hub.ts](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/services/tldw/mcp-hub.ts) for type reuse only
+
+### Stage 2: Readiness summaries and first-use flow
+
+Goal: Add per-workflow status and next actions using existing endpoints.
+
+Deliverables:
+
+- `useMcpHubReadiness`
+- status strip for active workflow
+- first-use Setup behavior emphasizing Add Managed Server
+- empty-state copy alignment for Tool Catalog and Setup
+- summary error handling
+
+### Stage 3: Audit context and governance hardening
+
+Goal: Improve cross-workflow remediation without rewriting every object editor.
+
+Deliverables:
+
+- audit-origin context message beyond the Stage 1 open-and-focus drilldown
+- drilldown tests for each workflow group
+- status summary links from Audit to affected workflow/view
+- optional grouping of audit filters around workflow impact
+
+### Stage 4: Form-level UX follow-ups
+
+Goal: After the shell proves useful, simplify the largest editors.
+
+Candidate follow-ups:
+
+- split External Servers into server identity, credential slots, auth template, and secret configuration panels
+- make Profiles and Assignments use clearer progressive sections
+- make Workspaces use a trust-boundary language layer above path/workspace objects
+- make Governance Packs and Capability Mappings less JSON-first where possible
+
+These are intentionally outside the first shell slice.
+
+## Testing Plan
+
+### Unit and component tests
+
+Add or update focused tests under [apps/packages/ui/src/components/Option/MCPHub/__tests__](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/MCPHub/__tests__):
+
+- workflow config maps every current view key to exactly one workflow
+- default route lands on Setup / Servers & Credentials
+- invalid query parameters fall back to Setup / Servers & Credentials
+- selecting a workflow updates selected workflow and default child view
+- selecting a child view updates selected view
+- audit `Open` maps a finding to the expected workflow and child view
+- explainer dismissal behavior still works
+- readiness summary failure does not hide the selected child view
+
+### Extension route parity
+
+Update existing extension route tests so `/mcp-hub` still renders the shared workflow shell.
+
+Required checks:
+
+- extension route still imports `OptionMcpHub`
+- `/mcp-hub` renders the shared `McpHubPage`
+- `/settings/mcp-hub` continues to resolve to the shared hub route
+- route parity tests do not require extension-only MCP Hub behavior
+
+### E2E
+
+Update [mcp-hub.spec.ts](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/tldw-frontend/e2e/workflows/tier-2-features/mcp-hub.spec.ts):
+
+- page loads with MCP Hub heading and workflow navigation
+- each workflow can be selected
+- representative child views load and fire expected API calls:
+  - Setup / Tool Catalog -> `GET /api/v1/mcp/hub/tool-registry`
+  - Setup / Servers & Credentials -> `GET /api/v1/mcp/hub/external-servers`
+  - Access / Profiles -> `GET /api/v1/mcp/hub/permission-profiles`
+  - Access / Assignments -> `GET /api/v1/mcp/hub/policy-assignments`
+  - Audit -> `GET /api/v1/mcp/hub/governance-audit`
+- audit drilldown opens the mapped workflow and child view
+
+### Verification commands
+
+Expected focused verification after implementation:
+
+```bash
+cd apps/tldw-frontend
+bunx vitest run ../packages/ui/src/components/Option/MCPHub/__tests__/McpHubPage.test.tsx ../packages/ui/src/components/Option/MCPHub/__tests__/McpHubPage.ftux.test.tsx
+bunx vitest run ../packages/ui/src/routes/__tests__/mcp-hub-route.test.tsx ../../apps/tldw-frontend/__tests__/extension/route-registry.mcp-hub.test.tsx
+npx playwright test e2e/workflows/tier-2-features/mcp-hub.spec.ts --reporter=line
+```
+
+Run `bun run verify:openapi` only if endpoint paths, generated clients, or OpenAPI-guarded service calls change.
+
+For this design-only task, Bandit is not applicable because no Python code is touched.
+
+## Risks
+
+### User muscle memory
+
+Existing users may expect the flat tab row. Mitigation: keep child view labels unchanged and support deep links by view key.
+
+### Query state complexity
+
+Workflow and child view state can drift if URL parsing is ad hoc. Mitigation: centralize mapping and validation in one config/helper module.
+
+### Summary fetch overhead
+
+Readiness summaries may trigger several endpoints on initial load. Mitigation: fetch per active workflow first or use lazy summary loading if the eager approach is too heavy.
+
+### Backend summary temptation
+
+A backend summary endpoint might be useful later, but adding it too early risks coupling the first UX slice to a broader API change. Mitigation: start frontend-first and promote a backend summary only after measuring duplicate work or latency.
+
+### Scope creep into form rewrites
+
+The largest current tabs are complex enough to absorb a full PR each. Mitigation: first implementation keeps child components mostly intact and limits form rewrites to follow-up tasks.
+
+## Open Implementation Decisions
+
+These decisions should be made during implementation planning, not in this design:
+
+- Whether workflow navigation should use Ant Design `Tabs`, segmented controls, or a small custom responsive nav.
+- Whether readiness summaries are eager for all workflows or lazy per active workflow.
+- Whether URL updates use router replace on every view change or only on top-level workflow changes.
+- Whether audit-origin context is page-level only or passed into child components for more specific focus messaging.
+
+## Decision
+
+Proceed with the workflow-first MCP Hub redesign as the implementation-ready direction. The first PR should focus on the workflow shell, route state, existing child view grouping, first-use Setup default, and test coverage. Deeper form simplification should be split into follow-up work after the shell lands.

--- a/Docs/superpowers/specs/2026-05-10-mcp-hub-workflow-first-control-panel-design.md
+++ b/Docs/superpowers/specs/2026-05-10-mcp-hub-workflow-first-control-panel-design.md
@@ -9,7 +9,7 @@ Backlog: TASK-211
 
 Redesign the MCP Hub control panel from an object-centric tab list into a workflow-first hub for WebUI and extension users.
 
-The current shared page in [McpHubPage.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/MCPHub/McpHubPage.tsx) exposes 11 peer tabs: Tool Catalog, Servers & Credentials, Profiles, Assignments, Approvals, Path Scopes, Capability Mappings, Workspace Sets, Shared Workspaces, Governance Packs, and Audit. Those are accurate backend concepts, but they ask users to already understand the MCP control plane before they can complete a basic task.
+The current shared page in [McpHubPage.tsx](../../../apps/packages/ui/src/components/Option/MCPHub/McpHubPage.tsx) exposes 11 peer tabs: Tool Catalog, Servers & Credentials, Profiles, Assignments, Approvals, Path Scopes, Capability Mappings, Workspace Sets, Shared Workspaces, Governance Packs, and Audit. Those are accurate backend concepts, but they ask users to already understand the MCP control plane before they can complete a basic task.
 
 The approved direction is the heavier workflow-first redesign. The new page should organize the same underlying capabilities around the jobs users are trying to complete:
 
@@ -66,30 +66,30 @@ From a senior UX/HCI perspective, the core issue is a mismatch between the syste
 
 ### Shared route and page
 
-- [apps/tldw-frontend/pages/mcp-hub.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/tldw-frontend/pages/mcp-hub.tsx) dynamically imports the shared route.
-- [apps/packages/ui/src/routes/option-mcp-hub.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/routes/option-mcp-hub.tsx) renders `McpHubPage` inside the option layout.
-- [apps/tldw-frontend/extension/routes/option-mcp-hub.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/tldw-frontend/extension/routes/option-mcp-hub.tsx) renders the same shared `McpHubPage` through the extension route.
-- [apps/packages/ui/src/routes/option-settings-mcp-hub.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/routes/option-settings-mcp-hub.tsx) redirects `/settings/mcp-hub` to `/mcp-hub`.
+- [apps/tldw-frontend/pages/mcp-hub.tsx](../../../apps/tldw-frontend/pages/mcp-hub.tsx) dynamically imports the shared route.
+- [apps/packages/ui/src/routes/option-mcp-hub.tsx](../../../apps/packages/ui/src/routes/option-mcp-hub.tsx) renders `McpHubPage` inside the option layout.
+- [apps/tldw-frontend/extension/routes/option-mcp-hub.tsx](../../../apps/tldw-frontend/extension/routes/option-mcp-hub.tsx) renders the same shared `McpHubPage` through the extension route.
+- [apps/packages/ui/src/routes/option-settings-mcp-hub.tsx](../../../apps/packages/ui/src/routes/option-settings-mcp-hub.tsx) redirects `/settings/mcp-hub` to `/mcp-hub`.
 
 ### Current MCP Hub component set
 
 The current components already map cleanly into workflow groups:
 
-- [ToolCatalogsTab.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/MCPHub/ToolCatalogsTab.tsx)
-- [ExternalServersTab.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/MCPHub/ExternalServersTab.tsx)
-- [PermissionProfilesTab.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/MCPHub/PermissionProfilesTab.tsx)
-- [PolicyAssignmentsTab.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/MCPHub/PolicyAssignmentsTab.tsx)
-- [PathScopesTab.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/MCPHub/PathScopesTab.tsx)
-- [WorkspaceSetsTab.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/MCPHub/WorkspaceSetsTab.tsx)
-- [SharedWorkspacesTab.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/MCPHub/SharedWorkspacesTab.tsx)
-- [ApprovalPoliciesTab.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/MCPHub/ApprovalPoliciesTab.tsx)
-- [GovernancePacksTab.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/MCPHub/GovernancePacksTab.tsx)
-- [CapabilityMappingsTab.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/MCPHub/CapabilityMappingsTab.tsx)
-- [GovernanceAuditTab.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/MCPHub/GovernanceAuditTab.tsx)
+- [ToolCatalogsTab.tsx](../../../apps/packages/ui/src/components/Option/MCPHub/ToolCatalogsTab.tsx)
+- [ExternalServersTab.tsx](../../../apps/packages/ui/src/components/Option/MCPHub/ExternalServersTab.tsx)
+- [PermissionProfilesTab.tsx](../../../apps/packages/ui/src/components/Option/MCPHub/PermissionProfilesTab.tsx)
+- [PolicyAssignmentsTab.tsx](../../../apps/packages/ui/src/components/Option/MCPHub/PolicyAssignmentsTab.tsx)
+- [PathScopesTab.tsx](../../../apps/packages/ui/src/components/Option/MCPHub/PathScopesTab.tsx)
+- [WorkspaceSetsTab.tsx](../../../apps/packages/ui/src/components/Option/MCPHub/WorkspaceSetsTab.tsx)
+- [SharedWorkspacesTab.tsx](../../../apps/packages/ui/src/components/Option/MCPHub/SharedWorkspacesTab.tsx)
+- [ApprovalPoliciesTab.tsx](../../../apps/packages/ui/src/components/Option/MCPHub/ApprovalPoliciesTab.tsx)
+- [GovernancePacksTab.tsx](../../../apps/packages/ui/src/components/Option/MCPHub/GovernancePacksTab.tsx)
+- [CapabilityMappingsTab.tsx](../../../apps/packages/ui/src/components/Option/MCPHub/CapabilityMappingsTab.tsx)
+- [GovernanceAuditTab.tsx](../../../apps/packages/ui/src/components/Option/MCPHub/GovernanceAuditTab.tsx)
 
 ### Service contract
 
-[mcp-hub.ts](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/services/tldw/mcp-hub.ts) already exposes typed client calls for:
+[mcp-hub.ts](../../../apps/packages/ui/src/services/tldw/mcp-hub.ts) already exposes typed client calls for:
 
 - tool registry summary
 - external servers and credential slots
@@ -488,9 +488,9 @@ Deliverables:
 
 Primary files:
 
-- [McpHubPage.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/MCPHub/McpHubPage.tsx)
-- new workflow config/component files under [MCPHub](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/MCPHub)
-- [mcp-hub.ts](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/services/tldw/mcp-hub.ts) for type reuse only
+- [McpHubPage.tsx](../../../apps/packages/ui/src/components/Option/MCPHub/McpHubPage.tsx)
+- new workflow config/component files under [MCPHub](../../../apps/packages/ui/src/components/Option/MCPHub)
+- [mcp-hub.ts](../../../apps/packages/ui/src/services/tldw/mcp-hub.ts) for type reuse only
 
 ### Stage 2: Readiness summaries and first-use flow
 
@@ -532,7 +532,7 @@ These are intentionally outside the first shell slice.
 
 ### Unit and component tests
 
-Add or update focused tests under [apps/packages/ui/src/components/Option/MCPHub/__tests__](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/MCPHub/__tests__).
+Add or update focused tests under [apps/packages/ui/src/components/Option/MCPHub/__tests__](../../../apps/packages/ui/src/components/Option/MCPHub/__tests__).
 
 Stage 1 expectations:
 
@@ -561,7 +561,7 @@ Required checks:
 
 ### E2E
 
-Update [mcp-hub.spec.ts](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/tldw-frontend/e2e/workflows/tier-2-features/mcp-hub.spec.ts):
+Update [mcp-hub.spec.ts](../../../apps/tldw-frontend/e2e/workflows/tier-2-features/mcp-hub.spec.ts):
 
 - page loads with MCP Hub heading and workflow navigation
 - page-object helpers move from tab-only `switchToTab` locators to workflow/view selection helpers

--- a/apps/packages/ui/src/assets/locale/en/tutorials.json
+++ b/apps/packages/ui/src/assets/locale/en/tutorials.json
@@ -244,8 +244,8 @@
       "catalogContent": "Browse all registered tools here. Each tool shows its capabilities and risk level.",
       "credentialsTitle": "Servers & Credentials",
       "credentialsContent": "Connect external MCP servers here. Each server provides additional tools for your AI assistant.",
-      "profilesTitle": "Permission Profiles",
-      "profilesContent": "Create permission profiles to control which tools each user or persona can access.",
+      "profilesTitle": "Access Workflow",
+      "profilesContent": "Use Access to create profiles and assign which tools each user or persona can reach.",
       "auditTitle": "Governance Audit",
       "auditContent": "Review policy findings and configuration issues across all your MCP Hub settings."
     }

--- a/apps/packages/ui/src/components/Option/MCPHub/McpHubPage.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/McpHubPage.tsx
@@ -1,5 +1,6 @@
-import { useRef, useState } from "react"
-import { Alert, Tabs, Typography } from "antd"
+import { useMemo, useRef, useState, type ReactNode } from "react"
+import { useSearchParams } from "react-router-dom"
+import { Alert, Button, Tabs, Typography } from "antd"
 
 import { ApprovalPoliciesTab } from "./ApprovalPoliciesTab"
 import { CapabilityMappingsTab } from "./CapabilityMappingsTab"
@@ -15,21 +16,46 @@ import { WorkspaceSetsTab } from "./WorkspaceSetsTab"
 import type {
   McpHubDrillAction,
   McpHubDrillTarget,
-  McpHubGovernanceAuditNavigateTarget,
-  McpHubGovernanceAuditTabKey
+  McpHubGovernanceAuditNavigateTarget
 } from "@/services/tldw/mcp-hub"
 import {
   persistMcpHubExplainerDismissed,
   readMcpHubExplainerDismissed
 } from "@/utils/ftux-storage"
+import {
+  MCP_HUB_VIEW_LABELS,
+  MCP_HUB_WORKFLOW_ORDER,
+  MCP_HUB_WORKFLOWS,
+  resolveMcpHubRouteState,
+  workflowForMcpHubView,
+  type McpHubRouteState,
+  type McpHubViewKey,
+  type McpHubWorkflowKey
+} from "./mcpHubWorkflowConfig"
 
 export const McpHubPage = () => {
-  const [activeTab, setActiveTab] = useState<McpHubGovernanceAuditTabKey>("tool-catalogs")
+  const [searchParams, setSearchParams] = useSearchParams()
   const [explainerDismissed, setExplainerDismissed] = useState(
     () => readMcpHubExplainerDismissed()
   )
   const [drillTarget, setDrillTarget] = useState<McpHubDrillTarget | null>(null)
   const requestIdRef = useRef(0)
+
+  const routeState = useMemo(
+    () =>
+      resolveMcpHubRouteState({
+        workflow: searchParams.get("workflow"),
+        view: searchParams.get("view")
+      }),
+    [searchParams]
+  )
+
+  const updateRouteState = (nextState: McpHubRouteState) => {
+    const nextParams = new URLSearchParams(searchParams)
+    nextParams.set("workflow", nextState.workflow)
+    nextParams.set("view", nextState.view)
+    setSearchParams(nextParams, { replace: true })
+  }
 
   const _deriveDrillAction = (
     target: McpHubGovernanceAuditNavigateTarget
@@ -52,7 +78,10 @@ export const McpHubPage = () => {
       action: _deriveDrillAction(target),
       request_id: requestIdRef.current
     })
-    setActiveTab(target.tab)
+    updateRouteState({
+      workflow: workflowForMcpHubView(target.tab),
+      view: target.tab
+    })
   }
 
   const handleDrillHandled = (requestId: number) => {
@@ -63,6 +92,66 @@ export const McpHubPage = () => {
     setExplainerDismissed(true)
     persistMcpHubExplainerDismissed()
   }
+
+  const handleWorkflowChange = (workflow: McpHubWorkflowKey) => {
+    updateRouteState({
+      workflow,
+      view: MCP_HUB_WORKFLOWS[workflow].defaultView
+    })
+  }
+
+  const handleViewChange = (view: string) => {
+    const nextView = view as McpHubViewKey
+    updateRouteState({
+      workflow: workflowForMcpHubView(nextView),
+      view: nextView
+    })
+  }
+
+  const tabContentByView: Record<McpHubViewKey, ReactNode> = {
+    "tool-catalogs": <ToolCatalogsTab />,
+    credentials: (
+      <ExternalServersTab
+        drillTarget={drillTarget}
+        onDrillHandled={handleDrillHandled}
+      />
+    ),
+    profiles: <PermissionProfilesTab />,
+    assignments: (
+      <PolicyAssignmentsTab
+        drillTarget={drillTarget}
+        onDrillHandled={handleDrillHandled}
+      />
+    ),
+    approvals: <ApprovalPoliciesTab />,
+    "path-scopes": <PathScopesTab />,
+    "capability-mappings": <CapabilityMappingsTab />,
+    "workspace-sets": (
+      <WorkspaceSetsTab
+        drillTarget={drillTarget}
+        onDrillHandled={handleDrillHandled}
+      />
+    ),
+    "shared-workspaces": (
+      <SharedWorkspacesTab
+        drillTarget={drillTarget}
+        onDrillHandled={handleDrillHandled}
+      />
+    ),
+    "governance-packs": <GovernancePacksTab />,
+    audit: <GovernanceAuditTab onOpen={handleOpen} />
+  }
+
+  const activeWorkflow = MCP_HUB_WORKFLOWS[routeState.workflow]
+  const childTabItems = activeWorkflow.views.map((view) => ({
+    key: view,
+    label: (
+      <span data-testid={`mcp-hub-tab-${view}`}>
+        {MCP_HUB_VIEW_LABELS[view]}
+      </span>
+    ),
+    children: tabContentByView[view]
+  }))
 
   return (
     <div className="flex h-full min-h-0 flex-col gap-4 p-4" data-testid="mcp-hub-shell">
@@ -80,92 +169,42 @@ export const McpHubPage = () => {
           closable
           onClose={handleExplainerClose}
           title="Getting Started with MCP Hub"
-          description="MCP Hub lets you connect external tool servers, manage permissions, and govern how AI models interact with outside services. Start by browsing the Tool Catalog to discover available tools, then set up Profiles and Credentials to configure access."
+          description="MCP Hub lets you connect external tool servers, manage permissions, and govern how AI models interact with outside services. Start by adding or checking Servers & Credentials, then use the Tool Catalog to verify available tools."
         />
       )}
+      <div
+        className="flex flex-wrap gap-2"
+        data-testid="mcp-hub-workflows"
+        role="group"
+        aria-label="MCP Hub workflows"
+      >
+        {MCP_HUB_WORKFLOW_ORDER.map((workflow) => {
+          const definition = MCP_HUB_WORKFLOWS[workflow]
+          const isActive = workflow === routeState.workflow
+          return (
+            <Button
+              key={workflow}
+              type={isActive ? "primary" : "default"}
+              aria-pressed={isActive}
+              data-testid={`mcp-hub-workflow-${workflow}`}
+              onClick={() => handleWorkflowChange(workflow)}
+            >
+              {definition.label}
+            </Button>
+          )
+        })}
+      </div>
+      <Typography.Text
+        type="secondary"
+        data-testid="mcp-hub-workflow-description"
+      >
+        {activeWorkflow.description}
+      </Typography.Text>
       <Tabs
         data-testid="mcp-hub-tabs"
-        activeKey={activeTab}
-        onChange={(activeKey) =>
-          setActiveTab(activeKey as McpHubGovernanceAuditTabKey)
-        }
-        items={[
-          {
-            key: "tool-catalogs",
-            label: <span data-testid="mcp-hub-tab-tool-catalogs">Tool Catalog</span>,
-            children: <ToolCatalogsTab />
-          },
-          {
-            key: "credentials",
-            label: <span data-testid="mcp-hub-tab-credentials">Servers & Credentials</span>,
-            children: (
-              <ExternalServersTab
-                drillTarget={drillTarget}
-                onDrillHandled={handleDrillHandled}
-              />
-            )
-          },
-          {
-            key: "profiles",
-            label: <span data-testid="mcp-hub-tab-profiles">Profiles</span>,
-            children: <PermissionProfilesTab />
-          },
-          {
-            key: "assignments",
-            label: <span data-testid="mcp-hub-tab-assignments">Assignments</span>,
-            children: (
-              <PolicyAssignmentsTab
-                drillTarget={drillTarget}
-                onDrillHandled={handleDrillHandled}
-              />
-            )
-          },
-          {
-            key: "approvals",
-            label: <span data-testid="mcp-hub-tab-approvals">Approvals</span>,
-            children: <ApprovalPoliciesTab />
-          },
-          {
-            key: "path-scopes",
-            label: <span data-testid="mcp-hub-tab-path-scopes">Path Scopes</span>,
-            children: <PathScopesTab />
-          },
-          {
-            key: "capability-mappings",
-            label: <span data-testid="mcp-hub-tab-capability-mappings">Capability Mappings</span>,
-            children: <CapabilityMappingsTab />
-          },
-          {
-            key: "workspace-sets",
-            label: <span data-testid="mcp-hub-tab-workspace-sets">Workspace Sets</span>,
-            children: (
-              <WorkspaceSetsTab
-                drillTarget={drillTarget}
-                onDrillHandled={handleDrillHandled}
-              />
-            )
-          },
-          {
-            key: "shared-workspaces",
-            label: <span data-testid="mcp-hub-tab-shared-workspaces">Shared Workspaces</span>,
-            children: (
-              <SharedWorkspacesTab
-                drillTarget={drillTarget}
-                onDrillHandled={handleDrillHandled}
-              />
-            )
-          },
-          {
-            key: "governance-packs",
-            label: <span data-testid="mcp-hub-tab-governance-packs">Governance Packs</span>,
-            children: <GovernancePacksTab />
-          },
-          {
-            key: "audit",
-            label: <span data-testid="mcp-hub-tab-audit">Audit</span>,
-            children: <GovernanceAuditTab onOpen={handleOpen} />
-          }
-        ]}
+        activeKey={routeState.view}
+        onChange={handleViewChange}
+        items={childTabItems}
       />
     </div>
   )

--- a/apps/packages/ui/src/components/Option/MCPHub/__tests__/McpHubPage.ftux.test.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/__tests__/McpHubPage.ftux.test.tsx
@@ -2,6 +2,7 @@
 import { describe, expect, it, vi, beforeEach } from "vitest"
 import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
+import { MemoryRouter } from "react-router-dom"
 
 vi.mock("../PermissionProfilesTab", () => ({
   PermissionProfilesTab: () => <div>profiles tab</div>
@@ -39,24 +40,31 @@ vi.mock("../CapabilityMappingsTab", () => ({
 
 import { McpHubPage } from "../McpHubPage"
 
+const renderMcpHubPage = () =>
+  render(
+    <MemoryRouter initialEntries={["/mcp-hub"]}>
+      <McpHubPage />
+    </MemoryRouter>
+  )
+
 describe("McpHubPage FTUX", () => {
   beforeEach(() => {
     localStorage.clear()
   })
 
   it("renders the subtitle with Model Context Protocol text", () => {
-    render(<McpHubPage />)
+    renderMcpHubPage()
     expect(screen.getByText(/Model Context Protocol/)).toBeTruthy()
   })
 
   it("shows the explainer card on first visit", () => {
-    render(<McpHubPage />)
+    renderMcpHubPage()
     expect(screen.getByTestId("mcp-hub-explainer")).toBeTruthy()
   })
 
   it("hides the explainer card after dismissal and persists to localStorage", async () => {
     const user = userEvent.setup()
-    render(<McpHubPage />)
+    renderMcpHubPage()
 
     const explainer = screen.getByTestId("mcp-hub-explainer")
     expect(explainer).toBeTruthy()
@@ -71,28 +79,28 @@ describe("McpHubPage FTUX", () => {
 
   it("does not show the explainer card if previously dismissed", () => {
     localStorage.setItem("tldw:mcp-hub:explainer-dismissed", "true")
-    render(<McpHubPage />)
+    renderMcpHubPage()
     expect(screen.queryByTestId("mcp-hub-explainer")).toBeNull()
   })
 
   it("migrates the legacy explainer dismissal key on read", () => {
     localStorage.setItem("tldw_mcp_hub_explainer_dismissed", "true")
 
-    render(<McpHubPage />)
+    renderMcpHubPage()
 
     expect(screen.queryByTestId("mcp-hub-explainer")).toBeNull()
     expect(localStorage.getItem("tldw:mcp-hub:explainer-dismissed")).toBe("true")
     expect(localStorage.getItem("tldw_mcp_hub_explainer_dismissed")).toBeNull()
   })
 
-  it("defaults to the Tool Catalog tab", () => {
-    render(<McpHubPage />)
-    expect(screen.getByText("catalog tab")).toBeTruthy()
+  it("defaults to the Servers & Credentials view", () => {
+    renderMcpHubPage()
+    expect(screen.getByText("credentials tab")).toBeTruthy()
   })
 
-  it("has data-testid attributes on shell and tabs", () => {
-    render(<McpHubPage />)
+  it("has data-testid attributes on shell and workflow navigation", () => {
+    renderMcpHubPage()
     expect(screen.getByTestId("mcp-hub-shell")).toBeTruthy()
-    expect(screen.getByTestId("mcp-hub-tabs")).toBeTruthy()
+    expect(screen.getByTestId("mcp-hub-workflows")).toBeTruthy()
   })
 })

--- a/apps/packages/ui/src/components/Option/MCPHub/__tests__/McpHubPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/__tests__/McpHubPage.test.tsx
@@ -2,6 +2,7 @@
 import { describe, expect, it, vi } from "vitest"
 import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
+import { MemoryRouter, useLocation } from "react-router-dom"
 
 vi.mock("../PermissionProfilesTab", () => ({
   PermissionProfilesTab: () => <div>profiles tab</div>
@@ -52,24 +53,100 @@ vi.mock("../CapabilityMappingsTab", () => ({
 
 import { McpHubPage } from "../McpHubPage"
 
+const LocationProbe = () => {
+  const location = useLocation()
+  return <div data-testid="location-probe">{`${location.pathname}${location.search}`}</div>
+}
+
+const renderMcpHubPage = (initialEntry = "/mcp-hub") =>
+  render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <McpHubPage />
+      <LocationProbe />
+    </MemoryRouter>
+  )
+
 describe("McpHubPage", () => {
-  it("renders the audit tab alongside the existing MCP Hub tabs", async () => {
-    render(<McpHubPage />)
+  it("renders workflow navigation with the current MCP Hub child views grouped inside it", async () => {
+    renderMcpHubPage()
+
+    expect(screen.getByTestId("mcp-hub-workflows")).toBeTruthy()
+    expect(screen.getByText("Setup")).toBeTruthy()
+    expect(screen.getByText("Access")).toBeTruthy()
+    expect(screen.getByText("Workspaces")).toBeTruthy()
+    expect(screen.getByText("Governance")).toBeTruthy()
+    expect(screen.getByText("Audit")).toBeTruthy()
+    expect(screen.getByText("Servers & Credentials")).toBeTruthy()
+    expect(screen.getByText("Tool Catalog")).toBeTruthy()
+  })
+
+  it("defaults to Setup / Servers & Credentials", () => {
+    renderMcpHubPage()
+
+    expect(screen.getByText("credentials tab")).toBeTruthy()
+    expect(screen.getByTestId("mcp-hub-workflow-setup")).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    )
+  })
+
+  it("derives the active workflow and view from query state", () => {
+    renderMcpHubPage("/mcp-hub?workflow=access&view=assignments")
+
+    expect(screen.getByText("assignments tab")).toBeTruthy()
+    expect(screen.getByTestId("mcp-hub-workflow-access")).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    )
+  })
+
+  it("updates query state when selecting a workflow", async () => {
+    const user = userEvent.setup()
+    renderMcpHubPage()
+
+    await user.click(screen.getByTestId("mcp-hub-workflow-workspaces"))
+
+    expect(screen.getByText("path scopes tab")).toBeTruthy()
+    expect(screen.getByTestId("location-probe")).toHaveTextContent(
+      "/mcp-hub?workflow=workspaces&view=path-scopes"
+    )
+  })
+
+  it("keeps expert child views available inside their workflows", async () => {
+    const user = userEvent.setup()
+    renderMcpHubPage()
+
+    await user.click(screen.getByTestId("mcp-hub-workflow-access"))
 
     expect(screen.getByText("Profiles")).toBeTruthy()
     expect(screen.getByText("Assignments")).toBeTruthy()
-    expect(screen.getByText("Audit")).toBeTruthy()
+
+    await user.click(screen.getByText("Assignments"))
+
+    expect(screen.getByText("assignments tab")).toBeTruthy()
+  })
+
+  it("keeps governance child views available inside the Governance workflow", async () => {
+    const user = userEvent.setup()
+    renderMcpHubPage()
+
+    await user.click(screen.getByTestId("mcp-hub-workflow-governance"))
+
     expect(screen.getByText("Capability Mappings")).toBeTruthy()
     expect(screen.getByText("Governance Packs")).toBeTruthy()
   })
 
-  it("opens the requested MCP Hub tab from the audit view", async () => {
+  it("opens the requested workflow child view from the audit view", async () => {
     const user = userEvent.setup()
-    render(<McpHubPage />)
+    renderMcpHubPage()
 
-    await user.click(screen.getByText("Audit"))
+    await user.click(screen.getByTestId("mcp-hub-workflow-audit"))
     await user.click(screen.getByRole("button", { name: /open assignment from audit/i }))
 
     expect(screen.getByText("assignments tab")).toBeTruthy()
+    expect(screen.getByTestId("mcp-hub-workflow-access")).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    )
   })
 })

--- a/apps/packages/ui/src/components/Option/MCPHub/__tests__/McpHubWorkflowConfig.test.ts
+++ b/apps/packages/ui/src/components/Option/MCPHub/__tests__/McpHubWorkflowConfig.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  DEFAULT_MCP_HUB_ROUTE_STATE,
+  MCP_HUB_VIEW_KEYS,
+  MCP_HUB_WORKFLOWS,
+  getDefaultMcpHubView,
+  resolveMcpHubRouteState,
+  workflowForMcpHubView
+} from "../mcpHubWorkflowConfig"
+
+describe("mcpHubWorkflowConfig", () => {
+  it("maps every current MCP Hub view key to exactly one workflow", () => {
+    const configuredViews = Object.values(MCP_HUB_WORKFLOWS).flatMap(
+      (workflow) => workflow.views
+    )
+
+    expect(new Set(configuredViews)).toEqual(new Set(MCP_HUB_VIEW_KEYS))
+    expect(configuredViews).toHaveLength(MCP_HUB_VIEW_KEYS.length)
+
+    for (const view of MCP_HUB_VIEW_KEYS) {
+      expect(workflowForMcpHubView(view)).toBeTruthy()
+    }
+  })
+
+  it("uses Setup / Servers & Credentials as the default route state", () => {
+    expect(DEFAULT_MCP_HUB_ROUTE_STATE).toEqual({
+      workflow: "setup",
+      view: "credentials"
+    })
+    expect(getDefaultMcpHubView("setup")).toBe("credentials")
+  })
+
+  it("derives workflow from a valid view when query workflow disagrees", () => {
+    expect(
+      resolveMcpHubRouteState({
+        workflow: "setup",
+        view: "assignments"
+      })
+    ).toEqual({
+      workflow: "access",
+      view: "assignments"
+    })
+  })
+
+  it("keeps a valid workflow deep link when the view query is invalid", () => {
+    expect(
+      resolveMcpHubRouteState({
+        workflow: "workspaces",
+        view: "not-real"
+      })
+    ).toEqual({
+      workflow: "workspaces",
+      view: "path-scopes"
+    })
+  })
+
+  it("falls back to Setup / Servers & Credentials for invalid query values", () => {
+    expect(
+      resolveMcpHubRouteState({
+        workflow: "missing",
+        view: "not-real"
+      })
+    ).toEqual(DEFAULT_MCP_HUB_ROUTE_STATE)
+  })
+})

--- a/apps/packages/ui/src/components/Option/MCPHub/mcpHubWorkflowConfig.ts
+++ b/apps/packages/ui/src/components/Option/MCPHub/mcpHubWorkflowConfig.ts
@@ -22,20 +22,6 @@ export type McpHubWorkflowDefinition = {
   defaultView: McpHubViewKey
 }
 
-export const MCP_HUB_VIEW_KEYS = [
-  "tool-catalogs",
-  "credentials",
-  "profiles",
-  "assignments",
-  "approvals",
-  "path-scopes",
-  "capability-mappings",
-  "workspace-sets",
-  "shared-workspaces",
-  "governance-packs",
-  "audit"
-] as const satisfies readonly McpHubViewKey[]
-
 export const MCP_HUB_VIEW_LABELS = {
   "tool-catalogs": "Tool Catalog",
   credentials: "Servers & Credentials",
@@ -49,6 +35,10 @@ export const MCP_HUB_VIEW_LABELS = {
   "governance-packs": "Governance Packs",
   audit: "Audit Findings"
 } as const satisfies Record<McpHubViewKey, string>
+
+export const MCP_HUB_VIEW_KEYS = Object.keys(
+  MCP_HUB_VIEW_LABELS
+) as McpHubViewKey[]
 
 export const MCP_HUB_WORKFLOWS = {
   setup: {
@@ -111,7 +101,7 @@ const viewToWorkflow = MCP_HUB_WORKFLOW_ORDER.reduce(
     }
     return mapping
   },
-  {} as Record<McpHubViewKey, McpHubWorkflowKey>
+  {} as Partial<Record<McpHubViewKey, McpHubWorkflowKey>>
 )
 
 export const isMcpHubWorkflowKey = (
@@ -124,7 +114,13 @@ export const isMcpHubViewKey = (
 
 export const workflowForMcpHubView = (
   view: McpHubViewKey
-): McpHubWorkflowKey => viewToWorkflow[view]
+): McpHubWorkflowKey => {
+  const workflow = viewToWorkflow[view]
+  if (!workflow) {
+    throw new Error(`MCP Hub view "${view}" is not assigned to a workflow.`)
+  }
+  return workflow
+}
 
 export const getDefaultMcpHubView = (
   workflow: McpHubWorkflowKey
@@ -149,10 +145,6 @@ export const resolveMcpHubRouteState = ({
       workflow,
       view: getDefaultMcpHubView(workflow)
     }
-  }
-
-  if (view) {
-    return DEFAULT_MCP_HUB_ROUTE_STATE
   }
 
   return DEFAULT_MCP_HUB_ROUTE_STATE

--- a/apps/packages/ui/src/components/Option/MCPHub/mcpHubWorkflowConfig.ts
+++ b/apps/packages/ui/src/components/Option/MCPHub/mcpHubWorkflowConfig.ts
@@ -1,0 +1,159 @@
+import type { McpHubGovernanceAuditTabKey } from "@/services/tldw/mcp-hub"
+
+export type McpHubWorkflowKey =
+  | "setup"
+  | "access"
+  | "workspaces"
+  | "governance"
+  | "audit"
+
+export type McpHubViewKey = McpHubGovernanceAuditTabKey
+
+export type McpHubRouteState = {
+  workflow: McpHubWorkflowKey
+  view: McpHubViewKey
+}
+
+export type McpHubWorkflowDefinition = {
+  key: McpHubWorkflowKey
+  label: string
+  description: string
+  views: readonly McpHubViewKey[]
+  defaultView: McpHubViewKey
+}
+
+export const MCP_HUB_VIEW_KEYS = [
+  "tool-catalogs",
+  "credentials",
+  "profiles",
+  "assignments",
+  "approvals",
+  "path-scopes",
+  "capability-mappings",
+  "workspace-sets",
+  "shared-workspaces",
+  "governance-packs",
+  "audit"
+] as const satisfies readonly McpHubViewKey[]
+
+export const MCP_HUB_VIEW_LABELS = {
+  "tool-catalogs": "Tool Catalog",
+  credentials: "Servers & Credentials",
+  profiles: "Profiles",
+  assignments: "Assignments",
+  approvals: "Approvals",
+  "path-scopes": "Path Scopes",
+  "capability-mappings": "Capability Mappings",
+  "workspace-sets": "Workspace Sets",
+  "shared-workspaces": "Shared Workspaces",
+  "governance-packs": "Governance Packs",
+  audit: "Audit Findings"
+} as const satisfies Record<McpHubViewKey, string>
+
+export const MCP_HUB_WORKFLOWS = {
+  setup: {
+    key: "setup",
+    label: "Setup",
+    description: "Connect MCP servers, configure credentials, and verify available tools.",
+    views: ["credentials", "tool-catalogs"],
+    defaultView: "credentials"
+  },
+  access: {
+    key: "access",
+    label: "Access",
+    description: "Define profiles and assign tool access to users, groups, and defaults.",
+    views: ["profiles", "assignments"],
+    defaultView: "profiles"
+  },
+  workspaces: {
+    key: "workspaces",
+    label: "Workspaces",
+    description: "Define trusted local paths and shared workspace boundaries.",
+    views: ["path-scopes", "workspace-sets", "shared-workspaces"],
+    defaultView: "path-scopes"
+  },
+  governance: {
+    key: "governance",
+    label: "Governance",
+    description: "Manage approvals, governance packs, and capability adapters.",
+    views: ["approvals", "governance-packs", "capability-mappings"],
+    defaultView: "approvals"
+  },
+  audit: {
+    key: "audit",
+    label: "Audit",
+    description: "Find and remediate risky or broken MCP Hub configuration.",
+    views: ["audit"],
+    defaultView: "audit"
+  }
+} as const satisfies Record<McpHubWorkflowKey, McpHubWorkflowDefinition>
+
+export const MCP_HUB_WORKFLOW_ORDER = [
+  "setup",
+  "access",
+  "workspaces",
+  "governance",
+  "audit"
+] as const satisfies readonly McpHubWorkflowKey[]
+
+export const DEFAULT_MCP_HUB_ROUTE_STATE: McpHubRouteState = {
+  workflow: "setup",
+  view: "credentials"
+}
+
+const workflowKeys = new Set<string>(MCP_HUB_WORKFLOW_ORDER)
+const viewKeys = new Set<string>(MCP_HUB_VIEW_KEYS)
+
+const viewToWorkflow = MCP_HUB_WORKFLOW_ORDER.reduce(
+  (mapping, workflow) => {
+    for (const view of MCP_HUB_WORKFLOWS[workflow].views) {
+      mapping[view] = workflow
+    }
+    return mapping
+  },
+  {} as Record<McpHubViewKey, McpHubWorkflowKey>
+)
+
+export const isMcpHubWorkflowKey = (
+  value: string | null | undefined
+): value is McpHubWorkflowKey => Boolean(value && workflowKeys.has(value))
+
+export const isMcpHubViewKey = (
+  value: string | null | undefined
+): value is McpHubViewKey => Boolean(value && viewKeys.has(value))
+
+export const workflowForMcpHubView = (
+  view: McpHubViewKey
+): McpHubWorkflowKey => viewToWorkflow[view]
+
+export const getDefaultMcpHubView = (
+  workflow: McpHubWorkflowKey
+): McpHubViewKey => MCP_HUB_WORKFLOWS[workflow].defaultView
+
+export const resolveMcpHubRouteState = ({
+  workflow,
+  view
+}: {
+  workflow?: string | null
+  view?: string | null
+}): McpHubRouteState => {
+  if (isMcpHubViewKey(view)) {
+    return {
+      workflow: workflowForMcpHubView(view),
+      view
+    }
+  }
+
+  if (isMcpHubWorkflowKey(workflow)) {
+    return {
+      workflow,
+      view: getDefaultMcpHubView(workflow)
+    }
+  }
+
+  if (view) {
+    return DEFAULT_MCP_HUB_ROUTE_STATE
+  }
+
+  return DEFAULT_MCP_HUB_ROUTE_STATE
+}

--- a/apps/packages/ui/src/public/_locales/en/tutorials.json
+++ b/apps/packages/ui/src/public/_locales/en/tutorials.json
@@ -432,10 +432,10 @@
     "message": "Flashcards Basics"
   },
   "flashcards_basics_description": {
-    "message": "Use study, manage, and import / export flows to maintain spaced-repetition decks"
+    "message": "Use study, manage, and transfer flows to maintain spaced-repetition decks"
   },
   "flashcards_basics_tabsTitle": {
-    "message": "Study, Manage, Import / Export"
+    "message": "Study, Manage, Transfer"
   },
   "flashcards_basics_tabsContent": {
     "message": "Switch tabs to study cards, manage deck contents, and import or export card data."
@@ -452,17 +452,47 @@
   "flashcards_basics_manageContent": {
     "message": "Open the Manage tab to search cards, filter by deck/tags, and perform bulk updates."
   },
-  "flashcards_basics_importExportTitle": {
-    "message": "Import / Export Tab"
+  "flashcards_basics_transferTitle": {
+    "message": "Transfer Tab"
   },
-  "flashcards_basics_importExportContent": {
-    "message": "Use Import / Export for CSV/JSON/APKG import and export workflows."
+  "flashcards_basics_transferContent": {
+    "message": "Use Transfer for CSV/JSON/APKG import and export workflows."
   },
   "flashcards_basics_quizTitle": {
     "message": "Bridge to Quiz"
   },
   "flashcards_basics_quizContent": {
     "message": "Jump into Quiz mode from your selected deck to validate retention with assessments."
+  },
+  "moderation_basics_label": {
+    "message": "Content Controls Basics"
+  },
+  "moderation_basics_description": {
+    "message": "Learn how to set up content safety rules, blocklists, and test moderation."
+  },
+  "moderation_basics_heroTitle": {
+    "message": "Moderation Dashboard"
+  },
+  "moderation_basics_heroContent": {
+    "message": "This is your content safety hub. The status badge shows whether your server is connected."
+  },
+  "moderation_basics_policyTitle": {
+    "message": "Policy & Settings"
+  },
+  "moderation_basics_policyContent": {
+    "message": "Start here. Set your base content safety policy — what categories to filter and how strictly."
+  },
+  "moderation_basics_blocklistTitle": {
+    "message": "Blocklist Studio"
+  },
+  "moderation_basics_blocklistContent": {
+    "message": "Add specific words, phrases, or patterns you want to always block or flag."
+  },
+  "moderation_basics_testTitle": {
+    "message": "Test Sandbox"
+  },
+  "moderation_basics_testContent": {
+    "message": "Try your rules in real time. Type a message and see whether it would be allowed or blocked."
   },
   "worldBooks_basics_label": {
     "message": "World Books Basics"
@@ -500,22 +530,130 @@
   "worldBooks_basics_actionsContent": {
     "message": "Create a new world book or import an existing JSON bundle to seed your knowledge base."
   },
-  "watchlists_basics_label": { "message": "Watchlists Basics" },
-  "watchlists_basics_description": { "message": "Learn how to add feeds, create monitors, and review collected articles" },
-  "watchlists_basics_setupTitle": { "message": "Quick Setup" },
-  "watchlists_basics_setupContent": { "message": "Start here to add your first feed and create a monitor. The guided setup walks you through it step by step." },
-  "watchlists_basics_feedsTitle": { "message": "Add Feeds" },
-  "watchlists_basics_feedsContent": { "message": "Feeds are sources like RSS feeds or websites that your monitors check for new content." },
-  "watchlists_basics_monitorsTitle": { "message": "Create Monitors" },
-  "watchlists_basics_monitorsContent": { "message": "Monitors run on a schedule to fetch and process content from your feeds. Choose a preset schedule like daily or hourly." },
-  "watchlists_basics_articlesTitle": { "message": "Review Articles" },
-  "watchlists_basics_articlesContent": { "message": "Articles are collected content from successful monitor runs. Switch to the Articles tab to browse and read them." },
-  "monitoring_basics_label": { "message": "Monitoring Basics" },
-  "monitoring_basics_description": { "message": "Learn how to monitor server health and set up alert rules" },
-  "monitoring_basics_overviewTitle": { "message": "System Overview" },
-  "monitoring_basics_overviewContent": { "message": "This section shows your server's current health metrics and security status. Use the refresh button or enable auto-refresh to keep it up to date." },
-  "monitoring_basics_createRuleTitle": { "message": "Create Alert Rules" },
-  "monitoring_basics_createRuleContent": { "message": "Set up rules to be notified when metrics cross thresholds. Pick a metric name, set a threshold and duration, then choose a severity level." },
-  "monitoring_basics_historyTitle": { "message": "Alert History" },
-  "monitoring_basics_historyContent": { "message": "When alerts trigger, they appear here. You can assign alerts to yourself, snooze them, or escalate to critical." }
+  "mcpHub_basics_label": {
+    "message": "MCP Hub Basics"
+  },
+  "mcpHub_basics_description": {
+    "message": "Learn how to browse tools, connect servers, and manage permissions."
+  },
+  "mcpHub_basics_welcomeTitle": {
+    "message": "Welcome to MCP Hub"
+  },
+  "mcpHub_basics_welcomeContent": {
+    "message": "MCP Hub manages external AI tools. Start here to see what tools are available and connect new servers."
+  },
+  "mcpHub_basics_catalogTitle": {
+    "message": "Tool Catalog"
+  },
+  "mcpHub_basics_catalogContent": {
+    "message": "Browse all registered tools here. Each tool shows its capabilities and risk level."
+  },
+  "mcpHub_basics_credentialsTitle": {
+    "message": "Servers & Credentials"
+  },
+  "mcpHub_basics_credentialsContent": {
+    "message": "Connect external MCP servers here. Each server provides additional tools for your AI assistant."
+  },
+  "mcpHub_basics_profilesTitle": {
+    "message": "Access Workflow"
+  },
+  "mcpHub_basics_profilesContent": {
+    "message": "Use Access to create profiles and assign which tools each user or persona can reach."
+  },
+  "mcpHub_basics_auditTitle": {
+    "message": "Governance Audit"
+  },
+  "mcpHub_basics_auditContent": {
+    "message": "Review policy findings and configuration issues across all your MCP Hub settings."
+  },
+  "quiz_basics_label": {
+    "message": "Quiz Basics"
+  },
+  "quiz_basics_description": {
+    "message": "Learn how to generate, take, and review quizzes from your media content."
+  },
+  "quiz_basics_tabsTitle": {
+    "message": "Quiz Playground"
+  },
+  "quiz_basics_tabsContent": {
+    "message": "The Quiz Playground has five tabs. Generate quizzes from your media, create them manually, take quizzes, manage your library, and review results."
+  },
+  "quiz_basics_generateTitle": {
+    "message": "Generate from Media"
+  },
+  "quiz_basics_generateContent": {
+    "message": "Start here. Select a video, article, or document from your media library, and the AI will generate quiz questions for you."
+  },
+  "quiz_basics_createTitle": {
+    "message": "Create Manually"
+  },
+  "quiz_basics_createContent": {
+    "message": "Prefer to write your own? Create quizzes with multiple choice, true/false, fill-in-the-blank, and matching questions."
+  },
+  "quiz_basics_takeTitle": {
+    "message": "Take a Quiz"
+  },
+  "quiz_basics_takeContent": {
+    "message": "Once you have quizzes, come here to take them. Your answers are saved and scored automatically."
+  },
+  "quiz_basics_resultsTitle": {
+    "message": "Review Results"
+  },
+  "quiz_basics_resultsContent": {
+    "message": "See your scores, review incorrect answers, and track your progress over time."
+  },
+  "watchlists_basics_label": {
+    "message": "Watchlists Basics"
+  },
+  "watchlists_basics_description": {
+    "message": "Learn how to add feeds, create monitors, and review collected articles"
+  },
+  "watchlists_basics_setupTitle": {
+    "message": "Quick Setup"
+  },
+  "watchlists_basics_setupContent": {
+    "message": "Start here to add your first feed and create a monitor. The guided setup walks you through it step by step."
+  },
+  "watchlists_basics_feedsTitle": {
+    "message": "Add Feeds"
+  },
+  "watchlists_basics_feedsContent": {
+    "message": "Feeds are sources like RSS feeds or websites that your monitors check for new content."
+  },
+  "watchlists_basics_monitorsTitle": {
+    "message": "Create Monitors"
+  },
+  "watchlists_basics_monitorsContent": {
+    "message": "Monitors run on a schedule to fetch and process content from your feeds. Choose a preset schedule like daily or hourly."
+  },
+  "watchlists_basics_articlesTitle": {
+    "message": "Review Articles"
+  },
+  "watchlists_basics_articlesContent": {
+    "message": "Articles are collected content from successful monitor runs. Switch to the Articles tab to browse and read them."
+  },
+  "monitoring_basics_label": {
+    "message": "Monitoring Basics"
+  },
+  "monitoring_basics_description": {
+    "message": "Learn how to monitor server health and set up alert rules"
+  },
+  "monitoring_basics_overviewTitle": {
+    "message": "System Overview"
+  },
+  "monitoring_basics_overviewContent": {
+    "message": "This section shows your server's current health metrics and security status. Use the refresh button or enable auto-refresh to keep it up to date."
+  },
+  "monitoring_basics_createRuleTitle": {
+    "message": "Create Alert Rules"
+  },
+  "monitoring_basics_createRuleContent": {
+    "message": "Set up rules to be notified when metrics cross thresholds. Pick a metric name, set a threshold and duration, then choose a severity level."
+  },
+  "monitoring_basics_historyTitle": {
+    "message": "Alert History"
+  },
+  "monitoring_basics_historyContent": {
+    "message": "When alerts trigger, they appear here. You can assign alerts to yourself, snooze them, or escalate to critical."
+  }
 }

--- a/apps/packages/ui/src/tutorials/__tests__/flashcards-tutorial.test.ts
+++ b/apps/packages/ui/src/tutorials/__tests__/flashcards-tutorial.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest"
+import { getTutorialById } from "../registry"
+
+describe("Flashcards tutorial registration", () => {
+  it("uses current transfer locale keys for the transfer step", () => {
+    const tutorial = getTutorialById("flashcards-basics")
+    expect(tutorial).toBeDefined()
+
+    const transferStep = tutorial!.steps.find((step) =>
+      step.target.includes("flashcards-import-format")
+    )
+
+    expect(transferStep).toMatchObject({
+      titleKey: "tutorials:flashcards.basics.transferTitle",
+      contentKey: "tutorials:flashcards.basics.transferContent",
+      titleFallback: "Transfer Tab",
+      contentFallback: "Use Transfer for CSV/JSON/APKG import and export workflows."
+    })
+  })
+})

--- a/apps/packages/ui/src/tutorials/__tests__/mcp-hub-tutorial.test.ts
+++ b/apps/packages/ui/src/tutorials/__tests__/mcp-hub-tutorial.test.ts
@@ -20,4 +20,14 @@ describe("MCPHub tutorial registration", () => {
       expect(step.target).toMatch(/\[data-testid=/)
     }
   })
+
+  it("targets persistent workflow controls for sections outside the default Setup view", () => {
+    const tutorial = getTutorialById("mcp-hub-basics")!
+    const targets = tutorial.steps.map((step) => step.target)
+
+    expect(targets).toContain('[data-testid="mcp-hub-workflow-access"]')
+    expect(targets).toContain('[data-testid="mcp-hub-workflow-audit"]')
+    expect(targets).not.toContain('[data-testid="mcp-hub-tab-profiles"]')
+    expect(targets).not.toContain('[data-testid="mcp-hub-tab-audit"]')
+  })
 })

--- a/apps/packages/ui/src/tutorials/definitions/flashcards.ts
+++ b/apps/packages/ui/src/tutorials/definitions/flashcards.ts
@@ -12,14 +12,14 @@ const flashcardsBasics: TutorialDefinition = {
   labelFallback: "Flashcards Basics",
   descriptionKey: "tutorials:flashcards.basics.description",
   descriptionFallback:
-    "Use study, manage, and import / export flows to maintain spaced-repetition decks",
+    "Use study, manage, and transfer flows to maintain spaced-repetition decks",
   icon: Library,
   priority: 1,
   steps: [
     {
       target: '[data-testid="flashcards-tabs"]',
       titleKey: "tutorials:flashcards.basics.tabsTitle",
-      titleFallback: "Study, Manage, Import / Export",
+      titleFallback: "Study, Manage, Transfer",
       contentKey: "tutorials:flashcards.basics.tabsContent",
       contentFallback:
         "Switch tabs to study cards, manage deck contents, and import / export card data.",
@@ -46,11 +46,11 @@ const flashcardsBasics: TutorialDefinition = {
     },
     {
       target: '[data-testid="flashcards-import-format"], [data-testid="flashcards-import-help-accordion"]',
-      titleKey: "tutorials:flashcards.basics.importExportTitle",
-      titleFallback: "Import / Export Tab",
-      contentKey: "tutorials:flashcards.basics.importExportContent",
+      titleKey: "tutorials:flashcards.basics.transferTitle",
+      titleFallback: "Transfer Tab",
+      contentKey: "tutorials:flashcards.basics.transferContent",
       contentFallback:
-        "Use Import / Export for CSV/JSON/APKG import and export workflows.",
+        "Use Transfer for CSV/JSON/APKG import and export workflows.",
       placement: "left"
     },
     {

--- a/apps/packages/ui/src/tutorials/definitions/mcp-hub.ts
+++ b/apps/packages/ui/src/tutorials/definitions/mcp-hub.ts
@@ -47,17 +47,17 @@ const mcpHubBasics: TutorialDefinition = {
       disableBeacon: true
     },
     {
-      target: '[data-testid="mcp-hub-tab-profiles"]',
+      target: '[data-testid="mcp-hub-workflow-access"]',
       titleKey: "tutorials:mcpHub.basics.profilesTitle",
-      titleFallback: "Permission Profiles",
+      titleFallback: "Access Workflow",
       contentKey: "tutorials:mcpHub.basics.profilesContent",
       contentFallback:
-        "Create permission profiles to control which tools each user or persona can access.",
+        "Use Access to create profiles and assign which tools each user or persona can reach.",
       placement: "bottom",
       disableBeacon: true
     },
     {
-      target: '[data-testid="mcp-hub-tab-audit"]',
+      target: '[data-testid="mcp-hub-workflow-audit"]',
       titleKey: "tutorials:mcpHub.basics.auditTitle",
       titleFallback: "Governance Audit",
       contentKey: "tutorials:mcpHub.basics.auditContent",

--- a/apps/tldw-frontend/e2e/utils/page-objects/MCPHubPage.ts
+++ b/apps/tldw-frontend/e2e/utils/page-objects/MCPHubPage.ts
@@ -151,10 +151,12 @@ export class MCPHubPage extends BasePage {
 
   async selectWorkflow(workflow: MCPHubWorkflowKey): Promise<void> {
     await this.workflowButton(workflow).click()
+    await this.expectWorkflowSelected(workflow)
   }
 
   async selectView(view: MCPHubViewKey): Promise<void> {
     await this.selectWorkflow(VIEW_TO_WORKFLOW[view])
+    await expect(this.viewTabControl(view)).toBeVisible()
     await this.viewTab(view).click()
   }
 

--- a/apps/tldw-frontend/e2e/utils/page-objects/MCPHubPage.ts
+++ b/apps/tldw-frontend/e2e/utils/page-objects/MCPHubPage.ts
@@ -5,6 +5,40 @@ import { type Page, type Locator, expect } from "@playwright/test"
 import { BasePage, type InteractiveElement } from "./BasePage"
 import { waitForAppShell, waitForConnection } from "../helpers"
 
+export type MCPHubWorkflowKey =
+  | "setup"
+  | "access"
+  | "workspaces"
+  | "governance"
+  | "audit"
+
+export type MCPHubViewKey =
+  | "profiles"
+  | "assignments"
+  | "path-scopes"
+  | "workspace-sets"
+  | "shared-workspaces"
+  | "audit"
+  | "approvals"
+  | "governance-packs"
+  | "capability-mappings"
+  | "tool-catalogs"
+  | "credentials"
+
+const VIEW_TO_WORKFLOW: Record<MCPHubViewKey, MCPHubWorkflowKey> = {
+  profiles: "access",
+  assignments: "access",
+  "path-scopes": "workspaces",
+  "workspace-sets": "workspaces",
+  "shared-workspaces": "workspaces",
+  audit: "audit",
+  approvals: "governance",
+  "governance-packs": "governance",
+  "capability-mappings": "governance",
+  "tool-catalogs": "setup",
+  credentials: "setup",
+}
+
 export class MCPHubPage extends BasePage {
   constructor(page: Page) {
     super(page)
@@ -12,14 +46,13 @@ export class MCPHubPage extends BasePage {
 
   // -- Navigation ------------------------------------------------------------
 
-  async goto(): Promise<void> {
-    await this.page.goto("/mcp-hub", { waitUntil: "domcontentloaded" })
+  async goto(path = "/mcp-hub"): Promise<void> {
+    await this.page.goto(path, { waitUntil: "domcontentloaded" })
     await waitForConnection(this.page)
   }
 
   async assertPageReady(): Promise<void> {
     await waitForAppShell(this.page, 30_000)
-    // Wait for MCP Hub heading or any tab content to appear
     const heading = this.page.getByRole("heading", { name: /mcp hub/i })
     await heading.first().waitFor({ state: "visible", timeout: 20_000 }).catch(() => {})
   }
@@ -31,91 +64,111 @@ export class MCPHubPage extends BasePage {
     return this.page.getByRole("heading", { name: /mcp hub/i })
   }
 
+  get workflows(): Locator {
+    return this.page.getByTestId("mcp-hub-workflows")
+  }
+
+  workflowButton(workflow: MCPHubWorkflowKey): Locator {
+    return this.page.getByTestId(`mcp-hub-workflow-${workflow}`)
+  }
+
+  viewTab(view: MCPHubViewKey): Locator {
+    return this.page.getByTestId(`mcp-hub-tab-${view}`)
+  }
+
+  viewTabControl(view: MCPHubViewKey): Locator {
+    return this.viewTab(view).locator("xpath=ancestor::*[@role='tab']")
+  }
+
   /** Profiles tab */
   get profilesTab(): Locator {
-    return this.page.getByRole("tab", { name: /profiles/i })
+    return this.viewTab("profiles")
   }
 
   /** Assignments tab */
   get assignmentsTab(): Locator {
-    return this.page.getByRole("tab", { name: /assignments/i })
+    return this.viewTab("assignments")
   }
 
   /** Path Scopes tab */
   get pathScopesTab(): Locator {
-    return this.page.getByRole("tab", { name: /path scopes/i })
+    return this.viewTab("path-scopes")
   }
 
   /** Workspace Sets tab */
   get workspaceSetsTab(): Locator {
-    return this.page.getByRole("tab", { name: /workspace sets/i })
+    return this.viewTab("workspace-sets")
   }
 
   /** Shared Workspaces tab */
   get sharedWorkspacesTab(): Locator {
-    return this.page.getByRole("tab", { name: /shared workspaces/i })
+    return this.viewTab("shared-workspaces")
   }
 
   /** Audit tab */
   get auditTab(): Locator {
-    return this.page.getByRole("tab", { name: /^audit$/i })
+    return this.viewTab("audit")
   }
 
   /** Approvals tab */
   get approvalsTab(): Locator {
-    return this.page.getByRole("tab", { name: /approvals/i })
+    return this.viewTab("approvals")
   }
 
   /** Catalog tab */
   get catalogTab(): Locator {
-    return this.page.getByRole("tab", { name: /catalog/i })
+    return this.viewTab("tool-catalogs")
   }
 
   /** Credentials tab */
   get credentialsTab(): Locator {
-    return this.page.getByRole("tab", { name: /credentials/i })
+    return this.viewTab("credentials")
   }
 
   // -- Helpers ---------------------------------------------------------------
 
-  /** All available tab keys */
-  static readonly TAB_KEYS = [
+  static readonly WORKFLOW_KEYS = [
+    "setup",
+    "access",
+    "workspaces",
+    "governance",
+    "audit",
+  ] as const
+
+  static readonly VIEW_KEYS = [
     "profiles",
     "assignments",
-    "pathScopes",
-    "workspaceSets",
-    "sharedWorkspaces",
+    "path-scopes",
+    "workspace-sets",
+    "shared-workspaces",
     "audit",
     "approvals",
-    "catalog",
+    "governance-packs",
+    "capability-mappings",
+    "tool-catalogs",
     "credentials",
   ] as const
 
-  /** Switch to a specific tab */
-  async switchToTab(
-    tab:
-      | "profiles"
-      | "assignments"
-      | "pathScopes"
-      | "workspaceSets"
-      | "sharedWorkspaces"
-      | "audit"
-      | "approvals"
-      | "catalog"
-      | "credentials"
-  ): Promise<void> {
-    const tabLocator = {
-      profiles: this.profilesTab,
-      assignments: this.assignmentsTab,
-      pathScopes: this.pathScopesTab,
-      workspaceSets: this.workspaceSetsTab,
-      sharedWorkspaces: this.sharedWorkspacesTab,
-      audit: this.auditTab,
-      approvals: this.approvalsTab,
-      catalog: this.catalogTab,
-      credentials: this.credentialsTab,
-    }[tab]
-    await tabLocator.click()
+  async selectWorkflow(workflow: MCPHubWorkflowKey): Promise<void> {
+    await this.workflowButton(workflow).click()
+  }
+
+  async selectView(view: MCPHubViewKey): Promise<void> {
+    await this.selectWorkflow(VIEW_TO_WORKFLOW[view])
+    await this.viewTab(view).click()
+  }
+
+  async expectWorkflowSelected(workflow: MCPHubWorkflowKey): Promise<void> {
+    await expect(this.workflowButton(workflow)).toHaveAttribute("aria-pressed", "true")
+  }
+
+  async expectViewSelected(view: MCPHubViewKey): Promise<void> {
+    await expect(this.viewTabControl(view)).toHaveAttribute("aria-selected", "true")
+  }
+
+  /** Backward-compatible helper for older tests. Prefer selectView(). */
+  async switchToTab(tab: MCPHubViewKey): Promise<void> {
+    await this.selectView(tab)
   }
 
   // -- Interactive elements for assertAllButtonsWired() ----------------------
@@ -123,8 +176,42 @@ export class MCPHubPage extends BasePage {
   async getInteractiveElements(): Promise<InteractiveElement[]> {
     return [
       {
-        name: "Profiles tab",
+        name: "Access workflow",
+        locator: this.workflowButton("access"),
+        expectation: {
+          type: "state_change",
+          stateCheck: async (page) =>
+            page.locator('[data-testid="mcp-hub-workflow-access"]').getAttribute("aria-pressed"),
+        },
+      },
+      {
+        name: "Workspaces workflow",
+        locator: this.workflowButton("workspaces"),
+        expectation: {
+          type: "state_change",
+          stateCheck: async (page) =>
+            page
+              .locator('[data-testid="mcp-hub-workflow-workspaces"]')
+              .getAttribute("aria-pressed"),
+        },
+      },
+      {
+        name: "Governance workflow",
+        locator: this.workflowButton("governance"),
+        expectation: {
+          type: "state_change",
+          stateCheck: async (page) =>
+            page
+              .locator('[data-testid="mcp-hub-workflow-governance"]')
+              .getAttribute("aria-pressed"),
+        },
+      },
+      {
+        name: "Profiles view",
         locator: this.profilesTab,
+        setup: async () => {
+          await this.selectWorkflow("access")
+        },
         expectation: {
           type: "api_call",
           apiPattern: /\/api\/v1\/mcp\/hub\/permission-profiles/,
@@ -132,8 +219,11 @@ export class MCPHubPage extends BasePage {
         },
       },
       {
-        name: "Assignments tab",
+        name: "Assignments view",
         locator: this.assignmentsTab,
+        setup: async () => {
+          await this.selectWorkflow("access")
+        },
         expectation: {
           type: "api_call",
           apiPattern: /\/api\/v1\/mcp\/hub\/policy-assignments/,
@@ -141,8 +231,11 @@ export class MCPHubPage extends BasePage {
         },
       },
       {
-        name: "Catalog tab",
+        name: "Tool Catalog view",
         locator: this.catalogTab,
+        setup: async () => {
+          await this.selectWorkflow("setup")
+        },
         expectation: {
           type: "api_call",
           apiPattern: /\/api\/v1\/mcp\/hub\/tool-registry/,

--- a/apps/tldw-frontend/e2e/workflows/tier-2-features/mcp-hub.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/tier-2-features/mcp-hub.spec.ts
@@ -2,10 +2,9 @@
  * MCP Hub E2E Tests (Tier 2)
  *
  * Tests the MCP Hub page lifecycle:
- * - Page loads with heading and tab navigation
- * - Tab switching between Profiles, Assignments, Path Scopes, Workspace Sets,
- *   Shared Workspaces, Audit, Approvals, Catalog, and Credentials
- * - API calls fired on tab interactions (permission-profiles, policy-assignments, tool-registry)
+ * - Page loads with heading and workflow navigation
+ * - Workflow and child-view switching across Setup, Access, Workspaces, Governance, and Audit
+ * - API calls fired on representative child-view interactions
  *
  * Run: npx playwright test e2e/workflows/tier-2-features/mcp-hub.spec.ts
  */
@@ -32,7 +31,7 @@ test.describe("MCP Hub", () => {
   // =========================================================================
 
   test.describe("Page Load", () => {
-    test("should render the MCP Hub page with heading and tabs", async ({
+    test("should render the MCP Hub page with heading and workflow navigation", async ({
       authedPage,
       diagnostics,
     }) => {
@@ -43,17 +42,22 @@ test.describe("MCP Hub", () => {
       const headingVisible = await mcpHub.heading.isVisible().catch(() => false)
       expect(headingVisible).toBe(true)
 
-      // Core tabs should be present
-      await expect(mcpHub.profilesTab).toBeVisible()
-      await expect(mcpHub.assignmentsTab).toBeVisible()
-      await expect(mcpHub.auditTab).toBeVisible()
-      await expect(mcpHub.catalogTab).toBeVisible()
+      await expect(mcpHub.workflows).toBeVisible()
+      await expect(mcpHub.workflowButton("setup")).toBeVisible()
+      await expect(mcpHub.workflowButton("access")).toBeVisible()
+      await expect(mcpHub.workflowButton("workspaces")).toBeVisible()
+      await expect(mcpHub.workflowButton("governance")).toBeVisible()
+      await expect(mcpHub.workflowButton("audit")).toBeVisible()
+
+      await mcpHub.expectWorkflowSelected("setup")
+      await mcpHub.expectViewSelected("credentials")
       await expect(mcpHub.credentialsTab).toBeVisible()
+      await expect(mcpHub.catalogTab).toBeVisible()
 
       await assertNoCriticalErrors(diagnostics)
     })
 
-    test("should switch between all tabs without errors", async ({
+    test("should switch between workflows and child views without errors", async ({
       authedPage,
       diagnostics,
     }) => {
@@ -64,31 +68,41 @@ test.describe("MCP Hub", () => {
       const headingVisible = await mcpHub.heading.isVisible().catch(() => false)
       if (!headingVisible) return
 
-      for (const tab of [
+      for (const workflow of MCPHubPage.WORKFLOW_KEYS) {
+        await mcpHub.selectWorkflow(workflow)
+        await mcpHub.expectWorkflowSelected(workflow)
+      }
+
+      for (const view of [
         "assignments",
-        "pathScopes",
-        "workspaceSets",
-        "sharedWorkspaces",
+        "path-scopes",
+        "workspace-sets",
+        "shared-workspaces",
         "audit",
         "approvals",
-        "catalog",
+        "governance-packs",
+        "capability-mappings",
+        "tool-catalogs",
         "credentials",
         "profiles",
       ] as const) {
-        await mcpHub.switchToTab(tab)
-        const tabLocator = {
-          assignments: mcpHub.assignmentsTab,
-          pathScopes: mcpHub.pathScopesTab,
-          workspaceSets: mcpHub.workspaceSetsTab,
-          sharedWorkspaces: mcpHub.sharedWorkspacesTab,
-          audit: mcpHub.auditTab,
-          approvals: mcpHub.approvalsTab,
-          catalog: mcpHub.catalogTab,
-          credentials: mcpHub.credentialsTab,
-          profiles: mcpHub.profilesTab,
-        }[tab]
-        await expect(tabLocator).toHaveAttribute("aria-selected", "true")
+        await mcpHub.selectView(view)
+        await mcpHub.expectViewSelected(view)
       }
+
+      await assertNoCriticalErrors(diagnostics)
+    })
+
+    test("should hydrate workflow and child view from query state", async ({
+      authedPage,
+      diagnostics,
+    }) => {
+      mcpHub = new MCPHubPage(authedPage)
+      await mcpHub.goto("/mcp-hub?workflow=access&view=assignments")
+      await mcpHub.assertPageReady()
+
+      await mcpHub.expectWorkflowSelected("access")
+      await mcpHub.expectViewSelected("assignments")
 
       await assertNoCriticalErrors(diagnostics)
     })
@@ -113,17 +127,12 @@ test.describe("MCP Hub", () => {
       const headingVisible = await mcpHub.heading.isVisible().catch(() => false)
       if (!headingVisible) return
 
-      // Profiles is the default tab, so the API call should already have fired
-      // Switch away and back to trigger a fresh call
-      await mcpHub.switchToTab("audit")
-      await expect(mcpHub.auditTab).toHaveAttribute("aria-selected", "true")
-
       const apiCall = expectApiCall(authedPage, {
         url: /\/api\/v1\/mcp\/hub\/permission-profiles/,
         method: "GET",
       }, 15_000)
 
-      await mcpHub.switchToTab("profiles")
+      await mcpHub.selectView("profiles")
 
       try {
         const { response } = await apiCall
@@ -156,7 +165,42 @@ test.describe("MCP Hub", () => {
         method: "GET",
       }, 15_000)
 
-      await mcpHub.switchToTab("assignments")
+      await mcpHub.selectView("assignments")
+
+      try {
+        const { response } = await apiCall
+        expect(response.status()).toBeLessThan(500)
+      } catch {
+        // MCP Hub API may not be available on this server version
+      }
+
+      await assertNoCriticalErrors(diagnostics)
+    })
+  })
+
+  test.describe("Servers & Credentials API", () => {
+    test("should fire GET /api/v1/mcp/hub/external-servers on Servers & Credentials view", async ({
+      authedPage,
+      serverInfo,
+      diagnostics,
+    }) => {
+      skipIfServerUnavailable(serverInfo)
+
+      mcpHub = new MCPHubPage(authedPage)
+      await mcpHub.goto()
+      await mcpHub.assertPageReady()
+
+      const headingVisible = await mcpHub.heading.isVisible().catch(() => false)
+      if (!headingVisible) return
+
+      await mcpHub.selectView("audit")
+
+      const apiCall = expectApiCall(authedPage, {
+        url: /\/api\/v1\/mcp\/hub\/external-servers/,
+        method: "GET",
+      }, 15_000)
+
+      await mcpHub.selectView("credentials")
 
       try {
         const { response } = await apiCall
@@ -189,7 +233,40 @@ test.describe("MCP Hub", () => {
         method: "GET",
       }, 15_000)
 
-      await mcpHub.switchToTab("catalog")
+      await mcpHub.selectView("tool-catalogs")
+
+      try {
+        const { response } = await apiCall
+        expect(response.status()).toBeLessThan(500)
+      } catch {
+        // MCP Hub API may not be available on this server version
+      }
+
+      await assertNoCriticalErrors(diagnostics)
+    })
+  })
+
+  test.describe("Governance Audit API", () => {
+    test("should fire GET /api/v1/mcp/hub/audit/findings on Audit view", async ({
+      authedPage,
+      serverInfo,
+      diagnostics,
+    }) => {
+      skipIfServerUnavailable(serverInfo)
+
+      mcpHub = new MCPHubPage(authedPage)
+      await mcpHub.goto()
+      await mcpHub.assertPageReady()
+
+      const headingVisible = await mcpHub.heading.isVisible().catch(() => false)
+      if (!headingVisible) return
+
+      const apiCall = expectApiCall(authedPage, {
+        url: /\/api\/v1\/mcp\/hub\/audit\/findings/,
+        method: "GET",
+      }, 15_000)
+
+      await mcpHub.selectView("audit")
 
       try {
         const { response } = await apiCall

--- a/apps/tldw-frontend/e2e/workflows/tier-2-features/mcp-hub.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/tier-2-features/mcp-hub.spec.ts
@@ -73,19 +73,7 @@ test.describe("MCP Hub", () => {
         await mcpHub.expectWorkflowSelected(workflow)
       }
 
-      for (const view of [
-        "assignments",
-        "path-scopes",
-        "workspace-sets",
-        "shared-workspaces",
-        "audit",
-        "approvals",
-        "governance-packs",
-        "capability-mappings",
-        "tool-catalogs",
-        "credentials",
-        "profiles",
-      ] as const) {
+      for (const view of MCPHubPage.VIEW_KEYS) {
         await mcpHub.selectView(view)
         await mcpHub.expectViewSelected(view)
       }

--- a/backlog/tasks/task-211 - Design-MCP-Hub-workflow-first-control-panel-UX.md
+++ b/backlog/tasks/task-211 - Design-MCP-Hub-workflow-first-control-panel-UX.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - Codex
 created_date: '2026-05-10 02:39'
-updated_date: '2026-05-10 02:45'
+updated_date: '2026-05-10 02:52'
 labels:
   - ux
   - mcp-hub
@@ -51,6 +51,8 @@ Approved design-doc plan:
 6. Include implementation sequencing, risks, non-goals, and focused verification requirements.
 7. Run the brainstorming spec-document-reviewer loop and resolve any blocking review findings.
 8. Commit only the spec and Backlog task updates, leaving unrelated dirty files untouched.
+
+Follow-up spec hardening approved by user after design review: fix the incorrect Audit endpoint in the verification plan, clarify Stage 1 vs Stage 2 readiness wording/tests, add the shared WebUI/extension routing-shim constraint for URL state, explicitly call out E2E page-object migration, add concrete workflow-config/helper unit-test verification, and resolve minor IA child-order ambiguity if present.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -59,25 +61,29 @@ Approved design-doc plan:
 Created for the approved workflow-first MCP Hub UX design. User selected the heavier redesign direction over a staged control-center overlay or light copy/empty-state polish.
 
 Spec review loop completed after three passes. First pass approved with advisory clarifications; second pass found planning ambiguities in readiness staging and binding inputs; third pass approved after those were fixed. Placeholder scan found no TODO/TBD/FIXME/PLACEHOLDER markers. Bandit is not applicable because only Markdown design/task files were changed.
+
+Reopened for a documentation-only follow-up based on review findings before implementation continues. Scope remains the design spec and Backlog task only.
+
+Follow-up spec hardening completed. The design now uses the actual audit findings endpoint, removes Stage 1 readiness ambiguity, names the shared route-state shim constraint, calls out page-object migration, and includes a focused workflow-config unit-test command. Verification: spec stale-term scan has no matches in the design doc for governance-audit or first implementation ambiguity; git diff --check passed for touched spec/task files. Bandit remains not applicable because only Markdown files changed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Created docs/superpowers/specs/2026-05-10-mcp-hub-workflow-first-control-panel-design.md for the approved workflow-first MCP Hub redesign.
+Created Docs/superpowers/specs/2026-05-10-mcp-hub-workflow-first-control-panel-design.md for the approved workflow-first MCP Hub redesign.
 
 What changed:
 - Added an implementation-ready design spec that maps existing MCP Hub object views into Setup, Access, Workspaces, Governance, and Audit workflows.
 - Defined route/query state, legacy internal view-key compatibility, audit drilldown behavior, frontend-first readiness summary boundaries, accessibility/responsive requirements, implementation staging, and focused WebUI/extension verification.
 - Clarified after review that Stage 1 is the workflow shell plus URL/drilldown behavior, while Stage 2 owns readiness/status aggregation and richer first-use guidance.
+- Follow-up hardening fixed the Audit verification endpoint to `/api/v1/mcp/hub/audit/findings`, aligned Setup child-view order with the Setup-first default, added the shared `react-router-dom` shim constraint for URL state, split Stage 1 vs Stage 2 readiness tests, called out E2E page-object migration, and named a workflow-config unit-test target.
 
 Why:
 - The current 11-tab MCP Hub layout exposes backend object types as peer navigation and hides the real user workflow. The spec preserves current capabilities while planning a workflow-first control panel that better supports first-time setup and governance/admin work.
 
 Verification:
-- Placeholder scan: no TODO/TBD/FIXME/PLACEHOLDER markers.
-- Spec review loop: approved on the third pass after resolving readiness-staging and credential-binding input ambiguities.
-- git diff --cached --check: passed.
+- Spec stale-term scan: no matches in the design doc for `governance-audit`, `first implementation should`, or `first implementation program`.
+- `git diff --check -- Docs/superpowers/specs/2026-05-10-mcp-hub-workflow-first-control-panel-design.md backlog/tasks/task-211...`: passed.
 - Bandit skipped because this task touched only Markdown design/task files.
 
 Scope:

--- a/backlog/tasks/task-211 - Design-MCP-Hub-workflow-first-control-panel-UX.md
+++ b/backlog/tasks/task-211 - Design-MCP-Hub-workflow-first-control-panel-UX.md
@@ -1,0 +1,96 @@
+---
+id: TASK-211
+title: Design MCP Hub workflow-first control panel UX
+status: Done
+assignee:
+  - Codex
+created_date: '2026-05-10 02:39'
+updated_date: '2026-05-10 02:45'
+labels:
+  - ux
+  - mcp-hub
+  - webui
+  - extension
+  - design
+dependencies: []
+references:
+  - apps/packages/ui/src/components/Option/MCPHub/McpHubPage.tsx
+  - apps/packages/ui/src/components/Option/MCPHub
+  - apps/packages/ui/src/services/tldw/mcp-hub.ts
+documentation:
+  - docs/superpowers/specs/2026-03-27-mcp-hub-navigation-parity-design.md
+  - Docs/MCP/mcp_hub_management.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create an implementation-ready design spec for replacing the current object-centric MCP Hub tab row with a workflow-first WebUI/extension control panel. Scope is design documentation only: preserve current implementation behavior while defining the future IA, component contract, readiness summaries, deep-link handling, audit drilldown mapping, and verification plan.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Design spec is written under docs/superpowers/specs with the approved workflow-first IA and staged implementation scope.
+- [x] #2 Spec explicitly maps existing MCP Hub child views into Setup, Access, Workspaces, Governance, and Audit workflows.
+- [x] #3 Spec covers URL/deep-link compatibility, audit drilldown behavior, readiness/status summaries, and frontend-first aggregation boundaries.
+- [x] #4 Spec includes implementation sequencing and focused verification plan for shared WebUI/extension behavior.
+- [x] #5 Spec review loop is completed and issues are either resolved or documented.
+- [x] #6 Only the design spec and associated Backlog task changes are committed; unrelated dirty worktree files remain untouched.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Approved design-doc plan:
+1. Write an implementation-ready design spec for a workflow-first MCP Hub control panel in docs/superpowers/specs/2026-05-10-mcp-hub-workflow-first-control-panel-design.md.
+2. Preserve current implementation scope in the spec: no code changes yet, reuse existing MCP Hub child components in the first implementation slice, and avoid backend changes unless frontend aggregation proves insufficient.
+3. Specify the top-level workflow IA: Setup, Access, Workspaces, Governance, Audit.
+4. Map current child views into workflow groups and define URL/deep-link behavior plus audit drilldown mapping.
+5. Define readiness/status summaries, empty-state behavior, and first-use guidance for the shared WebUI/extension surface.
+6. Include implementation sequencing, risks, non-goals, and focused verification requirements.
+7. Run the brainstorming spec-document-reviewer loop and resolve any blocking review findings.
+8. Commit only the spec and Backlog task updates, leaving unrelated dirty files untouched.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Created for the approved workflow-first MCP Hub UX design. User selected the heavier redesign direction over a staged control-center overlay or light copy/empty-state polish.
+
+Spec review loop completed after three passes. First pass approved with advisory clarifications; second pass found planning ambiguities in readiness staging and binding inputs; third pass approved after those were fixed. Placeholder scan found no TODO/TBD/FIXME/PLACEHOLDER markers. Bandit is not applicable because only Markdown design/task files were changed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Created docs/superpowers/specs/2026-05-10-mcp-hub-workflow-first-control-panel-design.md for the approved workflow-first MCP Hub redesign.
+
+What changed:
+- Added an implementation-ready design spec that maps existing MCP Hub object views into Setup, Access, Workspaces, Governance, and Audit workflows.
+- Defined route/query state, legacy internal view-key compatibility, audit drilldown behavior, frontend-first readiness summary boundaries, accessibility/responsive requirements, implementation staging, and focused WebUI/extension verification.
+- Clarified after review that Stage 1 is the workflow shell plus URL/drilldown behavior, while Stage 2 owns readiness/status aggregation and richer first-use guidance.
+
+Why:
+- The current 11-tab MCP Hub layout exposes backend object types as peer navigation and hides the real user workflow. The spec preserves current capabilities while planning a workflow-first control panel that better supports first-time setup and governance/admin work.
+
+Verification:
+- Placeholder scan: no TODO/TBD/FIXME/PLACEHOLDER markers.
+- Spec review loop: approved on the third pass after resolving readiness-staging and credential-binding input ambiguities.
+- git diff --cached --check: passed.
+- Bandit skipped because this task touched only Markdown design/task files.
+
+Scope:
+- No implementation code changed.
+- Unrelated existing dirty files and other untracked backlog tasks were left untouched.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-211 - Design-MCP-Hub-workflow-first-control-panel-UX.md
+++ b/backlog/tasks/task-211 - Design-MCP-Hub-workflow-first-control-panel-UX.md
@@ -3,7 +3,7 @@ id: TASK-211
 title: Design MCP Hub workflow-first control panel UX
 status: Done
 assignee:
-  - Codex
+  - '@Codex'
 created_date: '2026-05-10 02:39'
 updated_date: '2026-05-10 02:52'
 labels:

--- a/backlog/tasks/task-214 - Implement-MCP-Hub-workflow-shell.md
+++ b/backlog/tasks/task-214 - Implement-MCP-Hub-workflow-shell.md
@@ -1,0 +1,74 @@
+---
+id: TASK-214
+title: Implement MCP Hub workflow shell
+status: Done
+assignee:
+  - '@Codex'
+created_date: '2026-05-10 02:54'
+updated_date: '2026-05-10 03:46'
+labels:
+  - ux
+  - mcp-hub
+  - webui
+  - extension
+  - implementation
+dependencies: []
+references:
+  - apps/packages/ui/src/components/Option/MCPHub/McpHubPage.tsx
+  - apps/packages/ui/src/components/Option/MCPHub/mcpHubWorkflowConfig.ts
+  - apps/packages/ui/src/tutorials/definitions/mcp-hub.ts
+  - apps/tldw-frontend/e2e/workflows/tier-2-features/mcp-hub.spec.ts
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-05-10-mcp-hub-workflow-first-control-panel-design.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Stage 1 of the approved MCP Hub workflow-first design: replace the flat object-centric tab row with workflow and child-view navigation while preserving existing child components and service contracts.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Workflow config maps every current MCP Hub view into exactly one workflow.
+- [x] #2 McpHubPage defaults to Setup / Servers & Credentials and supports workflow/view query state.
+- [x] #3 Audit drilldown opens the mapped workflow and child view while preserving focus context.
+- [x] #4 Shared WebUI/extension route behavior uses the existing router shim path rather than direct window history.
+- [x] #5 Focused unit/component and E2E/page-object tests cover workflow navigation, deep links, audit drilldown, and route parity.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing tests for workflow config, default route/query parsing, workflow/view selection, and audit drilldown mapping. 2. Implement workflow config and route-state helpers. 3. Refactor McpHubPage to render workflow navigation plus child-view navigation while reusing existing child components. 4. Update MCP Hub E2E page object and tests from tab locators to workflow/view helpers. 5. Run focused frontend tests, E2E where feasible, and Markdown/task verification.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+In isolated branch codex/mcp-hub-workflow-shell, completed the unit/component red-green loop for Stage 1 workflow shell. Red run failed on missing workflow config and old tab/default behavior. Green run: bunx vitest run ../packages/ui/src/components/Option/MCPHub/__tests__/McpHubWorkflowConfig.test.ts ../packages/ui/src/components/Option/MCPHub/__tests__/McpHubPage.test.tsx ../packages/ui/src/components/Option/MCPHub/__tests__/McpHubPage.ftux.test.tsx passed 18 tests across 3 files; jsdom emitted existing CSS parse warnings.
+
+Added final hardening after review: MCP Hub tutorial now targets persistent workflow buttons for non-default sections, and route-state resolution preserves a valid workflow deep link when view is invalid.
+
+Verification: focused Vitest suite passed 29 tests across MCP Hub config/page/FTUX/route/tutorial coverage; touched-file ESLint exited 0 with the existing Next pages-directory warning; git diff --check passed; Playwright MCP Hub spec passed 3 page/navigation/query tests and skipped 5 backend-dependent API checks via server availability guard. Full bunx tsc --noEmit --pretty false remains blocked by unrelated existing errors in EmbeddingsModelSelectionConfig.tsx, persona-visuals.ts, and lib/api/vnPlay.ts. Bandit skipped because touched implementation files are frontend TypeScript/JSON and Backlog metadata only.
+
+After touching the MCP Hub tutorial locale text, mechanically regenerated apps/packages/ui/src/public/_locales/en/tutorials.json from the nested source locale so the extension locale mirror test passes.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the workflow-first MCP Hub shell: workflow navigation, child-view tabs, workflow/view URL state, Setup / Servers & Credentials default, audit drilldown remapping, updated E2E page object/spec coverage, and tutorial targets that remain visible under the new shell. Synced the extension tutorial locale mirror after updating MCP Hub tutorial text. Verified focused UI, route, tutorial, lint, whitespace, locale mirror, and MCP Hub browser E2E checks; documented the unrelated full TypeScript baseline failures and non-Python Bandit skip.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-220 - Address-PR-1498-review-feedback.md
+++ b/backlog/tasks/task-220 - Address-PR-1498-review-feedback.md
@@ -1,0 +1,60 @@
+---
+id: TASK-220
+title: Address PR 1498 review feedback
+status: Done
+assignee:
+  - '@Codex'
+created_date: '2026-05-10 04:52'
+updated_date: '2026-05-10 04:58'
+labels:
+  - mcp-hub
+  - webui
+  - review-fix
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1498'
+  - apps/packages/ui/src/components/Option/MCPHub/mcpHubWorkflowConfig.ts
+  - apps/tldw-frontend/e2e/utils/page-objects/MCPHubPage.ts
+  - apps/tldw-frontend/e2e/workflows/tier-2-features/mcp-hub.spec.ts
+  - apps/packages/ui/src/tutorials/definitions/flashcards.ts
+  - >-
+    Docs/superpowers/specs/2026-05-10-mcp-hub-workflow-first-control-panel-design.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address actionable CodeRabbit and Qodo feedback on PR #1498 while keeping the branch scoped to MCP Hub workflow shell review fixes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 CodeRabbit review comments are verified and addressed or documented.
+- [x] #2 Qodo review findings are verified and addressed or documented.
+- [x] #3 Focused frontend tests and MCP Hub E2E checks are rerun after fixes.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Resolved actionable review feedback on PR #1498. CodeRabbit: removed redundant route fallback branch, reused MCPHubPage.VIEW_KEYS in E2E spec, normalized TASK-211 assignee to @Codex. Qodo: updated Flashcards tutorial transfer i18n keys/fallbacks with a regression test, converted local absolute design-doc links to repo-relative links, derived MCP_HUB_VIEW_KEYS from labels and made workflowForMcpHubView fail loudly for unmapped valid views, and added E2E page-object waits after workflow switches.
+
+Verification: flashcards tutorial regression test failed before the fix and passed after. Focused Vitest suite passed 31 tests across MCP Hub config/page/route/tutorial/locale coverage and flashcards tutorial coverage. Touched-file ESLint exited 0 with the existing Next pages-directory warning. git diff --check passed. MCP Hub Playwright spec passed 3 page/navigation/query tests and skipped 5 backend-dependent API checks via server availability guard. bunx tsc --noEmit --pretty false remains blocked by unrelated existing errors in EmbeddingsModelSelectionConfig.tsx, persona-visuals.ts, and lib/api/vnPlay.ts. Bandit skipped because touched implementation files are frontend TypeScript/Markdown/Backlog metadata only.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed PR #1498 CodeRabbit and Qodo review feedback with scoped fixes: Flashcards tutorial transfer i18n keys, repo-relative design-doc links, workflow config key drift hardening, E2E workflow/view wait hardening, canonical MCPHubPage.VIEW_KEYS usage, redundant route fallback cleanup, and TASK-211 assignee formatting. Verified focused frontend tests, lint, diff whitespace, and MCP Hub Playwright; documented the unrelated TypeScript baseline blocker and non-Python Bandit skip.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Adds the workflow-first MCP Hub shell with top-level Setup, Access, Workspaces, Governance, and Audit navigation plus child-view tabs.
- Preserves existing MCP Hub child components and service contracts while adding workflow/view URL state and audit drilldown remapping.
- Updates MCP Hub unit, route, tutorial, locale mirror, page-object, and Playwright coverage.

## Human Change Summary Required
This PR is draft because repo policy requires a human-written Change summary before AI-authored work is merge-ready. Please add the final human-owned rationale before marking ready for review.

## Test Plan
- [x] `bunx vitest run ../packages/ui/src/components/Option/MCPHub/__tests__/McpHubWorkflowConfig.test.ts ../packages/ui/src/components/Option/MCPHub/__tests__/McpHubPage.test.tsx ../packages/ui/src/components/Option/MCPHub/__tests__/McpHubPage.ftux.test.tsx ../packages/ui/src/routes/__tests__/mcp-hub-route.test.tsx __tests__/extension/route-registry.mcp-hub.test.ts ../packages/ui/src/tutorials/__tests__/mcp-hub-tutorial.test.ts ../packages/ui/src/tutorials/__tests__/locale-mirror.test.ts`
- [x] `apps/tldw-frontend/node_modules/.bin/eslint -c apps/tldw-frontend/eslint.config.mjs <touched MCP Hub files>`
- [x] `git diff --check origin/dev..HEAD`
- [x] `bunx playwright test e2e/workflows/tier-2-features/mcp-hub.spec.ts --reporter=line` - 3 passed, 5 skipped by backend availability guard
- [ ] `bunx tsc --noEmit --pretty false` - currently blocked by unrelated existing errors in EmbeddingsModelSelectionConfig.tsx, persona-visuals.ts, and lib/api/vnPlay.ts
- [x] Bandit skipped: no Python implementation files touched
