### PR TITLE
Add Persona Chat judge calibration policy

### DIFF
--- a/Docs/Reviews/PERSONA_CHAT_JUDGE_EVALUATION_CONTRACT_2026_05_11.md
+++ b/Docs/Reviews/PERSONA_CHAT_JUDGE_EVALUATION_CONTRACT_2026_05_11.md
@@ -76,7 +76,9 @@ The default production threshold is 20 pass and 20 fail cases per dimension. The
 
 `evaluate_persona_chat_judge_report_policy()` classifies offline harness reports as `advisory` or `blocked` before any report is treated as a calibration signal. The helper accepts the harness dataclass or the JSON object produced by the offline review command.
 
-The policy blocks reports with malformed report fields, invalid candidate envelopes, missing candidates, extra candidate ids, verdict agreement below the configured threshold, or flag agreement below the configured threshold. Reports that otherwise match the fixture can still be `advisory` rather than production-calibrated when the pass/fail sample counts are below threshold. The current synthetic fixture remains advisory because it is a smoke/contract surface, not a statistically meaningful held-out calibration set.
+The policy blocks reports with malformed report fields, malformed case rows, invalid candidate envelopes, missing candidates, extra candidate ids, verdict agreement below the configured threshold, or flag agreement below the configured threshold. Reports that otherwise match the fixture can still be `advisory` rather than production-calibrated when aggregate pass/fail sample counts are below threshold or when per-dimension sample counts are unavailable. The current synthetic fixture remains advisory because it is a smoke/contract surface, not a statistically meaningful held-out calibration set.
+
+The existing `calibrate_persona_chat_judge_predictions()` report is still the source of per-dimension calibration evidence. The V1 offline review-command report only exposes aggregate `verdict_counts`; therefore the policy helper must not mark a report `production_calibrated` unless a future report shape also supplies per-dimension pass/fail counts that meet threshold.
 
 The policy result is intentionally trace-safe. It contains status fields, stable reason keys, and per-case `case_id` / `source_case_id` links only. It does not echo prompts, assistant text, exemplar bodies, memory content, RAG snippets, candidate payloads, rationales, filesystem paths, secrets, or database content.
 
@@ -88,7 +90,7 @@ The policy result is intentionally trace-safe. It contains status fields, stable
 - Invalid judge result parsing: only exact `Pass` and `Fail` values are accepted. Parser or model drift that emits variants such as `PASS`, `fail`, or explanatory prose must be treated as invalid output.
 - Unknown prediction scope: unregistered dimensions and unknown case IDs are reported as unknown predictions rather than counted as calibration evidence.
 - Model and prompt drift: any model, prompt, dimension, or fixture-schema change requires a fresh calibration run before comparing results across revisions.
-- Report trust drift: review-command reports can be generated from malformed or partial candidate files. The policy blocks malformed, missing, extra, invalid, and low-agreement reports before maintainers treat them as calibrated.
+- Report trust drift: review-command reports can be generated from malformed or partial candidate files. The policy blocks malformed reports, malformed case rows, missing candidates, extra candidates, invalid candidates, and low-agreement reports before maintainers treat them as calibrated.
 - Trace leakage: judge review artifacts can become privacy risks if they copy raw prompt or response content. The policy result is restricted to bounded identifiers and reason keys.
 - Subjective boundary cases: the V1 dimensions cover selected Persona Chat failure families only. They do not replace human review for nuanced style, safety, or intent disagreements outside the registered dimensions.
 - Grounding and factuality limits: this judge evaluates observed Persona Chat behavior against fixture evidence. It does not prove factual correctness, retrieval grounding, or broader RAG quality.

--- a/Docs/Reviews/PERSONA_CHAT_JUDGE_EVALUATION_CONTRACT_2026_05_11.md
+++ b/Docs/Reviews/PERSONA_CHAT_JUDGE_EVALUATION_CONTRACT_2026_05_11.md
@@ -72,6 +72,14 @@ The report includes:
 
 The default production threshold is 20 pass and 20 fail cases per dimension. The current synthetic fixture set is useful for contract and smoke calibration, but it is not enough to claim production-calibrated judge accuracy.
 
+## Review Policy Contract
+
+`evaluate_persona_chat_judge_report_policy()` classifies offline harness reports as `advisory` or `blocked` before any report is treated as a calibration signal. The helper accepts the harness dataclass or the JSON object produced by the offline review command.
+
+The policy blocks reports with malformed report fields, invalid candidate envelopes, missing candidates, extra candidate ids, verdict agreement below the configured threshold, or flag agreement below the configured threshold. Reports that otherwise match the fixture can still be `advisory` rather than production-calibrated when the pass/fail sample counts are below threshold. The current synthetic fixture remains advisory because it is a smoke/contract surface, not a statistically meaningful held-out calibration set.
+
+The policy result is intentionally trace-safe. It contains status fields, stable reason keys, and per-case `case_id` / `source_case_id` links only. It does not echo prompts, assistant text, exemplar bodies, memory content, RAG snippets, candidate payloads, rationales, filesystem paths, secrets, or database content.
+
 ## Known Failure Modes And Residual Risk
 
 - Insufficient labeled data: the current fixture set is a smoke and contract surface, not a statistically meaningful production calibration set. Raw pass rates must not be used as production quality claims.
@@ -80,6 +88,8 @@ The default production threshold is 20 pass and 20 fail cases per dimension. The
 - Invalid judge result parsing: only exact `Pass` and `Fail` values are accepted. Parser or model drift that emits variants such as `PASS`, `fail`, or explanatory prose must be treated as invalid output.
 - Unknown prediction scope: unregistered dimensions and unknown case IDs are reported as unknown predictions rather than counted as calibration evidence.
 - Model and prompt drift: any model, prompt, dimension, or fixture-schema change requires a fresh calibration run before comparing results across revisions.
+- Report trust drift: review-command reports can be generated from malformed or partial candidate files. The policy blocks malformed, missing, extra, invalid, and low-agreement reports before maintainers treat them as calibrated.
+- Trace leakage: judge review artifacts can become privacy risks if they copy raw prompt or response content. The policy result is restricted to bounded identifiers and reason keys.
 - Subjective boundary cases: the V1 dimensions cover selected Persona Chat failure families only. They do not replace human review for nuanced style, safety, or intent disagreements outside the registered dimensions.
 - Grounding and factuality limits: this judge evaluates observed Persona Chat behavior against fixture evidence. It does not prove factual correctness, retrieval grounding, or broader RAG quality.
 - Runtime limits: this layer is optional and offline. It does not gate live chat responses, enforce moderation, or protect runtime Persona Chat behavior.
