### PR TITLE
Add VN script starter templates

### DIFF
--- a/Docs/API-related/VN_PLATFORM_API.md
+++ b/Docs/API-related/VN_PLATFORM_API.md
@@ -48,6 +48,33 @@ Example:
 
 `/api/v1/vn/vn-audio` is reserved for a future VN-scoped TTS module. Current clients must only call VN audio routes when both `enabled_modules.audio` and `features.tts_jobs` are `true`; otherwise use the existing `/api/v1/audio` APIs directly.
 
+## VN Script Starter Templates
+
+VN script starter templates are exposed under the existing scripts resource:
+
+- `GET /api/v1/vn/vn-scripts/templates`
+- `POST /api/v1/vn/vn-scripts/templates/{template_id}/scripts`
+
+The catalog endpoint returns preview-safe metadata only. Each item includes a stable `id`, `label`, `description`, `category`, `recommended_content_rating`, `required_capabilities`, `preview`, `default_title`, and `default_description`. It intentionally omits full draft JSON, raw prompts, provider/model settings, and policy or generation profile overrides so custom frontends can display the catalog without becoming a second source of truth.
+
+Built-in V1 template IDs are `linear_scene`, `authored_choices`, `generated_choice_set`, `scene_update`, and `confirm_gated_generation`.
+
+Create-from-template accepts the same script metadata as normal script creation, including `primary_asset_pack_id`, optional policy/generation profile IDs, generation profile maps, and content rating. The response contains:
+
+```json
+{
+  "script": { "id": 12, "title": "Linear Scene", "status": "draft" },
+  "draft": {
+    "script_id": 12,
+    "revision": 1,
+    "draft": { "schema_version": "vn_script_program.v1" },
+    "diagnostics": { "valid": true, "errors": [], "warnings": [] }
+  }
+}
+```
+
+After creation, the script is a normal authored script. Clients should use the standard draft, validation, diagnostics, and publish endpoints for further editing.
+
 ## Policy Profiles
 
 VN policy definitions are global server configuration stored in the AuthNZ database. This lets admins create one profile that is visible to all API clients and custom frontends. Per-resource effective policy snapshots remain in the owning user's ChaChaNotes database so script/session/asset history preserves the exact settings used at creation time.

--- a/Docs/superpowers/plans/2026-05-12-vn-script-starter-templates.md
+++ b/Docs/superpowers/plans/2026-05-12-vn-script-starter-templates.md
@@ -1,0 +1,256 @@
+# VN Script Starter Templates Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
+
+**Goal:** Add backend-owned VN script starter templates and a guided WebUI creation flow for issue #1604.
+
+**Architecture:** Keep templates as deterministic backend catalog data exposed by the existing `/api/v1/vn/vn-scripts` router. Template instantiation creates a normal script shell and replaces its draft through the same validation path used by custom clients, so publish/runtime semantics remain unchanged. The WebUI only lists templates and calls the backend create-from-template flow; it does not duplicate template content or validation logic.
+
+**Tech Stack:** FastAPI, Pydantic, existing `VNScriptService`, existing VN script validator, pytest, Next.js/React, Vitest.
+
+---
+
+## File Structure
+
+- Create `tldw_Server_API/app/core/VN_Scripts/templates.py` for built-in template definitions, sanitized catalog payloads, deterministic draft instantiation, and template lookup errors.
+- Modify `tldw_Server_API/app/core/VN_Scripts/service.py` to expose `list_templates()` and `create_script_from_template()`.
+- Modify `tldw_Server_API/app/api/v1/schemas/vn_script_schemas.py` to add template catalog and create-from-template request/response schemas.
+- Modify `tldw_Server_API/app/api/v1/endpoints/vn_scripts.py` to add `GET /templates` and `POST /templates/{template_id}/scripts`.
+- Modify `tldw_Server_API/tests/VN_Scripts/test_vn_scripts_api.py` for endpoint coverage.
+- Modify `tldw_Server_API/tests/VN_Scripts/test_vn_script_validator.py` or add a focused template test if service-level validation needs lower-level coverage.
+- Modify `apps/tldw-frontend/types/vn-scripts.ts`, `apps/tldw-frontend/lib/api/vnScripts.ts`, and existing VN scripts tests for the client contract.
+- Modify `apps/tldw-frontend/components/vn-scripts/VNScriptsWorkbench.tsx` and its tests to add the guided template picker.
+- Update `backlog/tasks/task-298 - Add-VN-script-starter-templates-and-guided-authoring.md` with completion notes and verification.
+
+## Task 1: Backend Template Catalog And Instantiation
+
+**Files:**
+- Create: `tldw_Server_API/app/core/VN_Scripts/templates.py`
+- Modify: `tldw_Server_API/app/core/VN_Scripts/service.py`
+- Test: `tldw_Server_API/tests/VN_Scripts/test_vn_scripts_api.py`
+
+- [x] **Step 1: Write failing API tests**
+
+Add tests proving:
+
+```python
+def test_template_catalog_lists_preview_safe_starter_templates(client):
+    response = client.get("/api/v1/vn/vn-scripts/templates")
+    assert response.status_code == 200
+    payload = response.json()
+    assert {item["id"] for item in payload["items"]} >= {
+        "linear_scene",
+        "authored_choices",
+        "generated_choice_set",
+        "scene_update",
+        "confirm_gated_generation",
+    }
+    assert "draft" not in payload["items"][0]
+    assert "raw_prompt" not in payload["items"][0]
+```
+
+```python
+def test_create_script_from_template_stores_valid_draft(client, chacha_dbs):
+    asset_pack_id, _ = _create_asset_pack(chacha_dbs[42])
+    response = client.post(
+        "/api/v1/vn/vn-scripts/templates/linear_scene/scripts",
+        json={
+            "title": "Template Route",
+            "primary_asset_pack_id": asset_pack_id,
+            "content_rating": "general",
+        },
+    )
+    assert response.status_code == 201
+    script_id = response.json()["script"]["id"]
+    draft = client.get(f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft").json()
+    assert draft["revision"] == 1
+    assert draft["diagnostics"]["valid"] is True
+    assert draft["draft"]["primary_asset_pack_id"] == asset_pack_id
+```
+
+- [x] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/VN_Scripts/test_vn_scripts_api.py::test_template_catalog_lists_preview_safe_starter_templates tldw_Server_API/tests/VN_Scripts/test_vn_scripts_api.py::test_create_script_from_template_stores_valid_draft -q
+```
+
+Expected: fail because the template endpoint does not exist.
+
+- [x] **Step 3: Implement catalog module**
+
+Create immutable template definitions with:
+
+- Stable IDs: `linear_scene`, `authored_choices`, `generated_choice_set`, `scene_update`, `confirm_gated_generation`.
+- Catalog fields: `id`, `label`, `description`, `category`, `recommended_content_rating`, `required_capabilities`, `preview`, `default_title`, `default_description`.
+- Draft factory that accepts script metadata and returns a valid `vn_script_program.v1` draft using only supported opcodes.
+- Sanitized catalog output that never includes full draft JSON, raw prompts, internal comments, or policy overrides.
+
+- [x] **Step 4: Implement service methods**
+
+Add `VNScriptService.list_templates()` and `VNScriptService.create_script_from_template(...)`. The create method should:
+
+- Reuse `create_script(...)`.
+- Build the template draft with the created script metadata.
+- Validate through `replace_draft(...)` using `if_revision=0`.
+- Return both the script metadata and draft response.
+
+- [x] **Step 5: Run tests to verify GREEN**
+
+Run the same focused pytest command. Expected: pass.
+
+## Task 2: Backend API Schemas And Safety Cases
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/schemas/vn_script_schemas.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/vn_scripts.py`
+- Test: `tldw_Server_API/tests/VN_Scripts/test_vn_scripts_api.py`
+
+- [x] **Step 1: Write failing safety tests**
+
+Add tests for:
+
+- Unknown template ID returns 404 with `template_not_found`.
+- Create-from-template validates unknown profile IDs the same as normal create.
+- Template-created generated-choice drafts validate and publish through existing paths.
+- Catalog entries do not contain `policy_profile_id`, `generation_profile_id`, or hidden draft bodies.
+
+- [x] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/VN_Scripts/test_vn_scripts_api.py -q
+```
+
+Expected: new tests fail before endpoint/schema work is complete.
+
+- [x] **Step 3: Implement schemas and endpoints**
+
+Add:
+
+- `VNScriptTemplateSummary`
+- `VNScriptTemplateListResponse`
+- `VNScriptCreateFromTemplateRequest`
+- `VNScriptCreateFromTemplateResponse`
+
+Endpoint shape:
+
+- `GET /api/v1/vn/vn-scripts/templates`
+- `POST /api/v1/vn/vn-scripts/templates/{template_id}/scripts`
+
+The POST endpoint should resolve profiles before script creation, resolve audio refs if a template ever includes media refs, and map `template_not_found` to 404.
+
+- [x] **Step 4: Run backend tests to verify GREEN**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/VN_Scripts -q
+```
+
+Expected: pass.
+
+## Task 3: Frontend API Client And Types
+
+**Files:**
+- Modify: `apps/tldw-frontend/types/vn-scripts.ts`
+- Modify: `apps/tldw-frontend/lib/api/vnScripts.ts`
+- Test: `apps/tldw-frontend/__tests__/vn-scripts/vnScriptsApi.test.ts`
+
+- [x] **Step 1: Write failing Vitest client tests**
+
+Add tests proving:
+
+- `listVNScriptTemplates()` calls `/vn/vn-scripts/templates`.
+- `createVNScriptFromTemplate(templateId, request)` calls `/vn/vn-scripts/templates/{templateId}/scripts` with the request payload.
+
+- [x] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+bunx vitest run apps/tldw-frontend/__tests__/vn-scripts/vnScriptsApi.test.ts
+```
+
+Expected: fail because functions/types are missing.
+
+- [x] **Step 3: Implement TypeScript contract**
+
+Add interfaces mirroring backend schemas and two API helpers:
+
+- `listVNScriptTemplates(): Promise<VNScriptTemplateListResponse>`
+- `createVNScriptFromTemplate(templateId: string, request: VNScriptCreateFromTemplateRequest): Promise<VNScriptCreateFromTemplateResponse>`
+
+- [x] **Step 4: Run tests to verify GREEN**
+
+Run the same Vitest command. Expected: pass.
+
+## Task 4: WebUI Template Picker
+
+**Files:**
+- Modify: `apps/tldw-frontend/components/vn-scripts/VNScriptsWorkbench.tsx`
+- Test: `apps/tldw-frontend/__tests__/vn-scripts/VNScriptsWorkbench.test.tsx`
+
+- [x] **Step 1: Write failing component tests**
+
+Add tests proving:
+
+- Templates load on mount and render as selectable starter options.
+- Selecting a template and submitting calls `createVNScriptFromTemplate` rather than raw `createVNScript`.
+- Created template scripts are prepended, selected, and their returned draft is shown without waiting for a stale detail reload.
+- The plain shell path still works when the user selects a blank/custom option.
+
+- [x] **Step 2: Run component test to verify RED**
+
+Run:
+
+```bash
+bunx vitest run apps/tldw-frontend/__tests__/vn-scripts/VNScriptsWorkbench.test.tsx
+```
+
+Expected: fail because template helpers/UI do not exist.
+
+- [x] **Step 3: Implement WebUI flow**
+
+Add a compact template picker in the create form. Keep the current raw shell creation as “Blank/custom JSON”. When a template is selected:
+
+- Submit through `createVNScriptFromTemplate`.
+- Use returned `script` and `draft` to update selected state immediately.
+- Still expose the JSON editor, validation, diagnostics, save, and publish controls.
+- Keep visible text concise and operational.
+
+- [x] **Step 4: Run component test to verify GREEN**
+
+Run the same Vitest command. Expected: pass.
+
+## Task 5: Documentation, Verification, And Closeout
+
+**Files:**
+- Modify: `Docs/superpowers/plans/2026-05-12-vn-script-starter-templates.md`
+- Modify: `backlog/tasks/task-298 - Add-VN-script-starter-templates-and-guided-authoring.md`
+- Possibly modify API docs if the repo has a VN scripts doc page.
+
+- [x] **Step 1: Document custom frontend contract**
+
+Add concise implementation notes that describe the two endpoints, stable template IDs, sanitized catalog payload, and create-from-template behavior.
+
+- [x] **Step 2: Run verification**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/VN_Scripts -q
+bunx vitest run apps/tldw-frontend/__tests__/vn-scripts/vnScriptsApi.test.ts apps/tldw-frontend/__tests__/vn-scripts/VNScriptsWorkbench.test.tsx
+source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/vn_scripts.py tldw_Server_API/app/api/v1/schemas/vn_script_schemas.py tldw_Server_API/app/core/VN_Scripts -f json -o /tmp/bandit_vn_script_templates.json
+git diff --check
+```
+
+- [x] **Step 3: Update Backlog task**
+
+Check completed acceptance criteria, record verification output, and add a final summary.
+
+- [x] **Step 4: Commit**
+
+Commit all task files, backend, frontend, tests, and docs in one focused commit for #1604.

