### PR TITLE
Document ACP downstream-agent release caveat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to Some kind of Versioning
 - Expanded ACP release-signoff evidence for permission denial, reconnect, and
   recovery paths with deterministic frontend hook coverage and a readiness
   addendum that separates automated evidence from live downstream-agent caveats.
+- ACP release notes now explicitly limit downstream-agent support to
+  protocol/runner validation unless operators configure and verify a real
+  downstream ACP stdio agent plus required provider credentials. Binary
+  detection for tools such as Claude Code or Codex is not, by itself, a
+  live-agent create/prompt/cancel verification. (Issue #1504)
 
 ### Fixed
 

--- a/Docs/Development/ACP_Production_Readiness.md
+++ b/Docs/Development/ACP_Production_Readiness.md
@@ -133,9 +133,14 @@ python -m bandit -r <touched_python_paths> -f json -o /tmp/bandit_acp_<task>.jso
 - Workspace `env_vars` are stored as plaintext orchestration metadata and passed
   to ACP session creation. Treat them as operational configuration, not a secret
   vault; prefer external secret managers where available.
-- Live downstream agents need their own binaries, API keys, and workspace
-  permissions. Stub-agent protocol tests are not a substitute for live-agent
-  release notes.
+- Live downstream agents need their own ACP stdio-compatible entrypoints, API
+  keys, and workspace permissions. Stub-agent protocol tests are not a
+  substitute for live-agent verification before release notes claim downstream
+  agent support.
+- Until #1504 records a real downstream-agent create/prompt/cancel run, release
+  notes must describe ACP downstream-agent support as protocol/runner
+  validation only. Binary presence for tools such as Claude Code or Codex is not
+  enough unless the configured command is verified to speak ACP stdio.
 - Browser E2E requires a running backend, deterministic auth state, and a known
   API key. If a child issue only changes backend internals, browser E2E can be
   deferred until the UX and closeout rows.

--- a/backlog/tasks/task-230 - Document-ACP-downstream-agent-release-caveat.md
+++ b/backlog/tasks/task-230 - Document-ACP-downstream-agent-release-caveat.md
@@ -1,0 +1,56 @@
+---
+id: TASK-230
+title: Document ACP downstream-agent release caveat
+status: Done
+assignee: []
+created_date: '2026-05-10 06:46'
+updated_date: '2026-05-10 06:47'
+labels:
+  - acp
+  - release-signoff
+  - docs
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1504'
+  - 'https://github.com/rmusser01/tldw_server/issues/1500'
+documentation:
+  - Docs/Development/ACP_Production_Readiness.md
+  - Docs/Development/Agent_Client_Protocol.md
+  - CHANGELOG.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Issue #1504 live signoff found the Go runner build/test gate green and the backend ACP runner healthy when ACP_RUNNER_CWD is pointed at tools/tldw-agent, but this host does not currently have provider API-key env vars or an installed downstream ACP stdio agent suitable for a real create/prompt/cancel verification. Make the release-facing caveat explicit so ACP release notes do not claim live downstream-agent support beyond protocol/runner validation until a real downstream ACP agent is configured and verified.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 CHANGELOG.md or the active release-note surface explicitly says ACP downstream-agent support is limited to protocol/runner validation unless a real downstream ACP stdio agent plus provider credentials are configured and verified.
+- [x] #2 The caveat references the operator prerequisites without exposing secrets or implying Codex/Claude CLI support that was not live-verified.
+- [x] #3 Issue #1504 evidence can cite the doc change plus the runner and backend health checks.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Docs-only caveat added to CHANGELOG.md and Docs/Development/ACP_Production_Readiness.md after live #1504 validation found runner/backend health green but no real downstream ACP stdio agent/provider credentials available. Verification: git diff --check passed; rg confirmed release caveat text. Bandit skipped because only docs/backlog files changed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added explicit ACP downstream-agent release caveat. The release surface now limits downstream-agent support to protocol/runner validation unless a real downstream ACP stdio agent and required provider credentials are configured and verified. Recorded docs-only verification and non-code Bandit skip.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Change summary

- Adds an Unreleased changelog caveat for ACP downstream-agent support.
- Clarifies the ACP production-readiness caveat: downstream-agent support is protocol/runner validation only until a real ACP stdio downstream agent and provider credentials are configured and live-verified.
- Adds Backlog TASK-230 for the #1504 docs-only release signoff slice.
- Rebases the branch on current dev after #1517 and keeps both ACP release caveats.

## Why

Live #1504 validation found the Go runner gate and backend runner health are green, but this host does not currently have provider API-key env vars or a verified downstream ACP stdio agent. Binary presence for Claude Code/Codex is not enough to claim live create/prompt/cancel support.

## Verification

- `cd tools/tldw-agent && ./scripts/verify-local-build.sh`
- Backend started with `ACP_RUNNER_CWD=/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/acp-downstream-agent-signoff/tools/tldw-agent`
- `GET /api/v1/health` returned `status: ok`
- `GET /api/v1/acp/health` returned `overall: ok`, runner `status: ok`, runner_probe `status: ok`
- `GET /api/v1/acp/agents` showed Claude Code/Codex require setup because provider API keys are not present; Aider/Goose/Continue/OpenCode unavailable; Custom Agent configured
- `git diff --check`
- `git diff --check origin/dev..HEAD`
- `rg -n "downstream-agent support|protocol/runner validation|ACP stdio-compatible|Binary presence|Supported downstream ACP agents|None certified|TASK-230" CHANGELOG.md Docs/Development/ACP_Production_Readiness.md "backlog/tasks/task-230 - Document-ACP-downstream-agent-release-caveat.md"`

## Merge gate

AI-authored PR: per repo policy, a human-written Change summary is required before merge.