### PR TITLE
Add VN Play branch timeline UX

### DIFF
--- a/Docs/API-related/VN_PLAY_API.md
+++ b/Docs/API-related/VN_PLAY_API.md
@@ -521,3 +521,5 @@ Recognized metadata fields include `safety_metadata.age_status`, `safety_metadat
 ## Frontend Workspace
 
 The Next.js workspace is available at `/vn-play`. It can create Freeform and Story sessions, list sessions, submit Freeform turns, submit Story choices, render returned dialogue/events, and show current scene metadata.
+
+For Story/CYOA sessions, the workspace uses `GET /api/v1/vn/vn-play/sessions/{session_id}/branch-navigation` for the player-facing branch timeline and `POST /api/v1/vn/vn-play/sessions/{session_id}/branches/{branch_id}/restore` for guarded branch resume/restore controls. Frontends should treat branch labels, active-path state, warnings, and restore target availability as backend-owned data instead of reconstructing branch state from raw events.

--- a/Docs/superpowers/plans/2026-05-12-vn-play-branch-timeline-restore-ux.md
+++ b/Docs/superpowers/plans/2026-05-12-vn-play-branch-timeline-restore-ux.md
@@ -1,0 +1,254 @@
+# VN Play Branch Timeline Restore UX Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a player-facing VN Play branch timeline and restore UX that consumes the backend-owned branch navigation API for Story/CYOA sessions.
+
+**Architecture:** Keep branch semantics server-authoritative. The frontend adds typed client helpers for `/branch-navigation` and `/branches/{branch_id}/restore`, renders the server-shaped read model in a focused play component, and refreshes session state from backend responses after restore. The component must not reconstruct branches from raw events or infer restore targets beyond the backend-provided `restore` capability payload.
+
+**Tech Stack:** Next.js/React, TypeScript, Vitest, Testing Library, existing `@web/lib/api/vnPlay` API helper style, existing VN Play runtime idempotency and recoverable-error helpers.
+
+---
+
+### Task 1: Typed Branch Navigation Client Contract
+
+**Files:**
+- Modify: `apps/tldw-frontend/types/vn-play.ts`
+- Modify: `apps/tldw-frontend/lib/api/vnPlay.ts`
+- Test: `apps/tldw-frontend/__tests__/vn-play/vnPlayApi.test.ts`
+
+- [x] **Step 1: Add failing API client tests**
+
+Add coverage that calls:
+
+```ts
+await getVNPlayBranchNavigation(1);
+await restoreVNPlayBranch(1, 12, {
+  client_scene_version: 6,
+  idempotency_key: 'restore-branch-12',
+  target: 'choice_point',
+});
+```
+
+Expected mocked calls:
+
+```ts
+expect(mocks.apiClient.get).toHaveBeenCalledWith('/vn/vn-play/sessions/1/branch-navigation');
+expect(mocks.apiClient.post).toHaveBeenCalledWith('/vn/vn-play/sessions/1/branches/12/restore', {
+  client_scene_version: 6,
+  idempotency_key: 'restore-branch-12',
+  target: 'choice_point',
+});
+```
+
+- [x] **Step 2: Run red test**
+
+Run from `apps/tldw-frontend`:
+
+```bash
+bun run test:run __tests__/vn-play/vnPlayApi.test.ts -t 'branch navigation'
+```
+
+Expected: FAIL because the helper/types do not exist yet.
+
+- [x] **Step 3: Add TypeScript types**
+
+Mirror `VNPlayBranchNavigationResponse`, `VNPlayBranchNavigationNode`, `VNPlayBranchPathStep`, `VNPlayBranchRestoreRequest`, `VNPlayBranchRestoreResponse`, warnings, event ranges, generated-choice refs, and restore capability from `tldw_Server_API/app/api/v1/schemas/vn_play_schemas.py`.
+
+Keep literal targets:
+
+```ts
+export type VNPlayBranchRestoreTarget = 'branch_latest' | 'choice_point';
+```
+
+- [x] **Step 4: Add API helpers**
+
+Add:
+
+```ts
+export function getVNPlayBranchNavigation(sessionId: number): Promise<VNPlayBranchNavigationResponse> {
+  return apiClient.get(`${VN_PLAY_BASE}/sessions/${sessionId}/branch-navigation`);
+}
+
+export function restoreVNPlayBranch(
+  sessionId: number,
+  branchId: number,
+  request: VNPlayBranchRestoreRequest
+): Promise<VNPlayBranchRestoreResponse> {
+  return apiClient.post(`${VN_PLAY_BASE}/sessions/${sessionId}/branches/${branchId}/restore`, request);
+}
+```
+
+- [x] **Step 5: Run green test**
+
+```bash
+bun run test:run __tests__/vn-play/vnPlayApi.test.ts -t 'branch navigation'
+```
+
+Expected: PASS.
+
+### Task 2: Branch Timeline Presentation Component
+
+**Files:**
+- Create: `apps/tldw-frontend/components/vn-play/BranchTimelinePanel.tsx`
+- Test: `apps/tldw-frontend/__tests__/vn-play/BranchTimelinePanel.test.tsx`
+
+- [x] **Step 1: Write failing render tests**
+
+Cover:
+- no Story session or no branches shows a concise no-branches empty state.
+- active path renders as ordered choice breadcrumbs from `active_path`.
+- branches render labels, choice text, active/on-path state, depth, event range summary, warnings, and restore buttons only when `restore.supported`.
+- `branch_latest` and `choice_point` buttons use backend-provided `restore.target_names`; do not invent unavailable targets.
+
+- [x] **Step 2: Run red component tests**
+
+```bash
+bun run test:run __tests__/vn-play/BranchTimelinePanel.test.tsx
+```
+
+Expected: FAIL because the component does not exist.
+
+- [x] **Step 3: Implement the component**
+
+Props:
+
+```ts
+interface BranchTimelinePanelProps {
+  navigation: VNPlayBranchNavigationResponse | null;
+  isLoading?: boolean;
+  restoringBranchId?: number | null;
+  restoreTarget?: VNPlayBranchRestoreTarget | null;
+  onRestoreBranch?: (branchId: number, target: VNPlayBranchRestoreTarget) => void | Promise<void>;
+}
+```
+
+Rendering rules:
+- Show only player-safe branch data from `navigation`.
+- Label `branch_latest` as `Resume branch`.
+- Label `choice_point` as `Return to choice`.
+- Mark `is_active` as `Active`.
+- Mark `is_on_active_path` as `On path`.
+- Render warnings with `message ?? code`.
+- Keep layout dense and inside one component panel; do not nest cards inside cards.
+
+- [x] **Step 4: Run green component tests**
+
+```bash
+bun run test:run __tests__/vn-play/BranchTimelinePanel.test.tsx
+```
+
+Expected: PASS.
+
+### Task 3: Workspace Wiring And Restore Flow
+
+**Files:**
+- Modify: `apps/tldw-frontend/components/vn-play/VNPlayWorkspace.tsx`
+- Test: `apps/tldw-frontend/__tests__/vn-play/VNPlayWorkspace.test.tsx`
+
+- [x] **Step 1: Add failing workspace tests**
+
+Add tests that:
+- load `getVNPlayBranchNavigation(sessionId)` with the selected Story session.
+- render player-facing branch timeline content outside the runtime inspector.
+- call `restoreVNPlayBranch(sessionId, branchId, { client_scene_version, idempotency_key, target })`.
+- update selected session, events, checkpoints, branches, and branch navigation from the restore response.
+- surface `stale_scene_version`, `turn_in_progress`, and `restore_action_in_progress` as recoverable play-state messages.
+
+- [x] **Step 2: Run red workspace tests**
+
+```bash
+bun run test:run __tests__/vn-play/VNPlayWorkspace.test.tsx -t 'branch'
+```
+
+Expected: FAIL for missing API mock/import/component wiring.
+
+- [x] **Step 3: Load branch navigation with session collections**
+
+Replace branch-only loading with:
+- `getVNPlayBranchNavigation(selectedSession.id)` for branch UX.
+- `listVNPlayBranches(selectedSession.id)` may remain for inspector compatibility if needed.
+
+Failure behavior:
+- If branch navigation fails, keep session playable and show an unobtrusive branch-panel error/empty state.
+
+- [x] **Step 4: Implement branch restore handler**
+
+Use:
+
+```ts
+idempotency_key: createVNPlayIdempotencyKey('restore-branch')
+client_scene_version: sceneVersion
+target
+```
+
+On success:
+- set `selectedSession` from `response.session`.
+- merge the session in the session list.
+- update scene from `response.current_scene`.
+- update branch navigation from `response.branch_navigation`.
+- refresh `events`, `checkpoints`, and compatibility `branches`.
+
+On recoverable conflicts:
+- use `getVNPlayErrorInfo` and `isRecoverableVNPlayConflict` patterns already used by turn handling.
+- reload selected session where appropriate.
+
+- [x] **Step 5: Run green workspace tests**
+
+```bash
+bun run test:run __tests__/vn-play/VNPlayWorkspace.test.tsx -t 'branch'
+```
+
+Expected: PASS.
+
+### Task 4: Docs, Task Notes, And Verification
+
+**Files:**
+- Modify: `Docs/API-related/VN_PLAY_API.md`
+- Modify: `backlog/tasks/task-284 - Add-VN-Play-branch-timeline-and-restore-UX.md`
+
+- [x] **Step 1: Update frontend workspace docs**
+
+In the Frontend Workspace section, document that `/vn-play` now uses backend branch navigation for Story branch timeline and restore controls.
+
+- [x] **Step 2: Run focused frontend tests**
+
+```bash
+bun run test:run __tests__/vn-play/vnPlayApi.test.ts __tests__/vn-play/BranchTimelinePanel.test.tsx __tests__/vn-play/VNPlayWorkspace.test.tsx __tests__/vn-play/SceneStage.test.tsx __tests__/vn-play/vnPlayRuntime.test.ts
+```
+
+Expected: PASS.
+
+- [x] **Step 3: Run lint and diff hygiene**
+
+```bash
+bun run lint -- components/vn-play/BranchTimelinePanel.tsx components/vn-play/VNPlayWorkspace.tsx __tests__/vn-play/BranchTimelinePanel.test.tsx __tests__/vn-play/VNPlayWorkspace.test.tsx __tests__/vn-play/vnPlayApi.test.ts
+git diff --check
+```
+
+Expected: lint exits 0 with only existing repo-wide warnings if present; diff check exits 0.
+
+- [x] **Step 4: Record Bandit status**
+
+Bandit is not applicable if this slice only touches TypeScript/React, Markdown, and Backlog metadata. If backend Python changes become necessary, run Bandit on touched backend paths before finalizing.
+
+- [x] **Step 5: Update Backlog task**
+
+Record verification results, known skips, and final summary in `TASK-284`.
+
+- [x] **Step 6: Commit**
+
+```bash
+git add \
+  apps/tldw-frontend/types/vn-play.ts \
+  apps/tldw-frontend/lib/api/vnPlay.ts \
+  apps/tldw-frontend/components/vn-play/BranchTimelinePanel.tsx \
+  apps/tldw-frontend/components/vn-play/VNPlayWorkspace.tsx \
+  apps/tldw-frontend/__tests__/vn-play/BranchTimelinePanel.test.tsx \
+  apps/tldw-frontend/__tests__/vn-play/VNPlayWorkspace.test.tsx \
+  apps/tldw-frontend/__tests__/vn-play/vnPlayApi.test.ts \
+  Docs/API-related/VN_PLAY_API.md \
+  "backlog/tasks/task-284 - Add-VN-Play-branch-timeline-and-restore-UX.md" \
+  Docs/superpowers/plans/2026-05-12-vn-play-branch-timeline-restore-ux.md
+git commit -m "Add VN Play branch timeline UX"
+```

--- a/apps/tldw-frontend/__tests__/vn-play/BranchTimelinePanel.test.tsx
+++ b/apps/tldw-frontend/__tests__/vn-play/BranchTimelinePanel.test.tsx
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import BranchTimelinePanel from '@web/components/vn-play/BranchTimelinePanel';
+import type { VNPlayBranchNavigationResponse } from '@web/types/vn-play';
+
+function navigation(overrides: Partial<VNPlayBranchNavigationResponse> = {}): VNPlayBranchNavigationResponse {
+  return {
+    session_id: 1,
+    mode: 'story',
+    scene_version: 6,
+    last_event_id: 41,
+    active_branch_node_id: 12,
+    active_path: [
+      {
+        branch_id: 8,
+        branch_label: 'Open the archive door',
+        choice_id: 'open-door',
+        choice_text: 'Open the archive door',
+        depth: 1,
+      },
+      {
+        branch_id: 12,
+        branch_label: 'Step inside',
+        choice_id: 'step-inside',
+        choice_text: 'Step inside',
+        depth: 2,
+      },
+    ],
+    branches: [
+      {
+        branch_id: 12,
+        parent_branch_id: 8,
+        parent_event_id: 32,
+        choice_selected_event_id: 33,
+        branch_label: 'Step inside',
+        choice_id: 'step-inside',
+        choice_text: 'Step inside',
+        branch_path: [],
+        depth: 2,
+        status: 'active',
+        is_active: true,
+        is_on_active_path: true,
+        event_range: {
+          start_event_id: 33,
+          start_sequence_number: 18,
+          latest_event_id: 41,
+          latest_sequence_number: 26,
+        },
+        subtree_event_range: {
+          start_event_id: 33,
+          start_sequence_number: 18,
+          latest_event_id: 41,
+          latest_sequence_number: 26,
+        },
+        restore: {
+          supported: true,
+          default_target: 'branch_latest',
+          target_names: ['branch_latest', 'choice_point'],
+          targets: {
+            branch_latest: { event_id: 41, sequence_number: 26 },
+            choice_point: { event_id: 32 },
+          },
+        },
+        warnings: [
+          {
+            code: 'parent_branch_unresolved',
+            severity: 'warning',
+            recoverable: true,
+            message: 'Parent branch could not be resolved from branch path prefix.',
+            branch_id: 12,
+          },
+        ],
+      },
+      {
+        branch_id: 14,
+        branch_label: 'Read the plaque',
+        choice_id: 'read-plaque',
+        choice_text: 'Read the plaque',
+        branch_path: [],
+        depth: 2,
+        status: 'active',
+        is_active: false,
+        is_on_active_path: false,
+        event_range: {},
+        subtree_event_range: {},
+        restore: {
+          supported: true,
+          default_target: 'branch_latest',
+          target_names: ['branch_latest'],
+          targets: {
+            branch_latest: { event_id: 44, sequence_number: 29 },
+          },
+        },
+        warnings: [],
+      },
+    ],
+    warnings: [],
+    ...overrides,
+  };
+}
+
+describe('BranchTimelinePanel', () => {
+  it('renders an empty state when no branch navigation is available', () => {
+    render(<BranchTimelinePanel navigation={null} />);
+
+    expect(screen.getByText('Branch timeline')).toBeInTheDocument();
+    expect(screen.getByText(/No Story branches are available yet/i)).toBeInTheDocument();
+  });
+
+  it('renders active path and backend-provided branch restore targets', () => {
+    render(<BranchTimelinePanel navigation={navigation()} onRestoreBranch={vi.fn()} />);
+
+    expect(screen.getByText('Open the archive door')).toBeInTheDocument();
+    expect(screen.getAllByText('Step inside')).toHaveLength(2);
+    expect(screen.getByText('Active')).toBeInTheDocument();
+    expect(screen.getByText('On path')).toBeInTheDocument();
+    expect(screen.getByText(/Events 18-26/i)).toBeInTheDocument();
+    expect(screen.getByText('Parent branch could not be resolved from branch path prefix.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /resume branch: step inside/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /return to choice: step inside/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /resume branch: read the plaque/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /return to choice: read the plaque/i })).not.toBeInTheDocument();
+  });
+
+  it('submits restore target selected by the user', async () => {
+    const user = userEvent.setup();
+    const onRestoreBranch = vi.fn();
+
+    render(<BranchTimelinePanel navigation={navigation()} onRestoreBranch={onRestoreBranch} />);
+
+    await user.click(screen.getByRole('button', { name: /return to choice: step inside/i }));
+
+    expect(onRestoreBranch).toHaveBeenCalledWith(12, 'choice_point');
+  });
+});

--- a/apps/tldw-frontend/__tests__/vn-play/BranchTimelinePanel.test.tsx
+++ b/apps/tldw-frontend/__tests__/vn-play/BranchTimelinePanel.test.tsx
@@ -133,4 +133,65 @@ describe('BranchTimelinePanel', () => {
 
     expect(onRestoreBranch).toHaveBeenCalledWith(12, 'choice_point');
   });
+
+  it('renders duplicate warning codes without duplicate React keys', () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    try {
+      render(
+        <BranchTimelinePanel
+          navigation={navigation({
+            warnings: [
+              {
+                code: 'branch_warning',
+                severity: 'warning',
+                recoverable: true,
+                message: 'Global warning A',
+              },
+              {
+                code: 'branch_warning',
+                severity: 'warning',
+                recoverable: true,
+                message: 'Global warning B',
+              },
+            ],
+            branches: [
+              {
+                ...navigation().branches[0],
+                warnings: [
+                  {
+                    code: 'branch_warning',
+                    severity: 'warning',
+                    recoverable: true,
+                    message: 'Branch warning A',
+                    branch_id: 12,
+                  },
+                  {
+                    code: 'branch_warning',
+                    severity: 'warning',
+                    recoverable: true,
+                    message: 'Branch warning B',
+                    branch_id: 12,
+                  },
+                ],
+              },
+            ],
+          })}
+          onRestoreBranch={vi.fn()}
+        />
+      );
+
+      expect(screen.getByText('Global warning A')).toBeInTheDocument();
+      expect(screen.getByText('Global warning B')).toBeInTheDocument();
+      expect(screen.getByText('Branch warning A')).toBeInTheDocument();
+      expect(screen.getByText('Branch warning B')).toBeInTheDocument();
+      expect(
+        consoleErrorSpy.mock.calls.some((call) =>
+          call.some((value) => String(value).includes('Encountered two children with the same key'))
+        )
+      ).toBe(false);
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
 });

--- a/apps/tldw-frontend/__tests__/vn-play/VNPlayWorkspace.test.tsx
+++ b/apps/tldw-frontend/__tests__/vn-play/VNPlayWorkspace.test.tsx
@@ -943,8 +943,10 @@ describe('VNPlayWorkspace', () => {
     const restoredSession: VNPlaySession = {
       ...session,
       scene_version: 7,
-      scene_state: { scene_version: 7 },
+      scene_state: undefined,
+      current_scene: undefined,
     };
+    const restoredScene = { scene_version: 7, location_key: 'restored-branch' };
     const branchNavigation: VNPlayBranchNavigationResponse = {
       session_id: 1,
       mode: 'story',
@@ -1004,7 +1006,7 @@ describe('VNPlayWorkspace', () => {
       target_event_id: 17,
       scene_version: 7,
       session: restoredSession,
-      current_scene: restoredSession.scene_state,
+      current_scene: restoredScene,
       branch_navigation: restoredNavigation,
       branch_id: 12,
       target: 'choice_point',
@@ -1026,6 +1028,7 @@ describe('VNPlayWorkspace', () => {
     await waitFor(() => {
       expect(screen.getAllByText('Scene 7').length).toBeGreaterThan(0);
     });
+    expect(await screen.findByText('restored-branch')).toBeInTheDocument();
   });
 
   it('surfaces branch restore in-progress conflicts as recoverable play state', async () => {
@@ -1100,6 +1103,99 @@ describe('VNPlayWorkspace', () => {
     expect(await screen.findByText(/branch restore is already in progress/i)).toBeInTheDocument();
     expect(screen.queryByText('restore_action_in_progress')).not.toBeInTheDocument();
     expect(mocks.getVNPlaySession).toHaveBeenCalledWith(1);
+  });
+
+  it('does not submit overlapping branch restore requests', async () => {
+    const deferred = createDeferred<{
+      status: 'completed';
+      replayed: false;
+      restore_event_id: number;
+      target_event_id: number;
+      scene_version: number;
+      session: VNPlaySession;
+      current_scene: { scene_version: number };
+      branch_navigation: VNPlayBranchNavigationResponse;
+      branch_id: number;
+      target: 'branch_latest';
+    }>();
+    const session: VNPlaySession = {
+      id: 1,
+      mode: 'story',
+      title: 'Archive Door',
+      primary_character_id: 1,
+      vn_asset_pack_id: 2,
+      scene_version: 6,
+      scene_state: { scene_version: 6 },
+    };
+    const branchNavigation: VNPlayBranchNavigationResponse = {
+      session_id: 1,
+      mode: 'story',
+      scene_version: 6,
+      last_event_id: 26,
+      active_branch_node_id: 12,
+      active_path: [],
+      branches: [
+        {
+          branch_id: 12,
+          parent_branch_id: null,
+          parent_event_id: 17,
+          choice_selected_event_id: 18,
+          branch_label: 'Step inside',
+          choice_id: 'open-door',
+          choice_text: 'Open the archive door',
+          branch_path: [],
+          depth: 1,
+          status: 'active',
+          is_active: true,
+          is_on_active_path: true,
+          event_range: {
+            start_event_id: 18,
+            start_sequence_number: 18,
+            latest_event_id: 26,
+            latest_sequence_number: 26,
+          },
+          subtree_event_range: {
+            start_event_id: 18,
+            start_sequence_number: 18,
+            latest_event_id: 26,
+            latest_sequence_number: 26,
+          },
+          restore: {
+            supported: true,
+            default_target: 'branch_latest',
+            target_names: ['branch_latest'],
+            targets: {
+              branch_latest: { event_id: 26, scene_version: 6 },
+            },
+          },
+          warnings: [],
+        },
+      ],
+      warnings: [],
+    };
+    mockVNPlayApi({ branchNavigation, sessions: [session] });
+    mocks.restoreVNPlayBranch.mockReturnValue(deferred.promise);
+
+    render(<VNPlayWorkspace />);
+
+    const restoreButton = await screen.findByRole('button', { name: /resume branch: step inside/i });
+    fireEvent.click(restoreButton);
+    fireEvent.click(restoreButton);
+
+    expect(mocks.restoreVNPlayBranch).toHaveBeenCalledTimes(1);
+    deferred.resolve({
+      status: 'completed',
+      replayed: false,
+      restore_event_id: 51,
+      target_event_id: 26,
+      scene_version: 7,
+      session: { ...session, scene_version: 7 },
+      current_scene: { scene_version: 7 },
+      branch_navigation: { ...branchNavigation, scene_version: 7 },
+      branch_id: 12,
+      target: 'branch_latest',
+    });
+    await waitFor(() => expect(screen.getAllByText('Scene 7').length).toBeGreaterThan(0));
   });
 
   it('renders scripted generation history without raw debug payloads', async () => {

--- a/apps/tldw-frontend/__tests__/vn-play/VNPlayWorkspace.test.tsx
+++ b/apps/tldw-frontend/__tests__/vn-play/VNPlayWorkspace.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type {
   VNPlayBranch,
+  VNPlayBranchNavigationResponse,
   VNPlayCheckpoint,
   VNPlayGenerationHistoryResponse,
   VNPlayGenerationRevisionDebugResponse,
@@ -14,6 +15,7 @@ import type {
 const mocks = vi.hoisted(() => ({
   createVNPlayCheckpoint: vi.fn(),
   createVNPlaySession: vi.fn(),
+  getVNPlayBranchNavigation: vi.fn(),
   getVNPlayGenerationRevisionDebug: vi.fn(),
   getVNPlaySession: vi.fn(),
   getVNAssetReadiness: vi.fn(),
@@ -27,6 +29,7 @@ const mocks = vi.hoisted(() => ({
   listCharacters: vi.fn(),
   listVNAssetPacks: vi.fn(),
   regenerateVNPlayGeneration: vi.fn(),
+  restoreVNPlayBranch: vi.fn(),
   restoreVNPlaySession: vi.fn(),
   retryLastVNPlayTurn: vi.fn(),
   submitVNPlayTurn: vi.fn(),
@@ -44,6 +47,7 @@ vi.mock('@web/lib/api/vnPlay', () => ({
     mocks.confirmVNPlayGenerationRequest(...args),
   createVNPlayCheckpoint: (...args: unknown[]) => mocks.createVNPlayCheckpoint(...args),
   createVNPlaySession: (...args: unknown[]) => mocks.createVNPlaySession(...args),
+  getVNPlayBranchNavigation: (...args: unknown[]) => mocks.getVNPlayBranchNavigation(...args),
   getVNPlayGenerationRevisionDebug: (...args: unknown[]) =>
     mocks.getVNPlayGenerationRevisionDebug(...args),
   getVNPlaySession: (...args: unknown[]) => mocks.getVNPlaySession(...args),
@@ -56,6 +60,7 @@ vi.mock('@web/lib/api/vnPlay', () => ({
   listVNPlaySessions: (...args: unknown[]) => mocks.listVNPlaySessions(...args),
   listVNPlaySetupOptions: (...args: unknown[]) => mocks.listVNPlaySetupOptions(...args),
   regenerateVNPlayGeneration: (...args: unknown[]) => mocks.regenerateVNPlayGeneration(...args),
+  restoreVNPlayBranch: (...args: unknown[]) => mocks.restoreVNPlayBranch(...args),
   restoreVNPlaySession: (...args: unknown[]) => mocks.restoreVNPlaySession(...args),
   retryLastVNPlayTurn: (...args: unknown[]) => mocks.retryLastVNPlayTurn(...args),
   submitVNPlayTurn: (...args: unknown[]) => mocks.submitVNPlayTurn(...args),
@@ -161,6 +166,17 @@ const defaultGenerationHistory: VNPlayGenerationHistoryResponse = {
   },
 };
 
+const emptyBranchNavigation: VNPlayBranchNavigationResponse = {
+  session_id: 1,
+  mode: 'story',
+  scene_version: 0,
+  last_event_id: null,
+  active_branch_node_id: null,
+  active_path: [],
+  branches: [],
+  warnings: [],
+};
+
 function setupPack(overrides: Partial<VNPlaySetupAssetPackOption> = {}): VNPlaySetupAssetPackOption {
   return {
     ...defaultSetupOptions.asset_packs[0],
@@ -217,11 +233,13 @@ function createDeferred<T>() {
 }
 
 function mockVNPlayApi({
+  branchNavigation = emptyBranchNavigation,
   branches = [],
   checkpoints = [],
   generations = defaultGenerationHistory,
   sessions = [],
 }: {
+  branchNavigation?: VNPlayBranchNavigationResponse | null;
   branches?: VNPlayBranch[];
   checkpoints?: VNPlayCheckpoint[];
   generations?: VNPlayGenerationHistoryResponse;
@@ -231,6 +249,7 @@ function mockVNPlayApi({
   mocks.listVNPlayEvents.mockResolvedValue([]);
   mocks.listVNPlayCheckpoints.mockResolvedValue(checkpoints);
   mocks.listVNPlayBranches.mockResolvedValue(branches);
+  mocks.getVNPlayBranchNavigation.mockResolvedValue(branchNavigation);
   mocks.listVNPlayGenerations.mockResolvedValue(generations);
   mocks.listVNPlayGenerationRevisions.mockResolvedValue(defaultGenerationHistory);
   mocks.getVNPlayGenerationRevisionDebug.mockResolvedValue({
@@ -294,6 +313,21 @@ function mockVNPlayApi({
   mocks.restoreVNPlaySession.mockImplementation(async (sessionId: number) =>
     sessions.find((session) => session.id === sessionId) ?? sessions[0]
   );
+  mocks.restoreVNPlayBranch.mockImplementation(async (sessionId: number, branchId: number, request) => {
+    const session = sessions.find((candidate) => candidate.id === sessionId) ?? sessions[0];
+    return {
+      status: 'completed',
+      replayed: false,
+      restore_event_id: 51,
+      target_event_id: request.target === 'choice_point' ? 41 : 50,
+      scene_version: session?.scene_version ?? 0,
+      session,
+      current_scene: session?.scene_state ?? session?.current_scene ?? { scene_version: 0 },
+      branch_navigation: branchNavigation ?? emptyBranchNavigation,
+      branch_id: branchId,
+      target: request.target,
+    };
+  });
   mocks.retryLastVNPlayTurn.mockResolvedValue({
     turn_request_id: 11,
     status: 'completed',
@@ -817,6 +851,255 @@ describe('VNPlayWorkspace', () => {
     expect(screen.getByText('Door branch')).toBeInTheDocument();
     expect(mocks.listVNPlayCheckpoints).toHaveBeenCalledWith(1);
     expect(mocks.listVNPlayBranches).toHaveBeenCalledWith(1);
+  });
+
+  it('renders player-facing branch navigation for story sessions', async () => {
+    const session: VNPlaySession = {
+      id: 1,
+      mode: 'story',
+      title: 'Archive Door',
+      primary_character_id: 1,
+      vn_asset_pack_id: 2,
+      scene_version: 6,
+      scene_state: { scene_version: 6 },
+    };
+    const branchNavigation: VNPlayBranchNavigationResponse = {
+      session_id: 1,
+      mode: 'story',
+      scene_version: 6,
+      last_event_id: 26,
+      active_branch_node_id: 12,
+      active_path: [
+        {
+          branch_id: 12,
+          branch_label: 'Step inside',
+          choice_id: 'open-door',
+          choice_text: 'Open the archive door',
+          depth: 1,
+        },
+      ],
+      branches: [
+        {
+          branch_id: 12,
+          parent_branch_id: null,
+          parent_event_id: 17,
+          choice_selected_event_id: 18,
+          branch_label: 'Step inside',
+          choice_id: 'open-door',
+          choice_text: 'Open the archive door',
+          branch_path: [],
+          depth: 1,
+          status: 'active',
+          is_active: true,
+          is_on_active_path: true,
+          event_range: {
+            start_event_id: 18,
+            start_sequence_number: 18,
+            latest_event_id: 26,
+            latest_sequence_number: 26,
+          },
+          subtree_event_range: {
+            start_event_id: 18,
+            start_sequence_number: 18,
+            latest_event_id: 26,
+            latest_sequence_number: 26,
+          },
+          restore: {
+            supported: true,
+            default_target: 'branch_latest',
+            target_names: ['branch_latest', 'choice_point'],
+            targets: {
+              branch_latest: { event_id: 26, scene_version: 6 },
+              choice_point: { event_id: 17, scene_version: 5 },
+            },
+          },
+          warnings: [],
+        },
+      ],
+      warnings: [],
+    };
+    mockVNPlayApi({ branchNavigation, sessions: [session] });
+
+    render(<VNPlayWorkspace />);
+
+    expect(await screen.findByText('Branch timeline')).toBeInTheDocument();
+    expect(screen.getAllByText('Open the archive door').length).toBeGreaterThan(0);
+    expect(screen.getByRole('button', { name: /resume branch: step inside/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /return to choice: step inside/i })).toBeInTheDocument();
+    expect(mocks.getVNPlayBranchNavigation).toHaveBeenCalledWith(1);
+  });
+
+  it('restores a story branch using the selected backend target', async () => {
+    const user = userEvent.setup();
+    const session: VNPlaySession = {
+      id: 1,
+      mode: 'story',
+      title: 'Archive Door',
+      primary_character_id: 1,
+      vn_asset_pack_id: 2,
+      scene_version: 6,
+      scene_state: { scene_version: 6 },
+    };
+    const restoredSession: VNPlaySession = {
+      ...session,
+      scene_version: 7,
+      scene_state: { scene_version: 7 },
+    };
+    const branchNavigation: VNPlayBranchNavigationResponse = {
+      session_id: 1,
+      mode: 'story',
+      scene_version: 6,
+      last_event_id: 26,
+      active_branch_node_id: 12,
+      active_path: [],
+      branches: [
+        {
+          branch_id: 12,
+          parent_branch_id: null,
+          parent_event_id: 17,
+          choice_selected_event_id: 18,
+          branch_label: 'Step inside',
+          choice_id: 'open-door',
+          choice_text: 'Open the archive door',
+          branch_path: [],
+          depth: 1,
+          status: 'active',
+          is_active: true,
+          is_on_active_path: true,
+          event_range: {
+            start_event_id: 18,
+            start_sequence_number: 18,
+            latest_event_id: 26,
+            latest_sequence_number: 26,
+          },
+          subtree_event_range: {
+            start_event_id: 18,
+            start_sequence_number: 18,
+            latest_event_id: 26,
+            latest_sequence_number: 26,
+          },
+          restore: {
+            supported: true,
+            default_target: 'branch_latest',
+            target_names: ['branch_latest', 'choice_point'],
+            targets: {
+              branch_latest: { event_id: 26, scene_version: 6 },
+              choice_point: { event_id: 17, scene_version: 5 },
+            },
+          },
+          warnings: [],
+        },
+      ],
+      warnings: [],
+    };
+    const restoredNavigation: VNPlayBranchNavigationResponse = {
+      ...branchNavigation,
+      scene_version: 7,
+    };
+    mockVNPlayApi({ branchNavigation, sessions: [session] });
+    mocks.restoreVNPlayBranch.mockResolvedValue({
+      status: 'completed',
+      replayed: false,
+      restore_event_id: 51,
+      target_event_id: 17,
+      scene_version: 7,
+      session: restoredSession,
+      current_scene: restoredSession.scene_state,
+      branch_navigation: restoredNavigation,
+      branch_id: 12,
+      target: 'choice_point',
+    });
+    mocks.getVNPlaySession.mockResolvedValue(restoredSession);
+    mocks.getVNPlayBranchNavigation.mockResolvedValueOnce(branchNavigation).mockResolvedValueOnce(restoredNavigation);
+
+    render(<VNPlayWorkspace />);
+
+    await user.click(await screen.findByRole('button', { name: /return to choice: step inside/i }));
+
+    await waitFor(() => {
+      expect(mocks.restoreVNPlayBranch).toHaveBeenCalledWith(1, 12, {
+        client_scene_version: 6,
+        idempotency_key: expect.stringMatching(/^restore-branch-/),
+        target: 'choice_point',
+      });
+    });
+    await waitFor(() => {
+      expect(screen.getAllByText('Scene 7').length).toBeGreaterThan(0);
+    });
+  });
+
+  it('surfaces branch restore in-progress conflicts as recoverable play state', async () => {
+    const user = userEvent.setup();
+    const session: VNPlaySession = {
+      id: 1,
+      mode: 'story',
+      title: 'Archive Door',
+      primary_character_id: 1,
+      vn_asset_pack_id: 2,
+      scene_version: 6,
+      scene_state: { scene_version: 6 },
+    };
+    const branchNavigation: VNPlayBranchNavigationResponse = {
+      session_id: 1,
+      mode: 'story',
+      scene_version: 6,
+      last_event_id: 26,
+      active_branch_node_id: 12,
+      active_path: [],
+      branches: [
+        {
+          branch_id: 12,
+          parent_branch_id: null,
+          parent_event_id: 17,
+          choice_selected_event_id: 18,
+          branch_label: 'Step inside',
+          choice_id: 'open-door',
+          choice_text: 'Open the archive door',
+          branch_path: [],
+          depth: 1,
+          status: 'active',
+          is_active: true,
+          is_on_active_path: true,
+          event_range: {
+            start_event_id: 18,
+            start_sequence_number: 18,
+            latest_event_id: 26,
+            latest_sequence_number: 26,
+          },
+          subtree_event_range: {
+            start_event_id: 18,
+            start_sequence_number: 18,
+            latest_event_id: 26,
+            latest_sequence_number: 26,
+          },
+          restore: {
+            supported: true,
+            default_target: 'branch_latest',
+            target_names: ['branch_latest'],
+            targets: {
+              branch_latest: { event_id: 26, scene_version: 6 },
+            },
+          },
+          warnings: [],
+        },
+      ],
+      warnings: [],
+    };
+    mockVNPlayApi({ branchNavigation, sessions: [session] });
+    mocks.restoreVNPlayBranch.mockRejectedValueOnce(
+      Object.assign(new Error('restore_action_in_progress'), {
+        code: 'restore_action_in_progress',
+        status: 409,
+      })
+    );
+
+    render(<VNPlayWorkspace />);
+
+    await user.click(await screen.findByRole('button', { name: /resume branch: step inside/i }));
+
+    expect(await screen.findByText(/branch restore is already in progress/i)).toBeInTheDocument();
+    expect(screen.queryByText('restore_action_in_progress')).not.toBeInTheDocument();
+    expect(mocks.getVNPlaySession).toHaveBeenCalledWith(1);
   });
 
   it('renders scripted generation history without raw debug payloads', async () => {

--- a/apps/tldw-frontend/__tests__/vn-play/vnPlayApi.test.ts
+++ b/apps/tldw-frontend/__tests__/vn-play/vnPlayApi.test.ts
@@ -20,6 +20,7 @@ import {
   createVNPlayCheckpoint,
   createVNPlaySession,
   deleteVNPlaySession,
+  getVNPlayBranchNavigation,
   getVNPlayGenerationRevision,
   getVNPlayGenerationRevisionDebug,
   getVNPlaySession,
@@ -31,6 +32,7 @@ import {
   listVNPlaySessions,
   listVNPlaySetupOptions,
   regenerateVNPlayGeneration,
+  restoreVNPlayBranch,
   restoreVNPlaySession,
   retryLastVNPlayTurn,
   submitVNPlayTurn,
@@ -124,6 +126,22 @@ describe('vnPlay api client', () => {
       idempotency_key: 'restore-1',
     });
     expect(mocks.apiClient.get).toHaveBeenCalledWith('/vn/vn-play/sessions/1/branches');
+  });
+
+  it('calls branch navigation and guarded branch restore endpoints', async () => {
+    await getVNPlayBranchNavigation(1);
+    await restoreVNPlayBranch(1, 12, {
+      client_scene_version: 6,
+      idempotency_key: 'restore-branch-12',
+      target: 'choice_point',
+    });
+
+    expect(mocks.apiClient.get).toHaveBeenCalledWith('/vn/vn-play/sessions/1/branch-navigation');
+    expect(mocks.apiClient.post).toHaveBeenCalledWith('/vn/vn-play/sessions/1/branches/12/restore', {
+      client_scene_version: 6,
+      idempotency_key: 'restore-branch-12',
+      target: 'choice_point',
+    });
   });
 
   it('loads VN play setup options with server-side selector parameters', async () => {

--- a/apps/tldw-frontend/components/vn-play/BranchTimelinePanel.tsx
+++ b/apps/tldw-frontend/components/vn-play/BranchTimelinePanel.tsx
@@ -1,0 +1,152 @@
+import React from 'react';
+import { GitBranch, RotateCcw } from 'lucide-react';
+import { Badge } from '@web/components/ui/Badge';
+import { Button } from '@web/components/ui/Button';
+import type {
+  VNPlayBranchNavigationNode,
+  VNPlayBranchNavigationResponse,
+  VNPlayBranchRestoreTarget,
+} from '@web/types/vn-play';
+
+export interface BranchTimelinePanelProps {
+  isLoading?: boolean;
+  navigation: VNPlayBranchNavigationResponse | null;
+  onRestoreBranch?: (branchId: number, target: VNPlayBranchRestoreTarget) => void | Promise<void>;
+  restoreTarget?: VNPlayBranchRestoreTarget | null;
+  restoringBranchId?: number | null;
+}
+
+function branchLabel(branch: VNPlayBranchNavigationNode): string {
+  return branch.branch_label || branch.choice_text || `Branch ${branch.branch_id}`;
+}
+
+function targetLabel(target: VNPlayBranchRestoreTarget): string {
+  return target === 'choice_point' ? 'Return to choice' : 'Resume branch';
+}
+
+function eventRangeLabel(branch: VNPlayBranchNavigationNode): string | null {
+  const start = branch.event_range.start_sequence_number;
+  const latest = branch.event_range.latest_sequence_number;
+  if (typeof start === 'number' && typeof latest === 'number') {
+    return `Events ${start}-${latest}`;
+  }
+  if (typeof latest === 'number') {
+    return `Latest event ${latest}`;
+  }
+  return null;
+}
+
+export default function BranchTimelinePanel({
+  isLoading = false,
+  navigation,
+  onRestoreBranch,
+  restoreTarget = null,
+  restoringBranchId = null,
+}: BranchTimelinePanelProps) {
+  const branches = navigation?.branches ?? [];
+  const activePath = navigation?.active_path ?? [];
+
+  return (
+    <section className="rounded-md border border-border bg-surface p-4">
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <GitBranch aria-hidden className="h-4 w-4 text-text-muted" />
+          <h2 className="text-lg font-semibold">Branch timeline</h2>
+        </div>
+        {navigation && <Badge variant="neutral">Scene {navigation.scene_version}</Badge>}
+      </div>
+
+      {isLoading && <p className="text-sm text-text-muted">Loading branch timeline...</p>}
+
+      {!isLoading && branches.length === 0 && (
+        <p className="text-sm text-text-muted">
+          No Story branches are available yet. Branches appear after Story choices are selected.
+        </p>
+      )}
+
+      {!isLoading && activePath.length > 0 && (
+        <div className="mb-4 rounded-md border border-border bg-bg px-3 py-2">
+          <p className="mb-2 text-xs uppercase tracking-normal text-text-muted">Active path</p>
+          <ol className="flex flex-wrap gap-2 text-sm">
+            {activePath.map((step) => (
+              <li key={`${step.branch_id}-${step.depth}`} className="flex items-center gap-2">
+                <span className="rounded-sm bg-surface px-2 py-1">
+                  {step.choice_text || step.branch_label || `Branch ${step.branch_id}`}
+                </span>
+              </li>
+            ))}
+          </ol>
+        </div>
+      )}
+
+      {navigation?.warnings?.length ? (
+        <ul className="mb-4 grid gap-2">
+          {navigation.warnings.map((warning) => (
+            <li key={`${warning.code}-${warning.branch_id ?? 'global'}`} className="text-sm text-warn">
+              {warning.message || warning.code}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      {branches.length > 0 && (
+        <ul className="grid gap-3">
+          {branches.map((branch) => {
+            const label = branchLabel(branch);
+            const rangeLabel = eventRangeLabel(branch);
+            const restoreTargets = branch.restore.supported ? branch.restore.target_names : [];
+
+            return (
+              <li key={branch.branch_id} className="rounded-md border border-border bg-bg p-3">
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <p className="font-medium">{label}</p>
+                      {branch.is_active && <Badge variant="success">Active</Badge>}
+                      {branch.is_on_active_path && <Badge variant="neutral">On path</Badge>}
+                    </div>
+                    {branch.choice_text && branch.choice_text !== label && (
+                      <p className="mt-1 text-sm text-text-muted">{branch.choice_text}</p>
+                    )}
+                    <p className="mt-1 text-xs text-text-muted">
+                      Depth {branch.depth}
+                      {rangeLabel ? ` · ${rangeLabel}` : ''}
+                    </p>
+                    {branch.warnings.length > 0 && (
+                      <ul className="mt-2 grid gap-1">
+                        {branch.warnings.map((warning) => (
+                          <li key={`${branch.branch_id}-${warning.code}`} className="text-xs text-warn">
+                            {warning.message || warning.code}
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+                  {restoreTargets.length > 0 && onRestoreBranch && (
+                    <div className="flex flex-wrap gap-2">
+                      {restoreTargets.map((target) => (
+                        <Button
+                          key={target}
+                          aria-label={`${targetLabel(target)}: ${label}`}
+                          className="gap-1"
+                          loading={restoringBranchId === branch.branch_id && restoreTarget === target}
+                          onClick={() => void onRestoreBranch(branch.branch_id, target)}
+                          size="xs"
+                          type="button"
+                          variant={target === branch.restore.default_target ? 'secondary' : 'ghost'}
+                        >
+                          <RotateCcw aria-hidden className="h-3.5 w-3.5" />
+                          {targetLabel(target)}
+                        </Button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/apps/tldw-frontend/components/vn-play/BranchTimelinePanel.tsx
+++ b/apps/tldw-frontend/components/vn-play/BranchTimelinePanel.tsx
@@ -3,6 +3,7 @@ import { GitBranch, RotateCcw } from 'lucide-react';
 import { Badge } from '@web/components/ui/Badge';
 import { Button } from '@web/components/ui/Button';
 import type {
+  VNPlayBranchWarning,
   VNPlayBranchNavigationNode,
   VNPlayBranchNavigationResponse,
   VNPlayBranchRestoreTarget,
@@ -34,6 +35,14 @@ function eventRangeLabel(branch: VNPlayBranchNavigationNode): string | null {
     return `Latest event ${latest}`;
   }
   return null;
+}
+
+function warningKey(
+  warning: VNPlayBranchWarning,
+  index: number,
+  scope: string | number
+): string {
+  return `${scope}-${warning.code}-${warning.branch_id ?? 'global'}-${warning.event_id ?? 'no-event'}-${index}`;
 }
 
 export default function BranchTimelinePanel({
@@ -81,8 +90,8 @@ export default function BranchTimelinePanel({
 
       {navigation?.warnings?.length ? (
         <ul className="mb-4 grid gap-2">
-          {navigation.warnings.map((warning) => (
-            <li key={`${warning.code}-${warning.branch_id ?? 'global'}`} className="text-sm text-warn">
+          {navigation.warnings.map((warning, index) => (
+            <li key={warningKey(warning, index, 'global')} className="text-sm text-warn">
               {warning.message || warning.code}
             </li>
           ))}
@@ -114,8 +123,8 @@ export default function BranchTimelinePanel({
                     </p>
                     {branch.warnings.length > 0 && (
                       <ul className="mt-2 grid gap-1">
-                        {branch.warnings.map((warning) => (
-                          <li key={`${branch.branch_id}-${warning.code}`} className="text-xs text-warn">
+                        {branch.warnings.map((warning, index) => (
+                          <li key={warningKey(warning, index, branch.branch_id)} className="text-xs text-warn">
                             {warning.message || warning.code}
                           </li>
                         ))}

--- a/apps/tldw-frontend/components/vn-play/VNPlayWorkspace.tsx
+++ b/apps/tldw-frontend/components/vn-play/VNPlayWorkspace.tsx
@@ -3,6 +3,7 @@ import { BookOpen, MessageSquarePlus } from 'lucide-react';
 import Link from 'next/link';
 import { Badge } from '@web/components/ui/Badge';
 import { Button } from '@web/components/ui/Button';
+import BranchTimelinePanel from '@web/components/vn-play/BranchTimelinePanel';
 import ChoicePanel from '@web/components/vn-play/ChoicePanel';
 import DialoguePanel from '@web/components/vn-play/DialoguePanel';
 import GenerationInspector from '@web/components/vn-play/GenerationInspector';
@@ -18,6 +19,7 @@ import SessionList, { VNPlayModeFilter } from '@web/components/vn-play/SessionLi
 import {
   createVNPlayCheckpoint,
   createVNPlaySession,
+  getVNPlayBranchNavigation,
   getVNPlaySession,
   activateVNPlayGenerationRevision,
   cancelVNPlayGenerationRequest,
@@ -28,12 +30,15 @@ import {
   listVNPlayGenerations,
   listVNPlaySessions,
   regenerateVNPlayGeneration,
+  restoreVNPlayBranch,
   restoreVNPlaySession,
   retryLastVNPlayTurn,
 } from '@web/lib/api/vnPlay';
 import { isAdmin } from '@web/lib/authz';
 import type {
   VNPlayBranch,
+  VNPlayBranchNavigationResponse,
+  VNPlayBranchRestoreTarget,
   VNPlayCheckpoint,
   VNPlayChoice,
   VNPlayEvent,
@@ -68,6 +73,9 @@ function recoveryCopy(status: string | null): string | null {
   if (status === 'turn_in_progress') {
     return 'A turn is already in progress for this session. Wait for it to finish, then reload if needed.';
   }
+  if (status === 'restore_action_in_progress') {
+    return 'A branch restore is already in progress for this session. Wait for it to finish, then reload if needed.';
+  }
   if (status === 'turn_failed') {
     return 'The last turn failed before completion. You can retry the stored turn request without duplicating the user input.';
   }
@@ -101,6 +109,8 @@ export default function VNPlayWorkspace({
   const [events, setEvents] = useState<VNPlayEvent[]>([]);
   const [checkpoints, setCheckpoints] = useState<VNPlayCheckpoint[]>([]);
   const [branches, setBranches] = useState<VNPlayBranch[]>([]);
+  const [branchNavigation, setBranchNavigation] = useState<VNPlayBranchNavigationResponse | null>(null);
+  const [branchTimelineError, setBranchTimelineError] = useState<string | null>(null);
   const [generations, setGenerations] = useState<VNPlayGenerationHistoryItem[]>([]);
   const [generationPagination, setGenerationPagination] = useState<VNPlayOffsetPagination | null>(null);
   const [modeFilter, setModeFilter] = useState<VNPlayModeFilter>('all');
@@ -110,12 +120,50 @@ export default function VNPlayWorkspace({
   const [isCreatingCheckpoint, setIsCreatingCheckpoint] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [isLoadingGenerations, setIsLoadingGenerations] = useState(false);
+  const [isLoadingBranchNavigation, setIsLoadingBranchNavigation] = useState(false);
   const [isRetryingTurn, setIsRetryingTurn] = useState(false);
   const [restoringCheckpointId, setRestoringCheckpointId] = useState<number | null>(null);
+  const [restoringBranchId, setRestoringBranchId] = useState<number | null>(null);
+  const [restoringBranchTarget, setRestoringBranchTarget] = useState<VNPlayBranchRestoreTarget | null>(null);
   const [turnStatus, setTurnStatus] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const selectedSessionId = selectedSession?.id;
   const canViewGenerationDebug = useMemo(() => canViewDebugForCurrentUser(), []);
+
+  const fetchBranchNavigation = useCallback(async (
+    sessionId: number,
+    mode?: VNPlayMode | null
+  ): Promise<{ error: string | null; navigation: VNPlayBranchNavigationResponse | null }> => {
+    if (mode !== 'story') {
+      return { error: null, navigation: null };
+    }
+
+    try {
+      const nextBranchNavigation = await getVNPlayBranchNavigation(sessionId);
+      return { error: null, navigation: nextBranchNavigation };
+    } catch (branchError) {
+      return {
+        error: branchError instanceof Error ? branchError.message : 'Failed to load branch timeline',
+        navigation: null,
+      };
+    }
+  }, []);
+
+  const reloadBranchNavigation = useCallback(async (
+    sessionId: number,
+    mode?: VNPlayMode | null
+  ): Promise<VNPlayBranchNavigationResponse | null> => {
+    setIsLoadingBranchNavigation(mode === 'story');
+    try {
+      const result = await fetchBranchNavigation(sessionId, mode);
+      setBranchTimelineError(result.error);
+      const nextBranchNavigation = result.navigation;
+      setBranchNavigation(nextBranchNavigation);
+      return nextBranchNavigation;
+    } finally {
+      setIsLoadingBranchNavigation(false);
+    }
+  }, [fetchBranchNavigation]);
 
   useEffect(() => {
     let cancelled = false;
@@ -162,6 +210,9 @@ export default function VNPlayWorkspace({
       setEvents([]);
       setCheckpoints([]);
       setBranches([]);
+      setBranchNavigation(null);
+      setBranchTimelineError(null);
+      setIsLoadingBranchNavigation(false);
       setGenerations([]);
       setGenerationPagination(null);
       return;
@@ -170,17 +221,27 @@ export default function VNPlayWorkspace({
     let cancelled = false;
     async function loadSessionCollections() {
       setIsLoadingGenerations(true);
+      setIsLoadingBranchNavigation(selectedSession?.mode === 'story');
       try {
-        const [nextEvents, nextCheckpoints, nextBranches, nextGenerations] = await Promise.all([
+        const [
+          nextEvents,
+          nextCheckpoints,
+          nextBranches,
+          nextGenerations,
+          nextBranchNavigation,
+        ] = await Promise.all([
           listVNPlayEvents(selectedSessionId),
           listVNPlayCheckpoints(selectedSessionId),
           listVNPlayBranches(selectedSessionId),
           listVNPlayGenerations(selectedSessionId, { limit: GENERATION_HISTORY_PAGE_SIZE, offset: 0 }),
+          fetchBranchNavigation(selectedSessionId, selectedSession?.mode),
         ]);
         if (!cancelled) {
           setEvents(nextEvents);
           setCheckpoints(nextCheckpoints);
           setBranches(nextBranches);
+          setBranchNavigation(nextBranchNavigation.navigation);
+          setBranchTimelineError(nextBranchNavigation.error);
           setGenerations(nextGenerations.items ?? []);
           setGenerationPagination(nextGenerations.pagination ?? null);
         }
@@ -189,12 +250,15 @@ export default function VNPlayWorkspace({
           setEvents([]);
           setCheckpoints([]);
           setBranches([]);
+          setBranchNavigation(null);
+          setBranchTimelineError(null);
           setGenerations([]);
           setGenerationPagination(null);
         }
       } finally {
         if (!cancelled) {
           setIsLoadingGenerations(false);
+          setIsLoadingBranchNavigation(false);
         }
       }
     }
@@ -203,7 +267,7 @@ export default function VNPlayWorkspace({
     return () => {
       cancelled = true;
     };
-  }, [selectedSessionId]);
+  }, [fetchBranchNavigation, selectedSession?.mode, selectedSessionId]);
 
   const filteredSessions = useMemo(() => {
     if (modeFilter === 'all') return sessions;
@@ -225,6 +289,8 @@ export default function VNPlayWorkspace({
       setEvents([]);
       setCheckpoints([]);
       setBranches([]);
+      setBranchNavigation(null);
+      setBranchTimelineError(null);
       setGenerations([]);
       setGenerationPagination(null);
       setModeFilter('all');
@@ -236,19 +302,20 @@ export default function VNPlayWorkspace({
     }
   }, []);
 
-  const reloadSessionCollections = useCallback(async (sessionId: number) => {
+  const reloadSessionCollections = useCallback(async (sessionId: number, mode?: VNPlayMode | null) => {
     const [nextEvents, nextCheckpoints, nextBranches, nextGenerations] = await Promise.all([
       listVNPlayEvents(sessionId),
       listVNPlayCheckpoints(sessionId),
       listVNPlayBranches(sessionId),
       listVNPlayGenerations(sessionId, { limit: GENERATION_HISTORY_PAGE_SIZE, offset: 0 }),
     ]);
+    await reloadBranchNavigation(sessionId, mode ?? selectedSession?.mode);
     setEvents(nextEvents);
     setCheckpoints(nextCheckpoints);
     setBranches(nextBranches);
     setGenerations(nextGenerations.items ?? []);
     setGenerationPagination(nextGenerations.pagination ?? null);
-  }, []);
+  }, [reloadBranchNavigation, selectedSession?.mode]);
 
   const loadMoreGenerations = useCallback(async () => {
     if (!selectedSessionId || !generationPagination?.has_more) return;
@@ -272,7 +339,7 @@ export default function VNPlayWorkspace({
     setSessions((previous) =>
       previous.map((session) => (session.id === nextSession.id ? nextSession : session))
     );
-    await reloadSessionCollections(sessionId);
+    await reloadSessionCollections(sessionId, nextSession.mode);
     return nextSession;
   }, [reloadSessionCollections]);
 
@@ -299,7 +366,7 @@ export default function VNPlayWorkspace({
         previous.map((session) => (session.id === response.session?.id ? response.session : session))
       );
       try {
-        await reloadSessionCollections(response.session.id);
+        await reloadSessionCollections(response.session.id, response.session.mode);
       } catch {
         // Keep response-derived session state when the follow-up collection refresh is unavailable.
       }
@@ -355,6 +422,8 @@ export default function VNPlayWorkspace({
       setTurnStatus(
         errorInfo.code === 'turn_in_progress' || /turn_in_progress/i.test(errorInfo.message)
           ? 'turn_in_progress'
+          : errorInfo.code === 'restore_action_in_progress' || /restore_action_in_progress/i.test(errorInfo.message)
+            ? 'restore_action_in_progress'
           : 'stale_scene_version'
       );
       setError(null);
@@ -410,13 +479,60 @@ export default function VNPlayWorkspace({
       setSessions((previous) =>
         previous.map((session) => (session.id === restored.id ? restored : session))
       );
-      await reloadSessionCollections(selectedSession.id);
+      await reloadSessionCollections(selectedSession.id, restored.mode);
     } catch (restoreError) {
       setError(restoreError instanceof Error ? restoreError.message : 'Failed to restore checkpoint');
     } finally {
       setRestoringCheckpointId(null);
     }
   }, [reloadSessionCollections, sceneVersion, selectedSession]);
+
+  const handleRestoreBranch = useCallback(async (
+    branchId: number,
+    target: VNPlayBranchRestoreTarget
+  ) => {
+    if (!selectedSession) return;
+
+    setRestoringBranchId(branchId);
+    setRestoringBranchTarget(target);
+    setError(null);
+    try {
+      const restored = await restoreVNPlayBranch(selectedSession.id, branchId, {
+        client_scene_version: sceneVersion,
+        idempotency_key: createVNPlayIdempotencyKey('restore-branch'),
+        target,
+      });
+      setTurnStatus(restored.status);
+      setSelectedSession(restored.session);
+      setSessions((previous) =>
+        previous.map((session) => (session.id === restored.session.id ? restored.session : session))
+      );
+      setBranchNavigation(restored.branch_navigation);
+      await reloadSessionCollections(restored.session.id, restored.session.mode);
+    } catch (restoreError) {
+      const errorInfo = getVNPlayErrorInfo(restoreError);
+      if (isRecoverableVNPlayConflict(restoreError)) {
+        setTurnStatus(
+          errorInfo.code === 'turn_in_progress' || /turn_in_progress/i.test(errorInfo.message)
+            ? 'turn_in_progress'
+            : errorInfo.code === 'restore_action_in_progress' || /restore_action_in_progress/i.test(errorInfo.message)
+              ? 'restore_action_in_progress'
+              : 'stale_scene_version'
+        );
+        setError(null);
+        try {
+          await reloadSelectedSession(selectedSession.id);
+        } catch {
+          setError(errorInfo.message);
+        }
+        return;
+      }
+      setError(errorInfo.message);
+    } finally {
+      setRestoringBranchId(null);
+      setRestoringBranchTarget(null);
+    }
+  }, [reloadSelectedSession, reloadSessionCollections, sceneVersion, selectedSession]);
 
   const handleRetryLastTurn = useCallback(async () => {
     if (!selectedSession) return;
@@ -524,35 +640,54 @@ export default function VNPlayWorkspace({
           />
 
           <section className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(300px,380px)]">
-            <div className="rounded-md border border-border bg-surface p-4">
-              <h2 className="mb-4 text-lg font-semibold">Scene</h2>
-              {selectedSession && sceneState ? (
-                <div className="grid gap-4">
-                  <div>
-                    <p className="text-xs uppercase tracking-normal text-text-muted">Selected session</p>
-                    <p className="font-medium">Selected session: {selectedSession.title}</p>
-                  </div>
-                  <SceneStage events={events} sceneState={sceneState} showDialogue={false} />
-                  <DialoguePanel
-                    events={events}
-                    mode={selectedSession.mode}
-                    sceneVersion={sceneVersion}
-                    sessionId={selectedSession.id}
-                    onError={handleTurnError}
-                    onTurn={(response) => void handleTurn(response)}
-                  />
-                  {selectedSession.mode === 'story' && (
-                    <ChoicePanel
-                      choices={choices}
+            <div className="grid gap-4">
+              <div className="rounded-md border border-border bg-surface p-4">
+                <h2 className="mb-4 text-lg font-semibold">Scene</h2>
+                {selectedSession && sceneState ? (
+                  <div className="grid gap-4">
+                    <div>
+                      <p className="text-xs uppercase tracking-normal text-text-muted">Selected session</p>
+                      <p className="font-medium">Selected session: {selectedSession.title}</p>
+                    </div>
+                    <SceneStage events={events} sceneState={sceneState} showDialogue={false} />
+                    <DialoguePanel
+                      events={events}
+                      mode={selectedSession.mode}
                       sceneVersion={sceneVersion}
                       sessionId={selectedSession.id}
                       onError={handleTurnError}
                       onTurn={(response) => void handleTurn(response)}
                     />
+                    {selectedSession.mode === 'story' && (
+                      <ChoicePanel
+                        choices={choices}
+                        sceneVersion={sceneVersion}
+                        sessionId={selectedSession.id}
+                        onError={handleTurnError}
+                        onTurn={(response) => void handleTurn(response)}
+                      />
+                    )}
+                  </div>
+                ) : (
+                  <p className="text-sm text-text-muted">No session selected.</p>
+                )}
+              </div>
+
+              {selectedSession?.mode === 'story' && (
+                <>
+                  {branchTimelineError && (
+                    <div className="rounded-md border border-warn/30 bg-warn/10 px-3 py-2 text-sm text-warn">
+                      {branchTimelineError}
+                    </div>
                   )}
-                </div>
-              ) : (
-                <p className="text-sm text-text-muted">No session selected.</p>
+                  <BranchTimelinePanel
+                    isLoading={isLoadingBranchNavigation}
+                    navigation={branchNavigation}
+                    onRestoreBranch={handleRestoreBranch}
+                    restoringBranchId={restoringBranchId}
+                    restoreTarget={restoringBranchTarget}
+                  />
+                </>
               )}
             </div>
 

--- a/apps/tldw-frontend/components/vn-play/VNPlayWorkspace.tsx
+++ b/apps/tldw-frontend/components/vn-play/VNPlayWorkspace.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { BookOpen, MessageSquarePlus } from 'lucide-react';
 import Link from 'next/link';
 import { Badge } from '@web/components/ui/Badge';
@@ -82,6 +82,39 @@ function recoveryCopy(status: string | null): string | null {
   return null;
 }
 
+function recoverableConflictStatus(errorInfo: ReturnType<typeof getVNPlayErrorInfo>): string {
+  if (errorInfo.code === 'turn_in_progress' || /turn_in_progress/i.test(errorInfo.message)) {
+    return 'turn_in_progress';
+  }
+  if (
+    errorInfo.code === 'restore_action_in_progress' ||
+    /restore_action_in_progress/i.test(errorInfo.message)
+  ) {
+    return 'restore_action_in_progress';
+  }
+  return 'stale_scene_version';
+}
+
+function mergeSessionScene(
+  session: VNPlaySession,
+  scene: VNPlaySceneState | null | undefined,
+  sceneVersion?: number
+): VNPlaySession {
+  const nextSceneVersion = sceneVersion ?? scene?.scene_version ?? session.scene_version;
+  if (!scene) {
+    return {
+      ...session,
+      scene_version: nextSceneVersion,
+    };
+  }
+  return {
+    ...session,
+    scene_version: nextSceneVersion,
+    scene_state: scene,
+    current_scene: scene,
+  };
+}
+
 function canViewDebugForCurrentUser(): boolean {
   if (typeof window === 'undefined') return true;
   const hasJwtToken = Boolean(window.localStorage.getItem('access_token'));
@@ -128,7 +161,21 @@ export default function VNPlayWorkspace({
   const [turnStatus, setTurnStatus] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const selectedSessionId = selectedSession?.id;
+  const selectedSessionIdRef = useRef<number | null>(selectedSessionId ?? null);
+  const restoreOperationRef = useRef(0);
+  const restoreInFlightRef = useRef(false);
   const canViewGenerationDebug = useMemo(() => canViewDebugForCurrentUser(), []);
+
+  useEffect(() => {
+    const nextSelectedSessionId = selectedSessionId ?? null;
+    if (selectedSessionIdRef.current !== nextSelectedSessionId) {
+      restoreOperationRef.current += 1;
+      restoreInFlightRef.current = false;
+      setRestoringBranchId(null);
+      setRestoringBranchTarget(null);
+    }
+    selectedSessionIdRef.current = nextSelectedSessionId;
+  }, [selectedSessionId]);
 
   const fetchBranchNavigation = useCallback(async (
     sessionId: number,
@@ -302,14 +349,24 @@ export default function VNPlayWorkspace({
     }
   }, []);
 
-  const reloadSessionCollections = useCallback(async (sessionId: number, mode?: VNPlayMode | null) => {
+  const reloadSessionCollections = useCallback(async (
+    sessionId: number,
+    mode?: VNPlayMode | null,
+    nextBranchNavigation?: VNPlayBranchNavigationResponse | null
+  ) => {
     const [nextEvents, nextCheckpoints, nextBranches, nextGenerations] = await Promise.all([
       listVNPlayEvents(sessionId),
       listVNPlayCheckpoints(sessionId),
       listVNPlayBranches(sessionId),
       listVNPlayGenerations(sessionId, { limit: GENERATION_HISTORY_PAGE_SIZE, offset: 0 }),
     ]);
-    await reloadBranchNavigation(sessionId, mode ?? selectedSession?.mode);
+    if (nextBranchNavigation !== undefined) {
+      setBranchNavigation(nextBranchNavigation);
+      setBranchTimelineError(null);
+      setIsLoadingBranchNavigation(false);
+    } else {
+      await reloadBranchNavigation(sessionId, mode ?? selectedSession?.mode);
+    }
     setEvents(nextEvents);
     setCheckpoints(nextCheckpoints);
     setBranches(nextBranches);
@@ -419,13 +476,7 @@ export default function VNPlayWorkspace({
     const isConflict = isRecoverableVNPlayConflict(turnError);
 
     if (isConflict && selectedSession) {
-      setTurnStatus(
-        errorInfo.code === 'turn_in_progress' || /turn_in_progress/i.test(errorInfo.message)
-          ? 'turn_in_progress'
-          : errorInfo.code === 'restore_action_in_progress' || /restore_action_in_progress/i.test(errorInfo.message)
-            ? 'restore_action_in_progress'
-          : 'stale_scene_version'
-      );
+      setTurnStatus(recoverableConflictStatus(errorInfo));
       setError(null);
       try {
         await reloadSelectedSession(selectedSession.id);
@@ -491,48 +542,63 @@ export default function VNPlayWorkspace({
     branchId: number,
     target: VNPlayBranchRestoreTarget
   ) => {
-    if (!selectedSession) return;
+    if (!selectedSession || restoringBranchId !== null || restoreInFlightRef.current) return;
 
+    const sessionId = selectedSession.id;
+    const operationId = restoreOperationRef.current + 1;
+    restoreOperationRef.current = operationId;
+    restoreInFlightRef.current = true;
+    const isCurrentRestore = () =>
+      restoreOperationRef.current === operationId && selectedSessionIdRef.current === sessionId;
     setRestoringBranchId(branchId);
     setRestoringBranchTarget(target);
     setError(null);
     try {
-      const restored = await restoreVNPlayBranch(selectedSession.id, branchId, {
+      const restored = await restoreVNPlayBranch(sessionId, branchId, {
         client_scene_version: sceneVersion,
         idempotency_key: createVNPlayIdempotencyKey('restore-branch'),
         target,
       });
+      if (!isCurrentRestore()) return;
+      const nextSession = mergeSessionScene(restored.session, restored.current_scene, restored.scene_version);
       setTurnStatus(restored.status);
-      setSelectedSession(restored.session);
+      setSelectedSession(nextSession);
       setSessions((previous) =>
-        previous.map((session) => (session.id === restored.session.id ? restored.session : session))
+        previous.map((session) => (session.id === nextSession.id ? nextSession : session))
       );
       setBranchNavigation(restored.branch_navigation);
-      await reloadSessionCollections(restored.session.id, restored.session.mode);
+      await reloadSessionCollections(nextSession.id, nextSession.mode, restored.branch_navigation);
     } catch (restoreError) {
       const errorInfo = getVNPlayErrorInfo(restoreError);
       if (isRecoverableVNPlayConflict(restoreError)) {
-        setTurnStatus(
-          errorInfo.code === 'turn_in_progress' || /turn_in_progress/i.test(errorInfo.message)
-            ? 'turn_in_progress'
-            : errorInfo.code === 'restore_action_in_progress' || /restore_action_in_progress/i.test(errorInfo.message)
-              ? 'restore_action_in_progress'
-              : 'stale_scene_version'
-        );
+        if (!isCurrentRestore()) return;
+        setTurnStatus(recoverableConflictStatus(errorInfo));
         setError(null);
         try {
-          await reloadSelectedSession(selectedSession.id);
+          await reloadSelectedSession(sessionId);
+          if (!isCurrentRestore()) return;
         } catch {
+          if (!isCurrentRestore()) return;
           setError(errorInfo.message);
         }
         return;
       }
+      if (!isCurrentRestore()) return;
       setError(errorInfo.message);
     } finally {
-      setRestoringBranchId(null);
-      setRestoringBranchTarget(null);
+      if (isCurrentRestore()) {
+        restoreInFlightRef.current = false;
+        setRestoringBranchId(null);
+        setRestoringBranchTarget(null);
+      }
     }
-  }, [reloadSelectedSession, reloadSessionCollections, sceneVersion, selectedSession]);
+  }, [
+    reloadSelectedSession,
+    reloadSessionCollections,
+    restoringBranchId,
+    sceneVersion,
+    selectedSession,
+  ]);
 
   const handleRetryLastTurn = useCallback(async () => {
     if (!selectedSession) return;

--- a/apps/tldw-frontend/components/vn-play/runtime.ts
+++ b/apps/tldw-frontend/components/vn-play/runtime.ts
@@ -4,7 +4,11 @@ export interface VNPlayErrorInfo {
   status?: number;
 }
 
-const RECOVERABLE_TURN_CODES = new Set(['stale_scene_version', 'turn_in_progress']);
+const RECOVERABLE_TURN_CODES = new Set([
+  'stale_scene_version',
+  'turn_in_progress',
+  'restore_action_in_progress',
+]);
 
 function asRecord(value: unknown): Record<string, unknown> | null {
   return value !== null && typeof value === 'object' && !Array.isArray(value)
@@ -73,5 +77,5 @@ export function isRecoverableVNPlayConflict(error: unknown): boolean {
   const info = getVNPlayErrorInfo(error);
   if (info.code && RECOVERABLE_TURN_CODES.has(info.code)) return true;
   if (info.status === 409) return true;
-  return /stale_scene_version|turn_in_progress/i.test(info.message);
+  return /stale_scene_version|turn_in_progress|restore_action_in_progress/i.test(info.message);
 }

--- a/apps/tldw-frontend/lib/api/vnPlay.ts
+++ b/apps/tldw-frontend/lib/api/vnPlay.ts
@@ -1,6 +1,9 @@
 import { apiClient } from '@web/lib/api';
 import type {
   VNPlayBranch,
+  VNPlayBranchNavigationResponse,
+  VNPlayBranchRestoreRequest,
+  VNPlayBranchRestoreResponse,
   VNPlayCheckpoint,
   VNPlayCheckpointCreate,
   VNPlayEvent,
@@ -97,6 +100,20 @@ export function restoreVNPlaySession(
 
 export function listVNPlayBranches(sessionId: number): Promise<VNPlayBranch[]> {
   return apiClient.get(`${VN_PLAY_BASE}/sessions/${sessionId}/branches`);
+}
+
+export function getVNPlayBranchNavigation(
+  sessionId: number
+): Promise<VNPlayBranchNavigationResponse> {
+  return apiClient.get(`${VN_PLAY_BASE}/sessions/${sessionId}/branch-navigation`);
+}
+
+export function restoreVNPlayBranch(
+  sessionId: number,
+  branchId: number,
+  request: VNPlayBranchRestoreRequest
+): Promise<VNPlayBranchRestoreResponse> {
+  return apiClient.post(`${VN_PLAY_BASE}/sessions/${sessionId}/branches/${branchId}/restore`, request);
 }
 
 export function listVNPlayGenerations(

--- a/apps/tldw-frontend/types/vn-play.ts
+++ b/apps/tldw-frontend/types/vn-play.ts
@@ -7,6 +7,8 @@ export type VNPlaySetupTrustSource = 'local_pack' | 'latest_import_journal' | 'u
 export type VNPlaySetupWarningSeverity = 'info' | 'warning' | 'high_risk';
 export type VNPlaySetupCompatibilityStatus = 'compatible' | 'different_character' | 'unknown';
 export type VNPlaySetupEmptyStateScope = 'global' | 'filter' | 'page';
+export type VNPlayBranchRestoreTarget = 'branch_latest' | 'choice_point';
+export type VNPlayBranchWarningSeverity = 'info' | 'warning' | 'high_risk';
 export type VNPlayTurnStatus =
   | 'pending'
   | 'model_calling'
@@ -361,4 +363,94 @@ export interface VNPlayBranch {
   status?: string;
   created_at?: string | null;
   updated_at?: string | null;
+}
+
+export interface VNPlayBranchWarning {
+  code: string;
+  severity: VNPlayBranchWarningSeverity;
+  recoverable: boolean;
+  message?: string | null;
+  branch_id?: number | null;
+  event_id?: number | null;
+}
+
+export interface VNPlayBranchEventRange {
+  start_event_id?: number | null;
+  start_sequence_number?: number | null;
+  latest_event_id?: number | null;
+  latest_sequence_number?: number | null;
+}
+
+export interface VNPlayBranchRestoreCapability {
+  supported: boolean;
+  default_target?: VNPlayBranchRestoreTarget | null;
+  target_names: VNPlayBranchRestoreTarget[];
+  targets: Partial<Record<VNPlayBranchRestoreTarget, Record<string, number | null> | null>>;
+}
+
+export interface VNPlayGeneratedChoiceRef {
+  generation_id: number;
+  revision_id: number;
+  choice_id: string;
+}
+
+export interface VNPlayBranchPathStep {
+  branch_id: number;
+  branch_label?: string | null;
+  choice_id?: string | null;
+  choice_text?: string | null;
+  generated_choice?: VNPlayGeneratedChoiceRef | null;
+  depth: number;
+}
+
+export interface VNPlayBranchNavigationNode {
+  branch_id: number;
+  parent_branch_id?: number | null;
+  parent_event_id?: number | null;
+  choice_selected_event_id?: number | null;
+  branch_label?: string | null;
+  choice_id?: string | null;
+  choice_text?: string | null;
+  generated_choice?: VNPlayGeneratedChoiceRef | null;
+  branch_path: Record<string, unknown>[];
+  depth: number;
+  status: string;
+  is_active: boolean;
+  is_on_active_path: boolean;
+  event_range: VNPlayBranchEventRange;
+  subtree_event_range: VNPlayBranchEventRange;
+  restore: VNPlayBranchRestoreCapability;
+  warnings: VNPlayBranchWarning[];
+}
+
+export interface VNPlayBranchNavigationResponse {
+  session_id: number;
+  mode: VNPlayMode;
+  scene_version: number;
+  last_event_id?: number | null;
+  active_branch_node_id?: number | null;
+  active_path: VNPlayBranchPathStep[];
+  branches: VNPlayBranchNavigationNode[];
+  warnings: VNPlayBranchWarning[];
+}
+
+export interface VNPlayBranchRestoreRequest {
+  client_scene_version: number;
+  idempotency_key: string;
+  target: VNPlayBranchRestoreTarget;
+}
+
+export interface VNPlayBranchRestoreResponse {
+  status: string;
+  replayed: boolean;
+  restore_event_id: number;
+  target_event_id?: number | null;
+  scene_version: number;
+  session: VNPlaySession;
+  current_scene: VNPlaySceneState;
+  branch_navigation: VNPlayBranchNavigationResponse;
+  branch_id?: number | null;
+  checkpoint_id?: number | null;
+  save_slot_id?: number | null;
+  target?: VNPlayBranchRestoreTarget | null;
 }

--- a/backlog/tasks/task-284 - Add-VN-Play-branch-timeline-and-restore-UX.md
+++ b/backlog/tasks/task-284 - Add-VN-Play-branch-timeline-and-restore-UX.md
@@ -1,0 +1,78 @@
+---
+id: TASK-284
+title: Add VN Play branch timeline and restore UX
+status: In Progress
+assignee: []
+created_date: '2026-05-12 03:03'
+updated_date: '2026-05-12 03:04'
+labels:
+  - vn-play
+  - webui
+  - branch-navigation
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1592'
+  - 'https://github.com/rmusser01/tldw_server/issues/1391'
+documentation:
+  - Docs/API-related/VN_PLAY_API.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement GitHub issue #1592: add a player-facing VN Play branch timeline/navigation surface in the WebUI so Story/CYOA users can inspect branch history and safely restore/resume branches using backend-owned branch navigation APIs. Keep branch semantics server-authoritative; do not reconstruct branch state from raw events or add frontend-owned branching rules. The main checkout is dirty, so this task is implemented in .worktrees/vn-play-branch-timeline-1592 on branch codex/vn-play-branch-timeline-1592.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Frontend API helpers and types cover existing VN Play branch navigation and guarded branch restore endpoints without duplicating backend branch semantics.
+- [x] #2 Story sessions show player-facing branch history/path information with active branch status, useful empty states, and no reliance on debug-only inspector details.
+- [x] #3 Branch restore/resume controls call backend guarded restore APIs with idempotency keys and show loading, stale, in-progress, and recoverable error states.
+- [x] #4 Existing checkpoint creation/restore, generated-choice play, and inspector workflows continue to work.
+- [x] #5 Focused frontend tests cover branch timeline rendering, active branch state, restore payloads, recovery states, and no-branch empty states.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Plan of record: Docs/superpowers/plans/2026-05-12-vn-play-branch-timeline-restore-ux.md
+
+Stages:
+1. Add typed branch navigation and branch restore frontend API helpers.
+2. Add BranchTimelinePanel with active path, restore target buttons, warnings, and empty states.
+3. Wire VNPlayWorkspace to load branch navigation and call guarded branch restore.
+4. Update docs, task notes, and run focused verification.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Created implementation plan for GitHub issue #1592 after verifying PR #1590 was merged and issue #1587 closed. Worktree: .worktrees/vn-play-branch-timeline-1592. Baseline frontend VN tests could not run before dependency setup because vitest is not installed in the fresh worktree; install/link dependencies before implementation verification.
+
+Implemented typed frontend VN Play branch navigation and branch restore helpers, BranchTimelinePanel, and VNPlayWorkspace wiring against backend-owned branch navigation APIs. The workspace now keeps branch semantics server-authoritative, refreshes branch navigation with session collections, and handles guarded branch restore with idempotency keys plus recoverable stale/in-progress states.
+
+Verification:
+- `bun run test:run __tests__/vn-play/vnPlayApi.test.ts __tests__/vn-play/BranchTimelinePanel.test.tsx __tests__/vn-play/VNPlayWorkspace.test.tsx __tests__/vn-play/SceneStage.test.tsx __tests__/vn-play/vnPlayRuntime.test.ts` passed: 5 files, 54 tests.
+- `bun run lint -- components/vn-play/BranchTimelinePanel.tsx components/vn-play/VNPlayWorkspace.tsx __tests__/vn-play/BranchTimelinePanel.test.tsx __tests__/vn-play/VNPlayWorkspace.test.tsx __tests__/vn-play/vnPlayApi.test.ts` exited 0 with existing repo-wide warnings only.
+- `git diff --check` exited 0.
+- Bandit skipped because this slice touched TypeScript/React, Markdown, and Backlog metadata only.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added backend-owned VN Play branch navigation support to the frontend: typed branch navigation/restore API helpers, a Story branch timeline panel with active-path and restore-target rendering, and workspace wiring that refreshes branch navigation alongside session collections.
+
+Branch restore controls now call the guarded backend restore endpoint with scene-version and idempotency protection, update the selected session from the restore response, and surface stale/in-progress restore conflicts as recoverable play-state messages. Documentation now notes that custom frontends should use the backend branch-navigation read model rather than deriving branch state from raw events.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-284 - Add-VN-Play-branch-timeline-and-restore-UX.md
+++ b/backlog/tasks/task-284 - Add-VN-Play-branch-timeline-and-restore-UX.md
@@ -57,6 +57,18 @@ Verification:
 - `bun run lint -- components/vn-play/BranchTimelinePanel.tsx components/vn-play/VNPlayWorkspace.tsx __tests__/vn-play/BranchTimelinePanel.test.tsx __tests__/vn-play/VNPlayWorkspace.test.tsx __tests__/vn-play/vnPlayApi.test.ts` exited 0 with existing repo-wide warnings only.
 - `git diff --check` exited 0.
 - Bandit skipped because this slice touched TypeScript/React, Markdown, and Backlog metadata only.
+
+Review fix pass for PR #1595:
+- Merged `branch_restore.current_scene` into the selected session and session list state so the Scene panel uses the authoritative restore scene even when the response session omits embedded scene state.
+- Added restore in-flight and operation/session guards to prevent overlapping restore requests and ignore stale async completions after session changes.
+- Reused restore response branch navigation in collection refresh to avoid an immediate redundant branch-navigation request.
+- Extracted recoverable conflict status mapping and made warning list keys collision-safe with event/index fallback.
+- Added regression coverage for duplicate warning keys, scene-state merge from `current_scene`, and overlapping branch restore suppression.
+
+Review verification:
+- `bun run test:run __tests__/vn-play/vnPlayApi.test.ts __tests__/vn-play/BranchTimelinePanel.test.tsx __tests__/vn-play/VNPlayWorkspace.test.tsx __tests__/vn-play/SceneStage.test.tsx __tests__/vn-play/vnPlayRuntime.test.ts` passed: 5 files, 56 tests.
+- `bun run lint -- components/vn-play/BranchTimelinePanel.tsx components/vn-play/VNPlayWorkspace.tsx __tests__/vn-play/BranchTimelinePanel.test.tsx __tests__/vn-play/VNPlayWorkspace.test.tsx __tests__/vn-play/vnPlayApi.test.ts` exited 0 with existing repo-wide warnings only.
+- `git diff --check` exited 0.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary

- Add typed frontend helpers for VN Play branch navigation and guarded branch restore.
- Add a player-facing Story branch timeline panel that renders backend-provided active path, branch state, warnings, and restore targets.
- Wire the VN Play workspace to load branch navigation, call branch restore with scene-version/idempotency guards, and surface recoverable restore conflicts.

## Verification

- `bun run test:run __tests__/vn-play/vnPlayApi.test.ts __tests__/vn-play/BranchTimelinePanel.test.tsx __tests__/vn-play/VNPlayWorkspace.test.tsx __tests__/vn-play/SceneStage.test.tsx __tests__/vn-play/vnPlayRuntime.test.ts`
- `bun run lint -- components/vn-play/BranchTimelinePanel.tsx components/vn-play/VNPlayWorkspace.tsx __tests__/vn-play/BranchTimelinePanel.test.tsx __tests__/vn-play/VNPlayWorkspace.test.tsx __tests__/vn-play/vnPlayApi.test.ts` exited 0 with existing repo-wide warnings only.
- `git diff --check HEAD~1..HEAD`

## Notes

- Bandit is not applicable for this slice because it touches TypeScript/React, Markdown, and Backlog metadata only.
- Related issue: #1592
- AI-generated PR merge gate: requester should add the required human-written Change summary before merge.
