### PR TITLE
Migrate SourcesPane ready label to registry

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -5324,17 +5324,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "canonical-state-label:src/components/Option/WorkspacePlayground/SourcesPane/index.tsx:Ready",
-    "path": "src/components/Option/WorkspacePlayground/SourcesPane/index.tsx",
-    "rule": "canonical-state-label",
-    "subject": "Ready",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing hardcoded \"Ready\" state label in src/components/Option/WorkspacePlayground/SourcesPane/index.tsx before the guard.",
-    "replacement": "getDesignSystemState(...)",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "canonical-state-label:src/components/Option/WorkspacePlayground/WorkspaceHeader.tsx:Degraded",
     "path": "src/components/Option/WorkspacePlayground/WorkspaceHeader.tsx",
     "rule": "canonical-state-label",

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/SourcesPane/index.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/SourcesPane/index.tsx
@@ -27,6 +27,7 @@ import {
   Popconfirm,
   Modal
 } from "antd"
+import { getDesignSystemState } from "@/design-system"
 import { useWorkspaceStore } from "@/store/workspace"
 import type { WorkspaceSourceType } from "@/types/workspace"
 import { tldwClient } from "@/services/tldw/TldwApiClient"
@@ -141,6 +142,7 @@ export const SourcesPane: React.FC<SourcesPaneProps> = ({
   onResetAdvancedSourceFilters
 }) => {
   const { t } = useTranslation(["playground", "common"])
+  const readyState = getDesignSystemState("ready")
   const [messageApi, messageContextHolder] = message.useMessage()
   const patchSourceListViewState = React.useCallback(
     (patch: Partial<SourceListViewState>) => {
@@ -1065,7 +1067,7 @@ export const SourcesPane: React.FC<SourcesPaneProps> = ({
       ? t("playground:sources.statusProcessing", "Processing")
       : isError
         ? t("playground:sources.statusErrorShort", "Error")
-        : t("playground:sources.statusReady", "Ready")
+        : readyState.label
     const sourceStatusClass = isProcessing
       ? "border-primary/30 bg-primary/10 text-primary"
       : isError

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/SourcesPane.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/SourcesPane.design-system.test.tsx
@@ -1,0 +1,127 @@
+import { render, screen, within } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { WorkspaceSource } from "@/types/workspace"
+
+import { SourcesPane } from "../SourcesPane"
+
+const mockGetDesignSystemState = vi.hoisted(() => vi.fn())
+
+vi.mock("@/design-system", () => ({
+  getDesignSystemState: mockGetDesignSystemState
+}))
+
+const workspaceStoreState = {
+  sources: [] as WorkspaceSource[],
+  selectedSourceIds: [] as string[],
+  sourceFolders: [] as Array<{
+    id: string
+    workspaceId: string
+    name: string
+    parentFolderId: string | null
+    createdAt: Date
+    updatedAt: Date
+  }>,
+  sourceFolderMemberships: [] as Array<{ folderId: string; sourceId: string }>,
+  selectedSourceFolderIds: [] as string[],
+  activeFolderId: null as string | null,
+  sourceSearchQuery: "",
+  sourceFocusTarget: null as { sourceId: string; token: number } | null,
+  toggleSourceSelection: vi.fn(),
+  toggleSourceFolderSelection: vi.fn(),
+  selectAllSources: vi.fn(),
+  deselectAllSources: vi.fn(),
+  setSelectedSourceIds: vi.fn(),
+  setSourceSearchQuery: vi.fn(),
+  clearSourceFocusTarget: vi.fn(),
+  openAddSourceModal: vi.fn(),
+  addSource: vi.fn(),
+  removeSource: vi.fn(),
+  removeSources: vi.fn(),
+  restoreSource: vi.fn(),
+  reorderSource: vi.fn(),
+  setActiveFolder: vi.fn(),
+  assignSourceToFolders: vi.fn(),
+  getEffectiveSelectedSources: vi.fn(() => [])
+}
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      _key: string,
+      defaultValueOrOptions?:
+        | string
+        | {
+            count?: number
+            defaultValue?: string
+          },
+      interpolationValues?: {
+        count?: number
+      }
+    ) => {
+      if (typeof defaultValueOrOptions === "string") {
+        return defaultValueOrOptions.replace(
+          "{{count}}",
+          String(interpolationValues?.count ?? "")
+        )
+      }
+      if (defaultValueOrOptions?.defaultValue) {
+        return defaultValueOrOptions.defaultValue.replace(
+          "{{count}}",
+          String(defaultValueOrOptions.count ?? "")
+        )
+      }
+      return _key
+    }
+  })
+}))
+
+vi.mock("@/store/workspace", () => ({
+  useWorkspaceStore: (
+    selector: (state: typeof workspaceStoreState) => unknown
+  ) => selector(workspaceStoreState)
+}))
+
+vi.mock("../SourcesPane/AddSourceModal", () => ({
+  AddSourceModal: () => <div data-testid="add-source-modal" />
+}))
+
+describe("SourcesPane design-system state labels", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetDesignSystemState.mockImplementation((key: string) => ({
+      key,
+      label: key === "ready" ? "Registry Ready" : key,
+      severity: key === "ready" ? "success" : "neutral"
+    }))
+    workspaceStoreState.sources = [
+      {
+        id: "source-1",
+        mediaId: 101,
+        title: "Registry-backed source",
+        type: "pdf",
+        status: "ready",
+        addedAt: new Date("2026-03-11T00:00:00.000Z")
+      }
+    ]
+    workspaceStoreState.selectedSourceIds = []
+    workspaceStoreState.sourceFolders = []
+    workspaceStoreState.sourceFolderMemberships = []
+    workspaceStoreState.selectedSourceFolderIds = []
+    workspaceStoreState.activeFolderId = null
+    workspaceStoreState.sourceSearchQuery = ""
+    workspaceStoreState.sourceFocusTarget = null
+    workspaceStoreState.getEffectiveSelectedSources.mockReturnValue([])
+  })
+
+  it("uses the design-system registry label for ready source status badges", () => {
+    render(<SourcesPane />)
+
+    const sourceRow = screen
+      .getByText("Registry-backed source")
+      .closest('[data-source-id="source-1"]') as HTMLElement
+
+    expect(within(sourceRow).getByText("Registry Ready")).toBeInTheDocument()
+    expect(mockGetDesignSystemState).toHaveBeenCalledWith("ready")
+  })
+})

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/SourcesPane.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/SourcesPane.design-system.test.tsx
@@ -1,15 +1,32 @@
 import { render, screen, within } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import { getDesignSystemState } from "@/design-system"
 import type { WorkspaceSource } from "@/types/workspace"
 
 import { SourcesPane } from "../SourcesPane"
 
