### PR TITLE
Migrate AsciiSpinner loading label to registry

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -1463,7 +1463,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx:Alert#antd-alert-chatbooksplaygroundpage-type-error-line-1709-xiyye1",
+    "id": "antd-product-state-import:src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx:Alert#antd-alert-chatbooksplaygroundpage-type-error-line-1771-zqdsu6",
     "path": "src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -1474,7 +1474,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx:Alert#antd-alert-chatbooksplaygroundpage-type-info-line-1594-11zyt83",
+    "id": "antd-product-state-import:src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx:Alert#antd-alert-chatbooksplaygroundpage-type-info-line-1634-1axorno",
     "path": "src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -1485,7 +1485,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx:Alert#antd-alert-chatbooksplaygroundpage-type-info-line-1701-1fhvw6z",
+    "id": "antd-product-state-import:src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx:Alert#antd-alert-chatbooksplaygroundpage-type-info-line-1763-gjv3e3",
     "path": "src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -1496,7 +1496,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx:Alert#antd-alert-chatbooksplaygroundpage-type-info-line-1830-hrfk06",
+    "id": "antd-product-state-import:src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx:Alert#antd-alert-chatbooksplaygroundpage-type-info-line-1947-nzkapb",
     "path": "src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -1507,7 +1507,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx:Alert#antd-alert-chatbooksplaygroundpage-type-warning-line-188-1431cba",
+    "id": "antd-product-state-import:src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx:Alert#antd-alert-chatbooksplaygroundpage-type-warning-line-185-13hsq85",
     "path": "src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -1518,7 +1518,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx:Alert#antd-alert-chatbooksplaygroundpage-type-warning-line-208-vp1oe",
+    "id": "antd-product-state-import:src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx:Alert#antd-alert-chatbooksplaygroundpage-type-warning-line-200-1uw8tkg",
     "path": "src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -1529,7 +1529,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx:Alert#antd-alert-contenttypepicker-type-info-line-766-g4tn6i",
+    "id": "antd-product-state-import:src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx:Alert#antd-alert-chatbooksplaygroundpage-type-warning-line-219-rcwumt",
     "path": "src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -1540,7 +1540,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx:Alert#antd-alert-contenttypepicker-type-warning-line-816-1o53a06",
+    "id": "antd-product-state-import:src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx:Alert#antd-alert-contenttypepicker-type-info-line-767-get8vh",
     "path": "src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -1551,7 +1551,18 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx:Alert#antd-alert-contenttypepicker-type-warning-line-884-1to71s1",
+    "id": "antd-product-state-import:src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx:Alert#antd-alert-contenttypepicker-type-warning-line-817-1of2vp5",
+    "path": "src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx",
+    "rule": "antd-product-state-import",
+    "subject": "Alert",
+    "state": "allowed_legacy_exception",
+    "owner": "design-system",
+    "reason": "Existing AntD Alert product-state UI in src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx before the stable duplicate-id guard.",
+    "replacement": "tldw design-system state primitive",
+    "migrationQueue": "shared-product-state"
+  },
+  {
+    "id": "antd-product-state-import:src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx:Alert#antd-alert-contenttypepicker-type-warning-line-885-1te7g32",
     "path": "src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -5045,17 +5056,6 @@
     "state": "allowed_legacy_exception",
     "owner": "design-system",
     "reason": "Existing hardcoded \"Loading\" state label in src/components/Common/PromptSelect.tsx before the guard.",
-    "replacement": "getDesignSystemState(...)",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "canonical-state-label:src/components/Common/SplashScreen/effects/tech/AsciiSpinner.ts:Loading",
-    "path": "src/components/Common/SplashScreen/effects/tech/AsciiSpinner.ts",
-    "rule": "canonical-state-label",
-    "subject": "Loading",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing hardcoded \"Loading\" state label in src/components/Common/SplashScreen/effects/tech/AsciiSpinner.ts before the guard.",
     "replacement": "getDesignSystemState(...)",
     "migrationQueue": "shared-product-state"
   },

--- a/apps/packages/ui/src/components/Common/SplashScreen/effects/tech/AsciiSpinner.ts
+++ b/apps/packages/ui/src/components/Common/SplashScreen/effects/tech/AsciiSpinner.ts
@@ -1,7 +1,10 @@
+import { getDesignSystemState } from "@/design-system";
 import { CharGrid } from "../../engine/CharGrid";
 import type { SplashEffect } from "../../engine/types";
 
 const SPINNER_FRAMES = ["|", "/", "-", "\\"];
