### PR TITLE
Add ACP certification smoke harness

### DIFF
--- a/Docs/Development/ACP_Certification_Checklist.md
+++ b/Docs/Development/ACP_Certification_Checklist.md
@@ -1,0 +1,146 @@
+# ACP Downstream-Agent Certification Checklist
+
+Use this checklist when updating
+`Docs/Development/ACP_Compatibility_Matrix.md` or claiming support for a named
+downstream agent. It separates stub protocol evidence from live-agent evidence
+so release notes do not overclaim compatibility.
+
+## Certification Modes
+
+| Mode | Use for | Evidence level |
+| --- | --- | --- |
+| `stub-smoke` | Proving the in-repo server, runner, mocked browser, and support-view paths still work. | `stub_smoke_tested` |
+| `live-e2e` | Proving a named downstream agent binary works on a named host/runtime profile. | `live_e2e_tested` |
+| `sandbox` | Proving Docker, Lima, VZ, or another configured sandbox runtime works for the agent/profile. | `sandbox_tested` |
+
+The `stub-smoke` mode is CI-friendly and useful for release health. It does not
+certify Codex, Claude Code, OpenCode, or a custom third-party binary.
+
+## Smoke Harness
+
+The focused harness lives at:
+
+```bash
+python Helper_Scripts/Testing-related/acp_certification_smoke.py --profile stub-smoke
+```
+
+It emits a machine-readable or Markdown command manifest. The manifest reuses
+existing ACP checks instead of introducing a second test suite.
+
+```bash
+# Markdown manifest for release evidence
+python Helper_Scripts/Testing-related/acp_certification_smoke.py --profile stub-smoke
+
+# JSON manifest for issue bots or local scripts
+python Helper_Scripts/Testing-related/acp_certification_smoke.py --profile stub-smoke --format json
+
+# Run safe stub-smoke commands locally
+python Helper_Scripts/Testing-related/acp_certification_smoke.py --profile stub-smoke --run
+```
+
+Live E2E evidence requires explicit operator-provided state and refuses to run
+without these variables:
+
+```bash
+export TLDW_E2E_SERVER_URL=127.0.0.1:8000
+export TLDW_E2E_API_KEY=<local-api-key>
+export ACP_AGENT_PROFILE=<profile-key-from-matrix>
+
+python Helper_Scripts/Testing-related/acp_certification_smoke.py --profile live-e2e --format json
+python Helper_Scripts/Testing-related/acp_certification_smoke.py --profile live-e2e --run
+```
+
+## Stub-Smoke Checklist
+
+Run this when updating the stub row or when validating release health without a
+live downstream agent:
+
+- Emit the manifest and attach it to the issue/PR evidence.
+- Run backend ACP smoke coverage from the manifest.
+- Run `tools/tldw-agent/scripts/verify-local-build.sh` from the manifest.
+- Run the mocked Agent Tasks browser setup/run/diagnose flow when frontend
+  dependencies are installed.
+- Record any skipped command with a reason such as missing frontend
+  dependencies or unavailable browser runtime.
+
+Minimum capability IDs expected from stub-smoke evidence:
+
+- `init`
+- `session_new`
+- `prompt`
+- `structured_completion`
+- `diagnostics`
+- `cancel_close`
+- `artifacts`
+- `review_loop`
+- `workspace_env`
+- `mcp_injection`
+- `redacted_support_view`
+
+`workspace_env` and `mcp_injection` can be limited/mocked in stub-smoke mode.
+Do not upgrade those checks to live support without named host/runtime evidence.
+
+## Live-E2E Checklist
+
+Run this when changing a candidate agent row from `documented_unverified` to
+`supported`, `supported_with_caveats`, or `experimental`:
+
+- Record host OS, runtime profile, repo commit, branch, and tldw_server config.
+- Record downstream agent binary path and version.
+- Record required provider credentials or local login state as present without
+  exposing secret values.
+- Confirm the configured profile can start through `/api/v1/acp/health` or
+  `/api/v1/acp/setup-guide`.
+- Exercise session create, prompt, structured completion, diagnostics, cancel,
+  and close/teardown.
+- Exercise artifacts, review loop, workspace env, MCP server injection, and
+  redacted support views when those capabilities are part of the claim.
+- Record unsupported or skipped capabilities with caveat taxonomy labels from
+  `ACP_Compatibility_Matrix.md`.
+
+Live E2E evidence should include the JSON manifest plus command output summary,
+not raw secrets or full transcript payloads. Use `?redacted=true` support views
+for transcript and artifact snippets in public evidence.
+
+## Sandbox Checklist
+
+Run this only when a support claim includes sandbox behavior:
+
+- Record sandbox runtime (`docker`, `lima`, `vz`, or other configured backend).
+- Confirm missing runtime/configuration fails closed with actionable setup
+  guidance.
+- Confirm workspace bind/mount behavior, cwd, env, and network policy.
+- Confirm sandbox-specific diagnostics can distinguish host runtime problems
+  from downstream-agent protocol errors.
+
+Sandbox evidence can be separate from host live E2E evidence. A host-supported
+agent is not sandbox-supported until these checks pass.
+
+## Evidence Record
+
+Use this template in #1539, per-agent follow-up issues, or PR closeout comments.
+
+```text
+Agent:
+Profile key:
+Support state:
+Verification level:
+Commit/branch:
+Host/runtime:
+Agent binary/version:
+Config profile:
+Manifest command:
+Commands run:
+Capability results:
+Caveats:
+Follow-up issue:
+```
+
+## Updating The Matrix
+
+1. Update only the row whose evidence changed.
+2. Keep support state and verification level aligned with the evidence.
+3. Use `documented_unverified` when setup is documented but not verified.
+4. Use `unsupported` only for proven protocol incompatibility.
+5. Link follow-up issues for every failed or skipped capability that matters to
+   the support claim.

