### PR TITLE
Add Persona/Buddy diagnostics surface

### DIFF
--- a/Docs/Reviews/PERSONA_BUDDY_CURRENT_STATE_AUDIT_2026_05_10.md
+++ b/Docs/Reviews/PERSONA_BUDDY_CURRENT_STATE_AUDIT_2026_05_10.md
@@ -116,6 +116,7 @@ The MCP module provides enough current capability for composability: read capabi
 1. Persona/Buddy diagnostics surface
    - Scope: read-only diagnostic card/API helper, selected persona id/name, profile load status, buddy summary presence, active visual pack id/status/diagnostic, websocket connected/session id/last event, wake armed/state/rejection reason, MCP persona_visuals readiness.
    - Out of scope: new MCP tools, new renderer behavior, Persona Chat quality changes.
+   - Implementation tracking: Stage 1 Persona/Buddy diagnostics is tracked by GitHub issue #1511 and the implementation plan in `Docs/superpowers/plans/2026-05-10-persona-buddy-diagnostics-implementation-plan.md`.
 
 2. Live voice/wake recovery copy and reason mapping
    - Scope: map existing server reason codes and client recovery modes to user-facing remediation in Live Session, including saved-profile/runtime wake mismatch and reconnect/copy/reset actions.

--- a/Docs/superpowers/plans/2026-05-10-persona-buddy-diagnostics-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-10-persona-buddy-diagnostics-implementation-plan.md
@@ -1,0 +1,513 @@
+# Persona/Buddy Diagnostics Surface Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the first Stage 1 Persona/Buddy reliability slice: a compact, read-only diagnostics surface for Persona Garden / Persona Live / Buddy shell state.
+
+**Architecture:** Keep V1 frontend-only and reference-backed by existing runtime state. A pure diagnostics projector converts current persona, Buddy, Live, wake, MCP capability, and visual diagnostic inputs into a small state model; a presentational panel renders it with the existing design-system state components; the Persona sidepanel route wires current state into the projector without changing backend contracts or healthy control flows.
+
+**Tech Stack:** Next.js/React, TypeScript, Vitest, Testing Library, existing `StatePanel` / `RecoveryCallout` design-system components, existing Persona visual diagnostics helpers.
+
+---
+
+## Context
+
+This plan follows the merged Stage 0 audit in `Docs/Reviews/PERSONA_BUDDY_CURRENT_STATE_AUDIT_2026_05_10.md` and GitHub issue `#1511`.
+
+The Stage 1 scope is intentionally narrow:
+
+- Add read-only diagnostics for the existing Persona/Buddy runtime.
+- Use existing client/runtime state only.
+- Do not add new MCP tools, backend endpoints, renderer behavior, native/background wake support, Persona Chat quality/eval work, or VN/CYOA changes.
+- Keep visual-pack failures fail-open: the assistant should continue to render or fall back while diagnostics explain what is degraded.
+
+## File Structure
+
+- Create: `apps/packages/ui/src/components/PersonaGarden/personaBuddyDiagnostics.ts`
+  - Pure TypeScript diagnostics model and projector.
+  - Converts route/runtime inputs into `healthy`, `unavailable`, `degraded`, or `recovering` plus diagnostic rows.
+  - No React imports.
+
+- Create: `apps/packages/ui/src/components/PersonaGarden/PersonaBuddyDiagnosticsPanel.tsx`
+  - Small presentational component around the diagnostics projection.
+  - Reuses `StatePanel` or `RecoveryCallout` from `apps/packages/ui/src/components/ui/state/`.
+
+- Create: `apps/packages/ui/src/components/PersonaGarden/__tests__/personaBuddyDiagnostics.test.ts`
+  - Unit coverage for the projector.
+
+- Create: `apps/packages/ui/src/components/PersonaGarden/__tests__/PersonaBuddyDiagnosticsPanel.test.tsx`
+  - Rendering coverage for the compact panel.
+
+- Modify: `apps/packages/ui/src/components/PersonaGarden/LiveSessionPanel.tsx`
+  - Add an optional `diagnostics?: React.ReactNode` slot.
+  - Render the slot without changing existing controls, assistant voice, error, transcript, or composer ordering semantics.
+
+- Modify: `apps/packages/ui/src/routes/sidepanel-persona.tsx`
+  - Build diagnostics inputs from existing route state.
+  - Pass the diagnostics panel into `LiveSessionPanel`.
+  - Use `capabilities.hasMcp` as the current MCP transport readiness signal; mark persona-visuals tool readiness as unknown when the route does not have a more specific client-side signal.
+
+- Modify: `apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx`
+  - Add one route-level degraded-state assertion proving the diagnostics surface appears while existing Persona Live controls remain available.
+
+- Modify: `Docs/Reviews/PERSONA_BUDDY_CURRENT_STATE_AUDIT_2026_05_10.md`
+  - Add a brief implementation note linking the Stage 1 diagnostics slice to issue `#1511` and the implementation plan.
+
+- Modify: `backlog/tasks/task-228 - Add-Persona-Buddy-diagnostics-surface.md`
+  - Keep Backlog status, plan, verification, and final summary current.
+
+## State Model
+
+Use a small, explicit projection type so behavior is testable without rendering the full route.
+
+```ts
+export type PersonaBuddyDiagnosticState =
+  | "healthy"
+  | "unavailable"
+  | "degraded"
+  | "recovering";
+
+export type PersonaBuddyDiagnosticRow = {
+  label: string;
+  value: string;
+  state?: PersonaBuddyDiagnosticState;
+  detail?: string;
+};
+
+export type PersonaBuddyDiagnostics = {
+  state: PersonaBuddyDiagnosticState;
+  title: string;
+  message: string;
+  rows: PersonaBuddyDiagnosticRow[];
+};
+```
+
+Severity rules, highest priority first:
+
+1. `unavailable`: server capabilities are still unavailable, persona support is missing, or no selected persona can be resolved.
+2. `recovering`: Live session is reconnecting/connecting, or live voice recovery mode is active.
+3. `degraded`: existing feature is available but impaired, such as Live websocket error, wake warning, text-only TTS fallback, visual pack load/render diagnostic with warning/error severity, or MCP unavailable.
+4. `healthy`: core Persona Live / Buddy state is usable, with informational rows allowed.
+
+Important visual-pack nuance:
+
+- `no_active_pack` is informational by default because a persona can validly use the default buddy avatar.
+- broken, unsupported, missing, or failed visual packs are degraded but fail open.
+
+## Task 1: Pure Diagnostics Projector
+
+**Files:**
+- Create: `apps/packages/ui/src/components/PersonaGarden/personaBuddyDiagnostics.ts`
+- Test: `apps/packages/ui/src/components/PersonaGarden/__tests__/personaBuddyDiagnostics.test.ts`
+
+- [ ] **Step 1: Write failing unit tests**
+
+Cover these cases:
+
+```ts
+it("returns healthy diagnostics for connected persona live state", () => {
+  const diagnostics = buildPersonaBuddyDiagnostics({
+    selectedPersona: { id: "persona-1", name: "Ada" },
+    profileState: "loaded",
+    buddySummary: "Uses the active persona profile.",
+    capabilities: { hasPersona: true, hasMcp: true },
+    liveSession: { connected: true, connecting: false, sessionId: "session-1" },
+    liveVoice: { state: "idle", recoveryMode: "none" },
+    wake: { armed: true, detectorState: "ready" },
+    visual: { packLoadStatus: "loaded", diagnostic: null },
+  });
+
+  expect(diagnostics.state).toBe("healthy");
+  expect(diagnostics.rows).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ label: "Persona", value: "Ada" }),
+      expect.objectContaining({ label: "Live session", value: "Connected" }),
+    ]),
+  );
+});
+
+it("marks missing persona support unavailable", () => {
+  const diagnostics = buildPersonaBuddyDiagnostics({
+    selectedPersona: null,
+    profileState: "idle",
+    buddySummary: null,
+    capabilities: { hasPersona: false, hasMcp: false },
+    liveSession: { connected: false, connecting: false, sessionId: null },
+    liveVoice: { state: "idle", recoveryMode: "none" },
+    wake: { armed: false, detectorState: "idle" },
+    visual: { packLoadStatus: "idle", diagnostic: null },
+  });
+
+  expect(diagnostics.state).toBe("unavailable");
+  expect(diagnostics.message).toMatch(/persona/i);
+});
+
+it("marks reconnecting live voice state recovering", () => {
+  const diagnostics = buildPersonaBuddyDiagnostics({
+    selectedPersona: { id: "persona-1", name: "Ada" },
+    profileState: "loaded",
+    buddySummary: "Ready",
+    capabilities: { hasPersona: true, hasMcp: true },
+    liveSession: { connected: false, connecting: true, sessionId: "session-1" },
+    liveVoice: { state: "listening", recoveryMode: "reconnect" },
+    wake: { armed: true, detectorState: "ready" },
+    visual: { packLoadStatus: "loaded", diagnostic: null },
+  });
+
+  expect(diagnostics.state).toBe("recovering");
+  expect(diagnostics.rows).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ label: "Live session", state: "recovering" }),
+    ]),
+  );
+});
+
+it("marks broken visual packs degraded without treating no active pack as broken", () => {
+  const diagnostics = buildPersonaBuddyDiagnostics({
+    selectedPersona: { id: "persona-1", name: "Ada" },
+    profileState: "loaded",
+    buddySummary: "Ready",
+    capabilities: { hasPersona: true, hasMcp: true },
+    liveSession: { connected: true, connecting: false, sessionId: "session-1" },
+    liveVoice: { state: "idle", recoveryMode: "none" },
+    wake: { armed: true, detectorState: "ready" },
+    visual: {
+      packLoadStatus: "error",
+      diagnostic: {
+        code: "missing_manifest",
+        severity: "warning",
+        message: "Visual pack manifest is missing.",
+      },
+    },
+  });
+
+  expect(diagnostics.state).toBe("degraded");
+  expect(diagnostics.rows).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ label: "Visual pack", state: "degraded" }),
+    ]),
+  );
+});
+```
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/PersonaGarden/__tests__/personaBuddyDiagnostics.test.ts
+```
+
+Expected: FAIL because `personaBuddyDiagnostics.ts` does not exist.
+
+- [ ] **Step 2: Implement the projector**
+
+Implementation requirements:
+
+- Export stable input/output types.
+- Keep copy concise and actionable.
+- Do not import React.
+- Accept nullable/unknown values from the route without throwing.
+- Convert missing optional state to `"Unavailable"` or `"Unknown"` rows instead of hiding the row.
+
+Suggested helper shape:
+
+```ts
+const stateRank: Record<PersonaBuddyDiagnosticState, number> = {
+  healthy: 0,
+  degraded: 1,
+  recovering: 2,
+  unavailable: 3,
+};
+
+function worseState(
+  current: PersonaBuddyDiagnosticState,
+  candidate: PersonaBuddyDiagnosticState,
+): PersonaBuddyDiagnosticState {
+  return stateRank[candidate] > stateRank[current] ? candidate : current;
+}
+```
+
+- [ ] **Step 3: Run projector tests**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/PersonaGarden/__tests__/personaBuddyDiagnostics.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit Task 1**
+
+```bash
+git add apps/packages/ui/src/components/PersonaGarden/personaBuddyDiagnostics.ts \
+  apps/packages/ui/src/components/PersonaGarden/__tests__/personaBuddyDiagnostics.test.ts \
+  "backlog/tasks/task-228 - Add-Persona-Buddy-diagnostics-surface.md"
+git commit -m "feat(ui): add persona buddy diagnostics projector"
+```
+
+## Task 2: Diagnostics Panel Component
+
+**Files:**
+- Create: `apps/packages/ui/src/components/PersonaGarden/PersonaBuddyDiagnosticsPanel.tsx`
+- Test: `apps/packages/ui/src/components/PersonaGarden/__tests__/PersonaBuddyDiagnosticsPanel.test.tsx`
+
+- [ ] **Step 1: Write failing render tests**
+
+```tsx
+it("renders compact diagnostics rows", () => {
+  render(
+    <PersonaBuddyDiagnosticsPanel
+      diagnostics={{
+        state: "degraded",
+        title: "Persona Buddy degraded",
+        message: "Visual pack needs attention.",
+        rows: [
+          { label: "Persona", value: "Ada", state: "healthy" },
+          { label: "Visual pack", value: "Missing manifest", state: "degraded" },
+        ],
+      }}
+    />,
+  );
+
+  expect(screen.getByText("Persona Buddy degraded")).toBeInTheDocument();
+  expect(screen.getByText("Visual pack")).toBeInTheDocument();
+  expect(screen.getByText("Missing manifest")).toBeInTheDocument();
+});
+```
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/PersonaGarden/__tests__/PersonaBuddyDiagnosticsPanel.test.tsx
+```
+
+Expected: FAIL because the component does not exist.
+
+- [ ] **Step 2: Implement the panel**
+
+Implementation requirements:
+
+- Use the existing `StatePanel` component from `apps/packages/ui/src/components/ui/state/StatePanel.tsx` unless its layout conflicts with Persona Live.
+- Keep it compact and unblocked: do not add modals, route changes, or hidden required interactions.
+- Add `data-testid="persona-buddy-diagnostics"` to the root.
+- Map diagnostic rows to `StatePanelDiagnostic[]`.
+- Prefer existing tones/copy patterns; do not create a new design-system variant.
+
+- [ ] **Step 3: Run panel tests**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/PersonaGarden/__tests__/PersonaBuddyDiagnosticsPanel.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit Task 2**
+
+```bash
+git add apps/packages/ui/src/components/PersonaGarden/PersonaBuddyDiagnosticsPanel.tsx \
+  apps/packages/ui/src/components/PersonaGarden/__tests__/PersonaBuddyDiagnosticsPanel.test.tsx \
+  "backlog/tasks/task-228 - Add-Persona-Buddy-diagnostics-surface.md"
+git commit -m "feat(ui): add persona buddy diagnostics panel"
+```
+
+## Task 3: Persona Live Route Integration
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/PersonaGarden/LiveSessionPanel.tsx`
+- Modify: `apps/packages/ui/src/routes/sidepanel-persona.tsx`
+- Modify: `apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx`
+
+- [ ] **Step 1: Write a failing route-level degraded-state test**
+
+Add a test that mounts the Persona sidepanel with:
+
+- persona capability enabled,
+- Live tab active,
+- selected persona resolved,
+- a visual-pack degraded signal or wake warning,
+- normal Live controls still visible.
+
+Expected assertions:
+
+```ts
+expect(await screen.findByTestId("persona-buddy-diagnostics")).toBeInTheDocument();
+expect(screen.getByText(/degraded/i)).toBeInTheDocument();
+expect(screen.getByRole("button", { name: /connect|disconnect|start/i })).toBeInTheDocument();
+```
+
+Use existing mocks in `sidepanel-persona.test.tsx`; do not create a separate route harness unless the current test file cannot express the state.
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx -t "diagnostics"
+```
+
+Expected: FAIL because the route does not render the diagnostics panel.
+
+- [ ] **Step 2: Add a diagnostics slot to `LiveSessionPanel`**
+
+Change props:
+
+```tsx
+export interface LiveSessionPanelProps {
+  controls: React.ReactNode;
+  assistantVoice: React.ReactNode;
+  diagnostics?: React.ReactNode;
+  error?: React.ReactNode;
+  pendingPlan?: React.ReactNode;
+  transcript: React.ReactNode;
+  composer: React.ReactNode;
+}
+```
+
+Render `diagnostics` near the voice/status controls, before transcript content, so it is visible but does not interrupt the transcript/composer workflow.
+
+- [ ] **Step 3: Build diagnostics inputs in `sidepanel-persona.tsx`**
+
+Use existing route state only:
+
+- selected persona id/name from current persona selection/profile state,
+- profile loading/error/loaded state,
+- Buddy summary/dormant state from current Buddy shell context,
+- Live websocket/session state from `usePersonaLiveSession`,
+- live voice state/recovery/warnings from `useLiveVoiceController`,
+- wake armed/detector/warning fields already passed to `AssistantVoiceCard`,
+- visual feedback and visual diagnostics already available from existing helpers or from a narrow route-local check,
+- `capabilities.hasMcp` for MCP transport readiness.
+
+Do not add a backend request for diagnostics in this task.
+
+- [ ] **Step 4: Render `PersonaBuddyDiagnosticsPanel` in the Live tab**
+
+Pass the rendered diagnostics node into:
+
+```tsx
+<LiveSessionPanel
+  controls={liveControls}
+  assistantVoice={assistantVoiceCard}
+  diagnostics={<PersonaBuddyDiagnosticsPanel diagnostics={personaBuddyDiagnostics} />}
+  error={liveSessionStatusPanels}
+  pendingPlan={pendingPlanCard}
+  transcript={transcriptPanel}
+  composer={composerPanel}
+/>
+```
+
+If route variables differ, keep the same intent: diagnostics is a sibling of existing Live status controls, not a replacement.
+
+- [ ] **Step 5: Run focused route test**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx -t "diagnostics"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 3**
+
+```bash
+git add apps/packages/ui/src/components/PersonaGarden/LiveSessionPanel.tsx \
+  apps/packages/ui/src/routes/sidepanel-persona.tsx \
+  apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx \
+  "backlog/tasks/task-228 - Add-Persona-Buddy-diagnostics-surface.md"
+git commit -m "feat(ui): surface persona buddy diagnostics in live view"
+```
+
+## Task 4: Documentation, Verification, And Backlog Closeout
+
+**Files:**
+- Modify: `Docs/Reviews/PERSONA_BUDDY_CURRENT_STATE_AUDIT_2026_05_10.md`
+- Modify: `backlog/tasks/task-228 - Add-Persona-Buddy-diagnostics-surface.md`
+
+- [ ] **Step 1: Add a Stage 1 implementation note to the audit**
+
+Add a short note under the Stage 1 diagnostics recommendation:
+
+```md
+Implementation tracking: Stage 1 Persona/Buddy diagnostics is tracked by
+GitHub issue #1511 and the implementation plan in
+Docs/superpowers/plans/2026-05-10-persona-buddy-diagnostics-implementation-plan.md.
+```
+
+- [ ] **Step 2: Run focused tests**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/PersonaGarden/__tests__/personaBuddyDiagnostics.test.ts \
+  apps/packages/ui/src/components/PersonaGarden/__tests__/PersonaBuddyDiagnosticsPanel.test.tsx \
+  apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx -t "diagnostics"
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run related visual diagnostics regression test**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/personaVisualDiagnostics.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run diff and security checks**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no whitespace errors.
+
+Bandit: skipped for this implementation if only TypeScript/Markdown/Backlog files changed. If Python files are touched, run Bandit on those touched Python paths using the repository virtual environment.
+
+- [ ] **Step 5: Update Backlog task**
+
+Mark acceptance criteria complete only after verification passes. Record:
+
+- files changed,
+- test commands and results,
+- Bandit skip or output,
+- PR URL when available.
+
+- [ ] **Step 6: Commit Task 4**
+
+```bash
+git add Docs/Reviews/PERSONA_BUDDY_CURRENT_STATE_AUDIT_2026_05_10.md \
+  "backlog/tasks/task-228 - Add-Persona-Buddy-diagnostics-surface.md"
+git commit -m "docs: track persona buddy diagnostics stage one"
+```
+
+## Final Verification Before PR
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/PersonaGarden/__tests__/personaBuddyDiagnostics.test.ts \
+  apps/packages/ui/src/components/PersonaGarden/__tests__/PersonaBuddyDiagnosticsPanel.test.tsx \
+  apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx -t "diagnostics"
+bunx vitest run apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/personaVisualDiagnostics.test.ts
+git diff --check
+```
+
+Expected:
+
+- All Vitest commands pass.
+- `git diff --check` reports no errors.
+- No Bandit run is required unless Python files are touched.
+
+## PR Notes
+
+The PR description should include a human-editable `Change summary` placeholder and mention:
+
+- This is Stage 1 of issue `#1511` under epic `#1510`.
+- The diagnostics surface is read-only and frontend-only.
+- The implementation uses existing Persona/Buddy runtime state and visual diagnostic helpers.
+- No new MCP tools, backend endpoints, renderer behavior, native wake support, Persona Chat quality changes, or VN/CYOA changes are included.

