### PR TITLE
Surface ACP compatibility status in setup paths

### DIFF
--- a/apps/packages/ui/src/components/Option/AgentRegistry/__tests__/AgentRegistryPage.connection.test.tsx
+++ b/apps/packages/ui/src/components/Option/AgentRegistry/__tests__/AgentRegistryPage.connection.test.tsx
@@ -234,4 +234,43 @@ describe("AgentRegistryPage connection config", () => {
     expect(await screen.findByText(/Runner source PATH path \/opt\/homebrew\/bin\/go/i)).toBeInTheDocument()
     expect(screen.getByText(/1\/1 agents available/i)).toBeInTheDocument()
   })
+
+  it("renders ACP compatibility support and verification states separately from runtime setup", async () => {
+    acpMocks.getAvailableAgents.mockResolvedValue({
+      agents: [
+        {
+          type: "codex",
+          name: "Codex CLI",
+          description: "Configured locally",
+          is_configured: true,
+          support_state: "documented_unverified",
+          verification_level: "documented_only",
+          compatibility_notes: "Configured locally, but live-agent compatibility is not certified.",
+          compatibility_docs_url: "/docs-static/Development/ACP_Compatibility_Matrix.md"
+        },
+        {
+          type: "stub",
+          name: "In-repo ACP stub",
+          description: "Protocol fixture",
+          is_configured: true,
+          support_state: "supported_with_caveats",
+          verification_level: "stub_smoke_tested",
+          compatibility_notes: "Stub protocol coverage only."
+        }
+      ]
+    })
+
+    render(<AgentRegistryPage />)
+
+    expect(await screen.findByText("Codex CLI")).toBeInTheDocument()
+    expect(screen.getByText("documented_unverified")).toBeInTheDocument()
+    expect(screen.getByText("documented_only")).toBeInTheDocument()
+    expect(screen.getByText("supported_with_caveats")).toBeInTheDocument()
+    expect(screen.getByText("stub_smoke_tested")).toBeInTheDocument()
+    expect(screen.getByText(/configured but compatibility is documented_unverified/i)).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: /Compatibility matrix/i })).toHaveAttribute(
+      "href",
+      "/docs-static/Development/ACP_Compatibility_Matrix.md"
+    )
+  })
 })

--- a/apps/packages/ui/src/components/Option/AgentRegistry/index.tsx
+++ b/apps/packages/ui/src/components/Option/AgentRegistry/index.tsx
@@ -15,6 +15,7 @@ import { useCanonicalConnectionConfig } from "@/hooks/useCanonicalConnectionConf
 import { ACPRestClient } from "@/services/acp/client"
 import { buildACPAuthHeaders, buildACPClientConfig } from "@/services/acp/connection"
 import { normalizeACPHealthStatus, type ACPHealthStatus } from "@/services/acp/readiness"
