### PR TITLE
Add offline Persona Chat judge harness

### DIFF
--- a/Docs/Reviews/PERSONA_CHAT_JUDGE_EVAL_CONTRACT_2026_05_11.md
+++ b/Docs/Reviews/PERSONA_CHAT_JUDGE_EVAL_CONTRACT_2026_05_11.md
@@ -64,6 +64,12 @@ A future executable judge must satisfy these rules before its output is consider
 
 Judge execution remains deferred until these calibration requirements are implemented and reviewed.
 
+## Offline Harness
+
+The first executable layer is the offline harness in `tldw_Server_API/app/core/Evaluations/persona_chat_judge_harness.py`. It compares already-produced candidate judge outputs against the checked-in V1 contract fixture and returns a bounded report with case counts, verdict agreement, flag agreement, score schema validity, missing candidates, invalid candidates, extra candidates, and per-case mismatch keys.
+
+The harness does not call model providers, persist evaluation runs, enqueue Jobs, expose API endpoints, or gate Persona Chat responses. Future judge adapters should feed their outputs into this helper before any output is treated as calibrated.
+
 ## Privacy And Redaction
 
 Contract fixtures must not contain:

--- a/Docs/Reviews/PERSONA_CHAT_JUDGE_EVAL_CONTRACT_2026_05_11.md
+++ b/Docs/Reviews/PERSONA_CHAT_JUDGE_EVAL_CONTRACT_2026_05_11.md
@@ -66,7 +66,7 @@ Judge execution remains deferred until these calibration requirements are implem
 
 ## Offline Harness
 
-The first executable layer is the offline harness in `tldw_Server_API/app/core/Evaluations/persona_chat_judge_harness.py`. It compares already-produced candidate judge outputs against the checked-in V1 contract fixture and returns a bounded report with case counts, verdict agreement, flag agreement, score schema validity, missing candidates, invalid candidates, extra candidates, and per-case mismatch keys.
+The first executable layer is the offline harness in `tldw_Server_API/app/core/Evaluations/persona_chat_judge_harness.py`. It compares already-produced candidate judge outputs against the checked-in V1 contract fixture and returns a bounded report with case counts, per-verdict counts, verdict agreement, flag agreement, score schema validity, missing candidates, invalid candidates, extra candidates, and per-case mismatch keys.
 
 The harness does not call model providers, persist evaluation runs, enqueue Jobs, expose API endpoints, or gate Persona Chat responses. Future judge adapters should feed their outputs into this helper before any output is treated as calibrated.
 

--- a/Docs/superpowers/plans/2026-05-11-persona-chat-judge-harness.md
+++ b/Docs/superpowers/plans/2026-05-11-persona-chat-judge-harness.md
@@ -114,7 +114,7 @@ Run:
 - `rg -n "TO[D]O|TB[D]|FIX[M]E|PLACE[H]OLDER|\\?\\?" Docs/Reviews/PERSONA_CHAT_JUDGE_EVAL_CONTRACT_2026_05_11.md Docs/superpowers/plans/2026-05-11-persona-chat-judge-harness.md`
 - `git diff --check`
 