--- a/Docs/Development/ACP_Compatibility_Matrix.md
+++ b/Docs/Development/ACP_Compatibility_Matrix.md
@@ -9,6 +9,9 @@ The matrix is intentionally documentation-first. Updating support status should
 not require code changes unless a surface needs to display a newly documented
 field.
 
+For the reproducible certification workflow and command manifest, see
+`ACP_Certification_Checklist.md`.
+
 ## Scope
 
 This matrix covers downstream ACP-compatible agents launched by `tldw-agent`
@@ -122,6 +125,12 @@ Follow-up issue:
 ```
 
 ## Minimum Certification Checklists
+
+Use `Helper_Scripts/Testing-related/acp_certification_smoke.py` to emit the
+current command manifest for `stub-smoke` and `live-e2e` evidence. The helper
+reuses the existing backend ACP suites, mocked browser flow, and Go runner
+verification rather than defining a parallel test harness. The detailed operator
+checklist lives in `ACP_Certification_Checklist.md`.
 
 ### Documented Only
 

--- a/Docs/Development/ACP_Production_Readiness.md
+++ b/Docs/Development/ACP_Production_Readiness.md
@@ -35,7 +35,7 @@ Recommended order: seed #1472, then complete #1479, #1478, #1476, #1475,
 
 | Surface | Owner modules | Required evidence | Verification commands | Pass/fail gate | Runtime caveats |
 | --- | --- | --- | --- | --- | --- |
-| ACP REST, WebSocket, SSE, and session lifecycle | `tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py`, `tldw_Server_API/app/core/Agent_Client_Protocol/`, `Docs/Development/ACP_Compatibility_Matrix.md` | Session create, prompt, cancel, close, reconnect, streaming, and error paths are covered; named downstream-agent support claims use the compatibility matrix support states and evidence fields. | `source .venv/bin/activate`; `python -m pytest tldw_Server_API/tests/Agent_Client_Protocol -q` | Pass when focused ACP pytest suite is green and failures distinguish user errors from server faults. | Stub-agent tests are sufficient for base protocol; live downstream agents should be verified through `ACP_Compatibility_Matrix.md` before release notes claim support. |
+| ACP REST, WebSocket, SSE, and session lifecycle | `tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py`, `tldw_Server_API/app/core/Agent_Client_Protocol/`, `Docs/Development/ACP_Compatibility_Matrix.md`, `Docs/Development/ACP_Certification_Checklist.md` | Session create, prompt, cancel, close, reconnect, streaming, and error paths are covered; named downstream-agent support claims use the compatibility matrix support states, checklist, smoke manifest, and evidence fields. | `source .venv/bin/activate`; `python -m pytest tldw_Server_API/tests/Agent_Client_Protocol -q` | Pass when focused ACP pytest suite is green and failures distinguish user errors from server faults. | Stub-agent tests are sufficient for base protocol; live downstream agents should be verified through `ACP_Certification_Checklist.md` and `ACP_Compatibility_Matrix.md` before release notes claim support. |
 | Agent orchestration tasks | `tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py`, `tldw_Server_API/app/core/Agent_Orchestration/`, orchestration DB helpers | Tasks persist status, attempts, outputs, completion reason, and retry/timeout state. | `source .venv/bin/activate`; `python -m pytest tldw_Server_API/tests/Agent_Orchestration -q` | Pass when task state transitions are durable and completion signals satisfy #1479. | Background-worker tests may need runtime feature flags if a local worker pool is not enabled by default. |
 | Structured completion and failure semantics | ACP schemas, orchestration service, run handlers, session store | Every run records terminal state, reason, timestamps, and retriable/non-retriable classification. | Focus the new/changed tests from #1479 plus `python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/test_acp_run_handler.py tldw_Server_API/tests/Agent_Orchestration/test_orchestration_service.py -q` | Pass when UI and API can consume the same terminal state without text parsing. | This is a blocker for reviewer loops, schedules, and production run history. |
 | Reviewer-agent loop and triage history | Orchestration service, task APIs, run/history DB tables | Review requests, reviewer responses, decisions, follow-up tasks, and overrides are durable. | Add #1478 focused pytest coverage, then include it in the orchestration suite. | Pass when a reviewer decision can be traced from task request to final run history. | Do not count manual GitHub comments as triage history unless they are linked from durable ACP state. |
@@ -73,6 +73,17 @@ python -m pytest \
   tldw_Server_API/tests/Agent_Orchestration/test_orchestration_api.py \
   -q
 ```
