### PR TITLE
Migrate sidepanel context state labels to registry

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -2310,7 +2310,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/MCPHub/ExternalServersTab.tsx:Alert#antd-alert-externalserverstab-type-error-line-644-t7ij7i",
+    "id": "antd-product-state-import:src/components/Option/MCPHub/ExternalServersTab.tsx:Alert#antd-alert-externalserverstab-type-error-line-713-1hs0tt5",
     "path": "src/components/Option/MCPHub/ExternalServersTab.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -2321,7 +2321,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/MCPHub/ExternalServersTab.tsx:Alert#antd-alert-externalserverstab-type-info-no-external-serv-yz8d33",
+    "id": "antd-product-state-import:src/components/Option/MCPHub/ExternalServersTab.tsx:Alert#antd-alert-externalserverstab-type-info-no-external-serv-1cu94hi",
     "path": "src/components/Option/MCPHub/ExternalServersTab.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -2332,7 +2332,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/MCPHub/ExternalServersTab.tsx:Alert#antd-alert-externalserverstab-type-success-line-645-1190gva",
+    "id": "antd-product-state-import:src/components/Option/MCPHub/ExternalServersTab.tsx:Alert#antd-alert-externalserverstab-type-success-line-714-15smgsz",
     "path": "src/components/Option/MCPHub/ExternalServersTab.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -2343,13 +2343,35 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/MCPHub/ExternalServersTab.tsx:Alert#antd-alert-externalserverstab-type-success-template-vali-1svn067",
+    "id": "antd-product-state-import:src/components/Option/MCPHub/ExternalServersTab.tsx:Alert#antd-alert-externalserverstab-type-success-template-vali-stzgp4",
     "path": "src/components/Option/MCPHub/ExternalServersTab.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
     "state": "allowed_legacy_exception",
     "owner": "design-system",
     "reason": "Existing AntD Alert product-state UI in src/components/Option/MCPHub/ExternalServersTab.tsx before the stable duplicate-id guard.",
+    "replacement": "tldw design-system state primitive",
+    "migrationQueue": "shared-product-state"
+  },
+  {
+    "id": "antd-product-state-import:src/components/Option/MCPHub/ExternalServersTab.tsx:Alert#antd-alert-externalserverstab-type-success-no-credential-1ffju3v",
+    "path": "src/components/Option/MCPHub/ExternalServersTab.tsx",
+    "rule": "antd-product-state-import",
+    "subject": "Alert",
+    "state": "allowed_legacy_exception",
+    "owner": "design-system",
+    "reason": "Existing AntD Alert product-state UI in src/components/Option/MCPHub/ExternalServersTab.tsx on current dev; baseline refresh captures current shared-product-state debt.",
+    "replacement": "tldw design-system state primitive",
+    "migrationQueue": "shared-product-state"
+  },
+  {
+    "id": "antd-product-state-import:src/components/Option/MCPHub/ExternalServersTab.tsx:Alert#antd-alert-externalserverstab-type-success-auth-template-1ljuumz",
+    "path": "src/components/Option/MCPHub/ExternalServersTab.tsx",
+    "rule": "antd-product-state-import",
+    "subject": "Alert",
+    "state": "allowed_legacy_exception",
+    "owner": "design-system",
+    "reason": "Existing AntD Alert product-state UI in src/components/Option/MCPHub/ExternalServersTab.tsx on current dev; baseline refresh captures current shared-product-state debt.",
     "replacement": "tldw design-system state primitive",
     "migrationQueue": "shared-product-state"
   },
@@ -2552,7 +2574,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/MCPHub/ToolCatalogsTab.tsx:Alert#antd-alert-toolcatalogstab-type-error-line-81-mfnzqs",
+    "id": "antd-product-state-import:src/components/Option/MCPHub/ToolCatalogsTab.tsx:Alert#antd-alert-toolcatalogstab-type-error-line-132-wgi5lv",
     "path": "src/components/Option/MCPHub/ToolCatalogsTab.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -2563,7 +2585,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/MCPHub/ToolCatalogsTab.tsx:Alert#antd-alert-toolcatalogstab-type-info-line-144-1gkg8km",
