### PR TITLE
Add Persona Chat judge execution artifacts

### DIFF
--- a/Docs/Reviews/PERSONA_CHAT_JUDGE_EVALUATION_CONTRACT_2026_05_11.md
+++ b/Docs/Reviews/PERSONA_CHAT_JUDGE_EVALUATION_CONTRACT_2026_05_11.md
@@ -62,6 +62,14 @@ Fail-closed execution results use stable error keys only: `malformed_json`, `inv
 
 The execution adapter feeds `calibrate_persona_chat_judge_predictions()` for per-dimension calibration. The offline harness, review command, and policy helper remain the separate report-review path for already-produced V1 contract candidate outputs.
 
+## Execution Artifact Contract
+
+`build_persona_chat_judge_execution_artifact()` wraps an explicit offline execution result with the existing per-dimension calibration report. The artifact is a review record only. It is JSON-serializable, sets `offline_only=true`, keeps `runtime_gating_allowed=false`, and includes bounded provider/model metadata, input case ids, represented dimension keys, prediction/failure counts, sanitized prediction fields, stable failure error keys, and calibration metrics.
+
+The artifact does not include prompts, user input, assistant text, expected context dumps, response observation dumps, exemplar bodies, raw critique text, provider exception strings, local paths, secrets, or database content. Evidence entries are field references only; anything that does not look like a bounded identifier is redacted. Calibration missing/unknown prediction links are serialized as bounded `case_id` and `dimension_key` pairs.
+
+Execution artifacts do not persist themselves and do not imply production trust. Callers that write the artifact to disk remain responsible for choosing an explicit review path and for keeping raw judge inputs/results out of adjacent files.
+
 ## Calibration Contract
 
 `calibrate_persona_chat_judge_predictions()` compares predicted judge results to expected fixture labels before outputs can be treated as useful quality signals.
@@ -102,7 +110,7 @@ The policy result is intentionally trace-safe. It contains status fields, stable
 - Unknown prediction scope: unregistered dimensions and unknown case IDs are reported as unknown predictions rather than counted as calibration evidence.
 - Model and prompt drift: any model, prompt, dimension, or fixture-schema change requires a fresh calibration run before comparing results across revisions.
 - Report trust drift: review-command reports can be generated from malformed or partial candidate files. The policy blocks malformed reports, malformed case rows, missing candidates, extra candidates, invalid candidates, and low-agreement reports before maintainers treat them as calibrated.
-- Trace leakage: judge review artifacts can become privacy risks if they copy raw prompt or response content. The policy result is restricted to bounded identifiers and reason keys.
+- Trace leakage: judge review artifacts can become privacy risks if they copy raw prompt or response content. Execution artifacts and policy results are restricted to bounded identifiers, sanitized prediction/failure fields, calibration metrics, and reason keys.
 - Subjective boundary cases: the V1 dimensions cover selected Persona Chat failure families only. They do not replace human review for nuanced style, safety, or intent disagreements outside the registered dimensions.
 - Grounding and factuality limits: this judge evaluates observed Persona Chat behavior against fixture evidence. It does not prove factual correctness, retrieval grounding, or broader RAG quality.
 - Runtime limits: this layer is optional and offline. It does not gate live chat responses, enforce moderation, or protect runtime Persona Chat behavior.
@@ -128,4 +136,4 @@ Focused tests live in `tldw_Server_API/tests/Evaluations/test_persona_chat_judge
 
 Policy tests live in `tldw_Server_API/tests/Evaluations/test_persona_chat_judge_policy.py` and cover advisory classification for the synthetic fixture, blocked invalid/missing/extra/low-agreement reports, dict report input compatibility, stable JSON serialization, and raw-text exclusion.
 
-Execution tests live in `tldw_Server_API/tests/Evaluations/test_persona_chat_judge_execution.py` and cover valid prediction parsing, bounded malformed JSON and shape failures, invalid result and evidence handling, unknown dimension rejection, duplicate execution-key handling, provider exception redaction, and feeding predictions into the existing calibration helper.
+Execution tests live in `tldw_Server_API/tests/Evaluations/test_persona_chat_judge_execution.py` and cover valid prediction parsing, bounded malformed JSON and shape failures, invalid result and evidence handling, unknown dimension rejection, duplicate execution-key handling, provider exception redaction, feeding predictions into the existing calibration helper, trace-safe execution artifact serialization, failure-only artifacts, calibration warning serialization, and raw-content leak resistance.

--- a/Docs/Reviews/PERSONA_CHAT_JUDGE_EVALUATION_CONTRACT_2026_05_11.md
+++ b/Docs/Reviews/PERSONA_CHAT_JUDGE_EVALUATION_CONTRACT_2026_05_11.md
@@ -64,9 +64,9 @@ The execution adapter feeds `calibrate_persona_chat_judge_predictions()` for per
 
 ## Execution Artifact Contract
 
-`build_persona_chat_judge_execution_artifact()` wraps an explicit offline execution result with the existing per-dimension calibration report. The artifact is a review record only. It is JSON-serializable, sets `offline_only=true`, keeps `runtime_gating_allowed=false`, and includes bounded provider/model metadata, input case ids, represented dimension keys, prediction/failure counts, sanitized prediction fields, stable failure error keys, and calibration metrics.
+`build_persona_chat_judge_execution_artifact()` wraps an explicit offline execution result with the existing per-dimension calibration report. The artifact is a review record only. It is JSON-serializable, sets `offline_only=true`, keeps `runtime_gating_allowed=false`, and includes bounded provider/model metadata, the actual input row count, deduplicated input case ids, sorted represented dimension keys, prediction/failure counts, sanitized prediction fields, stable failure error keys, and calibration metrics.
 
-The artifact does not include prompts, user input, assistant text, expected context dumps, response observation dumps, exemplar bodies, raw critique text, provider exception strings, local paths, secrets, or database content. Evidence entries are field references only; anything that does not look like a bounded identifier is redacted. Calibration missing/unknown prediction links are serialized as bounded `case_id` and `dimension_key` pairs.
+The artifact does not include prompts, user input, assistant text, expected context dumps, response observation dumps, exemplar bodies, raw critique text, provider exception strings, local paths, secrets, or database content. Evidence entries are field references only; anything that does not look like a bounded identifier is redacted. Calibration missing/unknown prediction links are serialized as bounded `case_id` and `dimension_key` pairs. Calibration warnings are serialized as stable `warning_keys`, not free-form warning sentences.
 
 Execution artifacts do not persist themselves and do not imply production trust. Callers that write the artifact to disk remain responsible for choosing an explicit review path and for keeping raw judge inputs/results out of adjacent files.
 