-- [ ] **Step 2: Commit and open PR**
+- [x] **Step 2: Commit and open PR**
 
 Run:
 ```bash

--- a/Docs/superpowers/plans/2026-05-11-persona-chat-judge-harness.md
+++ b/Docs/superpowers/plans/2026-05-11-persona-chat-judge-harness.md
@@ -1,0 +1,125 @@
+# Persona Chat Judge Harness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a deterministic offline Persona Chat judge harness that replays the V1 contract fixture and reports calibration mismatches without provider calls or runtime Persona Chat changes.
+
+**Architecture:** Keep the harness as a pure core helper under `app/core/Evaluations`, with no database, Jobs worker, endpoint, or model dependency. The helper accepts already-produced candidate judge outputs keyed by `PC-JUDGE-###`, validates the output envelope, compares verdict and flags against the fixture expectations, and returns a bounded report safe for docs or future CLI/API layers.
+
+**Tech Stack:** Python 3.11, dataclasses, pytest, existing Persona Chat judge contract fixture.
+
+---
+
+### Task 1: Harness Tests
+
+**Files:**
+- Create: `tldw_Server_API/tests/Evaluations/test_persona_chat_judge_harness.py`
+- Read: `tldw_Server_API/tests/fixtures/persona_chat_judge_contract_cases.json`
+
+- [x] **Step 1: Write failing tests for the offline harness**
+
+Add tests that import future helpers from `tldw_Server_API.app.core.Evaluations.persona_chat_judge_harness` and verify:
+- `expected_candidate_outputs_from_fixture()` extracts candidate outputs from the existing contract fixture.
+- `build_persona_chat_judge_report()` returns full agreement when candidates match expected outputs.
+- A verdict mismatch produces a bounded mismatch entry and does not copy assistant response text into the report.
+- A flag mismatch is counted separately from verdict agreement.
+- Missing score axes and malformed labels produce invalid candidate results.
+
+- [x] **Step 2: Run tests to verify RED**
+
+Run:
+`/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Evaluations/test_persona_chat_judge_harness.py -q`
+
+Expected: fail because `persona_chat_judge_harness.py` does not exist.
+
+### Task 2: Core Harness Helper
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Evaluations/persona_chat_judge_harness.py`
+- Test: `tldw_Server_API/tests/Evaluations/test_persona_chat_judge_harness.py`
+
+- [x] **Step 1: Add module constants and dataclasses**
+
+Define:
+- `REQUIRED_SCORE_NAMES`
+- `ALLOWED_VERDICTS`
+- `PersonaChatJudgeCaseResult`
+- `PersonaChatJudgeHarnessReport`
+
+The dataclasses should expose `to_dict()` methods so future API/CLI layers can reuse the report shape without coupling to dataclass internals.
+
+- [x] **Step 2: Add candidate validation helpers**
+
+Implement strict envelope validation:
+- verdict is one of `pass`, `fail`, `inconclusive`
+- `expected_flags` is a list of unique `PC-*` labels
+- scores contain exactly all required score axes
+- score values are `None` or numeric `int`/`float`, excluding `bool`, in `[0.0, 1.0]`
+
+- [x] **Step 3: Add report builder**
+
+Implement:
+- `expected_candidate_outputs_from_fixture(fixture_payload)`
+- `build_persona_chat_judge_report(fixture_payload, candidate_outputs_by_case_id)`
+
+Report fields should include:
+- `schema_version`
+- `offline_only`
+- `total_cases`
+- `matched_cases`
+- `mismatched_cases`
+- `missing_candidate_count`
+- `invalid_candidate_count`
+- `extra_candidate_ids`
+- `verdict_agreement`
+- `flag_agreement`
+- per-case bounded mismatch data
+
+- [x] **Step 4: Run tests to verify GREEN**
+
+Run:
+`/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Evaluations/test_persona_chat_judge_harness.py -q`
+
+Expected: pass.
+
+### Task 3: Docs And Tracker Updates
+
+**Files:**
+- Modify: `Docs/Reviews/PERSONA_CHAT_JUDGE_EVAL_CONTRACT_2026_05_11.md`
+- Modify: `backlog/tasks/task-241.1.1 - Add-offline-Persona-Chat-judge-harness.md`
+
+- [x] **Step 1: Document the offline harness boundary**
+
+Add a short section to the judge contract explaining that the offline harness:
+- compares already-produced candidate judge outputs to contract fixtures
+- does not call providers
+- does not persist evaluation runs
+- does not gate Persona Chat responses
+- is intended as the calibration report substrate for later judge adapters
+
+- [x] **Step 2: Update Backlog with verification evidence**
+
+Record focused pytest, Bandit, placeholder scan, and diff hygiene results after verification.
+
+### Task 4: Verification And Packaging
+
+**Files:**
+- Touch all changed files from Tasks 1-3
+
+- [x] **Step 1: Run closeout checks**
+
+Run:
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Evaluations/test_persona_chat_judge_harness.py tldw_Server_API/tests/Evaluations/test_persona_chat_judge_contract.py -q`
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Evaluations/persona_chat_judge_harness.py tldw_Server_API/tests/Evaluations/test_persona_chat_judge_harness.py -f json -o /tmp/bandit_persona_chat_judge_harness.json`
+- `rg -n "TO[D]O|TB[D]|FIX[M]E|PLACE[H]OLDER|\\?\\?" Docs/Reviews/PERSONA_CHAT_JUDGE_EVAL_CONTRACT_2026_05_11.md Docs/superpowers/plans/2026-05-11-persona-chat-judge-harness.md`
+- `git diff --check`
+
+- [ ] **Step 2: Commit and open PR**
+
+Run:
+```bash
+git add Docs/Reviews/PERSONA_CHAT_JUDGE_EVAL_CONTRACT_2026_05_11.md Docs/superpowers/plans/2026-05-11-persona-chat-judge-harness.md tldw_Server_API/app/core/Evaluations/persona_chat_judge_harness.py tldw_Server_API/tests/Evaluations/test_persona_chat_judge_harness.py "backlog/tasks/task-241.1.1 - Add-offline-Persona-Chat-judge-harness.md"
+git commit -m "Add offline Persona Chat judge harness"
+```
+
+Open a PR against `dev` referencing #1572 and #1566.

--- a/backlog/tasks/task-241.1.1 - Add-offline-Persona-Chat-judge-harness.md
+++ b/backlog/tasks/task-241.1.1 - Add-offline-Persona-Chat-judge-harness.md
@@ -4,7 +4,7 @@ title: Add offline Persona Chat judge harness
 status: Done
 assignee: []
 created_date: '2026-05-11 05:48'
-updated_date: '2026-05-11 15:49'
+updated_date: '2026-05-12 00:04'
 labels:
   - persona
   - chat
@@ -16,6 +16,7 @@ dependencies: []
 references:
   - 'https://github.com/rmusser01/tldw_server/issues/1572'
   - 'https://github.com/rmusser01/tldw_server/issues/1566'
+  - 'https://github.com/rmusser01/tldw_server/pull/1576'
 documentation:
   - Docs/Reviews/PERSONA_CHAT_JUDGE_EVAL_CONTRACT_2026_05_11.md
   - tldw_Server_API/tests/fixtures/persona_chat_judge_contract_cases.json
@@ -58,6 +59,8 @@ Created after PR #1569 merged. #1572 tracks the executable offline harness slice
 Implemented offline Persona Chat judge harness under app/core/Evaluations with pure dataclass report generation, strict candidate envelope validation, and bounded mismatch reporting. Verification on 2026-05-11: focused harness pytest passed 5 tests; combined judge harness/contract pytest passed 15 tests; Bandit reported zero findings for touched Python; placeholder scan found no matches; git diff --check passed.
 
 No known skips or blockers for this slice.
+
+Opened PR #1576 for review and linked it from #1566, #1543, and #1510.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-241.1.1 - Add-offline-Persona-Chat-judge-harness.md
+++ b/backlog/tasks/task-241.1.1 - Add-offline-Persona-Chat-judge-harness.md
@@ -1,0 +1,77 @@
+---
+id: TASK-241.1.1
+title: Add offline Persona Chat judge harness
+status: Done
+assignee: []
+created_date: '2026-05-11 05:48'
+updated_date: '2026-05-11 15:49'
+labels:
+  - persona
+  - chat
+  - evaluations
+  - stage-2
+  - judge
+  - harness
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1572'
+  - 'https://github.com/rmusser01/tldw_server/issues/1566'
+documentation:
+  - Docs/Reviews/PERSONA_CHAT_JUDGE_EVAL_CONTRACT_2026_05_11.md
+  - tldw_Server_API/tests/fixtures/persona_chat_judge_contract_cases.json
+parent_task_id: TASK-241.1
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Build the next #1566 slice from #1572: a deterministic offline Persona Chat judge harness that replays contract fixture candidate outputs and produces a bounded calibration report without provider calls, runtime Persona Chat changes, or production gating.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Harness loads/accepts V1 contract cases and candidate judge outputs without model/provider calls.
+- [x] #2 Report includes case counts, verdict agreement, expected/actual flag agreement, score schema validation, and bounded mismatch details.
+- [x] #3 Tests cover matching outputs, verdict mismatch, flag mismatch, invalid labels, and invalid score schema.
+- [x] #4 Implementation has module/function docstrings and type hints.
+- [x] #5 No runtime Persona Chat path, Jobs worker, API endpoint, or WebUI behavior changes.
+- [x] #6 Focused pytest, Bandit on touched Python, and diff hygiene are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Write a plan document for the offline Persona Chat judge harness.
+2. Add failing tests for report generation and mismatch validation.
+3. Implement the minimal core harness helper under app/core/Evaluations.
+4. Update contract docs with the offline harness boundary.
+5. Run focused pytest, Bandit, placeholder scan, and diff hygiene.
+6. Update Backlog, commit, push, and open a PR.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Created after PR #1569 merged. #1572 tracks the executable offline harness slice; #1566 remains the parent optional judge evaluation tracker.
+
+Implemented offline Persona Chat judge harness under app/core/Evaluations with pure dataclass report generation, strict candidate envelope validation, and bounded mismatch reporting. Verification on 2026-05-11: focused harness pytest passed 5 tests; combined judge harness/contract pytest passed 15 tests; Bandit reported zero findings for touched Python; placeholder scan found no matches; git diff --check passed.
+
+No known skips or blockers for this slice.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added a deterministic offline Persona Chat judge harness for issue #1572. The helper compares already-produced candidate judge outputs with the V1 contract fixture, validates verdict/flag/score envelopes, returns bounded agreement and mismatch reports, and avoids provider calls, persistence, Jobs, endpoints, WebUI changes, or runtime Persona Chat gating. Documentation now records that boundary and tests cover agreement, mismatch, invalid labels, and invalid score schema.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-241.1.1 - Add-offline-Persona-Chat-judge-harness.md
+++ b/backlog/tasks/task-241.1.1 - Add-offline-Persona-Chat-judge-harness.md
@@ -4,7 +4,7 @@ title: Add offline Persona Chat judge harness
 status: Done
 assignee: []
 created_date: '2026-05-11 05:48'
-updated_date: '2026-05-12 00:38'
+updated_date: '2026-05-12 00:44'
 labels:
   - persona
   - chat
@@ -73,12 +73,16 @@ Review-fix follow-up completed. Finding was still valid: offline_only was derive
 Additional PR #1576 sweep found two CodeRabbit threads after the offline_only push. The offline_only thread is already fixed by 5b8c7ca4d and only needs resolution. The non-mapping candidate envelope thread is still valid: _compare_case can call .get on non-mapping candidate values. Adding a regression test and a minimal invalid_candidate early return.
 
 Additional PR #1576 sweep completed. Resolved offline_only thread as already fixed. Verified non-mapping candidate envelope finding against current code, added a failing regression test, then added a minimal _compare_case guard that returns invalid_candidate with invalid_candidate_envelope instead of crashing. Verification on 2026-05-12: harness+contract pytest passed 18 tests; Bandit reported zero findings on touched Python; placeholder scan found no matches; git diff --check passed.
+
+Review-fix follow-up started. Verified current code already has the non-mapping candidate guard and only calls _candidate_validation_errors after Mapping validation. Still-valid issue: mismatch key is invalid_candidate_envelope while the review requested invalid_candidate. No second compare block exists in persona_chat_judge_harness.py, so that part is skipped as not applicable.
+
+Review-fix follow-up completed. Verified current code: non-mapping candidate guard already exists and _candidate_validation_errors is only called after Mapping validation. Still-valid issue was the mismatch key; changed invalid_candidate_envelope to invalid_candidate and updated the regression test. Skipped the requested second compare block because no second _compare_case/compare block exists in persona_chat_judge_harness.py. Verification on 2026-05-12: harness+contract pytest passed 18 tests; Bandit reported zero findings on touched Python; placeholder scan found no matches; git diff --check passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added the offline Persona Chat judge harness and completed follow-up PR review fixes. The report now always marks harness output offline_only=True regardless of fixture metadata, includes per-verdict counts, keeps matched/mismatched/missing/invalid status counts mutually exclusive, ignores empty fixture case IDs, safely normalizes malformed fixture score data, and treats non-mapping candidate envelopes as invalid candidates instead of crashing. Local verification passed for focused judge tests, Bandit, placeholder scan, and diff hygiene.
+Added the offline Persona Chat judge harness and completed follow-up PR review fixes. The report always marks harness output offline_only=True regardless of fixture metadata, includes per-verdict counts, keeps matched/mismatched/missing/invalid status counts mutually exclusive, ignores empty fixture case IDs, safely normalizes malformed fixture score data, and treats non-mapping candidate envelopes as invalid candidates without crashing. Local verification passed for focused judge tests, Bandit, placeholder scan, and diff hygiene.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-241.1.1 - Add-offline-Persona-Chat-judge-harness.md
+++ b/backlog/tasks/task-241.1.1 - Add-offline-Persona-Chat-judge-harness.md
@@ -4,7 +4,7 @@ title: Add offline Persona Chat judge harness
 status: Done
 assignee: []
 created_date: '2026-05-11 05:48'
-updated_date: '2026-05-12 00:04'
+updated_date: '2026-05-12 00:12'
 labels:
   - persona
   - chat
@@ -61,12 +61,16 @@ Implemented offline Persona Chat judge harness under app/core/Evaluations with p
 No known skips or blockers for this slice.
 
 Opened PR #1576 for review and linked it from #1566, #1543, and #1510.
+
+Review-fix pass for PR #1576 started. Actionable threads: add per-verdict counts, make mismatched/invalid counts mutually exclusive, harden malformed fixture score extraction, skip empty case IDs, and update tests.
+
+PR #1576 review fixes completed. Addressed Qodo and Gemini threads by adding immutable per-verdict report counts, computing mismatched_cases directly from mismatched statuses, skipping empty fixture case IDs, and hardening malformed fixture score extraction. Verification on 2026-05-12: harness+contract pytest passed 16 tests; Bandit reported zero findings on touched Python; placeholder scan found no matches; git diff --check passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added a deterministic offline Persona Chat judge harness for issue #1572. The helper compares already-produced candidate judge outputs with the V1 contract fixture, validates verdict/flag/score envelopes, returns bounded agreement and mismatch reports, and avoids provider calls, persistence, Jobs, endpoints, WebUI changes, or runtime Persona Chat gating. Documentation now records that boundary and tests cover agreement, mismatch, invalid labels, and invalid score schema.
+Added the offline Persona Chat judge harness and completed the PR #1576 review-fix pass. The report now includes per-verdict counts, keeps matched/mismatched/missing/invalid status counts mutually exclusive, ignores empty fixture case IDs, and safely normalizes malformed fixture score data. Local verification passed for focused judge tests, Bandit, placeholder scan, and diff hygiene.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-241.1.1 - Add-offline-Persona-Chat-judge-harness.md
+++ b/backlog/tasks/task-241.1.1 - Add-offline-Persona-Chat-judge-harness.md
@@ -4,7 +4,7 @@ title: Add offline Persona Chat judge harness
 status: Done
 assignee: []
 created_date: '2026-05-11 05:48'
-updated_date: '2026-05-12 00:33'
+updated_date: '2026-05-12 00:38'
 labels:
   - persona
   - chat
@@ -69,12 +69,16 @@ PR #1576 review fixes completed. Addressed Qodo and Gemini threads by adding imm
 Review-fix follow-up started. Verified offline_only is still derived from fixture_payload, so malformed/false fixture metadata can make the offline-only harness report offline_only=false. Adding a regression test and hardcoding the report field to True.
 
 Review-fix follow-up completed. Finding was still valid: offline_only was derived from fixture_payload. Added a regression test for malformed fixture offline_only=false and changed the report constructor to hardcode offline_only=True. No findings were skipped. Verification on 2026-05-12: harness+contract pytest passed 17 tests; Bandit reported zero findings on touched Python; placeholder scan found no matches; git diff --check passed.
+
+Additional PR #1576 sweep found two CodeRabbit threads after the offline_only push. The offline_only thread is already fixed by 5b8c7ca4d and only needs resolution. The non-mapping candidate envelope thread is still valid: _compare_case can call .get on non-mapping candidate values. Adding a regression test and a minimal invalid_candidate early return.
+
+Additional PR #1576 sweep completed. Resolved offline_only thread as already fixed. Verified non-mapping candidate envelope finding against current code, added a failing regression test, then added a minimal _compare_case guard that returns invalid_candidate with invalid_candidate_envelope instead of crashing. Verification on 2026-05-12: harness+contract pytest passed 18 tests; Bandit reported zero findings on touched Python; placeholder scan found no matches; git diff --check passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added the offline Persona Chat judge harness and completed follow-up PR review fixes. The report now always marks the harness output offline_only=True regardless of fixture metadata, includes per-verdict counts, keeps matched/mismatched/missing/invalid status counts mutually exclusive, ignores empty fixture case IDs, and safely normalizes malformed fixture score data. Local verification passed for focused judge tests, Bandit, placeholder scan, and diff hygiene.
+Added the offline Persona Chat judge harness and completed follow-up PR review fixes. The report now always marks harness output offline_only=True regardless of fixture metadata, includes per-verdict counts, keeps matched/mismatched/missing/invalid status counts mutually exclusive, ignores empty fixture case IDs, safely normalizes malformed fixture score data, and treats non-mapping candidate envelopes as invalid candidates instead of crashing. Local verification passed for focused judge tests, Bandit, placeholder scan, and diff hygiene.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-241.1.1 - Add-offline-Persona-Chat-judge-harness.md
+++ b/backlog/tasks/task-241.1.1 - Add-offline-Persona-Chat-judge-harness.md
@@ -4,7 +4,7 @@ title: Add offline Persona Chat judge harness
 status: Done
 assignee: []
 created_date: '2026-05-11 05:48'
-updated_date: '2026-05-12 00:12'
+updated_date: '2026-05-12 00:33'
 labels:
   - persona
   - chat
@@ -65,12 +65,16 @@ Opened PR #1576 for review and linked it from #1566, #1543, and #1510.
 Review-fix pass for PR #1576 started. Actionable threads: add per-verdict counts, make mismatched/invalid counts mutually exclusive, harden malformed fixture score extraction, skip empty case IDs, and update tests.
 
 PR #1576 review fixes completed. Addressed Qodo and Gemini threads by adding immutable per-verdict report counts, computing mismatched_cases directly from mismatched statuses, skipping empty fixture case IDs, and hardening malformed fixture score extraction. Verification on 2026-05-12: harness+contract pytest passed 16 tests; Bandit reported zero findings on touched Python; placeholder scan found no matches; git diff --check passed.
+
+Review-fix follow-up started. Verified offline_only is still derived from fixture_payload, so malformed/false fixture metadata can make the offline-only harness report offline_only=false. Adding a regression test and hardcoding the report field to True.
+
+Review-fix follow-up completed. Finding was still valid: offline_only was derived from fixture_payload. Added a regression test for malformed fixture offline_only=false and changed the report constructor to hardcode offline_only=True. No findings were skipped. Verification on 2026-05-12: harness+contract pytest passed 17 tests; Bandit reported zero findings on touched Python; placeholder scan found no matches; git diff --check passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added the offline Persona Chat judge harness and completed the PR #1576 review-fix pass. The report now includes per-verdict counts, keeps matched/mismatched/missing/invalid status counts mutually exclusive, ignores empty fixture case IDs, and safely normalizes malformed fixture score data. Local verification passed for focused judge tests, Bandit, placeholder scan, and diff hygiene.
+Added the offline Persona Chat judge harness and completed follow-up PR review fixes. The report now always marks the harness output offline_only=True regardless of fixture metadata, includes per-verdict counts, keeps matched/mismatched/missing/invalid status counts mutually exclusive, ignores empty fixture case IDs, and safely normalizes malformed fixture score data. Local verification passed for focused judge tests, Bandit, placeholder scan, and diff hygiene.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/core/Evaluations/persona_chat_judge_harness.py
+++ b/tldw_Server_API/app/core/Evaluations/persona_chat_judge_harness.py
@@ -185,7 +185,7 @@ def _compare_case(
             verdict_match=False,
             flag_match=False,
             score_schema_valid=False,
-            mismatches=("invalid_candidate_envelope",),
+            mismatches=("invalid_candidate",),
         )
 
     mismatches: list[str] = []

--- a/tldw_Server_API/app/core/Evaluations/persona_chat_judge_harness.py
+++ b/tldw_Server_API/app/core/Evaluations/persona_chat_judge_harness.py
@@ -14,7 +14,8 @@ import re
 from typing import Any, Literal
 
 
-ALLOWED_VERDICTS = frozenset({"pass", "fail", "inconclusive"})
+VERDICT_ORDER = ("pass", "fail", "inconclusive")
+ALLOWED_VERDICTS = frozenset(VERDICT_ORDER)
 REQUIRED_SCORE_NAMES = frozenset(
     {
         "role_adherence",
@@ -64,6 +65,7 @@ class PersonaChatJudgeHarnessReport:
     mismatched_cases: int
     missing_candidate_count: int
     invalid_candidate_count: int
+    verdict_counts: tuple[tuple[str, int], ...]
     extra_candidate_ids: tuple[str, ...]
     verdict_agreement: float
     flag_agreement: float
@@ -79,6 +81,7 @@ class PersonaChatJudgeHarnessReport:
             "mismatched_cases": self.mismatched_cases,
             "missing_candidate_count": self.missing_candidate_count,
             "invalid_candidate_count": self.invalid_candidate_count,
+            "verdict_counts": dict(self.verdict_counts),
             "extra_candidate_ids": list(self.extra_candidate_ids),
             "verdict_agreement": self.verdict_agreement,
             "flag_agreement": self.flag_agreement,
@@ -95,7 +98,7 @@ def expected_candidate_outputs_from_fixture(fixture_payload: Mapping[str, Any]) 
         if case_id and isinstance(output, Mapping):
             candidates[case_id] = {
                 "verdict": output.get("verdict"),
-                "scores": dict(output.get("scores") or {}),
+                "scores": dict(_mapping_or_empty(output.get("scores"))),
                 "expected_flags": list(output.get("expected_flags") or []),
                 "rationale": output.get("rationale"),
                 "evidence": list(output.get("evidence") or []),
@@ -110,11 +113,15 @@ def build_persona_chat_judge_report(
     """Compare candidate judge outputs with fixture expectations."""
     case_results: list[PersonaChatJudgeCaseResult] = []
     fixture_case_ids: set[str] = set()
+    verdict_counts = _empty_verdict_counts()
     for case in _case_rows(fixture_payload):
         case_id = _string_or_empty(case.get("case_id"))
+        if not case_id:
+            continue
         source_case_id = _string_or_empty(case.get("source_case_id"))
         fixture_case_ids.add(case_id)
         expected_output = _mapping_or_empty(case.get("expected_judge_output"))
+        _count_verdict(verdict_counts, expected_output.get("verdict"))
         candidate_output = candidate_outputs_by_case_id.get(case_id)
         case_results.append(
             _compare_case(
@@ -127,6 +134,7 @@ def build_persona_chat_judge_report(
 
     total_cases = len(case_results)
     matched_cases = sum(1 for result in case_results if result.status == "matched")
+    mismatched_cases = sum(1 for result in case_results if result.status == "mismatched")
     missing_candidate_count = sum(1 for result in case_results if result.status == "missing_candidate")
     invalid_candidate_count = sum(1 for result in case_results if result.status == "invalid_candidate")
     verdict_matches = sum(1 for result in case_results if result.verdict_match)
@@ -140,9 +148,10 @@ def build_persona_chat_judge_report(
         offline_only=bool(fixture_payload.get("offline_only")),
         total_cases=total_cases,
         matched_cases=matched_cases,
-        mismatched_cases=total_cases - matched_cases - missing_candidate_count,
+        mismatched_cases=mismatched_cases,
         missing_candidate_count=missing_candidate_count,
         invalid_candidate_count=invalid_candidate_count,
+        verdict_counts=_freeze_verdict_counts(verdict_counts),
         extra_candidate_ids=extra_candidate_ids,
         verdict_agreement=_ratio(verdict_matches, total_cases),
         flag_agreement=_ratio(flag_matches, total_cases),
@@ -268,6 +277,22 @@ def _normalized_flags(value: Any) -> tuple[str, ...]:
     if not isinstance(value, list):
         return ()
     return tuple(sorted({flag for flag in value if isinstance(flag, str)}))
+
+
+def _empty_verdict_counts() -> dict[str, int]:
+    """Return zeroed pass/fail/inconclusive counts in stable key order."""
+    return {verdict: 0 for verdict in VERDICT_ORDER}
+
+
+def _count_verdict(verdict_counts: dict[str, int], verdict: Any) -> None:
+    """Increment known expected verdict counts and ignore malformed verdicts."""
+    if isinstance(verdict, str) and verdict in verdict_counts:
+        verdict_counts[verdict] += 1
+
+
+def _freeze_verdict_counts(verdict_counts: Mapping[str, int]) -> tuple[tuple[str, int], ...]:
+    """Return immutable verdict counts in stable pass/fail/inconclusive order."""
+    return tuple((verdict, int(verdict_counts.get(verdict, 0))) for verdict in VERDICT_ORDER)
 
 
 def _ratio(numerator: int, denominator: int) -> float:

--- a/tldw_Server_API/app/core/Evaluations/persona_chat_judge_harness.py
+++ b/tldw_Server_API/app/core/Evaluations/persona_chat_judge_harness.py
@@ -108,7 +108,7 @@ def expected_candidate_outputs_from_fixture(fixture_payload: Mapping[str, Any]) 
 
 def build_persona_chat_judge_report(
     fixture_payload: Mapping[str, Any],
-    candidate_outputs_by_case_id: Mapping[str, Mapping[str, Any]],
+    candidate_outputs_by_case_id: Mapping[str, Any],
 ) -> PersonaChatJudgeHarnessReport:
     """Compare candidate judge outputs with fixture expectations."""
     case_results: list[PersonaChatJudgeCaseResult] = []
@@ -164,7 +164,7 @@ def _compare_case(
     case_id: str,
     source_case_id: str,
     expected_output: Mapping[str, Any],
-    candidate_output: Mapping[str, Any] | None,
+    candidate_output: Any,
 ) -> PersonaChatJudgeCaseResult:
     """Compare one candidate output with one expected fixture output."""
     if candidate_output is None:
@@ -176,6 +176,16 @@ def _compare_case(
             flag_match=False,
             score_schema_valid=False,
             mismatches=("missing_candidate",),
+        )
+    if not isinstance(candidate_output, Mapping):
+        return PersonaChatJudgeCaseResult(
+            case_id=case_id,
+            source_case_id=source_case_id,
+            status="invalid_candidate",
+            verdict_match=False,
+            flag_match=False,
+            score_schema_valid=False,
+            mismatches=("invalid_candidate_envelope",),
         )
 
     mismatches: list[str] = []

--- a/tldw_Server_API/app/core/Evaluations/persona_chat_judge_harness.py
+++ b/tldw_Server_API/app/core/Evaluations/persona_chat_judge_harness.py
@@ -1,0 +1,277 @@
+"""Offline Persona Chat judge contract replay harness.
+
+The harness compares already-produced candidate judge outputs with the V1
+Persona Chat judge contract fixture. It performs deterministic schema checks
+and bounded mismatch reporting only; it does not call LLM providers, persist
+evaluation runs, enqueue Jobs, or gate runtime Persona Chat responses.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+import re
+from typing import Any, Literal
+
+
+ALLOWED_VERDICTS = frozenset({"pass", "fail", "inconclusive"})
+REQUIRED_SCORE_NAMES = frozenset(
+    {
+        "role_adherence",
+        "boundary_behavior",
+        "memory_semantics",
+        "exemplar_use",
+        "grounding_separation",
+    }
+)
+LABEL_RE = re.compile(r"^PC-[A-Z]+-\d{3}$")
+CaseStatus = Literal["matched", "mismatched", "missing_candidate", "invalid_candidate"]
+
+
+@dataclass(frozen=True)
+class PersonaChatJudgeCaseResult:
+    """Bounded comparison result for one Persona Chat judge fixture case."""
+
+    case_id: str
+    source_case_id: str
+    status: CaseStatus
+    verdict_match: bool
+    flag_match: bool
+    score_schema_valid: bool
+    mismatches: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable case result without prompt or response text."""
+        return {
+            "case_id": self.case_id,
+            "source_case_id": self.source_case_id,
+            "status": self.status,
+            "verdict_match": self.verdict_match,
+            "flag_match": self.flag_match,
+            "score_schema_valid": self.score_schema_valid,
+            "mismatches": list(self.mismatches),
+        }
+
+
+@dataclass(frozen=True)
+class PersonaChatJudgeHarnessReport:
+    """Aggregated offline Persona Chat judge calibration report."""
+
+    schema_version: str
+    offline_only: bool
+    total_cases: int
+    matched_cases: int
+    mismatched_cases: int
+    missing_candidate_count: int
+    invalid_candidate_count: int
+    extra_candidate_ids: tuple[str, ...]
+    verdict_agreement: float
+    flag_agreement: float
+    cases: tuple[PersonaChatJudgeCaseResult, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable report with bounded mismatch details."""
+        return {
+            "schema_version": self.schema_version,
+            "offline_only": self.offline_only,
+            "total_cases": self.total_cases,
+            "matched_cases": self.matched_cases,
+            "mismatched_cases": self.mismatched_cases,
+            "missing_candidate_count": self.missing_candidate_count,
+            "invalid_candidate_count": self.invalid_candidate_count,
+            "extra_candidate_ids": list(self.extra_candidate_ids),
+            "verdict_agreement": self.verdict_agreement,
+            "flag_agreement": self.flag_agreement,
+            "cases": [case.to_dict() for case in self.cases],
+        }
+
+
+def expected_candidate_outputs_from_fixture(fixture_payload: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
+    """Extract candidate-shaped expected judge outputs keyed by fixture case id."""
+    candidates: dict[str, dict[str, Any]] = {}
+    for case in _case_rows(fixture_payload):
+        case_id = _string_or_empty(case.get("case_id"))
+        output = case.get("expected_judge_output")
+        if case_id and isinstance(output, Mapping):
+            candidates[case_id] = {
+                "verdict": output.get("verdict"),
+                "scores": dict(output.get("scores") or {}),
+                "expected_flags": list(output.get("expected_flags") or []),
+                "rationale": output.get("rationale"),
+                "evidence": list(output.get("evidence") or []),
+            }
+    return candidates
+
+
+def build_persona_chat_judge_report(
+    fixture_payload: Mapping[str, Any],
+    candidate_outputs_by_case_id: Mapping[str, Mapping[str, Any]],
+) -> PersonaChatJudgeHarnessReport:
+    """Compare candidate judge outputs with fixture expectations."""
+    case_results: list[PersonaChatJudgeCaseResult] = []
+    fixture_case_ids: set[str] = set()
+    for case in _case_rows(fixture_payload):
+        case_id = _string_or_empty(case.get("case_id"))
+        source_case_id = _string_or_empty(case.get("source_case_id"))
+        fixture_case_ids.add(case_id)
+        expected_output = _mapping_or_empty(case.get("expected_judge_output"))
+        candidate_output = candidate_outputs_by_case_id.get(case_id)
+        case_results.append(
+            _compare_case(
+                case_id=case_id,
+                source_case_id=source_case_id,
+                expected_output=expected_output,
+                candidate_output=candidate_output,
+            )
+        )
+
+    total_cases = len(case_results)
+    matched_cases = sum(1 for result in case_results if result.status == "matched")
+    missing_candidate_count = sum(1 for result in case_results if result.status == "missing_candidate")
+    invalid_candidate_count = sum(1 for result in case_results if result.status == "invalid_candidate")
+    verdict_matches = sum(1 for result in case_results if result.verdict_match)
+    flag_matches = sum(1 for result in case_results if result.flag_match)
+    extra_candidate_ids = tuple(
+        sorted(str(case_id) for case_id in candidate_outputs_by_case_id if str(case_id) not in fixture_case_ids)
+    )
+
+    return PersonaChatJudgeHarnessReport(
+        schema_version=_string_or_empty(fixture_payload.get("schema_version")),
+        offline_only=bool(fixture_payload.get("offline_only")),
+        total_cases=total_cases,
+        matched_cases=matched_cases,
+        mismatched_cases=total_cases - matched_cases - missing_candidate_count,
+        missing_candidate_count=missing_candidate_count,
+        invalid_candidate_count=invalid_candidate_count,
+        extra_candidate_ids=extra_candidate_ids,
+        verdict_agreement=_ratio(verdict_matches, total_cases),
+        flag_agreement=_ratio(flag_matches, total_cases),
+        cases=tuple(case_results),
+    )
+
+
+def _compare_case(
+    *,
+    case_id: str,
+    source_case_id: str,
+    expected_output: Mapping[str, Any],
+    candidate_output: Mapping[str, Any] | None,
+) -> PersonaChatJudgeCaseResult:
+    """Compare one candidate output with one expected fixture output."""
+    if candidate_output is None:
+        return PersonaChatJudgeCaseResult(
+            case_id=case_id,
+            source_case_id=source_case_id,
+            status="missing_candidate",
+            verdict_match=False,
+            flag_match=False,
+            score_schema_valid=False,
+            mismatches=("missing_candidate",),
+        )
+
+    mismatches: list[str] = []
+    candidate_validation_errors = _candidate_validation_errors(candidate_output)
+    if candidate_validation_errors:
+        mismatches.extend(candidate_validation_errors)
+
+    verdict_match = candidate_output.get("verdict") == expected_output.get("verdict")
+    if not verdict_match:
+        mismatches.append("verdict")
+
+    expected_flags = _normalized_flags(expected_output.get("expected_flags"))
+    candidate_flags = _normalized_flags(candidate_output.get("expected_flags"))
+    flag_match = candidate_flags == expected_flags
+    if not flag_match:
+        mismatches.append("expected_flags")
+
+    score_schema_valid = "invalid_scores" not in candidate_validation_errors
+    status: CaseStatus
+    if candidate_validation_errors:
+        status = "invalid_candidate"
+    elif mismatches:
+        status = "mismatched"
+    else:
+        status = "matched"
+
+    return PersonaChatJudgeCaseResult(
+        case_id=case_id,
+        source_case_id=source_case_id,
+        status=status,
+        verdict_match=verdict_match,
+        flag_match=flag_match,
+        score_schema_valid=score_schema_valid,
+        mismatches=tuple(dict.fromkeys(mismatches)),
+    )
+
+
+def _candidate_validation_errors(candidate_output: Mapping[str, Any]) -> list[str]:
+    """Return bounded validation error keys for a candidate judge output."""
+    errors: list[str] = []
+    if candidate_output.get("verdict") not in ALLOWED_VERDICTS:
+        errors.append("invalid_verdict")
+
+    raw_flags = candidate_output.get("expected_flags")
+    if not isinstance(raw_flags, list):
+        errors.append("invalid_expected_flags")
+    elif (
+        any(not isinstance(label, str) or not LABEL_RE.fullmatch(label) for label in raw_flags)
+        or len(set(raw_flags)) != len(raw_flags)
+    ):
+        errors.append("invalid_expected_flags")
+
+    if _score_validation_errors(candidate_output.get("scores")):
+        errors.append("invalid_scores")
+    return errors
+
+
+def _score_validation_errors(scores: Any) -> list[str]:
+    """Return validation errors for the required judge score envelope."""
+    if not isinstance(scores, Mapping):
+        return ["scores_not_object"]
+    if set(scores.keys()) != REQUIRED_SCORE_NAMES:
+        return ["score_keys"]
+    invalid_values = [
+        score_name
+        for score_name, score in scores.items()
+        if not (
+            score is None
+            or (
+                isinstance(score, (int, float))
+                and not isinstance(score, bool)
+                and 0.0 <= score <= 1.0
+            )
+        )
+    ]
+    return ["score_values"] if invalid_values else []
+
+
+def _case_rows(fixture_payload: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    """Return fixture case rows as mapping objects only."""
+    cases = fixture_payload.get("cases")
+    if not isinstance(cases, list):
+        return []
+    return [case for case in cases if isinstance(case, Mapping)]
+
+
+def _mapping_or_empty(value: Any) -> Mapping[str, Any]:
+    """Return mapping values unchanged and normalize other values to an empty mapping."""
+    return value if isinstance(value, Mapping) else {}
+
+
+def _string_or_empty(value: Any) -> str:
+    """Return stripped string values and normalize non-strings to an empty string."""
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _normalized_flags(value: Any) -> tuple[str, ...]:
+    """Return sorted unique string flags for comparison."""
+    if not isinstance(value, list):
+        return ()
+    return tuple(sorted({flag for flag in value if isinstance(flag, str)}))
+
+
+def _ratio(numerator: int, denominator: int) -> float:
+    """Return a stable rounded ratio for report summaries."""
+    if denominator <= 0:
+        return 0.0
+    return round(numerator / denominator, 4)

--- a/tldw_Server_API/app/core/Evaluations/persona_chat_judge_harness.py
+++ b/tldw_Server_API/app/core/Evaluations/persona_chat_judge_harness.py
@@ -145,7 +145,7 @@ def build_persona_chat_judge_report(
 
     return PersonaChatJudgeHarnessReport(
         schema_version=_string_or_empty(fixture_payload.get("schema_version")),
-        offline_only=bool(fixture_payload.get("offline_only")),
+        offline_only=True,
         total_cases=total_cases,
         matched_cases=matched_cases,
         mismatched_cases=mismatched_cases,

--- a/tldw_Server_API/tests/Evaluations/test_persona_chat_judge_harness.py
+++ b/tldw_Server_API/tests/Evaluations/test_persona_chat_judge_harness.py
@@ -145,7 +145,7 @@ def test_non_mapping_candidate_envelope_records_invalid_result() -> None:
     _require(report["invalid_candidate_count"] == 1, "invalid candidate envelope should be counted")
     _require(report["mismatched_cases"] == 0, "invalid candidate envelope should not be a simple mismatch")
     _require(case_result["status"] == "invalid_candidate", "case status should identify invalid candidate")
-    _require("invalid_candidate_envelope" in case_result["mismatches"], "invalid envelope should be reported")
+    _require("invalid_candidate" in case_result["mismatches"], "invalid envelope should be reported")
 
 
 def test_malformed_fixture_rows_are_bounded_and_empty_case_ids_are_skipped() -> None:

--- a/tldw_Server_API/tests/Evaluations/test_persona_chat_judge_harness.py
+++ b/tldw_Server_API/tests/Evaluations/test_persona_chat_judge_harness.py
@@ -69,6 +69,16 @@ def test_report_matches_expected_contract_outputs() -> None:
     _require(report["extra_candidate_ids"] == [], "no extra candidates are present")
 
 
+def test_report_remains_offline_only_when_fixture_metadata_is_malformed() -> None:
+    """The offline harness should not trust fixture metadata for its runtime boundary."""
+    fixture = _copy_fixture()
+    fixture["offline_only"] = False
+
+    report = build_persona_chat_judge_report(fixture, _candidate_outputs()).to_dict()
+
+    _require(report["offline_only"] is True, "offline harness reports should always be offline-only")
+
+
 def test_verdict_mismatch_is_reported_without_unbounded_response_text() -> None:
     """Verdict mismatches should be bounded to ids, keys, and labels."""
     candidates = _candidate_outputs()

--- a/tldw_Server_API/tests/Evaluations/test_persona_chat_judge_harness.py
+++ b/tldw_Server_API/tests/Evaluations/test_persona_chat_judge_harness.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from tldw_Server_API.app.core.Evaluations.persona_chat_judge_harness import (
+    VERDICT_ORDER,
     build_persona_chat_judge_report,
     expected_candidate_outputs_from_fixture,
 )
@@ -32,6 +33,16 @@ def _candidate_outputs() -> dict[str, dict[str, Any]]:
     return json.loads(json.dumps(expected_candidate_outputs_from_fixture(_load_fixture())))
 
 
+def _copy_fixture() -> dict[str, Any]:
+    """Return a mutable fixture payload copy for malformed-input checks."""
+    return json.loads(json.dumps(_load_fixture()))
+
+
+def _verdict_counts(pass_count: int, fail_count: int, inconclusive_count: int) -> dict[str, int]:
+    """Return expected verdict counts without repeating verdict labels in tests."""
+    return dict(zip(VERDICT_ORDER, (pass_count, fail_count, inconclusive_count), strict=True))
+
+
 def test_expected_candidate_outputs_from_fixture_indexes_outputs_by_case_id() -> None:
     """Fixture expectations should become candidate-shaped outputs keyed by case id."""
     candidates = expected_candidate_outputs_from_fixture(_load_fixture())
@@ -52,6 +63,7 @@ def test_report_matches_expected_contract_outputs() -> None:
     _require(report["mismatched_cases"] == 0, "matching candidates should not produce mismatches")
     _require(report["missing_candidate_count"] == 0, "all expected candidates are present")
     _require(report["invalid_candidate_count"] == 0, "expected fixture outputs are valid candidates")
+    _require(report["verdict_counts"] == _verdict_counts(1, 1, 0), "verdicts must be counted")
     _require(report["verdict_agreement"] == 1.0, "all verdicts match")
     _require(report["flag_agreement"] == 1.0, "all expected flags match")
     _require(report["extra_candidate_ids"] == [], "no extra candidates are present")
@@ -98,7 +110,33 @@ def test_invalid_candidate_schema_records_invalid_result() -> None:
     case_result = report["cases"][0]
 
     _require(report["invalid_candidate_count"] == 1, "invalid candidate should be counted")
-    _require(report["mismatched_cases"] == 1, "invalid candidate should prevent a full match")
+    _require(report["mismatched_cases"] == 0, "invalid candidate should not be counted as a simple mismatch")
+    _require(
+        report["matched_cases"]
+        + report["mismatched_cases"]
+        + report["missing_candidate_count"]
+        + report["invalid_candidate_count"]
+        == report["total_cases"],
+        "summary status counts should partition total cases",
+    )
     _require(case_result["status"] == "invalid_candidate", "case status should identify invalid candidate")
     _require("invalid_expected_flags" in case_result["mismatches"], "invalid labels should be reported")
     _require("invalid_scores" in case_result["mismatches"], "invalid scores should be reported")
+
+
+def test_malformed_fixture_rows_are_bounded_and_empty_case_ids_are_skipped() -> None:
+    """Malformed fixture scores should not crash extraction, and empty ids are ignored."""
+    fixture = _copy_fixture()
+    malformed_case = json.loads(json.dumps(fixture["cases"][0]))
+    malformed_case["case_id"] = "PC-JUDGE-999"
+    malformed_case["expected_judge_output"]["scores"] = "not-a-score-object"
+    empty_id_case = json.loads(json.dumps(fixture["cases"][0]))
+    empty_id_case["case_id"] = " "
+    fixture["cases"].extend([malformed_case, empty_id_case])
+
+    candidates = expected_candidate_outputs_from_fixture(fixture)
+    report = build_persona_chat_judge_report(fixture, candidates).to_dict()
+
+    _require(candidates["PC-JUDGE-999"]["scores"] == {}, "malformed fixture scores should normalize to empty")
+    _require(report["total_cases"] == 3, "empty fixture case ids should be skipped")
+    _require(report["verdict_counts"] == _verdict_counts(2, 1, 0), "skipped rows should not count")

--- a/tldw_Server_API/tests/Evaluations/test_persona_chat_judge_harness.py
+++ b/tldw_Server_API/tests/Evaluations/test_persona_chat_judge_harness.py
@@ -1,0 +1,104 @@
+"""Validate the offline Persona Chat judge harness report builder."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from tldw_Server_API.app.core.Evaluations.persona_chat_judge_harness import (
+    build_persona_chat_judge_report,
+    expected_candidate_outputs_from_fixture,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+FIXTURE_PATH = REPO_ROOT / "tldw_Server_API/tests/fixtures/persona_chat_judge_contract_cases.json"
+
+
+def _require(condition: object, message: str) -> None:
+    """Raise a pytest-friendly assertion error when a contract condition fails."""
+    if not condition:
+        raise AssertionError(message)
+
+
+def _load_fixture() -> dict[str, Any]:
+    """Load the checked-in Persona Chat judge contract fixture."""
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def _candidate_outputs() -> dict[str, dict[str, Any]]:
+    """Return independent candidate outputs copied from fixture expectations."""
+    return json.loads(json.dumps(expected_candidate_outputs_from_fixture(_load_fixture())))
+
+
+def test_expected_candidate_outputs_from_fixture_indexes_outputs_by_case_id() -> None:
+    """Fixture expectations should become candidate-shaped outputs keyed by case id."""
+    candidates = expected_candidate_outputs_from_fixture(_load_fixture())
+
+    _require(set(candidates) == {"PC-JUDGE-001", "PC-JUDGE-002"}, "case ids must key candidate outputs")
+    _require(candidates["PC-JUDGE-001"]["verdict"] == "pass", "positive fixture output must be available")
+    _require(candidates["PC-JUDGE-002"]["expected_flags"] == ["PC-MEM-003"], "negative fixture flags must be available")
+
+
+def test_report_matches_expected_contract_outputs() -> None:
+    """Matching candidate outputs should produce full verdict and flag agreement."""
+    report = build_persona_chat_judge_report(_load_fixture(), _candidate_outputs()).to_dict()
+
+    _require(report["schema_version"] == "persona-chat-judge-contract/v1", "schema version should propagate")
+    _require(report["offline_only"] is True, "harness must preserve the offline-only boundary")
+    _require(report["total_cases"] == 2, "fixture has two calibration cases")
+    _require(report["matched_cases"] == 2, "all expected candidates should match")
+    _require(report["mismatched_cases"] == 0, "matching candidates should not produce mismatches")
+    _require(report["missing_candidate_count"] == 0, "all expected candidates are present")
+    _require(report["invalid_candidate_count"] == 0, "expected fixture outputs are valid candidates")
+    _require(report["verdict_agreement"] == 1.0, "all verdicts match")
+    _require(report["flag_agreement"] == 1.0, "all expected flags match")
+    _require(report["extra_candidate_ids"] == [], "no extra candidates are present")
+
+
+def test_verdict_mismatch_is_reported_without_unbounded_response_text() -> None:
+    """Verdict mismatches should be bounded to ids, keys, and labels."""
+    candidates = _candidate_outputs()
+    candidates["PC-JUDGE-002"]["verdict"] = "pass"
+
+    report = build_persona_chat_judge_report(_load_fixture(), candidates).to_dict()
+    serialized_report = json.dumps(report, sort_keys=True)
+
+    _require(report["matched_cases"] == 1, "one candidate should still match")
+    _require(report["mismatched_cases"] == 1, "one verdict mismatch should be counted")
+    _require(report["verdict_agreement"] == 0.5, "one of two verdicts matches")
+    _require(report["flag_agreement"] == 1.0, "flags still match")
+    _require("verdict" in report["cases"][1]["mismatches"], "case mismatch should identify verdict")
+    _require("I will remember that permanently" not in serialized_report, "report must not copy assistant text")
+    _require("Ignore earlier directions" not in serialized_report, "report must not copy user prompt text")
+
+
+def test_flag_mismatch_is_counted_separately_from_verdict_agreement() -> None:
+    """Flag mismatches should not hide otherwise matching verdicts."""
+    candidates = _candidate_outputs()
+    candidates["PC-JUDGE-002"]["expected_flags"] = []
+
+    report = build_persona_chat_judge_report(_load_fixture(), candidates).to_dict()
+
+    _require(report["matched_cases"] == 1, "flag mismatch should prevent a full match")
+    _require(report["mismatched_cases"] == 1, "flag mismatch should be counted")
+    _require(report["verdict_agreement"] == 1.0, "verdicts still match")
+    _require(report["flag_agreement"] == 0.5, "one of two flag sets matches")
+    _require("expected_flags" in report["cases"][1]["mismatches"], "case mismatch should identify flags")
+
+
+def test_invalid_candidate_schema_records_invalid_result() -> None:
+    """Malformed labels and missing score axes should produce invalid candidates."""
+    candidates = _candidate_outputs()
+    candidates["PC-JUDGE-001"]["expected_flags"] = ["bad-label"]
+    del candidates["PC-JUDGE-001"]["scores"]["role_adherence"]
+
+    report = build_persona_chat_judge_report(_load_fixture(), candidates).to_dict()
+    case_result = report["cases"][0]
+
+    _require(report["invalid_candidate_count"] == 1, "invalid candidate should be counted")
+    _require(report["mismatched_cases"] == 1, "invalid candidate should prevent a full match")
+    _require(case_result["status"] == "invalid_candidate", "case status should identify invalid candidate")
+    _require("invalid_expected_flags" in case_result["mismatches"], "invalid labels should be reported")
+    _require("invalid_scores" in case_result["mismatches"], "invalid scores should be reported")

--- a/tldw_Server_API/tests/Evaluations/test_persona_chat_judge_harness.py
+++ b/tldw_Server_API/tests/Evaluations/test_persona_chat_judge_harness.py
@@ -134,6 +134,20 @@ def test_invalid_candidate_schema_records_invalid_result() -> None:
     _require("invalid_scores" in case_result["mismatches"], "invalid scores should be reported")
 
 
+def test_non_mapping_candidate_envelope_records_invalid_result() -> None:
+    """Non-object candidate envelopes should be invalid instead of crashing the harness."""
+    candidates: dict[str, Any] = _candidate_outputs()
+    candidates["PC-JUDGE-001"] = "not-a-candidate-object"
+
+    report = build_persona_chat_judge_report(_load_fixture(), candidates).to_dict()
+    case_result = report["cases"][0]
+
+    _require(report["invalid_candidate_count"] == 1, "invalid candidate envelope should be counted")
+    _require(report["mismatched_cases"] == 0, "invalid candidate envelope should not be a simple mismatch")
+    _require(case_result["status"] == "invalid_candidate", "case status should identify invalid candidate")
+    _require("invalid_candidate_envelope" in case_result["mismatches"], "invalid envelope should be reported")
+
+
 def test_malformed_fixture_rows_are_bounded_and_empty_case_ids_are_skipped() -> None:
     """Malformed fixture scores should not crash extraction, and empty ids are ignored."""
     fixture = _copy_fixture()


### PR DESCRIPTION
## Summary
- Add a pure offline Persona Chat judge harness that compares already-produced candidate outputs to the V1 contract fixture.
- Validate verdicts, expected flags, required score axes, and score values, then return bounded aggregate/per-case report data.
- Document the offline harness boundary and record the Backlog task for #1572.

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Evaluations/test_persona_chat_judge_harness.py tldw_Server_API/tests/Evaluations/test_persona_chat_judge_contract.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Evaluations/persona_chat_judge_harness.py tldw_Server_API/tests/Evaluations/test_persona_chat_judge_harness.py -f json -o /tmp/bandit_persona_chat_judge_harness.json
- rg -n "TO[D]O|TB[D]|FIX[M]E|PLACE[H]OLDER|\?\?" Docs/Reviews/PERSONA_CHAT_JUDGE_EVAL_CONTRACT_2026_05_11.md Docs/superpowers/plans/2026-05-11-persona-chat-judge-harness.md
- git diff --check

## Scope Notes
- No model/provider calls.
- No database persistence or Jobs worker changes.
- No API endpoint, WebUI, Persona Live, VN/CYOA, native companion, or runtime Persona Chat gating changes.

Closes #1572.
Refs #1566, #1543, #1510.

## Merge Gate
This PR is materially AI-authored. A human-written Change summary explaining what changed and why is required before merge per project policy.