+    "id": "antd-product-state-import:src/components/Option/MCPHub/ToolCatalogsTab.tsx:Alert#antd-alert-toolcatalogstab-type-info-line-211-1n06m9h",
     "path": "src/components/Option/MCPHub/ToolCatalogsTab.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -2574,7 +2596,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/MCPHub/ToolCatalogsTab.tsx:Alert#antd-alert-toolcatalogstab-type-warning-line-152-v45tfb",
+    "id": "antd-product-state-import:src/components/Option/MCPHub/ToolCatalogsTab.tsx:Alert#antd-alert-toolcatalogstab-type-warning-line-219-a0ksw3",
     "path": "src/components/Option/MCPHub/ToolCatalogsTab.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -2585,13 +2607,35 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/MCPHub/ToolCatalogsTab.tsx:Alert#antd-alert-toolcatalogstab-type-warning-line-102-1nejb2u",
+    "id": "antd-product-state-import:src/components/Option/MCPHub/ToolCatalogsTab.tsx:Alert#antd-alert-toolcatalogstab-type-warning-line-169-1qh02b5",
     "path": "src/components/Option/MCPHub/ToolCatalogsTab.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
     "state": "allowed_legacy_exception",
     "owner": "design-system",
     "reason": "Existing AntD Alert product-state UI in src/components/Option/MCPHub/ToolCatalogsTab.tsx before the stable duplicate-id guard.",
+    "replacement": "tldw design-system state primitive",
+    "migrationQueue": "shared-product-state"
+  },
+  {
+    "id": "antd-product-state-import:src/components/Option/MCPHub/ToolCatalogsTab.tsx:Alert#antd-alert-toolcatalogstab-type-warning-tools-are-regist-lmd30i",
+    "path": "src/components/Option/MCPHub/ToolCatalogsTab.tsx",
+    "rule": "antd-product-state-import",
+    "subject": "Alert",
+    "state": "allowed_legacy_exception",
+    "owner": "design-system",
+    "reason": "Existing AntD Alert product-state UI in src/components/Option/MCPHub/ToolCatalogsTab.tsx on current dev; baseline refresh captures current shared-product-state debt.",
+    "replacement": "tldw design-system state primitive",
+    "migrationQueue": "shared-product-state"
+  },
+  {
+    "id": "antd-product-state-import:src/components/Option/MCPHub/ToolCatalogsTab.tsx:Alert#antd-alert-toolcatalogstab-type-warning-could-not-load-s-1487orj",
+    "path": "src/components/Option/MCPHub/ToolCatalogsTab.tsx",
+    "rule": "antd-product-state-import",
+    "subject": "Alert",
+    "state": "allowed_legacy_exception",
+    "owner": "design-system",
+    "reason": "Existing AntD Alert product-state UI in src/components/Option/MCPHub/ToolCatalogsTab.tsx on current dev; baseline refresh captures current shared-product-state debt.",
     "replacement": "tldw design-system state primitive",
     "migrationQueue": "shared-product-state"
   },
@@ -5342,28 +5386,6 @@
     "state": "allowed_legacy_exception",
     "owner": "design-system",
     "reason": "Existing hardcoded \"Ready\" state label in src/components/Review/ReviewPage.tsx before the guard.",
-    "replacement": "getDesignSystemState(...)",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "canonical-state-label:src/components/Sidepanel/Chat/conversation-context-utils.ts:Blocked",
-    "path": "src/components/Sidepanel/Chat/conversation-context-utils.ts",
-    "rule": "canonical-state-label",
-    "subject": "Blocked",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing hardcoded \"Blocked\" state label in src/components/Sidepanel/Chat/conversation-context-utils.ts before the guard.",
-    "replacement": "getDesignSystemState(...)",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "canonical-state-label:src/components/Sidepanel/Chat/conversation-context-utils.ts:Ready",
-    "path": "src/components/Sidepanel/Chat/conversation-context-utils.ts",
-    "rule": "canonical-state-label",
-    "subject": "Ready",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing hardcoded \"Ready\" state label in src/components/Sidepanel/Chat/conversation-context-utils.ts before the guard.",
     "replacement": "getDesignSystemState(...)",
     "migrationQueue": "shared-product-state"
   },