+import type { ACPSupportState, ACPVerificationLevel } from "@/services/acp/types"
 import { resolveBrowserRequestTransport } from "@/services/tldw/request-core"
 
 type AgentEntry = {
@@ -24,6 +25,18 @@ type AgentEntry = {
   status: "available" | "unavailable" | "requires_setup"
   reason?: string
   is_default?: boolean
+  support_state: ACPSupportState
+  verification_level: ACPVerificationLevel
+  compatibility_notes?: string
+  compatibility_docs_url?: string | null
+}
+
+const COMPATIBILITY_COLOR: Record<ACPSupportState, "success" | "warning" | "error" | "processing" | "default"> = {
+  supported: "success",
+  supported_with_caveats: "processing",
+  experimental: "warning",
+  documented_unverified: "warning",
+  unsupported: "error"
 }
 
 export const AgentRegistryPage: React.FC = () => {
@@ -55,7 +68,11 @@ export const AgentRegistryPage: React.FC = () => {
           type: agent.type,
           name: agent.name,
           description: agent.description,
-          status: agent.is_configured ? "available" : "requires_setup"
+          status: agent.is_configured ? "available" : "requires_setup",
+          support_state: agent.support_state ?? "documented_unverified",
+          verification_level: agent.verification_level ?? "documented_only",
+          compatibility_notes: agent.compatibility_notes,
+          compatibility_docs_url: agent.compatibility_docs_url
         }))
       )
     } catch (err) {
@@ -241,6 +258,8 @@ const AgentCard: React.FC<{ agent: AgentEntry }> = ({ agent }) => {
       : agent.status === "requires_setup"
         ? "Setup Required"
         : "Unavailable"
+  const showUnverifiedWarning =
+    agent.status === "available" && agent.support_state === "documented_unverified"
 
   return (
     <div className="rounded-lg border border-border p-4 transition-shadow hover:shadow-md">
@@ -262,6 +281,35 @@ const AgentCard: React.FC<{ agent: AgentEntry }> = ({ agent }) => {
       <p className="mb-3 text-sm text-muted-foreground">
         {agent.description || `Agent type: ${agent.type}`}
       </p>
+
+      <div className="mb-3 flex flex-wrap items-center gap-2 text-xs">
+        <Tag color={COMPATIBILITY_COLOR[agent.support_state]}>
+          {agent.support_state}
+        </Tag>
+        <Tag>{agent.verification_level}</Tag>
+        {agent.compatibility_docs_url && (
+          <a
+            className="text-primary hover:underline"
+            href={agent.compatibility_docs_url}
+            target="_blank"
+            rel="noreferrer"
+          >
+            Compatibility matrix
+          </a>
+        )}
+      </div>
+
+      {agent.compatibility_notes && (
+        <div className="mb-3 rounded bg-muted px-2 py-1.5 text-xs text-muted-foreground">
+          {agent.compatibility_notes}
+        </div>
+      )}
+
+      {showUnverifiedWarning && (
+        <div className="mb-3 rounded bg-yellow-50 p-2 text-xs text-yellow-700 dark:bg-yellow-900/20 dark:text-yellow-400">
+          Configured but compatibility is documented_unverified. Run the ACP certification checklist before release claims.
+        </div>
+      )}
 
       {agent.reason && (
         <div className="mb-3 rounded bg-yellow-50 p-2 text-xs text-yellow-700 dark:bg-yellow-900/20 dark:text-yellow-400">

--- a/apps/packages/ui/src/services/acp/types.ts
+++ b/apps/packages/ui/src/services/acp/types.ts
@@ -9,6 +9,19 @@
 // -----------------------------------------------------------------------------
 
 export type ACPAgentType = string
+export type ACPSupportState =
+  | "supported"
+  | "supported_with_caveats"
+  | "experimental"
+  | "documented_unverified"
+  | "unsupported"
+
+export type ACPVerificationLevel =
+  | "documented_only"
+  | "stub_smoke_tested"
+  | "live_e2e_tested"
+  | "sandbox_tested"
+  | "production_supported"
 
 export interface ACPAgentInfo {
   type: ACPAgentType
@@ -16,6 +29,10 @@ export interface ACPAgentInfo {
   description: string
   is_configured: boolean
   requires_api_key?: string | null
+  support_state?: ACPSupportState
+  verification_level?: ACPVerificationLevel
+  compatibility_notes?: string
+  compatibility_docs_url?: string | null
 }
 
 export interface ACPAgentListResponse {

--- a/backlog/tasks/task-253 - Surface-ACP-compatibility-status-in-setup-paths.md
+++ b/backlog/tasks/task-253 - Surface-ACP-compatibility-status-in-setup-paths.md
@@ -1,0 +1,74 @@
+---
+id: TASK-253
+title: Surface ACP compatibility status in setup paths
+status: In Progress
+assignee: []
+created_date: '2026-05-11 00:35'
+updated_date: '2026-05-11 04:32'
+labels:
+  - ACP
+  - compatibility
+  - frontend
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1539'
+  - 'https://github.com/rmusser01/tldw_server/pull/1555'
+documentation:
+  - Docs/Development/ACP_Compatibility_Matrix.md
+  - Docs/Development/ACP_Certification_Checklist.md
+  - Docs/Development/Agent_Client_Protocol.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement #1539 PR3: make downstream-agent compatibility status visible in Agent Registry/setup paths using the same support-state language as the ACP compatibility docs. Keep scope status-oriented: shared status/caveat contract, setup/registry surfacing, docs/release-note linkage. Do not build installer or marketplace behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Agent Registry/setup surfaces can distinguish configured-but-unverified from verified/supported.
+- [x] #2 Docs and UI use the same support-state language.
+- [x] #3 Release notes can make accurate live-agent claims.
+- [x] #4 Unsupported or unverified states are actionable without implying installer or marketplace support.
+- [x] #5 Remaining per-agent live verification is split into follow-up issues or documented as out of scope for #1539.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:NOTES:BEGIN -->
+
+Opened PR #1562: https://github.com/rmusser01/tldw_server/pull/1562.
+
+Created follow-up live-certification issues #1563 and #1564 for remaining commercial and OSS/custom agent verification work.
+
+Added PR3 progress comment to #1539: https://github.com/rmusser01/tldw_server/issues/1539#issuecomment-4416884893.
+
+PR #1562 review fixes: added Pydantic setup-guide response models, switched compatibility docs URLs to /docs-static/Development/ACP_Compatibility_Matrix.md, normalized invalid support_state/verification_level values to conservative defaults, and moved the static UI compatibility color map out of AgentCard.
+
+Review-fix verification passing: python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/test_acp_agent_registry.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_health.py -q; ./node_modules/.bin/vitest run src/components/Option/AgentRegistry/__tests__/AgentRegistryPage.connection.test.tsx --maxWorkers=1 --no-file-parallelism; python -m py_compile touched ACP Python files; git diff --check; Bandit JSON at /tmp/bandit_acp_compatibility_status_surfaces.json with zero findings.
+<!-- SECTION:NOTES:END -->
+
+Implemented ACP compatibility status surfacing across registry metadata, /api/v1/acp/health, /api/v1/acp/setup-guide, /api/v1/acp/agents, and the WebUI Agent Registry.
+
+Verification passing: python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/test_acp_agent_registry.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_health.py -q; ./node_modules/.bin/vitest run src/components/Option/AgentRegistry/__tests__/AgentRegistryPage.connection.test.tsx --maxWorkers=1 --no-file-parallelism; python -m py_compile touched ACP Python files; git diff --check; Bandit JSON at /tmp/bandit_acp_compatibility_status_surfaces.json with zero findings.
+
+Repo-wide UI TypeScript check attempted with ./node_modules/.bin/tsc --noEmit -p tsconfig.json and failed on existing unrelated baseline errors outside this ACP/Agent Registry slice.
+<!-- SECTION:NOTES:END -->
+
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+- [x] #7 Focused UI/backend tests updated or added
+- [x] #8 Bandit run for touched Python paths or documented skip
+- [x] #9 PR3 progress comment added to #1539
+<!-- DOD:END -->

--- a/tldw_Server_API/Config_Files/agents.yaml
+++ b/tldw_Server_API/Config_Files/agents.yaml
@@ -13,6 +13,12 @@
 #   default: Whether this is the default agent (only one should be true)
 #   install_instructions: Steps to install the agent (list of strings)
 #   docs_url: Link to agent documentation
+#   support_state: ACP compatibility state; one of supported,
+#     supported_with_caveats, experimental, documented_unverified, unsupported
+#   verification_level: Evidence level; one of documented_only,
+#     stub_smoke_tested, live_e2e_tested, sandbox_tested, production_supported
+#   compatibility_notes: Release-facing compatibility caveat
+#   compatibility_docs_url: Compatibility matrix or evidence document
 
 agents:
   - type: claude_code
@@ -26,6 +32,10 @@ agents:
     install_instructions:
       - "npm install -g @anthropic-ai/claude-code"
     docs_url: "https://docs.anthropic.com/en/docs/claude-code"
+    support_state: documented_unverified
+    verification_level: documented_only
+    compatibility_notes: "Configured-agent setup is documented, but live Claude Code ACP compatibility is not certified yet."
+    compatibility_docs_url: "/docs-static/Development/ACP_Compatibility_Matrix.md"
 
   - type: codex
     name: OpenAI Codex CLI
@@ -37,6 +47,10 @@ agents:
     install_instructions:
       - "npm install -g @openai/codex"
     docs_url: "https://github.com/openai/codex"
+    support_state: documented_unverified
+    verification_level: documented_only
+    compatibility_notes: "Configured-agent setup is documented, but live Codex ACP compatibility is not certified yet."
+    compatibility_docs_url: "/docs-static/Development/ACP_Compatibility_Matrix.md"
 
   - type: aider
     name: Aider
@@ -46,6 +60,10 @@ agents:
     install_instructions:
       - "pip install aider-chat"
     docs_url: "https://aider.chat"
+    support_state: documented_unverified
+    verification_level: documented_only
+    compatibility_notes: "Configured-agent setup is documented, but live Aider ACP compatibility is not certified yet."
+    compatibility_docs_url: "/docs-static/Development/ACP_Compatibility_Matrix.md"
 
   - type: goose
     name: Goose
@@ -56,6 +74,10 @@ agents:
       - "brew install block/goose/goose"
       - "# or: cargo install goose-cli"
     docs_url: "https://github.com/block/goose"
+    support_state: documented_unverified
+    verification_level: documented_only
+    compatibility_notes: "Configured-agent setup is documented, but live Goose ACP compatibility is not certified yet."
+    compatibility_docs_url: "/docs-static/Development/ACP_Compatibility_Matrix.md"
 
   - type: continue_dev
     name: Continue
@@ -66,6 +88,10 @@ agents:
       - "npm install -g @continuedev/cli"
     docs_url: "https://continue.dev"
     default: false
+    support_state: documented_unverified
+    verification_level: documented_only
+    compatibility_notes: "Configured-agent setup is documented, but live Continue ACP compatibility is not certified yet."
+    compatibility_docs_url: "/docs-static/Development/ACP_Compatibility_Matrix.md"
 
   - type: opencode
     name: OpenCode
@@ -78,6 +104,10 @@ agents:
       - "go install github.com/sst/opencode@latest"
     docs_url: "https://github.com/sst/opencode"
     default: false
+    support_state: documented_unverified
+    verification_level: documented_only
+    compatibility_notes: "Configured-agent setup is documented, but live OpenCode ACP compatibility is not certified yet."
+    compatibility_docs_url: "/docs-static/Development/ACP_Compatibility_Matrix.md"
 
   - type: custom
     name: Custom Agent
@@ -87,3 +117,7 @@ agents:
     env: {}
     requires_api_key: null
     default: false
+    support_state: documented_unverified
+    verification_level: documented_only
+    compatibility_notes: "Custom ACP profiles require certification evidence before release claims."
+    compatibility_docs_url: "/docs-static/Development/ACP_Compatibility_Matrix.md"

--- a/tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py
+++ b/tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py
@@ -16,11 +16,14 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, WebSocket, WebSocketDisconnect, status
 from fastapi.responses import StreamingResponse
 from loguru import logger
+from pydantic import ValidationError
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, TokenScopeGuard, User
 
 from tldw_Server_API.app.api.v1.endpoints._in_memory_limits import SlidingWindowLimiter
 from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.schemas.agent_client_protocol import (
+    ACP_COMPATIBILITY_DOCS_URL,
+    ACPAgentCompatibilityStatus,
     ACPAgentInfo,
     ACPAgentListResponse,
     ACPAgentHealthEntry,
@@ -32,6 +35,7 @@ from tldw_Server_API.app.api.v1.schemas.agent_client_protocol import (
     ACPAsyncPromptResponse,
     ACPCheckpointListResponse,
     ACPHealthResponse,
+    ACPSetupGuideResponse,
     ACPRollbackRequest,
     ACPRollbackResponse,
     ACPSessionCancelRequest,
@@ -171,6 +175,20 @@ _ACP_DIAGNOSTIC_REASON_MAP: dict[str, str] = {
     "runtime_error": "failed_runtime",
     "invariant_violation": "invariant_violation",
 }
+_ACP_SUPPORT_STATES = frozenset({
+    "supported",
+    "supported_with_caveats",
+    "experimental",
+    "documented_unverified",
+    "unsupported",
+})
+_ACP_VERIFICATION_LEVELS = frozenset({
+    "documented_only",
+    "stub_smoke_tested",
+    "live_e2e_tested",
+    "sandbox_tested",
+    "production_supported",
+})
 
 
 def get_acp_runtime_policy_service() -> ACPRuntimePolicyService:
@@ -1587,10 +1605,59 @@ def _check_agent_availability(agent_type: str) -> dict[str, Any]:
             "status": "unknown",
             "binary_found": False,
             "api_key_set": False,
+            "support_state": "documented_unverified",
+            "verification_level": "documented_only",
+            "compatibility_notes": "Agent is not present in the registry; live-agent ACP compatibility has not been certified.",
+            "compatibility_docs_url": ACP_COMPATIBILITY_DOCS_URL,
         }
     result = entry.check_availability()
     result["agent_type"] = agent_type
     return result
+
+
+def _build_agent_compatibility_status(source: Any) -> ACPAgentCompatibilityStatus:
+    """Return ACP compatibility metadata with conservative defaults."""
+    get_value = source.get if isinstance(source, dict) else lambda key, default=None: getattr(source, key, default)
+
+    support_state = str(get_value("support_state") or "documented_unverified")
+    verification_level = str(get_value("verification_level") or "documented_only")
+    if support_state not in _ACP_SUPPORT_STATES:
+        support_state = "documented_unverified"
+    if verification_level not in _ACP_VERIFICATION_LEVELS:
+        verification_level = "documented_only"
+    notes = (
+        get_value("compatibility_notes")
+        or "Configured locally; live-agent ACP compatibility has not been certified."
+    )
+    docs_url = get_value("compatibility_docs_url") or ACP_COMPATIBILITY_DOCS_URL
+    if str(docs_url).startswith("Docs/"):
+        docs_url = f"/docs-static/{str(docs_url).removeprefix('Docs/')}"
+    return ACPAgentCompatibilityStatus(
+        support_state=support_state,
+        verification_level=verification_level,
+        notes=str(notes),
+        docs_url=str(docs_url),
+    )
+
+
+def _compatibility_setup_steps(compatibility: ACPAgentCompatibilityStatus) -> list[str]:
+    """Return setup-guide actions for ACP compatibility certification state."""
+    support_state = compatibility.support_state
+    if support_state == "documented_unverified":
+        return [
+            "Run the ACP certification checklist before claiming live-agent support.",
+            "Record evidence in the ACP compatibility matrix after live verification.",
+        ]
+    if support_state == "unsupported":
+        return [
+            "Do not claim ACP support for this agent until the compatibility issue is resolved.",
+            "Open or link a follow-up issue before release if this agent must ship.",
+        ]
+    if support_state == "experimental":
+        return ["Treat this ACP integration as experimental and review the compatibility caveats before release."]
+    if support_state == "supported_with_caveats":
+        return ["Review the ACP compatibility matrix caveats before release claims."]
+    return []
 
 
 @router.get(
@@ -1627,6 +1694,10 @@ async def acp_health(
             "binary_found": avail.get("binary_found", False),
             "api_key_set": avail.get("api_key_set", False),
             "is_configured": avail.get("is_configured", False),
+            "support_state": avail.get("support_state", "documented_unverified"),
+            "verification_level": avail.get("verification_level", "documented_only"),
+            "compatibility_notes": avail.get("compatibility_notes", ""),
+            "compatibility_docs_url": avail.get("compatibility_docs_url"),
         })
     result["agents"] = agents_status
 
@@ -1694,6 +1765,7 @@ async def acp_health(
 
 @router.get(
     "/setup-guide",
+    response_model=ACPSetupGuideResponse,
     dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="acp.setup_guide"))],
 )
 async def acp_setup_guide(
@@ -1740,6 +1812,7 @@ async def acp_setup_guide(
             "agent_type": reg_entry.type,
             "name": reg_entry.name,
             "status": avail.get("status", "unknown"),
+            "compatibility": _build_agent_compatibility_status(reg_entry),
             "steps": [],
         }
 
@@ -1751,6 +1824,8 @@ async def acp_setup_guide(
 
         if not avail.get("api_key_set", True) and reg_entry.requires_api_key:
             guide_item["steps"].append(f"Set {reg_entry.requires_api_key} environment variable or add to .env file")
+
+        guide_item["steps"].extend(_compatibility_setup_steps(guide_item["compatibility"]))
 
         if not guide_item["steps"]:
             guide_item["steps"] = [f"{reg_entry.name} is fully configured"]
@@ -1778,6 +1853,9 @@ def _get_static_agents() -> tuple[list[ACPAgentInfo], str]:
             description="Anthropic's Claude Code agent for software development tasks",
             is_configured=bool(anthropic_key),
             requires_api_key="ANTHROPIC_API_KEY" if not anthropic_key else None,
+            support_state="documented_unverified",
+            verification_level="documented_only",
+            compatibility_notes="Static fallback only; live Claude Code ACP compatibility has not been certified.",
         )
     )
 
@@ -1789,6 +1867,9 @@ def _get_static_agents() -> tuple[list[ACPAgentInfo], str]:
             description="OpenAI's Codex agent for code generation and analysis",
             is_configured=bool(openai_key),
             requires_api_key="OPENAI_API_KEY" if not openai_key else None,
+            support_state="documented_unverified",
+            verification_level="documented_only",
+            compatibility_notes="Static fallback only; live Codex ACP compatibility has not been certified.",
         )
     )
 
@@ -1799,6 +1880,9 @@ def _get_static_agents() -> tuple[list[ACPAgentInfo], str]:
             description="Open-source coding agent (github.com/sst/opencode)",
             is_configured=True,
             requires_api_key=None,
+            support_state="documented_unverified",
+            verification_level="documented_only",
+            compatibility_notes="Static fallback only; live OpenCode ACP compatibility has not been certified.",
         )
     )
 
@@ -1809,6 +1893,9 @@ def _get_static_agents() -> tuple[list[ACPAgentInfo], str]:
             description="Configure a custom agent with your own settings",
             is_configured=True,
             requires_api_key=None,
+            support_state="documented_unverified",
+            verification_level="documented_only",
+            compatibility_notes="Custom agent profiles require certification evidence before release claims.",
         )
     )
 
@@ -1825,6 +1912,7 @@ def _get_registry_agents() -> tuple[list[ACPAgentInfo], str] | None:
             return None
         agents: list[ACPAgentInfo] = []
         for item in available:
+            compatibility = _build_agent_compatibility_status(item)
             agents.append(
                 ACPAgentInfo(
                     type=str(item["type"]),
@@ -1832,6 +1920,10 @@ def _get_registry_agents() -> tuple[list[ACPAgentInfo], str] | None:
                     description=str(item.get("description", "")),
                     is_configured=bool(item.get("is_configured", False)),
                     requires_api_key=item.get("missing_api_key"),
+                    support_state=compatibility.support_state,
+                    verification_level=compatibility.verification_level,
+                    compatibility_notes=compatibility.notes,
+                    compatibility_docs_url=compatibility.docs_url,
                 )
             )
         return agents, registry.default_type
@@ -1870,15 +1962,23 @@ async def _get_available_agents() -> tuple[list[ACPAgentInfo], str]:
         requires_api_key = item.get("requiresApiKey")
         if requires_api_key is None:
             requires_api_key = item.get("requires_api_key")
-        agents.append(
-            ACPAgentInfo(
+        compatibility = _build_agent_compatibility_status(item)
+        try:
+            agent_info = ACPAgentInfo(
                 type=str(agent_type),
                 name=str(name),
                 description=str(item.get("description") or ""),
                 is_configured=bool(is_configured),
                 requires_api_key=str(requires_api_key) if requires_api_key else None,
+                support_state=compatibility.support_state,
+                verification_level=compatibility.verification_level,
+                compatibility_notes=compatibility.notes,
+                compatibility_docs_url=compatibility.docs_url,
             )
-        )
+        except ValidationError:
+            logger.warning("Skipping invalid ACP runner agent entry: {}", agent_type)
+            continue
+        agents.append(agent_info)
 
     if not agents:
         return _get_static_agents()

--- a/tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py
+++ b/tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py
@@ -22,6 +22,21 @@ def _default_offset_pagination_aliases(response):
 
 # Agent type identifiers are user-configurable strings.
 ACPAgentType = str
+ACP_COMPATIBILITY_DOCS_URL = "/docs-static/Development/ACP_Compatibility_Matrix.md"
+ACPSupportState = Literal[
+    "supported",
+    "supported_with_caveats",
+    "experimental",
+    "documented_unverified",
+    "unsupported",
+]
+ACPVerificationLevel = Literal[
+    "documented_only",
+    "stub_smoke_tested",
+    "live_e2e_tested",
+    "sandbox_tested",
+    "production_supported",
+]
 
 
 class ACPAgentInfo(BaseModel):
@@ -36,12 +51,75 @@ class ACPAgentInfo(BaseModel):
         default=None,
         description="Name of required API key if not configured (e.g., 'ANTHROPIC_API_KEY')",
     )
+    support_state: ACPSupportState = Field(
+        default="documented_unverified",
+        description="Compatibility support state from the ACP compatibility matrix.",
+    )
+    verification_level: ACPVerificationLevel = Field(
+        default="documented_only",
+        description="Evidence level behind the compatibility support state.",
+    )
+    compatibility_notes: str = Field(
+        default="Configured locally; live-agent ACP compatibility has not been certified.",
+        description="Human-readable compatibility caveat or certification note.",
+    )
+    compatibility_docs_url: str | None = Field(
+        default=ACP_COMPATIBILITY_DOCS_URL,
+        description="Documentation path or URL for compatibility details.",
+    )
 
 
 class ACPAgentListResponse(BaseModel):
     """Response for listing available agents."""
     agents: list[ACPAgentInfo] = Field(default_factory=list)
     default_agent: ACPAgentType = Field(default="custom")
+
+
+class ACPAgentCompatibilityStatus(BaseModel):
+    """Compatibility status for an ACP downstream agent."""
+    support_state: ACPSupportState = Field(
+        default="documented_unverified",
+        description="Compatibility support state from the ACP compatibility matrix.",
+    )
+    verification_level: ACPVerificationLevel = Field(
+        default="documented_only",
+        description="Evidence level behind the compatibility support state.",
+    )
+    notes: str = Field(
+        default="Configured locally; live-agent ACP compatibility has not been certified.",
+        description="Human-readable compatibility caveat or certification note.",
+    )
+    docs_url: str = Field(
+        default=ACP_COMPATIBILITY_DOCS_URL,
+        description="Served documentation URL for compatibility details.",
+    )
+
+
+class ACPSetupGuideComponent(BaseModel):
+    """Setup guide entry for a non-agent ACP component."""
+    component: str = Field(..., description="Component identifier")
+    status: str = Field(default="unknown", description="Runtime setup status")
+    steps: list[str] = Field(default_factory=list, description="Actionable setup steps")
+
+
+class ACPSetupGuideAgent(BaseModel):
+    """Setup guide entry for one ACP downstream agent."""
+    agent_type: ACPAgentType = Field(..., description="Agent type identifier")
+    name: str = Field(..., description="Human-readable agent name")
+    status: str = Field(default="unknown", description="Runtime setup status")
+    compatibility: ACPAgentCompatibilityStatus = Field(
+        default_factory=ACPAgentCompatibilityStatus,
+        description="Compatibility support status and evidence level.",
+    )
+    steps: list[str] = Field(default_factory=list, description="Actionable setup or certification steps")
+    docs_url: str | None = Field(default=None, description="Agent documentation URL")
+
+
+class ACPSetupGuideResponse(BaseModel):
+    """Response for ACP setup-guide diagnostics."""
+    timestamp: str = Field(..., description="ISO 8601 timestamp")
+    runner: ACPSetupGuideComponent = Field(..., description="Runner setup guidance")
+    guides: list[ACPSetupGuideAgent] = Field(default_factory=list, description="Agent setup guidance")
 
 
 class ACPAgentRegisterRequest(BaseModel):

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py
@@ -22,6 +22,9 @@ except ImportError:
     yaml = None  # type: ignore[assignment]
 
 
+ACP_COMPATIBILITY_DOCS_URL = "/docs-static/Development/ACP_Compatibility_Matrix.md"
+
+
 @dataclass
 class AgentRegistryEntry:
     """A single agent entry from the registry."""
@@ -35,6 +38,22 @@ class AgentRegistryEntry:
     default: bool = False
     install_instructions: list[str] = field(default_factory=list)
     docs_url: str | None = None
+    support_state: Literal[
+        "supported",
+        "supported_with_caveats",
+        "experimental",
+        "documented_unverified",
+        "unsupported",
+    ] = "documented_unverified"
+    verification_level: Literal[
+        "documented_only",
+        "stub_smoke_tested",
+        "live_e2e_tested",
+        "sandbox_tested",
+        "production_supported",
+    ] = "documented_only"
+    compatibility_notes: str = "Configured locally; live-agent ACP compatibility has not been certified."
+    compatibility_docs_url: str | None = ACP_COMPATIBILITY_DOCS_URL
 
     # Protocol adapter fields (new for agent workspace harness)
     protocol: Literal["stdio", "mcp", "openai_tool_use"] = "stdio"
@@ -61,6 +80,10 @@ class AgentRegistryEntry:
             "type": self.type,
             "name": self.name,
             "description": self.description,
+            "support_state": self.support_state,
+            "verification_level": self.verification_level,
+            "compatibility_notes": self.compatibility_notes,
+            "compatibility_docs_url": self.compatibility_docs_url,
         }
 
         # Check binary
