### PR TITLE
Migrate SourceStatusPanels degraded label to registry

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -3938,17 +3938,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Sources/SourceStatusPanels.tsx:Tag",
-    "path": "src/components/Option/Sources/SourceStatusPanels.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Tag",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Tag product-state UI in src/components/Option/Sources/SourceStatusPanels.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Sources/SourcesWorkspacePage.tsx:Alert",
     "path": "src/components/Option/Sources/SourcesWorkspacePage.tsx",
     "rule": "antd-product-state-import",
@@ -5342,17 +5331,6 @@
     "state": "allowed_legacy_exception",
     "owner": "design-system",
     "reason": "Existing hardcoded \"Degraded\" state label in src/components/Option/Sources/SourceItemsTable.tsx before the guard.",
-    "replacement": "getDesignSystemState(...)",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "canonical-state-label:src/components/Option/Sources/SourceStatusPanels.tsx:Degraded",
-    "path": "src/components/Option/Sources/SourceStatusPanels.tsx",
-    "rule": "canonical-state-label",
-    "subject": "Degraded",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing hardcoded \"Degraded\" state label in src/components/Option/Sources/SourceStatusPanels.tsx before the guard.",
     "replacement": "getDesignSystemState(...)",
     "migrationQueue": "shared-product-state"
   },

--- a/apps/packages/ui/src/components/Option/Sources/SourceStatusPanels.tsx
+++ b/apps/packages/ui/src/components/Option/Sources/SourceStatusPanels.tsx
@@ -1,6 +1,11 @@
 import React from "react"
 import { Tag } from "antd"
 
+import { getDesignSystemState } from "@/design-system"
+import {
+  Badge,
+  getBadgeVariantForDesignSystemSeverity
+} from "@/components/ui/primitives"
 import type { IngestionSourceSummary } from "@/types/ingestion-sources"
 
 type SourceStatusPanelsProps = {
@@ -17,10 +22,22 @@ export const SourceStatusPanels: React.FC<SourceStatusPanelsProps> = ({ source }
     )
   }
 
