### PR TITLE
Close stale Persona/Buddy Backlog tracker statuses

### DIFF
--- a/backlog/tasks/task-192 - Design-persona-visual-pack-duplicate-to-persona-workflow.md
+++ b/backlog/tasks/task-192 - Design-persona-visual-pack-duplicate-to-persona-workflow.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-192
 title: Design persona visual pack duplicate-to-persona workflow
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-09 21:18'
-updated_date: '2026-05-09 21:26'
+updated_date: '2026-05-12 05:57'
 labels:
   - persona
   - buddy
@@ -41,12 +41,18 @@ Spec review iteration 1 found one blocking ambiguity: same-persona duplication w
 Design self-review before implementation planning found and patched three issues: public API response is now the existing PersonaVisualPackResponse with asset_id_map kept internal only; idempotency keys are explicitly out of V1; duplicate now copies only manifest-referenced assets so unaccepted generated candidates and stale uploads are not copied. Also tightened preflight/cleanup guidance for source asset membership, checksum, file existence, and partial target draft failures.
 <!-- SECTION:NOTES:END -->
 
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Completed the duplicate-to-persona design for issue #1450. The spec documents same-user cross-persona draft duplication, physical asset copy/remap behavior, explicit same-persona rejection, V1 non-goals, API/service/frontend/test expectations, and implementation review corrections. The follow-up implementation shipped through PR #1467, and issue #1450 is closed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-194 - Implement-persona-visual-pack-duplicate-to-persona-workflow.md
+++ b/backlog/tasks/task-194 - Implement-persona-visual-pack-duplicate-to-persona-workflow.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-194
 title: Implement persona visual pack duplicate-to-persona workflow
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-09 21:42'
-updated_date: '2026-05-09 22:29'
+updated_date: '2026-05-12 05:57'
 labels:
   - persona
   - buddy

--- a/backlog/tasks/task-203 - Implement-personal-Persona-Visual-pack-library-foundation.md
+++ b/backlog/tasks/task-203 - Implement-personal-Persona-Visual-pack-library-foundation.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-203
 title: Implement personal Persona Visual pack library foundation
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-09 23:41'
-updated_date: '2026-05-10 01:43'
+updated_date: '2026-05-12 05:57'
 labels:
   - persona
   - buddy

--- a/backlog/tasks/task-257 - Add-optional-calibrated-Persona-Chat-judge-evaluation.md
+++ b/backlog/tasks/task-257 - Add-optional-calibrated-Persona-Chat-judge-evaluation.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-257
 title: Add optional calibrated Persona Chat judge evaluation
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-11 05:14'
-updated_date: '2026-05-12 03:02'
+updated_date: '2026-05-12 05:59'
 labels:
   - persona-chat
   - evaluations
@@ -60,6 +60,8 @@ Docstring follow-up: added concise helper docstrings in persona_chat_judge.py to
 Additional review follow-up: added a focused regression test proving calibrate_persona_chat_judge_predictions rejects invalid result values even when a prediction object bypasses dataclass post-init validation.
 
 Reopened on 2026-05-12 because #1566 remains open for the next PR-sized optional judge execution slice. New subtask TASK-257.3 tracks GitHub issue #1591 for the offline executable adapter boundary.
+
+Stage 2 closeout update: issue #1566 and tracker #1543 were closed after PR #1603 merged the offline artifact CLI slice. TASK-257 remains the parent Backlog record for the optional Persona Chat judge V1 and now reflects the closed GitHub tracker state; later judge persistence/review surfaces should use new tasks/issues.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
@@ -68,6 +70,8 @@ Reopened on 2026-05-12 because #1566 remains open for the next PR-sized optional
 Added an optional/offline Persona Chat judge contract and calibration helper tied to existing deterministic quality fixtures. The implementation defines binary judge dimensions, fixture-derived judge inputs, structured prompt generation, and label-based calibration metrics without changing runtime Persona Chat behavior or adding a live eval service.
 
 PR review follow-up hardened the calibration contract by rejecting missing identity fields, duplicate input/prediction keys, and invalid judge result values before metric calculation. The contract documentation now records known judge failure modes, residual V1 risks, and the offline/runtime boundary.
+
+Stage 2 closeout: the optional judge V1 now includes the follow-up no-provider harness, offline review command, calibration policy, executable adapter boundary, trace-safe execution artifacts, and artifact CLI through PR #1603. Issues #1566 and #1543 are closed, with runtime Persona Chat behavior unchanged.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-298 - Close-stale-Persona-Buddy-Backlog-statuses.md
+++ b/backlog/tasks/task-298 - Close-stale-Persona-Buddy-Backlog-statuses.md
@@ -1,0 +1,59 @@
+---
+id: TASK-298
+title: Close stale Persona/Buddy Backlog statuses
+status: Done
+assignee: []
+created_date: '2026-05-12 05:56'
+updated_date: '2026-05-12 06:01'
+labels:
+  - persona
+  - buddy
+  - backlog
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Clean up committed Backlog metadata for completed Persona/Buddy and Persona Chat Stage 2 work whose acceptance criteria and Definition of Done are already checked but status still says In Progress.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Completed Persona Visual and Persona Chat Stage 2 parent tasks are marked Done.
+- [x] #2 Only tracker metadata changes are made; runtime code is unchanged.
+- [x] #3 Verification records diff hygiene and confirms no Python code changed.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Verify the referenced GitHub issues are closed, update the stale task statuses/final notes, and run git diff --check.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verified GitHub issue #1450 is closed, issue #1468 is closed, and visual-pack reuse/library epic #1449 is closed. Updated TASK-192, TASK-194, and TASK-203 from In Progress to Done; TASK-192 also now has checked Definition of Done items and a final summary matching its completed design evidence.
+
+Also updated TASK-257 from In Progress to Done after closing GitHub issues #1566 and #1543; this keeps the Persona Chat Stage 2 parent Backlog record aligned with the completed optional judge V1.
+
+Verification: git diff --check passed. Backlog In Progress list no longer includes Persona/Buddy, Persona Visual, or Persona Chat judge tasks; remaining In Progress items are unrelated WebUI/VN/ACP work. Bandit skipped because this cleanup touches Backlog Markdown metadata only and no Python code changed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Cleaned up stale Persona/Buddy Backlog metadata only. TASK-192, TASK-194, TASK-203, and TASK-257 now reflect their completed state; no runtime code or product behavior changed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- mark completed Persona Visual Backlog tasks TASK-192, TASK-194, and TASK-203 as Done
- mark Persona Chat Stage 2 parent task TASK-257 as Done after #1566/#1543 closeout
- add TASK-298 documenting this tracker-only cleanup

## Verification
- `git diff --check`
- `backlog task list --plain --status "In Progress"` no longer lists Persona/Buddy, Persona Visual, or Persona Chat judge tasks
- Bandit skipped: Markdown-only Backlog metadata change, no Python code touched

## Change summary
Human-authored Change summary required before merge per repo policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marked stale Persona Visual and Persona Chat Stage 2 backlog tasks as Done and added `TASK-298` to record the tracker-only cleanup. Updates are metadata-only (no runtime code); TASK-192, TASK-194, TASK-203, and TASK-257 now reflect completed work and align with closed issues.

<sup>Written for commit d3fc0c582e7d8b2b6108be6ca70a53f1d3002562. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