@@ -159,6 +182,15 @@ class AgentRegistry:
                 default=bool(item.get("default", False)),
                 install_instructions=list(item.get("install_instructions", [])),
                 docs_url=item.get("docs_url"),
+                support_state=item.get("support_state", "documented_unverified"),
+                verification_level=item.get("verification_level", "documented_only"),
+                compatibility_notes=str(
+                    item.get(
+                        "compatibility_notes",
+                        "Configured locally; live-agent ACP compatibility has not been certified.",
+                    )
+                ),
+                compatibility_docs_url=item.get("compatibility_docs_url", ACP_COMPATIBILITY_DOCS_URL),
                 mcp_orchestration=item.get("mcp_orchestration", "agent_driven"),
                 mcp_entry_tool=str(item.get("mcp_entry_tool", "execute")),
                 mcp_structured_response=bool(item.get("mcp_structured_response", False)),
@@ -229,6 +261,10 @@ class AgentRegistry:
                     default=bool(row.get("is_default", 0)),
                     install_instructions=self._load_json(row.get("install_instructions"), []),
                     docs_url=row.get("docs_url"),
+                    support_state="documented_unverified",
+                    verification_level="documented_only",
+                    compatibility_notes="Registered dynamically; live-agent ACP compatibility has not been certified.",
+                    compatibility_docs_url=ACP_COMPATIBILITY_DOCS_URL,
                     mcp_orchestration=row.get("mcp_orchestration", "agent_driven"),
                     mcp_entry_tool=row.get("mcp_entry_tool", "execute"),
                     mcp_structured_response=bool(row.get("mcp_structured_response", 0)),

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_agent_registry.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_agent_registry.py
@@ -28,6 +28,10 @@ agents:
     env: {}
     requires_api_key: null
     default: false
