### PR TITLE
Define ACP downstream-agent compatibility matrix

### DIFF
--- a/Docs/Development/ACP_Compatibility_Matrix.md
+++ b/Docs/Development/ACP_Compatibility_Matrix.md
@@ -1,0 +1,203 @@
+# ACP Downstream-Agent Compatibility Matrix
+
+This document is the updateable contract for downstream agents launched through
+the Agent Client Protocol (ACP) runner. It defines support states, verification
+levels, required evidence, and caveat language for release notes, setup guides,
+Agent Registry status, and operator troubleshooting.
+
+The matrix is intentionally documentation-first. Updating support status should
+not require code changes unless a surface needs to display a newly documented
+field.
+
+## Scope
+
+This matrix covers downstream ACP-compatible agents launched by `tldw-agent`
+through stdio, including Codex, Claude Code, OpenCode, custom ACP agents, and
+the in-repo stub/smoke profile. It does not define a public agent marketplace,
+installer, or guarantee for every third-party implementation.
+
+Compatibility evidence must distinguish:
+
+- protocol incompatibility in the downstream agent;
+- missing local binary, provider key, workspace allowlist, or host runtime;
+- unverified optional capabilities such as artifacts, MCP injection, sandbox
+  behavior, or reviewer loops.
+
+## Support States
+
+| State | Meaning | Release language |
+| --- | --- | --- |
+| `supported` | Required checks for the stated verification level passed on a current branch and host profile. | May be listed as supported for the verified host/profile. |
+| `supported_with_caveats` | Core protocol checks passed, but one or more optional capabilities or host runtimes have explicit caveats. | May be listed as supported with the named caveats. |
+| `experimental` | Basic behavior works in limited testing, but coverage is incomplete or host-dependent. | May be offered for early adopters; avoid production-support claims. |
+| `documented_unverified` | Configuration is documented, but no current run evidence exists. | May appear in setup docs as a candidate only. |
+| `unsupported` | The agent does not speak the required ACP stdio contract or fails a required check for reasons not attributable to local prerequisites. | Do not present as usable through ACP until retested. |
+
+Use `documented_unverified` rather than `unsupported` when the only blocker is
+missing local setup such as absent credentials, missing binary, or unavailable
+host runtime.
+
+## Verification Levels
+
+| Level | Required evidence | Typical use |
+| --- | --- | --- |
+| `documented_only` | Configuration snippet and prerequisite list are documented. No current run evidence is required. | Candidate agents and custom agent templates. |
+| `stub_smoke_tested` | In-repo stub or fixture proves the ACP server/runner path can create a session, prompt, stream/update, cancel/close, and record diagnostics. | Baseline protocol health in CI. |
+| `live_e2e_tested` | A real downstream agent binary ran through the server/runner path on a named host profile with provider credentials. | Release notes that claim a specific agent works locally. |
+| `sandbox_tested` | Live or stub agent ran inside the configured sandbox backend and passed workspace/root/runtime checks. | Claims about Docker, Lima, or VZ isolation. |
+| `production_supported` | Live E2E and relevant sandbox or workspace checks passed, caveats are documented, and the setup surface can explain failures. | Enterprise/operator support claims. |
+
+Verification levels are cumulative only where relevant. For example, an agent can
+be `live_e2e_tested` on the host runner while sandbox behavior remains
+unverified.
+
+## Capability Checks
+
+Each matrix row should use these stable check IDs. Mark each check as `pass`,
+`fail`, `skip`, or `n/a`, and explain every `fail` or `skip` in the caveats
+column.
+
+| Check ID | Capability | Minimum evidence |
+| --- | --- | --- |
+| `init` | Runner starts downstream process and receives `initialize` capabilities. | Health/setup output or session creation log. |
+| `session_new` | ACP session starts with expected agent type and cwd/env profile. | `POST /api/v1/acp/sessions/new` result or orchestration run record. |
+| `prompt` | Prompt request returns a completion or structured terminal state. | `session/prompt`, async task result, or WebSocket transcript. |
+| `structured_completion` | Terminal status, reason code, and error/retry classification are machine-readable. | Session events or orchestration task run detail. |
+| `artifacts` | Agent-produced artifacts appear through ACP artifact drill-through when applicable. | `/artifacts` result or explicit `n/a`. |
+| `diagnostics` | Failures expose normalized diagnostics without raw server-log inspection. | `/diagnostics` result or task failure context. |
+| `cancel_close` | Cancel and close/teardown paths finish without orphaned runner state. | `/cancel`, `/close`, teardown, or reconciliation evidence. |
+| `review_loop` | Reviewer decisions or manual review state attach to durable task/run history when applicable. | Agent Tasks or orchestration task detail evidence. |
+| `workspace_env` | Workspace cwd, allowed roots, and per-session env are applied or fail closed. | Workspace health/session request evidence. |
+| `mcp_injection` | Workspace MCP servers are injected or explicitly unsupported. | Session request, setup status, or caveat. |
+| `sandbox` | Configured sandbox backend starts and enforces workspace/runtime policy. | Sandbox runner test or live sandbox run evidence. |
+| `redacted_support_view` | Detail/events/artifacts can be viewed through redacted support mode. | `?redacted=true` endpoint evidence. |
+
+## Matrix Schema
+
+Store the compatibility matrix as Markdown so operators can update it in a docs
+PR without code changes. A row must include:
+
+| Field | Required | Description |
+| --- | --- | --- |
+| Agent | Yes | Human-readable downstream agent or profile name. |
+| Profile key | Yes | Stable key used in docs/setup examples, such as `codex`, `claude_code`, `opencode`, `custom_acp`, or `stub`. |
+| Transport/runner mode | Yes | `host_stdio`, `sandbox_stdio`, or `stub_fixture`. |
+| Host/runtime | Yes | OS/runtime profile such as `macos-host`, `linux-host`, `docker`, `lima`, or `vz`. |
+| Version | Yes | Agent binary version, commit, or `unknown` with caveat. |
+| Support state | Yes | One of the support states above. |
+| Verification level | Yes | Highest verified level from the verification-level table. |
+| Capability checks | Yes | Compact status list using the stable check IDs. |
+| Evidence | Yes | Link or text naming command, branch/commit, date, and result. |
+| Caveats | Yes | Empty only when no caveats remain for the claimed state. |
+| Follow-up | No | Issue/PR link for missing capability, bug, or future retest. |
+
+## Current Matrix
+
+| Agent | Profile key | Mode | Host/runtime | Version | Support state | Verification level | Capability checks | Evidence | Caveats | Follow-up |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| In-repo ACP stub profile | `stub` | `stub_fixture` | CI/local host | repo commit | `supported_with_caveats` | `stub_smoke_tested` | `init=pass`, `session_new=pass`, `prompt=pass`, `structured_completion=pass`, `diagnostics=pass`, `cancel_close=pass`, `redacted_support_view=pass`, `artifacts=limited`, `review_loop=n/a`, `workspace_env=limited`, `mcp_injection=n/a`, `sandbox=n/a` | Backend ACP pytest and mocked browser setup/run/diagnose evidence in `ACP_Production_Readiness.md`. | Proves server/runner protocol behavior, not live third-party agent compatibility. | Add per-release evidence when this row is updated. |
+| Codex CLI | `codex` | `host_stdio` | host dependent | unknown | `documented_unverified` | `documented_only` | `init=skip`, `session_new=skip`, `prompt=skip`, `structured_completion=skip`, `artifacts=skip`, `diagnostics=skip`, `cancel_close=skip`, `review_loop=skip`, `workspace_env=skip`, `mcp_injection=skip`, `sandbox=skip`, `redacted_support_view=skip` | Configuration example exists in `Agent_Client_Protocol.md`. | Requires installed ACP-compatible Codex command, provider credentials, and live stdio verification before release claims. | Create per-agent verification issue when a test host is available. |
+| Claude Code | `claude_code` | `host_stdio` | host dependent | unknown | `documented_unverified` | `documented_only` | `init=skip`, `session_new=skip`, `prompt=skip`, `structured_completion=skip`, `artifacts=skip`, `diagnostics=skip`, `cancel_close=skip`, `review_loop=skip`, `workspace_env=skip`, `mcp_injection=skip`, `sandbox=skip`, `redacted_support_view=skip` | Configuration example exists in `Agent_Client_Protocol.md`. | Requires installed ACP-compatible Claude command, provider credentials, and live stdio verification before release claims. | Create per-agent verification issue when a test host is available. |
+| OpenCode | `opencode` | `host_stdio` | host dependent | unknown | `documented_unverified` | `documented_only` | `init=skip`, `session_new=skip`, `prompt=skip`, `structured_completion=skip`, `artifacts=skip`, `diagnostics=skip`, `cancel_close=skip`, `review_loop=skip`, `workspace_env=skip`, `mcp_injection=skip`, `sandbox=skip`, `redacted_support_view=skip` | Candidate profile tracked by #1539. | Requires an ACP stdio-compatible OpenCode entrypoint and live verification. | Create per-agent verification issue when a test host is available. |
+| Custom ACP-compatible agent | `custom_acp` | `host_stdio` or `sandbox_stdio` | host dependent | operator supplied | `documented_unverified` | `documented_only` | `init=skip`, `session_new=skip`, `prompt=skip`, `structured_completion=skip`, `artifacts=skip`, `diagnostics=skip`, `cancel_close=skip`, `review_loop=skip`, `workspace_env=skip`, `mcp_injection=skip`, `sandbox=skip`, `redacted_support_view=skip` | Custom command template exists in `Agent_Client_Protocol.md`. | Operators must provide binary, args, env, workspace policy, and evidence. | Split into a dedicated issue when a named implementation is evaluated. |
+
+## Evidence Record Template
+
+Use one record per agent/profile/host combination. Add the record to the issue or
+PR that updates the matrix.
+
+```text
+Agent:
+Profile key:
+Support state:
+Verification level:
+Commit/branch:
+Host/runtime:
+Agent binary/version:
+Config profile:
+Commands:
+Capability results:
+Caveats:
+Follow-up issue:
+```
+
+## Minimum Certification Checklists
+
+### Documented Only
+
+- Document command, args, required environment, and workspace prerequisites.
+- State whether the agent is expected to speak ACP stdio directly or through a
+  wrapper.
+- Mark support state `documented_unverified` unless prior evidence exists.
+
+### Stub Or Smoke Tested
+
+- Run focused ACP backend tests covering session lifecycle, WebSocket/update
+  flow, diagnostics, cancel/close, and redacted views.
+- Run the Go runner verification script when runner code or profile behavior is
+  part of the claim.
+- Record commit, command, and result in the evidence record.
+
+### Live E2E Tested
+
+- Verify the downstream binary is installed and record its version.
+- Run a real session through tldw_server using the configured runner profile.
+- Exercise `init`, `session_new`, `prompt`, `structured_completion`,
+  `diagnostics`, and `cancel_close`.
+- Exercise `artifacts`, `review_loop`, `workspace_env`, and `mcp_injection` when
+  the support claim mentions those capabilities.
+- Query redacted support views for sessions that include transcript or artifact
+  data.
+
+### Sandbox Tested
+
+- Record sandbox backend (`docker`, `lima`, `vz`, or other configured runtime).
+- Prove missing runtime/configuration fails closed with stable setup guidance.
+- Run or explicitly skip workspace bind/mount, cwd, env, and network behavior.
+- Do not upgrade a host-only live E2E result to sandbox-tested without this
+  evidence.
+
+### Production Supported
+
+- Live E2E checks are current for the release branch.
+- Required sandbox/workspace checks for the release claim are current.
+- Setup and Agent Registry surfaces can explain missing prerequisites.
+- Known caveats are linked to follow-up issues and release notes use the same
+  caveat language.
+
+## Caveat Taxonomy
+
+Use these labels so Agent Registry/setup/docs/admin reporting can reuse the same
+language later:
+
+| Caveat | Meaning |
+| --- | --- |
+| `protocol_incompatibility` | Agent does not satisfy ACP stdio contract or required JSON-RPC behavior. |
+| `binary_missing` | Expected command is not installed or not on PATH. |
+| `credentials_missing` | Provider/API key or account login is unavailable. |
+| `workspace_config_missing` | Workspace allowlist, cwd, or root policy is not configured. |
+| `host_runtime_missing` | Docker/Lima/VZ or other required host runtime is unavailable. |
+| `sandbox_unverified` | Host mode works or is documented, but sandbox mode has no current evidence. |
+| `mcp_injection_unverified` | Workspace MCP server injection has no current evidence for this agent. |
+| `artifact_capability_unverified` | Agent output/artifact behavior has no current evidence. |
+| `review_loop_unverified` | Reviewer-agent or manual review loop behavior has no current evidence. |
+| `redacted_view_unverified` | Support-safe redacted views were not checked for this agent run. |
+
+## Status Surface Plan
+
+The compatibility matrix should feed these surfaces when implementation work
+begins:
+
+- Agent Registry: show support state, verification level, last evidence date,
+  and top caveats next to each configured agent.
+- `/api/v1/acp/setup-guide`: include configured-but-unverified vs verified
+  status and prerequisite-specific actions.
+- `/api/v1/acp/health` and `/api/v1/acp/agents/health`: keep runtime failures
+  separate from protocol incompatibilities.
+- ACP operator docs and release notes: use only the support-state and caveat
+  language from this document.
+- Future admin reporting (#1537): aggregate by support state, verification
+  level, and caveat taxonomy rather than inventing a second failure vocabulary.
+
+Until a UI/API contract lands, this Markdown file is the source of truth for
+compatibility claims and can be updated independently in documentation PRs.

--- a/Docs/Development/ACP_Production_Readiness.md
+++ b/Docs/Development/ACP_Production_Readiness.md
@@ -26,6 +26,7 @@ verified production deployment on a specific host.
 | [#1474](https://github.com/rmusser01/tldw_server/issues/1474) | Schedules, triggers, and background runs | Proves unattended runs are controlled, observable, and recoverable. |
 | [#1473](https://github.com/rmusser01/tldw_server/issues/1473) | Agent Tasks, Playground, and Registry UX | Proves the production UI supports setup, execution, review, and troubleshooting. |
 | [#1480](https://github.com/rmusser01/tldw_server/issues/1480) | PRD and operational docs refresh | Brings design, operator, and user-facing docs in sync with the verified implementation. |
+| [#1539](https://github.com/rmusser01/tldw_server/issues/1539) | Downstream-agent compatibility matrix | Defines live-agent support states, certification levels, evidence fields, and caveat taxonomy for future release claims. |
 
 Recommended order: seed #1472, then complete #1479, #1478, #1476, #1475,
 #1477, #1474, #1473, #1480, and finally close #1472.
@@ -34,7 +35,7 @@ Recommended order: seed #1472, then complete #1479, #1478, #1476, #1475,
 
 | Surface | Owner modules | Required evidence | Verification commands | Pass/fail gate | Runtime caveats |
 | --- | --- | --- | --- | --- | --- |
-| ACP REST, WebSocket, SSE, and session lifecycle | `tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py`, `tldw_Server_API/app/core/Agent_Client_Protocol/` | Session create, prompt, cancel, close, reconnect, streaming, and error paths are covered. | `source .venv/bin/activate`; `python -m pytest tldw_Server_API/tests/Agent_Client_Protocol -q` | Pass when focused ACP pytest suite is green and failures distinguish user errors from server faults. | Stub-agent tests are sufficient for base protocol; live downstream agents should be verified before release notes claim support. |
+| ACP REST, WebSocket, SSE, and session lifecycle | `tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py`, `tldw_Server_API/app/core/Agent_Client_Protocol/`, `Docs/Development/ACP_Compatibility_Matrix.md` | Session create, prompt, cancel, close, reconnect, streaming, and error paths are covered; named downstream-agent support claims use the compatibility matrix support states and evidence fields. | `source .venv/bin/activate`; `python -m pytest tldw_Server_API/tests/Agent_Client_Protocol -q` | Pass when focused ACP pytest suite is green and failures distinguish user errors from server faults. | Stub-agent tests are sufficient for base protocol; live downstream agents should be verified through `ACP_Compatibility_Matrix.md` before release notes claim support. |
 | Agent orchestration tasks | `tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py`, `tldw_Server_API/app/core/Agent_Orchestration/`, orchestration DB helpers | Tasks persist status, attempts, outputs, completion reason, and retry/timeout state. | `source .venv/bin/activate`; `python -m pytest tldw_Server_API/tests/Agent_Orchestration -q` | Pass when task state transitions are durable and completion signals satisfy #1479. | Background-worker tests may need runtime feature flags if a local worker pool is not enabled by default. |
 | Structured completion and failure semantics | ACP schemas, orchestration service, run handlers, session store | Every run records terminal state, reason, timestamps, and retriable/non-retriable classification. | Focus the new/changed tests from #1479 plus `python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/test_acp_run_handler.py tldw_Server_API/tests/Agent_Orchestration/test_orchestration_service.py -q` | Pass when UI and API can consume the same terminal state without text parsing. | This is a blocker for reviewer loops, schedules, and production run history. |
 | Reviewer-agent loop and triage history | Orchestration service, task APIs, run/history DB tables | Review requests, reviewer responses, decisions, follow-up tasks, and overrides are durable. | Add #1478 focused pytest coverage, then include it in the orchestration suite. | Pass when a reviewer decision can be traced from task request to final run history. | Do not count manual GitHub comments as triage history unless they are linked from durable ACP state. |
@@ -136,7 +137,8 @@ python -m bandit -r <touched_python_paths> -f json -o /tmp/bandit_acp_<task>.jso
 - Live downstream agents need their own ACP stdio-compatible entrypoints, API
   keys, and workspace permissions. Stub-agent protocol tests are not a
   substitute for live-agent verification before release notes claim downstream
-  agent support.
+  agent support. Use `ACP_Compatibility_Matrix.md` for support states,
+  verification levels, caveat taxonomy, and evidence records.
 - Until #1504 records a real downstream-agent create/prompt/cancel run, release
   notes must describe ACP downstream-agent support as protocol/runner
   validation only. Binary presence for tools such as Claude Code or Codex is not

--- a/Docs/Development/Agent_Client_Protocol.md
+++ b/Docs/Development/Agent_Client_Protocol.md
@@ -12,6 +12,8 @@ for the ACP module.
 - Operator and contributor guide: this document.
 - Release readiness and evidence checklist:
   [ACP_Production_Readiness.md](ACP_Production_Readiness.md)
+- Downstream-agent compatibility matrix and certification contract:
+  [ACP_Compatibility_Matrix.md](ACP_Compatibility_Matrix.md)
 - Governance, RBAC, approval, and audit details:
   [ACP_Governance_Audit.md](ACP_Governance_Audit.md)
 
@@ -21,6 +23,10 @@ for the ACP module.
 - **WebSocket endpoint** for real-time session streaming at `/api/v1/acp/sessions/{session_id}/stream`.
 - **Permission UI flow** - Permission requests are sent to connected WebSocket clients for approval.
 - ACP runner exists in `tools/tldw-agent` and proxies to a downstream ACP agent.
+- Downstream-agent support claims are governed by
+  [ACP_Compatibility_Matrix.md](ACP_Compatibility_Matrix.md). Stub-agent
+  protocol coverage is not the same as live Codex, Claude Code, OpenCode, or
+  custom-agent certification.
 - Session lifecycle is supported: `session/new`, `session/prompt`, `session/cancel`,
   and `_tldw/session/close`.
 - Downstream capabilities are reflected in `initialize`.
@@ -542,6 +548,21 @@ SANDBOX_DOCKER_BIND_WORKSPACE=1
 
 The runner launches the downstream ACP agent based on:
 `~/.tldw-agent/config.yaml` (or the HOME specified in runner_env)
+
+### Compatibility Status
+
+Configuration examples in this section document candidate downstream-agent
+profiles. They are not support claims by themselves. Before release notes,
+Agent Registry, or setup surfaces describe a named agent as supported, update
+`ACP_Compatibility_Matrix.md` with the agent version, host/runtime profile,
+support state, verification level, capability-check results, evidence command,
+caveats, and follow-up issue.
+
+Use `documented_unverified` for agents that have a documented command profile
+but no current live evidence. Use `unsupported` only when the agent is proven not
+to satisfy the ACP stdio/protocol contract; missing binaries, credentials,
+workspace allowlists, or host runtimes are setup caveats rather than protocol
+incompatibilities.
 
 ### Complete Configuration Example
 

--- a/backlog/tasks/task-247 - ACP-compatibility-matrix-contract-for-downstream-agents.md
+++ b/backlog/tasks/task-247 - ACP-compatibility-matrix-contract-for-downstream-agents.md
@@ -1,0 +1,59 @@
+---
+id: TASK-247
+title: ACP compatibility matrix contract for downstream agents
+status: Done
+assignee: []
+created_date: '2026-05-10 21:21'
+updated_date: '2026-05-10 21:24'
+labels:
+  - ACP
+  - compatibility
+  - docs
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1539'
+  - 'https://github.com/rmusser01/tldw_server/issues/1532'
+documentation:
+  - Docs/Development/Agent_Client_Protocol.md
+  - Docs/Development/ACP_Production_Readiness.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement #1539 PR 1: document the ACP downstream-agent compatibility matrix contract, support states, verification levels, evidence fields, caveat taxonomy, and where status should surface. Keep scope to docs/contract and avoid installer or marketplace implementation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Compatibility matrix format is documented.
+- [x] #2 Minimum certification checks and required evidence fields are listed.
+- [x] #3 Support states distinguish protocol incompatibility from missing local runtime, API key, provider, or host prerequisites.
+- [x] #4 Agent Registry/setup/docs have a planned place for compatibility status.
+- [x] #5 The matrix can be updated without code changes.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented docs-only #1539 PR 1 contract in isolated worktree .worktrees/acp-compatibility-matrix-contract on branch codex/acp-compatibility-matrix-contract. Added Docs/Development/ACP_Compatibility_Matrix.md and linked it from Agent_Client_Protocol.md and ACP_Production_Readiness.md.
+
+Verification: git diff --check passed. Targeted rg confirmed compatibility doc links, support-state language, current matrix, caveat taxonomy, and status surface plan. Bandit not run because this slice changes docs and Backlog metadata only; no Python code was touched.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added the ACP downstream-agent compatibility matrix contract for #1539 PR 1. The new docs define support states, verification levels, capability checks, required evidence fields, current documented/unverified agent rows, minimum certification checklists, caveat taxonomy, and the planned setup/Agent Registry/admin reporting status surfaces. Linked the contract from the ACP operator guide and production readiness matrix. Verification was docs-focused: git diff --check and targeted rg review passed; Bandit was skipped because no Python code changed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary

- add `Docs/Development/ACP_Compatibility_Matrix.md` as the docs-owned contract for downstream-agent support states, verification levels, capability checks, evidence fields, and caveat taxonomy
- seed current matrix rows for the in-repo stub profile plus Codex CLI, Claude Code, OpenCode, and custom ACP-compatible agents without overclaiming live support
- link the compatibility contract from the ACP operator guide and production readiness matrix
- add Backlog task `TASK-247` closeout notes for #1539 PR 1

## Verification

- `git diff --check`
- `rg -n "ACP_Compatibility_Matrix|documented_unverified|protocol_incompatibility|Current Matrix|Status Surface Plan|Bandit not run" Docs/Development/ACP_Compatibility_Matrix.md Docs/Development/Agent_Client_Protocol.md Docs/Development/ACP_Production_Readiness.md backlog/tasks/task-247\ -\ ACP-compatibility-matrix-contract-for-downstream-agents.md`

Bandit was not run because this PR only changes docs and Backlog metadata; no Python code changed.

## Change summary

AI-generated draft. Human requester must replace this section with their own summary before merge per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

Closes part of #1539.