### PR TITLE
Migrate ReviewPage ready status label to registry

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -5423,17 +5423,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "canonical-state-label:src/components/Review/ReviewPage.tsx:Ready",
-    "path": "src/components/Review/ReviewPage.tsx",
-    "rule": "canonical-state-label",
-    "subject": "Ready",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing hardcoded \"Ready\" state label in src/components/Review/ReviewPage.tsx before the guard.",
-    "replacement": "getDesignSystemState(...)",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "canonical-state-label:src/routes/sidepanel-chat.tsx:Ready",
     "path": "src/routes/sidepanel-chat.tsx",
     "rule": "canonical-state-label",

--- a/apps/packages/ui/src/components/Review/ReviewPage.tsx
+++ b/apps/packages/ui/src/components/Review/ReviewPage.tsx
@@ -57,6 +57,7 @@ import {
 } from "@/services/settings/ui-settings"
 import { resolveApiProviderForModel } from "@/utils/resolve-api-provider"
 import { DEFAULT_ANALYSIS_SUMMARY_PROMPT } from "@/utils/default-prompts"
+import { getDesignSystemState } from "@/design-system"
 const Markdown = React.lazy(() => import("@/components/Common/Markdown"))
 
 type MediaItem = any
@@ -415,7 +416,10 @@ export const ReviewPage: React.FC<ReviewPageProps> = ({
       }
       if (/(ready|completed|done|success)/.test(v)) {
         return {
-          label: t("review:reviewPage.statusReady", "Ready"),
+          label: t(
+            "review:reviewPage.statusReady",
+            getDesignSystemState("ready")?.label
+          ),
           color: "green"
         }
       }

--- a/apps/packages/ui/src/components/Review/__tests__/ReviewPage.connection.test.tsx
+++ b/apps/packages/ui/src/components/Review/__tests__/ReviewPage.connection.test.tsx
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
   hasCompletedFirstRun: true,
   navigate: vi.fn(),
   checkOnce: vi.fn(),
+  queryData: [] as Array<Record<string, unknown>>,
   promptSearch: {
     query: "",
     setQuery: vi.fn(),
@@ -42,6 +43,14 @@ vi.mock("react-i18next", () => ({
   })
 }))
 