+    support_state: supported_with_caveats
+    verification_level: stub_smoke_tested
+    compatibility_notes: Stub protocol coverage only
+    compatibility_docs_url: /docs-static/Development/ACP_Compatibility_Matrix.md
 """
 
 
@@ -98,6 +102,27 @@ agents:
     assert entry.mcp_llm_model == "gpt-4o"
     assert entry.mcp_max_iterations == 7
     assert entry.mcp_refresh_tools is True
+
+
+def test_registry_loads_compatibility_fields_from_yaml(registry_file):
+    """YAML-defined compatibility fields should populate registry entries and availability."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.agent_registry import AgentRegistry
+
+    reg = AgentRegistry(yaml_path=registry_file)
+    reg.load()
+
+    entry = reg.get_entry("test_agent")
+    assert entry is not None
+    assert entry.support_state == "supported_with_caveats"
+    assert entry.verification_level == "stub_smoke_tested"
+    assert entry.compatibility_notes == "Stub protocol coverage only"
+    assert entry.compatibility_docs_url == "/docs-static/Development/ACP_Compatibility_Matrix.md"
+
+    availability = entry.check_availability()
+    assert availability["support_state"] == "supported_with_caveats"
+    assert availability["verification_level"] == "stub_smoke_tested"
+    assert availability["compatibility_notes"] == "Stub protocol coverage only"
+    assert availability["compatibility_docs_url"] == "/docs-static/Development/ACP_Compatibility_Matrix.md"
 
 
 def test_registry_get_entry_none(registry_file):

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_health.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_health.py
@@ -201,6 +201,8 @@ def test_acp_health_agents_detection(client_user_only, stub_runner_client):
     for agent in agents:
         assert "status" in agent
         assert agent["status"] in ("available", "unavailable", "requires_setup", "unknown")