+
+### ACP Certification Manifests
+
+```bash
+python Helper_Scripts/Testing-related/acp_certification_smoke.py --profile stub-smoke --format json
+python Helper_Scripts/Testing-related/acp_certification_smoke.py --profile live-e2e --format json
+```
+
+Use `--run` only when the profile prerequisites are satisfied. `stub-smoke`
+runs safe-by-default in-repo gates; `live-e2e` refuses to run without
+`TLDW_E2E_SERVER_URL`, `TLDW_E2E_API_KEY`, and `ACP_AGENT_PROFILE`.
 
 ### Frontend Unit Contracts
 

--- a/Docs/Development/Agent_Client_Protocol.md
+++ b/Docs/Development/Agent_Client_Protocol.md
@@ -14,6 +14,8 @@ for the ACP module.
   [ACP_Production_Readiness.md](ACP_Production_Readiness.md)
 - Downstream-agent compatibility matrix and certification contract:
   [ACP_Compatibility_Matrix.md](ACP_Compatibility_Matrix.md)
+- Downstream-agent certification checklist and smoke manifest:
+  [ACP_Certification_Checklist.md](ACP_Certification_Checklist.md)
 - Governance, RBAC, approval, and audit details:
   [ACP_Governance_Audit.md](ACP_Governance_Audit.md)
 