+vi.mock("@/design-system", () => ({
+  getDesignSystemState: (key: string) => ({
+    key,
+    label: key === "ready" ? "Registry Ready" : key,
+    severity: "neutral"
+  })
+}))
+
 vi.mock("react-router-dom", async () => {
   const actual = await vi.importActual<typeof import("react-router-dom")>(
     "react-router-dom"
@@ -54,7 +63,7 @@ vi.mock("react-router-dom", async () => {
 
 vi.mock("@tanstack/react-query", () => ({
   useQuery: () => ({
-    data: [],
+    data: mocks.queryData,
     isFetching: false,
     refetch: vi.fn()
   })
@@ -72,21 +81,50 @@ vi.mock("antd", () => {
       {children}
     </button>
   )
+  const InputBase = ({
+    allowClear: _allowClear,
+    onPressEnter: _onPressEnter,
+    ...props
+  }: React.InputHTMLAttributes<HTMLInputElement> & {
+    allowClear?: boolean
+    onPressEnter?: () => void
+  }) => <input {...props} />
 
   return {
     Button,
     Checkbox: () => <input type="checkbox" />,
     Divider: () => <hr />,
     Empty: ({ description }: { description?: React.ReactNode }) => <div>{description}</div>,
-    Input: Object.assign(
-      (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+    Input: Object.assign(InputBase, {
+      TextArea: (
+        props: React.TextareaHTMLAttributes<HTMLTextAreaElement>
+      ) => <textarea {...props} />
+    }),
+    List: Object.assign(
+      ({
+        children,
+        dataSource = [],
+        renderItem
+      }: {
+        children?: React.ReactNode
+        dataSource?: unknown[]
+        renderItem?: (item: unknown, index: number) => React.ReactNode
+      }) => (
+        <div>
+          {children}
+          {dataSource.map((item, index) => (
+            <React.Fragment key={index}>
+              {renderItem?.(item, index)}
+            </React.Fragment>
+          ))}
+        </div>
+      ),
       {
-        TextArea: (
-          props: React.TextareaHTMLAttributes<HTMLTextAreaElement>
-        ) => <textarea {...props} />
+        Item: ({ children }: { children?: React.ReactNode }) => (
+          <div>{children}</div>
+        )
       }
     ),
-    List: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
     Space: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
     Spin: () => <div>loading</div>,
     Tag: ({ children }: { children?: React.ReactNode }) => <span>{children}</span>,
@@ -99,6 +137,9 @@ vi.mock("antd", () => {
     Select: ({ children }: { children?: React.ReactNode }) => <select>{children}</select>,
     Pagination: () => <div />,
     Radio: {
+      Button: ({ children }: { children?: React.ReactNode }) => (
+        <button type="button">{children}</button>
+      ),
       Group: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>
     },
     Modal: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
@@ -298,6 +339,7 @@ describe("ReviewPage connection states", () => {
     mocks.hasCompletedFirstRun = true
     mocks.navigate.mockReset()
     mocks.checkOnce.mockReset()
+    mocks.queryData = []
     mocks.promptSearch.setQuery.mockReset()
     mocks.promptSearch.setIncludeLocal.mockReset()
     mocks.promptSearch.setIncludeServer.mockReset()
@@ -344,5 +386,21 @@ describe("ReviewPage connection states", () => {
     expect(
       screen.queryByText("Add your credentials to use Review")
     ).not.toBeInTheDocument()
+  })
+
+  it("uses the design-system registry fallback for ready status labels", () => {
+    mocks.queryData = [
+      {
+        kind: "media",
+        id: "ready-media",
+        title: "Ready media",
+        meta: { status: "ready" },
+        raw: {}
+      }
+    ]
+
+    renderPage()
+
+    expect(screen.getByText("Registry Ready")).toBeInTheDocument()
   })
 })

--- a/backlog/tasks/task-281 - Migrate-ReviewPage-ready-status-label-to-design-system-registry.md
+++ b/backlog/tasks/task-281 - Migrate-ReviewPage-ready-status-label-to-design-system-registry.md
@@ -1,0 +1,56 @@
+---
+id: TASK-281
+title: Migrate ReviewPage ready status label to design-system registry
+status: Done
+assignee: []
+created_date: '2026-05-12 01:27'
+updated_date: '2026-05-12 01:50'
+labels:
+  - design-system
+  - frontend
+  - product-state
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Remove the ReviewPage hardcoded Ready product-state label from the guard baseline by sourcing the ready status fallback from the design-system state registry without changing review status behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 ReviewPage ready status fallback label is sourced from the design-system state registry instead of a hardcoded canonical label.
+- [x] #2 The product-state guard baseline no longer includes the ReviewPage Ready-label exception.
+- [x] #3 Focused regression coverage proves the registry fallback is used for the ReviewPage ready status label.
+- [x] #4 Design-system guard verification passes for this slice.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+PR: https://github.com/rmusser01/tldw_server/pull/1585
+
+Updated ReviewPage ready status fallback to use getDesignSystemState("ready")?.label. Added focused behavior coverage in ReviewPage.connection.test.tsx by mocking the design-system registry to return a distinctive ready label and asserting ReviewPage renders that fallback for a ready media result. Removed the matching canonical-state-label baseline exception.
+
+Verification: red ReviewPage guard failed before implementation, then ReviewPage guard passed, product-state guard tests passed, verify:design-system-state passed, git diff --check passed, touched-path tsc filter returned no matches. Bandit skipped because this is a frontend TypeScript/test-only slice with no Python runtime changes.
+
+Addressed PR review feedback by making the ready state lookup optional and replacing the source-string guard with behavior coverage. This removed the __dirname source-path helper called out in review. Re-ran ReviewPage guard, product-state guard tests, verify:design-system-state, git diff --check, and touched-path tsc filter after the review fixes.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated the ReviewPage ready status fallback label to the design-system state registry and removed its product-state guard baseline exception. Focused coverage now prevents the ready status fallback from regressing to a hardcoded canonical label.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Route the ReviewPage ready status fallback label through `getDesignSystemState("ready").label`.
- Add a focused ReviewPage source guard covering the ready status registry fallback.
- Remove the ReviewPage Ready-label product-state baseline exception.

## Test Plan
- `bunx vitest run src/components/Review/__tests__/ReviewPage.connection.test.tsx --reporter=dot`
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot`
- `bun run verify:design-system-state`
- `git diff --check`
- `bunx tsc --noEmit --pretty false 2>&1 | rg -n "ReviewPage|design-system-product-state-baseline"` returned no touched-path matches; full frontend `tsc` remains repo-noisy.
