### PR TITLE
Map Persona Live wake recovery reasons

### DIFF
--- a/Docs/superpowers/plans/2026-05-10-persona-live-wake-recovery-reasons.md
+++ b/Docs/superpowers/plans/2026-05-10-persona-live-wake-recovery-reasons.md
@@ -1,0 +1,209 @@
+# Persona Live Wake Recovery Reasons Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Map existing Persona Live voice and wake degraded states to stable reason codes and concise recovery copy surfaced through the current hook and Buddy diagnostics UI.
+
+**Architecture:** Keep runtime behavior unchanged and add reason metadata beside the existing warning strings. The hook remains the source of truth for live voice and wake codes; Buddy diagnostics consumes those codes to render specific recovery copy instead of inferring from ad hoc warning text.
+
+**Tech Stack:** React hooks, TypeScript, Vitest, Testing Library, existing Persona Garden diagnostics components.
+
+**Tracking:** Backlog `TASK-233`; GitHub issue `#1519`; Stage 0 audit `Docs/Reviews/PERSONA_BUDDY_CURRENT_STATE_AUDIT_2026_05_10.md`.
+
+---
+
+## File Structure
+
+- Modify `apps/packages/ui/src/hooks/usePersonaLiveVoiceController.tsx`
+  - Add exported reason-code types.
+  - Store `warningReasonCode` and `wakeWarningReasonCode` alongside existing `warning` and `wakeWarning`.
+  - Set/clear codes at the same points existing warning copy is set/cleared.
+- Modify `apps/packages/ui/src/components/PersonaGarden/personaBuddyDiagnostics.ts`
+  - Accept the hook reason codes in `liveVoice` and `wake` inputs.
+  - Map known reason codes to concise recovery copy and diagnostic states.
+- Modify `apps/packages/ui/src/routes/sidepanel-persona.tsx`
+  - Pass the new hook codes into `buildPersonaBuddyDiagnostics`.
+- Modify `apps/packages/ui/src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx`
+  - Cover controller reason codes for no wake phrases, detector unavailable/error, wake rejection, manual mode, TTS fallback, disconnected/reconnect, and teardown clearing.
+- Modify `apps/packages/ui/src/components/PersonaGarden/__tests__/personaBuddyDiagnostics.test.ts`
+  - Cover diagnostics output for reason-coded live voice and wake states.
+- Update `backlog/tasks/task-233 - Map-Persona-Live-voice-and-wake-recovery-reasons.md`
+  - Record plan path, touched files, verification, and final summary.
+
+## Task 1: Hook Reason Codes
+
+**Files:**
+- Modify: `apps/packages/ui/src/hooks/usePersonaLiveVoiceController.tsx`
+- Test: `apps/packages/ui/src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx`
+
+- [ ] **Step 1: Write failing hook tests**
+
+Add expectations such as:
+
+```ts
+expect(result.current.wakeWarningReasonCode).toBe("wake_not_configured")
+expect(result.current.wakeWarningReasonCode).toBe("wake_detector_unavailable")
+expect(result.current.wakeWarningReasonCode).toBe("wake_activation_rejected_not_saved_in_profile")
+expect(result.current.warningReasonCode).toBe("voice_manual_mode_required")
+expect(result.current.warningReasonCode).toBe("voice_tts_unavailable_text_only")
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx --maxWorkers=1
+```
+
+Expected: FAIL because the controller does not expose reason-code fields yet.
+
+- [ ] **Step 3: Implement minimal hook metadata**
+
+Add exported string-literal union types:
+
+```ts
+export type PersonaLiveVoiceWarningReasonCode =
+  | "live_voice_disconnected"
+  | "server_stt_unavailable"
+  | "live_voice_source_pending"
+  | "barge_in_disabled"
+  | "voice_capture_error"
+  | "voice_no_transcript"
+  | "voice_manual_mode_required"
+  | "voice_tts_unavailable_text_only"
+  | "voice_commit_ignored_already_committed"
+  | "voice_trigger_not_heard"
+  | "voice_empty_command_after_trigger"
+
+export type PersonaWakeWarningReasonCode =
+  | "wake_not_configured"
+  | "wake_detector_unavailable"
+  | "wake_detector_permission_denied"
+  | "wake_detector_error"
+  | "wake_activation_disconnected"
+  | "wake_activation_send_failed"
+  | "wake_activation_rejected_not_saved_in_profile"
+  | "wake_activation_rejected_missing_from_runtime_config"
+  | "wake_activation_rejected_phrase_not_configured"
+  | "wake_activation_rejected"
+```
+
+Set these codes wherever the existing hook sets `warning` or `wakeWarning`; clear them whenever the corresponding warning is cleared.
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run the same hook test command. Expected: PASS.
+
+## Task 2: Diagnostics Mapping
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/PersonaGarden/personaBuddyDiagnostics.ts`
+- Test: `apps/packages/ui/src/components/PersonaGarden/__tests__/personaBuddyDiagnostics.test.ts`
+
+- [ ] **Step 1: Write failing diagnostics tests**
+
+Add tests that pass reason codes into `buildPersonaBuddyDiagnostics` and assert rows use specific recovery copy:
+
+```ts
+expect(diagnostics.rows).toEqual(
+  expect.arrayContaining([
+    expect.objectContaining({
+      label: "Wake",
+      value: "Permission needed",
+      detail: expect.stringMatching(/manual controls remain available/i)
+    })
+  ])
+)
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/components/PersonaGarden/__tests__/personaBuddyDiagnostics.test.ts --maxWorkers=1
+```
+
+Expected: FAIL because diagnostics does not accept or map reason codes.
+
+- [ ] **Step 3: Implement minimal mapper**
+
+Add small records for known live voice and wake reason codes. Keep copy short and action-oriented, and avoid broken-state language when fallback controls remain available.
+
+- [ ] **Step 4: Run diagnostics tests to verify GREEN**
+
+Run the same diagnostics test command. Expected: PASS.
+
+## Task 3: Route Wiring
+
+**Files:**
+- Modify: `apps/packages/ui/src/routes/sidepanel-persona.tsx`
+- Test: existing hook and diagnostics tests
+
+- [ ] **Step 1: Wire reason codes into diagnostics input**
+
+Pass:
+
+```ts
+warningReasonCode: liveVoiceController.warningReasonCode
+wakeWarningReasonCode: liveVoiceController.wakeWarningReasonCode
+```
+
+- [ ] **Step 2: Run focused tests**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx src/components/PersonaGarden/__tests__/personaBuddyDiagnostics.test.ts --maxWorkers=1
+```
+
+Expected: PASS.
+
+## Task 4: Verification and Closeout
+
+**Files:**
+- Modify: `backlog/tasks/task-233 - Map-Persona-Live-voice-and-wake-recovery-reasons.md`
+
+- [ ] **Step 1: Run final focused verification**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx src/components/PersonaGarden/__tests__/personaBuddyDiagnostics.test.ts src/components/PersonaGarden/__tests__/LiveSessionPanel.test.tsx --maxWorkers=1
+git diff --check
+```
+
+Expected: PASS and no whitespace errors.
+
+- [ ] **Step 2: Bandit scope decision**
+
+This slice touches frontend TypeScript and Backlog metadata only. Record Bandit as not applicable unless backend Python changes are added.
+
+- [ ] **Step 3: Update Backlog task**
+
+Mark acceptance criteria complete, record verification commands/results, link this plan, and add final summary.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Docs/superpowers/plans/2026-05-10-persona-live-wake-recovery-reasons.md \
+  "backlog/tasks/task-233 - Map-Persona-Live-voice-and-wake-recovery-reasons.md" \
+  apps/packages/ui/src/hooks/usePersonaLiveVoiceController.tsx \
+  apps/packages/ui/src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx \
+  apps/packages/ui/src/components/PersonaGarden/personaBuddyDiagnostics.ts \
+  apps/packages/ui/src/components/PersonaGarden/__tests__/personaBuddyDiagnostics.test.ts \
+  apps/packages/ui/src/routes/sidepanel-persona.tsx
+git commit -m "feat(ui): map persona live recovery reasons"
+```
+
+## Self-Review
+
+- The plan keeps the slice in Persona/Buddy live voice and wake paths, not VN code.
+- It does not add new runtime wake capabilities; it only names and surfaces existing states.
+- It avoids snapshot data, backend schema work, and MCP surface changes outside the current Stage 1 issue.
+- It preserves existing warning copy for the visible Assistant Voice card while improving diagnostics and testability.

