### PR TITLE
Migrate reading progress loading label to registry

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -5093,17 +5093,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "canonical-state-label:src/components/Media/hooks/useReadingProgress.tsx:Loading",
-    "path": "src/components/Media/hooks/useReadingProgress.tsx",
-    "rule": "canonical-state-label",
-    "subject": "Loading",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing hardcoded \"Loading\" state label in src/components/Media/hooks/useReadingProgress.tsx before the guard.",
-    "replacement": "getDesignSystemState(...)",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "canonical-state-label:src/components/Option/ACPPlayground/ACPSessionCreateModal.tsx:Ready",
     "path": "src/components/Option/ACPPlayground/ACPSessionCreateModal.tsx",
     "rule": "canonical-state-label",

--- a/apps/packages/ui/src/components/Media/__tests__/ContentViewer.stage15.accessibility.test.tsx
+++ b/apps/packages/ui/src/components/Media/__tests__/ContentViewer.stage15.accessibility.test.tsx
@@ -4,6 +4,10 @@ import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import { ContentViewer } from '../ContentViewer'
 
+const registryLabels = vi.hoisted(() => ({
+  loading: 'Loading via registry'
+}))
+
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (_key: string, fallbackOrOptions?: string | { defaultValue?: string }) => {
@@ -12,6 +16,24 @@ vi.mock('react-i18next', () => ({
     }
   })
 }))
+
+vi.mock('@/design-system', async (importActual) => {
+  const actual = await importActual<typeof import('@/design-system')>()
+
+  return {
+    ...actual,
+    getDesignSystemState: vi.fn(
+      (key: Parameters<typeof actual.getDesignSystemState>[0]) => {
+        const state = actual.getDesignSystemState(key)
+
+        return {
+          ...state,
+          label: key === 'loading' ? registryLabels.loading : state.label
+        }
+      }
+    )
+  }
+})
 
 vi.mock('@/hooks/useSetting', async () => {
   const React = await import('react')
@@ -85,7 +107,7 @@ describe('ContentViewer stage 15 content announcements', () => {
 
     const liveRegion = screen.getByTestId('content-selection-live-region')
     await waitFor(() =>
-      expect(liveRegion).toHaveTextContent('Loading Accessibility Item One')
+      expect(liveRegion).toHaveTextContent('Loading via registry Accessibility Item One')
     )
 
     rerender(

--- a/apps/packages/ui/src/components/Media/hooks/useReadingProgress.tsx
+++ b/apps/packages/ui/src/components/Media/hooks/useReadingProgress.tsx
@@ -5,6 +5,7 @@ import {
 } from '@/utils/media-navigation-target'
 import { applyMediaNavigationTarget } from '@/utils/media-navigation-target-actions'
 import { useMediaReadingProgress } from '@/hooks/useMediaReadingProgress'
+import { getDesignSystemState } from '@/design-system'
 import type { MediaResultItem } from '../types'
 
 const normalizeComparableText = (value: string): string =>
@@ -270,7 +271,9 @@ export function useReadingProgress(deps: UseReadingProgressDeps) {
 
     lastContentSelectionAnnouncementKeyRef.current = announcementKey
     const statusPrefix = isDetailLoading
-      ? t('review:mediaPage.contentAnnouncementLoading', { defaultValue: 'Loading' })
+      ? t('review:mediaPage.contentAnnouncementLoading', {
+          defaultValue: getDesignSystemState('loading').label
+        })
       : t('review:mediaPage.contentAnnouncementShowing', { defaultValue: 'Showing' })
     setContentSelectionAnnouncement(`${statusPrefix} ${selectedMediaAnnouncementLabel}`)
   }, [isDetailLoading, selectedMediaAnnouncementLabel, selectedMediaId, t])

--- a/backlog/tasks/task-276 - Migrate-reading-progress-loading-label-to-design-system-registry.md
+++ b/backlog/tasks/task-276 - Migrate-reading-progress-loading-label-to-design-system-registry.md
@@ -1,0 +1,57 @@
+---
+id: TASK-276
+title: Migrate reading progress loading label to design-system registry
+status: Done
+assignee: []
+created_date: '2026-05-12 00:18'
+labels:
+  - design-system
+  - frontend
+  - product-state
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Remove the remaining hardcoded reading-progress loading state label from the product-state guard baseline by routing it through the design-system state registry without changing reading progress behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The reading progress loading label is sourced from the design-system state registry instead of a hardcoded canonical label.
+- [x] #2 The product-state guard baseline no longer includes the reading progress loading-label exception.
+- [x] #3 Focused regression coverage proves the registry fallback is used for the loading label.
+- [x] #4 Design-system guard verification passes for this slice.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Notes
+
+- Updated `useReadingProgress` so the loading live-region prefix uses `getDesignSystemState('loading').label` as the i18n default value.
+- Updated the stage 15 accessibility regression test to mock the design-system loading label and assert that registry fallback appears in the content-selection announcement.
+- Removed the matching `canonical-state-label` baseline exception for `src/components/Media/hooks/useReadingProgress.tsx`.
+
+## Verification
+
+- PR: https://github.com/rmusser01/tldw_server/pull/1577
+- `bunx vitest run src/components/Media/__tests__/ContentViewer.stage15.accessibility.test.tsx --reporter=dot`
+- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot`
+- `bun run verify:design-system-state`
+- `git diff --check`
+- `bunx tsc --noEmit --pretty false 2>&1 | rg -n "useReadingProgress|ContentViewer.stage15.accessibility|design-system-product-state-baseline"` returned no touched-path matches; full frontend `tsc` remains repo-noisy.
+- Bandit skipped: frontend TypeScript/test-only slice with no Python runtime changes.
+
+## Final Summary
+
+Migrated the reading-progress loading announcement label to the design-system state registry and removed its product-state guard baseline exception. The focused accessibility test now proves the loading prefix follows the registry fallback while preserving the ready announcement behavior.


### PR DESCRIPTION
## Summary
- Route the reading-progress loading announcement prefix through `getDesignSystemState("loading")?.label`.
- Update the stage 15 accessibility regression test to prove the loading prefix follows the design-system registry fallback.
- Remove the matching product-state guard baseline exception and record TASK-276 verification.

## Test Plan
- `bunx vitest run src/components/Media/__tests__/ContentViewer.stage15.accessibility.test.tsx --reporter=dot`
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot`
- `bun run verify:design-system-state`
- `git diff --check`
- `bunx tsc --noEmit --pretty false 2>&1 | rg -n "useReadingProgress|ContentViewer.stage15.accessibility|design-system-product-state-baseline"` returned no touched-path matches.