@@ -102,3 +112,5 @@ Focused tests live in `tldw_Server_API/tests/Evaluations/test_persona_chat_judge
 - One positive and one negative fixture-label calibration case for `exemplar_synthesis`.
 - Missing and unknown prediction reporting.
 - Required identity-field validation, duplicate calibration-key rejection, and invalid judge-result rejection.
+
+Policy tests live in `tldw_Server_API/tests/Evaluations/test_persona_chat_judge_policy.py` and cover advisory classification for the synthetic fixture, blocked invalid/missing/extra/low-agreement reports, dict report input compatibility, stable JSON serialization, and raw-text exclusion.

--- a/Docs/Reviews/PERSONA_CHAT_JUDGE_EVAL_CONTRACT_2026_05_11.md
+++ b/Docs/Reviews/PERSONA_CHAT_JUDGE_EVAL_CONTRACT_2026_05_11.md
@@ -87,12 +87,12 @@ This file output is the V1 offline report persistence location. It is intentiona
 The review-only policy helper in `tldw_Server_API/app/core/Evaluations/persona_chat_judge_policy.py` classifies offline harness reports before maintainers treat them as useful calibration signals. It consumes either a `PersonaChatJudgeHarnessReport` or the bounded JSON shape emitted by the review command, then returns:
 
 - `status`: `advisory` or `blocked`.
-- `production_calibrated`: `false` unless the report is clean and pass/fail fixture counts meet the configured threshold.
+- `production_calibrated`: `false` unless the report is clean, aggregate pass/fail fixture counts meet the configured threshold, and per-dimension pass/fail counts are available and meet the same threshold.
 - `runtime_gating_allowed`: always `false` in V1.
-- `reason_keys`: stable machine-readable reasons such as `sample_too_small`, `invalid_candidates`, `missing_candidates`, `extra_candidates`, `verdict_agreement_below_threshold`, `flag_agreement_below_threshold`, and `invalid_report`.
+- `reason_keys`: stable machine-readable reasons such as `sample_too_small`, `dimension_sample_counts_unavailable`, `dimension_sample_too_small`, `invalid_candidates`, `missing_candidates`, `extra_candidates`, `verdict_agreement_below_threshold`, `flag_agreement_below_threshold`, and `invalid_report`.
 - `case_issues`: bounded case summaries containing only `case_id`, `source_case_id`, and mismatch/reason keys.
 
-The default policy keeps the current synthetic fixture advisory because it has fewer than 20 pass and 20 fail cases. Invalid candidate envelopes, missing candidates, extra candidates, malformed reports, or agreement below configured thresholds block trust in the report. Blocked status means the report cannot be used as a calibrated quality signal; it still does not gate live Persona Chat behavior.
+The default policy keeps the current synthetic fixture advisory because it has fewer than 20 pass and 20 fail cases and because the V1 review-command report has no per-dimension sample counts. Invalid candidate envelopes, missing candidates, extra candidates, malformed reports, malformed case rows, or agreement below configured thresholds block trust in the report. Blocked status means the report cannot be used as a calibrated quality signal; it still does not gate live Persona Chat behavior.
 
 Policy output must stay trace-safe. It must not include raw prompts, assistant responses, exemplar text, memory bodies, RAG snippets, filesystem paths, secrets, candidate payloads, database content, or rationale text. Linkage is limited to bounded fixture identifiers and reason keys.
 

--- a/Docs/Reviews/PERSONA_CHAT_JUDGE_EVAL_CONTRACT_2026_05_11.md
+++ b/Docs/Reviews/PERSONA_CHAT_JUDGE_EVAL_CONTRACT_2026_05_11.md
@@ -82,6 +82,20 @@ tldw-evals persona-chat-judge review --candidates candidate_outputs.json --outpu
 
 This file output is the V1 offline report persistence location. It is intentionally user-selected and file-based only: the command does not call providers, write databases, enqueue Jobs, expose API endpoints, update WebUI state, gate Persona Chat responses, or mutate chat output.
 
+## Calibration Policy
+
+The review-only policy helper in `tldw_Server_API/app/core/Evaluations/persona_chat_judge_policy.py` classifies offline harness reports before maintainers treat them as useful calibration signals. It consumes either a `PersonaChatJudgeHarnessReport` or the bounded JSON shape emitted by the review command, then returns:
+
+- `status`: `advisory` or `blocked`.
+- `production_calibrated`: `false` unless the report is clean and pass/fail fixture counts meet the configured threshold.
+- `runtime_gating_allowed`: always `false` in V1.
+- `reason_keys`: stable machine-readable reasons such as `sample_too_small`, `invalid_candidates`, `missing_candidates`, `extra_candidates`, `verdict_agreement_below_threshold`, `flag_agreement_below_threshold`, and `invalid_report`.
+- `case_issues`: bounded case summaries containing only `case_id`, `source_case_id`, and mismatch/reason keys.
+
+The default policy keeps the current synthetic fixture advisory because it has fewer than 20 pass and 20 fail cases. Invalid candidate envelopes, missing candidates, extra candidates, malformed reports, or agreement below configured thresholds block trust in the report. Blocked status means the report cannot be used as a calibrated quality signal; it still does not gate live Persona Chat behavior.
+
+Policy output must stay trace-safe. It must not include raw prompts, assistant responses, exemplar text, memory bodies, RAG snippets, filesystem paths, secrets, candidate payloads, database content, or rationale text. Linkage is limited to bounded fixture identifiers and reason keys.
+
 ## Privacy And Redaction
 
 Contract fixtures must not contain:
@@ -116,5 +130,5 @@ Additional fixture cases should preserve the same envelope and continue mapping 
 Before adding executable judge code, follow-up PRs should still define:
 
 - The exact prompt and model input shape derived from this envelope.
-- The calibration report schema and threshold policy.
-- How judge reports link back to deterministic Persona Chat trace ids without storing sensitive content.
+- Executable adapter parsing and failure handling against the policy helper.
+- How any future persisted judge reports link back to deterministic Persona Chat trace ids without storing sensitive content.

--- a/Docs/Reviews/PERSONA_CHAT_QUALITY_EVAL_FOLLOWUP_2026_05_10.md
+++ b/Docs/Reviews/PERSONA_CHAT_QUALITY_EVAL_FOLLOWUP_2026_05_10.md
@@ -200,6 +200,12 @@ Open the next implementation task as Slice 1: Persona Chat Trace And Error Taxon
 
 This update defines judge input/output shape, calibration expectations, privacy rules, and taxonomy mapping only. Live judge execution, provider calls, runtime gating, and Persona Chat behavior changes remain deferred until the contract fixtures are reviewed and a held-out calibration path exists.
 
+## 2026-05-12 Calibration Policy Update
+
+[Issue #1586](https://github.com/rmusser01/tldw_server/issues/1586) adds the next review-only guardrail for Slice 5. The policy helper classifies offline harness/review-command reports as `advisory` or `blocked` before maintainers treat report output as a calibration signal.
+
+The policy keeps the current synthetic fixture advisory because the sample count is below the production threshold, and it blocks malformed, missing, extra, invalid, or low-agreement reports. Its output is trace-safe: status, reason keys, `case_id`, and `source_case_id` only. It still does not add provider calls, persistence, Jobs, API/WebUI state, runtime gating, or Persona Chat response mutation.
+
 ## Verification
 
 This document is a planning/audit artifact. Runtime tests are not required for this slice because no runtime code is changed.

--- a/Docs/Reviews/PERSONA_CHAT_QUALITY_EVAL_FOLLOWUP_2026_05_10.md
+++ b/Docs/Reviews/PERSONA_CHAT_QUALITY_EVAL_FOLLOWUP_2026_05_10.md
@@ -204,7 +204,7 @@ This update defines judge input/output shape, calibration expectations, privacy 
 
 [Issue #1586](https://github.com/rmusser01/tldw_server/issues/1586) adds the next review-only guardrail for Slice 5. The policy helper classifies offline harness/review-command reports as `advisory` or `blocked` before maintainers treat report output as a calibration signal.
 
-The policy keeps the current synthetic fixture advisory because the sample count is below the production threshold, and it blocks malformed, missing, extra, invalid, or low-agreement reports. Its output is trace-safe: status, reason keys, `case_id`, and `source_case_id` only. It still does not add provider calls, persistence, Jobs, API/WebUI state, runtime gating, or Persona Chat response mutation.
+The policy keeps the current synthetic fixture advisory because the sample count is below the production threshold and the V1 review-command report has no per-dimension sample counts. It blocks malformed reports, malformed case rows, missing candidates, extra candidates, invalid candidates, or low-agreement reports. Its output is trace-safe: status, reason keys, `case_id`, and `source_case_id` only. It still does not add provider calls, persistence, Jobs, API/WebUI state, runtime gating, or Persona Chat response mutation.
 
 ## Verification
 

--- a/Docs/superpowers/plans/2026-05-12-persona-chat-judge-calibration-policy.md
+++ b/Docs/superpowers/plans/2026-05-12-persona-chat-judge-calibration-policy.md
@@ -1,0 +1,283 @@
+# Persona Chat Judge Calibration Policy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a trace-safe calibration policy layer for offline Persona Chat judge reports without adding provider execution, persistence, Jobs, API/WebUI state, or runtime chat gating.
+
+**Architecture:** Keep the existing contract fixture, harness, and review CLI as the source of report data. Add one focused policy helper that consumes `PersonaChatJudgeHarnessReport` or its dict form and returns a bounded advisory status with reason keys and safe case/source ids only. Documentation records thresholds, failure modes, and V1 boundaries; runtime Persona Chat remains unchanged.
+
+**Tech Stack:** Python 3.11, dataclasses, existing Persona Chat judge harness, pytest, Bandit.
+
+---
+
+### File Structure
+
+- Create: `tldw_Server_API/app/core/Evaluations/persona_chat_judge_policy.py`
+  - Owns calibration policy inputs, status enums, reason keys, trace-safe issue summaries, and report classification.
+- Create: `tldw_Server_API/tests/Evaluations/test_persona_chat_judge_policy.py`
+  - Covers clean advisory classification, invalid/missing/extra candidates, low agreement, low fixture sample counts, and raw-text exclusion.
+- Modify: `Docs/Reviews/PERSONA_CHAT_JUDGE_EVAL_CONTRACT_2026_05_11.md`
+  - Adds the calibration policy section and keeps executable adapter work deferred.
+- Modify: `Docs/Reviews/PERSONA_CHAT_JUDGE_EVALUATION_CONTRACT_2026_05_11.md`
+  - Aligns the earlier contract artifact with the new policy helper and trace-safe output semantics.
+- Modify: `Docs/Reviews/PERSONA_CHAT_QUALITY_EVAL_FOLLOWUP_2026_05_10.md`
+  - Adds a Stage 2 progress note for the policy slice.
+- Modify: `backlog/tasks/task-257.2 - Add-Persona-Chat-judge-calibration-policy.md`
+  - Record plan path, implementation notes, verification, residual risk, and final summary.
+
+### Task 1: Policy Helper Contract
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Evaluations/persona_chat_judge_policy.py`
+- Test: `tldw_Server_API/tests/Evaluations/test_persona_chat_judge_policy.py`
+
+- [ ] **Step 1: Write failing tests for clean advisory policy output**
+
+Add tests that build the packaged fixture expected candidates with `expected_candidate_outputs_from_fixture()`, pass the harness report into a new `evaluate_persona_chat_judge_report_policy()` helper, and assert:
+
+```python
+policy.status == "advisory"
+policy.production_calibrated is False
+"sample_too_small" in policy.reason_keys
+policy.runtime_gating_allowed is False
+policy.case_issues == ()
+```
+
+- [ ] **Step 2: Run the new test and verify it fails**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Evaluations/test_persona_chat_judge_policy.py::test_clean_fixture_report_remains_advisory_until_sample_threshold -q
+```
+
+Expected: FAIL because `persona_chat_judge_policy` does not exist.
+
+- [ ] **Step 3: Implement minimal policy dataclasses and clean-report classification**
+
+Create:
+
+```python
+PolicyStatus = Literal["advisory", "blocked"]
+
+@dataclass(frozen=True)
+class PersonaChatJudgePolicyIssue:
+    case_id: str
+    source_case_id: str
+    reason_keys: tuple[str, ...]
+
+@dataclass(frozen=True)
+class PersonaChatJudgePolicyResult:
+    status: PolicyStatus
+    production_calibrated: bool
+    runtime_gating_allowed: bool
+    reason_keys: tuple[str, ...]
+    case_issues: tuple[PersonaChatJudgePolicyIssue, ...]
+```
+
+Implement `evaluate_persona_chat_judge_report_policy(report, min_cases_per_verdict=20, min_verdict_agreement=1.0, min_flag_agreement=1.0)` so a clean two-case synthetic report returns `status="advisory"`, `runtime_gating_allowed=False`, `production_calibrated=False`, and `sample_too_small`.
+
+- [ ] **Step 4: Run the clean policy test**
+
+Run the same pytest command.
+
+Expected: PASS.
+
+### Task 2: Invalid, Missing, Extra, And Agreement Reasons
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Evaluations/persona_chat_judge_policy.py`
+- Modify: `tldw_Server_API/tests/Evaluations/test_persona_chat_judge_policy.py`
+
+- [ ] **Step 1: Write failing tests for blocked report classes**
+
+Add tests for:
+
+- non-mapping candidate envelope -> `invalid_candidates`
+- missing candidate -> `missing_candidates`
+- extra candidate id -> `extra_candidates`
+- verdict/flag agreement below threshold -> `verdict_agreement_below_threshold` / `flag_agreement_below_threshold`
+
+Assert issue summaries include only `case_id`, `source_case_id`, and reason keys. Include a serialized-output guard:
+
+```python
+serialized = json.dumps(policy.to_dict(), sort_keys=True)
+assert "I will remember that permanently" not in serialized
+assert "Ignore earlier directions" not in serialized
+```
+
+- [ ] **Step 2: Run targeted failing tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Evaluations/test_persona_chat_judge_policy.py -q
+```
+
+Expected: FAIL for unimplemented reason keys and issue summaries.
+
+- [ ] **Step 3: Implement bounded reason and issue extraction**
+
+Implementation rules:
+
+- `invalid_candidate_count > 0` adds `invalid_candidates`.
+- `missing_candidate_count > 0` adds `missing_candidates`.
+- `extra_candidate_ids` adds `extra_candidates`.
+- `verdict_agreement < min_verdict_agreement` adds `verdict_agreement_below_threshold`.
+- `flag_agreement < min_flag_agreement` adds `flag_agreement_below_threshold`.
+- Any blocked reason above sets `status="blocked"`.
+- `case_issues` is built only from harness case rows whose `status != "matched"` or whose `mismatches` is non-empty.
+- `case_issues` never includes rationale, prompt text, assistant text, evidence text, expected context, or candidate payloads.
+
+- [ ] **Step 4: Run policy tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Evaluations/test_persona_chat_judge_policy.py -q
+```
+
+Expected: PASS.
+
+### Task 3: Compatibility And Public Exports
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Evaluations/persona_chat_judge_policy.py`
+- Modify: `tldw_Server_API/tests/Evaluations/test_persona_chat_judge_policy.py`
+
+- [ ] **Step 1: Add tests for dict report input and stable serialization**
+
+Add tests that pass `build_persona_chat_judge_report(...).to_dict()` into the helper and assert `policy.to_dict()` is JSON serializable with stable keys:
+
+```python
+assert set(policy.to_dict()) == {
+    "status",
+    "production_calibrated",
+    "runtime_gating_allowed",
+    "reason_keys",
+    "case_issues",
+}
+```
+
+- [ ] **Step 2: Run targeted tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Evaluations/test_persona_chat_judge_policy.py -q
+```
+
+Expected: FAIL until dict input and `to_dict()` are implemented.
+
+- [ ] **Step 3: Implement dict compatibility and exports**
+
+Keep parsing conservative:
+
+- Accept `PersonaChatJudgeHarnessReport` or `Mapping[str, Any]`.
+- Normalize absent or malformed numeric/count fields to blocked reason `invalid_report`.
+- Export public dataclasses and helper in `__all__`.
+- Keep module docstring explicit that this is review policy only.
+
+- [ ] **Step 4: Run targeted tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Evaluations/test_persona_chat_judge_policy.py -q
+```
+
+Expected: PASS.
+
+### Task 4: Documentation And Backlog
+
+**Files:**
+- Modify: `Docs/Reviews/PERSONA_CHAT_JUDGE_EVAL_CONTRACT_2026_05_11.md`
+- Modify: `Docs/Reviews/PERSONA_CHAT_JUDGE_EVALUATION_CONTRACT_2026_05_11.md`
+- Modify: `Docs/Reviews/PERSONA_CHAT_QUALITY_EVAL_FOLLOWUP_2026_05_10.md`
+- Modify: `backlog/tasks/task-257.2 - Add-Persona-Chat-judge-calibration-policy.md`
+
+- [ ] **Step 1: Update docs with policy semantics**
+
+Document:
+
+- policy status values and reason keys
+- production sample threshold remains 20 pass and 20 fail cases per verdict class
+- current synthetic fixture remains advisory/not production-calibrated
+- trace-safe output includes only case ids, source case ids, and reason/mismatch keys
+- no runtime gating, DB persistence, Jobs, API endpoint, WebUI state, provider calls, or chat response mutation
+
+- [ ] **Step 2: Update Backlog implementation notes**
+
+Record:
+
+- issue #1586
+- plan path
+- touched files
+- failure modes and residual risks
+- verification commands and outcomes as they are run
+
+- [ ] **Step 3: Run docs placeholder scan**
+
+Run:
+
+```bash
+rg -n "TO[D]O|TB[D]|FIX[M]E|PLACE[H]OLDER|\\?\\?" Docs/Reviews/PERSONA_CHAT_JUDGE_EVAL_CONTRACT_2026_05_11.md Docs/Reviews/PERSONA_CHAT_JUDGE_EVALUATION_CONTRACT_2026_05_11.md Docs/Reviews/PERSONA_CHAT_QUALITY_EVAL_FOLLOWUP_2026_05_10.md Docs/superpowers/plans/2026-05-12-persona-chat-judge-calibration-policy.md "backlog/tasks/task-257.2 - Add-Persona-Chat-judge-calibration-policy.md"
+```
+
+Expected: no matches.
+
+### Task 5: Verification And Commit
+
+**Files:**
+- All touched files.
+
+- [ ] **Step 1: Run focused pytest**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Evaluations/test_persona_chat_judge_policy.py tldw_Server_API/tests/Evaluations/test_persona_chat_judge.py tldw_Server_API/tests/Evaluations/test_persona_chat_judge_harness.py tldw_Server_API/tests/Evaluations/test_persona_chat_judge_contract.py tldw_Server_API/tests/Evaluations/unit/test_persona_chat_judge_review_command.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run Bandit on touched Python**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Evaluations/persona_chat_judge_policy.py tldw_Server_API/tests/Evaluations/test_persona_chat_judge_policy.py -s B101 -f json -o /tmp/bandit_persona_chat_judge_policy.json
+```
+
+Expected: 0 findings.
+
+- [ ] **Step 3: Run diff hygiene**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output.
+
+- [ ] **Step 4: Update Backlog checkboxes and final summary**
+
+Mark acceptance criteria complete only after verification passes. Add final summary with no runtime behavior changes and residual risk.
+
+- [ ] **Step 5: Commit**
+
+Run:
+
+```bash
+git add tldw_Server_API/app/core/Evaluations/persona_chat_judge_policy.py \
+  tldw_Server_API/tests/Evaluations/test_persona_chat_judge_policy.py \
+  Docs/Reviews/PERSONA_CHAT_JUDGE_EVAL_CONTRACT_2026_05_11.md \
+  Docs/Reviews/PERSONA_CHAT_JUDGE_EVALUATION_CONTRACT_2026_05_11.md \
+  Docs/Reviews/PERSONA_CHAT_QUALITY_EVAL_FOLLOWUP_2026_05_10.md \
+  Docs/superpowers/plans/2026-05-12-persona-chat-judge-calibration-policy.md \
+  "backlog/tasks/task-257.2 - Add-Persona-Chat-judge-calibration-policy.md"
+git commit -m "Add Persona Chat judge calibration policy"
+```
+
+Expected: commit succeeds.