@@ -704,6 +706,22 @@ python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/test_acp_websocket.
 cd tools/tldw-agent
 ./scripts/verify-local-build.sh
 ```
+
+### Certification Smoke Manifest
+
+Use the certification helper when updating downstream-agent compatibility
+claims. The `stub-smoke` profile reuses the in-repo backend, runner, and mocked
+browser gates; the `live-e2e` profile documents the operator-supplied runtime
+state needed before claiming support for a named downstream agent.
+
+```bash
+python Helper_Scripts/Testing-related/acp_certification_smoke.py --profile stub-smoke --format json
+python Helper_Scripts/Testing-related/acp_certification_smoke.py --profile live-e2e --format json
+```
+
+Follow [ACP_Certification_Checklist.md](ACP_Certification_Checklist.md) before
+changing support states in
+[ACP_Compatibility_Matrix.md](ACP_Compatibility_Matrix.md).
 
 ## Behavior Summary
 

--- a/Helper_Scripts/Testing-related/acp_certification_smoke.py
+++ b/Helper_Scripts/Testing-related/acp_certification_smoke.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Emit or run ACP downstream-agent certification smoke manifests.
+
+The manifest reuses existing ACP test suites and runner checks. It does not
+invent a second compatibility test framework; it gives contributors one stable
+place to find the commands and capability IDs needed for matrix evidence.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+# subprocess is intentionally used to run static manifest argv with shell=False.
+import subprocess  # nosec B404
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+_MANIFESTS: dict[str, dict[str, Any]] = {
+    "stub-smoke": {
+        "profile": "stub-smoke",
+        "support_state": "supported_with_caveats",
+        "verification_level": "stub_smoke_tested",
+        "requires_live_agent": False,
+        "required_environment": [],
+        "notes": [
+            "Uses in-repo stub/mocked ACP paths only.",
+            "Does not certify a live Codex, Claude Code, OpenCode, or custom agent binary.",
+        ],
+        "commands": [
+            {
+                "id": "backend_acp_smoke",
+                "description": "Focused backend ACP lifecycle, diagnostics, retention/redaction, and orchestration smoke checks.",
+                "cwd": ".",
+                "argv": [
+                    "python",
+                    "-m",
+                    "pytest",
+                    "tldw_Server_API/tests/Agent_Client_Protocol/test_acp_e2e_smoke.py",
+                    "tldw_Server_API/tests/Agent_Client_Protocol/test_acp_endpoints.py",
+                    "tldw_Server_API/tests/Agent_Client_Protocol/test_acp_hardening_controls.py",
+                    "tldw_Server_API/tests/Agent_Client_Protocol/test_acp_run_handler.py",
+                    "tldw_Server_API/tests/Agent_Orchestration/test_orchestration_api.py",
+                    "-q",
+                ],
+                "capabilities": [
+                    "init",
+                    "session_new",
+                    "prompt",
+                    "structured_completion",
+                    "diagnostics",
+                    "cancel_close",
+                    "artifacts",
+                    "redacted_support_view",
+                    "review_loop",
+                ],
+                "safe_to_run_by_default": True,
+            },
+            {
+                "id": "go_runner_verify",
+                "description": "Build and test the in-repo tldw-agent runner binaries.",
+                "cwd": "tools/tldw-agent",
+                "argv": ["./scripts/verify-local-build.sh"],
+                "capabilities": ["init", "session_new", "prompt", "cancel_close"],
+                "safe_to_run_by_default": True,
+            },
+            {
+                "id": "browser_mocked_setup_run_diagnose",
+                "description": "Mocked browser ACP setup/run/diagnose flow for Agent Tasks.",
+                "cwd": "apps/tldw-frontend",
+                "argv": [
+                    "./node_modules/.bin/playwright",
+                    "test",
+                    "e2e/workflows/tier-3-automation/agent-tasks.spec.ts",
+                    "--grep",
+                    "guide ACP setup",
+                    "--reporter=line",
+                ],
+                "env": {
+                    "TLDW_WEB_URL": "http://localhost:18080",
+                    "TLDW_WEB_CMD": "bun run dev -- -p 18080",
+                },
+                "capabilities": [
+                    "diagnostics",
+                    "artifacts",
+                    "review_loop",
+                    "workspace_env",
+                    "mcp_injection",
+                ],
+                "safe_to_run_by_default": True,
+            },
+        ],
+    },
+    "live-e2e": {
+        "profile": "live-e2e",
+        "support_state": "supported_with_caveats",
+        "verification_level": "live_e2e_tested",
+        "requires_live_agent": True,
+        "required_environment": [
+            "TLDW_E2E_SERVER_URL",
+            "TLDW_E2E_API_KEY",
+            "ACP_AGENT_PROFILE",
+        ],
+        "notes": [
+            "Requires a running backend, API key, configured ACP runner profile, installed downstream agent binary, and provider credentials.",
+            "Use this only for named live-agent support claims.",
+        ],
+        "commands": [
+            {
+                "id": "live_backend_acp_e2e",
+                "description": "Live backend/browser ACP flow against a configured downstream agent profile.",
+                "cwd": "apps/tldw-frontend",
+                "argv": [
+                    "bunx",
+                    "playwright",
+                    "test",
+                    "e2e/workflows/tier-3-automation/acp-playground.spec.ts",
+                    "e2e/workflows/tier-3-automation/agent-registry.spec.ts",
+                    "e2e/workflows/tier-3-automation/agent-tasks.spec.ts",
+                    "--reporter=line",
+                ],
+                "env": {
+                    "TLDW_E2E_SERVER_URL": "${TLDW_E2E_SERVER_URL}",
+                    "TLDW_E2E_API_KEY": "${TLDW_E2E_API_KEY}",
+                    "ACP_AGENT_PROFILE": "${ACP_AGENT_PROFILE}",
+                },
+                "capabilities": [
+                    "init",
+                    "session_new",
+                    "prompt",
+                    "structured_completion",
+                    "artifacts",
+                    "diagnostics",
+                    "cancel_close",
+                    "review_loop",
+                    "workspace_env",
+                    "mcp_injection",
+                    "redacted_support_view",
+                ],
+                "safe_to_run_by_default": False,
+            },
+            {
+                "id": "live_runner_verify",
+                "description": "Verify the local runner build before attributing failures to the downstream agent.",
+                "cwd": "tools/tldw-agent",
+                "argv": ["./scripts/verify-local-build.sh"],
+                "capabilities": ["init", "session_new", "prompt", "cancel_close"],
+                "safe_to_run_by_default": False,
+            },
+        ],
+    },
+}
+
+
+def build_manifest(profile: str) -> dict[str, Any]:
+    """Return a copy of the certification manifest for a profile."""
+    if profile not in _MANIFESTS:
+        raise ValueError(f"Unknown ACP certification profile: {profile}")
+    return deepcopy(_MANIFESTS[profile])
+
+
+def render_manifest(profile: str, *, output_format: str = "markdown") -> str:
+    """Render a certification manifest as JSON or Markdown."""
+    manifest = build_manifest(profile)
+    if output_format == "json":
+        return json.dumps(manifest, indent=2, sort_keys=True)
+    if output_format != "markdown":
+        raise ValueError(f"Unsupported output format: {output_format}")
+
+    lines = [
+        f"# ACP Certification Manifest: {manifest['profile']}",
+        "",
+        f"- support_state: `{manifest['support_state']}`",
+        f"- verification_level: `{manifest['verification_level']}`",
+        f"- requires_live_agent: `{str(manifest['requires_live_agent']).lower()}`",
+    ]
+    if manifest["required_environment"]:
+        lines.append(f"- required_environment: `{', '.join(manifest['required_environment'])}`")
+    lines.append("")
+    lines.append("## Notes")
+    lines.extend(f"- {note}" for note in manifest["notes"])
+    lines.append("")
+    lines.append("## Commands")
+    for command in manifest["commands"]:
+        env_prefix = " ".join(
+            f"{key}={value}" for key, value in sorted(command.get("env", {}).items())
+        )
+        rendered_command = " ".join(command["argv"])
+        if env_prefix:
+            rendered_command = f"{env_prefix} {rendered_command}"
+        lines.extend(
+            [
+                f"### {command['id']}",
+                "",
+                command["description"],
+                "",
+                f"- cwd: `{command['cwd']}`",
+                f"- safe_to_run_by_default: `{str(command['safe_to_run_by_default']).lower()}`",
+                f"- capabilities: `{', '.join(command['capabilities'])}`",
+                "",
+                "```bash",
+                rendered_command,
+                "```",
+                "",
+            ]
+        )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _command_env(command: dict[str, Any]) -> dict[str, str]:
+    env = os.environ.copy()
+    for key, value in command.get("env", {}).items():
+        text = str(value)
+        if text.startswith("${") and text.endswith("}"):
+            env_name = text[2:-1]
+            env[key] = os.environ.get(env_name, "")
+        else:
+            env[key] = text
+    return env
+
+
+def run_manifest(profile: str) -> int:
+    """Run safe-by-default commands for a certification profile."""
+    manifest = build_manifest(profile)
+    if manifest["requires_live_agent"]:
+        missing = [
+            name for name in manifest["required_environment"]
+            if not os.environ.get(name)
+        ]
+        if missing:
+            print(
+                "Refusing to run live ACP certification without required environment: "
+                + ", ".join(missing),
+                file=sys.stderr,
+            )
+            return 2
+
+    for command in manifest["commands"]:
+        if not command["safe_to_run_by_default"] and not manifest["requires_live_agent"]:
+            continue
+        cwd = ROOT / command["cwd"]
+        print(f"==> {command['id']} ({cwd})")
+        result = subprocess.run(  # nosec B603
+            command["argv"],
+            cwd=str(cwd),
+            env=_command_env(command),
+            check=False,
+        )
+        if result.returncode != 0:
+            return int(result.returncode)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--profile",
+        choices=sorted(_MANIFESTS),
+        default="stub-smoke",
+        help="Certification profile to emit or run.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["markdown", "json"],
+        default="markdown",
+        help="Manifest output format.",
+    )
+    parser.add_argument(
+        "--run",
+        action="store_true",
+        help="Run the manifest commands instead of printing them.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.run:
+        return run_manifest(args.profile)
+
+    print(render_manifest(args.profile, output_format=args.format))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Helper_Scripts/Testing-related/acp_certification_smoke.py
+++ b/Helper_Scripts/Testing-related/acp_certification_smoke.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shlex
 # subprocess is intentionally used to run static manifest argv with shell=False.
 import subprocess  # nosec B404
 import sys
@@ -93,6 +94,7 @@ _MANIFESTS: dict[str, dict[str, Any]] = {
                     "mcp_injection",
                 ],
                 "safe_to_run_by_default": True,
+                "optional": True,
             },
         ],
     },