@@ -86,7 +86,7 @@ The report includes:
 - TNR: fail-labeled cases predicted as fail.
 - Missing predictions for dimensions represented by predictions or fixture labels in the batch.
 - Unknown predictions for unregistered dimensions or unknown case ids.
-- Warnings when class counts are too small for production calibration.
+- Stable warning keys when class counts are too small for production calibration or TPR/TNR cannot be computed.
 
 The default production threshold is 20 pass and 20 fail cases per dimension. The current synthetic fixture set is useful for contract and smoke calibration, but it is not enough to claim production-calibrated judge accuracy.
 

--- a/backlog/tasks/task-257.4 - Add-Persona-Chat-judge-trace-safe-execution-artifacts.md
+++ b/backlog/tasks/task-257.4 - Add-Persona-Chat-judge-trace-safe-execution-artifacts.md
@@ -1,0 +1,67 @@
+---
+id: TASK-257.4
+title: Add Persona Chat judge trace-safe execution artifacts
+status: Done
+assignee: []
+created_date: '2026-05-12 04:30'
+updated_date: '2026-05-12 04:35'
+labels:
+  - persona-chat
+  - evaluations
+  - stage-2
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1598'
+  - 'https://github.com/rmusser01/tldw_server/issues/1566'
+documentation:
+  - Docs/Reviews/PERSONA_CHAT_JUDGE_EVALUATION_CONTRACT_2026_05_11.md
+parent_task_id: TASK-257
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement GitHub issue #1598 as the next optional Persona Chat judge Stage 2 slice. Add a bounded review artifact for offline executable judge results by combining PersonaChatJudgeExecutionResult data with existing calibration metrics, while preserving V1 boundaries: no raw prompt/response/exemplar/exception leakage, no provider-specific execution, no persistence service, no Jobs/API/WebUI state, and no runtime Persona Chat gating.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A helper converts offline Persona Chat judge execution results plus fixture inputs into a JSON-serializable trace-safe artifact.
+- [x] #2 The artifact includes schema version, offline_only=true, runtime_gating_allowed=false, sanitized provider/model metadata, bounded prediction/failure counts, calibration metrics, missing/unknown prediction keys, and warnings without raw prompt or response content.
+- [x] #3 Failure-only artifacts preserve bounded error keys and sanitized case/dimension/provider/model metadata only.
+- [x] #4 Focused tests cover successful artifacts, failure-only artifacts, calibration warning serialization, and leak resistance.
+- [x] #5 Focused pytest, Bandit on touched Python scope, and git diff hygiene are recorded before closeout.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Write failing tests for execution artifact success, failure-only output, calibration warnings, and leakage resistance. 2. Implement the minimal trace-safe artifact dataclasses/helper near the execution boundary. 3. Export the helper, run focused tests, Bandit, and diff hygiene. 4. Update Backlog notes and linked GitHub issue with verification.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+RED/GREEN: Added failing artifact tests in test_persona_chat_judge_execution.py for successful execution artifact serialization, failure-only artifacts, calibration warning serialization, and raw-content leak resistance. Initial import check failed with ImportError for build_persona_chat_judge_execution_artifact, then passed after adding PersonaChatJudgeExecutionArtifact and the builder in persona_chat_judge_execution.py.
+
+Implementation: build_persona_chat_judge_execution_artifact now combines PersonaChatJudgeExecutionResult with calibrate_persona_chat_judge_predictions, serializes a trace-safe artifact with schema_version, offline_only=true, runtime_gating_allowed=false, sanitized provider/model, bounded input case ids, represented dimension keys, prediction/failure counts, sanitized predictions/failures, and calibration metrics/missing/unknown/warnings. Contract docs now describe the execution artifact boundary and leak constraints.
+
+Verification: baseline focused judge tests passed before implementation with 27 passed. New execution test file passed with 16 passed. Broader focused Persona Chat judge suite passed with 52 passed and 5 warnings. py_compile passed for persona_chat_judge_execution.py. Bandit on touched production/test Python paths wrote /tmp/bandit_persona_chat_judge_artifacts.json with results 0 and errors []. git diff --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added trace-safe Persona Chat judge execution artifacts for issue #1598. The new artifact helper combines bounded offline execution results with existing calibration metrics while preserving offline-only/no-runtime-gating boundaries and avoiding raw prompt, response, exemplar, exception, path, or secret leakage. Tests and docs cover success, failure-only, calibration warning, and leak-resistance behavior.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-257.4.1 - Address-PR-1600-review-comments.md
+++ b/backlog/tasks/task-257.4.1 - Address-PR-1600-review-comments.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-257.4.1
 title: Address PR 1600 review comments
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-12 04:47'
-updated_date: '2026-05-12 04:54'
+updated_date: '2026-05-12 04:57'
 labels:
   - persona-chat
   - evaluations
@@ -30,7 +30,7 @@ Address all actionable review comments on PR #1600 for the Persona Chat judge tr
 - [x] #3 Unsafe case-id redaction collisions do not emit duplicate predictions and do not crash artifact generation.
 - [x] #4 Artifact input counts report actual input row count rather than unique sanitized case-id count.
 - [x] #5 Represented dimension keys are deterministic and stable across prediction/failure/calibration sources.
-- [ ] #6 Focused tests, Bandit on touched Python scope, git diff hygiene, and PR replies/resolution are recorded.
+- [x] #6 Focused tests, Bandit on touched Python scope, git diff hygiene, and PR replies/resolution are recorded.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -45,14 +45,22 @@ Address all actionable review comments on PR #1600 for the Persona Chat judge tr
 Verified PR #1600 review surfaces and addressed still-valid findings: artifact serialization now re-sanitizes public IDs/results, emits structured calibration warning keys, counts actual input rows separately from deduplicated IDs, detects redaction collisions using sanitized prediction keys, and sorts represented dimension keys.
 
 Validation so far: focused execution tests passed, broader Persona Chat judge suite passed with 55 tests, py_compile passed, Bandit on touched Python scope passed with 0 findings, and git diff --check passed.
