### PR TITLE
Document Persona visual renderer adapter evaluation

### DIFF
--- a/Docs/Code_Documentation/Persona_Visual_Packs.md
+++ b/Docs/Code_Documentation/Persona_Visual_Packs.md
@@ -44,6 +44,18 @@ work. It keeps today's pack attached to one persona while leaving room for later
 duplicate-to-persona, import/export, and shared-library workflows without
 changing the core pack format.
 
+V1 validation and Buddy runtime support are intentionally limited to
+`sprite_frames`. Reserved renderer labels in API/UI types are not support
+claims until backend manifest validation, import preview, Buddy runtime
+rendering, and capability reporting all agree on the new renderer contract.
+
+Future renderer/provider adapter work is evaluated in
+`Docs/Design/2026-05-10-persona-visual-renderer-provider-adapter-evaluation.md`.
+That evaluation keeps Live2D, Rive, Lottie, Spine, and external MCP-compatible
+pack providers separate from the current V1 activation path. The recommended
+next step is a renderer capability contract and safe sprite atlas extension
+before any non-sprite adapter implementation.
+
 ## Personal Library
 
 The personal library is a user-scoped metadata layer over existing Persona

--- a/Docs/Design/2026-05-10-persona-visual-renderer-provider-adapter-evaluation.md
+++ b/Docs/Design/2026-05-10-persona-visual-renderer-provider-adapter-evaluation.md
@@ -1,0 +1,402 @@
+# Persona Visual Renderer and Provider Adapter Evaluation
+
+Tracks GitHub issue #1497 under the Persona/Buddy visual-pack epic #1449.
+
+## Decision Summary
+
+Do not implement Live2D or another non-sprite renderer as the next code slice.
+The current Persona/Buddy system should first add a renderer/provider capability
+contract that keeps V1 `sprite_frames` behavior unchanged, then pursue a
+feature-flagged Live2D spike only after licensing, bundle validation, and
+fallback rules are explicit.
+
+Recommended sequencing:
+
+1. Keep `sprite_frames` as the only activatable runtime renderer for V1.
+2. Add a renderer registry/capabilities contract before accepting new
+   `renderer_type` values in manifests or imports.
+3. Add a sprite atlas/sprite-sheet performance extension inside the existing
+   sprite family before adding skeletal/model renderers.
+4. Run a Live2D adapter spike behind a feature flag, using local bundled assets
+   only and preserving review-before-activation.
+5. Treat external providers as draft-pack or generated-candidate producers, not
+   as live renderer plugins.
+
+This preserves the existing product invariants: assets are user-owned, packs are
+attached to one persona by default, manifests are the portability boundary,
+imports/generation/MCP durable changes stay review-first, and activation remains
+explicit.
+
+## Current Persona/Buddy Contract
+
+The implementation is already renderer-named but not renderer-pluggable:
+
+1. `tldw_Server_API/app/core/Persona/visuals.py` defines the supported visual
+   states, validates manifest version `1`, and only accepts
+   `renderer_type == "sprite_frames"` for activatable manifests.
+2. `tldw_Server_API/app/core/Persona/visual_service.py` validates uploads as
+   raster images, validates manifests during activation and candidate accept,
+   and creates duplicated packs as inactive drafts.
+3. `tldw_Server_API/app/core/Persona/visual_portability/preview.py` validates
+   imported archives by reusing the same manifest validator, so non-sprite
+   imports currently fail during preview.
+4. `apps/packages/ui/src/components/Common/PersonaBuddy/SpriteFrameRenderer.tsx`
+   renders state-resolved frame sequences or sprite-sheet regions and falls
+   back to text when an animation, asset, or region is invalid.
+5. `apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellDock.tsx`
+   gates runtime rendering on `visualPack.renderer_type === "sprite_frames"`.
+6. `apps/packages/ui/src/components/Common/PersonaBuddy/personaVisualState.ts`
+   resolves named Persona visual states independently of renderer format.
+
+The TypeScript and Pydantic renderer unions already include reserved labels such
+as `static_image`, `sprite_sheet`, and `live2d`, but those are not support
+claims. Backend validation and Buddy runtime rendering are still sprite/frame
+only.
+
+## Evaluation Criteria
+
+Any renderer or provider path must satisfy these constraints:
+
+1. User-owned assets stay scoped to a user and attached to one persona by
+   default.
+2. Pack data remains manifest-backed and portable through archive export/import.
+3. No import, generated candidate, library reuse, or MCP durable action silently
+   activates a pack.
+4. Runtime failure cannot block live assistant controls.
+5. Untrusted packs cannot execute JavaScript, load remote URLs, escape archive
+   paths, exceed bounded size/dimension limits, or leak assets across users.
+6. Renderer dependencies must be optional, feature-gated where needed, and
+   detectable by API/UI capabilities before users queue work.
+7. Licensing must be compatible with a local/self-hosted open-source project and
+   clear enough for users who import their own assets.
+
+## Candidate Renderer Paths
+
+### 1. Sprite Frames and Sprite Sheets
+
+Status: viable, keep as baseline and first implementation target.
+
+Fit:
+
+1. Matches the current `sprite_frames` manifest, asset upload validation, Buddy
+   renderer, import/export preview, generation review, library duplication, and
+   MCP draft semantics.
+2. Supports still poses, frame sequences, and sprite-sheet regions without new
+   runtime dependencies.
+3. Keeps generated providers simple: produce raster assets plus manifest patches.
+
+Limits:
+
+1. Large frame sequences can be heavy compared with skeletal/model runtimes.
+2. Complex motion, eye tracking, and parameterized expression control require
+   many frames or a future renderer.
+3. Runtime interpolation is limited to frame timing and fallback chains.
+
+Recommendation:
+
+Extend the existing renderer family before adding new renderer engines:
+
+1. Add optional `sprite_sheet`/atlas capability metadata only after backend
+   validation and Buddy rendering agree on the support boundary.
+2. Keep it within the same raster-safe validation model: bounded dimensions,
+   byte size, region bounds, checksums, no executable content.
+3. Treat this as the lowest-risk bridge between current sprite packs and richer
+   renderer adapters.
+
+### 2. Live2D Cubism Web
+
+Status: viable future spike, not immediate implementation.
+
+Fit:
+
+1. Live2D is the strongest expressive-persona match among evaluated options:
+   parameterized models, textures, motions, expressions, physics, pose files,
+   and WebGL rendering align with 2D assistant/persona expectations.
+2. The official Web SDK is designed for programmatic use of Cubism models, and
+   Live2D model metadata is centered on a `.model3.json` file that references
+   model and related assets such as `.moc3`, textures, motions, expressions,
+   physics, and pose data.
+
+Risks:
+
+1. Licensing is not a normal MIT dependency path. Live2D states that business
+   entities publishing content using the SDK need a release/publication license,
+   while individuals and small-scale enterprises have exemptions except for
+   expandable applications. The project needs a product/legal gate before any
+   default-enabled Live2D support.
+2. Cubism Core is not published on GitHub under the same terms as the framework;
+   the official docs say it is included in the SDK package from Live2D.
+3. Imported model bundles are multi-file and cross-referenced, so archive
+   preview must validate every local reference and reject remote URLs, absolute
+   paths, path traversal, duplicate member ambiguity, and missing checksums.
+4. Runtime memory and GPU/WebGL behavior need explicit bounds and fallback UI.
+5. Third-party wrappers can reduce integration effort but should not define the
+   project contract. The contract should be compatible with the official SDK
+   asset model first.
+
+Minimum manifest shape for a spike:
+
+```json
+{
+  "manifest_version": 2,
+  "renderer_type": "live2d",
+  "renderer_contract_version": 1,
+  "renderer_assets": {
+    "model3_json_asset_id": "asset-model-json",
+    "fallback_preview_asset_id": "asset-preview"
+  },
+  "states": {
+    "idle": {
+      "animation_id": "idle"
+    }
+  },
+  "animations": {
+    "idle": {
+      "motion_group": "Idle",
+      "expression_id": "default"
+    }
+  },
+  "fallbacks": {
+    "thinking": ["idle"]
+  }
+}
+```
+
+Open design points before implementation:
+
+1. Whether Live2D assets are stored as generic `PersonaVisualAsset` rows with
+   expanded roles or as a renderer-specific asset manifest section.
+2. Whether model-relative file references are remapped to asset ids during
+   import, or retained only inside a validated local bundle directory.
+3. Whether lip sync and look-at controls belong in the renderer adapter or a
+   higher-level Persona Live state bridge.
+4. How to surface license/setup status in generation readiness and renderer
+   capabilities without blocking sprite/frame users.
+
+Recommendation:
+
+Pursue Live2D only after the registry/capability and archive validation work is
+complete. The first Live2D PR should be an opt-in spike with mocked fixtures,
+feature gating, no cloud dependency, no automatic activation, and a static
+fallback frame for every pack.
+
+### 3. Rive
+
+Status: viable for simple interactive vector personas, defer for now.
+
+Fit:
+
+1. Rive's official web runtime is JavaScript/WASM and supports high-level
+   animation/state-machine control as well as lower-level render-loop control.
+2. Rive states its official runtimes are MIT-licensed for personal and
+   commercial applications.
+3. `.riv` files are compact and can map cleanly to named states.
+
+Limits:
+
+1. Rive is a general interactive animation format, not a persona model format.
+   It does not directly align with Live2D-style model, texture, expression, and
+   motion authoring.
+2. The authoring toolchain is external to the current Persona Garden editor.
+3. Runtime WASM loading, renderer choice, and asset loading need capability and
+   fallback work similar to Live2D.
+
+Recommendation:
+
+Do not implement before Live2D evaluation unless the product goal shifts toward
+lightweight vector mascots rather than model-backed persona avatars. Keep it as
+a possible future `rive` renderer after the registry exists.
+
+### 4. Lottie or dotLottie
+
+Status: viable for decorative/state animations, not recommended for primary
+persona model packs.
+
+Fit:
+
+1. `lottie-web` is MIT-licensed and renders After Effects/Bodymovin JSON with
+   SVG, canvas, or HTML renderers.
+2. Lottie is easy to use for authored idle/listening/thinking/speaking loops and
+   may be useful for simple built-in examples.
+
+Limits:
+
+1. Lottie is not a good user-uploaded persona model boundary by itself. It is an
+   animation playback format, not a structured character model format.
+2. SVG/HTML rendering paths increase the review burden for untrusted user
+   uploads. A future Lottie renderer would need strict JSON schema validation,
+   renderer restrictions, remote asset rejection, and possibly canvas-only
+   runtime policy.
+3. Mapping Persona state to Lottie segments is weaker than the current manifest
+   state/animation structure unless the project defines marker conventions.
+
+Recommendation:
+
+Reject as a near-term primary Persona/Buddy renderer. Consider later for bundled
+starter assets or simple user-authored loops after renderer registry and import
+validation are mature.
+
+### 5. Spine
+
+Status: reject for this effort.
+
+Fit:
+
+1. Spine is a mature 2D skeletal animation ecosystem with web runtimes.
+
+Risks:
+
+1. The official runtime license requires either terms tied to the Spine Editor
+   license or each user of products containing the runtimes to have their own
+   Spine Editor license unless distribution conditions are satisfied.
+2. The licensing and authoring requirements are too heavy for the current
+   self-hosted Persona/Buddy visual-pack goal.
+
+Recommendation:
+
+Do not pursue unless a future user base explicitly asks for Spine import and
+the licensing implications are accepted.
+
+### 6. Arbitrary HTML, SVG, JavaScript, or Web Components
+
+Status: reject.
+
+Fit:
+
+1. Maximum flexibility for custom avatars and third-party widgets.
+
+Risks:
+
+1. Conflicts with the review-first, local, user-owned safety model because packs
+   would become executable UI plugins.
+2. Introduces XSS, CSS escape, remote network loading, CSP, extension sidepanel,
+   and cross-user data exposure concerns.
+3. Hard to preserve deterministic fallback and archive portability.
+
+Recommendation:
+
+Never accept arbitrary executable renderer packs as Persona Visual Packs. If a
+future custom-renderer plugin system exists, it should be an admin-installed
+extension, not a user-uploaded pack.
+
+## Candidate Provider Paths
+
+Providers should create or transform packs; they should not become runtime
+renderers.
+
+### Local Image Generation Provider
+
+Status: viable, already aligned with current Jobs/candidate flow.
+
+The current generation model is the right abstraction: a background job produces
+raster assets and a proposed manifest patch, then the user accepts or rejects
+the candidate. Extend this path for more states, pose prompts, sprite sheets, or
+atlas output before adding renderer engines.
+
+### External MCP-Compatible Pack Provider
+
+Status: viable later, with strict review boundaries.
+
+An MCP provider should return one of:
+
+1. a proposed manifest patch for an existing draft pack,
+2. a generated-candidate payload,
+3. a portable pack archive for import preview,
+4. a request to create a new draft pack.
+
+It must never return executable renderer code, mutate the active pack, or bypass
+Persona Garden review.
+
+### Cloud Marketplace or Shared Library Provider
+
+Status: out of scope for this issue.
+
+Cloud/shared-provider semantics would need account, trust, moderation, quota,
+license, and cross-user sharing decisions. Keep #1497 focused on local/self-
+hosted renderer/provider feasibility.
+
+## Required Extension Points
+
+Add these before enabling non-sprite manifests:
+
+1. Backend renderer registry:
+   - renderer id, display name, supported manifest versions, supported asset
+     roles, MIME types/extensions, size limits, activatable flag, feature flag,
+     validation function, import/export support, and fallback requirements.
+2. API capability endpoint or field:
+   - expose available renderers and setup blockers to Persona Garden and MCP
+     tools, similar to generation readiness diagnostics.
+3. Manifest versioning:
+   - keep V1 `sprite_frames` intact.
+   - introduce `manifest_version: 2` or `renderer_contract_version` before
+     accepting renderer-specific payloads.
+4. Renderer asset metadata:
+   - support model, texture, motion, expression, physics, pose, atlas, preview,
+     fallback, license/readme, and source-manifest roles without relaxing
+     ownership checks.
+5. Import preview validation:
+   - renderer-specific archive validation must run during preview and report
+     warnings, blockers, quota estimates, fallback availability, and unsupported
+     renderer status before commit.
+6. Frontend renderer registry:
+   - Buddy should choose a renderer by registry lookup and fall back cleanly
+     when unsupported, missing, or feature-gated.
+7. MCP capability contract:
+   - `persona_visuals.capabilities` should distinguish runtime trigger support,
+     draft creation support, generation provider readiness, and renderer support.
+
+## Security and Portability Rules
+
+All renderer/provider follow-ups should enforce:
+
+1. No remote asset URLs inside manifests or renderer-specific files.
+2. No executable JavaScript, HTML, or unreviewed SVG in user-uploaded packs.
+3. Archive path normalization, duplicate-member rejection, size limits, and
+   checksum validation before preview succeeds.
+4. Renderer-specific file-reference validation before asset rows are created.
+5. Per-renderer maximum file count, total bytes, texture dimensions, and runtime
+   canvas bounds.
+6. Static fallback asset required for every non-sprite pack.
+7. Optional dependency failures must degrade to Buddy's existing text/static
+   summary without breaking live controls.
+8. Export archives must include enough renderer metadata to restore the same
+   draft pack on another device, but activation must remain separate.
+
+## Follow-Up Issue Slices
+
+1. Renderer capability registry for Persona Visual Packs:
+   define backend/frontend/MCP capability reporting while preserving
+   `sprite_frames` as the only activatable renderer.
+2. Sprite atlas/sprite-sheet V1.1:
+   formalize atlas validation and Buddy rendering as a safe performance
+   extension.
+3. Non-sprite manifest V2 design:
+   define renderer-specific asset roles, fallback requirements, and import
+   preview validation hooks.
+4. Live2D adapter spike:
+   opt-in Web renderer proof of concept using local fixtures, explicit license
+   gate, static fallback, and no automatic activation.
+5. External MCP pack-provider contract:
+   allow providers to submit draft packs, archive previews, or generated
+   candidates without runtime code or active-pack mutation.
+
+## Source Notes
+
+1. Live2D Cubism SDK for Web docs describe the Web SDK as a development kit for
+   programmatic Cubism model use and note that Cubism Core is included in the
+   official SDK package rather than published on GitHub:
+   https://docs.live2d.com/en/cubism-sdk-manual/cubism-sdk-for-web/
+2. Live2D model docs describe `.model3.json` as the file that tracks model
+   references and `.moc3` as the file containing model movement data:
+   https://docs.live2d.com/en/cubism-sdk-manual/model-web/
+3. Live2D SDK release licensing needs product review before release usage:
+   https://www.live2d.com/en/sdk/license/
+4. Rive official runtime docs describe the web runtime as JavaScript/WASM and
+   state the official runtimes are MIT-licensed:
+   https://rive.app/docs/runtimes/web/web-js and
+   https://rive.app/docs/runtimes/getting-started
+5. `lottie-web` is MIT-licensed and supports SVG, canvas, and HTML renderers:
+   https://github.com/airbnb/lottie-web
+6. Spine runtime licensing is not a simple permissive dependency fit for this
+   feature:
+   https://en.esotericsoftware.com/spine-runtimes-license

