### PR TITLE
Add VN script authoring WebUI

### DIFF
--- a/Docs/superpowers/plans/2026-05-12-vn-script-authoring-webui.md
+++ b/Docs/superpowers/plans/2026-05-12-vn-script-authoring-webui.md
@@ -1,0 +1,389 @@
+# VN Script Authoring WebUI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a bundled WebUI surface for creating, editing, validating, publishing, and selecting backend-owned VN scripts.
+
+**Architecture:** Keep script semantics, policy evaluation, manifest readiness, generation-profile checks, and publish validation on the API server. The frontend adds typed clients and a workbench that displays backend responses, edits JSON drafts as opaque script programs, and links published versions into the existing VN Play setup flow through backend setup-options data.
+
+**Tech Stack:** Next.js pages with dynamic imports, React state/hooks, existing `apiClient`, existing `JsonEditor`/`JsonViewer`, Vitest + Testing Library.
+
+---
+
+## File Structure
+
+- Create: `apps/tldw-frontend/types/vn-scripts.ts`
+  - TypeScript contract for `/api/v1/vn/vn-scripts` responses and request payloads.
+- Create: `apps/tldw-frontend/lib/api/vnScripts.ts`
+  - Thin API wrapper with canonical `/vn/vn-scripts` paths and offset-query helpers.
+- Create: `apps/tldw-frontend/components/vn-scripts/VNScriptsWorkbench.tsx`
+  - Script list, metadata create/update controls, draft JSON editor, validation/diagnostics, publish action, version list, manifest/policy summary.
+- Create: `apps/tldw-frontend/pages/vn-scripts.tsx`
+  - Dynamic route entrypoint for the workbench.
+- Modify: `apps/tldw-frontend/types/vn-play.ts`
+  - Add `scripted_story` mode, script setup option/default fields, script-version setup types, and `script_id`/`script_version_id` session create fields.
+- Modify: `apps/tldw-frontend/components/vn-play/NewSessionDialog.tsx`
+  - Add Scripted Story mode selection, script-version selector, warning acknowledgement handling, and link to `/vn-scripts` empty-state guidance.
+- Modify: `apps/tldw-frontend/components/vn-play/SessionList.tsx`
+  - Treat `scripted_story` as a first-class filter/rendered mode without collapsing it into Story/CYOA.
+- Modify: `apps/tldw-frontend/components/vn-play/VNPlayWorkspace.tsx`
+  - Allow opening the new-session dialog in scripted mode and link to the authoring workbench from setup empty states or header actions.
+- Test: `apps/tldw-frontend/__tests__/vn-scripts/vnScriptsApi.test.ts`
+- Test: `apps/tldw-frontend/__tests__/vn-scripts/VNScriptsWorkbench.test.tsx`
+- Test: extend `apps/tldw-frontend/__tests__/vn-play/VNPlayWorkspace.test.tsx`
+- Test: extend `apps/tldw-frontend/__tests__/vn-play/vnPlayApi.test.ts` if setup query/session-create coverage needs new scripted fields.
+- Modify: `backlog/tasks/task-289 - Add-VN-script-authoring-and-publish-WebUI.md`
+  - Track progress, verification, and final summary.
+
+## Task 1: VN Scripts API Client Contract
+
+**Files:**
+- Create: `apps/tldw-frontend/types/vn-scripts.ts`
+- Create: `apps/tldw-frontend/lib/api/vnScripts.ts`
+- Test: `apps/tldw-frontend/__tests__/vn-scripts/vnScriptsApi.test.ts`
+
+- [x] **Step 1: Write failing API-wrapper tests**
+
+Cover these calls with mocked `apiClient`:
+- `createVNScript`
+- `listVNScripts`
+- `getVNScript`
+- `patchVNScript`
+- `deleteVNScript`
+- `getVNScriptDraft`
+- `putVNScriptDraft`
+- `validateVNScriptDraft`
+- `getVNScriptDiagnostics`
+- `publishVNScript`
+- `listVNScriptVersions`
+- `getVNScriptVersion`
+- `getVNScriptManifestSnapshot`
+- `evaluateVNScriptVersionPolicy`
+
+Expected canonical paths:
+- `/vn/vn-scripts/scripts`
+- `/vn/vn-scripts/scripts/{script_id}/draft`
+- `/vn/vn-scripts/scripts/{script_id}/draft/validate`
+- `/vn/vn-scripts/scripts/{script_id}/draft/diagnostics`
+- `/vn/vn-scripts/scripts/{script_id}/publish`
+- `/vn/vn-scripts/scripts/{script_id}/versions`
+- `/vn/vn-scripts/scripts/{script_id}/versions/{version_id}`
+- `/vn/vn-scripts/scripts/{script_id}/versions/{version_id}/manifest-snapshot`
+- `/vn/vn-scripts/scripts/{script_id}/versions/{version_id}/policy/evaluate`
+
+Run:
+
+```bash
+cd apps/tldw-frontend
+bun run test:run __tests__/vn-scripts/vnScriptsApi.test.ts
+```
+
+Expected: fail because the new module does not exist.
+
+- [x] **Step 2: Add `vn-scripts` types**
+
+Mirror backend schema names from `tldw_Server_API/app/api/v1/schemas/vn_script_schemas.py`:
+- `VNScriptCreate`
+- `VNScriptPatch`
+- `VNScriptResponse`
+- `VNScriptListResponse`
+- `VNScriptDraftResponse`
+- `VNScriptDraftPutRequest`
+- `VNScriptValidateRequest`
+- `VNScriptValidationResponse`
+- `VNScriptDiagnosticsResponse`
+- `VNScriptPublishRequest`
+- `VNScriptPublishResponse`
+- `VNScriptVersionResponse`
+- `VNScriptVersionListResponse`
+- `VNScriptManifestSnapshotResponse`
+- `VNScriptVersionPolicyEvaluateRequest`
+- `VNScriptVersionPolicyEvaluateResponse`
+
+Use `Record<string, unknown>` for opaque draft/program/diagnostics/policy payloads. Do not interpret opcode semantics client-side.
+
+- [x] **Step 3: Add `vnScripts.ts` API wrapper**
+
+Follow `apps/tldw-frontend/lib/api/vnPlay.ts` patterns:
+
+```ts
+const VN_SCRIPTS_BASE = '/vn/vn-scripts';
+
+export function listVNScripts(query: VNScriptListQuery = {}): Promise<VNScriptListResponse> {
+  return apiClient.get(`${VN_SCRIPTS_BASE}/scripts`, { params: toQueryParams(query) });
+}
+```
+
+Publish must require caller-provided `idempotency_key`; the helper should not generate keys.
+
+- [x] **Step 4: Run API-wrapper tests**
+
+Run:
+
+```bash
+cd apps/tldw-frontend
+bun run test:run __tests__/vn-scripts/vnScriptsApi.test.ts
+```
+
+Expected: pass.
+
+## Task 2: Script Authoring Workbench
+
+**Files:**
+- Create: `apps/tldw-frontend/components/vn-scripts/VNScriptsWorkbench.tsx`
+- Create: `apps/tldw-frontend/pages/vn-scripts.tsx`
+- Test: `apps/tldw-frontend/__tests__/vn-scripts/VNScriptsWorkbench.test.tsx`
+
+- [x] **Step 1: Write failing workbench tests**
+
+Use mocked `@web/lib/api/vnScripts` helpers. Cover:
+- initial list loads scripts and selects the first item;
+- create form calls `createVNScript` with title, asset pack ID, policy profile, generation profile, and content rating;
+- draft JSON edits call `putVNScriptDraft` with `if_revision` and parsed JSON;
+- invalid local JSON shows an editor error and does not call the backend;
+- validate calls `validateVNScriptDraft` and renders backend errors/warnings;
+- diagnostics calls `getVNScriptDiagnostics` and renders safe JSON;
+- publish calls `publishVNScript` with an idempotency key and current draft revision;
+- version list renders version number, label, snapshot IDs, validation status, and created time;
+- manifest/policy summary buttons call `getVNScriptManifestSnapshot` and `evaluateVNScriptVersionPolicy`.
+
+Run:
+
+```bash
+cd apps/tldw-frontend
+bun run test:run __tests__/vn-scripts/VNScriptsWorkbench.test.tsx
+```
+
+Expected: fail because the workbench does not exist.
+
+- [x] **Step 2: Implement layout and loading state**
+
+Build a dense app surface, not a marketing page:
+- left pane: script list and create form;
+- center pane: metadata summary and draft JSON editor;
+- right/bottom pane: validation, diagnostics, published versions, manifest/policy summaries.
+
+Use existing `Button`, `Input`, `Badge`, `JsonEditor`, and `JsonViewer`. Keep cards only for repeated items and panels; avoid nested card styling.
+
+- [x] **Step 3: Implement list/create/select**
+
+Load `listVNScripts({ limit: 25, offset: 0 })` on mount. On create success, prepend/select the created script and load its draft/versions. Store errors as user-safe strings.
+
+- [x] **Step 4: Implement draft edit/save**
+
+When a script is selected:
+- call `getVNScriptDraft`;
+- show formatted JSON in `JsonEditor`;
+- track dirty state;
+- parse JSON on save;
+- call `putVNScriptDraft(script.id, { if_revision: draft.revision, draft: parsed })`;
+- on conflict/error, show backend error and keep unsaved editor text.
+
+Do not attempt to validate opcodes locally beyond JSON parse.
+
+- [x] **Step 5: Implement validation, diagnostics, publish, versions**
+
+Validation:
+- call `validateVNScriptDraft(script.id, parsed-or-current)`;
+- render `valid`, errors, and warnings from backend response.
+
+Diagnostics:
+- call `getVNScriptDiagnostics(script.id)`;
+- show `diagnostics` through `JsonViewer`.
+
+Publish:
+- call `publishVNScript(script.id, { draft_revision, label, idempotency_key, acknowledgements })`;
+- generate key with a local helper such as `vn-script-publish-${script.id}-${Date.now()}` plus UUID when available;
+- reload versions after success.
+- do not derive publish acknowledgement codes by stripping prefixes from validation warnings or by parsing messages. If the backend returns `script_publish_acknowledgement_required` and does not expose raw acknowledgement codes, render that publish error and ask the user to resolve/acknowledge through a backend-supported path in a follow-up. Only send acknowledgement strings that are explicitly exposed by the backend as publish acknowledgement codes.
+
+Versions:
+- call `listVNScriptVersions(script.id)`;
+- render safe snapshot IDs and validation summary;
+- provide buttons for manifest snapshot and policy evaluation.
+
+- [x] **Step 6: Add dynamic route**
+
+Create `apps/tldw-frontend/pages/vn-scripts.tsx`:
+
+```ts
+import dynamic from 'next/dynamic';
+
+export default dynamic(() => import('@web/components/vn-scripts/VNScriptsWorkbench'), { ssr: false });
+```
+
+- [x] **Step 7: Run workbench tests**
+
+Run:
+
+```bash
+cd apps/tldw-frontend
+bun run test:run __tests__/vn-scripts/VNScriptsWorkbench.test.tsx
+```
+
+Expected: pass.
+
+## Task 3: Scripted Story Setup Bridge
+
+**Files:**
+- Modify: `apps/tldw-frontend/types/vn-play.ts`
+- Modify: `apps/tldw-frontend/components/vn-play/NewSessionDialog.tsx`
+- Modify: `apps/tldw-frontend/components/vn-play/SessionList.tsx`
+- Modify: `apps/tldw-frontend/components/vn-play/VNPlayWorkspace.tsx`
+- Test: extend `apps/tldw-frontend/__tests__/vn-play/VNPlayWorkspace.test.tsx`
+- Test: extend `apps/tldw-frontend/__tests__/vn-play/vnPlayApi.test.ts`
+
+- [x] **Step 1: Write failing setup bridge tests**
+
+Add tests that:
+- setup options with `mode: 'scripted_story'` render published script-version choices;
+- no published scripts shows guidance linking to `/vn-scripts`;
+- creating a scripted session submits `mode: 'scripted_story'`, `script_id`, `script_version_id`, `vn_asset_pack_id` from the selected script option, `content_rating` from the selected script option, and `primary_character_id` derived from the backend-provided matching asset-pack option for `selectedScript.asset_pack_id`;
+- scripted-session acknowledgements submit top-level `acknowledgements: string[]` using only `selectedScript.warning_summary.warnings[].code` values that require acknowledgement, and do not use `settings.setup_acknowledgements`;
+- readiness or acknowledgement-required script warnings block submit until acknowledged;
+- `SessionList` and workspace mode controls show `Scripted Story` distinctly.
+
+Run:
+
+```bash
+cd apps/tldw-frontend
+bun run test:run __tests__/vn-play/VNPlayWorkspace.test.tsx __tests__/vn-play/vnPlayApi.test.ts
+```
+
+Expected: fail because frontend types and setup dialog do not support `scripted_story`.
+
+- [x] **Step 2: Extend VN Play frontend types**
+
+Update:
+- `VNPlayMode = 'freeform' | 'story' | 'scripted_story'`
+- `VNPlaySessionCreate` with `script_id?: number` and `script_version_id?: number`
+- `VNPlaySessionCreate` with top-level `acknowledgements?: string[]`
+- `VNPlaySession` with response fields `script_id`, `script_version_id`, `script_manifest_snapshot_id`, `script_policy_snapshot_id`, `script_generation_profile_snapshot_id`, and `script_position`
+- `VNPlaySetupScriptVersionOption` matching backend `VNPlaySetupScriptVersionOption`
+- `VNPlaySetupDefaults` with script/profile defaults
+- `VNPlaySetupOptionsResponse.script_versions`
+- Keep `VNPlaySetupOptionsResponse.pagination` aligned with the backend `VNPlaySetupPaginationSet`: it currently includes `characters` and `asset_packs` only. Do not add `pagination.script_versions` unless the backend contract changes in the same PR, which is out of scope for this frontend consumer slice.
+
+Keep unknown profile metadata as plain strings/records; do not embed frontend policy logic.
+
+- [x] **Step 3: Add script selector to `NewSessionDialog`**
+
+When mode is `scripted_story`:
+- call setup options with `mode: 'scripted_story'`;
+- render script-version selector from `setupOptions.script_versions`;
+- choose backend default script when available;
+- show script warning messages and readiness status;
+- if no scripts exist, show empty-state guidance linking to `/vn-scripts`;
+- use the selected script's `asset_pack_id` and match it to `setupOptions.asset_packs.find((pack) => pack.id === selectedScript.asset_pack_id)` to derive the required `primary_character_id`;
+- submit `content_rating` from the selected script version option so the create payload matches the published script's policy snapshot context;
+- include `script_id` and `script_version_id` in create payload.
+- include top-level backend `acknowledgements` only when the selected script option requires them. Use warning code strings from `selectedScript.warning_summary.warnings[].code`; do not send messages, do not strip prefixes, and do not reuse the asset-pack `settings.setup_acknowledgements` object shape for scripted-session policy acknowledgements.
+
+Manual-ID fallback may remain for freeform/story only unless setup options fail; if used for scripted mode, require script/version IDs too.
+
+- [x] **Step 4: Update workspace/session mode UI**
+
+Add a `Scripted Story` launch button or mode option near existing Freeform/Story controls. Update mode labels and filters to avoid treating scripted sessions as generic Story sessions.
+
+- [x] **Step 5: Run setup bridge tests**
+
+Run:
+
+```bash
+cd apps/tldw-frontend
+bun run test:run __tests__/vn-play/VNPlayWorkspace.test.tsx __tests__/vn-play/vnPlayApi.test.ts
+```
+
+Expected: pass.
+
+## Task 4: Closeout, Verification, And Task Updates
+
+**Files:**
+- Modify: `backlog/tasks/task-289 - Add-VN-script-authoring-and-publish-WebUI.md`
+- Optional modify: `Docs/API/VN.md` only if UI links or setup guidance need a doc note. Do not change backend API semantics.
+
+- [x] **Step 1: Run focused frontend tests**
+
+Run:
+
+```bash
+cd apps/tldw-frontend
+bun run test:run \
+  __tests__/vn-scripts/vnScriptsApi.test.ts \
+  __tests__/vn-scripts/VNScriptsWorkbench.test.tsx \
+  __tests__/vn-play/VNPlayWorkspace.test.tsx \
+  __tests__/vn-play/vnPlayApi.test.ts
+```
+
+- [x] **Step 2: Run targeted lint**
+
+Run:
+
+```bash
+cd apps/tldw-frontend
+bun run lint -- \
+  components/vn-scripts/VNScriptsWorkbench.tsx \
+  components/vn-play/NewSessionDialog.tsx \
+  components/vn-play/SessionList.tsx \
+  components/vn-play/VNPlayWorkspace.tsx \
+  __tests__/vn-scripts/vnScriptsApi.test.ts \
+  __tests__/vn-scripts/VNScriptsWorkbench.test.tsx \
+  __tests__/vn-play/VNPlayWorkspace.test.tsx \
+  __tests__/vn-play/vnPlayApi.test.ts
+```
+
+Existing repo-wide warnings are acceptable only if no new touched-file errors are present.
+
+- [x] **Step 3: Run TypeScript if practical**
+
+Run:
+
+```bash
+cd apps/tldw-frontend
+bunx tsc --noEmit --pretty false
+```
+
+If it fails on known existing `packages/ui` baseline errors, record exact files and confirm no touched-file diagnostics.
+
+- [x] **Step 4: Run diff hygiene**
+
+Run:
+
+```bash
+git diff --check
+```
+
+- [x] **Step 5: Record Bandit status**
+
+Bandit is not applicable if this remains a frontend-only TypeScript/React/Markdown slice. Record that in TASK-289 notes. If backend Python changes are added, run Bandit on touched Python paths.
+
+- [x] **Step 6: Update TASK-289**
+
+Check acceptance criteria, add verification notes, mark Definition of Done items, and add final summary.
+
+- [x] **Step 7: Commit**
+
+```bash
+git add \
+  apps/tldw-frontend/types/vn-scripts.ts \
+  apps/tldw-frontend/lib/api/vnScripts.ts \
+  apps/tldw-frontend/components/vn-scripts/VNScriptsWorkbench.tsx \
+  apps/tldw-frontend/pages/vn-scripts.tsx \
+  apps/tldw-frontend/types/vn-play.ts \
+  apps/tldw-frontend/components/vn-play/NewSessionDialog.tsx \
+  apps/tldw-frontend/components/vn-play/SessionList.tsx \
+  apps/tldw-frontend/components/vn-play/VNPlayWorkspace.tsx \
+  apps/tldw-frontend/__tests__/vn-scripts/vnScriptsApi.test.ts \
+  apps/tldw-frontend/__tests__/vn-scripts/VNScriptsWorkbench.test.tsx \
+  apps/tldw-frontend/__tests__/vn-play/VNPlayWorkspace.test.tsx \
+  apps/tldw-frontend/__tests__/vn-play/vnPlayApi.test.ts \
+  "backlog/tasks/task-289 - Add-VN-script-authoring-and-publish-WebUI.md" \
+  Docs/superpowers/plans/2026-05-12-vn-script-authoring-webui.md
+git commit -m "Add VN script authoring WebUI"
+```
+
+## Open Implementation Notes
+
+- If backend setup options expose script warning acknowledgements with a different payload shape than asset-pack warnings, follow the backend response exactly and avoid inventing a client-only acknowledgement model.
+- Keep the workbench JSON-first for this sprint. A graph editor or text DSL is explicitly out of scope.
+- If `JsonEditor` Monaco behavior is difficult in unit tests, mock it as a textarea in the workbench tests rather than weakening the production component.

--- a/apps/tldw-frontend/__tests__/vn-play/VNPlayWorkspace.test.tsx
+++ b/apps/tldw-frontend/__tests__/vn-play/VNPlayWorkspace.test.tsx
@@ -588,6 +588,50 @@ describe('VNPlayWorkspace', () => {
     );
   });
 