+
+PR replies posted and unresolved review threads resolved: Gemini deterministic dimension-key thread PRRT_kwDOL1aGf86BSxjZ, CodeRabbit final serialization boundary thread PRRT_kwDOL1aGf86BSzkQ, plus top-level PR summary comment https://github.com/rmusser01/tldw_server/pull/1600#issuecomment-4427462170.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed PR #1600 review findings by hardening Persona Chat judge execution artifacts: structured warning_keys replaced free-form calibration warnings, final to_dict serialization now re-sanitizes IDs/schema/results, unsafe redaction collisions become bounded duplicate_prediction failures, total_inputs reports actual input rows, represented dimension keys are sorted, and docs/tests were updated. Validation passed for the focused Persona Chat judge suite, py_compile, Bandit on touched Python scope with 0 findings, and git diff hygiene; PR review replies were posted and unresolved inline threads resolved.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-257.4.1 - Address-PR-1600-review-comments.md
+++ b/backlog/tasks/task-257.4.1 - Address-PR-1600-review-comments.md
@@ -1,0 +1,58 @@
+---
+id: TASK-257.4.1
+title: Address PR 1600 review comments
+status: In Progress
+assignee: []
+created_date: '2026-05-12 04:47'
+updated_date: '2026-05-12 04:54'
+labels:
+  - persona-chat
+  - evaluations
+  - review-fix
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1600'
+  - 'https://github.com/rmusser01/tldw_server/issues/1598'
+parent_task_id: TASK-257.4
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address all actionable review comments on PR #1600 for the Persona Chat judge trace-safe execution artifact slice. Verify each finding against current code, fix only still-valid issues, preserve the offline/no-runtime-gating boundary, and keep changes focused.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Artifact serialization emits structured bounded calibration warning keys instead of free-form warning sentences.
+- [x] #2 Artifact serialization defensively sanitizes public input_case_ids, dimension_keys, and prediction result fields at the final to_dict boundary.
+- [x] #3 Unsafe case-id redaction collisions do not emit duplicate predictions and do not crash artifact generation.
+- [x] #4 Artifact input counts report actual input row count rather than unique sanitized case-id count.
+- [x] #5 Represented dimension keys are deterministic and stable across prediction/failure/calibration sources.
+- [ ] #6 Focused tests, Bandit on touched Python scope, git diff hygiene, and PR replies/resolution are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing regression tests for Qodo/CodeRabbit/Gemini findings. 2. Patch artifact serialization and duplicate handling minimally. 3. Update docs/task notes if the JSON shape changes. 4. Run focused verification, commit, push, and resolve/reply to review threads.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verified PR #1600 review surfaces and addressed still-valid findings: artifact serialization now re-sanitizes public IDs/results, emits structured calibration warning keys, counts actual input rows separately from deduplicated IDs, detects redaction collisions using sanitized prediction keys, and sorts represented dimension keys.
+
+Validation so far: focused execution tests passed, broader Persona Chat judge suite passed with 55 tests, py_compile passed, Bandit on touched Python scope passed with 0 findings, and git diff --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/Evaluations/persona_chat_judge_execution.py
+++ b/tldw_Server_API/app/core/Evaluations/persona_chat_judge_execution.py
@@ -16,10 +16,13 @@ from typing import Any, Literal
 
 from tldw_Server_API.app.core.Evaluations.persona_chat_judge import (
     PERSONA_CHAT_JUDGE_DIMENSIONS,
+    PersonaChatJudgeCalibrationMetrics,
+    PersonaChatJudgeCalibrationReport,
     PersonaChatJudgeDimension,
     PersonaChatJudgeInput,
     PersonaChatJudgePrediction,
     build_persona_chat_judge_prompt,
+    calibrate_persona_chat_judge_predictions,
     get_persona_chat_judge_dimension,
 )
 
@@ -40,6 +43,8 @@ _VALID_RESULTS = frozenset(("Pass", "Fail"))
 _UNSAFE_METADATA_MARKERS = frozenset(
     ("api_key", "apikey", "credential", "password", "secret", "token")
 )
+_EXECUTION_ARTIFACT_SCHEMA_VERSION = "persona-chat-judge-execution-artifact.v1"
+_MIN_CASES_PER_CLASS_FOR_ARTIFACT = 20
 
 
 @dataclass(frozen=True)
@@ -90,6 +95,45 @@ class PersonaChatJudgeExecutionResult:
                 for prediction in self.predictions
             ],
             "failures": [failure.to_dict() for failure in self.failures],
