### PR TITLE
Docs: Persona/Buddy roadmap and current-state audit

### DIFF
--- a/Docs/Reviews/PERSONA_BUDDY_CURRENT_STATE_AUDIT_2026_05_10.md
+++ b/Docs/Reviews/PERSONA_BUDDY_CURRENT_STATE_AUDIT_2026_05_10.md
@@ -1,0 +1,159 @@
+# Persona/Buddy Current-State Audit
+
+Date checked: 2026-05-10
+
+## Summary Verdict
+
+The Persona/Buddy system is no longer a single placeholder surface. It has concrete server-owned profile/session contracts, a route-owned Persona Garden/Live UI, a floating Buddy shell, browser wake detection, visual packs, review-gated visual generation, a personal visual library, and internal MCP tools for visual-pack draft/runtime actions.
+
+Stage 1 should stay focused on reliability and product-hardening around the flows that already exist:
+
+- Add a small Persona/Buddy diagnostics surface that gathers profile, Buddy, visual pack, websocket, wake, and MCP-readiness status in one place.
+- Tighten recovery copy and recovery actions for live voice, websocket reconnect, wake rejection, visual-pack load/render failure, and setup detours.
+- Add smoke/E2E coverage that exercises the known-good happy paths and existing failure fallbacks together, not just one isolated component at a time.
+- Preserve the existing VN/CYOA boundary. Persona Visual Packs are Persona Buddy/Persona Live assets; VN asset-pack work is a portability precedent, not the runtime owner.
+
+Do not start Stage 2/3/4 work from this audit. Persona chat quality, broader MCP behaviors, native/background voice, richer renderer adapters, and shared-library/library-market features are follow-up stages.
+
+## Tracker State
+
+Live GitHub state was checked with `gh api graphql` against `rmusser01/tldw_server` on 2026-05-10.
+
+| Issue | State | Updated | Role in this audit |
+| --- | --- | --- | --- |
+| [#635 Tracking: Persona Chat enhancement](https://github.com/rmusser01/tldw_server/issues/635) | Open | 2025-11-23T01:12:14Z | Legacy umbrella. Body is broad but still has useful Persona Chat reference links in comments. |
+| [#1388 Track Live Personas visual identity and runtime assistant effort](https://github.com/rmusser01/tldw_server/issues/1388) | Closed | 2026-05-09T17:50:29Z | Prior visual identity/runtime tracker; closed. |
+| [#1389 Add internal persona_visuals MCP module and runtime visual overrides](https://github.com/rmusser01/tldw_server/issues/1389) | Closed | 2026-05-09T04:21:42Z | MCP visual tools/runtime override slice; closed. |
+| [#1428 Track Persona/Buddy visual pack reliability and product hardening](https://github.com/rmusser01/tldw_server/issues/1428) | Closed | 2026-05-09T20:59:05Z | Visual-pack reliability tracker; closed. |
+| [#1449 Epic: Persona/Buddy visual-pack reuse and libraries](https://github.com/rmusser01/tldw_server/issues/1449) | Closed | 2026-05-10T05:48:08Z | Visual-pack reuse/library epic; closed. |
+| [#1497 Research: Persona visual-pack renderer and provider adapter evaluation](https://github.com/rmusser01/tldw_server/issues/1497) | Closed | 2026-05-10T05:45:53Z | Renderer/provider research; closed. |
+| [#1391 Track character/persona CYOA-VN mode effort](https://github.com/rmusser01/tldw_server/issues/1391) | Open | 2026-05-10T01:25:36Z | Separate VN/CYOA tracker. Should not own Persona/Buddy runtime hardening. |
+
+Useful `#635` references preserved before any tracker rewrite:
+
+- [#635 comment: evaluations](https://github.com/rmusser01/tldw_server/issues/635#issuecomment-3454426336): StickToYourRoleLeaderboard, UGI-Leaderboard, NovelChallenge.
+- [#635 comment: Guided Generations](https://github.com/rmusser01/tldw_server/issues/635#issuecomment-3454426938): Samueras/Guided-Generations.
+- [#635 comment: 3D model assistants](https://github.com/rmusser01/tldw_server/issues/635#issuecomment-3454428039): semperai/amica.
+- [#635 comment: LlamaTale](https://github.com/rmusser01/tldw_server/issues/635#issuecomment-3567289751): neph1/LlamaTale.
+
+Recommendation: leave `#635` open until a new broader Persona/Buddy epic links this audit and explicitly splits Persona Chat quality from Buddy/Live reliability. After that, add a comment preserving the links above and either retitle `#635` to Persona Chat quality or close it as superseded by the new epic plus a Persona Chat sub-issue.
+
+## Contract Inventory
+
+| Flow | Server contract | Client owner | Persisted state | Session/runtime state | MCP/tool surface | Tests | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Persona Chat | Chat can resolve `assistant_kind=persona`, `assistant_id`, and `persona_memory_mode`; persona profiles project into chat assistant cards through `tldw_Server_API/app/core/Chat/chat_service.py:450` and `:474`. Persona exemplar prompt assembly is shared in `tldw_Server_API/app/core/Persona/exemplar_prompt_assembly.py:111`. | Shared chat hooks plus `apps/packages/ui/src/hooks/chat/personaServerChat.ts:96`. | Conversation assistant identity and memory mode; persona profiles in ChaCha. | Chat request/runtime guidance and optional memory/exemplar metadata. | Not Buddy-specific. Existing persona exemplar/runtime paths only. | `tldw_Server_API/tests/Chat/integration/test_persona_backed_chat_conversations.py:187`, `tldw_Server_API/tests/Chat/test_persona_prompt_assembly.py:41`. | Stage 2 is the right place for persona quality/evals; Stage 1 should only cover entry-point reliability/copy if Persona Chat is presented as a Buddy path. |
+| Persona Live stream | `/api/v1/persona/stream` websocket at `tldw_Server_API/app/api/v1/endpoints/persona.py:7177`, with auth/feature gate at `:7190`, event metadata at `:7321`, notices/deltas/tool frames at `:7331`, `:7349`, `:7364`, `:7385`, `:7418`. | `apps/packages/ui/src/routes/sidepanel-persona.tsx:464` via `usePersonaLiveSession`; WS URL builder in `apps/packages/ui/src/services/persona-stream.ts:4`. | Persona sessions via `persona_sessions`; preferences include live voice runtime. | Active WS, pending plans, tool calls/results, recovery state, live voice status. | Persona tool execution path; visual override payload can arrive through tool results. | `tldw_Server_API/tests/Persona/test_persona_ws.py:221`, `apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx:3879`, `apps/tldw-frontend/e2e/workflows/persona.spec.ts:136`. | Main Stage 1 target: aggregate connection/recovery diagnostics and make reconnect/copy-command states easier to interpret. |
+| Buddy shell | Server embeds `buddy_summary` in profile/catalog responses with `PersonaBuddySummary` at `tldw_Server_API/app/api/v1/schemas/persona.py:437`; dedicated buddy endpoint at `tldw_Server_API/app/api/v1/endpoints/persona.py:3617`. | Route-local render context in `apps/packages/ui/src/routes/sidepanel-persona.tsx:241`; shell resolution in `apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellHost.tsx:87`. | `persona_buddies` derived from persona profile state; overlay preferences preserved by DB tests. | Floating shell open/position bucket and live render context; not a server session. | Visual runtime overrides can influence state through the visual runtime store. | `tldw_Server_API/tests/Persona/test_persona_buddy_api.py:38`, `tldw_Server_API/tests/ChaChaNotesDB/test_persona_buddy_db.py:34`, `apps/packages/ui/src/store/__tests__/persona-buddy-shell.test.ts:12`. | Stage 1 should expose dormant/no-buddy and stale context diagnostics rather than adding new Buddy personality behavior. |
+| Persona Garden setup/profile | Profile CRUD at `tldw_Server_API/app/api/v1/endpoints/persona.py:3441`, `:3475`, `:3550`; setup state and analytics schemas at `tldw_Server_API/app/api/v1/schemas/persona.py:558` and `:570`. | `apps/packages/ui/src/routes/sidepanel-persona.tsx:294`; Persona Garden panels under `apps/packages/ui/src/components/PersonaGarden/`. | Profile fields, voice defaults, setup wizard status, setup analytics events. | Setup detours/handoff cards and in-route wizard state. | MCP setup-related controls are mediated through policy/tools panels, not a single setup MCP tool. | `apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx:881`, `:1187`, `:1349`, `:1517`, `:1795`. | Stage 1 should keep setup recovery scoped to existing detour/handoff paths and clarify what failed and where to retry. |
+| Wake/voice | Voice defaults schema at `tldw_Server_API/app/api/v1/schemas/persona.py:489`; runtime config normalization at `tldw_Server_API/app/api/v1/endpoints/persona.py:9138`; wake activation/rejection at `:9244`, `:9279`, `:9305`; deactivation at `:9313`. | `apps/packages/ui/src/routes/sidepanel-persona.tsx:557`; browser detector in `apps/packages/ui/src/hooks/personaWakeDetector.ts:76` and `:117`. | Saved trigger phrases and wake behavior on persona profile voice defaults. | Browser speech recognition state; runtime trigger phrases; one-shot/continuous wake gate. | Native companion is accepted as a detector kind on the server, but V1 browser docs say no background always-on mode. | `tldw_Server_API/tests/Persona/test_persona_ws.py:2303`, `:2519`, `:2605`, `apps/packages/ui/src/hooks/__tests__/personaWakeDetector.test.ts:59`, `apps/packages/ui/src/components/PersonaGarden/__tests__/LiveSessionPanel.test.tsx:156`. | Stage 1 should make wake rejection reasons visible and link them to saved-profile vs runtime mismatch. Native/background wake is Stage 3. |
+| Visual packs | Visual pack REST endpoints at `tldw_Server_API/app/api/v1/endpoints/persona.py:3844`, `:3896`, `:4017`, `:4100`, `:4196`; schemas begin at `tldw_Server_API/app/api/v1/schemas/persona.py:25` and `:73`. | `apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx`, `VisualPackReusePanel.tsx`, and Buddy shell active-pack loader at `apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellHost.tsx:312`. | `persona_visual_packs`, assets, candidates, portability jobs. | Active pack loaded into Buddy shell; render state derived from voice/tool/wake/recovery and runtime overrides. | `persona_visuals.*` MCP tools for draft and transient runtime actions. | `tldw_Server_API/tests/Persona/test_persona_visuals_api.py:190`, `:528`, `:853`, `apps/tldw-frontend/e2e/workflows/persona-live.spec.ts:582`, `:627`. | Stage 1 should retain the current fail-open UI rule: broken packs must not block Live controls. New renderers remain Stage 4. |
+| Personal visual library | Reference-backed schema at `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py:5270`; source lookup/upsert/list in `tldw_Server_API/app/core/DB_Management/chacha/persona_state_store.py:2603`, `:2641`, `:2768`. | `VisualPackReusePanel.tsx` and `apps/packages/ui/src/services/persona-visuals.ts:176`. | Library items reference source persona and source pack; no V1 snapshots. | None unless a library item is used to create a target draft. | `persona_visuals.library_items` and `persona_visuals.use_library_item`. | `tldw_Server_API/tests/ChaChaNotesDB/test_persona_visual_library_db.py:49`, `tldw_Server_API/tests/Persona/test_persona_visual_library_service.py:100`, `tldw_Server_API/app/core/MCP_unified/tests/test_persona_visuals_module.py:159`. | Stage 1 should only improve stale-source diagnostics/copy if surfaced in Persona Garden. Shared libraries/import-export expansion is later. |
+| MCP persona visual tools | Tool definitions at `tldw_Server_API/app/core/MCP_unified/modules/implementations/persona_visuals_module.py:63`; runtime override at `:324`; draft mutation at `:346` and `:368`; library use at `:402`; generation enqueue at `:433`. | Persona Live incoming payload handling in `apps/packages/ui/src/routes/sidepanel-persona.tsx:609`; runtime override store in `apps/packages/ui/src/store/persona-visual-runtime.ts:20`. | Draft packs and jobs when mutation/generation tools run. | Transient visual override expires in client store. | `capabilities`, `library_items`, `trigger_state`, `create_draft_pack`, `update_manifest`, `use_library_item`, `enqueue_generation`. | `tldw_Server_API/app/core/MCP_unified/tests/test_persona_visuals_module.py:57`, `:114`, `:218`, `:267`, `:305`, `:393`; `apps/packages/ui/src/store/__tests__/persona-visual-runtime.test.ts:10`. | Stage 1 can add readiness diagnostics around missing context/user/session and draft-only restrictions. Do not add new tools yet. |
+| Docs and test surface | Product/docs split Persona/Buddy from VN/CYOA in `Docs/Code_Documentation/Persona_Visual_Packs.md:167`; wake docs at `Docs/User_Guides/WebUI_Extension/Persona_Live_Wake_Phrases.md:1`; PRD reliability goals at `Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md:68`. | N/A | N/A | N/A | N/A | See test rows above plus Persona Garden component tests under `apps/packages/ui/src/components/PersonaGarden/__tests__/`. | Stage 1 should add a short user-facing troubleshooting/diagnostics doc only after the diagnostics shape exists. |
+
+## Evidence Table
+
+| Flow | Journey | Evidence files | API/runtime contracts | Existing tests | Issue links | Observed or inferred gap | Severity | Stage 1 recommendation |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Persona Live connect/send/plan | User opens Persona Garden, connects Live, sends text, sees plan, approves/cancels. | `tldw_Server_API/app/api/v1/endpoints/persona.py:7177`, `apps/packages/ui/src/routes/sidepanel-persona.tsx:464`, `apps/packages/ui/src/services/persona-stream.ts:4`. | WS auth, event sequencing, `notice`, `assistant_delta`, `tool_plan`, `tool_call`, `tool_result`. | Backend WS tests and UI/E2E tests listed above. | #1388 closed; #635 still broad. | Diagnostics are distributed across logs, route state, voice card, and test coverage; user cannot inspect one status object. | P1 | Add diagnostics aggregator/card for websocket auth, selected persona, session id, last event, pending plan, tool status, and reconnect action. |
+| Live voice and wake | User saves trigger phrases, connects Live, arms wake, phrase gates next spoken turn. | `schemas/persona.py:489`, `persona.py:9138`, `persona.py:9244`, `personaWakeDetector.ts:117`, wake guide. | Saved profile phrases plus runtime `voice_config`; server rejects if phrase is not both saved and active runtime config. | Wake backend and detector tests cover accept/reject/restart/fatal cases. | #1388 closed. | Rejection reasons exist server-side but are not clearly mapped to user remediation copy in the audit evidence. | P1 | Surface `WAKE_ACTIVATION_REJECTED` details in Live voice UI with exact saved-vs-runtime mismatch guidance. |
+| Voice recovery | User encounters stalled listening/thinking, then can wait/reset/copy/reconnect. | `sidepanel-persona.tsx:723`, `AssistantVoiceCard` tests around recovery actions. | Client-owned recovery mode; reconnect forces disconnect and triggers session recovery. | `LiveSessionPanel.test.tsx` recovery tests. | #1428 closed. | Recovery actions exist, but end-to-end reliability around actual WS reconnect + preserving draft/last command should be smoked together. | P1 | Add one smoke test for stalled voice recovery path and document what each recovery action preserves or resets. |
+| Buddy shell selection | User changes selected persona; Buddy shell shows route-local persona summary instead of stale persisted assistant. | `sidepanel-persona.tsx:241`, `BuddyShellHost.tsx:87`, `BuddyShellHost.tsx:312`. | Route-local context and selected-assistant fallback gate. | `sidepanel-persona.test.tsx:533`, `:619`, `:748`, `:816`; shell store tests. | #1388/#1428 closed. | Good coverage exists for stale assistant context; missing user-visible diagnostics for no Buddy row, disabled shell, or inactive surface. | P2 | Add a compact shell diagnostics/debug row in dev or diagnostics mode showing why Buddy is hidden/dormant. |
+| Visual pack load/render | Active visual pack renders in Buddy; broken pack does not block Live controls. | `BuddyShellHost.tsx:312`, `:393`; `persona.py:3844`, `:4196`; PRD lines for fail-open behavior. | REST active pack plus client diagnostics. | `persona-live.spec.ts:582`, `:627`, visual API/core tests. | #1428/#1449/#1497 closed. | Failure states are handled, but diagnostics are mostly local to shell rendering and not tied into broader Persona health. | P2 | Include active-pack id/load status/render diagnostic in the Stage 1 Persona/Buddy diagnostics surface. |
+| Persona Garden setup detours | First-run/setup moves between command creation, safety connections, live test, and handoff cards. | `sidepanel-persona.tsx:609`, Persona Garden setup components/tests. | Profile setup state, setup events, command dry-run, connection tests, live detour state. | Extensive route tests around setup and handoff failures. | #1388 closed. | The flow is well-covered but complex; smoke candidates should assert the core happy path and one failure detour. | P2 | Add a focused setup smoke checklist/test matrix rather than changing runtime behavior. |
+| Persona Chat | User starts a persona-backed chat from assistant selection and gets profile/exemplar/memory projection. | `personaServerChat.ts:96`, `chat_service.py:450`, `exemplar_prompt_assembly.py:111`. | Conversation assistant identity plus persona profile projection. | Chat integration and prompt assembly tests. | #635 open. | Chat quality/eval work is distinct from Live/Buddy reliability; current tracker conflates them. | P3 for Stage 1 | Create or retitle a Persona Chat quality sub-issue under broader epic; do not implement in Stage 1. |
+| MCP visual tools | Tool can inspect/modify draft visual packs or emit transient visual state override. | `persona_visuals_module.py:63`, `:324`, `:368`, `:402`, `:433`; `persona-visual-runtime.ts:20`. | Context-scoped persona/user/session; draft-only mutating tools; generation uses Jobs review queue. | MCP module tests. | #1389 closed. | Missing-context/draft-only failures are technically enforced, but not visible as a Persona readiness checklist. | P2 | Add MCP visual readiness diagnostics to Stage 1; hold new tools for Stage 3. |
+| VN/CYOA boundary | Persona Visual Packs are Buddy/Live assets, not VN runtime assets. | `Docs/Code_Documentation/Persona_Visual_Packs.md:167`, `Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md:27`, `Docs/Product/WebUI/Character_Chat_Terminology_Taxonomy_2026_05_09.md:14`. | N/A | Docs-only boundary plus previous visual-pack tests. | #1391 open. | Risk is roadmap drift, not current code failure. | P3 | Keep Stage 1 language and issue labels anchored to Persona/Buddy; link #1391 only as related/out of scope. |
+
+## Known-Good Flow Checklist
+
+| Flow | Current known-good path | Smoke/E2E candidate |
+| --- | --- | --- |
+| Setup happy path | Select persona, complete starter command/safety/test steps, record setup analytics, land in Live or Profiles with handoff card. | One route-level smoke that completes setup with dry-run success and verifies analytics event calls. |
+| Setup failure detour | Live test failure or command no-match detours to Live/Commands and returns after retry/save. | One route-level smoke for `dry_run no match -> command draft -> save -> return to test`. |
+| Persona Chat | Select persona assistant, ensure server chat with `assistant_kind=persona`, send message, verify persona memory mode. | One existing chat integration check is enough for Stage 1 unless Buddy entry points add a new Persona Chat CTA. |
+| Persona Live text | Connect WS, send `user_message`, receive plan, approve/cancel. | Existing Playwright mocked-WS flow plus backend WS tests; add diagnostics assertions when Stage 1 card exists. |
+| Live voice manual | Connect WS, send voice config, commit transcript, receive processing notice/plan or fallback notice. | Backend WS voice tests already cover; add UI smoke around recovery copy/reconnect. |
+| Wake | Save trigger phrase, arm wake, detector matches phrase, server accepts activation, next voice turn bypasses trigger gate. | Existing detector/backend tests; add UI assertion that rejected server reason appears in Live panel. |
+| Buddy display | Route-local selected persona supplies Buddy summary; shell opens, persists bucketed position, falls back cleanly when dormant. | Existing shell/route tests cover; add diagnostics visibility if shell hidden/dormant. |
+| Visual fallback | Active pack loads and follows state overrides; broken pack does not block Live controls. | Existing E2E covers active and broken pack. Stage 1 should add diagnostics detail assertion. |
+| MCP runtime trigger | `persona_visuals.trigger_state` returns `visual_state_override`, client stores transient override, Buddy resolves visual state. | Existing MCP and runtime store tests cover pieces; add integration assertion only if diagnostics reads MCP readiness. |
+| Recovery | Stalled voice or reconnect path lets user wait, reset, copy command, or reconnect. | Add one smoke for `recovery_mode -> copy last command -> reconnect` preserving expected text/session state. |
+
+## Flow-By-Flow Findings
+
+### Persona Live
+
+The websocket is server-owned and eventful enough to support diagnostics. It already carries session id, event sequence, reason codes, tool status, and processing notices. The frontend owns composition of route state, approvals, setup detours, voice controller, and Buddy shell context. Stage 1 should avoid changing stream semantics unless diagnostics reveal a missing field; a read-only diagnostics projection is lower risk.
+
+### Wake/Voice
+
+Wake support is explicit V1 browser-side speech recognition, not always-on background capture. The server correctly requires the phrase to be both saved on the selected profile and present in the live runtime config. The likely user-facing gap is explaining which side is missing and how to fix it. Stage 1 should make server reason codes actionable in the Live UI and setup docs.
+
+### Buddy Shell
+
+The shell has a clean selection model: route-local persona context wins, selected-assistant fallback only applies when explicitly allowed. Active-pack loading is isolated so visual failures do not block Live controls. Stage 1 should expose hidden/dormant reasons and active-pack diagnostics rather than inventing new shell behaviors.
+
+### Persona Garden
+
+Persona Garden is the owner of setup, profile defaults, voice defaults, commands, policies, connections, state docs, visuals, and setup analytics. Existing tests cover many detours and failure paths. Stage 1 should keep work concentrated on observability and smoke coverage for the first-run route rather than adding new setup steps.
+
+### Persona Chat
+
+Persona-backed chat exists through ordinary chat infrastructure and has real prompt/memory/exemplar integration. This should be tracked separately from Buddy shell/Live reliability. The current `#635` content is useful as research/input, but the issue title/body are too broad to drive Stage 1.
+
+### Visual Packs And Library
+
+The current implementation matches the accepted product direction: assets are user-owned, attached to a persona by default, stored as packs/manifests, and personal-library items are reference-backed. V1 should not add snapshots back. Stage 1 diagnostics can show active pack/library/source status, but import/export/shared-library expansion should stay later.
+
+### MCP Visual Tools
+
+The MCP module provides enough current capability for composability: read capabilities/library, transient runtime trigger, draft pack creation/update, library use, and review-gated generation enqueue. Stage 1 should only add readiness/error reporting around these existing tools. New tool categories belong in Stage 3.
+
+## Stage 1 Issue Recommendations
+
+1. Persona/Buddy diagnostics surface
+   - Scope: read-only diagnostic card/API helper, selected persona id/name, profile load status, buddy summary presence, active visual pack id/status/diagnostic, websocket connected/session id/last event, wake armed/state/rejection reason, MCP persona_visuals readiness.
+   - Out of scope: new MCP tools, new renderer behavior, Persona Chat quality changes.
+
+2. Live voice/wake recovery copy and reason mapping
+   - Scope: map existing server reason codes and client recovery modes to user-facing remediation in Live Session, including saved-profile/runtime wake mismatch and reconnect/copy/reset actions.
+   - Out of scope: native/background wake, new STT/TTS providers.
+
+3. Persona Garden setup smoke coverage
+   - Scope: one happy-path setup smoke and one failure-detour smoke using existing flows; preserve route-local Buddy context assertions.
+   - Out of scope: new setup wizard steps or new command semantics.
+
+4. Visual pack fail-open diagnostics
+   - Scope: centralize active-pack load/render diagnostics into the broader Persona/Buddy diagnostics surface and assert Live controls remain usable.
+   - Out of scope: renderer adapters, Live2D provider work, shared libraries.
+
+5. Tracker hygiene
+   - Scope: create/refresh a broader Persona/Buddy epic, link this audit, preserve `#635` references, split Persona Chat quality into a separate Stage 2 issue, and link `#1391` as VN/CYOA-related but out of Stage 1.
+   - Out of scope: closing `#635` without first preserving its useful references.
+
+## Explicit Non-Goals And VN/CYOA Boundary
+
+- Do not route Persona/Buddy work through VN/CYOA runtime ownership.
+- Do not add Live2D or additional renderer/provider adapters in Stage 1.
+- Do not add always-on/native/background voice in Stage 1.
+- Do not broaden MCP persona tools beyond diagnostics/readiness in Stage 1.
+- Do not change personal visual library storage away from reference-backed V1 semantics.
+- Do not make Persona Chat quality/eval work a dependency of reliability diagnostics.
+
+## Verification Commands And Skipped Checks
+
+Fresh verification for this docs-only audit:
+
+```bash
+git diff --check
+git status --short --branch
+```
+
+Result: `git diff --check` passed with no output before staging. `git status --short --branch` showed only the new audit report and the Stage 0 Backlog task as untracked changes.
+
+Not run:
+
+- Pytest/Vitest/Playwright were not run for this audit because no runtime code or tests changed. Existing tests were inspected by source path and line references.
+- Bandit is skipped for this task because the touched scope is Markdown-only documentation and Backlog metadata. No Python production or test code changed.

--- a/Docs/superpowers/plans/2026-05-10-persona-buddy-stage-0-audit-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-10-persona-buddy-stage-0-audit-implementation-plan.md
@@ -1,0 +1,330 @@
+# Persona/Buddy Stage 0 Audit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Produce an evidence-backed current-state audit for the Persona/Buddy assistant runtime before any reliability/UX implementation work begins.
+
+**Architecture:** This is a docs/reporting slice, not a runtime-code slice. The worker will inspect existing backend, frontend, tests, docs, and GitHub tracker state; record contract ownership and flow reliability in one audit report; then recommend Stage 1 reliability/UX issues that are justified by evidence.
+
+**Tech Stack:** Markdown, GitHub CLI, `rg`, FastAPI/Python source inspection, React/TypeScript source inspection, existing pytest/Vitest/Playwright tests when practical.
+
+---
+
+## Scope
+
+This plan implements Stage 0 from
+`Docs/superpowers/specs/2026-05-10-persona-buddy-assistant-maturity-roadmap-design.md`.
+
+Allowed changes:
+
+- Create `Docs/Reviews/PERSONA_BUDDY_CURRENT_STATE_AUDIT_2026_05_10.md`
+- Add screenshot or JSON evidence under `Docs/Reviews/assets/2026-05-10-persona-buddy-audit/` only if browser or API probes are actually run
+- Update the Backlog task for the audit
+
+Out of scope:
+
+- Runtime code changes
+- New tests or test rewrites
+- New persona capabilities
+- New MCP runtime triggers
+- New renderer behavior
+- Closing or rewriting `#635` before the audit preserves its useful references
+
+## Files To Inspect
+
+Backend and contracts:
+
+- `tldw_Server_API/app/api/v1/endpoints/persona.py`
+- `tldw_Server_API/app/api/v1/schemas/persona.py`
+- `tldw_Server_API/app/core/Persona/README.md`
+- `tldw_Server_API/app/core/Persona/session_manager.py`
+- `tldw_Server_API/app/core/Persona/memory_integration.py`
+- `tldw_Server_API/app/core/Persona/exemplar_prompt_assembly.py`
+- `tldw_Server_API/app/core/Persona/buddy.py`
+- `tldw_Server_API/app/core/Persona/visuals.py`
+- `tldw_Server_API/app/core/Persona/visual_service.py`
+- `tldw_Server_API/app/core/Persona/visual_library_service.py`
+- `tldw_Server_API/app/core/DB_Management/chacha/persona_state_store.py`
+- `tldw_Server_API/app/core/MCP_unified/modules/implementations/persona_visuals_module.py`
+- `tldw_Server_API/Config_Files/mcp_modules.yaml`
+- `tldw_Server_API/Config_Files/persona_archetypes/*.yaml`
+
+Frontend Persona/Buddy surfaces:
+
+- `apps/tldw-frontend/pages/persona.tsx`
+- `apps/tldw-frontend/extension/routes/sidepanel-persona.tsx`
+- `apps/packages/ui/src/routes/sidepanel-persona.tsx`
+- `apps/packages/ui/src/components/PersonaGarden/`
+- `apps/packages/ui/src/components/Common/PersonaBuddy/`
+- `apps/packages/ui/src/hooks/personaWakeDetector.ts`
+- `apps/packages/ui/src/hooks/chat/personaServerChat.ts`
+- `apps/packages/ui/src/services/persona-stream.ts`
+- `apps/packages/ui/src/services/persona-visuals.ts`
+- `apps/packages/ui/src/services/tldw/persona-setup-analytics.ts`
+- `apps/packages/ui/src/store/persona-buddy-shell.ts`
+- `apps/packages/ui/src/store/persona-visual-runtime.ts`
+- `apps/packages/ui/src/types/persona-buddy.ts`
+- `apps/packages/ui/src/types/persona-visuals.ts`
+
+Existing tests and E2E:
+
+- `tldw_Server_API/tests/Persona/`
+- `tldw_Server_API/tests/Chat/integration/test_persona_backed_chat_conversations.py`
+- `tldw_Server_API/tests/Chat/test_persona_prompt_assembly.py`
+- `tldw_Server_API/tests/Chat_NEW/integration/test_chat_persona_exemplars_integration.py`
+- `tldw_Server_API/tests/Chat_NEW/integration/test_chat_persona_selector_prompt_assembly_perf.py`
+- `tldw_Server_API/tests/VoiceAssistant/test_persona_voice_command_persistence.py`
+- `tldw_Server_API/tests/ChaChaNotesDB/test_persona_buddy_db.py`
+- `tldw_Server_API/tests/ChaChaNotesDB/test_persona_persistence_db.py`
+- `tldw_Server_API/tests/ChaChaNotesDB/test_persona_visuals_db.py`
+- `tldw_Server_API/tests/ChaChaNotesDB/test_persona_visual_library_db.py`
+- `tldw_Server_API/app/core/MCP_unified/tests/test_persona_visuals_module.py`
+- `apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx`
+- `apps/packages/ui/src/routes/__tests__/sidepanel-persona.command-handoff.test.tsx`
+- `apps/packages/ui/src/components/PersonaGarden/__tests__/`
+- `apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/`
+- `apps/packages/ui/src/hooks/__tests__/personaWakeDetector.test.ts`
+- `apps/packages/ui/src/services/__tests__/persona-stream.test.ts`
+- `apps/packages/ui/src/store/__tests__/persona-buddy-shell.test.ts`
+- `apps/packages/ui/src/store/__tests__/persona-visual-runtime.test.ts`
+- `apps/tldw-frontend/e2e/workflows/persona.spec.ts`
+- `apps/tldw-frontend/e2e/workflows/persona-live.spec.ts`
+- `apps/tldw-frontend/e2e/workflows/journeys/character-chat.spec.ts`
+
+Docs and prior design context:
+
+- `Docs/Design/Personas.md`
+- `Docs/Design/Character_Chat.md`
+- `Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md`
+- `Docs/Code_Documentation/Persona_Visual_Packs.md`
+- `Docs/Code_Documentation/Character_Chat.md`
+- `Docs/API/Voice_Assistant.md`
+- `Docs/User_Guides/WebUI_Extension/Persona_Live_Wake_Phrases.md`
+- `Docs/Product/WebUI/Character_Chat_Terminology_Taxonomy_2026_05_09.md`
+- `Docs/Design/2026-05-10-persona-visual-renderer-provider-adapter-evaluation.md`
+
+## Report Template
+
+The audit report must contain these sections:
+
+1. Summary verdict
+2. Tracker state checked on `YYYY-MM-DD`
+3. Contract inventory table
+4. Evidence table
+5. Known-good flow checklist
+6. Flow-by-flow findings
+7. `#635` migration recommendation
+8. Stage 1 issue recommendations
+9. Explicit non-goals and VN/CYOA boundary
+10. Verification commands and skipped checks
+
+Contract inventory columns:
+
+| Flow | Server contract | Client owner | Persisted state | Session/runtime state | MCP/tool surface | Tests | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+
+Evidence table columns:
+
+| Flow | Journey | Evidence files | API/runtime contracts | Existing tests | Issue links | Observed or inferred gap | Severity | Stage 1 recommendation |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+
+Severity rubric:
+
+- P0: Persona/Buddy flow is broken or blocks setup/live controls
+- P1: Existing feature works inconsistently or has misleading diagnostics
+- P2: Existing feature works but lacks clear copy, test coverage, or recovery affordance
+- P3: Future enhancement or cleanup, not Stage 1 reliability work
+
+## Task 1: Create Audit Report Skeleton And Tracker Snapshot
+
+**Files:**
+
+- Create: `Docs/Reviews/PERSONA_BUDDY_CURRENT_STATE_AUDIT_2026_05_10.md`
+- Optional create: `Docs/Reviews/assets/2026-05-10-persona-buddy-audit/tracker-state.json`
+- Update: Backlog task for the audit
+
+- [ ] Create the audit report with the required sections and empty tables.
+- [ ] Re-verify GitHub tracker state before making recommendations.
+
+Run:
+
+```bash
+gh issue view 635 --repo rmusser01/tldw_server --json number,title,state,url,body,comments,updatedAt
+gh issue view 1388 --repo rmusser01/tldw_server --json number,title,state,url,updatedAt
+gh issue view 1389 --repo rmusser01/tldw_server --json number,title,state,url,updatedAt
+gh issue view 1428 --repo rmusser01/tldw_server --json number,title,state,url,updatedAt
+gh issue view 1449 --repo rmusser01/tldw_server --json number,title,state,url,updatedAt
+gh issue view 1497 --repo rmusser01/tldw_server --json number,title,state,url,updatedAt
+gh issue view 1391 --repo rmusser01/tldw_server --json number,title,state,url,updatedAt
+```
+
+Expected:
+
+- `#635` state and useful body/comment links are recorded.
+- Closed visual/runtime tracker issues are confirmed or drift is called out.
+- No GitHub issue is edited in this task.
+
+- [ ] Extract useful `#635` links/comments into the report before recommending any rewrite or close action.
+- [ ] Record whether the audit is working from live GitHub state or from an unavailable/offline snapshot.
+- [ ] Commit only after the full audit is complete, not after the skeleton.
+
+## Task 2: Inventory Backend Contracts
+
+**Files:**
+
+- Read: backend and contract files listed above
+- Modify: `Docs/Reviews/PERSONA_BUDDY_CURRENT_STATE_AUDIT_2026_05_10.md`
+
+- [ ] Identify Persona profile, state docs, session, voice/wake, visual-pack, and buddy summary persistence boundaries.
+- [ ] Identify `/api/v1/persona` REST endpoints relevant to setup, profiles, sessions, visuals, buddy, analytics, command tests, and import/export.
+- [ ] Identify `/api/v1/persona/stream` websocket frame types, including `user_message`, live notices, tool-plan/tool-call/tool-result frames, `wake_activation`, and `wake_deactivation`.
+- [ ] Identify server-owned versus client-derived live state.
+- [ ] Identify MCP persona tool contracts for `persona_visuals.capabilities`, `persona_visuals.library_items`, `persona_visuals.trigger_state`, `persona_visuals.create_draft_pack`, `persona_visuals.update_manifest`, `persona_visuals.use_library_item`, and `persona_visuals.enqueue_generation`.
+- [ ] Populate the contract inventory table for backend-owned flows.
+- [ ] Add evidence rows for any missing diagnostics, ambiguous ownership, or brittle persistence/runtime seams.
+
+Useful commands:
+
+```bash
+rg -n "wake_activation|wake_deactivation|WAKE_ACTIVATION|voice_chat_trigger_phrases|wake_behavior|persona_visuals|websocket|WebSocket|notice|tool_plan|tool_call|tool_result" tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/app/api/v1/schemas/persona.py tldw_Server_API/app/core/Persona tldw_Server_API/app/core/MCP_unified/modules/implementations/persona_visuals_module.py
+rg -n "CREATE TABLE|persona_visual|persona_profile|persona_session|wake_behavior|voice_chat_trigger_phrases" tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py tldw_Server_API/app/core/DB_Management/chacha/persona_state_store.py
+```
+
+Expected:
+
+- The report says which contracts are persisted, which are runtime-only, and which are MCP-triggered.
+- Any Stage 1 candidate from backend inspection is limited to diagnostics/recovery/copy/test hardening.
+
+## Task 3: Inventory Frontend Surfaces
+
+**Files:**
+
+- Read: frontend files listed above
+- Modify: `Docs/Reviews/PERSONA_BUDDY_CURRENT_STATE_AUDIT_2026_05_10.md`
+
+- [ ] Map Persona Garden setup/profile/defaults/policies/visuals/live-session surfaces.
+- [ ] Map Persona Live route ownership in `sidepanel-persona.tsx`, including connection state, setup detours, handoff cards, and wake controls.
+- [ ] Map Persona Buddy shell state resolution, selected persona precedence, active-pack loading, visual fallback, popover actions, and dormant/no-buddy states.
+- [ ] Map wake detector behavior and browser/extension limitations.
+- [ ] Map Persona Chat entry points and persona-backed chat hooks without turning character-chat or VN/CYOA flows into the Persona/Buddy runtime.
+- [ ] Populate frontend rows in the contract inventory and evidence tables.
+- [ ] Add known-good flow checklist rows for setup, chat, live voice, wake, Buddy display, visual fallback, MCP runtime trigger, and recovery.
+
+Useful commands:
+
+```bash
+rg -n "wake|Wake|personaId|selectedPersona|Buddy|visual|Visual|live|Live|setup|handoff|connection|runtime|stream" apps/packages/ui/src/routes/sidepanel-persona.tsx apps/packages/ui/src/components/PersonaGarden apps/packages/ui/src/components/Common/PersonaBuddy apps/packages/ui/src/hooks apps/packages/ui/src/services apps/packages/ui/src/store
+rg -n "persona|Persona|character|Character|buddy|Buddy|wake|Wake" apps/tldw-frontend/pages/persona.tsx apps/tldw-frontend/extension/routes/sidepanel-persona.tsx apps/tldw-frontend/e2e/workflows
+```
+
+Expected:
+
+- The report distinguishes first-time setup, returning user, live-session, and recovery journeys.
+- The report cites concrete files for each frontend claim.
+
+## Task 4: Inventory Tests, Docs, And Existing Coverage
+
+**Files:**
+
+- Read: test and docs files listed above
+- Modify: `Docs/Reviews/PERSONA_BUDDY_CURRENT_STATE_AUDIT_2026_05_10.md`
+
+- [ ] Map existing backend tests to each audited flow.
+- [ ] Map existing frontend unit tests and E2E workflows to each audited flow.
+- [ ] Identify flows with tests but weak product copy or diagnostics.
+- [ ] Identify flows with UI affordances but no clear backend/runtime contract.
+- [ ] Identify flows that appear documented but are not protected by tests.
+- [ ] Populate smoke/E2E candidate list for Stage 1 reliability coverage.
+
+Optional verification commands if the local environment is ready:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Persona/test_persona_ws.py tldw_Server_API/tests/Persona/test_persona_buddy_api.py tldw_Server_API/tests/Persona/test_persona_voice_commands_api.py tldw_Server_API/tests/Persona/test_persona_visuals_api.py -q
+```
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/routes/__tests__/sidepanel-persona.test.tsx src/hooks/__tests__/personaWakeDetector.test.ts src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx src/services/__tests__/persona-stream.test.ts
+```
+
+```bash
+cd apps/tldw-frontend
+bunx playwright test e2e/workflows/persona.spec.ts e2e/workflows/persona-live.spec.ts --reporter=line
+```
+
+Expected:
+
+- If commands are run, exact pass/fail/skipped results are recorded.
+- If commands are not run, the report explains the environment blocker.
+- Test failures are recorded as evidence; do not fix them in this task.
+
+## Task 5: Synthesize Stage 1 Recommendations
+
+**Files:**
+
+- Modify: `Docs/Reviews/PERSONA_BUDDY_CURRENT_STATE_AUDIT_2026_05_10.md`
+
+- [ ] Create a concise summary verdict that separates existing capability from reliability/UX gaps.
+- [ ] Write `#635` migration recommendation that preserves useful links/comments and explains whether to keep, rewrite, or supersede the issue.
+- [ ] Recommend Stage 1 child issues only where the evidence table supports reliability diagnostics, recovery, copy, or existing-flow test coverage.
+- [ ] Mark non-Stage-1 items as Stage 2, Stage 3, Stage 4, or out of scope.
+- [ ] Keep `#1391` VN/CYOA compatibility-only unless the audit finds a concrete cross-surface boundary issue.
+
+Recommended Stage 1 issue format:
+
+```markdown
+### Candidate Issue: <title>
+
+Evidence:
+- <file/test/doc/issue reference>
+
+Problem:
+- <specific observed gap>
+
+Reliability/UX scope:
+- <diagnostic/recovery/copy/test-only fix>
+
+Out of scope:
+- <new capability/runtime expansion excluded>
+```
+
+Expected:
+
+- Recommendations are narrow enough for focused PRs.
+- No candidate issue depends on unverified assumptions.
+
+## Task 6: Verification And Closeout
+
+**Files:**
+
+- Modify: `Docs/Reviews/PERSONA_BUDDY_CURRENT_STATE_AUDIT_2026_05_10.md`
+- Update: Backlog task for the audit
+
+- [ ] Run `git diff --check`.
+- [ ] Run targeted `rg` checks to ensure required sections exist.
+
+Run:
+
+```bash
+git diff --check
+rg -n "Contract inventory|Evidence table|Known-good flow checklist|#635 migration|Stage 1 issue recommendations|VN/CYOA" Docs/Reviews/PERSONA_BUDDY_CURRENT_STATE_AUDIT_2026_05_10.md
+```
+
+- [ ] Document Bandit as not applicable if the audit remains docs/task-only.
+- [ ] Update the Backlog task with completed acceptance criteria, verification, skips, and final summary.
+- [ ] Commit the audit report and Backlog task.
+
+Commit message:
+
+```bash
+git add Docs/Reviews/PERSONA_BUDDY_CURRENT_STATE_AUDIT_2026_05_10.md backlog/tasks/<task-file>
+git commit -m "docs: audit persona buddy current state"
+```
+
+## Review Note
+
+The writing-plans skill normally requests a plan-document-reviewer subagent.
+This session may only spawn subagents when the user explicitly asks for
+delegation. If the user asks for review before execution, dispatch a focused
+plan-document-reviewer with this plan path and the roadmap spec path only.

--- a/Docs/superpowers/specs/2026-05-10-persona-buddy-assistant-maturity-roadmap-design.md
+++ b/Docs/superpowers/specs/2026-05-10-persona-buddy-assistant-maturity-roadmap-design.md
@@ -35,6 +35,10 @@ The visual-pack roadmap is complete as scoped. Future visual work should start
 from the `#1497` evaluation and be split into new targeted issues rather than
 reopening the completed visual-pack epic.
 
+Before any tracker mutation, Stage 0 should re-verify live GitHub state and
+record the checked date. The issue state above is the design baseline, not a
+permanent source of truth.
+
 ## Product Framing
 
 Persona/Buddy is one assistant runtime with several surfaces:
@@ -80,13 +84,21 @@ known-good.
 
 Deliverables:
 
-1. Audit document covering Persona Chat, Persona Live, Persona Buddy, Persona
-   Garden, wake/voice, MCP persona tools, visual packs, docs, unit/integration
-   tests, and E2E coverage.
-2. Issue tree that updates or supersedes `#635` with concrete scoped issues.
-3. Known-good flow checklist for setup, chat, live voice, wake, Buddy display,
-   visual fallback, MCP runtime trigger, and recovery.
-4. Explicit separation note for `#1391` VN/CYOA work so future assistant work
+1. Evidence-backed audit document covering Persona Chat, Persona Live, Persona
+   Buddy, Persona Garden, wake/voice, MCP persona tools, visual packs, docs,
+   unit/integration tests, and E2E coverage.
+2. Current contract inventory covering REST schemas, stream payloads, MCP tools,
+   DB/state ownership, frontend surfaces, docs, and test coverage for each
+   Persona/Buddy flow.
+3. Evidence table with at least: flow, user journey, source files, API/runtime
+   contracts, tests, linked issues, known failures, severity, and recommended
+   next issue.
+4. Proposed issue tree that updates or supersedes `#635` with concrete scoped
+   issues after the evidence table identifies real gaps.
+5. Known-good flow and smoke/E2E candidate checklist for setup, chat, live
+   voice, wake, Buddy display, visual fallback, MCP runtime trigger, and
+   recovery.
+6. Explicit separation note for `#1391` VN/CYOA work so future assistant work
    does not drift into VN runtime assumptions.
 
 Audit questions:
@@ -96,13 +108,18 @@ Audit questions:
 3. Which flows have UI affordances but no reliable backend/runtime contract?
 4. Which flows are mature enough for expansion, and which need stabilization
    first?
+5. Which current contracts are server-owned, client-derived, persisted,
+   session-scoped, or MCP-triggered?
 
 Acceptance for Stage 0:
 
 1. A maintainer can point to one document that says what exists, what is flaky,
    and what should be next.
-2. `#635` is either rewritten into a scoped tracker or replaced by new issues.
-3. No code is changed except docs/task records unless a separately approved
+2. The document includes a contract inventory and evidence table with file,
+   test, issue, and severity references for each audited flow.
+3. `#635` has a documented migration recommendation, including which useful
+   links/comments should be preserved before it is rewritten or closed.
+4. No code is changed except docs/task records unless a separately approved
    follow-up issue exists.
 
 ### Stage 1: Reliability and UX Baseline
@@ -111,6 +128,10 @@ Goal: make existing Persona/Buddy flows dependable, understandable, and
 recoverable before adding new persona intelligence or runtime expansion.
 
 This is the first implementation target.
+
+Scope boundary: Stage 1 only hardens existing reliability diagnostics, recovery,
+copy, and test coverage. It should not add new persona capabilities, new
+runtime triggers, new renderer behavior, or new Persona Chat intelligence.
 
 Why this comes first:
 
@@ -175,6 +196,11 @@ This stage should decompose `#635` into concrete slices. The links currently on
 the eval design, but they should not substitute for repo-specific acceptance
 criteria.
 
+Before adding LLM-as-judge recipes or subjective scoring, Stage 2 should start
+with human error analysis on representative traces. Each proposed eval should
+name the failure mode it catches, the source traces or fixtures that motivated
+it, and the deterministic checks that can run before any optional judge.
+
 Likely workstreams:
 
 1. Role adherence:
@@ -191,7 +217,8 @@ Likely workstreams:
      not.
 4. Persona eval harness:
    - adapt the useful ideas behind role-adherence and role-playing eval links
-     into local deterministic fixtures and optional LLM-as-judge evals.
+     into local deterministic fixtures and optional LLM-as-judge evals only
+     after representative traces and failure labels exist.
    - avoid vanity metrics; tie each eval to a failure mode.
 5. Chat UX:
    - show effective persona, active policy/tool constraints, memory/RAG
@@ -208,11 +235,18 @@ Acceptance for Stage 2:
 3. Role adherence and memory/RAG behavior have repeatable evaluation coverage.
 4. Persona Chat shares contracts with Persona Garden/Live instead of creating
    parallel persona state.
+5. Optional LLM judges are backed by human-reviewed examples and deterministic
+   baseline checks.
 
 ### Stage 3: Unified Runtime and MCP Expansion
 
 Goal: let tools, live state, approvals, and Persona Chat participate in a
 coherent assistant loop.
+
+Before any new runtime trigger or MCP persona capability is implemented, this
+stage requires a policy/security review that documents authorization scope,
+duration limits, audit visibility, failure behavior, and the boundary between
+transient runtime effects and durable persona mutations.
 
 Likely workstreams:
 
@@ -241,6 +275,8 @@ Acceptance for Stage 3:
 2. Buddy and Live surfaces can explain what the assistant is doing without
    racing each other.
 3. MCP-driven behavior is visible, bounded, and auditable.
+4. Runtime/MCP expansion has an explicit policy/security review before
+   implementation.
 
 ### Stage 4: Visual and Renderer Future Work
 
@@ -280,25 +316,34 @@ Create a new GitHub epic:
 
 1. `Epic: Persona/Buddy assistant maturity roadmap`
 
-Suggested child issues:
+Create one immediate child issue:
 
 1. `Audit: Persona/Buddy current-state reliability and UX baseline`
-2. `Sprint: Persona Live setup and recovery diagnostics`
-3. `Sprint: Persona wake/voice diagnostics and copy alignment`
-4. `Sprint: Buddy shell stale-context and fallback hardening`
-5. `Sprint: Persona MCP tool diagnostics and audit visibility`
-6. `Sprint: Persona Live/Buddy E2E reliability coverage`
-7. `Epic: Persona Chat quality and evaluation`
-8. `Research: Persona role-adherence and memory/RAG eval harness`
-9. `Sprint: Persona Chat effective-context UX`
-10. `Epic: Unified Persona runtime and MCP expansion`
-11. `Research: Persona live-state contract v2`
-12. `Epic: Persona visual renderer/provider follow-ups`
+
+Do not create the full child issue tree up front. Stage 0 should produce the
+evidence table first, then create or update only the child issues justified by
+observed gaps.
+
+Candidate child issues after Stage 0 evidence:
+
+1. `Sprint: Persona Live setup and recovery diagnostics`
+2. `Sprint: Persona wake/voice diagnostics and copy alignment`
+3. `Sprint: Buddy shell stale-context and fallback hardening`
+4. `Sprint: Persona MCP tool diagnostics and audit visibility`
+5. `Sprint: Persona Live/Buddy E2E reliability coverage`
+6. `Epic: Persona Chat quality and evaluation`
+7. `Research: Persona role-adherence and memory/RAG eval harness`
+8. `Sprint: Persona Chat effective-context UX`
+9. `Epic: Unified Persona runtime and MCP expansion`
+10. `Research: Persona live-state contract v2`
+11. `Epic: Persona visual renderer/provider follow-ups`
 
 Issue hygiene:
 
 1. Keep `#1391` open only for VN/CYOA work unless it is intentionally split.
-2. Rewrite or close `#635` after the Persona Chat quality epic exists.
+2. Before rewriting or closing `#635`, preserve its useful reference links,
+   comments, and role-playing/persona-eval notes in the Persona Chat quality
+   issue or audit report.
 3. Do not reopen `#1449`; future visual work should use new targeted issues.
 
 ## Testing Strategy
@@ -318,8 +363,9 @@ Stage 1 should prioritize:
 Stage 2 should add:
 
 1. Deterministic persona prompt/contract tests where possible.
-2. Optional eval recipes for subjective role-adherence and grounding behavior
-   only after failure modes are identified.
+2. Human-labeled representative traces before optional subjective judges.
+3. Optional eval recipes for role-adherence and grounding behavior only after
+   failure modes are identified and deterministic baselines exist.
 
 Stage 3 should add:
 
@@ -346,6 +392,9 @@ Stage 4 should add:
 5. Risk: VN/CYOA tracker work bleeds into assistant runtime.
    - Mitigation: keep `#1391` compatibility-only from this roadmap unless a
      future issue explicitly bridges the two.
+6. Risk: The issue tree becomes an unverified issue flood.
+   - Mitigation: create only the epic and Stage 0 audit first; let audit
+     evidence justify the remaining child issues.
 
 ## First Concrete Next Step
 
@@ -366,3 +415,12 @@ The audit should inspect the current code, docs, and tests for:
 
 The audit should produce a written report and a proposed issue tree for Stage 1.
 Only after that audit should implementation begin on reliability/UX fixes.
+
+Minimum report shape:
+
+1. Contract inventory table.
+2. Evidence table with severity and source links.
+3. Known-good flow checklist and smoke/E2E candidates.
+4. `#635` migration recommendation with preserved references.
+5. Stage 1 issue recommendations limited to reliability diagnostics and UX
+   hardening.

--- a/Docs/superpowers/specs/2026-05-10-persona-buddy-assistant-maturity-roadmap-design.md
+++ b/Docs/superpowers/specs/2026-05-10-persona-buddy-assistant-maturity-roadmap-design.md
@@ -1,0 +1,368 @@
+# Persona/Buddy Assistant Maturity Roadmap Design
+
+## Goal
+
+Create a staged roadmap for the broader Persona/Buddy assistant system after
+the Live Personas visual identity work, Persona Visual Packs foundation, and
+visual-pack reuse/library epics have landed.
+
+The roadmap should treat Persona Chat, Persona Live, Persona Buddy, Persona
+Garden, wake/voice behavior, MCP persona tools, and future renderer/provider
+work as one assistant runtime with multiple surfaces. The first implementation
+target is a reliability and UX baseline, not new capability expansion.
+
+## Current Verified Tracker State
+
+Current GitHub tracker state as of 2026-05-10:
+
+1. `#1388` Track Live Personas visual identity and runtime assistant effort:
+   closed.
+2. `#1389` Add internal `persona_visuals` MCP module and runtime visual
+   overrides: closed.
+3. `#1428` Track Persona/Buddy visual pack reliability and product hardening:
+   closed.
+4. `#1449` Epic: Persona/Buddy visual-pack reuse and libraries: closed.
+5. `#1497` Research: Persona visual-pack renderer and provider adapter
+   evaluation: closed by PR `#1506`.
+6. `#635` Tracking: Persona Chat enhancement: open, broad, stale, and useful as
+   a source bucket for Persona Chat quality work rather than as a precise
+   implementation plan.
+7. `#1391` Track character/persona CYOA-VN mode effort: open, but not the
+   primary Persona/Buddy assistant tracker. It should remain separate from
+   assistant-runtime planning except where compatibility boundaries matter.
+
+The visual-pack roadmap is complete as scoped. Future visual work should start
+from the `#1497` evaluation and be split into new targeted issues rather than
+reopening the completed visual-pack epic.
+
+## Product Framing
+
+Persona/Buddy is one assistant runtime with several surfaces:
+
+1. Persona Chat is the text-first interaction surface for persona behavior,
+   role adherence, memory/RAG grounding, and conversation continuity.
+2. Persona Live is the session runtime for voice, wake, live connection state,
+   approvals, tool status, streaming events, and recovery.
+3. Persona Buddy is the visible companion shell and persona identity facet. It
+   renders active visual packs when present and falls back to derived buddy
+   summary when visuals fail or are absent.
+4. Persona Garden is the authoring and configuration surface for profiles,
+   assistant defaults, voice/wake setup, visuals, policies, and setup/testing.
+5. MCP persona tools are the composability layer. Runtime actions must be
+   bounded and scoped; durable actions must remain draft/review/explicit-save
+   oriented.
+
+This framing keeps visual packs in context but does not let visual work dominate
+the broader assistant roadmap.
+
+## Architecture Principles
+
+1. Persona profile remains the source of truth for identity, defaults, policy,
+   voice/wake settings, and durable user-owned assistant configuration.
+2. Persona Live remains the runtime source for live state. New live behavior
+   should extend `/api/v1/persona/stream` rather than create a second runtime.
+3. Persona Buddy consumes resolved persona/live state and must degrade cleanly
+   when visuals, live state, or selected persona context are missing.
+4. Persona Chat quality work should reuse persona profile/session contracts
+   rather than invent a parallel role-playing engine.
+5. MCP actions must be scoped, auditable, duration-bounded for runtime effects,
+   and explicit-review for durable mutations.
+6. VN/CYOA work remains compatible but separate. Do not route Persona/Buddy
+   assistant behavior through VN scene state or VN Play runtime assumptions.
+
+## Roadmap Stages
+
+### Stage 0: Current-State Audit
+
+Goal: replace stale umbrella tracking with a concrete map of what the current
+Persona/Buddy system already does, where it is brittle, and which flows are
+known-good.
+
+Deliverables:
+
+1. Audit document covering Persona Chat, Persona Live, Persona Buddy, Persona
+   Garden, wake/voice, MCP persona tools, visual packs, docs, unit/integration
+   tests, and E2E coverage.
+2. Issue tree that updates or supersedes `#635` with concrete scoped issues.
+3. Known-good flow checklist for setup, chat, live voice, wake, Buddy display,
+   visual fallback, MCP runtime trigger, and recovery.
+4. Explicit separation note for `#1391` VN/CYOA work so future assistant work
+   does not drift into VN runtime assumptions.
+
+Audit questions:
+
+1. Which user journeys are currently supported end-to-end?
+2. Which flows have tests but weak product copy or diagnostics?
+3. Which flows have UI affordances but no reliable backend/runtime contract?
+4. Which flows are mature enough for expansion, and which need stabilization
+   first?
+
+Acceptance for Stage 0:
+
+1. A maintainer can point to one document that says what exists, what is flaky,
+   and what should be next.
+2. `#635` is either rewritten into a scoped tracker or replaced by new issues.
+3. No code is changed except docs/task records unless a separately approved
+   follow-up issue exists.
+
+### Stage 1: Reliability and UX Baseline
+
+Goal: make existing Persona/Buddy flows dependable, understandable, and
+recoverable before adding new persona intelligence or runtime expansion.
+
+This is the first implementation target.
+
+Why this comes first:
+
+1. Persona Live, Buddy, wake/voice, setup, MCP, and visual packs already have
+   significant runtime surface area.
+2. New Persona Chat quality work will be hard to evaluate if setup and live
+   state are unreliable.
+3. MCP/runtime expansion increases blast radius unless diagnostics, recovery,
+   and E2E coverage are already solid.
+4. Renderer/provider work depends on the Buddy/runtime fallback path being
+   trustworthy.
+
+Likely workstreams:
+
+1. Setup and live-session recovery:
+   - verify setup test detours into Live Session still work.
+   - reduce redundant connection clicks after recovery detours.
+   - ensure failed live tests explain what to fix and where.
+2. Wake/voice diagnostics:
+   - audit saved `voice_chat_trigger_phrases` and `wake_behavior` behavior.
+   - confirm manual wake arming copy matches actual browser/extension limits.
+   - expose rejection reasons and live detector state clearly.
+3. Buddy shell reliability:
+   - confirm selected persona context always wins over stale cached assistant
+     selection.
+   - keep visual fallback and derived buddy summary stable when active pack
+     load/render fails.
+   - make dormant/no-buddy states understandable.
+4. MCP persona tool diagnostics:
+   - ensure `persona_visuals` capability, runtime, durable draft, generation,
+     and library failures return actionable reasons.
+   - keep transient runtime triggers separate from durable changes in copy,
+     logs, and tests.
+5. E2E and regression coverage:
+   - cover setup to live detour.
+   - cover live connection failure and recovery.
+   - cover wake activation rejection and success paths with mocked browser
+     behavior.
+   - cover Buddy fallback with no active pack, broken pack, and stale selected
+     persona context.
+6. Docs and help copy:
+   - align user guides with current local/self-hosted behavior.
+   - explain what is session-scoped, profile-saved, transient, or durable.
+
+Acceptance for Stage 1:
+
+1. First-time and returning users can recover from live setup failures without
+   leaving the Persona workflow.
+2. Wake/voice state, rejections, and browser limitations are visible and
+   documented.
+3. Buddy never blocks Persona Live controls and never renders stale persona
+   identity when fresher context exists.
+4. MCP persona tool failures are actionable and scoped.
+5. Focused E2E/regression tests protect the highest-risk flows.
+
+### Stage 2: Persona Chat Quality
+
+Goal: make normal persona chat feel coherent, stable, and measurable.
+
+This stage should decompose `#635` into concrete slices. The links currently on
+`#635` point toward role-playing/persona behavior evaluations and should inform
+the eval design, but they should not substitute for repo-specific acceptance
+criteria.
+
+Likely workstreams:
+
+1. Role adherence:
+   - define how persona instructions layer with system prompts, character-card
+     imports, chat context, policies, and tool behavior.
+   - add regression tests for persona drift and instruction conflicts.
+2. Memory/RAG grounding:
+   - clarify when persona memory, conversation memory, notes, media, and RAG
+     sources affect persona chat.
+   - surface source/context state so users can tell what grounded the response.
+3. Conversation continuity:
+   - audit session-scoped versus persistent persona behavior.
+   - define when persona state carries across conversations and when it does
+     not.
+4. Persona eval harness:
+   - adapt the useful ideas behind role-adherence and role-playing eval links
+     into local deterministic fixtures and optional LLM-as-judge evals.
+   - avoid vanity metrics; tie each eval to a failure mode.
+5. Chat UX:
+   - show effective persona, active policy/tool constraints, memory/RAG
+     grounding, and status in a compact way.
+   - avoid turning Persona Chat into a separate product surface disconnected
+     from Persona Garden and Persona Live.
+
+Acceptance for Stage 2:
+
+1. `#635` is replaced by issues that each have clear behavior, tests, and UX
+   acceptance criteria.
+2. Users can understand what persona is active and what context is grounding
+   the response.
+3. Role adherence and memory/RAG behavior have repeatable evaluation coverage.
+4. Persona Chat shares contracts with Persona Garden/Live instead of creating
+   parallel persona state.
+
+### Stage 3: Unified Runtime and MCP Expansion
+
+Goal: let tools, live state, approvals, and Persona Chat participate in a
+coherent assistant loop.
+
+Likely workstreams:
+
+1. Richer live state contract:
+   - define canonical states for listening, thinking, speaking, tool running,
+     approval needed, recovery, error, offline, and future tool sub-states.
+   - document which states are server-owned, client-derived, or MCP-triggered.
+2. Approval and tool-status visibility:
+   - make pending tool plans and approval states visible in Persona Live, Buddy,
+     and relevant Chat surfaces.
+   - preserve destructive-action confirmation boundaries.
+3. MCP capability discovery:
+   - expand persona tool capability reporting beyond visuals where useful.
+   - keep persona-scoped capabilities distinct from global MCP server status.
+4. Scoped runtime triggers:
+   - add runtime triggers only where they have bounded duration and clear user
+     value.
+   - do not let runtime triggers mutate saved persona state.
+5. Audit/event visibility:
+   - make tool-driven persona behavior inspectable enough for debugging without
+     flooding the UI.
+
+Acceptance for Stage 3:
+
+1. Live state, tool state, and approval state have one documented contract.
+2. Buddy and Live surfaces can explain what the assistant is doing without
+   racing each other.
+3. MCP-driven behavior is visible, bounded, and auditable.
+
+### Stage 4: Visual and Renderer Future Work
+
+Goal: extend visual capabilities only after the broader runtime is stable.
+
+This stage starts from
+`Docs/Design/2026-05-10-persona-visual-renderer-provider-adapter-evaluation.md`
+and should stay behind new targeted issues.
+
+Likely workstreams:
+
+1. Renderer capability registry:
+   - expose supported renderers, feature flags, asset roles, manifest versions,
+     and setup blockers.
+2. Sprite atlas/sprite-sheet V1.1:
+   - improve sprite performance inside the current safe raster model.
+3. Non-sprite manifest V2:
+   - add renderer-specific validation hooks and fallback requirements without
+     breaking V1 `sprite_frames`.
+4. Feature-gated Live2D spike:
+   - use local fixtures, explicit licensing/setup gates, static fallback, and
+     no automatic activation.
+5. External MCP pack-provider contract:
+   - allow providers to submit draft packs, archive previews, or generated
+     candidates without runtime code or active-pack mutation.
+
+Acceptance for Stage 4:
+
+1. New renderer work cannot bypass review-before-activation.
+2. Unsupported renderer packs fail during preview or capability checks, not at
+   live runtime.
+3. Optional renderer dependencies degrade without breaking Persona Live.
+
+## Proposed Issue Tree
+
+Create a new GitHub epic:
+
+1. `Epic: Persona/Buddy assistant maturity roadmap`
+
+Suggested child issues:
+
+1. `Audit: Persona/Buddy current-state reliability and UX baseline`
+2. `Sprint: Persona Live setup and recovery diagnostics`
+3. `Sprint: Persona wake/voice diagnostics and copy alignment`
+4. `Sprint: Buddy shell stale-context and fallback hardening`
+5. `Sprint: Persona MCP tool diagnostics and audit visibility`
+6. `Sprint: Persona Live/Buddy E2E reliability coverage`
+7. `Epic: Persona Chat quality and evaluation`
+8. `Research: Persona role-adherence and memory/RAG eval harness`
+9. `Sprint: Persona Chat effective-context UX`
+10. `Epic: Unified Persona runtime and MCP expansion`
+11. `Research: Persona live-state contract v2`
+12. `Epic: Persona visual renderer/provider follow-ups`
+
+Issue hygiene:
+
+1. Keep `#1391` open only for VN/CYOA work unless it is intentionally split.
+2. Rewrite or close `#635` after the Persona Chat quality epic exists.
+3. Do not reopen `#1449`; future visual work should use new targeted issues.
+
+## Testing Strategy
+
+Stage 0 is documentation and issue decomposition only.
+
+Stage 1 should prioritize:
+
+1. Focused frontend tests around `sidepanel-persona.tsx`, Persona Garden setup
+   components, Buddy shell, incoming payload hooks, and wake/voice controls.
+2. Backend tests for `/api/v1/persona/stream` wake activation/rejection and MCP
+   persona tool diagnostics.
+3. E2E tests for mocked setup-to-live recovery, live failure recovery, Buddy
+   fallback, and visual state override behavior.
+4. Documentation checks through `git diff --check` for docs-only slices.
+
+Stage 2 should add:
+
+1. Deterministic persona prompt/contract tests where possible.
+2. Optional eval recipes for subjective role-adherence and grounding behavior
+   only after failure modes are identified.
+
+Stage 3 should add:
+
+1. Contract tests for live state payloads and MCP runtime events.
+2. Regression tests around approval/tool status propagation.
+
+Stage 4 should add:
+
+1. Renderer validation tests before runtime rendering tests.
+2. Fixture-based renderer tests, never external-provider-dependent baseline
+   tests.
+
+## Risks and Mitigations
+
+1. Risk: The roadmap becomes a vague mega-epic.
+   - Mitigation: Stage 0 produces issue slices before implementation.
+2. Risk: Persona Chat quality work invents a parallel persona engine.
+   - Mitigation: keep persona profile/session contracts authoritative.
+3. Risk: Runtime/MCP expansion bypasses user control.
+   - Mitigation: bounded runtime effects and explicit review for durable
+     changes.
+4. Risk: Visual work distracts from reliability.
+   - Mitigation: keep renderer/provider implementation in Stage 4.
+5. Risk: VN/CYOA tracker work bleeds into assistant runtime.
+   - Mitigation: keep `#1391` compatibility-only from this roadmap unless a
+     future issue explicitly bridges the two.
+
+## First Concrete Next Step
+
+Create and complete the Stage 0 audit issue:
+
+`Audit: Persona/Buddy current-state reliability and UX baseline`
+
+The audit should inspect the current code, docs, and tests for:
+
+1. Persona Chat.
+2. Persona Live.
+3. Persona Buddy shell.
+4. Persona Garden setup/profile/defaults/policies/visuals.
+5. Wake/voice behavior.
+6. MCP persona tools.
+7. Visual-pack fallback and diagnostics.
+8. Current E2E and unit coverage.
+
+The audit should produce a written report and a proposed issue tree for Stage 1.
+Only after that audit should implementation begin on reliability/UX fixes.

--- a/backlog/tasks/task-224 - Design-broader-Persona-Buddy-assistant-maturity-roadmap.md
+++ b/backlog/tasks/task-224 - Design-broader-Persona-Buddy-assistant-maturity-roadmap.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-224
 title: Design broader Persona/Buddy assistant maturity roadmap
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-10 06:26'
 labels:
@@ -29,11 +29,11 @@ Create the approved staged design spec for the broader Persona/Buddy assistant f
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Design spec documents the approved staged roadmap from audit through reliability/UX baseline, Persona Chat quality, runtime/MCP expansion, and visual/renderer future work.
-- [ ] #2 Spec identifies the first implementation target as reliability/UX baseline and explains why it precedes Persona Chat quality and runtime expansion.
-- [ ] #3 Spec is grounded in current repo surfaces and open/closed GitHub tracker state, including #635, #1388, #1389, #1449, and #1497.
-- [ ] #4 Spec lists proposed follow-up issue slices without implementing code.
-- [ ] #5 Verification and review status are recorded in the Backlog task.
+- [x] #1 Design spec documents the approved staged roadmap from audit through reliability/UX baseline, Persona Chat quality, runtime/MCP expansion, and visual/renderer future work.
+- [x] #2 Spec identifies the first implementation target as reliability/UX baseline and explains why it precedes Persona Chat quality and runtime expansion.
+- [x] #3 Spec is grounded in current repo surfaces and open/closed GitHub tracker state, including #635, #1388, #1389, #1449, and #1497.
+- [x] #4 Spec lists proposed follow-up issue slices without implementing code.
+- [x] #5 Verification and review status are recorded in the Backlog task.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -48,12 +48,12 @@ Create the approved staged design spec for the broader Persona/Buddy assistant f
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->
 
 ## Implementation Notes
@@ -64,5 +64,11 @@ Create the approved staged design spec for the broader Persona/Buddy assistant f
 - Spec grounds the roadmap in closed Persona/Buddy visual/runtime trackers and the open/stale #635 Persona Chat tracker.
 - Verification: `git diff --check` passed.
 - Bandit: skipped because this is a docs/backlog-only design change with no touched Python code.
-- Spec review status: pending explicit authorization to dispatch a reviewer subagent in this environment.
+- Spec review status: approved by reviewer subagent `019e109f-5507-7a21-8c63-acb055cf5b54` after the first review attempt stalled and was shut down without a verdict.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Committed the approved staged Persona/Buddy assistant maturity roadmap design. The spec identifies Stage 0 current-state audit as the immediate next planning slice and Stage 1 reliability/UX baseline as the first implementation target before Persona Chat quality, unified runtime/MCP expansion, and visual/renderer follow-ups.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-224 - Design-broader-Persona-Buddy-assistant-maturity-roadmap.md
+++ b/backlog/tasks/task-224 - Design-broader-Persona-Buddy-assistant-maturity-roadmap.md
@@ -1,0 +1,68 @@
+---
+id: TASK-224
+title: Design broader Persona/Buddy assistant maturity roadmap
+status: In Progress
+assignee: []
+created_date: '2026-05-10 06:26'
+labels:
+  - persona
+  - buddy
+  - roadmap
+  - design
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/635'
+  - 'https://github.com/rmusser01/tldw_server/issues/1388'
+  - 'https://github.com/rmusser01/tldw_server/issues/1449'
+documentation:
+  - Docs/Design/Personas.md
+  - Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md
+  - Docs/Code_Documentation/Persona_Visual_Packs.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create the approved staged design spec for the broader Persona/Buddy assistant functionality roadmap. The spec should start from the verified current state after the visual-pack epics closed, decompose Persona Chat, Persona Live, Buddy shell, Persona Garden, wake/voice, MCP persona tools, and renderer follow-up work into staged roadmap slices, and identify reliability/UX baseline as the first implementation target.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Design spec documents the approved staged roadmap from audit through reliability/UX baseline, Persona Chat quality, runtime/MCP expansion, and visual/renderer future work.
+- [ ] #2 Spec identifies the first implementation target as reliability/UX baseline and explains why it precedes Persona Chat quality and runtime expansion.
+- [ ] #3 Spec is grounded in current repo surfaces and open/closed GitHub tracker state, including #635, #1388, #1389, #1449, and #1497.
+- [ ] #4 Spec lists proposed follow-up issue slices without implementing code.
+- [ ] #5 Verification and review status are recorded in the Backlog task.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Write a design-only roadmap spec in `Docs/superpowers/specs/2026-05-10-persona-buddy-assistant-maturity-roadmap-design.md`.
+2. Ground the spec in the current Persona/Buddy surfaces, closed Live Personas and visual-pack trackers, open #635 Persona Chat tracker, and #1391 VN/CYOA separation.
+3. Preserve the approved staging: current-state audit, reliability/UX baseline first, Persona Chat quality, unified runtime/MCP expansion, and visual/renderer future work.
+4. List follow-up issue slices and acceptance gates without changing runtime code.
+5. Run documentation verification, record the review limitation for the subagent gate if no explicit subagent authorization is available, then commit the spec and task record.
+<!-- SECTION:PLAN:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Added `Docs/superpowers/specs/2026-05-10-persona-buddy-assistant-maturity-roadmap-design.md` with the approved staged roadmap.
+- First implementation target is Stage 1 reliability/UX baseline, preceded by Stage 0 current-state audit and issue-tree refresh.
+- Spec grounds the roadmap in closed Persona/Buddy visual/runtime trackers and the open/stale #635 Persona Chat tracker.
+- Verification: `git diff --check` passed.
+- Bandit: skipped because this is a docs/backlog-only design change with no touched Python code.
+- Spec review status: pending explicit authorization to dispatch a reviewer subagent in this environment.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-225 - Tighten-Persona-Buddy-roadmap-design-after-review.md
+++ b/backlog/tasks/task-225 - Tighten-Persona-Buddy-roadmap-design-after-review.md
@@ -1,0 +1,79 @@
+---
+id: TASK-225
+title: Tighten Persona/Buddy roadmap design after review
+status: Done
+assignee:
+  - Codex
+created_date: '2026-05-10 06:47'
+labels:
+  - persona
+  - buddy
+  - roadmap
+  - design
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/635'
+  - 'https://github.com/rmusser01/tldw_server/issues/1449'
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-05-10-persona-buddy-assistant-maturity-roadmap-design.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Patch the approved Persona/Buddy assistant maturity roadmap spec with the self-review clarifications requested by the user before continuing into implementation planning. Scope is docs/backlog only: strengthen Stage 0 evidence requirements, clarify Stage 1 boundaries, defer detailed issue creation until after audit evidence, preserve #635 reference migration, add Stage 3 policy/security gate, and require human error-analysis before eval/judge work.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Spec includes stronger Stage 0 evidence table and current contract inventory requirements.
+- [x] #2 Spec clearly limits Stage 1 to reliability diagnostics and UX hardening without new persona capabilities.
+- [x] #3 Spec defers broad child issue creation until Stage 0 evidence identifies concrete gaps.
+- [x] #4 Spec requires preserving useful #635 links/comments before tracker rewrite or closure.
+- [x] #5 Spec adds policy/security review gate before Stage 3 runtime/MCP trigger expansion.
+- [x] #6 Spec requires human error analysis and representative traces before Stage 2 LLM judge/eval recipes.
+- [x] #7 Verification and non-code Bandit skip are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Patch the roadmap spec to add explicit Stage 0 audit evidence requirements and contract inventory outputs.
+2. Clarify that Stage 1 is limited to reliability diagnostics and UX hardening of existing flows, not new persona capability expansion.
+3. Revise issue hygiene so only the epic and Stage 0 audit issue are immediate; Stage 0 evidence should produce concrete Stage 1 child issues.
+4. Add tracker hygiene instructions to preserve useful `#635` links/comments before rewriting or closing it.
+5. Add Stage 3 policy/security review gate before broader runtime/MCP triggers.
+6. Add Stage 2 error-analysis-first eval guidance before optional LLM judges or eval recipes.
+7. Run docs verification, record non-code Bandit skip, and commit the docs/backlog follow-up.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Patched `Docs/superpowers/specs/2026-05-10-persona-buddy-assistant-maturity-roadmap-design.md` with stronger Stage 0 contract/evidence deliverables and a minimum report shape.
+- Clarified Stage 1 as reliability diagnostics, recovery, copy, and tests only; new runtime triggers, renderer work, and Persona Chat intelligence stay out of the first implementation slice.
+- Revised issue guidance so only the epic plus Stage 0 audit issue are immediate; candidate child issues are created only after audit evidence identifies concrete gaps.
+- Added `#635` reference/comment preservation before tracker rewrite or closure.
+- Added policy/security review before Stage 3 runtime/MCP trigger expansion.
+- Added human error analysis and representative traces before Stage 2 optional LLM judges/eval recipes.
+- Verification: `git diff --check` passed; targeted `rg` checks confirmed the new design gates are present.
+- Bandit: skipped because this is a docs/backlog-only follow-up with no touched Python code.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Tightened the approved Persona/Buddy roadmap design after self-review. The spec now requires evidence-backed Stage 0 audit outputs, narrows Stage 1 to existing-flow reliability/UX hardening, defers broad issue creation until audit evidence exists, preserves useful `#635` context during tracker cleanup, gates Stage 3 runtime/MCP expansion on policy/security review, and makes Stage 2 eval work start from human-reviewed traces before optional LLM judges.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-226 - Create-Persona-Buddy-Stage-0-audit-implementation-plan.md
+++ b/backlog/tasks/task-226 - Create-Persona-Buddy-Stage-0-audit-implementation-plan.md
@@ -1,0 +1,78 @@
+---
+id: TASK-226
+title: Create Persona/Buddy Stage 0 audit implementation plan
+status: Done
+assignee:
+  - Codex
+created_date: '2026-05-10 06:57'
+labels:
+  - persona
+  - buddy
+  - roadmap
+  - audit
+  - plan
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/635'
+  - 'https://github.com/rmusser01/tldw_server/issues/1388'
+  - 'https://github.com/rmusser01/tldw_server/issues/1389'
+  - 'https://github.com/rmusser01/tldw_server/issues/1449'
+  - 'https://github.com/rmusser01/tldw_server/issues/1497'
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-05-10-persona-buddy-assistant-maturity-roadmap-design.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create a docs-only implementation plan for the Stage 0 Persona/Buddy current-state reliability and UX audit. The plan should be grounded in the approved roadmap spec, identify concrete repo files and GitHub tracker checks to inspect, and define how the audit report will produce the contract inventory, evidence table, known-good flow checklist, #635 migration recommendation, and Stage 1 issue recommendations without changing runtime code.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Plan document exists under Docs/superpowers/plans with a Stage 0 Persona/Buddy audit scope.
+- [x] #2 Plan identifies the audit report artifact to create and the repo surfaces to inspect for Persona Chat, Persona Live, Buddy shell, Persona Garden, wake/voice, MCP persona tools, visual packs, docs, and tests.
+- [x] #3 Plan includes steps to re-verify GitHub tracker state and preserve useful #635 links/comments before recommending tracker changes.
+- [x] #4 Plan requires a contract inventory, evidence table with severity/source links, known-good flow checklist, smoke/E2E candidates, and Stage 1 issue recommendations limited to reliability diagnostics and UX hardening.
+- [x] #5 Plan is docs/task-only and records verification plus non-code Bandit skip.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Inspect the approved roadmap spec and existing Persona/Buddy repo surfaces to ground the Stage 0 audit plan in real files.
+2. Create `Docs/superpowers/plans/2026-05-10-persona-buddy-stage-0-audit-implementation-plan.md`.
+3. In the plan, define the audit report artifact, tracker verification steps, repo-surface inventory, contract/evidence table requirements, known-good flow checklist, and Stage 1 issue recommendation rules.
+4. Keep the work docs/task-only; do not modify runtime code.
+5. Run documentation verification, record Bandit skip, update this task, and commit the plan.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Created `Docs/superpowers/plans/2026-05-10-persona-buddy-stage-0-audit-implementation-plan.md`.
+- Plan creates the audit report artifact at `Docs/Reviews/PERSONA_BUDDY_CURRENT_STATE_AUDIT_2026_05_10.md`.
+- Plan names backend Persona endpoints/schemas/core services, frontend Persona Garden/Live/Buddy/wake services, MCP `persona_visuals`, existing tests, E2E workflows, and docs to inspect.
+- Plan requires re-verifying tracker state and preserving useful `#635` body/comment references before recommending tracker changes.
+- Plan requires contract inventory, evidence table, known-good flow checklist, smoke/E2E candidates, and Stage 1 reliability/UX-only recommendations.
+- Verification: `git diff --check` passed; targeted `rg` checks confirmed required sections and key surfaces are present in the plan.
+- Bandit: skipped because this is a docs/backlog-only planning change with no touched Python code.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Created the Stage 0 Persona/Buddy current-state audit implementation plan. The plan is grounded in the approved roadmap spec, identifies concrete backend/frontend/test/doc surfaces, requires live GitHub tracker re-verification and `#635` reference preservation, and defines the audit report shape needed before Stage 1 reliability/UX implementation begins.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-227 - Audit-Persona-Buddy-current-state-reliability-and-UX-baseline.md
+++ b/backlog/tasks/task-227 - Audit-Persona-Buddy-current-state-reliability-and-UX-baseline.md
@@ -1,0 +1,85 @@
+---
+id: TASK-227
+title: Audit Persona/Buddy current-state reliability and UX baseline
+status: Done
+assignee:
+  - Codex
+created_date: '2026-05-10 07:03'
+updated_date: '2026-05-10 07:11'
+labels:
+  - persona
+  - buddy
+  - audit
+  - roadmap
+  - stage-0
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/635'
+  - 'https://github.com/rmusser01/tldw_server/issues/1388'
+  - 'https://github.com/rmusser01/tldw_server/issues/1389'
+  - 'https://github.com/rmusser01/tldw_server/issues/1428'
+  - 'https://github.com/rmusser01/tldw_server/issues/1449'
+  - 'https://github.com/rmusser01/tldw_server/issues/1497'
+  - 'https://github.com/rmusser01/tldw_server/issues/1391'
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-05-10-persona-buddy-assistant-maturity-roadmap-design.md
+  - >-
+    Docs/superpowers/plans/2026-05-10-persona-buddy-stage-0-audit-implementation-plan.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Execute Stage 0 of the approved Persona/Buddy assistant maturity roadmap. Produce a docs-only current-state audit report that re-verifies tracker state, preserves useful #635 references/comments, inventories backend/frontend/MCP contracts, maps existing tests and docs, captures known-good flows and smoke/E2E candidates, and recommends Stage 1 issues limited to reliability diagnostics, recovery, copy, and existing-flow test coverage. Do not change runtime code or edit GitHub issues in this task.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Audit report exists at Docs/Reviews/PERSONA_BUDDY_CURRENT_STATE_AUDIT_2026_05_10.md.
+- [x] #2 Report records live GitHub tracker state or explicitly documents any tracker verification blocker.
+- [x] #3 Report preserves useful #635 body/comment links before recommending tracker changes.
+- [x] #4 Report includes a contract inventory table covering Persona Chat, Persona Live, Buddy shell, Persona Garden, wake/voice, MCP persona tools, visual packs, docs, and tests.
+- [x] #5 Report includes an evidence table with source links, existing tests, gaps, severity, and Stage 1 recommendation for each audited flow.
+- [x] #6 Report includes a known-good flow checklist and smoke/E2E candidates.
+- [x] #7 Report recommends Stage 1 issues only for reliability diagnostics, recovery, copy, or existing-flow coverage, and marks other work as Stage 2/3/4 or out of scope.
+- [x] #8 Verification and non-code Bandit skip are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Follow `Docs/superpowers/plans/2026-05-10-persona-buddy-stage-0-audit-implementation-plan.md` inline:
+
+1. Create the audit report skeleton and tracker snapshot.
+2. Inventory backend contracts and ownership boundaries.
+3. Inventory frontend Persona/Buddy surfaces.
+4. Inventory tests, docs, and existing coverage.
+5. Synthesize Stage 1 reliability/UX-only recommendations and tracker hygiene.
+6. Run documentation verification, record non-code Bandit skip, update this task, and commit.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Created Docs/Reviews/PERSONA_BUDDY_CURRENT_STATE_AUDIT_2026_05_10.md. Live GitHub tracker state was checked with gh api graphql on 2026-05-10. The report preserves useful #635 references, inventories backend/frontend/MCP/test/doc contracts, and limits Stage 1 recommendations to diagnostics, recovery copy, and existing-flow smoke coverage.
+
+Verification: git diff --check passed with no output before staging. Pytest/Vitest/Playwright were intentionally not run because this is a docs-only audit. Bandit is skipped because no Python code changed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Completed the Stage 0 Persona/Buddy current-state audit. Added the audit report with live tracker state, preserved #635 references, contract inventory, evidence table, known-good flow checklist, Stage 1 reliability recommendations, VN/CYOA boundary, and verification/skipped-check notes.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Adds a Persona/Buddy assistant maturity roadmap design document covering Stage 0 through Stage 4.
- Records plan review follow-ups and tightens the roadmap around existing Persona/Buddy contracts instead of VN/CYOA runtime ownership.
- Adds the Stage 0 current-state audit with live tracker state, preserved #635 references, contract inventory, evidence table, known-good flow checklist, and Stage 1 reliability recommendations.

## Change summary
Draft PR note: this PR is AI-authored. Before this PR is marked ready or merged, the human requester must replace this section with a human-written Change summary that explains both what changed and why these implementation choices were made.

## Verification
- `git diff --check`
- `git diff --cached --check`
- Pytest/Vitest/Playwright not run; docs-only changes.
- Bandit skipped; no Python code changed.

## Tracking
- Preserves useful references from #635.
- Links and distinguishes closed visual/runtime trackers #1388, #1389, #1428, #1449, #1497.
- Keeps #1391 as related VN/CYOA work, not the Persona/Buddy Stage 1 owner.