--- a/apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellHost.tsx
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellHost.tsx
@@ -298,6 +298,9 @@ const BuddyShellHostInner: React.FC<BuddyShellHostInnerProps> = ({
   const [visualRenderError, setVisualRenderError] =
     React.useState<PersonaVisualRenderErrorState | null>(null)
   const runtimeOverride = usePersonaVisualRuntimeStore((state) => state.override)
+  const setVisualRuntimeDiagnostics = usePersonaVisualRuntimeStore(
+    (state) => state.setRuntimeDiagnostics
+  )
   const clearExpiredVisualOverride = usePersonaVisualRuntimeStore(
     (state) => state.clearExpired
   )
@@ -399,6 +402,35 @@ const BuddyShellHostInner: React.FC<BuddyShellHostInnerProps> = ({
       renderError: activeVisualRenderError,
       includeNoActivePack: visualPackLoadStatus === "loaded"
     })
+
+  React.useEffect(() => {
+    const activePersonaId = String(resolvedPersona.activePersonaId || "").trim()
+    if (!resolvedPersona.hasTargetPersona || !activePersonaId) {
+      setVisualRuntimeDiagnostics(null)
+      return
+    }
+
+    setVisualRuntimeDiagnostics({
+      personaId: activePersonaId,
+      sessionId: renderContext.live_session_id ?? null,
+      packId: visualPack?.id ?? null,
+      packTitle: visualPack?.title ?? null,
+      packLoadStatus: visualPackLoadStatus,
+      visualState,
+      diagnostic: visualDiagnostic,
+      updatedAt: Date.now()
+    })
+  }, [
+    renderContext.live_session_id,
+    resolvedPersona.activePersonaId,
+    resolvedPersona.hasTargetPersona,
+    setVisualRuntimeDiagnostics,
+    visualDiagnostic,
+    visualPack?.id,
+    visualPack?.title,
+    visualPackLoadStatus,
+    visualState
+  ])
   const portalRoot = ensurePortalRoot()
 
   if (!resolvedPersona.hasTargetPersona) {

--- a/apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellHost.tsx
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellHost.tsx
@@ -301,9 +301,15 @@ const BuddyShellHostInner: React.FC<BuddyShellHostInnerProps> = ({
   const setVisualRuntimeDiagnostics = usePersonaVisualRuntimeStore(
     (state) => state.setRuntimeDiagnostics
   )
+  const clearVisualRuntimeDiagnostics = usePersonaVisualRuntimeStore(
+    (state) => state.clearRuntimeDiagnostics
+  )
   const clearExpiredVisualOverride = usePersonaVisualRuntimeStore(
     (state) => state.clearExpired
   )
+  const visualDiagnosticsSourceId = `${root}:${
+    renderContext.surface_id || "unknown"
+  }`
 
   React.useEffect(() => {
     clearExpiredVisualOverride()
@@ -393,24 +399,34 @@ const BuddyShellHostInner: React.FC<BuddyShellHostInnerProps> = ({
     },
     [visualRenderKey]
   )
-  const visualDiagnostic: PersonaVisualDiagnostic | null =
-    getPrimaryPersonaVisualDiagnostic({
-      pack: visualPack,
-      visualState,
-      loadStatus: visualPackLoadStatus,
-      loadError: visualPackLoadError,
-      renderError: activeVisualRenderError,
-      includeNoActivePack: visualPackLoadStatus === "loaded"
-    })
+  const visualDiagnostic: PersonaVisualDiagnostic | null = React.useMemo(
+    () =>
+      getPrimaryPersonaVisualDiagnostic({
+        pack: visualPack,
+        visualState,
+        loadStatus: visualPackLoadStatus,
+        loadError: visualPackLoadError,
+        renderError: activeVisualRenderError,
+        includeNoActivePack: visualPackLoadStatus === "loaded"
+      }),
+    [
+      activeVisualRenderError,
+      visualPack,
+      visualPackLoadError,
+      visualPackLoadStatus,
+      visualState
+    ]
+  )
 
   React.useEffect(() => {
     const activePersonaId = String(resolvedPersona.activePersonaId || "").trim()
     if (!resolvedPersona.hasTargetPersona || !activePersonaId) {
-      setVisualRuntimeDiagnostics(null)
-      return
+      clearVisualRuntimeDiagnostics(visualDiagnosticsSourceId)
+      return undefined
     }
 
     setVisualRuntimeDiagnostics({
+      sourceId: visualDiagnosticsSourceId,
       personaId: activePersonaId,
       sessionId: renderContext.live_session_id ?? null,
       packId: visualPack?.id ?? null,
@@ -420,12 +436,17 @@ const BuddyShellHostInner: React.FC<BuddyShellHostInnerProps> = ({
       diagnostic: visualDiagnostic,
       updatedAt: Date.now()
     })
+    return () => {
+      clearVisualRuntimeDiagnostics(visualDiagnosticsSourceId)
+    }
   }, [
+    clearVisualRuntimeDiagnostics,
     renderContext.live_session_id,
     resolvedPersona.activePersonaId,
     resolvedPersona.hasTargetPersona,
     setVisualRuntimeDiagnostics,
     visualDiagnostic,
+    visualDiagnosticsSourceId,
     visualPack?.id,
     visualPack?.title,
     visualPackLoadStatus,

--- a/apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx
@@ -11,6 +11,7 @@ import {
   DEFAULT_PERSONA_BUDDY_SHELL_POSITIONS,
   usePersonaBuddyShellStore
 } from "@/store/persona-buddy-shell"
+import { usePersonaVisualRuntimeStore } from "@/store/persona-visual-runtime"
 import type { PersonaBuddyRenderContext } from "@/types/persona-buddy"
 import { BuddyShellHost } from "../BuddyShellHost"
 
@@ -182,6 +183,10 @@ describe("BuddyShellHost", () => {
           ...DEFAULT_PERSONA_BUDDY_SHELL_POSITIONS["sidepanel-desktop"]
         }
       }
+    })
+    usePersonaVisualRuntimeStore.setState({
+      override: null,
+      runtimeDiagnostics: null
     })
   })
 
@@ -505,6 +510,44 @@ describe("BuddyShellHost", () => {
         expect.stringContaining("/assets/idle.png")
       )
     })
+  })
+
+  it("clears published visual diagnostics when the host unmounts", async () => {
+    const visualPack = buildVisualPack("persona-1")
+    visualMocks.listPersonaVisualPacks.mockResolvedValue({
+      packs: [visualPack],
+      active_pack: visualPack
+    })
+
+    const view = renderHost({
+      context: {
+        surface_id: "persona-garden",
+        surface_active: true,
+        active_persona_id: "persona-1",
+        position_bucket: "sidepanel-desktop",
+        persona_source: "route-local",
+        buddy_summary: buildBuddySummary("persona-1"),
+        live_voice_state: "idle"
+      },
+      root: "sidepanel"
+    })
+
+    await waitFor(() => {
+      expect(
+        usePersonaVisualRuntimeStore.getState().runtimeDiagnostics
+      ).toEqual(
+        expect.objectContaining({
+          personaId: "persona-1",
+          packId: "pack-1",
+          packLoadStatus: "loaded",
+          visualState: "idle"
+        })
+      )
+    })
+
+    view.unmount()
+
+    expect(usePersonaVisualRuntimeStore.getState().runtimeDiagnostics).toBeNull()
   })
 
   it("links the active buddy popover to the persona Visuals workflow", () => {

--- a/apps/packages/ui/src/components/PersonaGarden/LiveSessionPanel.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/LiveSessionPanel.tsx
@@ -3,6 +3,7 @@ import React from "react"
 type LiveSessionPanelProps = {
   controls: React.ReactNode
   assistantVoice?: React.ReactNode
+  diagnostics?: React.ReactNode
   error: React.ReactNode
   pendingPlan: React.ReactNode
   transcript: React.ReactNode
@@ -12,6 +13,7 @@ type LiveSessionPanelProps = {
 export const LiveSessionPanel: React.FC<LiveSessionPanelProps> = ({
   controls,
   assistantVoice,
+  diagnostics,
   error,
   pendingPlan,
   transcript,
@@ -21,6 +23,7 @@ export const LiveSessionPanel: React.FC<LiveSessionPanelProps> = ({
     <div className="flex flex-1 flex-col gap-3">
       {controls}
       {assistantVoice}
+      {diagnostics}
       {error}
       {pendingPlan}
       {transcript}

--- a/apps/packages/ui/src/components/PersonaGarden/PersonaBuddyDiagnosticsPanel.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/PersonaBuddyDiagnosticsPanel.tsx
@@ -1,0 +1,54 @@
+import React from "react"
+
+import type { DesignSystemStateKey } from "@/design-system"
+import { cn } from "@/libs/utils"
+
+import {
+  StatePanel,
+  type StatePanelDiagnostic
+} from "../ui/state/StatePanel"
+import type {
+  PersonaBuddyDiagnosticState,
+  PersonaBuddyDiagnostics
+} from "./personaBuddyDiagnostics"
+
+export interface PersonaBuddyDiagnosticsPanelProps {
+  diagnostics: PersonaBuddyDiagnostics
+  className?: string
+}
+
+const panelStateByDiagnosticState: Record<
+  PersonaBuddyDiagnosticState,
+  DesignSystemStateKey
+> = {
+  healthy: "ready",
+  unavailable: "unavailable",
+  degraded: "degraded",
+  recovering: "retrying"
+}
+
+const mapDiagnosticRows = (
+  diagnostics: PersonaBuddyDiagnostics
+): StatePanelDiagnostic[] =>
+  diagnostics.rows.map((row) => {
+    return {
+      label: row.label,
+      value: row.detail ? `${row.value} - ${row.detail}` : row.value
+    }
+  })
+
+export const PersonaBuddyDiagnosticsPanel: React.FC<
+  PersonaBuddyDiagnosticsPanelProps
+> = ({ diagnostics, className }) => {
+  return (
+    <StatePanel
+      state={panelStateByDiagnosticState[diagnostics.state]}
+      title={diagnostics.title}
+      message={diagnostics.message}
+      diagnostics={mapDiagnosticRows(diagnostics)}
+      className={cn("shadow-none", className)}
+      data-testid="persona-buddy-diagnostics"
+      aria-live={diagnostics.state === "recovering" ? "polite" : undefined}
+    />
+  )
+}

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/PersonaBuddyDiagnosticsPanel.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/PersonaBuddyDiagnosticsPanel.test.tsx
@@ -1,0 +1,44 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { PersonaBuddyDiagnosticsPanel } from "../PersonaBuddyDiagnosticsPanel"
+
+describe("PersonaBuddyDiagnosticsPanel", () => {
+  it("renders compact diagnostics rows", () => {
+    render(
+      <PersonaBuddyDiagnosticsPanel
+        diagnostics={{
+          state: "degraded",
+          title: "Persona Buddy degraded",
+          message: "Visual pack needs attention.",
+          rows: [
+            { label: "Persona", value: "Ada", state: "healthy" },
+            { label: "Visual pack", value: "Missing manifest", state: "degraded" }
+          ]
+        }}
+      />
+    )
+
+    expect(screen.getByTestId("persona-buddy-diagnostics")).toBeInTheDocument()
+    expect(screen.getByText("Persona Buddy degraded")).toBeInTheDocument()
+    expect(screen.getByText("Visual pack")).toBeInTheDocument()
+    expect(screen.getByText("Missing manifest")).toBeInTheDocument()
+  })
+
+  it("maps recovering diagnostics to the design-system retrying state", () => {
+    render(
+      <PersonaBuddyDiagnosticsPanel
+        diagnostics={{
+          state: "recovering",
+          title: "Persona Buddy recovering",
+          message: "Live session is reconnecting.",
+          rows: [{ label: "Live session", value: "Reconnecting", state: "recovering" }]
+        }}
+      />
+    )
+
+    expect(screen.getByText("Retrying")).toBeInTheDocument()
+    expect(screen.getByText("Live session")).toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/personaBuddyDiagnostics.test.ts
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/personaBuddyDiagnostics.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest"
+
+import { buildPersonaBuddyDiagnostics } from "../personaBuddyDiagnostics"
+
+describe("buildPersonaBuddyDiagnostics", () => {
+  it("returns healthy diagnostics for connected persona live state", () => {
+    const diagnostics = buildPersonaBuddyDiagnostics({
+      selectedPersona: { id: "persona-1", name: "Ada" },
+      profileState: "loaded",
+      buddySummary: "Uses the active persona profile.",
+      capabilities: { hasPersona: true, hasMcp: true },
+      liveSession: { connected: true, connecting: false, sessionId: "session-1" },
+      liveVoice: { state: "idle", recoveryMode: "none" },
+      wake: { armed: true, detectorState: "ready", triggerPhrases: ["hey ada"] },
+      visual: { packLoadStatus: "loaded", diagnostic: null }
+    })
+
+    expect(diagnostics.state).toBe("healthy")
+    expect(diagnostics.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: "Persona", value: "Ada" }),
+        expect.objectContaining({ label: "Live session", value: "Connected" })
+      ])
+    )
+  })
+
+  it("marks missing persona support unavailable", () => {
+    const diagnostics = buildPersonaBuddyDiagnostics({
+      selectedPersona: null,
+      profileState: "idle",
+      buddySummary: null,
+      capabilities: { hasPersona: false, hasMcp: false },
+      liveSession: { connected: false, connecting: false, sessionId: null },
+      liveVoice: { state: "idle", recoveryMode: "none" },
+      wake: { armed: false, detectorState: "idle" },
+      visual: { packLoadStatus: "idle", diagnostic: null }
+    })
+
+    expect(diagnostics.state).toBe("unavailable")
+    expect(diagnostics.message).toMatch(/persona/i)
+  })
+
+  it("marks reconnecting live voice state recovering", () => {
+    const diagnostics = buildPersonaBuddyDiagnostics({
+      selectedPersona: { id: "persona-1", name: "Ada" },
+      profileState: "loaded",
+      buddySummary: "Ready",
+      capabilities: { hasPersona: true, hasMcp: true },
+      liveSession: { connected: false, connecting: true, sessionId: "session-1" },
+      liveVoice: { state: "listening", recoveryMode: "reconnect" },
+      wake: { armed: true, detectorState: "ready" },
+      visual: { packLoadStatus: "loaded", diagnostic: null }
+    })
+
+    expect(diagnostics.state).toBe("recovering")
+    expect(diagnostics.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: "Live session", state: "recovering" })
+      ])
+    )
+  })
+
+  it("marks broken visual packs degraded without treating no active pack as broken", () => {
+    const degraded = buildPersonaBuddyDiagnostics({
+      selectedPersona: { id: "persona-1", name: "Ada" },
+      profileState: "loaded",
+      buddySummary: "Ready",
+      capabilities: { hasPersona: true, hasMcp: true },
+      liveSession: { connected: true, connecting: false, sessionId: "session-1" },
+      liveVoice: { state: "idle", recoveryMode: "none" },
+      wake: { armed: true, detectorState: "ready" },
+      visual: {
+        packLoadStatus: "error",
+        diagnostic: {
+          code: "missing_manifest",
+          severity: "warning",
+          title: "Visual pack manifest is missing",
+          message: "Visual pack manifest is missing."
+        }
+      }
+    })
+
+    expect(degraded.state).toBe("degraded")
+    expect(degraded.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: "Visual pack", state: "degraded" })
+      ])
+    )
+
+    const fallback = buildPersonaBuddyDiagnostics({
+      selectedPersona: { id: "persona-1", name: "Ada" },
+      profileState: "loaded",
+      buddySummary: "Ready",
+      capabilities: { hasPersona: true, hasMcp: true },
+      liveSession: { connected: true, connecting: false, sessionId: "session-1" },
+      liveVoice: { state: "idle", recoveryMode: "none" },
+      wake: { armed: true, detectorState: "ready" },
+      visual: {
+        packLoadStatus: "idle",
+        diagnostic: {
+          code: "no_active_pack",
+          severity: "info",
+          title: "No active visual pack",
+          message: "This persona is using the text Buddy fallback."
+        }
+      }
+    })
+
+    expect(fallback.state).toBe("healthy")
+    expect(fallback.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: "Visual pack", state: "healthy" })
+      ])
+    )
+  })
+
+  it("surfaces wake warnings and MCP readiness as degraded diagnostics", () => {
+    const diagnostics = buildPersonaBuddyDiagnostics({
+      selectedPersona: { id: "persona-1", name: "Ada" },
+      profileState: "loaded",
+      buddySummary: "Ready",
+      capabilities: { hasPersona: true, hasMcp: false },
+      liveSession: { connected: true, connecting: false, sessionId: "session-1" },
+      liveVoice: { state: "idle", recoveryMode: "none" },
+      wake: {
+        armed: true,
+        detectorState: "unavailable",
+        warning: "Wake listening is unavailable in this browser context."
+      },
+      visual: { packLoadStatus: "loaded", diagnostic: null }
+    })
+
+    expect(diagnostics.state).toBe("degraded")
+    expect(diagnostics.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: "Wake", state: "degraded" }),
+        expect.objectContaining({ label: "MCP persona_visuals", state: "degraded" })
+      ])
+    )
+  })
+})

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/personaBuddyDiagnostics.test.ts
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/personaBuddyDiagnostics.test.ts
@@ -27,7 +27,7 @@ describe("buildPersonaBuddyDiagnostics", () => {
         expect.objectContaining({ label: "Persona", value: "Ada" }),
         expect.objectContaining({
           label: "Visual pack",
-          value: "Animated Pack",
+          value: "Animated Pack (pack-1)",
           detail: "Render state: Idle"
         }),
         expect.objectContaining({ label: "Live session", value: "Connected" })
@@ -146,6 +146,103 @@ describe("buildPersonaBuddyDiagnostics", () => {
       expect.arrayContaining([
         expect.objectContaining({ label: "Wake", state: "degraded" }),
         expect.objectContaining({ label: "MCP persona_visuals", state: "degraded" })
+      ])
+    )
+  })
+
+  it("does not mark intentionally dormant Buddy summaries as degraded", () => {
+    const diagnostics = buildPersonaBuddyDiagnostics({
+      selectedPersona: { id: "persona-1", name: "Ada" },
+      profileState: "loaded",
+      buddySummary: null,
+      capabilities: { hasPersona: true, hasMcp: true },
+      liveSession: { connected: false, connecting: false, sessionId: null },
+      liveVoice: { state: "idle", recoveryMode: "none" },
+      wake: { armed: false, detectorState: "idle" },
+      visual: { packLoadStatus: "idle", diagnostic: null }
+    })
+
+    expect(diagnostics.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "Buddy",
+          value: "Dormant",
+          state: "healthy"
+        })
+      ])
+    )
+    expect(diagnostics.state).toBe("healthy")
+  })
+
+  it("treats unconfirmed MCP and Persona capability readiness as degraded or unavailable", () => {
+    const unknownMcp = buildPersonaBuddyDiagnostics({
+      selectedPersona: { id: "persona-1", name: "Ada" },
+      profileState: "loaded",
+      buddySummary: "Ready",
+      capabilities: { hasPersona: true },
+      liveSession: { connected: false, connecting: false, sessionId: null },
+      liveVoice: { state: "idle", recoveryMode: "none" },
+      wake: { armed: false, detectorState: "idle" },
+      visual: { packLoadStatus: "idle", diagnostic: null }
+    })
+
+    expect(unknownMcp.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "MCP persona_visuals",
+          value: "Unknown",
+          state: "degraded"
+        })
+      ])
+    )
+    expect(unknownMcp.state).toBe("degraded")
+
+    const unknownPersonaCapability = buildPersonaBuddyDiagnostics({
+      selectedPersona: { id: "persona-1", name: "Ada" },
+      profileState: "loaded",
+      buddySummary: "Ready",
+      capabilities: { hasMcp: true },
+      liveSession: { connected: false, connecting: false, sessionId: null },
+      liveVoice: { state: "idle", recoveryMode: "none" },
+      wake: { armed: false, detectorState: "idle" },
+      visual: { packLoadStatus: "idle", diagnostic: null }
+    })
+
+    expect(unknownPersonaCapability.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "Server capability",
+          value: "Persona unavailable",
+          state: "unavailable"
+        })
+      ])
+    )
+    expect(unknownPersonaCapability.state).toBe("unavailable")
+  })
+
+  it("surfaces live session last events in the session diagnostics row", () => {
+    const diagnostics = buildPersonaBuddyDiagnostics({
+      selectedPersona: { id: "persona-1", name: "Ada" },
+      profileState: "loaded",
+      buddySummary: "Ready",
+      capabilities: { hasPersona: true, hasMcp: true },
+      liveSession: {
+        connected: true,
+        connecting: false,
+        sessionId: "session-1",
+        lastEvent: "ws_open"
+      },
+      liveVoice: { state: "idle", recoveryMode: "none" },
+      wake: { armed: false, detectorState: "idle" },
+      visual: { packLoadStatus: "idle", diagnostic: null }
+    })
+
+    expect(diagnostics.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "Live session",
+          detail: "Session session-1 - Last event: ws_open"
+        })
       ])
     )
   })

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/personaBuddyDiagnostics.test.ts
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/personaBuddyDiagnostics.test.ts
@@ -12,13 +12,24 @@ describe("buildPersonaBuddyDiagnostics", () => {
       liveSession: { connected: true, connecting: false, sessionId: "session-1" },
       liveVoice: { state: "idle", recoveryMode: "none" },
       wake: { armed: true, detectorState: "ready", triggerPhrases: ["hey ada"] },
-      visual: { packLoadStatus: "loaded", diagnostic: null }
+      visual: {
+        packId: "pack-1",
+        packTitle: "Animated Pack",
+        packLoadStatus: "loaded",
+        visualState: "idle",
+        diagnostic: null
+      }
     })
 
     expect(diagnostics.state).toBe("healthy")
     expect(diagnostics.rows).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ label: "Persona", value: "Ada" }),