+        }
+
+
+@dataclass(frozen=True)
+class PersonaChatJudgeExecutionArtifact:
+    """Trace-safe review artifact for one offline judge execution batch."""
+
+    schema_version: str
+    offline_only: bool
+    provider: str
+    model: str
+    runtime_gating_allowed: bool
+    input_case_ids: tuple[str, ...]
+    dimension_keys: tuple[str, ...]
+    predictions: tuple[PersonaChatJudgePrediction, ...]
+    failures: tuple[PersonaChatJudgeExecutionFailure, ...]
+    calibration: PersonaChatJudgeCalibrationReport
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return bounded JSON data without prompts, responses, or exceptions."""
+        predictions = [
+            _prediction_to_artifact_dict(prediction)
+            for prediction in self.predictions
+        ]
+        failures = [_failure_to_artifact_dict(failure) for failure in self.failures]
+        return {
+            "schema_version": self.schema_version,
+            "offline_only": self.offline_only,
+            "runtime_gating_allowed": self.runtime_gating_allowed,
+            "provider": _safe_metadata_text(self.provider),
+            "model": _safe_metadata_text(self.model),
+            "total_inputs": len(self.input_case_ids),
+            "input_case_ids": list(self.input_case_ids),
+            "dimension_keys": list(self.dimension_keys),
+            "prediction_count": len(predictions),
+            "failure_count": len(failures),
+            "predictions": predictions,
+            "failures": failures,
+            "calibration": _calibration_to_artifact_dict(self.calibration),
         }
 
 
@@ -188,6 +232,40 @@ def execute_persona_chat_judge(
         predictions=tuple(predictions),
         failures=tuple(failures),
         runtime_gating_allowed=False,
+    )
+
+
+def build_persona_chat_judge_execution_artifact(
+    inputs: Sequence[PersonaChatJudgeInput],
+    execution_result: PersonaChatJudgeExecutionResult,
+    *,
+    min_cases_per_class: int = _MIN_CASES_PER_CLASS_FOR_ARTIFACT,
+) -> PersonaChatJudgeExecutionArtifact:
+    """Combine offline execution output with bounded calibration review data."""
+    input_case_ids = tuple(
+        dict.fromkeys(
+            _safe_identifier_text(judge_input.case_id) for judge_input in inputs
+        )
+    )
+    calibration = calibrate_persona_chat_judge_predictions(
+        inputs,
+        execution_result.predictions,
+        min_cases_per_class=min_cases_per_class,
+    )
+    return PersonaChatJudgeExecutionArtifact(
+        schema_version=_EXECUTION_ARTIFACT_SCHEMA_VERSION,
+        offline_only=True,
+        provider=_safe_metadata_text(execution_result.provider),
+        model=_safe_metadata_text(execution_result.model),
+        runtime_gating_allowed=False,
+        input_case_ids=input_case_ids,
+        dimension_keys=_artifact_dimension_keys(
+            execution_result=execution_result,
+            calibration=calibration,
+        ),
+        predictions=execution_result.predictions,
+        failures=execution_result.failures,
+        calibration=calibration,
     )
 
 
@@ -325,8 +403,146 @@ def _safe_identifier_text(value: str) -> str:
     return text
 
 
+def _artifact_dimension_keys(
+    *,
+    execution_result: PersonaChatJudgeExecutionResult,
+    calibration: PersonaChatJudgeCalibrationReport,
+) -> tuple[str, ...]:
+    """Return stable sanitized dimensions represented in the artifact."""
+    dimension_keys: list[str] = []
+    for prediction in execution_result.predictions:
+        dimension_keys.append(_safe_identifier_text(prediction.dimension_key))
+    for failure in execution_result.failures:
+        dimension_keys.append(_safe_identifier_text(failure.dimension_key))
+    dimension_keys.extend(
+        _safe_identifier_text(dimension_key)
+        for dimension_key in calibration.metrics_by_dimension
+    )
+    dimension_keys.extend(
+        _safe_identifier_text(dimension_key)
+        for _, dimension_key in calibration.missing_predictions
+    )
+    dimension_keys.extend(
+        _safe_identifier_text(dimension_key)
+        for _, dimension_key in calibration.unknown_predictions
+    )
+    return tuple(dict.fromkeys(dimension_keys))
+
+
+def _prediction_to_artifact_dict(
+    prediction: PersonaChatJudgePrediction,
+) -> dict[str, Any]:
+    """Return trace-safe prediction fields for execution artifacts."""
+    return {
+        "case_id": _safe_identifier_text(prediction.case_id),
+        "dimension_key": _safe_identifier_text(prediction.dimension_key),
+        "result": prediction.result,
+        "critique": "provided" if prediction.critique else "omitted",
+        "evidence": [_safe_artifact_reference(item) for item in prediction.evidence],
+    }
+
+
+def _failure_to_artifact_dict(
+    failure: PersonaChatJudgeExecutionFailure,
+) -> dict[str, str]:
+    """Return trace-safe failure fields for execution artifacts."""
+    return {
+        "case_id": _safe_identifier_text(failure.case_id),
+        "dimension_key": _safe_identifier_text(failure.dimension_key),
+        "provider": _safe_metadata_text(failure.provider),
+        "model": _safe_metadata_text(failure.model),
+        "error_key": failure.error_key,
+    }
+
+
+def _calibration_to_artifact_dict(
+    calibration: PersonaChatJudgeCalibrationReport,
+) -> dict[str, Any]:
+    """Return JSON-safe calibration data with bounded identifiers."""
+    return {
+        "production_calibrated": calibration.production_calibrated,
+        "missing_predictions": _case_dimension_pairs(calibration.missing_predictions),
+        "unknown_predictions": _case_dimension_pairs(calibration.unknown_predictions),
+        "warnings": [_safe_warning_text(warning) for warning in calibration.warnings],
+        "metrics_by_dimension": {
+            _safe_identifier_text(dimension_key): _metrics_to_artifact_dict(metrics)
+            for dimension_key, metrics in sorted(calibration.metrics_by_dimension.items())
+        },
+    }
+
+
+def _case_dimension_pairs(
+    pairs: Sequence[tuple[str, str]],
+) -> list[dict[str, str]]:
+    """Return sanitized case/dimension pair dictionaries."""
+    return [
+        {
+            "case_id": _safe_identifier_text(case_id),
+            "dimension_key": _safe_identifier_text(dimension_key),
+        }
+        for case_id, dimension_key in pairs
+    ]
+
+
+def _metrics_to_artifact_dict(
+    metrics: PersonaChatJudgeCalibrationMetrics,
+) -> dict[str, Any]:
+    """Return bounded calibration metrics for one dimension."""
+    return {
+        "dimension_key": _safe_identifier_text(metrics.dimension_key),
+        "evaluated_cases": metrics.evaluated_cases,
+        "expected_passes": metrics.expected_passes,
+        "expected_fails": metrics.expected_fails,
+        "true_passes": metrics.true_passes,
+        "true_fails": metrics.true_fails,
+        "false_passes": metrics.false_passes,
+        "false_fails": metrics.false_fails,
+        "tpr": metrics.tpr,
+        "tnr": metrics.tnr,
+        "production_calibrated": metrics.production_calibrated,
+        "warnings": [_safe_warning_text(warning) for warning in metrics.warnings],
+    }
+
+
+def _safe_artifact_reference(value: str) -> str:
+    """Return evidence field references only when they look like identifiers."""
+    text = str(value).strip()
+    lowered = text.lower()
+    if (
+        not text
+        or len(text) > 128
+        or text.startswith(("/", "~"))
+        or "\\" in text
+        or "\n" in text
+        or "\r" in text
+        or any(marker in lowered for marker in _UNSAFE_METADATA_MARKERS)
+        or not all(char.isalnum() or char in "._-" for char in text)
+    ):
+        return "redacted"
+    return text
+
+
+def _safe_warning_text(value: str) -> str:
+    """Return bounded calibration warning text or a redaction marker."""
+    text = str(value).strip()
+    lowered = text.lower()
+    if (
+        not text
+        or len(text) > 256
+        or text.startswith(("/", "~"))
+        or "\\" in text
+        or "\n" in text
+        or "\r" in text
+        or any(marker in lowered for marker in _UNSAFE_METADATA_MARKERS)
+    ):
+        return "redacted"
+    return text
+
+
 __all__ = [
+    "build_persona_chat_judge_execution_artifact",
     "CompletionFn",
+    "PersonaChatJudgeExecutionArtifact",
     "PersonaChatJudgeExecutionErrorKey",
     "PersonaChatJudgeExecutionFailure",
     "PersonaChatJudgeExecutionResult",

--- a/tldw_Server_API/app/core/Evaluations/persona_chat_judge_execution.py
+++ b/tldw_Server_API/app/core/Evaluations/persona_chat_judge_execution.py
@@ -45,6 +45,9 @@ _UNSAFE_METADATA_MARKERS = frozenset(
 )
 _EXECUTION_ARTIFACT_SCHEMA_VERSION = "persona-chat-judge-execution-artifact.v1"
 _MIN_CASES_PER_CLASS_FOR_ARTIFACT = 20
+_CALIBRATION_WARNING_SAMPLE_TOO_SMALL = "calibration_sample_too_small"
+_CALIBRATION_WARNING_TPR_TNR_UNAVAILABLE = "tpr_tnr_unavailable"
+_CALIBRATION_WARNING_UNKNOWN = "calibration_warning"
 
 
 @dataclass(frozen=True)
@@ -107,6 +110,7 @@ class PersonaChatJudgeExecutionArtifact:
     provider: str
     model: str
     runtime_gating_allowed: bool
+    total_inputs: int
     input_case_ids: tuple[str, ...]
     dimension_keys: tuple[str, ...]
     predictions: tuple[PersonaChatJudgePrediction, ...]
@@ -115,20 +119,33 @@ class PersonaChatJudgeExecutionArtifact:
 
     def to_dict(self) -> dict[str, Any]:
         """Return bounded JSON data without prompts, responses, or exceptions."""
+        input_case_ids = tuple(
+            dict.fromkeys(
+                _safe_identifier_text(case_id) for case_id in self.input_case_ids
+            )
+        )
+        dimension_keys = tuple(
+            sorted(
+                dict.fromkeys(
+                    _safe_identifier_text(dimension_key)
+                    for dimension_key in self.dimension_keys
+                )
+            )
+        )
         predictions = [
             _prediction_to_artifact_dict(prediction)
             for prediction in self.predictions
         ]
         failures = [_failure_to_artifact_dict(failure) for failure in self.failures]
         return {
-            "schema_version": self.schema_version,
-            "offline_only": self.offline_only,
-            "runtime_gating_allowed": self.runtime_gating_allowed,
+            "schema_version": _safe_identifier_text(self.schema_version),
+            "offline_only": True,
+            "runtime_gating_allowed": False,
             "provider": _safe_metadata_text(self.provider),
             "model": _safe_metadata_text(self.model),
-            "total_inputs": len(self.input_case_ids),
-            "input_case_ids": list(self.input_case_ids),
-            "dimension_keys": list(self.dimension_keys),
+            "total_inputs": _safe_non_negative_int(self.total_inputs),
+            "input_case_ids": list(input_case_ids),
+            "dimension_keys": list(dimension_keys),
             "prediction_count": len(predictions),
             "failure_count": len(failures),
             "predictions": predictions,
@@ -155,8 +172,8 @@ def execute_persona_chat_judge(
     for judge_input in inputs:
         safe_case_id = _safe_identifier_text(judge_input.case_id)
         for dimension_key in dimension_keys:
-            prediction_key = (judge_input.case_id, dimension_key)
             safe_dimension_key = _safe_identifier_text(dimension_key)
+            prediction_key = (safe_case_id, safe_dimension_key)
             if prediction_key in seen_prediction_keys:
                 failures.append(
                     _failure(
@@ -258,6 +275,7 @@ def build_persona_chat_judge_execution_artifact(
         provider=_safe_metadata_text(execution_result.provider),
         model=_safe_metadata_text(execution_result.model),
         runtime_gating_allowed=False,
+        total_inputs=len(inputs),
         input_case_ids=input_case_ids,
         dimension_keys=_artifact_dimension_keys(
             execution_result=execution_result,
@@ -398,9 +416,19 @@ def _safe_identifier_text(value: str) -> str:
         or "\n" in text
         or "\r" in text
         or any(marker in lowered for marker in _UNSAFE_METADATA_MARKERS)
+        or not all(char.isalnum() or char in "._-" for char in text)
     ):
         return "redacted"
     return text
+
+
+def _safe_non_negative_int(value: int) -> int:
+    """Return non-negative integer counts and fail closed on malformed values."""
+    try:
+        number = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return max(0, number)
 
 
 def _artifact_dimension_keys(
@@ -409,24 +437,24 @@ def _artifact_dimension_keys(
     calibration: PersonaChatJudgeCalibrationReport,
 ) -> tuple[str, ...]:
     """Return stable sanitized dimensions represented in the artifact."""
-    dimension_keys: list[str] = []
+    dimension_keys: set[str] = set()
     for prediction in execution_result.predictions:
-        dimension_keys.append(_safe_identifier_text(prediction.dimension_key))
+        dimension_keys.add(_safe_identifier_text(prediction.dimension_key))
     for failure in execution_result.failures:
-        dimension_keys.append(_safe_identifier_text(failure.dimension_key))
-    dimension_keys.extend(
+        dimension_keys.add(_safe_identifier_text(failure.dimension_key))
+    dimension_keys.update(
         _safe_identifier_text(dimension_key)
         for dimension_key in calibration.metrics_by_dimension
     )
-    dimension_keys.extend(
+    dimension_keys.update(
         _safe_identifier_text(dimension_key)
         for _, dimension_key in calibration.missing_predictions
     )
-    dimension_keys.extend(
+    dimension_keys.update(
         _safe_identifier_text(dimension_key)
         for _, dimension_key in calibration.unknown_predictions
     )
-    return tuple(dict.fromkeys(dimension_keys))
+    return tuple(sorted(dimension_keys))
 
 
 def _prediction_to_artifact_dict(
@@ -436,7 +464,11 @@ def _prediction_to_artifact_dict(
     return {
         "case_id": _safe_identifier_text(prediction.case_id),
         "dimension_key": _safe_identifier_text(prediction.dimension_key),
-        "result": prediction.result,
+        "result": (
+            prediction.result
+            if isinstance(prediction.result, str) and prediction.result in _VALID_RESULTS
+            else "redacted"
+        ),
         "critique": "provided" if prediction.critique else "omitted",
         "evidence": [_safe_artifact_reference(item) for item in prediction.evidence],
     }
@@ -463,7 +495,7 @@ def _calibration_to_artifact_dict(
         "production_calibrated": calibration.production_calibrated,
         "missing_predictions": _case_dimension_pairs(calibration.missing_predictions),
         "unknown_predictions": _case_dimension_pairs(calibration.unknown_predictions),
-        "warnings": [_safe_warning_text(warning) for warning in calibration.warnings],
+        "warning_keys": _calibration_warning_keys(calibration),
         "metrics_by_dimension": {
             _safe_identifier_text(dimension_key): _metrics_to_artifact_dict(metrics)
             for dimension_key, metrics in sorted(calibration.metrics_by_dimension.items())
@@ -500,7 +532,7 @@ def _metrics_to_artifact_dict(
         "tpr": metrics.tpr,
         "tnr": metrics.tnr,
         "production_calibrated": metrics.production_calibrated,
-        "warnings": [_safe_warning_text(warning) for warning in metrics.warnings],
+        "warning_keys": _metric_warning_keys(metrics),
     }
 
 
@@ -522,21 +554,33 @@ def _safe_artifact_reference(value: str) -> str:
     return text
 
 
-def _safe_warning_text(value: str) -> str:
-    """Return bounded calibration warning text or a redaction marker."""
-    text = str(value).strip()
-    lowered = text.lower()
-    if (
-        not text
-        or len(text) > 256
-        or text.startswith(("/", "~"))
-        or "\\" in text
-        or "\n" in text
-        or "\r" in text
-        or any(marker in lowered for marker in _UNSAFE_METADATA_MARKERS)
-    ):
-        return "redacted"
-    return text
+def _calibration_warning_keys(
+    calibration: PersonaChatJudgeCalibrationReport,
+) -> list[str]:
+    """Return stable warning keys for the aggregate calibration report."""
+    warning_keys = _warning_keys_from_texts(calibration.warnings)
+    for metrics in calibration.metrics_by_dimension.values():
+        warning_keys.extend(_metric_warning_keys(metrics))
+    return list(dict.fromkeys(warning_keys))
+
+
+def _metric_warning_keys(metrics: PersonaChatJudgeCalibrationMetrics) -> list[str]:
+    """Return stable warning keys for one dimension's calibration metrics."""
+    return _warning_keys_from_texts(metrics.warnings)
+
+
+def _warning_keys_from_texts(warnings: Sequence[str]) -> list[str]:
+    """Map internal calibration warning text to trace-safe warning keys."""
+    warning_keys: list[str] = []
+    for warning in warnings:
+        text = str(warning)
+        if "calibration sample is too small for production use" in text:
+            warning_keys.append(_CALIBRATION_WARNING_SAMPLE_TOO_SMALL)
+        elif "requires both pass and fail labels to report TPR/TNR" in text:
+            warning_keys.append(_CALIBRATION_WARNING_TPR_TNR_UNAVAILABLE)
+        else:
+            warning_keys.append(_CALIBRATION_WARNING_UNKNOWN)
+    return list(dict.fromkeys(warning_keys))
 
 
 __all__ = [

--- a/tldw_Server_API/tests/Evaluations/test_persona_chat_judge_execution.py
+++ b/tldw_Server_API/tests/Evaluations/test_persona_chat_judge_execution.py
@@ -6,10 +6,12 @@ import json
 from typing import Any
 
 from tldw_Server_API.app.core.Evaluations.persona_chat_judge import (
+    PersonaChatJudgePrediction,
     build_persona_chat_judge_input,
     calibrate_persona_chat_judge_predictions,
 )
 from tldw_Server_API.app.core.Evaluations.persona_chat_judge_execution import (
+    PersonaChatJudgeExecutionArtifact,
     build_persona_chat_judge_execution_artifact,
     execute_persona_chat_judge,
 )
@@ -25,6 +27,17 @@ def _valid_response(*, result: str = "Fail") -> str:
             "evidence": ["persona_memory_mode", "assistant_text"],
         }
     )
