### PR TITLE
Migrate InspectorRail ready label to state registry

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -1100,7 +1100,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/AgentRegistry/index.tsx:Alert#antd-alert-agentregistrypage-type-error-line-313-zcr2cw",
+    "id": "antd-product-state-import:src/components/Option/AgentRegistry/index.tsx:Alert#antd-alert-agentregistrypage-type-error-line-194-1te5caj",
     "path": "src/components/Option/AgentRegistry/index.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -1111,7 +1111,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/AgentRegistry/index.tsx:Alert#antd-alert-agentregistrypage-type-warning-health-check-u-1tmrb37",
+    "id": "antd-product-state-import:src/components/Option/AgentRegistry/index.tsx:Alert#antd-alert-agentregistrypage-type-warning-health-check-u-17h5f40",
     "path": "src/components/Option/AgentRegistry/index.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -1122,7 +1122,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/AgentTasks/index.tsx:Alert#antd-alert-agenttaskspage-type-error-line-416-womu31",
+    "id": "antd-product-state-import:src/components/Option/AgentTasks/index.tsx:Alert#antd-alert-agenttaskspage-type-error-line-602-3sl8bm",
     "path": "src/components/Option/AgentTasks/index.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -1133,7 +1133,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/AgentTasks/index.tsx:Alert#antd-alert-agenttaskspage-type-warning-line-408-1vo7t8",
+    "id": "antd-product-state-import:src/components/Option/AgentTasks/index.tsx:Alert#antd-alert-agenttaskspage-type-warning-line-566-1tag24f",
     "path": "src/components/Option/AgentTasks/index.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -1144,7 +1144,18 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/AgentTasks/index.tsx:Tag#antd-tag-taskcard-color-error-needs-human-attention-line-14jo2cr",