--- a/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/conversation-context-utils.test.ts
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/conversation-context-utils.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { resolveContextReadiness } from "../conversation-context-utils"
+import type { ConversationContextComposition } from "@/types/conversation-context"
+
+const registryLabels = vi.hoisted(() => ({
+  ready: "Ready via registry",
+  blocked: "Blocked via registry"
+}))
+
+vi.mock("@/design-system", async (importActual) => {
+  const actual = await importActual<typeof import("@/design-system")>()
+
+  return {
+    ...actual,
+    getDesignSystemState: vi.fn(
+      (key: Parameters<typeof actual.getDesignSystemState>[0]) => {
+        const state = actual.getDesignSystemState(key)
+
+        return {
+          ...state,
+          label:
+            key === "ready"
+              ? registryLabels.ready
+              : key === "blocked"
+                ? registryLabels.blocked
+                : state.label
+        }
+      }
+    )
+  }
+})
+
+const buildComposition = (
+  readiness: ConversationContextComposition["readiness"]
+): ConversationContextComposition =>
+  ({
+    readiness
+  }) as ConversationContextComposition
+
+describe("resolveContextReadiness", () => {
+  beforeEach(() => {
+    registryLabels.ready = "Ready via registry"
+    registryLabels.blocked = "Blocked via registry"
+  })
+
+  it("uses design-system labels for canonical ready and blocked readiness", () => {
+    expect(
+      resolveContextReadiness({
+        composition: buildComposition("ready"),
+        status: "ready"
+      })
+    ).toMatchObject({
+      readiness: "ready",
+      label: "Ready via registry",
+      tone: "ready"
+    })
+
+    expect(
+      resolveContextReadiness({
+        composition: buildComposition("blocked"),
+        status: "ready"
+      })
+    ).toMatchObject({
+      readiness: "blocked",
+      label: "Blocked via registry",
+      tone: "blocked"
+    })
+  })
+
+  it("reads canonical readiness labels at resolution time", () => {
+    registryLabels.ready = "Ready after registry update"
+    registryLabels.blocked = "Blocked after registry update"
+
+    expect(
+      resolveContextReadiness({
+        composition: buildComposition("ready"),
+        status: "ready"
+      })
+    ).toMatchObject({
+      readiness: "ready",
+      label: "Ready after registry update",
+      tone: "ready"
+    })
+
+    expect(
+      resolveContextReadiness({
+        composition: buildComposition("blocked"),
+        status: "ready"
+      })
+    ).toMatchObject({
+      readiness: "blocked",
+      label: "Blocked after registry update",
+      tone: "blocked"
+    })
+  })
+})