+
+
+def _unsafe_prediction_for_artifact_test() -> PersonaChatJudgePrediction:
+    """Create an invalid prediction by bypassing dataclass validation."""
+    prediction = object.__new__(PersonaChatJudgePrediction)
+    object.__setattr__(prediction, "case_id", "/Users/private/token\nPC-CASE-015")
+    object.__setattr__(prediction, "dimension_key", "/Users/private/unsafe_dimension")
+    object.__setattr__(prediction, "result", "Maybe")
+    object.__setattr__(prediction, "critique", "raw critique should not appear")
+    object.__setattr__(prediction, "evidence", ("/Users/private/evidence",))
+    return prediction
 
 
 def test_execute_persona_chat_judge_collects_valid_prediction() -> None:
@@ -350,9 +363,18 @@ def test_build_execution_artifact_serializes_successful_calibration() -> None:
     calibration = payload["calibration"]
     assert calibration["production_calibrated"] is False  # nosec B101
     assert calibration["missing_predictions"] == []  # nosec B101
+    assert calibration["warning_keys"] == [  # nosec B101
+        "calibration_sample_too_small",
+        "tpr_tnr_unavailable",
+    ]
+    assert "warnings" not in calibration  # nosec B101
     metrics = calibration["metrics_by_dimension"]["memory_expectation_alignment"]
     assert metrics["true_fails"] == 1  # nosec B101