--- a/Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md
+++ b/Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md
@@ -310,8 +310,9 @@ by PR #1135 asset-pack portability:
 
 Users SHOULD be able to save an existing same-user visual pack into a personal
 library as metadata, not as an immediate asset copy. V1 library entries are
-user-scoped references to a source persona and source pack with display
-snapshots so stale entries can still be shown and removed.
+user-scoped references to a source persona and source pack. V1 intentionally
+does not store display snapshots; listing derives source display names from live
+source rows when those rows still resolve.
 
 Saving the same source pack SHOULD be idempotent. Using a library item SHOULD
 duplicate the referenced source pack to the chosen target persona as a draft and
@@ -569,8 +570,10 @@ baseline. The first reference-backed V1 slices are now covered:
    library entries and creating inactive target-persona drafts (#1496).
 6. Shared/cross-device libraries remain future work.
 7. External MCP-compatible visual providers remain future work.
-8. Live2D or other renderer adapter remains future work after the sprite/frame
-   path is stable.
+8. Renderer/provider adapter evaluation for Live2D and other future paths is
+   tracked by #1497 and the 2026-05-10 design evaluation.
+9. Live2D or other renderer adapter implementation remains future work after the
+   sprite/frame path and renderer capability contract are stable.
 
 ---
 
@@ -668,3 +671,9 @@ E2E:
 10. Issue #1450: Same-user Persona Visual pack duplicate-to-persona draft flow.
 11. Issue #1468: Personal Persona Visual pack library foundation.
 12. Issue #1490: Persona visual-pack import conflict choices.
+13. Issue #1493: Persona Garden reusable affordances.
+14. Issue #1496: MCP reusable-pack semantics for reference-backed personal
+    library entries.
+15. Issue #1497: Persona visual-pack renderer/provider adapter evaluation.
+16. Renderer/provider adapter evaluation:
+    `Docs/Design/2026-05-10-persona-visual-renderer-provider-adapter-evaluation.md`

--- a/backlog/tasks/task-221 - Evaluate-Persona-Visual-renderer-and-provider-adapters.md
+++ b/backlog/tasks/task-221 - Evaluate-Persona-Visual-renderer-and-provider-adapters.md
@@ -1,0 +1,72 @@
+---
+id: TASK-221
+title: Evaluate Persona Visual renderer and provider adapters
+status: Done
+assignee: []
+created_date: '2026-05-10 05:30'
+labels:
+  - persona
+  - visual-packs
+  - research
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1449'
+  - 'https://github.com/rmusser01/tldw_server/issues/1497'
+documentation:
+  - Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md
+  - Docs/Code_Documentation/Persona_Visual_Packs.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Research GitHub issue #1497 for the Persona/Buddy visual-pack system. Produce a repo-grounded evaluation of future renderer/provider adapter options, including Live2D-style model support and other local/self-hosted renderer paths, without implementing an adapter. The evaluation must preserve existing user-owned, manifest-backed, review-before-activation semantics and stay separate from VN Play asset-pack runtime work.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Evaluation names viable and rejected renderer/provider options with concrete tradeoffs.
+- [x] #2 Recommendation preserves user-owned, manifest-backed, review-first Persona/Buddy pack semantics.
+- [x] #3 Required manifest/API extension points are identified and scoped for future issues.
+- [x] #4 Runtime, licensing, security, portability, asset-size, dependency, and fallback risks are explicit enough to decide whether Live2D or another adapter should be pursued.
+- [x] #5 Documentation is committed and linked to GitHub issue #1497.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Ground the evaluation in the current Persona/Buddy visual-pack code and docs, especially manifest validation, Buddy runtime rendering, import/export preview, personal library semantics, and MCP durable/runtime boundaries.
+2. Check current external renderer/provider facts from primary sources where licensing or runtime behavior can drift.
+3. Add a docs-only renderer/provider adapter evaluation that names viable and rejected options, recommends sequencing, and identifies manifest/API extension points without implementing adapters.
+4. Update existing Persona Visual docs only where they need to link the evaluation or correct stale wording that conflicts with current reference-backed/no-snapshot library semantics.
+5. Run documentation verification, update this task with evidence, then commit the research slice for a PR linked to #1497.
+<!-- SECTION:PLAN:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Added `Docs/Design/2026-05-10-persona-visual-renderer-provider-adapter-evaluation.md` with a repo-grounded renderer/provider evaluation for #1497.
+- Recommended keeping `sprite_frames` as the only V1 activatable renderer while adding a renderer capability contract before non-sprite manifests.
+- Identified Live2D as the best expressive 2D persona candidate, gated by licensing, official SDK packaging, archive validation, dependency, and fallback requirements.
+- Deferred Rive/Lottie to later registry-backed renderer paths and rejected Spine plus arbitrary executable HTML/SVG/JS renderer packs for this slice.
+- Corrected stale PRD wording so the personal visual library remains reference-backed with no display snapshots.
+- Verification: `git diff --check` passed.
+- Bandit: skipped because this is a docs/backlog-only research change with no touched Python code.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Completed the #1497 research slice by documenting renderer/provider adapter options, recommended sequencing, manifest/API extension points, and runtime/licensing/security/portability risks for future Persona/Buddy visual-pack renderer support.
+<!-- SECTION:FINAL_SUMMARY:END -->


### PR DESCRIPTION
## Summary

- Adds a repo-grounded design evaluation for Persona/Buddy visual renderer and provider adapters under #1497.
- Recommends keeping `sprite_frames` as the only V1 activatable renderer while adding a renderer capability contract before non-sprite manifests.
- Evaluates Live2D, Rive, Lottie, Spine, arbitrary executable renderers, local generation providers, and external MCP-compatible pack providers.
- Links the evaluation from the Persona Visual docs and corrects stale PRD wording so the personal visual library remains reference-backed with no display snapshots.
- Adds Backlog task `TASK-221` for the research slice.

## Verification

- `git diff --cached --check`
- `git diff --check`
- Bandit skipped: docs/backlog-only change, no touched Python code.

## Change Summary

Human maintainer summary required before merge per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

Closes #1497.
