### PR TITLE
Migrate demo media ready labels to registry

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -5401,39 +5401,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "canonical-state-label:src/utils/demo-content.ts:Ready#label-ready-demo-content-line-137-151ahk2",
-    "path": "src/utils/demo-content.ts",
-    "rule": "canonical-state-label",
-    "subject": "Ready",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing hardcoded \"Ready\" state label in src/utils/demo-content.ts before the stable duplicate-id guard.",
-    "replacement": "getDesignSystemState(...)",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "canonical-state-label:src/utils/demo-content.ts:Ready#label-ready-demo-content-line-157-5ixvdc",
-    "path": "src/utils/demo-content.ts",
-    "rule": "canonical-state-label",
-    "subject": "Ready",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing hardcoded \"Ready\" state label in src/utils/demo-content.ts before the stable duplicate-id guard.",
-    "replacement": "getDesignSystemState(...)",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "canonical-state-label:src/utils/demo-content.ts:Ready#label-ready-demo-content-line-20-yq5yw3",
-    "path": "src/utils/demo-content.ts",
-    "rule": "canonical-state-label",
-    "subject": "Ready",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing hardcoded \"Ready\" state label in src/utils/demo-content.ts before the stable duplicate-id guard.",
-    "replacement": "getDesignSystemState(...)",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/recipe-configs/EmbeddingsModelSelectionConfig.tsx:Alert",
     "path": "src/components/Option/Evaluations/tabs/recipe-configs/EmbeddingsModelSelectionConfig.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Review/ReviewPage.tsx
