### PR TITLE
Implement OpenWebUI chat import

### DIFF
--- a/Docs/API-related/Chatbook_API_Documentation.md
+++ b/Docs/API-related/Chatbook_API_Documentation.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Chatbook API provides functionality for exporting and importing collections of content (conversations, notes, characters, etc.) in a portable archive format. This enables users to backup, share, and migrate their data between instances or users.
+The Chatbook API provides functionality for exporting and importing collections of content (conversations, notes, characters, etc.) in a portable archive format. It also supports importing OpenWebUI chat export JSON through the same import and preview endpoints. This enables users to backup, share, and migrate their data between instances or users.
 
 Developer Code Guide: `Docs/Code_Documentation/Guides/Chatbooks_Code_Guide.md:1`
 
@@ -61,7 +61,9 @@ Export (async)
 
 Import (sync/async)
   Client → POST /api/v1/chatbooks/import (multipart)
-         → Save temp → Validate ZIP → Secure extract → Import selections
+         → Save temp → Branch by source_format
+         → Chatbook archive: Validate ZIP → Secure extract → Import selections
+         → OpenWebUI JSON: Parse export JSON → Import chat trees
          ← Sync: { success, imported_items, warnings } or Async: { job_id }
 ```
 
@@ -137,15 +139,17 @@ Implementation notes:
 
 **Endpoint**: `POST /api/v1/chatbooks/import`
 
-**Description**: Import content from an uploaded chatbook file.
+**Description**: Import content from an uploaded chatbook archive or OpenWebUI chat export JSON.
 
 **Request**: Multipart form data + query parameters
-- `file` (form field): The chatbook file (required)
-- Additional import options are provided as query parameters (see Options JSON for fields). For example: `?conflict_resolution=skip&import_media=true`
+- `file` (form field): The import file (required)
+- `source_format` (form field or query parameter): `chatbook` (default) or `openwebui_json`
+- Additional import options are provided as query parameters or multipart fields (see Options JSON for fields). For example: `?conflict_resolution=skip&import_media=true`
 
 Supported options (as query parameters or structured by clients that map to query params):
 ```json
 {
+  "source_format": "chatbook",
   "content_selections": {
     "conversation": ["conv_123"],  // Only import specific items
     "note": []  // Import all notes
@@ -158,9 +162,14 @@ Supported options (as query parameters or structured by clients that map to quer
 }
 ```
 
+For `source_format=chatbook`, the upload must be a `.zip` or `.chatbook` archive. For `source_format=openwebui_json`, the upload must be a safe `.json` filename and the server does not run ZIP validation or Chatbook manifest extraction.
+
+OpenWebUI JSON import supports normal OpenWebUI "Export Chats" JSON files. It imports every valid chat as one tldw conversation and preserves all valid message branches through `parent_message_id`. Duplicate detection uses `source=openwebui` and a deterministic external reference. `skip` is the default duplicate behavior; `rename` creates an intentional second copy with a unique imported title and external reference. OpenWebUI v1 does not support `overwrite`, `merge`, direct `webui.db` import, admin export import, live OpenWebUI server import, attachment hydration, media import, embeddings import, or content selections.
+
 **Response**:
 ```json
 {
+  "source_format": "chatbook",
   "success": true,
   "message": "Chatbook imported successfully",
   "imported_items": {
@@ -171,18 +180,38 @@ Supported options (as query parameters or structured by clients that map to quer
 }
 ```
 
+**OpenWebUI JSON Response**:
+```json
+{
+  "source_format": "openwebui_json",
+  "success": true,
+  "message": "OpenWebUI chats imported successfully",
+  "openwebui_result": {
+    "imported_chats": 4,
+    "skipped_chats": 1,
+    "failed_chats": 0,
+    "imported_messages": 128,
+    "skipped_messages": 0,
+    "duplicate_chats": 1,
+    "warnings": []
+  }
+}
+```
+
 ### 3. Preview Chatbook
 
 **Endpoint**: `POST /api/v1/chatbooks/preview`
 
-**Description**: Preview chatbook contents without importing.
+**Description**: Preview chatbook archive or OpenWebUI JSON contents without importing.
 
 **Request**: Multipart form data
-- `file`: The chatbook file to preview
+- `file`: The file to preview
+- `source_format`: `chatbook` (default) or `openwebui_json`
 
 **Response**:
 ```json
 {
+  "source_format": "chatbook",
   "manifest": {
     "version": "1.0.0",
     "name": "My Chatbook",
@@ -194,6 +223,32 @@ Supported options (as query parameters or structured by clients that map to quer
     "total_characters": 3,
     "total_size_bytes": 5242880,
     "content_items": []  // Preview omits detailed items for performance
+  }
+}
+```
+
+**OpenWebUI JSON Preview Response**:
+```json
+{
+  "source_format": "openwebui_json",
+  "openwebui_preview": {
+    "chat_count": 5,
+    "message_count": 132,
+    "branched_chat_count": 2,
+    "duplicate_chat_count": 1,
+    "attachment_reference_count": 3,
+    "malformed_chat_count": 0,
+    "warnings": [],
+    "items": [
+      {
+        "title": "Research thread",
+        "external_ref": "chat_abc123",
+        "message_count": 31,
+        "branched": true,
+        "duplicate": false,
+        "warning_count": 0
+      }
+    ]
   }
 }
 ```
@@ -394,6 +449,8 @@ Lightweight liveness check for the Chatbooks subsystem.
 - rename: Add with modified name
 - merge: Combine with existing (future feature)
 ```
+
+OpenWebUI JSON imports support `skip` and `rename` in v1.
 
 ### ExportStatus Enum
 ```

--- a/Docs/User_Guides/WebUI_Extension/Chatbook_User_Guide.md
+++ b/Docs/User_Guides/WebUI_Extension/Chatbook_User_Guide.md
@@ -5,7 +5,7 @@
 1. [Introduction](#introduction)
 2. [Getting Started](#getting-started)
 3. [Exporting Content](#exporting-content)
-4. [Importing Chatbooks](#importing-chatbooks)
+4. [Importing Content](#importing-content)
 5. [Managing Jobs](#managing-jobs)
 6. [Best Practices](#best-practices)
 7. [Troubleshooting](#troubleshooting)
@@ -151,14 +151,30 @@ For more control over what to export:
 }
 ```
 
-## Importing Chatbooks
+## Importing Content
 
-### Basic Import
+### Basic Chatbook Import
 
 1. Click "Import Chatbook"
-2. Select your `.chatbook` file
-3. Choose conflict resolution strategy
-4. Click "Import"
+2. Select "Chatbook archive" as the source
+3. Select your `.chatbook` file
+4. Choose conflict resolution strategy
+5. Click "Import"
+
+### OpenWebUI Chat Import
+
+The same import tab can also import normal OpenWebUI "Export Chats" JSON files:
+
+1. Click "Import Chatbook"
+2. Select "OpenWebUI JSON" as the source
+3. Select the `.json` file produced by OpenWebUI's chat export
+4. Preview the file and review the chat, message, branch, duplicate, attachment-reference, malformed-chat, and warning counts
+5. Choose `skip` to avoid reimporting existing chats, or `rename` to intentionally create a second copy
+6. Click "Import"
+
+OpenWebUI import creates one tldw conversation for each valid OpenWebUI chat. It preserves all valid message branches as parent-linked message trees, not only the currently selected branch. Duplicate detection uses the OpenWebUI source reference stored on imported conversations, so repeated imports default to skipping previously imported chats.
+
+OpenWebUI v1 import supports standard exported chat JSON files only. It does not import directly from `webui.db`, OpenWebUI admin exports, or a live OpenWebUI server. File, image, and artifact references found in the export are preserved as message metadata only; the referenced attachment binaries are not hydrated in v1.
 
 ### Conflict Resolution Strategies
 
@@ -173,6 +189,7 @@ When importing content that already exists:
 - **Behavior**: Replaces existing items with imported versions
 - **Use When**: Imported version is more recent or authoritative
 - **Example**: Restoring from a backup after data corruption
+- **OpenWebUI**: Not available for OpenWebUI JSON imports in v1
 
 #### Rename
 - **Behavior**: Adds imported items with modified names
@@ -194,22 +211,27 @@ When importing content that already exists:
 - **Import Media**: Include media files from the chatbook
   - Default: true (recommended)
   - Set to false to save space
+  - OpenWebUI JSON imports ignore this option and preserve only attachment references
 
 - **Import Embeddings**: Include vector embeddings
   - Default: false (recreated as needed)
   - Set to true for exact search behavior
+  - OpenWebUI JSON imports do not import embeddings
 
 ### Preview Before Import
 
-Always preview a chatbook before importing:
+Always preview a chatbook or OpenWebUI export before importing:
 
 1. Click "Preview Chatbook"
 2. Select the file
 3. Review:
    - Total items by type
+   - OpenWebUI chat/message/branch counts when importing JSON
+   - Duplicate and malformed-chat counts
    - Creation date
    - Author information
    - Size
+   - Warnings
 4. Decide on import strategy
 
 ## Managing Jobs
@@ -422,13 +444,13 @@ A: Not currently. You need to start a new export job.
 ### Import Questions
 
 **Q: Will importing duplicate my content?**
-A: Depends on conflict resolution. Use "skip" to avoid duplicates.
+A: Depends on conflict resolution. Use "skip" to avoid duplicates. OpenWebUI JSON import defaults to `skip` and detects existing imported chats by `source=openwebui` plus the OpenWebUI external reference.
 
 **Q: Can I preview what will be imported?**
 A: Yes, use the preview endpoint to see contents without importing.
 
 **Q: What happens to media files during import?**
-A: They're imported if import_media is true and you have sufficient storage quota.
+A: Chatbook archive media is imported if import_media is true and you have sufficient storage quota. OpenWebUI JSON import preserves file, image, and artifact references as metadata only.
 
 **Q: Can I undo an import?**
 A: No automatic undo. Keep backups before importing.

--- a/Docs/superpowers/plans/2026-05-10-openwebui-chat-import-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-10-openwebui-chat-import-implementation-plan.md
@@ -41,7 +41,7 @@
 - [ ] Add regression tests proving archive mode still rejects `.json` and still validates archive integrity.
 - [ ] Add a multipart test proving `source_format` is honored when sent as a form field, because the current WebUI upload helper sends upload options through FormData fields.
 
-**Status:** Not Started
+**Status:** Complete
 
 ---
 
@@ -81,7 +81,7 @@
 - [ ] Test malformed chats are counted and warned while valid chats remain previewable.
 - [ ] Test preview duplicate flags using a fake duplicate lookup callback or service stub.
 
-**Status:** Not Started
+**Status:** Complete
 
 ---
 
@@ -110,7 +110,7 @@
 - [ ] Test conversation settings merge preserves existing settings keys while adding `openwebui_import`.
 - [ ] Test message metadata merge preserves existing `extra` keys while adding `openwebui_import`.
 
-**Status:** Not Started
+**Status:** Complete
 
 ---
 
@@ -154,7 +154,7 @@
 - [ ] Test conversation and message metadata persistence paths.
 - [ ] Test metadata write failures become warnings without failing the chat import.
 
-**Status:** Not Started
+**Status:** Complete
 
 ---
 
@@ -188,7 +188,7 @@
 - [ ] Add worker test proving JSON dispatch does not call `_import_chatbook_sync()`.
 - [ ] Add cleanup tests for invalid JSON preview/import paths where practical.
 
-**Status:** Not Started
+**Status:** Complete
 
 ---
 
@@ -224,7 +224,7 @@
 - [ ] Test unsupported controls are hidden or disabled in OpenWebUI mode.
 - [ ] Test OpenWebUI preview summary renders counts and warnings.
 
-**Status:** Not Started
+**Status:** Complete
 
 ---
 
@@ -248,14 +248,15 @@
 - [ ] Update the Backlog task with touched files, verification commands, skips, and final summary.
 
 **Verification Commands:**
-- [ ] `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Chatbooks/test_openwebui_import_adapter.py -v`
-- [ ] `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Chatbooks/test_chatbooks_api_preview.py tldw_Server_API/tests/Chatbooks/test_chatbooks_jobs_worker_import_defaults.py -v`
-- [ ] `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/ChaChaNotesDB -k "conversation or metadata" -v`
-- [ ] `bunx vitest run apps/packages/ui/src/components/Option/Chatbooks/__tests__`
-- [ ] `source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/chatbooks.py tldw_Server_API/app/core/Chatbooks tldw_Server_API/app/core/DB_Management/chacha -f json -o /tmp/bandit_openwebui_chat_import.json`
-- [ ] Run a manual browser smoke test of `/chatbooks` import mode if a frontend dev server is available in the implementation session.
+- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Chatbooks/test_openwebui_import_adapter.py tldw_Server_API/tests/Chatbooks/test_openwebui_import_service.py tldw_Server_API/tests/Chatbooks/test_chatbooks_api_error_and_preview_mapping.py::test_preview_openwebui_json_source_format_skips_archive_validation tldw_Server_API/tests/Chatbooks/test_chatbooks_api_error_and_preview_mapping.py::test_import_openwebui_json_source_format_skips_archive_validation tldw_Server_API/tests/Chatbooks/test_chatbooks_jobs_worker_import_defaults.py -v` - 11 passed.
+- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/ChaChaNotesDB -k "conversation or metadata" -v` - 62 passed, 235 deselected.
+- [x] `bun run test src/services/__tests__/tldw-api-client.chatbooks-openwebui.test.ts src/components/Option/Chatbooks/__tests__/ChatbooksPlaygroundPage.openwebui-import.test.tsx src/components/Option/Chatbooks/__tests__/ContentTypePicker.error-state.test.tsx` - 4 passed.
+- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/chatbooks.py tldw_Server_API/app/core/Chatbooks tldw_Server_API/app/core/DB_Management/chacha -f json -o /tmp/bandit_openwebui_chat_import.json` - 0 findings.
+- [x] `git diff --check` - clean.
+- [ ] Full `test_chatbooks_api_preview.py` was not rerun because this implementation session previously observed the baseline `test_preview_manifest_version_ok` path hanging; targeted preview/import endpoint coverage was run instead.
+- [ ] Manual browser smoke test was not run; the focused component and client tests covered the import source selector and multipart upload contract.
 
-**Status:** Not Started
+**Status:** Complete
 
 ---
 

--- a/Docs/superpowers/plans/2026-05-10-openwebui-chat-import-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-10-openwebui-chat-import-implementation-plan.md
@@ -1,0 +1,273 @@
+# OpenWebUI Chat Import Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship v1 OpenWebUI `Export Chats` JSON import through the existing Chatbooks import workflow, preserving all valid OpenWebUI message branches as tldw conversation/message trees while making repeated imports safe by `source=openwebui` and `external_ref`.
+
+**Architecture:** Keep Chatbooks as the upload, preview, quota, sync/async import, and jobs surface. Add a focused OpenWebUI JSON import adapter under `tldw_Server_API/app/core/Chatbooks/import_adapters/`, branch Chatbooks preview/import by a multipart `source_format` field before ZIP validation, persist imported conversations through existing ChaCha stores, and extend the current `/chatbooks` WebUI import tab with a source selector instead of creating a new page.
+
+**Tech Stack:** FastAPI, Pydantic, ChaCha SQLite/PostgreSQL store abstractions, core Jobs worker, pytest, Next.js/React, Ant Design, Vitest/Testing Library.
+
+---
+
+## Stage 1: Source Format Schemas And Validation Boundaries
+
+**Goal:** Add explicit source-format contracts and JSON-safe upload validation without changing the existing Chatbook archive behavior.
+
+**Success Criteria:**
+- `source_format` defaults to `chatbook` for existing clients.
+- `openwebui_json` uploads accept safe `.json` filenames and never run ZIP-only filename rewriting or archive validation.
+- Existing `.zip` and `.chatbook` preview/import behavior and tests remain unchanged.
+- API responses can carry OpenWebUI preview/import details without overloading the Chatbook manifest fields.
+
+**Implementation Tasks:**
+- [ ] Add a source-format type in `tldw_Server_API/app/api/v1/schemas/chatbook_schemas.py`, for example `ChatbookImportSourceFormat` with `chatbook` and `openwebui_json`.
+- [ ] Add `source_format: ChatbookImportSourceFormat = chatbook` to `ImportChatbookRequest`.
+- [ ] Add optional OpenWebUI response schemas in `chatbook_schemas.py`: `OpenWebUIPreviewChatItem`, `OpenWebUIImportPreview`, and `OpenWebUIImportResult`.
+- [ ] Extend `PreviewChatbookResponse` with `source_format` and `openwebui_preview`.
+- [ ] Extend `ImportChatbookResponse` with `source_format` and `openwebui_result`.
+- [ ] Add `source_format` to `preview_chatbook()` as a multipart form field, with the same default `chatbook` behavior as existing preview callers.
+- [ ] Verify `ImportChatbookRequest` can parse `source_format` from the actual upload path used by the WebUI; if `Depends()` only handles query parameters in this route, add explicit `Form` parsing or an `as_form` dependency while preserving existing query-param compatibility tested by current import tests.
+- [ ] Add a JSON-specific filename validator in `tldw_Server_API/app/core/Chatbooks/chatbook_validators.py`, or make the existing filename validator source-format aware, so `.json` is accepted only for `openwebui_json` and archive extensions remain archive-only.
+- [ ] Keep the current path traversal checks in `tldw_Server_API/app/api/v1/endpoints/chatbooks.py` before both archive and JSON handling.
+- [ ] Branch `preview_chatbook()` by `source_format` before `ChatbookValidator.validate_filename()` and `validate_zip_file()`.
+- [ ] Branch `import_chatbook()` by `source_format` before `ChatbookValidator.validate_filename()` and `validate_zip_file()`.
+- [ ] Keep quota checks, per-user temp directory handling, audit logging, and cleanup behavior shared between source formats.
+
+**Tests:**
+- [ ] Extend `tldw_Server_API/tests/Chatbooks/test_chatbooks_api_preview.py` to prove default preview still accepts Chatbook archives without sending `source_format`.
+- [ ] Add endpoint tests proving `source_format=openwebui_json` accepts a `.json` upload and does not call ZIP validation.
+- [ ] Add endpoint tests proving JSON mode rejects unsafe filenames, path traversal names, non-JSON extensions, malformed JSON, and top-level non-array JSON.
+- [ ] Add regression tests proving archive mode still rejects `.json` and still validates archive integrity.
+- [ ] Add a multipart test proving `source_format` is honored when sent as a form field, because the current WebUI upload helper sends upload options through FormData fields.
+
+**Status:** Not Started
+
+---
+
+## Stage 2: OpenWebUI Parser And Preview Adapter
+
+**Goal:** Parse normal OpenWebUI chat export JSON into a source-specific preview model with deterministic warnings, duplicate checks, and no database writes.
+
+**Success Criteria:**
+- Standard OpenWebUI wrapper objects and documented legacy chat objects are accepted.
+- Preview counts chats, messages, branched chats, duplicate chats, malformed chats, and attachment/artifact references.
+- Preview includes lightweight per-chat items when practical.
+- Parser and preview code are unit-testable without FastAPI.
+- Raw chat content is not logged or returned in warnings.
+
+**Implementation Tasks:**
+- [ ] Create `tldw_Server_API/app/core/Chatbooks/import_adapters/__init__.py`.
+- [ ] Create `tldw_Server_API/app/core/Chatbooks/import_adapters/openwebui.py`.
+- [ ] Add adapter dataclasses or Pydantic models for normalized chat plans, message plans, preview items, warnings, and import results.
+- [ ] Implement UTF-8 JSON loading with explicit errors for malformed JSON and non-array roots.
+- [ ] Implement standard wrapper detection where each item contains a `chat` object with `history.messages`.
+- [ ] Implement documented legacy chat-object handling where each array item is treated as the chat payload.
+- [ ] Derive stable external refs from OpenWebUI IDs when available, otherwise `openwebui:<index>:<sha256(canonical_chat_json)[0:16]>`.
+- [ ] Normalize title fallback order: OpenWebUI title, first user-message excerpt, then `OpenWebUI Import <YYYY-MM-DD>`.
+- [ ] Detect branched chats from multiple children, non-current branches, or non-linear parent relationships.
+- [ ] Count attachment, file, image, and artifact-like references without hydrating files.
+- [ ] Add preview service entry point on `ChatbookService`, for example `preview_openwebui_json(file_path: str)`.
+- [ ] During preview, call a new ChaCha duplicate helper from Stage 3 to mark duplicate items by `source=openwebui` and `external_ref`.
+- [ ] If parser work lands before the ChaCha helper work, keep duplicate detection behind an injected callback/service method and complete the duplicate-flag wiring after Stage 3.
+
+**Tests:**
+- [ ] Add `tldw_Server_API/tests/Chatbooks/test_openwebui_import_adapter.py`.
+- [ ] Test standard wrapper parsing with `chat.title`, `chat.models`, `history.currentId`, and `history.messages`.
+- [ ] Test legacy object parsing.
+- [ ] Test deterministic derived external refs for source objects without IDs.
+- [ ] Test branch detection and message counting across sibling branches.
+- [ ] Test attachment/artifact reference detection without file hydration.
+- [ ] Test malformed chats are counted and warned while valid chats remain previewable.
+- [ ] Test preview duplicate flags using a fake duplicate lookup callback or service stub.
+
+**Status:** Not Started
+
+---
+
+## Stage 3: ChaCha Duplicate And Metadata Helpers
+
+**Goal:** Add small store-level helpers needed by the importer while preserving the repository rule that database access goes through DB abstractions.
+
+**Success Criteria:**
+- Duplicate lookup is a reusable ChaCha helper, not ad hoc SQL in the adapter or endpoint.
+- Conversation import metadata is persisted under `conversation_settings.settings_json.openwebui_import`.
+- Message import metadata is persisted under `message_metadata.extra.openwebui_import`.
+- Metadata persistence failure produces warnings without rolling back an otherwise valid imported chat.
+
+**Implementation Tasks:**
+- [ ] Add `get_conversation_by_source_ref(source, external_ref, client_id=None, include_deleted=False)` to `tldw_Server_API/app/core/DB_Management/chacha/conversation_store.py`.
+- [ ] Expose the helper through `CharactersRAGDB` delegation if needed by existing store extraction patterns.
+- [ ] Use parameterized queries and honor `client_id`, defaulting to the DB instance client id when omitted.
+- [ ] Add a helper such as `merge_conversation_settings(conversation_id, patch)` if existing `upsert_conversation_settings()` cannot safely preserve unrelated settings keys.
+- [ ] Reuse existing `set_message_metadata_extra()` for message metadata; do not add a parallel metadata table.
+- [ ] Add tests for SQLite helper behavior and, if nearby patterns exist, PostgreSQL SQL generation/compatibility.
+
+**Tests:**
+- [ ] Add or extend `tldw_Server_API/tests/ChaChaNotesDB/test_chacha_conversation_store.py` or adjacent ChaCha tests for source/external-ref lookup.
+- [ ] Test helper excludes deleted conversations by default.
+- [ ] Test helper scopes results by client id.
+- [ ] Test conversation settings merge preserves existing settings keys while adding `openwebui_import`.
+- [ ] Test message metadata merge preserves existing `extra` keys while adding `openwebui_import`.
+
+**Status:** Not Started
+
+---
+
+## Stage 4: OpenWebUI Import Service Path
+
+**Goal:** Import valid OpenWebUI chats as normal tldw conversations/messages with preserved parent links, duplicate handling, and structured results.
+
+**Success Criteria:**
+- One OpenWebUI chat imports to one tldw conversation with `source=openwebui` and a deterministic `external_ref`.
+- All valid OpenWebUI message nodes are imported, not just the `history.currentId` active path.
+- Parent messages are inserted before descendants and `parent_message_id` points at mapped tldw message IDs.
+- Message IDs are UUID-shaped deterministic IDs, not raw OpenWebUI IDs.
+- Duplicate `skip` and `rename` behaviors match the approved design.
+- Partial import continues at chat granularity and returns useful counts/warnings.
+
+**Implementation Tasks:**
+- [ ] Add `ChatbookService.import_openwebui_json(...)` for sync import results.
+- [ ] Add a private helper to resolve the fallback assistant identity for OpenWebUI imports by reusing `_resolve_import_character_id(None)` or a narrower wrapper around `_get_fallback_character_id()`.
+- [ ] Validate that no valid chat is imported when no fallback character is available, and surface a clear source-format-specific error.
+- [ ] For each valid chat, check duplicate conversations with `get_conversation_by_source_ref("openwebui", external_ref, client_id)`.
+- [ ] For `skip`, count duplicate chats as skipped and do not insert messages.
+- [ ] For `rename`, generate a unique title and copy external ref suffix before deriving message IDs.
+- [ ] Create conversations with `source`, `external_ref`, current `client_id`, fallback `character_id`, and normalized title.
+- [ ] Store OpenWebUI conversation metadata in `conversation_settings.settings_json.openwebui_import`, including source timestamps, models, options, meta, pinned, folder id, and `history.currentId`.
+- [ ] Normalize roles: `user` and `assistant` are imported; unsupported roles are skipped with warnings for v1.
+- [ ] Convert valid Unix-second timestamps to UTC ISO strings before `db.add_message()`, using import time plus warnings for missing or invalid timestamps.
+- [ ] Generate UUIDv5 message IDs from an import namespace and source message ID.
+- [ ] Validate parent references, detect cycles, and topologically order messages before insertion.
+- [ ] Insert messages with `id`, `conversation_id`, `sender`, `content`, `timestamp`, and mapped `parent_message_id`.
+- [ ] Store per-message OpenWebUI metadata with source message id, source parent id, source children ids, model, done/context fields, attachment refs, and raw unsupported key names.
+- [ ] Avoid logging raw chat/message content in exceptions or warnings.
+
+**Tests:**
+- [ ] Test simple two-message import creates one conversation and two messages.
+- [ ] Test branched import creates all branch messages with correct `parent_message_id`.
+- [ ] Test parent-before-child ordering for unordered OpenWebUI message maps.
+- [ ] Test cycles, missing parents, malformed messages, and unsupported roles produce warnings and skip affected messages.
+- [ ] Test Unix timestamp conversion to UTC ISO strings.
+- [ ] Test duplicate `skip` prevents reimport.
+- [ ] Test duplicate `rename` creates a second conversation with unique external ref and non-colliding message IDs.
+- [ ] Test conversation and message metadata persistence paths.
+- [ ] Test metadata write failures become warnings without failing the chat import.
+
+**Status:** Not Started
+
+---
+
+## Stage 5: Async Jobs And Endpoint Dispatch
+
+**Goal:** Make OpenWebUI imports work in both sync and async Chatbooks flows while preserving existing import job lifecycle semantics.
+
+**Success Criteria:**
+- Sync OpenWebUI import returns `ImportChatbookResponse` with `source_format=openwebui_json` and `openwebui_result`.
+- Async OpenWebUI import creates an existing-style Chatbooks import job and enqueues a core Jobs payload containing `source_format=openwebui_json`.
+- The core Jobs worker dispatches JSON imports to the OpenWebUI service path and never treats JSON tokens as archives.
+- Temp files are cleaned up on success, failure, and enqueue failure according to the existing ownership model.
+- Existing archive import job tests keep passing.
+
+**Implementation Tasks:**
+- [ ] Extend `ChatbookService.import_chatbook()` with `source_format`, defaulting to `chatbook`.
+- [ ] Keep archive imports routed to the existing `_import_chatbook_sync()` path.
+- [ ] Route sync OpenWebUI imports to `import_openwebui_json()`.
+- [ ] Include `source_format` in core Jobs import payloads.
+- [ ] Include `source_format` in any Prompt Studio adapter payload branches if those branches still exist, even if they currently fall back to core Jobs.
+- [ ] Update `tldw_Server_API/app/core/Chatbooks/services/jobs_worker.py` to parse `source_format` and branch before calling `_resolve_import_archive_path()` or `_import_chatbook_sync()`.
+- [ ] Add or reuse a general uploaded-import-file path resolver for JSON files that allows the same temp/import roots but does not imply archive-only semantics in error messages.
+- [ ] Keep archive workers on `_resolve_import_archive_path()` and route JSON workers through the general resolver plus `import_openwebui_json()`.
+- [ ] Update import job completion result mapping to preserve `openwebui_result` when available.
+- [ ] Audit preview/import cleanup paths so JSON preview always removes temp files and async import lets the worker remove the uploaded JSON.
+
+**Tests:**
+- [ ] Extend `tldw_Server_API/tests/Chatbooks/test_chatbooks_jobs_worker_import_defaults.py` for `source_format=openwebui_json` dispatch.
+- [ ] Add endpoint sync import test for OpenWebUI JSON returning `openwebui_result`.
+- [ ] Add endpoint async import test verifying job payload includes `source_format`.
+- [ ] Add worker test proving JSON dispatch does not call `_import_chatbook_sync()`.
+- [ ] Add cleanup tests for invalid JSON preview/import paths where practical.
+
+**Status:** Not Started
+
+---
+
+## Stage 6: WebUI Import Experience
+
+**Goal:** Extend the existing `/chatbooks` import tab so users can choose between Chatbook archives and OpenWebUI JSON without adding another import page.
+
+**Success Criteria:**
+- Import tab has a source selector: `Chatbook archive` and `OpenWebUI JSON`.
+- Chatbook archive mode keeps current behavior.
+- OpenWebUI mode accepts `.json`, sends `source_format=openwebui_json` to preview/import, and renders OpenWebUI preview counts.
+- Unsupported archive-only options are hidden or disabled for OpenWebUI mode.
+- Unsupported conflict choices are not offered for OpenWebUI v1.
+
+**Implementation Tasks:**
+- [ ] Add source-format state to `apps/packages/ui/src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx`.
+- [ ] Change the upload `accept` value to `.zip,.chatbook` for archive mode and `.json` for OpenWebUI mode.
+- [ ] Update drop-zone copy to match the selected source format.
+- [ ] Update `handlePreview()` to call `tldwClient.previewChatbook(file, { source_format })`.
+- [ ] Update `handleImport()` to call `tldwClient.importChatbook(file, { source_format, ...existingOptions })`.
+- [ ] Render OpenWebUI preview summary from `openwebui_preview` when selected, including chat count, message count, branch count, duplicate count, attachment reference count, malformed count, and warnings.
+- [ ] In OpenWebUI mode, disable or hide media/embedding import controls.
+- [ ] In OpenWebUI mode, force `import_media=false`, `import_embeddings=false`, and omit Chatbook content selections from the request, even if prior archive-mode state had those options enabled.
+- [ ] In OpenWebUI mode, limit conflict choices to `skip` and `rename`.
+- [ ] Do not show the existing Chatbook content-type picker for OpenWebUI v1; v1 imports all valid chats from the selected JSON export.
+- [ ] Ensure switching source formats clears stale preview state and file selection.
+- [ ] Update `apps/packages/ui/src/services/tldw/domains/chat-rag.ts` and `apps/packages/ui/src/services/tldw/TldwApiClient.ts` method signatures to support preview/import option fields.
+
+**Tests:**
+- [ ] Add component tests under `apps/packages/ui/src/components/Option/Chatbooks/__tests__/` for source selector behavior.
+- [ ] Test OpenWebUI mode sends `source_format=openwebui_json` for preview and import.
+- [ ] Test archive mode keeps existing preview/import calls compatible.
+- [ ] Test unsupported controls are hidden or disabled in OpenWebUI mode.
+- [ ] Test OpenWebUI preview summary renders counts and warnings.
+
+**Status:** Not Started
+
+---
+
+## Stage 7: Documentation And Verification
+
+**Goal:** Document the supported v1 workflow and run focused verification across backend, frontend, and security checks.
+
+**Success Criteria:**
+- User-facing docs explain that v1 supports normal OpenWebUI `Export Chats` JSON only.
+- Docs explicitly list out-of-scope direct `webui.db`, admin export, live server, and attachment hydration support.
+- Backend and frontend focused tests pass.
+- Bandit is run on touched Python scope.
+- The implementation task and plan statuses are updated before final handoff.
+
+**Implementation Tasks:**
+- [ ] Update a Chatbooks or import-related doc under `Docs/` with the OpenWebUI JSON workflow.
+- [ ] Update the static API contract documentation under `Docs/API-related/` if the project keeps Chatbooks multipart schemas there in addition to generated OpenAPI output.
+- [ ] Mention duplicate behavior, branch preservation, warning semantics, and unsupported attachments/artifacts.
+- [ ] Keep `Docs/superpowers/specs/2026-05-10-openwebui-chat-import-design.md` as the design reference; do not duplicate the full design in user docs.
+- [ ] Update this plan file's stage statuses as implementation progresses.
+- [ ] Update the Backlog task with touched files, verification commands, skips, and final summary.
+
+**Verification Commands:**
+- [ ] `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Chatbooks/test_openwebui_import_adapter.py -v`
+- [ ] `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Chatbooks/test_chatbooks_api_preview.py tldw_Server_API/tests/Chatbooks/test_chatbooks_jobs_worker_import_defaults.py -v`
+- [ ] `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/ChaChaNotesDB -k "conversation or metadata" -v`
+- [ ] `bunx vitest run apps/packages/ui/src/components/Option/Chatbooks/__tests__`
+- [ ] `source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/chatbooks.py tldw_Server_API/app/core/Chatbooks tldw_Server_API/app/core/DB_Management/chacha -f json -o /tmp/bandit_openwebui_chat_import.json`
+- [ ] Run a manual browser smoke test of `/chatbooks` import mode if a frontend dev server is available in the implementation session.
+
+**Status:** Not Started
+
+---
+
+## Implementation Notes
+
+- The approved design reference is `Docs/superpowers/specs/2026-05-10-openwebui-chat-import-design.md`; keep v1 bounded to OpenWebUI chat JSON exports.
+- Do not implement direct `webui.db`, admin database export, live OpenWebUI import, or attachment hydration in this plan.
+- The current endpoint code validates Chatbook uploads as ZIP archives before service dispatch; OpenWebUI JSON must branch before that validation.
+- `ChatbookValidator.validate_filename()` is currently archive-only and rewrites unsupported extensions to `.zip`; avoid using it for JSON unless it is made source-format aware.
+- `ChatbookService._resolve_import_archive_path()` currently has archive wording but already constrains paths to per-user import/temp roots; either rename/generalize carefully or add a JSON-specific wrapper to avoid misleading errors.
+- Existing `ChatbookService._get_fallback_character_id()` and `_resolve_import_character_id()` can likely satisfy OpenWebUI's required conversation assistant identity without adding new persona/character concepts.
+- `ConversationStore.add_conversation()` already accepts `source` and `external_ref`.
+- `MessageStore.add_message()` already accepts caller-provided UUID string IDs and `parent_message_id`.
+- Use existing `upsert_conversation_settings()` / `get_conversation_settings()` and `set_message_metadata_extra()` rather than new metadata storage.
+- Avoid raw chat/message content in logs, warnings, audit metadata, and job errors.

--- a/Docs/superpowers/specs/2026-05-10-openwebui-chat-import-design.md
+++ b/Docs/superpowers/specs/2026-05-10-openwebui-chat-import-design.md
@@ -1,0 +1,492 @@
+# OpenWebUI Chat Import Design
+
+Date: 2026-05-10
+Owner: Codex collaboration session
+Status: User-approved design, pending implementation planning
+Backlog: TASK-233
+
+## Summary
+
+Add first-class import support for OpenWebUI chat JSON exports through the existing Chatbooks import workflow.
+
+The first version accepts the normal OpenWebUI `Export Chats` JSON file, previews the contents, and imports each OpenWebUI chat into tldw as a normal ChaCha conversation. It preserves the OpenWebUI message tree by mapping message parent links onto tldw `parent_message_id` values.
+
+Direct import from an OpenWebUI `webui.db`, admin database export, or live OpenWebUI instance is a planned follow-up and is explicitly out of scope for v1.
+
+## Source Format Context
+
+OpenWebUI's current import/export documentation describes chat exports as JSON arrays of chat objects. The standard object shape contains a `chat` object with `title`, `models`, and `history`; `history.messages` is a map of message ID to message object, and messages form a tree through `parentId` and `childrenIds`. OpenWebUI also documents a legacy format where each array item is treated directly as the chat data.
+
+Reference: https://docs.openwebui.com/features/chat-conversations/data-controls/import-export/
+
+## Goals
+
+1. Let users import all chats from an OpenWebUI exported JSON file.
+2. Reuse the existing Chatbooks import tab, preview behavior, quotas, async jobs, and job history.
+3. Preserve OpenWebUI branch structure using tldw message `parent_message_id`.
+4. Make repeated imports safe by detecting duplicates through `source=openwebui` and `external_ref=<openwebui_chat_id>`.
+5. Preserve useful OpenWebUI metadata where tldw has an existing safe place for it.
+6. Surface unsupported data, especially attachments/artifacts, as preview/import warnings instead of silently pretending it was imported.
+7. Keep the implementation bounded to JSON export import only.
+
+## Non-Goals
+
+1. Direct import from OpenWebUI `webui.db`.
+2. Direct import from an OpenWebUI admin database export.
+3. Live migration from a running OpenWebUI server.
+4. Hydrating OpenWebUI attachments, files, artifacts, or storage-provider objects.
+5. Migrating OpenWebUI users, permissions, sharing state, or folders as first-class tldw objects.
+6. Recreating OpenWebUI model/provider configuration in tldw provider settings.
+7. Importing ChatGPT exports directly unless they already conform to the OpenWebUI JSON shape accepted by the v1 parser.
+
+## Requirements Confirmed With User
+
+1. Support OpenWebUI chat JSON export first.
+2. Treat direct database/admin export import as planned future work.
+3. Preserve the full branched message tree.
+4. Start with message text, tree structure, and metadata; do not hydrate attachments in v1.
+5. Preserve unsupported attachment/artifact references as metadata or warnings where possible.
+6. Default duplicate behavior is skip by original OpenWebUI chat identity.
+7. Allow rename/import-copy behavior for users who intentionally want another imported copy.
+8. Put the feature in the existing Chatbooks import surface.
+
+## Current tldw Context
+
+### Chatbooks
+
+Chatbooks already owns portable import/export workflows:
+
+- `tldw_Server_API/app/api/v1/endpoints/chatbooks.py`
+- `tldw_Server_API/app/api/v1/schemas/chatbook_schemas.py`
+- `tldw_Server_API/app/core/Chatbooks/chatbook_service.py`
+- `tldw_Server_API/app/core/Chatbooks/chatbook_validators.py`
+- `tldw_Server_API/app/core/Chatbooks/services/jobs_worker.py`
+
+The module already provides:
+
+- per-user temp/import/export storage
+- upload validation and preview
+- sync and async import
+- import jobs stored in the user's ChaCha DB
+- core Jobs integration
+- conflict strategy support for `skip` and `rename`
+- existing WebUI route at `/chatbooks`
+
+The OpenWebUI importer should extend this portability surface instead of creating another import page.
+
+### ChaCha Conversations
+
+tldw conversations and messages already support the key target fields:
+
+- conversations have `source` and `external_ref`
+- messages have stable IDs and `parent_message_id`
+- conversation tree APIs already reconstruct trees from parent links
+- message metadata storage exists for additional details such as model, source IDs, and unsupported references
+
+This makes full OpenWebUI branch preservation feasible without changing the core chat model.
+
+## Approaches Considered
+
+### Approach 1: Chatbooks import adapter
+
+Add an OpenWebUI JSON adapter under the Chatbooks import workflow.
+
+Pros:
+
+- reuses the current user-facing import page
+- reuses preview, quotas, async jobs, and job history
+- keeps all chat portability workflows together
+- avoids a second import framework
+
+Cons:
+
+- Chatbooks service gains an external-format adapter path
+
+### Approach 2: Dedicated chat import endpoint
+
+Create a separate `/chat/import/openwebui` endpoint and a dedicated UI surface.
+
+Pros:
+
+- clear API boundary for one external source format
+
+Cons:
+
+- duplicates preview, conflict, upload, async job, and status behavior
+- creates another surface users must discover
+- makes follow-up external chat import formats harder to organize consistently
+
+### Approach 3: Convert JSON into a temporary Chatbook archive
+
+Convert OpenWebUI JSON into a generated Chatbook ZIP and then run the existing Chatbook importer.
+
+Pros:
+
+- maximum reuse of the existing Chatbook archive importer
+
+Cons:
+
+- adds an internal archive generation step
+- makes error reporting indirect
+- fights current Chatbook archive assumptions where imported conversations are native Chatbook content rather than source-specific migration records
+
+## Recommendation
+
+Use Approach 1.
+
+Add a focused OpenWebUI adapter to Chatbooks import. The adapter validates the JSON export, builds a preview summary, normalizes each OpenWebUI chat into an import plan, and writes tldw conversations/messages through existing ChaCha DB methods.
+
+## Backend Design
+
+### Modules
+
+Add a small import adapter package:
+
+```text
+tldw_Server_API/app/core/Chatbooks/import_adapters/
+  __init__.py
+  openwebui.py
+```
+
+The adapter owns source-format parsing and normalization only. It should not own endpoint concerns, quota logic, temp-file storage, or Jobs integration.
+
+Recommended internal types:
+
+- `OpenWebUIImportPreview`
+- `OpenWebUIPreviewChatItem`
+- `OpenWebUIConversationPlan`
+- `OpenWebUIMessagePlan`
+- `OpenWebUIImportResult`
+- `OpenWebUIImportWarning`
+
+These can be dataclasses or Pydantic models depending on local service style. They should be easy to unit test without FastAPI.
+
+### API Shape
+
+Extend Chatbooks preview/import requests with a source format selector:
+
+```text
+source_format = chatbook | openwebui_json
+```
+
+The default stays `chatbook` to preserve existing behavior. The UI should send `openwebui_json` explicitly when the user selects OpenWebUI JSON.
+
+Because the existing Chatbooks preview/import routes are multipart upload endpoints, `source_format` should be passed as a multipart form field alongside `file` and the existing import options.
+
+The backend may later add `auto`, but v1 should not depend on fragile inference. A clear source selector gives better errors and avoids accidental JSON uploads being interpreted as another format.
+
+OpenWebUI preview/import responses should be explicit extensions of the existing Chatbooks response models rather than overloading the Chatbook manifest. Add optional source-specific fields while preserving the current Chatbook fields for archive imports:
+
+```text
+PreviewChatbookResponse
+  source_format: chatbook | openwebui_json
+  manifest: existing Chatbook manifest summary, null for OpenWebUI JSON
+  openwebui_preview: OpenWebUIImportPreview | null
+
+ImportChatbookResponse
+  source_format: chatbook | openwebui_json
+  success/message/job_id: existing fields
+  openwebui_result: OpenWebUIImportResult | null for sync imports and completed job details when available
+```
+
+`OpenWebUIImportPreview` should include:
+
+- `chat_count`
+- `message_count`
+- `branched_chat_count`
+- `duplicate_chat_count`
+- `attachment_reference_count`
+- `malformed_chat_count`
+- `warnings`
+- `items`: lightweight per-chat summaries with source chat ref, title, message count, branch flag, duplicate flag, and warning count
+
+`OpenWebUIImportResult` should include:
+
+- `imported_chats`
+- `skipped_chats`
+- `failed_chats`
+- `imported_messages`
+- `skipped_messages`
+- `duplicate_chats`
+- `warnings`
+
+### Preview Flow
+
+For `source_format=chatbook`, keep the existing preview path unchanged.
+
+For `source_format=openwebui_json`:
+
+1. Save the uploaded `.json` to the same per-user temp area used by Chatbooks.
+2. Enforce the existing upload size and filename safety rules adapted for JSON.
+3. Parse JSON as UTF-8.
+4. Require a top-level array.
+5. Accept both OpenWebUI standard wrapper objects and documented legacy chat objects.
+6. Validate enough of each chat to count and preview it.
+7. Query existing conversations for duplicate `source=openwebui` and `external_ref`.
+8. Return a preview summary with counts and warnings.
+9. Clean up temp files according to the existing preview cleanup behavior.
+
+Preview should report:
+
+- source format
+- chat count
+- message count
+- branched chat count
+- duplicate chat count
+- attachment/artifact reference count
+- malformed chat count
+- skipped/unsupported field warnings
+- per-chat item summaries when practical
+
+### Import Flow
+
+For `source_format=chatbook`, keep the existing import path unchanged.
+
+For `source_format=openwebui_json`:
+
+1. Validate and parse the file with the OpenWebUI adapter.
+2. Resolve the default/fallback assistant identity required for current tldw conversations.
+3. For each valid OpenWebUI chat:
+   - derive an original chat external reference
+   - check for an existing non-deleted tldw conversation with `source=openwebui` and matching `external_ref`
+   - apply conflict strategy
+   - create one tldw conversation
+   - insert all valid message nodes with deterministic mapped IDs
+   - preserve parent links after mapping OpenWebUI IDs to tldw IDs
+   - record warnings for unsupported or malformed data
+4. Update import job counts and warnings.
+
+Partial import is allowed at the chat level. One malformed chat should not fail an entire large export. A malformed message inside an otherwise valid chat should be skipped with a warning unless it prevents safe tree preservation for dependent child messages.
+
+### Async Jobs
+
+OpenWebUI imports should use the same Chatbooks import job infrastructure:
+
+- user-scoped import job row in ChaCha
+- core Jobs payload for async mode
+- status transitions matching existing Chatbooks import jobs
+- cancellation before job start and best-effort in-flight behavior consistent with existing workers
+
+The Jobs payload should include `source_format=openwebui_json` so the worker dispatches to the correct import path.
+
+## Data Mapping
+
+### Conversation Mapping
+
+Each OpenWebUI chat becomes one tldw conversation.
+
+Map fields as follows:
+
+| OpenWebUI field | tldw field |
+| --- | --- |
+| chat title | `conversations.title` |
+| original chat ID | `conversations.external_ref` |
+| source format | `conversations.source = "openwebui"` |
+| current user | `conversations.client_id` |
+| fallback assistant | `conversations.character_id` or assistant identity required by current DB rules |
+| created timestamp | conversation metadata if native created timestamp cannot be preserved by current API |
+| updated timestamp | conversation metadata if native last-modified timestamp cannot be preserved by current API |
+| models/options/meta/pinned/folder_id | message/conversation metadata or import warnings |
+
+If the OpenWebUI export lacks a clear chat ID, derive a stable external ref from the chat index plus a hash of the normalized chat object. This keeps duplicate detection deterministic for the same file.
+
+Derived refs should be built from a canonical JSON representation:
+
+```text
+openwebui:<index>:<sha256(canonical_chat_json)[0:16]>
+```
+
+Canonical JSON means sorted keys, compact separators, and omission of import-only transient fields. This is enough for deterministic duplicate detection across repeated imports of the same exported file without claiming cross-file identity for chats that have no source ID.
+
+Conversation titles should use this fallback order:
+
+1. OpenWebUI chat title
+2. first user message excerpt
+3. `OpenWebUI Import <YYYY-MM-DD>`
+
+### Message Mapping
+
+Each OpenWebUI message object becomes one tldw message.
+
+Map fields as follows:
+
+| OpenWebUI field | tldw field |
+| --- | --- |
+| message ID | deterministic tldw message ID derived from the import namespace plus source message ID |
+| `parentId` | `messages.parent_message_id` after deterministic ID mapping |
+| `role` | `messages.sender` after role normalization |
+| `content` | `messages.content` |
+| `timestamp` | `messages.timestamp` |
+| `model`, `done`, `context`, source IDs, raw unsupported refs | message metadata |
+
+Role handling:
+
+- `user` -> `user`
+- `assistant` -> `assistant`
+- `system` and `tool` are not part of the documented OpenWebUI import roles for this JSON path and should be treated as unsupported in v1 unless implementation finds real OpenWebUI exports that require them and verifies downstream support
+- unknown or unsupported roles should be skipped with a warning
+
+Message ordering should be deterministic. The importer should insert parent messages before child messages. If the export contains cycles, missing parents, or invalid child links, the affected messages should be skipped with warnings rather than creating corrupted parent references.
+
+The import namespace prevents message ID collisions:
+
+- For the default `skip` path, namespace message IDs with the canonical OpenWebUI external ref.
+- For `rename`, generate a new import-copy namespace after the new tldw conversation ID or a generated import-copy UUID is known.
+- Store the original OpenWebUI message ID in metadata for both cases.
+- Never reuse the same deterministic tldw message IDs for a duplicate-copy import.
+
+### Branch Preservation
+
+OpenWebUI branches must be preserved by importing every valid message node, not just the active `history.currentId` path.
+
+The importer should:
+
+1. Read all messages from `history.messages`.
+2. Build an ID map from OpenWebUI message IDs to deterministic tldw message IDs.
+3. Validate parent references.
+4. Topologically insert root messages before descendants.
+5. Store every valid branch through `parent_message_id`.
+
+`history.currentId` should be preserved as metadata for future UI highlighting, but it should not cause non-current branches to be dropped.
+
+## Duplicate And Conflict Handling
+
+Default duplicate key:
+
+```text
+source = openwebui
+external_ref = <original OpenWebUI chat ID or derived stable ref>
+```
+
+Conflict strategies:
+
+- `skip`: default; skip the duplicate chat and count it as skipped.
+- `rename`: import another copy with a unique title and a modified external ref suffix so it does not collide with the original import identity.
+
+Existing unsupported strategies such as `overwrite` and `merge` should not be exposed for OpenWebUI v1 unless they are already fully supported by the endpoint and service. The UI should avoid offering unsupported choices for this source format.
+
+For `rename`, the imported conversation should receive:
+
+- a unique title
+- an external ref such as `<original-ref>#copy:<new-conversation-id-or-import-copy-id>`
+- message IDs namespaced by that copy ref
+
+This preserves duplicate detection for the original while allowing intentional copies without primary-key collisions.
+
+## Attachments And Unsupported Data
+
+V1 does not hydrate OpenWebUI attachments or artifact files.
+
+If message objects contain file, image, artifact, or attachment references:
+
+- preserve the original references in metadata where existing storage makes that safe
+- increment unsupported attachment/artifact counts
+- show warnings in preview and import results
+- do not create broken tldw attachments
+
+This is intentionally conservative because OpenWebUI deployments may store files differently depending on storage backend and export path.
+
+## Frontend Design
+
+Update the existing Chatbooks page at `/chatbooks`.
+
+The Import tab gets a source selector:
+
+- `Chatbook archive`
+- `OpenWebUI JSON`
+
+When `Chatbook archive` is selected:
+
+- preserve current behavior
+- accept `.zip` and `.chatbook` as supported by backend behavior
+- show current Chatbook manifest preview
+
+When `OpenWebUI JSON` is selected:
+
+- accept `.json`
+- call Chatbooks preview with `source_format=openwebui_json`
+- render an OpenWebUI-specific preview summary
+- disable unsupported options such as media/embedding import
+- show duplicate and unsupported attachment warnings
+- send `source_format=openwebui_json` on import
+
+The existing Jobs tab should continue to list import jobs. OpenWebUI jobs can be distinguished through job metadata if the API exposes it; otherwise they may appear as normal import jobs in v1.
+
+## Error Handling
+
+Hard failures:
+
+- invalid filename or unsafe path
+- non-JSON file for `openwebui_json`
+- malformed JSON
+- top-level value is not an array
+- file exceeds configured upload limits
+- no valid OpenWebUI chat objects found
+- no fallback assistant identity can be resolved for conversation creation
+
+Recoverable warnings:
+
+- individual malformed chat skipped
+- malformed message skipped
+- missing title fallback used
+- duplicate chat skipped
+- unsupported attachment/artifact reference preserved only as metadata or warning
+- unknown optional OpenWebUI field ignored
+- parent references invalid for a subset of messages
+
+Error messages should identify the source format and avoid logging raw message content.
+
+## Security And Privacy
+
+The importer handles private chat history, so it must follow the same posture as Chatbooks:
+
+- use per-user temp storage
+- keep import jobs scoped to the authenticated user
+- validate filenames and paths
+- reject path traversal
+- avoid raw chat content in logs
+- apply existing quotas and rate limits
+- avoid writing source JSON outside the per-user import/temp area
+
+No external network calls are required for v1.
+
+## Testing Plan
+
+Backend tests:
+
+1. Parser accepts standard OpenWebUI wrapper exports.
+2. Parser accepts documented legacy chat objects.
+3. Parser rejects malformed JSON and non-array roots.
+4. Preview counts chats, messages, branches, duplicates, and unsupported attachments.
+5. Import preserves message trees through `parent_message_id`.
+6. Import inserts parent messages before children.
+7. Import handles missing titles with deterministic fallbacks.
+8. Import skips duplicate conversations by `source=openwebui` and `external_ref`.
+9. Import supports rename/import-copy behavior for duplicates.
+10. Import records warnings for unsupported attachments/artifacts.
+11. Async job payload dispatches to the OpenWebUI importer.
+12. Existing Chatbook archive import/preview tests keep passing unchanged.
+
+Frontend tests:
+
+1. Import source selector switches between Chatbook archive and OpenWebUI JSON.
+2. OpenWebUI mode accepts `.json` and sends `source_format=openwebui_json`.
+3. OpenWebUI preview summary renders chat/message/branch/duplicate/warning counts.
+4. Unsupported Chatbook-only options are hidden or disabled in OpenWebUI mode.
+5. Chatbook archive mode behavior is unchanged.
+
+Verification:
+
+- focused backend unit tests for the adapter
+- focused endpoint tests for preview/import
+- focused frontend component tests for the import tab
+- no Bandit-specific code path is expected for the design doc; implementation work must run Bandit on touched Python scope
+
+## Follow-Up Work
+
+1. Direct OpenWebUI `webui.db` import.
+2. OpenWebUI admin database export import.
+3. Attachment/file hydration when the source export includes accessible file payloads.
+4. Folder/tag mapping into tldw-native organization surfaces.
+5. Import source auto-detection after explicit source-format behavior is stable.
+6. Optional UI highlighting of the imported active branch from `history.currentId`.

--- a/Docs/superpowers/specs/2026-05-10-openwebui-chat-import-design.md
+++ b/Docs/superpowers/specs/2026-05-10-openwebui-chat-import-design.md
@@ -173,6 +173,13 @@ The default stays `chatbook` to preserve existing behavior. The UI should send `
 
 Because the existing Chatbooks preview/import routes are multipart upload endpoints, `source_format` should be passed as a multipart form field alongside `file` and the existing import options.
 
+Implementation should add the same option to the frontend API helpers:
+
+- `previewChatbook(file, { source_format })`
+- `importChatbook(file, { source_format, ...existingOptions })`
+
+The current preview helper uploads only the file, so OpenWebUI preview support requires a small client update as well as the endpoint change.
+
 The backend may later add `auto`, but v1 should not depend on fragile inference. A clear source selector gives better errors and avoids accidental JSON uploads being interpreted as another format.
 
 OpenWebUI preview/import responses should be explicit extensions of the existing Chatbooks response models rather than overloading the Chatbook manifest. Add optional source-specific fields while preserving the current Chatbook fields for archive imports:
@@ -210,6 +217,33 @@ ImportChatbookResponse
 - `duplicate_chats`
 - `warnings`
 
+To preserve existing clients, new response fields should be optional and default to the Chatbook path:
+
+- `source_format` defaults to `chatbook`
+- `openwebui_preview` defaults to `null`
+- `openwebui_result` defaults to `null`
+
+Do not make existing archive-preview consumers depend on OpenWebUI-specific fields.
+
+### Endpoint Branching And Validation
+
+The current Chatbooks preview/import endpoints validate uploaded files as ZIP archives before calling the service. OpenWebUI JSON must branch by `source_format` before any ZIP-specific validation runs.
+
+For `source_format=chatbook`:
+
+- keep the existing Chatbook filename validation
+- keep the existing archive magic/integrity/manifest validation
+
+For `source_format=openwebui_json`:
+
+- preserve the existing path traversal and safe-temp-directory checks
+- require a `.json` filename after path normalization
+- do not call the current ZIP-only `ChatbookValidator.validate_filename()` path unless it is first made source-format aware, because the current validator only allows `.zip`/`.chatbook` and rewrites unsupported extensions to `.zip`
+- do not call `ChatbookValidator.validate_zip_file()`
+- validate JSON structure through the OpenWebUI adapter after saving to the per-user temp directory
+
+This should be called out in implementation planning because otherwise the new UI can send a valid `.json` upload and the existing endpoint will reject it before the adapter sees it.
+
 ### Preview Flow
 
 For `source_format=chatbook`, keep the existing preview path unchanged.
@@ -225,6 +259,8 @@ For `source_format=openwebui_json`:
 7. Query existing conversations for duplicate `source=openwebui` and `external_ref`.
 8. Return a preview summary with counts and warnings.
 9. Clean up temp files according to the existing preview cleanup behavior.
+
+Duplicate lookup should be exposed through a small ChaCha conversation-store helper, for example `get_conversation_by_source_ref(source, external_ref, client_id, include_deleted=False)`, rather than scattering ad hoc SQL through the adapter or endpoint. The schema already has an index on `(source, external_ref)`, so the helper should be straightforward and keeps the design aligned with the repository's DB abstraction rule.
 
 Preview should report:
 
@@ -269,6 +305,8 @@ OpenWebUI imports should use the same Chatbooks import job infrastructure:
 
 The Jobs payload should include `source_format=openwebui_json` so the worker dispatches to the correct import path.
 
+The core Jobs worker must branch on `source_format` before resolving the file as a Chatbook archive. For OpenWebUI JSON, it should resolve the file from the same allowed import/temp roots but skip archive-only path naming and ZIP integrity checks.
+
 ## Data Mapping
 
 ### Conversation Mapping
@@ -284,9 +322,30 @@ Map fields as follows:
 | source format | `conversations.source = "openwebui"` |
 | current user | `conversations.client_id` |
 | fallback assistant | `conversations.character_id` or assistant identity required by current DB rules |
-| created timestamp | conversation metadata if native created timestamp cannot be preserved by current API |
-| updated timestamp | conversation metadata if native last-modified timestamp cannot be preserved by current API |
-| models/options/meta/pinned/folder_id | message/conversation metadata or import warnings |
+| created timestamp | namespaced conversation settings metadata |
+| updated timestamp | namespaced conversation settings metadata |
+| models/options/meta/pinned/folder_id | namespaced conversation settings metadata or import warnings |
+
+The current `add_conversation()` path sets `created_at` and `last_modified` itself. V1 should not change conversation schema or mutate those columns after insert just to preserve OpenWebUI timestamps. Preserve source timestamps under a namespaced metadata object instead.
+
+Recommended conversation metadata location:
+
+```text
+conversation_settings.settings_json.openwebui_import = {
+  "source": "openwebui",
+  "external_ref": "...",
+  "created_at_unix": 1700000000,
+  "updated_at_unix": 1700000005,
+  "models": [...],
+  "options": {...},
+  "meta": {...},
+  "pinned": false,
+  "folder_id": null,
+  "history_current_id": "..."
+}
+```
+
+If `conversation_settings` persistence fails, the import should keep the conversation and add a warning rather than fail the whole chat.
 
 If the OpenWebUI export lacks a clear chat ID, derive a stable external ref from the chat index plus a hash of the normalized chat object. This keeps duplicate detection deterministic for the same file.
 
@@ -319,6 +378,8 @@ Map fields as follows:
 | `timestamp` | `messages.timestamp` |
 | `model`, `done`, `context`, source IDs, raw unsupported refs | message metadata |
 
+OpenWebUI timestamps are documented as Unix seconds. Convert valid Unix timestamps to UTC ISO-8601 strings before passing them to `add_message()`. Missing or invalid timestamps should fall back to import time with a warning count, not raw integers.
+
 Role handling:
 
 - `user` -> `user`
@@ -334,6 +395,25 @@ The import namespace prevents message ID collisions:
 - For `rename`, generate a new import-copy namespace after the new tldw conversation ID or a generated import-copy UUID is known.
 - Store the original OpenWebUI message ID in metadata for both cases.
 - Never reuse the same deterministic tldw message IDs for a duplicate-copy import.
+
+Use UUID-shaped deterministic IDs, such as UUIDv5 over `(namespace, source_message_id)`, rather than inserting raw OpenWebUI IDs directly. This keeps IDs compatible with existing tldw expectations while retaining stable parent mapping.
+
+Recommended message metadata location:
+
+```text
+message_metadata.extra.openwebui_import = {
+  "source_message_id": "...",
+  "source_parent_id": "...",
+  "source_children_ids": [...],
+  "model": "...",
+  "done": true,
+  "context": null,
+  "attachment_refs": [...],
+  "raw_unsupported_keys": [...]
+}
+```
+
+Do not store raw full message content redundantly in metadata.
 
 ### Branch Preservation
 
@@ -418,6 +498,7 @@ Hard failures:
 
 - invalid filename or unsafe path
 - non-JSON file for `openwebui_json`
+- JSON upload rejected by archive-only validation, which indicates an implementation bug rather than a user data problem
 - malformed JSON
 - top-level value is not an array
 - file exceeds configured upload limits

--- a/apps/packages/ui/src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx
+++ b/apps/packages/ui/src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx
@@ -1058,15 +1058,18 @@ export const ChatbooksPlaygroundPage: React.FC = () => {
   const [jobsError, setJobsError] = React.useState<string | null>(null)
   const [pollIndex, setPollIndex] = React.useState(0)
   const lastSignatureRef = React.useRef<string>("")
+  const previewRequestIdRef = React.useRef(0)
 
   const canUseChatbooks = capabilities?.hasChatbooks !== false
   const isOpenWebUIImport = importSourceFormat === "openwebui_json"
 
   React.useEffect(() => {
+    previewRequestIdRef.current += 1
     setImportFile(null)
     setPreviewManifest(null)
     setOpenwebuiPreview(null)
     setPreviewError(null)
+    setPreviewLoading(false)
     setImportSelections(buildSelectionState(() => [] as string[]))
     setImportIncludeAll(buildSelectionState(() => true))
     if (importSourceFormat === "openwebui_json") {
@@ -1389,6 +1392,11 @@ export const ChatbooksPlaygroundPage: React.FC = () => {
   }
 
   const handlePreview = async (file: File) => {
+    const requestId = previewRequestIdRef.current + 1
+    previewRequestIdRef.current = requestId
+    const sourceFormat = importSourceFormat
+    const isCurrentRequest = () => previewRequestIdRef.current === requestId
+
     setPreviewLoading(true)
     setPreviewError(null)
     setPreviewManifest(null)
@@ -1399,19 +1407,24 @@ export const ChatbooksPlaygroundPage: React.FC = () => {
     try {
       await tldwClient.initialize().catch(() => null)
       const res = await tldwClient.previewChatbook(file, {
-        source_format: importSourceFormat
+        source_format: sourceFormat
       })
+      if (!isCurrentRequest()) return
       if (res?.error) {
         setPreviewError(res.error)
-      } else if (importSourceFormat === "openwebui_json") {
+      } else if (sourceFormat === "openwebui_json") {
         setOpenwebuiPreview(res?.openwebui_preview || null)
       } else {
         setPreviewManifest(res?.manifest || null)
       }
     } catch (error) {
-      setPreviewError(error instanceof Error ? error.message : String(error))
+      if (isCurrentRequest()) {
+        setPreviewError(error instanceof Error ? error.message : String(error))
+      }
     } finally {
-      setPreviewLoading(false)
+      if (isCurrentRequest()) {
+        setPreviewLoading(false)
+      }
     }
   }
 
@@ -1731,7 +1744,7 @@ export const ChatbooksPlaygroundPage: React.FC = () => {
               void handlePreview(file as File)
               return false
             }}
-            disabled={!canUseChatbooks}
+            disabled={!canUseChatbooks || previewLoading || importSubmitting}
           >
             <p className="ant-upload-drag-icon">
               <InboxOutlined />

--- a/apps/packages/ui/src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx
+++ b/apps/packages/ui/src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx
@@ -89,6 +89,7 @@ type FetchParams = {
 }
 
 type JobKind = "export" | "import"
+type ImportSourceFormat = "chatbook" | "openwebui_json"
 
 type ChatbookJob = {
   job_id: string
@@ -1033,7 +1034,9 @@ export const ChatbooksPlaygroundPage: React.FC = () => {
   const [exportSubmitting, setExportSubmitting] = React.useState(false)
 
   const [importFile, setImportFile] = React.useState<File | null>(null)
+  const [importSourceFormat, setImportSourceFormat] = React.useState<ImportSourceFormat>("chatbook")
   const [previewManifest, setPreviewManifest] = React.useState<any | null>(null)
+  const [openwebuiPreview, setOpenwebuiPreview] = React.useState<any | null>(null)
   const [previewError, setPreviewError] = React.useState<string | null>(null)
   const [previewLoading, setPreviewLoading] = React.useState(false)
   const [conflictResolution, setConflictResolution] = React.useState("skip")
@@ -1057,6 +1060,23 @@ export const ChatbooksPlaygroundPage: React.FC = () => {
   const lastSignatureRef = React.useRef<string>("")
 
   const canUseChatbooks = capabilities?.hasChatbooks !== false
+  const isOpenWebUIImport = importSourceFormat === "openwebui_json"
+
+  React.useEffect(() => {
+    setImportFile(null)
+    setPreviewManifest(null)
+    setOpenwebuiPreview(null)
+    setPreviewError(null)
+    setImportSelections(buildSelectionState(() => [] as string[]))
+    setImportIncludeAll(buildSelectionState(() => true))
+    if (importSourceFormat === "openwebui_json") {
+      setImportMedia(false)
+      setImportEmbeddings(false)
+      setConflictResolution((current) =>
+        current === "rename" || current === "skip" ? current : "skip"
+      )
+    }
+  }, [importSourceFormat])
 
   React.useEffect(() => {
     clearFetchAllItemsCache()
@@ -1372,14 +1392,19 @@ export const ChatbooksPlaygroundPage: React.FC = () => {
     setPreviewLoading(true)
     setPreviewError(null)
     setPreviewManifest(null)
+    setOpenwebuiPreview(null)
     setImportFile(file)
     setImportSelections(buildSelectionState(() => [] as string[]))
     setImportIncludeAll(buildSelectionState(() => true))
     try {
       await tldwClient.initialize().catch(() => null)
-      const res = await tldwClient.previewChatbook(file)
+      const res = await tldwClient.previewChatbook(file, {
+        source_format: importSourceFormat
+      })
       if (res?.error) {
         setPreviewError(res.error)
+      } else if (importSourceFormat === "openwebui_json") {
+        setOpenwebuiPreview(res?.openwebui_preview || null)
       } else {
         setPreviewManifest(res?.manifest || null)
       }
@@ -1391,6 +1416,7 @@ export const ChatbooksPlaygroundPage: React.FC = () => {
   }
 
   const resolveImportSelections = () => {
+    if (isOpenWebUIImport) return undefined
     const anySelective = previewTypes.some((key) => !importIncludeAll[key])
     if (!anySelective) return undefined
     const selections: Record<string, string[]> = {}
@@ -1435,7 +1461,7 @@ export const ChatbooksPlaygroundPage: React.FC = () => {
       await tldwClient.initialize().catch(() => null)
       const contentSelections = resolveImportSelections()
       const normalizedSelections =
-        contentSelections && Object.keys(contentSelections).length
+        !isOpenWebUIImport && contentSelections && Object.keys(contentSelections).length
           ? contentSelections
           : undefined
       if (normalizedSelections) {
@@ -1454,10 +1480,11 @@ export const ChatbooksPlaygroundPage: React.FC = () => {
         }
       }
       const res = await tldwClient.importChatbook(importFile, {
+        source_format: importSourceFormat,
         conflict_resolution: conflictResolution,
         prefix_imported: prefixImported,
-        import_media: importMedia,
-        import_embeddings: importEmbeddings,
+        import_media: isOpenWebUIImport ? false : importMedia,
+        import_embeddings: isOpenWebUIImport ? false : importEmbeddings,
         async_mode: importAsync,
         content_selections: normalizedSelections
       })
@@ -1676,8 +1703,28 @@ export const ChatbooksPlaygroundPage: React.FC = () => {
         }
       >
         <div className="flex flex-col gap-4">
+          <Space wrap>
+            <Text>{t("settings:chatbooksPlayground.importSource", "Source")}</Text>
+            <Select
+              value={importSourceFormat}
+              onChange={(value) => setImportSourceFormat(value as ImportSourceFormat)}
+              className="min-w-[220px]"
+              options={[
+                {
+                  value: "chatbook",
+                  label: t("settings:chatbooksPlayground.sourceChatbook", "Chatbook archive")
+                },
+                {
+                  value: "openwebui_json",
+                  label: t("settings:chatbooksPlayground.sourceOpenWebUI", "OpenWebUI JSON")
+                }
+              ]}
+              disabled={!canUseChatbooks || previewLoading || importSubmitting}
+            />
+          </Space>
+
           <Upload.Dragger
-            accept=".zip"
+            accept={isOpenWebUIImport ? ".json" : ".zip,.chatbook"}
             multiple={false}
             showUploadList={false}
             beforeUpload={(file) => {
@@ -1690,7 +1737,9 @@ export const ChatbooksPlaygroundPage: React.FC = () => {
               <InboxOutlined />
             </p>
             <p className="ant-upload-text">
-              {t("settings:chatbooksPlayground.importDrop", "Drop a .zip chatbook or click to browse")}
+              {isOpenWebUIImport
+                ? t("settings:chatbooksPlayground.importDropOpenWebUI", "Drop an OpenWebUI .json export or click to browse")
+                : t("settings:chatbooksPlayground.importDrop", "Drop a .zip or .chatbook archive or click to browse")}
             </p>
             <p className="ant-upload-hint">
               {importFile?.name || t("settings:chatbooksPlayground.importHint", "Preview before import")}
@@ -1759,33 +1808,88 @@ export const ChatbooksPlaygroundPage: React.FC = () => {
             </Card>
           )}
 
+          {openwebuiPreview && (
+            <Card
+              size="small"
+              className="border-border"
+              title={t("settings:chatbooksPlayground.openwebuiPreviewSummary", "OpenWebUI preview")}
+            >
+              <div className="grid grid-cols-2 gap-3 md:grid-cols-3">
+                <div>
+                  <Text type="secondary">{t("settings:chatbooksPlayground.openwebuiChats", "Chats")}</Text>
+                  <div>{openwebuiPreview.chat_count ?? 0}</div>
+                </div>
+                <div>
+                  <Text type="secondary">{t("settings:chatbooksPlayground.openwebuiMessages", "Messages")}</Text>
+                  <div>{openwebuiPreview.message_count ?? 0}</div>
+                </div>
+                <div>
+                  <Text type="secondary">{t("settings:chatbooksPlayground.openwebuiBranches", "Branched")}</Text>
+                  <div>{openwebuiPreview.branched_chat_count ?? 0}</div>
+                </div>
+                <div>
+                  <Text type="secondary">{t("settings:chatbooksPlayground.openwebuiDuplicates", "Duplicates")}</Text>
+                  <div>{openwebuiPreview.duplicate_chat_count ?? 0}</div>
+                </div>
+                <div>
+                  <Text type="secondary">{t("settings:chatbooksPlayground.openwebuiAttachments", "Attachment refs")}</Text>
+                  <div>{openwebuiPreview.attachment_reference_count ?? 0}</div>
+                </div>
+                <div>
+                  <Text type="secondary">{t("settings:chatbooksPlayground.openwebuiMalformed", "Malformed")}</Text>
+                  <div>{openwebuiPreview.malformed_chat_count ?? 0}</div>
+                </div>
+              </div>
+              {Boolean(openwebuiPreview.warnings?.length) && (
+                <Alert
+                  type="warning"
+                  showIcon
+                  className="mt-3"
+                  title={t("settings:chatbooksPlayground.openwebuiWarnings", "Import warnings")}
+                  description={openwebuiPreview.warnings.slice(0, 3).join("\n")}
+                />
+              )}
+            </Card>
+          )}
+
           <Divider />
 
           <Space wrap>
             <Select
               value={conflictResolution}
               onChange={setConflictResolution}
-              options={[
-                { value: "skip", label: t("settings:chatbooksPlayground.conflictSkip", "Skip") },
-                { value: "overwrite", label: t("settings:chatbooksPlayground.conflictOverwrite", "Overwrite") },
-                { value: "rename", label: t("settings:chatbooksPlayground.conflictRename", "Rename") },
-                { value: "merge", label: t("settings:chatbooksPlayground.conflictMerge", "Merge") }
-              ]}
+              options={
+                isOpenWebUIImport
+                  ? [
+                      { value: "skip", label: t("settings:chatbooksPlayground.conflictSkip", "Skip") },
+                      { value: "rename", label: t("settings:chatbooksPlayground.conflictRename", "Rename") }
+                    ]
+                  : [
+                      { value: "skip", label: t("settings:chatbooksPlayground.conflictSkip", "Skip") },
+                      { value: "overwrite", label: t("settings:chatbooksPlayground.conflictOverwrite", "Overwrite") },
+                      { value: "rename", label: t("settings:chatbooksPlayground.conflictRename", "Rename") },
+                      { value: "merge", label: t("settings:chatbooksPlayground.conflictMerge", "Merge") }
+                    ]
+              }
               className="min-w-[160px]"
             />
             <Switch checked={prefixImported} onChange={setPrefixImported} />
             <Text>{t("settings:chatbooksPlayground.prefixImported", "Prefix imported")}</Text>
           </Space>
 
-          <Space wrap>
-            <Switch checked={importMedia} onChange={setImportMedia} />
-            <Text>{t("settings:chatbooksPlayground.importMedia", "Import media")}</Text>
-          </Space>
+          {!isOpenWebUIImport && (
+            <>
+              <Space wrap>
+                <Switch checked={importMedia} onChange={setImportMedia} />
+                <Text>{t("settings:chatbooksPlayground.importMedia", "Import media")}</Text>
+              </Space>
 
-          <Space wrap>
-            <Switch checked={importEmbeddings} onChange={setImportEmbeddings} />
-            <Text>{t("settings:chatbooksPlayground.importEmbeddings", "Import embeddings")}</Text>
-          </Space>
+              <Space wrap>
+                <Switch checked={importEmbeddings} onChange={setImportEmbeddings} />
+                <Text>{t("settings:chatbooksPlayground.importEmbeddings", "Import embeddings")}</Text>
+              </Space>
+            </>
+          )}
 
           <Space wrap>
             <Switch checked={importAsync} onChange={setImportAsync} />
@@ -1794,7 +1898,7 @@ export const ChatbooksPlaygroundPage: React.FC = () => {
         </div>
       </Card>
 
-      {previewManifest && previewTypes.length > 0 && (
+      {!isOpenWebUIImport && previewManifest && previewTypes.length > 0 && (
         <div className="flex flex-col gap-4">
           {previewTypes.map((key) => (
             <ContentTypePicker
@@ -1826,7 +1930,7 @@ export const ChatbooksPlaygroundPage: React.FC = () => {
         </div>
       )}
 
-      {previewManifest && previewTypes.length === 0 && (
+      {!isOpenWebUIImport && previewManifest && previewTypes.length === 0 && (
         <Alert
           type="info"
           showIcon
@@ -1842,7 +1946,7 @@ export const ChatbooksPlaygroundPage: React.FC = () => {
           type="primary"
           onClick={handleImport}
           loading={importSubmitting}
-          disabled={!canUseChatbooks}
+          disabled={!canUseChatbooks || !importFile || previewLoading}
         >
           {t("settings:chatbooksPlayground.importCta", "Import chatbook")}
         </Button>

--- a/apps/packages/ui/src/components/Option/Chatbooks/__tests__/ChatbooksPlaygroundPage.openwebui-import.test.tsx
+++ b/apps/packages/ui/src/components/Option/Chatbooks/__tests__/ChatbooksPlaygroundPage.openwebui-import.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 import { useQuery } from "@tanstack/react-query"
 import { ChatbooksPlaygroundPage } from "../ChatbooksPlaygroundPage"
@@ -117,6 +117,16 @@ vi.mock("@/components/Common/WorkspaceConnectionGate", () => ({
   default: ({ children }: { children: React.ReactNode }) => <>{children}</>
 }))
 
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
 if (!(globalThis as any).ResizeObserver) {
   ;(globalThis as any).ResizeObserver = class ResizeObserver {
     observe() {}
@@ -185,5 +195,74 @@ describe("ChatbooksPlaygroundPage OpenWebUI import mode", () => {
     expect(screen.queryByText("Import media")).not.toBeInTheDocument()
     expect(screen.queryByText("Import embeddings")).not.toBeInTheDocument()
     expect(container.querySelector(".ant-upload-drag input[type=\"file\"]")).toHaveAttribute("accept", ".json")
+  })
+
+  it("ignores stale OpenWebUI preview responses when a newer file is selected", async () => {
+    const firstPreview = deferred<any>()
+    const secondPreview = deferred<any>()
+    tldwClientMock.previewChatbook
+      .mockImplementationOnce(() => firstPreview.promise)
+      .mockImplementationOnce(() => secondPreview.promise)
+
+    const { container } = render(<ChatbooksPlaygroundPage />)
+
+    fireEvent.click(screen.getByRole("tab", { name: "Import" }))
+    const sourceSelect = screen
+      .getAllByRole("combobox")
+      .find((element) => (element as HTMLSelectElement).value === "chatbook")
+    fireEvent.change(sourceSelect!, { target: { value: "openwebui_json" } })
+
+    const firstUploadInput = container.querySelector(".ant-upload-drag input[type=\"file\"]") as HTMLInputElement
+    fireEvent.change(firstUploadInput, {
+      target: {
+        files: [new File(["[]"], "first.json", { type: "application/json" })]
+      }
+    })
+
+    const secondUploadInput = container.querySelector(".ant-upload-drag input[type=\"file\"]") as HTMLInputElement
+    fireEvent.change(secondUploadInput, {
+      target: {
+        files: [new File(["[]"], "second.json", { type: "application/json" })]
+      }
+    })
+
+    await waitFor(() => {
+      expect(tldwClientMock.previewChatbook).toHaveBeenCalledTimes(2)
+    })
+
+    await act(async () => {
+      secondPreview.resolve({
+        openwebui_preview: {
+          chat_count: 22,
+          message_count: 44,
+          branched_chat_count: 0,
+          duplicate_chat_count: 0,
+          attachment_reference_count: 0,
+          malformed_chat_count: 0,
+          warnings: []
+        }
+      })
+      await secondPreview.promise
+    })
+
+    expect(screen.getByText("22")).toBeInTheDocument()
+
+    await act(async () => {
+      firstPreview.resolve({
+        openwebui_preview: {
+          chat_count: 11,
+          message_count: 22,
+          branched_chat_count: 0,
+          duplicate_chat_count: 0,
+          attachment_reference_count: 0,
+          malformed_chat_count: 0,
+          warnings: []
+        }
+      })
+      await firstPreview.promise
+    })
+
+    expect(screen.getByText("22")).toBeInTheDocument()
+    expect(screen.queryByText("11")).not.toBeInTheDocument()
   })
 })

--- a/apps/packages/ui/src/components/Option/Chatbooks/__tests__/ChatbooksPlaygroundPage.openwebui-import.test.tsx
+++ b/apps/packages/ui/src/components/Option/Chatbooks/__tests__/ChatbooksPlaygroundPage.openwebui-import.test.tsx
@@ -1,0 +1,189 @@
+import React from "react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+import { useQuery } from "@tanstack/react-query"
+import { ChatbooksPlaygroundPage } from "../ChatbooksPlaygroundPage"
+
+const { useQueryMock, tldwClientMock } = vi.hoisted(() => ({
+  useQueryMock: vi.fn(),
+  tldwClientMock: {
+    initialize: vi.fn(async () => undefined),
+    listChatbookExportJobs: vi.fn(async () => ({ jobs: [] })),
+    listChatbookImportJobs: vi.fn(async () => ({ jobs: [] })),
+    getChatbookExportJob: vi.fn(),
+    getChatbookImportJob: vi.fn(),
+    downloadChatbookExport: vi.fn(),
+    cancelChatbookExportJob: vi.fn(),
+    cancelChatbookImportJob: vi.fn(),
+    cleanupChatbooks: vi.fn(),
+    removeChatbookExportJob: vi.fn(),
+    removeChatbookImportJob: vi.fn(),
+    exportChatbook: vi.fn(),
+    previewChatbook: vi.fn(),
+    importChatbook: vi.fn()
+  }
+}))
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: useQueryMock
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      key: string,
+      defaultValueOrOptions?:
+        | string
+        | {
+            defaultValue?: string
+          }
+    ) => {
+      if (typeof defaultValueOrOptions === "string") return defaultValueOrOptions
+      if (defaultValueOrOptions?.defaultValue) return defaultValueOrOptions.defaultValue
+      return key
+    }
+  })
+}))
+
+vi.mock("antd", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("antd")>()
+  const React = await import("react")
+  const Select = ({
+    value,
+    onChange,
+    options = [],
+    disabled,
+    className,
+    mode,
+    placeholder
+  }: any) => (
+    <select
+      aria-label={placeholder || "select"}
+      className={className}
+      disabled={disabled}
+      value={Array.isArray(value) ? value[0] || "" : value || ""}
+      onChange={(event) => {
+        const nextValue = event.target.value
+        onChange?.(mode === "tags" ? (nextValue ? [nextValue] : []) : nextValue)
+      }}
+    >
+      {(options as Array<{ value: string; label: React.ReactNode }>).map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  )
+  return {
+    ...actual,
+    Select
+  }
+})
+
+vi.mock("@/hooks/useServerOnline", () => ({
+  useServerOnline: () => true
+}))
+
+vi.mock("@/hooks/useServerCapabilities", () => ({
+  useServerCapabilities: () => ({
+    capabilities: {
+      hasChatbooks: true
+    }
+  })
+}))
+
+vi.mock("@/hooks/useAntdNotification", () => ({
+  useAntdNotification: () => ({
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn()
+  })
+}))
+
+vi.mock("@/services/tldw/TldwApiClient", () => ({
+  tldwClient: tldwClientMock
+}))
+
+vi.mock("@/services/background-proxy", () => ({
+  bgRequest: vi.fn()
+}))
+
+vi.mock("@/components/Common/PageShell", () => ({
+  PageShell: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}))
+
+vi.mock("@/components/Common/WorkspaceConnectionGate", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}))
+
+if (!(globalThis as any).ResizeObserver) {
+  ;(globalThis as any).ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+}
+
+describe("ChatbooksPlaygroundPage OpenWebUI import mode", () => {
+  const originalMatchMedia = window.matchMedia
+
+  beforeAll(() => {
+    if (typeof window.matchMedia !== "function") {
+      Object.defineProperty(window, "matchMedia", {
+        writable: true,
+        value: vi.fn().mockImplementation((query: string) => ({
+          matches: false,
+          media: query,
+          onchange: null,
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          dispatchEvent: vi.fn()
+        }))
+      })
+    }
+  })
+
+  afterAll(() => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: originalMatchMedia
+    })
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useQuery).mockReturnValue({
+      data: { items: [], total: 0 },
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn()
+    } as any)
+  })
+
+  it("switches the import tab to OpenWebUI JSON mode and hides archive-only controls", async () => {
+    const { container } = render(<ChatbooksPlaygroundPage />)
+
+    fireEvent.click(screen.getByRole("tab", { name: "Import" }))
+
+    expect(screen.getByText("Drop a .zip or .chatbook archive or click to browse")).toBeInTheDocument()
+    expect(screen.getByText("Import media")).toBeInTheDocument()
+    expect(screen.getByText("Import embeddings")).toBeInTheDocument()
+
+    const sourceSelect = screen
+      .getAllByRole("combobox")
+      .find((element) => (element as HTMLSelectElement).value === "chatbook")
+    expect(sourceSelect).not.toBeNull()
+    fireEvent.change(sourceSelect!, { target: { value: "openwebui_json" } })
+
+    await waitFor(() => {
+      expect(screen.getByText("Drop an OpenWebUI .json export or click to browse")).toBeInTheDocument()
+    })
+    expect(screen.queryByText("Import media")).not.toBeInTheDocument()
+    expect(screen.queryByText("Import embeddings")).not.toBeInTheDocument()
+    expect(container.querySelector(".ant-upload-drag input[type=\"file\"]")).toHaveAttribute("accept", ".json")
+  })
+})

--- a/apps/packages/ui/src/services/__tests__/tldw-api-client.chatbooks-openwebui.test.ts
+++ b/apps/packages/ui/src/services/__tests__/tldw-api-client.chatbooks-openwebui.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  bgRequest: vi.fn(),
+  bgUpload: vi.fn()
+}))
+
+vi.mock("@/services/background-proxy", () => ({
+  bgRequest: (...args: unknown[]) => mocks.bgRequest(...args),
+  bgUpload: (...args: unknown[]) => mocks.bgUpload(...args),
+  bgStream: vi.fn()
+}))
+
+vi.mock("@/utils/safe-storage", () => ({
+  createSafeStorage: () => ({
+    get: vi.fn(async () => null),
+    set: vi.fn(async () => undefined),
+    remove: vi.fn(async () => undefined)
+  }),
+  safeStorageSerde: {
+    serialize: (value: unknown) => value,
+    deserialize: (value: unknown) => value
+  }
+}))
+
+import { TldwApiClient } from "@/services/tldw/TldwApiClient"
+
+describe("TldwApiClient Chatbooks OpenWebUI import contract", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("sends source_format for OpenWebUI preview uploads", async () => {
+    mocks.bgUpload.mockResolvedValue({ openwebui_preview: { chat_count: 0 } })
+
+    const client = new TldwApiClient()
+    const file = new File(["[]"], "openwebui.json", { type: "application/json" })
+    await client.previewChatbook(file, { source_format: "openwebui_json" })
+
+    expect(mocks.bgUpload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "/api/v1/chatbooks/preview",
+        method: "POST",
+        fields: { source_format: "openwebui_json" },
+        file: expect.objectContaining({
+          name: "openwebui.json",
+          type: "application/json"
+        })
+      })
+    )
+  })
+
+  it("serializes import options as multipart fields", async () => {
+    mocks.bgUpload.mockResolvedValue({ success: true })
+
+    const client = new TldwApiClient()
+    const file = new File(["[]"], "openwebui.json", { type: "application/json" })
+    await client.importChatbook(file, {
+      source_format: "openwebui_json",
+      conflict_resolution: "rename",
+      prefix_imported: true,
+      import_media: false,
+      import_embeddings: false,
+      async_mode: true,
+      content_selections: { conversation: ["conv-1"] }
+    })
+
+    expect(mocks.bgUpload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "/api/v1/chatbooks/import",
+        method: "POST",
+        fields: expect.objectContaining({
+          source_format: "openwebui_json",
+          conflict_resolution: "rename",
+          prefix_imported: "true",
+          import_media: "false",
+          import_embeddings: "false",
+          async_mode: "true",
+          content_selections: JSON.stringify({ conversation: ["conv-1"] })
+        })
+      })
+    )
+  })
+})

--- a/apps/packages/ui/src/services/tldw/TldwApiClient.ts
+++ b/apps/packages/ui/src/services/tldw/TldwApiClient.ts
@@ -5480,13 +5480,16 @@ export class TldwApiClientBase {
     })
   }
 
-  async previewChatbook(file: File): Promise<any> {
+  async previewChatbook(file: File, options?: { source_format?: string }): Promise<any> {
     const data = await file.arrayBuffer()
     const name = file.name || "chatbook.zip"
     const type = file.type || "application/zip"
+    const fields: Record<string, any> = {}
+    if (options?.source_format) fields.source_format = options.source_format
     return await bgUpload<any>({
       path: "/api/v1/chatbooks/preview",
       method: "POST",
+      fields,
       file: { name, type, data }
     })
   }
@@ -5500,6 +5503,7 @@ export class TldwApiClientBase {
       import_embeddings?: boolean
       async_mode?: boolean
       content_selections?: Record<string, string[]>
+      source_format?: string
     }
   ): Promise<any> {
     const data = await file.arrayBuffer()
@@ -5508,7 +5512,13 @@ export class TldwApiClientBase {
     const normalized: Record<string, any> = {}
     for (const [k, v] of Object.entries(options || {})) {
       if (typeof v === "undefined" || v === null) continue
-      normalized[k] = typeof v === "boolean" ? (v ? "true" : "false") : v
+      if (typeof v === "boolean") {
+        normalized[k] = v ? "true" : "false"
+      } else if (typeof v === "object") {
+        normalized[k] = JSON.stringify(v)
+      } else {
+        normalized[k] = v
+      }
     }
     return await bgUpload<any>({
       path: "/api/v1/chatbooks/import",

--- a/apps/packages/ui/src/services/tldw/domains/chat-rag.ts
+++ b/apps/packages/ui/src/services/tldw/domains/chat-rag.ts
@@ -1740,13 +1740,20 @@ export const chatRagMethods = {
     })
   },
 
-  async previewChatbook(this: TldwApiClientCore, file: File): Promise<any> {
+  async previewChatbook(
+    this: TldwApiClientCore,
+    file: File,
+    options?: { source_format?: string }
+  ): Promise<any> {
     const data = await file.arrayBuffer()
     const name = file.name || "chatbook.zip"
     const type = file.type || "application/zip"
+    const fields: Record<string, any> = {}
+    if (options?.source_format) fields.source_format = options.source_format
     return await bgUpload<any>({
       path: "/api/v1/chatbooks/preview",
       method: "POST",
+      fields,
       file: { name, type, data }
     })
   },
@@ -1761,6 +1768,7 @@ export const chatRagMethods = {
       import_embeddings?: boolean
       async_mode?: boolean
       content_selections?: Record<string, string[]>
+      source_format?: string
     }
   ): Promise<any> {
     const data = await file.arrayBuffer()
@@ -1769,7 +1777,13 @@ export const chatRagMethods = {
     const normalized: Record<string, any> = {}
     for (const [k, v] of Object.entries(options || {})) {
       if (typeof v === "undefined" || v === null) continue
-      normalized[k] = typeof v === "boolean" ? (v ? "true" : "false") : v
+      if (typeof v === "boolean") {
+        normalized[k] = v ? "true" : "false"
+      } else if (typeof v === "object") {
+        normalized[k] = JSON.stringify(v)
+      } else {
+        normalized[k] = v
+      }
     }
     return await bgUpload<any>({
       path: "/api/v1/chatbooks/import",

--- a/backlog/tasks/task-233 - Design-OpenWebUI-chat-JSON-import.md
+++ b/backlog/tasks/task-233 - Design-OpenWebUI-chat-JSON-import.md
@@ -1,0 +1,66 @@
+---
+id: TASK-233
+title: Design OpenWebUI chat JSON import
+status: Done
+assignee:
+  - Codex
+created_date: '2026-05-10 16:15'
+updated_date: '2026-05-10 16:24'
+labels:
+  - chatbooks
+  - chat
+  - import
+  - design
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create the approved design spec for importing OpenWebUI chat JSON exports into tldw_server through the existing Chatbooks import workflow. V1 scope is OpenWebUI exported JSON only; direct OpenWebUI database/admin import is planned follow-up, not part of this design.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Spec documents OpenWebUI JSON import through the existing Chatbooks import surface
+- [x] #2 Spec requires preserving OpenWebUI message trees via parent_message_id
+- [x] #3 Spec captures duplicate handling using source=openwebui and external_ref
+- [x] #4 Spec records v1 exclusions including direct database import and attachment hydration
+- [x] #5 Spec is committed with this Backlog task
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Write the approved OpenWebUI chat JSON import design spec under Docs/superpowers/specs/2026-05-10-openwebui-chat-import-design.md.
+2. Capture architecture, data mapping, user flow, error handling, testing, and v1 exclusions exactly as approved in brainstorming.
+3. Run a spec review loop with a focused reviewer prompt and patch the spec if actionable issues are found.
+4. Verify the non-code change with git diff/checks, record Bandit as not applicable for design-only work, and commit only the spec plus TASK-233 tracking file.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Wrote design spec at Docs/superpowers/specs/2026-05-10-openwebui-chat-import-design.md and started the spec review loop.
+
+Spec review iteration 1 found message ID collision risk for rename imports and an underspecified OpenWebUI preview/import response contract. Patched the spec to add import-copy namespacing, explicit optional OpenWebUI preview/result response fields, canonical derived external refs, and stricter v1 role handling.
+
+Spec review iteration 2 approved. Applied advisory cleanup to specify source_format as a multipart form field and align response wording with existing success/message/job_id fields.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added a user-approved and reviewer-approved design spec for importing OpenWebUI chat JSON exports through the existing Chatbooks import workflow. The spec defines the v1 scope as JSON export import only, preserves full OpenWebUI message trees via parent_message_id, pins duplicate handling to source=openwebui plus external_ref, and excludes direct database import plus attachment hydration from v1. Verification included placeholder scan, full spec review, and two spec-review iterations; Bandit is not applicable because this task changed only documentation and Backlog tracking metadata.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-233 - Design-OpenWebUI-chat-JSON-import.md
+++ b/backlog/tasks/task-233 - Design-OpenWebUI-chat-JSON-import.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - Codex
 created_date: '2026-05-10 16:15'
-updated_date: '2026-05-10 16:24'
+updated_date: '2026-05-10 16:29'
 labels:
   - chatbooks
   - chat
@@ -36,7 +36,8 @@ Create the approved design spec for importing OpenWebUI chat JSON exports into t
 1. Write the approved OpenWebUI chat JSON import design spec under Docs/superpowers/specs/2026-05-10-openwebui-chat-import-design.md.
 2. Capture architecture, data mapping, user flow, error handling, testing, and v1 exclusions exactly as approved in brainstorming.
 3. Run a spec review loop with a focused reviewer prompt and patch the spec if actionable issues are found.
-4. Verify the non-code change with git diff/checks, record Bandit as not applicable for design-only work, and commit only the spec plus TASK-233 tracking file.
+4. Perform the user-requested design self-review against current Chatbooks/ChaCha code paths and patch concrete implementation-planning gaps.
+5. Verify the non-code change with content hygiene and git diff checks, record Bandit as not applicable for design-only work, and commit only the spec plus TASK-233 tracking file.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -47,12 +48,16 @@ Wrote design spec at Docs/superpowers/specs/2026-05-10-openwebui-chat-import-des
 Spec review iteration 1 found message ID collision risk for rename imports and an underspecified OpenWebUI preview/import response contract. Patched the spec to add import-copy namespacing, explicit optional OpenWebUI preview/result response fields, canonical derived external refs, and stricter v1 role handling.
 
 Spec review iteration 2 approved. Applied advisory cleanup to specify source_format as a multipart form field and align response wording with existing success/message/job_id fields.
+
+Reopened for user-requested design self-review before implementation planning. Found additional planning gaps to patch: OpenWebUI JSON must branch before ZIP validation, JSON filename handling cannot reuse the ZIP-only filename validator unchanged, source metadata should use explicit namespaced storage, and OpenWebUI Unix timestamps need explicit normalization.
+
+Design self-review patch added explicit endpoint/source-format branching before ZIP validation, JSON filename validation constraints, frontend helper changes for source_format, duplicate lookup helper guidance, namespaced conversation/message metadata, UUID-shaped deterministic message IDs, and Unix-second timestamp normalization.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added a user-approved and reviewer-approved design spec for importing OpenWebUI chat JSON exports through the existing Chatbooks import workflow. The spec defines the v1 scope as JSON export import only, preserves full OpenWebUI message trees via parent_message_id, pins duplicate handling to source=openwebui plus external_ref, and excludes direct database import plus attachment hydration from v1. Verification included placeholder scan, full spec review, and two spec-review iterations; Bandit is not applicable because this task changed only documentation and Backlog tracking metadata.
+Added and then self-reviewed the user-approved OpenWebUI chat JSON import design spec. The spec now defines OpenWebUI JSON import through the existing Chatbooks import surface, preserves message trees through parent_message_id, pins duplicate handling to source=openwebui plus external_ref, excludes direct database import and attachment hydration from v1, and hardens implementation planning around source_format branching, JSON-safe validation, frontend helper updates, duplicate lookup helpers, namespaced metadata, UUID-shaped deterministic message IDs, and Unix timestamp normalization. Verification included content-hygiene scans, full spec review, two spec-review iterations, and a follow-up self-review against current Chatbooks/ChaCha code paths; Bandit is not applicable because this task changed only documentation and Backlog tracking metadata.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-233.1 - Plan-OpenWebUI-chat-JSON-import-implementation.md
+++ b/backlog/tasks/task-233.1 - Plan-OpenWebUI-chat-JSON-import-implementation.md
@@ -1,0 +1,67 @@
+---
+id: TASK-233.1
+title: Plan OpenWebUI chat JSON import implementation
+status: Done
+assignee: []
+created_date: '2026-05-10 16:31'
+updated_date: '2026-05-10 16:36'
+labels: []
+dependencies: []
+documentation:
+  - Docs/superpowers/specs/2026-05-10-openwebui-chat-import-design.md
+parent_task_id: TASK-233
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create a repo-grounded implementation plan for importing normal OpenWebUI Export Chats JSON files through the existing Chatbooks import flow. The plan should carry forward the approved design decisions from TASK-233 and split the work into reviewable stages for backend parsing/import, Chatbooks API/job integration, ChaCha metadata helpers, frontend UX/client updates, tests, docs, and verification.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Implementation plan document is created under Docs/superpowers/plans with a task-specific filename.
+- [x] #2 Plan references the approved design decisions from TASK-233 and does not reopen out-of-scope direct database or live-server import work for v1.
+- [x] #3 Plan covers backend OpenWebUI JSON adapter, Chatbooks endpoint/schema/job branching, ChaCha duplicate/metadata helpers, frontend import controls, and documentation updates.
+- [x] #4 Plan includes concrete test and verification checkpoints for parser behavior, duplicate handling, message tree preservation, API preview/import flows, frontend behavior, and security validation.
+- [x] #5 Backlog task notes are updated with the plan path and review outcome before committing.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Inspect current Chatbooks backend import/preview paths, async worker payload handling, and ZIP validation boundaries.
+2. Inspect ChaCha conversation/message storage helpers for duplicate lookup and metadata persistence extension points.
+3. Inspect WebUI Chatbooks import UI and tldw client helpers for multipart option handling.
+4. Draft a staged implementation plan under Docs/superpowers/plans with tests, docs, and verification gates.
+5. Review the plan for ambiguity, missed edge cases, and implementation-order risks before committing.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Created implementation plan at Docs/superpowers/plans/2026-05-10-openwebui-chat-import-implementation-plan.md.
+
+Review pass completed against the approved TASK-233 design and current code paths in Chatbooks endpoints/service/worker, ChatbookValidator, ChaCha conversation/message stores, and the WebUI Chatbooks import tab.
+
+Plan review improvements added: multipart form parsing for source_format, JSON branching before ZIP validation, forcing unsupported OpenWebUI media/embedding options false despite current WebUI defaults, hiding Chatbook content selection for OpenWebUI v1, generalizing JSON path resolution wording, and updating static API docs if required.
+
+Verification: git diff --check passed. No pytest/Bandit run because this task only adds docs and Backlog planning metadata, not implementation code.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Created and reviewed the implementation plan for OpenWebUI chat JSON import. The plan keeps v1 bounded to normal OpenWebUI Export Chats JSON, extends the existing Chatbooks import path, preserves full message trees, covers duplicate/rename behavior, details backend/frontend/test/security stages, and records review-driven corrections for multipart source_format parsing and OpenWebUI option normalization.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-233.2 - Implement-OpenWebUI-chat-JSON-import.md
+++ b/backlog/tasks/task-233.2 - Implement-OpenWebUI-chat-JSON-import.md
@@ -1,0 +1,68 @@
+---
+id: TASK-233.2
+title: Implement OpenWebUI chat JSON import
+status: Done
+assignee: []
+created_date: '2026-05-10 16:52'
+labels: []
+dependencies: []
+documentation:
+  - Docs/superpowers/specs/2026-05-10-openwebui-chat-import-design.md
+  - >-
+    Docs/superpowers/plans/2026-05-10-openwebui-chat-import-implementation-plan.md
+parent_task_id: TASK-233
+priority: medium
+---
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Chatbooks preview/import accept source_format=chatbook by default and source_format=openwebui_json for safe JSON uploads without running ZIP validation.
+- [x] #2 OpenWebUI JSON adapter parses standard and legacy exports, previews counts and warnings, and imports valid chats while preserving full message trees with parent_message_id.
+- [x] #3 Duplicate handling uses source=openwebui and external_ref with skip by default and rename/import-copy support for intentional copies.
+- [x] #4 ChaCha conversation/message metadata preserves OpenWebUI source details under namespaced settings/metadata helpers.
+- [x] #5 Existing Chatbook archive preview/import behavior remains compatible and covered by regression tests.
+- [x] #6 WebUI Chatbooks import tab supports Chatbook archive and OpenWebUI JSON modes and sends source_format in multipart upload fields.
+- [x] #7 Focused backend/frontend tests and Bandit verification are recorded before final completion.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Follow Docs/superpowers/plans/2026-05-10-openwebui-chat-import-implementation-plan.md stage by stage. Use TDD for each behavior slice: write failing focused tests, verify red, implement minimal code, verify green, then refactor.
+<!-- SECTION:PLAN:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Notes
+
+- Added a Chatbooks OpenWebUI JSON import adapter for standard wrapper exports and legacy chat objects.
+- Extended preview/import schemas and endpoints with `source_format=chatbook|openwebui_json`, keeping Chatbook archive behavior as the default.
+- Added ChaCha source/external-ref duplicate lookup and persisted OpenWebUI conversation/message metadata under namespaced settings/metadata keys.
+- Routed OpenWebUI sync and Jobs imports through JSON-safe path resolution instead of ZIP/archive validation.
+- Extended the WebUI Chatbooks import tab with a source selector, JSON preview summary, OpenWebUI-specific conflict options, and multipart `source_format` upload fields.
+- Updated user and API docs for supported v1 behavior and out-of-scope direct `webui.db`, admin export, live server import, and attachment hydration.
+
+## Verification
+
+- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Chatbooks/test_openwebui_import_adapter.py tldw_Server_API/tests/Chatbooks/test_openwebui_import_service.py tldw_Server_API/tests/Chatbooks/test_chatbooks_api_error_and_preview_mapping.py::test_preview_openwebui_json_source_format_skips_archive_validation tldw_Server_API/tests/Chatbooks/test_chatbooks_api_error_and_preview_mapping.py::test_import_openwebui_json_source_format_skips_archive_validation tldw_Server_API/tests/Chatbooks/test_chatbooks_jobs_worker_import_defaults.py -v` - 11 passed.
+- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/ChaChaNotesDB -k "conversation or metadata" -v` - 62 passed, 235 deselected.
+- `bun run test src/services/__tests__/tldw-api-client.chatbooks-openwebui.test.ts src/components/Option/Chatbooks/__tests__/ChatbooksPlaygroundPage.openwebui-import.test.tsx src/components/Option/Chatbooks/__tests__/ContentTypePicker.error-state.test.tsx` - 4 passed.
+- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/chatbooks.py tldw_Server_API/app/core/Chatbooks tldw_Server_API/app/core/DB_Management/chacha -f json -o /tmp/bandit_openwebui_chat_import.json` - 0 findings.
+- `git diff --check` - clean.
+
+## Known Skips
+
+- Full `tldw_Server_API/tests/Chatbooks/test_chatbooks_api_preview.py` was not rerun because the implementation session previously observed the baseline `test_preview_manifest_version_ok` path hanging. The OpenWebUI preview/import endpoint paths were covered with targeted tests.
+- Manual browser smoke was not run; the WebUI source selector and multipart upload contract were covered with focused Vitest tests.
+
+## Final Summary
+
+Implemented v1 OpenWebUI chat JSON import through the existing Chatbooks workflow. The importer previews and imports normal OpenWebUI chat export JSON, preserves valid message branches as parent-linked tldw message trees, detects duplicates via `source=openwebui` and deterministic external refs, supports default skip plus intentional rename copies, preserves OpenWebUI metadata without hydrating attachments, and exposes the workflow in the WebUI import tab and docs.

--- a/backlog/tasks/task-233.2.1 - Address-PR-1542-OpenWebUI-import-review-comments.md
+++ b/backlog/tasks/task-233.2.1 - Address-PR-1542-OpenWebUI-import-review-comments.md
@@ -1,0 +1,64 @@
+---
+id: TASK-233.2.1
+title: 'Address PR #1542 OpenWebUI import review comments'
+status: Done
+assignee: []
+created_date: '2026-05-10 19:33'
+updated_date: '2026-05-10 19:46'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1542'
+documentation:
+  - >-
+    Docs/superpowers/plans/2026-05-10-openwebui-chat-import-implementation-plan.md
+parent_task_id: TASK-233.2
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve actionable review feedback on PR #1542 after rebasing the OpenWebUI chat JSON import branch onto dev.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 OpenWebUI preview rejects unsafe JSON paths with a user-facing error instead of surfacing a server error.
+- [x] #2 OpenWebUI imports do not count or parent-link messages when DB insertion fails, and per-chat failures do not leave retry-blocking partial conversations.
+- [x] #3 OpenWebUI import Jobs mark claimed validation failures as failed before raising.
+- [x] #4 ChaCha source-ref lookup safely maps tuple-style Postgres rows.
+- [x] #5 Frontend preview state ignores stale async preview responses after the selected file/source changes.
+- [x] #6 Review-only test comments are addressed without asserting internal staged file suffixes or leaking test files into shared service temp directories.
+- [x] #7 Targeted backend/frontend tests, git diff --check, and Bandit are rerun.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Review-fix pass for PR #1542: add failing regression tests for each actionable review issue, patch the service/worker/store/WebUI code narrowly, rerun targeted backend and frontend checks plus git diff --check and Bandit, then resolve stale or fixed review threads.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Review fixes implemented for PR #1542: safe OpenWebUI preview path errors, full per-chat rollback for failed message/settings/metadata writes, claimed import-job validation failure status, DB-owned cross-backend title lookup, tuple-style Postgres source-ref row conversion, stale WebUI preview response guard, multipart content_selections validation, non-UTF8 JSON rejection, and test hygiene cleanup.
+
+Verification: latest run passed 32 Chatbooks backend tests, 65 selected ChaCha conversation/metadata tests, and 5 targeted UI tests. git diff --check was clean. Bandit JSON results=0 and errors=0 at /tmp/bandit_openwebui_chat_import_review_fixes.json.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed the actionable PR #1542 review feedback for OpenWebUI chat import. The importer now handles unsafe preview paths as user-facing validation errors, rolls back failed OpenWebUI chat imports instead of leaving duplicate-blocking partial conversations, persists claimed async import validation failures as failed, delegates exact title checks to a DB-owned cross-backend helper, maps tuple-style Postgres source-ref rows safely, and ignores stale WebUI preview responses. Tests were expanded for these regressions and review-only test assertions were cleaned up.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-233.2.1 - Address-PR-1542-OpenWebUI-import-review-comments.md
+++ b/backlog/tasks/task-233.2.1 - Address-PR-1542-OpenWebUI-import-review-comments.md
@@ -4,7 +4,7 @@ title: 'Address PR #1542 OpenWebUI import review comments'
 status: Done
 assignee: []
 created_date: '2026-05-10 19:33'
-updated_date: '2026-05-10 19:46'
+updated_date: '2026-05-10 19:49'
 labels: []
 dependencies: []
 references:
@@ -45,12 +45,16 @@ Review-fix pass for PR #1542: add failing regression tests for each actionable r
 Review fixes implemented for PR #1542: safe OpenWebUI preview path errors, full per-chat rollback for failed message/settings/metadata writes, claimed import-job validation failure status, DB-owned cross-backend title lookup, tuple-style Postgres source-ref row conversion, stale WebUI preview response guard, multipart content_selections validation, non-UTF8 JSON rejection, and test hygiene cleanup.
 
 Verification: latest run passed 32 Chatbooks backend tests, 65 selected ChaCha conversation/metadata tests, and 5 targeted UI tests. git diff --check was clean. Bandit JSON results=0 and errors=0 at /tmp/bandit_openwebui_chat_import_review_fixes.json.
+
+Follow-up after the initial review-fix commit: multipart content_selections validation still returned FastAPI 422 before the endpoint parser for invalid form JSON. Added a default ImportChatbookRequest dependency so multipart fields are parsed explicitly by the endpoint and return HTTP 400.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Addressed the actionable PR #1542 review feedback for OpenWebUI chat import. The importer now handles unsafe preview paths as user-facing validation errors, rolls back failed OpenWebUI chat imports instead of leaving duplicate-blocking partial conversations, persists claimed async import validation failures as failed, delegates exact title checks to a DB-owned cross-backend helper, maps tuple-style Postgres source-ref rows safely, and ignores stale WebUI preview responses. Tests were expanded for these regressions and review-only test assertions were cleaned up.
+
+Follow-up verification after the multipart dependency fix: 44 focused backend tests passed, the targeted ChatbooksPlaygroundPage OpenWebUI Vitest file passed, git diff --check was clean, and Bandit returned results=[] for touched backend files in /tmp/bandit_openwebui_chat_import_review.json.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/api/v1/endpoints/chatbooks.py
+++ b/tldw_Server_API/app/api/v1/endpoints/chatbooks.py
@@ -9,6 +9,7 @@ Provides REST API endpoints for creating, importing, and managing chatbooks.
 """
 
 import asyncio
+import json
 import os
 import shutil
 from datetime import datetime, timezone
@@ -16,7 +17,7 @@ from pathlib import Path
 from typing import Optional
 from uuid import uuid4
 
-from fastapi import APIRouter, BackgroundTasks, Depends, File, HTTPException, Query, Request, UploadFile
+from fastapi import APIRouter, BackgroundTasks, Depends, File, Form, HTTPException, Query, Request, UploadFile
 from fastapi.responses import FileResponse
 from loguru import logger
 
@@ -39,7 +40,9 @@ from ..API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user as get_chacha
 from ..schemas.chatbook_schemas import (
     CancelJobResponse,
     ChatbookManifestResponse,
+    ChatbookImportSourceFormat,
     CleanupExpiredExportsResponse,
+    ConflictResolution as APIConflictResolution,
     ContinueExportRequest,
     CreateChatbookRequest,
     CreateChatbookResponse,
@@ -115,6 +118,21 @@ def _setup_secure_temp_directory(user_id: str) -> Path:
         raise HTTPException(status_code=400, detail="Invalid chatbooks temp directory path") from None
 
     return temp_dir
+
+
+def _parse_import_content_selections_field(value: str | None) -> dict | None:
+    """Parse multipart content_selections JSON, preserving omitted fields as None."""
+    if value is None or value == "":
+        return None
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError:
+        raise HTTPException(status_code=400, detail="content_selections must be valid JSON") from None
+    if parsed is None:
+        return None
+    if not isinstance(parsed, dict):
+        raise HTTPException(status_code=400, detail="content_selections must be a JSON object")
+    return parsed
 
 
 def _persist_completed_sync_export_job(
@@ -470,6 +488,13 @@ async def import_chatbook(
     request: Request,
     file: UploadFile = File(...),
     import_request: ImportChatbookRequest = Depends(),
+    source_format: ChatbookImportSourceFormat | None = Form(None),
+    conflict_resolution: APIConflictResolution | None = Form(None),
+    prefix_imported: bool | None = Form(None),
+    import_media: bool | None = Form(None),
+    import_embeddings: bool | None = Form(None),
+    async_mode: bool | None = Form(None),
+    content_selections: str | None = Form(None),
     service: ChatbookService = Depends(get_chatbook_service),
     user: User = Depends(get_request_user),
     audit_service=Depends(get_audit_service_for_user),
@@ -493,6 +518,22 @@ async def import_chatbook(
     """
     temp_file: Optional[Path] = None  # Initialize for proper cleanup in finally
     try:
+        source_format_value = source_format or import_request.source_format
+        import_request.source_format = source_format_value
+        if conflict_resolution is not None:
+            import_request.conflict_resolution = conflict_resolution
+        if prefix_imported is not None:
+            import_request.prefix_imported = prefix_imported
+        if import_media is not None:
+            import_request.import_media = import_media
+        if import_embeddings is not None:
+            import_request.import_embeddings = import_embeddings
+        if async_mode is not None:
+            import_request.async_mode = async_mode
+        parsed_content_selections = _parse_import_content_selections_field(content_selections)
+        if parsed_content_selections is not None:
+            import_request.content_selections = parsed_content_selections
+
         # Initialize quota manager (DB-backed)
         quota_manager = QuotaManager(str(user.id), getattr(user, "tier", "free"), db=service.db)
 
@@ -535,8 +576,11 @@ async def import_chatbook(
         ):
             raise HTTPException(status_code=400, detail="Invalid filename")
 
-        # Validate and sanitize filename
-        valid, error, safe_filename = ChatbookValidator.validate_filename(file.filename)
+        # Validate and sanitize filename for the selected source format.
+        if import_request.source_format == ChatbookImportSourceFormat.OPENWEBUI_JSON:
+            valid, error, safe_filename = ChatbookValidator.validate_json_filename(file.filename)
+        else:
+            valid, error, safe_filename = ChatbookValidator.validate_filename(file.filename)
         if not valid:
             raise HTTPException(status_code=400, detail=error)
         if Path(safe_filename).name != safe_filename or "/" in safe_filename or "\\" in safe_filename:
@@ -568,21 +612,22 @@ async def import_chatbook(
         with open(temp_file, "wb") as f:
             shutil.copyfileobj(file.file, f)
 
-        # Validate the uploaded ZIP file
-        valid, error = ChatbookValidator.validate_zip_file(str(temp_file))
-        if not valid:
-            try:
-                temp_file.unlink()
-            except _CHATBOOKS_NONCRITICAL_EXCEPTIONS as e:
-                logger.warning(
-                    f"Failed to remove invalid uploaded file during import: path={temp_file}, user={user.id}, error={e}"
+        # Validate chatbook archives before extraction. JSON sources are parsed by the adapter.
+        if import_request.source_format == ChatbookImportSourceFormat.CHATBOOK:
+            valid, error = ChatbookValidator.validate_zip_file(str(temp_file))
+            if not valid:
+                try:
+                    temp_file.unlink()
+                except _CHATBOOKS_NONCRITICAL_EXCEPTIONS as e:
+                    logger.warning(
+                        f"Failed to remove invalid uploaded file during import: path={temp_file}, user={user.id}, error={e}"
+                    )
+                _safe_increment_metric(
+                    "app_warning_events_total",
+                    labels={"component": "chatbooks", "event": "import_invalid_upload_cleanup_failed"},
+                    error_context="chatbooks import_invalid_upload_cleanup_failed",
                 )
-            _safe_increment_metric(
-                "app_warning_events_total",
-                labels={"component": "chatbooks", "event": "import_invalid_upload_cleanup_failed"},
-                error_context="chatbooks import_invalid_upload_cleanup_failed",
-            )
-            raise HTTPException(status_code=400, detail=error)
+                raise HTTPException(status_code=400, detail=error)
 
         # Convert content selections if provided (schema enum or string keys)
         content_selections = None
@@ -604,6 +649,7 @@ async def import_chatbook(
             import_embeddings=import_request.import_embeddings,
             async_mode=import_request.async_mode,
             request_id=rid,
+            source_format=import_request.source_format.value,
         )
 
         if success:
@@ -626,7 +672,12 @@ async def import_chatbook(
                     )
                 except _CHATBOOKS_NONCRITICAL_EXCEPTIONS as audit_err:
                     logger.warning(f"Failed to log audit event for import start: {audit_err}")
-                return ImportChatbookResponse(success=True, message=message, job_id=result)
+                return ImportChatbookResponse(
+                    success=True,
+                    message=message,
+                    source_format=import_request.source_format,
+                    job_id=result,
+                )
             else:
                 # Sync mode - return the structured import result from the service wrapper.
                 try:
@@ -645,9 +696,18 @@ async def import_chatbook(
                 except _CHATBOOKS_NONCRITICAL_EXCEPTIONS as audit_err:
                     logger.warning(f"Failed to log audit event for import completion: {audit_err}")
                 result_data = result if isinstance(result, dict) else {"imported_items": {}, "warnings": result or []}
+                if import_request.source_format == ChatbookImportSourceFormat.OPENWEBUI_JSON:
+                    return ImportChatbookResponse(
+                        success=True,
+                        message=message,
+                        source_format=import_request.source_format,
+                        openwebui_result=result_data,
+                        warnings=result_data.get("warnings") or [],
+                    )
                 return ImportChatbookResponse(
                     success=True,
                     message=message,
+                    source_format=import_request.source_format,
                     imported_items=result_data.get("imported_items") or {},
                     warnings=result_data.get("warnings") or [],
                 )
@@ -667,7 +727,12 @@ async def import_chatbook(
                             labels={"component": "chatbooks", "event": "import_cleanup_failed"},
                             error_context="chatbooks import_cleanup_failed",
                         )
-                return ImportChatbookResponse(success=False, message=message, job_id=result)
+                return ImportChatbookResponse(
+                    success=False,
+                    message=message,
+                    source_format=import_request.source_format,
+                    job_id=result,
+                )
             raise HTTPException(status_code=400, detail=message)
 
     except HTTPException:
@@ -698,6 +763,7 @@ async def import_chatbook(
 async def preview_chatbook(
     request: Request,
     file: UploadFile = File(...),
+    source_format: ChatbookImportSourceFormat = Form(ChatbookImportSourceFormat.CHATBOOK),
     service: ChatbookService = Depends(get_chatbook_service),
     user: User = Depends(get_request_user),
     audit_service=Depends(get_audit_service_for_user),
@@ -728,8 +794,11 @@ async def preview_chatbook(
         ):
             raise HTTPException(status_code=400, detail="Invalid filename")
 
-        # Validate and sanitize filename
-        valid, error, safe_filename = ChatbookValidator.validate_filename(file.filename)
+        # Validate and sanitize filename for the selected source format.
+        if source_format == ChatbookImportSourceFormat.OPENWEBUI_JSON:
+            valid, error, safe_filename = ChatbookValidator.validate_json_filename(file.filename)
+        else:
+            valid, error, safe_filename = ChatbookValidator.validate_filename(file.filename)
         if not valid:
             raise HTTPException(status_code=400, detail=error)
         if Path(safe_filename).name != safe_filename or "/" in safe_filename or "\\" in safe_filename:
@@ -767,21 +836,41 @@ async def preview_chatbook(
         with open(temp_file, "wb") as f:
             shutil.copyfileobj(file.file, f)
 
-        # Validate archive using centralized validator prior to extracting
-        ok, err = ChatbookValidator.validate_zip_file(str(temp_file))
-        if not ok:
+        # Validate chatbook archives before extraction. JSON sources are parsed by the adapter.
+        if source_format == ChatbookImportSourceFormat.CHATBOOK:
+            ok, err = ChatbookValidator.validate_zip_file(str(temp_file))
+            if not ok:
+                try:
+                    temp_file.unlink()
+                except _CHATBOOKS_NONCRITICAL_EXCEPTIONS as e:
+                    logger.warning(
+                        f"Failed to remove invalid uploaded file during preview: path={temp_file}, user={user.id}, error={e}"
+                    )
+                _safe_increment_metric(
+                    "app_warning_events_total",
+                    labels={"component": "chatbooks", "event": "preview_invalid_upload_cleanup_failed"},
+                    error_context="chatbooks preview_invalid_upload_cleanup_failed",
+                )
+                raise HTTPException(status_code=400, detail=err or "Invalid archive")
+
+        if source_format == ChatbookImportSourceFormat.OPENWEBUI_JSON:
+            preview_data, error = service.preview_openwebui_json(str(temp_file))
             try:
                 temp_file.unlink()
             except _CHATBOOKS_NONCRITICAL_EXCEPTIONS as e:
-                logger.warning(
-                    f"Failed to remove invalid uploaded file during preview: path={temp_file}, user={user.id}, error={e}"
+                logger.warning(f"Cleanup of preview temp file failed: path={temp_file}, user={user.id}, error={e}")
+                _safe_increment_metric(
+                    "app_warning_events_total",
+                    labels={"component": "chatbooks", "event": "preview_cleanup_failed"},
+                    error_context="chatbooks preview_cleanup_failed",
                 )
-            _safe_increment_metric(
-                "app_warning_events_total",
-                labels={"component": "chatbooks", "event": "preview_invalid_upload_cleanup_failed"},
-                error_context="chatbooks preview_invalid_upload_cleanup_failed",
+            if preview_data is None:
+                raise HTTPException(status_code=400, detail=error or "Invalid OpenWebUI JSON export")
+            return PreviewChatbookResponse(
+                source_format=source_format,
+                manifest=None,
+                openwebui_preview=preview_data,
             )
-            raise HTTPException(status_code=400, detail=err or "Invalid archive")
 
         # Preview chatbook
         manifest, error = service.preview_chatbook(str(temp_file))
@@ -861,7 +950,7 @@ async def preview_chatbook(
             )
         except _CHATBOOKS_NONCRITICAL_EXCEPTIONS as audit_err:
             logger.warning(f"Failed to log audit event for preview: {audit_err}")
-        return PreviewChatbookResponse(manifest=manifest_response)
+        return PreviewChatbookResponse(source_format=source_format, manifest=manifest_response)
 
     except HTTPException:
         raise

--- a/tldw_Server_API/app/api/v1/endpoints/chatbooks.py
+++ b/tldw_Server_API/app/api/v1/endpoints/chatbooks.py
@@ -162,6 +162,11 @@ def _parse_import_content_selections_field(value: str | None) -> dict[ContentTyp
     return _coerce_import_content_selections(parsed)
 
 
+def _default_import_chatbook_request() -> ImportChatbookRequest:
+    """Return default import options; multipart fields are parsed explicitly."""
+    return ImportChatbookRequest()
+
+
 def _persist_completed_sync_export_job(
     service: ChatbookService,
     user_id: str,
@@ -514,7 +519,7 @@ async def import_chatbook(
     background_tasks: BackgroundTasks,
     request: Request,
     file: UploadFile = File(...),
-    import_request: ImportChatbookRequest = Depends(),
+    import_request: ImportChatbookRequest = Depends(_default_import_chatbook_request),
     source_format: ChatbookImportSourceFormat | None = Form(None),
     conflict_resolution: APIConflictResolution | None = Form(None),
     prefix_imported: bool | None = Form(None),

--- a/tldw_Server_API/app/api/v1/endpoints/chatbooks.py
+++ b/tldw_Server_API/app/api/v1/endpoints/chatbooks.py
@@ -120,7 +120,34 @@ def _setup_secure_temp_directory(user_id: str) -> Path:
     return temp_dir
 
 
-def _parse_import_content_selections_field(value: str | None) -> dict | None:
+def _coerce_content_type_key(value: object) -> ContentType:
+    """Convert a raw API content type key into the core enum."""
+    raw_value = value.value if hasattr(value, "value") else value
+    if not isinstance(raw_value, str):
+        raise HTTPException(status_code=400, detail="content_selections keys must be content type strings")
+    try:
+        return ContentType(raw_value)
+    except ValueError:
+        raise HTTPException(status_code=400, detail=f"Unsupported content type in content_selections: {raw_value}") from None
+
+
+def _coerce_import_content_selections(value: object | None) -> dict[ContentType, list[str]] | None:
+    """Validate content selections before passing them to import code."""
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise HTTPException(status_code=400, detail="content_selections must be a JSON object")
+
+    coerced: dict[ContentType, list[str]] = {}
+    for raw_key, raw_ids in value.items():
+        content_type = _coerce_content_type_key(raw_key)
+        if not isinstance(raw_ids, list) or not all(isinstance(item, str) for item in raw_ids):
+            raise HTTPException(status_code=400, detail="content_selections values must be lists of strings")
+        coerced[content_type] = list(raw_ids)
+    return coerced
+
+
+def _parse_import_content_selections_field(value: str | None) -> dict[ContentType, list[str]] | None:
     """Parse multipart content_selections JSON, preserving omitted fields as None."""
     if value is None or value == "":
         return None
@@ -132,7 +159,7 @@ def _parse_import_content_selections_field(value: str | None) -> dict | None:
         return None
     if not isinstance(parsed, dict):
         raise HTTPException(status_code=400, detail="content_selections must be a JSON object")
-    return parsed
+    return _coerce_import_content_selections(parsed)
 
 
 def _persist_completed_sync_export_job(
@@ -533,6 +560,8 @@ async def import_chatbook(
         parsed_content_selections = _parse_import_content_selections_field(content_selections)
         if parsed_content_selections is not None:
             import_request.content_selections = parsed_content_selections
+        elif import_request.content_selections is not None:
+            import_request.content_selections = _coerce_import_content_selections(import_request.content_selections)
 
         # Initialize quota manager (DB-backed)
         quota_manager = QuotaManager(str(user.id), getattr(user, "tier", "free"), db=service.db)
@@ -854,7 +883,7 @@ async def preview_chatbook(
                 raise HTTPException(status_code=400, detail=err or "Invalid archive")
 
         if source_format == ChatbookImportSourceFormat.OPENWEBUI_JSON:
-            preview_data, error = service.preview_openwebui_json(str(temp_file))
+            preview_data, error = await asyncio.to_thread(service.preview_openwebui_json, str(temp_file))
             try:
                 temp_file.unlink()
             except _CHATBOOKS_NONCRITICAL_EXCEPTIONS as e:

--- a/tldw_Server_API/app/api/v1/schemas/chatbook_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/chatbook_schemas.py
@@ -41,6 +41,12 @@ class ConflictResolution(str, Enum):
     RENAME = "rename"      # Rename imported items
 
 
+class ChatbookImportSourceFormat(str, Enum):
+    """Supported source formats for Chatbooks import surfaces."""
+    CHATBOOK = "chatbook"
+    OPENWEBUI_JSON = "openwebui_json"
+
+
 class MediaQuality(str, Enum):
     """Media quality levels for export."""
     THUMBNAIL = "thumbnail"
@@ -125,6 +131,10 @@ class CreateChatbookRequest(BaseModel):
 
 class ImportChatbookRequest(BaseModel):
     """Request for importing a chatbook."""
+    source_format: ChatbookImportSourceFormat = Field(
+        ChatbookImportSourceFormat.CHATBOOK,
+        description="Uploaded source format"
+    )
     content_selections: Optional[dict[ContentType, list[str]]] = Field(
         None,
         description="Specific content to import, or None for all"
@@ -259,6 +269,39 @@ class ImportConflictResponse(BaseModel):
     new_title: Optional[str] = None
 
 
+class OpenWebUIPreviewChatItem(BaseModel):
+    """Lightweight preview row for one OpenWebUI chat."""
+    external_ref: str
+    title: str
+    message_count: int = Field(ge=0)
+    branched: bool = False
+    duplicate: bool = False
+    warning_count: int = Field(default=0, ge=0)
+
+
+class OpenWebUIImportPreview(BaseModel):
+    """OpenWebUI import preview counts."""
+    chat_count: int = Field(default=0, ge=0)
+    message_count: int = Field(default=0, ge=0)
+    branched_chat_count: int = Field(default=0, ge=0)
+    duplicate_chat_count: int = Field(default=0, ge=0)
+    attachment_reference_count: int = Field(default=0, ge=0)
+    malformed_chat_count: int = Field(default=0, ge=0)
+    warnings: list[str] = Field(default_factory=list)
+    items: list[OpenWebUIPreviewChatItem] = Field(default_factory=list)
+
+
+class OpenWebUIImportResult(BaseModel):
+    """OpenWebUI import result counts."""
+    imported_chats: int = Field(default=0, ge=0)
+    skipped_chats: int = Field(default=0, ge=0)
+    failed_chats: int = Field(default=0, ge=0)
+    imported_messages: int = Field(default=0, ge=0)
+    skipped_messages: int = Field(default=0, ge=0)
+    duplicate_chats: int = Field(default=0, ge=0)
+    warnings: list[str] = Field(default_factory=list)
+
+
 class CreateChatbookResponse(BaseModel):
     """Response for chatbook creation."""
     success: bool
@@ -271,10 +314,15 @@ class ImportChatbookResponse(BaseModel):
     """Response for chatbook import."""
     success: bool
     message: str
+    source_format: ChatbookImportSourceFormat = ChatbookImportSourceFormat.CHATBOOK
     job_id: Optional[str] = Field(None, description="Job ID if async mode")
     imported_items: Optional[dict[str, int]] = Field(
         None,
         description="Count of imported items by type"
+    )
+    openwebui_result: Optional[OpenWebUIImportResult] = Field(
+        None,
+        description="Structured import result for OpenWebUI JSON sources"
     )
     warnings: Optional[list[str]] = Field(
         None,
@@ -284,7 +332,9 @@ class ImportChatbookResponse(BaseModel):
 
 class PreviewChatbookResponse(BaseModel):
     """Response for chatbook preview."""
+    source_format: ChatbookImportSourceFormat = ChatbookImportSourceFormat.CHATBOOK
     manifest: Optional[ChatbookManifestResponse] = None
+    openwebui_preview: Optional[OpenWebUIImportPreview] = None
     error: Optional[str] = None
 
 

--- a/tldw_Server_API/app/core/Chatbooks/chatbook_service.py
+++ b/tldw_Server_API/app/core/Chatbooks/chatbook_service.py
@@ -30,7 +30,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from collections.abc import Callable
 from typing import Any
-from uuid import uuid4
+from uuid import NAMESPACE_URL, uuid4, uuid5
 
 import aiofiles
 import aiofiles.os
@@ -74,6 +74,12 @@ from .exceptions import (
     JobError,
     SecurityError,
     ValidationError,
+)
+from .import_adapters.openwebui import (
+    OpenWebUIConversationPlan,
+    OpenWebUIMessagePlan,
+    load_openwebui_export,
+    preview_openwebui_export,
 )
 
 _CHATBOOK_NONCRITICAL_EXCEPTIONS: tuple[type[BaseException], ...] = (
@@ -569,6 +575,10 @@ class ChatbookService:
             "Chatbook file path is outside allowed import directories",
             violation_type="import_path_outside_allowed_directories",
         )
+
+    def _resolve_import_upload_path(self, file_ref: str | Path) -> Path:
+        """Resolve an uploaded import file path within temp/import directories."""
+        return self._resolve_import_archive_path(file_ref)
 
     def _build_import_file_token(self, resolved_path: Path) -> str:
         """Return a tokenized relative path for import job payloads."""
@@ -1804,7 +1814,8 @@ class ChatbookService:
         import_media: bool = False,
         import_embeddings: bool = False,
         async_mode: bool = False,
-        request_id: str | None = None
+        request_id: str | None = None,
+        source_format: str = "chatbook",
     ) -> tuple[bool, str, str | dict[str, Any] | None]:
         """
         Import a chatbook.
@@ -1857,6 +1868,16 @@ class ChatbookService:
                 "Set import_media=false and import_embeddings=false."
             ), None
 
+        source_format_value = getattr(source_format, "value", str(source_format or "chatbook")).strip().lower()
+        if source_format_value not in {"chatbook", "openwebui_json"}:
+            return False, f"Unsupported import source format: {source_format}", None
+
+        if source_format_value == "openwebui_json":
+            if content_selections:
+                return False, "OpenWebUI JSON imports do not support content selections; all valid chats are imported.", None
+            if import_media or import_embeddings:
+                return False, "OpenWebUI JSON imports do not support media or embedding import options.", None
+
         # Reject explicit requests for unsupported content types
         if content_selections:
             unsupported_types = {
@@ -1878,10 +1899,18 @@ class ChatbookService:
                 ), None
 
         try:
-            resolved_path = self._resolve_import_archive_path(file_path)
+            if source_format_value == "openwebui_json":
+                resolved_path = self._resolve_import_upload_path(file_path)
+            else:
+                resolved_path = self._resolve_import_archive_path(file_path)
         except _CHATBOOK_NONCRITICAL_EXCEPTIONS as exc:
             logger.warning(f"Chatbooks import rejected file path: {exc}")
-            return False, "Invalid or potentially malicious archive file", None
+            detail = (
+                "Invalid or potentially malicious import file"
+                if source_format_value == "openwebui_json"
+                else "Invalid or potentially malicious archive file"
+            )
+            return False, detail, None
         file_token = self._build_import_file_token(resolved_path)
 
         if async_mode:
@@ -1894,6 +1923,7 @@ class ChatbookService:
                     "user_id": self.user_id,
                     "path": file_token,
                     "file_token": file_token,
+                    "source_format": source_format_value,
                     "import_media": import_media,
                     "import_embeddings": import_embeddings,
                     "conflict_resolution": str(conflict_resolution.value if hasattr(conflict_resolution, 'value') else conflict_resolution),
@@ -1929,6 +1959,7 @@ class ChatbookService:
                         "action": "import",
                         "chatbooks_job_id": job_id,
                         "file_token": file_token,
+                        "source_format": source_format_value,
                         "content_selections": {k.value if hasattr(k, 'value') else str(k): v for k, v in (content_selections or {}).items()},
                         "conflict_resolution": conflict_resolution.value if hasattr(conflict_resolution, 'value') else str(conflict_resolution),
                         "prefix_imported": bool(prefix_imported),
@@ -1969,6 +2000,13 @@ class ChatbookService:
 
             return True, f"Import job started: {job_id}", job_id
         else:
+            if source_format_value == "openwebui_json":
+                return await asyncio.to_thread(
+                    self.import_openwebui_json,
+                    str(resolved_path),
+                    conflict_resolution,
+                    prefix_imported,
+                )
             # Run synchronously (wrapped in executor for async compatibility)
             # Return (success, message, structured sync import result)
             return await asyncio.to_thread(
@@ -2291,6 +2329,293 @@ class ChatbookService:
                     fp.unlink()
             except _CHATBOOK_NONCRITICAL_EXCEPTIONS as _e:
                 logger.warning(f"Could not remove import archive (async) {file_path}: {_e}")
+
+    def _openwebui_duplicate_exists(self, external_ref: str) -> bool:
+        """Return whether an OpenWebUI conversation was already imported for this client."""
+        try:
+            return bool(
+                self.db.get_conversation_by_source_ref(
+                    "openwebui",
+                    external_ref,
+                    client_id=getattr(self.db, "client_id", None),
+                )
+            )
+        except _CHATBOOK_NONCRITICAL_EXCEPTIONS as exc:
+            logger.warning(f"OpenWebUI duplicate lookup failed for source ref {external_ref}: {exc}")
+            return False
+
+    def preview_openwebui_json(self, file_path: str) -> tuple[dict[str, Any] | None, str | None]:
+        """Preview an OpenWebUI chat export JSON file without writing to the database."""
+        try:
+            resolved_path = self._resolve_import_upload_path(file_path)
+            preview = preview_openwebui_export(
+                resolved_path,
+                duplicate_lookup=self._openwebui_duplicate_exists,
+            )
+            return preview.to_dict(), None
+        except ValueError as exc:
+            return None, str(exc)
+        except _CHATBOOK_NONCRITICAL_EXCEPTIONS as exc:
+            logger.error(f"Error previewing OpenWebUI JSON import: {exc}")
+            raise
+
+    @staticmethod
+    def _openwebui_timestamp_to_iso(value: Any) -> tuple[str, str | None]:
+        """Convert OpenWebUI timestamps to UTC ISO strings."""
+        if value is None or value == "":
+            return datetime.now(timezone.utc).isoformat(), "OpenWebUI message missing timestamp; using import time."
+        if isinstance(value, (int, float)):
+            try:
+                seconds = value / 1000 if value > 1_000_000_000_000 else value
+                return datetime.fromtimestamp(seconds, tz=timezone.utc).isoformat(), None
+            except (OSError, OverflowError, ValueError):
+                return datetime.now(timezone.utc).isoformat(), "OpenWebUI message has invalid timestamp; using import time."
+        if isinstance(value, str):
+            parsed = ChatbookService._parse_timestamp(value)
+            if parsed is not None:
+                return parsed.replace(tzinfo=timezone.utc).isoformat(), None
+        return datetime.now(timezone.utc).isoformat(), "OpenWebUI message has unsupported timestamp; using import time."
+
+    @staticmethod
+    def _ordered_openwebui_messages(
+        chat: OpenWebUIConversationPlan,
+    ) -> tuple[list[OpenWebUIMessagePlan], list[str]]:
+        """Order messages so parents are inserted before children."""
+        remaining = {message.source_id: message for message in chat.messages}
+        ordered: list[OpenWebUIMessagePlan] = []
+        inserted: set[str] = set()
+        warnings: list[str] = []
+
+        while remaining:
+            progressed = False
+            for source_id, message in list(remaining.items()):
+                parent_id = message.parent_source_id
+                if not parent_id or (parent_id not in remaining and parent_id in inserted):
+                    ordered.append(message)
+                    inserted.add(source_id)
+                    del remaining[source_id]
+                    progressed = True
+                    continue
+                if parent_id and parent_id not in remaining and parent_id not in inserted:
+                    warnings.append(
+                        f"OpenWebUI message {source_id} references missing parent {parent_id}; importing as root."
+                    )
+                    ordered.append(message)
+                    inserted.add(source_id)
+                    del remaining[source_id]
+                    progressed = True
+                    continue
+            if not progressed:
+                skipped_ids = ", ".join(sorted(remaining))
+                warnings.append(f"OpenWebUI message cycle or unresolved parent dependency skipped: {skipped_ids}")
+                break
+
+        return ordered, warnings
+
+    @staticmethod
+    def _openwebui_message_metadata(message: OpenWebUIMessagePlan) -> dict[str, Any]:
+        """Build namespaced per-message OpenWebUI import metadata."""
+        return {
+            "openwebui_import": {
+                "source_message_id": message.source_id,
+                "source_parent_id": message.parent_source_id,
+                "source_children_ids": list(message.children_source_ids),
+                "role": message.role,
+                "model": message.model,
+                "attachment_refs": list(message.attachment_refs),
+                "metadata": dict(message.metadata),
+            }
+        }
+
+    def _store_openwebui_conversation_settings(
+        self,
+        conversation_id: str,
+        chat: OpenWebUIConversationPlan,
+        external_ref: str,
+    ) -> bool:
+        """Merge OpenWebUI import metadata into conversation settings."""
+        current = self.db.get_conversation_settings(conversation_id) or {}
+        settings = current.get("settings") if isinstance(current, dict) else {}
+        if not isinstance(settings, dict):
+            settings = {}
+        merged = dict(settings)
+        merged["openwebui_import"] = {
+            "source": "openwebui",
+            "external_ref": external_ref,
+            "history_current_id": chat.history_current_id,
+            "branched": chat.is_branched,
+            "metadata": dict(chat.source_metadata),
+        }
+        return bool(self.db.upsert_conversation_settings(conversation_id, merged))
+
+    def import_openwebui_json(
+        self,
+        file_path: str,
+        conflict_resolution: ConflictResolution | str | None = None,
+        prefix_imported: bool = False,
+    ) -> tuple[bool, str, dict[str, Any] | None]:
+        """Synchronously import an OpenWebUI chat export JSON file."""
+        if isinstance(conflict_resolution, str):
+            try:
+                conflict_resolution = ConflictResolution(conflict_resolution)
+            except (ValueError, KeyError):
+                conflict_resolution = ConflictResolution.SKIP
+        elif conflict_resolution is None:
+            conflict_resolution = ConflictResolution.SKIP
+
+        if conflict_resolution not in {ConflictResolution.SKIP, ConflictResolution.RENAME}:
+            return False, "OpenWebUI imports support only skip or rename conflict handling.", None
+
+        fallback_character_id = self._get_fallback_character_id()
+        if fallback_character_id is None:
+            return False, "OpenWebUI import requires at least one fallback character.", None
+
+        try:
+            resolved_path = self._resolve_import_upload_path(file_path)
+            parsed = load_openwebui_export(resolved_path)
+        except ValueError as exc:
+            return False, str(exc), None
+        except _CHATBOOK_NONCRITICAL_EXCEPTIONS as exc:
+            logger.warning(f"OpenWebUI import rejected file path: {exc}")
+            return False, "Invalid or potentially malicious import file", None
+
+        result = {
+            "imported_chats": 0,
+            "skipped_chats": 0,
+            "failed_chats": 0,
+            "imported_messages": 0,
+            "skipped_messages": 0,
+            "duplicate_chats": 0,
+            "warnings": list(parsed.warnings),
+        }
+
+        for chat in parsed.chats:
+            import_external_ref = chat.external_ref
+            try:
+                existing = self.db.get_conversation_by_source_ref(
+                    "openwebui",
+                    import_external_ref,
+                    client_id=getattr(self.db, "client_id", None),
+                )
+                if existing:
+                    result["duplicate_chats"] += 1
+                    if conflict_resolution == ConflictResolution.SKIP:
+                        result["skipped_chats"] += 1
+                        continue
+                    import_external_ref = f"{chat.external_ref}#copy:{uuid4().hex[:8]}"
+
+                conversation_title = f"[Imported] {chat.title}" if prefix_imported else chat.title
+                if existing and conflict_resolution == ConflictResolution.RENAME:
+                    conversation_title = self._generate_openwebui_copy_title(conversation_title)
+
+                ordered_messages, order_warnings = self._ordered_openwebui_messages(chat)
+                result["warnings"].extend(order_warnings)
+                importable_messages = [
+                    message
+                    for message in ordered_messages
+                    if (message.role or "").lower() in {"user", "assistant"} and message.content.strip()
+                ]
+                skipped_for_role = len(ordered_messages) - len(importable_messages)
+                if skipped_for_role:
+                    result["skipped_messages"] += skipped_for_role
+                    result["warnings"].append(
+                        f"OpenWebUI chat {chat.external_ref} skipped {skipped_for_role} unsupported or empty messages."
+                    )
+                if not importable_messages:
+                    result["failed_chats"] += 1
+                    result["warnings"].append(f"OpenWebUI chat {chat.external_ref} has no importable messages.")
+                    continue
+
+                conversation_id = self.db.add_conversation(
+                    {
+                        "title": conversation_title,
+                        "character_id": fallback_character_id,
+                        "source": "openwebui",
+                        "external_ref": import_external_ref,
+                        "client_id": getattr(self.db, "client_id", None),
+                    }
+                )
+                if not conversation_id:
+                    result["failed_chats"] += 1
+                    result["warnings"].append(f"OpenWebUI chat {chat.external_ref} could not create a conversation.")
+                    continue
+
+                if not self._store_openwebui_conversation_settings(conversation_id, chat, import_external_ref):
+                    result["warnings"].append(
+                        f"OpenWebUI chat {chat.external_ref} imported but conversation metadata was not stored."
+                    )
+
+                message_id_map: dict[str, str] = {}
+                namespace = f"tldw-openwebui:{import_external_ref}"
+                for message in importable_messages:
+                    parent_message_id = (
+                        message_id_map.get(message.parent_source_id)
+                        if message.parent_source_id
+                        else None
+                    )
+                    timestamp, timestamp_warning = self._openwebui_timestamp_to_iso(message.timestamp)
+                    if timestamp_warning:
+                        result["warnings"].append(f"{timestamp_warning} source_message_id={message.source_id}")
+                    message_id = str(uuid5(NAMESPACE_URL, f"{namespace}:{message.source_id}"))
+                    self.db.add_message(
+                        {
+                            "id": message_id,
+                            "conversation_id": conversation_id,
+                            "parent_message_id": parent_message_id,
+                            "sender": (message.role or "user").lower(),
+                            "content": message.content,
+                            "timestamp": timestamp,
+                            "client_id": getattr(self.db, "client_id", None),
+                        }
+                    )
+                    message_id_map[message.source_id] = message_id
+                    result["imported_messages"] += 1
+                    if not self.db.set_message_metadata_extra(
+                        message_id,
+                        self._openwebui_message_metadata(message),
+                        merge=True,
+                    ):
+                        result["warnings"].append(
+                            f"OpenWebUI message {message.source_id} imported but metadata was not stored."
+                        )
+
+                result["imported_chats"] += 1
+            except _CHATBOOK_NONCRITICAL_EXCEPTIONS as exc:
+                result["failed_chats"] += 1
+                result["warnings"].append(f"OpenWebUI chat {chat.external_ref} failed to import: {exc}")
+
+        if parsed.malformed_chat_count:
+            result["failed_chats"] += parsed.malformed_chat_count
+
+        return True, "OpenWebUI import completed", result
+
+    def _openwebui_conversation_title_exists(self, title: str) -> bool:
+        """Return whether an exact conversation title already exists for the current client."""
+        if not hasattr(self.db, "execute_query"):
+            return bool(self._get_conversation_by_name(title))
+
+        query = "SELECT id FROM conversations WHERE title = ? AND deleted = 0"
+        params: list[Any] = [title]
+        client_id = getattr(self.db, "client_id", None)
+        if client_id is not None:
+            query += " AND client_id = ?"
+            params.append(client_id)
+        query += " LIMIT 1"
+        try:
+            cursor = self.db.execute_query(query, tuple(params))
+            rows = self._fetch_results(cursor) if cursor is not None else []
+            return bool(rows)
+        except _CHATBOOK_NONCRITICAL_EXCEPTIONS as exc:
+            logger.warning(f"OpenWebUI import could not check existing conversation title: {exc}")
+            return False
+
+    def _generate_openwebui_copy_title(self, base_title: str) -> str:
+        """Generate an OpenWebUI duplicate-copy title without FTS title search."""
+        for counter in range(1, 1001):
+            candidate = f"{base_title} ({counter})"
+            if not self._openwebui_conversation_title_exists(candidate):
+                return candidate
+        raise ValueError("Could not generate unique OpenWebUI conversation title after 1000 attempts")
 
     def preview_chatbook(self, file_path: str) -> tuple[ChatbookManifest | None, str | None]:
         """

--- a/tldw_Server_API/app/core/Chatbooks/chatbook_service.py
+++ b/tldw_Server_API/app/core/Chatbooks/chatbook_service.py
@@ -2356,8 +2356,8 @@ class ChatbookService:
         except ValueError as exc:
             return None, str(exc)
         except _CHATBOOK_NONCRITICAL_EXCEPTIONS as exc:
-            logger.error(f"Error previewing OpenWebUI JSON import: {exc}")
-            raise
+            logger.warning(f"OpenWebUI preview rejected file path: {exc}")
+            return None, "Invalid or potentially malicious import file"
 
     @staticmethod
     def _openwebui_timestamp_to_iso(value: Any) -> tuple[str, str | None]:
@@ -2448,6 +2448,28 @@ class ChatbookService:
         }
         return bool(self.db.upsert_conversation_settings(conversation_id, merged))
 
+    def _rollback_openwebui_conversation(
+        self,
+        conversation_id: str,
+        external_ref: str,
+        warnings: list[str],
+    ) -> None:
+        """Remove a partially-created OpenWebUI conversation after a chat-level failure."""
+        try:
+            if not hasattr(self.db, "hard_delete_conversation"):
+                warnings.append(
+                    f"OpenWebUI chat {external_ref} failed after conversation creation; rollback is unavailable."
+                )
+                return
+            if not self.db.hard_delete_conversation(conversation_id):
+                warnings.append(
+                    f"OpenWebUI chat {external_ref} failed after conversation creation; partial conversation cleanup did not remove a row."
+                )
+        except _CHATBOOK_NONCRITICAL_EXCEPTIONS as exc:
+            warnings.append(
+                f"OpenWebUI chat {external_ref} failed after conversation creation; rollback failed: {exc}"
+            )
+
     def import_openwebui_json(
         self,
         file_path: str,
@@ -2491,6 +2513,10 @@ class ChatbookService:
 
         for chat in parsed.chats:
             import_external_ref = chat.external_ref
+            conversation_id: str | None = None
+            chat_imported_messages = 0
+            chat_skipped_messages = 0
+            chat_warnings: list[str] = []
             try:
                 existing = self.db.get_conversation_by_source_ref(
                     "openwebui",
@@ -2509,7 +2535,7 @@ class ChatbookService:
                     conversation_title = self._generate_openwebui_copy_title(conversation_title)
 
                 ordered_messages, order_warnings = self._ordered_openwebui_messages(chat)
-                result["warnings"].extend(order_warnings)
+                chat_warnings.extend(order_warnings)
                 importable_messages = [
                     message
                     for message in ordered_messages
@@ -2517,12 +2543,14 @@ class ChatbookService:
                 ]
                 skipped_for_role = len(ordered_messages) - len(importable_messages)
                 if skipped_for_role:
-                    result["skipped_messages"] += skipped_for_role
-                    result["warnings"].append(
+                    chat_skipped_messages += skipped_for_role
+                    chat_warnings.append(
                         f"OpenWebUI chat {chat.external_ref} skipped {skipped_for_role} unsupported or empty messages."
                     )
                 if not importable_messages:
                     result["failed_chats"] += 1
+                    result["skipped_messages"] += chat_skipped_messages
+                    result["warnings"].extend(chat_warnings)
                     result["warnings"].append(f"OpenWebUI chat {chat.external_ref} has no importable messages.")
                     continue
 
@@ -2537,27 +2565,31 @@ class ChatbookService:
                 )
                 if not conversation_id:
                     result["failed_chats"] += 1
+                    result["skipped_messages"] += chat_skipped_messages
+                    result["warnings"].extend(chat_warnings)
                     result["warnings"].append(f"OpenWebUI chat {chat.external_ref} could not create a conversation.")
                     continue
 
                 if not self._store_openwebui_conversation_settings(conversation_id, chat, import_external_ref):
-                    result["warnings"].append(
-                        f"OpenWebUI chat {chat.external_ref} imported but conversation metadata was not stored."
+                    raise DatabaseError(
+                        f"OpenWebUI chat {chat.external_ref} conversation metadata was not stored."
                     )
 
                 message_id_map: dict[str, str] = {}
                 namespace = f"tldw-openwebui:{import_external_ref}"
                 for message in importable_messages:
-                    parent_message_id = (
-                        message_id_map.get(message.parent_source_id)
-                        if message.parent_source_id
-                        else None
-                    )
+                    parent_message_id = None
+                    if message.parent_source_id:
+                        parent_message_id = message_id_map.get(message.parent_source_id)
+                        if parent_message_id is None:
+                            chat_warnings.append(
+                                f"OpenWebUI message {message.source_id} imported as root because its parent was not imported."
+                            )
                     timestamp, timestamp_warning = self._openwebui_timestamp_to_iso(message.timestamp)
                     if timestamp_warning:
-                        result["warnings"].append(f"{timestamp_warning} source_message_id={message.source_id}")
+                        chat_warnings.append(f"{timestamp_warning} source_message_id={message.source_id}")
                     message_id = str(uuid5(NAMESPACE_URL, f"{namespace}:{message.source_id}"))
-                    self.db.add_message(
+                    inserted_message_id = self.db.add_message(
                         {
                             "id": message_id,
                             "conversation_id": conversation_id,
@@ -2568,20 +2600,42 @@ class ChatbookService:
                             "client_id": getattr(self.db, "client_id", None),
                         }
                     )
-                    message_id_map[message.source_id] = message_id
-                    result["imported_messages"] += 1
+                    if not inserted_message_id:
+                        raise DatabaseError(
+                            f"OpenWebUI message {message.source_id} could not be stored."
+                        )
+                    stored_message_id = str(inserted_message_id)
+                    message_id_map[message.source_id] = stored_message_id
+                    chat_imported_messages += 1
                     if not self.db.set_message_metadata_extra(
-                        message_id,
+                        stored_message_id,
                         self._openwebui_message_metadata(message),
                         merge=True,
                     ):
-                        result["warnings"].append(
-                            f"OpenWebUI message {message.source_id} imported but metadata was not stored."
+                        raise DatabaseError(
+                            f"OpenWebUI message {message.source_id} metadata was not stored."
                         )
 
+                if chat_imported_messages == 0:
+                    self._rollback_openwebui_conversation(conversation_id, chat.external_ref, chat_warnings)
+                    result["failed_chats"] += 1
+                    result["skipped_messages"] += chat_skipped_messages
+                    result["warnings"].extend(chat_warnings)
+                    result["warnings"].append(
+                        f"OpenWebUI chat {chat.external_ref} imported no messages and was rolled back."
+                    )
+                    continue
+
+                result["imported_messages"] += chat_imported_messages
+                result["skipped_messages"] += chat_skipped_messages
+                result["warnings"].extend(chat_warnings)
                 result["imported_chats"] += 1
             except _CHATBOOK_NONCRITICAL_EXCEPTIONS as exc:
+                if conversation_id:
+                    self._rollback_openwebui_conversation(conversation_id, chat.external_ref, chat_warnings)
                 result["failed_chats"] += 1
+                result["skipped_messages"] += chat_skipped_messages
+                result["warnings"].extend(chat_warnings)
                 result["warnings"].append(f"OpenWebUI chat {chat.external_ref} failed to import: {exc}")
 
         if parsed.malformed_chat_count:
@@ -2591,20 +2645,16 @@ class ChatbookService:
 
     def _openwebui_conversation_title_exists(self, title: str) -> bool:
         """Return whether an exact conversation title already exists for the current client."""
-        if not hasattr(self.db, "execute_query"):
-            return bool(self._get_conversation_by_name(title))
-
-        query = "SELECT id FROM conversations WHERE title = ? AND deleted = 0"
-        params: list[Any] = [title]
-        client_id = getattr(self.db, "client_id", None)
-        if client_id is not None:
-            query += " AND client_id = ?"
-            params.append(client_id)
-        query += " LIMIT 1"
         try:
-            cursor = self.db.execute_query(query, tuple(params))
-            rows = self._fetch_results(cursor) if cursor is not None else []
-            return bool(rows)
+            if hasattr(self.db, "conversation_title_exists"):
+                return bool(
+                    self.db.conversation_title_exists(
+                        title,
+                        client_id=getattr(self.db, "client_id", None),
+                    )
+                )
+            conversation = self._get_conversation_by_name(title)
+            return bool(conversation and conversation.get("title") == title and not conversation.get("deleted"))
         except _CHATBOOK_NONCRITICAL_EXCEPTIONS as exc:
             logger.warning(f"OpenWebUI import could not check existing conversation title: {exc}")
             return False

--- a/tldw_Server_API/app/core/Chatbooks/chatbook_validators.py
+++ b/tldw_Server_API/app/core/Chatbooks/chatbook_validators.py
@@ -38,6 +38,7 @@ class ChatbookValidator:
     # Filename patterns
     SAFE_FILENAME_PATTERN = re.compile(r'^[a-zA-Z0-9._\-]+$')
     VALID_EXTENSIONS = {'.zip', '.chatbook'}
+    VALID_JSON_EXTENSIONS = {'.json'}
 
     # Security patterns
     PATH_TRAVERSAL_PATTERN = re.compile(r'(\.\./|\.\.\\|^/|^~)')
@@ -99,6 +100,27 @@ class ChatbookValidator:
         Returns:
             Tuple of (is_valid, error_message, sanitized_filename)
         """
+        return cls._validate_filename_for_extensions(filename, cls.VALID_EXTENSIONS)
+
+    @classmethod
+    def validate_json_filename(cls, filename: str) -> tuple[bool, Optional[str], str]:
+        """
+        Validate and sanitize an OpenWebUI JSON import filename.
+
+        Args:
+            filename: The filename to validate
+
+        Returns:
+            Tuple of (is_valid, error_message, sanitized_filename)
+        """
+        return cls._validate_filename_for_extensions(filename, cls.VALID_JSON_EXTENSIONS)
+
+    @classmethod
+    def _validate_filename_for_extensions(
+        cls,
+        filename: str,
+        valid_extensions: set[str],
+    ) -> tuple[bool, Optional[str], str]:
         if not filename:
             return False, "No filename provided", ""
 
@@ -115,10 +137,10 @@ class ChatbookValidator:
 
         # Check extension - must end with a valid extension (not just contain it)
         lower_name = base_filename.lower()
-        has_valid_extension = any(lower_name.endswith(valid_ext) for valid_ext in cls.VALID_EXTENSIONS)
+        has_valid_extension = any(lower_name.endswith(valid_ext) for valid_ext in valid_extensions)
 
         if not has_valid_extension:
-            return False, f"Invalid file type. Allowed: {', '.join(cls.VALID_EXTENSIONS)}", ""
+            return False, f"Invalid file type. Allowed: {', '.join(sorted(valid_extensions))}", ""
 
         # Sanitize filename - remove dangerous characters
         sanitized = re.sub(r'[^a-zA-Z0-9._\-]', '_', base_filename)
@@ -132,9 +154,9 @@ class ChatbookValidator:
                 sanitized = f"{name_part}.{parts[1]}"
 
         # Ensure it ends with a valid extension after sanitization
-        if not any(sanitized.lower().endswith(ext) for ext in cls.VALID_EXTENSIONS):
-            # Force it to end with .zip
-            sanitized = sanitized.rsplit('.', 1)[0] + '.zip' if '.' in sanitized else sanitized + '.zip'
+        if not any(sanitized.lower().endswith(ext) for ext in valid_extensions):
+            default_ext = sorted(valid_extensions)[0]
+            sanitized = sanitized.rsplit('.', 1)[0] + default_ext if '.' in sanitized else sanitized + default_ext
 
         return True, None, sanitized
 

--- a/tldw_Server_API/app/core/Chatbooks/exceptions.py
+++ b/tldw_Server_API/app/core/Chatbooks/exceptions.py
@@ -434,9 +434,9 @@ def get_retry_delay(error: Exception, attempt: int = 1) -> int:
         return error.context['retry_after']
 
     # Exponential backoff with jitter
-    import random
+    import secrets
     base_delay = 2 ** attempt
-    jitter = random.uniform(0, 1)
+    jitter = secrets.randbelow(1000) / 1000
     return int(base_delay + jitter)
 
 

--- a/tldw_Server_API/app/core/Chatbooks/import_adapters/__init__.py
+++ b/tldw_Server_API/app/core/Chatbooks/import_adapters/__init__.py
@@ -1,0 +1,1 @@
+"""Import adapters for external Chatbooks-adjacent source formats."""

--- a/tldw_Server_API/app/core/Chatbooks/import_adapters/openwebui.py
+++ b/tldw_Server_API/app/core/Chatbooks/import_adapters/openwebui.py
@@ -1,0 +1,332 @@
+"""OpenWebUI chat export import adapter."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path
+from typing import Any, Callable
+
+
+_ATTACHMENT_KEYS = (
+    "files",
+    "attachments",
+    "images",
+    "artifacts",
+    "file_ids",
+    "fileIds",
+)
+
+
+@dataclass(frozen=True)
+class OpenWebUIMessagePlan:
+    """Normalized OpenWebUI message node ready for preview/import planning."""
+
+    source_id: str
+    role: str | None
+    content: str
+    timestamp: Any = None
+    parent_source_id: str | None = None
+    children_source_ids: list[str] = field(default_factory=list)
+    model: str | None = None
+    attachment_refs: list[Any] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class OpenWebUIConversationPlan:
+    """Normalized OpenWebUI conversation plan."""
+
+    external_ref: str
+    title: str
+    messages: list[OpenWebUIMessagePlan]
+    history_current_id: str | None = None
+    is_branched: bool = False
+    attachment_reference_count: int = 0
+    source_metadata: dict[str, Any] = field(default_factory=dict)
+    warnings: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class OpenWebUIParsedExport:
+    """Parsed OpenWebUI export with valid chats and aggregate warnings."""
+
+    chats: list[OpenWebUIConversationPlan]
+    malformed_chat_count: int = 0
+    warnings: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class OpenWebUIPreviewChatItem:
+    """Lightweight per-chat preview row."""
+
+    external_ref: str
+    title: str
+    message_count: int
+    branched: bool
+    duplicate: bool
+    warning_count: int
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable preview item."""
+        return {
+            "external_ref": self.external_ref,
+            "title": self.title,
+            "message_count": self.message_count,
+            "branched": self.branched,
+            "duplicate": self.duplicate,
+            "warning_count": self.warning_count,
+        }
+
+
+@dataclass(frozen=True)
+class OpenWebUIImportPreview:
+    """Aggregate OpenWebUI import preview."""
+
+    chat_count: int
+    message_count: int
+    branched_chat_count: int
+    duplicate_chat_count: int
+    attachment_reference_count: int
+    malformed_chat_count: int
+    warnings: list[str]
+    items: list[OpenWebUIPreviewChatItem]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable preview payload."""
+        return {
+            "chat_count": self.chat_count,
+            "message_count": self.message_count,
+            "branched_chat_count": self.branched_chat_count,
+            "duplicate_chat_count": self.duplicate_chat_count,
+            "attachment_reference_count": self.attachment_reference_count,
+            "malformed_chat_count": self.malformed_chat_count,
+            "warnings": list(self.warnings),
+            "items": [item.to_dict() for item in self.items],
+        }
+
+
+def _canonical_sha(value: Any) -> str:
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _coerce_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, ensure_ascii=False)
+    return str(value)
+
+
+def _coerce_optional_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _normalize_string_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(item) for item in value if item is not None and str(item).strip()]
+    if isinstance(value, tuple):
+        return [str(item) for item in value if item is not None and str(item).strip()]
+    text = str(value).strip()
+    return [text] if text else []
+
+
+def _collect_attachment_refs(message: dict[str, Any]) -> list[Any]:
+    refs: list[Any] = []
+    for key in _ATTACHMENT_KEYS:
+        value = message.get(key)
+        if not value:
+            continue
+        if isinstance(value, list):
+            refs.extend(value)
+        elif isinstance(value, dict):
+            refs.append(value)
+        else:
+            refs.append(value)
+    return refs
+
+
+def _build_title(chat_payload: dict[str, Any], messages: list[OpenWebUIMessagePlan]) -> str:
+    title = _coerce_optional_text(chat_payload.get("title") or chat_payload.get("name"))
+    if title:
+        return title
+    for message in messages:
+        if message.role == "user" and message.content.strip():
+            excerpt = " ".join(message.content.split())
+            return excerpt[:80] or f"OpenWebUI Import {date.today().isoformat()}"
+    return f"OpenWebUI Import {date.today().isoformat()}"
+
+
+def _extract_chat_payload(item: Any) -> tuple[dict[str, Any], dict[str, Any]] | None:
+    if not isinstance(item, dict):
+        return None
+    chat = item.get("chat")
+    if isinstance(chat, dict):
+        return chat, item
+    return item, {}
+
+
+def _derive_external_ref(
+    index: int,
+    item: Any,
+    wrapper: dict[str, Any],
+    chat_payload: dict[str, Any],
+) -> str:
+    for candidate in (
+        wrapper.get("id"),
+        wrapper.get("chat_id"),
+        chat_payload.get("id"),
+        chat_payload.get("chat_id"),
+    ):
+        text = _coerce_optional_text(candidate)
+        if text:
+            return text
+    return f"openwebui:{index}:{_canonical_sha(item)[:16]}"
+
+
+def _parse_message(source_key: str, value: Any) -> OpenWebUIMessagePlan | None:
+    if not isinstance(value, dict):
+        return None
+    source_id = _coerce_optional_text(value.get("id")) or str(source_key)
+    metadata = {
+        "model": value.get("model"),
+        "done": value.get("done"),
+        "context": value.get("context"),
+        "info": value.get("info"),
+    }
+    metadata = {key: item for key, item in metadata.items() if item is not None}
+    return OpenWebUIMessagePlan(
+        source_id=source_id,
+        role=_coerce_optional_text(value.get("role")),
+        content=_coerce_text(value.get("content")),
+        timestamp=value.get("timestamp"),
+        parent_source_id=_coerce_optional_text(value.get("parentId") or value.get("parent_id")),
+        children_source_ids=_normalize_string_list(value.get("childrenIds") or value.get("children_ids")),
+        model=_coerce_optional_text(value.get("model")),
+        attachment_refs=_collect_attachment_refs(value),
+        metadata=metadata,
+    )
+
+
+def _is_branched(messages: list[OpenWebUIMessagePlan]) -> bool:
+    if any(len(message.children_source_ids) > 1 for message in messages):
+        return True
+    source_ids = {message.source_id for message in messages}
+    root_count = sum(1 for message in messages if not message.parent_source_id or message.parent_source_id not in source_ids)
+    return root_count > 1
+
+
+def load_openwebui_export(file_path: str | Path) -> OpenWebUIParsedExport:
+    """Load and normalize an OpenWebUI chat export JSON file."""
+    path = Path(file_path)
+    try:
+        raw_data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError("Malformed OpenWebUI JSON export") from exc
+
+    if not isinstance(raw_data, list):
+        raise ValueError("OpenWebUI export top-level JSON value must be an array")
+
+    chats: list[OpenWebUIConversationPlan] = []
+    warnings: list[str] = []
+    malformed_chat_count = 0
+
+    for index, item in enumerate(raw_data):
+        extracted = _extract_chat_payload(item)
+        if extracted is None:
+            malformed_chat_count += 1
+            warnings.append(f"Chat at index {index} is not an object and was skipped.")
+            continue
+        chat_payload, wrapper = extracted
+        history = chat_payload.get("history")
+        messages_map = history.get("messages") if isinstance(history, dict) else None
+        if not isinstance(messages_map, dict):
+            malformed_chat_count += 1
+            warnings.append(f"Chat at index {index} does not contain history.messages and was skipped.")
+            continue
+
+        chat_warnings: list[str] = []
+        messages: list[OpenWebUIMessagePlan] = []
+        for source_key, value in messages_map.items():
+            message = _parse_message(str(source_key), value)
+            if message is None:
+                chat_warnings.append(f"Message {source_key} is malformed and was skipped.")
+                continue
+            messages.append(message)
+
+        current_id = _coerce_optional_text(history.get("currentId") or history.get("current_id"))
+        attachment_count = sum(len(message.attachment_refs) for message in messages)
+        chats.append(
+            OpenWebUIConversationPlan(
+                external_ref=_derive_external_ref(index, item, wrapper, chat_payload),
+                title=_build_title(chat_payload, messages),
+                messages=messages,
+                history_current_id=current_id,
+                is_branched=_is_branched(messages),
+                attachment_reference_count=attachment_count,
+                source_metadata={
+                    "models": chat_payload.get("models"),
+                    "options": chat_payload.get("options"),
+                    "meta": chat_payload.get("meta"),
+                    "pinned": chat_payload.get("pinned"),
+                    "folder_id": chat_payload.get("folder_id") or wrapper.get("folder_id"),
+                    "created_at": chat_payload.get("created_at") or wrapper.get("created_at"),
+                    "updated_at": chat_payload.get("updated_at") or wrapper.get("updated_at"),
+                },
+                warnings=chat_warnings,
+            )
+        )
+        warnings.extend(chat_warnings)
+
+    return OpenWebUIParsedExport(
+        chats=chats,
+        malformed_chat_count=malformed_chat_count,
+        warnings=warnings,
+    )
+
+
+def preview_openwebui_export(
+    file_path: str | Path,
+    duplicate_lookup: Callable[[str], bool] | None = None,
+) -> OpenWebUIImportPreview:
+    """Build a preview for an OpenWebUI chat export JSON file."""
+    parsed = load_openwebui_export(file_path)
+    duplicate_lookup = duplicate_lookup or (lambda _external_ref: False)
+
+    items: list[OpenWebUIPreviewChatItem] = []
+    duplicate_chat_count = 0
+    for chat in parsed.chats:
+        duplicate = bool(duplicate_lookup(chat.external_ref))
+        if duplicate:
+            duplicate_chat_count += 1
+        items.append(
+            OpenWebUIPreviewChatItem(
+                external_ref=chat.external_ref,
+                title=chat.title,
+                message_count=len(chat.messages),
+                branched=chat.is_branched,
+                duplicate=duplicate,
+                warning_count=len(chat.warnings),
+            )
+        )
+
+    return OpenWebUIImportPreview(
+        chat_count=len(parsed.chats),
+        message_count=sum(len(chat.messages) for chat in parsed.chats),
+        branched_chat_count=sum(1 for chat in parsed.chats if chat.is_branched),
+        duplicate_chat_count=duplicate_chat_count,
+        attachment_reference_count=sum(chat.attachment_reference_count for chat in parsed.chats),
+        malformed_chat_count=parsed.malformed_chat_count,
+        warnings=list(parsed.warnings),
+        items=items,
+    )

--- a/tldw_Server_API/app/core/Chatbooks/import_adapters/openwebui.py
+++ b/tldw_Server_API/app/core/Chatbooks/import_adapters/openwebui.py
@@ -230,9 +230,12 @@ def load_openwebui_export(file_path: str | Path) -> OpenWebUIParsedExport:
     """Load and normalize an OpenWebUI chat export JSON file."""
     path = Path(file_path)
     try:
-        raw_data = json.loads(path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError as exc:
+        with path.open("r", encoding="utf-8") as handle:
+            raw_data = json.load(handle)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
         raise ValueError("Malformed OpenWebUI JSON export") from exc
+    except OSError as exc:
+        raise ValueError("Unable to read OpenWebUI JSON export") from exc
 
     if not isinstance(raw_data, list):
         raise ValueError("OpenWebUI export top-level JSON value must be an array")

--- a/tldw_Server_API/app/core/Chatbooks/services/jobs_worker.py
+++ b/tldw_Server_API/app/core/Chatbooks/services/jobs_worker.py
@@ -121,7 +121,8 @@ def _map_content_selections(raw: Any) -> dict[ContentType, list]:
     for key, value in raw.items():
         try:
             selections[ContentType(key)] = list(value or [])
-        except Exception:
+        except (TypeError, ValueError) as exc:
+            logger.debug(f"Ignoring invalid Chatbooks content selection key {key!r}: {exc}")
             continue
     return selections
 
@@ -192,9 +193,49 @@ async def _handle_import(service: ChatbookService, payload: dict[str, Any], job_
 
     selections = _map_content_selections(payload.get("content_selections") or {})
     conflict_resolution = _parse_conflict_resolution(payload.get("conflict_resolution", "skip"))
+    source_format = str(payload.get("source_format") or "chatbook").strip().lower()
     file_ref = payload.get("file_token") or payload.get("file_path")
     if not file_ref or not str(file_ref).strip():
         raise ChatbooksJobError("Missing file reference for import job", retryable=False)
+    if source_format == "openwebui_json":
+        try:
+            resolved_path = service._resolve_import_upload_path(file_ref)
+        except Exception as exc:
+            raise ChatbooksJobError("Invalid or potentially malicious import file", retryable=False) from exc
+        resolved_file_path = str(resolved_path or "").strip()
+        if not resolved_file_path:
+            raise ChatbooksJobError("Invalid or potentially malicious import file", retryable=False)
+        try:
+            ok, msg, result = await asyncio.to_thread(
+                service.import_openwebui_json,
+                resolved_file_path,
+                conflict_resolution,
+                bool(payload.get("prefix_imported", False)),
+            )
+        finally:
+            try:
+                if resolved_path.exists() and resolved_path.is_file():
+                    resolved_path.unlink()
+            except Exception as cleanup_err:
+                logger.debug(f"Chatbooks Jobs worker: failed to remove OpenWebUI import file {resolved_path}: {cleanup_err}")
+
+        ij = service._get_import_job(job_id)
+        if ok:
+            if ij and ij.status != ImportStatus.CANCELLED:
+                ij.status = ImportStatus.COMPLETED
+                ij.completed_at = datetime.now(timezone.utc)
+                service._save_import_job(ij)
+            return {"openwebui_result": result or {}}
+
+        if ij:
+            ij.status = ImportStatus.FAILED
+            ij.completed_at = datetime.now(timezone.utc)
+            ij.error_message = msg
+            service._save_import_job(ij)
+        raise ChatbooksJobError(str(msg), retryable=False)
+
+    if source_format != "chatbook":
+        raise ChatbooksJobError(f"Unsupported import source format: {source_format}", retryable=False)
     try:
         resolved_path = service._resolve_import_archive_path(file_ref)
     except Exception as exc:

--- a/tldw_Server_API/app/core/Chatbooks/services/jobs_worker.py
+++ b/tldw_Server_API/app/core/Chatbooks/services/jobs_worker.py
@@ -136,6 +136,21 @@ def _parse_conflict_resolution(raw: Any) -> ConflictResolution:
         return ConflictResolution.SKIP
 
 
+def _mark_import_job_failed(service: ChatbookService, job_id: str, message: str) -> None:
+    """Persist a claimed import job failure before raising a worker error."""
+    ij = service._get_import_job(job_id)
+    if ij and ij.status != ImportStatus.CANCELLED:
+        ij.status = ImportStatus.FAILED
+        ij.completed_at = datetime.now(timezone.utc)
+        ij.error_message = message
+        service._save_import_job(ij)
+
+
+def _raise_import_job_failed(service: ChatbookService, job_id: str, message: str) -> None:
+    _mark_import_job_failed(service, job_id, message)
+    raise ChatbooksJobError(message, retryable=False)
+
+
 async def _handle_export(service: ChatbookService, payload: dict[str, Any], job_id: str) -> dict[str, Any]:
     if not service._claim_export_job(job_id):
         existing = service._get_export_job(job_id)
@@ -196,15 +211,16 @@ async def _handle_import(service: ChatbookService, payload: dict[str, Any], job_
     source_format = str(payload.get("source_format") or "chatbook").strip().lower()
     file_ref = payload.get("file_token") or payload.get("file_path")
     if not file_ref or not str(file_ref).strip():
-        raise ChatbooksJobError("Missing file reference for import job", retryable=False)
+        _raise_import_job_failed(service, job_id, "Missing file reference for import job")
     if source_format == "openwebui_json":
         try:
             resolved_path = service._resolve_import_upload_path(file_ref)
         except Exception as exc:
+            _mark_import_job_failed(service, job_id, "Invalid or potentially malicious import file")
             raise ChatbooksJobError("Invalid or potentially malicious import file", retryable=False) from exc
         resolved_file_path = str(resolved_path or "").strip()
         if not resolved_file_path:
-            raise ChatbooksJobError("Invalid or potentially malicious import file", retryable=False)
+            _raise_import_job_failed(service, job_id, "Invalid or potentially malicious import file")
         try:
             ok, msg, result = await asyncio.to_thread(
                 service.import_openwebui_json,
@@ -235,14 +251,15 @@ async def _handle_import(service: ChatbookService, payload: dict[str, Any], job_
         raise ChatbooksJobError(str(msg), retryable=False)
 
     if source_format != "chatbook":
-        raise ChatbooksJobError(f"Unsupported import source format: {source_format}", retryable=False)
+        _raise_import_job_failed(service, job_id, f"Unsupported import source format: {source_format}")
     try:
         resolved_path = service._resolve_import_archive_path(file_ref)
     except Exception as exc:
+        _mark_import_job_failed(service, job_id, "Invalid or potentially malicious archive file")
         raise ChatbooksJobError("Invalid or potentially malicious archive file", retryable=False) from exc
     resolved_file_path = str(resolved_path or "").strip()
     if not resolved_file_path:
-        raise ChatbooksJobError("Invalid or potentially malicious archive file", retryable=False)
+        _raise_import_job_failed(service, job_id, "Invalid or potentially malicious archive file")
     try:
         ok, msg, result = await asyncio.to_thread(
             service._import_chatbook_sync,

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -23672,6 +23672,7 @@ for _conversation_store_method in (
     "_normalize_conversation_assistant_identity",
     "add_conversation",
     "get_conversation_by_id",
+    "get_conversation_by_source_ref",
     "get_conversations_for_character",
     "count_conversations_for_user",
     "count_conversations_for_user_by_character",

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -23673,6 +23673,7 @@ for _conversation_store_method in (
     "add_conversation",
     "get_conversation_by_id",
     "get_conversation_by_source_ref",
+    "conversation_title_exists",
     "get_conversations_for_character",
     "count_conversations_for_user",
     "count_conversations_for_user_by_character",

--- a/tldw_Server_API/app/core/DB_Management/chacha/conversation_store.py
+++ b/tldw_Server_API/app/core/DB_Management/chacha/conversation_store.py
@@ -386,6 +386,53 @@ class ConversationStore:
             logger.error(f"Database error fetching conversation ID {conversation_id}: {exc}")
             raise
 
+    def get_conversation_by_source_ref(
+        self,
+        source: str,
+        external_ref: str,
+        client_id: str | None = None,
+        include_deleted: bool = False,
+    ) -> dict[str, Any] | None:
+        """Fetch one conversation by imported source identity scoped to a client."""
+        normalized_source = self._db._normalize_nullable_text(source)
+        normalized_ref = self._db._normalize_nullable_text(external_ref)
+        if not normalized_source or not normalized_ref:
+            return None
+
+        client_filter = self._db.client_id if client_id is None else client_id
+        if self._db.backend_type == BackendType.POSTGRESQL:
+            clauses = ["source = %s", "external_ref = %s"]
+            params: list[Any] = [normalized_source, normalized_ref]
+            if client_filter is not None:
+                clauses.append("client_id = %s")
+                params.append(client_filter)
+            if not include_deleted:
+                clauses.append("deleted = FALSE")
+            query = f"SELECT * FROM conversations WHERE {' AND '.join(clauses)} ORDER BY last_modified DESC LIMIT 1"  # nosec B608
+            try:
+                result = self._db.backend.execute(query, tuple(params))
+                row = result.fetchone()
+                return dict(row) if row else None
+            except CharactersRAGDBError as exc:
+                logger.error(f"Database error fetching conversation source ref {normalized_source}:{normalized_ref}: {exc}")
+                raise
+
+        clauses = ["source = ?", "external_ref = ?"]
+        params = [normalized_source, normalized_ref]
+        if client_filter is not None:
+            clauses.append("client_id = ?")
+            params.append(client_filter)
+        if not include_deleted:
+            clauses.append("deleted = 0")
+        query = f"SELECT * FROM conversations WHERE {' AND '.join(clauses)} ORDER BY last_modified DESC LIMIT 1"  # nosec B608
+        try:
+            cursor = self._db.execute_query(query, tuple(params))
+            row = cursor.fetchone()
+            return dict(row) if row else None
+        except CharactersRAGDBError as exc:
+            logger.error(f"Database error fetching conversation source ref {normalized_source}:{normalized_ref}: {exc}")
+            raise
+
     def get_conversations_for_character(
         self,
         character_id: int,

--- a/tldw_Server_API/app/core/DB_Management/chacha/conversation_store.py
+++ b/tldw_Server_API/app/core/DB_Management/chacha/conversation_store.py
@@ -25,6 +25,31 @@ class ConversationStore:
     def __init__(self, db: CharactersRAGDB) -> None:
         self._db = db
 
+    @staticmethod
+    def _result_row_to_dict(row: Any, result: Any | None = None) -> dict[str, Any] | None:
+        """Convert mapping and tuple-style backend result rows into dictionaries."""
+        if row is None:
+            return None
+        if isinstance(row, dict):
+            return dict(row)
+        row_mapping = getattr(row, "_mapping", None)
+        if row_mapping is not None:
+            return dict(row_mapping)
+        try:
+            return dict(row)
+        except (TypeError, ValueError):
+            pass
+
+        keys_attr = getattr(result, "keys", None)
+        keys = list(keys_attr() if callable(keys_attr) else (keys_attr or []))
+        if not keys:
+            description = getattr(result, "description", None)
+            if description:
+                keys = [column[0] for column in description]
+        if not keys:
+            raise CharactersRAGDBError("Database result row did not expose column names.")
+        return dict(zip(keys, row, strict=False))
+
     def _ensure_conversation_settings_table(self) -> None:
         """Ensure the conversation_settings table exists for the active backend."""
         if self._db.backend_type == BackendType.SQLITE:
@@ -401,36 +426,130 @@ class ConversationStore:
 
         client_filter = self._db.client_id if client_id is None else client_id
         if self._db.backend_type == BackendType.POSTGRESQL:
-            clauses = ["source = %s", "external_ref = %s"]
-            params: list[Any] = [normalized_source, normalized_ref]
-            if client_filter is not None:
-                clauses.append("client_id = %s")
-                params.append(client_filter)
-            if not include_deleted:
-                clauses.append("deleted = FALSE")
-            query = f"SELECT * FROM conversations WHERE {' AND '.join(clauses)} ORDER BY last_modified DESC LIMIT 1"  # nosec B608
+            if client_filter is not None and not include_deleted:
+                query = (
+                    "SELECT * FROM conversations "
+                    "WHERE source = %s AND external_ref = %s AND client_id = %s AND deleted = FALSE "
+                    "ORDER BY last_modified DESC LIMIT 1"
+                )
+                params: list[Any] = [normalized_source, normalized_ref, client_filter]
+            elif client_filter is not None:
+                query = (
+                    "SELECT * FROM conversations "
+                    "WHERE source = %s AND external_ref = %s AND client_id = %s "
+                    "ORDER BY last_modified DESC LIMIT 1"
+                )
+                params = [normalized_source, normalized_ref, client_filter]
+            elif not include_deleted:
+                query = (
+                    "SELECT * FROM conversations "
+                    "WHERE source = %s AND external_ref = %s AND deleted = FALSE "
+                    "ORDER BY last_modified DESC LIMIT 1"
+                )
+                params = [normalized_source, normalized_ref]
+            else:
+                query = (
+                    "SELECT * FROM conversations "
+                    "WHERE source = %s AND external_ref = %s "
+                    "ORDER BY last_modified DESC LIMIT 1"
+                )
+                params = [normalized_source, normalized_ref]
             try:
                 result = self._db.backend.execute(query, tuple(params))
-                row = result.fetchone()
-                return dict(row) if row else None
+                return self._result_row_to_dict(result.first, result)
             except CharactersRAGDBError as exc:
                 logger.error(f"Database error fetching conversation source ref {normalized_source}:{normalized_ref}: {exc}")
                 raise
 
-        clauses = ["source = ?", "external_ref = ?"]
-        params = [normalized_source, normalized_ref]
-        if client_filter is not None:
-            clauses.append("client_id = ?")
-            params.append(client_filter)
-        if not include_deleted:
-            clauses.append("deleted = 0")
-        query = f"SELECT * FROM conversations WHERE {' AND '.join(clauses)} ORDER BY last_modified DESC LIMIT 1"  # nosec B608
+        if client_filter is not None and not include_deleted:
+            query = (
+                "SELECT * FROM conversations "
+                "WHERE source = ? AND external_ref = ? AND client_id = ? AND deleted = 0 "
+                "ORDER BY last_modified DESC LIMIT 1"
+            )
+            params = [normalized_source, normalized_ref, client_filter]
+        elif client_filter is not None:
+            query = (
+                "SELECT * FROM conversations "
+                "WHERE source = ? AND external_ref = ? AND client_id = ? "
+                "ORDER BY last_modified DESC LIMIT 1"
+            )
+            params = [normalized_source, normalized_ref, client_filter]
+        elif not include_deleted:
+            query = (
+                "SELECT * FROM conversations "
+                "WHERE source = ? AND external_ref = ? AND deleted = 0 "
+                "ORDER BY last_modified DESC LIMIT 1"
+            )
+            params = [normalized_source, normalized_ref]
+        else:
+            query = (
+                "SELECT * FROM conversations "
+                "WHERE source = ? AND external_ref = ? "
+                "ORDER BY last_modified DESC LIMIT 1"
+            )
+            params = [normalized_source, normalized_ref]
         try:
             cursor = self._db.execute_query(query, tuple(params))
             row = cursor.fetchone()
             return dict(row) if row else None
         except CharactersRAGDBError as exc:
             logger.error(f"Database error fetching conversation source ref {normalized_source}:{normalized_ref}: {exc}")
+            raise
+
+    def conversation_title_exists(
+        self,
+        title: str,
+        client_id: str | None = None,
+        include_deleted: bool = False,
+    ) -> bool:
+        """Return whether an exact conversation title exists for the selected client."""
+        normalized_title = self._db._normalize_nullable_text(title)
+        if not normalized_title:
+            return False
+
+        client_filter = self._db.client_id if client_id is None else client_id
+        if self._db.backend_type == BackendType.POSTGRESQL:
+            if client_filter is not None and not include_deleted:
+                query = (
+                    "SELECT id FROM conversations "
+                    "WHERE title = %s AND client_id = %s AND deleted = FALSE "
+                    "LIMIT 1"
+                )
+                params: list[Any] = [normalized_title, client_filter]
+            elif client_filter is not None:
+                query = "SELECT id FROM conversations WHERE title = %s AND client_id = %s LIMIT 1"
+                params = [normalized_title, client_filter]
+            elif not include_deleted:
+                query = "SELECT id FROM conversations WHERE title = %s AND deleted = FALSE LIMIT 1"
+                params = [normalized_title]
+            else:
+                query = "SELECT id FROM conversations WHERE title = %s LIMIT 1"
+                params = [normalized_title]
+            try:
+                result = self._db.backend.execute(query, tuple(params))
+                return bool(result.first)
+            except CharactersRAGDBError as exc:
+                logger.error(f"Database error checking conversation title {normalized_title}: {exc}")
+                raise
+
+        if client_filter is not None and not include_deleted:
+            query = "SELECT id FROM conversations WHERE title = ? AND client_id = ? AND deleted = 0 LIMIT 1"
+            params = [normalized_title, client_filter]
+        elif client_filter is not None:
+            query = "SELECT id FROM conversations WHERE title = ? AND client_id = ? LIMIT 1"
+            params = [normalized_title, client_filter]
+        elif not include_deleted:
+            query = "SELECT id FROM conversations WHERE title = ? AND deleted = 0 LIMIT 1"
+            params = [normalized_title]
+        else:
+            query = "SELECT id FROM conversations WHERE title = ? LIMIT 1"
+            params = [normalized_title]
+        try:
+            cursor = self._db.execute_query(query, tuple(params))
+            return cursor.fetchone() is not None
+        except CharactersRAGDBError as exc:
+            logger.error(f"Database error checking conversation title {normalized_title}: {exc}")
             raise
 
     def get_conversations_for_character(

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_chacha_conversation_store.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_chacha_conversation_store.py
@@ -23,6 +23,7 @@ _DELEGATED_CONVERSATION_METHODS = {
     "_normalize_conversation_assistant_identity",
     "add_conversation",
     "get_conversation_by_id",
+    "get_conversation_by_source_ref",
     "get_conversations_for_character",
     "count_conversations_for_user",
     "count_conversations_for_user_by_character",
@@ -126,6 +127,67 @@ def test_conversation_store_roundtrip_preserves_scope_and_settings(db):
         scope_type="workspace",
         workspace_id="ws-store",
     ) == 1
+
+
+def test_conversation_store_get_conversation_by_source_ref_scopes_client_and_deleted(db):
+    conversation_id = db.add_conversation(
+        {
+            "character_id": 1,
+            "title": "OpenWebUI import",
+            "source": "openwebui",
+            "external_ref": "chat-1",
+            "client_id": db.client_id,
+        }
+    )
+    other_id = db.add_conversation(
+        {
+            "character_id": 1,
+            "title": "Other client import",
+            "source": "openwebui",
+            "external_ref": "chat-1",
+            "client_id": "other-client",
+        }
+    )
+
+    found = db.get_conversation_by_source_ref(
+        "openwebui",
+        "chat-1",
+        client_id=db.client_id,
+    )
+
+    assert found is not None
+    assert found["id"] == conversation_id
+    assert db.get_conversation_by_source_ref(
+        "openwebui",
+        "chat-1",
+        client_id="missing-client",
+    ) is None
+
+    created = db.get_conversation_by_id(conversation_id)
+    assert created is not None
+    assert db.soft_delete_conversation(conversation_id, expected_version=created["version"]) is True
+
+    assert db.get_conversation_by_source_ref(
+        "openwebui",
+        "chat-1",
+        client_id=db.client_id,
+    ) is None
+    deleted = db.get_conversation_by_source_ref(
+        "openwebui",
+        "chat-1",
+        client_id=db.client_id,
+        include_deleted=True,
+    )
+    assert deleted is not None
+    assert deleted["id"] == conversation_id
+
+    other = db.get_conversation_by_source_ref(
+        "openwebui",
+        "chat-1",
+        client_id="other-client",
+    )
+    assert other is not None
+    assert other["id"] == other_id
 
 
 def test_conversation_store_preserves_assistant_identity_updates(db):

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_chacha_conversation_store.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_chacha_conversation_store.py
@@ -5,7 +5,8 @@ from pathlib import Path
 
 import pytest
 
-from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import BackendType, CharactersRAGDB
+from tldw_Server_API.app.core.DB_Management.chacha.conversation_store import ConversationStore
 
 
 pytestmark = pytest.mark.unit
@@ -24,6 +25,7 @@ _DELEGATED_CONVERSATION_METHODS = {
     "add_conversation",
     "get_conversation_by_id",
     "get_conversation_by_source_ref",
+    "conversation_title_exists",
     "get_conversations_for_character",
     "count_conversations_for_user",
     "count_conversations_for_user_by_character",
@@ -188,6 +190,98 @@ def test_conversation_store_get_conversation_by_source_ref_scopes_client_and_del
     )
     assert other is not None
     assert other["id"] == other_id
+
+
+def test_conversation_store_maps_tuple_style_result_rows():
+    class TupleResult:
+        def keys(self):
+            return ["id", "source", "external_ref", "deleted"]
+
+    row = ("conversation-1", "openwebui", "chat-1", False)
+
+    assert ConversationStore._result_row_to_dict(row, TupleResult()) == {
+        "id": "conversation-1",
+        "source": "openwebui",
+        "external_ref": "chat-1",
+        "deleted": False,
+    }
+
+
+def test_conversation_store_source_ref_maps_tuple_style_postgres_result():
+    class FakeResult:
+        first = ("conversation-1", "openwebui", "chat-1", False)
+
+        def keys(self):
+            return ["id", "source", "external_ref", "deleted"]
+
+    class FakeBackend:
+        query = None
+        params = None
+
+        def execute(self, query, params):
+            self.query = query
+            self.params = params
+            return FakeResult()
+
+    class FakeDB:
+        backend_type = BackendType.POSTGRESQL
+        client_id = "postgres-client"
+
+        def __init__(self):
+            self.backend = FakeBackend()
+
+        @staticmethod
+        def _normalize_nullable_text(value):
+            return str(value).strip() or None
+
+    fake_db = FakeDB()
+    store = ConversationStore(fake_db)
+
+    assert store.get_conversation_by_source_ref("openwebui", "chat-1") == {
+        "id": "conversation-1",
+        "source": "openwebui",
+        "external_ref": "chat-1",
+        "deleted": False,
+    }
+    assert "source = %s" in fake_db.backend.query
+    assert "external_ref = %s" in fake_db.backend.query
+    assert "client_id = %s" in fake_db.backend.query
+    assert fake_db.backend.params == ("openwebui", "chat-1", "postgres-client")
+
+
+def test_conversation_store_title_exists_uses_postgres_placeholders():
+    class FakeResult:
+        first = {"id": "conversation-1"}
+
+    class FakeBackend:
+        query = None
+        params = None
+
+        def execute(self, query, params):
+            self.query = query
+            self.params = params
+            return FakeResult()
+
+    class FakeDB:
+        backend_type = BackendType.POSTGRESQL
+        client_id = "postgres-client"
+
+        def __init__(self):
+            self.backend = FakeBackend()
+
+        @staticmethod
+        def _normalize_nullable_text(value):
+            return str(value).strip() or None
+
+    fake_db = FakeDB()
+    store = ConversationStore(fake_db)
+
+    assert store.conversation_title_exists("Existing title") is True
+    assert "title = %s" in fake_db.backend.query
+    assert "client_id = %s" in fake_db.backend.query
+    assert "deleted = FALSE" in fake_db.backend.query
+    assert "?" not in fake_db.backend.query
+    assert fake_db.backend.params == ("Existing title", "postgres-client")
 
 
 def test_conversation_store_preserves_assistant_identity_updates(db):

--- a/tldw_Server_API/tests/Chatbooks/test_chatbooks_api_error_and_preview_mapping.py
+++ b/tldw_Server_API/tests/Chatbooks/test_chatbooks_api_error_and_preview_mapping.py
@@ -124,7 +124,7 @@ class _OpenWebUIPreviewService:
     db = None
 
     def preview_openwebui_json(self, file_path: str):
-        assert file_path.endswith(".json")
+        self.preview_path = file_path
         return {
             "chat_count": 1,
             "message_count": 2,
@@ -154,7 +154,6 @@ class _OpenWebUIImportService:
 
     async def import_chatbook(self, **kwargs):
         self.called_kwargs = kwargs
-        assert kwargs["file_path"].endswith(".json")
         assert kwargs["source_format"] == "openwebui_json"
         return True, "ok", {
             "imported_chats": 1,
@@ -334,6 +333,39 @@ def test_import_openwebui_json_source_format_skips_archive_validation(monkeypatc
     assert body["source_format"] == "openwebui_json"
     assert body["openwebui_result"]["imported_chats"] == 1
     assert service.called_kwargs["source_format"] == "openwebui_json"
+
+
+@pytest.mark.parametrize(
+    ("content_selections", "expected_detail"),
+    [
+        (
+            json.dumps({"not_a_content_type": ["item-1"]}),
+            "Unsupported content type in content_selections: not_a_content_type",
+        ),
+        (
+            json.dumps({"conversation": ["conv-1", 42]}),
+            "content_selections values must be lists of strings",
+        ),
+    ],
+)
+def test_import_rejects_invalid_multipart_content_selections(content_selections, expected_detail):
+    service = _OpenWebUIImportService()
+    app = _make_app(service)
+    files = {"file": ("openwebui.json", b"[]", "application/json")}
+    data = {
+        "source_format": "openwebui_json",
+        "content_selections": content_selections,
+        "import_media": "false",
+        "import_embeddings": "false",
+        "async_mode": "false",
+    }
+
+    with TestClient(app) as client:
+        response = client.post("/api/v1/chatbooks/import", files=files, data=data)
+
+    assert response.status_code == 400
+    assert response.json().get("detail") == expected_detail
+    assert service.called_kwargs is None
 
 
 def test_job_list_routes_include_canonical_pagination():

--- a/tldw_Server_API/tests/Chatbooks/test_chatbooks_api_error_and_preview_mapping.py
+++ b/tldw_Server_API/tests/Chatbooks/test_chatbooks_api_error_and_preview_mapping.py
@@ -120,6 +120,53 @@ class _PreviewExplodingService:
         raise RuntimeError("preview exploded")
 
 
+class _OpenWebUIPreviewService:
+    db = None
+
+    def preview_openwebui_json(self, file_path: str):
+        assert file_path.endswith(".json")
+        return {
+            "chat_count": 1,
+            "message_count": 2,
+            "branched_chat_count": 1,
+            "duplicate_chat_count": 0,
+            "attachment_reference_count": 0,
+            "malformed_chat_count": 0,
+            "warnings": [],
+            "items": [
+                {
+                    "external_ref": "chat-1",
+                    "title": "OpenWebUI chat",
+                    "message_count": 2,
+                    "branched": True,
+                    "duplicate": False,
+                    "warning_count": 0,
+                }
+            ],
+        }, None
+
+
+class _OpenWebUIImportService:
+    db = None
+
+    def __init__(self) -> None:
+        self.called_kwargs = None
+
+    async def import_chatbook(self, **kwargs):
+        self.called_kwargs = kwargs
+        assert kwargs["file_path"].endswith(".json")
+        assert kwargs["source_format"] == "openwebui_json"
+        return True, "ok", {
+            "imported_chats": 1,
+            "skipped_chats": 0,
+            "failed_chats": 0,
+            "imported_messages": 2,
+            "skipped_messages": 0,
+            "duplicate_chats": 0,
+            "warnings": [],
+        }
+
+
 class _ListJobsService:
     db = None
 
@@ -238,6 +285,55 @@ def test_preview_maps_unexpected_service_failures_to_500():
 
     assert response.status_code == 500
     assert response.json().get("detail") == "An error occurred while previewing the chatbook"
+
+
+def test_preview_openwebui_json_source_format_skips_archive_validation(monkeypatch):
+    app = _make_app(_OpenWebUIPreviewService())
+
+    def _fail_zip_validation(_path: str):
+        raise AssertionError("OpenWebUI JSON preview must not validate as a ZIP archive")
+
+    monkeypatch.setattr(chatbooks_endpoints.ChatbookValidator, "validate_zip_file", _fail_zip_validation)
+
+    files = {"file": ("openwebui.json", b"[]", "application/json")}
+    data = {"source_format": "openwebui_json"}
+
+    with TestClient(app) as client:
+        response = client.post("/api/v1/chatbooks/preview", files=files, data=data)
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["source_format"] == "openwebui_json"
+    assert body["manifest"] is None
+    assert body["openwebui_preview"]["chat_count"] == 1
+    assert body["openwebui_preview"]["items"][0]["branched"] is True
+
+
+def test_import_openwebui_json_source_format_skips_archive_validation(monkeypatch):
+    service = _OpenWebUIImportService()
+    app = _make_app(service)
+
+    def _fail_zip_validation(_path: str):
+        raise AssertionError("OpenWebUI JSON import must not validate as a ZIP archive")
+
+    monkeypatch.setattr(chatbooks_endpoints.ChatbookValidator, "validate_zip_file", _fail_zip_validation)
+
+    files = {"file": ("openwebui.json", b"[]", "application/json")}
+    data = {
+        "source_format": "openwebui_json",
+        "import_media": "false",
+        "import_embeddings": "false",
+        "async_mode": "false",
+    }
+
+    with TestClient(app) as client:
+        response = client.post("/api/v1/chatbooks/import", files=files, data=data)
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["source_format"] == "openwebui_json"
+    assert body["openwebui_result"]["imported_chats"] == 1
+    assert service.called_kwargs["source_format"] == "openwebui_json"
 
 
 def test_job_list_routes_include_canonical_pagination():

--- a/tldw_Server_API/tests/Chatbooks/test_chatbooks_jobs_worker_import_defaults.py
+++ b/tldw_Server_API/tests/Chatbooks/test_chatbooks_jobs_worker_import_defaults.py
@@ -68,3 +68,83 @@ async def test_handle_import_defaults_import_media_to_false(tmp_path):
     assert service.import_job.status == ImportStatus.COMPLETED
     assert isinstance(service.import_job.completed_at, datetime)
     assert not archive_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_handle_import_dispatches_openwebui_json_without_archive_import(tmp_path):
+    json_path = tmp_path / "openwebui.json"
+    json_path.write_text("[]", encoding="utf-8")
+
+    class FakeService:
+        def __init__(self):
+            self.import_job = SimpleNamespace(
+                job_id="job-openwebui",
+                status=ImportStatus.PENDING,
+                completed_at=None,
+                error_message=None,
+            )
+            self.openwebui_called = False
+            self.archive_called = False
+
+        def _claim_import_job(self, _job_id: str) -> bool:
+            return True
+
+        def _get_import_job(self, _job_id: str):
+            return self.import_job
+
+        def _save_import_job(self, ij):
+            self.import_job = ij
+
+        def _resolve_import_upload_path(self, _file_ref: str) -> Path:
+            return json_path
+
+        def _resolve_import_archive_path(self, _file_ref: str) -> Path:
+            raise AssertionError("OpenWebUI JSON imports must not use archive path resolution")
+
+        def _import_chatbook_sync(self, *args, **kwargs):
+            self.archive_called = True
+            raise AssertionError("OpenWebUI JSON imports must not call the archive importer")
+
+        def import_openwebui_json(
+            self,
+            file_path,
+            conflict_resolution,
+            prefix_imported,
+        ):
+            self.openwebui_called = True
+            assert file_path == str(json_path)
+            assert conflict_resolution.value == "skip"
+            assert prefix_imported is False
+            return True, "ok", {
+                "imported_chats": 1,
+                "skipped_chats": 0,
+                "failed_chats": 0,
+                "imported_messages": 2,
+                "skipped_messages": 0,
+                "duplicate_chats": 0,
+                "warnings": [],
+            }
+
+    service = FakeService()
+
+    result = await jobs_worker._handle_import(
+        service,
+        payload={"file_token": str(json_path), "source_format": "openwebui_json"},
+        job_id="job-openwebui",
+    )
+
+    assert result == {
+        "openwebui_result": {
+            "imported_chats": 1,
+            "skipped_chats": 0,
+            "failed_chats": 0,
+            "imported_messages": 2,
+            "skipped_messages": 0,
+            "duplicate_chats": 0,
+            "warnings": [],
+        }
+    }
+    assert service.openwebui_called is True
+    assert service.archive_called is False
+    assert service.import_job.status == ImportStatus.COMPLETED
+    assert not json_path.exists()

--- a/tldw_Server_API/tests/Chatbooks/test_chatbooks_jobs_worker_import_defaults.py
+++ b/tldw_Server_API/tests/Chatbooks/test_chatbooks_jobs_worker_import_defaults.py
@@ -148,3 +148,34 @@ async def test_handle_import_dispatches_openwebui_json_without_archive_import(tm
     assert service.archive_called is False
     assert service.import_job.status == ImportStatus.COMPLETED
     assert not json_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_handle_import_marks_claimed_validation_failure_as_failed():
+    class FakeService:
+        def __init__(self):
+            self.import_job = SimpleNamespace(
+                job_id="job-missing-file",
+                status=ImportStatus.PENDING,
+                completed_at=None,
+                error_message=None,
+            )
+
+        def _claim_import_job(self, _job_id: str) -> bool:
+            self.import_job.status = ImportStatus.IN_PROGRESS
+            return True
+
+        def _get_import_job(self, _job_id: str):
+            return self.import_job
+
+        def _save_import_job(self, ij):
+            self.import_job = ij
+
+    service = FakeService()
+
+    with pytest.raises(jobs_worker.ChatbooksJobError, match="Missing file reference"):
+        await jobs_worker._handle_import(service, payload={}, job_id="job-missing-file")
+
+    assert service.import_job.status == ImportStatus.FAILED
+    assert service.import_job.error_message == "Missing file reference for import job"
+    assert isinstance(service.import_job.completed_at, datetime)

--- a/tldw_Server_API/tests/Chatbooks/test_openwebui_import_adapter.py
+++ b/tldw_Server_API/tests/Chatbooks/test_openwebui_import_adapter.py
@@ -1,0 +1,130 @@
+import json
+
+import pytest
+
+from tldw_Server_API.app.core.Chatbooks.import_adapters.openwebui import (
+    load_openwebui_export,
+    preview_openwebui_export,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+def _standard_export():
+    return [
+        {
+            "id": "chat-standard",
+            "chat": {
+                "title": "Research thread",
+                "models": ["gpt-4o"],
+                "history": {
+                    "currentId": "assistant-1",
+                    "messages": {
+                        "root-user": {
+                            "id": "root-user",
+                            "role": "user",
+                            "content": "Explain retrieval augmented generation.",
+                            "timestamp": 1700000000,
+                            "childrenIds": ["assistant-1", "assistant-branch"],
+                        },
+                        "assistant-1": {
+                            "id": "assistant-1",
+                            "role": "assistant",
+                            "content": "Main answer",
+                            "parentId": "root-user",
+                            "timestamp": 1700000001,
+                            "model": "gpt-4o",
+                        },
+                        "assistant-branch": {
+                            "id": "assistant-branch",
+                            "role": "assistant",
+                            "content": "Alternative answer",
+                            "parentId": "root-user",
+                            "timestamp": 1700000002,
+                            "files": [{"id": "file-1", "name": "source.pdf"}],
+                        },
+                    },
+                },
+            },
+        }
+    ]
+
+
+def test_load_openwebui_export_accepts_standard_wrapper_and_preserves_branches(tmp_path):
+    export_path = tmp_path / "openwebui.json"
+    export_path.write_text(json.dumps(_standard_export()), encoding="utf-8")
+
+    parsed = load_openwebui_export(export_path)
+
+    assert parsed.malformed_chat_count == 0
+    assert len(parsed.chats) == 1
+    chat = parsed.chats[0]
+    assert chat.external_ref == "chat-standard"
+    assert chat.title == "Research thread"
+    assert chat.history_current_id == "assistant-1"
+    assert chat.is_branched is True
+    assert [message.source_id for message in chat.messages] == [
+        "root-user",
+        "assistant-1",
+        "assistant-branch",
+    ]
+    assert chat.messages[2].attachment_refs == [{"id": "file-1", "name": "source.pdf"}]
+
+
+def test_preview_counts_branches_attachments_and_duplicates(tmp_path):
+    export_path = tmp_path / "openwebui.json"
+    export_path.write_text(json.dumps(_standard_export()), encoding="utf-8")
+
+    preview = preview_openwebui_export(
+        export_path,
+        duplicate_lookup=lambda external_ref: external_ref == "chat-standard",
+    )
+
+    assert preview.chat_count == 1
+    assert preview.message_count == 3
+    assert preview.branched_chat_count == 1
+    assert preview.duplicate_chat_count == 1
+    assert preview.attachment_reference_count == 1
+    assert preview.malformed_chat_count == 0
+    assert preview.items[0].duplicate is True
+    assert preview.items[0].warning_count == 0
+
+
+def test_load_openwebui_export_accepts_legacy_chat_objects(tmp_path):
+    export_path = tmp_path / "legacy.json"
+    export_path.write_text(
+        json.dumps(
+            [
+                {
+                    "title": "Legacy chat",
+                    "history": {
+                        "messages": {
+                            "m1": {
+                                "role": "user",
+                                "content": "Legacy message",
+                                "timestamp": 1700000100,
+                            }
+                        }
+                    },
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    parsed = load_openwebui_export(export_path)
+
+    assert parsed.malformed_chat_count == 0
+    assert len(parsed.chats) == 1
+    assert parsed.chats[0].title == "Legacy chat"
+    assert parsed.chats[0].external_ref.startswith("openwebui:0:")
+    assert parsed.chats[0].messages[0].source_id == "m1"
+
+
+def test_load_openwebui_export_rejects_non_array_root(tmp_path):
+    export_path = tmp_path / "bad.json"
+    export_path.write_text(json.dumps({"chat": {}}), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="top-level JSON value must be an array"):
+        load_openwebui_export(export_path)

--- a/tldw_Server_API/tests/Chatbooks/test_openwebui_import_adapter.py
+++ b/tldw_Server_API/tests/Chatbooks/test_openwebui_import_adapter.py
@@ -128,3 +128,11 @@ def test_load_openwebui_export_rejects_non_array_root(tmp_path):
 
     with pytest.raises(ValueError, match="top-level JSON value must be an array"):
         load_openwebui_export(export_path)
+
+
+def test_load_openwebui_export_rejects_non_utf8_json(tmp_path):
+    export_path = tmp_path / "bad-encoding.json"
+    export_path.write_bytes(b"\xff\xfe")
+
+    with pytest.raises(ValueError, match="Malformed OpenWebUI JSON export"):
+        load_openwebui_export(export_path)

--- a/tldw_Server_API/tests/Chatbooks/test_openwebui_import_service.py
+++ b/tldw_Server_API/tests/Chatbooks/test_openwebui_import_service.py
@@ -1,0 +1,149 @@
+import json
+
+import pytest
+
+from tldw_Server_API.app.core.Chatbooks.chatbook_service import ChatbookService
+from tldw_Server_API.app.core.Chatbooks.chatbook_models import ConflictResolution
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture()
+def openwebui_service(tmp_path):
+    db = CharactersRAGDB(
+        db_path=str(tmp_path / "openwebui-import.sqlite"),
+        client_id="openwebui-import-user",
+    )
+    db.add_character_card({"name": "OpenWebUI Import Assistant"})
+    return ChatbookService(user_id="1", db=db)
+
+
+def _write_export(service: ChatbookService, payload: list[dict]) -> str:
+    path = service.temp_dir / "openwebui.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return str(path)
+
+
+def _branched_export() -> list[dict]:
+    return [
+        {
+            "id": "chat-branched",
+            "chat": {
+                "title": "Branch preserving import",
+                "models": ["gpt-4o"],
+                "history": {
+                    "currentId": "assistant-main",
+                    "messages": {
+                        "user-root": {
+                            "id": "user-root",
+                            "role": "user",
+                            "content": "Compare two retrieval strategies.",
+                            "timestamp": 1700000000,
+                            "childrenIds": ["assistant-main", "assistant-alt"],
+                        },
+                        "assistant-main": {
+                            "id": "assistant-main",
+                            "role": "assistant",
+                            "content": "Use hybrid retrieval.",
+                            "parentId": "user-root",
+                            "timestamp": 1700000001,
+                            "model": "gpt-4o",
+                        },
+                        "assistant-alt": {
+                            "id": "assistant-alt",
+                            "role": "assistant",
+                            "content": "Use keyword search first.",
+                            "parentId": "user-root",
+                            "timestamp": 1700000002,
+                            "files": [{"id": "file-1", "name": "notes.pdf"}],
+                        },
+                    },
+                },
+            },
+        }
+    ]
+
+
+def test_import_openwebui_json_preserves_branch_parent_links_and_metadata(openwebui_service):
+    path = _write_export(openwebui_service, _branched_export())
+
+    success, message, result = openwebui_service.import_openwebui_json(path, ConflictResolution.SKIP)
+
+    assert success is True, message
+    assert result is not None
+    assert result["imported_chats"] == 1
+    assert result["imported_messages"] == 3
+
+    db = openwebui_service.db
+    conversation = db.get_conversation_by_source_ref(
+        "openwebui",
+        "chat-branched",
+        client_id=db.client_id,
+    )
+    assert conversation is not None
+    assert conversation["title"] == "Branch preserving import"
+
+    messages = db.get_messages_for_conversation(conversation["id"])
+    by_content = {message["content"]: message for message in messages}
+    root = by_content["Compare two retrieval strategies."]
+    main = by_content["Use hybrid retrieval."]
+    alt = by_content["Use keyword search first."]
+    assert root["parent_message_id"] is None
+    assert main["parent_message_id"] == root["id"]
+    assert alt["parent_message_id"] == root["id"]
+
+    settings = db.get_conversation_settings(conversation["id"])
+    assert settings is not None
+    assert settings["settings"]["openwebui_import"]["history_current_id"] == "assistant-main"
+
+    alt_metadata = db.get_message_metadata(alt["id"])
+    assert alt_metadata is not None
+    assert alt_metadata["extra"]["openwebui_import"]["source_message_id"] == "assistant-alt"
+    assert alt_metadata["extra"]["openwebui_import"]["attachment_refs"] == [
+        {"id": "file-1", "name": "notes.pdf"}
+    ]
+
+
+def test_import_openwebui_json_duplicate_skip_uses_source_external_ref(openwebui_service):
+    first_path = _write_export(openwebui_service, _branched_export())
+    success, _, first_result = openwebui_service.import_openwebui_json(first_path, ConflictResolution.SKIP)
+    assert success is True
+    assert first_result["imported_chats"] == 1
+
+    second_path = _write_export(openwebui_service, _branched_export())
+    success, message, second_result = openwebui_service.import_openwebui_json(second_path, ConflictResolution.SKIP)
+
+    assert success is True, message
+    assert second_result["duplicate_chats"] == 1
+    assert second_result["skipped_chats"] == 1
+    assert second_result["imported_chats"] == 0
+
+
+def test_import_openwebui_json_duplicate_rename_creates_intentional_copy(openwebui_service):
+    first_path = _write_export(openwebui_service, _branched_export())
+    success, _, first_result = openwebui_service.import_openwebui_json(first_path, ConflictResolution.SKIP)
+    assert success is True
+    assert first_result["imported_chats"] == 1
+
+    second_path = _write_export(openwebui_service, _branched_export())
+    success, message, second_result = openwebui_service.import_openwebui_json(
+        second_path,
+        ConflictResolution.RENAME,
+    )
+
+    assert success is True, message
+    assert second_result["duplicate_chats"] == 1
+    assert second_result["skipped_chats"] == 0
+    assert second_result["imported_chats"] == 1
+    conversations = openwebui_service.db.get_conversations_for_user(openwebui_service.db.client_id)
+    openwebui_conversations = [
+        conversation
+        for conversation in conversations
+        if conversation["source"] == "openwebui"
+    ]
+    assert len(openwebui_conversations) == 2
+    external_refs = {conversation["external_ref"] for conversation in openwebui_conversations}
+    assert "chat-branched" in external_refs
+    assert any(ref.startswith("chat-branched#copy:") for ref in external_refs)

--- a/tldw_Server_API/tests/Chatbooks/test_openwebui_import_service.py
+++ b/tldw_Server_API/tests/Chatbooks/test_openwebui_import_service.py
@@ -2,6 +2,7 @@ import json
 
 import pytest
 
+from tldw_Server_API.app.core.Chatbooks.exceptions import DatabaseError
 from tldw_Server_API.app.core.Chatbooks.chatbook_service import ChatbookService
 from tldw_Server_API.app.core.Chatbooks.chatbook_models import ConflictResolution
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
@@ -17,7 +18,12 @@ def openwebui_service(tmp_path):
         client_id="openwebui-import-user",
     )
     db.add_character_card({"name": "OpenWebUI Import Assistant"})
-    return ChatbookService(user_id="1", db=db)
+    service = ChatbookService(user_id="1", db=db)
+    service.temp_dir = tmp_path / "chatbooks-temp"
+    service.import_dir = tmp_path / "chatbooks-imports"
+    service.temp_dir.mkdir(parents=True, exist_ok=True)
+    service.import_dir.mkdir(parents=True, exist_ok=True)
+    return service
 
 
 def _write_export(service: ChatbookService, payload: list[dict]) -> str:
@@ -119,6 +125,121 @@ def test_import_openwebui_json_duplicate_skip_uses_source_external_ref(openwebui
     assert second_result["duplicate_chats"] == 1
     assert second_result["skipped_chats"] == 1
     assert second_result["imported_chats"] == 0
+
+
+def test_preview_openwebui_json_returns_error_for_unsafe_upload_path(openwebui_service, tmp_path):
+    outside_path = tmp_path / "outside-openwebui.json"
+    outside_path.write_text("[]", encoding="utf-8")
+
+    preview, error = openwebui_service.preview_openwebui_json(str(outside_path))
+
+    assert preview is None
+    assert error == "Invalid or potentially malicious import file"
+
+
+def test_import_openwebui_json_rolls_back_when_message_insert_fails(openwebui_service, monkeypatch):
+    payload = _branched_export()
+    path = _write_export(openwebui_service, payload)
+
+    original_add_message = openwebui_service.db.add_message
+
+    def flaky_add_message(message_data):
+        if message_data["content"] == "Use keyword search first.":
+            return None
+        return original_add_message(message_data)
+
+    monkeypatch.setattr(openwebui_service.db, "add_message", flaky_add_message)
+
+    success, message, result = openwebui_service.import_openwebui_json(path, ConflictResolution.SKIP)
+
+    assert success is True, message
+    assert result["imported_chats"] == 0
+    assert result["imported_messages"] == 0
+    assert result["failed_chats"] == 1
+
+    assert openwebui_service.db.get_conversation_by_source_ref(
+        "openwebui",
+        "chat-branched",
+        client_id=openwebui_service.db.client_id,
+        include_deleted=True,
+    ) is None
+
+
+def test_preview_openwebui_json_returns_error_for_non_utf8_json(openwebui_service):
+    path = openwebui_service.temp_dir / "bad-encoding.json"
+    path.write_bytes(b"\xff\xfe")
+
+    preview, error = openwebui_service.preview_openwebui_json(str(path))
+
+    assert preview is None
+    assert error == "Malformed OpenWebUI JSON export"
+
+
+def test_import_openwebui_json_rolls_back_when_metadata_insert_fails(openwebui_service, monkeypatch):
+    path = _write_export(openwebui_service, _branched_export())
+
+    monkeypatch.setattr(openwebui_service.db, "set_message_metadata_extra", lambda *_args, **_kwargs: False)
+
+    success, message, result = openwebui_service.import_openwebui_json(path, ConflictResolution.SKIP)
+
+    assert success is True, message
+    assert result["imported_chats"] == 0
+    assert result["failed_chats"] == 1
+    assert openwebui_service.db.get_conversation_by_source_ref(
+        "openwebui",
+        "chat-branched",
+        client_id=openwebui_service.db.client_id,
+        include_deleted=True,
+    ) is None
+
+
+def test_import_openwebui_json_rolls_back_conversation_when_chat_fails_after_create(
+    openwebui_service,
+    monkeypatch,
+):
+    path = _write_export(openwebui_service, _branched_export())
+
+    def fail_settings(*_args, **_kwargs):
+        raise DatabaseError("settings write failed")
+
+    monkeypatch.setattr(openwebui_service, "_store_openwebui_conversation_settings", fail_settings)
+
+    success, message, result = openwebui_service.import_openwebui_json(path, ConflictResolution.SKIP)
+
+    assert success is True, message
+    assert result["imported_chats"] == 0
+    assert result["failed_chats"] == 1
+    assert openwebui_service.db.get_conversation_by_source_ref(
+        "openwebui",
+        "chat-branched",
+        client_id=openwebui_service.db.client_id,
+        include_deleted=True,
+    ) is None
+
+
+def test_openwebui_copy_title_lookup_uses_db_title_abstraction():
+    class FakeDB:
+        client_id = "postgres-client"
+        call = None
+
+        def conversation_title_exists(self, title, *, client_id, include_deleted=False):
+            self.call = {
+                "title": title,
+                "client_id": client_id,
+                "include_deleted": include_deleted,
+            }
+            return True
+
+    fake_db = FakeDB()
+    service = object.__new__(ChatbookService)
+    service.db = fake_db
+
+    assert service._openwebui_conversation_title_exists("Existing title") is True
+    assert fake_db.call == {
+        "title": "Existing title",
+        "client_id": "postgres-client",
+        "include_deleted": False,
+    }
 
 
 def test_import_openwebui_json_duplicate_rename_creates_intentional_copy(openwebui_service):


### PR DESCRIPTION
## Summary

- Adds `source_format=openwebui_json` support to Chatbooks preview/import so normal OpenWebUI "Export Chats" JSON can be imported through the existing upload, quota, sync/async, and Jobs workflow.
- Implements an OpenWebUI parser/import service that preserves valid branched message trees, stores OpenWebUI metadata, and detects duplicates via `source=openwebui` plus deterministic external refs.
- Extends the WebUI import tab, API/client contracts, tests, and docs for Chatbook archive vs OpenWebUI JSON modes.

## Test Plan

- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Chatbooks/test_openwebui_import_adapter.py tldw_Server_API/tests/Chatbooks/test_openwebui_import_service.py tldw_Server_API/tests/Chatbooks/test_chatbooks_api_error_and_preview_mapping.py::test_preview_openwebui_json_source_format_skips_archive_validation tldw_Server_API/tests/Chatbooks/test_chatbooks_api_error_and_preview_mapping.py::test_import_openwebui_json_source_format_skips_archive_validation tldw_Server_API/tests/Chatbooks/test_chatbooks_jobs_worker_import_defaults.py -v`
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/ChaChaNotesDB -k "conversation or metadata" -v`
- [x] `bun run test src/services/__tests__/tldw-api-client.chatbooks-openwebui.test.ts src/components/Option/Chatbooks/__tests__/ChatbooksPlaygroundPage.openwebui-import.test.tsx src/components/Option/Chatbooks/__tests__/ContentTypePicker.error-state.test.tsx`
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/chatbooks.py tldw_Server_API/app/core/Chatbooks tldw_Server_API/app/core/DB_Management/chacha -f json -o /tmp/bandit_openwebui_chat_import.json`
- [x] `git diff --check`

## Known Notes

- Full `test_chatbooks_api_preview.py` was not rerun because this implementation session previously observed the baseline `test_preview_manifest_version_ok` path hanging; targeted OpenWebUI preview/import endpoint tests were run instead.
- Manual browser smoke was not run; the source selector and multipart upload contract are covered by focused Vitest tests.
- Merge gate: because this PR was materially AI-authored, a human-written `Change summary` explaining what changed and why should be added before merge.