--- a/Docs/superpowers/specs/2026-05-10-vn-platform-api-design.md
+++ b/Docs/superpowers/specs/2026-05-10-vn-platform-api-design.md
@@ -445,6 +445,8 @@ or historical sessions.
 
 | Method | Path | Purpose |
 | --- | --- | --- |
+| `GET` | `/templates` | List preview-safe starter templates. |
+| `POST` | `/templates/{template_id}/scripts` | Create a script shell with a validated starter draft. |
 | `POST` | `/scripts` | Create a script shell. |
 | `GET` | `/scripts` | List owned scripts. |
 | `GET` | `/scripts/{script_id}` | Read script metadata. |
@@ -459,6 +461,31 @@ or historical sessions.
 | `GET` | `/scripts/{script_id}/versions/{version_id}` | Read immutable version. |
 | `GET` | `/scripts/{script_id}/versions/{version_id}/manifest-snapshot` | Inspect pinned manifest. |
 | `POST` | `/scripts/{script_id}/versions/{version_id}/policy/evaluate` | Preflight a version. |
+
+### Starter Templates
+
+Starter templates are backend-owned catalog entries for custom frontends and the
+bundled `/vn-scripts` WebUI. `GET /templates` returns only preview-safe metadata:
+stable `id`, `label`, `description`, `category`, `recommended_content_rating`,
+`required_capabilities`, `preview`, `default_title`, and
+`default_description`. Catalog responses must not expose full draft JSON, raw
+prompts, internal/debug fields, policy profile IDs, generation profile IDs, or
+model/provider settings.
+
+V1 built-ins are:
+
+- `linear_scene`
+- `authored_choices`
+- `generated_choice_set`
+- `scene_update`
+- `confirm_gated_generation`
+
+`POST /templates/{template_id}/scripts` creates a normal owned VN script and
+stores the starter draft through the same draft replacement and diagnostics path
+used by `PUT /scripts/{script_id}/draft`. The response includes both `script`
+and `draft`; after creation, clients treat the script like any other authored
+script. Validation and publishing remain server-side authority. Unknown template
+IDs return `404 template_not_found`.
 
 ### Draft Save
 