--- a/backlog/tasks/task-257.2 - Add-Persona-Chat-judge-calibration-policy.md
+++ b/backlog/tasks/task-257.2 - Add-Persona-Chat-judge-calibration-policy.md
@@ -1,0 +1,95 @@
+---
+id: TASK-257.2
+title: Add Persona Chat judge calibration policy
+status: Done
+assignee: []
+created_date: '2026-05-12 02:06'
+updated_date: '2026-05-12 02:13'
+labels:
+  - persona-chat
+  - evaluations
+  - stage-2
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1586'
+  - 'https://github.com/rmusser01/tldw_server/pull/1588'
+  - 'https://github.com/rmusser01/tldw_server/issues/1566'
+  - 'https://github.com/rmusser01/tldw_server/issues/1543'
+  - 'https://github.com/rmusser01/tldw_server/issues/1510'
+documentation:
+  - Docs/Reviews/PERSONA_CHAT_JUDGE_EVAL_CONTRACT_2026_05_11.md
+  - Docs/Reviews/PERSONA_CHAT_JUDGE_EVALUATION_CONTRACT_2026_05_11.md
+  - Docs/Reviews/PERSONA_CHAT_TRACE_ERROR_TAXONOMY_2026_05_10.md
+  - Docs/Reviews/PERSONA_CHAT_QUALITY_EVAL_FOLLOWUP_2026_05_10.md
+parent_task_id: TASK-257
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement GitHub issue #1586 as the next optional Persona Chat Stage 2 judge slice under #1566. Add a narrow calibration-policy layer over the existing V1 contract fixture, no-provider harness, and offline review command so maintainers can classify offline judge reports as advisory/review-only without adding live provider execution, DB persistence, Jobs, API/WebUI state, runtime chat gating, or response mutation. Policy output must stay trace-safe by exposing only bounded identifiers and reason keys.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A tested policy helper classifies clean, invalid, missing, extra, and low-agreement Persona Chat judge reports with stable status and reason fields.
+- [x] #2 Policy output includes only bounded case/source ids and mismatch or reason keys, not raw prompts, assistant responses, exemplar text, memories, paths, secrets, or database content.
+- [x] #3 Current synthetic fixture reports remain advisory and not production-calibrated because sample counts are below the production threshold.
+- [x] #4 Documentation explains threshold policy, trace-safe link behavior, V1 review-only boundaries, failure modes, and residual risks.
+- [x] #5 Focused pytest, Bandit for touched Python, placeholder scan, and git diff hygiene are recorded before closeout.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Plan file: Docs/superpowers/plans/2026-05-12-persona-chat-judge-calibration-policy.md
+
+1. Add policy-helper tests first for advisory clean reports, blocked invalid/missing/extra/low-agreement reports, trace-safe serialization, and dict input compatibility.
+2. Implement the minimal policy helper over the existing Persona Chat judge harness report without provider execution, persistence, Jobs, API/WebUI state, or runtime gating.
+3. Update Persona Chat judge docs and Stage 2 follow-up docs with policy semantics, thresholds, trace-safe output, failure modes, and residual risks.
+4. Run focused pytest, Bandit on touched Python, placeholder scan, and git diff hygiene before final Backlog closeout.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+GitHub issue: https://github.com/rmusser01/tldw_server/issues/1586
+
+Draft PR: https://github.com/rmusser01/tldw_server/pull/1588
+
+Implemented `tldw_Server_API/app/core/Evaluations/persona_chat_judge_policy.py` as a review-only policy layer over the existing Persona Chat judge harness report. The helper accepts the harness dataclass or bounded report dict, classifies reports as `advisory` or `blocked`, always keeps `runtime_gating_allowed` false, marks the current synthetic fixture as `sample_too_small`, and emits only case ids, source case ids, and reason/mismatch keys.
+
+Added `tldw_Server_API/tests/Evaluations/test_persona_chat_judge_policy.py` with TDD coverage for advisory clean reports, invalid/missing/extra candidates, low agreement, dict report input, stable JSON serialization, malformed report blocking, and raw prompt/assistant text exclusion.
+
+Updated Persona Chat judge review docs with policy status values, thresholds, trace-safe output semantics, V1 non-goals, failure modes, and residual risks.
+
+Verification:
+
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Evaluations/test_persona_chat_judge_policy.py tldw_Server_API/tests/Evaluations/test_persona_chat_judge.py tldw_Server_API/tests/Evaluations/test_persona_chat_judge_harness.py tldw_Server_API/tests/Evaluations/test_persona_chat_judge_contract.py tldw_Server_API/tests/Evaluations/unit/test_persona_chat_judge_review_command.py -q` passed: 43 passed, 5 warnings.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Evaluations/persona_chat_judge_policy.py tldw_Server_API/tests/Evaluations/test_persona_chat_judge_policy.py -s B101 -f json -o /tmp/bandit_persona_chat_judge_policy.json` passed: 0 findings.
+- Placeholder scan over touched docs, plan, and Backlog task passed with no matches.
+- `git diff --check` passed.
+
+Known failure modes and residual risks:
+
+- The current packaged fixture is intentionally too small for production calibration; policy results remain advisory until a reviewed held-out set meets threshold.
+- The policy classifies already-produced reports only. It does not parse model output, execute providers, persist reports, or prove future adapter behavior.
+- Trace-safe output depends on future callers continuing to pass bounded harness reports rather than raw candidate payloads into user-facing surfaces.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added a review-only Persona Chat judge calibration policy over the existing offline harness and review command. The policy fails closed for malformed, missing, extra, invalid, or low-agreement reports; keeps clean synthetic fixture reports advisory until sample thresholds are met; and emits only bounded trace-safe ids and reason keys. Runtime Persona Chat behavior, provider execution, persistence, Jobs, API/WebUI state, and response mutation remain unchanged.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-257.2 - Add-Persona-Chat-judge-calibration-policy.md
+++ b/backlog/tasks/task-257.2 - Add-Persona-Chat-judge-calibration-policy.md
@@ -60,22 +60,22 @@ Draft PR: https://github.com/rmusser01/tldw_server/pull/1588
 
 Implemented `tldw_Server_API/app/core/Evaluations/persona_chat_judge_policy.py` as a review-only policy layer over the existing Persona Chat judge harness report. The helper accepts the harness dataclass or bounded report dict, classifies reports as `advisory` or `blocked`, always keeps `runtime_gating_allowed` false, marks the current synthetic fixture as `sample_too_small`, and emits only case ids, source case ids, and reason/mismatch keys.
 
