### PR TITLE
Add persona visual library MCP reuse

### DIFF
--- a/Docs/Code_Documentation/Persona_Visual_Packs.md
+++ b/Docs/Code_Documentation/Persona_Visual_Packs.md
@@ -79,6 +79,21 @@ Current personal-library API routes:
 4. `DELETE /api/v1/persona/visual-library/{item_id}`
 5. `POST /api/v1/persona/visual-library/{item_id}/use`
 
+Current personal-library MCP tools:
+
+1. `persona_visuals.library_items` lists the current user's non-deleted
+   reference-backed library entries. It is read-only and derives live source
+   persona/pack names from the source rows when those rows still resolve.
+2. `persona_visuals.use_library_item` duplicates an available library source
+   pack to a target persona as an inactive draft through the same service path
+   as the REST API. It returns `review_required: true` and never activates the
+   target persona pack.
+
+The MCP library tools stay separate from `persona_visuals.trigger_state`.
+Runtime state triggers are transient session behavior; library reuse is a
+durable draft-creation action that must preserve review and explicit activation
+semantics.
+
 Core implementation points:
 
 1. `persona_visual_library_items` in the ChaChaNotes persona store.
@@ -86,6 +101,8 @@ Core implementation points:
 3. `PersonaVisualLibraryService` for ownership checks, metadata normalization,
    stale-source rejection on use, and duplicate-to-persona draft creation.
 4. `VisualPackEditor` for save/list/edit/remove/use controls in Persona Garden.
+5. `PersonaVisualsModule` for MCP discovery and draft reuse on top of the same
+   reference-backed service semantics.
 
 ## Import Preview And Commit
 

--- a/Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md
+++ b/Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md
@@ -401,7 +401,7 @@ review items. They MUST NOT silently activate packs.
    - user id
    - source persona id and source pack id when still available
    - title, notes, and tags
-   - source persona and pack display snapshots
+   - live source persona and pack display names when source rows still resolve
    - source pack version and current source version
    - source available/source changed flags
    - version and timestamps
@@ -441,10 +441,12 @@ The internal `persona_visuals` MCP module is the V1 MCP integration point.
 Supported tool families:
 
 1. `persona_visuals.capabilities`
-2. `persona_visuals.trigger_state`
-3. `persona_visuals.create_draft_pack`
-4. `persona_visuals.update_manifest`
-5. `persona_visuals.enqueue_generation`
+2. `persona_visuals.library_items`
+3. `persona_visuals.trigger_state`
+4. `persona_visuals.create_draft_pack`
+5. `persona_visuals.update_manifest`
+6. `persona_visuals.use_library_item`
+7. `persona_visuals.enqueue_generation`
 
 Rules:
 
@@ -455,6 +457,9 @@ Rules:
    unauthorized persona/pack access.
 5. Tool outputs that affect runtime state should be visible in live status and
    audit metadata where existing infrastructure supports it.
+6. Personal-library MCP tools are user-scoped and reference-backed. Listing
+   derives source display names from live rows, and using a library item creates
+   an inactive target-persona draft through duplicate semantics.
 
 ---
 
