### PR TITLE
Migrate WorkspaceStatusBar degraded label to registry

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -5335,17 +5335,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "canonical-state-label:src/components/Option/WorkspacePlayground/WorkspaceStatusBar.tsx:Degraded",
-    "path": "src/components/Option/WorkspacePlayground/WorkspaceStatusBar.tsx",
-    "rule": "canonical-state-label",
-    "subject": "Degraded",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing hardcoded \"Degraded\" state label in src/components/Option/WorkspacePlayground/WorkspaceStatusBar.tsx before the guard.",
-    "replacement": "getDesignSystemState(...)",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "canonical-state-label:src/components/Option/WritingPlayground/index.tsx:Ready",
     "path": "src/components/Option/WritingPlayground/index.tsx",
     "rule": "canonical-state-label",

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/WorkspaceStatusBar.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/WorkspaceStatusBar.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { useTranslation } from "react-i18next"
 import { Tooltip, Modal, Button } from "antd"
 import { Loader2, Trash2 } from "lucide-react"
+import { getDesignSystemState } from "@/design-system"
 import { useConnectionStore } from "@/store/connection"
 import { deriveConnectionUxState, type ConnectionUxState } from "@/types/connection"
 import { WORKSPACE_STORAGE_KEY } from "@/store/workspace-events"