+    "id": "antd-product-state-import:src/components/Option/AgentTasks/index.tsx:Alert#antd-alert-agenttaskspage-type-warning-acp-setup-needs-a-iqib32",
+    "path": "src/components/Option/AgentTasks/index.tsx",
+    "rule": "antd-product-state-import",
+    "subject": "Alert",
+    "state": "allowed_legacy_exception",
+    "owner": "design-system",
+    "reason": "Existing AntD Alert product-state UI in src/components/Option/AgentTasks/index.tsx on current dev; baseline refresh captures current shared-product-state debt.",
+    "replacement": "tldw design-system state primitive",
+    "migrationQueue": "shared-product-state"
+  },
+  {
+    "id": "antd-product-state-import:src/components/Option/AgentTasks/index.tsx:Tag#antd-tag-taskcard-color-error-needs-human-attention-line-164f3ho",
     "path": "src/components/Option/AgentTasks/index.tsx",
     "rule": "antd-product-state-import",
     "subject": "Tag",
@@ -1155,7 +1166,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/AgentTasks/index.tsx:Tag#antd-tag-taskcard-color-processing-running-line-721-k3zhrq",
+    "id": "antd-product-state-import:src/components/Option/AgentTasks/index.tsx:Tag#antd-tag-taskcard-color-processing-running-line-1117-zq2s4w",
     "path": "src/components/Option/AgentTasks/index.tsx",
     "rule": "antd-product-state-import",
     "subject": "Tag",
@@ -2299,7 +2310,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/MCPHub/ExternalServersTab.tsx:Alert#antd-alert-externalserverstab-type-error-line-583-x7269a",
+    "id": "antd-product-state-import:src/components/Option/MCPHub/ExternalServersTab.tsx:Alert#antd-alert-externalserverstab-type-error-line-644-t7ij7i",
     "path": "src/components/Option/MCPHub/ExternalServersTab.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -2310,7 +2321,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/MCPHub/ExternalServersTab.tsx:Alert#antd-alert-externalserverstab-type-info-no-external-serv-1vfpcn4",
+    "id": "antd-product-state-import:src/components/Option/MCPHub/ExternalServersTab.tsx:Alert#antd-alert-externalserverstab-type-info-no-external-serv-yz8d33",
     "path": "src/components/Option/MCPHub/ExternalServersTab.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -2321,7 +2332,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/MCPHub/ExternalServersTab.tsx:Alert#antd-alert-externalserverstab-type-success-line-584-1kgvx90",
+    "id": "antd-product-state-import:src/components/Option/MCPHub/ExternalServersTab.tsx:Alert#antd-alert-externalserverstab-type-success-line-645-1190gva",
     "path": "src/components/Option/MCPHub/ExternalServersTab.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -2332,7 +2343,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/MCPHub/ExternalServersTab.tsx:Alert#antd-alert-externalserverstab-type-success-template-vali-1ljgp77",
+    "id": "antd-product-state-import:src/components/Option/MCPHub/ExternalServersTab.tsx:Alert#antd-alert-externalserverstab-type-success-template-vali-1svn067",
     "path": "src/components/Option/MCPHub/ExternalServersTab.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -2541,7 +2552,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/MCPHub/ToolCatalogsTab.tsx:Alert#antd-alert-toolcatalogstab-type-error-line-53-iik5bz",
+    "id": "antd-product-state-import:src/components/Option/MCPHub/ToolCatalogsTab.tsx:Alert#antd-alert-toolcatalogstab-type-error-line-81-mfnzqs",
     "path": "src/components/Option/MCPHub/ToolCatalogsTab.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -2552,7 +2563,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/MCPHub/ToolCatalogsTab.tsx:Alert#antd-alert-toolcatalogstab-type-info-line-116-1gky7o9",
+    "id": "antd-product-state-import:src/components/Option/MCPHub/ToolCatalogsTab.tsx:Alert#antd-alert-toolcatalogstab-type-info-line-144-1gkg8km",
     "path": "src/components/Option/MCPHub/ToolCatalogsTab.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -2563,7 +2574,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/MCPHub/ToolCatalogsTab.tsx:Alert#antd-alert-toolcatalogstab-type-warning-line-124-pk4b1y",
+    "id": "antd-product-state-import:src/components/Option/MCPHub/ToolCatalogsTab.tsx:Alert#antd-alert-toolcatalogstab-type-warning-line-152-v45tfb",
     "path": "src/components/Option/MCPHub/ToolCatalogsTab.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -2574,7 +2585,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/MCPHub/ToolCatalogsTab.tsx:Alert#antd-alert-toolcatalogstab-type-warning-line-74-146ei0y",
+    "id": "antd-product-state-import:src/components/Option/MCPHub/ToolCatalogsTab.tsx:Alert#antd-alert-toolcatalogstab-type-warning-line-102-1nejb2u",
     "path": "src/components/Option/MCPHub/ToolCatalogsTab.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -5082,17 +5093,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "canonical-state-label:src/components/Option/ChatWorkspace/InspectorRail.tsx:Ready",
-    "path": "src/components/Option/ChatWorkspace/InspectorRail.tsx",
-    "rule": "canonical-state-label",
-    "subject": "Ready",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing hardcoded \"Ready\" state label in src/components/Option/ChatWorkspace/InspectorRail.tsx before the guard.",
-    "replacement": "getDesignSystemState(...)",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "canonical-state-label:src/components/Option/CompanionHome/CompanionHomePage.tsx:Setup required#label-setup-required-companionhomepage-line-119-ne2x8o",
     "path": "src/components/Option/CompanionHome/CompanionHomePage.tsx",
     "rule": "canonical-state-label",
@@ -5574,6 +5574,50 @@
     "owner": "design-system",
     "reason": "Existing Alert product-state UI in src/components/Option/Evaluations/tabs/RecipesTab.tsx after the embeddings recipe flow merge; baseline refresh captures current dev debt.",
     "replacement": "tldw design-system state primitive",
+    "migrationQueue": "shared-product-state"
+  },
+  {
+    "id": "canonical-state-label:src/components/PersonaGarden/personaBuddyDiagnostics.ts:Ready#label-ready-personabuddydiagnostics-line-116-v09kqm",
+    "path": "src/components/PersonaGarden/personaBuddyDiagnostics.ts",
+    "rule": "canonical-state-label",
+    "subject": "Ready",
+    "state": "allowed_legacy_exception",
+    "owner": "design-system",
+    "reason": "Existing hardcoded \"Ready\" state label in src/components/PersonaGarden/personaBuddyDiagnostics.ts on current dev; baseline refresh captures current shared-product-state debt.",
+    "replacement": "getDesignSystemState(...)",
+    "migrationQueue": "shared-product-state"
+  },
+  {
+    "id": "canonical-state-label:src/components/PersonaGarden/personaBuddyDiagnostics.ts:Ready#label-ready-personabuddydiagnostics-line-127-1qda4me",
+    "path": "src/components/PersonaGarden/personaBuddyDiagnostics.ts",
+    "rule": "canonical-state-label",
+    "subject": "Ready",
+    "state": "allowed_legacy_exception",
+    "owner": "design-system",
+    "reason": "Existing hardcoded \"Ready\" state label in src/components/PersonaGarden/personaBuddyDiagnostics.ts on current dev; baseline refresh captures current shared-product-state debt.",
+    "replacement": "getDesignSystemState(...)",
+    "migrationQueue": "shared-product-state"
+  },
+  {
+    "id": "canonical-state-label:src/components/PersonaGarden/personaBuddyDiagnostics.ts:Loading#label-loading-personabuddydiagnostics-line-173-gk5tgm",
+    "path": "src/components/PersonaGarden/personaBuddyDiagnostics.ts",
+    "rule": "canonical-state-label",
+    "subject": "Loading",
+    "state": "allowed_legacy_exception",
+    "owner": "design-system",
+    "reason": "Existing hardcoded \"Loading\" state label in src/components/PersonaGarden/personaBuddyDiagnostics.ts on current dev; baseline refresh captures current shared-product-state debt.",
+    "replacement": "getDesignSystemState(...)",
+    "migrationQueue": "shared-product-state"
+  },
+  {
+    "id": "canonical-state-label:src/components/PersonaGarden/personaBuddyDiagnostics.ts:Loading#label-loading-personabuddydiagnostics-line-612-1pmf966",
+    "path": "src/components/PersonaGarden/personaBuddyDiagnostics.ts",
+    "rule": "canonical-state-label",
+    "subject": "Loading",
+    "state": "allowed_legacy_exception",
+    "owner": "design-system",
+    "reason": "Existing hardcoded \"Loading\" state label in src/components/PersonaGarden/personaBuddyDiagnostics.ts on current dev; baseline refresh captures current shared-product-state debt.",
+    "replacement": "getDesignSystemState(...)",
     "migrationQueue": "shared-product-state"
   }
 ]