-    assert metrics["warnings"]  # nosec B101
+    assert metrics["warning_keys"] == [  # nosec B101
+        "calibration_sample_too_small",
+        "tpr_tnr_unavailable",
+    ]
+    assert "warnings" not in metrics  # nosec B101
 
 
 def test_build_execution_artifact_serializes_failure_only_result() -> None:
@@ -389,6 +411,10 @@ def test_build_execution_artifact_serializes_failure_only_result() -> None:
             "dimension_key": "memory_expectation_alignment",
         }
     ]
+    assert payload["calibration"]["warning_keys"] == [  # nosec B101
+        "calibration_sample_too_small",
+        "tpr_tnr_unavailable",
+    ]
 
 
 def test_build_execution_artifact_redacts_unsafe_metadata_and_raw_content() -> None:
@@ -419,3 +445,110 @@ def test_build_execution_artifact_redacts_unsafe_metadata_and_raw_content() -> N
     assert "sk-secret-model" not in serialized  # nosec B101
     assert "I will remember that permanently" not in serialized  # nosec B101
     assert "Remember that my patio tomatoes" not in serialized  # nosec B101
+    assert "calibration sample is too small" not in serialized  # nosec B101
+
+
+def test_execution_artifact_to_dict_sanitizes_public_fields() -> None:
+    """Direct artifact construction should still serialize trace-safe data."""
+    judge_input = build_persona_chat_judge_input(case_by_id("PC-CASE-015"))
+    calibration = calibrate_persona_chat_judge_predictions(
+        [judge_input],
+        (),
+        min_cases_per_class=1,
+    )
+    artifact = PersonaChatJudgeExecutionArtifact(
+        schema_version="/Users/private/schema-secret",
+        offline_only=False,
+        provider="/Users/private/token",
+        model="sk-secret-model",
+        runtime_gating_allowed=True,
+        total_inputs=1,
+        input_case_ids=("/Users/private/token\nPC-CASE-015",),
+        dimension_keys=(
+            "/Users/private/unsafe_dimension",
+            "memory_expectation_alignment",
+        ),
+        predictions=(_unsafe_prediction_for_artifact_test(),),
+        failures=(),
+        calibration=calibration,
+    )
+
+    payload = artifact.to_dict()
+    serialized = json.dumps(payload, sort_keys=True)
+
+    assert payload["schema_version"] == "redacted"  # nosec B101
+    assert payload["offline_only"] is True  # nosec B101
+    assert payload["runtime_gating_allowed"] is False  # nosec B101
+    assert payload["provider"] == "redacted"  # nosec B101
+    assert payload["model"] == "redacted"  # nosec B101
+    assert payload["input_case_ids"] == ["redacted"]  # nosec B101
+    assert payload["dimension_keys"] == [  # nosec B101
+        "memory_expectation_alignment",
+        "redacted",
+    ]
+    assert payload["predictions"][0]["case_id"] == "redacted"  # nosec B101
+    assert payload["predictions"][0]["dimension_key"] == "redacted"  # nosec B101
+    assert payload["predictions"][0]["result"] == "redacted"  # nosec B101
+    assert payload["predictions"][0]["evidence"] == ["redacted"]  # nosec B101
+    assert "/Users/private/token" not in serialized  # nosec B101
+    assert "sk-secret-model" not in serialized  # nosec B101
+    assert "raw critique should not appear" not in serialized  # nosec B101
+
+
+def test_execution_artifact_handles_redaction_collision_without_crashing() -> None:
+    """Unsafe case-id collisions should become bounded duplicate failures."""
+    first_case = case_by_id("PC-CASE-015")
+    first_case["case_id"] = "/Users/private/first-token\nPC-CASE-015"
+    second_case = case_by_id("PC-CASE-015")
+    second_case["case_id"] = "/Users/private/second-token\nPC-CASE-015"
+    inputs = [
+        build_persona_chat_judge_input(first_case),
+        build_persona_chat_judge_input(second_case),
+    ]
+
+    execution_result = execute_persona_chat_judge(
+        inputs,
+        dimension_keys=["memory_expectation_alignment"],
+        completion=lambda _request: _valid_response(),
+        provider="fake-provider",
+        model="fake-model",
+    )
+    payload = build_persona_chat_judge_execution_artifact(
+        inputs,
+        execution_result,
+        min_cases_per_class=1,
+    ).to_dict()
+
+    assert len(execution_result.predictions) == 1  # nosec B101
+    assert execution_result.failures[0].error_key == "duplicate_prediction"  # nosec B101
+    assert payload["total_inputs"] == 2  # nosec B101
+    assert payload["input_case_ids"] == ["redacted"]  # nosec B101
+    assert payload["prediction_count"] == 1  # nosec B101
+    assert payload["failure_count"] == 1  # nosec B101
+    assert payload["failures"][0]["case_id"] == "redacted"  # nosec B101
+
+
+def test_execution_artifact_sorts_dimension_keys() -> None:
+    """Represented artifact dimensions should be deterministic."""
+    judge_input = build_persona_chat_judge_input(case_by_id("PC-CASE-015"))
+
+    execution_result = execute_persona_chat_judge(
+        [judge_input],
+        dimension_keys=[
+            "memory_expectation_alignment",
+            "boundary_refusal",
+        ],
+        completion=lambda _request: _valid_response(),
+        provider="fake-provider",
+        model="fake-model",
+    )
+    payload = build_persona_chat_judge_execution_artifact(
+        [judge_input],
+        execution_result,
+        min_cases_per_class=1,
+    ).to_dict()
+
+    assert payload["dimension_keys"] == [  # nosec B101
+        "boundary_refusal",
+        "memory_expectation_alignment",
+    ]