+        expect.objectContaining({
+          label: "Visual pack",
+          value: "Animated Pack",
+          detail: "Render state: Idle"
+        }),
         expect.objectContaining({ label: "Live session", value: "Connected" })
       ])
     )

--- a/apps/packages/ui/src/components/PersonaGarden/personaBuddyDiagnostics.ts
+++ b/apps/packages/ui/src/components/PersonaGarden/personaBuddyDiagnostics.ts
@@ -95,6 +95,12 @@ const titleCase = (value: string | null | undefined, fallback = "Unknown") => {
     .replace(/\b\w/g, (letter) => letter.toUpperCase())
 }
 
+const joinDetails = (parts: Array<string | null | undefined>) =>
+  parts
+    .map((part) => String(part || "").trim())
+    .filter(Boolean)
+    .join(" - ") || undefined
+
 const summarizeBuddy = (
   buddySummary: PersonaBuddyDiagnosticsInput["buddySummary"]
 ): PersonaBuddyDiagnosticRow => {
@@ -122,7 +128,7 @@ const summarizeBuddy = (
   return {
     label: "Buddy",
     value: "Dormant",
-    state: "degraded",
+    state: "healthy",
     detail: "No Buddy summary is attached to the selected persona."
   }
 }
@@ -131,6 +137,9 @@ const summarizeVisual = (
   visual: PersonaBuddyDiagnosticsInput["visual"]
 ): PersonaBuddyDiagnosticRow => {
   const diagnostic = visual?.diagnostic
+  const packId = String(visual?.packId || "").trim()
+  const packTitle = String(visual?.packTitle || "").trim()
+  const packIdDetail = packId ? `Pack ID: ${packId}` : undefined
   const renderState = visual?.visualState
     ? `Render state: ${titleCase(visual.visualState)}`
     : undefined
@@ -139,7 +148,7 @@ const summarizeVisual = (
       label: "Visual pack",
       value: "Default Buddy fallback",
       state: "healthy",
-      detail: [diagnostic.message, renderState].filter(Boolean).join(" - ")
+      detail: joinDetails([diagnostic.message, packIdDetail, renderState])
     }
   }
 
@@ -148,7 +157,7 @@ const summarizeVisual = (
       label: "Visual pack",
       value: diagnostic.title || titleCase(diagnostic.code),
       state: diagnostic.severity === "info" ? "healthy" : "degraded",
-      detail: [diagnostic.message, renderState].filter(Boolean).join(" - ")
+      detail: joinDetails([diagnostic.message, packIdDetail, renderState])
     }
   }
 