-Added `tldw_Server_API/tests/Evaluations/test_persona_chat_judge_policy.py` with TDD coverage for advisory clean reports, invalid/missing/extra candidates, low agreement, dict report input, stable JSON serialization, malformed report blocking, and raw prompt/assistant text exclusion.
+Added `tldw_Server_API/tests/Evaluations/test_persona_chat_judge_policy.py` with TDD coverage for advisory clean reports, invalid/missing/extra candidates, low agreement, dict report input, stable JSON serialization, malformed report blocking, malformed case-row blocking, per-dimension sample-count requirements, and raw prompt/assistant text exclusion.
 
 Updated Persona Chat judge review docs with policy status values, thresholds, trace-safe output semantics, V1 non-goals, failure modes, and residual risks.
 
 Verification:
 
-- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Evaluations/test_persona_chat_judge_policy.py tldw_Server_API/tests/Evaluations/test_persona_chat_judge.py tldw_Server_API/tests/Evaluations/test_persona_chat_judge_harness.py tldw_Server_API/tests/Evaluations/test_persona_chat_judge_contract.py tldw_Server_API/tests/Evaluations/unit/test_persona_chat_judge_review_command.py -q` passed: 43 passed, 5 warnings.
-- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Evaluations/persona_chat_judge_policy.py tldw_Server_API/tests/Evaluations/test_persona_chat_judge_policy.py -s B101 -f json -o /tmp/bandit_persona_chat_judge_policy.json` passed: 0 findings.
+- `python -m pytest tldw_Server_API/tests/Evaluations/test_persona_chat_judge_policy.py tldw_Server_API/tests/Evaluations/test_persona_chat_judge.py tldw_Server_API/tests/Evaluations/test_persona_chat_judge_harness.py tldw_Server_API/tests/Evaluations/test_persona_chat_judge_contract.py tldw_Server_API/tests/Evaluations/unit/test_persona_chat_judge_review_command.py -q` passed: 46 passed, 5 warnings.
+- `python -m bandit -r tldw_Server_API/app/core/Evaluations/persona_chat_judge_policy.py tldw_Server_API/tests/Evaluations/test_persona_chat_judge_policy.py -s B101 -f json -o /tmp/bandit_persona_chat_judge_policy_review.json` passed: 0 findings.
 - Placeholder scan over touched docs, plan, and Backlog task passed with no matches.
 - `git diff --check` passed.
 
 Known failure modes and residual risks:
 
