### PR TITLE
Add Persona Garden setup smoke coverage

### DIFF
--- a/apps/packages/ui/src/components/PersonaGarden/SetupStarterCommandsStep.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/SetupStarterCommandsStep.tsx
@@ -97,16 +97,19 @@ export const SetupStarterCommandsStep: React.FC<SetupStarterCommandsStepProps> =
               disabled={saving}
               onClick={() => {
                 const wasChecked = checkedKeys.has(template.key)
+                const shouldRetrySelected = Boolean(retryHint) && wasChecked
                 setCheckedKeys((prev) => {
                   const next = new Set(prev)
                   if (next.has(template.key)) {
-                    next.delete(template.key)
+                    if (!shouldRetrySelected) {
+                      next.delete(template.key)
+                    }
                   } else {
                     next.add(template.key)
                   }
                   return next
                 })
-                if (!wasChecked) {
+                if (!wasChecked || shouldRetrySelected) {
                   onCreateFromTemplate(template.key)
                 }
               }}

--- a/apps/packages/ui/src/components/PersonaGarden/SetupStarterCommandsStep.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/SetupStarterCommandsStep.tsx
@@ -43,10 +43,14 @@ export const SetupStarterCommandsStep: React.FC<SetupStarterCommandsStepProps> =
   const [checkedKeys, setCheckedKeys] = React.useState<Set<string>>(
     () => new Set(defaultTemplateKeys)
   )
+  const [lastRequestedTemplateKey, setLastRequestedTemplateKey] = React.useState<string | null>(
+    null
+  )
 
   // Sync checked keys when defaultTemplateKeys changes (new archetype selected)
   React.useEffect(() => {
     setCheckedKeys(new Set(defaultTemplateKeys))
+    setLastRequestedTemplateKey(null)
   }, [defaultTemplateKeys])
 
   const [toolName, setToolName] = React.useState("")
@@ -55,6 +59,16 @@ export const SetupStarterCommandsStep: React.FC<SetupStarterCommandsStepProps> =
     error && /starter command/i.test(error)
       ? "Try a starter template again, add an MCP starter instead, or continue without starter commands."
       : null
+  const retryTemplate = React.useMemo(() => {
+    if (!retryHint || !lastRequestedTemplateKey || !checkedKeys.has(lastRequestedTemplateKey)) {
+      return null
+    }
+    return (
+      PERSONA_STARTER_COMMAND_TEMPLATES.find(
+        (template) => template.key === lastRequestedTemplateKey
+      ) || null
+    )
+  }, [checkedKeys, lastRequestedTemplateKey, retryHint])
 
   const handleCreateMcpStarter = React.useCallback(() => {
     const normalizedToolName = String(toolName || "").trim()
@@ -77,6 +91,16 @@ export const SetupStarterCommandsStep: React.FC<SetupStarterCommandsStepProps> =
           {retryHint ? (
             <div className="mt-1 text-xs text-red-100">{retryHint}</div>
           ) : null}
+          {retryTemplate ? (
+            <button
+              type="button"
+              className="mt-2 rounded-md border border-red-300/50 px-3 py-1 text-xs font-medium text-red-50 disabled:cursor-not-allowed disabled:opacity-60"
+              disabled={saving}
+              onClick={() => onCreateFromTemplate(retryTemplate.key)}
+            >
+              Retry {retryTemplate.label}
+            </button>
+          ) : null}
         </div>
       ) : null}
       <div className="space-y-2">
@@ -97,19 +121,21 @@ export const SetupStarterCommandsStep: React.FC<SetupStarterCommandsStepProps> =
               disabled={saving}
               onClick={() => {
                 const wasChecked = checkedKeys.has(template.key)
-                const shouldRetrySelected = Boolean(retryHint) && wasChecked
                 setCheckedKeys((prev) => {
                   const next = new Set(prev)
                   if (next.has(template.key)) {
-                    if (!shouldRetrySelected) {
-                      next.delete(template.key)
-                    }
+                    next.delete(template.key)
                   } else {
                     next.add(template.key)
                   }
                   return next
                 })
-                if (!wasChecked || shouldRetrySelected) {
+                if (wasChecked) {
+                  if (lastRequestedTemplateKey === template.key) {
+                    setLastRequestedTemplateKey(null)
+                  }
+                } else {
+                  setLastRequestedTemplateKey(template.key)
                   onCreateFromTemplate(template.key)
                 }
               }}

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/SetupStarterCommandsStep.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/SetupStarterCommandsStep.test.tsx
@@ -78,7 +78,7 @@ describe("SetupStarterCommandsStep", () => {
     expect(onCreateFromTemplate).not.toHaveBeenCalled()
   })
 
-  it("retries an already-selected template when starter-command creation failed", () => {
+  it("keeps selected-template toggle semantics and exposes an explicit retry action", () => {
     const onCreateFromTemplate = vi.fn()
 
     render(
@@ -94,6 +94,16 @@ describe("SetupStarterCommandsStep", () => {
 
     const searchNotes = screen.getByRole("button", { name: "Search Notes" })
     fireEvent.click(searchNotes)
+
+    expect(onCreateFromTemplate).not.toHaveBeenCalled()
+    expect(searchNotes).toHaveAttribute("aria-pressed", "false")
+
+    fireEvent.click(searchNotes)
+    expect(onCreateFromTemplate).toHaveBeenCalledWith("notes-search")
+    expect(searchNotes).toHaveAttribute("aria-pressed", "true")
+
+    onCreateFromTemplate.mockClear()
+    fireEvent.click(screen.getByRole("button", { name: "Retry Search Notes" }))
 
     expect(onCreateFromTemplate).toHaveBeenCalledWith("notes-search")
     expect(searchNotes).toHaveAttribute("aria-pressed", "true")

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/SetupStarterCommandsStep.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/SetupStarterCommandsStep.test.tsx
@@ -78,6 +78,27 @@ describe("SetupStarterCommandsStep", () => {
     expect(onCreateFromTemplate).not.toHaveBeenCalled()
   })
 
+  it("retries an already-selected template when starter-command creation failed", () => {
+    const onCreateFromTemplate = vi.fn()
+
+    render(
+      <SetupStarterCommandsStep
+        saving={false}
+        error="Failed to create starter command"
+        defaultCommands={[{ template_key: "notes-search" }]}
+        onCreateFromTemplate={onCreateFromTemplate}
+        onCreateMcpStarter={vi.fn()}
+        onSkip={vi.fn()}
+      />
+    )
+
+    const searchNotes = screen.getByRole("button", { name: "Search Notes" })
+    fireEvent.click(searchNotes)
+
+    expect(onCreateFromTemplate).toHaveBeenCalledWith("notes-search")
+    expect(searchNotes).toHaveAttribute("aria-pressed", "true")
+  })
+
   it("creates an MCP-backed starter command from an explicit tool and phrase", () => {
     const onCreateMcpStarter = vi.fn()
 

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
@@ -1804,7 +1804,7 @@ describe("SidepanelPersona", () => {
     expect(await screen.findByText("Failed to create starter command")).toBeInTheDocument()
     expect(screen.getByTestId("assistant-setup-current-step")).toHaveTextContent("commands")
 
-    fireEvent.click(screen.getByRole("button", { name: "Search Notes" }))
+    fireEvent.click(screen.getByRole("button", { name: "Retry Search Notes" }))
 
     await waitFor(() => {
       expect(screen.getByTestId("assistant-setup-current-step")).toHaveTextContent("safety")

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
@@ -1654,6 +1654,212 @@ describe("SidepanelPersona", () => {
     })
   })
 
+  it("smoke-tests setup from persona choice through starter retry and dry-run handoff", async () => {
+    mocks.location.search = "?persona_id=garden-helper&tab=profiles"
+    mocks.getConfig.mockResolvedValue({
+      serverUrl: "http://127.0.0.1:8000",
+      authMode: "single-user",
+      apiKey: ""
+    })
+
+    let profileVersion = 2
+    let starterAttempts = 0
+    let currentVoiceDefaults = {
+      confirmation_mode: "destructive_only"
+    }
+    let currentSetup = {
+      status: "in_progress",
+      version: 1,
+      run_id: "setup-smoke-run",
+      current_step: "persona",
+      completed_steps: [],
+      completed_at: null,
+      last_test_type: null
+    }
+    const setupEventBodies: Array<Record<string, unknown>> = []
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string; body?: any }) => {
+      const method = String(init?.method || "GET").toUpperCase()
+      if (path.includes("/persona/catalog")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [{ id: "garden-helper", name: "Garden Helper" }]
+        })
+      }
+      if (path.includes("/persona/profiles/garden-helper/setup-analytics")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            persona_id: "garden-helper",
+            summary: {
+              total_runs: 0,
+              completion_rate: 0,
+              first_post_setup_action_rate: 0
+            }
+          })
+        })
+      }
+      if (path.includes("/persona/profiles/garden-helper/setup-events") && method === "POST") {
+        setupEventBodies.push(init?.body || {})
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            event_id: init?.body?.event_id || "evt-setup-smoke",
+            run_id: init?.body?.run_id || "setup-smoke-run",
+            event_type: init?.body?.event_type || "step_viewed",
+            deduped: false,
+            created_at: "2026-03-14T10:00:00.000Z"
+          })
+        })
+      }
+      if (path.includes("/persona/profiles/garden-helper/voice-analytics")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            persona_id: "garden-helper",
+            summary: { total_runs: 0, matched_runs: 0, fallback_runs: 0 }
+          })
+        })
+      }
+      if (
+        path.includes("/persona/profiles/garden-helper/voice-commands/test") &&
+        method === "POST"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            heard_text: init?.body?.heard_text,
+            matched: true,
+            command_name: "Search Notes"
+          })
+        })
+      }
+      if (
+        path.includes("/persona/profiles/garden-helper/voice-commands") &&
+        method === "POST"
+      ) {
+        starterAttempts += 1
+        if (starterAttempts === 1) {
+          return Promise.resolve({
+            ok: false,
+            error: "Failed to create starter command",
+            json: async () => ({})
+          })
+        }
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ id: "cmd-search-notes" })
+        })
+      }
+      if (path.includes("/persona/profiles/garden-helper")) {
+        if (method === "PATCH") {
+          profileVersion += 1
+          currentVoiceDefaults = {
+            ...currentVoiceDefaults,
+            ...(init?.body?.voice_defaults || {})
+          }
+          currentSetup = {
+            ...currentSetup,
+            ...(init?.body?.setup || {})
+          }
+        }
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            id: "garden-helper",
+            version: profileVersion,
+            voice_defaults: currentVoiceDefaults,
+            setup: currentSetup,
+            use_persona_state_context_default: true
+          })
+        })
+      }
+      return Promise.resolve({
+        ok: false,
+        error: `unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(<SidepanelPersona />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId("assistant-setup-current-step")).toHaveTextContent("persona")
+    })
+
+    fireEvent.click(await screen.findByRole("button", { name: "Use Garden Helper persona" }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("assistant-setup-current-step")).toHaveTextContent("voice")
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Save assistant defaults" }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("assistant-setup-current-step")).toHaveTextContent("commands")
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Search Notes" }))
+
+    expect(await screen.findByText("Failed to create starter command")).toBeInTheDocument()
+    expect(screen.getByTestId("assistant-setup-current-step")).toHaveTextContent("commands")
+
+    fireEvent.click(screen.getByRole("button", { name: "Search Notes" }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("assistant-setup-current-step")).toHaveTextContent("safety")
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Ask for destructive actions" }))
+    fireEvent.click(screen.getByRole("button", { name: "No external connections for now" }))
+    fireEvent.click(screen.getByRole("button", { name: "Save safety choices" }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("assistant-setup-current-step")).toHaveTextContent("test")
+    })
+
+    fireEvent.change(screen.getByPlaceholderText("Try a spoken phrase"), {
+      target: { value: "search notes for project alpha" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Run dry-run test" }))
+
+    await screen.findByText(/Matched Search Notes/i)
+
+    fireEvent.click(screen.getByRole("button", { name: "Finish with dry-run test" }))
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("assistant-setup-overlay")).not.toBeInTheDocument()
+    })
+
+    expect(starterAttempts).toBe(2)
+    expect(currentSetup.status).toBe("completed")
+    expect(currentSetup.completed_steps).toEqual([
+      "persona",
+      "voice",
+      "commands",
+      "safety",
+      "test"
+    ])
+    expect(screen.getByTestId("persona-setup-handoff-card")).toHaveTextContent(
+      "Assistant setup complete"
+    )
+    expect(screen.getByTestId("persona-setup-handoff-card")).toHaveTextContent(
+      "Added 1 starter command"
+    )
+    expect(screen.getByTestId("persona-setup-handoff-card")).toHaveTextContent(
+      "Ask for destructive actions"
+    )
+    await waitFor(() => {
+      expect(
+        setupEventBodies.some(
+          (body) =>
+            body.event_type === "setup_completed" &&
+            body.completion_type === "dry_run"
+        )
+      ).toBe(true)
+    })
+  })
+
   it("keeps the commands step in place with retry guidance when starter creation fails", async () => {
     mocks.location.search = "?persona_id=garden-helper&tab=commands"
 

--- a/backlog/tasks/task-238 - Add-Persona-Garden-setup-smoke-coverage.md
+++ b/backlog/tasks/task-238 - Add-Persona-Garden-setup-smoke-coverage.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - Codex
 created_date: '2026-05-10 17:04'
-updated_date: '2026-05-10 19:02'
+updated_date: '2026-05-10 19:06'
 labels:
   - persona
   - buddy
@@ -15,6 +15,7 @@ dependencies: []
 references:
   - 'https://github.com/rmusser01/tldw_server/issues/1510'
   - 'https://github.com/rmusser01/tldw_server/issues/1533'
+  - 'https://github.com/rmusser01/tldw_server/pull/1534'
 documentation:
   - Docs/Reviews/PERSONA_BUDDY_CURRENT_STATE_AUDIT_2026_05_10.md
 priority: medium

--- a/backlog/tasks/task-238 - Add-Persona-Garden-setup-smoke-coverage.md
+++ b/backlog/tasks/task-238 - Add-Persona-Garden-setup-smoke-coverage.md
@@ -1,0 +1,68 @@
+---
+id: TASK-238
+title: Add Persona Garden setup smoke coverage
+status: Done
+assignee:
+  - Codex
+created_date: '2026-05-10 17:04'
+updated_date: '2026-05-10 19:02'
+labels:
+  - persona
+  - buddy
+  - stage-1
+  - testing
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1510'
+  - 'https://github.com/rmusser01/tldw_server/issues/1533'
+documentation:
+  - Docs/Reviews/PERSONA_BUDDY_CURRENT_STATE_AUDIT_2026_05_10.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add the next Stage 1 Persona/Buddy reliability slice from epic #1510. Focus on smoke-hardening the existing Persona Garden assistant setup path so route-level setup entry, resume, recovery, and handoff states are covered without changing the setup product flow. Keep this limited to Persona Garden/Buddy; do not add VN/CYOA behavior, native/background voice behavior, or new persona capabilities.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Existing Persona Garden setup entry/resume/finish paths have focused smoke coverage.
+- [x] #2 Smoke coverage verifies setup handoff state and at least one recovery path using existing contracts.
+- [x] #3 Implementation keeps normal healthy setup behavior unchanged and avoids new backend contracts.
+- [x] #4 Focused frontend verification is run and unrelated baseline failures, if any, are recorded separately.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Inspect existing Persona Garden setup tests and route/component boundaries.
+2. Add the smallest failing smoke test for the uncovered setup path.
+3. Patch test utilities or code only if the smoke test exposes a real gap.
+4. Run focused Vitest/Playwright-appropriate checks plus diff hygiene and update tracker notes.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added a route-level Persona Garden setup smoke test that starts at persona choice, retries a failed starter-template creation, completes safety/test steps, and verifies dry-run handoff state. The smoke exposed a real retry gap in SetupStarterCommandsStep: a failed template creation left the template selected, so the next click only unchecked it. Patched the component to treat selected-template clicks as retries while an error is visible, preserving normal unchecked behavior when no error is present.
+
+Verification passed: bun run test src/components/PersonaGarden/__tests__/SetupStarterCommandsStep.test.tsx src/routes/__tests__/sidepanel-persona.test.tsx --maxWorkers=1 (84 tests); git diff --check. Bandit skipped because touched files are TypeScript/Backlog only.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added Persona Garden setup smoke coverage for the full persona-choice to dry-run handoff path, including starter-command failure recovery. Fixed the retry behavior so a selected starter template can be retried while an error is visible instead of only being unchecked. Verification: focused Vitest files passed with 84 tests; git diff --check passed; Bandit skipped for TypeScript-only changes.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-238 - Add-Persona-Garden-setup-smoke-coverage.md
+++ b/backlog/tasks/task-238 - Add-Persona-Garden-setup-smoke-coverage.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - Codex
 created_date: '2026-05-10 17:04'
-updated_date: '2026-05-10 19:06'
+updated_date: '2026-05-10 19:20'
 labels:
   - persona
   - buddy
@@ -47,15 +47,17 @@ Add the next Stage 1 Persona/Buddy reliability slice from epic #1510. Focus on s
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Added a route-level Persona Garden setup smoke test that starts at persona choice, retries a failed starter-template creation, completes safety/test steps, and verifies dry-run handoff state. The smoke exposed a real retry gap in SetupStarterCommandsStep: a failed template creation left the template selected, so the next click only unchecked it. Patched the component to treat selected-template clicks as retries while an error is visible, preserving normal unchecked behavior when no error is present.
+Added a route-level Persona Garden setup smoke test that starts at persona choice, exercises starter-template failure recovery, completes safety/test steps, and verifies dry-run handoff state. The smoke exposed a starter-command recovery gap, and PR review clarified the required behavior: selected template clicks must continue to toggle/uncheck normally. The component now keeps those toggle semantics and exposes a dedicated Retry <template> action in the starter-command error banner for explicit retry.
 
 Verification passed: bun run test src/components/PersonaGarden/__tests__/SetupStarterCommandsStep.test.tsx src/routes/__tests__/sidepanel-persona.test.tsx --maxWorkers=1 (84 tests); git diff --check. Bandit skipped because touched files are TypeScript/Backlog only.
+
+PR #1534 review follow-up addressed the Gemini and Qodo findings by replacing the selected-template retry shortcut with the explicit retry action and updating the route smoke to use that path.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added Persona Garden setup smoke coverage for the full persona-choice to dry-run handoff path, including starter-command failure recovery. Fixed the retry behavior so a selected starter template can be retried while an error is visible instead of only being unchecked. Verification: focused Vitest files passed with 84 tests; git diff --check passed; Bandit skipped for TypeScript-only changes.
+Added Persona Garden setup smoke coverage for the full persona-choice to dry-run handoff path, including starter-command failure recovery. Addressed PR #1534 review feedback by preserving selected starter-template toggle/uncheck semantics and moving retry behavior to an explicit Retry <template> action. Verification: focused Vitest files passed with 84 tests; git diff --check passed; Bandit skipped for TypeScript-only changes.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary
- Adds route-level Persona Garden setup smoke coverage from persona choice through dry-run handoff.
- Covers starter-command failure recovery and verifies setup handoff state.
- Fixes selected starter-template retry behavior when a starter-command error is visible.

## Test Plan
- bun run test src/components/PersonaGarden/__tests__/SetupStarterCommandsStep.test.tsx src/routes/__tests__/sidepanel-persona.test.tsx --maxWorkers=1
- git diff --check origin/dev..HEAD

## Tracker
Closes #1533
Part of #1510

## Merge Gate Note
AI-authored PR: the human requester must add or own the required Change summary before merge.