+  const degradedState =
+    summary.degraded_count > 0 ? getDesignSystemState("degraded") : null
+
   return (
     <div className="flex flex-wrap gap-2">
       <Tag color="blue">Changed {summary.changed_count}</Tag>
-      {summary.degraded_count > 0 && <Tag color="orange">Degraded {summary.degraded_count}</Tag>}
+      {degradedState ? (
+        <Badge
+          variant={getBadgeVariantForDesignSystemSeverity(
+            degradedState.severity
+          )}
+          size="md"
+        >
+          {degradedState.label} {summary.degraded_count}
+        </Badge>
+      ) : null}
       {summary.conflict_count > 0 && <Tag color="volcano">Detached {summary.conflict_count}</Tag>}
       <Tag>{source.last_sync_status || "Unknown status"}</Tag>
     </div>

--- a/apps/packages/ui/src/components/Option/Sources/__tests__/SourceStatusPanels.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Option/Sources/__tests__/SourceStatusPanels.design-system.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { SourceStatusPanels } from "../SourceStatusPanels"
+import type { IngestionSourceSummary } from "@/types/ingestion-sources"
+import { getDesignSystemState } from "@/design-system"
+
+vi.mock("@/design-system", () => ({
+  getDesignSystemState: vi.fn((key: string) => ({
+    key,
+    label: key === "degraded" ? "Registry Degraded" : key,
+    severity: key === "degraded" ? "warning" : "neutral"
+  }))
+}))
+
+const makeSource = (
+  overrides: Partial<IngestionSourceSummary> = {}
+): IngestionSourceSummary => ({
+  id: "source-1",
+  user_id: 1,
+  source_type: "archive_snapshot",
+  sink_type: "notes",
+  policy: "canonical",
+  enabled: true,
+  schedule_enabled: false,
+  schedule_config: {},
+  config: {},
+  last_sync_status: "synced",
+  last_successful_sync_summary: {
+    changed_count: 3,
+    degraded_count: 2,
+    conflict_count: 0,
+    sink_failure_count: 0,
+    ingestion_failure_count: 0,
+    created_count: 0,
+    updated_count: 0,
+    deleted_count: 0,
+    unchanged_count: 0
+  },
+  ...overrides
+})
+
+describe("SourceStatusPanels design-system state labels", () => {
+  beforeEach(() => {
+    vi.mocked(getDesignSystemState).mockClear()
+  })
+
+  it("uses the design-system registry label for degraded summaries", () => {
+    render(<SourceStatusPanels source={makeSource()} />)
+
+    expect(screen.getByText("Registry Degraded 2")).toBeInTheDocument()
+    expect(getDesignSystemState).toHaveBeenCalledWith("degraded")
+  })
+
+  it("renders degraded summaries with the design-system Badge primitive", () => {
+    render(<SourceStatusPanels source={makeSource()} />)
+
+    const badge = screen.getByText("Registry Degraded 2")
+
+    expect(badge).toHaveAttribute("data-ds-component", "Badge")
+    expect(badge).toHaveAttribute("data-ds-variant", "warning")
+    expect(badge).not.toHaveClass("ant-tag")
+  })
+})

--- a/backlog/tasks/task-282 - Migrate-SourceStatusPanels-degraded-label-to-design-system-registry.md
+++ b/backlog/tasks/task-282 - Migrate-SourceStatusPanels-degraded-label-to-design-system-registry.md
@@ -1,0 +1,56 @@
+---
+id: TASK-282
+title: Migrate SourceStatusPanels degraded label to design-system registry
+status: Done
+assignee: []
+created_date: '2026-05-12 02:05'
+updated_date: '2026-05-12 03:04'
+labels:
+  - design-system
+  - frontend
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replace the hardcoded degraded status label in SourceStatusPanels with the design-system state registry fallback while preserving the numeric summary text and existing tag rendering.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Focused tests prove the rendered degraded summary uses the registry fallback label without source-string assertions.
+- [x] #2 The matching canonical-state-label and stale AntD Tag baseline exceptions are removed and the design-system state guard passes.
+- [x] #3 The degraded status label in SourceStatusPanels comes from getDesignSystemState("degraded").label.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Red test first: SourceStatusPanels.design-system.test.tsx initially failed because the component rendered Degraded 2 instead of the mocked registry label Registry Degraded 2.
+
+Verification passed: SourceStatusPanels design-system test; SourceDetailPage plus SourceStatusPanels tests; product-state guard tests; bun run verify:design-system-state; git diff --check; touched-path tsc filter produced no SourceStatusPanels or baseline errors. Bandit skipped because this is frontend TypeScript/test-only work.
+
+PR review follow-up: Gemini flagged the module-level degraded label constant and remaining AntD Tag usage for the degraded state; Qodo flagged that variable-based registry labels make the AntD product-state guard lose visibility. Plan is to remove the AntD degraded Tag by using a design-system badge primitive and to keep label lookup inside the component render path.
+
+PR review fix implemented: removed the module-level DEGRADED_STATE_LABEL constant, resolves the degraded state inside SourceStatusPanels render, and renders the degraded summary with the design-system Badge primitive using getBadgeVariantForDesignSystemSeverity. Added test assertions that the registry lookup happens during render and the degraded summary renders as data-ds-component=Badge with warning variant, not AntD Tag.
+
+Review-fix verification passed: SourceDetailPage plus SourceStatusPanels tests; product-state guard tests; bun run verify:design-system-state; git diff --check; touched-path tsc filter produced no SourceStatusPanels or baseline output.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated SourceStatusPanels degraded summary labels to the design-system state registry and badge primitive, added focused render coverage for registry lookup and Badge rendering, and removed the resolved baseline exceptions for the component.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
Summary:
- Replace SourceStatusPanels' degraded summary label with the design-system `degraded` state label.
- Add focused render coverage proving the label comes from the registry fallback.
- Remove the resolved canonical-state-label baseline entry plus the now-stale AntD Tag baseline entry.

Tests:
- `bunx vitest run src/components/Option/Sources/__tests__/SourceDetailPage.test.tsx src/components/Option/Sources/__tests__/SourceStatusPanels.design-system.test.tsx --reporter=dot`
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot`
- `bun run verify:design-system-state`
- `git diff --check`
- `bunx tsc --noEmit --pretty false 2>&1 | rg -n "SourceStatusPanels|design-system-product-state-baseline"` (no touched-path output)

Backlog: TASK-282