--- a/Docs/superpowers/plans/2026-05-10-persona-live-wake-recovery-reasons.md
+++ b/Docs/superpowers/plans/2026-05-10-persona-live-wake-recovery-reasons.md
@@ -67,7 +67,6 @@ Add exported string-literal union types:
 export type PersonaLiveVoiceWarningReasonCode =
   | "live_voice_disconnected"
   | "server_stt_unavailable"
-  | "live_voice_source_pending"
   | "barge_in_disabled"
   | "voice_capture_error"
   | "voice_no_transcript"
@@ -90,7 +89,7 @@ export type PersonaWakeWarningReasonCode =
   | "wake_activation_rejected"
 ```
 
-Set these codes wherever the existing hook sets `warning` or `wakeWarning`; clear them whenever the corresponding warning is cleared.
+Set these codes wherever the existing hook sets `warning` or `wakeWarning`; clear them whenever the corresponding warning is cleared. `!liveVoiceSourceReady` should continue to queue the pending start without setting warning metadata because it is a short hydration state rather than a user-visible recovery condition.
 
 - [ ] **Step 4: Run tests to verify GREEN**
 

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/personaBuddyDiagnostics.test.ts
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/personaBuddyDiagnostics.test.ts
@@ -150,6 +150,96 @@ describe("buildPersonaBuddyDiagnostics", () => {
     )
   })
 
+  it("uses live voice reason codes for recovery-oriented diagnostics copy", () => {
+    const diagnostics = buildPersonaBuddyDiagnostics({
+      selectedPersona: { id: "persona-1", name: "Ada" },
+      profileState: "loaded",
+      buddySummary: "Ready",
+      capabilities: { hasPersona: true, hasMcp: true },
+      liveSession: { connected: true, connecting: false, sessionId: "session-1" },
+      liveVoice: {
+        state: "idle",
+        recoveryMode: "none",
+        warning:
+          "Server VAD unavailable for this live session. Use Send now to commit heard speech manually.",
+        warningReasonCode: "voice_manual_mode_required",
+        manualModeRequired: true
+      },
+      wake: { armed: false, detectorState: "idle" },
+      visual: { packLoadStatus: "loaded", diagnostic: null }
+    })
+
+    expect(diagnostics.state).toBe("degraded")
+    expect(diagnostics.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "Live voice",
+          value: "Manual commit required",
+          state: "degraded",
+          detail: expect.stringMatching(/manual controls remain available/i)
+        })
+      ])
+    )
+  })
+
+  it("uses wake reason codes without treating disabled wake as broken Persona Live", () => {
+    const permissionNeeded = buildPersonaBuddyDiagnostics({
+      selectedPersona: { id: "persona-1", name: "Ada" },
+      profileState: "loaded",
+      buddySummary: "Ready",
+      capabilities: { hasPersona: true, hasMcp: true },
+      liveSession: { connected: true, connecting: false, sessionId: "session-1" },
+      liveVoice: { state: "idle", recoveryMode: "none" },
+      wake: {
+        armed: true,
+        detectorState: "error",
+        warning: "Microphone permission is blocked.",
+        warningReasonCode: "wake_detector_permission_denied"
+      },
+      visual: { packLoadStatus: "loaded", diagnostic: null }
+    })
+
+    expect(permissionNeeded.state).toBe("degraded")
+    expect(permissionNeeded.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "Wake",
+          value: "Permission needed",
+          state: "degraded",
+          detail: expect.stringMatching(/manual controls remain available/i)
+        })
+      ])
+    )
+
+    const notConfigured = buildPersonaBuddyDiagnostics({
+      selectedPersona: { id: "persona-1", name: "Ada" },
+      profileState: "loaded",
+      buddySummary: "Ready",
+      capabilities: { hasPersona: true, hasMcp: true },
+      liveSession: { connected: true, connecting: false, sessionId: "session-1" },
+      liveVoice: { state: "idle", recoveryMode: "none" },
+      wake: {
+        armed: false,
+        detectorState: "idle",
+        warning: "Add a persona trigger phrase before arming wake listening.",
+        warningReasonCode: "wake_not_configured"
+      },
+      visual: { packLoadStatus: "loaded", diagnostic: null }
+    })
+
+    expect(notConfigured.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "Wake",
+          value: "Not configured",
+          state: "healthy",
+          detail: expect.stringMatching(/manual controls remain available/i)
+        })
+      ])
+    )
+    expect(notConfigured.state).toBe("healthy")
+  })
+
   it("does not mark intentionally dormant Buddy summaries as degraded", () => {
     const diagnostics = buildPersonaBuddyDiagnostics({
       selectedPersona: { id: "persona-1", name: "Ada" },

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/personaBuddyDiagnostics.test.ts
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/personaBuddyDiagnostics.test.ts
@@ -180,6 +180,35 @@ describe("buildPersonaBuddyDiagnostics", () => {
         })
       ])
     )
+    expect(
+      diagnostics.rows.find((row) => row.label === "Live voice")?.detail
+    ).not.toMatch(/Server VAD unavailable/)
+
+    const captureError = buildPersonaBuddyDiagnostics({
+      selectedPersona: { id: "persona-1", name: "Ada" },
+      profileState: "loaded",
+      buddySummary: "Ready",
+      capabilities: { hasPersona: true, hasMcp: true },
+      liveSession: { connected: true, connecting: false, sessionId: "session-1" },
+      liveVoice: {
+        state: "error",
+        recoveryMode: "none",
+        warning: "USB microphone disappeared.",
+        warningReasonCode: "voice_capture_error"
+      },
+      wake: { armed: false, detectorState: "idle" },
+      visual: { packLoadStatus: "loaded", diagnostic: null }
+    })
+
+    expect(captureError.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "Live voice",
+          value: "Capture issue",
+          detail: expect.stringMatching(/USB microphone disappeared/)
+        })
+      ])
+    )
   })
 
   it("uses wake reason codes without treating disabled wake as broken Persona Live", () => {
@@ -210,6 +239,9 @@ describe("buildPersonaBuddyDiagnostics", () => {
         })
       ])
     )
+    expect(
+      permissionNeeded.rows.find((row) => row.label === "Wake")?.detail
+    ).not.toMatch(/Microphone permission is blocked/)
 
     const notConfigured = buildPersonaBuddyDiagnostics({
       selectedPersona: { id: "persona-1", name: "Ada" },
@@ -237,7 +269,36 @@ describe("buildPersonaBuddyDiagnostics", () => {
         })
       ])
     )
+    expect(
+      notConfigured.rows.find((row) => row.label === "Wake")?.detail
+    ).not.toMatch(/Add a persona trigger phrase/)
     expect(notConfigured.state).toBe("healthy")
+
+    const detectorError = buildPersonaBuddyDiagnostics({
+      selectedPersona: { id: "persona-1", name: "Ada" },
+      profileState: "loaded",
+      buddySummary: "Ready",
+      capabilities: { hasPersona: true, hasMcp: true },
+      liveSession: { connected: true, connecting: false, sessionId: "session-1" },
+      liveVoice: { state: "idle", recoveryMode: "none" },
+      wake: {
+        armed: true,
+        detectorState: "error",
+        warning: "Speech recognition restart failed.",
+        warningReasonCode: "wake_detector_error"
+      },
+      visual: { packLoadStatus: "loaded", diagnostic: null }
+    })
+
+    expect(detectorError.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "Wake",
+          value: "Detector issue",
+          detail: expect.stringMatching(/Speech recognition restart failed/)
+        })
+      ])
+    )
   })
 
   it("does not mark intentionally dormant Buddy summaries as degraded", () => {

--- a/apps/packages/ui/src/components/PersonaGarden/personaBuddyDiagnostics.ts
+++ b/apps/packages/ui/src/components/PersonaGarden/personaBuddyDiagnostics.ts
@@ -1,4 +1,8 @@
 import type { PersonaVisualDiagnostic } from "@/components/Common/PersonaBuddy/personaVisualDiagnostics"
+import type {
+  PersonaLiveVoiceWarningReasonCode,
+  PersonaWakeWarningReasonCode
+} from "@/hooks/usePersonaLiveVoiceController"
 
 export type PersonaBuddyDiagnosticState =
   | "healthy"
@@ -53,6 +57,7 @@ export type PersonaBuddyDiagnosticsInput = {
     state?: string | null
     recoveryMode?: string | null
     warning?: string | null
+    warningReasonCode?: PersonaLiveVoiceWarningReasonCode | null
     activeToolStatus?: string | null
     textOnlyDueToTtsFailure?: boolean
     manualModeRequired?: boolean
@@ -61,6 +66,7 @@ export type PersonaBuddyDiagnosticsInput = {
     armed?: boolean
     detectorState?: string | null
     warning?: string | null
+    warningReasonCode?: PersonaWakeWarningReasonCode | null
     triggerPhrases?: string[] | null
     behavior?: string | null
   } | null
@@ -242,6 +248,137 @@ const summarizeLiveSession = (
   }
 }
 
+const LIVE_VOICE_WARNING_DIAGNOSTICS: Record<
+  PersonaLiveVoiceWarningReasonCode,
+  {
+    value: string
+    state: PersonaBuddyDiagnosticState
+    detail: string
+  }
+> = {
+  barge_in_disabled: {
+    value: "Barge-in off",
+    state: "healthy",
+    detail: "Wait for speech playback to finish before starting the next voice turn."
+  },
+  live_voice_disconnected: {
+    value: "Reconnect needed",
+    state: "recovering",
+    detail: "Reconnect Persona Live to send spoken commands; text controls remain available."
+  },
+  server_stt_unavailable: {
+    value: "Speech input unavailable",
+    state: "degraded",
+    detail:
+      "Server speech transcription is unavailable. Text chat and manual controls remain available."
+  },
+  voice_capture_error: {
+    value: "Capture issue",
+    state: "degraded",
+    detail:
+      "Check microphone permissions or device selection; text and manual controls remain available."
+  },
+  voice_no_transcript: {
+    value: "No transcript captured",
+    state: "healthy",
+    detail: "Try speaking again or use text input; manual controls remain available."
+  },
+  voice_manual_mode_required: {
+    value: "Manual commit required",
+    state: "degraded",
+    detail:
+      "Server auto-commit is unavailable. Use Send now; manual controls remain available."
+  },
+  voice_tts_unavailable_text_only: {
+    value: "Text-only fallback",
+    state: "degraded",
+    detail:
+      "Speech playback is unavailable. Text responses and manual controls remain available."
+  },
+  voice_commit_ignored_already_committed: {
+    value: "Already sent",
+    state: "healthy",
+    detail: "The current utterance was already committed; continue with the next turn."
+  },
+  voice_trigger_not_heard: {
+    value: "Wake phrase required",
+    state: "healthy",
+    detail:
+      "The last transcript did not include a configured trigger phrase. Manual controls remain available."
+  },
+  voice_empty_command_after_trigger: {
+    value: "Command missing",
+    state: "healthy",
+    detail:
+      "The wake phrase was removed, but no command remained. Try again or use manual controls."
+  }
+}
+
+const WAKE_WARNING_DIAGNOSTICS: Record<
+  PersonaWakeWarningReasonCode,
+  {
+    value: string
+    state: PersonaBuddyDiagnosticState
+    detail: string
+  }
+> = {
+  wake_not_configured: {
+    value: "Not configured",
+    state: "healthy",
+    detail: "Add a saved persona trigger phrase to arm wake; manual controls remain available."
+  },
+  wake_detector_unavailable: {
+    value: "Browser unsupported",
+    state: "degraded",
+    detail:
+      "This browser context cannot run wake listening. Start and Send now controls remain available."
+  },
+  wake_detector_permission_denied: {
+    value: "Permission needed",
+    state: "degraded",
+    detail: "Allow microphone access for wake listening; manual controls remain available."
+  },
+  wake_detector_error: {
+    value: "Detector issue",
+    state: "degraded",
+    detail: "Wake listening hit a browser detector error; manual controls remain available."
+  },
+  wake_activation_disconnected: {
+    value: "Reconnect needed",
+    state: "recovering",
+    detail:
+      "Wake phrase was heard while Persona Live was disconnected. Manual controls remain available."
+  },
+  wake_activation_send_failed: {
+    value: "Activation send failed",
+    state: "recovering",
+    detail: "Wake remains armed when possible; manual controls remain available."
+  },
+  wake_activation_rejected_not_saved_in_profile: {
+    value: "Wake phrase rejected",
+    state: "degraded",
+    detail:
+      "The heard phrase is not saved on this persona. Save it before relying on wake listening."
+  },
+  wake_activation_rejected_missing_from_runtime_config: {
+    value: "Wake config stale",
+    state: "recovering",
+    detail:
+      "Reconnect Persona Live or save voice defaults again; manual controls remain available."
+  },
+  wake_activation_rejected_phrase_not_configured: {
+    value: "Wake phrase rejected",
+    state: "degraded",
+    detail:
+      "The phrase is not configured for this live session. Check the selected persona trigger phrases."
+  },
+  wake_activation_rejected: {
+    value: "Wake rejected",
+    state: "degraded",
+    detail: "Wake activation was rejected. Manual controls remain available."
+  }
+}
+
 const summarizeLiveVoice = (
   liveVoice: PersonaBuddyDiagnosticsInput["liveVoice"]
 ): PersonaBuddyDiagnosticRow => {
@@ -252,6 +389,17 @@ const summarizeLiveVoice = (
       value: "Recovering",
       state: "recovering",
       detail: titleCase(recoveryMode)
+    }
+  }
+
+  const reasonCode = liveVoice?.warningReasonCode || null
+  const mappedWarning = reasonCode ? LIVE_VOICE_WARNING_DIAGNOSTICS[reasonCode] : null
+  if (mappedWarning) {
+    return {
+      label: "Live voice",
+      value: mappedWarning.value,
+      state: mappedWarning.state,
+      detail: joinDetails([mappedWarning.detail, liveVoice?.warning])
     }
   }
 
@@ -280,6 +428,17 @@ const summarizeWake = (
   wake: PersonaBuddyDiagnosticsInput["wake"]
 ): PersonaBuddyDiagnosticRow => {
   const detectorState = String(wake?.detectorState || "idle").trim()
+  const reasonCode = wake?.warningReasonCode || null
+  const mappedWarning = reasonCode ? WAKE_WARNING_DIAGNOSTICS[reasonCode] : null
+  if (mappedWarning) {
+    return {
+      label: "Wake",
+      value: mappedWarning.value,
+      state: mappedWarning.state,
+      detail: joinDetails([mappedWarning.detail, wake?.warning])
+    }
+  }
+
   if (wake?.warning || detectorState === "unavailable" || detectorState === "error") {
     return {
       label: "Wake",

--- a/apps/packages/ui/src/components/PersonaGarden/personaBuddyDiagnostics.ts
+++ b/apps/packages/ui/src/components/PersonaGarden/personaBuddyDiagnostics.ts
@@ -379,6 +379,32 @@ const WAKE_WARNING_DIAGNOSTICS: Record<
   }
 }
 
+const LIVE_VOICE_DYNAMIC_WARNING_CODES = new Set<PersonaLiveVoiceWarningReasonCode>([
+  "voice_capture_error"
+])
+
+const WAKE_DYNAMIC_WARNING_CODES = new Set<PersonaWakeWarningReasonCode>([
+  "wake_detector_error"
+])
+
+const mappedLiveVoiceDetail = (
+  reasonCode: PersonaLiveVoiceWarningReasonCode,
+  mappedDetail: string,
+  warning: string | null | undefined
+) =>
+  LIVE_VOICE_DYNAMIC_WARNING_CODES.has(reasonCode)
+    ? joinDetails([mappedDetail, warning])
+    : mappedDetail
+
+const mappedWakeDetail = (
+  reasonCode: PersonaWakeWarningReasonCode,
+  mappedDetail: string,
+  warning: string | null | undefined
+) =>
+  WAKE_DYNAMIC_WARNING_CODES.has(reasonCode)
+    ? joinDetails([mappedDetail, warning])
+    : mappedDetail
+
 const summarizeLiveVoice = (
   liveVoice: PersonaBuddyDiagnosticsInput["liveVoice"]
 ): PersonaBuddyDiagnosticRow => {
@@ -399,7 +425,11 @@ const summarizeLiveVoice = (
       label: "Live voice",
       value: mappedWarning.value,
       state: mappedWarning.state,
-      detail: joinDetails([mappedWarning.detail, liveVoice?.warning])
+      detail: mappedLiveVoiceDetail(
+        reasonCode,
+        mappedWarning.detail,
+        liveVoice?.warning
+      )
     }
   }
 
@@ -435,7 +465,7 @@ const summarizeWake = (
       label: "Wake",
       value: mappedWarning.value,
       state: mappedWarning.state,
-      detail: joinDetails([mappedWarning.detail, wake?.warning])
+      detail: mappedWakeDetail(reasonCode, mappedWarning.detail, wake?.warning)
     }
   }
 

--- a/apps/packages/ui/src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx
+++ b/apps/packages/ui/src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx
@@ -240,6 +240,83 @@ describe("usePersonaLiveVoiceController", () => {
 
     expect(wakeHarness.detector.start).not.toHaveBeenCalled()
     expect(result.current.wakeWarning).toMatch(/trigger phrase/i)
+    expect(result.current.wakeWarningReasonCode).toBe("wake_not_configured")
+  })
+
+  it("marks unavailable wake detector state with a stable recovery reason", async () => {
+    const detector: WakeDetector = {
+      isAvailable: vi.fn(async () => false),
+      start: vi.fn(async () => undefined),
+      stop: vi.fn(async () => undefined)
+    }
+    const ws = {
+      readyState: WebSocket.OPEN,
+      send: vi.fn()
+    } as unknown as WebSocket
+
+    const { result } = renderHook(() =>
+      usePersonaLiveVoiceController({
+        ws,
+        connected: true,
+        sessionId: "sess-1",
+        personaId: "persona-1",
+        resolvedDefaults,
+        canUseServerStt: true,
+        wakeTriggerPhrases: ["hey helper"],
+        wakeDetectorFactory: () => detector
+      })
+    )
+
+    await act(async () => {
+      await result.current.toggleWakeArmed()
+    })
+
+    expect(detector.start).not.toHaveBeenCalled()
+    expect(result.current.wakeArmed).toBe(false)
+    expect(result.current.wakeDetectorState).toBe("unavailable")
+    expect(result.current.wakeWarning).toMatch(/unavailable/i)
+    expect(result.current.wakeWarningReasonCode).toBe("wake_detector_unavailable")
+  })
+
+  it("maps wake detector permission errors to a recovery reason", async () => {
+    const detector: WakeDetector = {
+      isAvailable: vi.fn(async () => true),
+      start: vi.fn(async (nextConfig) => {
+        nextConfig.onStateChange?.("error")
+        nextConfig.onError?.({
+          code: "not-allowed",
+          message: "Microphone permission is blocked."
+        })
+      }),
+      stop: vi.fn(async () => undefined)
+    }
+    const ws = {
+      readyState: WebSocket.OPEN,
+      send: vi.fn()
+    } as unknown as WebSocket
+
+    const { result } = renderHook(() =>
+      usePersonaLiveVoiceController({
+        ws,
+        connected: true,
+        sessionId: "sess-1",
+        personaId: "persona-1",
+        resolvedDefaults,
+        canUseServerStt: true,
+        wakeTriggerPhrases: ["hey helper"],
+        wakeDetectorFactory: () => detector
+      })
+    )
+
+    await act(async () => {
+      await result.current.toggleWakeArmed()
+    })
+
+    expect(result.current.wakeDetectorState).toBe("error")
+    expect(result.current.wakeWarning).toMatch(/permission/i)
+    expect(result.current.wakeWarningReasonCode).toBe(
+      "wake_detector_permission_denied"
+    )
   })
 
   it("starts the wake detector with raw saved phrases", async () => {
@@ -353,6 +430,7 @@ describe("usePersonaLiveVoiceController", () => {
 
     expect(result.current.wakeArmed).toBe(true)
     expect(result.current.wakeWarning).toMatch(/activation could not be sent/i)
+    expect(result.current.wakeWarningReasonCode).toBe("wake_activation_send_failed")
     expect(wakeHarness.detector.stop).not.toHaveBeenCalled()
     expect(hookMocks.micStart).not.toHaveBeenCalled()
   })
@@ -397,6 +475,9 @@ describe("usePersonaLiveVoiceController", () => {
     await waitFor(() => {
       expect(result.current.wakeWarning).toMatch(/saved trigger phrase/i)
     })
+    expect(result.current.wakeWarningReasonCode).toBe(
+      "wake_activation_rejected_not_saved_in_profile"
+    )
     expect(result.current.wakeArmed).toBe(true)
   })
 
@@ -440,6 +521,9 @@ describe("usePersonaLiveVoiceController", () => {
     await waitFor(() => {
       expect(result.current.wakeWarning).toMatch(/live voice configuration/i)
     })
+    expect(result.current.wakeWarningReasonCode).toBe(
+      "wake_activation_rejected_missing_from_runtime_config"
+    )
     expect(result.current.wakeArmed).toBe(true)
   })
 
@@ -2098,6 +2182,7 @@ describe("usePersonaLiveVoiceController", () => {
     expect(result.current.manualModeRequired).toBe(true)
     expect(result.current.canSendNow).toBe(true)
     expect(result.current.warning).toContain("Use Send now")
+    expect(result.current.warningReasonCode).toBe("voice_manual_mode_required")
 
     const stopCallsBeforeSend = hookMocks.micStop.mock.calls.length
 
@@ -2155,6 +2240,7 @@ describe("usePersonaLiveVoiceController", () => {
     })
     expect(result.current.textOnlyDueToTtsFailure).toBe(true)
     expect(result.current.warning).toContain("Continuing in text-only mode.")
+    expect(result.current.warningReasonCode).toBe("voice_tts_unavailable_text_only")
   })
 
   it("cancels a queued auto-resume before hydration finishes", async () => {

--- a/apps/packages/ui/src/hooks/usePersonaLiveVoiceController.tsx
+++ b/apps/packages/ui/src/hooks/usePersonaLiveVoiceController.tsx
@@ -24,6 +24,30 @@ export type PersonaLiveVoiceState =
 
 export type PersonaLiveVoiceRecoveryMode = "none" | "listening_stuck" | "thinking_stuck"
 export type PersonaLiveVadPreset = "conservative" | "balanced" | "fast" | "custom"
+export type PersonaLiveVoiceWarningReasonCode =
+  | "barge_in_disabled"
+  | "live_voice_disconnected"
+  | "server_stt_unavailable"
+  | "voice_capture_error"
+  | "voice_no_transcript"
+  | "voice_manual_mode_required"
+  | "voice_tts_unavailable_text_only"
+  | "voice_commit_ignored_already_committed"
+  | "voice_trigger_not_heard"
+  | "voice_empty_command_after_trigger"
+
+export type PersonaWakeWarningReasonCode =
+  | "wake_not_configured"
+  | "wake_detector_unavailable"
+  | "wake_detector_permission_denied"
+  | "wake_detector_error"
+  | "wake_activation_disconnected"
+  | "wake_activation_send_failed"
+  | "wake_activation_rejected_not_saved_in_profile"
+  | "wake_activation_rejected_missing_from_runtime_config"
+  | "wake_activation_rejected_phrase_not_configured"
+  | "wake_activation_rejected"
+
 type PersonaWakeStopReason =
   | "disarmed"
   | "route_leave"
@@ -115,6 +139,12 @@ const WAKE_REJECTION_MESSAGES: Record<string, string> = {
     "session. Check the selected persona's saved trigger phrases."
 }
 
+const WAKE_REJECTION_REASON_CODES: Record<string, PersonaWakeWarningReasonCode> = {
+  not_saved_in_profile: "wake_activation_rejected_not_saved_in_profile",
+  missing_from_runtime_config: "wake_activation_rejected_missing_from_runtime_config",
+  phrase_not_configured: "wake_activation_rejected_phrase_not_configured"
+}
+
 const formatWakeActivationRejectedMessage = (
   payload: PersonaLiveVoicePayload
 ): string => {
@@ -123,6 +153,23 @@ const formatWakeActivationRejectedMessage = (
     WAKE_REJECTION_MESSAGES[reason] ||
     String(payload?.message || "Wake activation was rejected.")
   )
+}
+
+const getWakeActivationRejectedReasonCode = (
+  payload: PersonaLiveVoicePayload
+): PersonaWakeWarningReasonCode => {
+  const reason = String(payload?.wake_rejection_reason || "").trim()
+  return WAKE_REJECTION_REASON_CODES[reason] || "wake_activation_rejected"
+}
+
+const getWakeDetectorErrorReasonCode = (
+  code: string | null | undefined
+): PersonaWakeWarningReasonCode => {
+  const normalized = String(code || "").trim().toLowerCase()
+  if (normalized === "not-allowed" || normalized === "service-not-allowed") {
+    return "wake_detector_permission_denied"
+  }
+  return "wake_detector_error"
 }
 
 export const usePersonaLiveVoiceController = ({
@@ -140,6 +187,8 @@ export const usePersonaLiveVoiceController = ({
   const [lastCommittedText, setLastCommittedText] = React.useState("")
   const [activeToolStatus, setActiveToolStatus] = React.useState("")
   const [warning, setWarning] = React.useState<string | null>(null)
+  const [warningReasonCode, setWarningReasonCode] =
+    React.useState<PersonaLiveVoiceWarningReasonCode | null>(null)
   const [manualModeRequired, setManualModeRequired] = React.useState(false)
   const [textOnlyDueToTtsFailure, setTextOnlyDueToTtsFailure] = React.useState(false)
   const [sessionAutoResume, setSessionAutoResume] = React.useState(resolvedDefaults.autoResume)
@@ -177,6 +226,8 @@ export const usePersonaLiveVoiceController = ({
   const [wakeDetectorState, setWakeDetectorState] =
     React.useState<WakeDetectorState>("idle")
   const [wakeWarning, setWakeWarning] = React.useState<string | null>(null)
+  const [wakeWarningReasonCode, setWakeWarningReasonCode] =
+    React.useState<PersonaWakeWarningReasonCode | null>(null)
   const [sessionWakeBehavior, setSessionWakeBehavior] =
     React.useState<PersonaWakeBehavior>(resolvedDefaults.wakeBehavior)
 
@@ -264,11 +315,33 @@ export const usePersonaLiveVoiceController = ({
     setMinUtteranceSecs(next.minUtteranceSecs)
   }, [])
 
+  const setVoiceWarning = React.useCallback(
+    (
+      message: string | null,
+      reasonCode: PersonaLiveVoiceWarningReasonCode | null = null
+    ) => {
+      setWarning(message)
+      setWarningReasonCode(message ? reasonCode : null)
+    },
+    []
+  )
+
+  const setWakeRecoveryWarning = React.useCallback(
+    (
+      message: string | null,
+      reasonCode: PersonaWakeWarningReasonCode | null = null
+    ) => {
+      setWakeWarning(message)
+      setWakeWarningReasonCode(message ? reasonCode : null)
+    },
+    []
+  )
+
   const clearTransientWarning = React.useCallback(() => {
     if (textOnlyDueToTtsFailureRef.current) return
     if (manualModeRequiredRef.current) return
-    setWarning(null)
-  }, [])
+    setVoiceWarning(null)
+  }, [setVoiceWarning])
 
   const clearAwaitingTtsTimeout = React.useCallback(() => {
     if (awaitingTtsTimeoutRef.current != null && typeof window !== "undefined") {
@@ -309,9 +382,9 @@ export const usePersonaLiveVoiceController = ({
       error instanceof Error
         ? error.message
         : "Live voice capture failed. Check microphone permissions and audio setup."
-    setWarning(message)
+    setVoiceWarning(message, "voice_capture_error")
     setState("error")
-  }, [])
+  }, [setVoiceWarning])
 
   const {
     start: audioStart,
@@ -343,14 +416,20 @@ export const usePersonaLiveVoiceController = ({
   const sendVoiceCommit = React.useCallback(
     (transcript: string, source = "persona_live_voice_manual") => {
       if (!connected || !sessionId || !ws || ws.readyState !== WebSocket.OPEN) {
-        setWarning("Live voice is disconnected. Reconnect Persona Garden to send spoken commands.")
+        setVoiceWarning(
+          "Live voice is disconnected. Reconnect Persona Garden to send spoken commands.",
+          "live_voice_disconnected"
+        )
         setState("error")
         return
       }
 
       const normalizedTranscript = String(transcript || "").trim()
       if (!normalizedTranscript) {
-        setWarning("No speech transcript was captured for that live turn.")
+        setVoiceWarning(
+          "No speech transcript was captured for that live turn.",
+          "voice_no_transcript"
+        )
         setState("idle")
         return
       }
@@ -371,13 +450,24 @@ export const usePersonaLiveVoiceController = ({
         handleVoiceError(error)
       }
     },
-    [armThinkingRecovery, clearTransientWarning, connected, handleVoiceError, sessionId, ws]
+    [
+      armThinkingRecovery,
+      clearTransientWarning,
+      connected,
+      handleVoiceError,
+      sessionId,
+      setVoiceWarning,
+      ws
+    ]
   )
 
   const sendWakeActivation = React.useCallback(
     (event: WakeDetectedEvent): boolean => {
       if (!connected || !sessionId || !ws || ws.readyState !== WebSocket.OPEN) {
-        setWakeWarning("Wake phrase heard, but Persona Live is not connected.")
+        setWakeRecoveryWarning(
+          "Wake phrase heard, but Persona Live is not connected.",
+          "wake_activation_disconnected"
+        )
         return false
       }
 
@@ -393,11 +483,14 @@ export const usePersonaLiveVoiceController = ({
         )
         return true
       } catch {
-        setWakeWarning("Wake phrase heard, but activation could not be sent.")
+        setWakeRecoveryWarning(
+          "Wake phrase heard, but activation could not be sent.",
+          "wake_activation_send_failed"
+        )
         return false
       }
     },
-    [connected, sessionId, ws]
+    [connected, sessionId, setWakeRecoveryWarning, ws]
   )
 
   const sendWakeDeactivation = React.useCallback(
@@ -439,12 +532,18 @@ export const usePersonaLiveVoiceController = ({
 
   const startMicCapture = React.useCallback(async () => {
     if (!canUseServerStt) {
-      setWarning("This tldw connection does not expose server speech transcription.")
+      setVoiceWarning(
+        "This tldw connection does not expose server speech transcription.",
+        "server_stt_unavailable"
+      )
       setState("error")
       return false
     }
     if (!connected || !sessionId || !ws || ws.readyState !== WebSocket.OPEN) {
-      setWarning("Connect Persona Garden before starting live voice.")
+      setVoiceWarning(
+        "Connect Persona Garden before starting live voice.",
+        "live_voice_disconnected"
+      )
       setState("error")
       return false
     }
@@ -476,6 +575,7 @@ export const usePersonaLiveVoiceController = ({
     liveVoiceSourceReady,
     sessionId,
     startMicStream,
+    setVoiceWarning,
     ws
   ])
 
@@ -569,10 +669,16 @@ export const usePersonaLiveVoiceController = ({
     setLastCommittedText("")
     setActiveToolStatus("")
     if (!manualModeRequiredRef.current && !textOnlyDueToTtsFailureRef.current) {
-      setWarning(null)
+      setVoiceWarning(null)
     }
     setState("idle")
-  }, [clearListeningRecoveryTimeout, clearThinkingRecovery, micActive, stopMicStream])
+  }, [
+    clearListeningRecoveryTimeout,
+    clearThinkingRecovery,
+    micActive,
+    setVoiceWarning,
+    stopMicStream
+  ])
 
   const keepListening = React.useCallback(() => {
     clearListeningRecoveryTimeout()
@@ -651,18 +757,24 @@ export const usePersonaLiveVoiceController = ({
   const startListening = React.useCallback(async () => {
     if (state === "speaking") {
       if (!sessionBargeIn) {
-        setWarning("Barge-in is off for this live session.")
+        setVoiceWarning("Barge-in is off for this live session.", "barge_in_disabled")
         return
       }
       stopCurrentPlayback()
     }
     if (!canUseServerStt) {
-      setWarning("This tldw connection does not expose server speech transcription.")
+      setVoiceWarning(
+        "This tldw connection does not expose server speech transcription.",
+        "server_stt_unavailable"
+      )
       setState("error")
       return
     }
     if (!connected || !sessionId || !ws || ws.readyState !== WebSocket.OPEN) {
-      setWarning("Connect Persona Garden before starting live voice.")
+      setVoiceWarning(
+        "Connect Persona Garden before starting live voice.",
+        "live_voice_disconnected"
+      )
       setState("error")
       return
     }
@@ -693,6 +805,7 @@ export const usePersonaLiveVoiceController = ({
     startMicCapture,
     stopCurrentPlayback,
     suspendWakeDetectorForLiveCapture,
+    setVoiceWarning,
     ws
   ])
 
@@ -703,7 +816,10 @@ export const usePersonaLiveVoiceController = ({
       .map((phrase) => String(phrase || "").trim())
       .filter(Boolean)
     if (phrases.length === 0) {
-      setWakeWarning("Add a persona trigger phrase before arming wake listening.")
+      setWakeRecoveryWarning(
+        "Add a persona trigger phrase before arming wake listening.",
+        "wake_not_configured"
+      )
       return
     }
 
@@ -714,7 +830,7 @@ export const usePersonaLiveVoiceController = ({
     wakeActiveRef.current = false
     setWakeArmed(true)
     if (!options.preserveWarning) {
-      setWakeWarning(null)
+      setWakeRecoveryWarning(null)
     }
     setWakeDetectorState("starting")
 
@@ -729,7 +845,10 @@ export const usePersonaLiveVoiceController = ({
       wakeActiveRef.current = false
       setWakeArmed(false)
       setWakeDetectorState("unavailable")
-      setWakeWarning("Wake listening is unavailable in this browser context.")
+      setWakeRecoveryWarning(
+        "Wake listening is unavailable in this browser context.",
+        "wake_detector_unavailable"
+      )
       return
     }
 
@@ -746,7 +865,11 @@ export const usePersonaLiveVoiceController = ({
         phrases,
         locale: resolvedDefaults.sttLanguage,
         onStateChange: setWakeDetectorState,
-        onError: (error) => setWakeWarning(error.message),
+        onError: (error) =>
+          setWakeRecoveryWarning(
+            error.message,
+            getWakeDetectorErrorReasonCode(error.code)
+          ),
         onWake: (event) => {
           if (!isCurrentStart() || wakeDetectorRef.current !== detector) return
           if (wakeActiveRef.current) return
@@ -776,13 +899,15 @@ export const usePersonaLiveVoiceController = ({
       wakeDetectorRef.current = null
       setWakeArmed(false)
       setWakeDetectorState("error")
-      setWakeWarning(
-        error instanceof Error ? error.message : "Wake listening could not start."
+      setWakeRecoveryWarning(
+        error instanceof Error ? error.message : "Wake listening could not start.",
+        "wake_detector_error"
       )
     }
   }, [
     resolvedDefaults.sttLanguage,
     sendWakeActivation,
+    setWakeRecoveryWarning,
     sessionWakeBehavior,
     startListening,
     wakeDetectorFactory,
@@ -850,7 +975,10 @@ export const usePersonaLiveVoiceController = ({
       if (!browserSpeechSupported()) {
         textOnlyDueToTtsFailureRef.current = true
         setTextOnlyDueToTtsFailure(true)
-        setWarning("Browser speech playback is unavailable. Continuing in text-only mode.")
+        setVoiceWarning(
+          "Browser speech playback is unavailable. Continuing in text-only mode.",
+          "voice_tts_unavailable_text_only"
+        )
         finishVoiceTurn()
         return
       }
@@ -879,7 +1007,10 @@ export const usePersonaLiveVoiceController = ({
         browserUtteranceActiveRef.current = false
         textOnlyDueToTtsFailureRef.current = true
         setTextOnlyDueToTtsFailure(true)
-        setWarning("Browser speech playback failed. Continuing in text-only mode.")
+        setVoiceWarning(
+          "Browser speech playback failed. Continuing in text-only mode.",
+          "voice_tts_unavailable_text_only"
+        )
         finishVoiceTurn()
       }
       setState("speaking")
@@ -889,6 +1020,7 @@ export const usePersonaLiveVoiceController = ({
       finishVoiceTurn,
       resolvedDefaults.sttLanguage,
       resolvedDefaults.ttsVoice,
+      setVoiceWarning,
       stopBrowserSpeech
     ]
   )
@@ -906,8 +1038,8 @@ export const usePersonaLiveVoiceController = ({
     setManualModeRequired(false)
     textOnlyDueToTtsFailureRef.current = false
     setTextOnlyDueToTtsFailure(false)
-    setWarning(null)
-    setWakeWarning(null)
+    setVoiceWarning(null)
+    setWakeRecoveryWarning(null)
     setHeardText("")
     heardTranscriptRef.current = ""
     setLastCommittedText("")
@@ -941,6 +1073,8 @@ export const usePersonaLiveVoiceController = ({
     resolvedDefaults.turnStopSecs,
     resolvedDefaults.vadThreshold,
     sessionId,
+    setVoiceWarning,
+    setWakeRecoveryWarning,
     stopMicStream,
     stopCurrentPlayback
   ])
@@ -962,7 +1096,7 @@ export const usePersonaLiveVoiceController = ({
       setListeningRecoveryCount(0)
       setThinkingRecoveryCount(0)
       setActiveToolStatus("")
-      setWakeWarning(null)
+      setWakeRecoveryWarning(null)
       setListeningRecoveryRestartKey(0)
       setThinkingRecoveryArmed(false)
       setThinkingRecoveryRestartKey(0)
@@ -987,6 +1121,7 @@ export const usePersonaLiveVoiceController = ({
     resolvedDefaults.turnStopSecs,
     resolvedDefaults.vadThreshold,
     resolvedDefaults.wakeBehavior,
+    setWakeRecoveryWarning,
     stopMicStream,
     stopCurrentPlayback
   ])
@@ -1192,12 +1327,15 @@ export const usePersonaLiveVoiceController = ({
       if (eventType === "notice") {
         const reasonCode = String(payload?.reason_code || "").trim().toUpperCase()
         if (reasonCode === "WAKE_ACTIVATION_ACCEPTED") {
-          setWakeWarning(null)
+          setWakeRecoveryWarning(null)
           return
         }
         if (reasonCode === "WAKE_ACTIVATION_REJECTED") {
           wakeActiveRef.current = false
-          setWakeWarning(formatWakeActivationRejectedMessage(payload))
+          setWakeRecoveryWarning(
+            formatWakeActivationRejectedMessage(payload),
+            getWakeActivationRejectedReasonCode(payload)
+          )
           if (wakeArmedRef.current) {
             void startWakeListening({ preserveWarning: true })
           }
@@ -1225,8 +1363,9 @@ export const usePersonaLiveVoiceController = ({
           clearThinkingRecovery()
           textOnlyDueToTtsFailureRef.current = true
           setTextOnlyDueToTtsFailure(true)
-          setWarning(
-            String(payload?.message || "Live TTS is unavailable. Continuing in text-only mode.")
+          setVoiceWarning(
+            String(payload?.message || "Live TTS is unavailable. Continuing in text-only mode."),
+            "voice_tts_unavailable_text_only"
           )
           finishVoiceTurn()
           return
@@ -1234,11 +1373,12 @@ export const usePersonaLiveVoiceController = ({
         if (reasonCode === "VOICE_MANUAL_MODE_REQUIRED") {
           manualModeRequiredRef.current = true
           setManualModeRequired(true)
-          setWarning(
+          setVoiceWarning(
             String(
               payload?.message ||
                 "Server VAD unavailable for this live session. Use Send now to commit heard speech manually."
-            )
+            ),
+            "voice_manual_mode_required"
           )
           return
         }
@@ -1254,7 +1394,7 @@ export const usePersonaLiveVoiceController = ({
           }
           setActiveToolStatus("")
           if (!manualModeRequiredRef.current && !textOnlyDueToTtsFailureRef.current) {
-            setWarning(null)
+            setVoiceWarning(null)
           }
           setRecoveryMode("none")
           armThinkingRecovery()
@@ -1263,7 +1403,10 @@ export const usePersonaLiveVoiceController = ({
         }
         if (reasonCode === "VOICE_COMMIT_IGNORED_ALREADY_COMMITTED") {
           setActiveToolStatus("")
-          setWarning(String(payload?.message || "This utterance was already committed."))
+          setVoiceWarning(
+            String(payload?.message || "This utterance was already committed."),
+            "voice_commit_ignored_already_committed"
+          )
           setState("thinking")
           return
         }
@@ -1271,8 +1414,9 @@ export const usePersonaLiveVoiceController = ({
           setActiveToolStatus("")
           setHeardText("")
           heardTranscriptRef.current = ""
-          setWarning(
-            String(payload?.message || "No trigger phrase was heard, so the transcript was ignored.")
+          setVoiceWarning(
+            String(payload?.message || "No trigger phrase was heard, so the transcript was ignored."),
+            "voice_trigger_not_heard"
           )
           if (wakeArmedRef.current) {
             wakeActiveRef.current = false
@@ -1285,11 +1429,12 @@ export const usePersonaLiveVoiceController = ({
           setActiveToolStatus("")
           setHeardText("")
           heardTranscriptRef.current = ""
-          setWarning(
+          setVoiceWarning(
             String(
               payload?.message ||
                 "The trigger phrase was removed, but no spoken command remained."
-            )
+            ),
+            "voice_empty_command_after_trigger"
           )
           if (wakeArmedRef.current) {
             wakeActiveRef.current = false
@@ -1300,7 +1445,10 @@ export const usePersonaLiveVoiceController = ({
         }
         if (reasonCode === "TRANSCRIPT_REQUIRED") {
           setActiveToolStatus("")
-          setWarning("No speech transcript was captured for that live turn.")
+          setVoiceWarning(
+            "No speech transcript was captured for that live turn.",
+            "voice_no_transcript"
+          )
           setState(micActive ? "listening" : "idle")
         }
       }
@@ -1316,6 +1464,8 @@ export const usePersonaLiveVoiceController = ({
       micActive,
       playBrowserSpeech,
       activeToolStatus,
+      setVoiceWarning,
+      setWakeRecoveryWarning,
       startWakeListening,
       state,
       stopMicStream,
@@ -1345,9 +1495,11 @@ export const usePersonaLiveVoiceController = ({
     lastCommittedText,
     activeToolStatus,
     warning,
+    warningReasonCode,
     wakeArmed,
     wakeDetectorState,
     wakeWarning,
+    wakeWarningReasonCode,
     sessionWakeBehavior,
     wakeTriggerPhrases,
     manualModeRequired,

--- a/apps/packages/ui/src/routes/sidepanel-persona.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-persona.tsx
@@ -1189,6 +1189,7 @@ const SidepanelPersona = ({
       state: liveVoiceController.state,
       recoveryMode: liveVoiceController.recoveryMode,
       warning: liveVoiceController.warning,
+      warningReasonCode: liveVoiceController.warningReasonCode,
       activeToolStatus: liveVoiceController.activeToolStatus,
       textOnlyDueToTtsFailure: liveVoiceController.textOnlyDueToTtsFailure,
       manualModeRequired: liveVoiceController.manualModeRequired
@@ -1197,6 +1198,7 @@ const SidepanelPersona = ({
       armed: liveVoiceController.wakeArmed,
       detectorState: liveVoiceController.wakeDetectorState,
       warning: liveVoiceController.wakeWarning,
+      warningReasonCode: liveVoiceController.wakeWarningReasonCode,
       triggerPhrases: liveVoiceController.wakeTriggerPhrases,
       behavior: liveVoiceController.sessionWakeBehavior
     },

--- a/backlog/tasks/task-233 - Map-Persona-Live-voice-and-wake-recovery-reasons.md
+++ b/backlog/tasks/task-233 - Map-Persona-Live-voice-and-wake-recovery-reasons.md
@@ -1,0 +1,79 @@
+---
+id: TASK-233
+title: Map Persona Live voice and wake recovery reasons
+status: Done
+assignee: []
+created_date: '2026-05-10 16:11'
+updated_date: '2026-05-10 16:29'
+labels:
+  - persona
+  - buddy
+  - live-voice
+  - wake
+  - recovery
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1510'
+  - 'https://github.com/rmusser01/tldw_server/issues/1519'
+documentation:
+  - Docs/Reviews/PERSONA_BUDDY_CURRENT_STATE_AUDIT_2026_05_10.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the next Stage 1 Persona/Buddy reliability slice. Normalize existing Persona Live voice and wake degraded/recovering states into stable reason codes and user-facing recovery copy without adding new runtime capabilities.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Existing live voice and wake states map to stable reason codes and concise recovery copy.
+- [x] #2 Unsupported browser, permission, detector unavailable, wake rejected, manual mode, TTS fallback, reconnect, and teardown states avoid misleading broken-state copy when manual controls remain available.
+- [x] #3 Persona Live or Buddy diagnostics surfaces the mapped recovery copy through existing UI paths.
+- [x] #4 Focused tests cover mapper behavior and at least one route or controller state.
+- [x] #5 Implementation links back to GitHub issue #1519 and the Stage 0 audit.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Plan: Docs/superpowers/plans/2026-05-10-persona-live-wake-recovery-reasons.md
+
+Implementation stages:
+1. Add stable live voice and wake warning reason codes to the Persona Live controller.
+2. Map those codes to recovery-oriented Buddy diagnostics copy.
+3. Wire route diagnostics input and verify hook/card/diagnostics behavior.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented stable hook metadata fields warningReasonCode and wakeWarningReasonCode for existing Persona Live voice/wake warning paths.
+
+Mapped reason-coded live voice and wake states in Buddy diagnostics so no-trigger/no-transcript/no-config cases do not read as broken when manual controls remain available.
+
+Verification: ./node_modules/.bin/vitest run src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx src/components/PersonaGarden/__tests__/personaBuddyDiagnostics.test.ts src/components/PersonaGarden/__tests__/LiveSessionPanel.test.tsx --maxWorkers=1 from apps/packages/ui passed: 3 files, 75 tests.
+
+Verification: git diff --check passed.
+
+Bandit: not applicable; this slice touches frontend TypeScript and Backlog/plan docs only, with no backend Python changes.
+
+Known skips/blockers: none for this slice; Bandit remains not applicable because no backend Python changed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added stable Persona Live voice and wake recovery reason codes to the existing controller and surfaced them through Buddy diagnostics copy. The slice keeps runtime behavior unchanged while making unsupported browser, permission, rejected wake activation, manual mode, TTS fallback, disconnected, and non-broken fallback states explicit and test-covered.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-233 - Map-Persona-Live-voice-and-wake-recovery-reasons.md
+++ b/backlog/tasks/task-233 - Map-Persona-Live-voice-and-wake-recovery-reasons.md
@@ -4,7 +4,7 @@ title: Map Persona Live voice and wake recovery reasons
 status: Done
 assignee: []
 created_date: '2026-05-10 16:11'
-updated_date: '2026-05-10 16:29'
+updated_date: '2026-05-10 16:53'
 labels:
   - persona
   - buddy
@@ -60,6 +60,14 @@ Verification: git diff --check passed.
 Bandit: not applicable; this slice touches frontend TypeScript and Backlog/plan docs only, with no backend Python changes.
 
 Known skips/blockers: none for this slice; Bandit remains not applicable because no backend Python changed.
+
+PR review sweep: addressing Gemini comments on stale live_voice_source_pending plan text and redundant diagnostics detail joining.
+
+PR review fixes: removed stale live_voice_source_pending from the plan snippet because source readiness is queued hydration rather than a warning/recovery state; tightened diagnostics details to append raw warnings only for dynamic capture/detector errors.
+
+Review-fix verification: ./node_modules/.bin/vitest run src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx src/components/PersonaGarden/__tests__/personaBuddyDiagnostics.test.ts src/components/PersonaGarden/__tests__/LiveSessionPanel.test.tsx --maxWorkers=1 passed: 3 files, 75 tests.
+
+Review-fix verification: git diff --check passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary


### PR DESCRIPTION
## Summary
- Add stable Persona Live voice and wake warning reason codes beside the existing warning strings.
- Map those codes into Buddy diagnostics copy so fallback/manual states do not read as broken when controls still work.
- Add focused hook and diagnostics coverage plus the TASK-233 implementation plan.

## Verification
- `./node_modules/.bin/vitest run src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx src/components/PersonaGarden/__tests__/personaBuddyDiagnostics.test.ts src/components/PersonaGarden/__tests__/LiveSessionPanel.test.tsx --maxWorkers=1` from `apps/packages/ui` passed: 3 files, 75 tests.
- `git diff --check origin/dev...HEAD` passed.
- Bandit not applicable: frontend TypeScript/docs/task metadata only.

Closes #1519
Part of #1510

## Merge Gate
Draft until a human-authored Change summary is added per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.