--- a/tldw_Server_API/tests/Evaluations/test_persona_chat_judge_execution.py
+++ b/tldw_Server_API/tests/Evaluations/test_persona_chat_judge_execution.py
@@ -10,6 +10,7 @@ from tldw_Server_API.app.core.Evaluations.persona_chat_judge import (
     calibrate_persona_chat_judge_predictions,
 )
 from tldw_Server_API.app.core.Evaluations.persona_chat_judge_execution import (
+    build_persona_chat_judge_execution_artifact,
     execute_persona_chat_judge,
 )
 from tldw_Server_API.tests.Persona.persona_chat_quality_cases import case_by_id
@@ -316,3 +317,105 @@ def test_execute_persona_chat_judge_predictions_feed_calibration() -> None:
     metrics = report.metrics_by_dimension["memory_expectation_alignment"]
     assert metrics.true_fails == 1  # nosec B101
     assert report.production_calibrated is False  # nosec B101
+
+
+def test_build_execution_artifact_serializes_successful_calibration() -> None:
+    """Execution artifacts should combine bounded predictions and calibration."""
+    judge_input = build_persona_chat_judge_input(case_by_id("PC-CASE-015"))
+    execution_result = execute_persona_chat_judge(
+        [judge_input],
+        dimension_keys=["memory_expectation_alignment"],
+        completion=lambda _request: _valid_response(),
+        provider="fake-provider",
+        model="fake-model",
+    )
+
+    artifact = build_persona_chat_judge_execution_artifact(
+        [judge_input],
+        execution_result,
+        min_cases_per_class=1,
+    )
+    payload = artifact.to_dict()
+
+    assert payload["schema_version"] == "persona-chat-judge-execution-artifact.v1"  # nosec B101
+    assert payload["offline_only"] is True  # nosec B101
+    assert payload["runtime_gating_allowed"] is False  # nosec B101
+    assert payload["provider"] == "fake-provider"  # nosec B101
+    assert payload["model"] == "fake-model"  # nosec B101
+    assert payload["input_case_ids"] == ["PC-CASE-015"]  # nosec B101
+    assert payload["dimension_keys"] == ["memory_expectation_alignment"]  # nosec B101
+    assert payload["prediction_count"] == 1  # nosec B101
+    assert payload["failure_count"] == 0  # nosec B101
+    assert payload["predictions"][0]["critique"] == "provided"  # nosec B101
+    calibration = payload["calibration"]
+    assert calibration["production_calibrated"] is False  # nosec B101
+    assert calibration["missing_predictions"] == []  # nosec B101
+    metrics = calibration["metrics_by_dimension"]["memory_expectation_alignment"]
+    assert metrics["true_fails"] == 1  # nosec B101
+    assert metrics["warnings"]  # nosec B101
+
+
+def test_build_execution_artifact_serializes_failure_only_result() -> None:
+    """Execution artifacts should preserve bounded failure keys for review."""
+    judge_input = build_persona_chat_judge_input(case_by_id("PC-CASE-015"))
+    execution_result = execute_persona_chat_judge(
+        [judge_input],
+        dimension_keys=["memory_expectation_alignment"],
+        completion=lambda _request: "not json",
+        provider="fake-provider",
+        model="fake-model",
+    )
+
+    payload = build_persona_chat_judge_execution_artifact(
+        [judge_input],
+        execution_result,
+        min_cases_per_class=1,
+    ).to_dict()
+
+    assert payload["prediction_count"] == 0  # nosec B101
+    assert payload["failure_count"] == 1  # nosec B101
+    assert payload["failures"] == [  # nosec B101
+        {
+            "case_id": "PC-CASE-015",
+            "dimension_key": "memory_expectation_alignment",
+            "provider": "fake-provider",
+            "model": "fake-model",
+            "error_key": "malformed_json",
+        }
+    ]
+    assert payload["calibration"]["missing_predictions"] == [  # nosec B101
+        {
+            "case_id": "PC-CASE-015",
+            "dimension_key": "memory_expectation_alignment",
+        }
+    ]
+
+
+def test_build_execution_artifact_redacts_unsafe_metadata_and_raw_content() -> None:
+    """Execution artifacts should not leak raw prompts, responses, paths, or secrets."""
+    fixture_case = case_by_id("PC-CASE-015")
+    fixture_case["case_id"] = "/Users/private/token\nPC-CASE-015"
+    judge_input = build_persona_chat_judge_input(fixture_case)
+    execution_result = execute_persona_chat_judge(
+        [judge_input],
+        dimension_keys=["memory_expectation_alignment"],
+        completion=lambda _request: "I will remember that permanently",
+        provider="/Users/private/token",
+        model="sk-secret-model",
+    )
+
+    payload = build_persona_chat_judge_execution_artifact(
+        [judge_input],
+        execution_result,
+        min_cases_per_class=1,
+    ).to_dict()
+    serialized = json.dumps(payload, sort_keys=True)
+
+    assert payload["provider"] == "redacted"  # nosec B101
+    assert payload["model"] == "redacted"  # nosec B101
+    assert payload["input_case_ids"] == ["redacted"]  # nosec B101
+    assert payload["failures"][0]["case_id"] == "redacted"  # nosec B101
+    assert "/Users/private/token" not in serialized  # nosec B101
+    assert "sk-secret-model" not in serialized  # nosec B101
+    assert "I will remember that permanently" not in serialized  # nosec B101
+    assert "Remember that my patio tomatoes" not in serialized  # nosec B101