+const LOADING_LABEL = getDesignSystemState("loading").label;
+const LOADING_DOT_SUFFIXES = ["   ", ".  ", ".. ", "..."] as const;
 
 const BIG_SPINNER: string[][] = [
   [
@@ -72,7 +75,7 @@ export default class AsciiSpinner implements SplashEffect {
 
     // Loading dots
     const dots = Math.floor(this.elapsed / 400) % 4;
-    const dotStr = "Loading" + ".".repeat(dots) + " ".repeat(3 - dots);
+    const dotStr = LOADING_LABEL + LOADING_DOT_SUFFIXES[dots];
     grid.writeCentered(17, dotStr, "#aaaaaa");
 
     // Progress bar

--- a/apps/packages/ui/src/components/Common/SplashScreen/effects/tech/__tests__/AsciiSpinner.design-system.test.ts
+++ b/apps/packages/ui/src/components/Common/SplashScreen/effects/tech/__tests__/AsciiSpinner.design-system.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { getDesignSystemState } from "@/design-system"
+import AsciiSpinner from "../AsciiSpinner"
+
+const registryLabels = vi.hoisted(() => ({
+  loading: "Loading via registry"
+}))
+
+vi.mock("@/design-system", async (importActual) => {
+  const actual = await importActual<typeof import("@/design-system")>()
+
+  return {
+    ...actual,
+    getDesignSystemState: vi.fn(
+      (key: Parameters<typeof actual.getDesignSystemState>[0]) => {
+        const state = actual.getDesignSystemState(key)
+
+        return {
+          ...state,
+          label: key === "loading" ? registryLabels.loading : state.label
+        }
+      }
+    )
+  }
+})
+
+describe("AsciiSpinner design-system labels", () => {
+  it("renders the loading row from the design-system loading state label", () => {
+    const effect = new AsciiSpinner()
+    effect.init({} as CanvasRenderingContext2D, 800, 480)
+    effect.update(0, 16)
+
+    const grid = (effect as unknown as {
+      grid: {
+        renderToCanvas: (ctx: CanvasRenderingContext2D, cellW: number, cellH: number) => void
+        writeCentered: (row: number, text: string, color: string) => void
+      }
+    }).grid
+    const writeCenteredSpy = vi.spyOn(grid, "writeCentered")
+    vi.spyOn(grid, "renderToCanvas").mockImplementation(() => {})
+    vi.mocked(getDesignSystemState).mockClear()
+
+    effect.render({} as CanvasRenderingContext2D)
+
+    expect(writeCenteredSpy).toHaveBeenCalledWith(17, "Loading via registry   ", "#aaaaaa")
+    expect(getDesignSystemState).not.toHaveBeenCalled()
+  })
+})

--- a/backlog/tasks/task-246 - Migrate-AsciiSpinner-loading-label-to-design-system-registry.md
+++ b/backlog/tasks/task-246 - Migrate-AsciiSpinner-loading-label-to-design-system-registry.md
@@ -1,0 +1,66 @@
+---
+id: TASK-246
+title: Migrate AsciiSpinner loading label to design-system registry
+status: Done
+assignee: []
+created_date: '2026-05-10 21:12'
+updated_date: '2026-05-10 21:31'
+labels:
+  - design-system
+  - frontend
+  - product-state
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue the frontend design-system product-state cleanup by replacing the Common SplashScreen AsciiSpinner hardcoded Loading text with the canonical design-system loading state label while preserving spinner animation, dot padding, progress rendering, and canvas behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 AsciiSpinner builds its loading text from getDesignSystemState('loading').label rather than a hardcoded Loading literal.
+- [x] #2 The existing spinner frames, loading dot behavior, progress bar, and render positions remain unchanged.
+- [x] #3 Focused coverage proves the rendered loading row uses the design-system loading label.
+- [x] #4 The matching AsciiSpinner Loading canonical-state-label baseline exception is removed and the design-system verifier passes.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused red test for AsciiSpinner.render with mocked CharGrid and mocked design-system loading label. 2. Route the rendered loading row through getDesignSystemState('loading').label without changing dot/progress behavior. 3. Remove the AsciiSpinner Loading baseline exception. 4. Verify focused test, product-state guard test, design-system verifier, diff check, and touched-scope typecheck output.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented AsciiSpinner loading label registry lookup via getDesignSystemState('loading').label, added focused Vitest coverage that first failed against the hardcoded literal and now passes, removed the AsciiSpinner canonical-state-label baseline exception, and refreshed current ChatbooksPlaygroundPage AntD Alert baseline IDs after origin/dev drift blocked the full verifier.
+
+Verification: focused AsciiSpinner Vitest passed; product-state guard Vitest passed; bun run verify:design-system-state passed; git diff --check passed; full UI tsc still exits 2 on existing repo-wide type baseline, with no filtered matches for the touched SplashScreen/AsciiSpinner paths. Bandit not applicable because touched implementation files are TypeScript/JSON/Backlog markdown only.
+
+PR: https://github.com/rmusser01/tldw_server/pull/1553
+
+PR review follow-up: Gemini flagged the render-loop loading label lookup and repeated dot suffix string construction in AsciiSpinner.ts. The label is static for this effect, so the follow-up will cache the registry label and dot suffixes outside render while preserving row 17 output.
+
+PR review follow-up implemented: cached the loading design-system label at module scope and replaced per-render repeat/concatenation with precomputed dot suffixes, preserving the exact row 17 strings. Tightened the focused test so it fails if render calls getDesignSystemState after module initialization.
+
+Review follow-up verification: focused AsciiSpinner Vitest passed after failing red on the render-loop lookup; product-state guard Vitest passed; bun run verify:design-system-state passed; git diff --check passed; filtered UI tsc output for AsciiSpinner/SplashScreen touched paths returned no matches while the full command still exits nonzero on existing repo-wide baseline errors.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+AsciiSpinner now sources the loading label from the registry once at module initialization and uses precomputed loading dot suffixes in render. The focused regression test covers both the registry label output and absence of per-render registry lookup; the PR review thread was addressed without changing visible spinner behavior.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Source AsciiSpinner loading text from getDesignSystemState("loading").label while preserving the existing row, dot padding, spinner frames, and progress rendering.
- Add focused Vitest coverage that proves the rendered loading row uses the registry label.
- Remove the migrated AsciiSpinner canonical-state-label baseline exception and refresh current ChatbooksPlaygroundPage baseline IDs that had drifted on dev.
- Track the work in Backlog TASK-246.

## Verification
- bunx vitest run src/components/Common/SplashScreen/effects/tech/__tests__/AsciiSpinner.design-system.test.ts --reporter=dot
- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot
- bun run verify:design-system-state
- git diff --check
- git diff --cached --check
- bunx tsc --noEmit --pretty false (expected repo-wide existing failures; filtered output had no matches for touched SplashScreen/AsciiSpinner paths)

## AI-authored PR merge gate
This PR was materially authored by AI. Before merge, the human requester needs to add a Change summary explaining what changed and why these implementation choices were made.