### PR TITLE
Stabilize ACP Agent Registry E2E readiness

### DIFF
--- a/apps/tldw-frontend/e2e/utils/page-objects/AgentRegistryPage.ts
+++ b/apps/tldw-frontend/e2e/utils/page-objects/AgentRegistryPage.ts
@@ -13,6 +13,11 @@ import { type Page, type Locator } from "@playwright/test"
 import { BasePage, type InteractiveElement } from "./BasePage"
 import { waitForAppShell, waitForConnection } from "../helpers"
 
+export interface AgentRegistryHealthState {
+  loaded: boolean
+  unavailable: boolean
+}
+
 export class AgentRegistryPage extends BasePage {
   constructor(page: Page) {
     super(page)
@@ -95,17 +100,35 @@ export class AgentRegistryPage extends BasePage {
   /** Wait for the health card to finish its loading state. */
   async waitForHealthSettled(timeout = 20_000): Promise<void> {
     await Promise.race([
-      this.runnerBinaryLabel.waitFor({ state: "visible", timeout }),
+      Promise.all([
+        this.runnerBinaryLabel.waitFor({ state: "visible", timeout }),
+        this.agentStatusLabel.waitFor({ state: "visible", timeout }),
+        this.apiKeysLabel.waitFor({ state: "visible", timeout }),
+      ]),
       this.healthUnavailableWarning.waitFor({ state: "visible", timeout }),
     ])
   }
 
+  /** Wait once for health to settle, then read the resulting state. */
+  async getHealthState(timeout = 20_000): Promise<AgentRegistryHealthState> {
+    await this.waitForHealthSettled(timeout)
+    const [runnerVisible, agentVisible, apiKeysVisible, unavailable] =
+      await Promise.all([
+        this.runnerBinaryLabel.isVisible().catch(() => false),
+        this.agentStatusLabel.isVisible().catch(() => false),
+        this.apiKeysLabel.isVisible().catch(() => false),
+        this.healthUnavailableWarning.isVisible().catch(() => false),
+      ])
+
+    return {
+      loaded: runnerVisible && agentVisible && apiKeysVisible,
+      unavailable,
+    }
+  }
+
   /** Check if health data loaded successfully (status indicators are visible) */
   async isHealthDataLoaded(): Promise<boolean> {
-    await this.waitForHealthSettled().catch(() => {})
-    const runnerVisible = await this.runnerBinaryLabel.isVisible().catch(() => false)
-    const agentVisible = await this.agentStatusLabel.isVisible().catch(() => false)
-    return runnerVisible && agentVisible
+    return (await this.getHealthState()).loaded
   }
 
   /** Wait for the agent list to finish its loading state. */
@@ -127,8 +150,7 @@ export class AgentRegistryPage extends BasePage {
 
   /** Check if the page is showing health warning (server unreachable) */
   async isHealthUnavailable(): Promise<boolean> {
-    await this.waitForHealthSettled().catch(() => {})
-    return this.healthUnavailableWarning.isVisible().catch(() => false)
+    return (await this.getHealthState()).unavailable
   }
 
   // -- Interactive elements for assertAllButtonsWired() ----------------------

--- a/apps/tldw-frontend/e2e/utils/page-objects/AgentRegistryPage.ts
+++ b/apps/tldw-frontend/e2e/utils/page-objects/AgentRegistryPage.ts
@@ -9,7 +9,7 @@
  * Route: /agents
  * Component: packages/ui/src/components/Option/AgentRegistry/index.tsx
  */
-import { type Page, type Locator, expect } from "@playwright/test"
+import { type Page, type Locator } from "@playwright/test"
 import { BasePage, type InteractiveElement } from "./BasePage"
 import { waitForAppShell, waitForConnection } from "../helpers"
 
@@ -92,20 +92,42 @@ export class AgentRegistryPage extends BasePage {
 
   // -- Helpers ----------------------------------------------------------------
 
+  /** Wait for the health card to finish its loading state. */
+  async waitForHealthSettled(timeout = 20_000): Promise<void> {
+    await Promise.race([
+      this.runnerBinaryLabel.waitFor({ state: "visible", timeout }),
+      this.healthUnavailableWarning.waitFor({ state: "visible", timeout }),
+    ])
+  }
+
   /** Check if health data loaded successfully (status indicators are visible) */
   async isHealthDataLoaded(): Promise<boolean> {
+    await this.waitForHealthSettled().catch(() => {})
     const runnerVisible = await this.runnerBinaryLabel.isVisible().catch(() => false)
     const agentVisible = await this.agentStatusLabel.isVisible().catch(() => false)
     return runnerVisible && agentVisible
   }
 
+  /** Wait for the agent list to finish its loading state. */
+  async waitForAgentListSettled(timeout = 20_000): Promise<void> {
+    await Promise.race([
+      this.agentCards.first().waitFor({ state: "visible", timeout }),
+      this.launchButtons.first().waitFor({ state: "visible", timeout }),
+      this.noAgentsMessage.waitFor({ state: "visible", timeout }),
+    ])
+  }
+
   /** Get the count of visible agent cards */
   async getAgentCount(): Promise<number> {
-    return this.agentCards.count()
+    await this.waitForAgentListSettled()
+    const cardCount = await this.agentCards.count()
+    if (cardCount > 0) return cardCount
+    return this.launchButtons.count()
   }
 
   /** Check if the page is showing health warning (server unreachable) */
   async isHealthUnavailable(): Promise<boolean> {
+    await this.waitForHealthSettled().catch(() => {})
     return this.healthUnavailableWarning.isVisible().catch(() => false)
   }
 

--- a/apps/tldw-frontend/e2e/workflows/tier-3-automation/agent-registry.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/tier-3-automation/agent-registry.spec.ts
@@ -60,13 +60,12 @@ test.describe("Agent Registry", () => {
       await registry.assertPageReady()
 
       // Either health data is loaded or the warning is shown
-      const healthLoaded = await registry.isHealthDataLoaded()
-      const healthUnavailable = await registry.isHealthUnavailable()
+      const healthState = await registry.getHealthState()
 
-      expect(healthLoaded || healthUnavailable).toBe(true)
+      expect(healthState.loaded || healthState.unavailable).toBe(true)
 
       // If health data is loaded, all three indicators should be visible
-      if (healthLoaded) {
+      if (healthState.loaded) {
         await expect(registry.runnerBinaryLabel).toBeVisible()
         await expect(registry.agentStatusLabel).toBeVisible()
         await expect(registry.apiKeysLabel).toBeVisible()

--- a/backlog/tasks/task-222 - Stabilize-ACP-Agent-Registry-live-E2E-readiness.md
+++ b/backlog/tasks/task-222 - Stabilize-ACP-Agent-Registry-live-E2E-readiness.md
@@ -1,0 +1,58 @@
+---
+id: TASK-222
+title: Stabilize ACP Agent Registry live E2E readiness
+status: In Progress
+assignee: []
+created_date: '2026-05-10 05:44'
+labels:
+  - acp
+  - e2e
+  - release-signoff
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1505'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The ACP release-signoff run for GitHub issue #1505 found that the Agent Registry E2E can assert before the live agent list finishes loading. The page eventually renders the expected registered agents, so the task is to make the E2E page object wait for the real settled state before counting cards, without masking genuine backend or UI errors.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Agent Registry page object waits for either rendered agent entries or the no-agents empty state before list assertions run.
+- [x] #2 Live Agent Registry E2E no longer fails while the page is still showing loading spinners.
+- [x] #3 The focused ACP tier-3 browser specs pass against the seeded live backend.
+- [x] #4 GitHub issue #1505 is updated with the before/after validation evidence.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Notes
+
+- Reproduced the live Agent Registry race with the seeded backend: the focused `should show agent cards or empty state` test failed before the agent list left its loading state.
+- Added explicit health-card and agent-list settled waits to the Agent Registry E2E page object.
+- Removed an existing unused `expect` import from the touched page object so the focused lint check is clean.
+- Bandit is not applicable because this task only touches TypeScript E2E page-object code and a Backlog task record.
+
+## Verification
+
+- Red: `TLDW_WEB_URL=http://localhost:8080 TLDW_WEB_AUTOSTART=false TLDW_SERVER_URL=http://127.0.0.1:8000 TLDW_API_KEY=<seeded> TLDW_E2E_ALLOW_OFFLINE=0 bunx playwright test e2e/workflows/tier-3-automation/agent-registry.spec.ts -g 'should show agent cards or empty state' --reporter=line` failed with the original assertion.
+- Focused green: same command passed after the agent-list wait fix.
+- Health focused green: `TLDW_WEB_URL=http://localhost:18083 TLDW_WEB_CMD='bun run dev -- -p 18083' ... bunx playwright test e2e/workflows/tier-3-automation/agent-registry.spec.ts -g 'should show health status indicators or health unavailable warning' --reporter=line` passed.
+- Final live slice: `TLDW_WEB_URL=http://localhost:18083 TLDW_WEB_CMD='bun run dev -- -p 18083' TLDW_SERVER_URL=http://127.0.0.1:8000 TLDW_API_KEY=<seeded> TLDW_E2E_ALLOW_OFFLINE=0 bunx playwright test e2e/workflows/tier-3-automation/acp-playground.spec.ts e2e/workflows/tier-3-automation/agent-registry.spec.ts e2e/workflows/tier-3-automation/agent-tasks.spec.ts --reporter=line` passed `19 passed (2.2m)`.
+- Focused lint: `bunx eslint e2e/utils/page-objects/AgentRegistryPage.ts` passed with no warnings.
+
+## Final Summary
+
+Stabilized the ACP Agent Registry E2E page object by waiting for the health card and registered-agent list to finish loading before sampling their state. The full live ACP tier-3 browser slice passes against the seeded backend after the fix. Evidence was posted to GitHub issue #1505 and parent tracker #1500; #1505 remains open pending PR #1507 merge or explicit acceptance of local branch validation.

--- a/backlog/tasks/task-222 - Stabilize-ACP-Agent-Registry-live-E2E-readiness.md
+++ b/backlog/tasks/task-222 - Stabilize-ACP-Agent-Registry-live-E2E-readiness.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-222
 title: Stabilize ACP Agent Registry live E2E readiness
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-10 05:44'
+updated_date: '2026-05-10 15:34'
 labels:
   - acp
   - e2e
@@ -28,18 +29,9 @@ The ACP release-signoff run for GitHub issue #1505 found that the Agent Registry
 - [x] #4 GitHub issue #1505 is updated with the before/after validation evidence.
 <!-- AC:END -->
 
-## Definition of Done
-<!-- DOD:BEGIN -->
-- [x] #1 Acceptance criteria completed
-- [x] #2 Tests or verification recorded
-- [x] #3 Documentation updated when relevant
-- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [x] #5 Final summary added
-- [x] #6 Known skips or blockers documented
-<!-- DOD:END -->
-
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 - Reproduced the live Agent Registry race with the seeded backend: the focused `should show agent cards or empty state` test failed before the agent list left its loading state.
 - Added explicit health-card and agent-list settled waits to the Agent Registry E2E page object.
 - Removed an existing unused `expect` import from the touched page object so the focused lint check is clean.
@@ -53,6 +45,21 @@ The ACP release-signoff run for GitHub issue #1505 found that the Agent Registry
 - Final live slice: `TLDW_WEB_URL=http://localhost:18083 TLDW_WEB_CMD='bun run dev -- -p 18083' TLDW_SERVER_URL=http://127.0.0.1:8000 TLDW_API_KEY=<seeded> TLDW_E2E_ALLOW_OFFLINE=0 bunx playwright test e2e/workflows/tier-3-automation/acp-playground.spec.ts e2e/workflows/tier-3-automation/agent-registry.spec.ts e2e/workflows/tier-3-automation/agent-tasks.spec.ts --reporter=line` passed `19 passed (2.2m)`.
 - Focused lint: `bunx eslint e2e/utils/page-objects/AgentRegistryPage.ts` passed with no warnings.
 
+Review follow-up for PR #1507: replaced swallowed health-settle waits with an observable getHealthState() helper and updated the health-status spec to read loaded/unavailable state after one settle wait. Added explicit parent #1500 evidence URL to the final summary for auditability.
+<!-- SECTION:NOTES:END -->
+
 ## Final Summary
 
-Stabilized the ACP Agent Registry E2E page object by waiting for the health card and registered-agent list to finish loading before sampling their state. The full live ACP tier-3 browser slice passes against the seeded backend after the fix. Evidence was posted to GitHub issue #1505 and parent tracker #1500; #1505 remains open pending PR #1507 merge or explicit acceptance of local branch validation.
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Stabilized the ACP Agent Registry E2E page object by waiting for the health card and registered-agent list to finish loading before sampling their state, then tightened the health-status path to read the settled health state once. The full live ACP tier-3 browser slice passes against the seeded backend after the fix. Evidence was posted to GitHub issue #1505 (https://github.com/rmusser01/tldw_server/issues/1505#issuecomment-4414619125) and parent tracker #1500 (https://github.com/rmusser01/tldw_server/issues/1500#issuecomment-4414620632); #1505 remains open pending PR #1507 merge or explicit acceptance of local branch validation.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary

- Wait for the Agent Registry health card to settle before sampling health indicators in E2E page-object helpers.
- Wait for the registered-agent list to render agents or the empty state before counting cards.
- Remove an unused Playwright import from the touched page object.

## Verification

- `bunx eslint e2e/utils/page-objects/AgentRegistryPage.ts`
- Red check reproduced before the fix: focused Agent Registry list test failed on the original loading race.
- Focused Agent Registry list test passed after the wait fix.
- Focused Agent Registry health test passed after the health wait fix.
- Post-rebase live ACP tier-3 slice passed: `19 passed (2.2m)` with `TLDW_SERVER_URL=http://127.0.0.1:8000`, seeded single-user API key, and `TLDW_E2E_ALLOW_OFFLINE=0`.

## Tracking

- Backlog: TASK-222
- GitHub issue: #1505

## Merge Gate

This PR is AI-authored and is intentionally draft. A human-written Change summary is required before marking ready for review or merge, per the repo policy.