--- a/apps/tldw-frontend/__tests__/vn-scripts/VNScriptsWorkbench.test.tsx
+++ b/apps/tldw-frontend/__tests__/vn-scripts/VNScriptsWorkbench.test.tsx
@@ -3,11 +3,13 @@ import { fireEvent, render, screen, waitFor, within } from '@testing-library/rea
 import userEvent from '@testing-library/user-event';
 
 const mocks = vi.hoisted(() => ({
+  createVNScriptFromTemplate: vi.fn(),
   createVNScript: vi.fn(),
   evaluateVNScriptVersionPolicy: vi.fn(),
   getVNScriptDiagnostics: vi.fn(),
   getVNScriptDraft: vi.fn(),
   getVNScriptManifestSnapshot: vi.fn(),
+  listVNScriptTemplates: vi.fn(),
   listVNScripts: vi.fn(),
   listVNScriptVersions: vi.fn(),
   publishVNScript: vi.fn(),
@@ -16,11 +18,13 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@web/lib/api/vnScripts', () => ({
+  createVNScriptFromTemplate: (...args: unknown[]) => mocks.createVNScriptFromTemplate(...args),
   createVNScript: (...args: unknown[]) => mocks.createVNScript(...args),
   evaluateVNScriptVersionPolicy: (...args: unknown[]) => mocks.evaluateVNScriptVersionPolicy(...args),
   getVNScriptDiagnostics: (...args: unknown[]) => mocks.getVNScriptDiagnostics(...args),
   getVNScriptDraft: (...args: unknown[]) => mocks.getVNScriptDraft(...args),
   getVNScriptManifestSnapshot: (...args: unknown[]) => mocks.getVNScriptManifestSnapshot(...args),
+  listVNScriptTemplates: (...args: unknown[]) => mocks.listVNScriptTemplates(...args),
   listVNScripts: (...args: unknown[]) => mocks.listVNScripts(...args),
   listVNScriptVersions: (...args: unknown[]) => mocks.listVNScriptVersions(...args),
   publishVNScript: (...args: unknown[]) => mocks.publishVNScript(...args),
@@ -123,6 +127,53 @@ const secondVersionResponse = {
   generation_profile_snapshot_id: 323,
 };
 
+const linearTemplate = {
+  id: 'linear_scene',
+  label: 'Linear scene',
+  description: 'Start with one authored scene.',
+  category: 'starter',
+  recommended_content_rating: 'general',
+  required_capabilities: ['dialogue'],
+  preview: { scenes: 1, choices: 0 },
+  default_title: 'Linear scene',
+  default_description: 'A simple authored opener.',
+};
+
+const choiceTemplate = {
+  id: 'authored_choices',
+  label: 'Authored choices',
+  description: 'Start with player choices.',
+  category: 'starter',
+  recommended_content_rating: 'teen',
+  required_capabilities: ['dialogue', 'choices'],
+  preview: { scenes: 2, choices: 2 },
+  default_title: 'Choice scene',
+  default_description: 'An opener with two choices.',
+};
+
+const templateScript = {
+  id: 21,
+  title: 'Template Route',
+  description: 'A simple authored opener.',
+  status: 'draft',
+  primary_asset_pack_id: 55,
+  policy_profile_id: 'teen-policy',
+  generation_profile_id: 'story-default',
+  generation_profiles: {},
+  content_rating: 'general',
+};
+
+const templateDraftResponse = {
+  script_id: 21,
+  revision: 1,
+  draft: {
+    version: 'vn_script_program.v1',
+    primary_asset_pack_id: 55,
+    scenes: [{ id: 'template_start', text: 'Template opening.' }],
+  },
+  diagnostics: { valid: true },
+};
+
 function createDeferred<T>() {
   let resolve!: (value: T) => void;
   let reject!: (reason?: unknown) => void;
@@ -144,10 +195,15 @@ function mockList(items = [openingScript, secondScript]) {
   });
 }
 
+function mockTemplates(items = [linearTemplate, choiceTemplate]) {
+  mocks.listVNScriptTemplates.mockResolvedValue({ items });
+}
+
 describe('VNScriptsWorkbench', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockList();
+    mockTemplates();
     mocks.createVNScript.mockResolvedValue({
       ...secondScript,
       id: 9,
@@ -156,6 +212,10 @@ describe('VNScriptsWorkbench', () => {
       policy_profile_id: 'policy-explicit',
       generation_profile_id: 'gen-explicit',
       content_rating: 'mature',
+    });
+    mocks.createVNScriptFromTemplate.mockResolvedValue({
+      script: templateScript,
+      draft: templateDraftResponse,
     });
     mocks.getVNScriptDraft.mockResolvedValue(draftResponse);
     mocks.putVNScriptDraft.mockResolvedValue({
@@ -264,6 +324,78 @@ describe('VNScriptsWorkbench', () => {
     expect(await screen.findByText('Script #9')).toBeInTheDocument();
     expect(mocks.getVNScriptDraft).toHaveBeenCalledWith(9);
     expect(mocks.listVNScriptVersions).toHaveBeenCalledWith(9);
+  });
+
+  it('loads templates on mount and renders starter options', async () => {
+    const user = userEvent.setup();
+    render(<VNScriptsWorkbench />);
+
+    expect(await screen.findByLabelText('Starter template')).toBeInTheDocument();
+    await waitFor(() => expect(mocks.listVNScriptTemplates).toHaveBeenCalledTimes(1));
+    expect(screen.getByRole('option', { name: 'Blank/custom JSON' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Linear scene' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Authored choices' })).toBeInTheDocument();
+    await user.selectOptions(screen.getByLabelText('Starter template'), 'linear_scene');
+    expect(screen.getByText('Start with one authored scene.')).toBeInTheDocument();
+  });
+
+  it('creates from a selected template and shows the returned draft immediately', async () => {
+    const user = userEvent.setup();
+    render(<VNScriptsWorkbench />);
+
+    await screen.findByRole('button', { name: /Opening Route/ });
+    await user.selectOptions(screen.getByLabelText('Starter template'), 'linear_scene');
+    await user.clear(screen.getByLabelText('Title'));
+    await user.type(screen.getByLabelText('Title'), 'Template Route');
+    await user.clear(screen.getByLabelText('Primary asset pack ID'));
+    await user.type(screen.getByLabelText('Primary asset pack ID'), '55');
+    await user.clear(screen.getByLabelText('Policy profile ID'));
+    await user.type(screen.getByLabelText('Policy profile ID'), 'teen-policy');
+    await user.clear(screen.getByLabelText('Generation profile ID'));
+    await user.type(screen.getByLabelText('Generation profile ID'), 'story-default');
+    await user.selectOptions(screen.getByLabelText('Content rating'), 'general');
+    await user.click(screen.getByRole('button', { name: 'Create script' }));
+
+    await waitFor(() => {
+      expect(mocks.createVNScriptFromTemplate).toHaveBeenCalledWith('linear_scene', {
+        title: 'Template Route',
+        description: 'A simple authored opener.',
+        primary_asset_pack_id: 55,
+        policy_profile_id: 'teen-policy',
+        generation_profile_id: 'story-default',
+        content_rating: 'general',
+      });
+    });
+    expect(mocks.createVNScript).not.toHaveBeenCalled();
+    expect(await screen.findByText('Script #21')).toBeInTheDocument();
+    expect(screen.getByDisplayValue(/template_start/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Template Route/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save draft' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'Validate' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'Diagnostics' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'Publish' })).toBeEnabled();
+  });
+
+  it('keeps the blank custom JSON path on the normal create endpoint', async () => {
+    const user = userEvent.setup();
+    render(<VNScriptsWorkbench />);
+
+    await screen.findByRole('button', { name: /Opening Route/ });
+    await user.selectOptions(screen.getByLabelText('Starter template'), 'blank');
+    await user.clear(screen.getByLabelText('Title'));
+    await user.type(screen.getByLabelText('Title'), 'Blank Route');
+    await user.clear(screen.getByLabelText('Primary asset pack ID'));
+    await user.type(screen.getByLabelText('Primary asset pack ID'), '46');
+    await user.click(screen.getByRole('button', { name: 'Create script' }));
+
+    await waitFor(() => {
+      expect(mocks.createVNScript).toHaveBeenCalledWith({
+        title: 'Blank Route',
+        primary_asset_pack_id: 46,
+        content_rating: 'teen',
+      });
+    });
+    expect(mocks.createVNScriptFromTemplate).not.toHaveBeenCalled();
   });
 
   it('omits empty optional profile IDs when creating a script shell', async () => {

--- a/apps/tldw-frontend/__tests__/vn-scripts/vnScriptsApi.test.ts
+++ b/apps/tldw-frontend/__tests__/vn-scripts/vnScriptsApi.test.ts
@@ -15,6 +15,7 @@ vi.mock('@web/lib/api', () => ({
 }));
 
 import {
+  createVNScriptFromTemplate,
   createVNScript,
   deleteVNScript,
   evaluateVNScriptVersionPolicy,
@@ -23,6 +24,7 @@ import {
   getVNScriptDraft,
   getVNScriptManifestSnapshot,
   getVNScriptVersion,
+  listVNScriptTemplates,
   listVNScripts,
   listVNScriptVersions,
   patchVNScript,
@@ -143,5 +145,46 @@ describe('vnScripts api client', () => {
     expect(mocks.apiClient.get).toHaveBeenCalledWith('/vn/vn-scripts/scripts/1/versions', {
       params: {},
     });
+  });
+
+  it('calls the VN script template catalog endpoint', async () => {
+    mocks.apiClient.get.mockResolvedValueOnce({
+      items: [
+        {
+          id: 'linear_scene',
+          label: 'Linear scene',
+          description: 'Simple intro scene',
+          category: 'starter',
+          recommended_content_rating: 'general',
+          required_capabilities: [],
+          preview: { scenes: 1 },
+          default_title: 'Linear scene',
+          default_description: 'A simple starter scene',
+        },
+      ],
+    });
+
+    const response = await listVNScriptTemplates();
+
+    expect(response.items[0].id).toBe('linear_scene');
+    expect(mocks.apiClient.get).toHaveBeenCalledWith('/vn/vn-scripts/templates');
+  });
+
+  it('creates a VN script from a template endpoint with the request payload', async () => {
+    const request = {
+      title: 'Template Route',
+      description: 'Created from a starter',
+      primary_asset_pack_id: 7,
+      policy_profile_id: 'teen-policy',
+      generation_profile_id: 'story-default',
+      content_rating: 'teen' as const,
+    };
+
+    await createVNScriptFromTemplate('linear_scene', request);
+
+    expect(mocks.apiClient.post).toHaveBeenCalledWith(
+      '/vn/vn-scripts/templates/linear_scene/scripts',
+      request
+    );
   });
 });

--- a/apps/tldw-frontend/__tests__/vn-scripts/vnScriptsApi.test.ts
+++ b/apps/tldw-frontend/__tests__/vn-scripts/vnScriptsApi.test.ts
@@ -202,4 +202,18 @@ describe('vnScripts api client', () => {
       request
     );
   });
+
+  it('allows create-from-template requests to rely on server template title defaults', async () => {
+    const request = {
+      primary_asset_pack_id: 7,
+      content_rating: 'general' as const,
+    };
+
+    await createVNScriptFromTemplate('linear_scene', request);
+
+    expect(mocks.apiClient.post).toHaveBeenCalledWith(
+      '/vn/vn-scripts/templates/linear_scene/scripts',
+      request
+    );
+  });
 });

--- a/apps/tldw-frontend/__tests__/vn-scripts/vnScriptsApi.test.ts
+++ b/apps/tldw-frontend/__tests__/vn-scripts/vnScriptsApi.test.ts
@@ -187,4 +187,19 @@ describe('vnScripts api client', () => {
       request
     );
   });
+
+  it('encodes VN script template ids before building the create endpoint', async () => {
+    const request = {
+      title: 'Template Route',
+      primary_asset_pack_id: 7,
+      content_rating: 'general' as const,
+    };
+
+    await createVNScriptFromTemplate('linear scene/α', request);
+
+    expect(mocks.apiClient.post).toHaveBeenCalledWith(
+      '/vn/vn-scripts/templates/linear%20scene%2F%CE%B1/scripts',
+      request
+    );
+  });
 });

--- a/apps/tldw-frontend/components/vn-scripts/VNScriptsWorkbench.tsx
+++ b/apps/tldw-frontend/components/vn-scripts/VNScriptsWorkbench.tsx
@@ -4,11 +4,13 @@ import { Button } from '@web/components/ui/Button';
 import { Input } from '@web/components/ui/Input';
 import JsonEditor from '@web/components/ui/JsonEditor';
 import {
+  createVNScriptFromTemplate,
   createVNScript,
   evaluateVNScriptVersionPolicy,
   getVNScriptDiagnostics,
   getVNScriptDraft,
   getVNScriptManifestSnapshot,
+  listVNScriptTemplates,
   listVNScripts,
   listVNScriptVersions,
   publishVNScript,
@@ -20,6 +22,7 @@ import type {
   VNScriptDiagnosticsResponse,
   VNScriptDraftResponse,
   VNScriptResponse,
+  VNScriptTemplateSummary,
   VNScriptValidationResponse,
   VNScriptVersionResponse,
 } from '@web/types/vn-scripts';
@@ -98,6 +101,7 @@ function summaryLines(value: unknown): string[] {
 
 export default function VNScriptsWorkbench() {
   const [scripts, setScripts] = useState<VNScriptResponse[]>([]);
+  const [templates, setTemplates] = useState<VNScriptTemplateSummary[]>([]);
   const [selectedScript, setSelectedScript] = useState<VNScriptResponse | null>(null);
   const [draft, setDraft] = useState<VNScriptDraftResponse | null>(null);
   const [draftText, setDraftText] = useState('{}');
@@ -107,6 +111,7 @@ export default function VNScriptsWorkbench() {
   const [manifestSnapshots, setManifestSnapshots] = useState<Record<number, unknown>>({});
   const [policySummaries, setPolicySummaries] = useState<Record<number, unknown>>({});
   const [isLoadingScripts, setIsLoadingScripts] = useState(true);
+  const [isLoadingTemplates, setIsLoadingTemplates] = useState(true);
   const [isCreating, setIsCreating] = useState(false);
   const [isSavingDraft, setIsSavingDraft] = useState(false);
   const [isValidating, setIsValidating] = useState(false);
@@ -121,8 +126,10 @@ export default function VNScriptsWorkbench() {
   const [policyProfileId, setPolicyProfileId] = useState('');
   const [generationProfileId, setGenerationProfileId] = useState('');
   const [contentRating, setContentRating] = useState<VNScriptContentRating>('teen');
+  const [selectedTemplateId, setSelectedTemplateId] = useState('blank');
   const [publishLabel, setPublishLabel] = useState('');
   const selectedScriptIdRef = useRef<number | null>(null);
+  const draftHydrationRef = useRef<VNScriptDraftResponse | null>(null);
   const publishKeyRef = useRef<Record<string, string>>({});
 
   useEffect(() => {
@@ -139,11 +146,46 @@ export default function VNScriptsWorkbench() {
     ];
   }, [selectedScript]);
 
+  const selectedTemplate = useMemo(
+    () => templates.find((template) => template.id === selectedTemplateId) ?? null,
+    [selectedTemplateId, templates]
+  );
+
+  const handleTemplateChange = useCallback((templateId: string) => {
+    setSelectedTemplateId(templateId);
+    const nextTemplate = templates.find((template) => template.id === templateId);
+    if (!nextTemplate) return;
+    setTitle(nextTemplate.default_title);
+    setContentRating(nextTemplate.recommended_content_rating);
+  }, [templates]);
+
   const refreshVersions = useCallback(async (scriptId: number) => {
     const nextVersions = await listVNScriptVersions(scriptId);
     if (selectedScriptIdRef.current === scriptId) {
       setVersions(nextVersions.items ?? []);
     }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadTemplates() {
+      setIsLoadingTemplates(true);
+      try {
+        const response = await listVNScriptTemplates();
+        if (cancelled) return;
+        setTemplates(response.items ?? []);
+      } catch (loadError) {
+        if (!cancelled) setError(errorMessage(loadError, 'Failed to load VN script templates'));
+      } finally {
+        if (!cancelled) setIsLoadingTemplates(false);
+      }
+    }
+
+    void loadTemplates();
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   useEffect(() => {
@@ -185,6 +227,27 @@ export default function VNScriptsWorkbench() {
 
     let cancelled = false;
     async function loadScriptDetails() {
+      const hydratedDraft = draftHydrationRef.current;
+      if (hydratedDraft?.script_id === selectedScript.id) {
+        draftHydrationRef.current = null;
+        setDraft(hydratedDraft);
+        setDraftText(formatJson(hydratedDraft.draft));
+        setVersions([]);
+        setError(null);
+        setEditorError(null);
+        setStatusMessage(null);
+        setValidation(null);
+        setDiagnostics(null);
+        setManifestSnapshots({});
+        setPolicySummaries({});
+        try {
+          const nextVersions = await listVNScriptVersions(selectedScript.id);
+          if (!cancelled) setVersions(nextVersions.items ?? []);
+        } catch {
+          if (!cancelled) setVersions([]);
+        }
+        return;
+      }
       setDraft(null);
       setDraftText('{}');
       setVersions([]);
@@ -249,22 +312,51 @@ export default function VNScriptsWorkbench() {
     setError(null);
     setStatusMessage(null);
     try {
-      const created = await createVNScript({
+      const request = {
         title: title.trim(),
+        ...(selectedTemplate?.default_description
+          ? { description: selectedTemplate.default_description }
+          : {}),
         primary_asset_pack_id: parsedAssetPackId,
         ...(policyProfileId.trim() ? { policy_profile_id: policyProfileId.trim() } : {}),
         ...(generationProfileId.trim() ? { generation_profile_id: generationProfileId.trim() } : {}),
         content_rating: contentRating,
-      });
-      setScripts((previous) => [created, ...previous.filter((script) => script.id !== created.id)]);
-      setSelectedScript(created);
-      setStatusMessage(`Created script #${created.id}.`);
+      };
+      const created =
+        selectedTemplateId === 'blank'
+          ? await createVNScript(request)
+          : await createVNScriptFromTemplate(selectedTemplateId, request);
+      const createdScript = 'script' in created ? created.script : created;
+      if ('draft' in created) {
+        draftHydrationRef.current = created.draft;
+        setDraft(created.draft);
+        setDraftText(formatJson(created.draft.draft));
+        setVersions([]);
+        setValidation(null);
+        setDiagnostics(null);
+        setManifestSnapshots({});
+        setPolicySummaries({});
+      }
+      setScripts((previous) => [
+        createdScript,
+        ...previous.filter((script) => script.id !== createdScript.id),
+      ]);
+      setSelectedScript(createdScript);
+      setStatusMessage(`Created script #${createdScript.id}.`);
     } catch (createError) {
       setError(errorMessage(createError, 'Failed to create VN script'));
     } finally {
       setIsCreating(false);
     }
-  }, [contentRating, generationProfileId, policyProfileId, primaryAssetPackId, title]);
+  }, [
+    contentRating,
+    generationProfileId,
+    policyProfileId,
+    primaryAssetPackId,
+    selectedTemplate,
+    selectedTemplateId,
+    title,
+  ]);
 
   const handleSaveDraft = useCallback(async () => {
     if (!selectedScript || !draft) return;
@@ -479,6 +571,28 @@ export default function VNScriptsWorkbench() {
             <form onSubmit={handleCreateScript} className="rounded-md border border-border bg-surface p-3">
               <h2 className="mb-3 text-sm font-semibold">Create script</h2>
               <div className="space-y-3">
+                <div>
+                  <div className="mb-1 flex items-center justify-between gap-2">
+                    <label className="block text-sm font-medium text-text" htmlFor="vn-script-template">
+                      Starter template
+                    </label>
+                    {isLoadingTemplates && <span className="text-xs text-text-muted">Loading...</span>}
+                  </div>
+                  <select
+                    id="vn-script-template"
+                    className="block w-full rounded-md border-border bg-bg shadow-sm focus:border-primary focus:ring-primary"
+                    value={selectedTemplateId}
+                    onChange={(event) => handleTemplateChange(event.target.value)}
+                  >
+                    <option value="blank">Blank/custom JSON</option>
+                    {templates.map((template) => (
+                      <option key={template.id} value={template.id}>{template.label}</option>
+                    ))}
+                  </select>
+                  {selectedTemplate && (
+                    <p className="mt-1 text-xs text-text-muted">{selectedTemplate.description}</p>
+                  )}
+                </div>
                 <Input label="Title" value={title} onChange={(event) => setTitle(event.target.value)} />
                 <Input
                   label="Primary asset pack ID"

--- a/apps/tldw-frontend/lib/api/vnScripts.ts
+++ b/apps/tldw-frontend/lib/api/vnScripts.ts
@@ -1,6 +1,8 @@
 import { apiClient } from '@web/lib/api';
 import type {
   VNScriptCreate,
+  VNScriptCreateFromTemplateRequest,
+  VNScriptCreateFromTemplateResponse,
   VNScriptDiagnosticsResponse,
   VNScriptDraftPutRequest,
   VNScriptDraftResponse,
@@ -11,6 +13,7 @@ import type {
   VNScriptPublishRequest,
   VNScriptPublishResponse,
   VNScriptResponse,
+  VNScriptTemplateListResponse,
   VNScriptValidateRequest,
   VNScriptValidationResponse,
   VNScriptVersionListQuery,
@@ -32,6 +35,17 @@ function toQueryParams<T extends object>(query: T): QueryParams {
 
 export function createVNScript(request: VNScriptCreate): Promise<VNScriptResponse> {
   return apiClient.post(`${VN_SCRIPTS_BASE}/scripts`, request);
+}
+
+export function listVNScriptTemplates(): Promise<VNScriptTemplateListResponse> {
+  return apiClient.get(`${VN_SCRIPTS_BASE}/templates`);
+}
+
+export function createVNScriptFromTemplate(
+  templateId: string,
+  request: VNScriptCreateFromTemplateRequest
+): Promise<VNScriptCreateFromTemplateResponse> {
+  return apiClient.post(`${VN_SCRIPTS_BASE}/templates/${templateId}/scripts`, request);
 }
 
 export function listVNScripts(query: VNScriptListQuery = {}): Promise<VNScriptListResponse> {

--- a/apps/tldw-frontend/lib/api/vnScripts.ts
+++ b/apps/tldw-frontend/lib/api/vnScripts.ts
@@ -45,7 +45,7 @@ export function createVNScriptFromTemplate(
   templateId: string,
   request: VNScriptCreateFromTemplateRequest
 ): Promise<VNScriptCreateFromTemplateResponse> {
-  return apiClient.post(`${VN_SCRIPTS_BASE}/templates/${templateId}/scripts`, request);
+  return apiClient.post(`${VN_SCRIPTS_BASE}/templates/${encodeURIComponent(templateId)}/scripts`, request);
 }
 
 export function listVNScripts(query: VNScriptListQuery = {}): Promise<VNScriptListResponse> {

--- a/apps/tldw-frontend/types/vn-scripts.ts
+++ b/apps/tldw-frontend/types/vn-scripts.ts
@@ -70,7 +70,9 @@ export interface VNScriptTemplateListResponse {
   items: VNScriptTemplateSummary[];
 }
 
-export type VNScriptCreateFromTemplateRequest = VNScriptCreate;
+export type VNScriptCreateFromTemplateRequest = Omit<VNScriptCreate, 'title'> & {
+  title?: string | null;
+};
 
 export interface VNScriptCreateFromTemplateResponse {
   script: VNScriptResponse;

--- a/apps/tldw-frontend/types/vn-scripts.ts
+++ b/apps/tldw-frontend/types/vn-scripts.ts
@@ -54,6 +54,29 @@ export interface VNScriptListResponse {
   pagination: VNScriptOffsetPagination;
 }
 
+export interface VNScriptTemplateSummary {
+  id: string;
+  label: string;
+  description: string;
+  category: string;
+  recommended_content_rating: VNScriptContentRating;
+  required_capabilities: string[];
+  preview: Record<string, unknown>;
+  default_title: string;
+  default_description?: string | null;
+}
+
+export interface VNScriptTemplateListResponse {
+  items: VNScriptTemplateSummary[];
+}
+
+export type VNScriptCreateFromTemplateRequest = VNScriptCreate;
+
+export interface VNScriptCreateFromTemplateResponse {
+  script: VNScriptResponse;
+  draft: VNScriptDraftResponse;
+}
+
 export interface VNScriptDraftResponse {
   script_id: number;
   revision: number;

--- a/backlog/tasks/task-298 - Add-VN-script-starter-templates-and-guided-authoring.md
+++ b/backlog/tasks/task-298 - Add-VN-script-starter-templates-and-guided-authoring.md
@@ -61,8 +61,8 @@ Implementation will proceed in an isolated worktree on branch codex/vn-script-te
 ## Verification
 
 <!-- SECTION:VERIFICATION:BEGIN -->
-- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/VN_Scripts -q` -> 48 passed, 5 warnings.
-- `bunx vitest run __tests__/vn-scripts/vnScriptsApi.test.ts __tests__/vn-scripts/VNScriptsWorkbench.test.tsx` from `apps/tldw-frontend` -> 24 passed.
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/VN_Scripts -q` -> 49 passed, 5 warnings.
+- `bunx vitest run __tests__/vn-scripts/vnScriptsApi.test.ts __tests__/vn-scripts/VNScriptsWorkbench.test.tsx` from `apps/tldw-frontend` -> 25 passed.
 - `bunx eslint components/vn-scripts/VNScriptsWorkbench.tsx lib/api/vnScripts.ts types/vn-scripts.ts __tests__/vn-scripts/vnScriptsApi.test.ts __tests__/vn-scripts/VNScriptsWorkbench.test.tsx` from `apps/tldw-frontend` -> passed.
 - `source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/vn_scripts.py tldw_Server_API/app/api/v1/schemas/vn_script_schemas.py tldw_Server_API/app/core/VN_Scripts tldw_Server_API/app/core/DB_Management/VNScripts_DB.py -f json -o /tmp/bandit_vn_script_templates_review.json` -> passed, 0 findings.
 - `git diff --check` -> passed.

--- a/backlog/tasks/task-298 - Add-VN-script-starter-templates-and-guided-authoring.md
+++ b/backlog/tasks/task-298 - Add-VN-script-starter-templates-and-guided-authoring.md
@@ -1,0 +1,75 @@
+---
+id: TASK-298
+title: Add VN script starter templates and guided authoring
+status: Done
+assignee: []
+created_date: '2026-05-12 05:57'
+updated_date: '2026-05-12 06:33'
+labels:
+  - vn
+  - webui
+  - api
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1604'
+  - 'https://github.com/rmusser01/tldw_server/issues/1391'
+  - 'https://github.com/rmusser01/tldw_server/pull/1606'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement GitHub issue #1604: make VN script authoring easier by adding backend-owned starter templates that API clients and the bundled WebUI can use to create draft VN scripts, while preserving backend validation and publish as the authority. This should reduce blank-page friction without introducing a visual node editor or text DSL.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 API clients can list supported starter templates with stable IDs, labels, descriptions, required capabilities, and preview-safe metadata.
+- [x] #2 API clients can create a VN script draft from a template through a documented backend endpoint or request shape.
+- [x] #3 Template-created drafts validate through the existing diagnostics path and publish through the existing publish path.
+- [x] #4 The /vn-scripts WebUI can start from a template and still exposes the JSON editor and diagnostics panel for full control.
+- [x] #5 Tests prove template output is deterministic, user-owned, and cannot smuggle unsupported runtime directives or unsafe policy changes.
+- [x] #6 Relevant documentation or implementation notes describe the template contract for custom frontends.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Implementation will proceed in an isolated worktree on branch codex/vn-script-templates-1604. Scope: backend-owned VN script starter template catalog and create-from-template endpoint/request shape, TypeScript API/types, /vn-scripts WebUI template picker, focused backend/frontend tests, documentation/plan updates, and verification including Bandit for touched Python scope.
+<!-- SECTION:PLAN:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Added backend-owned starter template catalog endpoints under `/api/v1/vn/vn-scripts/templates`.
+- Added WebUI template selection while preserving the blank/custom JSON creation path.
+- Documented the custom frontend contract in `Docs/API-related/VN_PLATFORM_API.md` and the VN platform API spec.
+<!-- SECTION:NOTES:END -->
+
+## Verification
+
+<!-- SECTION:VERIFICATION:BEGIN -->
+- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/VN_Scripts -q` -> 47 passed, 5 warnings.
+- `bunx vitest run __tests__/vn-scripts/vnScriptsApi.test.ts __tests__/vn-scripts/VNScriptsWorkbench.test.tsx` from `apps/tldw-frontend` -> 23 passed.
+- `bunx eslint components/vn-scripts/VNScriptsWorkbench.tsx lib/api/vnScripts.ts types/vn-scripts.ts __tests__/vn-scripts/vnScriptsApi.test.ts __tests__/vn-scripts/VNScriptsWorkbench.test.tsx` from `apps/tldw-frontend` -> passed.
+- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/vn_scripts.py tldw_Server_API/app/api/v1/schemas/vn_script_schemas.py tldw_Server_API/app/core/VN_Scripts -f json -o /tmp/bandit_vn_script_templates.json` -> passed, 0 findings.
+- `git diff --check` -> passed.
+- Draft PR opened: https://github.com/rmusser01/tldw_server/pull/1606
+<!-- SECTION:VERIFICATION:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented backend-owned VN script starter templates and guided authoring for #1604. The API now exposes a sanitized template catalog plus create-from-template flow that stores normal script drafts through existing validation. The WebUI now loads the catalog, offers a compact starter selector, and immediately hydrates returned template drafts while keeping full JSON editing, diagnostics, validation, save, and publish controls available.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-298 - Add-VN-script-starter-templates-and-guided-authoring.md
+++ b/backlog/tasks/task-298 - Add-VN-script-starter-templates-and-guided-authoring.md
@@ -55,15 +55,16 @@ Implementation will proceed in an isolated worktree on branch codex/vn-script-te
 - Added backend-owned starter template catalog endpoints under `/api/v1/vn/vn-scripts/templates`.
 - Added WebUI template selection while preserving the blank/custom JSON creation path.
 - Documented the custom frontend contract in `Docs/API-related/VN_PLATFORM_API.md` and the VN platform API spec.
+- Addressed PR review follow-ups for atomic template draft creation, frontend template ID encoding, and portable verification commands.
 <!-- SECTION:NOTES:END -->
 
 ## Verification
 
 <!-- SECTION:VERIFICATION:BEGIN -->
-- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/VN_Scripts -q` -> 47 passed, 5 warnings.
-- `bunx vitest run __tests__/vn-scripts/vnScriptsApi.test.ts __tests__/vn-scripts/VNScriptsWorkbench.test.tsx` from `apps/tldw-frontend` -> 23 passed.
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/VN_Scripts -q` -> 48 passed, 5 warnings.
+- `bunx vitest run __tests__/vn-scripts/vnScriptsApi.test.ts __tests__/vn-scripts/VNScriptsWorkbench.test.tsx` from `apps/tldw-frontend` -> 24 passed.
 - `bunx eslint components/vn-scripts/VNScriptsWorkbench.tsx lib/api/vnScripts.ts types/vn-scripts.ts __tests__/vn-scripts/vnScriptsApi.test.ts __tests__/vn-scripts/VNScriptsWorkbench.test.tsx` from `apps/tldw-frontend` -> passed.
-- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/vn_scripts.py tldw_Server_API/app/api/v1/schemas/vn_script_schemas.py tldw_Server_API/app/core/VN_Scripts -f json -o /tmp/bandit_vn_script_templates.json` -> passed, 0 findings.
+- `source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/vn_scripts.py tldw_Server_API/app/api/v1/schemas/vn_script_schemas.py tldw_Server_API/app/core/VN_Scripts tldw_Server_API/app/core/DB_Management/VNScripts_DB.py -f json -o /tmp/bandit_vn_script_templates_review.json` -> passed, 0 findings.
 - `git diff --check` -> passed.
 - Draft PR opened: https://github.com/rmusser01/tldw_server/pull/1606
 <!-- SECTION:VERIFICATION:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/vn_scripts.py
+++ b/tldw_Server_API/app/api/v1/endpoints/vn_scripts.py
@@ -12,6 +12,8 @@ from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_
 from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
 from tldw_Server_API.app.api.v1.schemas.vn_script_schemas import (
     VNScriptCreate,
+    VNScriptCreateFromTemplateRequest,
+    VNScriptCreateFromTemplateResponse,
     VNScriptDiagnosticsResponse,
     VNScriptDraftPutRequest,
     VNScriptDraftResponse,
@@ -21,6 +23,8 @@ from tldw_Server_API.app.api.v1.schemas.vn_script_schemas import (
     VNScriptPublishRequest,
     VNScriptPublishResponse,
     VNScriptResponse,
+    VNScriptTemplateListResponse,
+    VNScriptTemplateSummary,
     VNScriptValidateRequest,
     VNScriptValidationResponse,
     VNScriptVersionListResponse,
@@ -28,6 +32,7 @@ from tldw_Server_API.app.api.v1.schemas.vn_script_schemas import (
     VNScriptVersionPolicyEvaluateResponse,
     VNScriptVersionResponse,
 )
+from tldw_Server_API.app.core.VN_Scripts.templates import get_template
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.AuthNZ.database import DatabasePool, get_db_pool
 from tldw_Server_API.app.core.AuthNZ.repos.generated_files_repo import AuthnzGeneratedFilesRepo
@@ -93,6 +98,70 @@ async def create_script(
     except ValueError as exc:
         raise _handle_value_error(exc) from exc
     return VNScriptResponse.model_validate(row)
+
+
+@router.get("/templates", response_model=VNScriptTemplateListResponse)
+async def list_templates(service: VNScriptService = Depends(_service)) -> VNScriptTemplateListResponse:
+    """List preview-safe VN script starter templates."""
+    return VNScriptTemplateListResponse(
+        items=[VNScriptTemplateSummary.model_validate(item) for item in service.list_templates()]
+    )
+
+
+@router.post(
+    "/templates/{template_id}/scripts",
+    response_model=VNScriptCreateFromTemplateResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_script_from_template(
+    template_id: str,
+    request: VNScriptCreateFromTemplateRequest,
+    service: VNScriptService = Depends(_service),
+    files_repo: AuthnzGeneratedFilesRepo = Depends(_generated_files_repo),
+    profile_store: VNPolicyProfileStore = Depends(_profile_store),
+) -> VNScriptCreateFromTemplateResponse:
+    """Create a normal VN script and store a validated starter-template draft."""
+    try:
+        template = get_template(template_id)
+        title = request.title or template.default_title
+        description = request.description if request.description is not None else template.default_description
+        policy_profile, generation_profile, generation_profiles = await _resolve_request_profiles(
+            policy_profile_id=request.policy_profile_id,
+            generation_profile_id=request.generation_profile_id,
+            generation_profiles=request.generation_profiles,
+            profile_store=profile_store,
+        )
+        draft_preview = service.create_script_from_template(
+            template_id,
+            title=title,
+            description=description,
+            primary_asset_pack_id=request.primary_asset_pack_id,
+            policy_profile_id=request.policy_profile_id,
+            generation_profile_id=request.generation_profile_id,
+            generation_profiles=request.generation_profiles,
+            content_rating=request.content_rating,
+            policy_profile=policy_profile,
+            generation_profile=generation_profile,
+            resolved_generation_profiles=generation_profiles,
+        )
+        audio_refs = await _resolve_accessible_audio_refs(
+            draft_preview["draft"]["draft"],
+            files_repo=files_repo,
+            owner_user_id=service.owner_user_id,
+        )
+        if audio_refs:
+            draft_preview["draft"] = service.replace_draft(
+                int(draft_preview["script"]["id"]),
+                if_revision=int(draft_preview["draft"]["revision"]),
+                draft=draft_preview["draft"]["draft"],
+                audio_refs=audio_refs,
+                policy_profile=policy_profile,
+                generation_profile=generation_profile,
+                generation_profiles=generation_profiles,
+            )
+    except ValueError as exc:
+        raise _handle_value_error(exc) from exc
+    return VNScriptCreateFromTemplateResponse.model_validate(draft_preview)
 
 
 @router.get("/scripts", response_model=VNScriptListResponse)
@@ -511,7 +580,7 @@ def _is_accessible_audio_record(record: Mapping[str, Any] | None, *, owner_user_
 
 def _handle_value_error(exc: ValueError) -> HTTPException:
     reason = str(exc) or "invalid_request"
-    if reason in {"script_not_found", "script_version_not_found"}:
+    if reason in {"script_not_found", "script_version_not_found", "template_not_found"}:
         return HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=vn_error_detail(ERROR_NOT_FOUND, reason, details={"reason": reason}),

--- a/tldw_Server_API/app/api/v1/endpoints/vn_scripts.py
+++ b/tldw_Server_API/app/api/v1/endpoints/vn_scripts.py
@@ -32,7 +32,7 @@ from tldw_Server_API.app.api.v1.schemas.vn_script_schemas import (
     VNScriptVersionPolicyEvaluateResponse,
     VNScriptVersionResponse,
 )
-from tldw_Server_API.app.core.VN_Scripts.templates import get_template
+from tldw_Server_API.app.core.VN_Scripts.templates import get_template, instantiate_template
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.AuthNZ.database import DatabasePool, get_db_pool
 from tldw_Server_API.app.core.AuthNZ.repos.generated_files_repo import AuthnzGeneratedFilesRepo
@@ -131,6 +131,17 @@ async def create_script_from_template(
             generation_profiles=request.generation_profiles,
             profile_store=profile_store,
         )
+        draft = instantiate_template(
+            template_id,
+            title=title,
+            primary_asset_pack_id=request.primary_asset_pack_id,
+            generation_profile_id=request.generation_profile_id,
+        )
+        audio_refs = await _resolve_accessible_audio_refs(
+            draft,
+            files_repo=files_repo,
+            owner_user_id=service.owner_user_id,
+        )
         draft_preview = service.create_script_from_template(
             template_id,
             title=title,
@@ -143,22 +154,9 @@ async def create_script_from_template(
             policy_profile=policy_profile,
             generation_profile=generation_profile,
             resolved_generation_profiles=generation_profiles,
+            audio_refs=audio_refs,
+            draft=draft,
         )
-        audio_refs = await _resolve_accessible_audio_refs(
-            draft_preview["draft"]["draft"],
-            files_repo=files_repo,
-            owner_user_id=service.owner_user_id,
-        )
-        if audio_refs:
-            draft_preview["draft"] = service.replace_draft(
-                int(draft_preview["script"]["id"]),
-                if_revision=int(draft_preview["draft"]["revision"]),
-                draft=draft_preview["draft"]["draft"],
-                audio_refs=audio_refs,
-                policy_profile=policy_profile,
-                generation_profile=generation_profile,
-                generation_profiles=generation_profiles,
-            )
     except ValueError as exc:
         raise _handle_value_error(exc) from exc
     return VNScriptCreateFromTemplateResponse.model_validate(draft_preview)

--- a/tldw_Server_API/app/api/v1/schemas/vn_script_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/vn_script_schemas.py
@@ -28,6 +28,7 @@ class VNScriptCreate(BaseModel):
 
     @model_validator(mode="after")
     def _merge_generation_profile_ids(self) -> "VNScriptCreate":
+        """Let legacy generation_profile_ids override generation_profiles when supplied."""
         if self.generation_profile_ids is not None:
             self.generation_profiles = dict(self.generation_profile_ids)
         return self
@@ -50,6 +51,7 @@ class VNScriptPatch(BaseModel):
 
     @model_validator(mode="after")
     def _merge_generation_profile_ids(self) -> "VNScriptPatch":
+        """Map legacy generation_profile_ids onto generation_profiles for patch compatibility."""
         if self.generation_profile_ids is not None:
             self.generation_profiles = dict(self.generation_profile_ids)
         return self
@@ -117,6 +119,7 @@ class VNScriptCreateFromTemplateRequest(BaseModel):
 
     @model_validator(mode="after")
     def _merge_generation_profile_ids(self) -> "VNScriptCreateFromTemplateRequest":
+        """Let legacy generation_profile_ids override generation_profiles for template creates."""
         if self.generation_profile_ids is not None:
             self.generation_profiles = dict(self.generation_profile_ids)
         return self

--- a/tldw_Server_API/app/api/v1/schemas/vn_script_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/vn_script_schemas.py
@@ -81,6 +81,47 @@ class VNScriptListResponse(BaseModel):
     pagination: OffsetPaginationMeta
 
 
+class VNScriptTemplateSummary(BaseModel):
+    """Preview-safe starter template catalog entry."""
+
+    id: str
+    label: str
+    description: str
+    category: str
+    recommended_content_rating: ContentRating
+    required_capabilities: list[str] = Field(default_factory=list)
+    preview: dict[str, Any]
+    default_title: str
+    default_description: str | None = None
+
+
+class VNScriptTemplateListResponse(BaseModel):
+    """Starter template catalog response."""
+
+    items: list[VNScriptTemplateSummary]
+
+
+class VNScriptCreateFromTemplateRequest(BaseModel):
+    """Create request for a VN script starter template."""
+
+    title: str | None = Field(default=None, min_length=1, max_length=200)
+    description: str | None = Field(default=None, max_length=1000)
+    primary_asset_pack_id: int = Field(..., ge=1)
+    policy_profile_id: str = Field(default="local_default", min_length=1, max_length=80)
+    generation_profile_id: str = Field(default="story_default", min_length=1, max_length=80)
+    generation_profiles: dict[str, str] = Field(default_factory=dict)
+    generation_profile_ids: dict[str, str] | None = None
+    content_rating: ContentRating = "general"
+
+    model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def _merge_generation_profile_ids(self) -> "VNScriptCreateFromTemplateRequest":
+        if self.generation_profile_ids is not None:
+            self.generation_profiles = dict(self.generation_profile_ids)
+        return self
+
+
 class VNScriptDraftResponse(BaseModel):
     """Mutable script draft response."""
 
@@ -88,6 +129,13 @@ class VNScriptDraftResponse(BaseModel):
     revision: int
     draft: dict[str, Any]
     diagnostics: dict[str, Any]
+
+
+class VNScriptCreateFromTemplateResponse(BaseModel):
+    """Create-from-template response with the stored draft."""
+
+    script: VNScriptResponse
+    draft: VNScriptDraftResponse
 
 
 class VNScriptDraftPutRequest(BaseModel):

--- a/tldw_Server_API/app/core/DB_Management/VNScripts_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/VNScripts_DB.py
@@ -147,8 +147,13 @@ class VNScriptsRepository:
         description: str | None = None,
         content_rating: str = "general",
         status: str = "draft",
+        initial_draft: Mapping[str, Any] | None = None,
+        initial_diagnostics: Mapping[str, Any] | None = None,
     ) -> dict[str, Any]:
         self._ensure_schema_initialized()
+        draft_revision = 1 if initial_draft is not None else 0
+        draft_payload = dict(initial_draft or {})
+        diagnostics_payload = dict(initial_diagnostics or {"valid": True, "errors": [], "warnings": []})
         with self.db.transaction() as conn:
             cursor = conn.execute(
                 """
@@ -187,9 +192,15 @@ class VNScriptsRepository:
                     draft_json,
                     diagnostics_json
                 )
-                VALUES (?, ?, 0, '{}', ?)
+                VALUES (?, ?, ?, ?, ?)
                 """,
-                (script_id, owner_user_id, _json_dump({"valid": True, "errors": [], "warnings": []})),
+                (
+                    script_id,
+                    owner_user_id,
+                    draft_revision,
+                    _json_dump(draft_payload),
+                    _json_dump(diagnostics_payload),
+                ),
             )
 
         script = self.get_script(script_id, owner_user_id=owner_user_id)

--- a/tldw_Server_API/app/core/VN_Scripts/service.py
+++ b/tldw_Server_API/app/core/VN_Scripts/service.py
@@ -63,6 +63,8 @@ class VNScriptService:
         generation_profiles: Mapping[str, str] | None = None,
         description: str | None = None,
         content_rating: str = "general",
+        initial_draft: Mapping[str, Any] | None = None,
+        initial_diagnostics: Mapping[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Create a script shell and its empty draft."""
         return self.repo.create_script(
@@ -74,6 +76,8 @@ class VNScriptService:
             generation_profile_id=generation_profile_id,
             generation_profiles=generation_profiles,
             content_rating=content_rating,
+            initial_draft=initial_draft,
+            initial_diagnostics=initial_diagnostics,
         )
 
     def list_scripts(self, *, limit: int = 50, offset: int = 0) -> tuple[list[dict[str, Any]], int]:
@@ -96,11 +100,37 @@ class VNScriptService:
         description: str | None = None,
         content_rating: str = "general",
         audio_refs: Mapping[str, Mapping[str, Any]] | None = None,
+        draft: Mapping[str, Any] | None = None,
         policy_profile: ProfileRow | None = None,
         generation_profile: ProfileRow | None = None,
         resolved_generation_profiles: Mapping[str, ProfileRow] | None = None,
     ) -> dict[str, Any]:
         """Create a normal script and store a validated template draft."""
+        template_draft = (
+            dict(draft)
+            if draft is not None
+            else instantiate_template(
+                template_id,
+                title=title,
+                primary_asset_pack_id=primary_asset_pack_id,
+                generation_profile_id=generation_profile_id,
+            )
+        )
+        script_metadata = _script_metadata_payload(
+            primary_asset_pack_id=primary_asset_pack_id,
+            policy_profile_id=policy_profile_id,
+            generation_profile_id=generation_profile_id,
+            generation_profiles=generation_profiles,
+            content_rating=content_rating,
+        )
+        validation = self.validate_draft_payload(
+            script_metadata,
+            template_draft,
+            audio_refs=audio_refs,
+            policy_profile=policy_profile,
+            generation_profile=generation_profile,
+            generation_profiles=resolved_generation_profiles,
+        )
         script = self.create_script(
             title=title,
             description=description,
@@ -109,22 +139,10 @@ class VNScriptService:
             generation_profile_id=generation_profile_id,
             generation_profiles=generation_profiles,
             content_rating=content_rating,
+            initial_draft=template_draft,
+            initial_diagnostics=validation,
         )
-        draft = instantiate_template(
-            template_id,
-            title=title,
-            primary_asset_pack_id=primary_asset_pack_id,
-            generation_profile_id=generation_profile_id,
-        )
-        draft_response = self.replace_draft(
-            int(script["id"]),
-            if_revision=0,
-            draft=draft,
-            audio_refs=audio_refs,
-            policy_profile=policy_profile,
-            generation_profile=generation_profile,
-            generation_profiles=resolved_generation_profiles,
-        )
+        draft_response = self.get_draft(int(script["id"]))
         return {"script": script, "draft": draft_response}
 
     def get_script(self, script_id: int) -> dict[str, Any]:
@@ -509,6 +527,23 @@ def _approved_slot_keys(manifest: Mapping[str, Any]) -> set[str]:
 
 def _empty_audio_refs(program: Mapping[str, Any]) -> Mapping[str, Mapping[str, Any]]:
     return {}
+
+
+def _script_metadata_payload(
+    *,
+    primary_asset_pack_id: int,
+    policy_profile_id: str,
+    generation_profile_id: str,
+    generation_profiles: Mapping[str, str] | None,
+    content_rating: str,
+) -> dict[str, Any]:
+    return {
+        "primary_asset_pack_id": primary_asset_pack_id,
+        "policy_profile_id": policy_profile_id,
+        "generation_profile_id": generation_profile_id,
+        "generation_profiles": dict(generation_profiles or {}),
+        "content_rating": content_rating,
+    }
 
 
 def _normalize_audio_refs(raw_refs: Mapping[str, Mapping[str, Any]] | None) -> dict[str, dict[str, Any]]:

--- a/tldw_Server_API/app/core/VN_Scripts/service.py
+++ b/tldw_Server_API/app/core/VN_Scripts/service.py
@@ -18,6 +18,7 @@ from tldw_Server_API.app.core.DB_Management.VNScripts_DB import VNScriptsReposit
 from tldw_Server_API.app.core.VN_Assets.service import VNAssetPackService
 from tldw_Server_API.app.core.VN_Platform.idempotency import canonical_payload_hash
 from tldw_Server_API.app.core.VN_Policy.service import evaluate_character_safety_definition
+from tldw_Server_API.app.core.VN_Scripts.templates import instantiate_template, list_template_catalog
 from tldw_Server_API.app.core.VN_Scripts.validator import VNScriptValidationContext, validate_script_program
 
 ManifestResolver = Callable[[int], Mapping[str, Any]]
@@ -78,6 +79,53 @@ class VNScriptService:
     def list_scripts(self, *, limit: int = 50, offset: int = 0) -> tuple[list[dict[str, Any]], int]:
         """List scripts owned by the current user."""
         return self.repo.list_scripts(owner_user_id=self.owner_user_id, limit=limit, offset=offset)
+
+    def list_templates(self) -> list[dict[str, Any]]:
+        """List built-in starter templates as preview-safe catalog entries."""
+        return list_template_catalog()
+
+    def create_script_from_template(
+        self,
+        template_id: str,
+        *,
+        title: str,
+        primary_asset_pack_id: int,
+        policy_profile_id: str = "local_default",
+        generation_profile_id: str = "story_default",
+        generation_profiles: Mapping[str, str] | None = None,
+        description: str | None = None,
+        content_rating: str = "general",
+        audio_refs: Mapping[str, Mapping[str, Any]] | None = None,
+        policy_profile: ProfileRow | None = None,
+        generation_profile: ProfileRow | None = None,
+        resolved_generation_profiles: Mapping[str, ProfileRow] | None = None,
+    ) -> dict[str, Any]:
+        """Create a normal script and store a validated template draft."""
+        script = self.create_script(
+            title=title,
+            description=description,
+            primary_asset_pack_id=primary_asset_pack_id,
+            policy_profile_id=policy_profile_id,
+            generation_profile_id=generation_profile_id,
+            generation_profiles=generation_profiles,
+            content_rating=content_rating,
+        )
+        draft = instantiate_template(
+            template_id,
+            title=title,
+            primary_asset_pack_id=primary_asset_pack_id,
+            generation_profile_id=generation_profile_id,
+        )
+        draft_response = self.replace_draft(
+            int(script["id"]),
+            if_revision=0,
+            draft=draft,
+            audio_refs=audio_refs,
+            policy_profile=policy_profile,
+            generation_profile=generation_profile,
+            generation_profiles=resolved_generation_profiles,
+        )
+        return {"script": script, "draft": draft_response}
 
     def get_script(self, script_id: int) -> dict[str, Any]:
         """Return an owned script or raise not found."""

--- a/tldw_Server_API/app/core/VN_Scripts/templates.py
+++ b/tldw_Server_API/app/core/VN_Scripts/templates.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any, Literal
 
@@ -31,7 +32,7 @@ class VNScriptTemplate:
             "category": self.category,
             "recommended_content_rating": self.recommended_content_rating,
             "required_capabilities": list(self.required_capabilities),
-            "preview": dict(self.preview),
+            "preview": deepcopy(self.preview),
             "default_title": self.default_title,
             "default_description": self.default_description,
         }
@@ -132,6 +133,7 @@ def instantiate_template(
 
 
 def _template_labels(template_id: str) -> dict[str, list[dict[str, Any]]]:
+    """Return deterministic label operation blocks for a known starter template."""
     if template_id == "linear_scene":
         return {
             "start": [

--- a/tldw_Server_API/app/core/VN_Scripts/templates.py
+++ b/tldw_Server_API/app/core/VN_Scripts/templates.py
@@ -1,0 +1,196 @@
+"""Built-in VN script starter templates."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+ContentRating = Literal["general", "teen", "suggestive", "mature"]
+
+
+@dataclass(frozen=True)
+class VNScriptTemplate:
+    """Static template metadata plus deterministic draft construction."""
+
+    id: str
+    label: str
+    description: str
+    category: str
+    recommended_content_rating: ContentRating
+    required_capabilities: tuple[str, ...]
+    preview: dict[str, Any]
+    default_title: str
+    default_description: str
+
+    def catalog_payload(self) -> dict[str, Any]:
+        """Return preview-safe metadata for clients."""
+        return {
+            "id": self.id,
+            "label": self.label,
+            "description": self.description,
+            "category": self.category,
+            "recommended_content_rating": self.recommended_content_rating,
+            "required_capabilities": list(self.required_capabilities),
+            "preview": dict(self.preview),
+            "default_title": self.default_title,
+            "default_description": self.default_description,
+        }
+
+
+_TEMPLATES: tuple[VNScriptTemplate, ...] = (
+    VNScriptTemplate(
+        id="linear_scene",
+        label="Linear scene",
+        description="A simple one-scene route with narration and an ending.",
+        category="starter",
+        recommended_content_rating="general",
+        required_capabilities=(),
+        preview={"flow": ["start"], "operations": ["narrate", "end"]},
+        default_title="Linear Scene",
+        default_description="A one-scene VN script starter.",
+    ),
+    VNScriptTemplate(
+        id="authored_choices",
+        label="Authored choices",
+        description="A short route with hand-authored player choices.",
+        category="branching",
+        recommended_content_rating="general",
+        required_capabilities=("authored_choices",),
+        preview={"flow": ["start", "accept", "decline"], "operations": ["choice", "narrate", "end"]},
+        default_title="Authored Choice Scene",
+        default_description="A VN script starter with two authored branches.",
+    ),
+    VNScriptTemplate(
+        id="generated_choice_set",
+        label="Generated choice set",
+        description="A starter route that asks the generation profile for structured player choices.",
+        category="guided_generation",
+        recommended_content_rating="general",
+        required_capabilities=("generation", "structured_output", "choice_set"),
+        preview={"flow": ["start", "generated_choice"], "operations": ["generate", "narrate", "end"]},
+        default_title="Generated Choice Scene",
+        default_description="A VN script starter that routes generated choices through an authored target.",
+    ),
+    VNScriptTemplate(
+        id="scene_update",
+        label="Scene update",
+        description="A starter route that requests a structured scene update from the generation profile.",
+        category="guided_generation",
+        recommended_content_rating="general",
+        required_capabilities=("generation", "structured_output", "scene_update"),
+        preview={"flow": ["start"], "operations": ["generate", "narrate", "end"]},
+        default_title="Generated Scene Update",
+        default_description="A VN script starter for generated scene updates.",
+    ),
+    VNScriptTemplate(
+        id="confirm_gated_generation",
+        label="Confirm-gated generation",
+        description="A starter route that requires user confirmation before applying generated text.",
+        category="safety",
+        recommended_content_rating="general",
+        required_capabilities=("generation", "user_confirmation"),
+        preview={"flow": ["start", "cancelled"], "operations": ["generate", "narrate", "end"]},
+        default_title="Confirm-Gated Generation",
+        default_description="A VN script starter with explicit confirmation and cancel paths.",
+    ),
+)
+
+_TEMPLATES_BY_ID = {template.id: template for template in _TEMPLATES}
+
+
+def list_template_catalog() -> list[dict[str, Any]]:
+    """Return all built-in templates as sanitized catalog entries."""
+    return [template.catalog_payload() for template in _TEMPLATES]
+
+
+def get_template(template_id: str) -> VNScriptTemplate:
+    """Return a built-in template or raise a stable not-found reason."""
+    try:
+        return _TEMPLATES_BY_ID[template_id]
+    except KeyError as exc:
+        raise ValueError("template_not_found") from exc
+
+
+def instantiate_template(
+    template_id: str,
+    *,
+    title: str,
+    primary_asset_pack_id: int,
+    generation_profile_id: str,
+) -> dict[str, Any]:
+    """Build a deterministic VN script program draft for a template."""
+    get_template(template_id)
+    return {
+        "schema_version": "vn_script_program.v1",
+        "title": title,
+        "primary_asset_pack_id": primary_asset_pack_id,
+        "entry_label": "start",
+        "variables": {},
+        "generation_defaults": {"profile_id": generation_profile_id, "persist_model_outputs": True},
+        "labels": _template_labels(template_id),
+    }
+
+
+def _template_labels(template_id: str) -> dict[str, list[dict[str, Any]]]:
+    if template_id == "linear_scene":
+        return {
+            "start": [
+                {"op": "narrate", "text": "The scene opens. Replace this line with your setup."},
+                {"op": "end"},
+            ]
+        }
+    if template_id == "authored_choices":
+        return {
+            "start": [
+                {"op": "narrate", "text": "A decision point appears."},
+                {
+                    "op": "choice",
+                    "id": "first_choice",
+                    "choices": [
+                        {"id": "accept", "text": "Take the direct path.", "target": "accept"},
+                        {"id": "decline", "text": "Pause and reconsider.", "target": "decline"},
+                    ],
+                },
+            ],
+            "accept": [{"op": "narrate", "text": "The direct path continues."}, {"op": "end"}],
+            "decline": [{"op": "narrate", "text": "The slower path reveals another detail."}, {"op": "end"}],
+        }
+    if template_id == "generated_choice_set":
+        return {
+            "start": [
+                {"op": "narrate", "text": "Set the scene before requesting generated choices."},
+                {
+                    "op": "generate",
+                    "scope": "turn",
+                    "max_choices": 2,
+                    "output_schema": "choice_set",
+                    "on_generated_choice": "generated_choice",
+                },
+                {"op": "end"},
+            ],
+            "generated_choice": [{"op": "narrate", "text": "Handle the selected generated choice here."}, {"op": "end"}],
+        }
+    if template_id == "scene_update":
+        return {
+            "start": [
+                {"op": "narrate", "text": "Describe the current scene state."},
+                {"op": "generate", "scope": "scene", "max_choices": 1, "output_schema": "scene_update"},
+                {"op": "end"},
+            ]
+        }
+    if template_id == "confirm_gated_generation":
+        return {
+            "start": [
+                {"op": "narrate", "text": "Prepare the player for generated continuation."},
+                {
+                    "op": "generate",
+                    "scope": "turn",
+                    "max_choices": 1,
+                    "requires_user_confirm": True,
+                    "on_cancel": "cancelled",
+                },
+                {"op": "end"},
+            ],
+            "cancelled": [{"op": "narrate", "text": "Generation was cancelled; continue with authored text."}, {"op": "end"}],
+        }
+    raise ValueError("template_not_found")

--- a/tldw_Server_API/tests/VN_Scripts/test_vn_scripts_api.py
+++ b/tldw_Server_API/tests/VN_Scripts/test_vn_scripts_api.py
@@ -152,6 +152,145 @@ def _create_script(client: TestClient, *, asset_pack_id: int) -> int:
     return int(response.json()["id"])
 
 
+def _contains_key(value: Any, key: str) -> bool:
+    if isinstance(value, dict):
+        return key in value or any(_contains_key(child, key) for child in value.values())
+    if isinstance(value, list):
+        return any(_contains_key(child, key) for child in value)
+    return False
+
+
+def test_template_catalog_lists_preview_safe_starter_templates(client: TestClient) -> None:
+    response = client.get("/api/v1/vn/vn-scripts/templates")
+
+    assert response.status_code == 200
+    payload = response.json()
+    template_ids = {item["id"] for item in payload["items"]}
+    assert template_ids == {
+        "linear_scene",
+        "authored_choices",
+        "generated_choice_set",
+        "scene_update",
+        "confirm_gated_generation",
+    }
+    for item in payload["items"]:
+        assert set(item) == {
+            "id",
+            "label",
+            "description",
+            "category",
+            "recommended_content_rating",
+            "required_capabilities",
+            "preview",
+            "default_title",
+            "default_description",
+        }
+        assert "draft" not in item
+        assert "raw_prompt" not in item
+        assert "policy_profile_id" not in item
+        assert "generation_profile_id" not in item
+        assert "generation_profiles" not in item
+
+
+def test_create_script_from_template_stores_valid_draft(
+    client: TestClient,
+    chacha_dbs: dict[int, CharactersRAGDB],
+) -> None:
+    asset_pack_id, _ = _create_asset_pack(chacha_dbs[42])
+
+    response = client.post(
+        "/api/v1/vn/vn-scripts/templates/linear_scene/scripts",
+        json={
+            "title": "Template Route",
+            "primary_asset_pack_id": asset_pack_id,
+            "content_rating": "general",
+        },
+    )
+
+    assert response.status_code == 201
+    script = response.json()["script"]
+    draft_response = response.json()["draft"]
+    script_id = script["id"]
+    stored_draft = client.get(f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft").json()
+    assert script["title"] == "Template Route"
+    assert draft_response["revision"] == 1
+    assert draft_response["diagnostics"]["valid"] is True
+    assert stored_draft["revision"] == 1
+    assert stored_draft["diagnostics"]["valid"] is True
+    assert stored_draft["draft"]["primary_asset_pack_id"] == asset_pack_id
+    assert _contains_key(stored_draft["draft"], "provider") is False
+    assert _contains_key(stored_draft["draft"], "model") is False
+    assert _contains_key(stored_draft["draft"], "policy_profile_id") is False
+
+
+def test_create_script_from_unknown_template_returns_not_found(client: TestClient) -> None:
+    response = client.post(
+        "/api/v1/vn/vn-scripts/templates/missing-template/scripts",
+        json={
+            "title": "Template Route",
+            "primary_asset_pack_id": 1,
+            "content_rating": "general",
+        },
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"]["details"]["reason"] == "template_not_found"
+
+
+def test_create_script_from_template_rejects_unknown_profiles(
+    client: TestClient,
+    chacha_dbs: dict[int, CharactersRAGDB],
+) -> None:
+    asset_pack_id, _ = _create_asset_pack(chacha_dbs[42])
+
+    response = client.post(
+        "/api/v1/vn/vn-scripts/templates/linear_scene/scripts",
+        json={
+            "title": "Template Route",
+            "primary_asset_pack_id": asset_pack_id,
+            "policy_profile_id": "missing_policy",
+            "generation_profile_id": "story_default",
+            "content_rating": "general",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["details"]["reason"] == "policy_profile_not_found"
+
+
+def test_generated_choice_template_validates_and_publishes(
+    client: TestClient,
+    chacha_dbs: dict[int, CharactersRAGDB],
+) -> None:
+    asset_pack_id, _ = _create_asset_pack(chacha_dbs[42])
+    create_response = client.post(
+        "/api/v1/vn/vn-scripts/templates/generated_choice_set/scripts",
+        json={
+            "title": "Generated Choice Route",
+            "primary_asset_pack_id": asset_pack_id,
+            "content_rating": "general",
+        },
+    )
+    script_id = create_response.json()["script"]["id"]
+
+    diagnostics_response = client.get(f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft/diagnostics")
+    publish_response = client.post(
+        f"/api/v1/vn/vn-scripts/scripts/{script_id}/publish",
+        json={
+            "draft_revision": 1,
+            "label": "template-v1",
+            "idempotency_key": "generated-choice-template-v1",
+            "acknowledgements": ["character_safety_missing"],
+        },
+    )
+
+    assert create_response.status_code == 201
+    assert diagnostics_response.status_code == 200
+    assert diagnostics_response.json()["diagnostics"]["valid"] is True
+    assert publish_response.status_code == 201
+    assert publish_response.json()["validation"]["valid"] is True
+
+
 def test_create_rejects_unknown_profiles(
     client: TestClient,
     chacha_dbs: dict[int, CharactersRAGDB],

--- a/tldw_Server_API/tests/VN_Scripts/test_vn_scripts_api.py
+++ b/tldw_Server_API/tests/VN_Scripts/test_vn_scripts_api.py
@@ -30,6 +30,7 @@ from tldw_Server_API.app.core.DB_Management.VNPolicy_DB import (
     VNPolicyProfileStore,
 )
 from tldw_Server_API.app.core.VN_Assets.service import VNAssetPackService
+from tldw_Server_API.app.core.VN_Scripts.templates import list_template_catalog
 
 pytestmark = pytest.mark.integration
 
@@ -153,6 +154,7 @@ def _create_script(client: TestClient, *, asset_pack_id: int) -> int:
 
 
 def _contains_key(value: Any, key: str) -> bool:
+    """Return true when a nested dict or list contains the requested dictionary key."""
     if isinstance(value, dict):
         return key in value or any(_contains_key(child, key) for child in value.values())
     if isinstance(value, list):
@@ -190,6 +192,15 @@ def test_template_catalog_lists_preview_safe_starter_templates(client: TestClien
         assert "policy_profile_id" not in item
         assert "generation_profile_id" not in item
         assert "generation_profiles" not in item
+
+
+def test_template_catalog_returns_isolated_preview_payloads() -> None:
+    first_catalog = list_template_catalog()
+    first_catalog[0]["preview"]["flow"].append("mutated")
+
+    second_catalog = list_template_catalog()
+
+    assert "mutated" not in second_catalog[0]["preview"]["flow"]
 
 
 def test_create_script_from_template_stores_valid_draft(

--- a/tldw_Server_API/tests/VN_Scripts/test_vn_scripts_api.py
+++ b/tldw_Server_API/tests/VN_Scripts/test_vn_scripts_api.py
@@ -258,6 +258,24 @@ def test_create_script_from_template_rejects_unknown_profiles(
     assert response.json()["detail"]["details"]["reason"] == "policy_profile_not_found"
 
 
+def test_create_script_from_template_does_not_persist_script_when_validation_fails(client: TestClient) -> None:
+    response = client.post(
+        "/api/v1/vn/vn-scripts/templates/linear_scene/scripts",
+        json={
+            "title": "Invalid Template Route",
+            "primary_asset_pack_id": 999_999,
+            "content_rating": "general",
+        },
+    )
+    scripts_response = client.get("/api/v1/vn/vn-scripts/scripts")
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["details"]["reason"] == "pack_not_found"
+    assert scripts_response.status_code == 200
+    assert scripts_response.json()["total"] == 0
+    assert scripts_response.json()["items"] == []
+
+
 def test_generated_choice_template_validates_and_publishes(
     client: TestClient,
     chacha_dbs: dict[int, CharactersRAGDB],


### PR DESCRIPTION
## Summary
- Adds backend-owned VN script starter template catalog and create-from-template API under `/api/v1/vn/vn-scripts/templates`.
- Adds TypeScript API/types and a `/vn-scripts` starter-template selector while preserving the blank/custom JSON path.
- Documents the custom frontend contract and records Backlog task TASK-298.

## Test Plan
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/VN_Scripts -q`
- [x] `bunx vitest run __tests__/vn-scripts/vnScriptsApi.test.ts __tests__/vn-scripts/VNScriptsWorkbench.test.tsx` from `apps/tldw-frontend`
- [x] `bunx eslint components/vn-scripts/VNScriptsWorkbench.tsx lib/api/vnScripts.ts types/vn-scripts.ts __tests__/vn-scripts/vnScriptsApi.test.ts __tests__/vn-scripts/VNScriptsWorkbench.test.tsx` from `apps/tldw-frontend`
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/vn_scripts.py tldw_Server_API/app/api/v1/schemas/vn_script_schemas.py tldw_Server_API/app/core/VN_Scripts -f json -o /tmp/bandit_vn_script_templates.json`
- [x] `git diff --check`

## Change summary
AI-authored draft summary only. Per project policy, a human-authored Change summary explaining what changed and why these implementation choices were made is required before this PR is merge-ready.

Refs #1604
Part of #1391

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds backend-owned VN script starter templates plus a create-from-template API, and updates the `/vn-scripts` WebUI to let users start from a template and immediately edit a hydrated draft. Supports #1604.

- **New Features**
  - Backend: `GET /api/v1/vn/vn-scripts/templates` returns a sanitized catalog (id, label, description, category, recommended_content_rating, required_capabilities, preview, default_title, default_description) with no draft bodies or model/provider/policy fields. Built-ins: `linear_scene`, `authored_choices`, `generated_choice_set`, `scene_update`, `confirm_gated_generation`. `POST /api/v1/vn/vn-scripts/templates/{template_id}/scripts` creates a normal script, stores a validated starter draft at rev 1, and returns `{ script, draft }`. Unknown templates 404 with `template_not_found`. Profile IDs validate like normal; supports merging `generation_profile_ids`; resolves accessible audio refs on draft; title/description may be omitted and fall back to template defaults; does not persist a script when creation validation fails.
  - Frontend API: Added `listVNScriptTemplates()` and `createVNScriptFromTemplate()` in `@web/lib/api/vnScripts` (URL-encodes template IDs), plus `VNScriptTemplateSummary`, `VNScriptTemplateListResponse`, `VNScriptCreateFromTemplateRequest`, and `VNScriptCreateFromTemplateResponse` in `@web/types/vn-scripts`.
  - WebUI: New starter selector in `VNScriptsWorkbench` with “Blank/custom JSON” as the default. Selecting a template pre-fills the title and content rating from defaults, auto-applies the template description when creating, calls create-from-template, and hydrates the returned draft immediately while keeping the JSON editor, diagnostics, validate, save, and publish controls. Blank path still uses the normal create endpoint.
  - Docs/Tests: API/spec docs updated. Tests cover catalog sanitization, unknown template 404s, profile validation, non-persistence on validation errors, generated-choice template publish path, and WebUI flows for template and blank creation.

- **Migration**
  - No breaking changes. Custom frontends can call `listVNScriptTemplates()` and `createVNScriptFromTemplate()` using stable template IDs.

<sup>Written for commit a50abe686a54d05af9591d387efa0c8f0c4aba53. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

