### PR TITLE
OpenWebUI attachment hydration

### DIFF
--- a/Docs/API-related/API_README.md
+++ b/Docs/API-related/API_README.md
@@ -129,6 +129,8 @@ Chatbooks provide portable backup, restore, sharing, and migration workflows. Th
 - `POST /api/v1/chatbooks/export` - create a `.chatbook` archive
 - `POST /api/v1/chatbooks/import` - import a `.chatbook` archive, OpenWebUI chat export JSON, or OpenWebUI database. Database imports require `selected_openwebui_user_id`.
 - `POST /api/v1/chatbooks/preview` - inspect a chatbook, OpenWebUI JSON export, or OpenWebUI database before importing
+- `POST /api/v1/chatbooks/openwebui/hydration/preview` - preview server-local OpenWebUI attachment hydration for imported conversation references
+- `POST /api/v1/chatbooks/openwebui/hydration/jobs` and `GET /api/v1/chatbooks/openwebui/hydration/jobs/{job_id}` - create and inspect OpenWebUI attachment hydration jobs
 - `GET /api/v1/chatbooks/export/jobs` and `GET /api/v1/chatbooks/import/jobs` - list background jobs
 - `GET /api/v1/chatbooks/download/{job_id}` - download a completed export
 

--- a/Docs/API-related/API_Tags_Index.md
+++ b/Docs/API-related/API_Tags_Index.md
@@ -35,4 +35,6 @@ Notes:
 | `mcp-unified` | MCP/Unified/Developer_Guide.md |
 | `workflows` | Coming soon |
 
+The `chatbooks` tag includes chatbook export/import, OpenWebUI JSON and database import, and OpenWebUI attachment hydration preview/job endpoints.
+
 If you spot a mismatch between tags and docs, please open an issue or PR.

--- a/Docs/API-related/Chatbook_API_Documentation.md
+++ b/Docs/API-related/Chatbook_API_Documentation.md
@@ -66,6 +66,14 @@ Import (sync/async)
          → OpenWebUI JSON: Parse export JSON → Import chat trees
          → OpenWebUI DB: Preview users → Require selected user → Import that user's chat trees and mirror folders
          ← Sync: { success, imported_items, warnings } or Async: { job_id }
+
+OpenWebUI attachment hydration
+  Client → POST /api/v1/chatbooks/openwebui/hydration/preview (JSON)
+         → Validate owner/admin access → Resolve data root under allowed roots
+         → Read imported OpenWebUI metadata + webui.db file rows → Return counts/warnings
+  Client → POST /api/v1/chatbooks/openwebui/hydration/jobs (JSON)
+         → Enqueue openwebui_attachment_hydration job
+  Worker → Copy referenced images, register supported files, optionally process files
 ```
 
 ## Authentication
@@ -173,7 +181,7 @@ For `source_format=chatbook`, the upload must be a `.zip` or `.chatbook` archive
 
 OpenWebUI JSON import supports normal OpenWebUI "Export Chats" JSON files. It imports every valid chat as one tldw conversation and preserves all valid message branches through `parent_message_id`.
 
-OpenWebUI webui.db database import supports uploaded SQLite databases copied from an OpenWebUI instance. Preview first, choose exactly one `selected_openwebui_user_id`, then import with `source_format=openwebui_db`. The import reads only chats owned by the selected source user. Source folders are mirrored into tldw folders under `OpenWebUI / <selected user> / ...`, and folder links are attached to imported conversations. Duplicate detection uses `source=openwebui` and a deterministic external reference for both JSON and DB imports. `skip` is the default duplicate behavior; `rename` creates an intentional second copy with a unique imported title and external reference. OpenWebUI v1 does not support `overwrite`, `merge`, admin export import, live OpenWebUI server import, attachment hydration, media import, embeddings import, or content selections. Files, images, and artifacts import as metadata references only.
+OpenWebUI webui.db database import supports uploaded SQLite databases copied from an OpenWebUI instance. Preview first, choose exactly one `selected_openwebui_user_id`, then import with `source_format=openwebui_db`. The import reads only chats owned by the selected source user. Source folders are mirrored into tldw folders under `OpenWebUI / <selected user> / ...`, and folder links are attached to imported conversations. Duplicate detection uses `source=openwebui` and a deterministic external reference for both JSON and DB imports. `skip` is the default duplicate behavior; `rename` creates an intentional second copy with a unique imported title and external reference. OpenWebUI v1 does not support `overwrite`, `merge`, admin export import, live OpenWebUI server import, embeddings import, content selections, or unreferenced attachment import. Files, images, and artifacts import as metadata references first; use the OpenWebUI attachment hydration endpoints after import to copy referenced images and register supported files from a server-local OpenWebUI data root.
 
 **Response**:
 ```json
@@ -309,7 +317,133 @@ OpenWebUI webui.db database import supports uploaded SQLite databases copied fro
 }
 ```
 
-### 4. Download Chatbook
+### 4. Preview OpenWebUI Attachment Hydration
+
+**Endpoint**: `POST /api/v1/chatbooks/openwebui/hydration/preview`
+
+**Description**: Preview hydration for files referenced by imported OpenWebUI conversations. This endpoint validates the server-local OpenWebUI data root, scans the selected imported tldw conversations for preserved OpenWebUI attachment metadata, resolves referenced files through `webui.db` and `uploads/`, and returns counts and warnings without copying files.
+
+Hydration v1 is reference-driven. It does not scan every file under `uploads/` and does not connect to a live OpenWebUI server.
+
+**Auth and path requirements**:
+- Single-user mode is allowed.
+- Multi-user mode requires an owner/admin principal authorized for the imported conversations.
+- `openwebui_data_root` must be a server-local path containing `webui.db` and `uploads/`.
+- The data root and resolved files must be under `Files.ingestion_source_allowed_roots`, `INGESTION_SOURCE_ALLOWED_ROOTS`, or `TLDW_INGESTION_SOURCE_ALLOWED_ROOTS`.
+
+**Request**: JSON
+```json
+{
+  "openwebui_data_root": "/srv/openwebui/data",
+  "scope": {
+    "conversation_ids": ["conv_123", "conv_456"],
+    "source_user_id": "user_abc123"
+  },
+  "process_supported_files": false
+}
+```
+
+Fields:
+- `openwebui_data_root`: required server-local OpenWebUI data root.
+- `scope.conversation_ids`: imported tldw conversation IDs to scan. Empty means no conversations are selected.
+- `scope.source_user_id`: optional OpenWebUI user id used for database `chat_file` fallback lookups.
+- `process_supported_files`: optional, defaults to `false`. When `true`, preview includes supported-file processing intent for non-image files.
+
+**Response**:
+```json
+{
+  "scope": {
+    "conversation_ids": ["conv_123", "conv_456"],
+    "source_user_id": "user_abc123"
+  },
+  "process_supported_files": false,
+  "summary": {
+    "referenced_files": 3,
+    "resolved_files": 2,
+    "image_files": 1,
+    "media_files": 1,
+    "missing_files": 1,
+    "unsupported_files": 0,
+    "failed_files": 0,
+    "hydrated_images": 0,
+    "registered_media_files": 0,
+    "already_hydrated": 0,
+    "processed_files": 0,
+    "warning_count": 1
+  },
+  "items": [
+    {
+      "conversation_id": "conv_123",
+      "message_id": "msg_123",
+      "file_id": "file_abc",
+      "status": "preview_ready",
+      "file_kind": "image",
+      "mime_type": "image/png"
+    }
+  ],
+  "warnings": ["1 referenced file was missing"]
+}
+```
+
+Common warnings include `missing_file`, `unsupported_file_type`, `file_too_large`, `path_rejected`, and paths outside allowed roots.
+
+### 5. Create OpenWebUI Attachment Hydration Job
+
+**Endpoint**: `POST /api/v1/chatbooks/openwebui/hydration/jobs`
+
+**Description**: Enqueue the same hydration operation as a background job. Use preview first; the WebUI gates job creation on a successful preview for the same payload.
+
+Image files are copied into tldw-owned storage and message metadata is updated. Non-image files are registered in the Media DB when available. File processing remains opt-in through `process_supported_files=true`; with the default `false`, supported non-image files are registered but not processed.
+
+Hydration output storage uses `OPENWEBUI_HYDRATION_MEDIA_STORAGE_PATH` when set, otherwise `MEDIA_STORAGE_PATH`, otherwise the server's default media storage directory.
+
+**Request**: Same JSON shape as preview.
+
+**Response**:
+```json
+{
+  "job_id": "123",
+  "job_uuid": "7d0d6a9a-4a48-4d35-bd4e-3e33b6f2dfb1",
+  "status": "pending",
+  "domain": "chatbooks",
+  "queue": "default",
+  "job_type": "openwebui_attachment_hydration",
+  "owner_user_id": "1",
+  "created_at": "2026-05-11T17:00:00Z",
+  "updated_at": "2026-05-11T17:00:00Z",
+  "result": null,
+  "error": null
+}
+```
+
+### 6. Get OpenWebUI Attachment Hydration Job
+
+**Endpoint**: `GET /api/v1/chatbooks/openwebui/hydration/jobs/{job_id}`
+
+**Description**: Return one OpenWebUI hydration job visible to the current caller. Non-admin users can only read their own jobs.
+
+**Response**:
+```json
+{
+  "job_id": "123",
+  "status": "completed",
+  "job_type": "openwebui_attachment_hydration",
+  "result": {
+    "summary": {
+      "referenced_files": 3,
+      "resolved_files": 2,
+      "hydrated_images": 1,
+      "registered_media_files": 1,
+      "processed_files": 0,
+      "warning_count": 1
+    },
+    "warnings": ["1 referenced file was missing"]
+  },
+  "error": null
+}
+```
+
+### 7. Download Chatbook
 
 **Endpoint**: `GET /api/v1/chatbooks/download/{job_id}`
 
@@ -322,7 +456,7 @@ Signed URLs (optional):
 - If `CHATBOOKS_ENFORCE_EXPIRY=true`, the server enforces job-level `expires_at` and returns `410` when expired.
 - Invalid or missing signature returns `403`; an expired `exp` parameter returns `410`.
 
-### 5. List Export Jobs
+### 8. List Export Jobs
 
 **Endpoint**: `GET /api/v1/chatbooks/export/jobs`
 
@@ -352,13 +486,13 @@ Signed URLs (optional):
 }
 ```
 
-### 6. Get Export Job Status
+### 9. Get Export Job Status
 
 **Endpoint**: `GET /api/v1/chatbooks/export/jobs/{job_id}`
 
 **Response**: Same as individual job in list response.
 
-### 7. List Import Jobs
+### 10. List Import Jobs
 
 **Endpoint**: `GET /api/v1/chatbooks/import/jobs`
 
@@ -390,13 +524,13 @@ Signed URLs (optional):
 }
 ```
 
-### 8. Get Import Job Status
+### 11. Get Import Job Status
 
 **Endpoint**: `GET /api/v1/chatbooks/import/jobs/{job_id}`
 
 **Response**: Same as individual job in list response.
 
-### 9. Cancel Export Job
+### 12. Cancel Export Job
 
 **Endpoint**: `DELETE /api/v1/chatbooks/export/jobs/{job_id}`
 
@@ -407,7 +541,7 @@ Signed URLs (optional):
 }
 ```
 
-### 10. Cancel Import Job
+### 13. Cancel Import Job
 
 **Endpoint**: `DELETE /api/v1/chatbooks/import/jobs/{job_id}`
 
@@ -418,7 +552,7 @@ Signed URLs (optional):
 }
 ```
 
-### 11. Remove Export Job
+### 14. Remove Export Job
 
 **Endpoint**: `DELETE /api/v1/chatbooks/export/jobs/{job_id}/remove`
 
@@ -433,7 +567,7 @@ Removes a completed or cancelled export job (and deletes the exported archive).
 }
 ```
 
-### 12. Remove Import Job
+### 15. Remove Import Job
 
 **Endpoint**: `DELETE /api/v1/chatbooks/import/jobs/{job_id}/remove`
 
@@ -448,7 +582,7 @@ Removes a completed or cancelled import job.
 }
 ```
 
-### 13. Cleanup Expired Exports
+### 16. Cleanup Expired Exports
 
 **Endpoint**: `POST /api/v1/chatbooks/cleanup`
 
@@ -462,7 +596,7 @@ Scheduled cleanup runs via the Chatbooks worker; use this endpoint to trigger a 
 }
 ```
 
-### 14. Service Health
+### 17. Service Health
 
 Lightweight liveness check for the Chatbooks subsystem.
 

--- a/Docs/API-related/Chatbook_API_Documentation.md
+++ b/Docs/API-related/Chatbook_API_Documentation.md
@@ -359,6 +359,8 @@ Fields:
   "process_supported_files": false,
   "summary": {
     "referenced_files": 3,
+    "returned_items": 3,
+    "omitted_items": 0,
     "resolved_files": 2,
     "image_files": 1,
     "media_files": 1,
@@ -385,7 +387,7 @@ Fields:
 }
 ```
 
-Common warnings include `missing_file`, `unsupported_file_type`, `file_too_large`, `path_rejected`, and paths outside allowed roots.
+`items` is capped to protect API clients from very large responses. Use `summary.referenced_files`, `summary.returned_items`, and `summary.omitted_items` to detect whether the response was truncated. Common warnings include `missing_file`, `unsupported_file_type`, `file_too_large`, `path_rejected`, and paths outside allowed roots.
 
 ### 5. Create OpenWebUI Attachment Hydration Job
 
@@ -431,6 +433,8 @@ Hydration output storage uses `OPENWEBUI_HYDRATION_MEDIA_STORAGE_PATH` when set,
   "result": {
     "summary": {
       "referenced_files": 3,
+      "returned_items": 3,
+      "omitted_items": 0,
       "resolved_files": 2,
       "hydrated_images": 1,
       "registered_media_files": 1,

--- a/Docs/API-related/chatbook_openapi.yaml
+++ b/Docs/API-related/chatbook_openapi.yaml
@@ -1129,6 +1129,14 @@ components:
         referenced_files:
           type: integer
           minimum: 0
+        returned_items:
+          type: integer
+          minimum: 0
+          description: Number of item records included in this response.
+        omitted_items:
+          type: integer
+          minimum: 0
+          description: Number of item records omitted because the response item cap was reached.
         resolved_files:
           type: integer
           minimum: 0

--- a/Docs/API-related/chatbook_openapi.yaml
+++ b/Docs/API-related/chatbook_openapi.yaml
@@ -218,6 +218,95 @@ paths:
         '500':
           $ref: '#/components/responses/InternalError'
 
+  /chatbooks/openwebui/hydration/preview:
+    post:
+      tags:
+        - Import
+      summary: Preview OpenWebUI attachment hydration
+      description: Preview files referenced by imported OpenWebUI conversations from a server-local OpenWebUI data root. The data root must contain webui.db and uploads/ and resolve under configured ingestion source allowed roots.
+      operationId: previewOpenWebUIAttachmentHydration
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OpenWebUIHydrationRequest'
+      responses:
+        '200':
+          description: Hydration preview retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OpenWebUIHydrationPreviewResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '429':
+          $ref: '#/components/responses/RateLimited'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /chatbooks/openwebui/hydration/jobs:
+    post:
+      tags:
+        - Jobs
+      summary: Create OpenWebUI attachment hydration job
+      description: Enqueue a background job that hydrates referenced OpenWebUI files for imported conversations. Image files are copied into tldw-owned storage, non-image files are registered in Media DB when available, and supported-file processing is opt-in.
+      operationId: createOpenWebUIAttachmentHydrationJob
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OpenWebUIHydrationRequest'
+      responses:
+        '200':
+          description: Hydration job created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OpenWebUIHydrationJobResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '429':
+          $ref: '#/components/responses/RateLimited'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /chatbooks/openwebui/hydration/jobs/{job_id}:
+    get:
+      tags:
+        - Jobs
+      summary: Get OpenWebUI attachment hydration job
+      description: Return one OpenWebUI hydration job visible to the current caller. Non-admin users can only read their own jobs.
+      operationId: getOpenWebUIAttachmentHydrationJob
+      parameters:
+        - $ref: '#/components/parameters/JobId'
+      responses:
+        '200':
+          description: Hydration job retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OpenWebUIHydrationJobResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimited'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
   /chatbooks/export/jobs:
     get:
       tags:
@@ -1004,6 +1093,175 @@ components:
           items:
             type: string
 
+    OpenWebUIHydrationScopeRequest:
+      type: object
+      properties:
+        conversation_ids:
+          type: array
+          maxItems: 1000
+          description: Imported tldw conversation IDs to scan. Empty means no conversations are selected.
+          items:
+            type: string
+        source_user_id:
+          type: string
+          nullable: true
+          description: Optional OpenWebUI source user ID used for chat_file fallback lookups.
+
+    OpenWebUIHydrationRequest:
+      type: object
+      required:
+        - openwebui_data_root
+      properties:
+        openwebui_data_root:
+          type: string
+          maxLength: 4096
+          description: Server-local OpenWebUI data root containing webui.db and uploads/. Must resolve under configured ingestion source allowed roots.
+        scope:
+          $ref: '#/components/schemas/OpenWebUIHydrationScopeRequest'
+        process_supported_files:
+          type: boolean
+          default: false
+          description: Opt-in flag for processing supported non-image files after registration. Defaults to false.
+
+    OpenWebUIHydrationSummary:
+      type: object
+      properties:
+        referenced_files:
+          type: integer
+          minimum: 0
+        resolved_files:
+          type: integer
+          minimum: 0
+        image_files:
+          type: integer
+          minimum: 0
+        media_files:
+          type: integer
+          minimum: 0
+        missing_files:
+          type: integer
+          minimum: 0
+        unsupported_files:
+          type: integer
+          minimum: 0
+        failed_files:
+          type: integer
+          minimum: 0
+        hydrated_images:
+          type: integer
+          minimum: 0
+        registered_media_files:
+          type: integer
+          minimum: 0
+        already_hydrated:
+          type: integer
+          minimum: 0
+        processed_files:
+          type: integer
+          minimum: 0
+        warning_count:
+          type: integer
+          minimum: 0
+
+    OpenWebUIHydrationItem:
+      type: object
+      properties:
+        conversation_id:
+          type: string
+          nullable: true
+        message_id:
+          type: string
+          nullable: true
+        file_id:
+          type: string
+          nullable: true
+        status:
+          type: string
+        warning_code:
+          type: string
+          nullable: true
+        source:
+          type: string
+          nullable: true
+        file_kind:
+          type: string
+          nullable: true
+        mime_type:
+          type: string
+          nullable: true
+        media_id:
+          type: integer
+          nullable: true
+        media_file_id:
+          type: string
+          nullable: true
+        checksum:
+          type: string
+          nullable: true
+        processing_status:
+          type: string
+          nullable: true
+
+    OpenWebUIHydrationPreviewResponse:
+      type: object
+      properties:
+        scope:
+          $ref: '#/components/schemas/OpenWebUIHydrationScopeRequest'
+        process_supported_files:
+          type: boolean
+          default: false
+        summary:
+          $ref: '#/components/schemas/OpenWebUIHydrationSummary'
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenWebUIHydrationItem'
+        warnings:
+          type: array
+          items:
+            type: string
+
+    OpenWebUIHydrationJobResponse:
+      type: object
+      required:
+        - job_id
+        - status
+      properties:
+        job_id:
+          type: string
+        job_uuid:
+          type: string
+          nullable: true
+        status:
+          type: string
+        domain:
+          type: string
+          default: chatbooks
+        queue:
+          type: string
+          default: default
+        job_type:
+          type: string
+          default: openwebui_attachment_hydration
+        owner_user_id:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+          nullable: true
+        updated_at:
+          type: string
+          format: date-time
+          nullable: true
+        result:
+          type: object
+          nullable: true
+          additionalProperties: true
+        error:
+          type: string
+          nullable: true
+
     ExportJobResponse:
       type: object
       required:
@@ -1186,6 +1444,16 @@ components:
           example:
             detail: Authentication required
             error_type: AuthenticationError
+
+    Forbidden:
+      description: Permission denied
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            detail: OpenWebUI hydration requires owner or admin access
+            error_type: PermissionError
 
     NotFound:
       description: Resource not found

--- a/Docs/Published/API-related/API_README.md
+++ b/Docs/Published/API-related/API_README.md
@@ -129,6 +129,8 @@ Chatbooks provide portable backup, restore, sharing, and migration workflows. Th
 - `POST /api/v1/chatbooks/export` - create a `.chatbook` archive
 - `POST /api/v1/chatbooks/import` - import a `.chatbook` archive, OpenWebUI chat export JSON, or OpenWebUI database. Database imports require `selected_openwebui_user_id`.
 - `POST /api/v1/chatbooks/preview` - inspect a chatbook, OpenWebUI JSON export, or OpenWebUI database before importing
+- `POST /api/v1/chatbooks/openwebui/hydration/preview` - preview server-local OpenWebUI attachment hydration for imported conversation references
+- `POST /api/v1/chatbooks/openwebui/hydration/jobs` and `GET /api/v1/chatbooks/openwebui/hydration/jobs/{job_id}` - create and inspect OpenWebUI attachment hydration jobs
 - `GET /api/v1/chatbooks/export/jobs` and `GET /api/v1/chatbooks/import/jobs` - list background jobs
 - `GET /api/v1/chatbooks/download/{job_id}` - download a completed export
 

--- a/Docs/Published/API-related/API_Tags_Index.md
+++ b/Docs/Published/API-related/API_Tags_Index.md
@@ -35,4 +35,6 @@ Notes:
 | `mcp-unified` | MCP/Unified/Developer_Guide.md |
 | `workflows` | Coming soon |
 
+The `chatbooks` tag includes chatbook export/import, OpenWebUI JSON and database import, and OpenWebUI attachment hydration preview/job endpoints.
+
 If you spot a mismatch between tags and docs, please open an issue or PR.

--- a/Docs/Published/API-related/Chatbook_API_Documentation.md
+++ b/Docs/Published/API-related/Chatbook_API_Documentation.md
@@ -66,6 +66,14 @@ Import (sync/async)
          → OpenWebUI JSON: Parse export JSON → Import chat trees
          → OpenWebUI DB: Preview users → Require selected user → Import that user's chat trees and mirror folders
          ← Sync: { success, imported_items, warnings } or Async: { job_id }
+
+OpenWebUI attachment hydration
+  Client → POST /api/v1/chatbooks/openwebui/hydration/preview (JSON)
+         → Validate owner/admin access → Resolve data root under allowed roots
+         → Read imported OpenWebUI metadata + webui.db file rows → Return counts/warnings
+  Client → POST /api/v1/chatbooks/openwebui/hydration/jobs (JSON)
+         → Enqueue openwebui_attachment_hydration job
+  Worker → Copy referenced images, register supported files, optionally process files
 ```
 
 ## Authentication
@@ -173,7 +181,7 @@ For `source_format=chatbook`, the upload must be a `.zip` or `.chatbook` archive
 
 OpenWebUI JSON import supports normal OpenWebUI "Export Chats" JSON files. It imports every valid chat as one tldw conversation and preserves all valid message branches through `parent_message_id`.
 
-OpenWebUI webui.db database import supports uploaded SQLite databases copied from an OpenWebUI instance. Preview first, choose exactly one `selected_openwebui_user_id`, then import with `source_format=openwebui_db`. The import reads only chats owned by the selected source user. Source folders are mirrored into tldw folders under `OpenWebUI / <selected user> / ...`, and folder links are attached to imported conversations. Duplicate detection uses `source=openwebui` and a deterministic external reference for both JSON and DB imports. `skip` is the default duplicate behavior; `rename` creates an intentional second copy with a unique imported title and external reference. OpenWebUI v1 does not support `overwrite`, `merge`, admin export import, live OpenWebUI server import, attachment hydration, media import, embeddings import, or content selections. Files, images, and artifacts import as metadata references only.
+OpenWebUI webui.db database import supports uploaded SQLite databases copied from an OpenWebUI instance. Preview first, choose exactly one `selected_openwebui_user_id`, then import with `source_format=openwebui_db`. The import reads only chats owned by the selected source user. Source folders are mirrored into tldw folders under `OpenWebUI / <selected user> / ...`, and folder links are attached to imported conversations. Duplicate detection uses `source=openwebui` and a deterministic external reference for both JSON and DB imports. `skip` is the default duplicate behavior; `rename` creates an intentional second copy with a unique imported title and external reference. OpenWebUI v1 does not support `overwrite`, `merge`, admin export import, live OpenWebUI server import, embeddings import, content selections, or unreferenced attachment import. Files, images, and artifacts import as metadata references first; use the OpenWebUI attachment hydration endpoints after import to copy referenced images and register supported files from a server-local OpenWebUI data root.
 
 **Response**:
 ```json
@@ -309,7 +317,133 @@ OpenWebUI webui.db database import supports uploaded SQLite databases copied fro
 }
 ```
 
-### 4. Download Chatbook
+### 4. Preview OpenWebUI Attachment Hydration
+
+**Endpoint**: `POST /api/v1/chatbooks/openwebui/hydration/preview`
+
+**Description**: Preview hydration for files referenced by imported OpenWebUI conversations. This endpoint validates the server-local OpenWebUI data root, scans the selected imported tldw conversations for preserved OpenWebUI attachment metadata, resolves referenced files through `webui.db` and `uploads/`, and returns counts and warnings without copying files.
+
+Hydration v1 is reference-driven. It does not scan every file under `uploads/` and does not connect to a live OpenWebUI server.
+
+**Auth and path requirements**:
+- Single-user mode is allowed.
+- Multi-user mode requires an owner/admin principal authorized for the imported conversations.
+- `openwebui_data_root` must be a server-local path containing `webui.db` and `uploads/`.
+- The data root and resolved files must be under `Files.ingestion_source_allowed_roots`, `INGESTION_SOURCE_ALLOWED_ROOTS`, or `TLDW_INGESTION_SOURCE_ALLOWED_ROOTS`.
+
+**Request**: JSON
+```json
+{
+  "openwebui_data_root": "/srv/openwebui/data",
+  "scope": {
+    "conversation_ids": ["conv_123", "conv_456"],
+    "source_user_id": "user_abc123"
+  },
+  "process_supported_files": false
+}
+```
+
+Fields:
+- `openwebui_data_root`: required server-local OpenWebUI data root.
+- `scope.conversation_ids`: imported tldw conversation IDs to scan. Empty means no conversations are selected.
+- `scope.source_user_id`: optional OpenWebUI user id used for database `chat_file` fallback lookups.
+- `process_supported_files`: optional, defaults to `false`. When `true`, preview includes supported-file processing intent for non-image files.
+
+**Response**:
+```json
+{
+  "scope": {
+    "conversation_ids": ["conv_123", "conv_456"],
+    "source_user_id": "user_abc123"
+  },
+  "process_supported_files": false,
+  "summary": {
+    "referenced_files": 3,
+    "resolved_files": 2,
+    "image_files": 1,
+    "media_files": 1,
+    "missing_files": 1,
+    "unsupported_files": 0,
+    "failed_files": 0,
+    "hydrated_images": 0,
+    "registered_media_files": 0,
+    "already_hydrated": 0,
+    "processed_files": 0,
+    "warning_count": 1
+  },
+  "items": [
+    {
+      "conversation_id": "conv_123",
+      "message_id": "msg_123",
+      "file_id": "file_abc",
+      "status": "preview_ready",
+      "file_kind": "image",
+      "mime_type": "image/png"
+    }
+  ],
+  "warnings": ["1 referenced file was missing"]
+}
+```
+
+Common warnings include `missing_file`, `unsupported_file_type`, `file_too_large`, `path_rejected`, and paths outside allowed roots.
+
+### 5. Create OpenWebUI Attachment Hydration Job
+
+**Endpoint**: `POST /api/v1/chatbooks/openwebui/hydration/jobs`
+
+**Description**: Enqueue the same hydration operation as a background job. Use preview first; the WebUI gates job creation on a successful preview for the same payload.
+
+Image files are copied into tldw-owned storage and message metadata is updated. Non-image files are registered in the Media DB when available. File processing remains opt-in through `process_supported_files=true`; with the default `false`, supported non-image files are registered but not processed.
+
+Hydration output storage uses `OPENWEBUI_HYDRATION_MEDIA_STORAGE_PATH` when set, otherwise `MEDIA_STORAGE_PATH`, otherwise the server's default media storage directory.
+
+**Request**: Same JSON shape as preview.
+
+**Response**:
+```json
+{
+  "job_id": "123",
+  "job_uuid": "7d0d6a9a-4a48-4d35-bd4e-3e33b6f2dfb1",
+  "status": "pending",
+  "domain": "chatbooks",
+  "queue": "default",
+  "job_type": "openwebui_attachment_hydration",
+  "owner_user_id": "1",
+  "created_at": "2026-05-11T17:00:00Z",
+  "updated_at": "2026-05-11T17:00:00Z",
+  "result": null,
+  "error": null
+}
+```
+
+### 6. Get OpenWebUI Attachment Hydration Job
+
+**Endpoint**: `GET /api/v1/chatbooks/openwebui/hydration/jobs/{job_id}`
+
+**Description**: Return one OpenWebUI hydration job visible to the current caller. Non-admin users can only read their own jobs.
+
+**Response**:
+```json
+{
+  "job_id": "123",
+  "status": "completed",
+  "job_type": "openwebui_attachment_hydration",
+  "result": {
+    "summary": {
+      "referenced_files": 3,
+      "resolved_files": 2,
+      "hydrated_images": 1,
+      "registered_media_files": 1,
+      "processed_files": 0,
+      "warning_count": 1
+    },
+    "warnings": ["1 referenced file was missing"]
+  },
+  "error": null
+}
+```
+
+### 7. Download Chatbook
 
 **Endpoint**: `GET /api/v1/chatbooks/download/{job_id}`
 
@@ -322,7 +456,7 @@ Signed URLs (optional):
 - If `CHATBOOKS_ENFORCE_EXPIRY=true`, the server enforces job-level `expires_at` and returns `410` when expired.
 - Invalid or missing signature returns `403`; an expired `exp` parameter returns `410`.
 
-### 5. List Export Jobs
+### 8. List Export Jobs
 
 **Endpoint**: `GET /api/v1/chatbooks/export/jobs`
 
@@ -352,13 +486,13 @@ Signed URLs (optional):
 }
 ```
 
-### 6. Get Export Job Status
+### 9. Get Export Job Status
 
 **Endpoint**: `GET /api/v1/chatbooks/export/jobs/{job_id}`
 
 **Response**: Same as individual job in list response.
 
-### 7. List Import Jobs
+### 10. List Import Jobs
 
 **Endpoint**: `GET /api/v1/chatbooks/import/jobs`
 
@@ -390,13 +524,13 @@ Signed URLs (optional):
 }
 ```
 
-### 8. Get Import Job Status
+### 11. Get Import Job Status
 
 **Endpoint**: `GET /api/v1/chatbooks/import/jobs/{job_id}`
 
 **Response**: Same as individual job in list response.
 
-### 9. Cancel Export Job
+### 12. Cancel Export Job
 
 **Endpoint**: `DELETE /api/v1/chatbooks/export/jobs/{job_id}`
 
@@ -407,7 +541,7 @@ Signed URLs (optional):
 }
 ```
 
-### 10. Cancel Import Job
+### 13. Cancel Import Job
 
 **Endpoint**: `DELETE /api/v1/chatbooks/import/jobs/{job_id}`
 
@@ -418,7 +552,7 @@ Signed URLs (optional):
 }
 ```
 
-### 11. Remove Export Job
+### 14. Remove Export Job
 
 **Endpoint**: `DELETE /api/v1/chatbooks/export/jobs/{job_id}/remove`
 
@@ -433,7 +567,7 @@ Removes a completed or cancelled export job (and deletes the exported archive).
 }
 ```
 
-### 12. Remove Import Job
+### 15. Remove Import Job
 
 **Endpoint**: `DELETE /api/v1/chatbooks/import/jobs/{job_id}/remove`
 
@@ -448,7 +582,7 @@ Removes a completed or cancelled import job.
 }
 ```
 
-### 13. Cleanup Expired Exports
+### 16. Cleanup Expired Exports
 
 **Endpoint**: `POST /api/v1/chatbooks/cleanup`
 
@@ -462,7 +596,7 @@ Scheduled cleanup runs via the Chatbooks worker; use this endpoint to trigger a 
 }
 ```
 
-### 14. Service Health
+### 17. Service Health
 
 Lightweight liveness check for the Chatbooks subsystem.
 

--- a/Docs/Published/API-related/Chatbook_API_Documentation.md
+++ b/Docs/Published/API-related/Chatbook_API_Documentation.md
@@ -359,6 +359,8 @@ Fields:
   "process_supported_files": false,
   "summary": {
     "referenced_files": 3,
+    "returned_items": 3,
+    "omitted_items": 0,
     "resolved_files": 2,
     "image_files": 1,
     "media_files": 1,
@@ -385,7 +387,7 @@ Fields:
 }
 ```
 
-Common warnings include `missing_file`, `unsupported_file_type`, `file_too_large`, `path_rejected`, and paths outside allowed roots.
+`items` is capped to protect API clients from very large responses. Use `summary.referenced_files`, `summary.returned_items`, and `summary.omitted_items` to detect whether the response was truncated. Common warnings include `missing_file`, `unsupported_file_type`, `file_too_large`, `path_rejected`, and paths outside allowed roots.
 
 ### 5. Create OpenWebUI Attachment Hydration Job
 
@@ -431,6 +433,8 @@ Hydration output storage uses `OPENWEBUI_HYDRATION_MEDIA_STORAGE_PATH` when set,
   "result": {
     "summary": {
       "referenced_files": 3,
+      "returned_items": 3,
+      "omitted_items": 0,
       "resolved_files": 2,
       "hydrated_images": 1,
       "registered_media_files": 1,

--- a/Docs/Published/API-related/chatbook_openapi.yaml
+++ b/Docs/Published/API-related/chatbook_openapi.yaml
@@ -1129,6 +1129,14 @@ components:
         referenced_files:
           type: integer
           minimum: 0
+        returned_items:
+          type: integer
+          minimum: 0
+          description: Number of item records included in this response.
+        omitted_items:
+          type: integer
+          minimum: 0
+          description: Number of item records omitted because the response item cap was reached.
         resolved_files:
           type: integer
           minimum: 0

--- a/Docs/Published/API-related/chatbook_openapi.yaml
+++ b/Docs/Published/API-related/chatbook_openapi.yaml
@@ -218,6 +218,95 @@ paths:
         '500':
           $ref: '#/components/responses/InternalError'
 
+  /chatbooks/openwebui/hydration/preview:
+    post:
+      tags:
+        - Import
+      summary: Preview OpenWebUI attachment hydration
+      description: Preview files referenced by imported OpenWebUI conversations from a server-local OpenWebUI data root. The data root must contain webui.db and uploads/ and resolve under configured ingestion source allowed roots.
+      operationId: previewOpenWebUIAttachmentHydration
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OpenWebUIHydrationRequest'
+      responses:
+        '200':
+          description: Hydration preview retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OpenWebUIHydrationPreviewResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '429':
+          $ref: '#/components/responses/RateLimited'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /chatbooks/openwebui/hydration/jobs:
+    post:
+      tags:
+        - Jobs
+      summary: Create OpenWebUI attachment hydration job
+      description: Enqueue a background job that hydrates referenced OpenWebUI files for imported conversations. Image files are copied into tldw-owned storage, non-image files are registered in Media DB when available, and supported-file processing is opt-in.
+      operationId: createOpenWebUIAttachmentHydrationJob
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OpenWebUIHydrationRequest'
+      responses:
+        '200':
+          description: Hydration job created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OpenWebUIHydrationJobResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '429':
+          $ref: '#/components/responses/RateLimited'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /chatbooks/openwebui/hydration/jobs/{job_id}:
+    get:
+      tags:
+        - Jobs
+      summary: Get OpenWebUI attachment hydration job
+      description: Return one OpenWebUI hydration job visible to the current caller. Non-admin users can only read their own jobs.
+      operationId: getOpenWebUIAttachmentHydrationJob
+      parameters:
+        - $ref: '#/components/parameters/JobId'
+      responses:
+        '200':
+          description: Hydration job retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OpenWebUIHydrationJobResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimited'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
   /chatbooks/export/jobs:
     get:
       tags:
@@ -1004,6 +1093,175 @@ components:
           items:
             type: string
 
+    OpenWebUIHydrationScopeRequest:
+      type: object
+      properties:
+        conversation_ids:
+          type: array
+          maxItems: 1000
+          description: Imported tldw conversation IDs to scan. Empty means no conversations are selected.
+          items:
+            type: string
+        source_user_id:
+          type: string
+          nullable: true
+          description: Optional OpenWebUI source user ID used for chat_file fallback lookups.
+
+    OpenWebUIHydrationRequest:
+      type: object
+      required:
+        - openwebui_data_root
+      properties:
+        openwebui_data_root:
+          type: string
+          maxLength: 4096
+          description: Server-local OpenWebUI data root containing webui.db and uploads/. Must resolve under configured ingestion source allowed roots.
+        scope:
+          $ref: '#/components/schemas/OpenWebUIHydrationScopeRequest'
+        process_supported_files:
+          type: boolean
+          default: false
+          description: Opt-in flag for processing supported non-image files after registration. Defaults to false.
+
+    OpenWebUIHydrationSummary:
+      type: object
+      properties:
+        referenced_files:
+          type: integer
+          minimum: 0
+        resolved_files:
+          type: integer
+          minimum: 0
+        image_files:
+          type: integer
+          minimum: 0
+        media_files:
+          type: integer
+          minimum: 0
+        missing_files:
+          type: integer
+          minimum: 0
+        unsupported_files:
+          type: integer
+          minimum: 0
+        failed_files:
+          type: integer
+          minimum: 0
+        hydrated_images:
+          type: integer
+          minimum: 0
+        registered_media_files:
+          type: integer
+          minimum: 0
+        already_hydrated:
+          type: integer
+          minimum: 0
+        processed_files:
+          type: integer
+          minimum: 0
+        warning_count:
+          type: integer
+          minimum: 0
+
+    OpenWebUIHydrationItem:
+      type: object
+      properties:
+        conversation_id:
+          type: string
+          nullable: true
+        message_id:
+          type: string
+          nullable: true
+        file_id:
+          type: string
+          nullable: true
+        status:
+          type: string
+        warning_code:
+          type: string
+          nullable: true
+        source:
+          type: string
+          nullable: true
+        file_kind:
+          type: string
+          nullable: true
+        mime_type:
+          type: string
+          nullable: true
+        media_id:
+          type: integer
+          nullable: true
+        media_file_id:
+          type: string
+          nullable: true
+        checksum:
+          type: string
+          nullable: true
+        processing_status:
+          type: string
+          nullable: true
+
+    OpenWebUIHydrationPreviewResponse:
+      type: object
+      properties:
+        scope:
+          $ref: '#/components/schemas/OpenWebUIHydrationScopeRequest'
+        process_supported_files:
+          type: boolean
+          default: false
+        summary:
+          $ref: '#/components/schemas/OpenWebUIHydrationSummary'
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenWebUIHydrationItem'
+        warnings:
+          type: array
+          items:
+            type: string
+
+    OpenWebUIHydrationJobResponse:
+      type: object
+      required:
+        - job_id
+        - status
+      properties:
+        job_id:
+          type: string
+        job_uuid:
+          type: string
+          nullable: true
+        status:
+          type: string
+        domain:
+          type: string
+          default: chatbooks
+        queue:
+          type: string
+          default: default
+        job_type:
+          type: string
+          default: openwebui_attachment_hydration
+        owner_user_id:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+          nullable: true
+        updated_at:
+          type: string
+          format: date-time
+          nullable: true
+        result:
+          type: object
+          nullable: true
+          additionalProperties: true
+        error:
+          type: string
+          nullable: true
+
     ExportJobResponse:
       type: object
       required:
@@ -1186,6 +1444,16 @@ components:
           example:
             detail: Authentication required
             error_type: AuthenticationError
+
+    Forbidden:
+      description: Permission denied
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            detail: OpenWebUI hydration requires owner or admin access
+            error_type: PermissionError
 
     NotFound:
       description: Resource not found

--- a/Docs/Published/User_Guides/WebUI_Extension/Chatbook_User_Guide.md
+++ b/Docs/Published/User_Guides/WebUI_Extension/Chatbook_User_Guide.md
@@ -196,7 +196,36 @@ Use database import when you have local access to the OpenWebUI SQLite database 
 
 Database import reads chats only for the selected source user. It does not import every user from the database by default. Folder paths are mirrored into tldw folders under `OpenWebUI / <selected user> / ...`; if the same folder name is already used elsewhere, tldw keeps the displayed path but safely disambiguates the backing collection name.
 
-Files, images, and artifacts import as metadata references only; binaries are not copied from the OpenWebUI attachment store. OpenWebUI v1 import does not connect to a live OpenWebUI server, import admin exports, hydrate attachments, import media binaries, import embeddings, or apply content selections.
+OpenWebUI import first preserves files, images, and artifacts as metadata references. The import step does not copy binaries from the OpenWebUI attachment store. Use the separate attachment hydration workflow below after the conversations are imported.
+
+#### Hydrating OpenWebUI Attachments
+
+OpenWebUI attachment hydration is a follow-up step for imported conversations. V1 hydrates only referenced files preserved during OpenWebUI JSON or database import; it does not scan every file in an OpenWebUI instance and does not connect to a live OpenWebUI server.
+
+Before hydrating, copy or mount the OpenWebUI data directory on the tldw_server host. The data root must contain:
+
+- `webui.db`
+- `uploads/`
+
+The data root and all resolved files must be under configured allowed roots. Configure those roots with `Files.ingestion_source_allowed_roots` in `config.txt`, or with `INGESTION_SOURCE_ALLOWED_ROOTS` / `TLDW_INGESTION_SOURCE_ALLOWED_ROOTS`. Multiple roots can be separated with commas or the platform path separator. If no allowed roots are configured, or if the OpenWebUI data root resolves outside them, preview and jobs are rejected.
+
+To hydrate from the WebUI:
+
+1. Import the OpenWebUI JSON or database first.
+2. In the Chatbooks import tab, use the OpenWebUI attachment hydration panel.
+3. Enter the server-local OpenWebUI data root.
+4. Enter the imported tldw conversation IDs to scan. For database imports, keep the selected OpenWebUI source user when shown.
+5. Click "Preview attachments" and review referenced, resolved, missing, image, media, and warning counts.
+6. Leave "Process supported files" off unless you want supported non-image files processed after registration.
+7. Click "Run hydration job" only after the preview matches the intended root and scope.
+
+Image files are copied into tldw-owned storage and message metadata is updated so imported image references can resolve from tldw. Non-image files are registered in the Media DB when available. Processing supported non-image files is opt-in and defaults to false; without that opt-in, hydration registers the file reference but does not run ingestion processing.
+
+Hydration output storage uses `OPENWEBUI_HYDRATION_MEDIA_STORAGE_PATH` when set, otherwise `MEDIA_STORAGE_PATH`, otherwise the server's default media storage directory.
+
+Hydration requires a single-user session or a user/admin allowed to operate on the imported conversations. Common warnings include missing files, unsupported file types, oversized files, path rejected, and path outside allowed roots.
+
+OpenWebUI v1 import does not import admin exports, import embeddings, apply content selections, or import unreferenced OpenWebUI files.
 
 ### Conflict Resolution Strategies
 
@@ -233,7 +262,7 @@ When importing content that already exists:
 - **Import Media**: Not supported yet
   - Default: false
   - Keep this set to false; the server rejects true values in v1
-  - OpenWebUI JSON and database imports preserve only attachment references
+  - OpenWebUI JSON and database imports preserve attachment references first; use OpenWebUI attachment hydration after import to copy referenced images and register supported files
 
 - **Import Embeddings**: Not supported yet
   - Default: false
@@ -250,6 +279,7 @@ Always preview a chatbook or OpenWebUI export before importing:
    - Total items by type
    - OpenWebUI chat/message/branch counts when importing JSON
    - OpenWebUI database users, folder counts, and selected-user destination namespace when importing `webui.db`
+   - OpenWebUI hydration referenced/resolved file counts before running a hydration job
    - Duplicate and malformed-chat counts
    - Creation date
    - Author information
@@ -473,7 +503,7 @@ A: Depends on conflict resolution. Use "skip" to avoid duplicates. OpenWebUI JSO
 A: Yes, use the preview endpoint to see contents without importing.
 
 **Q: What happens to media files during import?**
-A: Chatbook media import is not supported yet; keep `import_media=false`. OpenWebUI JSON and database imports preserve file, image, and artifact references as metadata only.
+A: Chatbook media import is not supported yet; keep `import_media=false`. OpenWebUI JSON and database imports preserve file, image, and artifact references first. Run OpenWebUI attachment hydration after import when you have the server-local OpenWebUI data root and want to copy referenced images or register supported files.
 
 **Q: Can I undo an import?**
 A: No automatic undo. Keep backups before importing.

--- a/Docs/User_Guides/WebUI_Extension/Chatbook_User_Guide.md
+++ b/Docs/User_Guides/WebUI_Extension/Chatbook_User_Guide.md
@@ -196,7 +196,36 @@ Use database import when you have local access to the OpenWebUI SQLite database 
 
 Database import reads chats only for the selected source user. It does not import every user from the database by default. Folder paths are mirrored into tldw folders under `OpenWebUI / <selected user> / ...`; if the same folder name is already used elsewhere, tldw keeps the displayed path but safely disambiguates the backing collection name.
 
-Files, images, and artifacts import as metadata references only; binaries are not copied from the OpenWebUI attachment store. OpenWebUI v1 import does not connect to a live OpenWebUI server, import admin exports, hydrate attachments, import media binaries, import embeddings, or apply content selections.
+OpenWebUI import first preserves files, images, and artifacts as metadata references. The import step does not copy binaries from the OpenWebUI attachment store. Use the separate attachment hydration workflow below after the conversations are imported.
+
+#### Hydrating OpenWebUI Attachments
+
+OpenWebUI attachment hydration is a follow-up step for imported conversations. V1 hydrates only referenced files preserved during OpenWebUI JSON or database import; it does not scan every file in an OpenWebUI instance and does not connect to a live OpenWebUI server.
+
+Before hydrating, copy or mount the OpenWebUI data directory on the tldw_server host. The data root must contain:
+
+- `webui.db`
+- `uploads/`
+
+The data root and all resolved files must be under configured allowed roots. Configure those roots with `Files.ingestion_source_allowed_roots` in `config.txt`, or with `INGESTION_SOURCE_ALLOWED_ROOTS` / `TLDW_INGESTION_SOURCE_ALLOWED_ROOTS`. Multiple roots can be separated with commas or the platform path separator. If no allowed roots are configured, or if the OpenWebUI data root resolves outside them, preview and jobs are rejected.
+
+To hydrate from the WebUI:
+
+1. Import the OpenWebUI JSON or database first.
+2. In the Chatbooks import tab, use the OpenWebUI attachment hydration panel.
+3. Enter the server-local OpenWebUI data root.
+4. Enter the imported tldw conversation IDs to scan. For database imports, keep the selected OpenWebUI source user when shown.
+5. Click "Preview attachments" and review referenced, resolved, missing, image, media, and warning counts.
+6. Leave "Process supported files" off unless you want supported non-image files processed after registration.
+7. Click "Run hydration job" only after the preview matches the intended root and scope.
+
+Image files are copied into tldw-owned storage and message metadata is updated so imported image references can resolve from tldw. Non-image files are registered in the Media DB when available. Processing supported non-image files is opt-in and defaults to false; without that opt-in, hydration registers the file reference but does not run ingestion processing.
+
+Hydration output storage uses `OPENWEBUI_HYDRATION_MEDIA_STORAGE_PATH` when set, otherwise `MEDIA_STORAGE_PATH`, otherwise the server's default media storage directory.
+
+Hydration requires a single-user session or a user/admin allowed to operate on the imported conversations. Common warnings include missing files, unsupported file types, oversized files, path rejected, and path outside allowed roots.
+
+OpenWebUI v1 import does not import admin exports, import embeddings, apply content selections, or import unreferenced OpenWebUI files.
 
 ### Conflict Resolution Strategies
 
@@ -233,7 +262,7 @@ When importing content that already exists:
 - **Import Media**: Not supported yet
   - Default: false
   - Keep this set to false; the server rejects true values in v1
-  - OpenWebUI JSON and database imports preserve only attachment references
+  - OpenWebUI JSON and database imports preserve attachment references first; use OpenWebUI attachment hydration after import to copy referenced images and register supported files
 
 - **Import Embeddings**: Not supported yet
   - Default: false
@@ -250,6 +279,7 @@ Always preview a chatbook or OpenWebUI export before importing:
    - Total items by type
    - OpenWebUI chat/message/branch counts when importing JSON
    - OpenWebUI database users, folder counts, and selected-user destination namespace when importing `webui.db`
+   - OpenWebUI hydration referenced/resolved file counts before running a hydration job
    - Duplicate and malformed-chat counts
    - Creation date
    - Author information
@@ -473,7 +503,7 @@ A: Depends on conflict resolution. Use "skip" to avoid duplicates. OpenWebUI JSO
 A: Yes, use the preview endpoint to see contents without importing.
 
 **Q: What happens to media files during import?**
-A: Chatbook media import is not supported yet; keep `import_media=false`. OpenWebUI JSON and database imports preserve file, image, and artifact references as metadata only.
+A: Chatbook media import is not supported yet; keep `import_media=false`. OpenWebUI JSON and database imports preserve file, image, and artifact references first. Run OpenWebUI attachment hydration after import when you have the server-local OpenWebUI data root and want to copy referenced images or register supported files.
 
 **Q: Can I undo an import?**
 A: No automatic undo. Keep backups before importing.

--- a/Docs/superpowers/plans/2026-05-11-openwebui-attachment-hydration-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-11-openwebui-attachment-hydration-implementation-plan.md
@@ -1,0 +1,994 @@
+# OpenWebUI Attachment Hydration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a post-import OpenWebUI attachment hydration workflow that restores referenced images to imported chat messages and registers referenced non-image files in Media DB from a trusted local OpenWebUI data root.
+
+**Architecture:** Keep chat import unchanged and add a separate Chatbooks hydration surface. A focused backend service reads imported OpenWebUI metadata, validates a server-local data root under configured ingestion-source allowed roots, resolves `file` and `chat_file` rows from `webui.db`, copies bytes into tldw-owned storage, updates message hydration metadata with deep-merge semantics, and runs through a dedicated `openwebui_attachment_hydration` Jobs contract for long-running work.
+
+**Tech Stack:** FastAPI, Pydantic, SQLite via `sqlite3`, existing ChaChaNotesDB message metadata/image APIs, Media DB `Media`/`MediaFiles`, core Jobs, pytest, Bandit, React/Ant Design, Vitest.
+
+---
+
+## Source Inputs
+
+- Design spec: `Docs/superpowers/specs/2026-05-11-openwebui-attachment-hydration-design.md`
+- Prior OpenWebUI JSON plan: `Docs/superpowers/plans/2026-05-10-openwebui-chat-import-implementation-plan.md`
+- Prior OpenWebUI DB plan: `Docs/superpowers/plans/2026-05-10-openwebui-db-chat-import-implementation-plan.md`
+- OpenWebUI DB helper: `tldw_Server_API/app/core/DB_Management/OpenWebUI_DB.py`
+- OpenWebUI import adapter: `tldw_Server_API/app/core/Chatbooks/import_adapters/openwebui.py`
+- OpenWebUI DB adapter: `tldw_Server_API/app/core/Chatbooks/import_adapters/openwebui_db.py`
+- Chatbooks service: `tldw_Server_API/app/core/Chatbooks/chatbook_service.py`
+- Chatbooks Jobs worker: `tldw_Server_API/app/core/Chatbooks/services/jobs_worker.py`
+- Chatbooks API: `tldw_Server_API/app/api/v1/endpoints/chatbooks.py`
+- Chatbooks API schemas: `tldw_Server_API/app/api/v1/schemas/chatbook_schemas.py`
+- ChaCha message store: `tldw_Server_API/app/core/DB_Management/chacha/message_store.py`
+- Media DB runtime helpers: `tldw_Server_API/app/core/DB_Management/media_db/runtime/media_entrypoint_ops.py`
+- MediaFiles runtime helpers: `tldw_Server_API/app/core/DB_Management/media_db/runtime/media_file_ops.py`
+- Allowed local path helper: `tldw_Server_API/app/core/Ingestion_Media_Processing/path_utils.py`
+- Ingestion allowed-root config: `tldw_Server_API/app/core/config.py`
+- Chatbooks WebUI: `apps/packages/ui/src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx`
+- WebUI client methods: `apps/packages/ui/src/services/tldw/TldwApiClient.ts` and `apps/packages/ui/src/services/tldw/domains/chat-rag.ts`
+
+## Constraints
+
+- V1 accepts a server-local OpenWebUI data root only. It does not accept uploaded ZIP bundles and does not call live OpenWebUI APIs.
+- Hydrate only attachments referenced by imported OpenWebUI chats plus DB `chat_file` fallback for those imported chats.
+- Do not alter baseline OpenWebUI JSON or DB chat import semantics.
+- Do not make `file` or `chat_file` tables mandatory for text-only `openwebui_db` import.
+- Do not use global content-hash dedupe for binary file registration.
+- Do not reuse media rows across tldw users.
+- Do not store durable Media DB records pointing at the OpenWebUI source path.
+- Do not overwrite or duplicate existing non-OpenWebUI message images.
+- Do not rely on `set_message_metadata_extra(..., merge=True)` for nested `openwebui_import` updates.
+- Do not trust file extension or OpenWebUI MIME metadata for image embedding; sniff bytes conservatively.
+- Do not log raw chat content, message content, arbitrary absolute source paths, or file bytes.
+- Run Python commands from repo root after `source .venv/bin/activate`.
+- Run Bandit on touched backend code before claiming completion.
+
+## File Structure
+
+Create:
+
+- `tldw_Server_API/app/core/Chatbooks/openwebui_hydration.py`
+  - Hydration dataclasses, preview/result summaries, reference extraction, local data-root validation, file resolution, file classification, metadata merging, image hydration, and non-image registration orchestration.
+  - No FastAPI request parsing and no raw SQL beyond calling DB_Management helpers.
+- `tldw_Server_API/app/core/Chatbooks/openwebui_hydration_jobs.py`
+  - Constants and small helpers for core Jobs payload creation: domain, queue, job type, payload normalization.
+- `tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_db_helpers.py`
+  - Hydration-specific OpenWebUI DB file/chat_file schema and row helper tests.
+- `tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_paths.py`
+  - Data-root validation and path traversal/symlink/file-candidate tests.
+- `tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_service.py`
+  - Reference extraction, preview summaries, metadata merge, image hydration, non-image registration, dedupe, and partial failure tests.
+- `tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_api.py`
+  - Preview/job endpoint contract and authorization tests.
+- `tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_jobs_worker.py`
+  - Dedicated Jobs routing and worker revalidation tests.
+
+Modify:
+
+- `tldw_Server_API/app/core/DB_Management/OpenWebUI_DB.py`
+  - Add hydration-specific `file` and `chat_file` schema validation and read-only row helpers.
+- `tldw_Server_API/app/core/DB_Management/chacha/message_store.py`
+  - Add post-insert message-image append helper that can append after current max position inside a caller-managed transaction.
+- `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`
+  - Expose the new message image helper through the legacy DB facade if required by the existing delegation pattern.
+- `tldw_Server_API/app/core/Chatbooks/chatbook_service.py`
+  - Wire hydration preview and job creation helper methods while keeping existing import/export paths untouched.
+- `tldw_Server_API/app/core/Chatbooks/services/jobs_worker.py`
+  - Route `job_type=openwebui_attachment_hydration` to the hydration service.
+- `tldw_Server_API/app/api/v1/schemas/chatbook_schemas.py`
+  - Add hydration request/response schemas and result item schemas.
+- `tldw_Server_API/app/api/v1/endpoints/chatbooks.py`
+  - Add `/openwebui/hydration/preview`, `/openwebui/hydration/jobs`, and `/openwebui/hydration/jobs/{job_id}`.
+- `apps/packages/ui/src/services/tldw/TldwApiClient.ts`
+  - Add hydration preview/job/status client methods.
+- `apps/packages/ui/src/services/tldw/domains/chat-rag.ts`
+  - Mirror hydration client methods in the domain client.
+- `apps/packages/ui/src/services/__tests__/tldw-api-client.chatbooks-openwebui.test.ts`
+  - Add API-client contract coverage for hydration endpoints.
+- `apps/packages/ui/src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx`
+  - Add authorized hydration UI in the Chatbooks import area.
+- `apps/packages/ui/src/components/Option/Chatbooks/__tests__/ChatbooksPlaygroundPage.openwebui-import.test.tsx`
+  - Add hydration UI tests.
+- User/API docs:
+  - `Docs/User_Guides/WebUI_Extension/Chatbook_User_Guide.md`
+  - `Docs/API-related/Chatbook_API_Documentation.md`
+  - `Docs/API-related/chatbook_openapi.yaml`
+  - `Docs/API-related/API_README.md`
+  - `Docs/API-related/API_Tags_Index.md`
+  - `Docs/Published/User_Guides/WebUI_Extension/Chatbook_User_Guide.md`
+  - `Docs/Published/API-related/Chatbook_API_Documentation.md`
+  - `Docs/Published/API-related/chatbook_openapi.yaml`
+  - `Docs/Published/API-related/API_README.md`
+  - `Docs/Published/API-related/API_Tags_Index.md`
+- `tldw_Server_API/tests/Docs/test_chatbook_openwebui_import_docs.py`
+  - Add docs regression coverage for hydration discoverability.
+
+## Stage 1: OpenWebUI File DB Helpers
+
+**Goal:** Add read-only helpers for OpenWebUI `file` and `chat_file` rows without changing chat-import validation.
+
+**Success Criteria:** Hydration can validate file tables and load rows by file/chat ids; existing `open_validated_openwebui_db()` still accepts DBs with only chat-import tables.
+
+**Tests:** `tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_db_helpers.py`
+
+**Status:** Not Started
+
+### Task 1.1: Write failing DB helper tests
+
+**Files:**
+- Create: `tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_db_helpers.py`
+- Modify: `tldw_Server_API/app/core/DB_Management/OpenWebUI_DB.py`
+
+- [ ] Add a temporary SQLite fixture with `user`, `chat`, `folder`, `file`, and `chat_file` tables:
+
+```python
+def write_openwebui_hydration_db(path: Path) -> Path:
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE user (id TEXT PRIMARY KEY, name TEXT, email TEXT, created_at INTEGER, updated_at INTEGER)")
+    conn.execute("CREATE TABLE folder (id TEXT PRIMARY KEY, parent_id TEXT, user_id TEXT, name TEXT, items TEXT, meta TEXT, is_expanded INTEGER, created_at INTEGER, updated_at INTEGER)")
+    conn.execute("CREATE TABLE chat (id TEXT PRIMARY KEY, user_id TEXT, title TEXT, chat TEXT, created_at INTEGER, updated_at INTEGER, share_id TEXT, archived INTEGER, pinned INTEGER, meta TEXT, folder_id TEXT)")
+    conn.execute("CREATE TABLE file (id TEXT PRIMARY KEY, user_id TEXT, hash TEXT, filename TEXT, path TEXT, data TEXT, meta TEXT, created_at INTEGER, updated_at INTEGER)")
+    conn.execute("CREATE TABLE chat_file (id TEXT PRIMARY KEY, chat_id TEXT, file_id TEXT, message_id TEXT, user_id TEXT, created_at INTEGER, updated_at INTEGER)")
+    ...
+```
+
+- [ ] Test `validate_openwebui_file_schema(conn)` fails when `file` is missing.
+- [ ] Test `validate_openwebui_file_schema(conn)` fails when `file.id`, `file.user_id`, or `file.filename` is missing.
+- [ ] Test baseline `validate_openwebui_schema(conn)` still passes without `file` and `chat_file`.
+- [ ] Test `load_openwebui_file_rows_for_ids(conn, ["file-a"], user_id="owui-user")` returns only that user's row.
+- [ ] Test `load_openwebui_chat_file_rows_for_chats(conn, ["chat-a"], user_id="owui-user")` ignores unrelated chats/users.
+- [ ] Test helpers use bound parameters by checking ids containing quotes are treated as literal values.
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_db_helpers.py -q
+```
+
+Expected: FAIL because the helper functions do not exist.
+
+### Task 1.2: Implement hydration-specific OpenWebUI DB helpers
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/DB_Management/OpenWebUI_DB.py`
+
+- [ ] Add `HYDRATION_FILE_SCHEMA` and `HYDRATION_CHAT_FILE_SCHEMA` constants separate from `REQUIRED_SCHEMA`.
+- [ ] Add `validate_openwebui_file_schema(conn: sqlite3.Connection) -> None`.
+- [ ] Add `load_openwebui_file_rows_for_ids(conn, file_ids, user_id=None)`.
+- [ ] Add `load_openwebui_chat_file_rows_for_chats(conn, chat_ids, user_id=None)`.
+- [ ] Add `iter_openwebui_files_for_user(conn, user_id)` only for future/full-library support; do not use it for v1 default hydration scope.
+- [ ] Keep all SQL parameterized.
+- [ ] Return `sqlite3.Row` objects for consistency with the existing OpenWebUI DB helpers.
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_db_helpers.py -q
+python -m pytest tldw_Server_API/tests/Chatbooks/test_openwebui_db_import_adapter.py -q
+```
+
+Expected: PASS. The second command proves text-only DB import validation was not broadened.
+
+### Task 1.3: Commit DB helper slice
+
+- [ ] Run `git diff --check`.
+- [ ] Commit:
+
+```bash
+git add tldw_Server_API/app/core/DB_Management/OpenWebUI_DB.py \
+        tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_db_helpers.py
+git commit -m "Add OpenWebUI hydration DB helpers"
+```
+
+## Stage 2: Hydration Service Core And Path Safety
+
+**Goal:** Build preview-safe path validation, reference extraction, source row lookup, and file resolution without writing images/media yet.
+
+**Success Criteria:** Preview can identify referenced files, resolve safe source paths under the OpenWebUI data root/uploads root, classify basic file kinds, and report per-reference warnings without copying bytes.
+
+**Tests:** `tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_paths.py`, first service tests in `test_openwebui_hydration_service.py`
+
+**Status:** Not Started
+
+### Task 2.1: Write failing path and preview tests
+
+**Files:**
+- Create: `tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_paths.py`
+- Create: `tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_service.py`
+- Create: `tldw_Server_API/app/core/Chatbooks/openwebui_hydration.py`
+
+- [ ] Test data root outside `INGESTION_SOURCE_ALLOWED_ROOTS` is rejected.
+- [ ] Test missing `webui.db` is a fatal preview error.
+- [ ] Test missing `uploads/` is a fatal preview error only when referenced file bytes are needed.
+- [ ] Test `file.path="../secret.txt"` is rejected as `path_rejected`.
+- [ ] Test symlink escape is rejected by canonical target checks.
+- [ ] Test fallback `uploads/{file.id}_{file.filename}` resolves when safe.
+- [ ] Test imported message metadata refs are extracted from `extra.openwebui_import.attachment_refs`.
+- [ ] Test unsupported ref shapes produce `unsupported_reference_shape`.
+- [ ] Test DB `chat_file` fallback uses preserved `openwebui_import.metadata.row_id` and skips fallback when absent.
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_paths.py \
+  tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_service.py \
+  -q
+```
+
+Expected: FAIL because `openwebui_hydration.py` does not exist.
+
+### Task 2.2: Implement preview data models and path resolution
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Chatbooks/openwebui_hydration.py`
+
+- [ ] Add dataclasses:
+  - `OpenWebUIHydrationScope`
+  - `OpenWebUIHydrationReference`
+  - `OpenWebUIHydrationResolvedFile`
+  - `OpenWebUIHydrationPreviewItem`
+  - `OpenWebUIHydrationPreview`
+  - `OpenWebUIHydrationResult`
+- [ ] Add `validate_openwebui_data_root(root: str | Path) -> OpenWebUIDataRoot`.
+- [ ] Use `get_ingestion_source_allowed_roots(reload=True)` or the same reload behavior established by ingestion-source tests.
+- [ ] Use `resolve_safe_local_path()` to confirm data root is under one allowed root.
+- [ ] Require canonical `webui.db` under data root.
+- [ ] Require canonical `uploads/` directory under data root.
+- [ ] Add `resolve_openwebui_file_path(file_row, data_root, uploads_root)`.
+- [ ] Try candidates in this order:
+  1. relative `file.path` under data root/uploads root
+  2. absolute `file.path` only if it canonicalizes under data root/uploads root
+  3. `uploads/{file.id}_{file.filename}`
+- [ ] Return structured warnings, not raw absolute paths, for user-facing preview.
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_paths.py -q
+```
+
+Expected: PASS.
+
+### Task 2.3: Implement reference extraction and preview assembly
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Chatbooks/openwebui_hydration.py`
+
+- [ ] Add `extract_openwebui_hydration_references(chacha_db, scope)`.
+- [ ] Query messages for the active tldw user/conversation scope using existing DB helpers where available; if no focused helper exists, add the smallest ChaCha helper needed rather than scanning raw DB files outside DB_Management.
+- [ ] Read current `message_metadata.extra.openwebui_import`.
+- [ ] Preserve the raw reference index and shape in the preview item.
+- [ ] Recognize dict ids from `id`, `file_id`, and `fileId`.
+- [ ] Recognize string refs only when non-empty.
+- [ ] Add DB fallback from `chat_file` rows only for imported conversation source chat ids.
+- [ ] Bound preview warning arrays to avoid huge responses.
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_service.py -k "preview or reference or fallback" -q
+```
+
+Expected: PASS.
+
+### Task 2.4: Commit preview/path slice
+
+- [ ] Run `git diff --check`.
+- [ ] Commit:
+
+```bash
+git add tldw_Server_API/app/core/Chatbooks/openwebui_hydration.py \
+        tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_paths.py \
+        tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_service.py
+git commit -m "Add OpenWebUI hydration preview service"
+```
+
+## Stage 3: ChaCha Image Hydration And Metadata Merge
+
+**Goal:** Restore safe image refs as message images after import, without losing original OpenWebUI metadata and without duplicating images on retry.
+
+**Success Criteria:** Image hydration appends to message images idempotently, records source-key to image-position mapping in metadata, and preserves original `openwebui_import` fields.
+
+**Tests:** `tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_service.py`
+
+**Status:** Not Started
+
+### Task 3.1: Write failing image and metadata merge tests
+
+**Files:**
+- Modify: `tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_service.py`
+- Modify: `tldw_Server_API/app/core/DB_Management/chacha/message_store.py`
+- Modify: `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`
+
+- [ ] Test a message with existing metadata:
+
+```python
+original = {
+    "openwebui_import": {
+        "source_message_id": "msg-a",
+        "source_parent_id": None,
+        "source_children_ids": [],
+        "role": "user",
+        "model": "model-a",
+        "attachment_refs": [{"id": "file-image"}],
+        "metadata": {"done": True},
+    }
+}
+```
+
+- [ ] Hydrate one PNG ref and assert all original keys remain.
+- [ ] Assert `hydration.items[0].status == "hydrated_image"`.
+- [ ] Assert image position is appended after any existing `message_images` positions.
+- [ ] Run hydration twice and assert one image row, with second item status `already_hydrated` or unchanged existing item.
+- [ ] Test oversized image returns `oversized`.
+- [ ] Test extension says `.png` but bytes are not image-like and returns `unsupported_file_type`.
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_service.py -k "image or metadata" -q
+```
+
+Expected: FAIL because append/idempotency helpers are missing.
+
+### Task 3.2: Add post-insert message image append helper
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/DB_Management/chacha/message_store.py`
+- Modify: `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`
+
+- [ ] Add `append_message_image(message_id: str, image_bytes: bytes, mime_type: str) -> int`.
+- [ ] Validate max image size using the same `MAX_MESSAGE_IMAGE_BYTES` setting used by `add_message()`.
+- [ ] Select `COALESCE(MAX(position), -1) + 1` for the message.
+- [ ] Insert a new row at that position.
+- [ ] Return the inserted position.
+- [ ] Keep transaction boundaries compatible with service-level calls; if service manages a larger transaction, expose a helper that accepts `commit=False` or uses existing DB transaction conventions.
+- [ ] Do not change `_insert_message_images()` behavior for normal chatbook import.
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_service.py -k "image" -q
+```
+
+Expected: still FAIL until service code calls the helper.
+
+### Task 3.3: Implement image hydration and deep metadata merge
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Chatbooks/openwebui_hydration.py`
+
+- [ ] Add `merge_openwebui_message_hydration_metadata(chacha_db, message_id, item_update)`.
+- [ ] Read `get_message_metadata(message_id)`.
+- [ ] Copy the full `extra.openwebui_import` object.
+- [ ] Add or update `hydration.version`, `last_job_id`, and `items`.
+- [ ] Preserve original `attachment_refs`, source ids, role, model, and metadata.
+- [ ] Add `hydrate_image_reference(...)`.
+- [ ] Derive `source_key = f"openwebui:file:{source_file_id}"` when file id exists, else `openwebui:hash:{sha256}`.
+- [ ] If `source_key` already appears in hydration items with `message_image_position`, return `already_hydrated` without inserting.
+- [ ] Sniff image bytes with a small allowlist for PNG, JPEG, GIF, and WebP signatures.
+- [ ] Append the image and record position.
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_service.py -k "image or metadata" -q
+```
+
+Expected: PASS.
+
+### Task 3.4: Commit image hydration slice
+
+- [ ] Run `git diff --check`.
+- [ ] Commit:
+
+```bash
+git add tldw_Server_API/app/core/Chatbooks/openwebui_hydration.py \
+        tldw_Server_API/app/core/DB_Management/chacha/message_store.py \
+        tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py \
+        tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_service.py
+git commit -m "Hydrate OpenWebUI image attachments"
+```
+
+## Stage 4: Non-Image Media Registration
+
+**Goal:** Register referenced non-image files as durable tldw Media DB entries without automatic processing.
+
+**Success Criteria:** Files are copied into tldw-owned storage, parent Media rows and MediaFiles rows are created with owner-aware source metadata, and dedupe does not cross tldw users or unrelated imports.
+
+**Tests:** `tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_service.py`
+
+**Status:** Not Started
+
+### Task 4.1: Write failing media registration tests
+
+**Files:**
+- Modify: `tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_service.py`
+
+- [ ] Test a PDF ref creates a Media row and a MediaFiles original row.
+- [ ] Assert the MediaFiles storage path is not under the OpenWebUI source data root.
+- [ ] Assert `source_hash` or `checksum` equals byte SHA-256.
+- [ ] Assert `owner_user_id` is the active tldw user and `visibility == "personal"`.
+- [ ] Assert a same `source_file_id` in the same user scope reuses the existing Media link.
+- [ ] Assert the same bytes for a different tldw user does not reuse another user's Media row.
+- [ ] Assert two source-id-less files with different filenames but empty extracted text do not collapse to the same placeholder content hash.
+- [ ] Assert `process_supported_files=false` leaves chunking/processing pending and does not enqueue processing.
+- [ ] Assert `process_supported_files=true` calls a mocked processing hook after registration and processing failure does not remove the MediaFiles row.
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_service.py -k "media or non_image or processing" -q
+```
+
+Expected: FAIL because non-image registration is missing.
+
+### Task 4.2: Implement durable copy and owner-aware media registration
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Chatbooks/openwebui_hydration.py`
+- Modify: Media DB helper files only if an owner-aware lookup helper is missing:
+  - `tldw_Server_API/app/core/DB_Management/media_db/runtime/query_ops.py`
+  - `tldw_Server_API/app/core/DB_Management/media_db/api.py`
+  - `tldw_Server_API/app/core/DB_Management/media_db/repositories/media_repository.py`
+
+- [ ] Add a storage helper that copies source bytes into a per-user tldw-owned import directory. Prefer an existing media storage convention if one exists; otherwise use a new Chatbooks-owned subdirectory under the configured user database/media area.
+- [ ] Use `open_safe_local_path()` for source file reads when practical.
+- [ ] Compute `sha256` from source bytes while streaming/copying.
+- [ ] Add owner-aware lookup by OpenWebUI source id in safe metadata/source URL.
+- [ ] Add owner-aware lookup by byte hash only inside current hydration run when no source id exists.
+- [ ] Register a parent Media row with:
+
+```python
+placeholder_content = json.dumps(
+    {
+        "source": "openwebui",
+        "source_file_id": source_file_id,
+        "filename": filename,
+        "mime_type": mime_type,
+        "sha256": byte_sha256,
+    },
+    sort_keys=True,
+)
+```
+
+- [ ] Use an OpenWebUI-specific URL:
+  - `openwebui://file/{source_file_id}` when source id exists
+  - `openwebui://run/{job_id}/{byte_sha256}` when source id is missing
+- [ ] Pass `source_hash=byte_sha256`, `owner_user_id=<tldw user id>`, and `visibility="personal"`.
+- [ ] Insert `MediaFiles` row with `file_type="original"`, copied storage path, original filename, file size, MIME type, and checksum.
+- [ ] Record `status="registered_media"` and `media_id`/`media_file_id` in message hydration metadata.
+- [ ] Keep optional processing hook separated behind `process_supported_files`.
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_service.py -k "media or non_image or processing" -q
+```
+
+Expected: PASS.
+
+### Task 4.3: Commit media registration slice
+
+- [ ] Run `git diff --check`.
+- [ ] Commit:
+
+```bash
+git add tldw_Server_API/app/core/Chatbooks/openwebui_hydration.py \
+        tldw_Server_API/app/core/DB_Management/media_db/runtime/query_ops.py \
+        tldw_Server_API/app/core/DB_Management/media_db/api.py \
+        tldw_Server_API/app/core/DB_Management/media_db/repositories/media_repository.py \
+        tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_service.py
+git commit -m "Register OpenWebUI attachments in Media DB"
+```
+
+If no Media DB helper files changed, omit them from `git add`.
+
+## Stage 5: API Schemas And Endpoints
+
+**Goal:** Expose hydration preview, job creation, and job status endpoints with stronger authorization than normal import.
+
+**Success Criteria:** Authorized single-user owner and multi-user admins can preview/enqueue; multi-user non-admins are rejected; request/response schemas match the service; endpoints do not leak raw source paths.
+
+**Tests:** `tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_api.py`
+
+**Status:** Not Started
+
+### Task 5.1: Write failing API contract and auth tests
+
+**Files:**
+- Create: `tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_api.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/chatbook_schemas.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/chatbooks.py`
+
+- [ ] Test `POST /api/v1/chatbooks/openwebui/hydration/preview` validates `openwebui_data_root`.
+- [ ] Test preview request passes `source_user_id`, `conversation_ids`, and `process_supported_files`.
+- [ ] Test preview response includes counts and warning totals.
+- [ ] Test multi-user non-admin receives 403.
+- [ ] Test single-user principal is allowed.
+- [ ] Test admin role/claim in multi-user mode is allowed.
+- [ ] Test response warnings redact full absolute paths.
+- [ ] Test `POST /api/v1/chatbooks/openwebui/hydration/jobs` enqueues a core Jobs row with job type `openwebui_attachment_hydration`.
+- [ ] Test `GET /api/v1/chatbooks/openwebui/hydration/jobs/{job_id}` rejects jobs not owned by the current user unless admin access is explicitly intended.
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_api.py -q
+```
+
+Expected: FAIL because schemas/endpoints do not exist.
+
+### Task 5.2: Add Pydantic hydration schemas
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/schemas/chatbook_schemas.py`
+
+- [ ] Add `OpenWebUIHydrationScopeRequest`.
+- [ ] Add `OpenWebUIHydrationPreviewRequest`.
+- [ ] Add `OpenWebUIHydrationJobRequest`.
+- [ ] Add `OpenWebUIHydrationItemResponse`.
+- [ ] Add `OpenWebUIHydrationSummaryResponse`.
+- [ ] Add `OpenWebUIHydrationPreviewResponse`.
+- [ ] Add `OpenWebUIHydrationJobResponse`.
+- [ ] Constrain `conversation_ids` to a bounded list of non-empty strings.
+- [ ] Keep `process_supported_files` default `False`.
+- [ ] Do not include raw source path fields in response schemas.
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_api.py -k "schema or preview" -q
+```
+
+Expected: schema-specific tests progress, endpoint tests still fail.
+
+### Task 5.3: Add endpoint authorization helper and preview route
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/endpoints/chatbooks.py`
+- Modify: `tldw_Server_API/app/core/Chatbooks/chatbook_service.py`
+
+- [ ] Add `_require_openwebui_hydration_access(user)`:
+  - allow single-user principal/current user as configured by existing auth helpers
+  - require admin-style claims/role in multi-user mode
+- [ ] Prefer existing auth helper patterns in `auth_deps.py`, `setup_deps.py`, or `chat_workflows_deps.py`.
+- [ ] Add service method `preview_openwebui_attachment_hydration(...)`.
+- [ ] Add endpoint `POST /api/v1/chatbooks/openwebui/hydration/preview`.
+- [ ] Convert service preview dataclasses to Pydantic response models.
+- [ ] Map validation/security errors to 400/403 without stack traces.
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_api.py -k "preview or auth" -q
+```
+
+Expected: PASS for preview/auth subset.
+
+### Task 5.4: Add job creation and status routes
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Chatbooks/openwebui_hydration_jobs.py`
+- Modify: `tldw_Server_API/app/core/Chatbooks/chatbook_service.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/chatbooks.py`
+
+- [ ] Add constants:
+
+```python
+CHATBOOKS_DOMAIN = "chatbooks"
+OPENWEBUI_ATTACHMENT_HYDRATION_JOB_TYPE = "openwebui_attachment_hydration"
+```
+
+- [ ] Add `create_openwebui_hydration_job(jobs_manager, payload, owner_user_id)`.
+- [ ] Service job payload includes:
+  - `user_id`
+  - `openwebui_data_root`
+  - `scope`
+  - `process_supported_files`
+  - preview confirmation token or preview summary hash if implemented
+- [ ] Revalidate authorization and roots in the worker, not only in endpoint.
+- [ ] Add endpoint `POST /api/v1/chatbooks/openwebui/hydration/jobs`.
+- [ ] Add endpoint `GET /api/v1/chatbooks/openwebui/hydration/jobs/{job_id}`.
+- [ ] Status endpoint reads core Jobs by uuid/id and filters by domain/job_type/owner.
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_api.py -q
+```
+
+Expected: PASS.
+
+### Task 5.5: Commit API slice
+
+- [ ] Run `git diff --check`.
+- [ ] Commit:
+
+```bash
+git add tldw_Server_API/app/api/v1/schemas/chatbook_schemas.py \
+        tldw_Server_API/app/api/v1/endpoints/chatbooks.py \
+        tldw_Server_API/app/core/Chatbooks/chatbook_service.py \
+        tldw_Server_API/app/core/Chatbooks/openwebui_hydration_jobs.py \
+        tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_api.py
+git commit -m "Expose OpenWebUI attachment hydration API"
+```
+
+## Stage 6: Jobs Worker Execution
+
+**Goal:** Execute hydration jobs asynchronously through a dedicated Chatbooks core Jobs type.
+
+**Success Criteria:** Worker routes only `openwebui_attachment_hydration`, revalidates permissions and paths, updates core Jobs result summary, and leaves existing import/export behavior unchanged.
+
+**Tests:** `tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_jobs_worker.py`, existing Chatbooks worker tests.
+
+**Status:** Not Started
+
+### Task 6.1: Write failing worker routing tests
+
+**Files:**
+- Create: `tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_jobs_worker.py`
+- Modify: `tldw_Server_API/app/core/Chatbooks/services/jobs_worker.py`
+
+- [ ] Test `_handle_job()` dispatches `job_type=openwebui_attachment_hydration`.
+- [ ] Test missing `openwebui_data_root` fails non-retryably.
+- [ ] Test worker calls hydration service and returns summary.
+- [ ] Test worker revalidates data root even when endpoint accepted the job.
+- [ ] Test existing `job_type=import` and `job_type=export` tests still pass.
+- [ ] Test unsupported job type still errors.
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_jobs_worker.py \
+  tldw_Server_API/tests/Chatbooks/test_chatbooks_jobs_worker_import_defaults.py \
+  -q
+```
+
+Expected: FAIL for missing hydration routing.
+
+### Task 6.2: Implement worker routing
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Chatbooks/services/jobs_worker.py`
+- Modify: `tldw_Server_API/app/core/Chatbooks/openwebui_hydration.py` if final result shape needs adjustment.
+
+- [ ] Import `OPENWEBUI_ATTACHMENT_HYDRATION_JOB_TYPE`.
+- [ ] Add `_handle_openwebui_attachment_hydration(service, payload, job)` or equivalent.
+- [ ] Normalize user id through existing `_normalize_user_id()`.
+- [ ] Validate required payload keys.
+- [ ] Call service method `run_openwebui_attachment_hydration(...)`.
+- [ ] Return JSON-safe summary:
+
+```python
+{
+    "referenced_files": result.referenced_files,
+    "resolved_files": result.resolved_files,
+    "hydrated_images": result.hydrated_images,
+    "registered_media_files": result.registered_media_files,
+    "already_hydrated": result.already_hydrated,
+    "missing_files": result.missing_files,
+    "unsupported_files": result.unsupported_files,
+    "failed_files": result.failed_files,
+    "processed_files": result.processed_files,
+    "warnings": result.warnings[:100],
+}
+```
+
+- [ ] Keep import/export routing unchanged.
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_jobs_worker.py \
+  tldw_Server_API/tests/Chatbooks/test_chatbooks_jobs_worker_import_defaults.py \
+  tldw_Server_API/tests/Chatbooks/test_chatbooks_jobs_adapter.py \
+  -q
+```
+
+Expected: PASS.
+
+### Task 6.3: Commit worker slice
+
+- [ ] Run `git diff --check`.
+- [ ] Commit:
+
+```bash
+git add tldw_Server_API/app/core/Chatbooks/services/jobs_worker.py \
+        tldw_Server_API/app/core/Chatbooks/openwebui_hydration.py \
+        tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_jobs_worker.py
+git commit -m "Run OpenWebUI hydration jobs"
+```
+
+## Stage 7: Frontend Hydration Workflow
+
+**Goal:** Make the feature discoverable in the existing Chatbooks import area with preview-first controls and opt-in processing.
+
+**Success Criteria:** Authorized users can enter an OpenWebUI data root, preview counts/warnings, enqueue hydration, and see status/result summary. Processing remains off by default.
+
+**Tests:** Vitest client and Chatbooks page tests.
+
+**Status:** Not Started
+
+### Task 7.1: Write failing API client tests
+
+**Files:**
+- Modify: `apps/packages/ui/src/services/__tests__/tldw-api-client.chatbooks-openwebui.test.ts`
+- Modify: `apps/packages/ui/src/services/tldw/TldwApiClient.ts`
+- Modify: `apps/packages/ui/src/services/tldw/domains/chat-rag.ts`
+
+- [ ] Test `previewOpenWebUIHydration({ openwebui_data_root, scope, process_supported_files })` POSTs JSON to `/chatbooks/openwebui/hydration/preview`.
+- [ ] Test `createOpenWebUIHydrationJob(...)` POSTs JSON to `/chatbooks/openwebui/hydration/jobs`.
+- [ ] Test `getOpenWebUIHydrationJob(jobId)` GETs `/chatbooks/openwebui/hydration/jobs/{jobId}`.
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/services/__tests__/tldw-api-client.chatbooks-openwebui.test.ts
+```
+
+Expected: FAIL because client methods do not exist.
+
+### Task 7.2: Implement frontend client methods
+
+**Files:**
+- Modify: `apps/packages/ui/src/services/tldw/TldwApiClient.ts`
+- Modify: `apps/packages/ui/src/services/tldw/domains/chat-rag.ts`
+
+- [ ] Add method names:
+  - `previewOpenWebUIHydration`
+  - `createOpenWebUIHydrationJob`
+  - `getOpenWebUIHydrationJob`
+- [ ] Use existing `request()`/`bgRequest()` conventions for JSON calls.
+- [ ] Do not use upload helpers; V1 sends server-local path text, not a file.
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/services/__tests__/tldw-api-client.chatbooks-openwebui.test.ts
+```
+
+Expected: PASS.
+
+### Task 7.3: Write failing Chatbooks UI tests
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/Chatbooks/__tests__/ChatbooksPlaygroundPage.openwebui-import.test.tsx`
+- Modify: `apps/packages/ui/src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx`
+
+- [ ] Test hydration controls are visible near OpenWebUI import when capability/auth allows.
+- [ ] Test the data root input is required before preview.
+- [ ] Test preview sends `process_supported_files: false` by default.
+- [ ] Test toggling processing sends `process_supported_files: true`.
+- [ ] Test preview counts render `referenced_files`, `hydrated_images`, `registered_media_files`, and warnings.
+- [ ] Test enqueue calls `createOpenWebUIHydrationJob` only after a successful preview.
+- [ ] Test non-authorized/capability-missing state hides or disables hydration controls.
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/Option/Chatbooks/__tests__/ChatbooksPlaygroundPage.openwebui-import.test.tsx
+```
+
+Expected: FAIL until UI is implemented.
+
+### Task 7.4: Implement Chatbooks hydration UI
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx`
+
+- [ ] Add local state:
+  - `hydrationDataRoot`
+  - `hydrationProcessingEnabled`
+  - `hydrationPreview`
+  - `hydrationJob`
+  - `hydrationLoading`
+  - `hydrationError`
+- [ ] Place controls in the existing import panel near OpenWebUI JSON/DB preview areas.
+- [ ] Use an input for server-local data root.
+- [ ] Use a checkbox/switch for opt-in processing.
+- [ ] Show preview counts and warnings in compact rows.
+- [ ] Disable job creation until preview succeeds.
+- [ ] Surface API errors with existing Ant Design alert/message patterns.
+- [ ] Add job id/status link or summary near existing job tracker.
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/Option/Chatbooks/__tests__/ChatbooksPlaygroundPage.openwebui-import.test.tsx
+```
+
+Expected: PASS.
+
+### Task 7.5: Commit frontend slice
+
+- [ ] Run `git diff --check`.
+- [ ] Commit:
+
+```bash
+git add apps/packages/ui/src/services/tldw/TldwApiClient.ts \
+        apps/packages/ui/src/services/tldw/domains/chat-rag.ts \
+        apps/packages/ui/src/services/__tests__/tldw-api-client.chatbooks-openwebui.test.ts \
+        apps/packages/ui/src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx \
+        apps/packages/ui/src/components/Option/Chatbooks/__tests__/ChatbooksPlaygroundPage.openwebui-import.test.tsx
+git commit -m "Add OpenWebUI hydration UI"
+```
+
+## Stage 8: Documentation And Final Verification
+
+**Goal:** Document the user workflow and API contract, then run focused verification and security checks.
+
+**Success Criteria:** Users can discover the feature, know the required local data-root shape, understand permissions/allowed roots, and see that processing is opt-in. Backend/frontend targeted tests and Bandit pass.
+
+**Tests:** Docs test plus focused backend/frontend suites.
+
+**Status:** Not Started
+
+### Task 8.1: Update user and API docs
+
+**Files:**
+- Modify: `Docs/User_Guides/WebUI_Extension/Chatbook_User_Guide.md`
+- Modify: `Docs/API-related/Chatbook_API_Documentation.md`
+- Modify: `Docs/API-related/chatbook_openapi.yaml`
+- Modify: `Docs/API-related/API_README.md`
+- Modify: `Docs/API-related/API_Tags_Index.md`
+- Modify: `Docs/Published/User_Guides/WebUI_Extension/Chatbook_User_Guide.md`
+- Modify: `Docs/Published/API-related/Chatbook_API_Documentation.md`
+- Modify: `Docs/Published/API-related/chatbook_openapi.yaml`
+- Modify: `Docs/Published/API-related/API_README.md`
+- Modify: `Docs/Published/API-related/API_Tags_Index.md`
+- Modify: `tldw_Server_API/tests/Docs/test_chatbook_openwebui_import_docs.py`
+
+- [ ] Document that v1 hydrates referenced files only.
+- [ ] Document required local root shape: `webui.db` plus `uploads/`.
+- [ ] Document `Files.ingestion_source_allowed_roots` and env var configuration.
+- [ ] Document image vs non-image behavior.
+- [ ] Document processing opt-in default.
+- [ ] Document single-user owner/admin permission requirement.
+- [ ] Document common warnings: missing files, unsupported type, oversized, path rejected.
+- [ ] Update docs tests to assert hydration feature text is present.
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Docs/test_chatbook_openwebui_import_docs.py -q
+```
+
+Expected: PASS.
+
+### Task 8.2: Run focused backend verification
+
+**Files:** no edits unless failures identify necessary fixes.
+
+- [ ] Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_db_helpers.py \
+  tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_paths.py \
+  tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_service.py \
+  tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_api.py \
+  tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_jobs_worker.py \
+  tldw_Server_API/tests/Chatbooks/test_openwebui_db_import_adapter.py \
+  tldw_Server_API/tests/Chatbooks/test_chatbooks_openwebui_db_api.py \
+  tldw_Server_API/tests/Chatbooks/test_chatbooks_jobs_worker_import_defaults.py \
+  -q
+```
+
+Expected: PASS.
+
+### Task 8.3: Run focused frontend verification
+
+**Files:** no edits unless failures identify necessary fixes.
+
+- [ ] Run:
+
+```bash
+bunx vitest run \
+  apps/packages/ui/src/services/__tests__/tldw-api-client.chatbooks-openwebui.test.ts \
+  apps/packages/ui/src/components/Option/Chatbooks/__tests__/ChatbooksPlaygroundPage.openwebui-import.test.tsx
+```
+
+Expected: PASS.
+
+### Task 8.4: Run Bandit on touched backend scope
+
+**Files:** no edits unless findings identify new issues.
+
+- [ ] Run:
+
+```bash
+source .venv/bin/activate
+python -m bandit -r \
+  tldw_Server_API/app/core/Chatbooks/openwebui_hydration.py \
+  tldw_Server_API/app/core/Chatbooks/openwebui_hydration_jobs.py \
+  tldw_Server_API/app/core/DB_Management/OpenWebUI_DB.py \
+  tldw_Server_API/app/core/DB_Management/chacha/message_store.py \
+  tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py \
+  tldw_Server_API/app/api/v1/endpoints/chatbooks.py \
+  tldw_Server_API/app/core/Chatbooks/services/jobs_worker.py \
+  -f json -o /tmp/bandit_openwebui_hydration.json
+```
+
+Expected: PASS or no new findings in touched hydration code. Fix new findings before continuing.
+
+### Task 8.5: Commit docs and verification slice
+
+- [ ] Run `git diff --check`.
+- [ ] Commit:
+
+```bash
+git add Docs/User_Guides/WebUI_Extension/Chatbook_User_Guide.md \
+        Docs/API-related/Chatbook_API_Documentation.md \
+        Docs/API-related/chatbook_openapi.yaml \
+        Docs/API-related/API_README.md \
+        Docs/API-related/API_Tags_Index.md \
+        Docs/Published/User_Guides/WebUI_Extension/Chatbook_User_Guide.md \
+        Docs/Published/API-related/Chatbook_API_Documentation.md \
+        Docs/Published/API-related/chatbook_openapi.yaml \
+        Docs/Published/API-related/API_README.md \
+        Docs/Published/API-related/API_Tags_Index.md \
+        tldw_Server_API/tests/Docs/test_chatbook_openwebui_import_docs.py
+git commit -m "Document OpenWebUI attachment hydration"
+```
+
+Omit any published mirror path that does not change in the implementation.
+
+## Final Branch Closeout
+
+- [ ] Run final status:
+
+```bash
+git status --short --branch
+```
+
+- [ ] Run final focused verification if any implementation task changed after Stage 8:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_db_helpers.py \
+  tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_paths.py \
+  tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_service.py \
+  tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_api.py \
+  tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_jobs_worker.py \
+  -q
+bunx vitest run \
+  apps/packages/ui/src/services/__tests__/tldw-api-client.chatbooks-openwebui.test.ts \
+  apps/packages/ui/src/components/Option/Chatbooks/__tests__/ChatbooksPlaygroundPage.openwebui-import.test.tsx
+```
+
+- [ ] Run final Bandit command from Task 8.4 if backend code changed after the previous Bandit run.
+- [ ] Update the Backlog implementation task with verification evidence and final summary.
+- [ ] Open or update a PR against `dev`.
+
+## Plan Review Notes
+
+- This plan intentionally keeps hydration separate from import and uses a dedicated Jobs type.
+- The largest implementation risk is Media DB registration. Do not start Stage 4 until the exact owner-aware Media DB helper approach is clear from current code.
+- The second largest risk is image idempotency. Metadata-only source-key tracking is acceptable for v1 only if tests prove retries do not duplicate rows. Add a source-mapping table if concurrent jobs make that unreliable.
+- A plan-review subagent was not dispatched while writing this document because this session requires explicit user permission before spawning delegated agents. Manual review should be treated as the current review pass unless the user explicitly approves subagent review.

--- a/Docs/superpowers/plans/2026-05-11-openwebui-attachment-hydration-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-11-openwebui-attachment-hydration-implementation-plan.md
@@ -753,7 +753,7 @@ Verification:
 
 **Tests:** Vitest client and Chatbooks page tests.
 
-**Status:** Not Started
+**Status:** Complete
 
 ### Task 7.1: Write failing API client tests
 
@@ -762,9 +762,12 @@ Verification:
 - Modify: `apps/packages/ui/src/services/tldw/TldwApiClient.ts`
 - Modify: `apps/packages/ui/src/services/tldw/domains/chat-rag.ts`
 
-- [ ] Test `previewOpenWebUIHydration({ openwebui_data_root, scope, process_supported_files })` POSTs JSON to `/chatbooks/openwebui/hydration/preview`.
-- [ ] Test `createOpenWebUIHydrationJob(...)` POSTs JSON to `/chatbooks/openwebui/hydration/jobs`.
-- [ ] Test `getOpenWebUIHydrationJob(jobId)` GETs `/chatbooks/openwebui/hydration/jobs/{jobId}`.
+- [x] Test `previewOpenWebUIHydration({ openwebui_data_root, scope, process_supported_files })` POSTs JSON to `/chatbooks/openwebui/hydration/preview`.
+- [x] Test `createOpenWebUIHydrationJob(...)` POSTs JSON to `/chatbooks/openwebui/hydration/jobs`.
+- [x] Test `getOpenWebUIHydrationJob(jobId)` GETs `/chatbooks/openwebui/hydration/jobs/{jobId}`.
+
+Verification:
+- 2026-05-11: `bun run test src/services/__tests__/tldw-api-client.chatbooks-openwebui.test.ts` from `apps/packages/ui` failed as expected with missing `previewOpenWebUIHydration`, `createOpenWebUIHydrationJob`, and `getOpenWebUIHydrationJob`.
 
 Run:
 
@@ -780,12 +783,15 @@ Expected: FAIL because client methods do not exist.
 - Modify: `apps/packages/ui/src/services/tldw/TldwApiClient.ts`
 - Modify: `apps/packages/ui/src/services/tldw/domains/chat-rag.ts`
 
-- [ ] Add method names:
+- [x] Add method names:
   - `previewOpenWebUIHydration`
   - `createOpenWebUIHydrationJob`
   - `getOpenWebUIHydrationJob`
-- [ ] Use existing `request()`/`bgRequest()` conventions for JSON calls.
-- [ ] Do not use upload helpers; V1 sends server-local path text, not a file.
+- [x] Use existing `request()`/`bgRequest()` conventions for JSON calls.
+- [x] Do not use upload helpers; V1 sends server-local path text, not a file.
+
+Verification:
+- 2026-05-11: `bun run test src/services/__tests__/tldw-api-client.chatbooks-openwebui.test.ts` from `apps/packages/ui` passed, 7 tests.
 
 Run:
 
@@ -801,13 +807,16 @@ Expected: PASS.
 - Modify: `apps/packages/ui/src/components/Option/Chatbooks/__tests__/ChatbooksPlaygroundPage.openwebui-import.test.tsx`
 - Modify: `apps/packages/ui/src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx`
 
-- [ ] Test hydration controls are visible near OpenWebUI import when capability/auth allows.
-- [ ] Test the data root input is required before preview.
-- [ ] Test preview sends `process_supported_files: false` by default.
-- [ ] Test toggling processing sends `process_supported_files: true`.
-- [ ] Test preview counts render `referenced_files`, `hydrated_images`, `registered_media_files`, and warnings.
-- [ ] Test enqueue calls `createOpenWebUIHydrationJob` only after a successful preview.
-- [ ] Test non-authorized/capability-missing state hides or disables hydration controls.
+- [x] Test hydration controls are visible near OpenWebUI import when capability/auth allows.
+- [x] Test the data root input is required before preview.
+- [x] Test preview sends `process_supported_files: false` by default.
+- [x] Test toggling processing sends `process_supported_files: true`.
+- [x] Test preview counts render `referenced_files`, `hydrated_images`, `registered_media_files`, and warnings.
+- [x] Test enqueue calls `createOpenWebUIHydrationJob` only after a successful preview.
+- [x] Test non-authorized/capability-missing state hides or disables hydration controls.
+
+Verification:
+- 2026-05-11: `bun run test src/components/Option/Chatbooks/__tests__/ChatbooksPlaygroundPage.openwebui-import.test.tsx` from `apps/packages/ui` failed as expected because the hydration controls were not present.
 
 Run:
 
@@ -822,20 +831,26 @@ Expected: FAIL until UI is implemented.
 **Files:**
 - Modify: `apps/packages/ui/src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx`
 
-- [ ] Add local state:
+- [x] Add local state:
   - `hydrationDataRoot`
   - `hydrationProcessingEnabled`
   - `hydrationPreview`
   - `hydrationJob`
   - `hydrationLoading`
   - `hydrationError`
-- [ ] Place controls in the existing import panel near OpenWebUI JSON/DB preview areas.
-- [ ] Use an input for server-local data root.
-- [ ] Use a checkbox/switch for opt-in processing.
-- [ ] Show preview counts and warnings in compact rows.
-- [ ] Disable job creation until preview succeeds.
-- [ ] Surface API errors with existing Ant Design alert/message patterns.
-- [ ] Add job id/status link or summary near existing job tracker.
+- [x] Place controls in the existing import panel near OpenWebUI JSON/DB preview areas.
+- [x] Use an input for server-local data root.
+- [x] Use a checkbox/switch for opt-in processing.
+- [x] Show preview counts and warnings in compact rows.
+- [x] Disable job creation until preview succeeds.
+- [x] Surface API errors with existing Ant Design alert/message patterns.
+- [x] Add job id/status link or summary near existing job tracker.
+
+Verification:
+- 2026-05-11: `bun run test src/components/Option/Chatbooks/__tests__/ChatbooksPlaygroundPage.openwebui-import.test.tsx` from `apps/packages/ui` passed, 6 tests.
+- 2026-05-11: `bun run test src/services/__tests__/tldw-api-client.chatbooks-openwebui.test.ts src/components/Option/Chatbooks/__tests__/ChatbooksPlaygroundPage.openwebui-import.test.tsx` from `apps/packages/ui` passed, 13 tests.
+- 2026-05-11: `bun run verify:openapi` from `apps/packages/ui` passed with 259 client paths verified and 10 existing reviewed exception paths.
+- 2026-05-11: `bunx tsc -p tsconfig.json --noEmit` from `apps/packages/ui` failed on existing unrelated package-wide baseline TypeScript errors; no reported error referenced the new Chatbooks hydration files.
 
 Run:
 
@@ -847,8 +862,11 @@ Expected: PASS.
 
 ### Task 7.5: Commit frontend slice
 
-- [ ] Run `git diff --check`.
-- [ ] Commit:
+- [x] Run `git diff --check`.
+
+Verification:
+- 2026-05-11: `git diff --check` passed.
+- [x] Commit:
 
 ```bash
 git add apps/packages/ui/src/services/tldw/TldwApiClient.ts \

--- a/Docs/superpowers/plans/2026-05-11-openwebui-attachment-hydration-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-11-openwebui-attachment-hydration-implementation-plan.md
@@ -652,7 +652,7 @@ Verification:
 
 **Tests:** `tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_jobs_worker.py`, existing Chatbooks worker tests.
 
-**Status:** Not Started
+**Status:** Complete
 
 ### Task 6.1: Write failing worker routing tests
 
@@ -660,12 +660,12 @@ Verification:
 - Create: `tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_jobs_worker.py`
 - Modify: `tldw_Server_API/app/core/Chatbooks/services/jobs_worker.py`
 
-- [ ] Test `_handle_job()` dispatches `job_type=openwebui_attachment_hydration`.
-- [ ] Test missing `openwebui_data_root` fails non-retryably.
-- [ ] Test worker calls hydration service and returns summary.
-- [ ] Test worker revalidates data root even when endpoint accepted the job.
-- [ ] Test existing `job_type=import` and `job_type=export` tests still pass.
-- [ ] Test unsupported job type still errors.
+- [x] Test `_handle_job()` dispatches `job_type=openwebui_attachment_hydration`.
+- [x] Test missing `openwebui_data_root` fails non-retryably.
+- [x] Test worker calls hydration service and returns summary.
+- [x] Test worker revalidates data root even when endpoint accepted the job.
+- [x] Test existing `job_type=import` and `job_type=export` tests still pass.
+- [x] Test unsupported job type still errors.
 
 Run:
 
@@ -683,14 +683,15 @@ Expected: FAIL for missing hydration routing.
 
 **Files:**
 - Modify: `tldw_Server_API/app/core/Chatbooks/services/jobs_worker.py`
-- Modify: `tldw_Server_API/app/core/Chatbooks/openwebui_hydration.py` if final result shape needs adjustment.
+- Modify: `tldw_Server_API/app/core/Chatbooks/chatbook_service.py`
+- Modify: `tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_service.py`
 
-- [ ] Import `OPENWEBUI_ATTACHMENT_HYDRATION_JOB_TYPE`.
-- [ ] Add `_handle_openwebui_attachment_hydration(service, payload, job)` or equivalent.
-- [ ] Normalize user id through existing `_normalize_user_id()`.
-- [ ] Validate required payload keys.
-- [ ] Call service method `run_openwebui_attachment_hydration(...)`.
-- [ ] Return JSON-safe summary:
+- [x] Import `OPENWEBUI_ATTACHMENT_HYDRATION_JOB_TYPE`.
+- [x] Add `_handle_openwebui_attachment_hydration(service, payload, job)` or equivalent.
+- [x] Normalize user id through existing `_normalize_user_id()`.
+- [x] Validate required payload keys.
+- [x] Call service method `run_openwebui_attachment_hydration(...)`.
+- [x] Return JSON-safe summary:
 
 ```python
 {
@@ -707,7 +708,7 @@ Expected: FAIL for missing hydration routing.
 }
 ```
 
-- [ ] Keep import/export routing unchanged.
+- [x] Keep import/export routing unchanged.
 
 Run:
 
@@ -724,15 +725,25 @@ Expected: PASS.
 
 ### Task 6.3: Commit worker slice
 
-- [ ] Run `git diff --check`.
-- [ ] Commit:
+- [x] Run `git diff --check`.
+- [x] Commit:
 
 ```bash
 git add tldw_Server_API/app/core/Chatbooks/services/jobs_worker.py \
-        tldw_Server_API/app/core/Chatbooks/openwebui_hydration.py \
+        tldw_Server_API/app/core/Chatbooks/chatbook_service.py \
+        tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_service.py \
         tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_jobs_worker.py
 git commit -m "Run OpenWebUI hydration jobs"
 ```
+
+Verification:
+- Red run before implementation: `test_openwebui_hydration_jobs_worker.py` failed because hydration jobs still required `chatbooks_job_id`.
+- `python -m pytest tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_jobs_worker.py tldw_Server_API/tests/Chatbooks/test_chatbooks_jobs_worker_import_defaults.py -q` -> 11 passed.
+- `python -m pytest tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_jobs_worker.py tldw_Server_API/tests/Chatbooks/test_chatbooks_jobs_worker_import_defaults.py tldw_Server_API/tests/Chatbooks/test_chatbooks_jobs_adapter.py -q` -> 13 passed.
+- `python -m pytest tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_jobs_worker.py tldw_Server_API/tests/Chatbooks/test_chatbooks_jobs_worker_import_defaults.py tldw_Server_API/tests/Chatbooks/test_chatbooks_jobs_adapter.py tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_service.py tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_api.py -q` -> 36 passed.
+- `python -m pytest tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_api.py tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_jobs_worker.py tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_paths.py tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_service.py tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_db_helpers.py tldw_Server_API/tests/Chatbooks/test_openwebui_db_import_adapter.py tldw_Server_API/tests/Chatbooks/test_chatbooks_jobs_worker_import_defaults.py tldw_Server_API/tests/Chatbooks/test_chatbooks_jobs_adapter.py -q` -> 61 passed.
+- `git diff --check` -> clean.
+- `python -m bandit -r tldw_Server_API/app/core/Chatbooks/services/jobs_worker.py tldw_Server_API/app/core/Chatbooks/chatbook_service.py -f json -o /tmp/bandit_openwebui_hydration_worker.json` -> 0 findings, 0 errors.
 
 ## Stage 7: Frontend Hydration Workflow
 

--- a/Docs/superpowers/plans/2026-05-11-openwebui-attachment-hydration-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-11-openwebui-attachment-hydration-implementation-plan.md
@@ -509,7 +509,7 @@ If no Media DB helper files changed, omit them from `git add`.
 
 **Tests:** `tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_api.py`
 
-**Status:** Not Started
+**Status:** Complete
 
 ### Task 5.1: Write failing API contract and auth tests
 
@@ -518,15 +518,15 @@ If no Media DB helper files changed, omit them from `git add`.
 - Modify: `tldw_Server_API/app/api/v1/schemas/chatbook_schemas.py`
 - Modify: `tldw_Server_API/app/api/v1/endpoints/chatbooks.py`
 
-- [ ] Test `POST /api/v1/chatbooks/openwebui/hydration/preview` validates `openwebui_data_root`.
-- [ ] Test preview request passes `source_user_id`, `conversation_ids`, and `process_supported_files`.
-- [ ] Test preview response includes counts and warning totals.
-- [ ] Test multi-user non-admin receives 403.
-- [ ] Test single-user principal is allowed.
-- [ ] Test admin role/claim in multi-user mode is allowed.
-- [ ] Test response warnings redact full absolute paths.
-- [ ] Test `POST /api/v1/chatbooks/openwebui/hydration/jobs` enqueues a core Jobs row with job type `openwebui_attachment_hydration`.
-- [ ] Test `GET /api/v1/chatbooks/openwebui/hydration/jobs/{job_id}` rejects jobs not owned by the current user unless admin access is explicitly intended.
+- [x] Test `POST /api/v1/chatbooks/openwebui/hydration/preview` validates `openwebui_data_root`.
+- [x] Test preview request passes `source_user_id`, `conversation_ids`, and `process_supported_files`.
+- [x] Test preview response includes counts and warning totals.
+- [x] Test multi-user non-admin receives 403.
+- [x] Test single-user principal is allowed.
+- [x] Test admin role/claim in multi-user mode is allowed.
+- [x] Test response warnings redact full absolute paths.
+- [x] Test `POST /api/v1/chatbooks/openwebui/hydration/jobs` enqueues a core Jobs row with job type `openwebui_attachment_hydration`.
+- [x] Test `GET /api/v1/chatbooks/openwebui/hydration/jobs/{job_id}` rejects jobs not owned by the current user unless admin access is explicitly intended.
 
 Run:
 
@@ -542,16 +542,16 @@ Expected: FAIL because schemas/endpoints do not exist.
 **Files:**
 - Modify: `tldw_Server_API/app/api/v1/schemas/chatbook_schemas.py`
 
-- [ ] Add `OpenWebUIHydrationScopeRequest`.
-- [ ] Add `OpenWebUIHydrationPreviewRequest`.
-- [ ] Add `OpenWebUIHydrationJobRequest`.
-- [ ] Add `OpenWebUIHydrationItemResponse`.
-- [ ] Add `OpenWebUIHydrationSummaryResponse`.
-- [ ] Add `OpenWebUIHydrationPreviewResponse`.
-- [ ] Add `OpenWebUIHydrationJobResponse`.
-- [ ] Constrain `conversation_ids` to a bounded list of non-empty strings.
-- [ ] Keep `process_supported_files` default `False`.
-- [ ] Do not include raw source path fields in response schemas.
+- [x] Add `OpenWebUIHydrationScopeRequest`.
+- [x] Add `OpenWebUIHydrationPreviewRequest`.
+- [x] Add `OpenWebUIHydrationJobRequest`.
+- [x] Add `OpenWebUIHydrationItemResponse`.
+- [x] Add `OpenWebUIHydrationSummaryResponse`.
+- [x] Add `OpenWebUIHydrationPreviewResponse`.
+- [x] Add `OpenWebUIHydrationJobResponse`.
+- [x] Constrain `conversation_ids` to a bounded list of non-empty strings.
+- [x] Keep `process_supported_files` default `False`.
+- [x] Do not include raw source path fields in response schemas.
 
 Run:
 
@@ -568,14 +568,14 @@ Expected: schema-specific tests progress, endpoint tests still fail.
 - Modify: `tldw_Server_API/app/api/v1/endpoints/chatbooks.py`
 - Modify: `tldw_Server_API/app/core/Chatbooks/chatbook_service.py`
 
-- [ ] Add `_require_openwebui_hydration_access(user)`:
+- [x] Add `_require_openwebui_hydration_access(user)`:
   - allow single-user principal/current user as configured by existing auth helpers
   - require admin-style claims/role in multi-user mode
-- [ ] Prefer existing auth helper patterns in `auth_deps.py`, `setup_deps.py`, or `chat_workflows_deps.py`.
-- [ ] Add service method `preview_openwebui_attachment_hydration(...)`.
-- [ ] Add endpoint `POST /api/v1/chatbooks/openwebui/hydration/preview`.
-- [ ] Convert service preview dataclasses to Pydantic response models.
-- [ ] Map validation/security errors to 400/403 without stack traces.
+- [x] Prefer existing auth helper patterns in `auth_deps.py`, `setup_deps.py`, or `chat_workflows_deps.py`.
+- [x] Add service method `preview_openwebui_attachment_hydration(...)`.
+- [x] Add endpoint `POST /api/v1/chatbooks/openwebui/hydration/preview`.
+- [x] Convert service preview dataclasses to Pydantic response models.
+- [x] Map validation/security errors to 400/403 without stack traces.
 
 Run:
 
@@ -593,24 +593,24 @@ Expected: PASS for preview/auth subset.
 - Modify: `tldw_Server_API/app/core/Chatbooks/chatbook_service.py`
 - Modify: `tldw_Server_API/app/api/v1/endpoints/chatbooks.py`
 
-- [ ] Add constants:
+- [x] Add constants:
 
 ```python
 CHATBOOKS_DOMAIN = "chatbooks"
 OPENWEBUI_ATTACHMENT_HYDRATION_JOB_TYPE = "openwebui_attachment_hydration"
 ```
 
-- [ ] Add `create_openwebui_hydration_job(jobs_manager, payload, owner_user_id)`.
-- [ ] Service job payload includes:
+- [x] Add `create_openwebui_hydration_job(jobs_manager, payload, owner_user_id)`.
+- [x] Service job payload includes:
   - `user_id`
   - `openwebui_data_root`
   - `scope`
   - `process_supported_files`
   - preview confirmation token or preview summary hash if implemented
-- [ ] Revalidate authorization and roots in the worker, not only in endpoint.
-- [ ] Add endpoint `POST /api/v1/chatbooks/openwebui/hydration/jobs`.
-- [ ] Add endpoint `GET /api/v1/chatbooks/openwebui/hydration/jobs/{job_id}`.
-- [ ] Status endpoint reads core Jobs by uuid/id and filters by domain/job_type/owner.
+- [ ] Revalidate authorization and roots in the worker, not only in endpoint. Deferred to Stage 6 worker execution.
+- [x] Add endpoint `POST /api/v1/chatbooks/openwebui/hydration/jobs`.
+- [x] Add endpoint `GET /api/v1/chatbooks/openwebui/hydration/jobs/{job_id}`.
+- [x] Status endpoint reads core Jobs by uuid/id and filters by domain/job_type/owner.
 
 Run:
 
@@ -623,8 +623,8 @@ Expected: PASS.
 
 ### Task 5.5: Commit API slice
 
-- [ ] Run `git diff --check`.
-- [ ] Commit:
+- [x] Run `git diff --check`.
+- [x] Commit:
 
 ```bash
 git add tldw_Server_API/app/api/v1/schemas/chatbook_schemas.py \
@@ -634,6 +634,15 @@ git add tldw_Server_API/app/api/v1/schemas/chatbook_schemas.py \
         tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_api.py
 git commit -m "Expose OpenWebUI attachment hydration API"
 ```
+
+Verification:
+- Red run before implementation: focused API tests failed because schemas/routes did not exist.
+- `python -m pytest tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_api.py -q` -> 7 passed.
+- `python -m pytest tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_api.py tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_paths.py tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_service.py tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_db_helpers.py tldw_Server_API/tests/Chatbooks/test_openwebui_db_import_adapter.py -q` -> 47 passed.
+- `python -m pytest tldw_Server_API/tests/Chatbooks/test_chatbooks_path_traversal.py -q` -> 3 passed.
+- `git diff --check` -> clean.
+- `python -m bandit -r tldw_Server_API/app/api/v1/endpoints/chatbooks.py tldw_Server_API/app/api/v1/schemas/chatbook_schemas.py tldw_Server_API/app/core/Chatbooks/chatbook_service.py tldw_Server_API/app/core/Chatbooks/openwebui_hydration_jobs.py -f json -o /tmp/bandit_openwebui_hydration_api.json` -> 0 findings, 0 errors.
+- Known non-gating check: `test_chatbooks_api_path_guard.py` with the path-traversal suite timed out during full `app.main` `TestClient` teardown after unrelated lifespan workers started.
 
 ## Stage 6: Jobs Worker Execution
 

--- a/Docs/superpowers/plans/2026-05-11-openwebui-attachment-hydration-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-11-openwebui-attachment-hydration-implementation-plan.md
@@ -412,22 +412,22 @@ git commit -m "Hydrate OpenWebUI image attachments"
 
 **Tests:** `tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_service.py`
 
-**Status:** Not Started
+**Status:** Complete
 
 ### Task 4.1: Write failing media registration tests
 
 **Files:**
 - Modify: `tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_service.py`
 
-- [ ] Test a PDF ref creates a Media row and a MediaFiles original row.
-- [ ] Assert the MediaFiles storage path is not under the OpenWebUI source data root.
-- [ ] Assert `source_hash` or `checksum` equals byte SHA-256.
-- [ ] Assert `owner_user_id` is the active tldw user and `visibility == "personal"`.
-- [ ] Assert a same `source_file_id` in the same user scope reuses the existing Media link.
-- [ ] Assert the same bytes for a different tldw user does not reuse another user's Media row.
-- [ ] Assert two source-id-less files with different filenames but empty extracted text do not collapse to the same placeholder content hash.
-- [ ] Assert `process_supported_files=false` leaves chunking/processing pending and does not enqueue processing.
-- [ ] Assert `process_supported_files=true` calls a mocked processing hook after registration and processing failure does not remove the MediaFiles row.
+- [x] Test a PDF ref creates a Media row and a MediaFiles original row.
+- [x] Assert the MediaFiles storage path is not under the OpenWebUI source data root.
+- [x] Assert `source_hash` or `checksum` equals byte SHA-256.
+- [x] Assert `owner_user_id` is the active tldw user and `visibility == "personal"`.
+- [x] Assert a same `source_file_id` in the same user scope reuses the existing Media link.
+- [x] Assert the same bytes for a different tldw user does not reuse another user's Media row.
+- [x] Assert two source-id-less files with different filenames but empty extracted text do not collapse to the same placeholder content hash.
+- [x] Assert `process_supported_files=false` leaves chunking/processing pending and does not enqueue processing.
+- [x] Assert `process_supported_files=true` calls a mocked processing hook after registration and processing failure does not remove the MediaFiles row.
 
 Run:
 
@@ -447,12 +447,12 @@ Expected: FAIL because non-image registration is missing.
   - `tldw_Server_API/app/core/DB_Management/media_db/api.py`
   - `tldw_Server_API/app/core/DB_Management/media_db/repositories/media_repository.py`
 
-- [ ] Add a storage helper that copies source bytes into a per-user tldw-owned import directory. Prefer an existing media storage convention if one exists; otherwise use a new Chatbooks-owned subdirectory under the configured user database/media area.
-- [ ] Use `open_safe_local_path()` for source file reads when practical.
-- [ ] Compute `sha256` from source bytes while streaming/copying.
-- [ ] Add owner-aware lookup by OpenWebUI source id in safe metadata/source URL.
-- [ ] Add owner-aware lookup by byte hash only inside current hydration run when no source id exists.
-- [ ] Register a parent Media row with:
+- [x] Add a storage helper that copies source bytes into a per-user tldw-owned import directory. Prefer an existing media storage convention if one exists; otherwise use a new Chatbooks-owned subdirectory under the configured user database/media area.
+- [x] Use `open_safe_local_path()` for source file reads when practical.
+- [x] Compute `sha256` from source bytes while streaming/copying.
+- [x] Add owner-aware lookup by OpenWebUI source id in safe metadata/source URL.
+- [x] Add owner-aware lookup by byte hash only inside current hydration run when no source id exists.
+- [x] Register a parent Media row with:
 
 ```python
 placeholder_content = json.dumps(
@@ -467,13 +467,14 @@ placeholder_content = json.dumps(
 )
 ```
 
-- [ ] Use an OpenWebUI-specific URL:
-  - `openwebui://file/{source_file_id}` when source id exists
-  - `openwebui://run/{job_id}/{byte_sha256}` when source id is missing
-- [ ] Pass `source_hash=byte_sha256`, `owner_user_id=<tldw user id>`, and `visibility="personal"`.
-- [ ] Insert `MediaFiles` row with `file_type="original"`, copied storage path, original filename, file size, MIME type, and checksum.
-- [ ] Record `status="registered_media"` and `media_id`/`media_file_id` in message hydration metadata.
-- [ ] Keep optional processing hook separated behind `process_supported_files`.
+- [x] Use an OpenWebUI-specific URL:
+  - `openwebui://user/{owner_user_id}/file/{source_file_id}` when source id exists
+  - `openwebui://user/{owner_user_id}/run/{job_id}/{byte_sha256}` when source id is missing
+  - Chosen instead of the earlier non-owner URL shape because `Media.url` is globally unique in the current schema.
+- [x] Pass `source_hash=byte_sha256`, `owner_user_id=<tldw user id>`, and `visibility="personal"`.
+- [x] Insert `MediaFiles` row with `file_type="original"`, copied storage path, original filename, file size, MIME type, and checksum.
+- [x] Record `status="registered_media"` and `media_id`/`media_file_id` in message hydration metadata.
+- [x] Keep optional processing hook separated behind `process_supported_files`.
 
 Run:
 
@@ -486,8 +487,8 @@ Expected: PASS.
 
 ### Task 4.3: Commit media registration slice
 
-- [ ] Run `git diff --check`.
-- [ ] Commit:
+- [x] Run `git diff --check`.
+- [x] Commit:
 
 ```bash
 git add tldw_Server_API/app/core/Chatbooks/openwebui_hydration.py \

--- a/Docs/superpowers/plans/2026-05-11-openwebui-attachment-hydration-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-11-openwebui-attachment-hydration-implementation-plan.md
@@ -300,7 +300,7 @@ git commit -m "Add OpenWebUI hydration preview service"
 
 **Tests:** `tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_service.py`
 
-**Status:** Not Started
+**Status:** Complete
 
 ### Task 3.1: Write failing image and metadata merge tests
 
@@ -309,7 +309,7 @@ git commit -m "Add OpenWebUI hydration preview service"
 - Modify: `tldw_Server_API/app/core/DB_Management/chacha/message_store.py`
 - Modify: `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`
 
-- [ ] Test a message with existing metadata:
+- [x] Test a message with existing metadata:
 
 ```python
 original = {
@@ -325,12 +325,13 @@ original = {
 }
 ```
 
-- [ ] Hydrate one PNG ref and assert all original keys remain.
-- [ ] Assert `hydration.items[0].status == "hydrated_image"`.
-- [ ] Assert image position is appended after any existing `message_images` positions.
-- [ ] Run hydration twice and assert one image row, with second item status `already_hydrated` or unchanged existing item.
-- [ ] Test oversized image returns `oversized`.
-- [ ] Test extension says `.png` but bytes are not image-like and returns `unsupported_file_type`.
+- [x] Hydrate one PNG ref and assert all original keys remain.
+- [x] Assert `hydration.items[0].status == "hydrated_image"`.
+- [x] Assert image position is appended after any existing `message_images` positions.
+- [x] Run hydration twice and assert one image row, with second item status `already_hydrated` or unchanged existing item.
+- [x] Test oversized image returns `oversized`.
+- [x] Test extension says `.png` but bytes are not image-like and returns `unsupported_file_type`.
+- [x] Test metadata update failure rolls back the appended image row.
 
 Run:
 
@@ -347,13 +348,13 @@ Expected: FAIL because append/idempotency helpers are missing.
 - Modify: `tldw_Server_API/app/core/DB_Management/chacha/message_store.py`
 - Modify: `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`
 
-- [ ] Add `append_message_image(message_id: str, image_bytes: bytes, mime_type: str) -> int`.
-- [ ] Validate max image size using the same `MAX_MESSAGE_IMAGE_BYTES` setting used by `add_message()`.
-- [ ] Select `COALESCE(MAX(position), -1) + 1` for the message.
-- [ ] Insert a new row at that position.
-- [ ] Return the inserted position.
-- [ ] Keep transaction boundaries compatible with service-level calls; if service manages a larger transaction, expose a helper that accepts `commit=False` or uses existing DB transaction conventions.
-- [ ] Do not change `_insert_message_images()` behavior for normal chatbook import.
+- [x] Add `append_message_image(message_id: str, image_bytes: bytes, mime_type: str) -> int`.
+- [x] Validate max image size using the same `MAX_MESSAGE_IMAGE_BYTES` setting used by `add_message()`.
+- [x] Select `COALESCE(MAX(position), -1) + 1` for the message.
+- [x] Insert a new row at that position.
+- [x] Return the inserted position.
+- [x] Keep transaction boundaries compatible with service-level calls; if service manages a larger transaction, expose a helper that accepts `commit=False` or uses existing DB transaction conventions.
+- [x] Do not change `_insert_message_images()` behavior for normal chatbook import.
 
 Run:
 
@@ -369,16 +370,17 @@ Expected: still FAIL until service code calls the helper.
 **Files:**
 - Modify: `tldw_Server_API/app/core/Chatbooks/openwebui_hydration.py`
 
-- [ ] Add `merge_openwebui_message_hydration_metadata(chacha_db, message_id, item_update)`.
-- [ ] Read `get_message_metadata(message_id)`.
-- [ ] Copy the full `extra.openwebui_import` object.
-- [ ] Add or update `hydration.version`, `last_job_id`, and `items`.
-- [ ] Preserve original `attachment_refs`, source ids, role, model, and metadata.
-- [ ] Add `hydrate_image_reference(...)`.
-- [ ] Derive `source_key = f"openwebui:file:{source_file_id}"` when file id exists, else `openwebui:hash:{sha256}`.
-- [ ] If `source_key` already appears in hydration items with `message_image_position`, return `already_hydrated` without inserting.
-- [ ] Sniff image bytes with a small allowlist for PNG, JPEG, GIF, and WebP signatures.
-- [ ] Append the image and record position.
+- [x] Add `merge_openwebui_message_hydration_metadata(chacha_db, message_id, item_update)`.
+- [x] Read `get_message_metadata(message_id)`.
+- [x] Copy the full `extra.openwebui_import` object.
+- [x] Add or update `hydration.version`, `last_job_id`, and `items`.
+- [x] Preserve original `attachment_refs`, source ids, role, model, and metadata.
+- [x] Add `hydrate_image_reference(...)`.
+- [x] Derive `source_key = f"openwebui:file:{source_file_id}"` when file id exists, else `openwebui:hash:{sha256}`.
+- [x] If `source_key` already appears in hydration items with `message_image_position`, return `already_hydrated` without inserting.
+- [x] Sniff image bytes with a small allowlist for PNG, JPEG, GIF, and WebP signatures.
+- [x] Append the image and record position.
+- [x] Wrap image insert plus metadata update in one transaction when the DB exposes transaction support.
 
 Run:
 
@@ -391,8 +393,8 @@ Expected: PASS.
 
 ### Task 3.4: Commit image hydration slice
 
-- [ ] Run `git diff --check`.
-- [ ] Commit:
+- [x] Run `git diff --check`.
+- [x] Commit:
 
 ```bash
 git add tldw_Server_API/app/core/Chatbooks/openwebui_hydration.py \

--- a/Docs/superpowers/plans/2026-05-11-openwebui-attachment-hydration-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-11-openwebui-attachment-hydration-implementation-plan.md
@@ -885,7 +885,7 @@ git commit -m "Add OpenWebUI hydration UI"
 
 **Tests:** Docs test plus focused backend/frontend suites.
 
-**Status:** Not Started
+**Status:** Complete
 
 ### Task 8.1: Update user and API docs
 
@@ -902,14 +902,17 @@ git commit -m "Add OpenWebUI hydration UI"
 - Modify: `Docs/Published/API-related/API_Tags_Index.md`
 - Modify: `tldw_Server_API/tests/Docs/test_chatbook_openwebui_import_docs.py`
 
-- [ ] Document that v1 hydrates referenced files only.
-- [ ] Document required local root shape: `webui.db` plus `uploads/`.
-- [ ] Document `Files.ingestion_source_allowed_roots` and env var configuration.
-- [ ] Document image vs non-image behavior.
-- [ ] Document processing opt-in default.
-- [ ] Document single-user owner/admin permission requirement.
-- [ ] Document common warnings: missing files, unsupported type, oversized, path rejected.
-- [ ] Update docs tests to assert hydration feature text is present.
+- [x] Document that v1 hydrates referenced files only.
+- [x] Document required local root shape: `webui.db` plus `uploads/`.
+- [x] Document `Files.ingestion_source_allowed_roots` and env var configuration.
+- [x] Document image vs non-image behavior.
+- [x] Document processing opt-in default.
+- [x] Document single-user owner/admin permission requirement.
+- [x] Document common warnings: missing files, unsupported type, oversized, path rejected.
+- [x] Update docs tests to assert hydration feature text is present.
+
+Verification:
+- 2026-05-11: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Docs/test_chatbook_openwebui_import_docs.py -q` passed, 6 passed, 5 warnings.
 
 Run:
 
@@ -924,7 +927,7 @@ Expected: PASS.
 
 **Files:** no edits unless failures identify necessary fixes.
 
-- [ ] Run:
+- [x] Run:
 
 ```bash
 source .venv/bin/activate
@@ -942,11 +945,14 @@ python -m pytest \
 
 Expected: PASS.
 
+Verification:
+- 2026-05-11: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_db_helpers.py tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_paths.py tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_service.py tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_api.py tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_jobs_worker.py tldw_Server_API/tests/Chatbooks/test_openwebui_db_import_adapter.py tldw_Server_API/tests/Chatbooks/test_chatbooks_openwebui_db_api.py tldw_Server_API/tests/Chatbooks/test_chatbooks_jobs_worker_import_defaults.py -q` passed, 65 passed, 5 warnings.
+
 ### Task 8.3: Run focused frontend verification
 
 **Files:** no edits unless failures identify necessary fixes.
 
-- [ ] Run:
+- [x] Run:
 
 ```bash
 bunx vitest run \
@@ -956,11 +962,14 @@ bunx vitest run \
 
 Expected: PASS.
 
+Verification:
+- 2026-05-11: `bun run test src/services/__tests__/tldw-api-client.chatbooks-openwebui.test.ts src/components/Option/Chatbooks/__tests__/ChatbooksPlaygroundPage.openwebui-import.test.tsx` from `apps/packages/ui` passed, 13 passed.
+
 ### Task 8.4: Run Bandit on touched backend scope
 
 **Files:** no edits unless findings identify new issues.
 
-- [ ] Run:
+- [x] Run:
 
 ```bash
 source .venv/bin/activate
@@ -977,10 +986,13 @@ python -m bandit -r \
 
 Expected: PASS or no new findings in touched hydration code. Fix new findings before continuing.
 
+Verification:
+- 2026-05-11: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Chatbooks/openwebui_hydration.py tldw_Server_API/app/core/Chatbooks/openwebui_hydration_jobs.py tldw_Server_API/app/core/DB_Management/OpenWebUI_DB.py tldw_Server_API/app/core/DB_Management/chacha/message_store.py tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py tldw_Server_API/app/api/v1/endpoints/chatbooks.py tldw_Server_API/app/core/Chatbooks/services/jobs_worker.py -f json -o /tmp/bandit_openwebui_hydration.json` passed with 0 findings and 0 errors.
+
 ### Task 8.5: Commit docs and verification slice
 
-- [ ] Run `git diff --check`.
-- [ ] Commit:
+- [x] Run `git diff --check`.
+- [x] Commit:
 
 ```bash
 git add Docs/User_Guides/WebUI_Extension/Chatbook_User_Guide.md \

--- a/Docs/superpowers/plans/2026-05-11-openwebui-attachment-hydration-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-11-openwebui-attachment-hydration-implementation-plan.md
@@ -114,7 +114,7 @@ Modify:
 
 **Tests:** `tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_db_helpers.py`
 
-**Status:** Not Started
+**Status:** Complete
 
 ### Task 1.1: Write failing DB helper tests
 
@@ -122,7 +122,7 @@ Modify:
 - Create: `tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_db_helpers.py`
 - Modify: `tldw_Server_API/app/core/DB_Management/OpenWebUI_DB.py`
 
-- [ ] Add a temporary SQLite fixture with `user`, `chat`, `folder`, `file`, and `chat_file` tables:
+- [x] Add a temporary SQLite fixture with `user`, `chat`, `folder`, `file`, and `chat_file` tables:
 
 ```python
 def write_openwebui_hydration_db(path: Path) -> Path:
@@ -135,12 +135,12 @@ def write_openwebui_hydration_db(path: Path) -> Path:
     ...
 ```
 
-- [ ] Test `validate_openwebui_file_schema(conn)` fails when `file` is missing.
-- [ ] Test `validate_openwebui_file_schema(conn)` fails when `file.id`, `file.user_id`, or `file.filename` is missing.
-- [ ] Test baseline `validate_openwebui_schema(conn)` still passes without `file` and `chat_file`.
-- [ ] Test `load_openwebui_file_rows_for_ids(conn, ["file-a"], user_id="owui-user")` returns only that user's row.
-- [ ] Test `load_openwebui_chat_file_rows_for_chats(conn, ["chat-a"], user_id="owui-user")` ignores unrelated chats/users.
-- [ ] Test helpers use bound parameters by checking ids containing quotes are treated as literal values.
+- [x] Test `validate_openwebui_file_schema(conn)` fails when `file` is missing.
+- [x] Test `validate_openwebui_file_schema(conn)` fails when `file.id`, `file.user_id`, or `file.filename` is missing.
+- [x] Test baseline `validate_openwebui_schema(conn)` still passes without `file` and `chat_file`.
+- [x] Test `load_openwebui_file_rows_for_ids(conn, ["file-a"], user_id="owui-user")` returns only that user's row.
+- [x] Test `load_openwebui_chat_file_rows_for_chats(conn, ["chat-a"], user_id="owui-user")` ignores unrelated chats/users.
+- [x] Test helpers use bound parameters by checking ids containing quotes are treated as literal values.
 
 Run:
 
@@ -156,13 +156,13 @@ Expected: FAIL because the helper functions do not exist.
 **Files:**
 - Modify: `tldw_Server_API/app/core/DB_Management/OpenWebUI_DB.py`
 
-- [ ] Add `HYDRATION_FILE_SCHEMA` and `HYDRATION_CHAT_FILE_SCHEMA` constants separate from `REQUIRED_SCHEMA`.
-- [ ] Add `validate_openwebui_file_schema(conn: sqlite3.Connection) -> None`.
-- [ ] Add `load_openwebui_file_rows_for_ids(conn, file_ids, user_id=None)`.
-- [ ] Add `load_openwebui_chat_file_rows_for_chats(conn, chat_ids, user_id=None)`.
-- [ ] Add `iter_openwebui_files_for_user(conn, user_id)` only for future/full-library support; do not use it for v1 default hydration scope.
-- [ ] Keep all SQL parameterized.
-- [ ] Return `sqlite3.Row` objects for consistency with the existing OpenWebUI DB helpers.
+- [x] Add `HYDRATION_FILE_SCHEMA` and `HYDRATION_CHAT_FILE_SCHEMA` constants separate from `REQUIRED_SCHEMA`.
+- [x] Add `validate_openwebui_file_schema(conn: sqlite3.Connection) -> None`.
+- [x] Add `load_openwebui_file_rows_for_ids(conn, file_ids, user_id=None)`.
+- [x] Add `load_openwebui_chat_file_rows_for_chats(conn, chat_ids, user_id=None)`.
+- [x] Add `iter_openwebui_files_for_user(conn, user_id)` only for future/full-library support; do not use it for v1 default hydration scope.
+- [x] Keep all SQL parameterized.
+- [x] Return `sqlite3.Row` objects for consistency with the existing OpenWebUI DB helpers.
 
 Run:
 
@@ -176,8 +176,8 @@ Expected: PASS. The second command proves text-only DB import validation was not
 
 ### Task 1.3: Commit DB helper slice
 
-- [ ] Run `git diff --check`.
-- [ ] Commit:
+- [x] Run `git diff --check`.
+- [x] Commit:
 
 ```bash
 git add tldw_Server_API/app/core/DB_Management/OpenWebUI_DB.py \

--- a/Docs/superpowers/plans/2026-05-11-openwebui-attachment-hydration-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-11-openwebui-attachment-hydration-implementation-plan.md
@@ -193,7 +193,7 @@ git commit -m "Add OpenWebUI hydration DB helpers"
 
 **Tests:** `tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_paths.py`, first service tests in `test_openwebui_hydration_service.py`
 
-**Status:** Not Started
+**Status:** Complete
 
 ### Task 2.1: Write failing path and preview tests
 
@@ -202,15 +202,15 @@ git commit -m "Add OpenWebUI hydration DB helpers"
 - Create: `tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_service.py`
 - Create: `tldw_Server_API/app/core/Chatbooks/openwebui_hydration.py`
 
-- [ ] Test data root outside `INGESTION_SOURCE_ALLOWED_ROOTS` is rejected.
-- [ ] Test missing `webui.db` is a fatal preview error.
-- [ ] Test missing `uploads/` is a fatal preview error only when referenced file bytes are needed.
-- [ ] Test `file.path="../secret.txt"` is rejected as `path_rejected`.
-- [ ] Test symlink escape is rejected by canonical target checks.
-- [ ] Test fallback `uploads/{file.id}_{file.filename}` resolves when safe.
-- [ ] Test imported message metadata refs are extracted from `extra.openwebui_import.attachment_refs`.
-- [ ] Test unsupported ref shapes produce `unsupported_reference_shape`.
-- [ ] Test DB `chat_file` fallback uses preserved `openwebui_import.metadata.row_id` and skips fallback when absent.
+- [x] Test data root outside `INGESTION_SOURCE_ALLOWED_ROOTS` is rejected.
+- [x] Test missing `webui.db` is a fatal preview error.
+- [x] Test missing `uploads/` is a fatal preview error only when referenced file bytes are needed.
+- [x] Test `file.path="../secret.txt"` is rejected as `path_rejected`.
+- [x] Test symlink escape is rejected by canonical target checks.
+- [x] Test fallback `uploads/{file.id}_{file.filename}` resolves when safe.
+- [x] Test imported message metadata refs are extracted from `extra.openwebui_import.attachment_refs`.
+- [x] Test unsupported ref shapes produce `unsupported_reference_shape`.
+- [x] Test DB `chat_file` fallback uses preserved `openwebui_import.metadata.row_id` and skips fallback when absent.
 
 Run:
 
@@ -229,24 +229,24 @@ Expected: FAIL because `openwebui_hydration.py` does not exist.
 **Files:**
 - Create: `tldw_Server_API/app/core/Chatbooks/openwebui_hydration.py`
 
-- [ ] Add dataclasses:
+- [x] Add dataclasses:
   - `OpenWebUIHydrationScope`
   - `OpenWebUIHydrationReference`
   - `OpenWebUIHydrationResolvedFile`
   - `OpenWebUIHydrationPreviewItem`
   - `OpenWebUIHydrationPreview`
   - `OpenWebUIHydrationResult`
-- [ ] Add `validate_openwebui_data_root(root: str | Path) -> OpenWebUIDataRoot`.
-- [ ] Use `get_ingestion_source_allowed_roots(reload=True)` or the same reload behavior established by ingestion-source tests.
-- [ ] Use `resolve_safe_local_path()` to confirm data root is under one allowed root.
-- [ ] Require canonical `webui.db` under data root.
-- [ ] Require canonical `uploads/` directory under data root.
-- [ ] Add `resolve_openwebui_file_path(file_row, data_root, uploads_root)`.
-- [ ] Try candidates in this order:
+- [x] Add `validate_openwebui_data_root(root: str | Path) -> OpenWebUIDataRoot`.
+- [x] Use `get_ingestion_source_allowed_roots(reload=True)` or the same reload behavior established by ingestion-source tests.
+- [x] Use `resolve_safe_local_path()` to confirm data root is under one allowed root.
+- [x] Require canonical `webui.db` under data root.
+- [x] Resolve canonical `uploads/` under data root and require it when file bytes are needed.
+- [x] Add `resolve_openwebui_file_path(file_row, data_root)`.
+- [x] Try candidates in this order:
   1. relative `file.path` under data root/uploads root
   2. absolute `file.path` only if it canonicalizes under data root/uploads root
   3. `uploads/{file.id}_{file.filename}`
-- [ ] Return structured warnings, not raw absolute paths, for user-facing preview.
+- [x] Return structured warnings, not raw absolute paths, for user-facing preview.
 
 Run:
 
@@ -262,14 +262,14 @@ Expected: PASS.
 **Files:**
 - Modify: `tldw_Server_API/app/core/Chatbooks/openwebui_hydration.py`
 
-- [ ] Add `extract_openwebui_hydration_references(chacha_db, scope)`.
-- [ ] Query messages for the active tldw user/conversation scope using existing DB helpers where available; if no focused helper exists, add the smallest ChaCha helper needed rather than scanning raw DB files outside DB_Management.
-- [ ] Read current `message_metadata.extra.openwebui_import`.
-- [ ] Preserve the raw reference index and shape in the preview item.
-- [ ] Recognize dict ids from `id`, `file_id`, and `fileId`.
-- [ ] Recognize string refs only when non-empty.
-- [ ] Add DB fallback from `chat_file` rows only for imported conversation source chat ids.
-- [ ] Bound preview warning arrays to avoid huge responses.
+- [x] Add `extract_openwebui_hydration_references(chacha_db, scope)`.
+- [x] Query messages for the active tldw user/conversation scope using existing DB helpers where available; if no focused helper exists, add the smallest ChaCha helper needed rather than scanning raw DB files outside DB_Management.
+- [x] Read current `message_metadata.extra.openwebui_import`.
+- [x] Preserve the raw reference index and shape in the preview item.
+- [x] Recognize dict ids from `id`, `file_id`, and `fileId`.
+- [x] Recognize string refs only when non-empty.
+- [x] Add DB fallback from `chat_file` rows only for imported conversation source chat ids.
+- [x] Bound preview warning arrays to avoid huge responses.
 
 Run:
 
@@ -282,8 +282,8 @@ Expected: PASS.
 
 ### Task 2.4: Commit preview/path slice
 
-- [ ] Run `git diff --check`.
-- [ ] Commit:
+- [x] Run `git diff --check`.
+- [x] Commit:
 
 ```bash
 git add tldw_Server_API/app/core/Chatbooks/openwebui_hydration.py \

--- a/Docs/superpowers/specs/2026-05-11-openwebui-attachment-hydration-design.md
+++ b/Docs/superpowers/specs/2026-05-11-openwebui-attachment-hydration-design.md
@@ -2,7 +2,7 @@
 
 Date: 2026-05-11
 Owner: Codex collaboration session
-Status: User-approved design, pending implementation planning
+Status: User-approved design, reviewed and amended, pending implementation planning
 Backlog: TASK-233.14
 
 ## Summary
@@ -151,6 +151,91 @@ Use Approach 2.
 
 Implement a separate OpenWebUI attachment hydration job that targets only imported-chat references. V1 uses a trusted server-local OpenWebUI data root, restores images as message attachments, registers non-image files in Media DB, and records per-reference hydration status in message metadata. Processing remains opt-in.
 
+## Design Review Findings And Adjustments
+
+Review against the current Chatbooks, OpenWebUI DB, Jobs, ChaCha image, path-safety, and Media DB code found several constraints that should shape the implementation plan.
+
+### 1. Metadata Updates Need Deep Merge Semantics
+
+`ChaChaNotesDB.set_message_metadata_extra(..., merge=True)` currently merges only top-level keys in `message_metadata.extra`. Passing a partial value such as:
+
+```json
+{"openwebui_import": {"hydration": {"items": []}}}
+```
+
+would replace the existing `openwebui_import` block and could discard source message ids, parent/child ids, role, model, and original `attachment_refs`.
+
+Implementation must read the current message metadata, update `extra.openwebui_import.hydration` in memory, and write the full `openwebui_import` object back. A focused helper such as `merge_openwebui_message_hydration_metadata(message_id, hydration_patch)` is preferred over repeatedly open-coding this read-modify-write logic. Tests must prove original import metadata survives hydration status updates.
+
+### 2. Existing Message Images Have No Source Key
+
+The `message_images` table is keyed by `(message_id, position)` and stores only bytes, MIME type, and timestamps. It cannot directly express "this row came from OpenWebUI file id X." A retry-safe design therefore cannot rely on the table alone for idempotency.
+
+V1 should use message metadata as the source index for hydrated OpenWebUI images:
+
+- derive a stable `source_key` from source file id when present, else from run-local content hash
+- check existing `openwebui_import.hydration.items` for that source key before inserting
+- append images after the current maximum message image position unless the same source key is already recorded
+- update image rows and hydration metadata in one DB transaction where practical
+- never overwrite existing non-OpenWebUI image positions
+
+If this becomes too fragile, add a small source-mapping table rather than overloading image position semantics. The implementation plan should make this an explicit checkpoint.
+
+### 3. Media DB Registration Must Avoid Text-Content Dedupe Pitfalls
+
+The current `add_media_with_keywords` path is text-content oriented: it requires `content`, hashes that text, and has existing URL/content-hash dedupe behavior that is not inherently scoped to one OpenWebUI import or one tldw user. That is risky for binary attachment registration, especially if all unprocessed files use empty placeholder content.
+
+V1 must not blindly register binary files through `add_media_with_keywords(content="")`.
+
+Recommended implementation direction:
+
+- copy the OpenWebUI source file into a tldw-owned durable storage location before creating the Media DB file row
+- compute the file byte SHA-256 and store it as `source_hash` and/or `MediaFiles.checksum`
+- use a stable OpenWebUI-specific URL such as `openwebui://file/<source_file_id>` when a source id exists, or `openwebui://run/<hydration_job_id>/<sha256>` for source-id-less refs
+- set `owner_user_id` and `visibility="personal"` explicitly
+- use or add owner-aware lookup helpers for OpenWebUI source ids and file hashes; do not reuse a Media row owned by another user
+- if a placeholder `Media.content` value is required, include source id, filename, MIME, and byte hash so the content hash is not identical for unrelated files
+
+The implementation plan should identify the exact Media DB helper to use or introduce before coding this path.
+
+### 4. Hydration Should Be Its Own Chatbooks Job Type
+
+The current Chatbooks Jobs worker uses the `chatbooks` domain with `job_type="export"` or `job_type="import"` and requires a `chatbooks_job_id` that maps to the Chatbooks export/import job records. Hydration should not overload the import job type, because it has different inputs, status, retry, and result semantics.
+
+V1 should use a dedicated core Jobs contract, for example:
+
+```text
+domain = chatbooks
+queue = CHATBOOKS_JOBS_QUEUE or default
+job_type = openwebui_attachment_hydration
+```
+
+The design still allows the UI to present hydration near import history, but the worker routing, job payload, result summary, and cancellation semantics should be separate from archive/chat import. If the UI needs durable history beyond core Jobs retention, add a minimal Chatbooks-side hydration job journal instead of reusing import job rows.
+
+### 5. Hydration DB Schema Checks Must Not Regress Chat Import
+
+The existing OpenWebUI DB chat import validates only the tables needed for chat/folder import. Hydration needs `file` and sometimes `chat_file`, but making those mandatory in the existing `open_validated_openwebui_db()` helper would break chat import for databases that are still valid for text-only migration.
+
+Add hydration-specific validation such as `validate_openwebui_file_schema(conn)` or an `include_file_tables=True` option used only by the hydration flow. Missing `file` or `chat_file` should be a hydration preview/job failure, not a baseline OpenWebUI chat import failure.
+
+### 6. Preserve Original Source Chat Identity For DB Fallbacks
+
+For `openwebui_db` imports, source chat identity can live in conversation settings under the OpenWebUI metadata. If conflict resolution creates a copied tldw conversation, the conversation external reference may no longer be the raw OpenWebUI chat id. Hydration should therefore prefer the preserved DB metadata such as `openwebui_import.metadata.row_id` when looking up `chat_file` rows.
+
+If a future implementation discovers that a needed original source id was not preserved for a source format, patch the importer metadata first rather than guessing from renamed external refs. For JSON imports, `chat_file` fallback is inherently weaker because there may be no selected source user or local DB chat row identity.
+
+### 7. Reference Extraction Is Limited By What Import Preserved
+
+The current OpenWebUI JSON/DB adapters preserve attachment refs from known top-level message keys such as `files`, `attachments`, `images`, `artifacts`, `file_ids`, and `fileIds`. Hydration should not assume it can reconstruct refs that the importer never stored.
+
+If implementation finds additional OpenWebUI reference shapes in real exports, extend the import adapter and tests first so future imports preserve those refs. Existing imported chats can only hydrate from the metadata already present plus DB-level `chat_file` fallback where source chat ids are reliable.
+
+### 8. File Classification Needs Byte-Level Guardrails
+
+The design already calls for MIME/type policy, but implementation should not trust extension or OpenWebUI metadata alone. Image embedding should use conservative byte sniffing, enforce existing message-image byte caps, and reject polyglot or unknown files as non-image/unsupported rather than embedding them.
+
+Non-image registration should also enforce per-file and total-run byte caps before copying into tldw storage.
+
 ## User Workflow
 
 1. User imports OpenWebUI chats through JSON or uploaded `webui.db` using the existing Chatbooks import UI.
@@ -210,6 +295,8 @@ iter_openwebui_files_for_user(conn, user_id)
 
 The hydrator should use file-id lookups derived from imported metadata first. `chat_file` rows can fill gaps when message-level attachment refs are incomplete, but v1 should still keep the scope constrained to imported chat ids.
 
+Do not add file-table requirements to the baseline chat-import schema validation path. Hydration should call a separate file-schema validation helper so a missing or incompatible `file`/`chat_file` table blocks only hydration.
+
 ### Path Resolution
 
 Input is an OpenWebUI data root, not arbitrary paths to individual files.
@@ -250,6 +337,8 @@ Supported reference forms in v1:
 Unsupported refs should remain in metadata with a hydration status of `unsupported_reference_shape`.
 
 For `openwebui_db` imports, source chat ids and selected user metadata are available. For `openwebui_json` imports, file IDs may exist in the JSON refs but source user may be absent; the job can resolve by file id and warn when user ownership cannot be verified.
+
+When resolving DB-backed `chat_file` fallback rows, use preserved source DB metadata such as `openwebui_import.metadata.row_id` instead of any tldw duplicate-copy external ref. If the original source chat id is absent, skip the fallback and report a warning rather than broadening scope.
 
 ### Hydration Status Metadata
 
@@ -294,6 +383,8 @@ Allowed statuses:
 
 The implementation may store a job-level summary separately, but message metadata should be sufficient for chat rendering and future retries.
 
+Because the existing metadata merge helper is shallow at the `openwebui_import` level, implementation must update this block with a full read-modify-write merge. Hydration metadata writes must preserve existing source ids, roles, parent/child ids, model metadata, and original attachment refs.
+
 ### Image Hydration
 
 Images should be restored as chat-message images when:
@@ -309,6 +400,8 @@ append_message_image_if_absent(message_id, source_key, image_bytes, mime_type)
 ```
 
 `source_key` should be derived from OpenWebUI source file id or run-local hash so retries are idempotent. If the current message image table cannot store source keys, add a small metadata-side guard and use deterministic positions carefully. Do not duplicate images on rerun.
+
+The current table cannot store source keys. V1 should record the source-key to image-position mapping in `openwebui_import.hydration.items` and append to the next free position only when the source key is absent. If retries or concurrent jobs make metadata-only idempotency unreliable, add a small message-image source mapping table before shipping image hydration.
 
 ### Non-Image File Registration
 
@@ -331,6 +424,8 @@ Recommended source metadata:
 
 The Media DB record should be discoverable as an imported OpenWebUI attachment and should link back from the message hydration metadata. The exact storage/copy location should follow existing Media DB file storage conventions; do not leave records pointing at the OpenWebUI source path as the durable copy.
 
+Implementation must avoid content-text dedupe traps in the current Media DB add path. Binary file registration should copy bytes first, persist a `MediaFiles` row with checksum, and use owner-aware source-id/file-hash lookup. If `add_media_with_keywords` is used for the parent Media row, it must receive a non-empty placeholder content value derived from the source id, filename, MIME, and byte hash, plus explicit `source_hash`, `owner_user_id`, and `visibility`.
+
 If `process_supported_files=true`, the implementation should enqueue or invoke existing ingestion/reprocessing flows for supported file types after registration. Processing failures should not undo registration.
 
 ### Deduplication
@@ -348,6 +443,16 @@ This avoids storage bloat during retries without collapsing unrelated source rec
 ## API And Jobs Design
 
 Use Jobs for hydration because this is user-visible, may be long-running, needs progress, and should be retryable.
+
+Use a dedicated Chatbooks Jobs type rather than the existing import type:
+
+```text
+domain = chatbooks
+job_type = openwebui_attachment_hydration
+queue = CHATBOOKS_JOBS_QUEUE or default
+```
+
+The existing export/import worker can be extended to route this job type, or a small sibling worker can be added if that keeps ownership cleaner. The payload should not require `chatbooks_job_id` unless a separate hydration journal is added.
 
 Suggested endpoint shape:
 
@@ -467,6 +572,12 @@ Backend tests:
 10. Run-local hash dedupe works only inside one hydration run when source IDs are absent.
 11. Missing source files produce warnings and do not fail the whole job.
 12. Multi-user non-admin requests are rejected.
+13. Hydration metadata updates preserve existing `openwebui_import` fields despite shallow DB metadata merge behavior.
+14. Media registration does not reuse another user's media row when content bytes or placeholder content collide.
+15. Binary registration does not create identical placeholder-content hashes for unrelated unprocessed files.
+16. Hydration-specific `file`/`chat_file` schema validation does not change baseline OpenWebUI chat import validation.
+17. DB `chat_file` fallback uses preserved source chat ids and skips fallback when only renamed tldw external refs are available.
+18. Dedicated `openwebui_attachment_hydration` Jobs routing does not interfere with existing Chatbooks import/export job handling.
 
 Frontend tests:
 

--- a/Docs/superpowers/specs/2026-05-11-openwebui-attachment-hydration-design.md
+++ b/Docs/superpowers/specs/2026-05-11-openwebui-attachment-hydration-design.md
@@ -1,0 +1,504 @@
+# OpenWebUI Attachment Hydration Design
+
+Date: 2026-05-11
+Owner: Codex collaboration session
+Status: User-approved design, pending implementation planning
+Backlog: TASK-233.14
+
+## Summary
+
+Add a post-import hydration workflow for OpenWebUI attachment and file bytes after OpenWebUI JSON or `webui.db` chat import.
+
+The existing OpenWebUI import paths preserve attachment, file, image, and artifact references as metadata only. This follow-up lets an operator point tldw at a trusted local copy of the OpenWebUI data directory and hydrate only the files referenced by already-imported OpenWebUI chats. Hydration is deliberately separate from chat import so chat migration remains fast, retryable, and safe even when an OpenWebUI `uploads/` tree is large or partially missing.
+
+V1 targets a local server bundle first: an OpenWebUI data root containing `webui.db` and `uploads/`, both under configured allowed roots. Uploaded ZIP bundles and live OpenWebUI API hydration are planned extensions, not v1 behavior.
+
+## Source Context
+
+OpenWebUI documents its SQLite database under the OpenWebUI data directory beside `uploads/` and `vector_db`. Its schema includes `chat`, `chat_file`, and `file` tables. The `file` table stores file identifiers, user ownership, hashes, filenames, paths, data, metadata, and timestamps; the `chat_file` table links files to chats and optionally messages. OpenWebUI plugin docs also describe the common uploaded-file path convention under `/app/backend/data/uploads/{file_id}_{filename}`.
+
+References:
+
+- OpenWebUI database schema: https://docs.openwebui.com/reference/database-schema/
+- OpenWebUI file management: https://docs.openwebui.com/features/chat-conversations/data-controls/files/
+- OpenWebUI reserved file arguments: https://docs.openwebui.com/features/plugin/development/reserved-args/
+
+The schema and path convention should be treated as versioned source data, not as a permanent API. The hydrator must preview compatibility before copying bytes and must report missing or unsupported file references without failing the entire hydration run.
+
+## Goals
+
+1. Hydrate OpenWebUI file bytes for chats already imported through `source_format=openwebui_json` or `source_format=openwebui_db`.
+2. Keep hydration as a separate post-import job with progress, retry, and partial-failure reporting.
+3. Support a trusted server-local OpenWebUI data root first.
+4. Hydrate only files referenced by imported OpenWebUI chats, not the entire OpenWebUI file library.
+5. Restore supported images onto imported chat messages where possible.
+6. Register non-image files as tldw Media DB entries and link them from imported message metadata.
+7. Make document/media processing opt-in instead of automatic.
+8. Deduplicate by OpenWebUI source file id first, then by run-local content hash when the source id is absent.
+9. Restrict server-local hydration to the single-user owner in single-user mode and admins in multi-user mode.
+10. Constrain all server-local paths to configured allowed roots.
+
+## Non-Goals
+
+1. Hydrate attachments during the existing chat import transaction.
+2. Import every OpenWebUI file owned by a selected source user.
+3. Accept uploaded ZIP bundles containing `webui.db` and `uploads/` in v1.
+4. Connect to a live OpenWebUI server or fetch files through OpenWebUI APIs in v1.
+5. Recreate OpenWebUI knowledge bases, channels, permissions, or sharing state.
+6. Process, chunk, transcribe, OCR, embed, or analyze files by default.
+7. Globally deduplicate user files by content hash across unrelated imports.
+8. Read arbitrary server-local paths outside configured allowed roots.
+
+## Requirements Confirmed With User
+
+1. Design both local-bundle and live-API concepts, but implement the local bundle first.
+2. Use a hybrid target model: inline images become chat-message attachments; non-image files become Media DB items linked from message metadata.
+3. Run hydration as a separate post-import job.
+4. Support server-local paths first, with uploaded ZIP bundles as a later extension.
+5. Hydrate only files referenced by imported chats.
+6. Register files by default; expose processing as an explicit option.
+7. Deduplicate by source file id first, then run-local content hash fallback.
+8. Allow server-local hydration for the single-user owner or multi-user admins only.
+
+## Current tldw Context
+
+### OpenWebUI Import Metadata
+
+The merged OpenWebUI import paths already normalize message references into `OpenWebUIMessagePlan.attachment_refs`. During import, `ChatbookService._openwebui_message_metadata()` stores them under:
+
+```text
+message_metadata.extra.openwebui_import.attachment_refs
+```
+
+The same metadata block stores source message ids, parent ids, child ids, role, model, and source-specific metadata. The hydrator should treat this metadata as the source-of-truth for "referenced by imported chats" and should not scan the entire OpenWebUI file table as the default scope.
+
+### Existing Message Image Storage
+
+Chatbook archive import already restores embedded images by passing `images` into `ChaChaNotesDB.add_message()`, which persists image bytes into the `message_images` table. Hydration happens after messages already exist, so implementation will need a focused ChaCha helper for post-insert image attachment, such as appending or replacing hydrated OpenWebUI image slots idempotently.
+
+The helper should preserve existing non-OpenWebUI images and should avoid duplicate image rows on retries.
+
+### Existing Media Storage
+
+The Media DB has `add_media_with_keywords`, file-record helpers such as `insert_media_file`, and lookup helpers such as `get_media_by_hash` and `get_media_by_uuid`. The hydrator should register non-image source files through the Media DB rather than inventing a Chatbooks-private file store.
+
+For v1, "register" means create a durable tldw-side record and source metadata link without running expensive processing. If the user enables processing, hydration can enqueue or call the existing media ingestion path for supported file types as a later implementation stage.
+
+### Local Allowed Roots
+
+The repository already has a configured local-source allowlist via:
+
+```text
+Files.ingestion_source_allowed_roots
+INGESTION_SOURCE_ALLOWED_ROOTS
+TLDW_INGESTION_SOURCE_ALLOWED_ROOTS
+```
+
+Hydration should reuse the same allowed-root resolver and path checks. The OpenWebUI data root, `webui.db`, `uploads/`, and every resolved source file path must remain under an allowed root after canonicalization.
+
+## Approaches Considered
+
+### Approach 1: Inline hydration during chat import
+
+OpenWebUI chat import reads source files and writes image/media records before returning success.
+
+Pros:
+
+- one user action
+- import result immediately includes hydrated files
+
+Cons:
+
+- slows and destabilizes the already-working chat import path
+- makes retrying attachment failures require reimporting chats
+- couples file processing and SQLite/file-tree access to conversation creation
+- large `uploads/` trees can turn a chat import into a long-running storage job
+
+### Approach 2: Separate post-import hydration job
+
+Chat import remains text/tree/metadata migration. A second job reads imported OpenWebUI metadata, resolves source file rows and bytes, writes image/media records, and updates message metadata with hydration status.
+
+Pros:
+
+- retryable without duplicating conversations
+- natural place for progress, partial failures, and per-file warnings
+- easier to gate behind admin/single-user-owner permissions
+- keeps chat migration fast and predictable
+
+Cons:
+
+- introduces another job/action surface
+- users need to provide the OpenWebUI data root after or alongside import
+
+### Approach 3: Full OpenWebUI file library migration
+
+Import every file row for the selected OpenWebUI user, whether referenced by imported chats or not.
+
+Pros:
+
+- broader backup coverage
+- can eventually support knowledge base migration
+
+Cons:
+
+- imports unrelated and stale files
+- makes dedupe and destination semantics unclear
+- expands scope beyond chat migration
+
+## Recommendation
+
+Use Approach 2.
+
+Implement a separate OpenWebUI attachment hydration job that targets only imported-chat references. V1 uses a trusted server-local OpenWebUI data root, restores images as message attachments, registers non-image files in Media DB, and records per-reference hydration status in message metadata. Processing remains opt-in.
+
+## User Workflow
+
+1. User imports OpenWebUI chats through JSON or uploaded `webui.db` using the existing Chatbooks import UI.
+2. User chooses "Hydrate OpenWebUI attachments" from the Chatbooks import area or an imported OpenWebUI result/job detail.
+3. UI asks for:
+   - OpenWebUI data root path, such as `/path/to/openwebui/data`
+   - selected source user when the imported scope is DB-backed or ambiguous
+   - optional processing flag for supported files
+   - optional dry-run/preview first
+4. Backend validates permissions and allowed roots.
+5. Backend previews hydration:
+   - referenced file count
+   - resolvable file count
+   - image count
+   - non-image count
+   - missing/ambiguous/oversized/unsupported count
+   - estimated bytes
+6. User starts the hydration job.
+7. Job updates imported message metadata as each reference is hydrated, skipped, missing, or failed.
+8. UI shows job status and the final summary. Imported chat messages show restored images where supported, and file references link to registered Media DB entries.
+
+## Backend Design
+
+### New Domain Service
+
+Add a focused service module under Chatbooks, for example:
+
+```text
+tldw_Server_API/app/core/Chatbooks/openwebui_hydration.py
+```
+
+Responsibilities:
+
+- validate OpenWebUI data root and expected children
+- build a referenced-file index from imported message metadata
+- read OpenWebUI `file` and `chat_file` rows through DB_Management helpers
+- resolve file bytes under `uploads/`
+- classify image versus non-image targets
+- enforce file size and MIME/type policy
+- compute content hashes
+- deduplicate within the selected tldw user scope
+- write message image rows or Media DB records through existing DB abstractions
+- update message metadata with hydration results
+- return preview and job result summaries
+
+It should not own auth, FastAPI request parsing, UI state, or low-level raw SQL.
+
+### DB_Management Helpers
+
+Extend `tldw_Server_API/app/core/DB_Management/OpenWebUI_DB.py` so SQL remains in DB_Management. New helpers should be read-only:
+
+```text
+load_openwebui_file_rows_for_ids(conn, file_ids, user_id=None)
+load_openwebui_chat_file_rows_for_chats(conn, chat_ids, user_id=None)
+iter_openwebui_files_for_user(conn, user_id)
+```
+
+The hydrator should use file-id lookups derived from imported metadata first. `chat_file` rows can fill gaps when message-level attachment refs are incomplete, but v1 should still keep the scope constrained to imported chat ids.
+
+### Path Resolution
+
+Input is an OpenWebUI data root, not arbitrary paths to individual files.
+
+Resolution rules:
+
+1. Resolve the data root under configured allowed roots.
+2. Require a readable `webui.db` under the data root.
+3. Require an `uploads/` directory under the data root for actual bytes.
+4. For each file row, try safe path candidates in order:
+   - `file.path` if it is relative under the data root or uploads root
+   - `file.path` if absolute and still under the data root or uploads root
+   - `uploads/{file.id}_{file.filename}`
+   - future-compatible variants only if covered by tests
+5. Reject any candidate that escapes allowed roots or the OpenWebUI data root after canonicalization.
+6. Treat symlinks conservatively: canonical target must stay under the data root and allowed roots.
+7. Missing files become per-reference warnings, not job-fatal errors.
+
+The preview should expose counts and warnings without returning raw absolute paths to non-admin clients. Admin-facing diagnostics may include sanitized path suffixes when useful.
+
+### Reference Extraction
+
+The hydrator should scan tldw messages with `message_metadata.extra.openwebui_import` for the active tldw user. It should collect:
+
+- tldw conversation id
+- tldw message id
+- OpenWebUI source chat external ref
+- OpenWebUI source message id
+- source user id when present
+- attachment refs
+
+Supported reference forms in v1:
+
+- dicts with `id`, `file_id`, or `fileId`
+- dicts with `name`, `filename`, `mime_type`, `type`, or `content_type` as enrichment
+- string ids when the value is clearly a file id
+
+Unsupported refs should remain in metadata with a hydration status of `unsupported_reference_shape`.
+
+For `openwebui_db` imports, source chat ids and selected user metadata are available. For `openwebui_json` imports, file IDs may exist in the JSON refs but source user may be absent; the job can resolve by file id and warn when user ownership cannot be verified.
+
+### Hydration Status Metadata
+
+Update message metadata without replacing the existing import record:
+
+```json
+{
+  "openwebui_import": {
+    "attachment_refs": [{ "...": "..." }],
+    "hydration": {
+      "version": 1,
+      "last_job_id": "job_...",
+      "items": [
+        {
+          "source_file_id": "file-1",
+          "source_hash": "sha256:...",
+          "source_filename": "notes.pdf",
+          "status": "registered_media",
+          "kind": "document",
+          "media_id": 123,
+          "media_file_id": "file-row-or-uuid",
+          "message_image_position": null,
+          "warnings": []
+        }
+      ]
+    }
+  }
+}
+```
+
+Allowed statuses:
+
+- `hydrated_image`
+- `registered_media`
+- `already_hydrated`
+- `missing_source_file`
+- `unsupported_reference_shape`
+- `unsupported_file_type`
+- `oversized`
+- `path_rejected`
+- `failed`
+
+The implementation may store a job-level summary separately, but message metadata should be sufficient for chat rendering and future retries.
+
+### Image Hydration
+
+Images should be restored as chat-message images when:
+
+- file MIME/type is image-like or safe sniffing identifies a supported image
+- file size is within the existing message-image size limit or a new OpenWebUI hydration-specific image cap
+- file path passes all root checks
+
+Implementation needs a ChaCha DB helper for post-insert images, for example:
+
+```text
+append_message_image_if_absent(message_id, source_key, image_bytes, mime_type)
+```
+
+`source_key` should be derived from OpenWebUI source file id or run-local hash so retries are idempotent. If the current message image table cannot store source keys, add a small metadata-side guard and use deterministic positions carefully. Do not duplicate images on rerun.
+
+### Non-Image File Registration
+
+Non-image files should become Media DB entries by default, without automatic processing.
+
+Recommended source metadata:
+
+```json
+{
+  "source": "openwebui",
+  "source_kind": "attachment",
+  "source_file_id": "file-1",
+  "source_chat_ref": "chat-1",
+  "source_message_id": "msg-1",
+  "source_user_id": "user-a",
+  "content_hash": "sha256:...",
+  "openwebui_filename": "notes.pdf"
+}
+```
+
+The Media DB record should be discoverable as an imported OpenWebUI attachment and should link back from the message hydration metadata. The exact storage/copy location should follow existing Media DB file storage conventions; do not leave records pointing at the OpenWebUI source path as the durable copy.
+
+If `process_supported_files=true`, the implementation should enqueue or invoke existing ingestion/reprocessing flows for supported file types after registration. Processing failures should not undo registration.
+
+### Deduplication
+
+Deduplication should be conservative:
+
+1. For the same tldw user, if an OpenWebUI `source_file_id` has already been hydrated, reuse the existing image/media link where compatible.
+2. If no source file id exists, dedupe by content hash only within the current hydration run.
+3. Do not globally merge unrelated files solely because bytes match.
+4. Do not reuse media across tldw users in multi-user mode.
+5. Preserve each original OpenWebUI reference in message metadata even when the underlying tldw media item is reused.
+
+This avoids storage bloat during retries without collapsing unrelated source records across imports.
+
+## API And Jobs Design
+
+Use Jobs for hydration because this is user-visible, may be long-running, needs progress, and should be retryable.
+
+Suggested endpoint shape:
+
+```text
+POST /api/v1/chatbooks/openwebui/hydration/preview
+POST /api/v1/chatbooks/openwebui/hydration/jobs
+GET  /api/v1/chatbooks/openwebui/hydration/jobs/{job_id}
+```
+
+Preview request:
+
+```json
+{
+  "openwebui_data_root": "/srv/migrations/openwebui/data",
+  "scope": {
+    "source_user_id": "user-a",
+    "conversation_ids": ["optional", "tldw", "conversation", "ids"]
+  },
+  "process_supported_files": false
+}
+```
+
+Job request uses the same fields plus explicit confirmation of the preview if the implementation wants preview-first safety.
+
+Result summary:
+
+```json
+{
+  "referenced_files": 42,
+  "resolved_files": 39,
+  "hydrated_images": 12,
+  "registered_media_files": 24,
+  "already_hydrated": 3,
+  "missing_files": 2,
+  "unsupported_files": 1,
+  "failed_files": 0,
+  "processed_files": 0,
+  "warnings": []
+}
+```
+
+Job payload should include normalized root tokens or absolute paths only after server-side validation. Job workers must revalidate roots and permissions at execution time, not just at enqueue time.
+
+## Authorization And Security
+
+Server-local hydration reads local filesystem paths, so it requires stronger gates than normal upload import.
+
+Rules:
+
+1. Single-user mode: allow the single-user owner.
+2. Multi-user mode: require admin.
+3. Always require every path to resolve under `ingestion_source_allowed_roots`.
+4. Revalidate paths in the worker.
+5. Do not log raw chat content, message content, or full arbitrary source paths.
+6. Do not follow symlinks outside the allowed root/data root.
+7. Enforce per-file and total-run byte caps.
+8. Enforce MIME and file-extension policy before image embedding or Media DB registration.
+9. Keep failures per-file unless the data root or DB itself is invalid.
+10. Redact source paths from non-admin job status surfaces where practical.
+
+## Frontend Design
+
+Place the workflow in the existing Chatbooks import area, because OpenWebUI chat import already lives there.
+
+Suggested UI behavior:
+
+- Show "Hydrate OpenWebUI attachments" only when the current user is authorized.
+- Let the user enter a server-local OpenWebUI data root.
+- Explain that the root should contain `webui.db` and `uploads/`.
+- Offer a preview action before enqueueing the job.
+- Show counts for images, files, missing refs, unsupported refs, and estimated bytes.
+- Default `process_supported_files` to off.
+- Allow scope narrowing to imported OpenWebUI conversations or selected source user.
+- Surface final job results near import history.
+
+Do not add a new global OpenWebUI migration page in v1.
+
+## Error Handling
+
+Fatal preview/job errors:
+
+- unauthorized user
+- no allowed roots configured
+- data root outside allowed roots
+- missing or unreadable `webui.db`
+- unsupported OpenWebUI DB schema for file hydration
+- missing `uploads/` directory when referenced files need byte hydration
+
+Per-reference warnings:
+
+- missing file row
+- missing source bytes
+- ambiguous source ref
+- unsupported reference shape
+- unsupported file type
+- oversized file
+- rejected path escape
+- failed image insert
+- failed Media DB registration
+- optional processing failed
+
+Hydration should continue after per-reference warnings and summarize them.
+
+## Testing Strategy
+
+Backend tests:
+
+1. Local data root outside allowed roots is rejected.
+2. Worker revalidates data root even if enqueue accepted it.
+3. OpenWebUI DB file rows resolve only under the data root/uploads root.
+4. Path traversal and symlink escape candidates are rejected.
+5. Referenced-only extraction ignores unrelated file rows for the same user.
+6. Image refs create idempotent message image attachments.
+7. Non-image refs create Media DB records and metadata links without processing by default.
+8. `process_supported_files=true` triggers the chosen ingestion/processing hook and does not undo registration on processing failure.
+9. Source-file-id dedupe reuses existing hydrated records.
+10. Run-local hash dedupe works only inside one hydration run when source IDs are absent.
+11. Missing source files produce warnings and do not fail the whole job.
+12. Multi-user non-admin requests are rejected.
+
+Frontend tests:
+
+1. Authorized users see the hydration action; unauthorized users do not.
+2. Preview sends the data root and processing flag.
+3. Preview result renders counts and warnings.
+4. Job creation is disabled until preview succeeds or required fields are valid.
+5. Processing is opt-in and defaults off.
+
+Security checks:
+
+- Bandit on touched backend hydration and DB helper files.
+- `git diff --check`.
+- Focused pytest for Chatbooks, OpenWebUI DB helpers, ChaCha message images, Media DB registration, and Jobs worker dispatch.
+
+## Documentation Plan
+
+Update user and API docs after implementation:
+
+- explain local OpenWebUI data-root requirements
+- explain that v1 hydrates only referenced files
+- explain image versus non-image behavior
+- document opt-in processing
+- document permissions and allowed-root setup
+- document missing-file and unsupported-file warnings
+- keep live API and ZIP bundle hydration listed as future work
+
+## Follow-Up Work
+
+1. Uploaded ZIP bundle containing `webui.db` and `uploads/`, with strict ZIP bomb/path traversal protection.
+2. Live OpenWebUI API hydration with URL/token auth, pagination, and version compatibility checks.
+3. Full OpenWebUI file library migration for selected users.
+4. Knowledge base migration using OpenWebUI `knowledge` and `knowledge_file` tables.
+5. Source-format auto-detection for local bundles after explicit workflows are stable.
+6. More granular user controls for which file types to hydrate or process.

--- a/apps/packages/ui/src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx
+++ b/apps/packages/ui/src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx
@@ -1078,6 +1078,7 @@ export const ChatbooksPlaygroundPage: React.FC = () => {
 
   const [importFile, setImportFile] = React.useState<File | null>(null)
   const [importSourceFormat, setImportSourceFormat] = React.useState<ImportSourceFormat>("chatbook")
+  const [importPreviewVersion, setImportPreviewVersion] = React.useState(0)
   const [previewManifest, setPreviewManifest] = React.useState<any | null>(null)
   const [openwebuiPreview, setOpenwebuiPreview] = React.useState<any | null>(null)
   const [openwebuiDbPreview, setOpenwebuiDbPreview] = React.useState<any | null>(null)
@@ -1128,6 +1129,7 @@ export const ChatbooksPlaygroundPage: React.FC = () => {
     setPreviewManifest(null)
     setOpenwebuiPreview(null)
     setOpenwebuiDbPreview(null)
+    setImportPreviewVersion(0)
     setSelectedOpenWebUIUserId("")
     setPreviewError(null)
     setPreviewLoading(false)
@@ -1210,8 +1212,18 @@ export const ChatbooksPlaygroundPage: React.FC = () => {
   ])
 
   const hydrationPayloadSignature = React.useMemo(
-    () => JSON.stringify(hydrationPayload),
-    [hydrationPayload]
+    () =>
+      JSON.stringify({
+        hydrationPayload,
+        import_preview: {
+          source_format: importSourceFormat,
+          version: importPreviewVersion,
+          file_name: importFile?.name || "",
+          file_size: importFile?.size || 0,
+          file_last_modified: importFile?.lastModified || 0
+        }
+      }),
+    [hydrationPayload, importFile, importPreviewVersion, importSourceFormat]
   )
 
   const hydrationPreviewIsCurrent = Boolean(
@@ -1518,10 +1530,16 @@ export const ChatbooksPlaygroundPage: React.FC = () => {
     setPreviewManifest(null)
     setOpenwebuiPreview(null)
     setOpenwebuiDbPreview(null)
+    setImportPreviewVersion(requestId)
     setSelectedOpenWebUIUserId("")
     setImportFile(file)
     setImportSelections(buildSelectionState(() => [] as string[]))
     setImportIncludeAll(buildSelectionState(() => true))
+    setHydrationPreview(null)
+    setHydrationPreviewSignature("")
+    setHydrationPreviewError(null)
+    setHydrationJob(null)
+    setHydrationJobError(null)
     try {
       await tldwClient.initialize().catch(() => null)
       const res = await tldwClient.previewChatbook(file, {

--- a/apps/packages/ui/src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx
+++ b/apps/packages/ui/src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx
@@ -129,6 +129,33 @@ type OpenWebUIDatabasePreviewUser = {
   warnings?: string[]
 }
 
+type OpenWebUIHydrationSummary = {
+  referenced_files?: number
+  resolved_files?: number
+  image_files?: number
+  media_files?: number
+  missing_files?: number
+  unsupported_files?: number
+  failed_files?: number
+  hydrated_images?: number
+  registered_media_files?: number
+  already_hydrated?: number
+  processed_files?: number
+  warning_count?: number
+}
+
+type OpenWebUIHydrationPreviewState = {
+  summary?: OpenWebUIHydrationSummary
+  warnings?: string[]
+}
+
+type OpenWebUIHydrationJobState = {
+  job_id?: string
+  status?: string
+  result?: any
+  error?: string | null
+}
+
 const parseIdList = (raw: string) =>
   raw
     .split(/[\n,]+/)
@@ -1069,6 +1096,18 @@ export const ChatbooksPlaygroundPage: React.FC = () => {
     buildSelectionState(() => true)
   )
   const [importSubmitting, setImportSubmitting] = React.useState(false)
+  const [hydrationDataRoot, setHydrationDataRoot] = React.useState("")
+  const [hydrationConversationIdsRaw, setHydrationConversationIdsRaw] = React.useState("")
+  const [hydrationSourceUserId, setHydrationSourceUserId] = React.useState("")
+  const [hydrationProcessSupportedFiles, setHydrationProcessSupportedFiles] = React.useState(false)
+  const [hydrationPreview, setHydrationPreview] =
+    React.useState<OpenWebUIHydrationPreviewState | null>(null)
+  const [hydrationPreviewSignature, setHydrationPreviewSignature] = React.useState("")
+  const [hydrationPreviewError, setHydrationPreviewError] = React.useState<string | null>(null)
+  const [hydrationPreviewLoading, setHydrationPreviewLoading] = React.useState(false)
+  const [hydrationJob, setHydrationJob] = React.useState<OpenWebUIHydrationJobState | null>(null)
+  const [hydrationJobError, setHydrationJobError] = React.useState<string | null>(null)
+  const [hydrationJobLoading, setHydrationJobLoading] = React.useState(false)
 
   const [exportJobs, setExportJobs] = React.useState<ChatbookJob[]>([])
   const [importJobs, setImportJobs] = React.useState<ChatbookJob[]>([])
@@ -1094,6 +1133,12 @@ export const ChatbooksPlaygroundPage: React.FC = () => {
     setPreviewLoading(false)
     setImportSelections(buildSelectionState(() => [] as string[]))
     setImportIncludeAll(buildSelectionState(() => true))
+    setHydrationPreview(null)
+    setHydrationPreviewSignature("")
+    setHydrationPreviewError(null)
+    setHydrationPreviewLoading(false)
+    setHydrationJob(null)
+    setHydrationJobError(null)
     if (importSourceFormat === "openwebui_json" || importSourceFormat === "openwebui_db") {
       setImportMedia(false)
       setImportEmbeddings(false)
@@ -1135,6 +1180,42 @@ export const ChatbooksPlaygroundPage: React.FC = () => {
         (user) => user.source_user_id === selectedOpenWebUIUserId
       ) || null,
     [openwebuiDbUsers, selectedOpenWebUIUserId]
+  )
+
+  const effectiveHydrationSourceUserId =
+    isOpenWebUIDatabaseImport && selectedOpenWebUIUserId
+      ? selectedOpenWebUIUserId
+      : hydrationSourceUserId.trim()
+
+  const hydrationPayload = React.useMemo(() => {
+    const scope: {
+      conversation_ids: string[]
+      source_user_id?: string
+    } = {
+      conversation_ids: parseIdList(hydrationConversationIdsRaw)
+    }
+    if (effectiveHydrationSourceUserId) {
+      scope.source_user_id = effectiveHydrationSourceUserId
+    }
+    return {
+      openwebui_data_root: hydrationDataRoot.trim(),
+      scope,
+      process_supported_files: hydrationProcessSupportedFiles
+    }
+  }, [
+    effectiveHydrationSourceUserId,
+    hydrationConversationIdsRaw,
+    hydrationDataRoot,
+    hydrationProcessSupportedFiles
+  ])
+
+  const hydrationPayloadSignature = React.useMemo(
+    () => JSON.stringify(hydrationPayload),
+    [hydrationPayload]
+  )
+
+  const hydrationPreviewIsCurrent = Boolean(
+    hydrationPreview && hydrationPreviewSignature === hydrationPayloadSignature
   )
 
   const activeJobs = React.useMemo(() => {
@@ -1574,6 +1655,81 @@ export const ChatbooksPlaygroundPage: React.FC = () => {
     }
   }
 
+  const handleHydrationPreview = async () => {
+    if (!hydrationPayload.openwebui_data_root) {
+      notification.error({
+        message: t(
+          "settings:chatbooksPlayground.openwebuiHydrationRootRequired",
+          "OpenWebUI data root is required."
+        )
+      })
+      return
+    }
+
+    setHydrationPreviewLoading(true)
+    setHydrationPreviewError(null)
+    setHydrationJob(null)
+    setHydrationJobError(null)
+    try {
+      await tldwClient.initialize().catch(() => null)
+      const res = await tldwClient.previewOpenWebUIHydration(hydrationPayload)
+      setHydrationPreview(res || null)
+      setHydrationPreviewSignature(hydrationPayloadSignature)
+    } catch (error) {
+      setHydrationPreview(null)
+      setHydrationPreviewSignature("")
+      setHydrationPreviewError(error instanceof Error ? error.message : String(error))
+    } finally {
+      setHydrationPreviewLoading(false)
+    }
+  }
+
+  const handleCreateHydrationJob = async () => {
+    if (!hydrationPreviewIsCurrent) {
+      notification.error({
+        message: t(
+          "settings:chatbooksPlayground.openwebuiHydrationPreviewRequired",
+          "Preview attachments before creating a hydration job."
+        )
+      })
+      return
+    }
+
+    setHydrationJobLoading(true)
+    setHydrationJobError(null)
+    try {
+      await tldwClient.initialize().catch(() => null)
+      const res = await tldwClient.createOpenWebUIHydrationJob(hydrationPayload)
+      setHydrationJob(res || null)
+      notification.success({
+        message: t(
+          "settings:chatbooksPlayground.openwebuiHydrationJobQueued",
+          "Hydration job created"
+        )
+      })
+    } catch (error) {
+      setHydrationJobError(error instanceof Error ? error.message : String(error))
+    } finally {
+      setHydrationJobLoading(false)
+    }
+  }
+
+  const handleRefreshHydrationJob = async () => {
+    if (!hydrationJob?.job_id) return
+
+    setHydrationJobLoading(true)
+    setHydrationJobError(null)
+    try {
+      await tldwClient.initialize().catch(() => null)
+      const res = await tldwClient.getOpenWebUIHydrationJob(hydrationJob.job_id)
+      setHydrationJob(res || null)
+    } catch (error) {
+      setHydrationJobError(error instanceof Error ? error.message : String(error))
+    } finally {
+      setHydrationJobLoading(false)
+    }
+  }
+
   const jobTrackerList = React.useMemo(() => {
     const exportCards = exportJobs.map((job) => ({ ...job, kind: "export" as const }))
     const importCards = importJobs.map((job) => ({ ...job, kind: "import" as const }))
@@ -1777,6 +1933,16 @@ export const ChatbooksPlaygroundPage: React.FC = () => {
           "settings:chatbooksPlayground.importDrop",
           "Drop a .zip or .chatbook archive or click to browse"
         )
+
+  const hydrationSummary = hydrationPreview?.summary || {}
+  const hydrationWarnings = Array.isArray(hydrationPreview?.warnings)
+    ? hydrationPreview.warnings
+    : []
+  const hydrationJobResult = hydrationJob?.result
+  const hydrationJobSummary =
+    hydrationJobResult && typeof hydrationJobResult === "object"
+      ? (hydrationJobResult as { summary?: OpenWebUIHydrationSummary }).summary
+      : undefined
 
   const importTab = (
     <>
@@ -2021,7 +2187,7 @@ export const ChatbooksPlaygroundPage: React.FC = () => {
                 )}
                 description={t(
                   "settings:chatbooksPlayground.openwebuiDbAttachmentRefsDescription",
-                  "Files, images, and artifacts import as metadata references only; binaries are not copied."
+                  "Files, images, and artifacts import as metadata references first. Use attachment hydration below to copy images and register supported files from your OpenWebUI data root."
                 )}
               />
 
@@ -2032,6 +2198,320 @@ export const ChatbooksPlaygroundPage: React.FC = () => {
                   className="mt-3"
                   title={t("settings:chatbooksPlayground.openwebuiWarnings", "Import warnings")}
                   description={openwebuiDbPreview.warnings.slice(0, 3).join("\n")}
+                />
+              )}
+            </Card>
+          )}
+
+          {isOpenWebUIImport && (
+            <Card
+              size="small"
+              className="border-border"
+              title={t(
+                "settings:chatbooksPlayground.openwebuiHydrationTitle",
+                "OpenWebUI attachment hydration"
+              )}
+            >
+              <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                <div>
+                  <Text type="secondary">
+                    {t(
+                      "settings:chatbooksPlayground.openwebuiHydrationRoot",
+                      "Data root"
+                    )}
+                  </Text>
+                  <Input
+                    aria-label={t(
+                      "settings:chatbooksPlayground.openwebuiHydrationRootLabel",
+                      "OpenWebUI data root"
+                    ) as string}
+                    value={hydrationDataRoot}
+                    onChange={(event) => setHydrationDataRoot(event.target.value)}
+                    placeholder="/app/backend/data"
+                    disabled={!canUseChatbooks || hydrationPreviewLoading || hydrationJobLoading}
+                  />
+                </div>
+                <div>
+                  <Text type="secondary">
+                    {t(
+                      "settings:chatbooksPlayground.openwebuiHydrationSourceUser",
+                      "Source user"
+                    )}
+                  </Text>
+                  <Input
+                    aria-label={t(
+                      "settings:chatbooksPlayground.openwebuiHydrationSourceUserLabel",
+                      "OpenWebUI source user id"
+                    ) as string}
+                    value={
+                      isOpenWebUIDatabaseImport && selectedOpenWebUIUserId
+                        ? selectedOpenWebUIUserId
+                        : hydrationSourceUserId
+                    }
+                    onChange={(event) => setHydrationSourceUserId(event.target.value)}
+                    placeholder={t(
+                      "settings:chatbooksPlayground.openwebuiHydrationSourceUserPlaceholder",
+                      "Optional source user id"
+                    ) as string}
+                    disabled={
+                      !canUseChatbooks ||
+                      hydrationPreviewLoading ||
+                      hydrationJobLoading ||
+                      (isOpenWebUIDatabaseImport && Boolean(selectedOpenWebUIUserId))
+                    }
+                  />
+                </div>
+                <div className="md:col-span-2">
+                  <Text type="secondary">
+                    {t(
+                      "settings:chatbooksPlayground.openwebuiHydrationConversationIds",
+                      "Imported conversation IDs"
+                    )}
+                  </Text>
+                  <Input.TextArea
+                    aria-label={t(
+                      "settings:chatbooksPlayground.openwebuiHydrationConversationIdsLabel",
+                      "Imported conversation IDs"
+                    ) as string}
+                    value={hydrationConversationIdsRaw}
+                    onChange={(event) => setHydrationConversationIdsRaw(event.target.value)}
+                    autoSize={{ minRows: 2, maxRows: 4 }}
+                    placeholder={t(
+                      "settings:chatbooksPlayground.openwebuiHydrationConversationIdsPlaceholder",
+                      "Paste tldw conversation ids, one per line or comma-separated"
+                    ) as string}
+                    disabled={!canUseChatbooks || hydrationPreviewLoading || hydrationJobLoading}
+                  />
+                </div>
+              </div>
+
+              <div className="mt-3 flex flex-wrap items-center gap-3">
+                <Space>
+                  <Switch
+                    aria-label={t(
+                      "settings:chatbooksPlayground.openwebuiHydrationProcessFiles",
+                      "Process supported files"
+                    ) as string}
+                    checked={hydrationProcessSupportedFiles}
+                    onChange={setHydrationProcessSupportedFiles}
+                    disabled={!canUseChatbooks || hydrationPreviewLoading || hydrationJobLoading}
+                  />
+                  <Text>
+                    {t(
+                      "settings:chatbooksPlayground.openwebuiHydrationProcessFiles",
+                      "Process supported files"
+                    )}
+                  </Text>
+                </Space>
+                <Button
+                  aria-label={t(
+                    "settings:chatbooksPlayground.openwebuiHydrationPreview",
+                    "Preview attachments"
+                  ) as string}
+                  onClick={() => void handleHydrationPreview()}
+                  loading={hydrationPreviewLoading}
+                  disabled={
+                    !canUseChatbooks ||
+                    !hydrationPayload.openwebui_data_root ||
+                    hydrationJobLoading
+                  }
+                >
+                  {t(
+                    "settings:chatbooksPlayground.openwebuiHydrationPreview",
+                    "Preview attachments"
+                  )}
+                </Button>
+                <Button
+                  aria-label={t(
+                    "settings:chatbooksPlayground.openwebuiHydrationRun",
+                    "Run hydration job"
+                  ) as string}
+                  type="primary"
+                  onClick={() => void handleCreateHydrationJob()}
+                  loading={hydrationJobLoading}
+                  disabled={
+                    !canUseChatbooks ||
+                    !hydrationPreviewIsCurrent ||
+                    hydrationPreviewLoading
+                  }
+                >
+                  {t(
+                    "settings:chatbooksPlayground.openwebuiHydrationRun",
+                    "Run hydration job"
+                  )}
+                </Button>
+              </div>
+
+              {hydrationPreview && !hydrationPreviewIsCurrent && (
+                <Alert
+                  type="info"
+                  showIcon
+                  className="mt-3"
+                  title={t(
+                    "settings:chatbooksPlayground.openwebuiHydrationPreviewStale",
+                    "Preview needs refresh"
+                  )}
+                />
+              )}
+
+              {hydrationPreviewError && (
+                <Alert
+                  type="error"
+                  showIcon
+                  className="mt-3"
+                  title={t(
+                    "settings:chatbooksPlayground.openwebuiHydrationPreviewError",
+                    "Attachment preview failed"
+                  )}
+                  description={hydrationPreviewError}
+                />
+              )}
+
+              {hydrationPreview && (
+                <div className="mt-3">
+                  <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+                    <div>
+                      <Text type="secondary">
+                        {t(
+                          "settings:chatbooksPlayground.openwebuiHydrationReferenced",
+                          "Referenced files"
+                        )}
+                      </Text>
+                      <div>{hydrationSummary.referenced_files ?? 0}</div>
+                    </div>
+                    <div>
+                      <Text type="secondary">
+                        {t(
+                          "settings:chatbooksPlayground.openwebuiHydrationResolved",
+                          "Resolved files"
+                        )}
+                      </Text>
+                      <div>{hydrationSummary.resolved_files ?? 0}</div>
+                    </div>
+                    <div>
+                      <Text type="secondary">
+                        {t(
+                          "settings:chatbooksPlayground.openwebuiHydrationImages",
+                          "Image files"
+                        )}
+                      </Text>
+                      <div>{hydrationSummary.image_files ?? 0}</div>
+                    </div>
+                    <div>
+                      <Text type="secondary">
+                        {t(
+                          "settings:chatbooksPlayground.openwebuiHydrationMedia",
+                          "Media files"
+                        )}
+                      </Text>
+                      <div>{hydrationSummary.media_files ?? 0}</div>
+                    </div>
+                    <div>
+                      <Text type="secondary">
+                        {t(
+                          "settings:chatbooksPlayground.openwebuiHydrationMissing",
+                          "Missing files"
+                        )}
+                      </Text>
+                      <div>{hydrationSummary.missing_files ?? 0}</div>
+                    </div>
+                    <div>
+                      <Text type="secondary">
+                        {t(
+                          "settings:chatbooksPlayground.openwebuiHydrationUnsupported",
+                          "Unsupported files"
+                        )}
+                      </Text>
+                      <div>{hydrationSummary.unsupported_files ?? 0}</div>
+                    </div>
+                    <div>
+                      <Text type="secondary">
+                        {t(
+                          "settings:chatbooksPlayground.openwebuiHydrationHydratedImages",
+                          "Hydrated images"
+                        )}
+                      </Text>
+                      <div>{hydrationSummary.hydrated_images ?? 0}</div>
+                    </div>
+                    <div>
+                      <Text type="secondary">
+                        {t(
+                          "settings:chatbooksPlayground.openwebuiHydrationRegisteredMedia",
+                          "Registered media"
+                        )}
+                      </Text>
+                      <div>{hydrationSummary.registered_media_files ?? 0}</div>
+                    </div>
+                  </div>
+
+                  {Boolean(hydrationWarnings.length) && (
+                    <Alert
+                      type="warning"
+                      showIcon
+                      className="mt-3"
+                      title={t(
+                        "settings:chatbooksPlayground.openwebuiHydrationWarnings",
+                        "Hydration warnings"
+                      )}
+                      description={hydrationWarnings.slice(0, 3).join("\n")}
+                    />
+                  )}
+                </div>
+              )}
+
+              {hydrationJobError && (
+                <Alert
+                  type="error"
+                  showIcon
+                  className="mt-3"
+                  title={t(
+                    "settings:chatbooksPlayground.openwebuiHydrationJobError",
+                    "Hydration job failed"
+                  )}
+                  description={hydrationJobError}
+                />
+              )}
+
+              {hydrationJob && (
+                <Alert
+                  type={hydrationJob.status === "failed" ? "error" : "info"}
+                  showIcon
+                  className="mt-3"
+                  title={t(
+                    "settings:chatbooksPlayground.openwebuiHydrationJobStatus",
+                    "Hydration job"
+                  )}
+                  description={
+                    <div className="flex flex-col gap-1">
+                      <Space wrap>
+                        {hydrationJob.job_id && <Tag>{hydrationJob.job_id}</Tag>}
+                        {hydrationJob.status && <Tag>{hydrationJob.status}</Tag>}
+                        <Button
+                          size="small"
+                          onClick={() => void handleRefreshHydrationJob()}
+                          loading={hydrationJobLoading}
+                        >
+                          {t(
+                            "settings:chatbooksPlayground.refresh",
+                            "Refresh"
+                          )}
+                        </Button>
+                      </Space>
+                      {hydrationJobSummary && (
+                        <Text type="secondary">
+                          {t(
+                            "settings:chatbooksPlayground.openwebuiHydrationJobSummary",
+                            {
+                              defaultValue:
+                                "Hydrated {{images}} images and registered {{media}} files.",
+                              images: hydrationJobSummary.hydrated_images ?? 0,
+                              media: hydrationJobSummary.registered_media_files ?? 0
+                            }
+                          )}
+                        </Text>
+                      )}
+                    </div>
+                  }
                 />
               )}
             </Card>

--- a/apps/packages/ui/src/components/Option/Chatbooks/__tests__/ChatbooksPlaygroundPage.openwebui-import.test.tsx
+++ b/apps/packages/ui/src/components/Option/Chatbooks/__tests__/ChatbooksPlaygroundPage.openwebui-import.test.tsx
@@ -4,7 +4,10 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vites
 import { useQuery } from "@tanstack/react-query"
 import { ChatbooksPlaygroundPage } from "../ChatbooksPlaygroundPage"
 
-const { useQueryMock, tldwClientMock } = vi.hoisted(() => ({
+const { capabilitiesMock, useQueryMock, tldwClientMock } = vi.hoisted(() => ({
+  capabilitiesMock: {
+    hasChatbooks: true
+  },
   useQueryMock: vi.fn(),
   tldwClientMock: {
     initialize: vi.fn(async () => undefined),
@@ -20,7 +23,10 @@ const { useQueryMock, tldwClientMock } = vi.hoisted(() => ({
     removeChatbookImportJob: vi.fn(),
     exportChatbook: vi.fn(),
     previewChatbook: vi.fn(),
-    importChatbook: vi.fn()
+    importChatbook: vi.fn(),
+    previewOpenWebUIHydration: vi.fn(),
+    createOpenWebUIHydrationJob: vi.fn(),
+    getOpenWebUIHydrationJob: vi.fn()
   }
 }))
 
@@ -86,9 +92,7 @@ vi.mock("@/hooks/useServerOnline", () => ({
 
 vi.mock("@/hooks/useServerCapabilities", () => ({
   useServerCapabilities: () => ({
-    capabilities: {
-      hasChatbooks: true
-    }
+    capabilities: capabilitiesMock
   })
 }))
 
@@ -165,6 +169,7 @@ describe("ChatbooksPlaygroundPage OpenWebUI import mode", () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    capabilitiesMock.hasChatbooks = true
     vi.mocked(useQuery).mockReturnValue({
       data: { items: [], total: 0 },
       isLoading: false,
@@ -365,4 +370,155 @@ describe("ChatbooksPlaygroundPage OpenWebUI import mode", () => {
     expect(screen.getByText("22")).toBeInTheDocument()
     expect(screen.queryByText("11")).not.toBeInTheDocument()
   })
+
+  it("previews OpenWebUI hydration before enabling job creation", async () => {
+    tldwClientMock.previewOpenWebUIHydration.mockResolvedValueOnce({
+      summary: {
+        referenced_files: 3,
+        resolved_files: 2,
+        image_files: 1,
+        media_files: 1,
+        missing_files: 1,
+        unsupported_files: 0,
+        failed_files: 0,
+        hydrated_images: 0,
+        registered_media_files: 0,
+        already_hydrated: 0,
+        processed_files: 0,
+        warning_count: 1
+      },
+      warnings: ["Missing 1 source file"]
+    })
+    tldwClientMock.createOpenWebUIHydrationJob.mockResolvedValueOnce({
+      job_id: "hydration-job-1",
+      status: "queued"
+    })
+
+    render(<ChatbooksPlaygroundPage />)
+
+    fireEvent.click(screen.getByRole("tab", { name: "Import" }))
+    const sourceSelect = screen
+      .getAllByRole("combobox")
+      .find((element) => (element as HTMLSelectElement).value === "chatbook")
+    fireEvent.change(sourceSelect!, { target: { value: "openwebui_json" } })
+
+    fireEvent.change(screen.getByLabelText("OpenWebUI data root"), {
+      target: { value: "/srv/openwebui" }
+    })
+    fireEvent.change(screen.getByLabelText("Imported conversation IDs"), {
+      target: { value: "conv-a\nconv-b" }
+    })
+    fireEvent.change(screen.getByLabelText("OpenWebUI source user id"), {
+      target: { value: "ow-user" }
+    })
+
+    const runButton = screen.getByRole("button", { name: "Run hydration job" })
+    expect(runButton).toBeDisabled()
+
+    fireEvent.click(screen.getByRole("button", { name: "Preview attachments" }))
+
+    await waitFor(() => {
+      expect(tldwClientMock.previewOpenWebUIHydration).toHaveBeenCalledWith({
+        openwebui_data_root: "/srv/openwebui",
+        scope: {
+          conversation_ids: ["conv-a", "conv-b"],
+          source_user_id: "ow-user"
+        },
+        process_supported_files: false
+      })
+    })
+    await waitFor(() => {
+      expect(screen.getByText("Referenced files")).toBeInTheDocument()
+      expect(screen.getByText("Missing 1 source file")).toBeInTheDocument()
+    })
+
+    fireEvent.click(runButton)
+
+    await waitFor(() => {
+      expect(tldwClientMock.createOpenWebUIHydrationJob).toHaveBeenCalledWith({
+        openwebui_data_root: "/srv/openwebui",
+        scope: {
+          conversation_ids: ["conv-a", "conv-b"],
+          source_user_id: "ow-user"
+        },
+        process_supported_files: false
+      })
+    })
+    expect(screen.getByText("queued")).toBeInTheDocument()
+  })
+
+  it("requires a fresh hydration preview after opting into supported-file processing", async () => {
+    tldwClientMock.previewOpenWebUIHydration.mockResolvedValue({
+      summary: {
+        referenced_files: 1,
+        resolved_files: 1,
+        image_files: 0,
+        media_files: 1,
+        missing_files: 0,
+        unsupported_files: 0,
+        failed_files: 0,
+        hydrated_images: 0,
+        registered_media_files: 0,
+        already_hydrated: 0,
+        processed_files: 1,
+        warning_count: 0
+      },
+      warnings: []
+    })
+
+    render(<ChatbooksPlaygroundPage />)
+
+    fireEvent.click(screen.getByRole("tab", { name: "Import" }))
+    const sourceSelect = screen
+      .getAllByRole("combobox")
+      .find((element) => (element as HTMLSelectElement).value === "chatbook")
+    fireEvent.change(sourceSelect!, { target: { value: "openwebui_json" } })
+
+    fireEvent.change(screen.getByLabelText("OpenWebUI data root"), {
+      target: { value: "/srv/openwebui" }
+    })
+    fireEvent.change(screen.getByLabelText("Imported conversation IDs"), {
+      target: { value: "conv-a" }
+    })
+
+    const runButton = screen.getByRole("button", { name: "Run hydration job" })
+    fireEvent.click(screen.getByRole("button", { name: "Preview attachments" }))
+    await waitFor(() => {
+      expect(runButton).toBeEnabled()
+    })
+
+    fireEvent.click(screen.getByRole("switch", { name: "Process supported files" }))
+    expect(runButton).toBeDisabled()
+
+    fireEvent.click(screen.getByRole("button", { name: "Preview attachments" }))
+    await waitFor(() => {
+      expect(tldwClientMock.previewOpenWebUIHydration).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          process_supported_files: true
+        })
+      )
+    })
+    await waitFor(() => {
+      expect(runButton).toBeEnabled()
+    })
+  }, 10000)
+
+  it("disables OpenWebUI hydration controls when Chatbooks capability is unavailable", async () => {
+    const { rerender } = render(<ChatbooksPlaygroundPage />)
+
+    fireEvent.click(screen.getByRole("tab", { name: "Import" }))
+    const sourceSelect = screen
+      .getAllByRole("combobox")
+      .find((element) => (element as HTMLSelectElement).value === "chatbook")
+    fireEvent.change(sourceSelect!, { target: { value: "openwebui_json" } })
+
+    capabilitiesMock.hasChatbooks = false
+    rerender(<ChatbooksPlaygroundPage />)
+
+    expect(screen.getByLabelText("OpenWebUI data root")).toBeDisabled()
+    expect(screen.getByLabelText("Imported conversation IDs")).toBeDisabled()
+    expect(screen.getByRole("switch", { name: "Process supported files" })).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Preview attachments" })).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Run hydration job" })).toBeDisabled()
+  }, 10000)
 })

--- a/apps/packages/ui/src/components/Option/Chatbooks/__tests__/ChatbooksPlaygroundPage.openwebui-import.test.tsx
+++ b/apps/packages/ui/src/components/Option/Chatbooks/__tests__/ChatbooksPlaygroundPage.openwebui-import.test.tsx
@@ -447,6 +447,85 @@ describe("ChatbooksPlaygroundPage OpenWebUI import mode", () => {
     expect(screen.getByText("queued")).toBeInTheDocument()
   })
 
+  it("requires a fresh hydration preview after selecting a new OpenWebUI preview file", async () => {
+    tldwClientMock.previewChatbook.mockResolvedValue({
+      openwebui_preview: {
+        chat_count: 1,
+        message_count: 2,
+        branched_chat_count: 0,
+        duplicate_chat_count: 0,
+        attachment_reference_count: 1,
+        malformed_chat_count: 0,
+        warnings: []
+      }
+    })
+    tldwClientMock.previewOpenWebUIHydration.mockResolvedValue({
+      summary: {
+        referenced_files: 1,
+        resolved_files: 1,
+        image_files: 1,
+        media_files: 0,
+        missing_files: 0,
+        unsupported_files: 0,
+        failed_files: 0,
+        hydrated_images: 0,
+        registered_media_files: 0,
+        already_hydrated: 0,
+        processed_files: 0,
+        warning_count: 0
+      },
+      warnings: []
+    })
+
+    const { container } = render(<ChatbooksPlaygroundPage />)
+
+    fireEvent.click(screen.getByRole("tab", { name: "Import" }))
+    const sourceSelect = screen
+      .getAllByRole("combobox")
+      .find((element) => (element as HTMLSelectElement).value === "chatbook")
+    fireEvent.change(sourceSelect!, { target: { value: "openwebui_json" } })
+
+    const uploadInput = container.querySelector(".ant-upload-drag input[type=\"file\"]") as HTMLInputElement
+    fireEvent.change(uploadInput, {
+      target: {
+        files: [new File(["[]"], "first.json", { type: "application/json" })]
+      }
+    })
+    await waitFor(() => {
+      expect(tldwClientMock.previewChatbook).toHaveBeenCalledTimes(1)
+    })
+    await waitFor(() => {
+      expect(screen.getByText("OpenWebUI preview")).toBeInTheDocument()
+    })
+
+    fireEvent.change(screen.getByLabelText("OpenWebUI data root"), {
+      target: { value: "/srv/openwebui" }
+    })
+    fireEvent.change(screen.getByLabelText("Imported conversation IDs"), {
+      target: { value: "conv-a" }
+    })
+
+    const runButton = screen.getByRole("button", { name: "Run hydration job" })
+    fireEvent.click(screen.getByRole("button", { name: "Preview attachments" }))
+    await waitFor(() => {
+      expect(runButton).toBeEnabled()
+    })
+
+    const secondUploadInput = container.querySelector(".ant-upload-drag input[type=\"file\"]") as HTMLInputElement
+    fireEvent.change(secondUploadInput, {
+      target: {
+        files: [new File(["[]"], "second.json", { type: "application/json" })]
+      }
+    })
+    await waitFor(() => {
+      expect(tldwClientMock.previewChatbook).toHaveBeenCalledTimes(2)
+    })
+
+    expect(runButton).toBeDisabled()
+    fireEvent.click(runButton)
+    expect(tldwClientMock.createOpenWebUIHydrationJob).not.toHaveBeenCalled()
+  }, 10000)
+
   it("requires a fresh hydration preview after opting into supported-file processing", async () => {
     tldwClientMock.previewOpenWebUIHydration.mockResolvedValue({
       summary: {

--- a/apps/packages/ui/src/services/__tests__/tldw-api-client.chatbooks-openwebui.test.ts
+++ b/apps/packages/ui/src/services/__tests__/tldw-api-client.chatbooks-openwebui.test.ts
@@ -133,4 +133,68 @@ describe("TldwApiClient Chatbooks OpenWebUI import contract", () => {
       })
     )
   })
+
+  it("previews OpenWebUI attachment hydration with a JSON request", async () => {
+    mocks.bgRequest.mockResolvedValue({ summary: { referenced_files: 1 } })
+
+    const client = new TldwApiClient()
+    const payload = {
+      openwebui_data_root: "/srv/openwebui",
+      scope: {
+        conversation_ids: ["conv-a"],
+        source_user_id: "ow-user"
+      },
+      process_supported_files: false
+    }
+
+    await client.previewOpenWebUIHydration(payload)
+
+    expect(mocks.bgRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "/api/v1/chatbooks/openwebui/hydration/preview",
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: payload
+      })
+    )
+  })
+
+  it("creates an OpenWebUI attachment hydration job with a JSON request", async () => {
+    mocks.bgRequest.mockResolvedValue({ job_id: "42", status: "queued" })
+
+    const client = new TldwApiClient()
+    const payload = {
+      openwebui_data_root: "/srv/openwebui",
+      scope: {
+        conversation_ids: ["conv-a"],
+        source_user_id: "ow-user"
+      },
+      process_supported_files: true
+    }
+
+    await client.createOpenWebUIHydrationJob(payload)
+
+    expect(mocks.bgRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "/api/v1/chatbooks/openwebui/hydration/jobs",
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: payload
+      })
+    )
+  })
+
+  it("gets an OpenWebUI attachment hydration job by id", async () => {
+    mocks.bgRequest.mockResolvedValue({ job_id: "42", status: "completed" })
+
+    const client = new TldwApiClient()
+    await client.getOpenWebUIHydrationJob("job/42")
+
+    expect(mocks.bgRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "/api/v1/chatbooks/openwebui/hydration/jobs/job%2F42",
+        method: "GET"
+      })
+    )
+  })
 })

--- a/apps/packages/ui/src/services/tldw/TldwApiClient.ts
+++ b/apps/packages/ui/src/services/tldw/TldwApiClient.ts
@@ -249,6 +249,17 @@ export interface OpenAICredentialSourceSwitchResponse {
   updated_at?: string | null
 }
 
+export type OpenWebUIHydrationScopeRequest = {
+  conversation_ids?: string[]
+  source_user_id?: string | null
+}
+
+export type OpenWebUIHydrationRequest = {
+  openwebui_data_root: string
+  scope?: OpenWebUIHydrationScopeRequest
+  process_supported_files?: boolean
+}
+
 const getCurrentBrowserSurface = (): BrowserSurface => {
   if (typeof window === "undefined") {
     return "extension"
@@ -5526,6 +5537,32 @@ export class TldwApiClientBase {
       method: "POST",
       fields: normalized,
       file: { name, type, data }
+    })
+  }
+
+  async previewOpenWebUIHydration(payload: OpenWebUIHydrationRequest): Promise<any> {
+    return await bgRequest<any>({
+      path: "/api/v1/chatbooks/openwebui/hydration/preview",
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: payload
+    })
+  }
+
+  async createOpenWebUIHydrationJob(payload: OpenWebUIHydrationRequest): Promise<any> {
+    return await bgRequest<any>({
+      path: "/api/v1/chatbooks/openwebui/hydration/jobs",
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: payload
+    })
+  }
+
+  async getOpenWebUIHydrationJob(job_id: string): Promise<any> {
+    const id = encodeURIComponent(String(job_id))
+    return await bgRequest<any>({
+      path: `/api/v1/chatbooks/openwebui/hydration/jobs/${id}`,
+      method: "GET"
     })
   }
 

--- a/apps/packages/ui/src/services/tldw/domains/chat-rag.ts
+++ b/apps/packages/ui/src/services/tldw/domains/chat-rag.ts
@@ -19,6 +19,7 @@ import type {
   ConversationShareLinkCreateResponse,
   ConversationShareLinksListResponse,
   ConversationShareLinkResolveResponse,
+  OpenWebUIHydrationRequest,
   WorldBookProcessResponse,
 } from '../TldwApiClient'
 
@@ -1791,6 +1792,41 @@ export const chatRagMethods = {
       method: "POST",
       fields: normalized,
       file: { name, type, data }
+    })
+  },
+
+  async previewOpenWebUIHydration(
+    this: TldwApiClientCore,
+    payload: OpenWebUIHydrationRequest
+  ): Promise<any> {
+    return await bgRequest<any>({
+      path: "/api/v1/chatbooks/openwebui/hydration/preview",
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: payload
+    })
+  },
+
+  async createOpenWebUIHydrationJob(
+    this: TldwApiClientCore,
+    payload: OpenWebUIHydrationRequest
+  ): Promise<any> {
+    return await bgRequest<any>({
+      path: "/api/v1/chatbooks/openwebui/hydration/jobs",
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: payload
+    })
+  },
+
+  async getOpenWebUIHydrationJob(
+    this: TldwApiClientCore,
+    job_id: string
+  ): Promise<any> {
+    const id = encodeURIComponent(String(job_id))
+    return await bgRequest<any>({
+      path: `/api/v1/chatbooks/openwebui/hydration/jobs/${id}`,
+      method: "GET"
     })
   },
 

--- a/backlog/tasks/task-233.14 - Design-OpenWebUI-attachment-hydration.md
+++ b/backlog/tasks/task-233.14 - Design-OpenWebUI-attachment-hydration.md
@@ -1,0 +1,60 @@
+---
+id: TASK-233.14
+title: Design OpenWebUI attachment hydration
+status: Done
+assignee: []
+created_date: '2026-05-11 05:23'
+updated_date: '2026-05-11 05:28'
+labels:
+  - chatbooks
+  - openwebui
+  - design
+dependencies: []
+references:
+  - Docs/superpowers/specs/2026-05-10-openwebui-db-chat-import-design.md
+  - Docs/superpowers/specs/2026-05-10-openwebui-chat-import-design.md
+  - 'https://docs.openwebui.com/reference/database-schema/'
+  - 'https://docs.openwebui.com/features/chat-conversations/data-controls/files/'
+parent_task_id: TASK-233
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Design a v3 follow-up for hydrating OpenWebUI attachment/file bytes after JSON or database chat import. Scope is design only: local server bundle first, post-import hydration job, referenced files only, hybrid message-image and Media DB registration behavior, opt-in processing, dedupe policy, and server-local access controls.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Spec captures approved hydration source, scope, job model, target storage behavior, dedupe, and access policy
+- [x] #2 Spec is grounded in current Chatbooks/OpenWebUI import architecture and OpenWebUI DB/file documentation
+- [x] #3 Spec identifies non-goals and later extensions for ZIP bundles and live OpenWebUI API hydration
+- [x] #4 Design verification and review notes are recorded
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Created Docs/superpowers/specs/2026-05-11-openwebui-attachment-hydration-design.md covering the approved local-bundle-first hydration design, post-import Jobs workflow, referenced-file scope, hybrid image/Media DB storage, opt-in processing, dedupe policy, and access controls.
+
+Manual design review verified the spec references current Chatbooks/OpenWebUI import extension points, OpenWebUI DB/file docs, non-goals, and later ZIP/live-API extensions. A separate review subagent was not used because this session does not have explicit delegation permission.
+
+Verification: git diff --check passed. TODO/TBD/FIXME scan found no unresolved placeholders. Bandit skipped because this is documentation/task metadata only with no executable code touched.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added the approved OpenWebUI attachment hydration design spec and recorded verification. The spec is ready for user review before implementation planning.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-259 - Review-OpenWebUI-attachment-hydration-design.md
+++ b/backlog/tasks/task-259 - Review-OpenWebUI-attachment-hydration-design.md
@@ -1,0 +1,55 @@
+---
+id: TASK-259
+title: Review OpenWebUI attachment hydration design
+status: Done
+assignee: []
+created_date: '2026-05-11 05:33'
+updated_date: '2026-05-11 05:35'
+labels:
+  - chatbooks
+  - openwebui
+  - design-review
+dependencies: []
+references:
+  - Docs/superpowers/specs/2026-05-11-openwebui-attachment-hydration-design.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Review the approved OpenWebUI attachment hydration design for implementation risks, repo mismatches, and possible improvements before writing the implementation plan. Patch the design spec with actionable findings when needed.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Review spec against current Chatbooks, OpenWebUI DB, Jobs, ChaCha message image, allowed-path, and Media DB patterns
+- [x] #2 Document actionable design issues and improvements in the spec
+- [x] #3 Record verification and known skips
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Reviewed the approved hydration design against current repo surfaces: Chatbooks import metadata and worker routing, OpenWebUI DB validation, ChaCha message_images/idempotency, allowed-root path handling, and Media DB registration/dedupe behavior.
+
+Patched the spec with eight design-review adjustments: deep metadata merge, message image source-key limits, Media DB binary registration/dedupe constraints, dedicated hydration job type, hydration-specific file schema validation, original source chat identity for DB fallbacks, preserved-reference limits, and byte-level classification guardrails.
+
+Verification: git diff --check passed, targeted rg confirmed all review findings and the dedicated job type are present. Bandit skipped because this review patch changes docs/task metadata only.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Reviewed and amended the OpenWebUI attachment hydration design before implementation planning. The spec now documents the implementation risks and guardrails found in the current codebase.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-260 - Plan-OpenWebUI-attachment-hydration-implementation.md
+++ b/backlog/tasks/task-260 - Plan-OpenWebUI-attachment-hydration-implementation.md
@@ -1,0 +1,58 @@
+---
+id: TASK-260
+title: Plan OpenWebUI attachment hydration implementation
+status: Done
+assignee: []
+created_date: '2026-05-11 05:40'
+updated_date: '2026-05-11 05:45'
+labels:
+  - chatbooks
+  - openwebui
+  - planning
+dependencies: []
+references:
+  - Docs/superpowers/specs/2026-05-11-openwebui-attachment-hydration-design.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create the implementation plan for the reviewed OpenWebUI attachment hydration design. Scope is planning only: map files, TDD tasks, verification commands, security checks, and execution sequencing before code implementation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Plan maps backend, API, Jobs, DB helper, Media DB, ChaCha image, frontend, docs, and tests work
+- [x] #2 Plan incorporates reviewed design guardrails for metadata merge, media dedupe, job type, schema validation, source chat ids, and byte-level safety
+- [x] #3 Plan uses bite-sized TDD tasks with exact files, commands, and expected outcomes
+- [x] #4 Plan is saved under Docs/superpowers/plans and verification notes are recorded
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Created Docs/superpowers/plans/2026-05-11-openwebui-attachment-hydration-implementation-plan.md with staged backend, API, Jobs, DB helper, ChaCha image, Media DB, frontend, docs, and verification work.
+
+Plan incorporates the reviewed guardrails: deep OpenWebUI metadata merge, message-image source-key limitations, owner-aware Media DB binary registration, dedicated hydration job type, hydration-specific file schema validation, preserved source chat ids for DB fallback, preserved-reference limits, and byte-level file classification.
+
+Verification: git diff --check passed; targeted rg confirmed required plan header, stages, TDD commands, reviewed guardrails, openwebui_attachment_hydration job type, pytest/Vitest commands, and Bandit gate. Bandit skipped because this change is a planning document/task metadata only.
+
+Known skip: plan-review subagent was not dispatched because this session requires explicit user permission before spawning delegated agents; manual review was performed instead.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added the OpenWebUI attachment hydration implementation plan and recorded planning verification. Ready for user review before implementation execution.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-261 - Implement-OpenWebUI-hydration-DB-helper-slice.md
+++ b/backlog/tasks/task-261 - Implement-OpenWebUI-hydration-DB-helper-slice.md
@@ -1,0 +1,61 @@
+---
+id: TASK-261
+title: Implement OpenWebUI hydration DB helper slice
+status: Done
+assignee: []
+created_date: '2026-05-11 05:47'
+updated_date: '2026-05-11 15:51'
+labels:
+  - chatbooks
+  - openwebui
+  - implementation
+dependencies: []
+references:
+  - >-
+    Docs/superpowers/plans/2026-05-11-openwebui-attachment-hydration-implementation-plan.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Stage 1 of the OpenWebUI attachment hydration implementation plan: hydration-specific OpenWebUI file/chat_file schema validation and read-only row helpers, with regression tests proving baseline chat import validation is unchanged.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Hydration-specific file/chat_file schema validation is implemented separately from baseline OpenWebUI chat import validation
+- [x] #2 Read-only helpers load file rows by file ids and chat_file rows by chat ids with optional user scoping
+- [x] #3 Tests cover missing tables/columns, user scoping, parameterized literal ids, and baseline validation compatibility
+- [x] #4 Focused pytest and diff checks are recorded
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Stage 1 local execution after the implementer subagent hit the account usage limit. Follow TDD: add hydration DB helper tests, verify the red failure, implement read-only helpers in OpenWebUI_DB.py, run focused pytest/regression/diff/Bandit checks, then update acceptance criteria and commit.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+2026-05-11: Implementer subagent hit account usage limit; completed Stage 1 locally using TDD. Red run failed with missing hydration helper functions, then green run passed after implementing the DB helpers.
+
+Verification: pytest hydration DB helpers 9 passed; pytest existing OpenWebUI DB import adapter 9 passed; git diff --check clean; Bandit on OpenWebUI_DB.py wrote /tmp/bandit_openwebui_hydration_db_helpers.json with zero findings.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Stage 1 complete: added hydration-only OpenWebUI file/chat_file schema validation and read-only file/chat_file row helpers without broadening baseline chat-import validation. Added focused regression coverage for schema failures, user scoping, literal quoted ids, and text-only import compatibility. No known skips or blockers for this slice.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-262 - Implement-OpenWebUI-hydration-preview-and-path-safety-slice.md
+++ b/backlog/tasks/task-262 - Implement-OpenWebUI-hydration-preview-and-path-safety-slice.md
@@ -1,0 +1,63 @@
+---
+id: TASK-262
+title: Implement OpenWebUI hydration preview and path-safety slice
+status: Done
+assignee: []
+created_date: '2026-05-11 15:52'
+updated_date: '2026-05-11 16:01'
+labels:
+  - chatbooks
+  - openwebui
+  - implementation
+dependencies:
+  - TASK-261
+references:
+  - >-
+    Docs/superpowers/plans/2026-05-11-openwebui-attachment-hydration-implementation-plan.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Stage 2 of the OpenWebUI attachment hydration implementation plan: preview-safe data-root validation, file path resolution, reference extraction, and DB chat_file fallback without writing images or Media DB rows.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Data-root validation enforces ingestion-source allowed roots and requires webui.db plus uploads only when bytes are needed
+- [x] #2 OpenWebUI file path resolution rejects traversal and symlink escapes and supports safe uploads/{file.id}_{file.filename} fallback
+- [x] #3 Reference extraction reads preserved OpenWebUI import metadata and reports unsupported reference shapes without raw path leakage
+- [x] #4 DB chat_file fallback uses preserved OpenWebUI source chat row ids and skips fallback when absent
+- [x] #5 Focused pytest, diff checks, and Bandit for touched backend code are recorded
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Follow Stage 2 of the implementation plan locally because subagent execution is blocked by account quota. Use TDD: add path and preview/reference tests first, verify red, implement openwebui_hydration.py with dataclasses and pure service helpers, run focused pytest/regression/diff/Bandit checks, then update plan/task and commit.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+2026-05-11: Completed Stage 2 locally because subagent execution is blocked by account quota. Red run failed because openwebui_hydration.py did not exist; implementation added preview dataclasses, allowed-root validation, safe file-path resolution, basic byte classification, metadata reference extraction, and chat_file fallback using metadata.row_id only.
+
+Verification: combined pytest for hydration path/service/db-helper/OpenWebUI DB adapter returned 29 passed; git diff --check clean; Bandit on openwebui_hydration.py wrote /tmp/bandit_openwebui_hydration_preview_service.json with zero findings.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Stage 2 complete: added OpenWebUI hydration preview/path service helpers and focused tests. Data roots are constrained to ingestion-source allowed roots, webui.db is required, uploads is required only when bytes are needed, traversal and symlink escapes are rejected, fallback upload paths resolve safely, basic file kind classification is byte-sniffed, message metadata refs are extracted, unsupported ref shapes are reported, and DB chat_file fallback uses preserved row_id without guessing from external_ref. No known skips or blockers for this slice.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-263 - Implement-OpenWebUI-image-hydration-and-metadata-merge-slice.md
+++ b/backlog/tasks/task-263 - Implement-OpenWebUI-image-hydration-and-metadata-merge-slice.md
@@ -1,0 +1,65 @@
+---
+id: TASK-263
+title: Implement OpenWebUI image hydration and metadata merge slice
+status: Done
+assignee: []
+created_date: '2026-05-11 16:02'
+updated_date: '2026-05-11 16:12'
+labels:
+  - chatbooks
+  - openwebui
+  - implementation
+dependencies:
+  - TASK-262
+references:
+  - >-
+    Docs/superpowers/plans/2026-05-11-openwebui-attachment-hydration-implementation-plan.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Stage 3 of the OpenWebUI attachment hydration implementation plan: append safe hydrated images to existing chat messages, merge hydration status into OpenWebUI message metadata without losing original import metadata, and make image hydration retry-idempotent.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Post-insert message image append helper appends after existing image positions and enforces the existing message-image byte cap
+- [x] #2 Hydration metadata updates deep-merge under extra.openwebui_import.hydration while preserving original OpenWebUI import fields
+- [x] #3 Image hydration byte-sniffs PNG/JPEG/GIF/WebP, rejects oversized or unsupported bytes, and records structured statuses
+- [x] #4 Retrying the same source key does not duplicate message_images rows
+- [x] #5 Focused pytest, diff checks, and Bandit for touched backend code are recorded
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Follow Stage 3 of the implementation plan locally because subagent execution is blocked by account quota. Use TDD: extend hydration service tests for image/metadata behavior, verify red, add a ChaCha append_message_image helper plus facade export, implement image hydration and deep metadata merge in openwebui_hydration.py, run focused pytest/regression/diff/Bandit checks, then update task/plan and commit.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented Stage 3 image hydration locally after subagent quota blocked delegation: added append_message_image with commit=False support, deep OpenWebUI hydration metadata merge, byte-sniffed image hydration, idempotent source-key handling, and rollback on metadata update failure.
+
+Verification: pytest focused image/metadata slice passed 6 selected tests; full OpenWebUI Chatbooks regression set passed 35 tests; git diff --check passed; Bandit JSON at /tmp/bandit_openwebui_image_hydration.json had 0 results and 0 errors.
+
+Documentation for this slice is the implementation plan/task tracking update; user-facing hydration docs remain in the later docs stage of the plan.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Stage 3 complete: OpenWebUI image attachments can now be hydrated into ChaCha message_images while preserving original import metadata, enforcing image byte limits/signature checks, avoiding duplicate hydration on retry, and rolling back image insertion if metadata recording fails.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-264 - Implement-OpenWebUI-non-image-Media-registration-slice.md
+++ b/backlog/tasks/task-264 - Implement-OpenWebUI-non-image-Media-registration-slice.md
@@ -1,0 +1,61 @@
+---
+id: TASK-264
+title: Implement OpenWebUI non-image Media registration slice
+status: Done
+assignee: []
+created_date: '2026-05-11 16:14'
+updated_date: '2026-05-11 16:28'
+labels:
+  - chatbooks
+  - openwebui
+  - implementation
+dependencies:
+  - TASK-263
+references:
+  - >-
+    Docs/superpowers/plans/2026-05-11-openwebui-attachment-hydration-implementation-plan.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Stage 4 of the OpenWebUI attachment hydration implementation plan: register referenced non-image attachments as durable tldw-owned Media DB records without automatic processing by default.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 PDF/non-image hydration creates a Media row and MediaFiles original row under tldw-owned storage
+- [x] #2 Registration records owner_user_id, personal visibility, byte checksum/source hash, and safe OpenWebUI source metadata
+- [x] #3 Dedupe is owner-aware and does not collapse unrelated source-id-less files
+- [x] #4 process_supported_files remains optional and processing failures do not remove registered MediaFiles rows
+- [x] #5 Focused pytest, diff checks, and Bandit for touched backend code are recorded
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Follow Stage 4 of the implementation plan with TDD: inspect existing Media DB add/file helper contracts, add failing non-image registration tests, implement durable copy plus owner-aware registration in openwebui_hydration.py using existing Media DB APIs where possible, keep processing hook optional, verify, update tracking, and commit.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verification: service/media registration focus passed with 15 tests; combined OpenWebUI hydration/import + MediaFiles + SQLite MediaDB suite passed with 108 tests; git diff --check passed; Bandit on touched backend code wrote /tmp/bandit_openwebui_media_registration.json with 0 results and 0 errors.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented Stage 4 non-image OpenWebUI attachment registration. Non-image refs now create owner-scoped Media rows, copy source bytes into tldw-owned per-user storage, insert MediaFiles original rows, record safe hydration metadata, preserve owner-aware dedupe without cross-user reuse, and keep optional processing behind process_supported_files with failed processing recorded without deleting the registered file.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-265 - Implement-OpenWebUI-attachment-hydration-API-slice.md
+++ b/backlog/tasks/task-265 - Implement-OpenWebUI-attachment-hydration-API-slice.md
@@ -1,0 +1,55 @@
+---
+id: TASK-265
+title: Implement OpenWebUI attachment hydration API slice
+status: Done
+assignee: []
+created_date: '2026-05-11 16:30'
+updated_date: '2026-05-11 16:48'
+labels:
+  - chatbooks
+  - openwebui
+  - implementation
+dependencies:
+  - TASK-264
+references:
+  - >-
+    Docs/superpowers/plans/2026-05-11-openwebui-attachment-hydration-implementation-plan.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Stage 5 of the OpenWebUI attachment hydration implementation plan: expose preview, job creation, and job status API contracts for attachment hydration.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Pydantic request/response schemas cover preview/job requests and redact raw source paths
+- [x] #2 Preview endpoint authorizes access and returns hydration summary/counts
+- [x] #3 Job creation endpoint enqueues a chatbooks openwebui_attachment_hydration Jobs row with scoped payload
+- [x] #4 Job status endpoint returns only owned/admin-visible hydration jobs
+- [x] #5 Focused pytest, diff checks, and Bandit for touched backend code are recorded
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented Stage 5 API slice: added OpenWebUI hydration request/response schemas, preview endpoint, job create/status endpoints, chatbooks Jobs helper, safe preview normalization, recursive path redaction for job result/error values, and focused API tests. Multi-user non-admin callers are denied for server-local hydration; single-user and admin principals are allowed. Worker-side root/authorization revalidation remains in Stage 6. Verification: focused API tests 7 passed; broader OpenWebUI hydration/import suite 47 passed; chatbooks path traversal suite 3 passed; git diff --check clean; Bandit report /tmp/bandit_openwebui_hydration_api.json has 0 findings and 0 errors. Known non-gating check: combining test_chatbooks_api_path_guard.py with path traversal timed out in full app.main TestClient teardown after unrelated lifespan workers started.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Stage 5 exposes the OpenWebUI attachment hydration API contract: schemas for preview/jobs, an admin/single-user gated preview route, core Jobs enqueue/status routes for openwebui_attachment_hydration, raw-path-free preview items, and recursive redaction for job result/error strings. Verification recorded: API tests 7 passed, OpenWebUI hydration/import suite 47 passed, chatbooks path traversal suite 3 passed, diff check clean, Bandit 0 findings. The remaining worker-side execution and revalidation is intentionally deferred to Stage 6.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-266 - Implement-OpenWebUI-attachment-hydration-worker-slice.md
+++ b/backlog/tasks/task-266 - Implement-OpenWebUI-attachment-hydration-worker-slice.md
@@ -1,0 +1,55 @@
+---
+id: TASK-266
+title: Implement OpenWebUI attachment hydration worker slice
+status: Done
+assignee: []
+created_date: '2026-05-11 16:50'
+updated_date: '2026-05-11 16:58'
+labels:
+  - chatbooks
+  - openwebui
+  - implementation
+dependencies:
+  - TASK-265
+references:
+  - >-
+    Docs/superpowers/plans/2026-05-11-openwebui-attachment-hydration-implementation-plan.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Stage 6 of the OpenWebUI attachment hydration implementation plan: route openwebui_attachment_hydration Jobs through the Chatbooks worker, revalidate payload/root requirements, call the hydration service, and return a JSON-safe summary.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Worker dispatches job_type=openwebui_attachment_hydration without changing import/export routing
+- [x] #2 Missing or invalid required payload fields fail non-retryably with descriptive errors
+- [x] #3 Worker revalidates data root and user scope before hydration execution
+- [x] #4 Worker returns a JSON-safe hydration summary with warnings capped/redacted
+- [x] #5 Focused worker pytest, import/export regression checks, diff checks, and Bandit are recorded
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented Stage 6 worker slice: added worker routing for openwebui_attachment_hydration without requiring legacy chatbooks_job_id, added non-retryable payload/root validation, called ChatbookService.run_openwebui_attachment_hydration, returned capped/redacted JSON-safe Jobs summaries, and preserved existing import/export routing. Added service execution support that revalidates the OpenWebUI data root with uploads required, hydrates image references, registers non-image attachments through Media DB when available, and records summary counts. Verification: initial red worker run failed as expected on missing hydration routing; worker/import tests 11 passed; worker/import/adapter tests 13 passed; broader worker/API/service tests 36 passed; full OpenWebUI hydration/import + worker slice 61 passed; git diff --check clean; Bandit report /tmp/bandit_openwebui_hydration_worker.json has 0 findings and 0 errors.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Stage 6 routes openwebui_attachment_hydration Jobs through the Chatbooks worker, revalidates payload/root requirements in the worker/service layer, runs actual hydration execution, and stores a capped/redacted summary result. Existing import/export worker paths remain covered by regression tests. Verification recorded: 61 focused OpenWebUI hydration/import and Chatbooks worker tests passed, diff check clean, Bandit 0 findings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-267 - Implement-OpenWebUI-attachment-hydration-frontend-workflow.md
+++ b/backlog/tasks/task-267 - Implement-OpenWebUI-attachment-hydration-frontend-workflow.md
@@ -1,0 +1,59 @@
+---
+id: TASK-267
+title: Implement OpenWebUI attachment hydration frontend workflow
+status: Done
+assignee: []
+created_date: '2026-05-11 16:59'
+updated_date: '2026-05-11 17:21'
+labels:
+  - chatbooks
+  - openwebui
+  - frontend
+  - implementation
+dependencies:
+  - TASK-266
+references:
+  - >-
+    Docs/superpowers/plans/2026-05-11-openwebui-attachment-hydration-implementation-plan.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Stage 7 of the OpenWebUI attachment hydration plan: add frontend API client methods and a preview-first Chatbooks import workflow for server-local OpenWebUI attachment hydration.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Frontend API client exposes preview, create job, and get job methods for OpenWebUI hydration
+- [x] #2 Chatbooks import UI shows discoverable hydration controls near OpenWebUI import
+- [x] #3 Preview requires a data root and sends process_supported_files false by default
+- [x] #4 Opt-in processing toggles process_supported_files true and job creation is gated on successful preview
+- [x] #5 Preview/job status counts and warnings render using existing UI patterns
+- [x] #6 Focused Vitest/client/UI checks and diff checks are recorded
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented Stage 7 frontend workflow: added OpenWebUI hydration client methods and import-tab hydration controls for data root, conversation ids, optional source user, preview, opt-in supported-file processing, job creation, job refresh, summary counts, and warnings.
+
+Verification: bun run test src/services/__tests__/tldw-api-client.chatbooks-openwebui.test.ts src/components/Option/Chatbooks/__tests__/ChatbooksPlaygroundPage.openwebui-import.test.tsx from apps/packages/ui passed, 13 tests. bun run verify:openapi passed with reviewed baseline exception paths. git diff --check passed. Package-wide bunx tsc -p tsconfig.json --noEmit still fails on existing unrelated baseline TypeScript errors; no reported error referenced the new Chatbooks hydration files. Bandit not applicable for this frontend-only slice. User docs are owned by Stage 8.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added the Stage 7 frontend workflow for OpenWebUI attachment hydration. The UI package now exposes preview/create/get hydration client methods and the Chatbooks import panel shows OpenWebUI hydration controls with data-root entry, imported conversation id scope, optional source user, default-off supported-file processing, preview summaries/warnings, gated job creation, and job status refresh. Verification: focused client/page Vitest suite passed with 13 tests, verify:openapi passed, git diff --check passed. Package-wide TypeScript still has unrelated baseline failures outside this slice; Bandit was not applicable because this slice touched frontend TypeScript only.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-268 - Document-OpenWebUI-attachment-hydration.md
+++ b/backlog/tasks/task-268 - Document-OpenWebUI-attachment-hydration.md
@@ -1,0 +1,56 @@
+---
+id: TASK-268
+title: Document OpenWebUI attachment hydration
+status: Done
+assignee: []
+created_date: '2026-05-11 17:22'
+updated_date: '2026-05-11 17:32'
+labels:
+  - chatbooks
+  - openwebui
+  - docs
+  - verification
+dependencies:
+  - TASK-267
+references:
+  - >-
+    Docs/superpowers/plans/2026-05-11-openwebui-attachment-hydration-implementation-plan.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Stage 8 of the OpenWebUI attachment hydration plan: document the user workflow and API contract, update docs tests, and run final focused verification for the hydration feature.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 User guide documents v1 referenced-file hydration workflow and local OpenWebUI root shape
+- [x] #2 API docs and OpenAPI docs list hydration preview/job endpoints and request/response behavior
+- [x] #3 Docs cover allowed roots, permissions, image/non-image behavior, opt-in processing, and common warnings
+- [x] #4 Docs test asserts hydration documentation text is present
+- [x] #5 Focused backend/frontend verification and Bandit results are recorded
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Completed Stage 8 documentation for OpenWebUI attachment hydration. Verification run: docs pytest 6 passed; focused backend pytest 65 passed; focused frontend Vitest 13 passed; Bandit reported 0 findings and 0 errors; git diff --check passed before task finalization.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Updated the Chatbook user guide, API docs, OpenAPI fragment, API README/tag index, and published mirrors so users can discover OpenWebUI attachment hydration after chat import. The docs now explain the local OpenWebUI root shape, allowed-root configuration, owner/admin permissions, image versus non-image behavior, opt-in processing, output storage, and common warnings. Added docs regression assertions for the hydration user/API/OpenAPI contract. Verification: docs pytest 6 passed; focused backend hydration/import pytest 65 passed; focused frontend Vitest 13 passed; Bandit on touched backend hydration scope reported 0 findings and 0 errors. Known residual: the package-wide UI tsc check still has unrelated baseline errors from outside the new hydration files.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-269 - Address-PR-1575-OpenWebUI-hydration-review-comments.md
+++ b/backlog/tasks/task-269 - Address-PR-1575-OpenWebUI-hydration-review-comments.md
@@ -1,0 +1,61 @@
+---
+id: TASK-269
+title: Address PR 1575 OpenWebUI hydration review comments
+status: Done
+assignee: []
+created_date: '2026-05-12 00:15'
+updated_date: '2026-05-12 00:20'
+labels:
+  - chatbooks
+  - openwebui
+  - review-fix
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1575'
+  - >-
+    Docs/superpowers/plans/2026-05-11-openwebui-attachment-hydration-implementation-plan.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address actionable review comments on PR #1575 for OpenWebUI attachment hydration: per-reference error handling in non-image registration, batched chat_file fallback lookup, and capped hydration response items.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Non-image registration catches copy and Media DB failures per reference and records warning/status instead of terminating the hydration run
+- [x] #2 chat_file fallback references are loaded with one batched lookup for all source chat IDs in scope
+- [x] #3 Preview and job result item lists are capped and expose overflow counts without unbounded response payloads
+- [x] #4 Focused tests cover the review fixes
+- [x] #5 Verification and Bandit results are recorded
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused failing tests for per-item non-image failure handling, batched chat_file fallback lookup, and response item caps. 2. Patch OpenWebUI hydration service and DB helper to satisfy the review comments. 3. Run focused pytest/Bandit/git diff checks, update task, commit, push, and verify PR threads.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Addressed Gemini review feedback on PR #1575: non-image Media DB/copy failures now return per-item media_registration_failed results, chat_file fallback uses one batched lookup for source chat ids, and preview/job responses cap returned items with returned_items/omitted_items summary counters. Verification: targeted review regression pytest 4 passed; focused hydration/docs pytest 75 passed; Bandit report /tmp/bandit_openwebui_hydration_review.json has 0 findings and 0 errors; git diff --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed the actionable PR #1575 review comments for OpenWebUI attachment hydration. The hydration service now keeps jobs running when non-image copy or Media DB operations fail by recording a per-reference media_registration_failed item. chat_file fallback extraction now batches source chat lookups instead of querying once per conversation. Preview and job results now cap returned item arrays and expose returned_items/omitted_items counters in the summary, with API schema and docs updated to match. Added regression tests for all three review findings. Verification: review regression pytest 4 passed; focused hydration/docs pytest 75 passed; Bandit on touched backend scope reported 0 findings and 0 errors; git diff --check passed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-277 - Address-PR-1575-CodeRabbit-and-Qodo-hydration-review-comments.md
+++ b/backlog/tasks/task-277 - Address-PR-1575-CodeRabbit-and-Qodo-hydration-review-comments.md
@@ -1,0 +1,54 @@
+---
+id: TASK-277
+title: Address PR 1575 CodeRabbit and Qodo hydration review comments
+status: Done
+assignee: []
+created_date: '2026-05-12 00:24'
+updated_date: '2026-05-12 00:30'
+labels:
+  - openwebui
+  - chatbooks
+  - review-fix
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1575'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the current actionable review comments on PR #1575 for the OpenWebUI attachment hydration feature. The review surface includes bounded image reads, hydration preview freshness in the frontend, accurate warning counts with capped warning lists, restrictive storage permissions, Windows path redaction, safer concurrent message image append position allocation, and targeted API test hardening.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 All current actionable CodeRabbit and Qodo review comments on PR #1575 are verified and addressed or explicitly resolved as already fixed.
+- [x] #2 Regression tests cover bounded image reads, warning count truncation behavior, storage directory permissions, Windows/UNC warning redaction, append-position retry behavior, API authorization fixture hardening, and hydration preview invalidation.
+- [x] #3 Focused backend and frontend tests for touched hydration paths pass locally.
+- [x] #4 Bandit runs clean on touched backend implementation files and diff whitespace checks pass.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verified and fixed current PR #1575 CodeRabbit/Qodo comments: bounded image reads, import-preview freshness in the hydration run gate, full warning totals with truncated warning lists, private attachment storage root permissions, Windows/UNC warning redaction, retry-on-conflict for appended message image positions, and API test fixture/schema hardening.
+
+Verification: targeted backend review regressions passed (7 selected); focused OpenWebUI hydration backend/docs suite passed (79 passed); OpenWebUI import UI vitest file passed (7 passed); Bandit on touched backend implementation files reported 0 findings and 0 errors; git diff --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Resolved the second PR #1575 review sweep by addressing all current actionable CodeRabbit and Qodo comments and preserving the earlier Gemini fixes. Added regression coverage for the new failure modes and verified the touched backend/frontend hydration paths locally.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/chatbooks.py
+++ b/tldw_Server_API/app/api/v1/endpoints/chatbooks.py
@@ -11,6 +11,7 @@ Provides REST API endpoints for creating, importing, and managing chatbooks.
 import asyncio
 import json
 import os
+import re
 import shutil
 from datetime import datetime, timezone
 from pathlib import Path
@@ -23,10 +24,18 @@ from loguru import logger
 
 # Unified audit service
 from tldw_Server_API.app.api.v1.API_Deps.Audit_DB_Deps import get_audit_service_for_user
+from tldw_Server_API.app.api.v1.API_Deps.jobs_deps import get_job_manager
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal, is_single_user_principal
 from tldw_Server_API.app.core.Audit.unified_audit_service import AuditContext, AuditEventType
+from tldw_Server_API.app.core.Chatbooks.openwebui_hydration_jobs import (
+    OPENWEBUI_ATTACHMENT_HYDRATION_JOB_TYPE,
+    create_openwebui_hydration_job,
+    get_openwebui_hydration_job,
+)
+from tldw_Server_API.app.core.Jobs.manager import JobManager
 from tldw_Server_API.app.core.Logging.log_context import ensure_request_id, ensure_traceparent, get_ps_logger
 from tldw_Server_API.app.core.Metrics.metrics_manager import increment_counter
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, rbac_rate_limit, User
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal, get_request_user, rbac_rate_limit, User
 
 from ....core.Chatbooks.chatbook_models import ContentType, ExportJob, ExportStatus
 from ....core.Chatbooks.chatbook_service import ChatbookService
@@ -52,6 +61,10 @@ from ..schemas.chatbook_schemas import (
     ImportJobResponse,
     ListExportJobsResponse,
     ListImportJobsResponse,
+    OpenWebUIHydrationJobRequest,
+    OpenWebUIHydrationJobResponse,
+    OpenWebUIHydrationPreviewRequest,
+    OpenWebUIHydrationPreviewResponse,
     PreviewChatbookResponse,
     RemoveJobResponse,
 )
@@ -82,6 +95,9 @@ router = APIRouter(prefix="/chatbooks", tags=["chatbooks"])
 
 # Use central limiter instance
 
+_ADMIN_CLAIM_PERMISSIONS = {"*", "system.configure"}
+_ABSOLUTE_PATH_RE = re.compile(r"(?<![A-Za-z0-9_])/(?:[^\s,;:)\"']+/?)+")
+
 
 def _safe_increment_metric(metric_name: str, labels: dict, error_context: str = "") -> None:
     """Safely increment a metric, logging failures without raising."""
@@ -89,6 +105,86 @@ def _safe_increment_metric(metric_name: str, labels: dict, error_context: str = 
         increment_counter(metric_name, labels=labels)
     except _CHATBOOKS_NONCRITICAL_EXCEPTIONS:
         logger.debug("metrics increment failed")
+
+
+def _principal_has_admin_claims(principal: AuthPrincipal | None) -> bool:
+    """Return whether the principal carries explicit admin-style claims."""
+    if principal is None:
+        return False
+    if bool(getattr(principal, "is_admin", False)):
+        return True
+    roles = {
+        str(role).strip().lower()
+        for role in (principal.roles or [])
+        if str(role).strip()
+    }
+    if "admin" in roles:
+        return True
+    permissions = {
+        str(permission).strip().lower()
+        for permission in (principal.permissions or [])
+        if str(permission).strip()
+    }
+    return bool(permissions & _ADMIN_CLAIM_PERMISSIONS)
+
+
+def _require_openwebui_hydration_access(principal: AuthPrincipal) -> None:
+    """Allow local single-user access and explicit admin claims for server-local hydration."""
+    if is_single_user_principal(principal) or _principal_has_admin_claims(principal):
+        return
+    raise HTTPException(status_code=403, detail="OpenWebUI attachment hydration requires admin access")
+
+
+def _redact_hydration_warning(value: object) -> str:
+    """Redact absolute filesystem paths from hydration warning strings."""
+    return _ABSOLUTE_PATH_RE.sub("[redacted-path]", str(value))
+
+
+def _redact_hydration_value(value: object) -> object:
+    """Redact absolute filesystem paths in nested hydration response values."""
+    if isinstance(value, str):
+        return _redact_hydration_warning(value)
+    if isinstance(value, list):
+        return [_redact_hydration_value(item) for item in value]
+    if isinstance(value, tuple):
+        return [_redact_hydration_value(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _redact_hydration_value(item) for key, item in value.items()}
+    return value
+
+
+def _hydration_preview_response(
+    request_model: OpenWebUIHydrationPreviewRequest,
+    payload: dict,
+) -> OpenWebUIHydrationPreviewResponse:
+    """Normalize a service preview payload into the public response model."""
+    scope = payload.get("scope") if isinstance(payload.get("scope"), dict) else request_model.scope.model_dump()
+    return OpenWebUIHydrationPreviewResponse(
+        scope=scope,
+        process_supported_files=bool(payload.get("process_supported_files", request_model.process_supported_files)),
+        summary=payload.get("summary") or {},
+        items=list(payload.get("items") or []),
+        warnings=[_redact_hydration_warning(warning) for warning in (payload.get("warnings") or [])],
+    )
+
+
+def _job_to_openwebui_hydration_response(job: dict) -> OpenWebUIHydrationJobResponse:
+    """Convert a core Jobs row to the public OpenWebUI hydration job response."""
+    job_id = str(job.get("id") or job.get("job_id") or "")
+    result = _redact_hydration_value(job.get("result")) if isinstance(job.get("result"), dict) else None
+    return OpenWebUIHydrationJobResponse(
+        job_id=job_id,
+        job_uuid=str(job.get("uuid")) if job.get("uuid") is not None else None,
+        status=str(job.get("status") or "unknown"),
+        domain=str(job.get("domain") or "chatbooks"),
+        queue=str(job.get("queue") or "default"),
+        job_type=str(job.get("job_type") or OPENWEBUI_ATTACHMENT_HYDRATION_JOB_TYPE),
+        owner_user_id=str(job.get("owner_user_id")) if job.get("owner_user_id") is not None else None,
+        created_at=job.get("created_at"),
+        updated_at=job.get("updated_at"),
+        result=result if isinstance(result, dict) else None,
+        error=_redact_hydration_warning(job.get("error")) if job.get("error") is not None else None,
+    )
 
 
 def _setup_secure_temp_directory(user_id: str) -> Path:
@@ -1056,6 +1152,110 @@ async def preview_chatbook(
                     labels={"component": "chatbooks", "event": "preview_cleanup_failed"},
                     error_context="chatbooks preview_cleanup_failed",
                 )
+
+
+@router.post(
+    "/openwebui/hydration/preview",
+    response_model=OpenWebUIHydrationPreviewResponse,
+    dependencies=[Depends(rbac_rate_limit("chatbooks.openwebui_hydration.preview"))],
+)
+async def preview_openwebui_attachment_hydration(
+    hydration_request: OpenWebUIHydrationPreviewRequest,
+    request: Request,
+    service: ChatbookService = Depends(get_chatbook_service),
+    user: User = Depends(get_request_user),
+    principal: AuthPrincipal = Depends(get_auth_principal),
+):
+    """Preview hydration of OpenWebUI attachments preserved during DB import."""
+    _require_openwebui_hydration_access(principal)
+    try:
+        payload = await asyncio.to_thread(
+            service.preview_openwebui_attachment_hydration,
+            openwebui_data_root=hydration_request.openwebui_data_root,
+            scope=hydration_request.scope.model_dump(),
+            process_supported_files=hydration_request.process_supported_files,
+        )
+        return _hydration_preview_response(hydration_request, payload)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from None
+    except HTTPException:
+        raise
+    except _CHATBOOKS_NONCRITICAL_EXCEPTIONS:
+        get_ps_logger(
+            request_id=ensure_request_id(request),
+            ps_component="endpoint",
+            ps_job_kind="chatbooks",
+            traceparent=ensure_traceparent(request),
+        ).exception(f"Error previewing OpenWebUI attachment hydration for user {user.id}")
+        raise HTTPException(
+            status_code=500,
+            detail="An error occurred while previewing OpenWebUI attachment hydration",
+        ) from None
+
+
+@router.post(
+    "/openwebui/hydration/jobs",
+    response_model=OpenWebUIHydrationJobResponse,
+    dependencies=[Depends(rbac_rate_limit("chatbooks.openwebui_hydration.jobs.create"))],
+)
+async def create_openwebui_attachment_hydration_job(
+    hydration_request: OpenWebUIHydrationJobRequest,
+    request: Request,
+    user: User = Depends(get_request_user),
+    principal: AuthPrincipal = Depends(get_auth_principal),
+    jobs_manager: JobManager = Depends(get_job_manager),
+):
+    """Enqueue an OpenWebUI attachment hydration job."""
+    _require_openwebui_hydration_access(principal)
+    payload = {
+        "user_id": str(user.id),
+        "openwebui_data_root": hydration_request.openwebui_data_root,
+        "scope": hydration_request.scope.model_dump(),
+        "process_supported_files": hydration_request.process_supported_files,
+    }
+    try:
+        job = create_openwebui_hydration_job(
+            jobs_manager,
+            payload,
+            owner_user_id=str(user.id),
+            request_id=ensure_request_id(request),
+        )
+        return _job_to_openwebui_hydration_response(job)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from None
+    except _CHATBOOKS_NONCRITICAL_EXCEPTIONS:
+        get_ps_logger(
+            request_id=ensure_request_id(request),
+            ps_component="endpoint",
+            ps_job_kind="chatbooks",
+            traceparent=ensure_traceparent(request),
+        ).exception(f"Error enqueueing OpenWebUI attachment hydration job for user {user.id}")
+        raise HTTPException(
+            status_code=500,
+            detail="An error occurred while enqueueing OpenWebUI attachment hydration",
+        ) from None
+
+
+@router.get(
+    "/openwebui/hydration/jobs/{job_id}",
+    response_model=OpenWebUIHydrationJobResponse,
+    dependencies=[Depends(rbac_rate_limit("chatbooks.openwebui_hydration.jobs.get"))],
+)
+async def get_openwebui_attachment_hydration_job(
+    job_id: str,
+    user: User = Depends(get_request_user),
+    principal: AuthPrincipal = Depends(get_auth_principal),
+    jobs_manager: JobManager = Depends(get_job_manager),
+):
+    """Return one OpenWebUI attachment hydration job visible to the current caller."""
+    _require_openwebui_hydration_access(principal)
+    job = get_openwebui_hydration_job(jobs_manager, job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="OpenWebUI hydration job not found")
+    is_admin = _principal_has_admin_claims(principal) or is_single_user_principal(principal)
+    if not is_admin and str(job.get("owner_user_id") or "") != str(user.id):
+        raise HTTPException(status_code=404, detail="OpenWebUI hydration job not found")
+    return _job_to_openwebui_hydration_response(job)
 
 
 @router.get("/export/jobs", response_model=ListExportJobsResponse)

--- a/tldw_Server_API/app/api/v1/schemas/chatbook_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/chatbook_schemas.py
@@ -424,6 +424,8 @@ class OpenWebUIHydrationItemResponse(BaseModel):
 class OpenWebUIHydrationSummaryResponse(BaseModel):
     """Counts for an OpenWebUI attachment hydration preview or job result."""
     referenced_files: int = Field(default=0, ge=0)
+    returned_items: int = Field(default=0, ge=0)
+    omitted_items: int = Field(default=0, ge=0)
     resolved_files: int = Field(default=0, ge=0)
     image_files: int = Field(default=0, ge=0)
     media_files: int = Field(default=0, ge=0)

--- a/tldw_Server_API/app/api/v1/schemas/chatbook_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/chatbook_schemas.py
@@ -339,6 +339,128 @@ class OpenWebUIDatabaseImportResult(OpenWebUIImportResult):
     folder_links: int = Field(default=0, ge=0)
 
 
+class OpenWebUIHydrationScopeRequest(BaseModel):
+    """Scope for OpenWebUI attachment hydration over imported tldw conversations."""
+    conversation_ids: list[str] = Field(
+        default_factory=list,
+        max_length=1000,
+        description="Imported tldw conversation ids to scan. Empty means no conversations are selected.",
+    )
+    source_user_id: Optional[str] = Field(
+        default=None,
+        min_length=1,
+        max_length=255,
+        description="Optional OpenWebUI source user id used for chat_file fallback lookups.",
+    )
+
+    @field_validator("conversation_ids")
+    @classmethod
+    def validate_conversation_ids(cls, value: list[str]) -> list[str]:
+        """Trim and reject empty conversation ids."""
+        cleaned: list[str] = []
+        for item in value:
+            text = str(item).strip()
+            if not text:
+                raise ValueError("conversation_ids must not contain empty values")
+            cleaned.append(text)
+        return cleaned
+
+    @field_validator("source_user_id")
+    @classmethod
+    def validate_source_user_id(cls, value: Optional[str]) -> Optional[str]:
+        """Trim and reject blank OpenWebUI source user ids."""
+        if value is None:
+            return None
+        text = str(value).strip()
+        if not text:
+            raise ValueError("source_user_id must not be empty")
+        return text
+
+
+class OpenWebUIHydrationPreviewRequest(BaseModel):
+    """Request to preview OpenWebUI attachment hydration."""
+    openwebui_data_root: str = Field(..., min_length=1, max_length=4096)
+    scope: OpenWebUIHydrationScopeRequest = Field(default_factory=OpenWebUIHydrationScopeRequest)
+    process_supported_files: bool = Field(
+        default=False,
+        description="Preview whether supported non-image files would be processed after registration.",
+    )
+
+    @field_validator("openwebui_data_root")
+    @classmethod
+    def validate_openwebui_data_root(cls, value: str) -> str:
+        """Trim and reject empty roots."""
+        text = str(value).strip()
+        if not text:
+            raise ValueError("openwebui_data_root must not be empty")
+        return text
+
+
+class OpenWebUIHydrationJobRequest(OpenWebUIHydrationPreviewRequest):
+    """Request to enqueue an OpenWebUI attachment hydration job."""
+
+
+class OpenWebUIHydrationItemResponse(BaseModel):
+    """One user-safe OpenWebUI attachment hydration preview/status item."""
+    conversation_id: Optional[str] = None
+    message_id: Optional[str] = None
+    file_id: Optional[str] = None
+    status: str
+    warning_code: Optional[str] = None
+    raw_ref_index: Optional[int] = None
+    source: Optional[str] = None
+    raw_ref_shape: Optional[str] = None
+    job_id: Optional[str] = None
+    source_key: Optional[str] = None
+    message_image_position: Optional[int] = None
+    file_kind: Optional[str] = None
+    mime_type: Optional[str] = None
+    media_id: Optional[int] = None
+    media_file_id: Optional[str] = None
+    checksum: Optional[str] = None
+    processing_status: Optional[str] = None
+
+
+class OpenWebUIHydrationSummaryResponse(BaseModel):
+    """Counts for an OpenWebUI attachment hydration preview or job result."""
+    referenced_files: int = Field(default=0, ge=0)
+    resolved_files: int = Field(default=0, ge=0)
+    image_files: int = Field(default=0, ge=0)
+    media_files: int = Field(default=0, ge=0)
+    missing_files: int = Field(default=0, ge=0)
+    unsupported_files: int = Field(default=0, ge=0)
+    failed_files: int = Field(default=0, ge=0)
+    hydrated_images: int = Field(default=0, ge=0)
+    registered_media_files: int = Field(default=0, ge=0)
+    already_hydrated: int = Field(default=0, ge=0)
+    processed_files: int = Field(default=0, ge=0)
+    warning_count: int = Field(default=0, ge=0)
+
+
+class OpenWebUIHydrationPreviewResponse(BaseModel):
+    """Response for OpenWebUI attachment hydration preview."""
+    scope: OpenWebUIHydrationScopeRequest
+    process_supported_files: bool = False
+    summary: OpenWebUIHydrationSummaryResponse
+    items: list[OpenWebUIHydrationItemResponse] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+
+
+class OpenWebUIHydrationJobResponse(BaseModel):
+    """Response for OpenWebUI attachment hydration job creation/status."""
+    job_id: str
+    job_uuid: Optional[str] = None
+    status: str
+    domain: str = "chatbooks"
+    queue: str = "default"
+    job_type: str = "openwebui_attachment_hydration"
+    owner_user_id: Optional[str] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+    result: Optional[dict[str, Any]] = None
+    error: Optional[str] = None
+
+
 class CreateChatbookResponse(BaseModel):
     """Response for chatbook creation."""
     success: bool

--- a/tldw_Server_API/app/core/Chatbooks/chatbook_service.py
+++ b/tldw_Server_API/app/core/Chatbooks/chatbook_service.py
@@ -2626,8 +2626,9 @@ class ChatbookService:
             for item in items
             if item.get("warning_code")
         ]
+        total_warning_count = len(warnings) + len(item_warnings)
         warnings.extend(item_warnings[:MAX_PREVIEW_WARNING_ITEMS])
-        summary["warning_count"] = len(warnings)
+        summary["warning_count"] = total_warning_count
         returned_items, omitted_items = self._cap_openwebui_hydration_items(items)
         summary["returned_items"] = len(returned_items)
         summary["omitted_items"] = omitted_items
@@ -2655,7 +2656,9 @@ class ChatbookService:
                 storage_root = (ACTUAL_PROJECT_ROOT / storage_root).resolve(strict=False)
         else:
             storage_root = ACTUAL_PROJECT_ROOT / "Databases" / "media_storage"
-        storage_root.mkdir(parents=True, exist_ok=True)
+        storage_root.mkdir(parents=True, exist_ok=True, mode=0o700)
+        with contextlib.suppress(OSError):
+            storage_root.chmod(0o700)
         return storage_root
 
     @staticmethod

--- a/tldw_Server_API/app/core/Chatbooks/chatbook_service.py
+++ b/tldw_Server_API/app/core/Chatbooks/chatbook_service.py
@@ -132,6 +132,7 @@ _OPENWEBUI_FOLDER_MIRROR_EXCEPTIONS: tuple[type[BaseException], ...] = (
 )
 
 _CHATBOOK_TEMPLATE_MODES = {"pass_through", "render_on_export", "render_on_import"}
+MAX_OPENWEBUI_HYDRATION_RESPONSE_ITEMS = 1000
 
 try:  # Prompts database is optional in some deployments
     from ..DB_Management.Prompts_DB import PromptsDatabase  # type: ignore
@@ -2482,6 +2483,9 @@ class ChatbookService:
         summary = self._openwebui_hydration_summary(items)
         summary["referenced_files"] = len(items)
         summary["warning_count"] = len(warnings) + sum(1 for item in items if item.get("warning_code"))
+        returned_items, omitted_items = self._cap_openwebui_hydration_items(items)
+        summary["returned_items"] = len(returned_items)
+        summary["omitted_items"] = omitted_items
         return {
             "scope": {
                 "conversation_ids": list(conversation_ids),
@@ -2489,7 +2493,7 @@ class ChatbookService:
             },
             "process_supported_files": bool(process_supported_files),
             "summary": summary,
-            "items": items,
+            "items": returned_items,
             "warnings": warnings,
         }
 
@@ -2624,6 +2628,9 @@ class ChatbookService:
         ]
         warnings.extend(item_warnings[:MAX_PREVIEW_WARNING_ITEMS])
         summary["warning_count"] = len(warnings)
+        returned_items, omitted_items = self._cap_openwebui_hydration_items(items)
+        summary["returned_items"] = len(returned_items)
+        summary["omitted_items"] = omitted_items
         return {
             "scope": {
                 "conversation_ids": list(conversation_ids),
@@ -2631,7 +2638,7 @@ class ChatbookService:
             },
             "process_supported_files": bool(process_supported_files),
             "summary": summary,
-            "items": items,
+            "items": returned_items,
             "warnings": warnings,
         }
 
@@ -2679,6 +2686,8 @@ class ChatbookService:
         resolved = [item for item in items if item.get("status") == "resolved"]
         return {
             "referenced_files": len(items),
+            "returned_items": len(items),
+            "omitted_items": 0,
             "resolved_files": len(resolved),
             "image_files": sum(1 for item in resolved if item.get("file_kind") == "image"),
             "media_files": sum(1 for item in resolved if item.get("file_kind") != "image"),
@@ -2718,6 +2727,8 @@ class ChatbookService:
         }
         return {
             "referenced_files": len(items),
+            "returned_items": len(items),
+            "omitted_items": 0,
             "resolved_files": resolved_files,
             "image_files": image_files,
             "media_files": media_files,
@@ -2736,6 +2747,16 @@ class ChatbookService:
             "processed_files": sum(1 for item in items if item.get("processing_status") == "completed"),
             "warning_count": 0,
         }
+
+    @staticmethod
+    def _cap_openwebui_hydration_items(
+        items: list[dict[str, Any]],
+    ) -> tuple[list[dict[str, Any]], int]:
+        """Return a bounded hydration item list and omitted-item count."""
+        limit = max(0, int(MAX_OPENWEBUI_HYDRATION_RESPONSE_ITEMS))
+        if len(items) <= limit:
+            return list(items), 0
+        return list(items[:limit]), len(items) - limit
 
     @staticmethod
     def _openwebui_timestamp_to_iso(value: Any) -> tuple[str, str | None]:

--- a/tldw_Server_API/app/core/Chatbooks/chatbook_service.py
+++ b/tldw_Server_API/app/core/Chatbooks/chatbook_service.py
@@ -85,9 +85,20 @@ from .import_adapters.openwebui_db import (
     extract_openwebui_db_user,
     preview_openwebui_db as build_openwebui_db_preview,
 )
+from ..DB_Management.OpenWebUI_DB import (
+    load_openwebui_file_rows_for_ids,
+    open_validated_openwebui_db,
+    validate_openwebui_file_schema,
+)
 from .openwebui_folders import (
     build_openwebui_namespace_segments,
     mirror_openwebui_folder_for_conversation,
+)
+from .openwebui_hydration import (
+    OpenWebUIHydrationScope,
+    extract_openwebui_hydration_references,
+    resolve_openwebui_file_path,
+    validate_openwebui_data_root,
 )
 
 _CHATBOOK_NONCRITICAL_EXCEPTIONS: tuple[type[BaseException], ...] = (
@@ -2399,6 +2410,132 @@ class ChatbookService:
         except _CHATBOOK_NONCRITICAL_EXCEPTIONS as exc:
             logger.warning(f"OpenWebUI DB preview rejected file path: {exc}")
             return None, "Invalid or potentially malicious import file"
+
+    def preview_openwebui_attachment_hydration(
+        self,
+        *,
+        openwebui_data_root: str,
+        scope: dict[str, Any],
+        process_supported_files: bool = False,
+    ) -> dict[str, Any]:
+        """Preview OpenWebUI attachment hydration for already imported conversations."""
+        source_user_id = scope.get("source_user_id") or scope.get("openwebui_user_id")
+        conversation_ids = tuple(str(item).strip() for item in (scope.get("conversation_ids") or []) if str(item).strip())
+        data_root = validate_openwebui_data_root(openwebui_data_root, require_uploads=False)
+
+        items: list[dict[str, Any]] = []
+        warnings: list[str] = []
+        with open_validated_openwebui_db(data_root.webui_db_path) as conn:
+            validate_openwebui_file_schema(conn)
+            preview = extract_openwebui_hydration_references(
+                self.db,
+                OpenWebUIHydrationScope(
+                    conversation_ids=conversation_ids,
+                    openwebui_user_id=str(source_user_id).strip() if source_user_id else None,
+                ),
+                openwebui_conn=conn,
+            )
+            items.extend(self._openwebui_hydration_item_to_dict(item) for item in preview.items)
+            warnings.extend(str(warning) for warning in preview.warnings)
+
+            file_rows = load_openwebui_file_rows_for_ids(
+                conn,
+                tuple(reference.file_id for reference in preview.references),
+                str(source_user_id).strip() if source_user_id else None,
+            )
+            rows_by_id = {str(row["id"]): row for row in file_rows}
+            for reference in preview.references:
+                file_row = rows_by_id.get(reference.file_id)
+                if file_row is None:
+                    items.append(
+                        {
+                            "conversation_id": reference.conversation_id,
+                            "message_id": reference.message_id,
+                            "file_id": reference.file_id,
+                            "status": "missing_source_file_row",
+                            "warning_code": "missing_source_file_row",
+                            "raw_ref_index": reference.raw_ref_index,
+                            "source": reference.source,
+                        }
+                    )
+                    continue
+
+                resolved = resolve_openwebui_file_path(file_row, data_root)
+                warning_code = resolved.warning_codes[0] if resolved.warning_codes else None
+                items.append(
+                    {
+                        "conversation_id": reference.conversation_id,
+                        "message_id": reference.message_id,
+                        "file_id": reference.file_id,
+                        "status": resolved.status,
+                        "warning_code": warning_code,
+                        "raw_ref_index": reference.raw_ref_index,
+                        "source": reference.source,
+                        "file_kind": resolved.file_kind,
+                        "mime_type": resolved.mime_type,
+                    }
+                )
+
+        summary = self._openwebui_hydration_summary(items)
+        summary["referenced_files"] = len(items)
+        summary["warning_count"] = len(warnings) + sum(1 for item in items if item.get("warning_code"))
+        return {
+            "scope": {
+                "conversation_ids": list(conversation_ids),
+                "source_user_id": str(source_user_id).strip() if source_user_id else None,
+            },
+            "process_supported_files": bool(process_supported_files),
+            "summary": summary,
+            "items": items,
+            "warnings": warnings,
+        }
+
+    @staticmethod
+    def _openwebui_hydration_item_to_dict(item: Any) -> dict[str, Any]:
+        """Convert a hydration preview item to a raw-path-free dict."""
+        return {
+            "conversation_id": item.conversation_id,
+            "message_id": item.message_id,
+            "file_id": item.file_id,
+            "status": item.status,
+            "warning_code": item.warning_code,
+            "raw_ref_index": item.raw_ref_index,
+            "source": item.source,
+            "raw_ref_shape": item.raw_ref_shape,
+            "job_id": item.job_id,
+            "source_key": item.source_key,
+            "message_image_position": item.message_image_position,
+            "mime_type": item.mime_type,
+            "media_id": item.media_id,
+            "media_file_id": item.media_file_id,
+            "checksum": item.checksum,
+            "processing_status": item.processing_status,
+        }
+
+    @staticmethod
+    def _openwebui_hydration_summary(items: list[dict[str, Any]]) -> dict[str, int]:
+        """Build user-facing hydration preview counts."""
+        resolved = [item for item in items if item.get("status") == "resolved"]
+        return {
+            "referenced_files": len(items),
+            "resolved_files": len(resolved),
+            "image_files": sum(1 for item in resolved if item.get("file_kind") == "image"),
+            "media_files": sum(1 for item in resolved if item.get("file_kind") != "image"),
+            "missing_files": sum(
+                1 for item in items if item.get("status") in {"missing_file", "missing_source_file_row"}
+            ),
+            "unsupported_files": sum(
+                1
+                for item in items
+                if item.get("status") in {"unsupported_file_type", "unsupported_reference_shape"}
+            ),
+            "failed_files": sum(1 for item in items if item.get("status") in {"path_rejected"}),
+            "hydrated_images": 0,
+            "registered_media_files": 0,
+            "already_hydrated": 0,
+            "processed_files": 0,
+            "warning_count": 0,
+        }
 
     @staticmethod
     def _openwebui_timestamp_to_iso(value: Any) -> tuple[str, str | None]:

--- a/tldw_Server_API/app/core/Chatbooks/chatbook_service.py
+++ b/tldw_Server_API/app/core/Chatbooks/chatbook_service.py
@@ -36,7 +36,7 @@ import aiofiles
 import aiofiles.os
 from loguru import logger
 
-from tldw_Server_API.app.core.config import load_comprehensive_config, settings as core_settings
+from tldw_Server_API.app.core.config import ACTUAL_PROJECT_ROOT, load_comprehensive_config, settings as core_settings
 from tldw_Server_API.app.core.testing import is_truthy
 
 from ..DB_Management.ChaChaNotes_DB import CharactersRAGDB, CharactersRAGDBError
@@ -95,8 +95,11 @@ from .openwebui_folders import (
     mirror_openwebui_folder_for_conversation,
 )
 from .openwebui_hydration import (
+    MAX_PREVIEW_WARNING_ITEMS,
     OpenWebUIHydrationScope,
     extract_openwebui_hydration_references,
+    hydrate_image_reference,
+    register_non_image_reference,
     resolve_openwebui_file_path,
     validate_openwebui_data_root,
 )
@@ -2490,6 +2493,164 @@ class ChatbookService:
             "warnings": warnings,
         }
 
+    def run_openwebui_attachment_hydration(
+        self,
+        *,
+        openwebui_data_root: str,
+        scope: dict[str, Any],
+        process_supported_files: bool = False,
+        job_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Hydrate OpenWebUI attachments into tldw message images and Media DB records."""
+        if self.user_id_int is None:
+            raise ValueError("OpenWebUI attachment hydration requires a numeric user id.")
+
+        source_user_id = scope.get("source_user_id") or scope.get("openwebui_user_id")
+        conversation_ids = tuple(str(item).strip() for item in (scope.get("conversation_ids") or []) if str(item).strip())
+        data_root = validate_openwebui_data_root(openwebui_data_root, require_uploads=True)
+        media_db = self._get_media_db()
+        storage_root = self._openwebui_attachment_storage_root()
+        run_dedupe_cache: dict[tuple[str, str], int] = {}
+
+        items: list[dict[str, Any]] = []
+        warnings: list[str] = []
+        resolved_files = 0
+        image_files = 0
+        media_files = 0
+
+        with open_validated_openwebui_db(data_root.webui_db_path) as conn:
+            validate_openwebui_file_schema(conn)
+            preview = extract_openwebui_hydration_references(
+                self.db,
+                OpenWebUIHydrationScope(
+                    conversation_ids=conversation_ids,
+                    openwebui_user_id=str(source_user_id).strip() if source_user_id else None,
+                ),
+                openwebui_conn=conn,
+            )
+            items.extend(self._openwebui_hydration_item_to_dict(item) for item in preview.items)
+            warnings.extend(str(warning) for warning in preview.warnings)
+
+            file_rows = load_openwebui_file_rows_for_ids(
+                conn,
+                tuple(reference.file_id for reference in preview.references),
+                str(source_user_id).strip() if source_user_id else None,
+            )
+            rows_by_id = {str(row["id"]): row for row in file_rows}
+            for reference in preview.references:
+                file_row = rows_by_id.get(reference.file_id)
+                if file_row is None:
+                    items.append(
+                        {
+                            "conversation_id": reference.conversation_id,
+                            "message_id": reference.message_id,
+                            "file_id": reference.file_id,
+                            "status": "missing_source_file_row",
+                            "warning_code": "missing_source_file_row",
+                            "raw_ref_index": reference.raw_ref_index,
+                            "source": reference.source,
+                        }
+                    )
+                    continue
+
+                resolved = resolve_openwebui_file_path(file_row, data_root)
+                if resolved.status != "resolved":
+                    warning_code = resolved.warning_codes[0] if resolved.warning_codes else resolved.status
+                    items.append(
+                        {
+                            "conversation_id": reference.conversation_id,
+                            "message_id": reference.message_id,
+                            "file_id": reference.file_id,
+                            "status": resolved.status,
+                            "warning_code": warning_code,
+                            "raw_ref_index": reference.raw_ref_index,
+                            "source": reference.source,
+                            "file_kind": resolved.file_kind,
+                            "mime_type": resolved.mime_type,
+                        }
+                    )
+                    continue
+
+                resolved_files += 1
+                if resolved.file_kind == "image":
+                    image_files += 1
+                    item = hydrate_image_reference(
+                        self.db,
+                        reference,
+                        resolved,
+                        job_id=job_id,
+                    )
+                elif media_db is None:
+                    media_files += 1
+                    items.append(
+                        {
+                            "conversation_id": reference.conversation_id,
+                            "message_id": reference.message_id,
+                            "file_id": reference.file_id,
+                            "status": "media_db_unavailable",
+                            "warning_code": "media_db_unavailable",
+                            "raw_ref_index": reference.raw_ref_index,
+                            "source": reference.source,
+                            "file_kind": resolved.file_kind,
+                            "mime_type": resolved.mime_type,
+                        }
+                    )
+                    continue
+                else:
+                    media_files += 1
+                    item = register_non_image_reference(
+                        self.db,
+                        media_db,
+                        reference,
+                        resolved,
+                        owner_user_id=self.user_id_int,
+                        storage_root=storage_root,
+                        job_id=job_id,
+                        process_supported_files=bool(process_supported_files),
+                        run_dedupe_cache=run_dedupe_cache,
+                    )
+                items.append(self._openwebui_hydration_item_to_dict(item))
+
+        summary = self._openwebui_hydration_execution_summary(
+            items,
+            resolved_files=resolved_files,
+            image_files=image_files,
+            media_files=media_files,
+        )
+        item_warnings = [
+            f"{item.get('file_id') or 'unknown'}:{item.get('warning_code')}"
+            for item in items
+            if item.get("warning_code")
+        ]
+        warnings.extend(item_warnings[:MAX_PREVIEW_WARNING_ITEMS])
+        summary["warning_count"] = len(warnings)
+        return {
+            "scope": {
+                "conversation_ids": list(conversation_ids),
+                "source_user_id": str(source_user_id).strip() if source_user_id else None,
+            },
+            "process_supported_files": bool(process_supported_files),
+            "summary": summary,
+            "items": items,
+            "warnings": warnings,
+        }
+
+    def _openwebui_attachment_storage_root(self) -> Path:
+        """Return the tldw-owned storage root for hydrated non-image attachments."""
+        raw_path = (
+            os.getenv("OPENWEBUI_HYDRATION_MEDIA_STORAGE_PATH")
+            or os.getenv("MEDIA_STORAGE_PATH")
+            or ""
+        ).strip()
+        if raw_path:
+            storage_root = Path(raw_path).expanduser()
+            if not storage_root.is_absolute():
+                storage_root = (ACTUAL_PROJECT_ROOT / storage_root).resolve(strict=False)
+        else:
+            storage_root = ACTUAL_PROJECT_ROOT / "Databases" / "media_storage"
+        storage_root.mkdir(parents=True, exist_ok=True)
+        return storage_root
+
     @staticmethod
     def _openwebui_hydration_item_to_dict(item: Any) -> dict[str, Any]:
         """Convert a hydration preview item to a raw-path-free dict."""
@@ -2534,6 +2695,45 @@ class ChatbookService:
             "registered_media_files": 0,
             "already_hydrated": 0,
             "processed_files": 0,
+            "warning_count": 0,
+        }
+
+    @staticmethod
+    def _openwebui_hydration_execution_summary(
+        items: list[dict[str, Any]],
+        *,
+        resolved_files: int,
+        image_files: int,
+        media_files: int,
+    ) -> dict[str, int]:
+        """Build final hydration execution counts."""
+        statuses = [str(item.get("status") or "") for item in items]
+        failed_statuses = {
+            "media_db_unavailable",
+            "media_registration_failed",
+            "metadata_update_failed",
+            "message_missing",
+            "oversized",
+            "path_rejected",
+        }
+        return {
+            "referenced_files": len(items),
+            "resolved_files": resolved_files,
+            "image_files": image_files,
+            "media_files": media_files,
+            "missing_files": sum(
+                1 for status in statuses if status in {"missing_file", "missing_source_file_row"}
+            ),
+            "unsupported_files": sum(
+                1
+                for status in statuses
+                if status in {"unsupported_file_type", "unsupported_reference_shape"}
+            ),
+            "failed_files": sum(1 for status in statuses if status in failed_statuses),
+            "hydrated_images": statuses.count("hydrated_image"),
+            "registered_media_files": statuses.count("registered_media"),
+            "already_hydrated": statuses.count("already_hydrated") + statuses.count("already_registered_media"),
+            "processed_files": sum(1 for item in items if item.get("processing_status") == "completed"),
             "warning_count": 0,
         }
 

--- a/tldw_Server_API/app/core/Chatbooks/openwebui_hydration.py
+++ b/tldw_Server_API/app/core/Chatbooks/openwebui_hydration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import sqlite3
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -15,6 +16,10 @@ from tldw_Server_API.app.core.config import get_ingestion_source_allowed_roots
 
 
 MAX_PREVIEW_WARNING_ITEMS = 1000
+
+
+class _OpenWebUIHydrationMetadataError(RuntimeError):
+    """Raised internally to roll back image hydration when metadata cannot be recorded."""
 
 
 @dataclass(frozen=True)
@@ -74,6 +79,10 @@ class OpenWebUIHydrationPreviewItem:
     raw_ref_index: int | None = None
     source: str | None = None
     raw_ref_shape: str | None = None
+    job_id: str | None = None
+    source_key: str | None = None
+    message_image_position: int | None = None
+    mime_type: str | None = None
 
 
 @dataclass(frozen=True)
@@ -187,6 +196,11 @@ def resolve_openwebui_file_path(
     )
 
 
+def classify_openwebui_file(path: Path) -> tuple[str, str | None]:
+    """Classify a resolved OpenWebUI source file from conservative byte signatures."""
+    return _classify_file_path(path)
+
+
 def extract_openwebui_hydration_references(
     chacha_db: Any,
     scope: OpenWebUIHydrationScope,
@@ -264,6 +278,162 @@ def extract_openwebui_hydration_references(
     )
 
 
+def merge_openwebui_message_hydration_metadata(
+    chacha_db: Any,
+    message_id: str,
+    item_update: dict[str, Any],
+    *,
+    job_id: str | None = None,
+) -> bool:
+    """Deep-merge one hydration item into message metadata without replacing import metadata."""
+    current = chacha_db.get_message_metadata(message_id) or {}
+    current_extra = current.get("extra") if isinstance(current, dict) else {}
+    if not isinstance(current_extra, dict):
+        current_extra = {}
+    openwebui_import = current_extra.get("openwebui_import")
+    if not isinstance(openwebui_import, dict):
+        openwebui_import = {}
+    merged_openwebui_import = dict(openwebui_import)
+
+    hydration = merged_openwebui_import.get("hydration")
+    if not isinstance(hydration, dict):
+        hydration = {}
+    merged_hydration = dict(hydration)
+    items = merged_hydration.get("items")
+    if not isinstance(items, list):
+        items = []
+    merged_items = [dict(item) for item in items if isinstance(item, dict)]
+
+    source_key = _coerce_optional_text(item_update.get("source_key"))
+    replaced = False
+    if source_key:
+        for index, existing_item in enumerate(merged_items):
+            if existing_item.get("source_key") == source_key:
+                merged_items[index] = {**existing_item, **item_update}
+                replaced = True
+                break
+    if not replaced:
+        merged_items.append(dict(item_update))
+
+    merged_hydration["version"] = 1
+    if job_id is not None:
+        merged_hydration["last_job_id"] = job_id
+    merged_hydration["items"] = merged_items
+    merged_openwebui_import["hydration"] = merged_hydration
+
+    new_extra = dict(current_extra)
+    new_extra["openwebui_import"] = merged_openwebui_import
+    return bool(
+        chacha_db.add_message_metadata(
+            message_id,
+            tool_calls=current.get("tool_calls") if isinstance(current, dict) else None,
+            extra=new_extra,
+        )
+    )
+
+
+def hydrate_image_reference(
+    chacha_db: Any,
+    reference: OpenWebUIHydrationReference,
+    resolved_file: OpenWebUIHydrationResolvedFile,
+    *,
+    job_id: str | None = None,
+    max_image_bytes: int | None = None,
+) -> OpenWebUIHydrationPreviewItem:
+    """Hydrate one resolved image reference into a tldw message image slot."""
+    message_id = reference.message_id
+    if not message_id:
+        return _image_result_item(reference, "message_missing", job_id=job_id)
+    if resolved_file.path is None or resolved_file.status != "resolved":
+        return _image_result_item(reference, resolved_file.status, job_id=job_id)
+
+    try:
+        image_bytes = resolved_file.path.read_bytes()
+    except OSError:
+        return _image_result_item(reference, "missing_file", job_id=job_id)
+
+    image_limit = max_image_bytes if max_image_bytes is not None else _default_max_image_bytes()
+    if len(image_bytes) > image_limit:
+        return _image_result_item(reference, "oversized", job_id=job_id)
+
+    mime_type = _sniff_image_mime(image_bytes)
+    if mime_type is None:
+        return _image_result_item(reference, "unsupported_file_type", job_id=job_id)
+
+    source_key = _source_key_for_reference(reference, image_bytes)
+    existing_item = _existing_hydration_item(chacha_db, message_id, source_key)
+    if existing_item is not None and existing_item.get("message_image_position") is not None:
+        return _image_result_item(
+            reference,
+            "already_hydrated",
+            job_id=job_id,
+            source_key=source_key,
+            message_image_position=int(existing_item["message_image_position"]),
+            mime_type=str(existing_item.get("mime_type") or mime_type),
+        )
+
+    item_update = {
+        "source_key": source_key,
+        "source_file_id": reference.file_id,
+        "source_message_id": reference.source_message_id,
+        "status": "hydrated_image",
+        "message_image_position": None,
+        "mime_type": mime_type,
+        "job_id": job_id,
+    }
+    try:
+        if hasattr(chacha_db, "transaction"):
+            with chacha_db.transaction():
+                position = int(
+                    chacha_db.append_message_image(
+                        message_id,
+                        image_bytes,
+                        mime_type,
+                        commit=False,
+                    )
+                )
+                item_update["message_image_position"] = position
+                if not merge_openwebui_message_hydration_metadata(
+                    chacha_db,
+                    message_id,
+                    item_update,
+                    job_id=job_id,
+                ):
+                    raise _OpenWebUIHydrationMetadataError("Failed to record OpenWebUI hydration metadata.")
+        else:
+            position = int(chacha_db.append_message_image(message_id, image_bytes, mime_type))
+            item_update["message_image_position"] = position
+            if not merge_openwebui_message_hydration_metadata(
+                chacha_db,
+                message_id,
+                item_update,
+                job_id=job_id,
+            ):
+                return _image_result_item(
+                    reference,
+                    "metadata_update_failed",
+                    job_id=job_id,
+                    source_key=source_key,
+                    mime_type=mime_type,
+                )
+    except _OpenWebUIHydrationMetadataError:
+        return _image_result_item(
+            reference,
+            "metadata_update_failed",
+            job_id=job_id,
+            source_key=source_key,
+            mime_type=mime_type,
+        )
+    return _image_result_item(
+        reference,
+        "hydrated_image",
+        job_id=job_id,
+        source_key=source_key,
+        message_image_position=position,
+        mime_type=mime_type,
+    )
+
+
 def _resolve_declared_file_path(raw_path: str, data_root: OpenWebUIDataRoot) -> Path | None:
     candidate = Path(raw_path)
     roots = (data_root.root_path,)
@@ -312,6 +482,74 @@ def _classify_file_path(path: Path) -> tuple[str, str | None]:
     if header.startswith(b"%PDF"):
         return "document", "application/pdf"
     return "file", None
+
+
+def _sniff_image_mime(data: bytes) -> str | None:
+    if data.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if data.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if data.startswith((b"GIF87a", b"GIF89a")):
+        return "image/gif"
+    if len(data) >= 12 and data.startswith(b"RIFF") and data[8:12] == b"WEBP":
+        return "image/webp"
+    return None
+
+
+def _source_key_for_reference(reference: OpenWebUIHydrationReference, data: bytes) -> str:
+    if reference.file_id:
+        return f"openwebui:file:{reference.file_id}"
+    return f"openwebui:hash:{hashlib.sha256(data).hexdigest()}"
+
+
+def _existing_hydration_item(chacha_db: Any, message_id: str, source_key: str) -> dict[str, Any] | None:
+    metadata = chacha_db.get_message_metadata(message_id) or {}
+    openwebui_import = _openwebui_import_metadata(metadata)
+    if not openwebui_import:
+        return None
+    hydration = openwebui_import.get("hydration")
+    if not isinstance(hydration, dict):
+        return None
+    items = hydration.get("items")
+    if not isinstance(items, list):
+        return None
+    for item in items:
+        if isinstance(item, dict) and item.get("source_key") == source_key:
+            return item
+    return None
+
+
+def _image_result_item(
+    reference: OpenWebUIHydrationReference,
+    status: str,
+    *,
+    job_id: str | None = None,
+    source_key: str | None = None,
+    message_image_position: int | None = None,
+    mime_type: str | None = None,
+) -> OpenWebUIHydrationPreviewItem:
+    return OpenWebUIHydrationPreviewItem(
+        conversation_id=reference.conversation_id,
+        message_id=reference.message_id,
+        file_id=reference.file_id,
+        status=status,
+        warning_code=None if status in {"hydrated_image", "already_hydrated"} else status,
+        raw_ref_index=reference.raw_ref_index,
+        source=reference.source,
+        job_id=job_id,
+        source_key=source_key,
+        message_image_position=message_image_position,
+        mime_type=mime_type,
+    )
+
+
+def _default_max_image_bytes() -> int:
+    try:
+        from tldw_Server_API.app.core.config import settings  # noqa: E402
+
+        return int(settings.get("MAX_MESSAGE_IMAGE_BYTES", 5 * 1024 * 1024))
+    except (ImportError, AttributeError, TypeError, ValueError):
+        return 5 * 1024 * 1024
 
 
 def _load_conversation_messages(chacha_db: Any, conversation_id: str) -> list[dict[str, Any]]:

--- a/tldw_Server_API/app/core/Chatbooks/openwebui_hydration.py
+++ b/tldw_Server_API/app/core/Chatbooks/openwebui_hydration.py
@@ -3,15 +3,22 @@
 from __future__ import annotations
 
 import hashlib
+import json
+import shutil
 import sqlite3
+from collections.abc import Callable, MutableMapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Mapping
+from urllib.parse import quote
 
 from tldw_Server_API.app.core.DB_Management.OpenWebUI_DB import (
     load_openwebui_chat_file_rows_for_chats,
 )
-from tldw_Server_API.app.core.Ingestion_Media_Processing.path_utils import resolve_safe_local_path
+from tldw_Server_API.app.core.Ingestion_Media_Processing.path_utils import (
+    open_safe_local_path,
+    resolve_safe_local_path,
+)
 from tldw_Server_API.app.core.config import get_ingestion_source_allowed_roots
 
 
@@ -83,6 +90,11 @@ class OpenWebUIHydrationPreviewItem:
     source_key: str | None = None
     message_image_position: int | None = None
     mime_type: str | None = None
+    media_id: int | None = None
+    media_file_id: str | None = None
+    checksum: str | None = None
+    storage_path: str | None = None
+    processing_status: str | None = None
 
 
 @dataclass(frozen=True)
@@ -434,6 +446,195 @@ def hydrate_image_reference(
     )
 
 
+def register_non_image_reference(
+    chacha_db: Any,
+    media_db: Any,
+    reference: OpenWebUIHydrationReference,
+    resolved_file: OpenWebUIHydrationResolvedFile,
+    *,
+    owner_user_id: int,
+    storage_root: str | Path,
+    job_id: str | None = None,
+    process_supported_files: bool = False,
+    processing_hook: Callable[..., Any] | None = None,
+    run_dedupe_cache: MutableMapping[tuple[str, str], int] | None = None,
+) -> OpenWebUIHydrationPreviewItem:
+    """Register one resolved non-image OpenWebUI attachment in Media DB."""
+    message_id = reference.message_id
+    if not message_id:
+        return _media_result_item(reference, "message_missing", job_id=job_id)
+    if resolved_file.path is None or resolved_file.status != "resolved":
+        return _media_result_item(reference, resolved_file.status, job_id=job_id)
+    if resolved_file.file_kind == "image":
+        return _media_result_item(reference, "unsupported_file_type", job_id=job_id)
+    if not resolved_file.path.is_file():
+        return _media_result_item(reference, "missing_file", job_id=job_id)
+
+    checksum = _sha256_file(resolved_file.path)
+    source_key = _source_key_for_digest(reference, checksum)
+    existing_item = _existing_hydration_item(chacha_db, message_id, source_key)
+    if existing_item is not None and existing_item.get("media_id") is not None:
+        return _media_result_item(
+            reference,
+            "already_registered_media",
+            job_id=job_id,
+            source_key=source_key,
+            media_id=int(existing_item["media_id"]),
+            media_file_id=_coerce_optional_text(existing_item.get("media_file_id")),
+            checksum=_coerce_optional_text(existing_item.get("checksum")) or checksum,
+            storage_path=_coerce_optional_text(existing_item.get("storage_path")),
+            mime_type=_coerce_optional_text(existing_item.get("mime_type")) or resolved_file.mime_type,
+            processing_status=_coerce_optional_text(existing_item.get("processing_status")),
+        )
+
+    source_file_id = _coerce_optional_text(reference.file_id) or _coerce_optional_text(resolved_file.file_id)
+    filename = _safe_storage_filename(resolved_file.filename or resolved_file.path.name)
+    mime_type = resolved_file.mime_type or _guess_mime_type(filename)
+    media_url = _openwebui_media_url(
+        owner_user_id=owner_user_id,
+        source_file_id=source_file_id,
+        checksum=checksum,
+        job_id=job_id,
+    )
+    placeholder_content = _openwebui_placeholder_content(
+        source_file_id=source_file_id,
+        filename=filename,
+        mime_type=mime_type,
+        checksum=checksum,
+    )
+    safe_metadata = _openwebui_safe_metadata(
+        reference=reference,
+        source_file_id=source_file_id,
+        filename=filename,
+        mime_type=mime_type,
+        checksum=checksum,
+        job_id=job_id,
+    )
+
+    media_id = _deduped_media_id_from_run_cache(
+        owner_user_id=owner_user_id,
+        source_file_id=source_file_id,
+        checksum=checksum,
+        run_dedupe_cache=run_dedupe_cache,
+    )
+    if media_id is None:
+        media_id, _, _ = media_db.add_media_with_keywords(
+            url=media_url,
+            title=filename,
+            media_type=_media_type_for_file(resolved_file, mime_type, filename),
+            content=placeholder_content,
+            keywords=["openwebui", "attachment"],
+            safe_metadata=json.dumps(safe_metadata, sort_keys=True),
+            source_hash=checksum,
+            visibility="personal",
+            owner_user_id=owner_user_id,
+        )
+    if media_id is None:
+        return _media_result_item(
+            reference,
+            "media_registration_failed",
+            job_id=job_id,
+            source_key=source_key,
+            checksum=checksum,
+            mime_type=mime_type,
+        )
+    media_id = int(media_id)
+    if run_dedupe_cache is not None and not source_file_id:
+        run_dedupe_cache[(str(owner_user_id), checksum)] = media_id
+
+    media_file = media_db.get_media_file(media_id, "original")
+    status = "already_registered_media" if media_file else "registered_media"
+    if media_file:
+        media_file_id = str(media_file["uuid"])
+        storage_path = str(media_file["storage_path"])
+    else:
+        storage_path = _copy_openwebui_attachment_to_storage(
+            source_path=resolved_file.path,
+            storage_root=storage_root,
+            owner_user_id=owner_user_id,
+            media_id=media_id,
+            filename=filename,
+        )
+        media_file_id = str(
+            media_db.insert_media_file(
+                media_id=media_id,
+                file_type="original",
+                storage_path=storage_path,
+                original_filename=filename,
+                file_size=resolved_file.path.stat().st_size,
+                mime_type=mime_type,
+                checksum=checksum,
+            )
+        )
+
+    processing_status = "skipped"
+    warning_code = None
+    if process_supported_files:
+        if processing_hook is None:
+            processing_status = "not_configured"
+        else:
+            try:
+                processing_hook(
+                    media_db=media_db,
+                    media_id=media_id,
+                    media_file_id=media_file_id,
+                    storage_path=storage_path,
+                    owner_user_id=owner_user_id,
+                )
+                processing_status = "completed"
+            except Exception:
+                processing_status = "failed"
+                warning_code = "processing_failed"
+
+    item_update = {
+        "source_key": source_key,
+        "source_file_id": source_file_id,
+        "source_message_id": reference.source_message_id,
+        "status": "registered_media",
+        "media_id": media_id,
+        "media_file_id": media_file_id,
+        "checksum": checksum,
+        "storage_path": storage_path,
+        "mime_type": mime_type,
+        "job_id": job_id,
+        "processing_status": processing_status,
+    }
+    if warning_code is not None:
+        item_update["warning_code"] = warning_code
+    if not merge_openwebui_message_hydration_metadata(
+        chacha_db,
+        message_id,
+        item_update,
+        job_id=job_id,
+    ):
+        return _media_result_item(
+            reference,
+            "metadata_update_failed",
+            job_id=job_id,
+            source_key=source_key,
+            media_id=media_id,
+            media_file_id=media_file_id,
+            checksum=checksum,
+            storage_path=storage_path,
+            mime_type=mime_type,
+            processing_status=processing_status,
+        )
+
+    return _media_result_item(
+        reference,
+        status,
+        job_id=job_id,
+        source_key=source_key,
+        media_id=media_id,
+        media_file_id=media_file_id,
+        checksum=checksum,
+        storage_path=storage_path,
+        mime_type=mime_type,
+        warning_code=warning_code,
+        processing_status=processing_status,
+    )
+
+
 def _resolve_declared_file_path(raw_path: str, data_root: OpenWebUIDataRoot) -> Path | None:
     candidate = Path(raw_path)
     roots = (data_root.root_path,)
@@ -497,9 +698,13 @@ def _sniff_image_mime(data: bytes) -> str | None:
 
 
 def _source_key_for_reference(reference: OpenWebUIHydrationReference, data: bytes) -> str:
+    return _source_key_for_digest(reference, hashlib.sha256(data).hexdigest())
+
+
+def _source_key_for_digest(reference: OpenWebUIHydrationReference, digest: str) -> str:
     if reference.file_id:
         return f"openwebui:file:{reference.file_id}"
-    return f"openwebui:hash:{hashlib.sha256(data).hexdigest()}"
+    return f"openwebui:hash:{digest}"
 
 
 def _existing_hydration_item(chacha_db: Any, message_id: str, source_key: str) -> dict[str, Any] | None:
@@ -541,6 +746,177 @@ def _image_result_item(
         message_image_position=message_image_position,
         mime_type=mime_type,
     )
+
+
+def _media_result_item(
+    reference: OpenWebUIHydrationReference,
+    status: str,
+    *,
+    job_id: str | None = None,
+    source_key: str | None = None,
+    media_id: int | None = None,
+    media_file_id: str | None = None,
+    checksum: str | None = None,
+    storage_path: str | None = None,
+    mime_type: str | None = None,
+    warning_code: str | None = None,
+    processing_status: str | None = None,
+) -> OpenWebUIHydrationPreviewItem:
+    return OpenWebUIHydrationPreviewItem(
+        conversation_id=reference.conversation_id,
+        message_id=reference.message_id,
+        file_id=reference.file_id,
+        status=status,
+        warning_code=warning_code
+        if warning_code is not None
+        else None
+        if status in {"registered_media", "already_registered_media"}
+        else status,
+        raw_ref_index=reference.raw_ref_index,
+        source=reference.source,
+        job_id=job_id,
+        source_key=source_key,
+        mime_type=mime_type,
+        media_id=media_id,
+        media_file_id=media_file_id,
+        checksum=checksum,
+        storage_path=storage_path,
+        processing_status=processing_status,
+    )
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    handle = open_safe_local_path(path, path.parent, mode="rb")
+    if handle is None:
+        raise ValueError("OpenWebUI attachment source path is unsafe.")
+    with handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _safe_storage_filename(filename: str | None) -> str:
+    safe_name = Path(filename or "attachment").name.strip().strip(".")
+    if not safe_name:
+        return "attachment"
+    return safe_name.replace("/", "_").replace("\\", "_")
+
+
+def _guess_mime_type(filename: str) -> str:
+    suffix = Path(filename).suffix.lower()
+    if suffix == ".pdf":
+        return "application/pdf"
+    if suffix in {".txt", ".md", ".markdown"}:
+        return "text/plain"
+    if suffix in {".json"}:
+        return "application/json"
+    return "application/octet-stream"
+
+
+def _media_type_for_file(
+    resolved_file: OpenWebUIHydrationResolvedFile,
+    mime_type: str,
+    filename: str,
+) -> str:
+    if mime_type == "application/pdf" or filename.lower().endswith(".pdf"):
+        return "pdf"
+    if resolved_file.file_kind in {"document", "file"}:
+        return resolved_file.file_kind
+    return "file"
+
+
+def _openwebui_media_url(
+    *,
+    owner_user_id: int,
+    source_file_id: str | None,
+    checksum: str,
+    job_id: str | None,
+) -> str:
+    safe_owner = quote(str(owner_user_id), safe="")
+    if source_file_id:
+        safe_source_file_id = quote(source_file_id, safe="")
+        return f"openwebui://user/{safe_owner}/file/{safe_source_file_id}"
+    safe_job_id = quote(job_id or "manual", safe="")
+    return f"openwebui://user/{safe_owner}/run/{safe_job_id}/{checksum}"
+
+
+def _openwebui_placeholder_content(
+    *,
+    source_file_id: str | None,
+    filename: str,
+    mime_type: str,
+    checksum: str,
+) -> str:
+    return json.dumps(
+        {
+            "source": "openwebui",
+            "source_file_id": source_file_id,
+            "filename": filename,
+            "mime_type": mime_type,
+            "sha256": checksum,
+        },
+        sort_keys=True,
+    )
+
+
+def _openwebui_safe_metadata(
+    *,
+    reference: OpenWebUIHydrationReference,
+    source_file_id: str | None,
+    filename: str,
+    mime_type: str,
+    checksum: str,
+    job_id: str | None,
+) -> dict[str, Any]:
+    return {
+        "source": "openwebui",
+        "source_file_id": source_file_id,
+        "source_chat_id": reference.source_chat_id,
+        "source_message_id": reference.source_message_id,
+        "filename": filename,
+        "mime_type": mime_type,
+        "sha256": checksum,
+        "hydration_job_id": job_id,
+    }
+
+
+def _deduped_media_id_from_run_cache(
+    *,
+    owner_user_id: int,
+    source_file_id: str | None,
+    checksum: str,
+    run_dedupe_cache: MutableMapping[tuple[str, str], int] | None,
+) -> int | None:
+    if source_file_id or run_dedupe_cache is None:
+        return None
+    return run_dedupe_cache.get((str(owner_user_id), checksum))
+
+
+def _copy_openwebui_attachment_to_storage(
+    *,
+    source_path: Path,
+    storage_root: str | Path,
+    owner_user_id: int,
+    media_id: int,
+    filename: str,
+) -> str:
+    root = Path(storage_root).expanduser().resolve()
+    relative_path = Path(str(owner_user_id)) / "media" / str(media_id) / _safe_storage_filename(filename)
+    target_path = resolve_safe_local_path(root / relative_path, root)
+    if target_path is None:
+        raise ValueError("OpenWebUI attachment storage path is unsafe.")
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    source_handle = open_safe_local_path(source_path, source_path.parent, mode="rb")
+    if source_handle is None:
+        raise ValueError("OpenWebUI attachment source path is unsafe.")
+    with source_handle:
+        target_handle = open_safe_local_path(target_path, root, mode="wb")
+        if target_handle is None:
+            raise ValueError("OpenWebUI attachment storage path is unsafe.")
+        with target_handle:
+            shutil.copyfileobj(source_handle, target_handle, length=1024 * 1024)
+    return str(relative_path)
 
 
 def _default_max_image_bytes() -> int:

--- a/tldw_Server_API/app/core/Chatbooks/openwebui_hydration.py
+++ b/tldw_Server_API/app/core/Chatbooks/openwebui_hydration.py
@@ -365,12 +365,16 @@ def hydrate_image_reference(
     if resolved_file.path is None or resolved_file.status != "resolved":
         return _image_result_item(reference, resolved_file.status, job_id=job_id)
 
+    image_limit = max_image_bytes if max_image_bytes is not None else _default_max_image_bytes()
     try:
-        image_bytes = resolved_file.path.read_bytes()
+        handle = open_safe_local_path(resolved_file.path, resolved_file.path.parent, mode="rb")
+        if handle is None:
+            return _image_result_item(reference, "missing_file", job_id=job_id)
+        with handle:
+            image_bytes = handle.read(image_limit + 1)
     except OSError:
         return _image_result_item(reference, "missing_file", job_id=job_id)
 
-    image_limit = max_image_bytes if max_image_bytes is not None else _default_max_image_bytes()
     if len(image_bytes) > image_limit:
         return _image_result_item(reference, "oversized", job_id=job_id)
 

--- a/tldw_Server_API/app/core/Chatbooks/openwebui_hydration.py
+++ b/tldw_Server_API/app/core/Chatbooks/openwebui_hydration.py
@@ -223,6 +223,7 @@ def extract_openwebui_hydration_references(
     references: list[OpenWebUIHydrationReference] = []
     items: list[OpenWebUIHydrationPreviewItem] = []
     seen_keys: set[tuple[str, str | None, str, str]] = set()
+    chat_file_contexts: dict[str, list[tuple[str, dict[str, str]]]] = {}
 
     for conversation_id in scope.conversation_ids:
         messages = _load_conversation_messages(chacha_db, conversation_id)
@@ -274,15 +275,20 @@ def extract_openwebui_hydration_references(
                 )
 
         if openwebui_conn is not None:
-            _extend_references_from_chat_file_fallback(
-                references=references,
-                seen_keys=seen_keys,
-                openwebui_conn=openwebui_conn,
-                chacha_db=chacha_db,
-                conversation_id=conversation_id,
-                source_message_to_tldw_id=source_message_to_tldw_id,
-                openwebui_user_id=scope.openwebui_user_id,
-            )
+            source_chat_id = _source_chat_id_from_conversation_settings(chacha_db, conversation_id)
+            if source_chat_id:
+                chat_file_contexts.setdefault(source_chat_id, []).append(
+                    (conversation_id, source_message_to_tldw_id)
+                )
+
+    if openwebui_conn is not None and chat_file_contexts:
+        _extend_references_from_chat_file_fallback(
+            references=references,
+            seen_keys=seen_keys,
+            openwebui_conn=openwebui_conn,
+            chat_file_contexts=chat_file_contexts,
+            openwebui_user_id=scope.openwebui_user_id,
+        )
 
     return OpenWebUIHydrationPreview(
         references=tuple(references),
@@ -470,7 +476,17 @@ def register_non_image_reference(
     if not resolved_file.path.is_file():
         return _media_result_item(reference, "missing_file", job_id=job_id)
 
-    checksum = _sha256_file(resolved_file.path)
+    try:
+        checksum = _sha256_file(resolved_file.path)
+    except Exception:
+        return _media_result_item(
+            reference,
+            "media_registration_failed",
+            job_id=job_id,
+            source_key=f"openwebui:file:{reference.file_id}" if reference.file_id else None,
+            warning_code="media_registration_failed",
+            mime_type=resolved_file.mime_type,
+        )
     source_key = _source_key_for_digest(reference, checksum)
     existing_item = _existing_hydration_item(chacha_db, message_id, source_key)
     if existing_item is not None and existing_item.get("media_id") is not None:
@@ -517,17 +533,28 @@ def register_non_image_reference(
         checksum=checksum,
         run_dedupe_cache=run_dedupe_cache,
     )
-    if media_id is None:
-        media_id, _, _ = media_db.add_media_with_keywords(
-            url=media_url,
-            title=filename,
-            media_type=_media_type_for_file(resolved_file, mime_type, filename),
-            content=placeholder_content,
-            keywords=["openwebui", "attachment"],
-            safe_metadata=json.dumps(safe_metadata, sort_keys=True),
-            source_hash=checksum,
-            visibility="personal",
-            owner_user_id=owner_user_id,
+    try:
+        if media_id is None:
+            media_id, _, _ = media_db.add_media_with_keywords(
+                url=media_url,
+                title=filename,
+                media_type=_media_type_for_file(resolved_file, mime_type, filename),
+                content=placeholder_content,
+                keywords=["openwebui", "attachment"],
+                safe_metadata=json.dumps(safe_metadata, sort_keys=True),
+                source_hash=checksum,
+                visibility="personal",
+                owner_user_id=owner_user_id,
+            )
+    except Exception:
+        return _media_result_item(
+            reference,
+            "media_registration_failed",
+            job_id=job_id,
+            source_key=source_key,
+            checksum=checksum,
+            mime_type=mime_type,
+            warning_code="media_registration_failed",
         )
     if media_id is None:
         return _media_result_item(
@@ -539,32 +566,45 @@ def register_non_image_reference(
             mime_type=mime_type,
         )
     media_id = int(media_id)
-    if run_dedupe_cache is not None and not source_file_id:
-        run_dedupe_cache[(str(owner_user_id), checksum)] = media_id
 
-    media_file = media_db.get_media_file(media_id, "original")
-    status = "already_registered_media" if media_file else "registered_media"
-    if media_file:
-        media_file_id = str(media_file["uuid"])
-        storage_path = str(media_file["storage_path"])
-    else:
-        storage_path = _copy_openwebui_attachment_to_storage(
-            source_path=resolved_file.path,
-            storage_root=storage_root,
-            owner_user_id=owner_user_id,
-            media_id=media_id,
-            filename=filename,
-        )
-        media_file_id = str(
-            media_db.insert_media_file(
+    storage_path = None
+    media_file_id = None
+    try:
+        media_file = media_db.get_media_file(media_id, "original")
+        status = "already_registered_media" if media_file else "registered_media"
+        if media_file:
+            media_file_id = str(media_file["uuid"])
+            storage_path = str(media_file["storage_path"])
+        else:
+            storage_path = _copy_openwebui_attachment_to_storage(
+                source_path=resolved_file.path,
+                storage_root=storage_root,
+                owner_user_id=owner_user_id,
                 media_id=media_id,
-                file_type="original",
-                storage_path=storage_path,
-                original_filename=filename,
-                file_size=resolved_file.path.stat().st_size,
-                mime_type=mime_type,
-                checksum=checksum,
+                filename=filename,
             )
+            media_file_id = str(
+                media_db.insert_media_file(
+                    media_id=media_id,
+                    file_type="original",
+                    storage_path=storage_path,
+                    original_filename=filename,
+                    file_size=resolved_file.path.stat().st_size,
+                    mime_type=mime_type,
+                    checksum=checksum,
+                )
+            )
+    except Exception:
+        return _media_result_item(
+            reference,
+            "media_registration_failed",
+            job_id=job_id,
+            source_key=source_key,
+            media_id=media_id,
+            checksum=checksum,
+            storage_path=storage_path,
+            mime_type=mime_type,
+            warning_code="media_registration_failed",
         )
 
     processing_status = "skipped"
@@ -601,12 +641,16 @@ def register_non_image_reference(
     }
     if warning_code is not None:
         item_update["warning_code"] = warning_code
-    if not merge_openwebui_message_hydration_metadata(
-        chacha_db,
-        message_id,
-        item_update,
-        job_id=job_id,
-    ):
+    try:
+        metadata_saved = merge_openwebui_message_hydration_metadata(
+            chacha_db,
+            message_id,
+            item_update,
+            job_id=job_id,
+        )
+    except Exception:
+        metadata_saved = False
+    if not metadata_saved:
         return _media_result_item(
             reference,
             "metadata_update_failed",
@@ -619,6 +663,8 @@ def register_non_image_reference(
             mime_type=mime_type,
             processing_status=processing_status,
         )
+    if run_dedupe_cache is not None and not source_file_id:
+        run_dedupe_cache[(str(owner_user_id), checksum)] = media_id
 
     return _media_result_item(
         reference,
@@ -971,43 +1017,43 @@ def _extend_references_from_chat_file_fallback(
     references: list[OpenWebUIHydrationReference],
     seen_keys: set[tuple[str, str | None, str, str]],
     openwebui_conn: sqlite3.Connection,
-    chacha_db: Any,
-    conversation_id: str,
-    source_message_to_tldw_id: dict[str, str],
+    chat_file_contexts: Mapping[str, list[tuple[str, dict[str, str]]]],
     openwebui_user_id: str | None,
 ) -> None:
-    source_chat_id = _source_chat_id_from_conversation_settings(chacha_db, conversation_id)
-    if not source_chat_id:
-        return
     rows = load_openwebui_chat_file_rows_for_chats(
         openwebui_conn,
-        [source_chat_id],
+        tuple(chat_file_contexts.keys()),
         user_id=openwebui_user_id,
     )
     for row in rows:
         file_id = _row_text(row, "file_id")
         if not file_id:
             continue
+        source_chat_id = _row_text(row, "chat_id")
+        if not source_chat_id:
+            continue
+        contexts = chat_file_contexts.get(source_chat_id, [])
         source_message_id = _row_text(row, "message_id")
-        message_id = source_message_to_tldw_id.get(source_message_id) if source_message_id else None
-        if source_message_id and message_id is None:
-            continue
-        key = (conversation_id, message_id, file_id, "chat_file")
-        if key in seen_keys:
-            continue
-        seen_keys.add(key)
-        references.append(
-            OpenWebUIHydrationReference(
-                conversation_id=conversation_id,
-                message_id=message_id,
-                file_id=file_id,
-                raw_ref_index=None,
-                raw_ref=dict(row),
-                source="chat_file",
-                source_chat_id=source_chat_id,
-                source_message_id=source_message_id,
+        for conversation_id, source_message_to_tldw_id in contexts:
+            message_id = source_message_to_tldw_id.get(source_message_id) if source_message_id else None
+            if source_message_id and message_id is None:
+                continue
+            key = (conversation_id, message_id, file_id, "chat_file")
+            if key in seen_keys:
+                continue
+            seen_keys.add(key)
+            references.append(
+                OpenWebUIHydrationReference(
+                    conversation_id=conversation_id,
+                    message_id=message_id,
+                    file_id=file_id,
+                    raw_ref_index=None,
+                    raw_ref=dict(row),
+                    source="chat_file",
+                    source_chat_id=source_chat_id,
+                    source_message_id=source_message_id,
+                )
             )
-        )
 
 
 def _source_chat_id_from_conversation_settings(chacha_db: Any, conversation_id: str) -> str | None:

--- a/tldw_Server_API/app/core/Chatbooks/openwebui_hydration.py
+++ b/tldw_Server_API/app/core/Chatbooks/openwebui_hydration.py
@@ -1,0 +1,450 @@
+"""Preview helpers for hydrating OpenWebUI attachment references."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping
+
+from tldw_Server_API.app.core.DB_Management.OpenWebUI_DB import (
+    load_openwebui_chat_file_rows_for_chats,
+)
+from tldw_Server_API.app.core.Ingestion_Media_Processing.path_utils import resolve_safe_local_path
+from tldw_Server_API.app.core.config import get_ingestion_source_allowed_roots
+
+
+MAX_PREVIEW_WARNING_ITEMS = 1000
+
+
+@dataclass(frozen=True)
+class OpenWebUIDataRoot:
+    """Validated server-local OpenWebUI data root paths."""
+
+    root_path: Path
+    webui_db_path: Path
+    uploads_path: Path
+
+
+@dataclass(frozen=True)
+class OpenWebUIHydrationScope:
+    """Imported tldw scope to scan for preserved OpenWebUI references."""
+
+    conversation_ids: tuple[str, ...] = ()
+    openwebui_user_id: str | None = None
+
+
+@dataclass(frozen=True)
+class OpenWebUIHydrationReference:
+    """One OpenWebUI file reference found on an imported message."""
+
+    conversation_id: str
+    message_id: str | None
+    file_id: str
+    raw_ref_index: int | None
+    raw_ref: Any
+    source: str
+    source_chat_id: str | None = None
+    source_message_id: str | None = None
+
+
+@dataclass(frozen=True)
+class OpenWebUIHydrationResolvedFile:
+    """Path-resolution result for one OpenWebUI file row."""
+
+    file_id: str | None
+    filename: str | None
+    path: Path | None
+    status: str
+    source: str | None = None
+    file_kind: str | None = None
+    mime_type: str | None = None
+    warning_codes: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class OpenWebUIHydrationPreviewItem:
+    """User-safe preview item for a reference warning or resolution state."""
+
+    conversation_id: str | None
+    message_id: str | None
+    file_id: str | None
+    status: str
+    warning_code: str | None = None
+    raw_ref_index: int | None = None
+    source: str | None = None
+    raw_ref_shape: str | None = None
+
+
+@dataclass(frozen=True)
+class OpenWebUIHydrationPreview:
+    """Preview summary for OpenWebUI attachment hydration."""
+
+    references: tuple[OpenWebUIHydrationReference, ...] = ()
+    items: tuple[OpenWebUIHydrationPreviewItem, ...] = ()
+    warnings: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class OpenWebUIHydrationResult:
+    """Final result placeholder for later hydration stages."""
+
+    items: tuple[OpenWebUIHydrationPreviewItem, ...] = ()
+    warnings: tuple[str, ...] = ()
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+def validate_openwebui_data_root(root: str | Path, *, require_uploads: bool = False) -> OpenWebUIDataRoot:
+    """Validate that an OpenWebUI data root is under configured allowed roots."""
+    candidate = Path(root).expanduser()
+    if not candidate.is_absolute():
+        candidate = Path.cwd() / candidate
+    resolved_candidate = candidate.resolve(strict=False)
+
+    allowed_roots = get_ingestion_source_allowed_roots(reload=True)
+    if not allowed_roots:
+        raise ValueError("No ingestion source allowed roots are configured.")
+
+    safe_root: Path | None = None
+    for allowed_root in allowed_roots:
+        safe_root = resolve_safe_local_path(resolved_candidate, allowed_root)
+        if safe_root is not None:
+            break
+    if safe_root is None:
+        raise ValueError("OpenWebUI data root must resolve under one of the configured allowed roots.")
+    if not safe_root.exists():
+        raise ValueError("OpenWebUI data root does not exist.")
+    if not safe_root.is_dir():
+        raise ValueError("OpenWebUI data root is not a directory.")
+
+    webui_db_path = resolve_safe_local_path(safe_root / "webui.db", safe_root)
+    if webui_db_path is None or not webui_db_path.is_file():
+        raise ValueError("OpenWebUI data root must contain webui.db.")
+
+    uploads_path = resolve_safe_local_path(safe_root / "uploads", safe_root)
+    if uploads_path is None:
+        raise ValueError("OpenWebUI uploads path is not safe.")
+    if require_uploads and not uploads_path.is_dir():
+        raise ValueError("OpenWebUI data root must contain uploads when file bytes are needed.")
+
+    return OpenWebUIDataRoot(
+        root_path=safe_root,
+        webui_db_path=webui_db_path,
+        uploads_path=uploads_path,
+    )
+
+
+def resolve_openwebui_file_path(
+    file_row: Mapping[str, Any],
+    data_root: OpenWebUIDataRoot,
+) -> OpenWebUIHydrationResolvedFile:
+    """Resolve an OpenWebUI file row to a safe local source file path."""
+    file_id = _row_text(file_row, "id")
+    filename = _row_text(file_row, "filename")
+    raw_path = _row_text(file_row, "path")
+
+    if raw_path:
+        resolved_from_path = _resolve_declared_file_path(raw_path, data_root)
+        if resolved_from_path is None:
+            return OpenWebUIHydrationResolvedFile(
+                file_id=file_id,
+                filename=filename,
+                path=None,
+                status="path_rejected",
+                warning_codes=("path_rejected",),
+            )
+        if resolved_from_path.is_file():
+            file_kind, mime_type = _classify_file_path(resolved_from_path)
+            return OpenWebUIHydrationResolvedFile(
+                file_id=file_id,
+                filename=filename,
+                path=resolved_from_path,
+                status="resolved",
+                source="file_path",
+                file_kind=file_kind,
+                mime_type=mime_type,
+            )
+
+    fallback = _resolve_uploads_id_filename_fallback(file_id=file_id, filename=filename, data_root=data_root)
+    if fallback is not None:
+        file_kind, mime_type = _classify_file_path(fallback)
+        return OpenWebUIHydrationResolvedFile(
+            file_id=file_id,
+            filename=filename,
+            path=fallback,
+            status="resolved",
+            source="uploads_id_filename",
+            file_kind=file_kind,
+            mime_type=mime_type,
+        )
+
+    return OpenWebUIHydrationResolvedFile(
+        file_id=file_id,
+        filename=filename,
+        path=None,
+        status="missing_file",
+        warning_codes=("missing_file",),
+    )
+
+
+def extract_openwebui_hydration_references(
+    chacha_db: Any,
+    scope: OpenWebUIHydrationScope,
+    *,
+    openwebui_conn: sqlite3.Connection | None = None,
+) -> OpenWebUIHydrationPreview:
+    """Extract preserved OpenWebUI file references from imported message metadata."""
+    references: list[OpenWebUIHydrationReference] = []
+    items: list[OpenWebUIHydrationPreviewItem] = []
+    seen_keys: set[tuple[str, str | None, str, str]] = set()
+
+    for conversation_id in scope.conversation_ids:
+        messages = _load_conversation_messages(chacha_db, conversation_id)
+        message_ids = [str(message["id"]) for message in messages if message.get("id") is not None]
+        metadata_by_message_id = _load_message_metadata_map(chacha_db, message_ids)
+        source_message_to_tldw_id: dict[str, str] = {}
+
+        for message_id in message_ids:
+            import_meta = _openwebui_import_metadata(metadata_by_message_id.get(message_id))
+            if not import_meta:
+                continue
+            source_message_id = _coerce_optional_text(import_meta.get("source_message_id"))
+            if source_message_id:
+                source_message_to_tldw_id[source_message_id] = message_id
+            raw_refs = import_meta.get("attachment_refs")
+            if not isinstance(raw_refs, list):
+                raw_refs = []
+            for raw_ref_index, raw_ref in enumerate(raw_refs):
+                file_id = _file_id_from_reference(raw_ref)
+                if file_id is None:
+                    _append_preview_warning(
+                        items,
+                        OpenWebUIHydrationPreviewItem(
+                            conversation_id=conversation_id,
+                            message_id=message_id,
+                            file_id=None,
+                            status="unsupported_reference_shape",
+                            warning_code="unsupported_reference_shape",
+                            raw_ref_index=raw_ref_index,
+                            source="message_metadata",
+                            raw_ref_shape=type(raw_ref).__name__,
+                        ),
+                    )
+                    continue
+                key = (conversation_id, message_id, file_id, "message_metadata")
+                if key in seen_keys:
+                    continue
+                seen_keys.add(key)
+                references.append(
+                    OpenWebUIHydrationReference(
+                        conversation_id=conversation_id,
+                        message_id=message_id,
+                        file_id=file_id,
+                        raw_ref_index=raw_ref_index,
+                        raw_ref=raw_ref,
+                        source="message_metadata",
+                        source_message_id=source_message_id,
+                    )
+                )
+
+        if openwebui_conn is not None:
+            _extend_references_from_chat_file_fallback(
+                references=references,
+                seen_keys=seen_keys,
+                openwebui_conn=openwebui_conn,
+                chacha_db=chacha_db,
+                conversation_id=conversation_id,
+                source_message_to_tldw_id=source_message_to_tldw_id,
+                openwebui_user_id=scope.openwebui_user_id,
+            )
+
+    return OpenWebUIHydrationPreview(
+        references=tuple(references),
+        items=tuple(items),
+    )
+
+
+def _resolve_declared_file_path(raw_path: str, data_root: OpenWebUIDataRoot) -> Path | None:
+    candidate = Path(raw_path)
+    roots = (data_root.root_path,)
+    if candidate.is_absolute() or not candidate.parts or candidate.parts[0] != "uploads":
+        roots = (data_root.root_path, data_root.uploads_path)
+    for base_dir in roots:
+        resolved = resolve_safe_local_path(candidate, base_dir)
+        if resolved is not None:
+            return resolved
+    return None
+
+
+def _resolve_uploads_id_filename_fallback(
+    *,
+    file_id: str | None,
+    filename: str | None,
+    data_root: OpenWebUIDataRoot,
+) -> Path | None:
+    if not file_id or not filename:
+        return None
+    safe_filename = Path(filename).name
+    if not safe_filename or safe_filename in {".", ".."}:
+        return None
+    fallback = data_root.uploads_path / f"{file_id}_{safe_filename}"
+    resolved = resolve_safe_local_path(fallback, data_root.uploads_path)
+    if resolved is None or not resolved.is_file():
+        return None
+    return resolved
+
+
+def _classify_file_path(path: Path) -> tuple[str, str | None]:
+    try:
+        with path.open("rb") as handle:
+            header = handle.read(16)
+    except OSError:
+        return "unknown", None
+
+    if header.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image", "image/png"
+    if header.startswith(b"\xff\xd8\xff"):
+        return "image", "image/jpeg"
+    if header.startswith((b"GIF87a", b"GIF89a")):
+        return "image", "image/gif"
+    if len(header) >= 12 and header.startswith(b"RIFF") and header[8:12] == b"WEBP":
+        return "image", "image/webp"
+    if header.startswith(b"%PDF"):
+        return "document", "application/pdf"
+    return "file", None
+
+
+def _load_conversation_messages(chacha_db: Any, conversation_id: str) -> list[dict[str, Any]]:
+    messages = chacha_db.get_messages_for_conversation(
+        conversation_id,
+        limit=1000,
+        offset=0,
+        order_by_timestamp="ASC",
+        include_deleted=False,
+    )
+    return [message for message in messages if isinstance(message, dict)]
+
+
+def _load_message_metadata_map(chacha_db: Any, message_ids: list[str]) -> dict[str, dict[str, Any]]:
+    if hasattr(chacha_db, "get_message_metadata_map"):
+        metadata_map = chacha_db.get_message_metadata_map(message_ids)
+        if isinstance(metadata_map, dict):
+            return metadata_map
+    metadata_by_message_id: dict[str, dict[str, Any]] = {}
+    if not hasattr(chacha_db, "get_message_metadata"):
+        return metadata_by_message_id
+    for message_id in message_ids:
+        metadata = chacha_db.get_message_metadata(message_id)
+        if isinstance(metadata, dict):
+            metadata_by_message_id[message_id] = metadata
+    return metadata_by_message_id
+
+
+def _openwebui_import_metadata(metadata: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(metadata, dict):
+        return None
+    extra = metadata.get("extra")
+    if not isinstance(extra, dict):
+        return None
+    openwebui_import = extra.get("openwebui_import")
+    if isinstance(openwebui_import, dict):
+        return openwebui_import
+    return None
+
+
+def _extend_references_from_chat_file_fallback(
+    *,
+    references: list[OpenWebUIHydrationReference],
+    seen_keys: set[tuple[str, str | None, str, str]],
+    openwebui_conn: sqlite3.Connection,
+    chacha_db: Any,
+    conversation_id: str,
+    source_message_to_tldw_id: dict[str, str],
+    openwebui_user_id: str | None,
+) -> None:
+    source_chat_id = _source_chat_id_from_conversation_settings(chacha_db, conversation_id)
+    if not source_chat_id:
+        return
+    rows = load_openwebui_chat_file_rows_for_chats(
+        openwebui_conn,
+        [source_chat_id],
+        user_id=openwebui_user_id,
+    )
+    for row in rows:
+        file_id = _row_text(row, "file_id")
+        if not file_id:
+            continue
+        source_message_id = _row_text(row, "message_id")
+        message_id = source_message_to_tldw_id.get(source_message_id) if source_message_id else None
+        if source_message_id and message_id is None:
+            continue
+        key = (conversation_id, message_id, file_id, "chat_file")
+        if key in seen_keys:
+            continue
+        seen_keys.add(key)
+        references.append(
+            OpenWebUIHydrationReference(
+                conversation_id=conversation_id,
+                message_id=message_id,
+                file_id=file_id,
+                raw_ref_index=None,
+                raw_ref=dict(row),
+                source="chat_file",
+                source_chat_id=source_chat_id,
+                source_message_id=source_message_id,
+            )
+        )
+
+
+def _source_chat_id_from_conversation_settings(chacha_db: Any, conversation_id: str) -> str | None:
+    if not hasattr(chacha_db, "get_conversation_settings"):
+        return None
+    settings_record = chacha_db.get_conversation_settings(conversation_id)
+    if not isinstance(settings_record, dict):
+        return None
+    settings = settings_record.get("settings")
+    if not isinstance(settings, dict):
+        return None
+    import_meta = settings.get("openwebui_import")
+    if not isinstance(import_meta, dict):
+        return None
+    metadata = import_meta.get("metadata")
+    if isinstance(metadata, dict):
+        row_id = _coerce_optional_text(metadata.get("row_id"))
+        if row_id:
+            return row_id
+    return None
+
+
+def _file_id_from_reference(raw_ref: Any) -> str | None:
+    if isinstance(raw_ref, str):
+        return _coerce_optional_text(raw_ref)
+    if isinstance(raw_ref, dict):
+        for key in ("id", "file_id", "fileId"):
+            file_id = _coerce_optional_text(raw_ref.get(key))
+            if file_id:
+                return file_id
+    return None
+
+
+def _append_preview_warning(
+    items: list[OpenWebUIHydrationPreviewItem],
+    item: OpenWebUIHydrationPreviewItem,
+) -> None:
+    if len(items) < MAX_PREVIEW_WARNING_ITEMS:
+        items.append(item)
+
+
+def _row_text(row: Mapping[str, Any], key: str) -> str | None:
+    try:
+        value = row[key]
+    except (KeyError, IndexError):
+        return None
+    return _coerce_optional_text(value)
+
+
+def _coerce_optional_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None

--- a/tldw_Server_API/app/core/Chatbooks/openwebui_hydration_jobs.py
+++ b/tldw_Server_API/app/core/Chatbooks/openwebui_hydration_jobs.py
@@ -1,0 +1,51 @@
+"""Core Jobs helpers for OpenWebUI attachment hydration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+CHATBOOKS_DOMAIN = "chatbooks"
+OPENWEBUI_ATTACHMENT_HYDRATION_JOB_TYPE = "openwebui_attachment_hydration"
+
+
+def create_openwebui_hydration_job(
+    jobs_manager: Any,
+    payload: dict[str, Any],
+    *,
+    owner_user_id: str,
+    request_id: str | None = None,
+) -> dict[str, Any]:
+    """Enqueue an OpenWebUI attachment hydration job in core Jobs."""
+    return jobs_manager.create_job(
+        domain=CHATBOOKS_DOMAIN,
+        queue="default",
+        job_type=OPENWEBUI_ATTACHMENT_HYDRATION_JOB_TYPE,
+        payload=dict(payload),
+        owner_user_id=str(owner_user_id),
+        priority=5,
+        max_retries=3,
+        request_id=request_id,
+    )
+
+
+def get_openwebui_hydration_job(jobs_manager: Any, job_id: str) -> dict[str, Any] | None:
+    """Fetch an OpenWebUI hydration job by numeric id or uuid and verify its type."""
+    raw_job_id = str(job_id).strip()
+    if not raw_job_id:
+        return None
+    job: dict[str, Any] | None
+    if raw_job_id.isdigit():
+        job = jobs_manager.get_job(int(raw_job_id))
+    else:
+        get_by_uuid = getattr(jobs_manager, "get_job_by_uuid", None)
+        if get_by_uuid is None:
+            return None
+        job = get_by_uuid(raw_job_id)
+    if not isinstance(job, dict):
+        return None
+    if str(job.get("domain") or "") != CHATBOOKS_DOMAIN:
+        return None
+    if str(job.get("job_type") or "") != OPENWEBUI_ATTACHMENT_HYDRATION_JOB_TYPE:
+        return None
+    return job

--- a/tldw_Server_API/app/core/Chatbooks/services/jobs_worker.py
+++ b/tldw_Server_API/app/core/Chatbooks/services/jobs_worker.py
@@ -52,7 +52,13 @@ from tldw_Server_API.app.core.Jobs.worker_sdk import WorkerConfig, WorkerSDK
 
 _CHATBOOKS_DOMAIN = "chatbooks"
 _MAX_HYDRATION_JOB_WARNINGS = 100
-_ABSOLUTE_PATH_RE = re.compile(r"(?<![A-Za-z0-9_])/(?:[^\s,;:)\"']+/?)+")
+_POSIX_ABS_PATH_RE = re.compile(r"(?<![A-Za-z0-9_])/(?:[^\s,;:)\"']+/?)+")
+_WINDOWS_ABS_PATH_RE = re.compile(
+    r"(?<![A-Za-z0-9_])[A-Za-z]:[\\/](?:[^\s,;:)\"']+[\\/]?)+"
+)
+_UNC_PATH_RE = re.compile(
+    r"(?<![A-Za-z0-9_])\\\\[^\\/\s,;:)\"']+(?:[\\/][^\s,;:)\"']+)+"
+)
 
 # Ensure worker runs in core backend mode.
 if os.getenv("CHATBOOKS_JOBS_BACKEND") not in {"", "core"}:
@@ -160,7 +166,10 @@ def _raise_import_job_failed(service: ChatbookService, job_id: str, message: str
 
 def _redact_hydration_warning(value: object) -> str:
     """Redact local absolute paths before persisting hydration warnings to Jobs."""
-    return _ABSOLUTE_PATH_RE.sub("[redacted-path]", str(value))
+    text = str(value)
+    text = _POSIX_ABS_PATH_RE.sub("[redacted-path]", text)
+    text = _WINDOWS_ABS_PATH_RE.sub("[redacted-path]", text)
+    return _UNC_PATH_RE.sub("[redacted-path]", text)
 
 
 def _hydration_job_id(job: dict[str, Any]) -> str | None:

--- a/tldw_Server_API/app/core/Chatbooks/services/jobs_worker.py
+++ b/tldw_Server_API/app/core/Chatbooks/services/jobs_worker.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import os
+import re
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -41,12 +42,17 @@ from tldw_Server_API.app.core.Chatbooks.chatbook_models import (
     ImportStatus,
 )
 from tldw_Server_API.app.core.Chatbooks.chatbook_service import ChatbookService
+from tldw_Server_API.app.core.Chatbooks.openwebui_hydration_jobs import (
+    OPENWEBUI_ATTACHMENT_HYDRATION_JOB_TYPE,
+)
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.core.Jobs.manager import JobManager
 from tldw_Server_API.app.core.Jobs.worker_sdk import WorkerConfig, WorkerSDK
 
 _CHATBOOKS_DOMAIN = "chatbooks"
+_MAX_HYDRATION_JOB_WARNINGS = 100
+_ABSOLUTE_PATH_RE = re.compile(r"(?<![A-Za-z0-9_])/(?:[^\s,;:)\"']+/?)+")
 
 # Ensure worker runs in core backend mode.
 if os.getenv("CHATBOOKS_JOBS_BACKEND") not in {"", "core"}:
@@ -150,6 +156,69 @@ def _mark_import_job_failed(service: ChatbookService, job_id: str, message: str)
 def _raise_import_job_failed(service: ChatbookService, job_id: str, message: str) -> None:
     _mark_import_job_failed(service, job_id, message)
     raise ChatbooksJobError(message, retryable=False)
+
+
+def _redact_hydration_warning(value: object) -> str:
+    """Redact local absolute paths before persisting hydration warnings to Jobs."""
+    return _ABSOLUTE_PATH_RE.sub("[redacted-path]", str(value))
+
+
+def _hydration_job_id(job: dict[str, Any]) -> str | None:
+    """Return a stable job identifier for hydration metadata."""
+    raw_job_id = job.get("uuid") or job.get("id") or job.get("job_id")
+    text = str(raw_job_id or "").strip()
+    return text or None
+
+
+def _openwebui_hydration_job_summary(result: Any) -> dict[str, Any]:
+    """Normalize a hydration service result into a JSON-safe core Jobs result."""
+    payload = result if isinstance(result, dict) else {}
+    summary = payload.get("summary") if isinstance(payload.get("summary"), dict) else {}
+    warnings = payload.get("warnings") if isinstance(payload.get("warnings"), list) else []
+    return {
+        "referenced_files": int(summary.get("referenced_files") or 0),
+        "resolved_files": int(summary.get("resolved_files") or 0),
+        "hydrated_images": int(summary.get("hydrated_images") or 0),
+        "registered_media_files": int(summary.get("registered_media_files") or 0),
+        "already_hydrated": int(summary.get("already_hydrated") or 0),
+        "missing_files": int(summary.get("missing_files") or 0),
+        "unsupported_files": int(summary.get("unsupported_files") or 0),
+        "failed_files": int(summary.get("failed_files") or 0),
+        "processed_files": int(summary.get("processed_files") or 0),
+        "warnings": [
+            _redact_hydration_warning(warning)
+            for warning in warnings[:_MAX_HYDRATION_JOB_WARNINGS]
+        ],
+    }
+
+
+async def _handle_openwebui_attachment_hydration(
+    service: ChatbookService,
+    payload: dict[str, Any],
+    job: dict[str, Any],
+) -> dict[str, Any]:
+    """Run one OpenWebUI attachment hydration job."""
+    openwebui_data_root = str(payload.get("openwebui_data_root") or "").strip()
+    if not openwebui_data_root:
+        raise ChatbooksJobError("Missing openwebui_data_root", retryable=False)
+    scope = payload.get("scope")
+    if scope is None:
+        scope = {}
+    if not isinstance(scope, dict):
+        raise ChatbooksJobError("OpenWebUI hydration scope must be an object", retryable=False)
+
+    try:
+        result = await asyncio.to_thread(
+            service.run_openwebui_attachment_hydration,
+            openwebui_data_root=openwebui_data_root,
+            scope=scope,
+            process_supported_files=bool(payload.get("process_supported_files", False)),
+            job_id=_hydration_job_id(job),
+        )
+    except ValueError as exc:
+        raise ChatbooksJobError(str(exc), retryable=False) from exc
+
+    return _openwebui_hydration_job_summary(result)
 
 
 async def _handle_export(service: ChatbookService, payload: dict[str, Any], job_id: str) -> dict[str, Any]:
@@ -356,6 +425,9 @@ async def _handle_job(job: dict[str, Any]) -> dict[str, Any]:
     service = _get_service(user_id)
 
     action = str(payload.get("action") or job.get("job_type") or "").lower()
+    if action == OPENWEBUI_ATTACHMENT_HYDRATION_JOB_TYPE:
+        return await _handle_openwebui_attachment_hydration(service, payload, job)
+
     chatbooks_job_id = str(payload.get("chatbooks_job_id") or "").strip()
     if not chatbooks_job_id:
         raise ChatbooksJobError("Missing chatbooks_job_id", retryable=False)

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -23738,6 +23738,7 @@ for _character_store_method in (
 for _message_store_method in (
     "add_message",
     "_insert_message_images",
+    "append_message_image",
     "get_message_images",
     "get_message_conversation_id",
     "get_message_by_id",

--- a/tldw_Server_API/app/core/DB_Management/OpenWebUI_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/OpenWebUI_DB.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sqlite3
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -37,10 +38,36 @@ REQUIRED_SCHEMA: dict[str, set[str]] = {
         "folder_id",
     },
 }
+HYDRATION_FILE_SCHEMA: dict[str, set[str]] = {
+    "file": {
+        "id",
+        "user_id",
+        "hash",
+        "filename",
+        "path",
+        "data",
+        "meta",
+        "created_at",
+        "updated_at",
+    },
+}
+HYDRATION_CHAT_FILE_SCHEMA: dict[str, set[str]] = {
+    "chat_file": {
+        "id",
+        "chat_id",
+        "file_id",
+        "message_id",
+        "user_id",
+        "created_at",
+        "updated_at",
+    },
+}
 TABLE_INFO_QUERIES = {
     "user": "PRAGMA table_info(user)",
     "folder": "PRAGMA table_info(folder)",
     "chat": "PRAGMA table_info(chat)",
+    "file": "PRAGMA table_info(file)",
+    "chat_file": "PRAGMA table_info(chat_file)",
 }
 
 
@@ -80,23 +107,37 @@ def open_validated_openwebui_db(file_path: str | Path) -> Iterator[sqlite3.Conne
 
 def validate_openwebui_schema(conn: sqlite3.Connection) -> None:
     """Validate the minimal OpenWebUI source tables required for chat import."""
+    _validate_required_schema(conn, REQUIRED_SCHEMA)
+
+
+def validate_openwebui_file_schema(conn: sqlite3.Connection) -> None:
+    """Validate OpenWebUI source tables required for attachment hydration."""
+    _validate_required_schema(conn, HYDRATION_FILE_SCHEMA | HYDRATION_CHAT_FILE_SCHEMA)
+
+
+def _validate_required_schema(conn: sqlite3.Connection, required_schema: dict[str, set[str]]) -> None:
+    """Validate that a source database contains the required tables and columns."""
     table_rows = conn.execute(
-        "SELECT name FROM sqlite_master WHERE type = 'table' AND name IN (?, ?, ?)",
-        tuple(REQUIRED_SCHEMA.keys()),
+        "SELECT name FROM sqlite_master WHERE type = 'table'",
     ).fetchall()
     tables = {str(row["name"]) for row in table_rows}
-    missing_tables = sorted(set(REQUIRED_SCHEMA) - tables)
+    missing_tables = sorted(set(required_schema) - tables)
     if missing_tables:
         missing = ", ".join(missing_tables)
         raise ValueError(f"missing required OpenWebUI table: {missing}")
 
-    for table, required_columns in REQUIRED_SCHEMA.items():
+    for table, required_columns in required_schema.items():
         column_rows = conn.execute(TABLE_INFO_QUERIES[table]).fetchall()
         columns = {str(row["name"]) for row in column_rows}
         missing_columns = sorted(required_columns - columns)
         if missing_columns:
             missing = ", ".join(missing_columns)
             raise ValueError(f"missing required OpenWebUI column in {table}: {missing}")
+
+
+def _normalize_ids(ids: list[str] | tuple[str, ...]) -> list[str]:
+    """Return string ids for query binding and drop empty batches early."""
+    return [str(row_id) for row_id in ids]
 
 
 def load_openwebui_users(conn: sqlite3.Connection) -> list[sqlite3.Row]:
@@ -155,3 +196,66 @@ def load_openwebui_folders_for_user(conn: sqlite3.Connection, user_id: str) -> d
         (user_id,),
     ).fetchall()
     return {str(row["id"]): row for row in rows}
+
+
+def load_openwebui_file_rows_for_ids(
+    conn: sqlite3.Connection,
+    file_ids: list[str] | tuple[str, ...],
+    user_id: str | None = None,
+) -> list[sqlite3.Row]:
+    """Return OpenWebUI file rows for the supplied file ids."""
+    normalized_file_ids = _normalize_ids(file_ids)
+    if not normalized_file_ids:
+        return []
+
+    return list(
+        conn.execute(
+            """
+            SELECT id, user_id, hash, filename, path, data, meta, created_at, updated_at
+            FROM file
+            WHERE id IN (SELECT CAST(value AS TEXT) FROM json_each(?))
+              AND (? IS NULL OR user_id = ?)
+            ORDER BY id
+            """,
+            (json.dumps(normalized_file_ids), user_id, user_id),
+        ).fetchall()
+    )
+
+
+def load_openwebui_chat_file_rows_for_chats(
+    conn: sqlite3.Connection,
+    chat_ids: list[str] | tuple[str, ...],
+    user_id: str | None = None,
+) -> list[sqlite3.Row]:
+    """Return OpenWebUI chat-file link rows for the supplied chat ids."""
+    normalized_chat_ids = _normalize_ids(chat_ids)
+    if not normalized_chat_ids:
+        return []
+
+    return list(
+        conn.execute(
+            """
+            SELECT id, chat_id, file_id, message_id, user_id, created_at, updated_at
+            FROM chat_file
+            WHERE chat_id IN (SELECT CAST(value AS TEXT) FROM json_each(?))
+              AND (? IS NULL OR user_id = ?)
+            ORDER BY chat_id, id
+            """,
+            (json.dumps(normalized_chat_ids), user_id, user_id),
+        ).fetchall()
+    )
+
+
+def iter_openwebui_files_for_user(conn: sqlite3.Connection, user_id: str) -> Iterator[sqlite3.Row]:
+    """Iterate all OpenWebUI file rows for a source user."""
+    return iter(
+        conn.execute(
+            """
+            SELECT id, user_id, hash, filename, path, data, meta, created_at, updated_at
+            FROM file
+            WHERE user_id = ?
+            ORDER BY COALESCE(updated_at, created_at, 0), id
+            """,
+            (user_id,),
+        )
+    )

--- a/tldw_Server_API/app/core/DB_Management/chacha/message_store.py
+++ b/tldw_Server_API/app/core/DB_Management/chacha/message_store.py
@@ -204,6 +204,55 @@ class MessageStore:
         )
         self._db.execute_many(query, params, commit=False)
 
+    def append_message_image(
+        self,
+        message_id: str,
+        image_bytes: bytes,
+        mime_type: str,
+        *,
+        commit: bool = True,
+    ) -> int:
+        """Append one image to a message after the current maximum image position."""
+        if isinstance(image_bytes, memoryview):
+            image_bytes = image_bytes.tobytes()
+        if not isinstance(image_bytes, (bytes, bytearray)):
+            raise InputError("image_bytes must be bytes-like.")  # noqa: TRY003
+        if not mime_type:
+            raise InputError("mime_type is required for message images.")  # noqa: TRY003
+
+        try:
+            from tldw_Server_API.app.core.config import settings  # noqa: E402
+
+            max_image_bytes = int(settings.get("MAX_MESSAGE_IMAGE_BYTES", 5 * 1024 * 1024))
+        except _CHACHA_NONCRITICAL_EXCEPTIONS:
+            max_image_bytes = 5 * 1024 * 1024
+        if len(image_bytes) > max_image_bytes:
+            raise InputError(  # noqa: TRY003
+                f"Message image attachment exceeds maximum size of {max_image_bytes} bytes"
+            )
+
+        def _append() -> int:
+            cursor = self._db.execute_query(
+                "SELECT COALESCE(MAX(position), -1) + 1 FROM message_images WHERE message_id = ?",
+                (message_id,),
+            )
+            row = cursor.fetchone()
+            position = int(row[0] if row is not None else 0)
+            self._db.execute_query(
+                """
+                INSERT INTO message_images (message_id, position, image_data, image_mime_type)
+                VALUES (?, ?, ?, ?)
+                """,
+                (message_id, position, bytes(image_bytes), str(mime_type)),
+                commit=False,
+            )
+            return position
+
+        if not commit:
+            return _append()
+        with self._db.transaction():
+            return _append()
+
     def get_message_images(self, message_id: str) -> list[dict[str, Any]]:
         """Fetch all images associated with a message, ordered by position."""
         try:

--- a/tldw_Server_API/app/core/DB_Management/chacha/message_store.py
+++ b/tldw_Server_API/app/core/DB_Management/chacha/message_store.py
@@ -231,7 +231,7 @@ class MessageStore:
                 f"Message image attachment exceeds maximum size of {max_image_bytes} bytes"
             )
 
-        def _append() -> int:
+        def _append_once() -> int:
             cursor = self._db.execute_query(
                 "SELECT COALESCE(MAX(position), -1) + 1 FROM message_images WHERE message_id = ?",
                 (message_id,),
@@ -248,10 +248,24 @@ class MessageStore:
             )
             return position
 
+        def _append_with_retries(*, transactional: bool) -> int:
+            last_error: Exception | None = None
+            for _ in range(5):
+                try:
+                    if transactional:
+                        with self._db.transaction():
+                            return _append_once()
+                    return _append_once()
+                except sqlite3.IntegrityError as exc:
+                    last_error = exc
+                    continue
+            raise ConflictError(  # noqa: TRY003
+                f"Concurrent append conflict for message image positions on message_id={message_id}",
+            ) from last_error
+
         if not commit:
-            return _append()
-        with self._db.transaction():
-            return _append()
+            return _append_with_retries(transactional=False)
+        return _append_with_retries(transactional=True)
 
     def get_message_images(self, message_id: str) -> list[dict[str, Any]]:
         """Fetch all images associated with a message, ordered by position."""

--- a/tldw_Server_API/app/core/DB_Management/media_db/repositories/media_repository.py
+++ b/tldw_Server_API/app/core/DB_Management/media_db/repositories/media_repository.py
@@ -110,6 +110,7 @@ class MediaRepository:
         if source_hash is not None:
             source_hash_str = str(source_hash).strip()
             source_hash_norm = source_hash_str if source_hash_str else None
+        owner_lookup_value = str(owner_user_id).strip() if owner_user_id is not None else None
         raw_url_input = str(url).strip() if url is not None else ""
         if raw_url_input:
             dedupe_url_candidates = media_dedupe_url_candidates(raw_url_input)
@@ -298,11 +299,19 @@ class MediaRepository:
                 )
 
                 if not row:
-                    row = _fetchone(
-                        "SELECT id, uuid, version, url, content_hash, source_hash, visibility, owner_user_id, org_id, team_id "
-                        "FROM Media WHERE content_hash = ? AND deleted = 0 LIMIT 1",
-                        (content_hash,),
-                    )
+                    if owner_lookup_value:
+                        row = _fetchone(
+                            "SELECT id, uuid, version, url, content_hash, source_hash, visibility, owner_user_id, org_id, team_id "
+                            "FROM Media WHERE content_hash = ? AND deleted = 0 "
+                            "AND COALESCE(CAST(owner_user_id AS TEXT), client_id) = ? LIMIT 1",
+                            (content_hash, owner_lookup_value),
+                        )
+                    else:
+                        row = _fetchone(
+                            "SELECT id, uuid, version, url, content_hash, source_hash, visibility, owner_user_id, org_id, team_id "
+                            "FROM Media WHERE content_hash = ? AND deleted = 0 LIMIT 1",
+                            (content_hash,),
+                        )
 
                 if row:
                     media_id = row["id"]

--- a/tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_api.py
+++ b/tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_api.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal, get_request_user
+from tldw_Server_API.app.api.v1.API_Deps.jobs_deps import get_job_manager
+from tldw_Server_API.app.api.v1.endpoints import chatbooks as chatbooks_mod
+from tldw_Server_API.app.api.v1.schemas import chatbook_schemas
+from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
+
+
+pytestmark = pytest.mark.unit
+
+
+class _DummyChatbookService:
+    db = None
+
+    def __init__(self) -> None:
+        self.preview_calls: list[dict[str, Any]] = []
+
+    def preview_openwebui_attachment_hydration(self, **kwargs) -> dict[str, Any]:
+        self.preview_calls.append(kwargs)
+        return {
+            "summary": {
+                "referenced_files": 1,
+                "resolved_files": 1,
+                "image_files": 1,
+                "media_files": 0,
+                "missing_files": 0,
+                "unsupported_files": 0,
+                "failed_files": 0,
+                "warning_count": 1,
+            },
+            "items": [
+                {
+                    "conversation_id": "conv-a",
+                    "message_id": "msg-a",
+                    "file_id": "file-a",
+                    "status": "resolved",
+                    "source": "message_metadata",
+                    "file_kind": "image",
+                    "mime_type": "image/png",
+                    "source_path": "/private/openwebui/uploads/file-a.png",
+                }
+            ],
+            "warnings": ["Resolved source at /private/openwebui/uploads/file-a.png"],
+        }
+
+
+class _FakeJobsManager:
+    def __init__(self) -> None:
+        self.created: list[dict[str, Any]] = []
+        self.rows: dict[int, dict[str, Any]] = {}
+        self.rows_by_uuid: dict[str, dict[str, Any]] = {}
+
+    def create_job(self, **kwargs) -> dict[str, Any]:
+        self.created.append(kwargs)
+        row = {
+            "id": len(self.created),
+            "uuid": f"job-uuid-{len(self.created)}",
+            "domain": kwargs["domain"],
+            "queue": kwargs["queue"],
+            "job_type": kwargs["job_type"],
+            "status": "queued",
+            "owner_user_id": kwargs["owner_user_id"],
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "payload": kwargs["payload"],
+            "result": None,
+            "error": None,
+        }
+        self.rows[int(row["id"])] = row
+        self.rows_by_uuid[str(row["uuid"])] = row
+        return row
+
+    def get_job(self, job_id: int) -> dict[str, Any] | None:
+        return self.rows.get(int(job_id))
+
+    def get_job_by_uuid(self, job_uuid: str) -> dict[str, Any] | None:
+        return self.rows_by_uuid.get(str(job_uuid))
+
+
+async def _user() -> User:
+    return User(id=1, username="tester", email=None, is_active=True)
+
+
+async def _other_user() -> User:
+    return User(id=2, username="other", email=None, is_active=True)
+
+
+async def _single_user_principal() -> AuthPrincipal:
+    return AuthPrincipal(kind="user", user_id=1, subject="single_user", roles=["admin"], permissions=["*"])
+
+
+async def _admin_principal() -> AuthPrincipal:
+    return AuthPrincipal(kind="user", user_id=1, roles=["admin"], permissions=[])
+
+
+async def _admin_flag_principal() -> AuthPrincipal:
+    return AuthPrincipal(kind="user", user_id=1, roles=[], permissions=[], is_admin=True)
+
+
+async def _non_admin_principal() -> AuthPrincipal:
+    return AuthPrincipal(kind="user", user_id=2, roles=[], permissions=[])
+
+
+def _make_app(
+    *,
+    service: _DummyChatbookService | None = None,
+    jobs: _FakeJobsManager | None = None,
+    principal_override=_single_user_principal,
+    user_override=_user,
+) -> FastAPI:
+    app = FastAPI()
+    app.include_router(chatbooks_mod.router, prefix="/api/v1")
+    app.dependency_overrides[chatbooks_mod.get_chatbook_service] = lambda: service or _DummyChatbookService()
+    app.dependency_overrides[get_request_user] = user_override
+    app.dependency_overrides[get_auth_principal] = principal_override
+    if jobs is not None:
+        app.dependency_overrides[get_job_manager] = lambda: jobs
+    return app
+
+
+def _hydration_payload() -> dict[str, Any]:
+    return {
+        "openwebui_data_root": "/srv/openwebui",
+        "scope": {
+            "conversation_ids": ["conv-a"],
+            "source_user_id": "ow-user",
+        },
+        "process_supported_files": False,
+    }
+
+
+def test_hydration_schema_rejects_empty_conversation_ids():
+    with pytest.raises(ValidationError):
+        chatbook_schemas.OpenWebUIHydrationPreviewRequest(
+            openwebui_data_root="/srv/openwebui",
+            scope={"conversation_ids": [""]},
+        )
+
+
+def test_hydration_schema_rejects_blank_source_user_id():
+    with pytest.raises(ValidationError):
+        chatbook_schemas.OpenWebUIHydrationPreviewRequest(
+            openwebui_data_root="/srv/openwebui",
+            scope={"source_user_id": "   "},
+        )
+
+
+def test_preview_allows_single_user_and_redacts_source_paths():
+    service = _DummyChatbookService()
+    app = _make_app(service=service, principal_override=_single_user_principal)
+
+    with TestClient(app) as client:
+        resp = client.post("/api/v1/chatbooks/openwebui/hydration/preview", json=_hydration_payload())
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["summary"]["referenced_files"] == 1
+    assert body["items"][0]["mime_type"] == "image/png"
+    assert "/private/openwebui" not in resp.text
+    assert service.preview_calls[0]["scope"]["conversation_ids"] == ["conv-a"]
+    assert service.preview_calls[0]["scope"]["source_user_id"] == "ow-user"
+    assert service.preview_calls[0]["process_supported_files"] is False
+
+
+def test_preview_rejects_multi_user_non_admin():
+    app = _make_app(principal_override=_non_admin_principal)
+
+    with TestClient(app) as client:
+        resp = client.post("/api/v1/chatbooks/openwebui/hydration/preview", json=_hydration_payload())
+
+    assert resp.status_code == 403, resp.text
+
+
+def test_hydration_job_creation_enqueues_core_job():
+    jobs = _FakeJobsManager()
+    app = _make_app(jobs=jobs, principal_override=_admin_flag_principal)
+
+    with TestClient(app) as client:
+        resp = client.post("/api/v1/chatbooks/openwebui/hydration/jobs", json=_hydration_payload())
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["job_type"] == "openwebui_attachment_hydration"
+    assert jobs.created[0]["domain"] == "chatbooks"
+    assert jobs.created[0]["job_type"] == "openwebui_attachment_hydration"
+    assert jobs.created[0]["owner_user_id"] == "1"
+    assert jobs.created[0]["payload"]["scope"]["conversation_ids"] == ["conv-a"]
+
+
+def test_hydration_job_status_rejects_multi_user_non_admin():
+    jobs = _FakeJobsManager()
+    jobs.create_job(
+        domain="chatbooks",
+        queue="default",
+        job_type="openwebui_attachment_hydration",
+        payload=_hydration_payload(),
+        owner_user_id="1",
+    )
+    app = _make_app(jobs=jobs, principal_override=_non_admin_principal, user_override=_other_user)
+
+    with TestClient(app) as client:
+        resp = client.get("/api/v1/chatbooks/openwebui/hydration/jobs/1")
+
+    assert resp.status_code == 403, resp.text
+
+
+def test_hydration_job_status_returns_admin_visible_job():
+    jobs = _FakeJobsManager()
+    job = jobs.create_job(
+        domain="chatbooks",
+        queue="default",
+        job_type="openwebui_attachment_hydration",
+        payload=_hydration_payload(),
+        owner_user_id="2",
+    )
+    job["result"] = {"warnings": ["Copied /private/openwebui/uploads/file-a.png"]}
+    job["error"] = "Failed at /private/openwebui/uploads/file-a.png"
+    app = _make_app(jobs=jobs, principal_override=_admin_principal, user_override=_user)
+
+    with TestClient(app) as client:
+        resp = client.get("/api/v1/chatbooks/openwebui/hydration/jobs/job-uuid-1")
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["job_uuid"] == "job-uuid-1"
+    assert resp.json()["owner_user_id"] == "2"
+    assert "/private/openwebui" not in resp.text

--- a/tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_api.py
+++ b/tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_api.py
@@ -95,7 +95,7 @@ async def _other_user() -> User:
 
 
 async def _single_user_principal() -> AuthPrincipal:
-    return AuthPrincipal(kind="user", user_id=1, subject="single_user", roles=["admin"], permissions=["*"])
+    return AuthPrincipal(kind="user", user_id=1, subject="single_user", roles=[], permissions=[])
 
 
 async def _admin_principal() -> AuthPrincipal:
@@ -150,7 +150,7 @@ def test_hydration_schema_rejects_blank_source_user_id():
     with pytest.raises(ValidationError):
         chatbook_schemas.OpenWebUIHydrationPreviewRequest(
             openwebui_data_root="/srv/openwebui",
-            scope={"source_user_id": "   "},
+            scope={"conversation_ids": ["conv-a"], "source_user_id": "   "},
         )
 
 

--- a/tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_db_helpers.py
+++ b/tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_db_helpers.py
@@ -1,0 +1,254 @@
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management import OpenWebUI_DB as openwebui_db_reader
+
+
+pytestmark = pytest.mark.unit
+
+
+OPENWEBUI_BASE_TABLES = {
+    "user": [
+        "id TEXT PRIMARY KEY",
+        "name TEXT",
+        "email TEXT",
+        "created_at INTEGER",
+        "updated_at INTEGER",
+    ],
+    "folder": [
+        "id TEXT PRIMARY KEY",
+        "parent_id TEXT",
+        "user_id TEXT",
+        "name TEXT",
+        "items TEXT",
+        "meta TEXT",
+        "is_expanded INTEGER",
+        "created_at INTEGER",
+        "updated_at INTEGER",
+    ],
+    "chat": [
+        "id TEXT PRIMARY KEY",
+        "user_id TEXT",
+        "title TEXT",
+        "chat TEXT",
+        "created_at INTEGER",
+        "updated_at INTEGER",
+        "share_id TEXT",
+        "archived INTEGER",
+        "pinned INTEGER",
+        "meta TEXT",
+        "folder_id TEXT",
+    ],
+}
+
+OPENWEBUI_FILE_COLUMNS = [
+    "id TEXT PRIMARY KEY",
+    "user_id TEXT",
+    "hash TEXT",
+    "filename TEXT",
+    "path TEXT",
+    "data TEXT",
+    "meta TEXT",
+    "created_at INTEGER",
+    "updated_at INTEGER",
+]
+
+OPENWEBUI_CHAT_FILE_COLUMNS = [
+    "id TEXT PRIMARY KEY",
+    "chat_id TEXT",
+    "file_id TEXT",
+    "message_id TEXT",
+    "user_id TEXT",
+    "created_at INTEGER",
+    "updated_at INTEGER",
+]
+
+
+def _column_name(definition: str) -> str:
+    return definition.split(" ", 1)[0]
+
+
+def _create_table(conn: sqlite3.Connection, name: str, columns: list[str]) -> None:
+    conn.execute(f"CREATE TABLE {name} ({', '.join(columns)})")
+
+
+def write_openwebui_hydration_db(
+    path: Path,
+    *,
+    include_file: bool = True,
+    include_chat_file: bool = True,
+    omit_file_columns: set[str] | None = None,
+    omit_chat_file_columns: set[str] | None = None,
+) -> Path:
+    conn = sqlite3.connect(path)
+    try:
+        for table, columns in OPENWEBUI_BASE_TABLES.items():
+            _create_table(conn, table, columns)
+
+        if include_file:
+            omitted = omit_file_columns or set()
+            file_columns = [
+                column for column in OPENWEBUI_FILE_COLUMNS if _column_name(column) not in omitted
+            ]
+            _create_table(conn, "file", file_columns)
+
+        if include_chat_file:
+            omitted = omit_chat_file_columns or set()
+            chat_file_columns = [
+                column
+                for column in OPENWEBUI_CHAT_FILE_COLUMNS
+                if _column_name(column) not in omitted
+            ]
+            _create_table(conn, "chat_file", chat_file_columns)
+
+        conn.commit()
+    finally:
+        conn.close()
+    return path
+
+
+def open_row_connection(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def test_validate_openwebui_file_schema_rejects_missing_file_table(tmp_path):
+    db_path = write_openwebui_hydration_db(tmp_path / "webui.db", include_file=False)
+
+    with open_row_connection(db_path) as conn:
+        with pytest.raises(ValueError, match="missing required OpenWebUI table: file"):
+            openwebui_db_reader.validate_openwebui_file_schema(conn)
+
+
+@pytest.mark.parametrize("column", ["id", "user_id", "filename"])
+def test_validate_openwebui_file_schema_rejects_missing_required_file_columns(
+    tmp_path,
+    column,
+):
+    db_path = write_openwebui_hydration_db(
+        tmp_path / f"missing-{column}.db",
+        omit_file_columns={column},
+    )
+
+    with open_row_connection(db_path) as conn:
+        with pytest.raises(ValueError, match=f"missing required OpenWebUI column in file: {column}"):
+            openwebui_db_reader.validate_openwebui_file_schema(conn)
+
+
+def test_validate_openwebui_file_schema_rejects_missing_chat_file_table(tmp_path):
+    db_path = write_openwebui_hydration_db(tmp_path / "webui.db", include_chat_file=False)
+
+    with open_row_connection(db_path) as conn:
+        with pytest.raises(ValueError, match="missing required OpenWebUI table: chat_file"):
+            openwebui_db_reader.validate_openwebui_file_schema(conn)
+
+
+def test_validate_openwebui_schema_still_accepts_text_only_import_schema(tmp_path):
+    db_path = write_openwebui_hydration_db(
+        tmp_path / "webui.db",
+        include_file=False,
+        include_chat_file=False,
+    )
+
+    with open_row_connection(db_path) as conn:
+        openwebui_db_reader.validate_openwebui_schema(conn)
+
+
+def test_load_openwebui_file_rows_for_ids_filters_by_user(tmp_path):
+    db_path = write_openwebui_hydration_db(tmp_path / "webui.db")
+
+    with open_row_connection(db_path) as conn:
+        conn.executemany(
+            """
+            INSERT INTO file (id, user_id, hash, filename, path, data, meta, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                ("file-a", "owui-user", "hash-a", "notes.pdf", "uploads/file-a_notes.pdf", "{}", "{}", 1, 2),
+                ("file-b", "other-user", "hash-b", "private.pdf", "uploads/file-b_private.pdf", "{}", "{}", 3, 4),
+                ("file-c", "owui-user", "hash-c", "image.png", "uploads/file-c_image.png", "{}", "{}", 5, 6),
+            ],
+        )
+        conn.commit()
+
+        rows = openwebui_db_reader.load_openwebui_file_rows_for_ids(
+            conn,
+            ["file-a", "file-b"],
+            user_id="owui-user",
+        )
+
+    assert [row["id"] for row in rows] == ["file-a"]
+    assert rows[0]["filename"] == "notes.pdf"
+
+
+def test_load_openwebui_chat_file_rows_for_chats_filters_by_chat_and_user(tmp_path):
+    db_path = write_openwebui_hydration_db(tmp_path / "webui.db")
+
+    with open_row_connection(db_path) as conn:
+        conn.executemany(
+            """
+            INSERT INTO chat_file (id, chat_id, file_id, message_id, user_id, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                ("link-a", "chat-a", "file-a", "message-a", "owui-user", 1, 2),
+                ("link-b", "chat-b", "file-b", "message-b", "owui-user", 3, 4),
+                ("link-c", "chat-a", "file-c", "message-c", "other-user", 5, 6),
+            ],
+        )
+        conn.commit()
+
+        rows = openwebui_db_reader.load_openwebui_chat_file_rows_for_chats(
+            conn,
+            ["chat-a"],
+            user_id="owui-user",
+        )
+
+    assert [row["id"] for row in rows] == ["link-a"]
+    assert rows[0]["file_id"] == "file-a"
+
+
+def test_hydration_row_helpers_treat_quoted_ids_as_literal_values(tmp_path):
+    db_path = write_openwebui_hydration_db(tmp_path / "webui.db")
+    quoted_file_id = "file-a' OR 1=1 --"
+    quoted_chat_id = "chat-a' OR 1=1 --"
+
+    with open_row_connection(db_path) as conn:
+        conn.executemany(
+            """
+            INSERT INTO file (id, user_id, hash, filename, path, data, meta, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (quoted_file_id, "owui-user", "hash-a", "quoted.txt", "uploads/quoted.txt", "{}", "{}", 1, 2),
+                ("file-b", "owui-user", "hash-b", "other.txt", "uploads/other.txt", "{}", "{}", 3, 4),
+            ],
+        )
+        conn.executemany(
+            """
+            INSERT INTO chat_file (id, chat_id, file_id, message_id, user_id, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                ("link-a", quoted_chat_id, quoted_file_id, "message-a", "owui-user", 1, 2),
+                ("link-b", "chat-b", "file-b", "message-b", "owui-user", 3, 4),
+            ],
+        )
+        conn.commit()
+
+        file_rows = openwebui_db_reader.load_openwebui_file_rows_for_ids(
+            conn,
+            [quoted_file_id],
+            user_id="owui-user",
+        )
+        chat_file_rows = openwebui_db_reader.load_openwebui_chat_file_rows_for_chats(
+            conn,
+            [quoted_chat_id],
+            user_id="owui-user",
+        )
+
+    assert [row["id"] for row in file_rows] == [quoted_file_id]
+    assert [row["id"] for row in chat_file_rows] == ["link-a"]

--- a/tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_jobs_worker.py
+++ b/tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_jobs_worker.py
@@ -153,6 +153,17 @@ async def test_handle_openwebui_hydration_caps_and_redacts_warnings(monkeypatch)
     assert "/private/openwebui" not in repr(result["warnings"])
 
 
+def test_redact_hydration_warning_redacts_windows_and_unc_paths():
+    warning = jobs_worker._redact_hydration_warning(
+        r"Failed C:\OpenWebUI\uploads\file.png and \\server\share\secret.pdf and /srv/openwebui/file.txt"
+    )
+
+    assert "C:\\OpenWebUI" not in warning
+    assert "\\\\server\\share" not in warning
+    assert "/srv/openwebui" not in warning
+    assert warning.count("[redacted-path]") == 3
+
+
 @pytest.mark.asyncio
 async def test_handle_job_unsupported_job_type_still_errors(monkeypatch):
     service = _FakeHydrationService()

--- a/tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_jobs_worker.py
+++ b/tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_jobs_worker.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tldw_Server_API.app.core.Chatbooks.openwebui_hydration_jobs import (
+    OPENWEBUI_ATTACHMENT_HYDRATION_JOB_TYPE,
+)
+from tldw_Server_API.app.core.Chatbooks.services import jobs_worker
+
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeHydrationService:
+    def __init__(self, *, result: dict[str, Any] | None = None, exc: Exception | None = None) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.result = result or {
+            "summary": {
+                "referenced_files": 2,
+                "resolved_files": 2,
+                "hydrated_images": 1,
+                "registered_media_files": 1,
+                "already_hydrated": 0,
+                "missing_files": 0,
+                "unsupported_files": 0,
+                "failed_files": 0,
+                "processed_files": 0,
+            },
+            "warnings": [],
+        }
+        self.exc = exc
+
+    def run_openwebui_attachment_hydration(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        if self.exc is not None:
+            raise self.exc
+        return self.result
+
+
+@pytest.mark.asyncio
+async def test_handle_job_dispatches_openwebui_hydration(monkeypatch):
+    service = _FakeHydrationService()
+    monkeypatch.setattr(jobs_worker, "_get_service", lambda user_id: service)
+
+    result = await jobs_worker._handle_job(
+        {
+            "id": 42,
+            "uuid": "job-uuid-42",
+            "job_type": OPENWEBUI_ATTACHMENT_HYDRATION_JOB_TYPE,
+            "owner_user_id": "7",
+            "payload": {
+                "openwebui_data_root": "/srv/openwebui",
+                "scope": {
+                    "conversation_ids": ["conv-a"],
+                    "source_user_id": "ow-user",
+                },
+                "process_supported_files": True,
+            },
+        }
+    )
+
+    assert result["referenced_files"] == 2
+    assert result["hydrated_images"] == 1
+    assert result["registered_media_files"] == 1
+    assert service.calls == [
+        {
+            "openwebui_data_root": "/srv/openwebui",
+            "scope": {
+                "conversation_ids": ["conv-a"],
+                "source_user_id": "ow-user",
+            },
+            "process_supported_files": True,
+            "job_id": "job-uuid-42",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_handle_openwebui_hydration_requires_data_root(monkeypatch):
+    service = _FakeHydrationService()
+    monkeypatch.setattr(jobs_worker, "_get_service", lambda user_id: service)
+
+    with pytest.raises(jobs_worker.ChatbooksJobError, match="Missing openwebui_data_root") as exc_info:
+        await jobs_worker._handle_job(
+            {
+                "id": 43,
+                "job_type": OPENWEBUI_ATTACHMENT_HYDRATION_JOB_TYPE,
+                "owner_user_id": "7",
+                "payload": {"scope": {"conversation_ids": ["conv-a"]}},
+            }
+        )
+
+    assert exc_info.value.retryable is False
+    assert service.calls == []
+
+
+@pytest.mark.asyncio
+async def test_handle_openwebui_hydration_root_validation_is_nonretryable(monkeypatch):
+    service = _FakeHydrationService(exc=ValueError("OpenWebUI data root must contain webui.db."))
+    monkeypatch.setattr(jobs_worker, "_get_service", lambda user_id: service)
+
+    with pytest.raises(jobs_worker.ChatbooksJobError, match="OpenWebUI data root must contain webui.db") as exc_info:
+        await jobs_worker._handle_job(
+            {
+                "id": 44,
+                "job_type": OPENWEBUI_ATTACHMENT_HYDRATION_JOB_TYPE,
+                "owner_user_id": "7",
+                "payload": {
+                    "openwebui_data_root": "/srv/openwebui",
+                    "scope": {"conversation_ids": ["conv-a"]},
+                },
+            }
+        )
+
+    assert exc_info.value.retryable is False
+
+
+@pytest.mark.asyncio
+async def test_handle_openwebui_hydration_caps_and_redacts_warnings(monkeypatch):
+    service = _FakeHydrationService(
+        result={
+            "summary": {
+                "referenced_files": 101,
+                "resolved_files": 0,
+                "hydrated_images": 0,
+                "registered_media_files": 0,
+                "already_hydrated": 0,
+                "missing_files": 0,
+                "unsupported_files": 0,
+                "failed_files": 101,
+                "processed_files": 0,
+            },
+            "warnings": [f"Failed /private/openwebui/uploads/file-{index}.png" for index in range(101)],
+        }
+    )
+    monkeypatch.setattr(jobs_worker, "_get_service", lambda user_id: service)
+
+    result = await jobs_worker._handle_job(
+        {
+            "id": 45,
+            "job_type": OPENWEBUI_ATTACHMENT_HYDRATION_JOB_TYPE,
+            "owner_user_id": "7",
+            "payload": {
+                "openwebui_data_root": "/srv/openwebui",
+                "scope": {"conversation_ids": ["conv-a"]},
+            },
+        }
+    )
+
+    assert len(result["warnings"]) == 100
+    assert "/private/openwebui" not in repr(result["warnings"])
+
+
+@pytest.mark.asyncio
+async def test_handle_job_unsupported_job_type_still_errors(monkeypatch):
+    service = _FakeHydrationService()
+    monkeypatch.setattr(jobs_worker, "_get_service", lambda user_id: service)
+
+    with pytest.raises(jobs_worker.ChatbooksJobError, match="Unsupported chatbooks job action: unknown"):
+        await jobs_worker._handle_job(
+            {
+                "id": 46,
+                "job_type": "unknown",
+                "owner_user_id": "7",
+                "payload": {"chatbooks_job_id": "legacy-job"},
+            }
+        )

--- a/tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_paths.py
+++ b/tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_paths.py
@@ -1,0 +1,133 @@
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.Chatbooks import openwebui_hydration as hydration
+
+
+pytestmark = pytest.mark.unit
+
+
+def _patch_allowed_roots(monkeypatch: pytest.MonkeyPatch, allowed_root: Path) -> None:
+    monkeypatch.setattr(
+        hydration,
+        "get_ingestion_source_allowed_roots",
+        lambda *, reload=False: (allowed_root.resolve(strict=False),),
+    )
+
+
+def _write_openwebui_data_root(base: Path, *, include_webui_db: bool = True, include_uploads: bool = True) -> Path:
+    data_root = base / "openwebui"
+    data_root.mkdir(parents=True)
+    if include_webui_db:
+        (data_root / "webui.db").write_bytes(b"SQLite format 3\x00")
+    if include_uploads:
+        (data_root / "uploads").mkdir()
+    return data_root
+
+
+def test_data_root_outside_allowed_roots_is_rejected(tmp_path, monkeypatch):
+    allowed_root = tmp_path / "allowed"
+    outside_root = tmp_path / "outside" / "openwebui"
+    allowed_root.mkdir()
+    outside_root.mkdir(parents=True)
+    _patch_allowed_roots(monkeypatch, allowed_root)
+
+    with pytest.raises(ValueError, match="allowed roots"):
+        hydration.validate_openwebui_data_root(outside_root)
+
+
+def test_missing_webui_db_is_rejected(tmp_path, monkeypatch):
+    allowed_root = tmp_path / "allowed"
+    data_root = _write_openwebui_data_root(allowed_root, include_webui_db=False)
+    _patch_allowed_roots(monkeypatch, allowed_root)
+
+    with pytest.raises(ValueError, match="webui.db"):
+        hydration.validate_openwebui_data_root(data_root)
+
+
+def test_missing_uploads_is_required_only_when_file_bytes_are_needed(tmp_path, monkeypatch):
+    allowed_root = tmp_path / "allowed"
+    data_root = _write_openwebui_data_root(allowed_root, include_uploads=False)
+    _patch_allowed_roots(monkeypatch, allowed_root)
+
+    validated = hydration.validate_openwebui_data_root(data_root)
+
+    assert validated.root_path == data_root.resolve(strict=False)
+    assert validated.uploads_path == data_root.resolve(strict=False) / "uploads"
+    with pytest.raises(ValueError, match="uploads"):
+        hydration.validate_openwebui_data_root(data_root, require_uploads=True)
+
+
+def test_file_path_traversal_is_rejected(tmp_path, monkeypatch):
+    allowed_root = tmp_path / "allowed"
+    data_root = _write_openwebui_data_root(allowed_root)
+    _patch_allowed_roots(monkeypatch, allowed_root)
+    validated = hydration.validate_openwebui_data_root(data_root, require_uploads=True)
+
+    resolved = hydration.resolve_openwebui_file_path(
+        {"id": "file-a", "filename": "notes.txt", "path": "../secret.txt"},
+        validated,
+    )
+
+    assert resolved.status == "path_rejected"
+    assert resolved.path is None
+    assert resolved.warning_codes == ("path_rejected",)
+
+
+def test_symlink_escape_is_rejected_by_canonical_target_checks(tmp_path, monkeypatch):
+    allowed_root = tmp_path / "allowed"
+    outside_root = tmp_path / "outside"
+    data_root = _write_openwebui_data_root(allowed_root)
+    outside_root.mkdir()
+    target = outside_root / "secret.txt"
+    target.write_text("secret", encoding="utf-8")
+    (data_root / "uploads" / "escape.txt").symlink_to(target)
+    _patch_allowed_roots(monkeypatch, allowed_root)
+    validated = hydration.validate_openwebui_data_root(data_root, require_uploads=True)
+
+    resolved = hydration.resolve_openwebui_file_path(
+        {"id": "file-a", "filename": "escape.txt", "path": "uploads/escape.txt"},
+        validated,
+    )
+
+    assert resolved.status == "path_rejected"
+    assert resolved.path is None
+
+
+def test_uploads_id_filename_fallback_resolves_when_safe(tmp_path, monkeypatch):
+    allowed_root = tmp_path / "allowed"
+    data_root = _write_openwebui_data_root(allowed_root)
+    fallback_path = data_root / "uploads" / "file-a_notes.pdf"
+    fallback_path.write_bytes(b"%PDF-1.4\n")
+    _patch_allowed_roots(monkeypatch, allowed_root)
+    validated = hydration.validate_openwebui_data_root(data_root, require_uploads=True)
+
+    resolved = hydration.resolve_openwebui_file_path(
+        {"id": "file-a", "filename": "notes.pdf", "path": None},
+        validated,
+    )
+
+    assert resolved.status == "resolved"
+    assert resolved.path == fallback_path.resolve(strict=False)
+    assert resolved.source == "uploads_id_filename"
+    assert resolved.file_kind == "document"
+    assert resolved.mime_type == "application/pdf"
+
+
+def test_resolved_image_file_path_classifies_basic_file_kind(tmp_path, monkeypatch):
+    allowed_root = tmp_path / "allowed"
+    data_root = _write_openwebui_data_root(allowed_root)
+    image_path = data_root / "uploads" / "file-image_image.png"
+    image_path.write_bytes(b"\x89PNG\r\n\x1a\nfake")
+    _patch_allowed_roots(monkeypatch, allowed_root)
+    validated = hydration.validate_openwebui_data_root(data_root, require_uploads=True)
+
+    resolved = hydration.resolve_openwebui_file_path(
+        {"id": "file-image", "filename": "image.png", "path": None},
+        validated,
+    )
+
+    assert resolved.status == "resolved"
+    assert resolved.file_kind == "image"
+    assert resolved.mime_type == "image/png"

--- a/tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_service.py
+++ b/tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_service.py
@@ -1,12 +1,16 @@
 import sqlite3
+from pathlib import Path
 from typing import Any
 
 import pytest
 
 from tldw_Server_API.app.core.Chatbooks import openwebui_hydration as hydration
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB, InputError
 
 
 pytestmark = pytest.mark.unit
+
+PNG_BYTES = b"\x89PNG\r\n\x1a\nfake-png"
 
 
 class FakeChaChaDB:
@@ -72,6 +76,65 @@ def _chat_file_connection() -> sqlite3.Connection:
         """
     )
     return conn
+
+
+@pytest.fixture()
+def real_hydration_db(tmp_path):
+    db = CharactersRAGDB(
+        db_path=str(tmp_path / "openwebui-hydration.sqlite"),
+        client_id="openwebui-hydration-test",
+    )
+    character_id = db.add_character_card({"name": "Hydration Assistant"})
+    conversation_id = db.add_conversation({"id": "conv-a", "character_id": character_id, "title": "Hydration"})
+    message_id = db.add_message(
+        {
+            "id": "msg-a",
+            "conversation_id": conversation_id,
+            "sender": "user",
+            "content": "message with existing image",
+            "images": [{"data": PNG_BYTES, "mime": "image/png"}],
+        }
+    )
+    db.add_message_metadata(
+        message_id,
+        extra={
+            "openwebui_import": {
+                "source_message_id": "source-msg-a",
+                "source_parent_id": None,
+                "source_children_ids": [],
+                "role": "user",
+                "model": "model-a",
+                "attachment_refs": [{"id": "file-image"}],
+                "metadata": {"done": True},
+            }
+        },
+    )
+    return db
+
+
+def _resolved_file(path: Path, *, file_id: str = "file-image") -> hydration.OpenWebUIHydrationResolvedFile:
+    file_kind, mime_type = hydration.classify_openwebui_file(path)
+    return hydration.OpenWebUIHydrationResolvedFile(
+        file_id=file_id,
+        filename=path.name,
+        path=path,
+        status="resolved",
+        source="file_path",
+        file_kind=file_kind,
+        mime_type=mime_type,
+    )
+
+
+def _reference(*, file_id: str = "file-image") -> hydration.OpenWebUIHydrationReference:
+    return hydration.OpenWebUIHydrationReference(
+        conversation_id="conv-a",
+        message_id="msg-a",
+        file_id=file_id,
+        raw_ref_index=0,
+        raw_ref={"id": file_id},
+        source="message_metadata",
+        source_message_id="source-msg-a",
+    )
 
 
 def test_imported_message_metadata_refs_are_extracted_from_openwebui_extra():
@@ -198,3 +261,113 @@ def test_db_chat_file_fallback_skips_conversations_without_source_row_id():
 
     assert preview.references == ()
     assert preview.items == ()
+
+
+def test_hydrate_png_ref_appends_image_and_preserves_openwebui_metadata(real_hydration_db, tmp_path):
+    image_path = tmp_path / "image.png"
+    image_path.write_bytes(PNG_BYTES)
+
+    item = hydration.hydrate_image_reference(
+        real_hydration_db,
+        _reference(),
+        _resolved_file(image_path),
+        job_id="job-a",
+    )
+
+    images = real_hydration_db.get_message_images("msg-a")
+    metadata = real_hydration_db.get_message_metadata("msg-a")
+    openwebui_import = metadata["extra"]["openwebui_import"]
+
+    assert item.status == "hydrated_image"
+    assert item.file_id == "file-image"
+    assert item.job_id == "job-a"
+    assert images[1]["position"] == 1
+    assert images[1]["image_data"] == PNG_BYTES
+    assert openwebui_import["source_message_id"] == "source-msg-a"
+    assert openwebui_import["source_parent_id"] is None
+    assert openwebui_import["source_children_ids"] == []
+    assert openwebui_import["role"] == "user"
+    assert openwebui_import["model"] == "model-a"
+    assert openwebui_import["attachment_refs"] == [{"id": "file-image"}]
+    assert openwebui_import["metadata"] == {"done": True}
+    assert openwebui_import["hydration"]["last_job_id"] == "job-a"
+    assert openwebui_import["hydration"]["items"][0]["status"] == "hydrated_image"
+    assert openwebui_import["hydration"]["items"][0]["message_image_position"] == 1
+
+
+def test_hydrate_png_ref_is_idempotent_for_existing_source_key(real_hydration_db, tmp_path):
+    image_path = tmp_path / "image.png"
+    image_path.write_bytes(PNG_BYTES)
+    resolved = _resolved_file(image_path)
+    reference = _reference()
+
+    first = hydration.hydrate_image_reference(real_hydration_db, reference, resolved, job_id="job-a")
+    second = hydration.hydrate_image_reference(real_hydration_db, reference, resolved, job_id="job-b")
+
+    images = real_hydration_db.get_message_images("msg-a")
+    metadata = real_hydration_db.get_message_metadata("msg-a")
+    hydration_items = metadata["extra"]["openwebui_import"]["hydration"]["items"]
+
+    assert first.status == "hydrated_image"
+    assert second.status == "already_hydrated"
+    assert len(images) == 2
+    assert len(hydration_items) == 1
+    assert hydration_items[0]["message_image_position"] == 1
+
+
+def test_hydrate_image_ref_rolls_back_when_metadata_update_fails(real_hydration_db, tmp_path, monkeypatch):
+    image_path = tmp_path / "image.png"
+    image_path.write_bytes(PNG_BYTES)
+
+    def fail_metadata_update(*_args, **_kwargs):
+        return False
+
+    monkeypatch.setattr(real_hydration_db, "add_message_metadata", fail_metadata_update)
+
+    item = hydration.hydrate_image_reference(
+        real_hydration_db,
+        _reference(file_id="file-rollback"),
+        _resolved_file(image_path, file_id="file-rollback"),
+        job_id="job-a",
+    )
+
+    assert item.status == "metadata_update_failed"
+    assert len(real_hydration_db.get_message_images("msg-a")) == 1
+
+
+def test_append_message_image_enforces_existing_message_image_byte_cap(real_hydration_db):
+    oversized = b"x" * ((5 * 1024 * 1024) + 1)
+
+    with pytest.raises(InputError, match="maximum size"):
+        real_hydration_db.append_message_image("msg-a", oversized, "image/png")
+
+
+def test_hydrate_image_ref_reports_oversized_without_inserting(real_hydration_db, tmp_path):
+    image_path = tmp_path / "large.png"
+    image_path.write_bytes(PNG_BYTES + b"x" * 32)
+
+    item = hydration.hydrate_image_reference(
+        real_hydration_db,
+        _reference(file_id="file-large"),
+        _resolved_file(image_path, file_id="file-large"),
+        job_id="job-a",
+        max_image_bytes=8,
+    )
+
+    assert item.status == "oversized"
+    assert len(real_hydration_db.get_message_images("msg-a")) == 1
+
+
+def test_hydrate_image_ref_rejects_png_extension_with_non_image_bytes(real_hydration_db, tmp_path):
+    image_path = tmp_path / "fake.png"
+    image_path.write_bytes(b"not actually an image")
+
+    item = hydration.hydrate_image_reference(
+        real_hydration_db,
+        _reference(file_id="file-fake"),
+        _resolved_file(image_path, file_id="file-fake"),
+        job_id="job-a",
+    )
+
+    assert item.status == "unsupported_file_type"
+    assert len(real_hydration_db.get_message_images("msg-a")) == 1

--- a/tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_service.py
+++ b/tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_service.py
@@ -7,6 +7,7 @@ from typing import Any
 import pytest
 
 from tldw_Server_API.app.core.Chatbooks import openwebui_hydration as hydration
+from tldw_Server_API.app.core.Chatbooks import chatbook_service as chatbook_service_mod
 from tldw_Server_API.app.core.Chatbooks.chatbook_service import ChatbookService
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB, InputError
 from tldw_Server_API.app.core.DB_Management.media_db.native_class import MediaDatabase
@@ -350,6 +351,65 @@ def test_db_chat_file_fallback_uses_preserved_openwebui_source_chat_row_id():
     assert preview.references[0].source == "chat_file"
 
 
+def test_db_chat_file_fallback_batches_source_chat_rows(monkeypatch):
+    conn = _chat_file_connection()
+    calls: list[tuple[tuple[str, ...], str | None]] = []
+
+    def fake_load_chat_file_rows(_conn, chat_ids, user_id=None):
+        calls.append((tuple(chat_ids), user_id))
+        return [
+            {
+                "id": "link-a",
+                "chat_id": "source-chat-a",
+                "file_id": "file-a",
+                "message_id": "source-msg-a",
+                "user_id": "owui-user",
+                "created_at": 1,
+                "updated_at": 1,
+            },
+            {
+                "id": "link-b",
+                "chat_id": "source-chat-b",
+                "file_id": "file-b",
+                "message_id": "source-msg-b",
+                "user_id": "owui-user",
+                "created_at": 2,
+                "updated_at": 2,
+            },
+        ]
+
+    monkeypatch.setattr(hydration, "load_openwebui_chat_file_rows_for_chats", fake_load_chat_file_rows)
+    db = FakeChaChaDB(
+        messages_by_conversation={
+            "conv-a": [{"id": "msg-a", "conversation_id": "conv-a"}],
+            "conv-b": [{"id": "msg-b", "conversation_id": "conv-b"}],
+        },
+        metadata_by_message_id={
+            "msg-a": _metadata(refs=[], source_message_id="source-msg-a"),
+            "msg-b": _metadata(refs=[], source_message_id="source-msg-b"),
+        },
+        settings_by_conversation={
+            "conv-a": {"settings": {"openwebui_import": {"metadata": {"row_id": "source-chat-a"}}}},
+            "conv-b": {"settings": {"openwebui_import": {"metadata": {"row_id": "source-chat-b"}}}},
+        },
+    )
+
+    preview = hydration.extract_openwebui_hydration_references(
+        db,
+        hydration.OpenWebUIHydrationScope(
+            conversation_ids=("conv-a", "conv-b"),
+            openwebui_user_id="owui-user",
+        ),
+        openwebui_conn=conn,
+    )
+
+    assert calls == [(("source-chat-a", "source-chat-b"), "owui-user")]
+    assert [(ref.conversation_id, ref.message_id, ref.file_id) for ref in preview.references] == [
+        ("conv-a", "msg-a", "file-a"),
+        ("conv-b", "msg-b", "file-b"),
+    ]
+
+
 def test_db_chat_file_fallback_skips_conversations_without_source_row_id():
     conn = _chat_file_connection()
     conn.execute(
@@ -680,6 +740,103 @@ def test_register_non_image_processing_hook_is_optional_and_failure_keeps_media_
     assert processed.status == "registered_media"
     assert processed.warning_code == "processing_failed"
     assert media_db.get_media_file(processed.media_id, "original") is not None
+
+
+def test_register_non_image_reports_copy_failure_without_terminating(
+    real_hydration_db,
+    media_db,
+    tmp_path,
+    monkeypatch,
+):
+    pdf_path = tmp_path / "source.pdf"
+    pdf_path.write_bytes(PDF_BYTES)
+    storage_root = tmp_path / "tldw-owned-storage"
+
+    def fail_copy(**_kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(hydration, "_copy_openwebui_attachment_to_storage", fail_copy)
+
+    item = hydration.register_non_image_reference(
+        real_hydration_db,
+        media_db,
+        _reference(file_id="file-copy-fails"),
+        _resolved_file(pdf_path, file_id="file-copy-fails"),
+        owner_user_id=101,
+        storage_root=storage_root,
+        job_id="job-media",
+    )
+
+    assert item.status == "media_registration_failed"
+    assert item.warning_code == "media_registration_failed"
+    assert item.media_id is not None
+
+
+def test_register_non_image_reports_media_file_insert_failure_without_terminating(
+    real_hydration_db,
+    media_db,
+    tmp_path,
+    monkeypatch,
+):
+    pdf_path = tmp_path / "source.pdf"
+    pdf_path.write_bytes(PDF_BYTES)
+    storage_root = tmp_path / "tldw-owned-storage"
+
+    def fail_insert_media_file(**_kwargs):
+        raise RuntimeError("insert failed")
+
+    monkeypatch.setattr(media_db, "insert_media_file", fail_insert_media_file)
+
+    item = hydration.register_non_image_reference(
+        real_hydration_db,
+        media_db,
+        _reference(file_id="file-insert-fails"),
+        _resolved_file(pdf_path, file_id="file-insert-fails"),
+        owner_user_id=101,
+        storage_root=storage_root,
+        job_id="job-media",
+    )
+
+    assert item.status == "media_registration_failed"
+    assert item.warning_code == "media_registration_failed"
+    assert item.media_id is not None
+    assert item.storage_path is not None
+
+
+def test_preview_and_run_hydration_cap_response_items(tmp_path, monkeypatch):
+    allowed_root = tmp_path / "allowed"
+    data_root = allowed_root / "openwebui"
+    uploads_dir = data_root / "uploads"
+    uploads_dir.mkdir(parents=True)
+    _write_openwebui_hydration_db(data_root)
+    _patch_allowed_roots(monkeypatch, allowed_root)
+    monkeypatch.setattr(chatbook_service_mod, "MAX_OPENWEBUI_HYDRATION_RESPONSE_ITEMS", 3)
+    refs = [{"id": f"missing-{index}"} for index in range(5)]
+    db = FakeChaChaDB(
+        messages_by_conversation={"conv-a": [{"id": "msg-a", "conversation_id": "conv-a"}]},
+        metadata_by_message_id={"msg-a": _metadata(refs=refs)},
+    )
+    service = ChatbookService("101", db, user_id_int=101)
+    monkeypatch.setattr(service, "_get_media_db", lambda: None)
+
+    preview = service.preview_openwebui_attachment_hydration(
+        openwebui_data_root=str(data_root),
+        scope={"conversation_ids": ["conv-a"], "source_user_id": "ow-user"},
+    )
+    result = service.run_openwebui_attachment_hydration(
+        openwebui_data_root=str(data_root),
+        scope={"conversation_ids": ["conv-a"], "source_user_id": "ow-user"},
+        job_id="job-run",
+    )
+
+    assert preview["summary"]["referenced_files"] == 5
+    assert preview["summary"]["returned_items"] == 3
+    assert preview["summary"]["omitted_items"] == 2
+    assert len(preview["items"]) == 3
+    assert result["summary"]["referenced_files"] == 5
+    assert result["summary"]["returned_items"] == 3
+    assert result["summary"]["omitted_items"] == 2
+    assert len(result["items"]) == 3
 
 
 def test_run_openwebui_attachment_hydration_hydrates_resolved_image(

--- a/tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_service.py
+++ b/tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_service.py
@@ -1,0 +1,200 @@
+import sqlite3
+from typing import Any
+
+import pytest
+
+from tldw_Server_API.app.core.Chatbooks import openwebui_hydration as hydration
+
+
+pytestmark = pytest.mark.unit
+
+
+class FakeChaChaDB:
+    def __init__(
+        self,
+        *,
+        messages_by_conversation: dict[str, list[dict[str, Any]]],
+        metadata_by_message_id: dict[str, dict[str, Any]],
+        settings_by_conversation: dict[str, dict[str, Any]] | None = None,
+    ) -> None:
+        self.messages_by_conversation = messages_by_conversation
+        self.metadata_by_message_id = metadata_by_message_id
+        self.settings_by_conversation = settings_by_conversation or {}
+
+    def get_messages_for_conversation(
+        self,
+        conversation_id: str,
+        limit: int = 1000,
+        offset: int = 0,
+        order_by_timestamp: str = "ASC",
+        include_deleted: bool = False,
+    ) -> list[dict[str, Any]]:
+        del limit, offset, order_by_timestamp, include_deleted
+        return list(self.messages_by_conversation.get(conversation_id, []))
+
+    def get_message_metadata_map(self, message_ids: list[str]) -> dict[str, dict[str, Any]]:
+        return {
+            message_id: self.metadata_by_message_id[message_id]
+            for message_id in message_ids
+            if message_id in self.metadata_by_message_id
+        }
+
+    def get_conversation_settings(self, conversation_id: str) -> dict[str, Any] | None:
+        return self.settings_by_conversation.get(conversation_id)
+
+
+def _metadata(*, refs: list[Any] | None = None, source_message_id: str = "source-msg-a") -> dict[str, Any]:
+    return {
+        "extra": {
+            "openwebui_import": {
+                "source_message_id": source_message_id,
+                "attachment_refs": list(refs or []),
+                "metadata": {},
+            }
+        }
+    }
+
+
+def _chat_file_connection() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        """
+        CREATE TABLE chat_file (
+            id TEXT PRIMARY KEY,
+            chat_id TEXT,
+            file_id TEXT,
+            message_id TEXT,
+            user_id TEXT,
+            created_at INTEGER,
+            updated_at INTEGER
+        )
+        """
+    )
+    return conn
+
+
+def test_imported_message_metadata_refs_are_extracted_from_openwebui_extra():
+    db = FakeChaChaDB(
+        messages_by_conversation={"conv-a": [{"id": "msg-a", "conversation_id": "conv-a"}]},
+        metadata_by_message_id={
+            "msg-a": _metadata(
+                refs=[
+                    {"id": "file-a", "name": "notes.pdf"},
+                    "file-b",
+                    {"file_id": "file-c"},
+                    {"fileId": "file-d"},
+                ]
+            )
+        },
+    )
+
+    preview = hydration.extract_openwebui_hydration_references(
+        db,
+        hydration.OpenWebUIHydrationScope(conversation_ids=("conv-a",)),
+    )
+
+    assert [ref.file_id for ref in preview.references] == ["file-a", "file-b", "file-c", "file-d"]
+    assert [ref.raw_ref_index for ref in preview.references] == [0, 1, 2, 3]
+    assert all(ref.message_id == "msg-a" for ref in preview.references)
+
+
+def test_unsupported_reference_shapes_are_reported_as_preview_items():
+    db = FakeChaChaDB(
+        messages_by_conversation={"conv-a": [{"id": "msg-a", "conversation_id": "conv-a"}]},
+        metadata_by_message_id={
+            "msg-a": _metadata(refs=[{"name": "missing-id"}, [], 42, ""]),
+        },
+    )
+
+    preview = hydration.extract_openwebui_hydration_references(
+        db,
+        hydration.OpenWebUIHydrationScope(conversation_ids=("conv-a",)),
+    )
+
+    assert preview.references == ()
+    assert [item.status for item in preview.items] == [
+        "unsupported_reference_shape",
+        "unsupported_reference_shape",
+        "unsupported_reference_shape",
+        "unsupported_reference_shape",
+    ]
+    assert {item.warning_code for item in preview.items} == {"unsupported_reference_shape"}
+
+
+def test_db_chat_file_fallback_uses_preserved_openwebui_source_chat_row_id():
+    conn = _chat_file_connection()
+    conn.executemany(
+        """
+        INSERT INTO chat_file (id, chat_id, file_id, message_id, user_id, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        [
+            ("link-a", "source-chat-a", "file-db", "source-msg-a", "owui-user", 1, 2),
+            ("link-b", "source-chat-b", "file-other", "source-msg-a", "owui-user", 3, 4),
+            ("link-c", "source-chat-a", "file-wrong-user", "source-msg-a", "other-user", 5, 6),
+        ],
+    )
+    db = FakeChaChaDB(
+        messages_by_conversation={"conv-a": [{"id": "msg-a", "conversation_id": "conv-a"}]},
+        metadata_by_message_id={"msg-a": _metadata(refs=[])},
+        settings_by_conversation={
+            "conv-a": {
+                "settings": {
+                    "openwebui_import": {
+                        "metadata": {"row_id": "source-chat-a"},
+                    }
+                }
+            }
+        },
+    )
+
+    preview = hydration.extract_openwebui_hydration_references(
+        db,
+        hydration.OpenWebUIHydrationScope(
+            conversation_ids=("conv-a",),
+            openwebui_user_id="owui-user",
+        ),
+        openwebui_conn=conn,
+    )
+
+    assert [ref.file_id for ref in preview.references] == ["file-db"]
+    assert preview.references[0].message_id == "msg-a"
+    assert preview.references[0].source == "chat_file"
+
+
+def test_db_chat_file_fallback_skips_conversations_without_source_row_id():
+    conn = _chat_file_connection()
+    conn.execute(
+        """
+        INSERT INTO chat_file (id, chat_id, file_id, message_id, user_id, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        ("link-a", "source-chat-a", "file-db", "source-msg-a", "owui-user", 1, 2),
+    )
+    db = FakeChaChaDB(
+        messages_by_conversation={"conv-a": [{"id": "msg-a", "conversation_id": "conv-a"}]},
+        metadata_by_message_id={"msg-a": _metadata(refs=[])},
+        settings_by_conversation={
+            "conv-a": {
+                "settings": {
+                    "openwebui_import": {
+                        "external_ref": "source-chat-a",
+                        "metadata": {},
+                    }
+                }
+            }
+        },
+    )
+
+    preview = hydration.extract_openwebui_hydration_references(
+        db,
+        hydration.OpenWebUIHydrationScope(
+            conversation_ids=("conv-a",),
+            openwebui_user_id="owui-user",
+        ),
+        openwebui_conn=conn,
+    )
+
+    assert preview.references == ()
+    assert preview.items == ()

--- a/tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_service.py
+++ b/tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_service.py
@@ -1,3 +1,5 @@
+import hashlib
+import json
 import sqlite3
 from pathlib import Path
 from typing import Any
@@ -6,11 +8,13 @@ import pytest
 
 from tldw_Server_API.app.core.Chatbooks import openwebui_hydration as hydration
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB, InputError
+from tldw_Server_API.app.core.DB_Management.media_db.native_class import MediaDatabase
 
 
 pytestmark = pytest.mark.unit
 
 PNG_BYTES = b"\x89PNG\r\n\x1a\nfake-png"
+PDF_BYTES = b"%PDF-1.4\nfake-pdf\n%%EOF"
 
 
 class FakeChaChaDB:
@@ -112,6 +116,16 @@ def real_hydration_db(tmp_path):
     return db
 
 
+@pytest.fixture()
+def media_db(tmp_path):
+    db = MediaDatabase(
+        db_path=str(tmp_path / "openwebui-media.sqlite"),
+        client_id="101",
+    )
+    yield db
+    db.close_connection()
+
+
 def _resolved_file(path: Path, *, file_id: str = "file-image") -> hydration.OpenWebUIHydrationResolvedFile:
     file_kind, mime_type = hydration.classify_openwebui_file(path)
     return hydration.OpenWebUIHydrationResolvedFile(
@@ -125,15 +139,31 @@ def _resolved_file(path: Path, *, file_id: str = "file-image") -> hydration.Open
     )
 
 
-def _reference(*, file_id: str = "file-image") -> hydration.OpenWebUIHydrationReference:
+def _reference(
+    *,
+    file_id: str = "file-image",
+    message_id: str | None = "msg-a",
+    source_message_id: str | None = "source-msg-a",
+) -> hydration.OpenWebUIHydrationReference:
     return hydration.OpenWebUIHydrationReference(
         conversation_id="conv-a",
-        message_id="msg-a",
+        message_id=message_id,
         file_id=file_id,
         raw_ref_index=0,
         raw_ref={"id": file_id},
         source="message_metadata",
-        source_message_id="source-msg-a",
+        source_message_id=source_message_id,
+    )
+
+
+def _add_hydration_message(db: CharactersRAGDB, message_id: str) -> str | None:
+    return db.add_message(
+        {
+            "id": message_id,
+            "conversation_id": "conv-a",
+            "sender": "user",
+            "content": f"message {message_id}",
+        }
     )
 
 
@@ -371,3 +401,188 @@ def test_hydrate_image_ref_rejects_png_extension_with_non_image_bytes(real_hydra
 
     assert item.status == "unsupported_file_type"
     assert len(real_hydration_db.get_message_images("msg-a")) == 1
+
+
+def test_register_pdf_ref_creates_owned_media_and_media_file(real_hydration_db, media_db, tmp_path):
+    source_root = tmp_path / "openwebui-source"
+    source_root.mkdir()
+    pdf_path = source_root / "source.pdf"
+    pdf_path.write_bytes(PDF_BYTES)
+    storage_root = tmp_path / "tldw-owned-storage"
+    expected_hash = hashlib.sha256(PDF_BYTES).hexdigest()
+
+    item = hydration.register_non_image_reference(
+        real_hydration_db,
+        media_db,
+        _reference(file_id="file-pdf"),
+        _resolved_file(pdf_path, file_id="file-pdf"),
+        owner_user_id=101,
+        storage_root=storage_root,
+        job_id="job-media",
+    )
+
+    media = media_db.get_media_by_id(item.media_id)
+    media_file = media_db.get_media_file(item.media_id, "original")
+    metadata = real_hydration_db.get_message_metadata("msg-a")
+    hydration_item = metadata["extra"]["openwebui_import"]["hydration"]["items"][0]
+    safe_metadata = json.loads(media_db.get_all_document_versions(item.media_id)[0]["safe_metadata"])
+
+    assert item.status == "registered_media"
+    assert item.media_id is not None
+    assert item.media_file_id == media_file["uuid"]
+    assert item.checksum == expected_hash
+    assert media["url"] == "openwebui://user/101/file/file-pdf"
+    assert media["source_hash"] == expected_hash
+    assert media["owner_user_id"] == 101
+    assert media["visibility"] == "personal"
+    assert media_file["checksum"] == expected_hash
+    assert media_file["mime_type"] == "application/pdf"
+    assert str(source_root) not in media_file["storage_path"]
+    assert (storage_root / media_file["storage_path"]).read_bytes() == PDF_BYTES
+    assert hydration_item["status"] == "registered_media"
+    assert hydration_item["media_id"] == item.media_id
+    assert hydration_item["media_file_id"] == item.media_file_id
+    assert safe_metadata["source"] == "openwebui"
+    assert safe_metadata["source_file_id"] == "file-pdf"
+    assert safe_metadata["sha256"] == expected_hash
+    assert "source_path" not in safe_metadata
+
+
+def test_register_same_source_file_reuses_owned_media_link(real_hydration_db, media_db, tmp_path):
+    pdf_path = tmp_path / "source.pdf"
+    pdf_path.write_bytes(PDF_BYTES)
+    storage_root = tmp_path / "tldw-owned-storage"
+    reference = _reference(file_id="file-reused")
+    resolved = _resolved_file(pdf_path, file_id="file-reused")
+
+    first = hydration.register_non_image_reference(
+        real_hydration_db,
+        media_db,
+        reference,
+        resolved,
+        owner_user_id=101,
+        storage_root=storage_root,
+        job_id="job-media",
+    )
+    second = hydration.register_non_image_reference(
+        real_hydration_db,
+        media_db,
+        reference,
+        resolved,
+        owner_user_id=101,
+        storage_root=storage_root,
+        job_id="job-media",
+    )
+
+    assert first.media_id == second.media_id
+    assert second.status == "already_registered_media"
+    assert len(media_db.get_media_files(first.media_id)) == 1
+
+
+def test_register_same_source_file_does_not_cross_tldw_users(real_hydration_db, media_db, tmp_path):
+    pdf_path = tmp_path / "source.pdf"
+    pdf_path.write_bytes(PDF_BYTES)
+    storage_root = tmp_path / "tldw-owned-storage"
+    _add_hydration_message(real_hydration_db, "msg-b")
+
+    first = hydration.register_non_image_reference(
+        real_hydration_db,
+        media_db,
+        _reference(file_id="file-shared", message_id="msg-a"),
+        _resolved_file(pdf_path, file_id="file-shared"),
+        owner_user_id=101,
+        storage_root=storage_root,
+        job_id="job-media",
+    )
+    second = hydration.register_non_image_reference(
+        real_hydration_db,
+        media_db,
+        _reference(file_id="file-shared", message_id="msg-b", source_message_id="source-msg-b"),
+        _resolved_file(pdf_path, file_id="file-shared"),
+        owner_user_id=202,
+        storage_root=storage_root,
+        job_id="job-media",
+    )
+
+    assert first.media_id != second.media_id
+    assert media_db.get_media_by_id(first.media_id)["url"] != media_db.get_media_by_id(second.media_id)["url"]
+    assert media_db.get_media_by_id(first.media_id)["owner_user_id"] == 101
+    assert media_db.get_media_by_id(second.media_id)["owner_user_id"] == 202
+
+
+def test_register_source_id_less_files_do_not_share_placeholder_content_hash(real_hydration_db, media_db, tmp_path):
+    first_path = tmp_path / "alpha.txt"
+    second_path = tmp_path / "beta.txt"
+    first_path.write_bytes(b"alpha")
+    second_path.write_bytes(b"beta")
+    storage_root = tmp_path / "tldw-owned-storage"
+    _add_hydration_message(real_hydration_db, "msg-b")
+
+    first = hydration.register_non_image_reference(
+        real_hydration_db,
+        media_db,
+        _reference(file_id="", message_id="msg-a"),
+        _resolved_file(first_path, file_id=""),
+        owner_user_id=101,
+        storage_root=storage_root,
+        job_id="job-media",
+    )
+    second = hydration.register_non_image_reference(
+        real_hydration_db,
+        media_db,
+        _reference(file_id="", message_id="msg-b", source_message_id="source-msg-b"),
+        _resolved_file(second_path, file_id=""),
+        owner_user_id=101,
+        storage_root=storage_root,
+        job_id="job-media",
+    )
+
+    assert first.media_id != second.media_id
+    assert media_db.get_media_by_id(first.media_id)["content_hash"] != media_db.get_media_by_id(
+        second.media_id
+    )["content_hash"]
+
+
+def test_register_non_image_processing_hook_is_optional_and_failure_keeps_media_file(
+    real_hydration_db,
+    media_db,
+    tmp_path,
+):
+    pdf_path = tmp_path / "source.pdf"
+    pdf_path.write_bytes(PDF_BYTES)
+    storage_root = tmp_path / "tldw-owned-storage"
+    calls: list[int] = []
+
+    def failing_processor(**kwargs):
+        calls.append(kwargs["media_id"])
+        raise RuntimeError("processor failed")
+
+    skipped = hydration.register_non_image_reference(
+        real_hydration_db,
+        media_db,
+        _reference(file_id="file-no-process"),
+        _resolved_file(pdf_path, file_id="file-no-process"),
+        owner_user_id=101,
+        storage_root=storage_root,
+        job_id="job-media",
+        process_supported_files=False,
+        processing_hook=failing_processor,
+    )
+    _add_hydration_message(real_hydration_db, "msg-b")
+    processed = hydration.register_non_image_reference(
+        real_hydration_db,
+        media_db,
+        _reference(file_id="file-process", message_id="msg-b", source_message_id="source-msg-b"),
+        _resolved_file(pdf_path, file_id="file-process"),
+        owner_user_id=101,
+        storage_root=storage_root,
+        job_id="job-media",
+        process_supported_files=True,
+        processing_hook=failing_processor,
+    )
+
+    assert calls == [processed.media_id]
+    assert skipped.processing_status == "skipped"
+    assert processed.status == "registered_media"
+    assert processed.warning_code == "processing_failed"
+    assert media_db.get_media_file(processed.media_id, "original") is not None

--- a/tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_service.py
+++ b/tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_service.py
@@ -7,6 +7,7 @@ from typing import Any
 import pytest
 
 from tldw_Server_API.app.core.Chatbooks import openwebui_hydration as hydration
+from tldw_Server_API.app.core.Chatbooks.chatbook_service import ChatbookService
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB, InputError
 from tldw_Server_API.app.core.DB_Management.media_db.native_class import MediaDatabase
 
@@ -80,6 +81,99 @@ def _chat_file_connection() -> sqlite3.Connection:
         """
     )
     return conn
+
+
+def _patch_allowed_roots(monkeypatch: pytest.MonkeyPatch, allowed_root: Path) -> None:
+    monkeypatch.setattr(
+        hydration,
+        "get_ingestion_source_allowed_roots",
+        lambda *, reload=False: (allowed_root.resolve(strict=False),),
+    )
+
+
+def _write_openwebui_hydration_db(data_root: Path) -> None:
+    conn = sqlite3.connect(data_root / "webui.db")
+    try:
+        conn.execute(
+            """
+            CREATE TABLE user (
+                id TEXT,
+                name TEXT,
+                email TEXT,
+                created_at INTEGER,
+                updated_at INTEGER
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE folder (
+                id TEXT,
+                parent_id TEXT,
+                user_id TEXT,
+                name TEXT,
+                items TEXT,
+                meta TEXT,
+                is_expanded INTEGER,
+                created_at INTEGER,
+                updated_at INTEGER
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE chat (
+                id TEXT,
+                user_id TEXT,
+                title TEXT,
+                chat TEXT,
+                created_at INTEGER,
+                updated_at INTEGER,
+                share_id TEXT,
+                archived INTEGER,
+                pinned INTEGER,
+                meta TEXT,
+                folder_id TEXT
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE file (
+                id TEXT,
+                user_id TEXT,
+                hash TEXT,
+                filename TEXT,
+                path TEXT,
+                data TEXT,
+                meta TEXT,
+                created_at INTEGER,
+                updated_at INTEGER
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE chat_file (
+                id TEXT,
+                chat_id TEXT,
+                file_id TEXT,
+                message_id TEXT,
+                user_id TEXT,
+                created_at INTEGER,
+                updated_at INTEGER
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO file (id, user_id, hash, filename, path, data, meta, created_at, updated_at)
+            VALUES ('file-image', 'ow-user', 'hash-image', 'image.png', 'uploads/file-image_image.png', '{}', '{}', 1, 1)
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
 
 
 @pytest.fixture()
@@ -586,3 +680,28 @@ def test_register_non_image_processing_hook_is_optional_and_failure_keeps_media_
     assert processed.status == "registered_media"
     assert processed.warning_code == "processing_failed"
     assert media_db.get_media_file(processed.media_id, "original") is not None
+
+
+def test_run_openwebui_attachment_hydration_hydrates_resolved_image(
+    real_hydration_db,
+    tmp_path,
+    monkeypatch,
+):
+    allowed_root = tmp_path / "allowed"
+    data_root = allowed_root / "openwebui"
+    uploads_dir = data_root / "uploads"
+    uploads_dir.mkdir(parents=True)
+    (uploads_dir / "file-image_image.png").write_bytes(PNG_BYTES)
+    _write_openwebui_hydration_db(data_root)
+    _patch_allowed_roots(monkeypatch, allowed_root)
+    service = ChatbookService("101", real_hydration_db, user_id_int=101)
+
+    result = service.run_openwebui_attachment_hydration(
+        openwebui_data_root=str(data_root),
+        scope={"conversation_ids": ["conv-a"], "source_user_id": "ow-user"},
+        job_id="job-run",
+    )
+
+    assert result["summary"]["hydrated_images"] == 1
+    assert result["summary"]["resolved_files"] == 1
+    assert len(real_hydration_db.get_message_images("msg-a")) == 2

--- a/tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_service.py
+++ b/tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_service.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import sqlite3
+import stat
 from pathlib import Path
 from typing import Any
 
@@ -526,9 +527,54 @@ def test_append_message_image_enforces_existing_message_image_byte_cap(real_hydr
         real_hydration_db.append_message_image("msg-a", oversized, "image/png")
 
 
+def test_append_message_image_retries_transient_position_conflict(real_hydration_db, monkeypatch):
+    original_execute_query = real_hydration_db.execute_query
+    conflicts = {"count": 0}
+
+    def flaky_execute_query(query, *args, **kwargs):
+        if "INSERT INTO message_images" in str(query) and conflicts["count"] == 0:
+            conflicts["count"] += 1
+            raise sqlite3.IntegrityError(
+                "UNIQUE constraint failed: message_images.message_id, message_images.position"
+            )
+        return original_execute_query(query, *args, **kwargs)
+
+    monkeypatch.setattr(real_hydration_db, "execute_query", flaky_execute_query)
+
+    position = real_hydration_db.append_message_image("msg-a", PNG_BYTES, "image/png")
+
+    assert conflicts["count"] == 1
+    assert position == 1
+    assert len(real_hydration_db.get_message_images("msg-a")) == 2
+
+
 def test_hydrate_image_ref_reports_oversized_without_inserting(real_hydration_db, tmp_path):
     image_path = tmp_path / "large.png"
     image_path.write_bytes(PNG_BYTES + b"x" * 32)
+
+    item = hydration.hydrate_image_reference(
+        real_hydration_db,
+        _reference(file_id="file-large"),
+        _resolved_file(image_path, file_id="file-large"),
+        job_id="job-a",
+        max_image_bytes=8,
+    )
+
+    assert item.status == "oversized"
+    assert len(real_hydration_db.get_message_images("msg-a")) == 1
+
+
+def test_hydrate_image_ref_checks_size_with_bounded_read(real_hydration_db, tmp_path, monkeypatch):
+    image_path = tmp_path / "large.png"
+    image_path.write_bytes(PNG_BYTES + b"x" * 32)
+    original_read_bytes = Path.read_bytes
+
+    def fail_unbounded_read(path: Path) -> bytes:
+        if path == image_path:
+            raise AssertionError("image hydration must not read the full file before size checks")
+        return original_read_bytes(path)
+
+    monkeypatch.setattr(Path, "read_bytes", fail_unbounded_read)
 
     item = hydration.hydrate_image_reference(
         real_hydration_db,
@@ -811,6 +857,7 @@ def test_preview_and_run_hydration_cap_response_items(tmp_path, monkeypatch):
     _write_openwebui_hydration_db(data_root)
     _patch_allowed_roots(monkeypatch, allowed_root)
     monkeypatch.setattr(chatbook_service_mod, "MAX_OPENWEBUI_HYDRATION_RESPONSE_ITEMS", 3)
+    monkeypatch.setattr(chatbook_service_mod, "MAX_PREVIEW_WARNING_ITEMS", 3)
     refs = [{"id": f"missing-{index}"} for index in range(5)]
     db = FakeChaChaDB(
         messages_by_conversation={"conv-a": [{"id": "msg-a", "conversation_id": "conv-a"}]},
@@ -836,7 +883,26 @@ def test_preview_and_run_hydration_cap_response_items(tmp_path, monkeypatch):
     assert result["summary"]["referenced_files"] == 5
     assert result["summary"]["returned_items"] == 3
     assert result["summary"]["omitted_items"] == 2
+    assert result["summary"]["warning_count"] == 5
     assert len(result["items"]) == 3
+    assert len(result["warnings"]) == 3
+
+
+def test_openwebui_attachment_storage_root_is_private(tmp_path, monkeypatch):
+    storage_root = tmp_path / "media-storage"
+    storage_root.mkdir(mode=0o755)
+    storage_root.chmod(0o755)
+    monkeypatch.setenv("OPENWEBUI_HYDRATION_MEDIA_STORAGE_PATH", str(storage_root))
+    service = ChatbookService(
+        "101",
+        FakeChaChaDB(messages_by_conversation={}, metadata_by_message_id={}),
+        user_id_int=101,
+    )
+
+    resolved = service._openwebui_attachment_storage_root()
+
+    assert resolved == storage_root
+    assert stat.S_IMODE(resolved.stat().st_mode) == 0o700
 
 
 def test_run_openwebui_attachment_hydration_hydrates_resolved_image(

--- a/tldw_Server_API/tests/Docs/test_chatbook_openwebui_import_docs.py
+++ b/tldw_Server_API/tests/Docs/test_chatbook_openwebui_import_docs.py
@@ -20,6 +20,11 @@ def test_openwebui_import_is_discoverable_from_user_guides() -> None:
     assert "webui.db" in guide_text  # nosec B101 - pytest assertion
     assert "selected OpenWebUI user" in guide_text  # nosec B101 - pytest assertion
     assert "OpenWebUI / <selected user>" in guide_text  # nosec B101 - pytest assertion
+    assert "OpenWebUI attachment hydration" in guide_text  # nosec B101
+    assert "`uploads/`" in guide_text  # nosec B101
+    assert "Files.ingestion_source_allowed_roots" in guide_text  # nosec B101
+    assert "INGESTION_SOURCE_ALLOWED_ROOTS" in guide_text  # nosec B101
+    assert "Process supported files" in guide_text  # nosec B101
     assert "OpenWebUI chat JSON migration" in readme_text  # nosec B101
     assert "OpenWebUI webui.db migration" in readme_text  # nosec B101
     assert "WebUI_Extension/Chatbook_User_Guide.md" in readme_text  # nosec B101
@@ -44,6 +49,11 @@ def test_openwebui_import_is_discoverable_from_api_docs() -> None:
     assert "OpenWebUI webui.db database" in api_doc  # nosec B101
     assert "selected_openwebui_user_id" in api_doc  # nosec B101
     assert "OpenWebUI / <selected user>" in api_doc  # nosec B101
+    assert "/api/v1/chatbooks/openwebui/hydration/preview" in api_doc  # nosec B101
+    assert "/api/v1/chatbooks/openwebui/hydration/jobs" in api_doc  # nosec B101
+    assert "process_supported_files" in api_doc  # nosec B101
+    assert "Files.ingestion_source_allowed_roots" in api_doc  # nosec B101
+    assert "OpenWebUI attachment hydration preview/job endpoints" in api_tags  # nosec B101
 
 
 def test_openwebui_import_is_reflected_in_published_docs() -> None:
@@ -59,8 +69,10 @@ def test_openwebui_import_is_reflected_in_published_docs() -> None:
 
     assert "OpenWebUI Chat Import" in published_guide  # nosec B101
     assert "OpenWebUI database" in published_guide  # nosec B101
+    assert "OpenWebUI attachment hydration" in published_guide  # nosec B101
     assert "source_format=openwebui_json" in published_api  # nosec B101
     assert "source_format=openwebui_db" in published_api  # nosec B101
+    assert "/api/v1/chatbooks/openwebui/hydration/preview" in published_api  # nosec B101
     assert "OpenWebUI JSON and database chat import" in feature_status  # nosec B101
 
 
@@ -91,7 +103,8 @@ def test_chatbook_import_docs_match_multipart_contract() -> None:
         assert "**Import Embeddings**: Not supported yet" in guide_text  # nosec B101
         assert "Keep this set to false" in guide_text  # nosec B101
         assert "Default: true" not in guide_text  # nosec B101
-        assert "Files, images, and artifacts import as metadata references only" in guide_text  # nosec B101
+        assert "OpenWebUI JSON and database imports preserve attachment references first" in guide_text  # nosec B101
+        assert "Run OpenWebUI attachment hydration after import" in guide_text  # nosec B101
 
 
 def test_chatbook_openapi_documents_openwebui_multipart_fields() -> None:
@@ -124,6 +137,14 @@ def test_chatbook_openapi_documents_openwebui_multipart_fields() -> None:
             "openwebui_db",
         ]
         assert "/chatbooks/import/jobs/{job_id}" in spec["paths"]  # nosec B101
+        assert "/chatbooks/openwebui/hydration/preview" in spec["paths"]  # nosec B101
+        assert "/chatbooks/openwebui/hydration/jobs" in spec["paths"]  # nosec B101
+        assert "/chatbooks/openwebui/hydration/jobs/{job_id}" in spec["paths"]  # nosec B101
+        hydration_request = spec["components"]["schemas"]["OpenWebUIHydrationRequest"]
+        assert "openwebui_data_root" in hydration_request["required"]  # nosec B101
+        assert hydration_request["properties"]["process_supported_files"]["default"] is False  # nosec B101
+        assert "OpenWebUIHydrationPreviewResponse" in spec["components"]["schemas"]  # nosec B101
+        assert "OpenWebUIHydrationJobResponse" in spec["components"]["schemas"]  # nosec B101
 
 
 def test_chatbook_openapi_database_import_result_matches_backend_schema() -> None:

--- a/tldw_Server_API/tests/Docs/test_chatbook_openwebui_import_docs.py
+++ b/tldw_Server_API/tests/Docs/test_chatbook_openwebui_import_docs.py
@@ -143,6 +143,9 @@ def test_chatbook_openapi_documents_openwebui_multipart_fields() -> None:
         hydration_request = spec["components"]["schemas"]["OpenWebUIHydrationRequest"]
         assert "openwebui_data_root" in hydration_request["required"]  # nosec B101
         assert hydration_request["properties"]["process_supported_files"]["default"] is False  # nosec B101
+        hydration_summary = spec["components"]["schemas"]["OpenWebUIHydrationSummary"]
+        assert "returned_items" in hydration_summary["properties"]  # nosec B101
+        assert "omitted_items" in hydration_summary["properties"]  # nosec B101
         assert "OpenWebUIHydrationPreviewResponse" in spec["components"]["schemas"]  # nosec B101
         assert "OpenWebUIHydrationJobResponse" in spec["components"]["schemas"]  # nosec B101
 


### PR DESCRIPTION
## Summary
- Adds a post-import OpenWebUI attachment hydration workflow for referenced local files, separate from baseline chat import.
- Restores image attachments into imported messages and registers non-image files in Media DB from a trusted local OpenWebUI data root.
- Adds preview/job APIs, Jobs worker handling, WebUI controls, docs, OpenAPI updates, and focused regression coverage.

## Test Plan
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Docs/test_chatbook_openwebui_import_docs.py -q
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_db_helpers.py tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_paths.py tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_service.py tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_api.py tldw_Server_API/tests/Chatbooks/test_openwebui_hydration_jobs_worker.py tldw_Server_API/tests/Chatbooks/test_openwebui_db_import_adapter.py tldw_Server_API/tests/Chatbooks/test_chatbooks_openwebui_db_api.py tldw_Server_API/tests/Chatbooks/test_chatbooks_jobs_worker_import_defaults.py -q
- [x] bun run test src/services/__tests__/tldw-api-client.chatbooks-openwebui.test.ts src/components/Option/Chatbooks/__tests__/ChatbooksPlaygroundPage.openwebui-import.test.tsx
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Chatbooks/openwebui_hydration.py tldw_Server_API/app/core/Chatbooks/openwebui_hydration_jobs.py tldw_Server_API/app/core/DB_Management/OpenWebUI_DB.py tldw_Server_API/app/core/DB_Management/chacha/message_store.py tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py tldw_Server_API/app/api/v1/endpoints/chatbooks.py tldw_Server_API/app/core/Chatbooks/services/jobs_worker.py -f json -o /tmp/bandit_openwebui_hydration.json
- [x] git diff --check

## Change Summary
Human-authored merge-gate summary still required before this AI-authored PR is marked ready.