+  it('falls back to all script warning codes when scripted-story acknowledgement is required at summary level', async () => {
+    const user = userEvent.setup();
+    mockVNPlayApi({ sessions: [] });
+    mocks.listVNPlaySetupOptions.mockResolvedValue(
+      setupOptions({
+        script_versions: [
+          setupScriptVersion({
+            warning_summary: {
+              highest_severity: 'high_risk',
+              requires_acknowledgement: true,
+              warnings: [
+                {
+                  code: 'script_summary_review',
+                  severity: 'high_risk',
+                  message: 'Review script summary warnings before launch.',
+                  requires_acknowledgement: false,
+                },
+              ],
+            },
+          }),
+        ],
+      })
+    );
+
+    render(<VNPlayWorkspace />);
+
+    await user.click(await screen.findByRole('button', { name: /new scripted story/i }));
+
+    expect(await screen.findByText(/Review script summary warnings before launch/i)).toBeInTheDocument();
+    await user.click(screen.getByRole('checkbox', { name: /I understand and want to proceed/i }));
+    await user.clear(screen.getByLabelText('Title'));
+    await user.type(screen.getByLabelText('Title'), 'Summary Acknowledged Script');
+    await user.click(screen.getByRole('button', { name: 'Create session' }));
+
+    await waitFor(() => {
+      expect(mocks.createVNPlaySession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mode: 'scripted_story',
+          acknowledgements: ['script_summary_review'],
+        })
+      );
+    });
+  });
+
   it('shows VN scripts guidance when no published script versions exist', async () => {
     const user = userEvent.setup();
     mockVNPlayApi({ sessions: [] });
@@ -609,10 +653,9 @@ describe('VNPlayWorkspace', () => {
     await user.click(await screen.findByRole('button', { name: /new scripted story/i }));
 
     expect(await screen.findByText(/No published VN script versions were found/i)).toBeInTheDocument();
-    expect(screen.getAllByRole('link', { name: /Open VN scripts/i })[0]).toHaveAttribute(
-      'href',
-      '/vn-scripts'
-    );
+    const scriptLinks = screen.getAllByRole('link', { name: /Open VN scripts/i });
+    expect(scriptLinks).toHaveLength(1);
+    expect(scriptLinks[0]).toHaveAttribute('href', '/vn-scripts');
     expect(screen.getByRole('button', { name: 'Create session' })).toBeDisabled();
   });
 
@@ -1161,6 +1204,41 @@ describe('VNPlayWorkspace', () => {
     expect(screen.getAllByText('Open the archive door').length).toBeGreaterThan(0);
     expect(screen.getByRole('button', { name: /resume branch: step inside/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /return to choice: step inside/i })).toBeInTheDocument();
+    expect(mocks.getVNPlayBranchNavigation).toHaveBeenCalledWith(1);
+  });
+
+  it('renders player-facing branch navigation for scripted-story sessions', async () => {
+    const session: VNPlaySession = {
+      id: 1,
+      mode: 'scripted_story',
+      title: 'Scripted Archive Door',
+      primary_character_id: 1,
+      vn_asset_pack_id: 2,
+      script_id: 44,
+      script_version_id: 5,
+      scene_version: 6,
+      scene_state: { scene_version: 6 },
+    };
+    const branchNavigation: VNPlayBranchNavigationResponse = {
+      ...emptyBranchNavigation,
+      mode: 'scripted_story',
+      scene_version: 6,
+      active_path: [
+        {
+          branch_id: 12,
+          branch_label: 'Scripted step',
+          choice_id: 'scripted-door',
+          choice_text: 'Follow the scripted branch',
+          depth: 1,
+        },
+      ],
+    };
+    mockVNPlayApi({ branchNavigation, sessions: [session] });
+
+    render(<VNPlayWorkspace />);
+
+    expect(await screen.findByText('Branch timeline')).toBeInTheDocument();
+    expect(screen.getAllByText('Follow the scripted branch').length).toBeGreaterThan(0);
     expect(mocks.getVNPlayBranchNavigation).toHaveBeenCalledWith(1);
   });
 

--- a/apps/tldw-frontend/__tests__/vn-play/VNPlayWorkspace.test.tsx
+++ b/apps/tldw-frontend/__tests__/vn-play/VNPlayWorkspace.test.tsx
@@ -10,6 +10,7 @@ import type {
   VNPlaySession,
   VNPlaySetupAssetPackOption,
   VNPlaySetupOptionsResponse,
+  VNPlaySetupScriptVersionOption,
 } from '@web/types/vn-play';
 
 const mocks = vi.hoisted(() => ({
@@ -135,6 +136,7 @@ const defaultSetupOptions: VNPlaySetupOptionsResponse = {
       recommended: true,
     },
   ],
+  script_versions: [],
   defaults: {
     mode: 'freeform',
     character_id: 7,
@@ -192,16 +194,55 @@ function setupPack(overrides: Partial<VNPlaySetupAssetPackOption> = {}): VNPlayS
   };
 }
 
+function setupScriptVersion(
+  overrides: Partial<VNPlaySetupScriptVersionOption> = {}
+): VNPlaySetupScriptVersionOption {
+  return {
+    id: 5,
+    script_id: 44,
+    title: 'Moonlit Archive Route',
+    version_number: 2,
+    label: 'published',
+    asset_pack_id: 12,
+    manifest_snapshot_id: 101,
+    policy_snapshot_id: 102,
+    generation_profile_snapshot_id: 103,
+    policy_profile_id: 'local-safe',
+    generation_profile_id: 'balanced',
+    generation_profile_key: 'default',
+    generation_profile_snapshot_immutable: true,
+    provider_class: 'hosted',
+    max_automatic_generation_batch_count: 2,
+    moderation_required: false,
+    estimated_cost_class: 'low',
+    supported_output_schemas: ['choice_set'],
+    dynamic_choice_support: true,
+    scene_update_support: true,
+    confirmation_required: false,
+    content_rating: 'teen',
+    ready: true,
+    warning_summary: {
+      highest_severity: 'info',
+      requires_acknowledgement: false,
+      warnings: [],
+    },
+    recommended: true,
+    ...overrides,
+  };
+}
+
 function setupOptions(
   overrides: Partial<VNPlaySetupOptionsResponse> = {}
 ): VNPlaySetupOptionsResponse {
   const characters = overrides.characters ?? defaultSetupOptions.characters;
   const assetPacks = overrides.asset_packs ?? defaultSetupOptions.asset_packs;
+  const scriptVersions = overrides.script_versions ?? defaultSetupOptions.script_versions;
   return {
     ...defaultSetupOptions,
     ...overrides,
     characters,
     asset_packs: assetPacks,
+    script_versions: scriptVersions,
     defaults: {
       ...defaultSetupOptions.defaults,
       ...overrides.defaults,
@@ -444,6 +485,159 @@ describe('VNPlayWorkspace', () => {
       });
     });
     expect(await screen.findByText('Moonlit Archive')).toBeInTheDocument();
+  });
+
+  it('creates a scripted-story session from a published script version', async () => {
+    const user = userEvent.setup();
+    mockVNPlayApi({ sessions: [] });
+    mocks.listVNPlaySetupOptions.mockResolvedValue(
+      setupOptions({
+        script_versions: [setupScriptVersion()],
+      })
+    );
+
+    render(<VNPlayWorkspace />);
+
+    await user.click(await screen.findByRole('button', { name: /new scripted story/i }));
+
+    expect(await screen.findByLabelText('Published script version')).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /Moonlit Archive Route v2.*published/i })).toBeInTheDocument();
+    expect(mocks.listVNPlaySetupOptions).toHaveBeenCalledWith({
+      content_rating: 'general',
+      mode: 'scripted_story',
+    });
+
+    await user.clear(screen.getByLabelText('Title'));
+    await user.type(screen.getByLabelText('Title'), 'Published Route Session');
+    await user.click(screen.getByRole('button', { name: 'Create session' }));
+
+    await waitFor(() => {
+      expect(mocks.createVNPlaySession).toHaveBeenCalledWith({
+        mode: 'scripted_story',
+        title: 'Published Route Session',
+        primary_character_id: 7,
+        vn_asset_pack_id: 12,
+        linked_chat_id: null,
+        content_rating: 'teen',
+        script_id: 44,
+        script_version_id: 5,
+      });
+    });
+  });
+
+  it('submits scripted-story acknowledgement codes as top-level fields', async () => {
+    const user = userEvent.setup();
+    mockVNPlayApi({ sessions: [] });
+    mocks.listVNPlaySetupOptions.mockResolvedValue(
+      setupOptions({
+        script_versions: [
+          setupScriptVersion({
+            warning_summary: {
+              highest_severity: 'high_risk',
+              requires_acknowledgement: true,
+              warnings: [
+                {
+                  code: 'script_policy_review',
+                  severity: 'high_risk',
+                  message: 'Review policy warnings before launch.',
+                  requires_acknowledgement: true,
+                },
+                {
+                  code: 'script_minor_note',
+                  severity: 'info',
+                  message: 'Informational script note.',
+                  requires_acknowledgement: false,
+                },
+              ],
+            },
+          }),
+        ],
+      })
+    );
+
+    render(<VNPlayWorkspace />);
+
+    await user.click(await screen.findByRole('button', { name: /new scripted story/i }));
+
+    expect(await screen.findByText(/Review policy warnings before launch/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Create session' })).toBeDisabled();
+    await user.click(screen.getByRole('checkbox', { name: /I understand and want to proceed/i }));
+    await user.clear(screen.getByLabelText('Title'));
+    await user.type(screen.getByLabelText('Title'), 'Acknowledged Script');
+    await user.click(screen.getByRole('button', { name: 'Create session' }));
+
+    await waitFor(() => {
+      expect(mocks.createVNPlaySession).toHaveBeenCalledWith({
+        mode: 'scripted_story',
+        title: 'Acknowledged Script',
+        primary_character_id: 7,
+        vn_asset_pack_id: 12,
+        linked_chat_id: null,
+        content_rating: 'teen',
+        script_id: 44,
+        script_version_id: 5,
+        acknowledgements: ['script_policy_review'],
+      });
+    });
+    expect(mocks.createVNPlaySession).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        settings: expect.objectContaining({
+          setup_acknowledgements: expect.anything(),
+        }),
+      })
+    );
+  });
+
+  it('shows VN scripts guidance when no published script versions exist', async () => {
+    const user = userEvent.setup();
+    mockVNPlayApi({ sessions: [] });
+    mocks.listVNPlaySetupOptions.mockResolvedValue(
+      setupOptions({
+        script_versions: [],
+        empty_states: [
+          {
+            code: 'no_script_versions',
+            scope: 'global',
+            message: 'No published VN script versions were found.',
+          },
+        ],
+      })
+    );
+
+    render(<VNPlayWorkspace />);
+
+    await user.click(await screen.findByRole('button', { name: /new scripted story/i }));
+
+    expect(await screen.findByText(/No published VN script versions were found/i)).toBeInTheDocument();
+    expect(screen.getAllByRole('link', { name: /Open VN scripts/i })[0]).toHaveAttribute(
+      'href',
+      '/vn-scripts'
+    );
+    expect(screen.getByRole('button', { name: 'Create session' })).toBeDisabled();
+  });
+
+  it('shows scripted-story sessions as their own mode filter and label', async () => {
+    mockVNPlayApi({
+      sessions: [
+        {
+          id: 1,
+          mode: 'scripted_story',
+          title: 'Published Route',
+          primary_character_id: 7,
+          vn_asset_pack_id: 12,
+          script_id: 44,
+          script_version_id: 5,
+          scene_version: 0,
+          scene_state: { scene_version: 0 },
+        },
+      ],
+    });
+
+    render(<VNPlayWorkspace />);
+
+    expect(await screen.findByRole('tab', { name: 'Scripted Story' })).toBeInTheDocument();
+    expect(screen.getByText('Published Route')).toBeInTheDocument();
+    expect(screen.getAllByText('Scripted Story').length).toBeGreaterThan(0);
   });
 
   it('uses backend setup options instead of client-side setup fan-out', async () => {
@@ -732,7 +926,7 @@ describe('VNPlayWorkspace', () => {
   it('keeps manual ID entry available when setup selectors fail to load', async () => {
     const user = userEvent.setup();
     mockVNPlayApi({ sessions: [] });
-    mocks.listVNPlaySetupOptions.mockRejectedValueOnce(new Error('setup options offline'));
+    mocks.listVNPlaySetupOptions.mockRejectedValue(new Error('setup options offline'));
 
     render(<VNPlayWorkspace />);
 
@@ -755,6 +949,47 @@ describe('VNPlayWorkspace', () => {
         vn_asset_pack_id: 21,
         linked_chat_id: null,
         content_rating: 'general',
+      });
+    });
+  });
+
+  it('requires script identifiers when scripted-story setup falls back to manual entry', async () => {
+    const user = userEvent.setup();
+    mockVNPlayApi({ sessions: [] });
+    mocks.listVNPlaySetupOptions.mockRejectedValue(new Error('setup options offline'));
+
+    render(<VNPlayWorkspace />);
+
+    await user.click(await screen.findByRole('button', { name: /new scripted story/i }));
+    expect(await screen.findByText(/Could not load setup options/i)).toBeInTheDocument();
+    expect(screen.getByLabelText('Script ID')).toBeInTheDocument();
+    expect(screen.getByLabelText('Script version ID')).toBeInTheDocument();
+
+    await user.clear(screen.getByLabelText('Title'));
+    await user.type(screen.getByLabelText('Title'), 'Manual Scripted Session');
+    await user.clear(screen.getByLabelText('Primary character ID'));
+    await user.type(screen.getByLabelText('Primary character ID'), '17');
+    await user.clear(screen.getByLabelText('VN asset pack ID'));
+    await user.type(screen.getByLabelText('VN asset pack ID'), '21');
+    await user.click(screen.getByRole('button', { name: 'Create session' }));
+
+    expect(await screen.findByText(/Enter script ID and script version ID/i)).toBeInTheDocument();
+    expect(mocks.createVNPlaySession).not.toHaveBeenCalled();
+
+    await user.type(screen.getByLabelText('Script ID'), '44');
+    await user.type(screen.getByLabelText('Script version ID'), '5');
+    await user.click(screen.getByRole('button', { name: 'Create session' }));
+
+    await waitFor(() => {
+      expect(mocks.createVNPlaySession).toHaveBeenCalledWith({
+        mode: 'scripted_story',
+        title: 'Manual Scripted Session',
+        primary_character_id: 17,
+        vn_asset_pack_id: 21,
+        linked_chat_id: null,
+        content_rating: 'general',
+        script_id: 44,
+        script_version_id: 5,
       });
     });
   });

--- a/apps/tldw-frontend/__tests__/vn-play/vnPlayApi.test.ts
+++ b/apps/tldw-frontend/__tests__/vn-play/vnPlayApi.test.ts
@@ -72,6 +72,30 @@ describe('vnPlay api client', () => {
     });
   });
 