--- a/apps/packages/ui/src/components/Sidepanel/Chat/conversation-context-utils.ts
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/conversation-context-utils.ts
@@ -1,3 +1,4 @@
+import { getDesignSystemState } from "@/design-system"
 import type {
   ConversationContextComposition,
   ConversationContextPiece,
@@ -141,10 +142,18 @@ export const resolveContextReadiness = ({
 
   const readiness = composition?.readiness ?? "ready"
   if (readiness === "blocked") {
-    return { readiness, label: "Blocked", tone: "blocked" }
+    return {
+      readiness,
+      label: getDesignSystemState("blocked").label,
+      tone: "blocked"
+    }
   }
   if (readiness === "partial") {
     return { readiness, label: "Partial", tone: "partial" }
   }
-  return { readiness, label: "Ready", tone: "ready" }
+  return {
+    readiness,
+    label: getDesignSystemState("ready").label,
+    tone: "ready"
+  }
 }

--- a/backlog/tasks/task-240 - Migrate-Sidepanel-conversation-context-state-labels.md
+++ b/backlog/tasks/task-240 - Migrate-Sidepanel-conversation-context-state-labels.md
@@ -1,0 +1,64 @@
+---
+id: TASK-240
+title: Migrate Sidepanel conversation context state labels
+status: Done
+assignee: []
+created_date: '2026-05-10 19:20'
+updated_date: '2026-05-10 19:33'
+labels:
+  - design-system
+  - frontend
+  - product-state
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1544'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue the frontend design-system product-state cleanup by replacing Sidepanel conversation-context readiness hardcoded Ready and Blocked labels with canonical design-system state registry labels while preserving existing readiness/tone behavior. Current dev also has bounded MCPHub product-state baseline drift, so this task refreshes those baseline records to keep the verifier green.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 resolveContextReadiness uses the design-system ready and blocked state registry labels for ready and blocked readiness states.
+- [x] #2 Focused utility coverage proves ready and blocked labels are supplied through the registry rather than hardcoded literals.
+- [x] #3 The matching conversation-context-utils Ready and Blocked baseline exceptions are removed and the design-system verifier passes.
+- [x] #4 Current dev MCPHub product-state baseline drift is reconciled without reintroducing the conversation-context Ready or Blocked exceptions.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+TDD red: conversation-context-utils test mocked ready and blocked registry labels as 'Ready via registry'/'Blocked via registry' and failed while resolveContextReadiness still returned literal Ready.
+
+Green verification after rebase onto origin/dev: conversation-context-utils focused Vitest passed (1 test); product-state guard unit test passed (52 tests); verify:design-system-state exited 0; git diff --check HEAD~1..HEAD exited 0. Broad bunx tsc still exits 2 with 239 baseline errors, and touched-scope filtering found no conversation-context/baseline/task/MCPHub matches.
+
+Bandit skipped: touched implementation is TypeScript/TSX/JSON/Backlog only, with no Python runtime code.
+
+Addressed PR review feedback for runtime registry label reads. Added regression coverage for mocked design-system label updates after import and moved ready/blocked label lookups into resolveContextReadiness so labels are resolved at call time. Focused Vitest now passes with 2 tests.
+
+Review-fix verification: focused conversation-context-utils Vitest passed with 2 tests, product-state guard passed with 52 tests, verify:design-system-state exited 0, git diff --check exited 0. Broad bunx tsc still exits 2 with 239 known baseline errors; touched-scope filter found no matches for conversation-context-utils, design-system baseline, task-240, MCPHub baseline files, or getDesignSystemState.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+resolveContextReadiness now uses getDesignSystemState('ready').label and getDesignSystemState('blocked').label for canonical ready and blocked readiness states, with a mocked-registry unit test proving the labels are not hardcoded. Removed the conversation-context-utils Ready/Blocked baseline exceptions and refreshed bounded current-dev MCPHub baseline drift so the design-system verifier exits 0.
+
+PR: https://github.com/rmusser01/tldw_server/pull/1544
+
+PR review follow-up: resolveContextReadiness now reads canonical ready/blocked labels at resolution time rather than caching them at module load, with regression coverage for runtime registry label updates.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Change summary
- Migrates Sidepanel conversation-context ready and blocked readiness labels to `getDesignSystemState(...)`.
- Adds a mocked-registry unit test so `resolveContextReadiness` must render registry-provided ready/blocked labels.
- Removes the conversation-context Ready/Blocked product-state baseline exceptions.
- Refreshes bounded current-dev MCPHub product-state baseline drift so the verifier is green.

## Verification
- `bunx vitest run src/components/Sidepanel/Chat/__tests__/conversation-context-utils.test.ts --reporter=dot`
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot`
- `bun run verify:design-system-state`
- `git diff --check HEAD~1..HEAD`
- `bunx tsc --noEmit --pretty false` still exits 2 on existing repo-wide TS debt; touched-scope filter found no conversation-context/baseline/task/MCPHub matches in `/tmp/tldw_ui_tsc_sidepanel_context_state_labels_rebased.txt`.
- Bandit skipped: UI-only TypeScript/TSX/JSON/Backlog changes.