### PR TITLE
Close out MCP Hub remediation tasks

### DIFF
--- a/backlog/tasks/task-223 - MCP-Hub-walkthrough-remediation-plan.md
+++ b/backlog/tasks/task-223 - MCP-Hub-walkthrough-remediation-plan.md
@@ -1,10 +1,11 @@
 ---
 id: TASK-223
 title: MCP Hub walkthrough remediation plan
-status: In Progress
-assignee: []
+status: Done
+assignee:
+  - '@Codex'
 created_date: '2026-05-10 06:13'
-updated_date: '2026-05-10 06:26'
+updated_date: '2026-05-10 19:20'
 labels:
   - mcp
   - webui
@@ -13,6 +14,9 @@ labels:
 dependencies: []
 documentation:
   - Docs/superpowers/specs/2026-05-10-mcp-hub-walkthrough-remediation-design.md
+references:
+  - https://github.com/rmusser01/tldw_server/pull/1514
+  - https://github.com/rmusser01/tldw_server/pull/1531
 priority: high
 ---
 
@@ -40,12 +44,14 @@ Spec review loop passed on first review. Reviewer status: Approved. Advisory rec
 No blocking spec-review issues found. Human review is the remaining process gate before transitioning to implementation-plan writing.
 
 After human-requested design review, clarified the spec around live MCP runtime resolution via get_mcp_server(), explicit ExternalServerManager.reconcile_servers(), normal chat/raw-preview scope, executable-tool data sources, and PR 2 setup isolation deliverables. Second spec review passed with no blocking issues. Advisory notes for implementation planning: resolve refresh endpoint path and external federation module-id fallback; include delete/disable runtime reconciliation flows; enumerate exact temp-path env/config values for walkthrough isolation.
+
+2026-05-10: Both child implementation phases are merged to dev. PR #1514 landed live external discovery refresh, chat payload correctness, and degraded readiness handling. PR #1531 landed setup-state polish, Tool Catalog recovery guidance, deployment diagnostics, toy MCP walkthrough docs, and skip-safe E2E coverage.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Design spec created, split into two PR-sized implementation tasks, reviewed by a spec-review subagent, and approved with no blocking issues. Bandit is not applicable because this task only added planning documents and Backlog task records.
+Design spec created, split into two PR-sized implementation tasks, reviewed, implemented, and merged through PR #1514 and PR #1531. The remediation program now covers live MCP external discovery, honest chat MCP request construction, degraded readiness entry, no-auth setup clarity, Tool Catalog recovery states, deployment diagnostics, and toy MCP walkthrough isolation. Bandit was handled in the implementation tasks where backend Python was touched; this closeout only updates Backlog task state.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-223.2 - PR-2-MCP-Hub-setup-polish-and-diagnostics.md
+++ b/backlog/tasks/task-223.2 - PR-2-MCP-Hub-setup-polish-and-diagnostics.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-223.2
 title: 'PR 2: MCP Hub setup polish and diagnostics'
-status: In Progress
+status: Done
 assignee:
   - '@Codex'
 created_date: '2026-05-10 06:13'
-updated_date: '2026-05-10 16:09'
+updated_date: '2026-05-10 19:20'
 labels:
   - mcp
   - webui
@@ -70,6 +70,7 @@ Stages:
 2026-05-10: Opened PR #1531 for branch codex/mcp-hub-pr2-setup-polish.
 2026-05-10: Addressed PR #1531 review feedback. Removed the committed toy walkthrough API key in favor of per-run generation, tightened Tool Catalog chat-executability guidance to chat-enabled tools only, surfaced external-server inventory load failures as a retryable unknown state instead of a false no-server empty state, and cleaned the Playwright toy MCP temp directory in finally.
 2026-05-10: Review-fix verification: `cd apps/packages/ui && bun run test src/components/Option/MCPHub/__tests__/ToolCatalogsTab.test.tsx` passed 9 tests. `cd apps/packages/ui && bun run test src/components/Option/MCPHub/__tests__/ExternalServersTab.test.tsx src/components/Option/MCPHub/__tests__/ToolCatalogsTab.test.tsx src/components/Option/MCPHub/__tests__/DeploymentDiagnosticsPanel.test.tsx src/components/Option/MCPHub/__tests__/McpHubPage.test.tsx` passed 4 files / 30 tests. `cd apps/tldw-frontend && bunx playwright test e2e/workflows/tier-2-features/mcp-hub.spec.ts --list` listed 9 tests. `cd apps/tldw-frontend && bunx playwright test e2e/workflows/tier-2-features/mcp-hub.spec.ts --reporter=line` passed 3 and skipped 6 live-server-dependent cases. `git diff --check` passed. Bandit remains skipped because the review fixes touched TypeScript, docs, and Playwright only; no Python production code was touched.
+2026-05-10: PR #1531 merged to dev at merge commit da374c5e8.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary


### PR DESCRIPTION
## Change summary

Needs a human-authored summary before merge per the repo AI-generated PR policy.

## What changed

- Mark TASK-223 and TASK-223.2 done after PR #1514 and PR #1531 merged.
- Record both merged PR links on the parent task.
- Add closeout notes tying the two-PR remediation program to the merged implementation PRs.

## Verification

- `git diff --check`