### PR DESCRIPTION
## Summary
- Adds `PersonaChatJudgeExecutionArtifact` plus `build_persona_chat_judge_execution_artifact()` to combine offline execution results with existing calibration metrics.
- Serializes bounded provider/model metadata, case/dimension ids, predictions, failures, missing/unknown prediction links, warnings, and calibration metrics without raw prompt or response content.
- Updates the Persona Chat judge contract doc and Backlog TASK-257.4 for issue #1598.

## V1 boundaries
- Offline review artifact only.
- No provider-specific execution, DB persistence, Jobs/API/WebUI state, runtime Persona Chat gating, or live response mutation.
- Draft PR until a human-authored Change summary is added per repo policy.

## Verification
- `python -m pytest tldw_Server_API/tests/Evaluations/test_persona_chat_judge.py tldw_Server_API/tests/Evaluations/test_persona_chat_judge_execution.py tldw_Server_API/tests/Evaluations/test_persona_chat_judge_harness.py tldw_Server_API/tests/Evaluations/test_persona_chat_judge_policy.py tldw_Server_API/tests/Evaluations/unit/test_persona_chat_judge_review_command.py -q` -> 52 passed, 5 warnings
- `python -m py_compile tldw_Server_API/app/core/Evaluations/persona_chat_judge_execution.py`
- `python -m bandit -r tldw_Server_API/app/core/Evaluations/persona_chat_judge_execution.py tldw_Server_API/tests/Evaluations/test_persona_chat_judge_execution.py -f json -o /tmp/bandit_persona_chat_judge_artifacts.json` -> results 0, errors []
- `git diff --check`

Fixes #1598