+++ b/apps/packages/ui/src/components/Review/ReviewPage.tsx
@@ -1729,8 +1729,8 @@ export const ReviewPage: React.FC<ReviewPageProps> = ({
                 </span>
                 <span className="text-[11px] text-text-muted">{c.meta}</span>
               </div>
-              <Tag color={c.status === "Processing" ? "orange" : "green"}>
-                {c.status}
+              <Tag color={c.statusKey === "processing" ? "orange" : "green"}>
+                {c.statusLabel}
               </Tag>
             </div>
             <div className="divide-y divide-border">

--- a/apps/packages/ui/src/components/Review/__tests__/ReviewPage.connection.test.tsx
+++ b/apps/packages/ui/src/components/Review/__tests__/ReviewPage.connection.test.tsx
@@ -190,7 +190,12 @@ vi.mock("@/components/Review/usePromptSearch", () => ({
 
 vi.mock("@/utils/demo-content", () => ({
   getDemoMediaItems: () => [
-    { title: "Demo review item", meta: "Demo metadata", status: "Ready" }
+    {
+      title: "Demo review item",
+      meta: "Demo metadata",
+      statusKey: "ready",
+      statusLabel: "Ready"
+    }
   ]
 }))
 

--- a/apps/packages/ui/src/utils/__tests__/demo-content.design-system.test.ts
+++ b/apps/packages/ui/src/utils/__tests__/demo-content.design-system.test.ts
@@ -1,0 +1,55 @@
+import type { TFunction } from "i18next"
+import { describe, expect, it, vi } from "vitest"
+import { getDemoMediaItems } from "../demo-content"
+
+const registryLabels = vi.hoisted(() => ({
+  ready: "Ready via registry"
+}))
+
+vi.mock("@/design-system", async (importActual) => {
+  const actual = await importActual<typeof import("@/design-system")>()
+
+  return {
+    ...actual,
+    getDesignSystemState: vi.fn(
+      (key: Parameters<typeof actual.getDesignSystemState>[0]) => {
+        const state = actual.getDesignSystemState(key)
+
+        return {
+          ...state,
+          label: key === "ready" ? registryLabels.ready : state.label
+        }
+      }
+    )
+  }
+})
+
+const t = ((_: string, options?: { defaultValue?: string }) =>
+  options?.defaultValue ?? "") as TFunction
+
+describe("getDemoMediaItems", () => {
+  it("uses the design-system ready label while preserving demo media order", () => {
+    const items = getDemoMediaItems(t)
+
+    expect(items.map((item) => item.id)).toEqual([
+      "demo-media-1",
+      "demo-media-2",
+      "demo-media-3"
+    ])
+    expect(items.map((item) => item.statusKey)).toEqual([
+      "ready",
+      "processing",
+      "ready"
+    ])
+    expect(items.map((item) => item.statusLabel)).toEqual([
+      "Ready via registry",
+      "Processing",
+      "Ready via registry"
+    ])
+    expect(items.map((item) => item.title)).toEqual([
+      "Demo media: Team call recording",
+      "Demo media: Product walkthrough",
+      "Demo media: Research article PDF"
+    ])
+  })
+})

--- a/apps/packages/ui/src/utils/__tests__/demo-content.design-system.test.ts
+++ b/apps/packages/ui/src/utils/__tests__/demo-content.design-system.test.ts
@@ -31,25 +31,32 @@ describe("getDemoMediaItems", () => {
   it("uses the design-system ready label while preserving demo media order", () => {
     const items = getDemoMediaItems(t)
 
-    expect(items.map((item) => item.id)).toEqual([
-      "demo-media-1",
-      "demo-media-2",
-      "demo-media-3"
-    ])
-    expect(items.map((item) => item.statusKey)).toEqual([
-      "ready",
-      "processing",
-      "ready"
-    ])
-    expect(items.map((item) => item.statusLabel)).toEqual([
-      "Ready via registry",
-      "Processing",
-      "Ready via registry"
-    ])
-    expect(items.map((item) => item.title)).toEqual([
-      "Demo media: Team call recording",
-      "Demo media: Product walkthrough",
-      "Demo media: Research article PDF"
+    expect(
+      items.map(({ id, statusKey, statusLabel, title }) => ({
+        id,
+        statusKey,
+        statusLabel,
+        title
+      }))
+    ).toEqual([
+      {
+        id: "demo-media-1",
+        statusKey: "ready",
+        statusLabel: "Ready via registry",
+        title: "Demo media: Team call recording"
+      },
+      {
+        id: "demo-media-2",
+        statusKey: "processing",
+        statusLabel: "Processing",
+        title: "Demo media: Product walkthrough"
+      },
+      {
+        id: "demo-media-3",
+        statusKey: "ready",
+        statusLabel: "Ready via registry",
+        title: "Demo media: Research article PDF"
+      }
     ])
   })
 })

--- a/apps/packages/ui/src/utils/demo-content.ts
+++ b/apps/packages/ui/src/utils/demo-content.ts
@@ -1,4 +1,5 @@
 import type { TFunction } from "i18next"
+import { getDesignSystemState } from "@/design-system"
 
 export type DemoFlashcardDeck = {
   id: string
@@ -13,11 +14,14 @@ export type DemoNotePreview = {
   updated_at: string
 }
 
+export type DemoMediaPreviewStatusKey = "ready" | "processing"
+
 export type DemoMediaPreview = {
   id: string
   title: string
   meta: string
-  status: "Ready" | "Processing"
+  statusKey: DemoMediaPreviewStatusKey
+  statusLabel: string
 }
 
 export type DemoQuizQuestion = {
@@ -125,38 +129,45 @@ export const getDemoNotes = (t: TFunction): DemoNotePreview[] => [
   }
 ]
 
-export const getDemoMediaItems = (t: TFunction): DemoMediaPreview[] => [
-  {
-    id: "demo-media-1",
-    title: t("review:mediaEmpty.demoSample1Title", {
-      defaultValue: "Demo media: Team call recording"
-    }),
-    meta: t("review:mediaEmpty.demoSample1Meta", {
-      defaultValue: "Video · 25 min · Keywords: standup, planning"
-    }),
-    status: "Ready"
-  },
-  {
-    id: "demo-media-2",
-    title: t("review:mediaEmpty.demoSample2Title", {
-      defaultValue: "Demo media: Product walkthrough"
-    }),
-    meta: t("review:mediaEmpty.demoSample2Meta", {
-      defaultValue: "Screen recording · 12 min · Keywords: onboarding"
-    }),
-    status: "Processing"
-  },
-  {
-    id: "demo-media-3",
-    title: t("review:mediaEmpty.demoSample3Title", {
-      defaultValue: "Demo media: Research article PDF"
-    }),
-    meta: t("review:mediaEmpty.demoSample3Meta", {
-      defaultValue: "PDF · 6 pages · Keywords: summarization"
-    }),
-    status: "Ready"
-  }
-]
+export const getDemoMediaItems = (t: TFunction): DemoMediaPreview[] => {
+  const readyStatusLabel = getDesignSystemState("ready").label
+
+  return [
+    {
+      id: "demo-media-1",
+      title: t("review:mediaEmpty.demoSample1Title", {
+        defaultValue: "Demo media: Team call recording"
+      }),
+      meta: t("review:mediaEmpty.demoSample1Meta", {
+        defaultValue: "Video · 25 min · Keywords: standup, planning"
+      }),
+      statusKey: "ready",
+      statusLabel: readyStatusLabel
+    },
+    {
+      id: "demo-media-2",
+      title: t("review:mediaEmpty.demoSample2Title", {
+        defaultValue: "Demo media: Product walkthrough"
+      }),
+      meta: t("review:mediaEmpty.demoSample2Meta", {
+        defaultValue: "Screen recording · 12 min · Keywords: onboarding"
+      }),
+      statusKey: "processing",
+      statusLabel: "Processing"
+    },
+    {
+      id: "demo-media-3",
+      title: t("review:mediaEmpty.demoSample3Title", {
+        defaultValue: "Demo media: Research article PDF"
+      }),
+      meta: t("review:mediaEmpty.demoSample3Meta", {
+        defaultValue: "PDF · 6 pages · Keywords: summarization"
+      }),
+      statusKey: "ready",
+      statusLabel: readyStatusLabel
+    }
+  ]
+}
 
 export const getDemoQuizzes = (t: TFunction): DemoQuiz[] => [
   {

--- a/backlog/tasks/task-242 - Migrate-demo-media-ready-labels-to-design-system-registry.md
+++ b/backlog/tasks/task-242 - Migrate-demo-media-ready-labels-to-design-system-registry.md
@@ -4,7 +4,7 @@ title: Migrate demo media ready labels to design-system registry
 status: Done
 assignee: []
 created_date: '2026-05-10 19:39'
-updated_date: '2026-05-10 19:56'
+updated_date: '2026-05-10 20:10'
 labels:
   - design-system
   - frontend
@@ -45,6 +45,10 @@ Verification: bunx vitest run src/utils/__tests__/demo-content.design-system.tes
 PR review fix: Qodo flagged that widening DemoMediaPreview.status to string made ReviewPage styling depend on display-label comparison. Added typed statusKey ('ready' | 'processing') plus statusLabel display text, updated ReviewPage to branch on statusKey, and updated the ReviewPage demo-content mock.
 
 Review-fix verification: bunx vitest run src/utils/__tests__/demo-content.design-system.test.ts --reporter=dot passed 1 test; bunx vitest run src/components/Review/__tests__/ReviewPage.connection.test.tsx --reporter=dot passed 3 tests; bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed 52 tests; bun run verify:design-system-state exited 0; git diff --check exited 0. Broad bunx tsc --noEmit --pretty false still exits 2 with the existing 239-line repo baseline and no touched-scope matches for demo-content, ReviewPage, ReviewPage.connection, baseline, task-242, statusKey/statusLabel, getDemoMediaItems, or getDesignSystemState.
+
+PR review follow-up: Gemini requested a more concise structural assertion in the focused demo-content test. Updated the test to assert each demo media item's id, typed status key, display status label, and title in one expected structure while preserving the same behavior coverage.
+
+Follow-up verification: bunx vitest run src/utils/__tests__/demo-content.design-system.test.ts --reporter=dot passed 1 test; git diff --check exited 0.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-242 - Migrate-demo-media-ready-labels-to-design-system-registry.md
+++ b/backlog/tasks/task-242 - Migrate-demo-media-ready-labels-to-design-system-registry.md
@@ -1,0 +1,68 @@
+---
+id: TASK-242
+title: Migrate demo media ready labels to design-system registry
+status: Done
+assignee: []
+created_date: '2026-05-10 19:39'
+updated_date: '2026-05-10 19:56'
+labels:
+  - design-system
+  - frontend
+  - product-state
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1547'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue the frontend design-system product-state cleanup by replacing Review demo media hardcoded Ready status labels in src/utils/demo-content.ts with the canonical design-system ready state label while preserving demo media item shape and existing Processing status behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 getDemoMediaItems supplies ready demo media status labels from getDesignSystemState('ready').label rather than hardcoded Ready literals.
+- [x] #2 Existing demo media titles, metadata, item order, and Processing status behavior remain unchanged.
+- [x] #3 Focused utility coverage proves ready labels come through the design-system registry.
+- [x] #4 The matching demo-content Ready canonical-state-label baseline exceptions are removed and the design-system verifier passes.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused utility test that mocks getDesignSystemState('ready') and proves getDemoMediaItems uses the registry label while preserving Processing and item order. 2. Replace the hardcoded demo Ready statuses with the ready state registry label. 3. Remove the three demo-content Ready baseline exceptions. 4. Verify focused test, product-state guard test, design-system verifier, diff check, and touched-scope typecheck output.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+TDD red: demo-content.design-system.test.ts mocked getDesignSystemState('ready') to return 'Ready via registry' and failed while getDemoMediaItems still returned literal Ready statuses. Green: getDemoMediaItems now uses getDesignSystemState('ready').label for the two ready demo media records and preserves Processing/item order. Removed the three demo-content Ready baseline exceptions.
+
+Verification: bunx vitest run src/utils/__tests__/demo-content.design-system.test.ts --reporter=dot passed 1 test; bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed 52 tests; bun run verify:design-system-state exited 0 and reports baseline exceptions 510 with canonical-state-label 37; git diff --check exited 0. Broad bunx tsc --noEmit --pretty false still exits 2 with the existing 239-line repo baseline and no touched-scope matches for demo-content, baseline, task-242, getDemoMediaItems, or getDesignSystemState. Bandit skipped because this slice only touches UI TypeScript, JSON baseline data, and Backlog metadata.
+
+PR review fix: Qodo flagged that widening DemoMediaPreview.status to string made ReviewPage styling depend on display-label comparison. Added typed statusKey ('ready' | 'processing') plus statusLabel display text, updated ReviewPage to branch on statusKey, and updated the ReviewPage demo-content mock.
+
+Review-fix verification: bunx vitest run src/utils/__tests__/demo-content.design-system.test.ts --reporter=dot passed 1 test; bunx vitest run src/components/Review/__tests__/ReviewPage.connection.test.tsx --reporter=dot passed 3 tests; bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed 52 tests; bun run verify:design-system-state exited 0; git diff --check exited 0. Broad bunx tsc --noEmit --pretty false still exits 2 with the existing 239-line repo baseline and no touched-scope matches for demo-content, ReviewPage, ReviewPage.connection, baseline, task-242, statusKey/statusLabel, getDemoMediaItems, or getDesignSystemState.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+getDemoMediaItems now resolves ready demo media status labels through getDesignSystemState('ready').label while leaving Processing and demo item order unchanged. Added focused mocked-registry utility coverage and removed the three src/utils/demo-content.ts Ready canonical-state-label baseline exceptions, reducing design-system product-state baseline debt from 513 to 510 entries.
+
+PR: https://github.com/rmusser01/tldw_server/pull/1547
+
+PR review follow-up: demo media now separates typed status identity from display text via statusKey/statusLabel, and ReviewPage styles demo media chips from statusKey rather than comparing localized display labels.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary\n- Route Review demo media ready statuses through getDesignSystemState('ready').label.\n- Add a focused mocked-registry utility test for getDemoMediaItems.\n- Remove the three demo-content Ready canonical-state-label baseline exceptions.\n\n## Verification\n- bunx vitest run src/utils/__tests__/demo-content.design-system.test.ts --reporter=dot\n- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot\n- bun run verify:design-system-state\n- git diff --check\n- bunx tsc --noEmit --pretty false exits 2 on the existing 239-line repo baseline; touched-scope filtering found no matches for this slice.\n\n## Notes\n- Bandit skipped: UI TypeScript/JSON/Backlog-only change.\n- AI-generated PR merge gate still requires the human requester to provide the final Change summary before merge.