+        assert "support_state" in agent
+        assert "verification_level" in agent
 
 
 def test_acp_health_runner_probe_with_running_client(client_user_only, stub_runner_client):
@@ -228,7 +230,71 @@ def test_acp_setup_guide_returns_guides(client_user_only, stub_runner_client):
         assert "name" in guide
         assert "status" in guide
         assert "steps" in guide
+        assert "compatibility" in guide
+        assert guide["compatibility"]["support_state"] in (
+            "supported",
+            "supported_with_caveats",
+            "experimental",
+            "documented_unverified",
+            "unsupported",
+        )
+        assert guide["compatibility"]["verification_level"] in (
+            "documented_only",
+            "stub_smoke_tested",
+            "live_e2e_tested",
+            "sandbox_tested",
+            "production_supported",
+        )
         assert len(guide["steps"]) > 0
+
+
+def test_acp_setup_guide_marks_configured_but_unverified_agents(client_user_only, stub_runner_client):
+    """Setup guide keeps runtime availability separate from compatibility support state."""
+    resp = client_user_only.get("/api/v1/acp/setup-guide?agent_type=custom")
+    assert resp.status_code == 200
+    data = resp.json()
+    guide = data["guides"][0]
+    compatibility = guide["compatibility"]
+    assert compatibility["support_state"] == "documented_unverified"
+    assert compatibility["verification_level"] == "documented_only"
+    assert compatibility["docs_url"] == "/docs-static/Development/ACP_Compatibility_Matrix.md"
+    assert any("certification checklist" in step.lower() for step in guide["steps"])
+
+
+def test_acp_agents_normalizes_invalid_runner_compatibility_values(
+    client_user_only,
+    stub_runner_client,
+    monkeypatch,
+):
+    """Runner-provided compatibility values are normalized before Pydantic validation."""
+    import tldw_Server_API.app.api.v1.endpoints.agent_client_protocol as acp_mod
+
+    async def _list_agents():
+        return {
+            "agents": [
+                {
+                    "type": "runner_agent",
+                    "name": "Runner Agent",
+                    "description": "Provided by runner",
+                    "isConfigured": True,
+                    "support_state": "not-a-real-state",
+                    "verification_level": "not-a-real-level",
+                    "compatibility_docs_url": "/docs-static/Development/ACP_Compatibility_Matrix.md",
+                }
+            ],
+            "defaultAgentType": "runner_agent",
+        }
+
+    monkeypatch.setattr(acp_mod, "_get_registry_agents", lambda: None)
+    stub_runner_client.list_agents = _list_agents
+
+    resp = client_user_only.get("/api/v1/acp/agents")
+    assert resp.status_code == 200
+    data = resp.json()
+    agent = data["agents"][0]
+    assert agent["support_state"] == "documented_unverified"
+    assert agent["verification_level"] == "documented_only"
+    assert agent["compatibility_docs_url"] == "/docs-static/Development/ACP_Compatibility_Matrix.md"
 
 
 def test_acp_setup_guide_filter_agent(client_user_only, stub_runner_client):


### PR DESCRIPTION
## Summary
- Add ACP compatibility support-state metadata to agent registry entries and API responses.
- Surface configured-but-unverified guidance in `/api/v1/acp/health`, `/api/v1/acp/setup-guide`, `/api/v1/acp/agents`, and the WebUI Agent Registry.
- Seed shipped agent registry rows with conservative `documented_unverified` / `documented_only` claims until live certification evidence exists.

## Change summary
TODO: Human-authored merge-gate summary required before merge. Please describe what changed and why these implementation choices were made.

## Verification
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/test_acp_agent_registry.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_health.py -q`
- `./node_modules/.bin/vitest run src/components/Option/AgentRegistry/__tests__/AgentRegistryPage.connection.test.tsx --maxWorkers=1 --no-file-parallelism`
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m py_compile tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py`
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py -f json -o /tmp/bandit_acp_compatibility_status_surfaces.json`
- `git diff --check`

## Notes
- Attempted `./node_modules/.bin/tsc --noEmit -p tsconfig.json`; it still fails on existing unrelated UI baseline type errors outside this ACP/Agent Registry slice.

Contributes to #1539.