@@ -483,9 +488,14 @@ Current and future portability/library work:
    source packs and creates target drafts through duplicate semantics (#1468).
 3. Import/export conflict choices support target title-match review and
    draft-only replacement (#1490).
-4. Future shared user libraries should be layered on top of the manifest-backed
+4. Persona Garden reusable affordances expose duplicate, personal library,
+   import, and draft creation paths without marketplace framing (#1493).
+5. MCP reusable-pack tools list personal library entries and create
+   target-persona drafts without snapshots, sharing, or automatic activation
+   (#1496).
+6. Future shared user libraries should be layered on top of the manifest-backed
    pack format rather than replacing it.
-5. Future cross-device sync, signed community packs, and external
+7. Future cross-device sync, signed community packs, and external
    MCP-compatible pack providers remain out of scope for V1.
 
 ---
@@ -552,9 +562,14 @@ baseline. The first reference-backed V1 slices are now covered:
    save/list/edit/remove/use in Persona Garden (#1468).
 3. Import/export conflict choices: complete for preview-backed target title
    conflicts, create-new draft commits, and reviewed draft replacement (#1490).
-4. Shared/cross-device libraries remain future work.
-5. External MCP-compatible visual providers remain future work.
-6. Live2D or other renderer adapter remains future work after the sprite/frame
+4. Persona Garden reusable affordances: complete for routing duplicate,
+   personal library, import, and draft creation flows without marketplace
+   framing (#1493).
+5. MCP reusable-pack semantics: complete for listing reference-backed personal
+   library entries and creating inactive target-persona drafts (#1496).
+6. Shared/cross-device libraries remain future work.
+7. External MCP-compatible visual providers remain future work.
+8. Live2D or other renderer adapter remains future work after the sprite/frame
    path is stable.
 
 ---

--- a/Docs/superpowers/plans/2026-05-10-persona-mcp-reuse-semantics.md
+++ b/Docs/superpowers/plans/2026-05-10-persona-mcp-reuse-semantics.md
@@ -1,0 +1,100 @@
+# Persona MCP Reuse Semantics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend the existing internal `persona_visuals` MCP module so same-user personal library entries can be listed and reused as reviewable target-persona drafts without bypassing ownership or activation gates.
+
+**Architecture:** Keep the MCP implementation as a thin tool layer over the existing ChaChaNotes persona store and `PersonaVisualLibraryService`. Add read-only library discovery plus one durable reuse action that delegates to the same duplicate-to-persona path used by the REST API. Do not introduce snapshots, shared-library semantics, marketplace behavior, or automatic activation.
+
+**Tech Stack:** FastAPI backend models, ChaChaNotes persona store, `PersonaVisualLibraryService`, MCP Unified module tools, pytest.
+
+---
+
+### Task 1: Add MCP Library Discovery
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/modules/implementations/persona_visuals_module.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_persona_visuals_module.py`
+
+- [x] **Step 1: Write the failing test**
+
+Add a test that creates two personas, a visual pack, saves it to the personal library, then calls `persona_visuals.library_items`. Assert the result includes `items`, `count`, reference-backed source ids, live source title/persona fields, `source_available`, and `source_changed`.
+
+- [x] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_persona_visuals_module.py -q
+```
+
+Expected: FAIL because `persona_visuals.library_items` is not registered.
+
+- [x] **Step 3: Implement the minimal tool**
+
+Add `persona_visuals.library_items` to `get_tools`, `execute_tool`, and `validate_tool_arguments`. Implement `_library_items_sync` using `db.list_persona_visual_library_items(user_id=..., include_deleted=False, limit=..., offset=...)` and a small `_library_item_summary` helper.
+
+- [x] **Step 4: Run the test to verify it passes**
+
+Run the same focused pytest command and confirm the new test passes with existing tests.
+
+### Task 2: Add MCP Library Reuse
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/modules/implementations/persona_visuals_module.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_persona_visuals_module.py`
+
+- [x] **Step 1: Write the failing success-path test**
+
+Add a test for `persona_visuals.use_library_item` that saves a source pack to the library, calls the tool with `item_id` and `target_persona_id`, and asserts the returned pack is a draft on the target persona with `review_required` true and no active target pack.
+
+- [x] **Step 2: Write the failing rejection-path tests**
+
+Add tests for a missing library item, an unavailable source pack, and missing target persona context. The source-unavailable path should soft-delete the source pack and assert the tool raises a clear failure instead of creating a draft.
+
+- [x] **Step 3: Run the tests to verify they fail**
+
+Run the focused MCP pytest command. Expected failures should be unknown tool or missing behavior, not fixture/setup errors.
+
+- [x] **Step 4: Implement the reuse tool**
+
+Register `persona_visuals.use_library_item`, validate `item_id`, optional `target_persona_id`, and optional `title`, then call `PersonaVisualLibraryService(db).use_item_for_persona(...)`. Return the target `pack` summary plus `library_item_id` and `review_required: true`.
+
+- [x] **Step 5: Run the tests to verify they pass**
+
+Run the focused MCP pytest command. Confirm existing runtime/draft/generation tool tests still pass.
+
+### Task 3: Document Tool Semantics
+
+**Files:**
+- Modify: `Docs/Code_Documentation/Persona_Visual_Packs.md`
+- Modify: `Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md`
+- Modify: `backlog/tasks/task-218 - Add-reusable-visual-pack-MCP-tool-semantics.md`
+
+- [x] **Step 1: Update docs**
+
+Document `persona_visuals.library_items` as read-only personal-library discovery and `persona_visuals.use_library_item` as a draft-creating durable action. Clarify that library items remain reference-backed and that live source names are derived from source rows, not snapshots.
+
+- [x] **Step 2: Update task status**
+
+Check completed TASK-218 acceptance criteria and add verification notes.
+
+- [x] **Step 3: Run verification**
+
+Run focused pytest, `git diff --check`, and Bandit on the touched backend module:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_persona_visuals_module.py -q
+python -m bandit -r tldw_Server_API/app/core/MCP_unified/modules/implementations/persona_visuals_module.py -f json -o /tmp/bandit_persona_mcp_reuse.json
+git diff --check
+```
+
+- [x] **Step 4: Commit**
+
+Stage the plan, task record, backend module, tests, and docs. Commit with:
+
+```bash
+git commit -m "feat: add persona visual library MCP reuse"
+```

--- a/backlog/tasks/task-218 - Add-reusable-visual-pack-MCP-tool-semantics.md
+++ b/backlog/tasks/task-218 - Add-reusable-visual-pack-MCP-tool-semantics.md
@@ -1,0 +1,68 @@
+---
+id: TASK-218
+title: Add reusable visual pack MCP/tool semantics
+status: Done
+assignee: []
+created_date: '2026-05-10 04:16'
+labels:
+  - persona
+  - mcp
+  - visual-packs
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1449'
+  - 'https://github.com/rmusser01/tldw_server/issues/1496'
+documentation:
+  - Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md
+  - Docs/Code_Documentation/Persona_Visual_Packs.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement GitHub issue #1496: extend the existing internal persona_visuals MCP/tool surface so user-owned reusable Persona/Buddy visual packs can be discovered and reused through the review-first personal-library semantics. This should build on the merged duplicate-to-persona, personal visual library, import/export conflict-choice, and Persona Garden affordance flows. Keep the scope Persona/Buddy specific; do not add cross-user sharing, marketplace behavior, external renderer adapters, automatic activation, or VN Play asset-pack runtime changes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 MCP/tool callers can inspect available reusable visual-pack capabilities without bypassing user/persona ownership checks.
+- [x] #2 Reusing a personal library entry through MCP creates a target-persona draft/review artifact and does not mutate active packs.
+- [x] #3 Tool schemas and documentation distinguish personal-library reuse from transient visual-state overrides.
+- [x] #4 Empty, missing, unauthorized, and stale-source cases fail closed with clear errors.
+- [x] #5 Focused backend tests cover successful reuse and the main rejection paths.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+- `Docs/superpowers/plans/2026-05-10-persona-mcp-reuse-semantics.md`
+<!-- SECTION:PLAN:END -->
+
+## Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Added `persona_visuals.library_items` for read-only reference-backed personal library discovery.
+- Added `persona_visuals.use_library_item` for creating inactive target-persona drafts through `PersonaVisualLibraryService`.
+- Updated Persona Visual Packs docs and PRD MCP contract copy, including removing stale display-snapshot wording.
+- Verification passed:
+  - `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_persona_visuals_module.py -q`
+  - `git diff --check`
+  - `python -m bandit -r tldw_Server_API/app/core/MCP_unified/modules/implementations/persona_visuals_module.py -f json -o /tmp/bandit_persona_mcp_reuse.json`
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented reusable Persona Visual pack MCP semantics for #1496. The internal `persona_visuals` module now lists user-scoped personal library entries and can reuse one by creating a reviewable inactive draft for a target persona through existing duplicate/library service semantics. Focused backend tests cover discovery, successful reuse, missing target context, missing items, and unavailable sources; docs now distinguish library reuse from transient runtime overrides.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-218 - Add-reusable-visual-pack-MCP-tool-semantics.md
+++ b/backlog/tasks/task-218 - Add-reusable-visual-pack-MCP-tool-semantics.md
@@ -59,6 +59,10 @@ Implement GitHub issue #1496: extend the existing internal persona_visuals MCP/t
   - `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_persona_visuals_module.py -q`
   - `git diff --check`
   - `python -m bandit -r tldw_Server_API/app/core/MCP_unified/modules/implementations/persona_visuals_module.py -f json -o /tmp/bandit_persona_mcp_reuse.json`
+- Reopened for PR #1499 review fixes:
+  - CodeRabbit: reject out-of-range `persona_visuals.library_items` offsets instead of silently capping.
+  - Qodo: reject provided-but-blank `target_persona_id` instead of falling back to persona scope.
+- Review fixes added targeted regression coverage and were verified with focused pytest, `git diff --check`, and Bandit.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/persona_visuals_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/persona_visuals_module.py
@@ -41,6 +41,8 @@ _PERSONA_VISUALS_NONCRITICAL_EXCEPTIONS = (
     ValueError,
 )
 
+_MAX_LIBRARY_ITEMS_OFFSET = 1_000_000
+
 
 class PersonaVisualsModule(BaseModule):
     """Internal persona visual-pack tools for draft edits and runtime state triggers."""
@@ -76,7 +78,12 @@ class PersonaVisualsModule(BaseModule):
                 parameters={
                     "properties": {
                         "limit": {"type": "integer", "minimum": 1, "maximum": 500, "default": 100},
-                        "offset": {"type": "integer", "minimum": 0, "default": 0},
+                        "offset": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": _MAX_LIBRARY_ITEMS_OFFSET,
+                            "default": 0,
+                        },
                     },
                 },
                 metadata={"category": "retrieval", "readOnlyHint": True, "auth_required": True},
@@ -136,7 +143,7 @@ class PersonaVisualsModule(BaseModule):
                 parameters={
                     "properties": {
                         "item_id": {"type": "string", "minLength": 1},
-                        "target_persona_id": {"type": "string"},
+                        "target_persona_id": {"type": "string", "minLength": 1},
                         "title": {"type": "string", "minLength": 1, "maxLength": 200},
                     },
                     "required": ["item_id"],
@@ -197,8 +204,8 @@ class PersonaVisualsModule(BaseModule):
                 limit = int(arguments["limit"])
                 if limit < 1 or limit > 500:
                     raise ValueError("limit must be between 1 and 500")
-            if arguments.get("offset") is not None and int(arguments["offset"]) < 0:
-                raise ValueError("offset must be non-negative")
+            if arguments.get("offset") is not None:
+                self._library_items_offset(arguments["offset"])
             return
         if tool_name == "persona_visuals.trigger_state":
             self._validate_optional_string(arguments, "persona_id")
@@ -237,7 +244,10 @@ class PersonaVisualsModule(BaseModule):
             item_id = str(arguments.get("item_id") or "").strip()
             if not item_id:
                 raise ValueError("item_id is required")
-            self._validate_optional_string(arguments, "target_persona_id")
+            if arguments.get("target_persona_id") is not None:
+                self._validate_optional_string(arguments, "target_persona_id")
+                if not str(arguments.get("target_persona_id") or "").strip():
+                    raise ValueError("target_persona_id cannot be empty")
             title = arguments.get("title")
             if title is not None:
                 if not isinstance(title, str):
@@ -291,7 +301,7 @@ class PersonaVisualsModule(BaseModule):
     def _library_items_sync(self, args: dict[str, Any], context: Any | None) -> dict[str, Any]:
         user_id = self._resolve_user_id(context)
         limit = self._bounded_int(args.get("limit"), default=100, minimum=1, maximum=500)
-        offset = self._bounded_int(args.get("offset"), default=0, minimum=0, maximum=1_000_000)
+        offset = self._library_items_offset(args.get("offset"))
         db = self._open_db(context)
         try:
             items = db.list_persona_visual_library_items(
@@ -538,8 +548,13 @@ class PersonaVisualsModule(BaseModule):
         return None
 
     def _resolve_target_persona_id(self, args: dict[str, Any], context: Any | None) -> str:
+        if args.get("target_persona_id") is not None:
+            explicit = str(args.get("target_persona_id") or "").strip()
+            if not explicit:
+                raise ValueError("target_persona_id cannot be empty")
+            return explicit
         try:
-            return self._resolve_persona_id({"persona_id": args.get("target_persona_id")}, context)
+            return self._resolve_persona_id({}, context)
         except ValueError as exc:
             raise ValueError("Missing target persona context for persona visuals library reuse") from exc
 
@@ -625,6 +640,18 @@ class PersonaVisualsModule(BaseModule):
         except (TypeError, ValueError):
             parsed = default
         return max(minimum, min(maximum, parsed))
+
+    @staticmethod
+    def _library_items_offset(value: Any) -> int:
+        if value is None:
+            return 0
+        try:
+            offset = int(value)
+        except (TypeError, ValueError):
+            raise ValueError("offset must be an integer between 0 and 1000000") from None
+        if offset < 0 or offset > _MAX_LIBRARY_ITEMS_OFFSET:
+            raise ValueError("offset must be between 0 and 1000000")
+        return offset
 
     @staticmethod
     def _validate_optional_string(arguments: dict[str, Any], key: str) -> None:

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/persona_visuals_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/persona_visuals_module.py
@@ -9,6 +9,10 @@ from loguru import logger
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 from tldw_Server_API.app.core.Jobs.manager import JobManager
 from tldw_Server_API.app.core.Persona.visual_jobs import create_generate_candidate_job
+from tldw_Server_API.app.core.Persona.visual_library_service import (
+    PersonaVisualLibraryService,
+    PersonaVisualLibraryServiceError,
+)
 from tldw_Server_API.app.core.Persona.visuals import (
     MAX_TRIGGER_DURATION_MS,
     MIN_TRIGGER_DURATION_MS,
@@ -67,6 +71,17 @@ class PersonaVisualsModule(BaseModule):
                 metadata={"category": "retrieval", "readOnlyHint": True, "auth_required": True},
             ),
             create_tool_definition(
+                name="persona_visuals.library_items",
+                description="List the current user's reference-backed personal Persona Visual library items.",
+                parameters={
+                    "properties": {
+                        "limit": {"type": "integer", "minimum": 1, "maximum": 500, "default": 100},
+                        "offset": {"type": "integer", "minimum": 0, "default": 0},
+                    },
+                },
+                metadata={"category": "retrieval", "readOnlyHint": True, "auth_required": True},
+            ),
+            create_tool_definition(
                 name="persona_visuals.trigger_state",
                 description="Emit a transient visual state override for the current persona session.",
                 parameters={
@@ -114,6 +129,21 @@ class PersonaVisualsModule(BaseModule):
                 metadata={"category": "management", "auth_required": True},
             ),
             create_tool_definition(
+                name="persona_visuals.use_library_item",
+                description=(
+                    "Create an inactive target-persona draft from a personal visual-library item."
+                ),
+                parameters={
+                    "properties": {
+                        "item_id": {"type": "string", "minLength": 1},
+                        "target_persona_id": {"type": "string"},
+                        "title": {"type": "string", "minLength": 1, "maxLength": 200},
+                    },
+                    "required": ["item_id"],
+                },
+                metadata={"category": "management", "auth_required": True},
+            ),
+            create_tool_definition(
                 name="persona_visuals.enqueue_generation",
                 description="Queue a persona visual generation job for human review.",
                 parameters={
@@ -144,12 +174,16 @@ class PersonaVisualsModule(BaseModule):
 
         if tool_name == "persona_visuals.capabilities":
             return await asyncio.to_thread(self._capabilities_sync, args, context)
+        if tool_name == "persona_visuals.library_items":
+            return await asyncio.to_thread(self._library_items_sync, args, context)
         if tool_name == "persona_visuals.trigger_state":
             return await asyncio.to_thread(self._trigger_state_sync, args, context)
         if tool_name == "persona_visuals.create_draft_pack":
             return await asyncio.to_thread(self._create_draft_pack_sync, args, context)
         if tool_name == "persona_visuals.update_manifest":
             return await asyncio.to_thread(self._update_manifest_sync, args, context)
+        if tool_name == "persona_visuals.use_library_item":
+            return await asyncio.to_thread(self._use_library_item_sync, args, context)
         if tool_name == "persona_visuals.enqueue_generation":
             return await asyncio.to_thread(self._enqueue_generation_sync, args, context)
         raise ValueError(f"Unknown tool: {tool_name}")
@@ -157,6 +191,14 @@ class PersonaVisualsModule(BaseModule):
     def validate_tool_arguments(self, tool_name: str, arguments: dict[str, Any]) -> None:
         if tool_name == "persona_visuals.capabilities":
             self._validate_optional_string(arguments, "persona_id")
+            return
+        if tool_name == "persona_visuals.library_items":
+            if arguments.get("limit") is not None:
+                limit = int(arguments["limit"])
+                if limit < 1 or limit > 500:
+                    raise ValueError("limit must be between 1 and 500")
+            if arguments.get("offset") is not None and int(arguments["offset"]) < 0:
+                raise ValueError("offset must be non-negative")
             return
         if tool_name == "persona_visuals.trigger_state":
             self._validate_optional_string(arguments, "persona_id")
@@ -190,6 +232,21 @@ class PersonaVisualsModule(BaseModule):
                 raise ValueError("manifest must be an object")
             if arguments.get("expected_version") is not None and int(arguments["expected_version"]) < 1:
                 raise ValueError("expected_version must be positive")
+            return
+        if tool_name == "persona_visuals.use_library_item":
+            item_id = str(arguments.get("item_id") or "").strip()
+            if not item_id:
+                raise ValueError("item_id is required")
+            self._validate_optional_string(arguments, "target_persona_id")
+            title = arguments.get("title")
+            if title is not None:
+                if not isinstance(title, str):
+                    raise ValueError("title must be a string")
+                normalized_title = title.strip()
+                if not normalized_title:
+                    raise ValueError("title cannot be empty")
+                if len(normalized_title) > 200:
+                    raise ValueError("title must be <= 200 chars")
             return
         if tool_name == "persona_visuals.enqueue_generation":
             self._validate_optional_string(arguments, "persona_id")
@@ -227,6 +284,29 @@ class PersonaVisualsModule(BaseModule):
                     self._pack_summary(db, pack, persona_id=persona_id, user_id=user_id)
                     for pack in draft_packs
                 ],
+            }
+        finally:
+            self._close_db(db)
+
+    def _library_items_sync(self, args: dict[str, Any], context: Any | None) -> dict[str, Any]:
+        user_id = self._resolve_user_id(context)
+        limit = self._bounded_int(args.get("limit"), default=100, minimum=1, maximum=500)
+        offset = self._bounded_int(args.get("offset"), default=0, minimum=0, maximum=1_000_000)
+        db = self._open_db(context)
+        try:
+            items = db.list_persona_visual_library_items(
+                user_id=user_id,
+                include_deleted=False,
+                limit=limit,
+                offset=offset,
+            )
+            summaries = [self._library_item_summary(item) for item in items]
+            return {
+                "items": summaries,
+                "count": len(summaries),
+                "limit": limit,
+                "offset": offset,
+                "reference_backed": True,
             }
         finally:
             self._close_db(db)
@@ -306,6 +386,37 @@ class PersonaVisualsModule(BaseModule):
                 "persona_id": persona_id,
                 "pack": self._pack_summary(db, updated, persona_id=persona_id, user_id=user_id),
             }
+        finally:
+            self._close_db(db)
+
+    def _use_library_item_sync(self, args: dict[str, Any], context: Any | None) -> dict[str, Any]:
+        user_id = self._resolve_user_id(context)
+        target_persona_id = self._resolve_target_persona_id(args, context)
+        item_id = str(args.get("item_id") or "").strip()
+        title = str(args.get("title") or "").strip() or None
+        db = self._open_db(context)
+        try:
+            service = PersonaVisualLibraryService(db)
+            duplicated = service.use_item_for_persona(
+                user_id=user_id,
+                item_id=item_id,
+                target_persona_id=target_persona_id,
+                title=title,
+            )
+            return {
+                "library_item_id": item_id,
+                "persona_id": target_persona_id,
+                "pack": self._pack_summary(
+                    db,
+                    duplicated,
+                    persona_id=target_persona_id,
+                    user_id=user_id,
+                ),
+                "review_required": True,
+                "activated": False,
+            }
+        except PersonaVisualLibraryServiceError as exc:
+            raise ValueError(str(exc)) from exc
         finally:
             self._close_db(db)
 
@@ -426,6 +537,12 @@ class PersonaVisualsModule(BaseModule):
                 return value.strip()
         return None
 
+    def _resolve_target_persona_id(self, args: dict[str, Any], context: Any | None) -> str:
+        try:
+            return self._resolve_persona_id({"persona_id": args.get("target_persona_id")}, context)
+        except ValueError as exc:
+            raise ValueError("Missing target persona context for persona visuals library reuse") from exc
+
     @staticmethod
     def _require_persona(db: CharactersRAGDB, *, persona_id: str, user_id: str) -> dict[str, Any]:
         profile = db.get_persona_profile(persona_id, user_id=user_id, include_deleted=False)
@@ -464,6 +581,24 @@ class PersonaVisualsModule(BaseModule):
             "assets_count": len(assets),
         }
 
+    @staticmethod
+    def _library_item_summary(item: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "id": str(item.get("id") or ""),
+            "title": str(item.get("title") or ""),
+            "notes": item.get("notes"),
+            "tags": [str(tag) for tag in list(item.get("tags") or [])],
+            "source_persona_id": item.get("source_persona_id"),
+            "source_pack_id": item.get("source_pack_id"),
+            "source_persona_name": item.get("source_persona_name"),
+            "source_pack_title": item.get("source_pack_title"),
+            "source_pack_version": item.get("source_pack_version"),
+            "source_current_version": item.get("source_current_version"),
+            "source_available": bool(item.get("source_available")),
+            "source_changed": bool(item.get("source_changed")),
+            "version": int(item.get("version") or 1),
+        }
+
     def _get_jobs_manager(self) -> Any:
         settings = self.config.settings or {}
         manager = settings.get("jobs_manager")
@@ -482,6 +617,14 @@ class PersonaVisualsModule(BaseModule):
         except (TypeError, ValueError):
             duration_ms = 1500
         return max(MIN_TRIGGER_DURATION_MS, min(MAX_TRIGGER_DURATION_MS, duration_ms))
+
+    @staticmethod
+    def _bounded_int(value: Any, *, default: int, minimum: int, maximum: int) -> int:
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            parsed = default
+        return max(minimum, min(maximum, parsed))
 
     @staticmethod
     def _validate_optional_string(arguments: dict[str, Any], key: str) -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_persona_visuals_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_persona_visuals_module.py
@@ -202,6 +202,19 @@ async def test_library_items_lists_reference_backed_personal_library_entries(cha
 
 
 @pytest.mark.asyncio
+async def test_library_items_rejects_out_of_range_offset(chacha_db) -> None:
+    _db, db_path = chacha_db
+    module = PersonaVisualsModule(ModuleConfig(name="persona_visuals"))
+
+    with pytest.raises(ValueError, match="offset must be between 0 and 1000000"):
+        await module.execute_tool(
+            "persona_visuals.library_items",
+            {"offset": 1_000_001},
+            context=_context(db_path),
+        )
+
+
+@pytest.mark.asyncio
 async def test_trigger_state_requires_context_rejects_unknown_states_and_clamps_duration(chacha_db) -> None:
     db, db_path = chacha_db
     persona_id = _create_persona(db)
@@ -346,6 +359,13 @@ async def test_use_library_item_rejects_missing_target_and_unavailable_sources(c
             "persona_visuals.use_library_item",
             {"item_id": item["id"]},
             context=_context(db_path),
+        )
+
+    with pytest.raises(ValueError, match="target_persona_id cannot be empty"):
+        await module.execute_tool(
+            "persona_visuals.use_library_item",
+            {"item_id": item["id"], "target_persona_id": "   "},
+            context=_context(db_path, target_persona_id),
         )
 
     db.soft_delete_persona_visual_pack_with_assets(

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_persona_visuals_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_persona_visuals_module.py
@@ -156,6 +156,52 @@ async def test_capabilities_returns_active_and_draft_pack_summaries(chacha_db) -
 
 
 @pytest.mark.asyncio
+async def test_library_items_lists_reference_backed_personal_library_entries(chacha_db) -> None:
+    db, db_path = chacha_db
+    source_persona_id = _create_persona(db, name="Source Persona")
+    source_pack = db.create_persona_visual_pack(
+        persona_id=source_persona_id,
+        user_id="1",
+        title="Reusable Source Pack",
+        manifest={"manifest_version": 1, "renderer_type": "sprite_frames"},
+    )
+    item = db.upsert_persona_visual_library_item(
+        user_id="1",
+        source_persona_id=source_persona_id,
+        source_pack_id=source_pack["id"],
+        title="Reusable Library Item",
+        notes="Use this across personas",
+        tags=["Idle", "Reusable"],
+    )
+    module = PersonaVisualsModule(ModuleConfig(name="persona_visuals"))
+
+    result = await module.execute_tool(
+        "persona_visuals.library_items",
+        {},
+        context=_context(db_path),
+    )
+
+    assert result["count"] == 1
+    assert result["items"] == [
+        {
+            "id": item["id"],
+            "title": "Reusable Library Item",
+            "notes": "Use this across personas",
+            "tags": ["idle", "reusable"],
+            "source_persona_id": source_persona_id,
+            "source_pack_id": source_pack["id"],
+            "source_persona_name": "Source Persona",
+            "source_pack_title": "Reusable Source Pack",
+            "source_pack_version": source_pack["version"],
+            "source_current_version": source_pack["version"],
+            "source_available": True,
+            "source_changed": False,
+            "version": item["version"],
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_trigger_state_requires_context_rejects_unknown_states_and_clamps_duration(chacha_db) -> None:
     db, db_path = chacha_db
     persona_id = _create_persona(db)
@@ -240,6 +286,87 @@ async def test_draft_tools_mutate_drafts_without_activating(chacha_db) -> None:
     assert updated["pack"]["status"] == "draft"
     assert updated["pack"]["version"] == created["pack"]["version"] + 1
     assert db.get_active_persona_visual_pack(persona_id=persona_id, user_id="1") is None
+
+
+@pytest.mark.asyncio
+async def test_use_library_item_creates_target_draft_without_activation(chacha_db) -> None:
+    db, db_path = chacha_db
+    source_persona_id = _create_persona(db, name="Source Persona")
+    target_persona_id = _create_persona(db, name="Target Persona")
+    source_pack = db.create_persona_visual_pack(
+        persona_id=source_persona_id,
+        user_id="1",
+        title="Reusable Source Pack",
+        manifest={"manifest_version": 1, "renderer_type": "sprite_frames"},
+    )
+    item = db.upsert_persona_visual_library_item(
+        user_id="1",
+        source_persona_id=source_persona_id,
+        source_pack_id=source_pack["id"],
+        title="Reusable Library Item",
+    )
+    module = PersonaVisualsModule(ModuleConfig(name="persona_visuals"))
+
+    result = await module.execute_tool(
+        "persona_visuals.use_library_item",
+        {"item_id": item["id"], "target_persona_id": target_persona_id, "title": "Target Draft"},
+        context=_context(db_path),
+    )
+
+    assert result["library_item_id"] == item["id"]
+    assert result["review_required"] is True
+    assert result["pack"]["persona_id"] == target_persona_id
+    assert result["pack"]["title"] == "Target Draft"
+    assert result["pack"]["status"] == "draft"
+    assert result["pack"]["parent_pack_id"] == source_pack["id"]
+    assert db.get_active_persona_visual_pack(persona_id=target_persona_id, user_id="1") is None
+
+
+@pytest.mark.asyncio
+async def test_use_library_item_rejects_missing_target_and_unavailable_sources(chacha_db) -> None:
+    db, db_path = chacha_db
+    source_persona_id = _create_persona(db, name="Source Persona")
+    target_persona_id = _create_persona(db, name="Target Persona")
+    source_pack = db.create_persona_visual_pack(
+        persona_id=source_persona_id,
+        user_id="1",
+        title="Reusable Source Pack",
+        manifest={"manifest_version": 1, "renderer_type": "sprite_frames"},
+    )
+    item = db.upsert_persona_visual_library_item(
+        user_id="1",
+        source_persona_id=source_persona_id,
+        source_pack_id=source_pack["id"],
+        title="Reusable Library Item",
+    )
+    module = PersonaVisualsModule(ModuleConfig(name="persona_visuals"))
+
+    with pytest.raises(ValueError, match="Missing target persona context"):
+        await module.execute_tool(
+            "persona_visuals.use_library_item",
+            {"item_id": item["id"]},
+            context=_context(db_path),
+        )
+
+    db.soft_delete_persona_visual_pack_with_assets(
+        pack_id=source_pack["id"],
+        persona_id=source_persona_id,
+        user_id="1",
+    )
+
+    with pytest.raises(ValueError, match="Source Persona Visual pack is no longer available"):
+        await module.execute_tool(
+            "persona_visuals.use_library_item",
+            {"item_id": item["id"], "target_persona_id": target_persona_id},
+            context=_context(db_path),
+        )
+
+    with pytest.raises(ValueError, match="Persona Visual library item not found"):
+        await module.execute_tool(
+            "persona_visuals.use_library_item",
+            {"item_id": "missing-item", "target_persona_id": target_persona_id},
+            context=_context(db_path),
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- add `persona_visuals.library_items` for read-only, reference-backed personal Persona Visual library discovery
- add `persona_visuals.use_library_item` to create inactive target-persona drafts through existing library/duplicate semantics
- update Persona Visual Packs docs and PRD MCP contract for reusable-pack tool boundaries

## Change summary

Maintainer-authored change summary required before merge per AI-generated PR policy.

## Verification

- `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_persona_visuals_module.py -q` - 9 passed
- `git diff --check`
- `git diff --check --cached`
- `python -m bandit -r tldw_Server_API/app/core/MCP_unified/modules/implementations/persona_visuals_module.py -f json -o /tmp/bandit_persona_mcp_reuse.json` - 0 findings

Closes #1496.