@@ -188,9 +190,10 @@ def render_manifest(profile: str, *, output_format: str = "markdown") -> str:
     lines.append("## Commands")
     for command in manifest["commands"]:
         env_prefix = " ".join(
-            f"{key}={value}" for key, value in sorted(command.get("env", {}).items())
+            f"{key}={_quote_shell_env_value(str(value))}"
+            for key, value in sorted(command.get("env", {}).items())
         )
-        rendered_command = " ".join(command["argv"])
+        rendered_command = shlex.join(str(arg) for arg in command["argv"])
         if env_prefix:
             rendered_command = f"{env_prefix} {rendered_command}"
         lines.extend(
@@ -201,6 +204,7 @@ def render_manifest(profile: str, *, output_format: str = "markdown") -> str:
                 "",
                 f"- cwd: `{command['cwd']}`",
                 f"- safe_to_run_by_default: `{str(command['safe_to_run_by_default']).lower()}`",
+                f"- optional: `{str(command.get('optional', False)).lower()}`",
                 f"- capabilities: `{', '.join(command['capabilities'])}`",
                 "",
                 "```bash",
@@ -212,7 +216,20 @@ def render_manifest(profile: str, *, output_format: str = "markdown") -> str:
     return "\n".join(lines).rstrip() + "\n"
 
 
+def _quote_shell_env_value(value: str) -> str:
+    """Return a shell-safe env value while preserving ${VAR} placeholders."""
+    if value.startswith("${") and value.endswith("}"):
+        return value
+    return shlex.quote(value)
+
+
 def _command_env(command: dict[str, Any]) -> dict[str, str]:
+    """Merge manifest env overrides into the process environment.
+
+    Values of the form `${NAME}` are resolved from the current process
+    environment so live-E2E manifests can declare required variables without
+    copying secret values into the manifest itself.
+    """
     env = os.environ.copy()
     for key, value in command.get("env", {}).items():
         text = str(value)
@@ -222,6 +239,36 @@ def _command_env(command: dict[str, Any]) -> dict[str, str]:
         else:
             env[key] = text
     return env
+
+
+def _missing_executable_reason(command: dict[str, Any], cwd: Path) -> str | None:
+    """Return a skip/fail reason when a path-like executable is unavailable."""
+    argv = command.get("argv", [])
+    if not argv:
+        return "command argv is empty"
+
+    executable = str(argv[0])
+    if "/" not in executable and not executable.startswith("."):
+        return None
+
+    executable_path = Path(executable)
+    if not executable_path.is_absolute():
+        executable_path = cwd / executable_path
+    if not executable_path.exists():
+        return f"executable not found: {executable_path}"
+    if not os.access(executable_path, os.X_OK):
+        return f"executable is not runnable: {executable_path}"
+    return None
+
+
+def _handle_missing_prerequisite(command: dict[str, Any], reason: str) -> int | None:
+    """Print skip/fail output for missing command prerequisites."""
+    command_id = command.get("id", "<unknown>")
+    if command.get("optional", False):
+        print(f"SKIP {command_id}: {reason}")
+        return None
+    print(f"FAIL {command_id}: {reason}", file=sys.stderr)
+    return 127
 
 
 def run_manifest(profile: str) -> int:
@@ -244,13 +291,30 @@ def run_manifest(profile: str) -> int:
         if not command["safe_to_run_by_default"] and not manifest["requires_live_agent"]:
             continue
         cwd = ROOT / command["cwd"]
+        if not cwd.exists():
+            handled = _handle_missing_prerequisite(command, f"cwd not found: {cwd}")
+            if handled is None:
+                continue
+            return handled
+        missing_executable = _missing_executable_reason(command, cwd)
+        if missing_executable:
+            handled = _handle_missing_prerequisite(command, missing_executable)
+            if handled is None:
+                continue
+            return handled
         print(f"==> {command['id']} ({cwd})")
-        result = subprocess.run(  # nosec B603
-            command["argv"],
-            cwd=str(cwd),
-            env=_command_env(command),
-            check=False,
-        )
+        try:
+            result = subprocess.run(  # nosec B603
+                command["argv"],
+                cwd=str(cwd),
+                env=_command_env(command),
+                check=False,
+            )
+        except FileNotFoundError as exc:
+            handled = _handle_missing_prerequisite(command, str(exc))
+            if handled is None:
+                continue
+            return handled
         if result.returncode != 0:
             return int(result.returncode)
     return 0

--- a/backlog/tasks/task-248 - ACP-certification-checklist-and-smoke-harness.md
+++ b/backlog/tasks/task-248 - ACP-certification-checklist-and-smoke-harness.md
@@ -68,12 +68,29 @@ passed; CLI JSON manifest emitted for `stub-smoke`; `py_compile` passed;
 
 Draft PR created: https://github.com/rmusser01/tldw_server/pull/1555.
 
+Review sweep for PR #1555: actionable feedback covers shell-safe Markdown
+rendering, run_manifest missing-dependency handling, run_manifest tests, test
+return type hints, and _command_env docstring. Reopening task for review fixes.
+
+Review fixes for PR #1555 implemented: shell-safe Markdown rendering with
+placeholder-preserving env quoting; optional missing executable/cwd handling for
+safe-to-run manifest commands; _command_env docstring; type hints for test
+helper/tests; run_manifest tests for live env refusal, nonzero propagation, and
+optional missing executable skip.
+
+Review-fix verification: `python -m pytest
+tldw_Server_API/tests/Helper_Scripts/test_acp_certification_smoke.py -q`
+passed; `stub-smoke` JSON emitted; Markdown output quotes `TLDW_WEB_CMD` and
+`--grep` pattern; `live-e2e --run` refuses without required env with exit 2;
+`py_compile` passed; `git diff --check` passed; Bandit JSON at
+`/tmp/bandit_acp_certification_smoke_review.json` has zero results.
+
 ## Final Summary
 
-Added a reproducible ACP downstream-agent certification workflow for #1539 PR2.
-The new checklist distinguishes stub-smoke, live-E2E, and sandbox evidence; the
-helper emits/runs static command manifests that reuse existing backend ACP
-suites, mocked browser setup/run/diagnose coverage, and Go runner verification;
-and ACP protocol/readiness/matrix docs now link to the workflow. Verified with
-focused pytest, CLI JSON output, py_compile, git diff --check, and Bandit on the
-new helper with zero findings.
+Added a reproducible ACP downstream-agent certification workflow for #1539 PR2
+and addressed PR #1555 review feedback. The helper now renders shell-safe
+Markdown command lines, preserves live env placeholders, skips missing optional
+prerequisites with explicit reasons, and has focused tests for manifest shape,
+Markdown rendering, live safety refusal, nonzero return propagation, and
+optional missing executable behavior. Verified with focused pytest, CLI manifest
+checks, py_compile, git diff --check, and Bandit with zero findings.

--- a/backlog/tasks/task-248 - ACP-certification-checklist-and-smoke-harness.md
+++ b/backlog/tasks/task-248 - ACP-certification-checklist-and-smoke-harness.md
@@ -1,0 +1,79 @@
+---
+id: TASK-248
+title: ACP certification checklist and smoke harness
+status: Done
+assignee: []
+created_date: '2026-05-10 21:32'
+labels:
+  - ACP
+  - compatibility
+  - certification
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1539'
+  - 'https://github.com/rmusser01/tldw_server/pull/1554'
+  - 'https://github.com/rmusser01/tldw_server/pull/1555'
+documentation:
+  - Docs/Development/ACP_Compatibility_Matrix.md
+  - Docs/Development/Agent_Client_Protocol.md
+  - Docs/Development/ACP_Production_Readiness.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement #1539 PR 2: make downstream-agent compatibility claims reproducible with documented certification checklists and a focused smoke harness that reuses existing ACP backend, orchestration, frontend, and Go runner verification where possible. Keep scope to certification workflow, docs, and helper automation; do not build installer or marketplace behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A contributor can certify an agent by following a checklist.
+- [x] #2 Certification does not require undocumented local state.
+- [x] #3 Stub/smoke-tested and live-E2E-tested levels are clearly different.
+- [x] #4 Minimum checks cover session start, prompt, structured completion, artifacts, diagnostics, cancel/close, review loop, workspace env, MCP server injection, and sandbox behavior where applicable.
+- [x] #5 Focused smoke harness or command manifest reuses existing ACP test suites and runner verification rather than inventing parallel checks.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Notes
+
+Implemented certification workflow for #1539 PR2 in worktree
+`.worktrees/acp-certification-smoke-harness`.
+
+Added `Docs/Development/ACP_Certification_Checklist.md` with `stub-smoke`,
+`live-e2e`, sandbox, evidence record, and matrix update checklists.
+
+Added `Helper_Scripts/Testing-related/acp_certification_smoke.py` plus pytest
+coverage in
+`tldw_Server_API/tests/Helper_Scripts/test_acp_certification_smoke.py`.
+
+Linked the checklist/harness from `ACP_Compatibility_Matrix.md`,
+`Agent_Client_Protocol.md`, and `ACP_Production_Readiness.md`.
+
+Verification: `python -m pytest
+tldw_Server_API/tests/Helper_Scripts/test_acp_certification_smoke.py -q`
+passed; CLI JSON manifest emitted for `stub-smoke`; `py_compile` passed;
+`git diff --check` passed; Bandit JSON at
+`/tmp/bandit_acp_certification_smoke.json` has zero results.
+
+Draft PR created: https://github.com/rmusser01/tldw_server/pull/1555.
+
+## Final Summary
+
+Added a reproducible ACP downstream-agent certification workflow for #1539 PR2.
+The new checklist distinguishes stub-smoke, live-E2E, and sandbox evidence; the
+helper emits/runs static command manifests that reuse existing backend ACP
+suites, mocked browser setup/run/diagnose coverage, and Go runner verification;
+and ACP protocol/readiness/matrix docs now link to the workflow. Verified with
+focused pytest, CLI JSON output, py_compile, git diff --check, and Bandit on the
+new helper with zero findings.

--- a/tldw_Server_API/tests/Helper_Scripts/test_acp_certification_smoke.py
+++ b/tldw_Server_API/tests/Helper_Scripts/test_acp_certification_smoke.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 import importlib.util
 import json
 from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
 
 
 SCRIPT_PATH = (
@@ -13,7 +16,7 @@ SCRIPT_PATH = (
 )
 
 
-def _load_module():
+def _load_module() -> ModuleType:
     spec = importlib.util.spec_from_file_location("acp_certification_smoke", SCRIPT_PATH)
     assert spec is not None
     module = importlib.util.module_from_spec(spec)
@@ -22,7 +25,7 @@ def _load_module():
     return module
 
 
-def test_stub_smoke_manifest_reuses_existing_acp_gates():
+def test_stub_smoke_manifest_reuses_existing_acp_gates() -> None:
     module = _load_module()
 
     manifest = module.build_manifest("stub-smoke")
@@ -50,7 +53,7 @@ def test_stub_smoke_manifest_reuses_existing_acp_gates():
     }.issubset(capability_ids)
 
 
-def test_live_e2e_manifest_requires_operator_supplied_runtime_state():
+def test_live_e2e_manifest_requires_operator_supplied_runtime_state() -> None:
     module = _load_module()
 
     manifest = module.build_manifest("live-e2e")
@@ -66,7 +69,7 @@ def test_live_e2e_manifest_requires_operator_supplied_runtime_state():
     assert all(command["safe_to_run_by_default"] is False for command in manifest["commands"])
 
 
-def test_manifest_json_output_is_stable_and_machine_readable():
+def test_manifest_json_output_is_stable_and_machine_readable() -> None:
     module = _load_module()
 
     rendered = module.render_manifest("stub-smoke", output_format="json")
@@ -76,3 +79,96 @@ def test_manifest_json_output_is_stable_and_machine_readable():
     assert payload["commands"][0]["argv"][0] in {"python", "python3"}
     assert payload["commands"][0]["cwd"] == "."
     assert payload["commands"][0]["safe_to_run_by_default"] is True
+
+
+def test_manifest_markdown_quotes_shell_tokens_with_spaces() -> None:
+    module = _load_module()
+
+    rendered = module.render_manifest("stub-smoke")
+
+    assert "'guide ACP setup'" in rendered
+    assert "TLDW_WEB_CMD='bun run dev -- -p 18080'" in rendered
+
+
+def test_manifest_markdown_keeps_live_env_placeholders_expandable() -> None:
+    module = _load_module()
+
+    rendered = module.render_manifest("live-e2e")
+
+    assert "TLDW_E2E_SERVER_URL=${TLDW_E2E_SERVER_URL}" in rendered
+    assert "TLDW_E2E_API_KEY=${TLDW_E2E_API_KEY}" in rendered
+    assert "ACP_AGENT_PROFILE=${ACP_AGENT_PROFILE}" in rendered
+
+
+def test_run_manifest_live_e2e_refuses_without_required_env(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = _load_module()
+    monkeypatch.delenv("TLDW_E2E_SERVER_URL", raising=False)
+    monkeypatch.delenv("TLDW_E2E_API_KEY", raising=False)
+    monkeypatch.delenv("ACP_AGENT_PROFILE", raising=False)
+
+    rc = module.run_manifest("live-e2e")
+    captured = capsys.readouterr()
+
+    assert rc == 2
+    assert "Refusing to run live ACP certification" in captured.err
+
+
+def test_run_manifest_returns_first_nonzero_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_module()
+    commands = module.build_manifest("stub-smoke")["commands"][:1]
+    monkeypatch.setattr(
+        module,
+        "build_manifest",
+        lambda _profile: {
+            "profile": "stub-smoke",
+            "requires_live_agent": False,
+            "required_environment": [],
+            "commands": commands,
+        },
+    )
+    monkeypatch.setattr(
+        module.subprocess,
+        "run",
+        lambda *_args, **_kwargs: SimpleNamespace(returncode=7),
+    )
+
+    rc = module.run_manifest("stub-smoke")
+
+    assert rc == 7
+
+
+def test_run_manifest_skips_optional_missing_executable(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = _load_module()
+    monkeypatch.setattr(
+        module,
+        "build_manifest",
+        lambda _profile: {
+            "profile": "stub-smoke",
+            "requires_live_agent": False,
+            "required_environment": [],
+            "commands": [
+                {
+                    "id": "optional_missing_browser",
+                    "cwd": ".",
+                    "argv": ["./definitely-missing-playwright"],
+                    "safe_to_run_by_default": True,
+                    "optional": True,
+                }
+            ],
+        },
+    )
+    monkeypatch.setattr(module.subprocess, "run", lambda *_args, **_kwargs: None)
+
+    rc = module.run_manifest("stub-smoke")
+    captured = capsys.readouterr()
+
+    assert rc == 0
+    assert "SKIP optional_missing_browser" in captured.out

--- a/tldw_Server_API/tests/Helper_Scripts/test_acp_certification_smoke.py
+++ b/tldw_Server_API/tests/Helper_Scripts/test_acp_certification_smoke.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "Helper_Scripts"
+    / "Testing-related"
+    / "acp_certification_smoke.py"
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("acp_certification_smoke", SCRIPT_PATH)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_stub_smoke_manifest_reuses_existing_acp_gates():
+    module = _load_module()
+
+    manifest = module.build_manifest("stub-smoke")
+
+    command_ids = {command["id"] for command in manifest["commands"]}
+    capability_ids = {
+        capability
+        for command in manifest["commands"]
+        for capability in command["capabilities"]
+    }
+
+    assert manifest["verification_level"] == "stub_smoke_tested"
+    assert manifest["requires_live_agent"] is False
+    assert "backend_acp_smoke" in command_ids
+    assert "go_runner_verify" in command_ids
+    assert "browser_mocked_setup_run_diagnose" in command_ids
+    assert {
+        "init",
+        "session_new",
+        "prompt",
+        "structured_completion",
+        "diagnostics",
+        "cancel_close",
+        "redacted_support_view",
+    }.issubset(capability_ids)
+
+
+def test_live_e2e_manifest_requires_operator_supplied_runtime_state():
+    module = _load_module()
+
+    manifest = module.build_manifest("live-e2e")
+
+    assert manifest["verification_level"] == "live_e2e_tested"
+    assert manifest["requires_live_agent"] is True
+    assert manifest["required_environment"] == [
+        "TLDW_E2E_SERVER_URL",
+        "TLDW_E2E_API_KEY",
+        "ACP_AGENT_PROFILE",
+    ]
+    assert any(command["id"] == "live_backend_acp_e2e" for command in manifest["commands"])
+    assert all(command["safe_to_run_by_default"] is False for command in manifest["commands"])
+
+
+def test_manifest_json_output_is_stable_and_machine_readable():
+    module = _load_module()
+
+    rendered = module.render_manifest("stub-smoke", output_format="json")
+    payload = json.loads(rendered)
+
+    assert payload["profile"] == "stub-smoke"
+    assert payload["commands"][0]["argv"][0] in {"python", "python3"}
+    assert payload["commands"][0]["cwd"] == "."
+    assert payload["commands"][0]["safe_to_run_by_default"] is True


### PR DESCRIPTION
## Summary
- Add ACP downstream-agent certification checklist covering stub-smoke, live-E2E, and sandbox evidence.
- Add `acp_certification_smoke.py` to emit/run static command manifests that reuse existing backend ACP tests, mocked browser setup/run/diagnose coverage, and Go runner verification.
- Link the checklist and manifest from the ACP compatibility matrix, protocol guide, and production readiness matrix.
- Add Backlog task TASK-248 for the #1539 PR2 slice.

## Verification
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Helper_Scripts/test_acp_certification_smoke.py -q`
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python Helper_Scripts/Testing-related/acp_certification_smoke.py --profile stub-smoke --format json`
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m py_compile Helper_Scripts/Testing-related/acp_certification_smoke.py`
- `git diff --check`
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r Helper_Scripts/Testing-related/acp_certification_smoke.py -f json -o /tmp/bandit_acp_certification_smoke.json` (zero findings)

## Change summary
AI-generated PR. Human requester must replace this section with a human-written summary explaining what changed and why these implementation choices were made before marking ready for merge.

Refs #1539.