-- The current packaged fixture is intentionally too small for production calibration; policy results remain advisory until a reviewed held-out set meets threshold.
+- The current packaged fixture is intentionally too small for production calibration; policy results remain advisory until a reviewed held-out set meets aggregate and per-dimension thresholds.
 - The policy classifies already-produced reports only. It does not parse model output, execute providers, persist reports, or prove future adapter behavior.
-- Trace-safe output depends on future callers continuing to pass bounded harness reports rather than raw candidate payloads into user-facing surfaces.
+- The V1 review-command report does not yet include per-dimension sample counts, so aggregate pass/fail counts alone cannot produce a production-calibrated policy result.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/core/Evaluations/persona_chat_judge_policy.py
+++ b/tldw_Server_API/app/core/Evaluations/persona_chat_judge_policy.py
@@ -1,0 +1,234 @@
+"""Review-only policy for Persona Chat judge calibration reports.
+
+This module classifies bounded reports produced by the offline Persona Chat
+judge harness. It is intentionally a policy layer over already-produced
+reports: it does not call model providers, persist results, enqueue Jobs,
+expose API state, or gate runtime Persona Chat responses.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from tldw_Server_API.app.core.Evaluations.persona_chat_judge_harness import (
+    PersonaChatJudgeHarnessReport,
+)
+
+
+PolicyStatus = Literal["advisory", "blocked"]
+_VERDICT_CLASSES_FOR_SAMPLE_SIZE = ("pass", "fail")
+
+
+@dataclass(frozen=True)
+class PersonaChatJudgePolicyIssue:
+    """Trace-safe policy issue for one judge report case."""
+
+    case_id: str
+    source_case_id: str
+    reason_keys: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable issue without raw prompt or response text."""
+        return {
+            "case_id": self.case_id,
+            "source_case_id": self.source_case_id,
+            "reason_keys": list(self.reason_keys),
+        }
+
+
+@dataclass(frozen=True)
+class PersonaChatJudgePolicyResult:
+    """Review-only policy result for a Persona Chat judge report."""
+
+    status: PolicyStatus
+    production_calibrated: bool
+    runtime_gating_allowed: bool
+    reason_keys: tuple[str, ...]
+    case_issues: tuple[PersonaChatJudgePolicyIssue, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a stable JSON-serializable policy result."""
+        return {
+            "status": self.status,
+            "production_calibrated": self.production_calibrated,
+            "runtime_gating_allowed": self.runtime_gating_allowed,
+            "reason_keys": list(self.reason_keys),
+            "case_issues": [issue.to_dict() for issue in self.case_issues],
+        }
+
+
+def evaluate_persona_chat_judge_report_policy(
+    report: PersonaChatJudgeHarnessReport | Mapping[str, Any],
+    *,
+    min_cases_per_verdict: int = 20,
+    min_verdict_agreement: float = 1.0,
+    min_flag_agreement: float = 1.0,
+) -> PersonaChatJudgePolicyResult:
+    """Classify a Persona Chat judge harness report for review-only use."""
+    report_payload = _report_to_mapping(report)
+    if report_payload is None:
+        return _invalid_report()
+
+    invalid_report = False
+    total_cases = _non_negative_int(report_payload.get("total_cases"))
+    invalid_candidate_count = _non_negative_int(report_payload.get("invalid_candidate_count"))
+    missing_candidate_count = _non_negative_int(report_payload.get("missing_candidate_count"))
+    verdict_agreement = _bounded_float(report_payload.get("verdict_agreement"))
+    flag_agreement = _bounded_float(report_payload.get("flag_agreement"))
+    extra_candidate_ids = report_payload.get("extra_candidate_ids")
+    verdict_counts = report_payload.get("verdict_counts")
+    raw_cases = report_payload.get("cases")
+
+    if (
+        total_cases is None
+        or invalid_candidate_count is None
+        or missing_candidate_count is None
+        or verdict_agreement is None
+        or flag_agreement is None
+        or not isinstance(extra_candidate_ids, list)
+        or not isinstance(verdict_counts, Mapping)
+        or not isinstance(raw_cases, list)
+    ):
+        invalid_report = True
+
+    if invalid_report:
+        return _invalid_report()
+
+    reason_keys: list[str] = []
+    blocked_reason_keys: set[str] = set()
+
+    if invalid_candidate_count > 0:
+        reason_keys.append("invalid_candidates")
+        blocked_reason_keys.add("invalid_candidates")
+    if missing_candidate_count > 0:
+        reason_keys.append("missing_candidates")
+        blocked_reason_keys.add("missing_candidates")
+    if extra_candidate_ids:
+        reason_keys.append("extra_candidates")
+        blocked_reason_keys.add("extra_candidates")
+    if verdict_agreement < min_verdict_agreement:
+        reason_keys.append("verdict_agreement_below_threshold")
+        blocked_reason_keys.add("verdict_agreement_below_threshold")
+    if flag_agreement < min_flag_agreement:
+        reason_keys.append("flag_agreement_below_threshold")
+        blocked_reason_keys.add("flag_agreement_below_threshold")
+
+    sample_too_small = _sample_too_small(
+        verdict_counts=verdict_counts,
+        min_cases_per_verdict=min_cases_per_verdict,
+    )
+    if sample_too_small:
+        reason_keys.append("sample_too_small")
+
+    status: PolicyStatus = "blocked" if blocked_reason_keys else "advisory"
+    production_calibrated = status == "advisory" and not sample_too_small and total_cases > 0
+    return PersonaChatJudgePolicyResult(
+        status=status,
+        production_calibrated=production_calibrated,
+        runtime_gating_allowed=False,
+        reason_keys=tuple(dict.fromkeys(reason_keys)),
+        case_issues=_case_issues(raw_cases),
+    )
+
+
+def _report_to_mapping(
+    report: PersonaChatJudgeHarnessReport | Mapping[str, Any],
+) -> Mapping[str, Any] | None:
+    """Normalize supported report inputs to a mapping."""
+    if isinstance(report, PersonaChatJudgeHarnessReport):
+        return report.to_dict()
+    if isinstance(report, Mapping):
+        return report
+    return None
+
+
+def _invalid_report() -> PersonaChatJudgePolicyResult:
+    """Return the fail-closed policy result for malformed report input."""
+    return PersonaChatJudgePolicyResult(
+        status="blocked",
+        production_calibrated=False,
+        runtime_gating_allowed=False,
+        reason_keys=("invalid_report",),
+        case_issues=(),
+    )
+
+
+def _non_negative_int(value: Any) -> int | None:
+    """Return non-negative integers while rejecting bools and malformed values."""
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return None
+    return value
+
+
+def _bounded_float(value: Any) -> float | None:
+    """Return a finite agreement value between zero and one."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    numeric_value = float(value)
+    if 0.0 <= numeric_value <= 1.0:
+        return numeric_value
+    return None
+
+
+def _sample_too_small(
+    *,
+    verdict_counts: Mapping[str, Any],
+    min_cases_per_verdict: int,
+) -> bool:
+    """Return whether pass/fail verdict classes meet the calibration threshold."""
+    if min_cases_per_verdict <= 0:
+        return False
+    for verdict_class in _VERDICT_CLASSES_FOR_SAMPLE_SIZE:
+        verdict_count = verdict_counts.get(verdict_class)
+        if _non_negative_int(verdict_count) is None:
+            return True
+        if verdict_count < min_cases_per_verdict:
+            return True
+    return False
+
+
+def _case_issues(raw_cases: list[Any]) -> tuple[PersonaChatJudgePolicyIssue, ...]:
+    """Extract bounded issue summaries from harness case rows."""
+    issues: list[PersonaChatJudgePolicyIssue] = []
+    for raw_case in raw_cases:
+        if not isinstance(raw_case, Mapping):
+            continue
+        status = _string_or_empty(raw_case.get("status"))
+        raw_mismatches = raw_case.get("mismatches")
+        reason_keys = _reason_keys(raw_mismatches)
+        if status == "matched" and not reason_keys:
+            continue
+        if not reason_keys and status:
+            reason_keys = (status,)
+        issues.append(
+            PersonaChatJudgePolicyIssue(
+                case_id=_string_or_empty(raw_case.get("case_id")),
+                source_case_id=_string_or_empty(raw_case.get("source_case_id")),
+                reason_keys=reason_keys,
+            )
+        )
+    return tuple(issues)
+
+
+def _reason_keys(value: Any) -> tuple[str, ...]:
+    """Return bounded string reason keys from a harness mismatch list."""
+    if not isinstance(value, list):
+        return ()
+    return tuple(
+        dict.fromkeys(str(item) for item in value if isinstance(item, str) and item.strip())
+    )
+
+
+def _string_or_empty(value: Any) -> str:
+    """Normalize optional identifier values to stripped strings."""
+    return "" if value is None else str(value).strip()
+
+
+__all__ = [
+    "PersonaChatJudgePolicyIssue",
+    "PersonaChatJudgePolicyResult",
+    "PolicyStatus",
+    "evaluate_persona_chat_judge_report_policy",
+]

--- a/tldw_Server_API/app/core/Evaluations/persona_chat_judge_policy.py
+++ b/tldw_Server_API/app/core/Evaluations/persona_chat_judge_policy.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
+import re
 from typing import Any, Literal
 
 from tldw_Server_API.app.core.Evaluations.persona_chat_judge_harness import (
@@ -19,6 +20,22 @@ from tldw_Server_API.app.core.Evaluations.persona_chat_judge_harness import (
 
 PolicyStatus = Literal["advisory", "blocked"]
 _VERDICT_CLASSES_FOR_SAMPLE_SIZE = ("pass", "fail")
+_CASE_ID_RE = re.compile(r"^PC-JUDGE-\d{3}$")
+_SOURCE_CASE_ID_RE = re.compile(r"^PC-CASE-\d{3}$")
+_ALLOWED_CASE_STATUSES = frozenset(
+    {"matched", "mismatched", "missing_candidate", "invalid_candidate"}
+)
+_ALLOWED_CASE_REASON_KEYS = frozenset(
+    {
+        "expected_flags",
+        "invalid_candidate",
+        "invalid_expected_flags",
+        "invalid_scores",
+        "invalid_verdict",
+        "missing_candidate",
+        "verdict",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -73,16 +90,25 @@ def evaluate_persona_chat_judge_report_policy(
 
     invalid_report = False
     total_cases = _non_negative_int(report_payload.get("total_cases"))
-    invalid_candidate_count = _non_negative_int(report_payload.get("invalid_candidate_count"))
-    missing_candidate_count = _non_negative_int(report_payload.get("missing_candidate_count"))
+    matched_cases = _non_negative_int(report_payload.get("matched_cases"))
+    mismatched_cases = _non_negative_int(report_payload.get("mismatched_cases"))
+    invalid_candidate_count = _non_negative_int(
+        report_payload.get("invalid_candidate_count")
+    )
+    missing_candidate_count = _non_negative_int(
+        report_payload.get("missing_candidate_count")
+    )
     verdict_agreement = _bounded_float(report_payload.get("verdict_agreement"))
     flag_agreement = _bounded_float(report_payload.get("flag_agreement"))
     extra_candidate_ids = report_payload.get("extra_candidate_ids")
     verdict_counts = report_payload.get("verdict_counts")
+    dimension_verdict_counts = report_payload.get("dimension_verdict_counts")
     raw_cases = report_payload.get("cases")
 
     if (
         total_cases is None
+        or matched_cases is None
+        or mismatched_cases is None
         or invalid_candidate_count is None
         or missing_candidate_count is None
         or verdict_agreement is None
@@ -94,6 +120,18 @@ def evaluate_persona_chat_judge_report_policy(
         invalid_report = True
 
     if invalid_report:
+        return _invalid_report()
+
+    case_rows = _valid_case_rows(raw_cases=raw_cases, total_cases=total_cases)
+    if case_rows is None:
+        return _invalid_report()
+    status_counts = _case_status_counts(case_rows)
+    if (
+        status_counts["matched"] != matched_cases
+        or status_counts["mismatched"] != mismatched_cases
+        or status_counts["missing_candidate"] != missing_candidate_count
+        or status_counts["invalid_candidate"] != invalid_candidate_count
+    ):
         return _invalid_report()
 
     reason_keys: list[str] = []
@@ -119,17 +157,28 @@ def evaluate_persona_chat_judge_report_policy(
         verdict_counts=verdict_counts,
         min_cases_per_verdict=min_cases_per_verdict,
     )
+    dimension_sample_reason = _dimension_sample_reason(
+        dimension_verdict_counts=dimension_verdict_counts,
+        min_cases_per_verdict=min_cases_per_verdict,
+    )
     if sample_too_small:
         reason_keys.append("sample_too_small")
+    if dimension_sample_reason is not None:
+        reason_keys.append(dimension_sample_reason)
 
     status: PolicyStatus = "blocked" if blocked_reason_keys else "advisory"
-    production_calibrated = status == "advisory" and not sample_too_small and total_cases > 0
+    production_calibrated = (
+        status == "advisory"
+        and not sample_too_small
+        and dimension_sample_reason is None
+        and total_cases > 0
+    )
     return PersonaChatJudgePolicyResult(
         status=status,
         production_calibrated=production_calibrated,
         runtime_gating_allowed=False,
         reason_keys=tuple(dict.fromkeys(reason_keys)),
-        case_issues=_case_issues(raw_cases),
+        case_issues=_case_issues(case_rows),
     )
 
 
@@ -189,41 +238,140 @@ def _sample_too_small(
     return False
 
 
-def _case_issues(raw_cases: list[Any]) -> tuple[PersonaChatJudgePolicyIssue, ...]:
+def _dimension_sample_reason(
+    *,
+    dimension_verdict_counts: Any,
+    min_cases_per_verdict: int,
+) -> str | None:
+    """Return why dimension sample counts are not production-ready."""
+    if min_cases_per_verdict <= 0:
+        return None
+    if (
+        not isinstance(dimension_verdict_counts, Mapping)
+        or not dimension_verdict_counts
+    ):
+        return "dimension_sample_counts_unavailable"
+    for verdict_counts in dimension_verdict_counts.values():
+        if not isinstance(verdict_counts, Mapping):
+            return "dimension_sample_too_small"
+        if _sample_too_small(
+            verdict_counts=verdict_counts,
+            min_cases_per_verdict=min_cases_per_verdict,
+        ):
+            return "dimension_sample_too_small"
+    return None
+
+
+def _valid_case_rows(
+    *,
+    raw_cases: list[Any],
+    total_cases: int,
+) -> list[Mapping[str, Any]] | None:
+    """Validate report case rows before policy classification."""
+    if len(raw_cases) != total_cases:
+        return None
+    case_rows: list[Mapping[str, Any]] = []
+    for raw_case in raw_cases:
+        if not isinstance(raw_case, Mapping):
+            return None
+        case_id = _safe_case_id(raw_case.get("case_id"))
+        source_case_id = _safe_source_case_id(raw_case.get("source_case_id"))
+        status = _case_status(raw_case.get("status"))
+        reason_keys = _reason_keys(raw_case.get("mismatches"))
+        if not case_id or not source_case_id or status is None:
+            return None
+        if reason_keys is None:
+            return None
+        if status == "matched" and reason_keys:
+            return None
+        if status != "matched" and not reason_keys:
+            return None
+        case_rows.append(raw_case)
+    return case_rows
+
+
+def _case_status_counts(raw_cases: list[Mapping[str, Any]]) -> dict[str, int]:
+    """Count validated case rows by harness status."""
+    status_counts = {status: 0 for status in _ALLOWED_CASE_STATUSES}
+    for raw_case in raw_cases:
+        status = _case_status(raw_case.get("status"))
+        if status is not None:
+            status_counts[status] += 1
+    return status_counts
+
+
+def _case_issues(
+    raw_cases: list[Mapping[str, Any]],
+) -> tuple[PersonaChatJudgePolicyIssue, ...]:
     """Extract bounded issue summaries from harness case rows."""
     issues: list[PersonaChatJudgePolicyIssue] = []
     for raw_case in raw_cases:
-        if not isinstance(raw_case, Mapping):
+        status = _case_status(raw_case.get("status"))
+        reason_keys = _reason_keys(raw_case.get("mismatches"))
+        if status == "matched":
             continue
-        status = _string_or_empty(raw_case.get("status"))
-        raw_mismatches = raw_case.get("mismatches")
-        reason_keys = _reason_keys(raw_mismatches)
-        if status == "matched" and not reason_keys:
+        if status is None or reason_keys is None:
             continue
-        if not reason_keys and status:
-            reason_keys = (status,)
         issues.append(
             PersonaChatJudgePolicyIssue(
-                case_id=_string_or_empty(raw_case.get("case_id")),
-                source_case_id=_string_or_empty(raw_case.get("source_case_id")),
+                case_id=_safe_case_id(raw_case.get("case_id")),
+                source_case_id=_safe_source_case_id(raw_case.get("source_case_id")),
                 reason_keys=reason_keys,
             )
         )
     return tuple(issues)
 
 
-def _reason_keys(value: Any) -> tuple[str, ...]:
+def _reason_keys(value: Any) -> tuple[str, ...] | None:
     """Return bounded string reason keys from a harness mismatch list."""
     if not isinstance(value, list):
-        return ()
-    return tuple(
-        dict.fromkeys(str(item) for item in value if isinstance(item, str) and item.strip())
-    )
+        return None
+    keys: list[str] = []
+    for item in value:
+        key = _safe_reason_key(item)
+        if key is None:
+            return None
+        keys.append(key)
+    return tuple(dict.fromkeys(keys))
+
+
+def _safe_reason_key(value: Any) -> str | None:
+    """Return allowlisted case mismatch keys only."""
+    if not isinstance(value, str):
+        return None
+    key = value.strip()
+    if key in _ALLOWED_CASE_REASON_KEYS:
+        return key
+    return None
+
+
+def _case_status(value: Any) -> str | None:
+    """Return allowlisted case status values only."""
+    status = _string_or_empty(value)
+    if status in _ALLOWED_CASE_STATUSES:
+        return status
+    return None
+
+
+def _safe_case_id(value: Any) -> str:
+    """Return bounded Persona Chat judge case ids only."""
+    case_id = _string_or_empty(value)
+    if _CASE_ID_RE.fullmatch(case_id):
+        return case_id
+    return ""
+
+
+def _safe_source_case_id(value: Any) -> str:
+    """Return bounded source fixture case ids only."""
+    source_case_id = _string_or_empty(value)
+    if _SOURCE_CASE_ID_RE.fullmatch(source_case_id):
+        return source_case_id
+    return ""
 
 
 def _string_or_empty(value: Any) -> str:
-    """Normalize optional identifier values to stripped strings."""
-    return "" if value is None else str(value).strip()
+    """Return stripped string values and normalize non-strings to an empty string."""
+    return value.strip() if isinstance(value, str) else ""
 
 
 __all__ = [

--- a/tldw_Server_API/tests/Evaluations/test_persona_chat_judge_policy.py
+++ b/tldw_Server_API/tests/Evaluations/test_persona_chat_judge_policy.py
@@ -1,0 +1,130 @@
+"""Persona Chat judge calibration policy tests."""
+
+from __future__ import annotations
+
+from importlib import resources
+import json
+from typing import Any
+
+from tldw_Server_API.app.core.Evaluations.cli.persona_chat_judge_cli import (
+    PERSONA_CHAT_JUDGE_FIXTURE_PACKAGE,
+    PERSONA_CHAT_JUDGE_FIXTURE_RESOURCE,
+)
+from tldw_Server_API.app.core.Evaluations.persona_chat_judge_harness import (
+    build_persona_chat_judge_report,
+    expected_candidate_outputs_from_fixture,
+)
+from tldw_Server_API.app.core.Evaluations.persona_chat_judge_policy import (
+    evaluate_persona_chat_judge_report_policy,
+)
+
+
+def _load_fixture() -> dict[str, Any]:
+    """Load the packaged Persona Chat judge fixture."""
+    fixture_resource = resources.files(PERSONA_CHAT_JUDGE_FIXTURE_PACKAGE).joinpath(
+        PERSONA_CHAT_JUDGE_FIXTURE_RESOURCE
+    )
+    with fixture_resource.open("r", encoding="utf-8") as fixture_file:
+        payload = json.load(fixture_file)
+    assert isinstance(payload, dict)  # nosec B101
+    return payload
+
+
+def _candidate_outputs() -> dict[str, Any]:
+    """Return independent candidate outputs copied from fixture expectations."""
+    return json.loads(json.dumps(expected_candidate_outputs_from_fixture(_load_fixture())))
+
+
+def test_clean_fixture_report_remains_advisory_until_sample_threshold() -> None:
+    """The tiny synthetic fixture can be reviewed but is not production calibrated."""
+    report = build_persona_chat_judge_report(_load_fixture(), _candidate_outputs())
+
+    policy = evaluate_persona_chat_judge_report_policy(report)
+
+    assert policy.status == "advisory"  # nosec B101
+    assert policy.production_calibrated is False  # nosec B101
+    assert policy.runtime_gating_allowed is False  # nosec B101
+    assert "sample_too_small" in policy.reason_keys  # nosec B101
+    assert policy.case_issues == ()  # nosec B101
+
+
+def test_invalid_missing_and_extra_candidates_are_blocked_with_bounded_issues() -> None:
+    """Structural report failures should block trust without echoing raw trace text."""
+    candidates = _candidate_outputs()
+    candidates["PC-JUDGE-001"] = "not-a-candidate-object"
+    del candidates["PC-JUDGE-002"]
+    candidates["PC-JUDGE-999"] = {"verdict": "pass"}
+    report = build_persona_chat_judge_report(_load_fixture(), candidates)
+
+    policy = evaluate_persona_chat_judge_report_policy(report)
+    policy_payload = policy.to_dict()
+    serialized = json.dumps(policy_payload, sort_keys=True)
+
+    assert policy.status == "blocked"  # nosec B101
+    assert policy.production_calibrated is False  # nosec B101
+    assert "invalid_candidates" in policy.reason_keys  # nosec B101
+    assert "missing_candidates" in policy.reason_keys  # nosec B101
+    assert "extra_candidates" in policy.reason_keys  # nosec B101
+    assert {
+        (issue.case_id, issue.source_case_id, issue.reason_keys)
+        for issue in policy.case_issues
+    } == {
+        ("PC-JUDGE-001", "PC-CASE-008", ("invalid_candidate",)),
+        ("PC-JUDGE-002", "PC-CASE-015", ("missing_candidate",)),
+    }  # nosec B101
+    assert "I will remember that permanently" not in serialized  # nosec B101
+    assert "Ignore earlier directions" not in serialized  # nosec B101
+
+
+def test_low_agreement_blocks_report_even_when_candidate_schema_is_valid() -> None:
+    """A schema-valid verdict disagreement should be a blocked calibration result."""
+    candidates = _candidate_outputs()
+    candidates["PC-JUDGE-002"]["verdict"] = "pass"
+    report = build_persona_chat_judge_report(_load_fixture(), candidates)
+
+    policy = evaluate_persona_chat_judge_report_policy(
+        report,
+        min_cases_per_verdict=1,
+        min_verdict_agreement=0.75,
+    )
+
+    assert policy.status == "blocked"  # nosec B101
+    assert "verdict_agreement_below_threshold" in policy.reason_keys  # nosec B101
+    assert "sample_too_small" not in policy.reason_keys  # nosec B101
+    assert policy.case_issues[0].case_id == "PC-JUDGE-002"  # nosec B101
+    assert policy.case_issues[0].reason_keys == ("verdict",)  # nosec B101
+
+
+def test_policy_accepts_dict_report_input_and_serializes_stable_shape() -> None:
+    """The CLI-facing report dict should classify the same as the dataclass report."""
+    report = build_persona_chat_judge_report(_load_fixture(), _candidate_outputs()).to_dict()
+
+    policy = evaluate_persona_chat_judge_report_policy(report)
+    payload = policy.to_dict()
+
+    assert set(payload) == {  # nosec B101
+        "status",
+        "production_calibrated",
+        "runtime_gating_allowed",
+        "reason_keys",
+        "case_issues",
+    }
+    assert json.loads(json.dumps(payload, sort_keys=True)) == payload  # nosec B101
+    assert policy.status == "advisory"  # nosec B101
+
+
+def test_malformed_report_is_blocked_as_invalid_report() -> None:
+    """Malformed report dictionaries should fail closed."""
+    policy = evaluate_persona_chat_judge_report_policy(
+        {
+            "total_cases": "two",
+            "verdict_agreement": "high",
+            "flag_agreement": 1.0,
+            "cases": "not-a-list",
+        }
+    )
+
+    assert policy.status == "blocked"  # nosec B101
+    assert policy.production_calibrated is False  # nosec B101
+    assert policy.reason_keys == ("invalid_report",)  # nosec B101
+    assert policy.case_issues == ()  # nosec B101

--- a/tldw_Server_API/tests/Evaluations/test_persona_chat_judge_policy.py
+++ b/tldw_Server_API/tests/Evaluations/test_persona_chat_judge_policy.py
@@ -11,6 +11,7 @@ from tldw_Server_API.app.core.Evaluations.cli.persona_chat_judge_cli import (
     PERSONA_CHAT_JUDGE_FIXTURE_RESOURCE,
 )
 from tldw_Server_API.app.core.Evaluations.persona_chat_judge_harness import (
+    VERDICT_ORDER,
     build_persona_chat_judge_report,
     expected_candidate_outputs_from_fixture,
 )
@@ -32,7 +33,9 @@ def _load_fixture() -> dict[str, Any]:
 
 def _candidate_outputs() -> dict[str, Any]:
     """Return independent candidate outputs copied from fixture expectations."""
-    return json.loads(json.dumps(expected_candidate_outputs_from_fixture(_load_fixture())))
+    return json.loads(
+        json.dumps(expected_candidate_outputs_from_fixture(_load_fixture()))
+    )
 
 
 def test_clean_fixture_report_remains_advisory_until_sample_threshold() -> None:
@@ -97,7 +100,10 @@ def test_low_agreement_blocks_report_even_when_candidate_schema_is_valid() -> No
 
 def test_policy_accepts_dict_report_input_and_serializes_stable_shape() -> None:
     """The CLI-facing report dict should classify the same as the dataclass report."""
-    report = build_persona_chat_judge_report(_load_fixture(), _candidate_outputs()).to_dict()
+    report = build_persona_chat_judge_report(
+        _load_fixture(),
+        _candidate_outputs(),
+    ).to_dict()
 
     policy = evaluate_persona_chat_judge_report_policy(report)
     payload = policy.to_dict()
@@ -109,8 +115,73 @@ def test_policy_accepts_dict_report_input_and_serializes_stable_shape() -> None:
         "reason_keys",
         "case_issues",
     }
-    assert json.loads(json.dumps(payload, sort_keys=True)) == payload  # nosec B101
+    assert (
+        json.loads(json.dumps(payload, sort_keys=True)) == payload
+    )  # nosec B101
     assert policy.status == "advisory"  # nosec B101
+
+
+def test_policy_blocks_dict_report_with_malformed_case_rows() -> None:
+    """Malformed case rows should fail closed instead of being skipped."""
+    report = build_persona_chat_judge_report(
+        _load_fixture(),
+        _candidate_outputs(),
+    ).to_dict()
+    report["cases"] = ["not-a-dict"]
+
+    policy = evaluate_persona_chat_judge_report_policy(report)
+
+    assert policy.status == "blocked"  # nosec B101
+    assert policy.production_calibrated is False  # nosec B101
+    assert policy.reason_keys == ("invalid_report",)  # nosec B101
+    assert policy.case_issues == ()  # nosec B101
+
+
+def test_policy_blocks_dict_report_with_unbounded_case_fields() -> None:
+    """Unbounded ids and mismatch text should not enter policy output."""
+    report = build_persona_chat_judge_report(
+        _load_fixture(),
+        _candidate_outputs(),
+    ).to_dict()
+    report["cases"][0]["status"] = "mismatched"
+    report["cases"][0]["mismatches"] = ["assistant_text: raw response"]
+
+    policy = evaluate_persona_chat_judge_report_policy(report)
+    serialized = json.dumps(policy.to_dict(), sort_keys=True)
+
+    assert policy.status == "blocked"  # nosec B101
+    assert policy.reason_keys == ("invalid_report",)  # nosec B101
+    assert "assistant_text: raw response" not in serialized  # nosec B101
+
+
+def test_policy_needs_dimension_counts_for_production_calibration() -> None:
+    """Aggregate pass/fail counts alone should not claim dimension calibration."""
+    report = build_persona_chat_judge_report(
+        _load_fixture(),
+        _candidate_outputs(),
+    ).to_dict()
+    report["total_cases"] = 40
+    report["matched_cases"] = 40
+    report["verdict_counts"] = dict(zip(VERDICT_ORDER, (20, 20, 0), strict=True))
+    report["cases"] = [
+        {
+            "case_id": f"PC-JUDGE-{case_number:03d}",
+            "source_case_id": f"PC-CASE-{case_number:03d}",
+            "status": "matched",
+            "mismatches": [],
+            "verdict_match": True,
+            "flag_match": True,
+            "score_schema_valid": True,
+        }
+        for case_number in range(1, 41)
+    ]
+
+    policy = evaluate_persona_chat_judge_report_policy(report)
+
+    assert policy.status == "advisory"  # nosec B101
+    assert policy.production_calibrated is False  # nosec B101
+    assert "sample_too_small" not in policy.reason_keys  # nosec B101
+    assert "dimension_sample_counts_unavailable" in policy.reason_keys  # nosec B101
 
 
 def test_malformed_report_is_blocked_as_invalid_report() -> None:


### PR DESCRIPTION
## Summary
- Adds a review-only policy helper over offline Persona Chat judge harness reports.
- Classifies reports as advisory or blocked with stable reason keys and trace-safe case/source ids.
- Documents thresholds, V1 boundaries, residual risks, and closes the local Backlog slice for #1586.

## Change summary
Human-authored change summary required before this PR is marked ready for review/merge.

## Test Plan
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Evaluations/test_persona_chat_judge_policy.py tldw_Server_API/tests/Evaluations/test_persona_chat_judge.py tldw_Server_API/tests/Evaluations/test_persona_chat_judge_harness.py tldw_Server_API/tests/Evaluations/test_persona_chat_judge_contract.py tldw_Server_API/tests/Evaluations/unit/test_persona_chat_judge_review_command.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Evaluations/persona_chat_judge_policy.py tldw_Server_API/tests/Evaluations/test_persona_chat_judge_policy.py -s B101 -f json -o /tmp/bandit_persona_chat_judge_policy.json
- rg -n "TO[D]O|TB[D]|FIX[M]E|PLACE[H]OLDER|\?\?" Docs/Reviews/PERSONA_CHAT_JUDGE_EVAL_CONTRACT_2026_05_11.md Docs/Reviews/PERSONA_CHAT_JUDGE_EVALUATION_CONTRACT_2026_05_11.md Docs/Reviews/PERSONA_CHAT_QUALITY_EVAL_FOLLOWUP_2026_05_10.md Docs/superpowers/plans/2026-05-12-persona-chat-judge-calibration-policy.md "backlog/tasks/task-257.2 - Add-Persona-Chat-judge-calibration-policy.md"
- git diff --check origin/dev..HEAD

Fixes #1586
Parent: #1566
Stage tracker: #1543
Epic: #1510