-const mockGetDesignSystemState = vi.hoisted(() => vi.fn())
-
-vi.mock("@/design-system", () => ({
-  getDesignSystemState: mockGetDesignSystemState
+const registryLabels = vi.hoisted(() => ({
+  ready: "Registry Ready"
 }))
+
+vi.mock("@/design-system", async (importActual) => {
+  const actual = await importActual<typeof import("@/design-system")>()
+
+  return {
+    ...actual,
+    getDesignSystemState: vi.fn(
+      (key: Parameters<typeof actual.getDesignSystemState>[0]) => {
+        const state = actual.getDesignSystemState(key)
+
+        return {
+          ...state,
+          label: key === "ready" ? registryLabels.ready : state.label
+        }
+      }
+    )
+  }
+})
 
 const workspaceStoreState = {
   sources: [] as WorkspaceSource[],
@@ -89,11 +106,6 @@ vi.mock("../SourcesPane/AddSourceModal", () => ({
 describe("SourcesPane design-system state labels", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockGetDesignSystemState.mockImplementation((key: string) => ({
-      key,
-      label: key === "ready" ? "Registry Ready" : key,
-      severity: key === "ready" ? "success" : "neutral"
-    }))
     workspaceStoreState.sources = [
       {
         id: "source-1",
@@ -121,7 +133,7 @@ describe("SourcesPane design-system state labels", () => {
       .getByText("Registry-backed source")
       .closest('[data-source-id="source-1"]') as HTMLElement
 
-    expect(within(sourceRow).getByText("Registry Ready")).toBeInTheDocument()
-    expect(mockGetDesignSystemState).toHaveBeenCalledWith("ready")
+    expect(within(sourceRow).getByText(registryLabels.ready)).toBeInTheDocument()
+    expect(vi.mocked(getDesignSystemState)).toHaveBeenCalledWith("ready")
   })
 })

--- a/backlog/tasks/task-285 - Migrate-SourcesPane-ready-label-to-design-system-registry.md
+++ b/backlog/tasks/task-285 - Migrate-SourcesPane-ready-label-to-design-system-registry.md
@@ -48,6 +48,8 @@ Replace the hardcoded ready source-status label in WorkspacePlayground SourcesPa
 - Red test first: `bunx vitest run src/components/Option/WorkspacePlayground/__tests__/SourcesPane.design-system.test.tsx --reporter=dot` failed because the source row still rendered `Ready` instead of the mocked registry label `Registry Ready`.
 - The ready status badge now reads the label from the design-system state registry; processing and error status labels remain on their existing translated text paths.
 - Removed the `canonical-state-label:src/components/Option/WorkspacePlayground/SourcesPane/index.tsx:Ready` baseline entry.
+- Review fix: updated the focused design-system test mock to preserve the real `@/design-system` module exports and override only `getDesignSystemState`, matching the existing registry-label test pattern.
+- Review disposition: did not apply optional chaining to `readyState.label` because `getDesignSystemState("ready")` is a typed lookup into the static design-system state registry; a missing `ready` key would violate the registry contract and should fail loudly instead of rendering an undefined badge.
 - Broad `SourcesPane` TypeScript filtering surfaced an existing unrelated error in `SourcesPane.stage5.transfer.test.tsx`; an exact touched-path filter for `SourcesPane/index.tsx`, `SourcesPane.design-system.test.tsx`, and the baseline file returned no output.
 - Bandit skipped: touched implementation is frontend TypeScript/test JSON only, with no Python code path.
 <!-- SECTION:NOTES:END -->
@@ -57,5 +59,5 @@ Replace the hardcoded ready source-status label in WorkspacePlayground SourcesPa
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Migrated the WorkspacePlayground SourcesPane ready source-status badge to the design-system state registry by resolving `getDesignSystemState("ready")` and rendering its label for ready rows. Added focused coverage that mocks the registry and scopes the assertion to a source row, proving the badge uses the registry-provided label without source-string assertions.
 
-Removed the now-obsolete canonical state label baseline exception. Verification passed with the focused SourcesPane design-system test, existing SourcesPane filters/sort coverage, the product-state guard unit suite, the design-system guard CLI, `git diff --check`, and an exact touched-path TypeScript error filter. Repo-wide TypeScript still has an unrelated pre-existing `SourcesPane.stage5.transfer.test.tsx` error.
+Removed the now-obsolete canonical state label baseline exception. Review feedback was addressed by preserving real design-system module exports in the test mock. Verification passed with the focused SourcesPane design-system test, existing SourcesPane filters/sort coverage, the product-state guard unit suite, the design-system guard CLI, `git diff --check`, and an exact touched-path TypeScript error filter. Repo-wide TypeScript still has an unrelated pre-existing `SourcesPane.stage5.transfer.test.tsx` error.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-285 - Migrate-SourcesPane-ready-label-to-design-system-registry.md
+++ b/backlog/tasks/task-285 - Migrate-SourcesPane-ready-label-to-design-system-registry.md
@@ -1,0 +1,61 @@
+---
+id: TASK-285
+title: Migrate SourcesPane ready label to design-system registry
+status: Done
+assignee: []
+created_date: '2026-05-12 03:37'
+labels:
+  - design-system
+  - frontend
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replace the hardcoded ready source-status label in WorkspacePlayground SourcesPane with the design-system state registry fallback while preserving status guardrail behavior and source row rendering.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Ready source status badge in SourcesPane displays the design-system ready state label.
+- [x] #2 Focused tests prove the ready badge label comes from the registry without source-string assertions.
+- [x] #3 The matching canonical-state-label baseline exception is removed and the design-system state guard passes.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused SourcesPane test that mocks the design-system registry and verifies ready source status badges use the registry-provided label.
+2. Replace the hardcoded ready source status label with `getDesignSystemState("ready").label` while leaving processing/error labels and guardrail behavior unchanged.
+3. Remove the matching `canonical-state-label` baseline exception and verify the product-state guard still passes.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Red test first: `bunx vitest run src/components/Option/WorkspacePlayground/__tests__/SourcesPane.design-system.test.tsx --reporter=dot` failed because the source row still rendered `Ready` instead of the mocked registry label `Registry Ready`.
+- The ready status badge now reads the label from the design-system state registry; processing and error status labels remain on their existing translated text paths.
+- Removed the `canonical-state-label:src/components/Option/WorkspacePlayground/SourcesPane/index.tsx:Ready` baseline entry.
+- Broad `SourcesPane` TypeScript filtering surfaced an existing unrelated error in `SourcesPane.stage5.transfer.test.tsx`; an exact touched-path filter for `SourcesPane/index.tsx`, `SourcesPane.design-system.test.tsx`, and the baseline file returned no output.
+- Bandit skipped: touched implementation is frontend TypeScript/test JSON only, with no Python code path.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated the WorkspacePlayground SourcesPane ready source-status badge to the design-system state registry by resolving `getDesignSystemState("ready")` and rendering its label for ready rows. Added focused coverage that mocks the registry and scopes the assertion to a source row, proving the badge uses the registry-provided label without source-string assertions.
+
+Removed the now-obsolete canonical state label baseline exception. Verification passed with the focused SourcesPane design-system test, existing SourcesPane filters/sort coverage, the product-state guard unit suite, the design-system guard CLI, `git diff --check`, and an exact touched-path TypeScript error filter. Repo-wide TypeScript still has an unrelated pre-existing `SourcesPane.stage5.transfer.test.tsx` error.
+<!-- SECTION:FINAL_SUMMARY:END -->


### PR DESCRIPTION
## Summary
- Migrate WorkspacePlayground SourcesPane ready source-status badge to the design-system state registry.
- Add focused registry-mock coverage that scopes the assertion to a source row.
- Remove the obsolete canonical-state-label baseline exception.

## Verification
- bunx vitest run src/components/Option/WorkspacePlayground/__tests__/SourcesPane.design-system.test.tsx --reporter=dot
- bunx vitest run src/components/Option/WorkspacePlayground/__tests__/SourcesPane.design-system.test.tsx src/components/Option/WorkspacePlayground/__tests__/SourcesPane.stage4.filters-and-sort.test.tsx --reporter=dot
- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot
- bun run verify:design-system-state
- git diff --check
- bunx tsc --noEmit --pretty false 2>&1 | rg -n "SourcesPane/index\.tsx|SourcesPane\.design-system\.test\.tsx|design-system-product-state-baseline"

## Notes
- Repo-wide TypeScript still reports an unrelated pre-existing error in SourcesPane.stage5.transfer.test.tsx when filtering broadly for SourcesPane.
- Bandit skipped: frontend TypeScript/test-only change.

Backlog: TASK-285