--- a/apps/packages/ui/src/components/Option/ChatWorkspace/InspectorRail.tsx
+++ b/apps/packages/ui/src/components/Option/ChatWorkspace/InspectorRail.tsx
@@ -1,3 +1,5 @@
+import { getDesignSystemState } from "@/design-system"
+
 export type InspectorRailStagedSource = {
   sourceId: string
   title: string
@@ -17,13 +19,14 @@ const panelClass = "rounded-md border border-border bg-surface px-3 py-2"
 const headingClass = "text-[11px] font-semibold text-text-muted"
 const valueClass = "mt-1 text-sm font-medium text-text"
 const mutedClass = "mt-1 text-xs text-text-muted"
+const READY_STATE_LABEL = getDesignSystemState("ready").label
 
 const getRuntimeLabel = (backendAvailable: boolean, streaming: boolean) => {
   if (!backendAvailable) {
     return "Server unavailable"
   }
 
-  return streaming ? "Streaming" : "Ready"
+  return streaming ? "Streaming" : READY_STATE_LABEL
 }
 
 export const InspectorRail = ({

--- a/apps/packages/ui/src/components/Option/ChatWorkspace/__tests__/InspectorRail.test.tsx
+++ b/apps/packages/ui/src/components/Option/ChatWorkspace/__tests__/InspectorRail.test.tsx
@@ -1,8 +1,26 @@
 import { render, screen } from "@testing-library/react"
 import { readFileSync } from "node:fs"
 import { resolve } from "node:path"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import { InspectorRail } from "../InspectorRail"
+
+vi.mock("@/design-system", async (importActual) => {
+  const actual = await importActual<typeof import("@/design-system")>()
+
+  return {
+    ...actual,
+    getDesignSystemState: vi.fn(
+      (key: Parameters<typeof actual.getDesignSystemState>[0]) => {
+        const state = actual.getDesignSystemState(key)
+
+        return {
+          ...state,
+          label: key === "ready" ? "Ready via registry" : state.label
+        }
+      }
+    )
+  }
+})
 
 describe("InspectorRail", () => {
   it("shows real scope and staged source state", () => {
@@ -25,6 +43,7 @@ describe("InspectorRail", () => {
     expect(screen.getByText("Operator Notes")).toBeInTheDocument()
     expect(screen.getByText("gpt-test")).toBeInTheDocument()
     expect(screen.getByText("Analyst")).toBeInTheDocument()
+    expect(screen.getByText("Ready via registry")).toBeInTheDocument()
   })
 
   it("labels inactive v1 panels honestly", () => {

--- a/backlog/tasks/task-239 - Migrate-InspectorRail-ready-label-and-refresh-product-state-baseline.md
+++ b/backlog/tasks/task-239 - Migrate-InspectorRail-ready-label-and-refresh-product-state-baseline.md
@@ -1,0 +1,58 @@
+---
+id: TASK-239
+title: Migrate InspectorRail ready label and refresh product-state baseline
+status: Done
+assignee: []
+created_date: '2026-05-10 19:06'
+updated_date: '2026-05-10 19:14'
+labels:
+  - design-system
+  - frontend
+  - product-state
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1536'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue the frontend design-system product-state cleanup by replacing InspectorRail's hardcoded idle Ready runtime label with the canonical ready state registry value while preserving current streaming and unavailable behavior. The latest dev baseline also had bounded product-state guard drift, so this task refreshes those baseline records to keep the verifier green.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 InspectorRail uses the design-system ready state registry label for its idle non-streaming runtime state.
+- [x] #2 Focused component coverage proves the ready label is supplied through the registry rather than a hardcoded literal.
+- [x] #3 The matching canonical-state-label baseline entry is removed and the design-system verifier passes.
+- [x] #4 Current dev product-state baseline drift is reconciled without reintroducing InspectorRail's Ready exception.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+TDD red: InspectorRail test mocked the design-system ready label as 'Ready via registry' and failed while the component still rendered literal Ready.
+
+Green verification: InspectorRail focused Vitest passed (4 tests); product-state guard unit test passed (52 tests); verify:design-system-state exited 0 with blocked=0 stale=0 baselineErrors=0; git diff --check exited 0. Broad bunx tsc still exits 2 with 239 baseline errors, and touched-scope filtering found no InspectorRail/baseline/touched-path matches.
+
+Bandit skipped: touched implementation is TypeScript/TSX/JSON/Backlog only, with no Python runtime code.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+InspectorRail now uses getDesignSystemState('ready').label for the idle non-streaming runtime label, with a mocked-registry regression test proving the label is not hardcoded. Removed the InspectorRail Ready baseline exception and refreshed bounded current-dev product-state baseline drift so the design-system verifier has blocked=0, stale=0, and baselineErrors=0.
+
+PR: https://github.com/rmusser01/tldw_server/pull/1536
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Change summary
- Migrates InspectorRail idle runtime Ready label to `getDesignSystemState("ready").label`.
- Adds a mocked-registry regression test so the component must render the registry-provided label.
- Removes the InspectorRail Ready baseline exception and refreshes bounded current-dev product-state baseline drift so the verifier is green.

## Verification
- `bunx vitest run src/components/Option/ChatWorkspace/__tests__/InspectorRail.test.tsx --reporter=dot`
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot`
- `bun run verify:design-system-state` (blocked=0, stale=0, baselineErrors=0)
- `git diff --check`
- `bunx tsc --noEmit --pretty false` still exits 2 on existing repo-wide TS debt; touched-scope filter found no InspectorRail/baseline/touched-path matches in `/tmp/tldw_ui_tsc_inspector_rail_ready_label.txt`.
- Bandit skipped: UI-only TypeScript/TSX/JSON/Backlog changes.