+  it('creates a scripted-story VN play session with script identifiers and policy acknowledgements', async () => {
+    await createVNPlaySession({
+      mode: 'scripted_story',
+      title: 'Published route',
+      primary_character_id: 7,
+      vn_asset_pack_id: 12,
+      content_rating: 'teen',
+      script_id: 44,
+      script_version_id: 5,
+      acknowledgements: ['script_policy_review'],
+    });
+
+    expect(mocks.apiClient.post).toHaveBeenCalledWith('/vn/vn-play/sessions', {
+      mode: 'scripted_story',
+      title: 'Published route',
+      primary_character_id: 7,
+      vn_asset_pack_id: 12,
+      content_rating: 'teen',
+      script_id: 44,
+      script_version_id: 5,
+      acknowledgements: ['script_policy_review'],
+    });
+  });
+
   it('submits a VN play turn with idempotency key and scene version', async () => {
     mocks.apiClient.post.mockResolvedValueOnce({
       events: [],
@@ -158,7 +182,7 @@ describe('vnPlay api client', () => {
     });
 
     await listVNPlaySetupOptions({
-      mode: 'story',
+      mode: 'scripted_story',
       selected_character_id: 7,
       content_rating: 'mature',
       character_query: 'mira',
@@ -167,7 +191,7 @@ describe('vnPlay api client', () => {
 
     expect(mocks.apiClient.get).toHaveBeenCalledWith('/vn/vn-play/setup-options', {
       params: {
-        mode: 'story',
+        mode: 'scripted_story',
         selected_character_id: 7,
         content_rating: 'mature',
         character_query: 'mira',

--- a/apps/tldw-frontend/__tests__/vn-scripts/VNScriptsWorkbench.test.tsx
+++ b/apps/tldw-frontend/__tests__/vn-scripts/VNScriptsWorkbench.test.tsx
@@ -1,0 +1,379 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const mocks = vi.hoisted(() => ({
+  createVNScript: vi.fn(),
+  evaluateVNScriptVersionPolicy: vi.fn(),
+  getVNScriptDiagnostics: vi.fn(),
+  getVNScriptDraft: vi.fn(),
+  getVNScriptManifestSnapshot: vi.fn(),
+  listVNScripts: vi.fn(),
+  listVNScriptVersions: vi.fn(),
+  publishVNScript: vi.fn(),
+  putVNScriptDraft: vi.fn(),
+  validateVNScriptDraft: vi.fn(),
+}));
+
+vi.mock('@web/lib/api/vnScripts', () => ({
+  createVNScript: (...args: unknown[]) => mocks.createVNScript(...args),
+  evaluateVNScriptVersionPolicy: (...args: unknown[]) => mocks.evaluateVNScriptVersionPolicy(...args),
+  getVNScriptDiagnostics: (...args: unknown[]) => mocks.getVNScriptDiagnostics(...args),
+  getVNScriptDraft: (...args: unknown[]) => mocks.getVNScriptDraft(...args),
+  getVNScriptManifestSnapshot: (...args: unknown[]) => mocks.getVNScriptManifestSnapshot(...args),
+  listVNScripts: (...args: unknown[]) => mocks.listVNScripts(...args),
+  listVNScriptVersions: (...args: unknown[]) => mocks.listVNScriptVersions(...args),
+  publishVNScript: (...args: unknown[]) => mocks.publishVNScript(...args),
+  putVNScriptDraft: (...args: unknown[]) => mocks.putVNScriptDraft(...args),
+  validateVNScriptDraft: (...args: unknown[]) => mocks.validateVNScriptDraft(...args),
+}));
+
+vi.mock('@web/components/ui/JsonEditor', () => ({
+  JsonEditor: ({
+    value,
+    onChange,
+    readOnly,
+  }: {
+    value: string;
+    onChange: (nextValue: string) => void;
+    readOnly?: boolean;
+  }) => (
+    <textarea
+      aria-label="Draft JSON"
+      readOnly={readOnly}
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+    />
+  ),
+  default: ({
+    value,
+    onChange,
+    readOnly,
+  }: {
+    value: string;
+    onChange: (nextValue: string) => void;
+    readOnly?: boolean;
+  }) => (
+    <textarea
+      aria-label="Draft JSON"
+      readOnly={readOnly}
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+    />
+  ),
+}));
+
+import VNScriptsWorkbench from '@web/components/vn-scripts/VNScriptsWorkbench';
+
+const openingScript = {
+  id: 1,
+  title: 'Opening Route',
+  status: 'draft',
+  primary_asset_pack_id: 7,
+  policy_profile_id: 'teen-policy',
+  generation_profile_id: 'story-default',
+  generation_profiles: {},
+  content_rating: 'teen',
+};
+
+const secondScript = {
+  id: 2,
+  title: 'Second Route',
+  status: 'ready',
+  primary_asset_pack_id: 8,
+  policy_profile_id: 'general-policy',
+  generation_profile_id: 'fast-default',
+  generation_profiles: {},
+  content_rating: 'general',
+};
+
+const draftResponse = {
+  script_id: 1,
+  revision: 3,
+  draft: { scenes: [{ id: 'start', text: 'Wake up.' }] },
+  diagnostics: { node_count: 1 },
+};
+
+const versionResponse = {
+  id: 12,
+  script_id: 1,
+  version_number: 2,
+  label: 'Launch candidate',
+  draft_revision: 3,
+  program: { scenes: [] },
+  asset_pack_id: 7,
+  manifest_snapshot_id: 101,
+  policy_snapshot_id: 202,
+  generation_profile_snapshot_id: 303,
+  generation_profile_snapshots: { narrator: 404 },
+  script_defaults: {},
+  validation: { valid: true, warnings: 0 },
+  created_at: '2026-05-12T10:15:00Z',
+};
+
+function mockList(items = [openingScript, secondScript]) {
+  mocks.listVNScripts.mockResolvedValue({
+    items,
+    limit: 25,
+    offset: 0,
+    total: items.length,
+    has_more: false,
+    pagination: { limit: 25, offset: 0, total: items.length, has_more: false },
+  });
+}
+
+describe('VNScriptsWorkbench', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockList();
+    mocks.createVNScript.mockResolvedValue({
+      ...secondScript,
+      id: 9,
+      title: 'Created Route',
+      primary_asset_pack_id: 44,
+      policy_profile_id: 'policy-explicit',
+      generation_profile_id: 'gen-explicit',
+      content_rating: 'mature',
+    });
+    mocks.getVNScriptDraft.mockResolvedValue(draftResponse);
+    mocks.putVNScriptDraft.mockResolvedValue({
+      ...draftResponse,
+      revision: 4,
+      draft: { scenes: [{ id: 'edited' }] },
+    });
+    mocks.validateVNScriptDraft.mockResolvedValue({
+      valid: false,
+      errors: [{ code: 'missing_start', message: 'Missing start node' }],
+      warnings: [{ code: 'unused_scene', message: 'Unused scene' }],
+    });
+    mocks.getVNScriptDiagnostics.mockResolvedValue({
+      script_id: 1,
+      revision: 3,
+      diagnostics: { graph: { nodes: 1 }, unreachable: ['unused'] },
+    });
+    mocks.publishVNScript.mockResolvedValue({
+      script_id: 1,
+      version_id: 13,
+      version_number: 3,
+      status: 'published',
+      asset_pack_id: 7,
+      manifest_snapshot_id: 111,
+      policy_snapshot_id: 222,
+      generation_profile_snapshot_id: 333,
+      generation_profile_snapshots: {},
+      validation: { valid: true },
+      created_at: '2026-05-12T10:20:00Z',
+    });
+    mocks.listVNScriptVersions.mockResolvedValue({
+      items: [versionResponse],
+      limit: 25,
+      offset: 0,
+      total: 1,
+      has_more: false,
+      pagination: { limit: 25, offset: 0, total: 1, has_more: false },
+    });
+    mocks.getVNScriptManifestSnapshot.mockResolvedValue({
+      id: 101,
+      script_id: 1,
+      version_id: 12,
+      asset_pack_id: 7,
+      manifest: { slots: ['background.interior'] },
+      manifest_hash: 'hash-101',
+      created_at: '2026-05-12T10:15:00Z',
+    });
+    mocks.evaluateVNScriptVersionPolicy.mockResolvedValue({
+      decision: 'allow',
+      profile_id: 'teen-policy',
+      reasons: [{ code: 'ok' }],
+      blocked: false,
+      requires_acknowledgement: false,
+      remediation: [],
+    });
+  });
+
+  it('loads scripts on mount, selects the first script, and renders its draft and versions', async () => {
+    render(<VNScriptsWorkbench />);
+
+    expect(await screen.findByRole('button', { name: /Opening Route/ })).toBeInTheDocument();
+    expect(mocks.listVNScripts).toHaveBeenCalledWith({ limit: 25, offset: 0 });
+    await waitFor(() => expect(mocks.getVNScriptDraft).toHaveBeenCalledWith(1));
+    await waitFor(() => expect(mocks.listVNScriptVersions).toHaveBeenCalledWith(1));
+
+    expect(screen.getByText('Second Route')).toBeInTheDocument();
+    expect(screen.getByText('Script #1')).toBeInTheDocument();
+    expect(screen.getByDisplayValue(/Wake up/)).toBeInTheDocument();
+    expect(screen.getByText('Version 2')).toBeInTheDocument();
+    expect(screen.getByText('Launch candidate')).toBeInTheDocument();
+    expect(screen.getByText('Manifest 101')).toBeInTheDocument();
+    expect(screen.getByText('Policy 202')).toBeInTheDocument();
+    expect(screen.getByText('Generation 303')).toBeInTheDocument();
+    expect(screen.getByText(/2026-05-12T10:15:00Z/)).toBeInTheDocument();
+  });
+
+  it('creates a script shell, prepends it, selects it, and loads its details', async () => {
+    const user = userEvent.setup();
+    render(<VNScriptsWorkbench />);
+
+    await screen.findByRole('button', { name: /Opening Route/ });
+    await user.clear(screen.getByLabelText('Title'));
+    await user.type(screen.getByLabelText('Title'), 'Created Route');
+    await user.clear(screen.getByLabelText('Primary asset pack ID'));
+    await user.type(screen.getByLabelText('Primary asset pack ID'), '44');
+    await user.clear(screen.getByLabelText('Policy profile ID'));
+    await user.type(screen.getByLabelText('Policy profile ID'), 'policy-explicit');
+    await user.clear(screen.getByLabelText('Generation profile ID'));
+    await user.type(screen.getByLabelText('Generation profile ID'), 'gen-explicit');
+    await user.selectOptions(screen.getByLabelText('Content rating'), 'mature');
+    await user.click(screen.getByRole('button', { name: 'Create script' }));
+
+    await waitFor(() => {
+      expect(mocks.createVNScript).toHaveBeenCalledWith({
+        title: 'Created Route',
+        primary_asset_pack_id: 44,
+        policy_profile_id: 'policy-explicit',
+        generation_profile_id: 'gen-explicit',
+        content_rating: 'mature',
+      });
+    });
+    expect(await screen.findByText('Script #9')).toBeInTheDocument();
+    expect(mocks.getVNScriptDraft).toHaveBeenCalledWith(9);
+    expect(mocks.listVNScriptVersions).toHaveBeenCalledWith(9);
+  });
+
+  it('omits empty optional profile IDs when creating a script shell', async () => {
+    const user = userEvent.setup();
+    render(<VNScriptsWorkbench />);
+
+    await screen.findByRole('button', { name: /Opening Route/ });
+    await user.clear(screen.getByLabelText('Title'));
+    await user.type(screen.getByLabelText('Title'), 'Default Profiles Route');
+    await user.clear(screen.getByLabelText('Primary asset pack ID'));
+    await user.type(screen.getByLabelText('Primary asset pack ID'), '45');
+    await user.click(screen.getByRole('button', { name: 'Create script' }));
+
+    await waitFor(() => {
+      expect(mocks.createVNScript).toHaveBeenCalledWith({
+        title: 'Default Profiles Route',
+        primary_asset_pack_id: 45,
+        content_rating: 'teen',
+      });
+    });
+  });
+
+  it('saves parsed draft JSON with the current revision', async () => {
+    const user = userEvent.setup();
+    render(<VNScriptsWorkbench />);
+
+    const editor = await screen.findByLabelText('Draft JSON');
+    fireEvent.change(editor, { target: { value: JSON.stringify({ scenes: [{ id: 'edited' }] }) } });
+    await user.click(screen.getByRole('button', { name: 'Save draft' }));
+
+    await waitFor(() => {
+      expect(mocks.putVNScriptDraft).toHaveBeenCalledWith(1, {
+        if_revision: 3,
+        draft: { scenes: [{ id: 'edited' }] },
+      });
+    });
+    expect(await screen.findByText('Draft saved at revision 4.')).toBeInTheDocument();
+  });
+
+  it('blocks draft save on invalid local JSON without calling the backend', async () => {
+    const user = userEvent.setup();
+    render(<VNScriptsWorkbench />);
+
+    const editor = await screen.findByLabelText('Draft JSON');
+    fireEvent.change(editor, { target: { value: '{"scenes":' } });
+    await user.click(screen.getByRole('button', { name: 'Save draft' }));
+
+    expect(await screen.findByText(/Draft JSON is invalid/)).toBeInTheDocument();
+    expect(mocks.putVNScriptDraft).not.toHaveBeenCalled();
+  });
+
+  it('blocks validation on invalid local JSON without validating stale saved content', async () => {
+    const user = userEvent.setup();
+    render(<VNScriptsWorkbench />);
+
+    const editor = await screen.findByLabelText('Draft JSON');
+    fireEvent.change(editor, { target: { value: '{"scenes":' } });
+    await user.click(screen.getByRole('button', { name: 'Validate' }));
+
+    expect(await screen.findByText(/Draft JSON is invalid/)).toBeInTheDocument();
+    expect(mocks.validateVNScriptDraft).not.toHaveBeenCalled();
+  });
+
+  it('validates draft JSON and renders backend errors and warnings', async () => {
+    const user = userEvent.setup();
+    render(<VNScriptsWorkbench />);
+
+    await screen.findByLabelText('Draft JSON');
+    await user.click(screen.getByRole('button', { name: 'Validate' }));
+
+    await waitFor(() => {
+      expect(mocks.validateVNScriptDraft).toHaveBeenCalledWith(1, {
+        draft: { scenes: [{ id: 'start', text: 'Wake up.' }] },
+      });
+    });
+    expect(await screen.findByText('Invalid')).toBeInTheDocument();
+    expect(screen.getByText(/missing_start/)).toBeInTheDocument();
+    expect(screen.getByText(/unused_scene/)).toBeInTheDocument();
+  });
+
+  it('loads diagnostics and renders the backend JSON payload', async () => {
+    const user = userEvent.setup();
+    render(<VNScriptsWorkbench />);
+
+    await screen.findByRole('button', { name: /Opening Route/ });
+    await user.click(screen.getByRole('button', { name: 'Diagnostics' }));
+
+    await waitFor(() => expect(mocks.getVNScriptDiagnostics).toHaveBeenCalledWith(1));
+    expect(await screen.findByText(/unreachable/)).toBeInTheDocument();
+    expect(screen.getByText(/unused/)).toBeInTheDocument();
+  });
+
+  it('publishes with an idempotency key and current draft revision without inferred acknowledgements', async () => {
+    const user = userEvent.setup();
+    render(<VNScriptsWorkbench />);
+
+    await screen.findByRole('button', { name: /Opening Route/ });
+    await user.type(screen.getByLabelText('Publish label'), 'Playable v1');
+    await user.click(screen.getByRole('button', { name: 'Publish' }));
+
+    await waitFor(() => {
+      expect(mocks.publishVNScript).toHaveBeenCalledWith(1, {
+        draft_revision: 3,
+        label: 'Playable v1',
+        idempotency_key: expect.stringMatching(/^vn-script-publish-1-/),
+        acknowledgements: [],
+      });
+    });
+    expect(mocks.listVNScriptVersions).toHaveBeenCalledWith(1);
+  });
+
+  it('surfaces publish acknowledgement-required errors without inferring codes', async () => {
+    const user = userEvent.setup();
+    mocks.publishVNScript.mockRejectedValueOnce(new Error('script_publish_acknowledgement_required'));
+    render(<VNScriptsWorkbench />);
+
+    await screen.findByRole('button', { name: /Opening Route/ });
+    await user.click(screen.getByRole('button', { name: 'Publish' }));
+
+    expect(await screen.findByText('script_publish_acknowledgement_required')).toBeInTheDocument();
+    expect(mocks.publishVNScript).toHaveBeenCalledWith(1, expect.objectContaining({
+      acknowledgements: [],
+    }));
+  });
+
+  it('loads manifest and policy summaries for a published version', async () => {
+    const user = userEvent.setup();
+    render(<VNScriptsWorkbench />);
+
+    const version = await screen.findByTestId('version-12');
+    await user.click(within(version).getByRole('button', { name: /Load manifest for version 2/i }));
+    await user.click(within(version).getByRole('button', { name: /Evaluate policy for version 2/i }));
+
+    await waitFor(() => expect(mocks.getVNScriptManifestSnapshot).toHaveBeenCalledWith(1, 12));
+    await waitFor(() => expect(mocks.evaluateVNScriptVersionPolicy).toHaveBeenCalledWith(1, 12));
+    expect(await screen.findByText(/background.interior/)).toBeInTheDocument();
+    expect(screen.getByText(/allow/)).toBeInTheDocument();
+  });
+});

--- a/apps/tldw-frontend/__tests__/vn-scripts/VNScriptsWorkbench.test.tsx
+++ b/apps/tldw-frontend/__tests__/vn-scripts/VNScriptsWorkbench.test.tsx
@@ -111,6 +111,28 @@ const versionResponse = {
   created_at: '2026-05-12T10:15:00Z',
 };
 
+const secondVersionResponse = {
+  ...versionResponse,
+  id: 22,
+  script_id: 2,
+  version_number: 4,
+  label: 'Second launch',
+  asset_pack_id: 8,
+  manifest_snapshot_id: 121,
+  policy_snapshot_id: 222,
+  generation_profile_snapshot_id: 323,
+};
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+  return { promise, reject, resolve };
+}
+
 function mockList(items = [openingScript, secondScript]) {
   mocks.listVNScripts.mockResolvedValue({
     items,
@@ -149,7 +171,11 @@ describe('VNScriptsWorkbench', () => {
     mocks.getVNScriptDiagnostics.mockResolvedValue({
       script_id: 1,
       revision: 3,
-      diagnostics: { graph: { nodes: 1 }, unreachable: ['unused'] },
+      diagnostics: {
+        graph: { nodes: 1 },
+        raw_debug_payload: 'secret raw payload',
+        unreachable: ['unused'],
+      },
     });
     mocks.publishVNScript.mockResolvedValue({
       script_id: 1,
@@ -177,14 +203,14 @@ describe('VNScriptsWorkbench', () => {
       script_id: 1,
       version_id: 12,
       asset_pack_id: 7,
-      manifest: { slots: ['background.interior'] },
+      manifest: { slots: ['background.interior'], raw_prompt: 'hidden prompt text' },
       manifest_hash: 'hash-101',
       created_at: '2026-05-12T10:15:00Z',
     });
     mocks.evaluateVNScriptVersionPolicy.mockResolvedValue({
       decision: 'allow',
       profile_id: 'teen-policy',
-      reasons: [{ code: 'ok' }],
+      reasons: [{ code: 'ok', internal_notes: 'hidden policy details' }],
       blocked: false,
       requires_acknowledgement: false,
       remediation: [],
@@ -318,7 +344,7 @@ describe('VNScriptsWorkbench', () => {
     expect(screen.getByText(/unused_scene/)).toBeInTheDocument();
   });
 
-  it('loads diagnostics and renders the backend JSON payload', async () => {
+  it('loads diagnostics and renders a sanitized backend summary', async () => {
     const user = userEvent.setup();
     render(<VNScriptsWorkbench />);
 
@@ -328,6 +354,8 @@ describe('VNScriptsWorkbench', () => {
     await waitFor(() => expect(mocks.getVNScriptDiagnostics).toHaveBeenCalledWith(1));
     expect(await screen.findByText(/unreachable/)).toBeInTheDocument();
     expect(screen.getByText(/unused/)).toBeInTheDocument();
+    expect(screen.getByText(/\[redacted\]/)).toBeInTheDocument();
+    expect(screen.queryByText(/secret raw payload/)).not.toBeInTheDocument();
   });
 
   it('publishes with an idempotency key and current draft revision without inferred acknowledgements', async () => {
@@ -342,11 +370,66 @@ describe('VNScriptsWorkbench', () => {
       expect(mocks.publishVNScript).toHaveBeenCalledWith(1, {
         draft_revision: 3,
         label: 'Playable v1',
-        idempotency_key: expect.stringMatching(/^vn-script-publish-1-/),
+        idempotency_key: expect.stringMatching(/^vn-script-publish-1-3-/),
         acknowledgements: [],
       });
     });
     expect(mocks.listVNScriptVersions).toHaveBeenCalledWith(1);
+  });
+
+  it('reuses the draft-scoped publish idempotency key when a publish is retried', async () => {
+    const user = userEvent.setup();
+    mocks.publishVNScript
+      .mockRejectedValueOnce(new Error('script_publish_acknowledgement_required'))
+      .mockResolvedValueOnce({
+        script_id: 1,
+        version_id: 13,
+        version_number: 3,
+        status: 'published',
+        asset_pack_id: 7,
+        manifest_snapshot_id: 111,
+        policy_snapshot_id: 222,
+        generation_profile_snapshot_id: 333,
+        generation_profile_snapshots: {},
+        validation: { valid: true },
+        created_at: '2026-05-12T10:20:00Z',
+      });
+    render(<VNScriptsWorkbench />);
+
+    await screen.findByRole('button', { name: /Opening Route/ });
+    await user.click(screen.getByRole('button', { name: 'Publish' }));
+    expect(await screen.findByText('script_publish_acknowledgement_required')).toBeInTheDocument();
+    const firstKey = mocks.publishVNScript.mock.calls[0][1].idempotency_key;
+
+    await user.click(screen.getByRole('button', { name: 'Publish' }));
+    await waitFor(() => expect(mocks.publishVNScript).toHaveBeenCalledTimes(2));
+    expect(mocks.publishVNScript.mock.calls[1][1].idempotency_key).toBe(firstKey);
+  });
+
+  it('keeps the optimistic publish result when version refresh fails after publish succeeds', async () => {
+    const user = userEvent.setup();
+    let versionListCalls = 0;
+    mocks.listVNScriptVersions.mockImplementation(async () => {
+      versionListCalls += 1;
+      if (versionListCalls === 1) {
+        return {
+          items: [versionResponse],
+          limit: 25,
+          offset: 0,
+          total: 1,
+          has_more: false,
+          pagination: { limit: 25, offset: 0, total: 1, has_more: false },
+        };
+      }
+      throw new Error('Failed to fetch versions from backend with internal stack payload');
+    });
+    render(<VNScriptsWorkbench />);
+
+    await screen.findByRole('button', { name: /Opening Route/ });
+    await user.click(screen.getByRole('button', { name: 'Publish' }));
+
+    expect(await screen.findByText('Version 3')).toBeInTheDocument();
+    expect(screen.getByText('Published, but failed to refresh versions')).toBeInTheDocument();
   });
 
   it('surfaces publish acknowledgement-required errors without inferring codes', async () => {
@@ -375,5 +458,68 @@ describe('VNScriptsWorkbench', () => {
     await waitFor(() => expect(mocks.evaluateVNScriptVersionPolicy).toHaveBeenCalledWith(1, 12));
     expect(await screen.findByText(/background.interior/)).toBeInTheDocument();
     expect(screen.getByText(/allow/)).toBeInTheDocument();
+    expect(screen.queryByText(/hidden prompt text/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/hidden policy details/)).not.toBeInTheDocument();
+  });
+
+  it('does not let a stale publish version refresh overwrite a newly selected script', async () => {
+    const user = userEvent.setup();
+    const staleRefresh = createDeferred<{
+      items: typeof versionResponse[];
+      limit: number;
+      offset: number;
+      total: number;
+      has_more: boolean;
+      pagination: { limit: number; offset: number; total: number; has_more: boolean };
+    }>();
+    let openingVersionCalls = 0;
+    mocks.getVNScriptDraft.mockImplementation(async (scriptId: number) =>
+      scriptId === 2
+        ? { ...draftResponse, script_id: 2, draft: { scenes: [{ id: 'second' }] } }
+        : draftResponse
+    );
+    mocks.listVNScriptVersions.mockImplementation((scriptId: number) => {
+      if (scriptId === 2) {
+        return Promise.resolve({
+          items: [secondVersionResponse],
+          limit: 25,
+          offset: 0,
+          total: 1,
+          has_more: false,
+          pagination: { limit: 25, offset: 0, total: 1, has_more: false },
+        });
+      }
+      openingVersionCalls += 1;
+      if (openingVersionCalls === 1) {
+        return Promise.resolve({
+          items: [versionResponse],
+          limit: 25,
+          offset: 0,
+          total: 1,
+          has_more: false,
+          pagination: { limit: 25, offset: 0, total: 1, has_more: false },
+        });
+      }
+      return staleRefresh.promise;
+    });
+    render(<VNScriptsWorkbench />);
+
+    await screen.findByRole('button', { name: /Opening Route/ });
+    await user.click(screen.getByRole('button', { name: 'Publish' }));
+    await waitFor(() => expect(mocks.publishVNScript).toHaveBeenCalledTimes(1));
+    await user.click(screen.getByRole('button', { name: /Second Route/ }));
+    await screen.findByText('Script #2');
+
+    staleRefresh.resolve({
+      items: [versionResponse],
+      limit: 25,
+      offset: 0,
+      total: 1,
+      has_more: false,
+      pagination: { limit: 25, offset: 0, total: 1, has_more: false },
+    });
+
+    expect(await screen.findByTestId('version-22')).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByTestId('version-12')).not.toBeInTheDocument());
   });
 });

--- a/apps/tldw-frontend/__tests__/vn-scripts/vnScriptsApi.test.ts
+++ b/apps/tldw-frontend/__tests__/vn-scripts/vnScriptsApi.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  apiClient: {
+    delete: vi.fn(),
+    get: vi.fn(),
+    patch: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+  },
+}));
+
+vi.mock('@web/lib/api', () => ({
+  apiClient: mocks.apiClient,
+}));
+
+import {
+  createVNScript,
+  deleteVNScript,
+  evaluateVNScriptVersionPolicy,
+  getVNScript,
+  getVNScriptDiagnostics,
+  getVNScriptDraft,
+  getVNScriptManifestSnapshot,
+  getVNScriptVersion,
+  listVNScripts,
+  listVNScriptVersions,
+  patchVNScript,
+  publishVNScript,
+  putVNScriptDraft,
+  validateVNScriptDraft,
+} from '@web/lib/api/vnScripts';
+
+describe('vnScripts api client', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.apiClient.delete.mockResolvedValue(undefined);
+    mocks.apiClient.get.mockResolvedValue({});
+    mocks.apiClient.patch.mockResolvedValue({});
+    mocks.apiClient.post.mockResolvedValue({});
+    mocks.apiClient.put.mockResolvedValue({});
+  });
+
+  it('calls script CRUD endpoints with expected paths and payloads', async () => {
+    mocks.apiClient.post.mockResolvedValueOnce({
+      id: 1,
+      title: 'Opening Route',
+      status: 'draft',
+      primary_asset_pack_id: 7,
+      policy_profile_id: 'local_default',
+      generation_profile_id: 'story_default',
+      generation_profiles: {},
+      content_rating: 'teen',
+    });
+
+    const created = await createVNScript({
+      title: 'Opening Route',
+      primary_asset_pack_id: 7,
+      content_rating: 'teen',
+    });
+    await listVNScripts({ limit: 10, offset: 20 });
+    await getVNScript(1);
+    await patchVNScript(1, { title: 'Updated Route', status: 'ready' });
+    await deleteVNScript(1);
+
+    expect(created.id).toBe(1);
+    expect(mocks.apiClient.post).toHaveBeenCalledWith('/vn/vn-scripts/scripts', {
+      title: 'Opening Route',
+      primary_asset_pack_id: 7,
+      content_rating: 'teen',
+    });
+    expect(mocks.apiClient.get).toHaveBeenCalledWith('/vn/vn-scripts/scripts', {
+      params: { limit: 10, offset: 20 },
+    });
+    expect(mocks.apiClient.get).toHaveBeenCalledWith('/vn/vn-scripts/scripts/1');
+    expect(mocks.apiClient.patch).toHaveBeenCalledWith('/vn/vn-scripts/scripts/1', {
+      title: 'Updated Route',
+      status: 'ready',
+    });
+    expect(mocks.apiClient.delete).toHaveBeenCalledWith('/vn/vn-scripts/scripts/1');
+  });
+
+  it('calls draft, validation, diagnostics, and publish endpoints', async () => {
+    const draft = { nodes: [{ id: 'start' }] };
+
+    await getVNScriptDraft(1);
+    await putVNScriptDraft(1, { if_revision: 2, draft });
+    await validateVNScriptDraft(1, { draft });
+    await getVNScriptDiagnostics(1);
+    await publishVNScript(1, {
+      draft_revision: 3,
+      label: 'First pass',
+      idempotency_key: 'publish-1',
+      acknowledgements: ['ack-1'],
+    });
+
+    expect(mocks.apiClient.get).toHaveBeenCalledWith('/vn/vn-scripts/scripts/1/draft');
+    expect(mocks.apiClient.put).toHaveBeenCalledWith('/vn/vn-scripts/scripts/1/draft', {
+      if_revision: 2,
+      draft,
+    });
+    expect(mocks.apiClient.post).toHaveBeenCalledWith('/vn/vn-scripts/scripts/1/draft/validate', {
+      draft,
+    });
+    expect(mocks.apiClient.get).toHaveBeenCalledWith('/vn/vn-scripts/scripts/1/draft/diagnostics');
+    expect(mocks.apiClient.post).toHaveBeenCalledWith('/vn/vn-scripts/scripts/1/publish', {
+      draft_revision: 3,
+      label: 'First pass',
+      idempotency_key: 'publish-1',
+      acknowledgements: ['ack-1'],
+    });
+  });
+
+  it('calls version, manifest snapshot, and policy evaluation endpoints', async () => {
+    await listVNScriptVersions(1, { limit: 5, offset: 10 });
+    await getVNScriptVersion(1, 4);
+    await getVNScriptManifestSnapshot(1, 4);
+    await evaluateVNScriptVersionPolicy(1, 4, { context: { mode: 'preview' } });
+
+    expect(mocks.apiClient.get).toHaveBeenCalledWith('/vn/vn-scripts/scripts/1/versions', {
+      params: { limit: 5, offset: 10 },
+    });
+    expect(mocks.apiClient.get).toHaveBeenCalledWith('/vn/vn-scripts/scripts/1/versions/4');
+    expect(mocks.apiClient.get).toHaveBeenCalledWith(
+      '/vn/vn-scripts/scripts/1/versions/4/manifest-snapshot'
+    );
+    expect(mocks.apiClient.post).toHaveBeenCalledWith(
+      '/vn/vn-scripts/scripts/1/versions/4/policy/evaluate',
+      { context: { mode: 'preview' } }
+    );
+  });
+});

--- a/apps/tldw-frontend/__tests__/vn-scripts/vnScriptsApi.test.ts
+++ b/apps/tldw-frontend/__tests__/vn-scripts/vnScriptsApi.test.ts
@@ -129,4 +129,19 @@ describe('vnScripts api client', () => {
       { context: { mode: 'preview' } }
     );
   });
+
+  it('omits nullish query values before passing params to the API client', async () => {
+    await listVNScripts({ limit: 10, offset: undefined } as Parameters<typeof listVNScripts>[0]);
+    await listVNScriptVersions(1, {
+      limit: undefined,
+      offset: undefined,
+    } as Parameters<typeof listVNScriptVersions>[1]);
+
+    expect(mocks.apiClient.get).toHaveBeenCalledWith('/vn/vn-scripts/scripts', {
+      params: { limit: 10 },
+    });
+    expect(mocks.apiClient.get).toHaveBeenCalledWith('/vn/vn-scripts/scripts/1/versions', {
+      params: {},
+    });
+  });
 });

--- a/apps/tldw-frontend/components/vn-play/NewSessionDialog.tsx
+++ b/apps/tldw-frontend/components/vn-play/NewSessionDialog.tsx
@@ -392,7 +392,7 @@ export default function NewSessionDialog({
       mode === 'scripted_story' && selectedScriptVersion
         ? [
             selectedScriptVersion.id,
-            ...requiredAcknowledgementWarningCodes(selectedScriptVersion.warning_summary),
+            ...acknowledgementWarningCodes(selectedScriptVersion.warning_summary),
           ].join(':')
         : acknowledgementKey(selectedPack),
     [mode, selectedPack, selectedScriptVersion]
@@ -488,7 +488,7 @@ export default function NewSessionDialog({
       request.script_id = selectedScriptVersion.script_id;
       request.script_version_id = selectedScriptVersion.id;
       if (selectedScriptRequiresAcknowledgement && acknowledgedSetupWarnings) {
-        request.acknowledgements = requiredAcknowledgementWarningCodes(selectedScriptVersion.warning_summary);
+        request.acknowledgements = acknowledgementWarningCodes(selectedScriptVersion.warning_summary);
       }
     } else if (usingManualIds && mode === 'scripted_story' && parsedScriptId && parsedScriptVersionId) {
       request.script_id = parsedScriptId;
@@ -611,7 +611,7 @@ export default function NewSessionDialog({
                     workspaceLabel="VN scripts"
                   />
                 )}
-                {!isLoadingSelectors && scriptVersions.length === 0 && (
+                {!isLoadingSelectors && scriptVersions.length === 0 && scriptEmptyStates.length === 0 && (
                   <div className="mt-2 rounded-md border border-warn/30 bg-warn/10 px-3 py-2 text-sm text-warn">
                     No published VN script versions are available.{' '}
                     <Link className="underline" href="/vn-scripts">

--- a/apps/tldw-frontend/components/vn-play/NewSessionDialog.tsx
+++ b/apps/tldw-frontend/components/vn-play/NewSessionDialog.tsx
@@ -1,4 +1,5 @@
 import React, { FormEvent, useEffect, useMemo, useRef, useState } from 'react';
+import Link from 'next/link';
 import { Button } from '@web/components/ui/Button';
 import { Input } from '@web/components/ui/Input';
 import { listVNPlaySetupOptions } from '@web/lib/api/vnPlay';
@@ -9,6 +10,8 @@ import type {
   VNPlaySetupCharacterOption,
   VNPlaySetupEmptyState,
   VNPlaySetupOptionsResponse,
+  VNPlaySetupScriptVersionOption,
+  VNPlaySetupWarningSummary,
 } from '@web/types/vn-play';
 
 export interface NewSessionDialogProps {
@@ -24,6 +27,7 @@ type SelectorMode = 'selectors' | 'manual';
 const SELECT_CLASS =
   'mt-1 block w-full rounded-md border-border bg-bg shadow-sm focus:border-primary focus:ring-primary';
 const EMPTY_ASSET_PACKS: VNPlaySetupAssetPackOption[] = [];
+const EMPTY_SCRIPT_VERSIONS: VNPlaySetupScriptVersionOption[] = [];
 const EMPTY_EMPTY_STATES: VNPlaySetupEmptyState[] = [];
 
 function parsePositiveInteger(value: string): number | null {
@@ -56,32 +60,40 @@ function humanizeValue(value: string): string {
   return value.replace(/_/g, ' ');
 }
 
-function requiresPackAcknowledgement(pack: VNPlaySetupAssetPackOption | null): boolean {
-  return Boolean(pack?.warning_summary.requires_acknowledgement);
+function requiresAcknowledgement(summary: VNPlaySetupWarningSummary | null | undefined): boolean {
+  return Boolean(summary?.requires_acknowledgement);
 }
 
-function acknowledgementWarningCodes(pack: VNPlaySetupAssetPackOption): string[] {
-  const requiredCodes = pack.warning_summary.warnings
-    .filter((warning) => warning.requires_acknowledgement)
-    .map((warning) => warning.code)
-    .filter(Boolean);
+function acknowledgementWarningCodes(summary: VNPlaySetupWarningSummary): string[] {
+  const requiredCodes = requiredAcknowledgementWarningCodes(summary);
 
   if (requiredCodes.length > 0) {
     return requiredCodes;
   }
 
-  return pack.warning_summary.warnings.map((warning) => warning.code).filter(Boolean);
+  return summary.warnings.map((warning) => warning.code).filter(Boolean);
+}
+
+function requiredAcknowledgementWarningCodes(summary: VNPlaySetupWarningSummary): string[] {
+  return summary.warnings
+    .filter((warning) => warning.requires_acknowledgement)
+    .map((warning) => warning.code)
+    .filter(Boolean);
+}
+
+function requiresPackAcknowledgement(pack: VNPlaySetupAssetPackOption | null): boolean {
+  return requiresAcknowledgement(pack?.warning_summary);
 }
 
 function acknowledgementKey(pack: VNPlaySetupAssetPackOption | null): string {
   if (!pack || !requiresPackAcknowledgement(pack)) return '';
-  return [pack.id, ...acknowledgementWarningCodes(pack)].join(':');
+  return [pack.id, ...acknowledgementWarningCodes(pack.warning_summary)].join(':');
 }
 
 function buildSetupAcknowledgement(pack: VNPlaySetupAssetPackOption) {
   return {
     asset_pack_id: pack.id,
-    warning_codes: acknowledgementWarningCodes(pack),
+    warning_codes: acknowledgementWarningCodes(pack.warning_summary),
     highest_severity: pack.warning_summary.highest_severity,
   };
 }
@@ -96,6 +108,22 @@ function packOptionLabel(pack: VNPlaySetupAssetPackOption): string {
   } else if (!pack.ready) {
     parts.push('not ready');
   } else if (requiresPackAcknowledgement(pack)) {
+    parts.push('review required');
+  }
+  return parts.join(' - ');
+}
+
+function scriptOptionLabel(script: VNPlaySetupScriptVersionOption): string {
+  const parts = [`${script.title} v${script.version_number}`];
+  if (script.label) {
+    parts.push(script.label);
+  }
+  if (script.recommended) {
+    parts.push('recommended');
+  }
+  if (!script.ready) {
+    parts.push('not ready');
+  } else if (requiresAcknowledgement(script.warning_summary)) {
     parts.push('review required');
   }
   return parts.join(' - ');
@@ -172,6 +200,11 @@ function packWarningMessages(pack: VNPlaySetupAssetPackOption | null): string[] 
   return messages.filter(Boolean);
 }
 
+function scriptWarningMessages(script: VNPlaySetupScriptVersionOption | null): string[] {
+  if (!script) return [];
+  return script.warning_summary.warnings.map((warning) => warning.message).filter(Boolean);
+}
+
 function emptyStatesFor(
   emptyStates: VNPlaySetupEmptyState[],
   codes: string[]
@@ -213,8 +246,11 @@ export default function NewSessionDialog({
   const [title, setTitle] = useState('Untitled VN play session');
   const [primaryCharacterId, setPrimaryCharacterId] = useState('1');
   const [vnAssetPackId, setVnAssetPackId] = useState('1');
+  const [scriptId, setScriptId] = useState('');
+  const [scriptVersionId, setScriptVersionId] = useState('');
   const [selectedCharacterId, setSelectedCharacterId] = useState('');
   const [selectedPackId, setSelectedPackId] = useState('');
+  const [selectedScriptVersionId, setSelectedScriptVersionId] = useState('');
   const [linkedChatId, setLinkedChatId] = useState('');
   const [contentRating, setContentRating] = useState('general');
   const [formError, setFormError] = useState<string | null>(null);
@@ -224,11 +260,16 @@ export default function NewSessionDialog({
   const [selectorError, setSelectorError] = useState<string | null>(null);
   const [acknowledgedSetupWarnings, setAcknowledgedSetupWarnings] = useState(false);
   const selectedPackIdRef = useRef(selectedPackId);
+  const selectedScriptVersionIdRef = useRef(selectedScriptVersionId);
   const applyingDefaultCharacterIdRef = useRef<string | null>(null);
 
   useEffect(() => {
     selectedPackIdRef.current = selectedPackId;
   }, [selectedPackId]);
+
+  useEffect(() => {
+    selectedScriptVersionIdRef.current = selectedScriptVersionId;
+  }, [selectedScriptVersionId]);
 
   useEffect(() => {
     if (open) {
@@ -237,6 +278,8 @@ export default function NewSessionDialog({
       setTitle('Untitled VN play session');
       setPrimaryCharacterId('1');
       setVnAssetPackId('1');
+      setScriptId('');
+      setScriptVersionId('');
       setLinkedChatId('');
       setFormError(null);
       setSelectorError(null);
@@ -244,6 +287,7 @@ export default function NewSessionDialog({
       setSetupOptions(null);
       setSelectedCharacterId('');
       setSelectedPackId('');
+      setSelectedScriptVersionId('');
       setContentRating('general');
       setAcknowledgedSetupWarnings(false);
     }
@@ -276,6 +320,16 @@ export default function NewSessionDialog({
           nextSelectedCharacter,
           parsePositiveInteger(selectedPackIdRef.current)
         );
+        const currentScriptVersionId = parsePositiveInteger(selectedScriptVersionIdRef.current);
+        const nextScriptVersions = nextOptions.script_versions ?? EMPTY_SCRIPT_VERSIONS;
+        const nextScriptVersion =
+          nextScriptVersions.find((script) => script.id === currentScriptVersionId) ??
+          (nextOptions.defaults.script_version_id
+            ? nextScriptVersions.find((script) => script.id === nextOptions.defaults.script_version_id)
+            : undefined) ??
+          nextScriptVersions.find((script) => script.recommended) ??
+          nextScriptVersions.find((script) => script.ready) ??
+          nextScriptVersions[0];
         const nextCharacterIdValue = nextCharacterId ? String(nextCharacterId) : '';
         const nextPackIdValue = nextPackId ? String(nextPackId) : '';
 
@@ -285,6 +339,7 @@ export default function NewSessionDialog({
           setSelectedCharacterId(nextCharacterIdValue);
         }
         setSelectedPackId(nextPackIdValue);
+        setSelectedScriptVersionId(nextScriptVersion ? String(nextScriptVersion.id) : '');
       } catch (error) {
         if (!cancelled) {
           const message = error instanceof Error ? error.message : 'Failed to load setup options';
@@ -307,8 +362,10 @@ export default function NewSessionDialog({
 
   const selectedCharacterIdNumber = parsePositiveInteger(selectedCharacterId);
   const selectedPackIdNumber = parsePositiveInteger(selectedPackId);
+  const selectedScriptVersionIdNumber = parsePositiveInteger(selectedScriptVersionId);
   const characters = useMemo(() => setupCharacters(setupOptions), [setupOptions]);
   const assetPacks = setupOptions?.asset_packs ?? EMPTY_ASSET_PACKS;
+  const scriptVersions = setupOptions?.script_versions ?? EMPTY_SCRIPT_VERSIONS;
   const emptyStates = setupOptions?.empty_states ?? EMPTY_EMPTY_STATES;
 
   const selectedCharacter = useMemo(
@@ -319,14 +376,39 @@ export default function NewSessionDialog({
     () => assetPacks.find((pack) => pack.id === selectedPackIdNumber) ?? null,
     [assetPacks, selectedPackIdNumber]
   );
-  const selectedPackAcknowledgementKey = useMemo(() => acknowledgementKey(selectedPack), [selectedPack]);
+  const selectedScriptVersion = useMemo(
+    () => scriptVersions.find((script) => script.id === selectedScriptVersionIdNumber) ?? null,
+    [scriptVersions, selectedScriptVersionIdNumber]
+  );
+  const selectedScriptAssetPack = useMemo(
+    () =>
+      selectedScriptVersion
+        ? assetPacks.find((pack) => pack.id === selectedScriptVersion.asset_pack_id) ?? null
+        : null,
+    [assetPacks, selectedScriptVersion]
+  );
+  const selectedPackAcknowledgementKey = useMemo(
+    () =>
+      mode === 'scripted_story' && selectedScriptVersion
+        ? [
+            selectedScriptVersion.id,
+            ...requiredAcknowledgementWarningCodes(selectedScriptVersion.warning_summary),
+          ].join(':')
+        : acknowledgementKey(selectedPack),
+    [mode, selectedPack, selectedScriptVersion]
+  );
 
   useEffect(() => {
     setAcknowledgedSetupWarnings(false);
   }, [selectedPackAcknowledgementKey]);
 
   const selectedPackWarnings = useMemo(() => packWarningMessages(selectedPack), [selectedPack]);
+  const selectedScriptWarnings = useMemo(
+    () => scriptWarningMessages(selectedScriptVersion),
+    [selectedScriptVersion]
+  );
   const selectedPackRequiresAcknowledgement = requiresPackAcknowledgement(selectedPack);
+  const selectedScriptRequiresAcknowledgement = requiresAcknowledgement(selectedScriptVersion?.warning_summary);
   const incompatiblePacks = useMemo(
     () => assetPacks.filter((pack) => pack.compatibility.status === 'different_character'),
     [assetPacks]
@@ -334,8 +416,13 @@ export default function NewSessionDialog({
   const selectorSubmitDisabled =
     selectorMode === 'selectors' &&
     (isLoadingSelectors ||
-      hasBlockingPackIssue(selectedPack, selectedCharacter) ||
-      (selectedPackRequiresAcknowledgement && !acknowledgedSetupWarnings));
+      (mode === 'scripted_story'
+        ? !selectedScriptVersion ||
+          !selectedScriptVersion.ready ||
+          !selectedScriptAssetPack ||
+          (selectedScriptRequiresAcknowledgement && !acknowledgedSetupWarnings)
+        : hasBlockingPackIssue(selectedPack, selectedCharacter) ||
+          (selectedPackRequiresAcknowledgement && !acknowledgedSetupWarnings)));
 
   if (!open) return null;
 
@@ -344,20 +431,42 @@ export default function NewSessionDialog({
     const usingManualIds = selectorMode === 'manual';
     const parsedPrimaryCharacterId = usingManualIds
       ? parsePositiveInteger(primaryCharacterId)
-      : selectedCharacterIdNumber;
-    const parsedPackId = usingManualIds ? parsePositiveInteger(vnAssetPackId) : selectedPackIdNumber;
+      : mode === 'scripted_story'
+        ? selectedScriptAssetPack?.primary_character_id ?? null
+        : selectedCharacterIdNumber;
+    const parsedPackId = usingManualIds
+      ? parsePositiveInteger(vnAssetPackId)
+      : mode === 'scripted_story'
+        ? selectedScriptVersion?.asset_pack_id ?? null
+        : selectedPackIdNumber;
+    const parsedScriptId = usingManualIds && mode === 'scripted_story' ? parsePositiveInteger(scriptId) : null;
+    const parsedScriptVersionId =
+      usingManualIds && mode === 'scripted_story' ? parsePositiveInteger(scriptVersionId) : null;
     const trimmedTitle = title.trim();
 
     if (!trimmedTitle || !parsedPrimaryCharacterId || !parsedPackId) {
       setFormError('Enter a title, character ID, and asset pack ID.');
       return;
     }
+    if (usingManualIds && mode === 'scripted_story' && (!parsedScriptId || !parsedScriptVersionId)) {
+      setFormError('Enter script ID and script version ID for scripted story sessions.');
+      return;
+    }
 
-    if (!usingManualIds && hasBlockingPackIssue(selectedPack, selectedCharacter)) {
+    if (!usingManualIds && mode === 'scripted_story' && (!selectedScriptVersion || !selectedScriptVersion.ready || !selectedScriptAssetPack)) {
+      setFormError('Select a runtime-ready published script version.');
+      return;
+    }
+    if (!usingManualIds && mode !== 'scripted_story' && hasBlockingPackIssue(selectedPack, selectedCharacter)) {
       setFormError('Select a compatible runtime-ready character and asset pack.');
       return;
     }
-    if (!usingManualIds && selectedPackRequiresAcknowledgement && !acknowledgedSetupWarnings) {
+    if (
+      !usingManualIds &&
+      ((mode === 'scripted_story' && selectedScriptRequiresAcknowledgement) ||
+        (mode !== 'scripted_story' && selectedPackRequiresAcknowledgement)) &&
+      !acknowledgedSetupWarnings
+    ) {
       setFormError('Acknowledge setup warnings before creating this session.');
       return;
     }
@@ -369,10 +478,22 @@ export default function NewSessionDialog({
       primary_character_id: parsedPrimaryCharacterId,
       vn_asset_pack_id: parsedPackId,
       linked_chat_id: linkedChatId.trim() || null,
-      content_rating: contentRating.trim() || 'general',
+      content_rating:
+        !usingManualIds && mode === 'scripted_story' && selectedScriptVersion
+          ? selectedScriptVersion.content_rating
+          : contentRating.trim() || 'general',
     };
 
-    if (!usingManualIds && selectedPackRequiresAcknowledgement && acknowledgedSetupWarnings && selectedPack) {
+    if (!usingManualIds && mode === 'scripted_story' && selectedScriptVersion) {
+      request.script_id = selectedScriptVersion.script_id;
+      request.script_version_id = selectedScriptVersion.id;
+      if (selectedScriptRequiresAcknowledgement && acknowledgedSetupWarnings) {
+        request.acknowledgements = requiredAcknowledgementWarningCodes(selectedScriptVersion.warning_summary);
+      }
+    } else if (usingManualIds && mode === 'scripted_story' && parsedScriptId && parsedScriptVersionId) {
+      request.script_id = parsedScriptId;
+      request.script_version_id = parsedScriptVersionId;
+    } else if (!usingManualIds && selectedPackRequiresAcknowledgement && acknowledgedSetupWarnings && selectedPack) {
       request.settings = {
         setup_acknowledgements: [buildSetupAcknowledgement(selectedPack)],
       };
@@ -391,13 +512,20 @@ export default function NewSessionDialog({
     'no_ready_packs',
     'no_compatible_packs',
   ]);
+  const scriptEmptyStates = emptyStatesFor(emptyStates, [
+    'no_script_versions',
+    'no_ready_script_versions',
+    'no_published_scripts',
+  ]);
 
   return (
     <div className="rounded-md border border-border bg-surface p-4">
       <div className="mb-4 flex items-start justify-between gap-3">
         <div>
           <h2 className="text-lg font-semibold">New VN play session</h2>
-          <p className="text-sm text-text-muted">{mode === 'story' ? 'Story/CYOA' : 'Freeform'}</p>
+          <p className="text-sm text-text-muted">
+            {mode === 'scripted_story' ? 'Scripted Story' : mode === 'story' ? 'Story/CYOA' : 'Freeform'}
+          </p>
         </div>
         <Button onClick={onClose} size="sm" type="button" variant="ghost">
           Close
@@ -414,6 +542,7 @@ export default function NewSessionDialog({
           >
             <option value="freeform">Freeform</option>
             <option value="story">Story/CYOA</option>
+            <option value="scripted_story">Scripted Story</option>
           </select>
         </label>
         <Input label="Title" value={title} onChange={(event) => setTitle(event.target.value)} />
@@ -437,9 +566,73 @@ export default function NewSessionDialog({
               value={vnAssetPackId}
               onChange={(event) => setVnAssetPackId(event.target.value)}
             />
+            {mode === 'scripted_story' && (
+              <>
+                <Input
+                  inputMode="numeric"
+                  label="Script ID"
+                  value={scriptId}
+                  onChange={(event) => setScriptId(event.target.value)}
+                />
+                <Input
+                  inputMode="numeric"
+                  label="Script version ID"
+                  value={scriptVersionId}
+                  onChange={(event) => setScriptVersionId(event.target.value)}
+                />
+              </>
+            )}
           </>
         ) : (
           <>
+            {mode === 'scripted_story' ? (
+              <div className="sm:col-span-2">
+                <label htmlFor="new-session-script-version" className="mb-1 block text-sm font-medium text-text">
+                  Published script version
+                </label>
+                <select
+                  className={SELECT_CLASS}
+                  disabled={isLoadingSelectors || scriptVersions.length === 0}
+                  id="new-session-script-version"
+                  value={selectedScriptVersionId}
+                  onChange={(event) => setSelectedScriptVersionId(event.target.value)}
+                >
+                  <option value="">Select a published script version</option>
+                  {scriptVersions.map((script) => (
+                    <option key={script.id} disabled={!script.ready} value={script.id}>
+                      {scriptOptionLabel(script)}
+                    </option>
+                  ))}
+                </select>
+                {!isLoadingSelectors && (
+                  <EmptyStateGuidance
+                    states={scriptEmptyStates}
+                    workspaceHref="/vn-scripts"
+                    workspaceLabel="VN scripts"
+                  />
+                )}
+                {!isLoadingSelectors && scriptVersions.length === 0 && (
+                  <div className="mt-2 rounded-md border border-warn/30 bg-warn/10 px-3 py-2 text-sm text-warn">
+                    No published VN script versions are available.{' '}
+                    <Link className="underline" href="/vn-scripts">
+                      Open VN scripts
+                    </Link>
+                  </div>
+                )}
+                {selectedScriptVersion && (
+                  <div className="mt-2 rounded-md border border-border bg-bg px-3 py-2 text-sm text-text-muted">
+                    <p className="font-medium text-text">
+                      {selectedScriptVersion.title} v{selectedScriptVersion.version_number}
+                    </p>
+                    <p>Content rating: {selectedScriptVersion.content_rating || 'general'}</p>
+                    <p>Asset pack: {selectedScriptVersion.asset_pack_id}</p>
+                    <p>Policy profile: {selectedScriptVersion.policy_profile_id}</p>
+                    <p>Generation profile: {selectedScriptVersion.generation_profile_key}</p>
+                  </div>
+                )}
+              </div>
+            ) : (
+              <>
             <div>
               <label htmlFor="new-session-character" className="mb-1 block text-sm font-medium text-text">
                 Character
@@ -519,8 +712,10 @@ export default function NewSessionDialog({
                 </div>
               )}
             </div>
+              </>
+            )}
 
-            {incompatiblePacks.length > 0 && selectedCharacter && (
+            {mode !== 'scripted_story' && incompatiblePacks.length > 0 && selectedCharacter && (
               <div className="rounded-md border border-warn/30 bg-warn/10 px-3 py-2 text-sm text-warn sm:col-span-2">
                 <p className="font-medium">Some packs are attached to other characters.</p>
                 <ul className="mt-1 list-disc space-y-1 pl-5">
@@ -534,7 +729,7 @@ export default function NewSessionDialog({
               </div>
             )}
 
-            {selectedPackWarnings.length > 0 && (
+            {mode !== 'scripted_story' && selectedPackWarnings.length > 0 && (
               <div className="rounded-md border border-warn/30 bg-warn/10 px-3 py-2 text-sm text-warn sm:col-span-2">
                 <p className="font-medium">Review pack readiness before starting.</p>
                 <ul className="mt-1 list-disc space-y-1 pl-5">
@@ -544,7 +739,18 @@ export default function NewSessionDialog({
                 </ul>
               </div>
             )}
-            {selectedPackRequiresAcknowledgement && (
+            {mode === 'scripted_story' && selectedScriptWarnings.length > 0 && (
+              <div className="rounded-md border border-warn/30 bg-warn/10 px-3 py-2 text-sm text-warn sm:col-span-2">
+                <p className="font-medium">Review script readiness before starting.</p>
+                <ul className="mt-1 list-disc space-y-1 pl-5">
+                  {selectedScriptWarnings.map((warning, index) => (
+                    <li key={`${warning}-${index}`}>{warning}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {((mode === 'scripted_story' && selectedScriptRequiresAcknowledgement) ||
+              (mode !== 'scripted_story' && selectedPackRequiresAcknowledgement)) && (
               <label className="flex items-start gap-2 rounded-md border border-warn/30 bg-warn/10 px-3 py-2 text-sm text-warn sm:col-span-2">
                 <input
                   checked={acknowledgedSetupWarnings}

--- a/apps/tldw-frontend/components/vn-play/SessionList.tsx
+++ b/apps/tldw-frontend/components/vn-play/SessionList.tsx
@@ -17,9 +17,11 @@ const modeFilters: Array<{ key: VNPlayModeFilter; label: string }> = [
   { key: 'all', label: 'All' },
   { key: 'freeform', label: 'Freeform' },
   { key: 'story', label: 'Story' },
+  { key: 'scripted_story', label: 'Scripted Story' },
 ];
 
 function modeLabel(mode: VNPlayMode): string {
+  if (mode === 'scripted_story') return 'Scripted Story';
   return mode === 'story' ? 'Story' : 'Freeform';
 }
 

--- a/apps/tldw-frontend/components/vn-play/VNPlayWorkspace.tsx
+++ b/apps/tldw-frontend/components/vn-play/VNPlayWorkspace.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { BookOpen, MessageSquarePlus } from 'lucide-react';
+import { BookOpen, MessageSquarePlus, ScrollText } from 'lucide-react';
 import Link from 'next/link';
 import { Badge } from '@web/components/ui/Badge';
 import { Button } from '@web/components/ui/Button';
@@ -54,6 +54,7 @@ import type {
 const GENERATION_HISTORY_PAGE_SIZE = 25;
 
 function sessionModeLabel(mode: VNPlayMode): string {
+  if (mode === 'scripted_story') return 'Scripted Story';
   return mode === 'story' ? 'Story/CYOA' : 'Freeform';
 }
 
@@ -181,7 +182,7 @@ export default function VNPlayWorkspace({
     sessionId: number,
     mode?: VNPlayMode | null
   ): Promise<{ error: string | null; navigation: VNPlayBranchNavigationResponse | null }> => {
-    if (mode !== 'story') {
+    if (mode !== 'story' && mode !== 'scripted_story') {
       return { error: null, navigation: null };
     }
 
@@ -268,7 +269,9 @@ export default function VNPlayWorkspace({
     let cancelled = false;
     async function loadSessionCollections() {
       setIsLoadingGenerations(true);
-      setIsLoadingBranchNavigation(selectedSession?.mode === 'story');
+      setIsLoadingBranchNavigation(
+        selectedSession?.mode === 'story' || selectedSession?.mode === 'scripted_story'
+      );
       try {
         const [
           nextEvents,
@@ -659,6 +662,21 @@ export default function VNPlayWorkspace({
                 <BookOpen aria-hidden className="h-4 w-4" />
                 New Story
               </Button>
+              <Button
+                className="gap-2"
+                onClick={() => handleNewSession('scripted_story')}
+                type="button"
+                variant="secondary"
+              >
+                <ScrollText aria-hidden className="h-4 w-4" />
+                New Scripted Story
+              </Button>
+              <Link
+                className="inline-flex items-center rounded-md border border-border px-3 py-2 text-sm font-medium text-text hover:bg-surface"
+                href="/vn-scripts"
+              >
+                VN scripts
+              </Link>
             </div>
           </div>
         </header>
@@ -724,7 +742,7 @@ export default function VNPlayWorkspace({
                       onError={handleTurnError}
                       onTurn={(response) => void handleTurn(response)}
                     />
-                    {selectedSession.mode === 'story' && (
+                    {(selectedSession.mode === 'story' || selectedSession.mode === 'scripted_story') && (
                       <ChoicePanel
                         choices={choices}
                         sceneVersion={sceneVersion}
@@ -739,7 +757,7 @@ export default function VNPlayWorkspace({
                 )}
               </div>
 
-              {selectedSession?.mode === 'story' && (
+              {(selectedSession?.mode === 'story' || selectedSession?.mode === 'scripted_story') && (
                 <>
                   {branchTimelineError && (
                     <div className="rounded-md border border-warn/30 bg-warn/10 px-3 py-2 text-sm text-warn">

--- a/apps/tldw-frontend/components/vn-play/VNPlayWorkspace.tsx
+++ b/apps/tldw-frontend/components/vn-play/VNPlayWorkspace.tsx
@@ -58,6 +58,10 @@ function sessionModeLabel(mode: VNPlayMode): string {
   return mode === 'story' ? 'Story/CYOA' : 'Freeform';
 }
 
+function hasBranchNavigation(mode?: VNPlayMode | null): boolean {
+  return mode === 'story' || mode === 'scripted_story';
+}
+
 function isVNPlayChoice(choice: VNPlayChoice | Record<string, unknown>): choice is VNPlayChoice {
   return (
     choice !== null &&
@@ -182,7 +186,7 @@ export default function VNPlayWorkspace({
     sessionId: number,
     mode?: VNPlayMode | null
   ): Promise<{ error: string | null; navigation: VNPlayBranchNavigationResponse | null }> => {
-    if (mode !== 'story' && mode !== 'scripted_story') {
+    if (!hasBranchNavigation(mode)) {
       return { error: null, navigation: null };
     }
 
@@ -201,7 +205,7 @@ export default function VNPlayWorkspace({
     sessionId: number,
     mode?: VNPlayMode | null
   ): Promise<VNPlayBranchNavigationResponse | null> => {
-    setIsLoadingBranchNavigation(mode === 'story');
+    setIsLoadingBranchNavigation(hasBranchNavigation(mode));
     try {
       const result = await fetchBranchNavigation(sessionId, mode);
       setBranchTimelineError(result.error);
@@ -269,9 +273,7 @@ export default function VNPlayWorkspace({
     let cancelled = false;
     async function loadSessionCollections() {
       setIsLoadingGenerations(true);
-      setIsLoadingBranchNavigation(
-        selectedSession?.mode === 'story' || selectedSession?.mode === 'scripted_story'
-      );
+      setIsLoadingBranchNavigation(hasBranchNavigation(selectedSession?.mode));
       try {
         const [
           nextEvents,

--- a/apps/tldw-frontend/components/vn-scripts/VNScriptsWorkbench.tsx
+++ b/apps/tldw-frontend/components/vn-scripts/VNScriptsWorkbench.tsx
@@ -1,9 +1,8 @@
-import React, { FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
+import React, { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Badge } from '@web/components/ui/Badge';
 import { Button } from '@web/components/ui/Button';
 import { Input } from '@web/components/ui/Input';
 import JsonEditor from '@web/components/ui/JsonEditor';
-import JsonViewer from '@web/components/ui/JsonViewer';
 import {
   createVNScript,
   evaluateVNScriptVersionPolicy,
@@ -20,10 +19,8 @@ import type {
   VNScriptContentRating,
   VNScriptDiagnosticsResponse,
   VNScriptDraftResponse,
-  VNScriptManifestSnapshotResponse,
   VNScriptResponse,
   VNScriptValidationResponse,
-  VNScriptVersionPolicyEvaluateResponse,
   VNScriptVersionResponse,
 } from '@web/types/vn-scripts';
 
@@ -34,16 +31,29 @@ function formatJson(value: unknown): string {
 }
 
 function errorMessage(error: unknown, fallback: string): string {
-  if (error instanceof Error && error.message) return error.message;
+  if (error instanceof Error && error.message) {
+    const message = error.message.trim();
+    if (/^[a-z0-9_.:-]{1,120}$/i.test(message)) return message;
+  }
   return fallback;
 }
 
-function createPublishIdempotencyKey(scriptId: number): string {
-  const suffix =
-    typeof crypto !== 'undefined' && 'randomUUID' in crypto
-      ? crypto.randomUUID()
-      : Math.random().toString(36).slice(2);
-  return `vn-script-publish-${scriptId}-${Date.now()}-${suffix}`;
+function randomIdSuffix(): string {
+  const randomSource = globalThis.crypto;
+  if (randomSource && 'randomUUID' in randomSource) {
+    return randomSource.randomUUID();
+  }
+  if (randomSource && 'getRandomValues' in randomSource) {
+    const values = new Uint32Array(2);
+    randomSource.getRandomValues(values);
+    return Array.from(values, (value) => value.toString(36)).join('-');
+  }
+  const highResolutionTime = globalThis.performance?.now?.() ?? Date.now();
+  return `${Date.now()}-${highResolutionTime.toString(36).replace('.', '')}`;
+}
+
+function createPublishIdempotencyKey(scriptId: number, draftRevision: number): string {
+  return `vn-script-publish-${scriptId}-${draftRevision}-${randomIdSuffix()}`;
 }
 
 function validationBadge(validation: Record<string, unknown>): string {
@@ -61,6 +71,31 @@ function statusVariant(status: string): 'neutral' | 'success' | 'warning' | 'dan
   return 'info';
 }
 
+function isSensitiveKey(key: string): boolean {
+  return /(raw|debug|secret|token|credential|internal|prompt)/i.test(key);
+}
+
+function summarizeValue(value: unknown, depth = 0): unknown {
+  if (depth > 3) return '[truncated]';
+  if (Array.isArray(value)) {
+    return value.slice(0, 8).map((item) => summarizeValue(item, depth + 1));
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, nestedValue]) => [
+        key,
+        isSensitiveKey(key) ? '[redacted]' : summarizeValue(nestedValue, depth + 1),
+      ])
+    );
+  }
+  return value;
+}
+
+function summaryLines(value: unknown): string[] {
+  const summarized = summarizeValue(value);
+  return (JSON.stringify(summarized ?? null, null, 2) ?? 'null').split('\n');
+}
+
 export default function VNScriptsWorkbench() {
   const [scripts, setScripts] = useState<VNScriptResponse[]>([]);
   const [selectedScript, setSelectedScript] = useState<VNScriptResponse | null>(null);
@@ -69,8 +104,8 @@ export default function VNScriptsWorkbench() {
   const [versions, setVersions] = useState<VNScriptVersionResponse[]>([]);
   const [validation, setValidation] = useState<VNScriptValidationResponse | null>(null);
   const [diagnostics, setDiagnostics] = useState<VNScriptDiagnosticsResponse | null>(null);
-  const [manifestSnapshots, setManifestSnapshots] = useState<Record<number, VNScriptManifestSnapshotResponse>>({});
-  const [policySummaries, setPolicySummaries] = useState<Record<number, VNScriptVersionPolicyEvaluateResponse>>({});
+  const [manifestSnapshots, setManifestSnapshots] = useState<Record<number, unknown>>({});
+  const [policySummaries, setPolicySummaries] = useState<Record<number, unknown>>({});
   const [isLoadingScripts, setIsLoadingScripts] = useState(true);
   const [isCreating, setIsCreating] = useState(false);
   const [isSavingDraft, setIsSavingDraft] = useState(false);
@@ -87,6 +122,12 @@ export default function VNScriptsWorkbench() {
   const [generationProfileId, setGenerationProfileId] = useState('');
   const [contentRating, setContentRating] = useState<VNScriptContentRating>('teen');
   const [publishLabel, setPublishLabel] = useState('');
+  const selectedScriptIdRef = useRef<number | null>(null);
+  const publishKeyRef = useRef<Record<string, string>>({});
+
+  useEffect(() => {
+    selectedScriptIdRef.current = selectedScript?.id ?? null;
+  }, [selectedScript?.id]);
 
   const selectedMeta = useMemo(() => {
     if (!selectedScript) return null;
@@ -100,7 +141,9 @@ export default function VNScriptsWorkbench() {
 
   const refreshVersions = useCallback(async (scriptId: number) => {
     const nextVersions = await listVNScriptVersions(scriptId);
-    setVersions(nextVersions.items ?? []);
+    if (selectedScriptIdRef.current === scriptId) {
+      setVersions(nextVersions.items ?? []);
+    }
   }, []);
 
   useEffect(() => {
@@ -142,6 +185,9 @@ export default function VNScriptsWorkbench() {
 
     let cancelled = false;
     async function loadScriptDetails() {
+      setDraft(null);
+      setDraftText('{}');
+      setVersions([]);
       setError(null);
       setEditorError(null);
       setStatusMessage(null);
@@ -279,20 +325,56 @@ export default function VNScriptsWorkbench() {
 
   const handlePublish = useCallback(async () => {
     if (!selectedScript || !draft) return;
+    const scriptId = selectedScript.id;
+    const publishScope = `${scriptId}:${draft.revision}`;
+    const idempotencyKey =
+      publishKeyRef.current[publishScope] ?? createPublishIdempotencyKey(scriptId, draft.revision);
+    publishKeyRef.current[publishScope] = idempotencyKey;
+
     setIsPublishing(true);
     setError(null);
     setStatusMessage(null);
+    let response: Awaited<ReturnType<typeof publishVNScript>>;
     try {
-      const response = await publishVNScript(selectedScript.id, {
+      response = await publishVNScript(scriptId, {
         draft_revision: draft.revision,
         label: publishLabel.trim() || null,
-        idempotency_key: createPublishIdempotencyKey(selectedScript.id),
+        idempotency_key: idempotencyKey,
         acknowledgements: [],
       });
-      setStatusMessage(`Published version ${response.version_number}.`);
-      await refreshVersions(selectedScript.id);
     } catch (publishError) {
       setError(errorMessage(publishError, 'Failed to publish script'));
+      setIsPublishing(false);
+      return;
+    }
+
+    delete publishKeyRef.current[publishScope];
+    setVersions((previous) => {
+      if (selectedScriptIdRef.current !== scriptId) return previous;
+      const optimisticVersion: VNScriptVersionResponse = {
+        id: response.version_id,
+        script_id: response.script_id,
+        version_number: response.version_number,
+        label: publishLabel.trim() || null,
+        draft_revision: draft.revision,
+        program: {},
+        asset_pack_id: response.asset_pack_id,
+        manifest_snapshot_id: response.manifest_snapshot_id,
+        policy_snapshot_id: response.policy_snapshot_id,
+        generation_profile_snapshot_id: response.generation_profile_snapshot_id,
+        generation_profile_snapshots: response.generation_profile_snapshots,
+        script_defaults: {},
+        validation: response.validation,
+        created_at: response.created_at,
+      };
+      return [optimisticVersion, ...previous.filter((version) => version.id !== optimisticVersion.id)];
+    });
+
+    try {
+      setStatusMessage(`Published version ${response.version_number}.`);
+      await refreshVersions(scriptId);
+    } catch (refreshError) {
+      setError(errorMessage(refreshError, 'Published, but failed to refresh versions'));
     } finally {
       setIsPublishing(false);
     }
@@ -303,7 +385,16 @@ export default function VNScriptsWorkbench() {
     setError(null);
     try {
       const snapshot = await getVNScriptManifestSnapshot(selectedScript.id, version.id);
-      setManifestSnapshots((previous) => ({ ...previous, [version.id]: snapshot }));
+      setManifestSnapshots((previous) => ({
+        ...previous,
+        [version.id]: {
+          id: snapshot.id,
+          asset_pack_id: snapshot.asset_pack_id,
+          manifest_hash: snapshot.manifest_hash,
+          manifest_summary: summarizeValue(snapshot.manifest),
+          created_at: snapshot.created_at,
+        },
+      }));
     } catch (manifestError) {
       setError(errorMessage(manifestError, 'Failed to load manifest snapshot'));
     }
@@ -314,7 +405,17 @@ export default function VNScriptsWorkbench() {
     setError(null);
     try {
       const summary = await evaluateVNScriptVersionPolicy(selectedScript.id, version.id);
-      setPolicySummaries((previous) => ({ ...previous, [version.id]: summary }));
+      setPolicySummaries((previous) => ({
+        ...previous,
+        [version.id]: {
+          decision: summary.decision,
+          profile_id: summary.profile_id,
+          blocked: summary.blocked,
+          requires_acknowledgement: summary.requires_acknowledgement,
+          reasons: summarizeValue(summary.reasons),
+          remediation: summary.remediation,
+        },
+      }));
     } catch (policyError) {
       setError(errorMessage(policyError, 'Failed to evaluate version policy'));
     }
@@ -455,7 +556,9 @@ export default function VNScriptsWorkbench() {
                   </Button>
                 </div>
               </div>
-              <JsonEditor value={draftText} onChange={setDraftText} height="52vh" readOnly={!selectedScript} />
+              <div className="min-h-[420px] flex-1">
+                <JsonEditor value={draftText} onChange={setDraftText} height="100%" readOnly={!selectedScript} />
+              </div>
             </div>
           </section>
 
@@ -509,7 +612,9 @@ export default function VNScriptsWorkbench() {
                 </Button>
               </div>
               {diagnostics ? (
-                <JsonViewer data={diagnostics.diagnostics} className="max-h-56 rounded-md bg-bg p-2 text-xs" />
+                <pre className="max-h-56 overflow-auto rounded-md bg-bg p-2 text-xs">
+                  {summaryLines(diagnostics.diagnostics).join('\n')}
+                </pre>
               ) : (
                 <p className="text-sm text-text-muted">Diagnostics are loaded on demand from the draft endpoint.</p>
               )}
@@ -579,13 +684,17 @@ export default function VNScriptsWorkbench() {
                     {manifestSnapshots[version.id] && (
                       <div className="mt-3">
                         <h4 className="mb-1 text-xs font-semibold uppercase text-text-muted">Manifest summary</h4>
-                        <JsonViewer data={manifestSnapshots[version.id]} className="max-h-48 rounded-md bg-surface2 p-2 text-xs" />
+                        <pre className="max-h-48 overflow-auto rounded-md bg-surface2 p-2 text-xs">
+                          {summaryLines(manifestSnapshots[version.id]).join('\n')}
+                        </pre>
                       </div>
                     )}
                     {policySummaries[version.id] && (
                       <div className="mt-3">
                         <h4 className="mb-1 text-xs font-semibold uppercase text-text-muted">Policy summary</h4>
-                        <JsonViewer data={policySummaries[version.id]} className="max-h-48 rounded-md bg-surface2 p-2 text-xs" />
+                        <pre className="max-h-48 overflow-auto rounded-md bg-surface2 p-2 text-xs">
+                          {summaryLines(policySummaries[version.id]).join('\n')}
+                        </pre>
                       </div>
                     )}
                   </article>

--- a/apps/tldw-frontend/components/vn-scripts/VNScriptsWorkbench.tsx
+++ b/apps/tldw-frontend/components/vn-scripts/VNScriptsWorkbench.tsx
@@ -1,0 +1,600 @@
+import React, { FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
+import { Badge } from '@web/components/ui/Badge';
+import { Button } from '@web/components/ui/Button';
+import { Input } from '@web/components/ui/Input';
+import JsonEditor from '@web/components/ui/JsonEditor';
+import JsonViewer from '@web/components/ui/JsonViewer';
+import {
+  createVNScript,
+  evaluateVNScriptVersionPolicy,
+  getVNScriptDiagnostics,
+  getVNScriptDraft,
+  getVNScriptManifestSnapshot,
+  listVNScripts,
+  listVNScriptVersions,
+  publishVNScript,
+  putVNScriptDraft,
+  validateVNScriptDraft,
+} from '@web/lib/api/vnScripts';
+import type {
+  VNScriptContentRating,
+  VNScriptDiagnosticsResponse,
+  VNScriptDraftResponse,
+  VNScriptManifestSnapshotResponse,
+  VNScriptResponse,
+  VNScriptValidationResponse,
+  VNScriptVersionPolicyEvaluateResponse,
+  VNScriptVersionResponse,
+} from '@web/types/vn-scripts';
+
+const contentRatings: VNScriptContentRating[] = ['general', 'teen', 'suggestive', 'mature'];
+
+function formatJson(value: unknown): string {
+  return JSON.stringify(value ?? {}, null, 2);
+}
+
+function errorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message) return error.message;
+  return fallback;
+}
+
+function createPublishIdempotencyKey(scriptId: number): string {
+  const suffix =
+    typeof crypto !== 'undefined' && 'randomUUID' in crypto
+      ? crypto.randomUUID()
+      : Math.random().toString(36).slice(2);
+  return `vn-script-publish-${scriptId}-${Date.now()}-${suffix}`;
+}
+
+function validationBadge(validation: Record<string, unknown>): string {
+  if (typeof validation.valid === 'boolean') {
+    return validation.valid ? 'Valid' : 'Invalid';
+  }
+  if (typeof validation.status === 'string') return validation.status;
+  return 'Validation saved';
+}
+
+function statusVariant(status: string): 'neutral' | 'success' | 'warning' | 'danger' | 'info' {
+  if (status === 'ready' || status === 'published') return 'success';
+  if (status === 'archived') return 'neutral';
+  if (status === 'draft') return 'warning';
+  return 'info';
+}
+
+export default function VNScriptsWorkbench() {
+  const [scripts, setScripts] = useState<VNScriptResponse[]>([]);
+  const [selectedScript, setSelectedScript] = useState<VNScriptResponse | null>(null);
+  const [draft, setDraft] = useState<VNScriptDraftResponse | null>(null);
+  const [draftText, setDraftText] = useState('{}');
+  const [versions, setVersions] = useState<VNScriptVersionResponse[]>([]);
+  const [validation, setValidation] = useState<VNScriptValidationResponse | null>(null);
+  const [diagnostics, setDiagnostics] = useState<VNScriptDiagnosticsResponse | null>(null);
+  const [manifestSnapshots, setManifestSnapshots] = useState<Record<number, VNScriptManifestSnapshotResponse>>({});
+  const [policySummaries, setPolicySummaries] = useState<Record<number, VNScriptVersionPolicyEvaluateResponse>>({});
+  const [isLoadingScripts, setIsLoadingScripts] = useState(true);
+  const [isCreating, setIsCreating] = useState(false);
+  const [isSavingDraft, setIsSavingDraft] = useState(false);
+  const [isValidating, setIsValidating] = useState(false);
+  const [isLoadingDiagnostics, setIsLoadingDiagnostics] = useState(false);
+  const [isPublishing, setIsPublishing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [editorError, setEditorError] = useState<string | null>(null);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+
+  const [title, setTitle] = useState('Untitled VN script');
+  const [primaryAssetPackId, setPrimaryAssetPackId] = useState('1');
+  const [policyProfileId, setPolicyProfileId] = useState('');
+  const [generationProfileId, setGenerationProfileId] = useState('');
+  const [contentRating, setContentRating] = useState<VNScriptContentRating>('teen');
+  const [publishLabel, setPublishLabel] = useState('');
+
+  const selectedMeta = useMemo(() => {
+    if (!selectedScript) return null;
+    return [
+      ['Asset pack', selectedScript.primary_asset_pack_id],
+      ['Policy', selectedScript.policy_profile_id],
+      ['Generation', selectedScript.generation_profile_id],
+      ['Rating', selectedScript.content_rating],
+    ];
+  }, [selectedScript]);
+
+  const refreshVersions = useCallback(async (scriptId: number) => {
+    const nextVersions = await listVNScriptVersions(scriptId);
+    setVersions(nextVersions.items ?? []);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadScripts() {
+      setIsLoadingScripts(true);
+      setError(null);
+      try {
+        const response = await listVNScripts({ limit: 25, offset: 0 });
+        if (cancelled) return;
+        const nextScripts = response.items ?? [];
+        setScripts(nextScripts);
+        setSelectedScript(nextScripts[0] ?? null);
+      } catch (loadError) {
+        if (!cancelled) setError(errorMessage(loadError, 'Failed to load VN scripts'));
+      } finally {
+        if (!cancelled) setIsLoadingScripts(false);
+      }
+    }
+
+    void loadScripts();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!selectedScript) {
+      setDraft(null);
+      setDraftText('{}');
+      setVersions([]);
+      setValidation(null);
+      setDiagnostics(null);
+      setManifestSnapshots({});
+      setPolicySummaries({});
+      return;
+    }
+
+    let cancelled = false;
+    async function loadScriptDetails() {
+      setError(null);
+      setEditorError(null);
+      setStatusMessage(null);
+      setValidation(null);
+      setDiagnostics(null);
+      setManifestSnapshots({});
+      setPolicySummaries({});
+      try {
+        const [nextDraft, nextVersions] = await Promise.all([
+          getVNScriptDraft(selectedScript.id),
+          listVNScriptVersions(selectedScript.id),
+        ]);
+        if (cancelled) return;
+        setDraft(nextDraft);
+        setDraftText(formatJson(nextDraft.draft));
+        setVersions(nextVersions.items ?? []);
+      } catch (loadError) {
+        if (!cancelled) {
+          setDraft(null);
+          setDraftText('{}');
+          setVersions([]);
+          setError(errorMessage(loadError, 'Failed to load script draft or versions'));
+        }
+      }
+    }
+
+    void loadScriptDetails();
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedScript]);
+
+  const parseDraftText = useCallback((): Record<string, unknown> | null => {
+    try {
+      const parsed = JSON.parse(draftText);
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        setEditorError('Draft JSON must be an object.');
+        return null;
+      }
+      setEditorError(null);
+      return parsed as Record<string, unknown>;
+    } catch (parseError) {
+      setEditorError(
+        `Draft JSON is invalid: ${parseError instanceof Error ? parseError.message : 'Parse failed'}`
+      );
+      return null;
+    }
+  }, [draftText]);
+
+  const handleCreateScript = useCallback(async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const parsedAssetPackId = Number(primaryAssetPackId);
+    if (!title.trim() || !Number.isInteger(parsedAssetPackId) || parsedAssetPackId <= 0) {
+      setError('Enter a title and a positive primary asset pack ID.');
+      return;
+    }
+
+    setIsCreating(true);
+    setError(null);
+    setStatusMessage(null);
+    try {
+      const created = await createVNScript({
+        title: title.trim(),
+        primary_asset_pack_id: parsedAssetPackId,
+        ...(policyProfileId.trim() ? { policy_profile_id: policyProfileId.trim() } : {}),
+        ...(generationProfileId.trim() ? { generation_profile_id: generationProfileId.trim() } : {}),
+        content_rating: contentRating,
+      });
+      setScripts((previous) => [created, ...previous.filter((script) => script.id !== created.id)]);
+      setSelectedScript(created);
+      setStatusMessage(`Created script #${created.id}.`);
+    } catch (createError) {
+      setError(errorMessage(createError, 'Failed to create VN script'));
+    } finally {
+      setIsCreating(false);
+    }
+  }, [contentRating, generationProfileId, policyProfileId, primaryAssetPackId, title]);
+
+  const handleSaveDraft = useCallback(async () => {
+    if (!selectedScript || !draft) return;
+    const parsed = parseDraftText();
+    if (!parsed) return;
+
+    setIsSavingDraft(true);
+    setError(null);
+    setStatusMessage(null);
+    try {
+      const updated = await putVNScriptDraft(selectedScript.id, {
+        if_revision: draft.revision,
+        draft: parsed,
+      });
+      setDraft(updated);
+      setDraftText(formatJson(updated.draft));
+      setStatusMessage(`Draft saved at revision ${updated.revision}.`);
+    } catch (saveError) {
+      setError(errorMessage(saveError, 'Failed to save draft'));
+    } finally {
+      setIsSavingDraft(false);
+    }
+  }, [draft, parseDraftText, selectedScript]);
+
+  const handleValidate = useCallback(async () => {
+    if (!selectedScript) return;
+    const requestDraft = parseDraftText();
+    if (!requestDraft) return;
+
+    setIsValidating(true);
+    setError(null);
+    setStatusMessage(null);
+    try {
+      const result = await validateVNScriptDraft(selectedScript.id, {
+        draft: requestDraft,
+      });
+      setValidation(result);
+    } catch (validateError) {
+      setError(errorMessage(validateError, 'Failed to validate draft'));
+    } finally {
+      setIsValidating(false);
+    }
+  }, [parseDraftText, selectedScript]);
+
+  const handleDiagnostics = useCallback(async () => {
+    if (!selectedScript) return;
+    setIsLoadingDiagnostics(true);
+    setError(null);
+    try {
+      const result = await getVNScriptDiagnostics(selectedScript.id);
+      setDiagnostics(result);
+    } catch (diagnosticsError) {
+      setError(errorMessage(diagnosticsError, 'Failed to load diagnostics'));
+    } finally {
+      setIsLoadingDiagnostics(false);
+    }
+  }, [selectedScript]);
+
+  const handlePublish = useCallback(async () => {
+    if (!selectedScript || !draft) return;
+    setIsPublishing(true);
+    setError(null);
+    setStatusMessage(null);
+    try {
+      const response = await publishVNScript(selectedScript.id, {
+        draft_revision: draft.revision,
+        label: publishLabel.trim() || null,
+        idempotency_key: createPublishIdempotencyKey(selectedScript.id),
+        acknowledgements: [],
+      });
+      setStatusMessage(`Published version ${response.version_number}.`);
+      await refreshVersions(selectedScript.id);
+    } catch (publishError) {
+      setError(errorMessage(publishError, 'Failed to publish script'));
+    } finally {
+      setIsPublishing(false);
+    }
+  }, [draft, publishLabel, refreshVersions, selectedScript]);
+
+  const handleManifestSnapshot = useCallback(async (version: VNScriptVersionResponse) => {
+    if (!selectedScript) return;
+    setError(null);
+    try {
+      const snapshot = await getVNScriptManifestSnapshot(selectedScript.id, version.id);
+      setManifestSnapshots((previous) => ({ ...previous, [version.id]: snapshot }));
+    } catch (manifestError) {
+      setError(errorMessage(manifestError, 'Failed to load manifest snapshot'));
+    }
+  }, [selectedScript]);
+
+  const handlePolicyEvaluate = useCallback(async (version: VNScriptVersionResponse) => {
+    if (!selectedScript) return;
+    setError(null);
+    try {
+      const summary = await evaluateVNScriptVersionPolicy(selectedScript.id, version.id);
+      setPolicySummaries((previous) => ({ ...previous, [version.id]: summary }));
+    } catch (policyError) {
+      setError(errorMessage(policyError, 'Failed to evaluate version policy'));
+    }
+  }, [selectedScript]);
+
+  return (
+    <main className="min-h-screen bg-bg text-text">
+      <div className="flex min-h-screen flex-col gap-3 p-4">
+        <header className="flex flex-wrap items-center justify-between gap-3 border-b border-border pb-3">
+          <div>
+            <h1 className="text-xl font-semibold">VN Scripts</h1>
+            <p className="text-sm text-text-muted">Author JSON drafts, inspect backend validation, and publish immutable versions.</p>
+          </div>
+          <div className="flex items-center gap-2 text-xs text-text-muted">
+            <Badge variant="info">Backend-owned validation</Badge>
+            <span>{scripts.length} loaded</span>
+          </div>
+        </header>
+
+        {(error || editorError || statusMessage) && (
+          <section className="grid gap-2 md:grid-cols-3">
+            {error && <div className="rounded-md border border-danger/30 bg-danger/10 p-2 text-sm text-danger">{error}</div>}
+            {editorError && <div className="rounded-md border border-warn/30 bg-warn/10 p-2 text-sm text-warn">{editorError}</div>}
+            {statusMessage && <div className="rounded-md border border-success/30 bg-success/10 p-2 text-sm text-success">{statusMessage}</div>}
+          </section>
+        )}
+
+        <div className="grid min-h-0 flex-1 gap-3 xl:grid-cols-[320px_minmax(0,1fr)_420px]">
+          <aside className="flex min-h-0 flex-col gap-3 border-r border-border pr-3">
+            <section className="rounded-md border border-border bg-surface p-3">
+              <div className="mb-2 flex items-center justify-between">
+                <h2 className="text-sm font-semibold">Scripts</h2>
+                {isLoadingScripts && <span className="text-xs text-text-muted">Loading...</span>}
+              </div>
+              <div className="max-h-80 space-y-2 overflow-auto">
+                {scripts.length === 0 && !isLoadingScripts && (
+                  <p className="text-sm text-text-muted">No VN scripts yet.</p>
+                )}
+                {scripts.map((script) => (
+                  <button
+                    key={script.id}
+                    type="button"
+                    onClick={() => setSelectedScript(script)}
+                    className={`w-full rounded-md border p-2 text-left text-sm transition ${
+                      selectedScript?.id === script.id
+                        ? 'border-primary bg-primary/10'
+                        : 'border-border bg-bg hover:bg-surface2'
+                    }`}
+                  >
+                    <span className="block font-medium">{script.title}</span>
+                    <span className="mt-1 flex flex-wrap items-center gap-2 text-xs text-text-muted">
+                      <Badge variant={statusVariant(script.status)}>{script.status}</Badge>
+                      <span>#{script.id}</span>
+                      <span>Pack {script.primary_asset_pack_id}</span>
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </section>
+
+            <form onSubmit={handleCreateScript} className="rounded-md border border-border bg-surface p-3">
+              <h2 className="mb-3 text-sm font-semibold">Create script</h2>
+              <div className="space-y-3">
+                <Input label="Title" value={title} onChange={(event) => setTitle(event.target.value)} />
+                <Input
+                  label="Primary asset pack ID"
+                  inputMode="numeric"
+                  value={primaryAssetPackId}
+                  onChange={(event) => setPrimaryAssetPackId(event.target.value)}
+                />
+                <Input
+                  label="Policy profile ID"
+                  value={policyProfileId}
+                  onChange={(event) => setPolicyProfileId(event.target.value)}
+                />
+                <Input
+                  label="Generation profile ID"
+                  value={generationProfileId}
+                  onChange={(event) => setGenerationProfileId(event.target.value)}
+                />
+                <label className="block text-sm font-medium text-text" htmlFor="vn-script-content-rating">
+                  Content rating
+                </label>
+                <select
+                  id="vn-script-content-rating"
+                  className="block w-full rounded-md border-border bg-bg shadow-sm focus:border-primary focus:ring-primary"
+                  value={contentRating}
+                  onChange={(event) => setContentRating(event.target.value as VNScriptContentRating)}
+                >
+                  {contentRatings.map((rating) => (
+                    <option key={rating} value={rating}>{rating}</option>
+                  ))}
+                </select>
+                <Button type="submit" size="sm" loading={isCreating} className="w-full">Create script</Button>
+              </div>
+            </form>
+          </aside>
+
+          <section className="flex min-h-0 flex-col gap-3">
+            <div className="rounded-md border border-border bg-surface p-3">
+              {selectedScript ? (
+                <>
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <h2 className="text-lg font-semibold">{selectedScript.title}</h2>
+                      <p className="text-sm text-text-muted">Script #{selectedScript.id}</p>
+                    </div>
+                    <Badge variant={statusVariant(selectedScript.status)}>{selectedScript.status}</Badge>
+                  </div>
+                  <dl className="mt-3 grid gap-2 text-sm sm:grid-cols-2 lg:grid-cols-4">
+                    {selectedMeta?.map(([label, value]) => (
+                      <div key={label} className="rounded-md border border-border bg-bg p-2">
+                        <dt className="text-xs uppercase text-text-muted">{label}</dt>
+                        <dd className="mt-1 break-words font-medium">{value}</dd>
+                      </div>
+                    ))}
+                  </dl>
+                </>
+              ) : (
+                <p className="text-sm text-text-muted">Select or create a script to edit its draft.</p>
+              )}
+            </div>
+
+            <div className="min-h-0 flex-1 rounded-md border border-border bg-surface p-3">
+              <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+                <div>
+                  <h2 className="text-sm font-semibold">Draft JSON</h2>
+                  <p className="text-xs text-text-muted">
+                    Revision {draft?.revision ?? 'n/a'}; JSON parsing only, opcode semantics stay on the API server.
+                  </p>
+                </div>
+                <div className="flex gap-2">
+                  <Button type="button" size="sm" variant="secondary" loading={isValidating} disabled={!selectedScript} onClick={handleValidate}>
+                    Validate
+                  </Button>
+                  <Button type="button" size="sm" loading={isSavingDraft} disabled={!selectedScript || !draft} onClick={handleSaveDraft}>
+                    Save draft
+                  </Button>
+                </div>
+              </div>
+              <JsonEditor value={draftText} onChange={setDraftText} height="52vh" readOnly={!selectedScript} />
+            </div>
+          </section>
+
+          <aside className="flex min-h-0 flex-col gap-3 overflow-auto">
+            <section className="rounded-md border border-border bg-surface p-3">
+              <div className="mb-3 flex items-center justify-between gap-2">
+                <h2 className="text-sm font-semibold">Validation</h2>
+                {validation && (
+                  <Badge variant={validation.valid ? 'success' : 'danger'}>
+                    {validation.valid ? 'Valid' : 'Invalid'}
+                  </Badge>
+                )}
+              </div>
+              {validation ? (
+                <div className="space-y-3 text-sm">
+                  <div>
+                    <h3 className="mb-1 text-xs font-semibold uppercase text-text-muted">Errors</h3>
+                    {validation.errors.length === 0 ? (
+                      <p className="text-text-muted">No errors.</p>
+                    ) : (
+                      <ul className="space-y-1">
+                        {validation.errors.map((item, index) => (
+                          <li key={index} className="rounded-md bg-danger/10 p-2 text-danger">{formatJson(item)}</li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+                  <div>
+                    <h3 className="mb-1 text-xs font-semibold uppercase text-text-muted">Warnings</h3>
+                    {validation.warnings.length === 0 ? (
+                      <p className="text-text-muted">No warnings.</p>
+                    ) : (
+                      <ul className="space-y-1">
+                        {validation.warnings.map((item, index) => (
+                          <li key={index} className="rounded-md bg-warn/10 p-2 text-warn">{formatJson(item)}</li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+                </div>
+              ) : (
+                <p className="text-sm text-text-muted">Run backend validation to see script readiness.</p>
+              )}
+            </section>
+
+            <section className="rounded-md border border-border bg-surface p-3">
+              <div className="mb-3 flex items-center justify-between gap-2">
+                <h2 className="text-sm font-semibold">Diagnostics</h2>
+                <Button type="button" size="xs" variant="secondary" loading={isLoadingDiagnostics} disabled={!selectedScript} onClick={handleDiagnostics}>
+                  Diagnostics
+                </Button>
+              </div>
+              {diagnostics ? (
+                <JsonViewer data={diagnostics.diagnostics} className="max-h-56 rounded-md bg-bg p-2 text-xs" />
+              ) : (
+                <p className="text-sm text-text-muted">Diagnostics are loaded on demand from the draft endpoint.</p>
+              )}
+            </section>
+
+            <section className="rounded-md border border-border bg-surface p-3">
+              <h2 className="mb-3 text-sm font-semibold">Publish</h2>
+              <div className="space-y-3">
+                <Input label="Publish label" value={publishLabel} onChange={(event) => setPublishLabel(event.target.value)} />
+                <p className="text-xs text-text-muted">
+                  Publish acknowledgements are only sent when the backend exposes publish-safe codes.
+                </p>
+                <Button type="button" size="sm" loading={isPublishing} disabled={!selectedScript || !draft} onClick={handlePublish}>
+                  Publish
+                </Button>
+              </div>
+            </section>
+
+            <section className="rounded-md border border-border bg-surface p-3">
+              <div className="mb-3 flex items-center justify-between gap-2">
+                <h2 className="text-sm font-semibold">Published versions</h2>
+                <Badge variant="neutral">{versions.length}</Badge>
+              </div>
+              <div className="space-y-3">
+                {versions.length === 0 && <p className="text-sm text-text-muted">No published versions yet.</p>}
+                {versions.map((version) => (
+                  <article
+                    key={version.id}
+                    data-testid={`version-${version.id}`}
+                    className="rounded-md border border-border bg-bg p-3"
+                  >
+                    <div className="flex flex-wrap items-start justify-between gap-2">
+                      <div>
+                        <h3 className="font-medium">Version {version.version_number}</h3>
+                        {version.label && <p className="text-sm text-text-muted">{version.label}</p>}
+                      </div>
+                      <Badge variant={validationBadge(version.validation) === 'Valid' ? 'success' : 'warning'}>
+                        {validationBadge(version.validation)}
+                      </Badge>
+                    </div>
+                    <dl className="mt-3 grid grid-cols-2 gap-2 text-xs">
+                      <div><dt className="text-text-muted">Manifest</dt><dd>Manifest {version.manifest_snapshot_id}</dd></div>
+                      <div><dt className="text-text-muted">Policy</dt><dd>Policy {version.policy_snapshot_id}</dd></div>
+                      <div><dt className="text-text-muted">Generation</dt><dd>Generation {version.generation_profile_snapshot_id}</dd></div>
+                      <div><dt className="text-text-muted">Created</dt><dd>{version.created_at}</dd></div>
+                    </dl>
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      <Button
+                        type="button"
+                        size="xs"
+                        variant="secondary"
+                        aria-label={`Load manifest for version ${version.version_number}`}
+                        onClick={() => void handleManifestSnapshot(version)}
+                      >
+                        Manifest
+                      </Button>
+                      <Button
+                        type="button"
+                        size="xs"
+                        variant="secondary"
+                        aria-label={`Evaluate policy for version ${version.version_number}`}
+                        onClick={() => void handlePolicyEvaluate(version)}
+                      >
+                        Policy
+                      </Button>
+                    </div>
+                    {manifestSnapshots[version.id] && (
+                      <div className="mt-3">
+                        <h4 className="mb-1 text-xs font-semibold uppercase text-text-muted">Manifest summary</h4>
+                        <JsonViewer data={manifestSnapshots[version.id]} className="max-h-48 rounded-md bg-surface2 p-2 text-xs" />
+                      </div>
+                    )}
+                    {policySummaries[version.id] && (
+                      <div className="mt-3">
+                        <h4 className="mb-1 text-xs font-semibold uppercase text-text-muted">Policy summary</h4>
+                        <JsonViewer data={policySummaries[version.id]} className="max-h-48 rounded-md bg-surface2 p-2 text-xs" />
+                      </div>
+                    )}
+                  </article>
+                ))}
+              </div>
+            </section>
+          </aside>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/tldw-frontend/lib/api/vnScripts.ts
+++ b/apps/tldw-frontend/lib/api/vnScripts.ts
@@ -1,0 +1,117 @@
+import { apiClient } from '@web/lib/api';
+import type {
+  VNScriptCreate,
+  VNScriptDiagnosticsResponse,
+  VNScriptDraftPutRequest,
+  VNScriptDraftResponse,
+  VNScriptListQuery,
+  VNScriptListResponse,
+  VNScriptManifestSnapshotResponse,
+  VNScriptPatch,
+  VNScriptPublishRequest,
+  VNScriptPublishResponse,
+  VNScriptResponse,
+  VNScriptValidateRequest,
+  VNScriptValidationResponse,
+  VNScriptVersionListQuery,
+  VNScriptVersionListResponse,
+  VNScriptVersionPolicyEvaluateRequest,
+  VNScriptVersionPolicyEvaluateResponse,
+  VNScriptVersionResponse,
+} from '@web/types/vn-scripts';
+
+const VN_SCRIPTS_BASE = '/vn/vn-scripts';
+
+type QueryParams = Record<string, string | number | boolean | null | undefined>;
+
+function toQueryParams<T extends object>(query: T): QueryParams {
+  return { ...query } as QueryParams;
+}
+
+export function createVNScript(request: VNScriptCreate): Promise<VNScriptResponse> {
+  return apiClient.post(`${VN_SCRIPTS_BASE}/scripts`, request);
+}
+
+export function listVNScripts(query: VNScriptListQuery = {}): Promise<VNScriptListResponse> {
+  return apiClient.get(`${VN_SCRIPTS_BASE}/scripts`, { params: toQueryParams(query) });
+}
+
+export function getVNScript(scriptId: number): Promise<VNScriptResponse> {
+  return apiClient.get(`${VN_SCRIPTS_BASE}/scripts/${scriptId}`);
+}
+
+export function patchVNScript(
+  scriptId: number,
+  request: VNScriptPatch
+): Promise<VNScriptResponse> {
+  return apiClient.patch(`${VN_SCRIPTS_BASE}/scripts/${scriptId}`, request);
+}
+
+export function deleteVNScript(scriptId: number): Promise<void> {
+  return apiClient.delete(`${VN_SCRIPTS_BASE}/scripts/${scriptId}`);
+}
+
+export function getVNScriptDraft(scriptId: number): Promise<VNScriptDraftResponse> {
+  return apiClient.get(`${VN_SCRIPTS_BASE}/scripts/${scriptId}/draft`);
+}
+
+export function putVNScriptDraft(
+  scriptId: number,
+  request: VNScriptDraftPutRequest
+): Promise<VNScriptDraftResponse> {
+  return apiClient.put(`${VN_SCRIPTS_BASE}/scripts/${scriptId}/draft`, request);
+}
+
+export function validateVNScriptDraft(
+  scriptId: number,
+  request: VNScriptValidateRequest = {}
+): Promise<VNScriptValidationResponse> {
+  return apiClient.post(`${VN_SCRIPTS_BASE}/scripts/${scriptId}/draft/validate`, request);
+}
+
+export function getVNScriptDiagnostics(scriptId: number): Promise<VNScriptDiagnosticsResponse> {
+  return apiClient.get(`${VN_SCRIPTS_BASE}/scripts/${scriptId}/draft/diagnostics`);
+}
+
+export function publishVNScript(
+  scriptId: number,
+  request: VNScriptPublishRequest
+): Promise<VNScriptPublishResponse> {
+  return apiClient.post(`${VN_SCRIPTS_BASE}/scripts/${scriptId}/publish`, request);
+}
+
+export function listVNScriptVersions(
+  scriptId: number,
+  query: VNScriptVersionListQuery = {}
+): Promise<VNScriptVersionListResponse> {
+  return apiClient.get(`${VN_SCRIPTS_BASE}/scripts/${scriptId}/versions`, {
+    params: toQueryParams(query),
+  });
+}
+
+export function getVNScriptVersion(
+  scriptId: number,
+  versionId: number
+): Promise<VNScriptVersionResponse> {
+  return apiClient.get(`${VN_SCRIPTS_BASE}/scripts/${scriptId}/versions/${versionId}`);
+}
+
+export function getVNScriptManifestSnapshot(
+  scriptId: number,
+  versionId: number
+): Promise<VNScriptManifestSnapshotResponse> {
+  return apiClient.get(
+    `${VN_SCRIPTS_BASE}/scripts/${scriptId}/versions/${versionId}/manifest-snapshot`
+  );
+}
+
+export function evaluateVNScriptVersionPolicy(
+  scriptId: number,
+  versionId: number,
+  request: VNScriptVersionPolicyEvaluateRequest = {}
+): Promise<VNScriptVersionPolicyEvaluateResponse> {
+  return apiClient.post(
+    `${VN_SCRIPTS_BASE}/scripts/${scriptId}/versions/${versionId}/policy/evaluate`,
+    request
+  );
+}

--- a/apps/tldw-frontend/lib/api/vnScripts.ts
+++ b/apps/tldw-frontend/lib/api/vnScripts.ts
@@ -25,7 +25,9 @@ const VN_SCRIPTS_BASE = '/vn/vn-scripts';
 type QueryParams = Record<string, string | number | boolean | null | undefined>;
 
 function toQueryParams<T extends object>(query: T): QueryParams {
-  return { ...query } as QueryParams;
+  return Object.fromEntries(
+    Object.entries(query).filter(([, value]) => value !== undefined && value !== null)
+  ) as QueryParams;
 }
 
 export function createVNScript(request: VNScriptCreate): Promise<VNScriptResponse> {

--- a/apps/tldw-frontend/pages/vn-scripts.tsx
+++ b/apps/tldw-frontend/pages/vn-scripts.tsx
@@ -1,0 +1,5 @@
+import dynamic from 'next/dynamic';
+
+export default dynamic(() => import('@web/components/vn-scripts/VNScriptsWorkbench'), {
+  ssr: false,
+});

--- a/apps/tldw-frontend/types/vn-play.ts
+++ b/apps/tldw-frontend/types/vn-play.ts
@@ -1,4 +1,4 @@
-export type VNPlayMode = 'freeform' | 'story';
+export type VNPlayMode = 'freeform' | 'story' | 'scripted_story';
 export type VNPlaySessionStatus = 'active' | 'paused' | 'completed' | 'archived' | 'failed';
 export type VNPlayTrustLevel = 'local' | 'trusted_restore' | 'untrusted_import' | 'mixed';
 export type VNPlayLinkedChatMode = 'read_only_context';
@@ -75,6 +75,12 @@ export interface VNPlaySession {
   asset_manifest_version?: string | null;
   source_world_book_ids?: number[];
   content_rating?: string;
+  script_id?: number | null;
+  script_version_id?: number | null;
+  script_manifest_snapshot_id?: number | null;
+  script_policy_snapshot_id?: number | null;
+  script_generation_profile_snapshot_id?: number | null;
+  script_position?: Record<string, unknown> | null;
   trust_level?: VNPlayTrustLevel;
   linked_chat_mode?: VNPlayLinkedChatMode;
   seed?: string | null;
@@ -98,6 +104,9 @@ export interface VNPlaySessionCreate {
   asset_manifest_version?: string | null;
   source_world_book_ids?: number[];
   content_rating?: string;
+  script_id?: number;
+  script_version_id?: number;
+  acknowledgements?: string[];
   trust_level?: VNPlayTrustLevel;
   linked_chat_mode?: VNPlayLinkedChatMode;
   seed?: string | null;
@@ -149,10 +158,42 @@ export interface VNPlaySetupAssetPackOption {
   recommended: boolean;
 }
 
+export interface VNPlaySetupScriptVersionOption {
+  id: number;
+  script_id: number;
+  title: string;
+  version_number: number;
+  label?: string | null;
+  asset_pack_id: number;
+  manifest_snapshot_id: number;
+  policy_snapshot_id: number;
+  generation_profile_snapshot_id?: number | null;
+  policy_profile_id: string;
+  generation_profile_id: string;
+  generation_profile_key: string;
+  generation_profile_snapshot_immutable: boolean;
+  provider_class?: string | null;
+  max_automatic_generation_batch_count?: number | null;
+  moderation_required?: boolean | null;
+  estimated_cost_class?: string | null;
+  supported_output_schemas: string[];
+  dynamic_choice_support: boolean;
+  scene_update_support: boolean;
+  confirmation_required: boolean;
+  content_rating: string;
+  ready: boolean;
+  warning_summary: VNPlaySetupWarningSummary;
+  recommended: boolean;
+}
+
 export interface VNPlaySetupDefaults {
   mode?: VNPlayMode | null;
   character_id?: number | null;
   asset_pack_id?: number | null;
+  script_id?: number | null;
+  script_version_id?: number | null;
+  policy_profile_id?: string | null;
+  generation_profile_id?: string | null;
   content_rating?: string | null;
 }
 
@@ -173,6 +214,7 @@ export interface VNPlaySetupOptionsResponse {
   characters: VNPlaySetupCharacterOption[];
   selected_character?: VNPlaySetupCharacterOption | null;
   asset_packs: VNPlaySetupAssetPackOption[];
+  script_versions: VNPlaySetupScriptVersionOption[];
   defaults: VNPlaySetupDefaults;
   pagination: {
     characters: VNPlaySetupPagination;

--- a/apps/tldw-frontend/types/vn-scripts.ts
+++ b/apps/tldw-frontend/types/vn-scripts.ts
@@ -1,0 +1,164 @@
+export type VNScriptStatus = 'draft' | 'ready' | 'archived';
+export type VNScriptContentRating = 'general' | 'teen' | 'suggestive' | 'mature';
+
+export interface VNScriptCreate {
+  title: string;
+  description?: string | null;
+  primary_asset_pack_id: number;
+  policy_profile_id?: string;
+  generation_profile_id?: string;
+  generation_profiles?: Record<string, string>;
+  generation_profile_ids?: Record<string, string> | null;
+  content_rating?: VNScriptContentRating;
+}
+
+export interface VNScriptPatch {
+  title?: string | null;
+  description?: string | null;
+  status?: VNScriptStatus | null;
+  primary_asset_pack_id?: number | null;
+  policy_profile_id?: string | null;
+  generation_profile_id?: string | null;
+  generation_profiles?: Record<string, string> | null;
+  generation_profile_ids?: Record<string, string> | null;
+  content_rating?: VNScriptContentRating | null;
+}
+
+export interface VNScriptResponse {
+  id: number;
+  title: string;
+  description?: string | null;
+  status: string;
+  primary_asset_pack_id: number;
+  policy_profile_id: string;
+  generation_profile_id: string;
+  generation_profiles: Record<string, string>;
+  content_rating: string;
+}
+
+export interface VNScriptOffsetPagination {
+  limit: number;
+  offset: number;
+  total?: number | null;
+  has_more: boolean;
+  next_offset?: number | null;
+}
+
+export interface VNScriptListResponse {
+  items: VNScriptResponse[];
+  limit: number;
+  offset: number;
+  total: number;
+  has_more: boolean;
+  next_offset?: number | null;
+  pagination: VNScriptOffsetPagination;
+}
+
+export interface VNScriptDraftResponse {
+  script_id: number;
+  revision: number;
+  draft: Record<string, unknown>;
+  diagnostics: Record<string, unknown>;
+}
+
+export interface VNScriptDraftPutRequest {
+  if_revision: number;
+  draft: Record<string, unknown>;
+}
+
+export interface VNScriptValidateRequest {
+  draft?: Record<string, unknown> | null;
+}
+
+export interface VNScriptValidationResponse {
+  valid: boolean;
+  errors: Array<Record<string, unknown>>;
+  warnings: Array<Record<string, unknown>>;
+}
+
+export interface VNScriptDiagnosticsResponse {
+  script_id: number;
+  revision: number;
+  diagnostics: Record<string, unknown>;
+}
+
+export interface VNScriptPublishRequest {
+  draft_revision: number;
+  label?: string | null;
+  idempotency_key: string;
+  acknowledgements?: string[];
+}
+
+export interface VNScriptPublishResponse {
+  script_id: number;
+  version_id: number;
+  version_number: number;
+  status: string;
+  asset_pack_id: number;
+  manifest_snapshot_id: number;
+  policy_snapshot_id: number;
+  generation_profile_snapshot_id: number;
+  generation_profile_snapshots: Record<string, number>;
+  validation: Record<string, unknown>;
+  created_at: string;
+}
+
+export interface VNScriptVersionResponse {
+  id: number;
+  script_id: number;
+  version_number: number;
+  label?: string | null;
+  draft_revision: number;
+  program: Record<string, unknown>;
+  asset_pack_id: number;
+  manifest_snapshot_id: number;
+  policy_snapshot_id: number;
+  generation_profile_snapshot_id: number;
+  generation_profile_snapshots: Record<string, number>;
+  script_defaults: Record<string, unknown>;
+  validation: Record<string, unknown>;
+  created_at: string;
+}
+
+export interface VNScriptVersionListResponse {
+  items: VNScriptVersionResponse[];
+  limit: number;
+  offset: number;
+  total: number;
+  has_more: boolean;
+  next_offset?: number | null;
+  pagination: VNScriptOffsetPagination;
+}
+
+export interface VNScriptManifestSnapshotResponse {
+  id: number;
+  script_id: number;
+  version_id?: number | null;
+  asset_pack_id: number;
+  manifest: Record<string, unknown>;
+  manifest_hash: string;
+  created_at: string;
+}
+
+export interface VNScriptVersionPolicyEvaluateRequest {
+  context?: Record<string, unknown>;
+}
+
+export interface VNScriptVersionPolicyEvaluateResponse {
+  decision: string;
+  profile_id: string;
+  reasons: Array<Record<string, unknown>>;
+  blocked: boolean;
+  requires_acknowledgement: boolean;
+  remediation: string[];
+}
+
+export interface VNScriptListQuery {
+  limit?: number;
+  offset?: number;
+}
+
+export interface VNScriptVersionListQuery {
+  limit?: number;
+  offset?: number;
+}

--- a/backlog/tasks/task-289 - Add-VN-script-authoring-and-publish-WebUI.md
+++ b/backlog/tasks/task-289 - Add-VN-script-authoring-and-publish-WebUI.md
@@ -1,0 +1,68 @@
+---
+id: TASK-289
+title: Add VN script authoring and publish WebUI
+status: Done
+assignee: []
+created_date: '2026-05-12 04:25'
+labels:
+  - vn-play
+  - webui
+  - vn-scripts
+milestone: VN CYOA mode
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1597'
+  - 'https://github.com/rmusser01/tldw_server/issues/1391'
+documentation:
+  - Docs/superpowers/specs/2026-05-10-vn-platform-api-design.md
+  - Docs/API/VN.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement GitHub issue #1597: add a bundled WebUI authoring surface for backend-owned VN Scripts API. Users should be able to create script shells, edit JSON drafts, validate diagnostics, publish immutable versions, inspect published summaries, and link published versions into scripted_story setup without duplicating backend validation policy manifest or generation-profile rules client-side.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Frontend VN Scripts API helpers/types cover script CRUD draft validation diagnostics publish versions manifest snapshot and policy evaluation endpoints.
+- [x] #2 A WebUI authoring route or panel lets users list/create/select scripts edit drafts with revision conflict handling validate diagnostics and publish with idempotency/readiness handling.
+- [x] #3 Published versions show safe summary metadata and are linked into scripted_story setup without client-owned validation rules.
+- [x] #4 Focused frontend tests cover helper contracts draft edit/save diagnostics rendering publish conflict/readiness states and setup linkage.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+- [x] #7 Focused frontend tests pass or known unrelated baseline failures are documented.
+- [x] #8 Frontend lint/diff hygiene run and results recorded.
+- [x] #9 Bandit applicability documented for frontend-only slice.
+<!-- DOD:END -->
+
+## Implementation Notes
+
+- Added typed VN Scripts API client helpers and response/request contracts for script CRUD, draft save/validation/diagnostics, publish, versions, manifest snapshots, and policy evaluation.
+- Added `/vn-scripts` WebUI workbench for script listing, shell creation, JSON draft editing, validation, diagnostics, publish, versions, and manifest/policy summaries.
+- Added scripted-story setup integration to VN Play: published script-version selector, `/vn-scripts` empty-state guidance, exact script/session create payload fields, required top-level acknowledgements, and distinct Scripted Story mode labels/filtering.
+- Review fixes applied: publish acknowledgements are not inferred, empty optional profile IDs are omitted from create payloads, validation blocks invalid visible JSON instead of validating stale draft content, version action buttons have version-specific accessible names, and scripted manual fallback requires script/version IDs.
+
+## Verification
+
+- PASS: `cd apps/tldw-frontend && bun run test:run __tests__/vn-scripts/vnScriptsApi.test.ts __tests__/vn-scripts/VNScriptsWorkbench.test.tsx __tests__/vn-play/VNPlayWorkspace.test.tsx __tests__/vn-play/vnPlayApi.test.ts` -> 4 files, 61 tests passed.
+- PASS: `cd apps/tldw-frontend && ./node_modules/.bin/eslint components/vn-scripts/VNScriptsWorkbench.tsx pages/vn-scripts.tsx lib/api/vnScripts.ts types/vn-scripts.ts types/vn-play.ts components/vn-play/NewSessionDialog.tsx components/vn-play/SessionList.tsx components/vn-play/VNPlayWorkspace.tsx __tests__/vn-scripts/vnScriptsApi.test.ts __tests__/vn-scripts/VNScriptsWorkbench.test.tsx __tests__/vn-play/VNPlayWorkspace.test.tsx __tests__/vn-play/vnPlayApi.test.ts` -> no output, exit 0.
+- PASS: `git diff --check`.
+- BASELINE BLOCKER: `cd apps/tldw-frontend && ./node_modules/.bin/tsc --noEmit --pretty false` fails in pre-existing untouched files under `../packages/ui/src/components/Option/Evaluations/tabs/recipe-configs/EmbeddingsModelSelectionConfig.tsx` and `../packages/ui/src/services/persona-visuals.ts`; no touched-file TypeScript diagnostics were reported before the baseline failure.
+- Bandit: not applicable. This slice changes TypeScript/React/Markdown task/plan files only; no Python files were touched.
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the VN script authoring frontend and scripted-story setup bridge for issue #1597. The frontend now has typed VN Scripts API helpers, a bundled `/vn-scripts` authoring workbench, and VN Play setup support for published script versions without duplicating backend-owned validation/policy rules. Scripted-story creation now derives pack/character/rating from backend setup options, sends script identifiers and top-level acknowledgement codes, and keeps Scripted Story distinct in session controls.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-289 - Add-VN-script-authoring-and-publish-WebUI.md
+++ b/backlog/tasks/task-289 - Add-VN-script-authoring-and-publish-WebUI.md
@@ -52,17 +52,22 @@ Implement GitHub issue #1597: add a bundled WebUI authoring surface for backend-
 - Added `/vn-scripts` WebUI workbench for script listing, shell creation, JSON draft editing, validation, diagnostics, publish, versions, and manifest/policy summaries.
 - Added scripted-story setup integration to VN Play: published script-version selector, `/vn-scripts` empty-state guidance, exact script/session create payload fields, required top-level acknowledgements, and distinct Scripted Story mode labels/filtering.
 - Review fixes applied: publish acknowledgements are not inferred, empty optional profile IDs are omitted from create payloads, validation blocks invalid visible JSON instead of validating stale draft content, version action buttons have version-specific accessible names, and scripted manual fallback requires script/version IDs.
+- PR review follow-up applied: draft-scoped publish idempotency keys are stable across retries, publish success is separated from version-refresh failure, stale version refreshes cannot overwrite a newly selected script, selected script changes clear stale draft/version state immediately, diagnostics/manifest/policy displays are summarized with sensitive raw/debug/internal fields redacted, scripted-story branch navigation uses the same loading behavior as story mode, scripted-story acknowledgement payloads fall back to all warning codes when the summary requires acknowledgement, and duplicate no-script setup guidance is suppressed.
 
 ## Verification
 
 - PASS: `cd apps/tldw-frontend && bun run test:run __tests__/vn-scripts/vnScriptsApi.test.ts __tests__/vn-scripts/VNScriptsWorkbench.test.tsx __tests__/vn-play/VNPlayWorkspace.test.tsx __tests__/vn-play/vnPlayApi.test.ts` -> 4 files, 61 tests passed.
+- PASS: `cd apps/tldw-frontend && bunx vitest run __tests__/vn-scripts/VNScriptsWorkbench.test.tsx __tests__/vn-scripts/vnScriptsApi.test.ts __tests__/vn-play/VNPlayWorkspace.test.tsx` -> 3 files, 60 tests passed after PR review fixes.
 - PASS: `cd apps/tldw-frontend && ./node_modules/.bin/eslint components/vn-scripts/VNScriptsWorkbench.tsx pages/vn-scripts.tsx lib/api/vnScripts.ts types/vn-scripts.ts types/vn-play.ts components/vn-play/NewSessionDialog.tsx components/vn-play/SessionList.tsx components/vn-play/VNPlayWorkspace.tsx __tests__/vn-scripts/vnScriptsApi.test.ts __tests__/vn-scripts/VNScriptsWorkbench.test.tsx __tests__/vn-play/VNPlayWorkspace.test.tsx __tests__/vn-play/vnPlayApi.test.ts` -> no output, exit 0.
+- PASS: `cd apps/tldw-frontend && ./node_modules/.bin/eslint components/vn-scripts/VNScriptsWorkbench.tsx components/vn-play/NewSessionDialog.tsx components/vn-play/VNPlayWorkspace.tsx lib/api/vnScripts.ts __tests__/vn-scripts/VNScriptsWorkbench.test.tsx __tests__/vn-scripts/vnScriptsApi.test.ts __tests__/vn-play/VNPlayWorkspace.test.tsx` -> no output, exit 0 after PR review fixes.
 - PASS: `git diff --check`.
-- BASELINE BLOCKER: `cd apps/tldw-frontend && ./node_modules/.bin/tsc --noEmit --pretty false` fails in pre-existing untouched files under `../packages/ui/src/components/Option/Evaluations/tabs/recipe-configs/EmbeddingsModelSelectionConfig.tsx` and `../packages/ui/src/services/persona-visuals.ts`; no touched-file TypeScript diagnostics were reported before the baseline failure.
+- BASELINE BLOCKER: `cd apps/tldw-frontend && ./node_modules/.bin/tsc --noEmit --pretty false` and `./node_modules/.bin/tsc --noEmit` fail in pre-existing untouched files under `../packages/ui/src/components/Option/Evaluations/tabs/recipe-configs/EmbeddingsModelSelectionConfig.tsx` and `../packages/ui/src/services/persona-visuals.ts`; no touched-file TypeScript diagnostics were reported before the baseline failure.
 - Bandit: not applicable. This slice changes TypeScript/React/Markdown task/plan files only; no Python files were touched.
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Implemented the VN script authoring frontend and scripted-story setup bridge for issue #1597. The frontend now has typed VN Scripts API helpers, a bundled `/vn-scripts` authoring workbench, and VN Play setup support for published script versions without duplicating backend-owned validation/policy rules. Scripted-story creation now derives pack/character/rating from backend setup options, sends script identifiers and top-level acknowledgement codes, and keeps Scripted Story distinct in session controls.
+
+PR review follow-up hardened retry/idempotency behavior, async selection races, publish refresh failure handling, safe summary rendering, scripted-story branch loading, acknowledgement fallback semantics, and empty-state duplication.
 <!-- SECTION:FINAL_SUMMARY:END -->


### PR DESCRIPTION
## Summary
- Adds typed frontend VN Scripts API helpers and `/vn-scripts` authoring workbench for script shells, JSON draft editing, validation, diagnostics, publishing, versions, and manifest/policy summaries.
- Extends VN Play setup for `scripted_story` sessions using backend-provided published script versions, exact script/session payload fields, required top-level acknowledgements, and distinct Scripted Story labels/filtering.
- Records TASK-289 and the implementation plan/verification trail for issue #1597.

## Test Plan
- [x] `cd apps/tldw-frontend && bun run test:run __tests__/vn-scripts/vnScriptsApi.test.ts __tests__/vn-scripts/VNScriptsWorkbench.test.tsx __tests__/vn-play/VNPlayWorkspace.test.tsx __tests__/vn-play/vnPlayApi.test.ts`
- [x] `cd apps/tldw-frontend && ./node_modules/.bin/eslint components/vn-scripts/VNScriptsWorkbench.tsx pages/vn-scripts.tsx lib/api/vnScripts.ts types/vn-scripts.ts types/vn-play.ts components/vn-play/NewSessionDialog.tsx components/vn-play/SessionList.tsx components/vn-play/VNPlayWorkspace.tsx __tests__/vn-scripts/vnScriptsApi.test.ts __tests__/vn-scripts/VNScriptsWorkbench.test.tsx __tests__/vn-play/VNPlayWorkspace.test.tsx __tests__/vn-play/vnPlayApi.test.ts`
- [x] `git diff --check`
- [ ] `cd apps/tldw-frontend && ./node_modules/.bin/tsc --noEmit --pretty false` fails in existing untouched `../packages/ui/...` baseline files; no touched-file diagnostics observed.

## Merge Gate
AI-generated PR: per repo policy, this needs a requester-authored `Change summary` before merge explaining what changed and why these choices were made.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a VN script authoring WebUI and typed VN Scripts API, and enables a new “Scripted Story” mode in VN Play that runs published script versions. Authors can create drafts, validate, and publish, then start sessions with those versions from the New Session dialog.

- **New Features**
  - `/vn-scripts` workbench: create script shells; edit JSON drafts; run validation/diagnostics; view manifest/policy summaries; publish immutable versions.
  - Typed VN Scripts client and types at `@web/lib/api/vnScripts` and `@web/types/vn-scripts`.
  - VN Play: adds `scripted_story` mode; setup options include published script versions; New Session dialog supports selecting a version, shows warnings, and requires acknowledgements; labels/filters updated to “Scripted Story”; branch navigation enabled. Session create accepts `script_id`, `script_version_id`, and `acknowledgements` (e.g., `script_policy_review`).
  - Types extended for script metadata on sessions; tests for the API client, workbench, and scripted session creation. Implements #1597 (TASK-289) by keeping validation/manifest checks on the backend and surfacing results in the UI.

<sup>Written for commit d52e73d0eae46160b2e209563ad06c380837552e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