@@ -157,7 +166,7 @@ const summarizeVisual = (
       label: "Visual pack",
       value: "Loading",
       state: "recovering",
-      detail: renderState
+      detail: joinDetails([packIdDetail, renderState])
     }
   }
 
@@ -166,16 +175,21 @@ const summarizeVisual = (
       label: "Visual pack",
       value: "Load failed",
       state: "degraded",
-      detail: ["The active visual pack could not be loaded.", renderState]
-        .filter(Boolean)
-        .join(" - ")
+      detail: joinDetails([
+        "The active visual pack could not be loaded.",
+        packIdDetail,
+        renderState
+      ])
     }
   }
 
-  const activePack = visual?.packTitle || visual?.packId
+  const activePack =
+    packTitle && packId
+      ? `${packTitle} (${packId})`
+      : packTitle || packId || ""
   return {
     label: "Visual pack",
-    value: activePack ? String(activePack) : "Default Buddy fallback",
+    value: activePack || "Default Buddy fallback",
     state: "healthy",
     detail: renderState
   }
@@ -184,12 +198,21 @@ const summarizeVisual = (
 const summarizeLiveSession = (
   liveSession: PersonaBuddyDiagnosticsInput["liveSession"]
 ): PersonaBuddyDiagnosticRow => {
+  const sessionDetail = liveSession?.sessionId
+    ? `Session ${liveSession.sessionId}`
+    : undefined
+  const lastEvent = String(liveSession?.lastEvent || "").trim()
+  const lastEventDetail =
+    lastEvent && lastEvent !== liveSession?.error
+      ? `Last event: ${lastEvent}`
+      : undefined
+
   if (liveSession?.connecting) {
     return {
       label: "Live session",
       value: "Reconnecting",
       state: "recovering",
-      detail: liveSession.sessionId ? `Session ${liveSession.sessionId}` : undefined
+      detail: joinDetails([sessionDetail, lastEventDetail])
     }
   }
 
@@ -198,7 +221,7 @@ const summarizeLiveSession = (
       label: "Live session",
       value: "Connection issue",
       state: "degraded",
-      detail: liveSession.error
+      detail: joinDetails([liveSession.error, lastEventDetail])
     }
   }
 
@@ -207,14 +230,15 @@ const summarizeLiveSession = (
       label: "Live session",
       value: "Connected",
       state: "healthy",
-      detail: liveSession.sessionId ? `Session ${liveSession.sessionId}` : undefined
+      detail: joinDetails([sessionDetail, lastEventDetail])
     }
   }
 
   return {
     label: "Live session",
     value: "Ready to connect",
-    state: "healthy"
+    state: "healthy",
+    detail: lastEventDetail
   }
 }
 
@@ -303,7 +327,7 @@ const summarizeMcp = (
   return {
     label: "MCP persona_visuals",
     value: "Unknown",
-    state: "healthy",
+    state: "degraded",
     detail: "Server capability discovery has not reported MCP readiness."
   }
 }
@@ -375,7 +399,7 @@ export const buildPersonaBuddyDiagnostics = ({
     }
     rows.push(row)
     state = worseState(state, row.state || "healthy")
-  } else if (!capabilities || capabilities.hasPersona === false) {
+  } else if (!capabilities || capabilities.hasPersona !== true) {
     const row: PersonaBuddyDiagnosticRow = {
       label: "Server capability",
       value: "Persona unavailable",

--- a/apps/packages/ui/src/components/PersonaGarden/personaBuddyDiagnostics.ts
+++ b/apps/packages/ui/src/components/PersonaGarden/personaBuddyDiagnostics.ts
@@ -68,6 +68,7 @@ export type PersonaBuddyDiagnosticsInput = {
     packId?: string | null
     packTitle?: string | null
     packLoadStatus?: "idle" | "loading" | "loaded" | "error"
+    visualState?: string | null
     diagnostic?: PersonaVisualDiagnostic | null
   } | null
 }
@@ -130,12 +131,15 @@ const summarizeVisual = (
   visual: PersonaBuddyDiagnosticsInput["visual"]
 ): PersonaBuddyDiagnosticRow => {
   const diagnostic = visual?.diagnostic
+  const renderState = visual?.visualState
+    ? `Render state: ${titleCase(visual.visualState)}`
+    : undefined
   if (diagnostic?.code === "no_active_pack") {
     return {
       label: "Visual pack",
       value: "Default Buddy fallback",
       state: "healthy",
-      detail: diagnostic.message
+      detail: [diagnostic.message, renderState].filter(Boolean).join(" - ")
     }
   }
 
@@ -144,7 +148,7 @@ const summarizeVisual = (
       label: "Visual pack",
       value: diagnostic.title || titleCase(diagnostic.code),
       state: diagnostic.severity === "info" ? "healthy" : "degraded",
-      detail: diagnostic.message
+      detail: [diagnostic.message, renderState].filter(Boolean).join(" - ")
     }
   }
 
@@ -152,7 +156,8 @@ const summarizeVisual = (
     return {
       label: "Visual pack",
       value: "Loading",
-      state: "recovering"
+      state: "recovering",
+      detail: renderState
     }
   }
 
@@ -161,7 +166,9 @@ const summarizeVisual = (
       label: "Visual pack",
       value: "Load failed",
       state: "degraded",
-      detail: "The active visual pack could not be loaded."
+      detail: ["The active visual pack could not be loaded.", renderState]
+        .filter(Boolean)
+        .join(" - ")
     }
   }
 
@@ -169,7 +176,8 @@ const summarizeVisual = (
   return {
     label: "Visual pack",
     value: activePack ? String(activePack) : "Default Buddy fallback",
-    state: "healthy"
+    state: "healthy",
+    detail: renderState
   }
 }
 