@@ -44,8 +45,10 @@ const deriveConnectionTone = (
     ux === "connected_degraded" ||
     ux === "demo_mode"
   ) {
+    const degradedState = getDesignSystemState("degraded")
+
     return {
-      label: "Degraded",
+      label: degradedState.label,
       detail: "Connection degraded",
       description: "",
       toneClass: "text-warning",

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/WorkspaceStatusBar.test.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/WorkspaceStatusBar.test.tsx
@@ -1,8 +1,13 @@
 import React from "react"
 import { render, screen } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { ConnectionPhase } from "@/types/connection"
+import { getDesignSystemState } from "@/design-system"
+import { ConnectionPhase, type ConnectionState } from "@/types/connection"
 import { WorkspaceStatusBar } from "../WorkspaceStatusBar"
+
+const registryLabels = vi.hoisted(() => ({
+  degraded: "Registry Degraded"
+}))
 
 const connectionStoreState = {
   state: {
@@ -24,7 +29,7 @@ const connectionStoreState = {
     userPersona: null,
     lastConfigUpdatedAt: null,
     checksSinceConfigChange: 0,
-  },
+  } as ConnectionState,
   checkOnce: vi.fn(),
 }
 
@@ -50,6 +55,24 @@ vi.mock("@/store/connection", () => ({
     selector: (state: typeof connectionStoreState) => unknown
   ) => selector(connectionStoreState),
 }))
+
+vi.mock("@/design-system", async (importActual) => {
+  const actual = await importActual<typeof import("@/design-system")>()
+
+  return {
+    ...actual,
+    getDesignSystemState: vi.fn(
+      (key: Parameters<typeof actual.getDesignSystemState>[0]) => {
+        const state = actual.getDesignSystemState(key)
+
+        return {
+          ...state,
+          label: key === "degraded" ? registryLabels.degraded : state.label
+        }
+      }
+    )
+  }
+})
 
 describe("WorkspaceStatusBar", () => {
   beforeEach(() => {
@@ -89,7 +112,7 @@ describe("WorkspaceStatusBar", () => {
   it("shows retry for authentication errors", () => {
     connectionStoreState.state.phase = ConnectionPhase.ERROR
     connectionStoreState.state.isConnected = false
-    connectionStoreState.state.errorKind = "error_auth"
+    connectionStoreState.state.errorKind = "auth"
 
     render(<WorkspaceStatusBar />)
 
@@ -104,5 +127,16 @@ describe("WorkspaceStatusBar", () => {
     render(<WorkspaceStatusBar />)
 
     expect(screen.queryByRole("button", { name: "Retry" })).not.toBeInTheDocument()
+  })
+
+  it("uses the design-system registry label for degraded connection status", () => {
+    connectionStoreState.state.errorKind = "partial"
+
+    render(<WorkspaceStatusBar />)
+
+    expect(screen.getByTestId("workspace-statusbar-connection")).toHaveTextContent(
+      registryLabels.degraded
+    )
+    expect(vi.mocked(getDesignSystemState)).toHaveBeenCalledWith("degraded")
   })
 })

--- a/backlog/tasks/task-289 - Migrate-WorkspaceStatusBar-degraded-label-to-design-system-registry.md
+++ b/backlog/tasks/task-289 - Migrate-WorkspaceStatusBar-degraded-label-to-design-system-registry.md
@@ -1,0 +1,61 @@
+---
+id: TASK-289
+title: Migrate WorkspaceStatusBar degraded label to design-system registry
+status: Done
+assignee: []
+created_date: '2026-05-12 04:26'
+labels:
+  - design-system
+  - frontend
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replace the hardcoded degraded connection label in WorkspacePlayground WorkspaceStatusBar with the design-system state registry fallback while preserving connection tone and retry behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The degraded connection indicator in WorkspaceStatusBar displays the design-system degraded state label.
+- [x] #2 Focused tests prove the degraded connection label comes from the registry without source-string assertions.
+- [x] #3 The matching canonical-state-label baseline exception is removed and the design-system state guard passes.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused WorkspaceStatusBar test that mocks the design-system registry and verifies degraded connection status uses the registry-provided label.
+2. Replace the hardcoded degraded connection label with `getDesignSystemState("degraded").label` while preserving tone classes, details, and retry behavior.
+3. Remove the matching `canonical-state-label` baseline exception and verify the product-state guard still passes.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Red test first: `bunx vitest run src/components/Option/WorkspacePlayground/__tests__/WorkspaceStatusBar.test.tsx --reporter=dot` failed because the degraded connection indicator still rendered `Degraded` instead of the mocked registry label `Registry Degraded`.
+- The degraded connection tone now reads its label from the design-system state registry; connected and disconnected labels remain unchanged.
+- Removed the `canonical-state-label:src/components/Option/WorkspacePlayground/WorkspaceStatusBar.tsx:Degraded` baseline entry.
+- Tightened the existing connection-state test mock typing to `ConnectionState` and corrected the auth error test fixture from `error_auth` to the valid `auth` error kind.
+- Bandit skipped: touched implementation is frontend TypeScript/test JSON only, with no Python code path.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated WorkspaceStatusBar's degraded connection indicator label to the design-system state registry by resolving `getDesignSystemState("degraded")` and rendering its label for degraded connection UX states. Added focused coverage that mocks the registry while preserving real design-system module exports, proving the degraded indicator uses the registry-provided label without source-string assertions.
+
+Removed the now-obsolete canonical state label baseline exception. Verification passed with the focused WorkspaceStatusBar test, the product-state guard unit suite, the design-system guard CLI, `git diff --check`, and an exact touched-path TypeScript error filter.
+<!-- SECTION:FINAL_SUMMARY:END -->


### PR DESCRIPTION
## Summary
- Migrate WorkspaceStatusBar degraded connection label to the design-system state registry.
- Add focused registry-mock coverage while preserving real design-system module exports.
- Remove the obsolete canonical-state-label baseline exception.

## Verification
- bunx vitest run src/components/Option/WorkspacePlayground/__tests__/WorkspaceStatusBar.test.tsx --reporter=dot
- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot
- bun run verify:design-system-state
- git diff --check
- bunx tsc --noEmit --pretty false 2>&1 | rg -n "WorkspaceStatusBar|design-system-product-state-baseline"

## Notes
- Bandit skipped: frontend TypeScript/test-only change.

Backlog: TASK-289

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the degraded connection label in `WorkspaceStatusBar` to the design-system state registry for consistent wording across the app. Implements TASK-289.

- **Refactors**
  - Replace hardcoded "Degraded" with `getDesignSystemState("degraded").label` while keeping tone and retry behavior.
  - Remove the `canonical-state-label` baseline exception for `WorkspaceStatusBar`.
  - Add focused tests that mock `@/design-system` to verify registry usage; fix auth error kind to `auth` and tighten typing.

<sup>Written for commit 12585ea0c0f77941d771e5d04086e885c2cb6a03. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