--- a/apps/packages/ui/src/components/PersonaGarden/personaBuddyDiagnostics.ts
+++ b/apps/packages/ui/src/components/PersonaGarden/personaBuddyDiagnostics.ts
@@ -1,0 +1,431 @@
+import type { PersonaVisualDiagnostic } from "@/components/Common/PersonaBuddy/personaVisualDiagnostics"
+
+export type PersonaBuddyDiagnosticState =
+  | "healthy"
+  | "unavailable"
+  | "degraded"
+  | "recovering"
+
+export type PersonaBuddyProfileState = "idle" | "loading" | "loaded" | "error"
+
+export type PersonaBuddyDiagnosticRow = {
+  label: string
+  value: string
+  state?: PersonaBuddyDiagnosticState
+  detail?: string
+}
+
+export type PersonaBuddyDiagnostics = {
+  state: PersonaBuddyDiagnosticState
+  title: string
+  message: string
+  rows: PersonaBuddyDiagnosticRow[]
+}
+
+export type PersonaBuddyDiagnosticsInput = {
+  selectedPersona?: {
+    id?: string | null
+    name?: string | null
+  } | null
+  profileState?: PersonaBuddyProfileState
+  profileError?: string | null
+  buddySummary?:
+    | string
+    | {
+        has_buddy?: boolean | null
+        persona_name?: string | null
+        role_summary?: string | null
+      }
+    | null
+  capabilities?: {
+    hasPersona?: boolean | null
+    hasMcp?: boolean | null
+  } | null
+  capabilitiesLoading?: boolean
+  liveSession?: {
+    connected?: boolean
+    connecting?: boolean
+    sessionId?: string | null
+    error?: string | null
+    lastEvent?: string | null
+  } | null
+  liveVoice?: {
+    state?: string | null
+    recoveryMode?: string | null
+    warning?: string | null
+    activeToolStatus?: string | null
+    textOnlyDueToTtsFailure?: boolean
+    manualModeRequired?: boolean
+  } | null
+  wake?: {
+    armed?: boolean
+    detectorState?: string | null
+    warning?: string | null
+    triggerPhrases?: string[] | null
+    behavior?: string | null
+  } | null
+  visual?: {
+    packId?: string | null
+    packTitle?: string | null
+    packLoadStatus?: "idle" | "loading" | "loaded" | "error"
+    diagnostic?: PersonaVisualDiagnostic | null
+  } | null
+}
+
+const stateRank: Record<PersonaBuddyDiagnosticState, number> = {
+  healthy: 0,
+  degraded: 1,
+  recovering: 2,
+  unavailable: 3
+}
+
+const worseState = (
+  current: PersonaBuddyDiagnosticState,
+  candidate: PersonaBuddyDiagnosticState
+): PersonaBuddyDiagnosticState =>
+  stateRank[candidate] > stateRank[current] ? candidate : current
+
+const titleCase = (value: string | null | undefined, fallback = "Unknown") => {
+  const normalized = String(value || "").trim()
+  if (!normalized) return fallback
+  return normalized
+    .replace(/[_-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .replace(/\b\w/g, (letter) => letter.toUpperCase())
+}
+
+const summarizeBuddy = (
+  buddySummary: PersonaBuddyDiagnosticsInput["buddySummary"]
+): PersonaBuddyDiagnosticRow => {
+  if (typeof buddySummary === "string" && buddySummary.trim()) {
+    return {
+      label: "Buddy",
+      value: "Ready",
+      state: "healthy",
+      detail: buddySummary.trim()
+    }
+  }
+
+  if (buddySummary && typeof buddySummary === "object") {
+    const roleSummary = String(buddySummary.role_summary || "").trim()
+    if (buddySummary.has_buddy || roleSummary) {
+      return {
+        label: "Buddy",
+        value: "Ready",
+        state: "healthy",
+        detail: roleSummary || "Buddy summary is attached to this persona."
+      }
+    }
+  }
+
+  return {
+    label: "Buddy",
+    value: "Dormant",
+    state: "degraded",
+    detail: "No Buddy summary is attached to the selected persona."
+  }
+}
+
+const summarizeVisual = (
+  visual: PersonaBuddyDiagnosticsInput["visual"]
+): PersonaBuddyDiagnosticRow => {
+  const diagnostic = visual?.diagnostic
+  if (diagnostic?.code === "no_active_pack") {
+    return {
+      label: "Visual pack",
+      value: "Default Buddy fallback",
+      state: "healthy",
+      detail: diagnostic.message
+    }
+  }
+
+  if (diagnostic) {
+    return {
+      label: "Visual pack",
+      value: diagnostic.title || titleCase(diagnostic.code),
+      state: diagnostic.severity === "info" ? "healthy" : "degraded",
+      detail: diagnostic.message
+    }
+  }
+
+  if (visual?.packLoadStatus === "loading") {
+    return {
+      label: "Visual pack",
+      value: "Loading",
+      state: "recovering"
+    }
+  }
+
+  if (visual?.packLoadStatus === "error") {
+    return {
+      label: "Visual pack",
+      value: "Load failed",
+      state: "degraded",
+      detail: "The active visual pack could not be loaded."
+    }
+  }
+
+  const activePack = visual?.packTitle || visual?.packId
+  return {
+    label: "Visual pack",
+    value: activePack ? String(activePack) : "Default Buddy fallback",
+    state: "healthy"
+  }
+}
+
+const summarizeLiveSession = (
+  liveSession: PersonaBuddyDiagnosticsInput["liveSession"]
+): PersonaBuddyDiagnosticRow => {
+  if (liveSession?.connecting) {
+    return {
+      label: "Live session",
+      value: "Reconnecting",
+      state: "recovering",
+      detail: liveSession.sessionId ? `Session ${liveSession.sessionId}` : undefined
+    }
+  }
+
+  if (liveSession?.error) {
+    return {
+      label: "Live session",
+      value: "Connection issue",
+      state: "degraded",
+      detail: liveSession.error
+    }
+  }
+
+  if (liveSession?.connected) {
+    return {
+      label: "Live session",
+      value: "Connected",
+      state: "healthy",
+      detail: liveSession.sessionId ? `Session ${liveSession.sessionId}` : undefined
+    }
+  }
+
+  return {
+    label: "Live session",
+    value: "Ready to connect",
+    state: "healthy"
+  }
+}
+
+const summarizeLiveVoice = (
+  liveVoice: PersonaBuddyDiagnosticsInput["liveVoice"]
+): PersonaBuddyDiagnosticRow => {
+  const recoveryMode = String(liveVoice?.recoveryMode || "none").trim()
+  if (recoveryMode && recoveryMode !== "none") {
+    return {
+      label: "Live voice",
+      value: "Recovering",
+      state: "recovering",
+      detail: titleCase(recoveryMode)
+    }
+  }
+
+  if (
+    liveVoice?.warning ||
+    liveVoice?.textOnlyDueToTtsFailure ||
+    liveVoice?.manualModeRequired
+  ) {
+    return {
+      label: "Live voice",
+      value: liveVoice.textOnlyDueToTtsFailure ? "Text-only fallback" : "Limited",
+      state: "degraded",
+      detail: liveVoice.warning || "Manual voice controls are required for this session."
+    }
+  }
+
+  return {
+    label: "Live voice",
+    value: titleCase(liveVoice?.state, "Idle"),
+    state: "healthy",
+    detail: liveVoice?.activeToolStatus || undefined
+  }
+}
+
+const summarizeWake = (
+  wake: PersonaBuddyDiagnosticsInput["wake"]
+): PersonaBuddyDiagnosticRow => {
+  const detectorState = String(wake?.detectorState || "idle").trim()
+  if (wake?.warning || detectorState === "unavailable" || detectorState === "error") {
+    return {
+      label: "Wake",
+      value: "Limited",
+      state: "degraded",
+      detail: wake?.warning || `Wake detector state: ${titleCase(detectorState)}`
+    }
+  }
+
+  const phrases = wake?.triggerPhrases?.filter((phrase) => phrase.trim())
+  return {
+    label: "Wake",
+    value: wake?.armed ? "Armed" : "Not armed",
+    state: "healthy",
+    detail:
+      phrases && phrases.length > 0
+        ? `Listening for ${phrases.join(", ")}`
+        : wake?.behavior
+          ? `Behavior: ${titleCase(wake.behavior)}`
+          : undefined
+  }
+}
+
+const summarizeMcp = (
+  capabilities: PersonaBuddyDiagnosticsInput["capabilities"]
+): PersonaBuddyDiagnosticRow => {
+  if (capabilities?.hasMcp === false) {
+    return {
+      label: "MCP persona_visuals",
+      value: "Transport unavailable",
+      state: "degraded",
+      detail: "MCP is not advertised by the current server capabilities."
+    }
+  }
+
+  if (capabilities?.hasMcp === true) {
+    return {
+      label: "MCP persona_visuals",
+      value: "Transport ready",
+      state: "healthy",
+      detail: "Tool-level readiness is not checked by this client state."
+    }
+  }
+
+  return {
+    label: "MCP persona_visuals",
+    value: "Unknown",
+    state: "healthy",
+    detail: "Server capability discovery has not reported MCP readiness."
+  }
+}
+
+const deriveTitleAndMessage = (
+  state: PersonaBuddyDiagnosticState,
+  rows: PersonaBuddyDiagnosticRow[]
+) => {
+  if (state === "unavailable") {
+    const unavailable = rows.find((row) => row.state === "unavailable")
+    return {
+      title: "Persona Buddy unavailable",
+      message:
+        unavailable?.detail ||
+        "Persona support is not available from the current server state."
+    }
+  }
+  if (state === "recovering") {
+    return {
+      title: "Persona Buddy recovering",
+      message:
+        "Live session or voice state is reconnecting. Existing controls remain available."
+    }
+  }
+  if (state === "degraded") {
+    return {
+      title: "Persona Buddy degraded",
+      message:
+        "Core controls are available, but one or more assistant surfaces need attention."
+    }
+  }
+  return {
+    title: "Persona Buddy ready",
+    message: "Persona Live, Buddy, wake, MCP, and visual state are ready."
+  }
+}
+
+export const buildPersonaBuddyDiagnostics = ({
+  selectedPersona = null,
+  profileState = "idle",
+  profileError = null,
+  buddySummary = null,
+  capabilities = null,
+  capabilitiesLoading = false,
+  liveSession = null,
+  liveVoice = null,
+  wake = null,
+  visual = null
+}: PersonaBuddyDiagnosticsInput): PersonaBuddyDiagnostics => {
+  let state: PersonaBuddyDiagnosticState = "healthy"
+  const rows: PersonaBuddyDiagnosticRow[] = []
+
+  const personaName = selectedPersona?.name || selectedPersona?.id
+  const personaRow: PersonaBuddyDiagnosticRow = {
+    label: "Persona",
+    value: personaName ? String(personaName) : "Not selected",
+    state: personaName ? "healthy" : "unavailable",
+    detail: selectedPersona?.id ? `ID: ${selectedPersona.id}` : "Select a persona to use Buddy."
+  }
+  rows.push(personaRow)
+  state = worseState(state, personaRow.state || "healthy")
+
+  if (capabilitiesLoading) {
+    const row: PersonaBuddyDiagnosticRow = {
+      label: "Server capability",
+      value: "Checking",
+      state: "recovering",
+      detail: "Waiting for server capability discovery."
+    }
+    rows.push(row)
+    state = worseState(state, row.state || "healthy")
+  } else if (!capabilities || capabilities.hasPersona === false) {
+    const row: PersonaBuddyDiagnosticRow = {
+      label: "Server capability",
+      value: "Persona unavailable",
+      state: "unavailable",
+      detail: "The current server does not advertise Persona support."
+    }
+    rows.push(row)
+    state = worseState(state, row.state || "healthy")
+  } else {
+    rows.push({
+      label: "Server capability",
+      value: "Persona ready",
+      state: "healthy"
+    })
+  }
+
+  const profileRow: PersonaBuddyDiagnosticRow =
+    profileState === "loading"
+      ? {
+          label: "Profile",
+          value: "Loading",
+          state: "recovering"
+        }
+      : profileState === "error"
+        ? {
+            label: "Profile",
+            value: "Load failed",
+            state: "degraded",
+            detail: profileError || "The selected persona profile could not be loaded."
+          }
+        : profileState === "loaded"
+          ? {
+              label: "Profile",
+              value: "Loaded",
+              state: "healthy"
+            }
+          : {
+              label: "Profile",
+              value: "Unknown",
+              state: "healthy"
+            }
+  rows.push(profileRow)
+  state = worseState(state, profileRow.state || "healthy")
+
+  const computedRows = [
+    summarizeBuddy(buddySummary),
+    summarizeVisual(visual),
+    summarizeLiveSession(liveSession),
+    summarizeLiveVoice(liveVoice),
+    summarizeWake(wake),
+    summarizeMcp(capabilities)
+  ]
+
+  for (const row of computedRows) {
+    rows.push(row)
+    state = worseState(state, row.state || "healthy")
+  }
+
+  const { title, message } = deriveTitleAndMessage(state, rows)
+  return { state, title, message, rows }
+}

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
@@ -533,6 +533,59 @@ describe("SidepanelPersona", () => {
     expect(screen.getByRole("button", { name: "Connect" })).toBeInTheDocument()
   })
 
+  it("shows profile load failures in Persona/Buddy diagnostics", async () => {
+    mocks.location.search = "?persona_id=research_assistant&tab=live"
+    mocks.capabilitiesState.capabilities = {
+      hasPersona: true,
+      hasPersonalization: true,
+      hasMcp: true
+    } as any
+    mocks.getConfig.mockResolvedValue({
+      serverUrl: "http://127.0.0.1:8000",
+      authMode: "single-user",
+      apiKey: "persona-key"
+    })
+    mocks.fetchWithAuth.mockImplementation((path: string) => {
+      if (path.includes("/persona/catalog")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [
+            { id: "research_assistant", name: "Research Assistant" }
+          ]
+        })
+      }
+      if (path.includes("/persona/profiles/research_assistant")) {
+        return Promise.resolve({
+          ok: false,
+          error: "Profile service offline",
+          json: async () => ({})
+        })
+      }
+      if (path.includes("/persona/sessions")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => []
+        })
+      }
+      return Promise.resolve({
+        ok: false,
+        error: `unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(<SidepanelPersona />)
+
+    await waitForLiveSessionPanel()
+    const diagnostics = await screen.findByTestId("persona-buddy-diagnostics")
+
+    expect(diagnostics).toHaveTextContent("Persona Buddy degraded")
+    expect(diagnostics).toHaveTextContent("Profile")
+    expect(diagnostics).toHaveTextContent("Load failed")
+    expect(diagnostics).toHaveTextContent("Profile service offline")
+    expect(screen.getByRole("button", { name: "Connect" })).toBeInTheDocument()
+  })
+
   it("boots persona selection and active tab from query params", async () => {
     mocks.location.search = "?persona_id=garden-helper&tab=profiles"
     mocks.getConfig.mockResolvedValue({

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
@@ -530,6 +530,7 @@ describe("SidepanelPersona", () => {
 
     expect(diagnostics).toHaveTextContent("Persona Buddy degraded")
     expect(diagnostics).toHaveTextContent("Visual pack did not load")
+    expect(diagnostics).toHaveTextContent("Pack ID: pack-1")
     expect(screen.getByRole("button", { name: "Connect" })).toBeInTheDocument()
   })
 

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
@@ -6,6 +6,7 @@ import {
   BuddyShellRenderContextProvider,
   useBuddyShellRenderContext
 } from "@/components/Common/PersonaBuddy"
+import { usePersonaVisualRuntimeStore } from "@/store/persona-visual-runtime"
 import { SELECTED_ASSISTANT_STORAGE_KEY } from "@/utils/selected-assistant-storage"
 
 const mocks = vi.hoisted(() => ({
@@ -349,6 +350,10 @@ describe("SidepanelPersona", () => {
     mocks.buildPersonaWebSocketUrl.mockReset()
     mocks.fetchCompanionConversationPrompts.mockReset()
     mocks.buddyShellContextSnapshots = []
+    usePersonaVisualRuntimeStore.setState({
+      override: null,
+      runtimeDiagnostics: null
+    } as any)
     mocks.buildPersonaWebSocketUrl.mockReturnValue(
       "ws://persona.test/api/v1/persona/stream"
     )
@@ -445,6 +450,87 @@ describe("SidepanelPersona", () => {
     expect(screen.getByRole("tab", { name: "Scopes" })).toBeInTheDocument()
     expect(screen.getByRole("tab", { name: "Policies" })).toBeInTheDocument()
     await waitForLiveSessionPanel()
+  })
+
+  it("renders degraded Persona/Buddy diagnostics from visual runtime state while controls stay available", async () => {
+    mocks.location.search = "?persona_id=research_assistant&tab=live"
+    mocks.capabilitiesState.capabilities = {
+      hasPersona: true,
+      hasPersonalization: true,
+      hasAudio: true,
+      hasMcp: true
+    } as any
+    usePersonaVisualRuntimeStore.setState({
+      runtimeDiagnostics: {
+        personaId: "research_assistant",
+        sessionId: null,
+        packId: "pack-1",
+        packTitle: "Broken Pack",
+        packLoadStatus: "error",
+        diagnostic: {
+          code: "load_failed",
+          severity: "warning",
+          title: "Visual pack did not load",
+          message: "The active visual pack could not be loaded."
+        },
+        updatedAt: 1_765_333_200_000
+      }
+    } as any)
+    mocks.getConfig.mockResolvedValue({
+      serverUrl: "http://127.0.0.1:8000",
+      authMode: "single-user",
+      apiKey: "persona-key"
+    })
+    mocks.fetchWithAuth.mockImplementation((path: string) => {
+      if (path.includes("/persona/catalog")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [
+            { id: "research_assistant", name: "Research Assistant" }
+          ]
+        })
+      }
+      if (path.includes("/persona/profiles/research_assistant")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            id: "research_assistant",
+            version: 1,
+            buddy_summary: {
+              has_buddy: true,
+              persona_name: "Research Assistant",
+              role_summary: "Keeps research sessions moving",
+              visual: null
+            },
+            voice_defaults: {
+              voice_chat_trigger_phrases: ["hey research"],
+              wake_behavior: "continuous"
+            },
+            use_persona_state_context_default: true
+          })
+        })
+      }
+      if (path.includes("/persona/sessions")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => []
+        })
+      }
+      return Promise.resolve({
+        ok: false,
+        error: `unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(<SidepanelPersona />)
+
+    await waitForLiveSessionPanel()
+    const diagnostics = await screen.findByTestId("persona-buddy-diagnostics")
+
+    expect(diagnostics).toHaveTextContent("Persona Buddy degraded")
+    expect(diagnostics).toHaveTextContent("Visual pack did not load")
+    expect(screen.getByRole("button", { name: "Connect" })).toBeInTheDocument()
   })
 
   it("boots persona selection and active tab from query params", async () => {

--- a/apps/packages/ui/src/routes/sidepanel-persona.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-persona.tsx
@@ -16,6 +16,11 @@ import { PersonaPolicySummary } from "@/components/Option/MCPHub"
 import type { PersonaTurnDetectionValues } from "@/components/PersonaGarden/PersonaTurnDetectionControls"
 import { AssistantVoiceCard } from "@/components/PersonaGarden/AssistantVoiceCard"
 import { AssistantDefaultsPanel } from "@/components/PersonaGarden/AssistantDefaultsPanel"
+import { PersonaBuddyDiagnosticsPanel } from "@/components/PersonaGarden/PersonaBuddyDiagnosticsPanel"
+import {
+  buildPersonaBuddyDiagnostics,
+  type PersonaBuddyProfileState
+} from "@/components/PersonaGarden/personaBuddyDiagnostics"
 import {
   PersonaSetupHandoffCard,
 } from "@/components/PersonaGarden/PersonaSetupHandoffCard"
@@ -221,6 +226,9 @@ const SidepanelPersona = ({
   })
   const setBuddyShellRenderContext = useSetBuddyShellRenderContext()
   const visualRuntimeOverride = usePersonaVisualRuntimeStore((state) => state.override)
+  const visualRuntimeDiagnostics = usePersonaVisualRuntimeStore(
+    (state) => state.runtimeDiagnostics
+  )
   const [buddyShellLiveContext, setBuddyShellLiveContext] = React.useState({
     live_voice_state: "idle",
     active_tool_status: "",
@@ -1119,6 +1127,66 @@ const SidepanelPersona = ({
       }
     : undefined
 
+  const activeBuddySummary =
+    (savedPersonaBuddySummaryPersonaId === selectedPersonaId
+      ? savedPersonaBuddySummary
+      : null) ??
+    selectedCatalogPersona?.buddy_summary ??
+    null
+  const personaProfileState: PersonaBuddyProfileState = personaProfileLoading
+    ? "loading"
+    : selectedPersonaId
+      ? "loaded"
+      : "idle"
+  const activeVisualRuntimeDiagnostics =
+    visualRuntimeDiagnostics &&
+    visualRuntimeDiagnostics.personaId === normalizedLivePersonaId &&
+    (!sessionId ||
+      !visualRuntimeDiagnostics.sessionId ||
+      visualRuntimeDiagnostics.sessionId === sessionId)
+      ? visualRuntimeDiagnostics
+      : null
+  const personaBuddyDiagnostics = buildPersonaBuddyDiagnostics({
+    selectedPersona: {
+      id: selectedPersonaId,
+      name: selectedPersonaName
+    },
+    profileState: personaProfileState,
+    buddySummary: activeBuddySummary,
+    capabilities,
+    capabilitiesLoading: capsLoading,
+    liveSession: {
+      connected,
+      connecting,
+      sessionId,
+      error
+    },
+    liveVoice: {
+      state: liveVoiceController.state,
+      recoveryMode: liveVoiceController.recoveryMode,
+      warning: liveVoiceController.warning,
+      activeToolStatus: liveVoiceController.activeToolStatus,
+      textOnlyDueToTtsFailure: liveVoiceController.textOnlyDueToTtsFailure,
+      manualModeRequired: liveVoiceController.manualModeRequired
+    },
+    wake: {
+      armed: liveVoiceController.wakeArmed,
+      detectorState: liveVoiceController.wakeDetectorState,
+      warning: liveVoiceController.wakeWarning,
+      triggerPhrases: liveVoiceController.wakeTriggerPhrases,
+      behavior: liveVoiceController.sessionWakeBehavior
+    },
+    visual: {
+      packId: activeVisualRuntimeDiagnostics?.packId ?? null,
+      packTitle: activeVisualRuntimeDiagnostics?.packTitle ?? null,
+      packLoadStatus: activeVisualRuntimeDiagnostics?.packLoadStatus ?? "idle",
+      diagnostic: activeVisualRuntimeDiagnostics?.diagnostic ?? null
+    }
+  })
+  const personaBuddyDiagnosticsPanel = !isCompanionMode ? (
+    <PersonaBuddyDiagnosticsPanel diagnostics={personaBuddyDiagnostics} />
+  ) : null
+
   const assistantVoiceCard = (
     <AssistantVoiceCard
       resolvedDefaults={resolvedLivePersonaVoiceDefaults}
@@ -1788,6 +1856,7 @@ const SidepanelPersona = ({
         <LazyLiveSessionPanel
           controls={liveSessionControls}
           assistantVoice={assistantVoiceCard}
+          diagnostics={personaBuddyDiagnosticsPanel}
           error={liveSessionStatusPanels}
           pendingPlan={pendingPlanCard}
           transcript={transcriptPanel}

--- a/apps/packages/ui/src/routes/sidepanel-persona.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-persona.tsx
@@ -1159,6 +1159,15 @@ const SidepanelPersona = ({
       visualRuntimeDiagnostics.sessionId === sessionId)
       ? visualRuntimeDiagnostics
       : null
+  const liveSessionLastEvent = error
+    ? `error: ${error}`
+    : connecting
+      ? "connecting"
+      : connected
+        ? "connected"
+        : sessionId
+          ? "disconnected"
+          : null
   const personaBuddyDiagnostics = buildPersonaBuddyDiagnostics({
     selectedPersona: {
       id: selectedPersonaId,
@@ -1173,7 +1182,8 @@ const SidepanelPersona = ({
       connected,
       connecting,
       sessionId,
-      error
+      error,
+      lastEvent: liveSessionLastEvent
     },
     liveVoice: {
       state: liveVoiceController.state,

--- a/apps/packages/ui/src/routes/sidepanel-persona.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-persona.tsx
@@ -197,6 +197,9 @@ const SidepanelPersona = ({
     number | null
   >(null)
   const [personaProfileLoading, setPersonaProfileLoading] = React.useState(false)
+  const [personaProfileError, setPersonaProfileError] = React.useState<string | null>(
+    null
+  )
   const [liveSessionVoiceDefaultsBaseline, setLiveSessionVoiceDefaultsBaseline] =
     React.useState<PersonaVoiceDefaults | null>(null)
   const [activeTab, setActiveTab] = React.useState<PersonaGardenTabKey>("live")
@@ -309,6 +312,7 @@ const SidepanelPersona = ({
       setSavedPersonaSetup(null)
       setSavedPersonaProfileVersion(null)
       setPersonaProfileLoading(false)
+      setPersonaProfileError(null)
       if (!connected) {
         setLiveSessionVoiceDefaultsBaseline(null)
       }
@@ -319,6 +323,7 @@ const SidepanelPersona = ({
     setSavedPersonaBuddySummary(null)
     setSavedPersonaBuddySummaryPersonaId(null)
     setPersonaProfileLoading(true)
+    setPersonaProfileError(null)
     ;(async () => {
       try {
         const response = await tldwClient.fetchWithAuth(
@@ -337,14 +342,20 @@ const SidepanelPersona = ({
           setSavedPersonaProfileVersion(
             typeof payload?.version === "number" ? payload.version : null
           )
+          setPersonaProfileError(null)
         }
-      } catch {
+      } catch (profileError) {
         if (!cancelled) {
           setSavedPersonaBuddySummary(null)
           setSavedPersonaBuddySummaryPersonaId(null)
           setSavedPersonaVoiceDefaults(null)
           setSavedPersonaSetup(null)
           setSavedPersonaProfileVersion(null)
+          setPersonaProfileError(
+            profileError instanceof Error
+              ? profileError.message
+              : "Failed to load persona profile"
+          )
         }
       } finally {
         if (!cancelled) {
@@ -1135,9 +1146,11 @@ const SidepanelPersona = ({
     null
   const personaProfileState: PersonaBuddyProfileState = personaProfileLoading
     ? "loading"
-    : selectedPersonaId
-      ? "loaded"
-      : "idle"
+    : personaProfileError
+      ? "error"
+      : selectedPersonaId
+        ? "loaded"
+        : "idle"
   const activeVisualRuntimeDiagnostics =
     visualRuntimeDiagnostics &&
     visualRuntimeDiagnostics.personaId === normalizedLivePersonaId &&
@@ -1152,6 +1165,7 @@ const SidepanelPersona = ({
       name: selectedPersonaName
     },
     profileState: personaProfileState,
+    profileError: personaProfileError,
     buddySummary: activeBuddySummary,
     capabilities,
     capabilitiesLoading: capsLoading,
@@ -1180,6 +1194,7 @@ const SidepanelPersona = ({
       packId: activeVisualRuntimeDiagnostics?.packId ?? null,
       packTitle: activeVisualRuntimeDiagnostics?.packTitle ?? null,
       packLoadStatus: activeVisualRuntimeDiagnostics?.packLoadStatus ?? "idle",
+      visualState: activeVisualRuntimeDiagnostics?.visualState ?? resolvedLiveVisualState,
       diagnostic: activeVisualRuntimeDiagnostics?.diagnostic ?? null
     }
   })

--- a/apps/packages/ui/src/store/__tests__/persona-visual-runtime.test.ts
+++ b/apps/packages/ui/src/store/__tests__/persona-visual-runtime.test.ts
@@ -4,7 +4,10 @@ import { usePersonaVisualRuntimeStore } from "../persona-visual-runtime"
 
 describe("persona visual runtime store", () => {
   beforeEach(() => {
-    usePersonaVisualRuntimeStore.setState({ override: null })
+    usePersonaVisualRuntimeStore.setState({
+      override: null,
+      runtimeDiagnostics: null
+    })
   })
 
   it("stores and clears expired runtime overrides", () => {
@@ -39,5 +42,31 @@ describe("persona visual runtime store", () => {
 
     usePersonaVisualRuntimeStore.getState().clearForSession("session-1")
     expect(usePersonaVisualRuntimeStore.getState().override).toBeNull()
+  })
+
+  it("clears runtime diagnostics only for the matching source", () => {
+    usePersonaVisualRuntimeStore.getState().setRuntimeDiagnostics({
+      sourceId: "sidepanel:persona-garden",
+      personaId: "persona-1",
+      sessionId: null,
+      packId: "pack-1",
+      packTitle: "Animated buddy",
+      packLoadStatus: "loaded",
+      visualState: "idle",
+      diagnostic: null,
+      updatedAt: 2000
+    })
+
+    usePersonaVisualRuntimeStore
+      .getState()
+      .clearRuntimeDiagnostics("web:persona-garden")
+    expect(usePersonaVisualRuntimeStore.getState().runtimeDiagnostics?.packId).toBe(
+      "pack-1"
+    )
+
+    usePersonaVisualRuntimeStore
+      .getState()
+      .clearRuntimeDiagnostics("sidepanel:persona-garden")
+    expect(usePersonaVisualRuntimeStore.getState().runtimeDiagnostics).toBeNull()
   })
 })

--- a/apps/packages/ui/src/store/persona-visual-runtime.ts
+++ b/apps/packages/ui/src/store/persona-visual-runtime.ts
@@ -12,6 +12,7 @@ export interface PersonaVisualRuntimeOverride {
 }
 
 export interface PersonaVisualRuntimeDiagnostics {
+  sourceId?: string
   personaId: string
   sessionId: string | null
   packId: string | null
@@ -29,6 +30,7 @@ type PersonaVisualRuntimeStore = {
   setRuntimeDiagnostics: (
     diagnostics: PersonaVisualRuntimeDiagnostics | null
   ) => void
+  clearRuntimeDiagnostics: (sourceId?: string) => void
   clearExpired: (now?: number) => void
   clearForSession: (sessionId: string | null) => void
 }
@@ -39,6 +41,15 @@ export const usePersonaVisualRuntimeStore = create<PersonaVisualRuntimeStore>(
     runtimeDiagnostics: null,
     setOverride: (override) => set({ override }),
     setRuntimeDiagnostics: (runtimeDiagnostics) => set({ runtimeDiagnostics }),
+    clearRuntimeDiagnostics: (sourceId) => {
+      const diagnostics = get().runtimeDiagnostics
+      if (
+        diagnostics &&
+        (!sourceId || !diagnostics.sourceId || diagnostics.sourceId === sourceId)
+      ) {
+        set({ runtimeDiagnostics: null })
+      }
+    },
     clearExpired: (now = Date.now()) => {
       const current = get().override
       if (current && current.expiresAt <= now) {

--- a/apps/packages/ui/src/store/persona-visual-runtime.ts
+++ b/apps/packages/ui/src/store/persona-visual-runtime.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand"
 
+import type { PersonaVisualDiagnostic } from "@/components/Common/PersonaBuddy/personaVisualDiagnostics"
 import type { PersonaVisualStateId } from "@/types/persona-visuals"
 
 export interface PersonaVisualRuntimeOverride {
@@ -10,9 +11,24 @@ export interface PersonaVisualRuntimeOverride {
   expiresAt: number
 }
 
+export interface PersonaVisualRuntimeDiagnostics {
+  personaId: string
+  sessionId: string | null
+  packId: string | null
+  packTitle: string | null
+  packLoadStatus: "idle" | "loading" | "loaded" | "error"
+  visualState: PersonaVisualStateId
+  diagnostic: PersonaVisualDiagnostic | null
+  updatedAt: number
+}
+
 type PersonaVisualRuntimeStore = {
   override: PersonaVisualRuntimeOverride | null
+  runtimeDiagnostics: PersonaVisualRuntimeDiagnostics | null
   setOverride: (override: PersonaVisualRuntimeOverride) => void
+  setRuntimeDiagnostics: (
+    diagnostics: PersonaVisualRuntimeDiagnostics | null
+  ) => void
   clearExpired: (now?: number) => void
   clearForSession: (sessionId: string | null) => void
 }
@@ -20,7 +36,9 @@ type PersonaVisualRuntimeStore = {
 export const usePersonaVisualRuntimeStore = create<PersonaVisualRuntimeStore>(
   (set, get) => ({
     override: null,
+    runtimeDiagnostics: null,
     setOverride: (override) => set({ override }),
+    setRuntimeDiagnostics: (runtimeDiagnostics) => set({ runtimeDiagnostics }),
     clearExpired: (now = Date.now()) => {
       const current = get().override
       if (current && current.expiresAt <= now) {
@@ -31,6 +49,10 @@ export const usePersonaVisualRuntimeStore = create<PersonaVisualRuntimeStore>(
       const current = get().override
       if (current && current.sessionId === sessionId) {
         set({ override: null })
+      }
+      const diagnostics = get().runtimeDiagnostics
+      if (diagnostics && diagnostics.sessionId === sessionId) {
+        set({ runtimeDiagnostics: null })
       }
     }
   })

--- a/backlog/tasks/task-228 - Add-Persona-Buddy-diagnostics-surface.md
+++ b/backlog/tasks/task-228 - Add-Persona-Buddy-diagnostics-surface.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - Codex
 created_date: '2026-05-10 07:18'
-updated_date: '2026-05-10 15:10'
+updated_date: '2026-05-10 15:15'
 labels:
   - persona
   - buddy
@@ -54,6 +54,8 @@ Stages:
 Planning started in isolated worktree .worktrees/persona-buddy-diagnostics on branch codex/persona-buddy-diagnostics. GitHub tracking: epic #1510, Stage 1 issue #1511.
 
 Task 1 complete: added pure Persona/Buddy diagnostics projector and unit tests. Verification: bunx vitest run apps/packages/ui/src/components/PersonaGarden/__tests__/personaBuddyDiagnostics.test.ts passed (5 tests).
+
+Task 2 complete: added PersonaBuddyDiagnosticsPanel using the existing StatePanel design-system component. Verification: bun run test src/components/PersonaGarden/__tests__/PersonaBuddyDiagnosticsPanel.test.tsx passed (2 tests) from apps/packages/ui.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-228 - Add-Persona-Buddy-diagnostics-surface.md
+++ b/backlog/tasks/task-228 - Add-Persona-Buddy-diagnostics-surface.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - Codex
 created_date: '2026-05-10 07:18'
-updated_date: '2026-05-10 15:21'
+updated_date: '2026-05-10 15:31'
 labels:
   - persona
   - buddy
@@ -15,6 +15,7 @@ dependencies: []
 references:
   - 'https://github.com/rmusser01/tldw_server/issues/1510'
   - 'https://github.com/rmusser01/tldw_server/issues/1511'
+  - 'https://github.com/rmusser01/tldw_server/pull/1518'
 documentation:
   - Docs/Reviews/PERSONA_BUDDY_CURRENT_STATE_AUDIT_2026_05_10.md
 priority: medium
@@ -60,6 +61,8 @@ Task 2 complete: added PersonaBuddyDiagnosticsPanel using the existing StatePane
 Task 3 complete: wired diagnostics into Persona Live, added visual runtime diagnostics to the existing persona visual runtime store, and published BuddyShellHost visual diagnostics for route consumption. Verification: bun run test src/routes/__tests__/sidepanel-persona.test.tsx -t diagnostics passed; bun run test src/store/__tests__/persona-visual-runtime.test.ts passed; bun run test src/components/PersonaGarden/__tests__/LiveSessionPanel.test.tsx passed; bun run test src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx -t visual passed.
 
 Final verification passed from apps/packages/ui: bun run test src/components/PersonaGarden/__tests__/personaBuddyDiagnostics.test.ts src/components/PersonaGarden/__tests__/PersonaBuddyDiagnosticsPanel.test.tsx src/components/Common/PersonaBuddy/__tests__/personaVisualDiagnostics.test.ts src/store/__tests__/persona-visual-runtime.test.ts src/components/PersonaGarden/__tests__/LiveSessionPanel.test.ts (33 tests); bun run test src/routes/__tests__/sidepanel-persona.test.tsx -t diagnostics (1 selected test); bun run test src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx -t visual (4 selected tests); git diff --check passed. Bandit skipped because no Python files changed.
+
+Draft PR opened: https://github.com/rmusser01/tldw_server/pull/1518
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-228 - Add-Persona-Buddy-diagnostics-surface.md
+++ b/backlog/tasks/task-228 - Add-Persona-Buddy-diagnostics-surface.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - Codex
 created_date: '2026-05-10 07:18'
-updated_date: '2026-05-10 07:23'
+updated_date: '2026-05-10 15:10'
 labels:
   - persona
   - buddy
@@ -52,6 +52,8 @@ Stages:
 
 <!-- SECTION:NOTES:BEGIN -->
 Planning started in isolated worktree .worktrees/persona-buddy-diagnostics on branch codex/persona-buddy-diagnostics. GitHub tracking: epic #1510, Stage 1 issue #1511.
+
+Task 1 complete: added pure Persona/Buddy diagnostics projector and unit tests. Verification: bunx vitest run apps/packages/ui/src/components/PersonaGarden/__tests__/personaBuddyDiagnostics.test.ts passed (5 tests).
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-228 - Add-Persona-Buddy-diagnostics-surface.md
+++ b/backlog/tasks/task-228 - Add-Persona-Buddy-diagnostics-surface.md
@@ -1,0 +1,65 @@
+---
+id: TASK-228
+title: Add Persona/Buddy diagnostics surface
+status: In Progress
+assignee:
+  - Codex
+created_date: '2026-05-10 07:18'
+updated_date: '2026-05-10 07:23'
+labels:
+  - persona
+  - buddy
+  - diagnostics
+  - stage-1
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1510'
+  - 'https://github.com/rmusser01/tldw_server/issues/1511'
+documentation:
+  - Docs/Reviews/PERSONA_BUDDY_CURRENT_STATE_AUDIT_2026_05_10.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the first Stage 1 Persona/Buddy reliability slice from the merged current-state audit. Add a narrow read-only diagnostics surface for the existing Persona Garden / Persona Live / Buddy shell runtime so degraded, unavailable, and recovery states are visible from one place. Keep the work centered on existing contracts and do not add new Persona capabilities, MCP tools, renderer behavior, native/background wake support, Persona Chat quality changes, or VN/CYOA runtime changes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Diagnostics projection covers selected persona identity, profile load state, Buddy summary/dormant state, active visual pack load/render diagnostic, Persona Live websocket/session state, live voice/recovery state, wake armed/state/rejection reason, and available persona_visuals MCP readiness from existing client/runtime state.
+- [ ] #2 Persona Garden or Live displays a compact diagnostics summary without blocking existing controls or changing normal healthy flows.
+- [ ] #3 Diagnostics distinguish healthy, unavailable, degraded, and recovering states with actionable copy derived from existing reason codes and state inputs.
+- [ ] #4 Broken or missing visual packs continue to fail open and expose the relevant visual diagnostic in the summary.
+- [ ] #5 Focused tests cover diagnostic derivation and at least one route-level degraded state.
+- [ ] #6 Docs or developer notes link back to the Stage 0 audit and GitHub issue #1511.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Implementation plan saved at Docs/superpowers/plans/2026-05-10-persona-buddy-diagnostics-implementation-plan.md.
+
+Stages:
+1. Add pure diagnostics projector and focused unit coverage.
+2. Add compact diagnostics panel using existing design-system state components.
+3. Wire diagnostics into Persona Live without changing healthy controls or backend contracts.
+4. Add Stage 1 audit note, run focused Vitest/diff checks, and update task closeout.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Planning started in isolated worktree .worktrees/persona-buddy-diagnostics on branch codex/persona-buddy-diagnostics. GitHub tracking: epic #1510, Stage 1 issue #1511.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-228 - Add-Persona-Buddy-diagnostics-surface.md
+++ b/backlog/tasks/task-228 - Add-Persona-Buddy-diagnostics-surface.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - Codex
 created_date: '2026-05-10 07:18'
-updated_date: '2026-05-10 15:15'
+updated_date: '2026-05-10 15:20'
 labels:
   - persona
   - buddy
@@ -56,6 +56,8 @@ Planning started in isolated worktree .worktrees/persona-buddy-diagnostics on br
 Task 1 complete: added pure Persona/Buddy diagnostics projector and unit tests. Verification: bunx vitest run apps/packages/ui/src/components/PersonaGarden/__tests__/personaBuddyDiagnostics.test.ts passed (5 tests).
 
 Task 2 complete: added PersonaBuddyDiagnosticsPanel using the existing StatePanel design-system component. Verification: bun run test src/components/PersonaGarden/__tests__/PersonaBuddyDiagnosticsPanel.test.tsx passed (2 tests) from apps/packages/ui.
+
+Task 3 complete: wired diagnostics into Persona Live, added visual runtime diagnostics to the existing persona visual runtime store, and published BuddyShellHost visual diagnostics for route consumption. Verification: bun run test src/routes/__tests__/sidepanel-persona.test.tsx -t diagnostics passed; bun run test src/store/__tests__/persona-visual-runtime.test.ts passed; bun run test src/components/PersonaGarden/__tests__/LiveSessionPanel.test.tsx passed; bun run test src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx -t visual passed.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-228 - Add-Persona-Buddy-diagnostics-surface.md
+++ b/backlog/tasks/task-228 - Add-Persona-Buddy-diagnostics-surface.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-228
 title: Add Persona/Buddy diagnostics surface
-status: In Progress
+status: Done
 assignee:
   - Codex
 created_date: '2026-05-10 07:18'
-updated_date: '2026-05-10 15:20'
+updated_date: '2026-05-10 15:21'
 labels:
   - persona
   - buddy
@@ -28,12 +28,12 @@ Implement the first Stage 1 Persona/Buddy reliability slice from the merged curr
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Diagnostics projection covers selected persona identity, profile load state, Buddy summary/dormant state, active visual pack load/render diagnostic, Persona Live websocket/session state, live voice/recovery state, wake armed/state/rejection reason, and available persona_visuals MCP readiness from existing client/runtime state.
-- [ ] #2 Persona Garden or Live displays a compact diagnostics summary without blocking existing controls or changing normal healthy flows.
-- [ ] #3 Diagnostics distinguish healthy, unavailable, degraded, and recovering states with actionable copy derived from existing reason codes and state inputs.
-- [ ] #4 Broken or missing visual packs continue to fail open and expose the relevant visual diagnostic in the summary.
-- [ ] #5 Focused tests cover diagnostic derivation and at least one route-level degraded state.
-- [ ] #6 Docs or developer notes link back to the Stage 0 audit and GitHub issue #1511.
+- [x] #1 Diagnostics projection covers selected persona identity, profile load state, Buddy summary/dormant state, active visual pack load/render diagnostic, Persona Live websocket/session state, live voice/recovery state, wake armed/state/rejection reason, and available persona_visuals MCP readiness from existing client/runtime state.
+- [x] #2 Persona Garden or Live displays a compact diagnostics summary without blocking existing controls or changing normal healthy flows.
+- [x] #3 Diagnostics distinguish healthy, unavailable, degraded, and recovering states with actionable copy derived from existing reason codes and state inputs.
+- [x] #4 Broken or missing visual packs continue to fail open and expose the relevant visual diagnostic in the summary.
+- [x] #5 Focused tests cover diagnostic derivation and at least one route-level degraded state.
+- [x] #6 Docs or developer notes link back to the Stage 0 audit and GitHub issue #1511.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -58,14 +58,22 @@ Task 1 complete: added pure Persona/Buddy diagnostics projector and unit tests. 
 Task 2 complete: added PersonaBuddyDiagnosticsPanel using the existing StatePanel design-system component. Verification: bun run test src/components/PersonaGarden/__tests__/PersonaBuddyDiagnosticsPanel.test.tsx passed (2 tests) from apps/packages/ui.
 
 Task 3 complete: wired diagnostics into Persona Live, added visual runtime diagnostics to the existing persona visual runtime store, and published BuddyShellHost visual diagnostics for route consumption. Verification: bun run test src/routes/__tests__/sidepanel-persona.test.tsx -t diagnostics passed; bun run test src/store/__tests__/persona-visual-runtime.test.ts passed; bun run test src/components/PersonaGarden/__tests__/LiveSessionPanel.test.tsx passed; bun run test src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx -t visual passed.
+
+Final verification passed from apps/packages/ui: bun run test src/components/PersonaGarden/__tests__/personaBuddyDiagnostics.test.ts src/components/PersonaGarden/__tests__/PersonaBuddyDiagnosticsPanel.test.tsx src/components/Common/PersonaBuddy/__tests__/personaVisualDiagnostics.test.ts src/store/__tests__/persona-visual-runtime.test.ts src/components/PersonaGarden/__tests__/LiveSessionPanel.test.ts (33 tests); bun run test src/routes/__tests__/sidepanel-persona.test.tsx -t diagnostics (1 selected test); bun run test src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx -t visual (4 selected tests); git diff --check passed. Bandit skipped because no Python files changed.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented Stage 1 Persona/Buddy diagnostics as a read-only frontend surface. Added a pure diagnostics projector, StatePanel-backed panel, Persona Live route integration, visual runtime diagnostics bridge from BuddyShellHost, focused tests for projection/panel/route visual degradation, and an audit tracking note for issue #1511. Verification passed; Bandit skipped because the touched scope is TypeScript/Markdown/Backlog only.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-228 - Add-Persona-Buddy-diagnostics-surface.md
+++ b/backlog/tasks/task-228 - Add-Persona-Buddy-diagnostics-surface.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - Codex
 created_date: '2026-05-10 07:18'
-updated_date: '2026-05-10 15:31'
+updated_date: '2026-05-10 15:45'
 labels:
   - persona
   - buddy
@@ -63,12 +63,16 @@ Task 3 complete: wired diagnostics into Persona Live, added visual runtime diagn
 Final verification passed from apps/packages/ui: bun run test src/components/PersonaGarden/__tests__/personaBuddyDiagnostics.test.ts src/components/PersonaGarden/__tests__/PersonaBuddyDiagnosticsPanel.test.tsx src/components/Common/PersonaBuddy/__tests__/personaVisualDiagnostics.test.ts src/store/__tests__/persona-visual-runtime.test.ts src/components/PersonaGarden/__tests__/LiveSessionPanel.test.ts (33 tests); bun run test src/routes/__tests__/sidepanel-persona.test.tsx -t diagnostics (1 selected test); bun run test src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx -t visual (4 selected tests); git diff --check passed. Bandit skipped because no Python files changed.
 
 Draft PR opened: https://github.com/rmusser01/tldw_server/pull/1518
+
+Code review fixes applied: profile fetch failures now surface as degraded diagnostics, visual runtime diagnostics are source-scoped and cleared on Buddy shell unmount, healthy visual pack diagnostics include render state, and runtime store tests reset diagnostics state.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Implemented Stage 1 Persona/Buddy diagnostics as a read-only frontend surface. Added a pure diagnostics projector, StatePanel-backed panel, Persona Live route integration, visual runtime diagnostics bridge from BuddyShellHost, focused tests for projection/panel/route visual degradation, and an audit tracking note for issue #1511. Verification passed; Bandit skipped because the touched scope is TypeScript/Markdown/Backlog only.
+
+Code-review fixes now surface profile load failures, clear source-scoped visual runtime diagnostics on Buddy shell lifecycle, include healthy visual render state, and cover the runtime store reset/source behavior.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-232 - Address-PR-1518-Persona-Buddy-diagnostics-review-comments.md
+++ b/backlog/tasks/task-232 - Address-PR-1518-Persona-Buddy-diagnostics-review-comments.md
@@ -1,0 +1,61 @@
+---
+id: TASK-232
+title: 'Address PR #1518 Persona/Buddy diagnostics review comments'
+status: Done
+assignee: []
+created_date: '2026-05-10 15:49'
+labels:
+  - persona
+  - buddy
+  - diagnostics
+  - review-fix
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1518'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve actionable PR #1518 review feedback for the Persona/Buddy diagnostics surface. Scope is limited to projector output correctness and review-thread cleanup for Stage 1 diagnostics.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Dormant Buddy summary is represented as non-degraded when the selected persona intentionally lacks a Buddy summary.
+- [x] #2 Unknown persona_visuals MCP readiness is represented as degraded or unconfirmed instead of healthy.
+- [x] #3 Core Persona server capability reports ready only when hasPersona is explicitly true.
+- [x] #4 Live session diagnostics include the last relevant event or reason code when present.
+- [x] #5 Visual pack diagnostics surface the active pack id even when a pack title is available.
+- [x] #6 Focused tests and diff checks pass.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Resolved PR #1518 review feedback by keeping intentionally dormant Buddy summaries healthy, treating unknown persona_visuals MCP readiness as degraded, requiring hasPersona to be explicitly true before reporting Persona capability ready, surfacing live session lastEvent in the session row, and preserving active visual pack ids when titles are present.
+
+Verification passed from apps/packages/ui:
+- bun run test src/components/PersonaGarden/__tests__/personaBuddyDiagnostics.test.ts
+- bun run test src/routes/__tests__/sidepanel-persona.test.tsx -t diagnostics
+- bun run test src/components/PersonaGarden/__tests__/personaBuddyDiagnostics.test.ts src/components/PersonaGarden/__tests__/PersonaBuddyDiagnosticsPanel.test.tsx src/components/Common/PersonaBuddy/__tests__/personaVisualDiagnostics.test.ts src/store/__tests__/persona-visual-runtime.test.ts src/components/PersonaGarden/__tests__/LiveSessionPanel.test.tsx
+
+Bandit skipped because the touched scope is TypeScript and Backlog Markdown only.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed all actionable PR #1518 review comments by tightening Persona/Buddy diagnostics state derivation and adding regression coverage for the reviewed cases. The patch keeps the diagnostics read-only and frontend-only.
+<!-- SECTION:FINAL_SUMMARY:END -->


### PR DESCRIPTION
## Change summary

<!-- Human maintainer: please replace this section with your own summary of what changed and why these implementation choices were made before merge. -->

- Adds a read-only Persona/Buddy diagnostics projection and compact Persona Live diagnostics panel.
- Bridges BuddyShellHost visual-pack diagnostics into the existing visual runtime store so Persona Live can show active-pack load/render health without a new backend contract.
- Adds focused tests for diagnostics derivation, panel rendering, route-level visual degradation, and adjacent visual runtime behavior.

## Scope

- Stage 1 of #1511 under epic #1510.
- Frontend-only diagnostics surface using existing Persona/Buddy runtime state.
- No new MCP tools, backend endpoints, renderer behavior, native wake support, Persona Chat quality changes, or VN/CYOA changes.

## Test plan

- [x] `bun run test src/components/PersonaGarden/__tests__/personaBuddyDiagnostics.test.ts src/components/PersonaGarden/__tests__/PersonaBuddyDiagnosticsPanel.test.tsx src/components/Common/PersonaBuddy/__tests__/personaVisualDiagnostics.test.ts src/store/__tests__/persona-visual-runtime.test.ts src/components/PersonaGarden/__tests__/LiveSessionPanel.test.tsx`
- [x] `bun run test src/routes/__tests__/sidepanel-persona.test.tsx -t "diagnostics"`
- [x] `bun run test src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx -t "visual"`
- [x] `git diff --check`
- [x] Bandit skipped: TypeScript/Markdown/Backlog-only change.
