### PR TITLE
Add ACP entrypoint strategy readiness surfaces

### DIFF
--- a/Docs/Development/ACP_Compatibility_Matrix.md
+++ b/Docs/Development/ACP_Compatibility_Matrix.md
@@ -185,8 +185,13 @@ language later:
 | Caveat | Meaning |
 | --- | --- |
 | `protocol_incompatibility` | Agent does not satisfy ACP stdio contract or required JSON-RPC behavior. |
+| `entrypoint_strategy_missing` | Registry row has no verified ACP stdio entrypoint strategy or command. |
 | `binary_missing` | Expected command is not installed or not on PATH. |
 | `credentials_missing` | Provider/API key or account login is unavailable. |
+| `adapter_required` | Agent needs a separate ACP adapter before live ACP certification can run. |
+| `adapter_missing` | Adapter-backed strategy is configured but the adapter command is unavailable. |
+| `acp_initialize_failed` | ACP stdio command started but failed the bounded initialize probe. |
+| `shell_builtin_collision` | Configured ACP command resolves to a shell builtin or alias-like value instead of an executable. |
 | `workspace_config_missing` | Workspace allowlist, cwd, or root policy is not configured. |
 | `host_runtime_missing` | Docker/Lima/VZ or other required host runtime is unavailable. |
 | `sandbox_unverified` | Host mode works or is documented, but sandbox mode has no current evidence. |

--- a/Docs/superpowers/plans/2026-05-12-acp-entrypoint-strategy-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-12-acp-entrypoint-strategy-implementation-plan.md
@@ -1,0 +1,1272 @@
+# ACP Entrypoint Strategy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the approved ACP downstream entrypoint strategy model for registry metadata, classification, certification manifests, and setup/status/API visibility.
+
+**Architecture:** Keep the compatibility matrix as the support-claim source of truth, and add a separate backend-owned entrypoint classification layer in the ACP registry. Registry rows carry explicit ACP launch metadata; a deterministic classifier turns those rows plus runtime discovery into probe state and blocker metadata; existing ACP status/setup/helper surfaces consume the same classifier output.
+
+**Tech Stack:** FastAPI, Pydantic, SQLite, YAML registry loading, pytest, Bandit, existing ACP certification smoke helper.
+
+---
+
+## Source Spec And Tracking
+
+- Spec: `Docs/superpowers/specs/2026-05-12-acp-downstream-entrypoint-strategy-design.md`
+- Backlog task: `TASK-287`
+- Related GitHub issues: `#1563`, `#1564`
+- Relevant skills: `@superpowers:test-driven-development`, `@superpowers:verification-before-completion`
+
+## File Structure
+
+- Modify `tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py`
+  - Owns registry entry fields, YAML/API entry loading, dynamic registration, availability checks, and the new deterministic classifier.
+- Modify `tldw_Server_API/app/core/DB_Management/ACP_Sessions_DB.py`
+  - Owns persisted dynamic agent registry fields and forward migrations for old databases.
+- Modify `tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py`
+  - Owns response/request models and enum validation for entrypoint strategy metadata.
+- Modify `tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py`
+  - Owns health, setup-guide, agent-list, register, and update response wiring.
+- Modify `tldw_Server_API/Config_Files/agents.yaml`
+  - Seeds explicit strategy metadata for built-in registry rows.
+- Modify `Helper_Scripts/Testing-related/acp_certification_smoke.py`
+  - Emits and optionally runs bounded profile-specific certification manifests.
+- Modify `Docs/Development/ACP_Compatibility_Matrix.md`
+  - Adds the entrypoint-specific caveat labels introduced by the spec.
+- Test files:
+  - `tldw_Server_API/tests/Agent_Client_Protocol/test_registry_entrypoint_strategy.py`
+  - `tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sessions_db.py`
+  - `tldw_Server_API/tests/Agent_Client_Protocol/test_registry_mcp_fields.py`
+  - `tldw_Server_API/tests/Agent_Client_Protocol/test_acp_health.py`
+  - `tldw_Server_API/tests/Helper_Scripts/test_acp_certification_smoke.py`
+
+## Constraints
+
+- Do not infer `acp_command` from `command`.
+- Do not mark Codex CLI or Claude Code as `adapter_acp` until a concrete adapter command is selected.
+- Do not install downstream agents, implement Codex/Claude adapters, or close `#1563` / `#1564`.
+- Do not treat existing MCP `protocol`, `mcp_transport`, or orchestration fields as ACP certification metadata.
+- Keep support-state claims controlled by `support_state` and `verification_level`.
+
+---
+
+### Task 1: Registry, API, And DB Strategy Metadata
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py`
+- Modify: `tldw_Server_API/app/core/DB_Management/ACP_Sessions_DB.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py`
+- Modify: `tldw_Server_API/Config_Files/agents.yaml`
+- Test: `tldw_Server_API/tests/Agent_Client_Protocol/test_registry_entrypoint_strategy.py`
+- Test: `tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sessions_db.py`
+- Test: `tldw_Server_API/tests/Agent_Client_Protocol/test_registry_mcp_fields.py`
+
+- [ ] **Step 1: Write failing registry metadata tests**
+
+Create `tldw_Server_API/tests/Agent_Client_Protocol/test_registry_entrypoint_strategy.py` with focused tests:
+
+```python
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.ACP_Sessions_DB import ACPSessionsDB
+from tldw_Server_API.app.core.Agent_Client_Protocol.agent_registry import (
+    AgentRegistry,
+    AgentRegistryEntry,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def acp_db(tmp_path):
+    db = ACPSessionsDB(db_path=str(tmp_path / "acp_sessions.db"))
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def test_entrypoint_strategy_defaults_to_documented_candidate() -> None:
+    entry = AgentRegistryEntry(type="legacy", name="Legacy")
+
+    assert entry.entrypoint_strategy == "documented_candidate"
+    assert entry.acp_command == ""
+    assert entry.acp_args == []
+    assert entry.adapter_source is None
+    assert entry.adapter_docs_url is None
+    assert entry.certification_blocker is None
+
+
+def test_registry_loads_entrypoint_strategy_fields_from_yaml(tmp_path) -> None:
+    yaml_file = tmp_path / "agents.yaml"
+    yaml_file.write_text(
+        """
+agents:
+  - type: opencode
+    name: OpenCode
+    command: opencode
+    entrypoint_strategy: native_acp
+    acp_command: opencode
+    acp_args: ["acp"]
+"""
+    )
+
+    registry = AgentRegistry(yaml_path=str(yaml_file))
+    registry.load()
+
+    entry = registry.get_entry("opencode")
+    assert entry is not None
+    assert entry.entrypoint_strategy == "native_acp"
+    assert entry.acp_command == "opencode"
+    assert entry.acp_args == ["acp"]
+
+
+def test_dynamic_registration_preserves_entrypoint_strategy_fields(acp_db) -> None:
+    registry = AgentRegistry(yaml_path="/missing.yaml", db=acp_db)
+
+    entry = registry.register_agent(
+        type="adapter_agent",
+        name="Adapter Agent",
+        command="agent-cli",
+        entrypoint_strategy="adapter_acp",
+        acp_command="agent-acp",
+        acp_args=["--stdio"],
+        adapter_source="example/agent-acp",
+        adapter_docs_url="https://example.test/agent-acp",
+        certification_blocker="adapter_missing",
+    )
+
+    assert entry.entrypoint_strategy == "adapter_acp"
+    assert entry.acp_command == "agent-acp"
+    assert entry.acp_args == ["--stdio"]
+
+    reloaded = AgentRegistry(yaml_path="/missing.yaml", db=acp_db)
+    reloaded._load_api_entries()
+    persisted = reloaded.get_entry("adapter_agent")
+    assert persisted is not None
+    assert persisted.entrypoint_strategy == "adapter_acp"
+    assert persisted.acp_command == "agent-acp"
+    assert persisted.acp_args == ["--stdio"]
+    assert persisted.adapter_source == "example/agent-acp"
+```
+
+- [ ] **Step 2: Write failing DB and schema tests**
+
+Extend `tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sessions_db.py`:
+
+```python
+import sqlite3
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.agent_registry import AgentRegistry
+
+
+def test_agent_entrypoint_strategy_fields_round_trip(self, db):
+    saved = db.save_agent_entry({
+        "agent_type": "adapter",
+        "name": "Adapter",
+        "entrypoint_strategy": "adapter_acp",
+        "acp_command": "adapter-acp",
+        "acp_args": '["--stdio"]',
+        "adapter_source": "example/adapter",
+        "adapter_docs_url": "https://example.test/adapter",
+        "certification_blocker": "adapter_missing",
+        "source": "api",
+    })
+
+    assert saved["entrypoint_strategy"] == "adapter_acp"
+    assert saved["acp_command"] == "adapter-acp"
+    assert saved["acp_args"] == '["--stdio"]'
+    assert saved["adapter_source"] == "example/adapter"
+    assert saved["certification_blocker"] == "adapter_missing"
+
+
+def test_legacy_agent_registry_rows_get_entrypoint_defaults(tmp_path):
+    db_path = tmp_path / "legacy_acp_sessions.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE agent_registry (
+            agent_type TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            description TEXT NOT NULL DEFAULT '',
+            command TEXT NOT NULL DEFAULT '',
+            args TEXT NOT NULL DEFAULT '[]',
+            env TEXT NOT NULL DEFAULT '{}',
+            requires_api_key TEXT,
+            is_default INTEGER NOT NULL DEFAULT 0,
+            install_instructions TEXT NOT NULL DEFAULT '[]',
+            docs_url TEXT,
+            mcp_orchestration TEXT NOT NULL DEFAULT 'agent_driven',
+            mcp_entry_tool TEXT NOT NULL DEFAULT 'execute',
+            mcp_structured_response INTEGER NOT NULL DEFAULT 0,
+            mcp_llm_provider TEXT,
+            mcp_llm_model TEXT,
+            mcp_max_iterations INTEGER NOT NULL DEFAULT 20,
+            mcp_refresh_tools INTEGER NOT NULL DEFAULT 0,
+            source TEXT NOT NULL DEFAULT 'api',
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        );
+        INSERT INTO agent_registry (
+            agent_type, name, command, source, created_at, updated_at
+        ) VALUES ('legacy_api', 'Legacy API', 'legacy-cli', 'api', '2026-01-01', '2026-01-01');
+        PRAGMA user_version=13;
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    db = ACPSessionsDB(db_path=str(db_path))
+    try:
+        row = db.get_agent_entry("legacy_api")
+        assert row["entrypoint_strategy"] == "documented_candidate"
+        assert row["acp_command"] == ""
+        assert row["acp_args"] == "[]"
+
+        registry = AgentRegistry(yaml_path="/missing.yaml", db=db)
+        registry._load_api_entries()
+        entry = registry.get_entry("legacy_api")
+        assert entry is not None
+        assert entry.entrypoint_strategy == "documented_candidate"
+        assert entry.acp_command == ""
+        assert entry.acp_args == []
+    finally:
+        db.close()
+```
+
+Extend `tldw_Server_API/tests/Agent_Client_Protocol/test_registry_mcp_fields.py`:
+
+```python
+from pydantic import ValidationError
+
+
+def test_agent_register_request_exposes_entrypoint_strategy_fields():
+    request = ACPAgentRegisterRequest(
+        agent_type="native",
+        name="Native",
+        entrypoint_strategy="native_acp",
+        acp_command="native-agent",
+        acp_args=["acp"],
+    )
+
+    assert request.entrypoint_strategy == "native_acp"
+    assert request.acp_command == "native-agent"
+    assert request.acp_args == ["acp"]
+
+
+def test_agent_register_request_rejects_invalid_entrypoint_strategy():
+    with pytest.raises(ValidationError):
+        ACPAgentRegisterRequest(
+            agent_type="bad",
+            name="Bad",
+            entrypoint_strategy="maybe_acp",
+        )
+```
+
+- [ ] **Step 3: Run tests and verify they fail for missing fields**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/Agent_Client_Protocol/test_registry_entrypoint_strategy.py \
+  tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sessions_db.py \
+  tldw_Server_API/tests/Agent_Client_Protocol/test_registry_mcp_fields.py \
+  -q
+```
+
+Expected: FAIL because strategy fields do not exist yet.
+
+- [ ] **Step 4: Add schema and persistence fields**
+
+In `tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py`, add:
+
+```python
+ACPEntryPointStrategy = Literal[
+    "native_acp",
+    "adapter_acp",
+    "documented_candidate",
+    "custom_template",
+]
+ACPProbeState = Literal["ready_to_probe", "blocked", "custom_template", "documented_only"]
+```
+
+Add request fields to `ACPAgentRegisterRequest` and optional update fields to `ACPAgentUpdateRequest`:
+
+```python
+entrypoint_strategy: ACPEntryPointStrategy = Field(default="documented_candidate")
+acp_command: str = Field(default="")
+acp_args: list[str] = Field(default_factory=list)
+adapter_source: str | None = Field(default=None)
+adapter_docs_url: str | None = Field(default=None)
+certification_blocker: str | None = Field(default=None)
+```
+
+In `tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py`, add matching fields to `AgentRegistryEntry`, thread them through YAML loading, `_load_api_entries()`, `register_agent()`, `_UPDATABLE_FIELDS`, and `update_agent()`.
+
+Add small runtime coercion helpers so invalid YAML or legacy DB text cannot leak invalid enum values into API responses:
+
+```python
+def _coerce_entrypoint_strategy(value: Any) -> AgentEntrypointStrategy:
+    if value in {"native_acp", "adapter_acp", "documented_candidate", "custom_template"}:
+        return value
+    return "documented_candidate"
+```
+
+Use the coercion helper in YAML loading and DB loading. Do not silently coerce Pydantic request payloads; request models should reject invalid literals.
+
+In `tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py`, pass the new request fields from `acp_register_agent()` and the agent update endpoint into the registry methods so API-backed rows preserve the same metadata as YAML rows.
+
+In `tldw_Server_API/app/core/DB_Management/ACP_Sessions_DB.py`:
+
+- Bump `_SCHEMA_VERSION` from `13` to `14`.
+- Add columns to the `agent_registry` `CREATE TABLE` block:
+
+```sql
+entrypoint_strategy TEXT NOT NULL DEFAULT 'documented_candidate',
+acp_command TEXT NOT NULL DEFAULT '',
+acp_args TEXT NOT NULL DEFAULT '[]',
+adapter_source TEXT,
+adapter_docs_url TEXT,
+certification_blocker TEXT,
+```
+
+- Add the same columns to `_ALLOWED_MIGRATION_COLUMNS["agent_registry"]`.
+- Add an `if current_version < 14:` migration using `_ensure_column(...)`.
+- Read and write those fields in `save_agent_entry()`.
+
+- [ ] **Step 5: Seed built-in registry rows**
+
+In `tldw_Server_API/Config_Files/agents.yaml`, add:
+
+```yaml
+entrypoint_strategy: native_acp
+acp_command: opencode
+acp_args:
+  - acp
+```
+
+for OpenCode, and the equivalent `goose` / `["acp"]` for Goose.
+
+Add:
+
+```yaml
+entrypoint_strategy: documented_candidate
+acp_command: ""
+acp_args: []
+certification_blocker: adapter_required
+```
+
+for Codex CLI and Claude Code. Do not set either row to `adapter_acp`.
+
+Add:
+
+```yaml
+entrypoint_strategy: documented_candidate
+acp_command: ""
+acp_args: []
+certification_blocker: entrypoint_strategy_missing
+```
+
+for Aider and Continue.
+
+Add:
+
+```yaml
+entrypoint_strategy: custom_template
+acp_command: ""
+acp_args: []
+```
+
+for Custom Agent.
+
+- [ ] **Step 6: Run task tests and commit**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/Agent_Client_Protocol/test_registry_entrypoint_strategy.py \
+  tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sessions_db.py \
+  tldw_Server_API/tests/Agent_Client_Protocol/test_registry_mcp_fields.py \
+  -q
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add \
+  tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py \
+  tldw_Server_API/app/core/DB_Management/ACP_Sessions_DB.py \
+  tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py \
+  tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py \
+  tldw_Server_API/Config_Files/agents.yaml \
+  tldw_Server_API/tests/Agent_Client_Protocol/test_registry_entrypoint_strategy.py \
+  tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sessions_db.py \
+  tldw_Server_API/tests/Agent_Client_Protocol/test_registry_mcp_fields.py
+git commit -m "feat: add ACP entrypoint strategy registry metadata"
+```
+
+---
+
+### Task 2: Deterministic Entrypoint Classifier
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py`
+- Modify: `Docs/Development/ACP_Compatibility_Matrix.md`
+- Test: `tldw_Server_API/tests/Agent_Client_Protocol/test_registry_entrypoint_strategy.py`
+
+- [ ] **Step 1: Write failing classifier tests**
+
+Add tests to `test_registry_entrypoint_strategy.py`:
+
+```python
+from tldw_Server_API.app.core.Agent_Client_Protocol.agent_registry import (
+    classify_agent_entrypoint,
+)
+
+
+def test_classifier_ready_to_probe_native_entrypoint(monkeypatch):
+    entry = AgentRegistryEntry(
+        type="opencode",
+        name="OpenCode",
+        entrypoint_strategy="native_acp",
+        acp_command="opencode",
+        acp_args=["acp"],
+    )
+
+    result = classify_agent_entrypoint(
+        entry,
+        command_resolver=lambda command: f"/usr/bin/{command}",
+        env_getter=lambda _name: "present",
+    )
+
+    assert result.probe_state == "ready_to_probe"
+    assert result.acp_command == "opencode"
+    assert result.acp_args == ["acp"]
+    assert result.primary_blocker is None
+    assert result.blockers == []
+
+
+def test_classifier_blocks_native_entrypoint_missing_command():
+    entry = AgentRegistryEntry(
+        type="goose",
+        name="Goose",
+        entrypoint_strategy="native_acp",
+        acp_command="goose",
+        acp_args=["acp"],
+    )
+
+    result = classify_agent_entrypoint(entry, command_resolver=lambda _command: None)
+
+    assert result.probe_state == "blocked"
+    assert result.primary_blocker == "binary_missing"
+    assert "binary_missing" in result.blockers
+
+
+def test_classifier_does_not_infer_native_acp_command_from_command():
+    entry = AgentRegistryEntry(
+        type="opencode",
+        name="OpenCode",
+        command="opencode",
+        entrypoint_strategy="native_acp",
+        acp_command="",
+    )
+
+    result = classify_agent_entrypoint(
+        entry,
+        command_resolver=lambda command: f"/usr/bin/{command}",
+    )
+
+    assert result.probe_state == "blocked"
+    assert result.primary_blocker == "entrypoint_strategy_missing"
+    assert result.acp_command == ""
+
+
+def test_classifier_does_not_infer_adapter_acp_command_from_command():
+    entry = AgentRegistryEntry(
+        type="codex",
+        name="Codex",
+        command="codex",
+        entrypoint_strategy="adapter_acp",
+        acp_command="",
+        adapter_source="example/codex-acp",
+    )
+
+    result = classify_agent_entrypoint(
+        entry,
+        command_resolver=lambda command: f"/usr/bin/{command}",
+    )
+
+    assert result.probe_state == "blocked"
+    assert result.primary_blocker == "entrypoint_strategy_missing"
+    assert result.acp_command == ""
+
+
+def test_classifier_documented_candidate_keeps_command_separate_from_acp_command():
+    entry = AgentRegistryEntry(
+        type="codex",
+        name="Codex",
+        command="codex",
+        entrypoint_strategy="documented_candidate",
+        acp_command="",
+        certification_blocker="adapter_required",
+    )
+
+    result = classify_agent_entrypoint(
+        entry,
+        command_resolver=lambda command: f"/usr/bin/{command}",
+    )
+
+    assert result.probe_state == "documented_only"
+    assert result.primary_blocker == "adapter_required"
+    assert result.acp_command == ""
+
+
+def test_classifier_documented_candidate_is_documented_only():
+    entry = AgentRegistryEntry(
+        type="codex",
+        name="Codex",
+        entrypoint_strategy="documented_candidate",
+        certification_blocker="adapter_required",
+    )
+
+    result = classify_agent_entrypoint(entry)
+
+    assert result.probe_state == "documented_only"
+    assert result.primary_blocker == "adapter_required"
+    assert result.acp_command == ""
+
+
+def test_classifier_adapter_requires_adapter_command():
+    entry = AgentRegistryEntry(
+        type="adapter",
+        name="Adapter",
+        entrypoint_strategy="adapter_acp",
+        acp_command="adapter-acp",
+        acp_args=[],
+        adapter_source="example/adapter",
+    )
+
+    result = classify_agent_entrypoint(entry, command_resolver=lambda _command: None)
+
+    assert result.probe_state == "blocked"
+    assert result.primary_blocker == "adapter_missing"
+
+
+def test_classifier_custom_template_is_never_probe_ready():
+    entry = AgentRegistryEntry(
+        type="custom",
+        name="Custom Agent",
+        entrypoint_strategy="custom_template",
+    )
+
+    result = classify_agent_entrypoint(entry)
+
+    assert result.probe_state == "custom_template"
+    assert result.acp_command == ""
+
+
+def test_classifier_rejects_shell_builtin_entrypoint():
+    entry = AgentRegistryEntry(
+        type="bad",
+        name="Bad",
+        entrypoint_strategy="native_acp",
+        acp_command="cd",
+    )
+
+    result = classify_agent_entrypoint(entry, command_resolver=lambda _command: "/bin/cd")
+
+    assert result.probe_state == "blocked"
+    assert result.primary_blocker == "shell_builtin_collision"
+```
+
+- [ ] **Step 2: Run classifier tests and verify failure**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/Agent_Client_Protocol/test_registry_entrypoint_strategy.py \
+  -q
+```
+
+Expected: FAIL because `classify_agent_entrypoint` does not exist.
+
+- [ ] **Step 3: Implement classifier**
+
+In `agent_registry.py`, add a frozen dataclass:
+
+```python
+@dataclass(frozen=True)
+class AgentEntrypointClassification:
+    profile_key: str
+    entrypoint_strategy: AgentEntrypointStrategy
+    probe_state: AgentProbeState
+    acp_command: str
+    acp_args: list[str]
+    primary_blocker: str | None
+    blockers: list[str]
+    status_message: str
+    docs_url: str | None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "profile_key": self.profile_key,
+            "entrypoint_strategy": self.entrypoint_strategy,
+            "probe_state": self.probe_state,
+            "acp_command": self.acp_command,
+            "acp_args": list(self.acp_args),
+            "primary_blocker": self.primary_blocker,
+            "blockers": list(self.blockers),
+            "status_message": self.status_message,
+            "docs_url": self.docs_url,
+        }
+```
+
+Add:
+
+```python
+_SHELL_BUILTIN_COMMANDS = frozenset({"alias", "cd", "export", "set", "source", "unset"})
+```
+
+Add `classify_agent_entrypoint(entry, *, command_resolver=shutil.which, env_getter=os.getenv)`. Rules:
+
+- `custom_template` returns `probe_state="custom_template"` and no command.
+- `documented_candidate` returns `probe_state="documented_only"` and uses `certification_blocker` when present.
+- `native_acp` or `adapter_acp` with no `acp_command` returns blocked with `entrypoint_strategy_missing`.
+- Shell builtins return blocked with `shell_builtin_collision`.
+- Missing adapter command on `adapter_acp` returns `adapter_missing`.
+- Missing native command returns `binary_missing`.
+- Missing required API key returns `credentials_missing`.
+- Otherwise return `ready_to_probe`.
+
+Do not call subprocesses or run ACP initialize here.
+
+- [ ] **Step 4: Update caveat taxonomy docs**
+
+In `Docs/Development/ACP_Compatibility_Matrix.md`, add rows under "Caveat Taxonomy":
+
+```markdown
+| `entrypoint_strategy_missing` | Registry row has no verified ACP stdio entrypoint strategy or command. |
+| `adapter_required` | Agent needs a separate ACP adapter before live ACP certification can run. |
+| `adapter_missing` | Adapter-backed strategy is configured but the adapter command is unavailable. |
+| `acp_initialize_failed` | ACP stdio command started but failed the bounded initialize probe. |
+| `shell_builtin_collision` | Configured ACP command resolves to a shell builtin or alias-like value instead of an executable. |
+```
+
+- [ ] **Step 5: Run tests and commit**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/Agent_Client_Protocol/test_registry_entrypoint_strategy.py \
+  -q
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add \
+  tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py \
+  tldw_Server_API/tests/Agent_Client_Protocol/test_registry_entrypoint_strategy.py \
+  Docs/Development/ACP_Compatibility_Matrix.md
+git commit -m "feat: classify ACP entrypoint probe readiness"
+```
+
+---
+
+### Task 3: Profile-Specific Certification Manifests
+
+**Files:**
+- Modify: `Helper_Scripts/Testing-related/acp_certification_smoke.py`
+- Test: `tldw_Server_API/tests/Helper_Scripts/test_acp_certification_smoke.py`
+
+- [ ] **Step 1: Write failing manifest tests**
+
+Extend `test_acp_certification_smoke.py`:
+
+```python
+def test_profile_manifest_renders_native_acp_entrypoint(monkeypatch) -> None:
+    module = _load_module()
+
+    manifest = module.build_agent_profile_manifest(
+        {
+            "type": "opencode",
+            "name": "OpenCode",
+            "entrypoint_strategy": "native_acp",
+            "acp_command": "opencode",
+            "acp_args": ["acp"],
+            "probe_state": "ready_to_probe",
+            "primary_blocker": None,
+            "blockers": [],
+            "status_message": "Ready to probe native ACP entrypoint.",
+            "docs_url": "/docs-static/Development/ACP_Compatibility_Matrix.md",
+        }
+    )
+
+    assert manifest["profile"] == "opencode"
+    assert manifest["entrypoint"]["entrypoint_strategy"] == "native_acp"
+    initialize = next(command for command in manifest["commands"] if command["id"] == "acp_initialize_probe")
+    assert initialize["argv"] == ["opencode", "acp"]
+    assert initialize["safe_to_run_by_default"] is False
+    assert [frame["method"] for frame in initialize["stdin_jsonl"]] == [
+        "initialize",
+        "session/new",
+        "session/prompt",
+    ]
+
+
+def test_profile_manifest_refuses_documented_candidate() -> None:
+    module = _load_module()
+
+    manifest = module.build_agent_profile_manifest(
+        {
+            "type": "codex",
+            "name": "Codex",
+            "entrypoint_strategy": "documented_candidate",
+            "acp_command": "",
+            "acp_args": [],
+            "probe_state": "documented_only",
+            "primary_blocker": "adapter_required",
+            "blockers": ["adapter_required"],
+            "status_message": "Codex requires an ACP adapter.",
+            "docs_url": "/docs-static/Development/ACP_Compatibility_Matrix.md",
+        }
+    )
+
+    assert manifest["requires_live_agent"] is True
+    assert manifest["commands"] == []
+    assert "adapter_required" in manifest["blockers"]
+
+
+def test_run_profile_manifest_uses_stdio_sequence_runner(monkeypatch) -> None:
+    module = _load_module()
+    sequences = []
+
+    monkeypatch.setenv("TLDW_E2E_SERVER_URL", "http://127.0.0.1:8000")
+    monkeypatch.setenv("TLDW_E2E_API_KEY", "test")
+    monkeypatch.setenv("ACP_AGENT_PROFILE", "opencode")
+    monkeypatch.setattr(module, "_missing_executable_reason", lambda *_args: None)
+    monkeypatch.setattr(
+        module,
+        "_run_stdio_jsonrpc_sequence",
+        lambda command, cwd: sequences.append((command, cwd)) or 0,
+    )
+
+    rc = module.run_manifest_dict({
+        "profile": "opencode",
+        "requires_live_agent": True,
+        "required_environment": ["TLDW_E2E_SERVER_URL", "TLDW_E2E_API_KEY", "ACP_AGENT_PROFILE"],
+        "commands": [{
+            "id": "acp_initialize_probe",
+            "cwd": ".",
+            "argv": ["opencode", "acp"],
+            "safe_to_run_by_default": False,
+            "stdin_jsonl": [
+                {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+                {"jsonrpc": "2.0", "id": 2, "method": "session/new", "params": {}},
+                {"jsonrpc": "2.0", "id": 3, "method": "session/prompt", "params": {"prompt": "Reply ok."}},
+            ],
+            "timeout_seconds": 10,
+        }],
+    })
+
+    assert rc == 0
+    assert sequences
+    command, _cwd = sequences[0]
+    assert [frame["method"] for frame in command["stdin_jsonl"]] == [
+        "initialize",
+        "session/new",
+        "session/prompt",
+    ]
+    assert command["timeout_seconds"] == 10
+
+
+def test_stdio_sequence_runner_stops_after_failed_initialize(monkeypatch) -> None:
+    module = _load_module()
+    written = []
+
+    class _Stdin:
+        def write(self, text):
+            written.append(text)
+
+        def flush(self):
+            return None
+
+    class _Stdout:
+        def readline(self):
+            return '{"jsonrpc":"2.0","id":1,"error":{"message":"init failed"}}\n'
+
+    class _Process:
+        stdin = _Stdin()
+        stdout = _Stdout()
+
+        def wait(self, timeout=None):
+            return 1
+
+        def kill(self):
+            return None
+
+    monkeypatch.setattr(module.subprocess, "Popen", lambda *_args, **_kwargs: _Process())
+
+    rc = module._run_stdio_jsonrpc_sequence({
+        "id": "acp_initialize_probe",
+        "cwd": ".",
+        "argv": ["opencode", "acp"],
+        "stdin_jsonl": [
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+            {"jsonrpc": "2.0", "id": 2, "method": "session/new", "params": {}},
+            {"jsonrpc": "2.0", "id": 3, "method": "session/prompt", "params": {}},
+        ],
+        "timeout_seconds": 10,
+    }, module.ROOT)
+
+    assert rc != 0
+    assert len(written) == 1
+    assert '"method": "initialize"' in written[0]
+```
+
+- [ ] **Step 2: Run helper tests and verify failure**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/Helper_Scripts/test_acp_certification_smoke.py \
+  -q
+```
+
+Expected: FAIL because profile manifest helpers do not exist.
+
+- [ ] **Step 3: Implement profile manifest builder**
+
+In `acp_certification_smoke.py`:
+
+- Add `build_agent_profile_manifest(entrypoint: dict[str, Any]) -> dict[str, Any]`.
+- Add `run_manifest_dict(manifest: dict[str, Any]) -> int`.
+- Keep existing `build_manifest("stub-smoke")` and `build_manifest("live-e2e")` behavior stable.
+- Add profile command shape only when `probe_state == "ready_to_probe"`.
+- Use one subprocess and an ordered JSON-RPC stdio sequence so `session/new`
+  and `session/prompt` are sent only after `initialize` returns a non-error
+  response:
+
+```python
+{
+    "id": "acp_initialize_probe",
+    "description": "Bounded ACP initialize probe for the selected downstream entrypoint.",
+    "cwd": ".",
+    "argv": [entrypoint["acp_command"], *entrypoint.get("acp_args", [])],
+    "stdin_jsonl": [
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "1",
+                "clientInfo": {"name": "tldw-server-certification-smoke", "version": "0"},
+            },
+        },
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "session/new",
+            "params": {"cwd": ".", "mcpServers": []},
+        },
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "session/prompt",
+            "params": {"prompt": "Reply with a short ACP certification acknowledgement."},
+        },
+    ],
+    "timeout_seconds": 10,
+    "capabilities": ["init", "session_new", "prompt"],
+    "safe_to_run_by_default": False,
+}
+```
+
+Update `render_manifest()` to print `stdin_jsonl` and blocker details when present.
+
+Update command execution as follows:
+
+- Commands without `stdin_jsonl` can keep the existing `subprocess.run(...)` path.
+- Commands with `stdin_jsonl` should use a new `_run_stdio_jsonrpc_sequence(command, cwd)` helper based on `subprocess.Popen(..., stdin=PIPE, stdout=PIPE, text=True)`.
+- `_run_stdio_jsonrpc_sequence()` writes the `initialize` frame first, reads one response line, and stops immediately when the response contains `error`.
+- Only after `initialize` succeeds should it write the `session/new` frame; only after `session/new` succeeds should it write the `session/prompt` frame.
+- Timeout handling should kill the process and return a nonzero code without hanging the test run.
+
+- [ ] **Step 4: Add CLI profile argument**
+
+Add an optional argument:
+
+```python
+parser.add_argument(
+    "--agent-profile",
+    help="Render or run a registry-backed agent profile manifest.",
+)
+```
+
+When supplied:
+
+- Load `get_agent_registry()`.
+- Fetch the named entry.
+- Classify with `classify_agent_entrypoint(entry)`.
+- Convert classification to `build_agent_profile_manifest(classification.as_dict() | {"type": entry.type, "name": entry.name})`.
+- Render or run that manifest.
+
+- [ ] **Step 5: Run helper tests and commit**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/Helper_Scripts/test_acp_certification_smoke.py \
+  -q
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add \
+  Helper_Scripts/Testing-related/acp_certification_smoke.py \
+  tldw_Server_API/tests/Helper_Scripts/test_acp_certification_smoke.py
+git commit -m "feat: add ACP profile certification manifests"
+```
+
+---
+
+### Task 4: Setup, Health, And Agent API Surfaces
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py`
+- Test: `tldw_Server_API/tests/Agent_Client_Protocol/test_acp_health.py`
+- Test: `tldw_Server_API/tests/Agent_Client_Protocol/test_acp_endpoints.py`
+
+- [ ] **Step 1: Write failing response-surface tests**
+
+Extend `test_acp_health.py`:
+
+```python
+def test_acp_agents_include_entrypoint_strategy_metadata(client_user_only, stub_runner_client):
+    resp = client_user_only.get("/api/v1/acp/agents")
+    assert resp.status_code == 200
+
+    agent = next(item for item in resp.json()["agents"] if item["type"] == "opencode")
+
+    assert agent["entrypoint"]["entrypoint_strategy"] == "native_acp"
+    assert agent["entrypoint"]["acp_command"] == "opencode"
+    assert agent["entrypoint"]["acp_args"] == ["acp"]
+    assert agent["entrypoint"]["probe_state"] in {"ready_to_probe", "blocked"}
+
+
+def test_acp_setup_guide_includes_entrypoint_blocker_steps(client_user_only, stub_runner_client):
+    resp = client_user_only.get("/api/v1/acp/setup-guide?agent_type=codex")
+    assert resp.status_code == 200
+
+    guide = resp.json()["guides"][0]
+
+    assert guide["entrypoint"]["entrypoint_strategy"] == "documented_candidate"
+    assert guide["entrypoint"]["primary_blocker"] == "adapter_required"
+    assert any("adapter" in step.lower() for step in guide["steps"])
+
+
+def test_acp_health_includes_entrypoint_metadata(client_user_only, stub_runner_client):
+    resp = client_user_only.get("/api/v1/acp/health")
+    assert resp.status_code == 200
+
+    agent = next(item for item in resp.json()["agents"] if item["agent_type"] == "custom")
+
+    assert "entrypoint" in agent
+    assert agent["entrypoint"]["entrypoint_strategy"] == "custom_template"
+```
+
+Extend `test_acp_endpoints.py` to prove API-backed dynamic rows receive and expose the same metadata:
+
+```python
+def test_register_agent_preserves_entrypoint_strategy_kwargs(
+    client_user_only,
+    monkeypatch,
+):
+    import types
+    import tldw_Server_API.app.api.v1.endpoints.agent_client_protocol as acp_endpoints
+    import tldw_Server_API.app.core.Agent_Client_Protocol.agent_registry as registry_mod
+
+    captured = {}
+
+    class _Registry:
+        def register_agent(self, **kwargs):
+            captured.update(kwargs)
+            return types.SimpleNamespace(type=kwargs["type"], name=kwargs["name"])
+
+    async def _admin_user():
+        return types.SimpleNamespace(id=1, is_admin=True)
+
+    monkeypatch.setattr(registry_mod, "get_agent_registry", lambda: _Registry())
+    client_user_only.app.dependency_overrides[acp_endpoints.get_request_user] = _admin_user
+    try:
+        response = client_user_only.post(
+            "/api/v1/acp/agents/register",
+            json={
+                "agent_type": "dynamic_adapter",
+                "name": "Dynamic Adapter",
+                "command": "agent-cli",
+                "entrypoint_strategy": "adapter_acp",
+                "acp_command": "agent-acp",
+                "acp_args": ["--stdio"],
+                "adapter_source": "example/agent-acp",
+                "adapter_docs_url": "https://example.test/agent-acp",
+                "certification_blocker": "adapter_missing",
+            },
+        )
+    finally:
+        client_user_only.app.dependency_overrides.pop(acp_endpoints.get_request_user, None)
+
+    assert response.status_code == 200
+    assert captured["entrypoint_strategy"] == "adapter_acp"
+    assert captured["acp_command"] == "agent-acp"
+    assert captured["acp_args"] == ["--stdio"]
+    assert captured["adapter_source"] == "example/agent-acp"
+    assert captured["certification_blocker"] == "adapter_missing"
+
+
+def test_dynamic_agent_list_exposes_entrypoint_strategy_metadata(
+    client_user_only,
+    monkeypatch,
+):
+    import tldw_Server_API.app.api.v1.endpoints.agent_client_protocol as acp_endpoints
+
+    monkeypatch.setattr(
+        acp_endpoints,
+        "_get_registry_agents",
+        lambda: (
+            [
+                acp_endpoints.ACPAgentInfo(
+                    type="dynamic_adapter",
+                    name="Dynamic Adapter",
+                    is_configured=False,
+                    entrypoint={
+                        "profile_key": "dynamic_adapter",
+                        "entrypoint_strategy": "adapter_acp",
+                        "probe_state": "blocked",
+                        "acp_command": "agent-acp",
+                        "acp_args": ["--stdio"],
+                        "primary_blocker": "adapter_missing",
+                        "blockers": ["adapter_missing"],
+                        "status_message": "Adapter command is missing.",
+                        "docs_url": "/docs-static/Development/ACP_Compatibility_Matrix.md",
+                    },
+                )
+            ],
+            "dynamic_adapter",
+        ),
+    )
+
+    response = client_user_only.get("/api/v1/acp/agents")
+
+    assert response.status_code == 200
+    agent = response.json()["agents"][0]
+    assert agent["entrypoint"]["entrypoint_strategy"] == "adapter_acp"
+    assert agent["entrypoint"]["acp_command"] == "agent-acp"
+    assert agent["entrypoint"]["primary_blocker"] == "adapter_missing"
+```
+
+- [ ] **Step 2: Run response tests and verify failure**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/Agent_Client_Protocol/test_acp_health.py \
+  -q
+```
+
+Expected: FAIL because response models do not expose `entrypoint`.
+
+- [ ] **Step 3: Add response model**
+
+In `agent_client_protocol.py`, add:
+
+```python
+class ACPAgentEntrypointStatus(BaseModel):
+    """ACP stdio entrypoint readiness for one downstream agent."""
+
+    profile_key: str = Field(..., description="Registry profile key")
+    entrypoint_strategy: ACPEntryPointStrategy = Field(default="documented_candidate")
+    probe_state: ACPProbeState = Field(default="documented_only")
+    acp_command: str = Field(default="")
+    acp_args: list[str] = Field(default_factory=list)
+    primary_blocker: str | None = Field(default=None)
+    blockers: list[str] = Field(default_factory=list)
+    status_message: str = Field(default="")
+    docs_url: str | None = Field(default=ACP_COMPATIBILITY_DOCS_URL)
+```
+
+Add `entrypoint: ACPAgentEntrypointStatus` to `ACPAgentInfo` and `ACPSetupGuideAgent`.
+
+- [ ] **Step 4: Wire endpoint helpers**
+
+In `agent_client_protocol.py` endpoint module:
+
+- Import `classify_agent_entrypoint`.
+- Add `_entrypoint_status_from_entry(reg_entry) -> dict[str, Any]`.
+- Add `_entrypoint_status_from_dict(item) -> dict[str, Any]` for runner/static fallback payloads.
+- Add `_entrypoint_setup_steps(entrypoint: dict[str, Any]) -> list[str]`.
+
+Setup steps should map:
+
+- `adapter_required` or `adapter_missing`: "Select and install a concrete ACP adapter command before live certification."
+- `binary_missing`: "Install the ACP entrypoint command and ensure it is on PATH."
+- `credentials_missing`: "Set the required provider credential before live certification."
+- `entrypoint_strategy_missing`: "Identify and configure a concrete ACP stdio entrypoint before live certification."
+- `shell_builtin_collision`: "Use an executable ACP command, not a shell builtin or alias."
+- `custom_template`: "Create a named custom ACP profile with command, args, env, workspace policy, and evidence bundle."
+
+Wire entrypoint metadata into:
+
+- `_check_agent_availability()`
+- `acp_health()`
+- `acp_setup_guide()`
+- `_get_static_agents()`
+- `_get_registry_agents()`
+- runner-provided `/agents` normalization path
+- `acp_register_agent()`
+- agent update endpoint, if present in the file
+
+- [ ] **Step 5: Run endpoint tests and commit**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/Agent_Client_Protocol/test_acp_health.py \
+  tldw_Server_API/tests/Agent_Client_Protocol/test_acp_endpoints.py \
+  -q
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add \
+  tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py \
+  tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py \
+  tldw_Server_API/tests/Agent_Client_Protocol/test_acp_health.py \
+  tldw_Server_API/tests/Agent_Client_Protocol/test_acp_endpoints.py
+git commit -m "feat: expose ACP entrypoint readiness in setup surfaces"
+```
+
+---
+
+### Task 5: Verification, Backlog Finalization, And PR Prep
+
+**Files:**
+- Modify: `backlog/tasks/task-287 - Implement-ACP-downstream-entrypoint-strategy-stages-1-3.md`
+
+- [ ] **Step 1: Run focused backend/helper tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/Agent_Client_Protocol/test_registry_entrypoint_strategy.py \
+  tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sessions_db.py \
+  tldw_Server_API/tests/Agent_Client_Protocol/test_registry_mcp_fields.py \
+  tldw_Server_API/tests/Helper_Scripts/test_acp_certification_smoke.py \
+  tldw_Server_API/tests/Agent_Client_Protocol/test_acp_health.py \
+  tldw_Server_API/tests/Agent_Client_Protocol/test_acp_endpoints.py \
+  -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run docs and diff checks**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output.
+
+Run:
+
+```bash
+rg -n "entrypoint_strategy|adapter_required|adapter_missing|shell_builtin_collision" \
+  tldw_Server_API/Config_Files/agents.yaml \
+  Docs/Development/ACP_Compatibility_Matrix.md \
+  Docs/superpowers/specs/2026-05-12-acp-downstream-entrypoint-strategy-design.md
+```
+
+Expected: strategy fields appear in YAML and caveat labels appear in docs/spec.
+
+- [ ] **Step 3: Run Bandit on touched Python scope**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m bandit -r \
+  tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py \
+  tldw_Server_API/app/core/DB_Management/ACP_Sessions_DB.py \
+  tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py \
+  tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py \
+  Helper_Scripts/Testing-related/acp_certification_smoke.py \
+  -f json -o /tmp/bandit_acp_entrypoint_strategy.json
+```
+
+Expected: no new findings in touched code. Existing nosec comments around static manifest subprocess execution should remain justified.
+
+- [ ] **Step 4: Update TASK-287**
+
+Use the Backlog CLI from the worktree:
+
+```bash
+backlog task edit TASK-287 --check-ac 1 --check-ac 2 --check-ac 3 --check-ac 4 --check-ac 5 --plain
+backlog task edit TASK-287 --check-dod 1 --check-dod 2 --check-dod 3 --check-dod 4 --check-dod 5 --check-dod 6 --plain
+backlog task edit TASK-287 --status Done --final-summary "Implemented ACP downstream entrypoint strategy metadata, deterministic probe classification, profile-specific certification manifests, and setup/status/API exposure. Verification: focused ACP registry/API/helper tests, git diff --check, docs grep, and Bandit on touched Python scope." --plain
+```
+
+- [ ] **Step 5: Final commit**
+
+Commit Backlog finalization:
+
+```bash
+git add "backlog/tasks/task-287 - Implement-ACP-downstream-entrypoint-strategy-stages-1-3.md"
+git commit -m "chore: finalize ACP entrypoint strategy task"
+```
+
+- [ ] **Step 6: Prepare PR**
+
+Check status:
+
+```bash
+git status --short --branch
+git log --oneline origin/dev..HEAD
+```
+
+If the branch is behind `origin/dev`, rebase before opening/updating the PR:
+
+```bash
+git fetch origin
+git rebase origin/dev
+```
+
+PR summary should explicitly say:
+
+- Adds entrypoint strategy metadata, not live support claims.
+- Keeps Codex/Claude as documented candidates until concrete adapter commands are chosen.
+- Adds dry-run/live-gated profile manifests but does not install or certify downstream agents.
+- Leaves `#1563` and `#1564` open for live certification unless replaced by narrower per-agent evidence issues.

--- a/Docs/superpowers/specs/2026-05-12-acp-downstream-entrypoint-strategy-design.md
+++ b/Docs/superpowers/specs/2026-05-12-acp-downstream-entrypoint-strategy-design.md
@@ -1,0 +1,391 @@
+# ACP Downstream Entrypoint Strategy Design
+
+Date: 2026-05-12
+Status: Proposed
+Tracking: TASK-286, GitHub issues #1563 and #1564
+
+## Summary
+
+ACP downstream certification currently treats an agent registry `command` as if
+it were the ACP stdio entrypoint. The May 11, 2026 blocker evidence showed that
+this is not reliable: `codex` and `claude` are user-facing CLIs, `codex
+mcp-server` speaks MCP rather than ACP, several OSS candidates were not
+installed, and custom profiles have no concrete command to test.
+
+This design introduces an explicit downstream entrypoint strategy model. Each
+registry profile can state whether ACP is reached through a native ACP command,
+an adapter-backed ACP command, a documented candidate, or a custom template.
+The backend can classify the profile, the certification helper can emit
+profile-specific probe manifests, and setup/status surfaces can explain the
+actual blocker without implying live support.
+
+The goal is not to install agents or implement adapters in the first PR. The
+goal is to make the product architecture honest enough that live certification
+can proceed agent by agent without repeating the same ambiguity.
+
+## Current Evidence
+
+The current compatibility matrix and certification notes preserve conservative
+support claims:
+
+- Codex CLI remains `documented_unverified` / `documented_only`. The configured
+  `codex` command did not answer ACP `initialize`, and `codex mcp-server`
+  answered MCP JSON-RPC rather than ACP.
+- Claude Code remains `documented_unverified` / `documented_only`. The
+  configured `claude` command exited before ACP `initialize` because local
+  auth state was missing, and no ACP-specific stdio entrypoint was identified.
+- Aider, Goose, Continue, and OpenCode remain `documented_unverified` /
+  `documented_only`. The local host did not have runnable downstream binaries
+  for those rows; `continue` resolved to a shell builtin rather than a CLI.
+- Custom profiles remain templates. They need a named command, args,
+  environment, workspace policy, host/runtime, version, and evidence before any
+  support claim.
+
+The latest public docs change the next step. OpenCode and Goose document native
+ACP commands, while Codex and Claude Code appear to require adapters. That means
+the architecture needs to represent both native and adapter-backed ACP
+entrypoints.
+
+## Goals
+
+1. Represent ACP entrypoint strategy explicitly in registry metadata.
+2. Classify each profile into a probeable or blocked state before certification
+   runs.
+3. Generate profile-specific probe manifests that test the ACP command, not the
+   user-facing CLI by accident.
+4. Keep setup/API/UI surfaces aligned with the compatibility matrix.
+5. Prevent blocker-documentation PRs from closing live-certification issues when
+   live evidence failed or never ran.
+6. Provide a staged path to certify native ACP agents first and adapter-backed
+   agents next.
+
+## Non-Goals
+
+- Do not install OpenCode, Goose, Codex adapters, Claude adapters, Aider, or
+  Continue as part of the architecture PR.
+- Do not implement a Codex or Claude adapter in the first PR.
+- Do not upgrade any profile to `supported`, `supported_with_caveats`, or
+  `live_e2e_tested` without real `initialize`, `session/new`, and prompt-path
+  evidence.
+- Do not claim generic support for arbitrary custom commands.
+- Do not replace the compatibility matrix as the source of release support
+  claims.
+
+## Entrypoint Strategies
+
+Each registry profile gets one explicit `entrypoint_strategy`:
+
+| Strategy | Meaning | Example |
+| --- | --- | --- |
+| `native_acp` | The downstream agent exposes an ACP stdio command directly. | `opencode acp`, `goose acp` |
+| `adapter_acp` | ACP is provided by a separate adapter binary or wrapper around the agent SDK/CLI. | `codex-acp`, Claude Code SDK adapter |
+| `documented_candidate` | Setup exists, but no ACP entrypoint has been identified or verified. | Aider, Continue until evidence changes |
+| `custom_template` | Operator must provide a concrete ACP-compatible command and evidence. | Custom profile |
+
+The strategy is product metadata, not a support claim. A profile can be
+`native_acp` and still remain `documented_unverified` until a live run passes.
+
+## Registry Metadata
+
+The existing registry fields remain useful for display and installation:
+`type`, `name`, `description`, `command`, `args`, `requires_api_key`,
+`install_instructions`, `docs_url`, `support_state`, `verification_level`,
+`compatibility_notes`, and `compatibility_docs_url`.
+
+Add fields that describe the actual ACP launch surface:
+
+```yaml
+entrypoint_strategy: native_acp | adapter_acp | documented_candidate | custom_template
+acp_command: opencode
+acp_args:
+  - acp
+adapter_source: null
+adapter_docs_url: null
+certification_blocker: binary_missing
+```
+
+Field intent:
+
+- `command` remains the familiar user-facing or install target command.
+- `args` remains the familiar user-facing default args, if any.
+- `acp_command` is the command that should answer ACP JSON-RPC over stdio.
+- `acp_args` are the args for the ACP entrypoint.
+- `adapter_source` names the adapter project or package when strategy is
+  `adapter_acp`.
+- `adapter_docs_url` links to the adapter docs or repository.
+- `certification_blocker` carries the current top blocker using the caveat
+  taxonomy from `ACP_Compatibility_Matrix.md` plus the entrypoint-specific
+  labels defined below. It should be omitted when no current blocker is known.
+
+The backend should default missing strategy fields conservatively, but
+certifiable strategies must be explicit:
+
+- Missing strategy means `documented_candidate`.
+- Missing `acp_command` for `native_acp` or `adapter_acp` is an entrypoint
+  strategy error.
+- `custom_template` can have empty `acp_command`, but it must never be
+  classified as ready to probe.
+- The first implementation should not infer `acp_command` from `command`.
+  Inference would hide the key distinction this design is adding: user-facing
+  CLI command and ACP stdio entrypoint are different concepts. A future
+  migration can add inference only for legacy compatibility, but seeded
+  registry rows should be explicit.
+
+Credential and workspace blockers do not need new registry metadata in the
+first implementation. The classifier should derive credential blockers from
+existing `requires_api_key` and runtime environment state, and workspace
+blockers from existing ACP workspace configuration.
+
+Strategy metadata applies to both YAML-backed and dynamically registered agent
+entries. Stage 1 must thread these fields through `AgentRegistryEntry`, YAML
+loading, API registration/update schemas, DB save/load, `_UPDATABLE_FIELDS`,
+and response serialization. Existing API-backed rows that lack the new fields
+should default to `documented_candidate` with an empty ACP command for backward
+compatibility.
+
+Do not reuse the existing `protocol`, `tool_execution_mode`,
+`mcp_transport`, or MCP orchestration fields as ACP certification metadata.
+Those fields describe how the workspace harness or MCP adapter talks to an
+agent. `entrypoint_strategy`, `acp_command`, and `acp_args` describe the
+downstream command that speaks Agent Client Protocol over stdio. An MCP stdio
+transport such as `codex mcp-server` is not automatically an ACP entrypoint.
+
+## Initial Target Classification
+
+| Profile | Initial strategy | Intended ACP entrypoint | Current support state |
+| --- | --- | --- | --- |
+| OpenCode | `native_acp` | `opencode acp` | `documented_unverified` until installed and tested |
+| Goose | `native_acp` | `goose acp` | `documented_unverified` until installed and tested |
+| Codex CLI | `documented_candidate` | none seeded until an exact adapter command is selected | `documented_unverified` |
+| Claude Code | `documented_candidate` | none seeded until an exact adapter command is selected | `documented_unverified` |
+| Aider | `documented_candidate` | none known in repo evidence | `documented_unverified` |
+| Continue | `documented_candidate` | none known in repo evidence | `documented_unverified` |
+| Custom | `custom_template` | operator supplied | `documented_unverified` |
+
+These classifications should be revisited when upstream docs or local evidence
+change. They should not upgrade support state on their own. Codex and Claude
+should not be seeded as `adapter_acp` until the project chooses concrete
+`acp_command` values such as a specific installed adapter binary. Once selected,
+the adapter command can be represented as `adapter_acp` and certified like any
+other ACP entrypoint.
+
+## Classifier
+
+Add a backend helper in the ACP registry layer that returns a normalized
+classification for a registry entry. It should be small, deterministic, and
+easy to test.
+
+Inputs:
+
+- Registry entry fields.
+- Registry source, so YAML and API-backed entries are classified consistently.
+- PATH command discovery result.
+- Required API key presence, without exposing secret values.
+- Optional custom profile fields.
+
+Output shape:
+
+```text
+profile_key:
+entrypoint_strategy:
+probe_state: ready_to_probe | blocked | custom_template | documented_only
+acp_command:
+acp_args:
+primary_blocker:
+blockers:
+status_message:
+docs_url:
+```
+
+Probe states:
+
+- `ready_to_probe`: strategy and ACP command are configured and the command is
+  resolvable.
+- `blocked`: the profile has a known ACP strategy but cannot be probed because
+  a command, adapter, credential, or workspace prerequisite is missing.
+- `custom_template`: the row is a template and requires a named custom profile.
+- `documented_only`: the row is a candidate with no known ACP entrypoint.
+
+The classifier does not run `initialize`; it only decides whether a probe can
+be attempted and why not.
+
+## Probe Manifest
+
+Extend `Helper_Scripts/Testing-related/acp_certification_smoke.py` so it can
+emit a profile-specific manifest. The profile manifest should reuse existing
+live-e2e concepts and add entrypoint probes:
+
+1. Resolve the ACP command from registry strategy metadata.
+2. Emit version/discovery commands.
+3. Emit a bounded ACP `initialize` probe for the selected `acp_command` and
+   `acp_args`.
+4. Emit `session/new` and `session/prompt` checks only when `initialize` passes
+   and required runtime env is present.
+5. Refuse to claim support when the profile is `documented_candidate`,
+   `custom_template`, missing its adapter, or missing required live env.
+
+The manifest should be useful without running live E2E. In dry-run mode it
+should explain:
+
+- what command would be executed;
+- what blocker prevents execution;
+- what evidence would be required to upgrade status.
+
+## Evidence And Status Rules
+
+Support state rules:
+
+- `documented_unverified` means setup is documented but live support is not
+  claimed.
+- `live_e2e_tested` requires at least ACP `initialize`, `session/new`, and one
+  prompt path success or a clearly classified auth-required response after the
+  ACP session exists.
+- `adapter_acp` is not weaker than `native_acp`; either can become supported if
+  evidence passes.
+- `custom_template` never becomes supported generically. Only a named custom
+  profile can be certified.
+
+Issue closeout rules:
+
+- A PR that documents blockers does not close #1563 or #1564.
+- A live-certification issue closes only when the named agent/profile has
+  successful live evidence, or when the issue is explicitly replaced by narrower
+  per-agent issues.
+- If an issue acceptance criterion says "evidence or explicit blocker
+  documented", it should be interpreted as completing the documentation slice,
+  not completing live certification.
+
+Failure taxonomy:
+
+Reuse the existing caveat taxonomy and add only the missing entrypoint-specific
+labels:
+
+- `entrypoint_strategy_missing`
+- `adapter_required`
+- `adapter_missing`
+- `acp_initialize_failed`
+- `shell_builtin_collision`
+
+## Setup/API/UI Surface Behavior
+
+Setup-guide, health, agents, and Agent Registry surfaces should expose the same
+model:
+
+- Strategy: native, adapter, documented candidate, or custom template.
+- Probe state: ready, blocked, documented-only, or template.
+- Top blocker and next action.
+- Link to compatibility docs and evidence.
+
+Examples:
+
+- OpenCode installed with `opencode acp` resolvable: "Ready to probe native ACP
+  entrypoint."
+- Goose not installed: "Native ACP command documented, but `goose` is missing."
+- Codex without adapter: "Codex requires an ACP adapter; `codex` is not the ACP
+  entrypoint."
+- Custom profile: "Provide a named ACP command, args, env, workspace policy,
+  and evidence bundle."
+
+The UI should not display these rows as "supported" until the matrix support
+state says so.
+
+## Testing
+
+Unit tests:
+
+- Registry parsing accepts all strategy values.
+- Missing strategy defaults to `documented_candidate`.
+- `native_acp` and `adapter_acp` require `acp_command`.
+- `custom_template` stays non-probeable without a concrete profile.
+- Classifier distinguishes missing command, adapter required, adapter missing,
+  shell builtin collision, and ready-to-probe states.
+- Dynamic registration create/update/reload preserves strategy metadata through
+  the API request schemas, registry persistence layer, and DB-backed reload.
+- Existing API-backed registry rows without strategy columns remain loadable and
+  classify as `documented_candidate`.
+
+Helper tests:
+
+- Profile-specific manifest includes `acp_command` and `acp_args`.
+- Native profile manifest renders `opencode acp` / `goose acp` style commands.
+- Adapter profile manifest renders adapter metadata and refuses when adapter is
+  absent.
+- Custom template manifest refuses and lists required custom evidence.
+- Live-run mode refuses without `TLDW_E2E_SERVER_URL`, `TLDW_E2E_API_KEY`, and
+  `ACP_AGENT_PROFILE`.
+
+Integration/status tests:
+
+- `/api/v1/acp/agents` and `/api/v1/acp/setup-guide` include strategy and
+  blocker metadata.
+- Dynamically registered agents expose the same strategy and blocker metadata
+  as YAML-backed agents.
+- Existing ACP health/status tests still pass.
+- Compatibility matrix and `agents.yaml` stay aligned for support state,
+  verification level, and strategy.
+
+Docs verification:
+
+- Matrix rows explain whether the profile is native, adapter-backed,
+  documented-only, or custom.
+- Release notes avoid live support claims until evidence exists.
+
+## Staged Implementation Plan
+
+Stage 1: Registry strategy schema and classifier
+
+- Add strategy fields to registry entries, API schemas, dynamic registration
+  persistence, and response serialization.
+- Seed initial strategy metadata.
+- Add classifier and focused tests.
+- Do not run live agent commands.
+
+Stage 2: Certification manifest profiles
+
+- Extend the smoke helper with profile-specific dry-run manifests.
+- Add bounded `initialize` probe command shape.
+- Add tests for native, adapter, documented candidate, and custom profiles.
+
+Stage 3: Setup/status surface alignment
+
+- Add strategy and blocker metadata to setup-guide and agent list responses.
+- Update frontend Agent Registry/setup copy if needed.
+- Keep the compatibility matrix as the support claim source of truth.
+
+Out of scope for this spec's first implementation plan:
+
+- installing or configuring live downstream agents;
+- certifying OpenCode, Goose, Codex, Claude, Aider, Continue, or a custom
+  profile;
+- closing #1563 or #1564;
+- implementing Codex or Claude adapters.
+
+Follow-on work after Stages 1-3:
+
+- Native ACP certification: install/configure one native ACP target first,
+  likely OpenCode or Goose, run the profile manifest, record evidence, and only
+  then update the relevant matrix row.
+- Adapter-backed certification: evaluate Codex and Claude adapters after the
+  framework can represent them. Treat each adapter as its own certifiable
+  command with version, source, and evidence.
+- Issue decomposition: decide whether #1563 and #1564 should remain aggregate
+  live-certification issues or split into narrower per-agent issues once
+  profile manifests can produce per-agent evidence bundles.
+
+## Open Questions
+
+1. Should adapter-backed profiles include package-manager hints such as npm,
+   pipx, or cargo package names in a first version?
+2. Should #1563 and #1564 be split into per-agent issues after Stage 1, or only
+   after profile manifests can produce per-agent evidence bundles?
+
+## References
+
+- ACP initialization protocol: https://agentclientprotocol.com/protocol/initialization
+- OpenCode ACP docs: https://open-code.ai/en/docs/acp
+- Goose ACP client docs: https://goose-docs.ai/docs/guides/acp-clients/
+- Claude Code via ACP adapter example: https://zed.dev/blog/claude-code-via-acp
+- Codex ACP adapter example: https://github.com/cola-io/codex-acp
+- Current compatibility matrix: `Docs/Development/ACP_Compatibility_Matrix.md`
+- Current certification checklist:
+  `Docs/Development/ACP_Certification_Checklist.md`

--- a/Helper_Scripts/Testing-related/acp_certification_smoke.py
+++ b/Helper_Scripts/Testing-related/acp_certification_smoke.py
@@ -183,6 +183,8 @@ def build_agent_profile_manifest(entrypoint: dict[str, Any]) -> dict[str, Any]:
 
     blockers = list(entrypoint.get("blockers") or [])
     primary_blocker = entrypoint.get("primary_blocker")
+    if entrypoint.get("probe_state") == "custom_template" and not primary_blocker:
+        primary_blocker = "custom_template"
     if primary_blocker and primary_blocker not in blockers:
         blockers.insert(0, str(primary_blocker))
 

--- a/Helper_Scripts/Testing-related/acp_certification_smoke.py
+++ b/Helper_Scripts/Testing-related/acp_certification_smoke.py
@@ -10,16 +10,20 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import select
 import shlex
 # subprocess is intentionally used to run static manifest argv with shell=False.
 import subprocess  # nosec B404
 import sys
+import time
 from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
 
 ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 
 _MANIFESTS: dict[str, dict[str, Any]] = {
@@ -166,9 +170,98 @@ def build_manifest(profile: str) -> dict[str, Any]:
     return deepcopy(_MANIFESTS[profile])
 
 
-def render_manifest(profile: str, *, output_format: str = "markdown") -> str:
-    """Render a certification manifest as JSON or Markdown."""
-    manifest = build_manifest(profile)
+def build_agent_profile_manifest(entrypoint: dict[str, Any]) -> dict[str, Any]:
+    """Return a profile-specific ACP certification probe manifest."""
+    profile = str(entrypoint.get("type") or entrypoint.get("profile_key") or "")
+    if not profile:
+        raise ValueError("Agent profile manifest requires a profile type")
+
+    blockers = list(entrypoint.get("blockers") or [])
+    primary_blocker = entrypoint.get("primary_blocker")
+    if primary_blocker and primary_blocker not in blockers:
+        blockers.insert(0, str(primary_blocker))
+
+    manifest: dict[str, Any] = {
+        "profile": profile,
+        "name": entrypoint.get("name") or profile,
+        "support_state": "documented_unverified",
+        "verification_level": "documented_only",
+        "requires_live_agent": True,
+        "required_environment": [
+            "TLDW_E2E_SERVER_URL",
+            "TLDW_E2E_API_KEY",
+            "ACP_AGENT_PROFILE",
+        ],
+        "entrypoint": {
+            "entrypoint_strategy": entrypoint.get("entrypoint_strategy"),
+            "probe_state": entrypoint.get("probe_state"),
+            "acp_command": entrypoint.get("acp_command") or "",
+            "acp_args": list(entrypoint.get("acp_args") or []),
+            "primary_blocker": primary_blocker,
+            "status_message": entrypoint.get("status_message") or "",
+            "docs_url": entrypoint.get("docs_url"),
+        },
+        "blockers": blockers,
+        "notes": [
+            str(entrypoint.get("status_message") or "Profile-specific ACP certification manifest."),
+            "Requires operator-provided runtime state and an installed downstream ACP entrypoint.",
+        ],
+        "commands": [],
+    }
+
+    if entrypoint.get("probe_state") == "ready_to_probe":
+        manifest["commands"].append(
+            {
+                "id": "acp_initialize_probe",
+                "description": "Bounded ACP initialize probe for the selected downstream entrypoint.",
+                "cwd": ".",
+                "argv": [
+                    str(entrypoint["acp_command"]),
+                    *[str(arg) for arg in entrypoint.get("acp_args", [])],
+                ],
+                "stdin_jsonl": [
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "method": "initialize",
+                        "params": {
+                            "protocolVersion": "1",
+                            "clientInfo": {
+                                "name": "tldw-server-certification-smoke",
+                                "version": "0",
+                            },
+                        },
+                    },
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 2,
+                        "method": "session/new",
+                        "params": {"cwd": ".", "mcpServers": []},
+                    },
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 3,
+                        "method": "session/prompt",
+                        "params": {
+                            "prompt": "Reply with a short ACP certification acknowledgement."
+                        },
+                    },
+                ],
+                "timeout_seconds": 10,
+                "capabilities": ["init", "session_new", "prompt"],
+                "safe_to_run_by_default": False,
+            }
+        )
+
+    return manifest
+
+
+def render_manifest_dict(
+    manifest: dict[str, Any],
+    *,
+    output_format: str = "markdown",
+) -> str:
+    """Render a certification manifest dictionary as JSON or Markdown."""
     if output_format == "json":
         return json.dumps(manifest, indent=2, sort_keys=True)
     if output_format != "markdown":
@@ -183,11 +276,32 @@ def render_manifest(profile: str, *, output_format: str = "markdown") -> str:
     ]
     if manifest["required_environment"]:
         lines.append(f"- required_environment: `{', '.join(manifest['required_environment'])}`")
+    if manifest.get("entrypoint"):
+        entrypoint = manifest["entrypoint"]
+        lines.extend(
+            [
+                f"- entrypoint_strategy: `{entrypoint.get('entrypoint_strategy')}`",
+                f"- probe_state: `{entrypoint.get('probe_state')}`",
+                f"- acp_command: `{entrypoint.get('acp_command')}`",
+            ]
+        )
+        if entrypoint.get("acp_args"):
+            lines.append(f"- acp_args: `{shlex.join(str(arg) for arg in entrypoint['acp_args'])}`")
+    if manifest.get("blockers"):
+        lines.append(f"- blockers: `{', '.join(str(blocker) for blocker in manifest['blockers'])}`")
     lines.append("")
     lines.append("## Notes")
     lines.extend(f"- {note}" for note in manifest["notes"])
+    if manifest.get("blockers"):
+        lines.append("")
+        lines.append("## Blockers")
+        lines.extend(f"- {blocker}" for blocker in manifest["blockers"])
     lines.append("")
     lines.append("## Commands")
+    if not manifest["commands"]:
+        lines.append("")
+        lines.append("No runnable commands for this manifest.")
+        return "\n".join(lines).rstrip() + "\n"
     for command in manifest["commands"]:
         env_prefix = " ".join(
             f"{key}={_quote_shell_env_value(str(value))}"
@@ -213,7 +327,23 @@ def render_manifest(profile: str, *, output_format: str = "markdown") -> str:
                 "",
             ]
         )
+        if command.get("stdin_jsonl"):
+            lines.extend(
+                [
+                    "stdin_jsonl:",
+                    "",
+                    "```jsonl",
+                    *[json.dumps(frame, sort_keys=True) for frame in command["stdin_jsonl"]],
+                    "```",
+                    "",
+                ]
+            )
     return "\n".join(lines).rstrip() + "\n"
+
+
+def render_manifest(profile: str, *, output_format: str = "markdown") -> str:
+    """Render a certification manifest as JSON or Markdown."""
+    return render_manifest_dict(build_manifest(profile), output_format=output_format)
 
 
 def _quote_shell_env_value(value: str) -> str:
@@ -271,9 +401,99 @@ def _handle_missing_prerequisite(command: dict[str, Any], reason: str) -> int | 
     return 127
 
 
-def run_manifest(profile: str) -> int:
-    """Run safe-by-default commands for a certification profile."""
-    manifest = build_manifest(profile)
+def _read_jsonrpc_response(process: subprocess.Popen[str], timeout_seconds: float) -> dict[str, Any] | None:
+    """Read one JSON-RPC line from a process stdout within a timeout."""
+    stdout = process.stdout
+    if stdout is None:
+        return None
+
+    if hasattr(stdout, "fileno"):
+        try:
+            readable, _, _ = select.select([stdout], [], [], timeout_seconds)
+        except (OSError, ValueError):
+            readable = [stdout]
+        if not readable:
+            return None
+
+    line = stdout.readline()
+    if not line:
+        return None
+    try:
+        payload = json.loads(line)
+    except json.JSONDecodeError:
+        return {"error": {"message": f"invalid JSON-RPC response: {line.strip()}"}}
+    if not isinstance(payload, dict):
+        return {"error": {"message": "JSON-RPC response is not an object"}}
+    return payload
+
+
+def _run_stdio_jsonrpc_sequence(command: dict[str, Any], cwd: Path) -> int:
+    """Run an ordered stdio JSON-RPC sequence, stopping after the first error."""
+    timeout_seconds = float(command.get("timeout_seconds", 10))
+    deadline = time.monotonic() + timeout_seconds
+    command_id = command.get("id", "<unknown>")
+    try:
+        process = subprocess.Popen(  # nosec B603
+            command["argv"],
+            cwd=str(cwd),
+            env=_command_env(command),
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        handled = _handle_missing_prerequisite(command, str(exc))
+        return 127 if handled is None else handled
+
+    for frame in command.get("stdin_jsonl", []):
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            process.kill()
+            print(f"FAIL {command_id}: timed out before {frame.get('method')}", file=sys.stderr)
+            return 124
+        if process.stdin is None:
+            process.kill()
+            print(f"FAIL {command_id}: subprocess stdin is unavailable", file=sys.stderr)
+            return 1
+        try:
+            process.stdin.write(json.dumps(frame) + "\n")
+            process.stdin.flush()
+        except BrokenPipeError:
+            process.kill()
+            print(f"FAIL {command_id}: subprocess closed stdin before {frame.get('method')}", file=sys.stderr)
+            return 1
+
+        response = _read_jsonrpc_response(process, remaining)
+        if response is None:
+            process.kill()
+            print(f"FAIL {command_id}: timed out waiting for {frame.get('method')} response", file=sys.stderr)
+            return 124
+        if response.get("error"):
+            process.kill()
+            print(
+                f"FAIL {command_id}: {frame.get('method')} returned error: "
+                + json.dumps(response["error"], sort_keys=True),
+                file=sys.stderr,
+            )
+            return 1
+
+    if process.stdin is not None:
+        try:
+            process.stdin.close()
+        except OSError:
+            pass
+
+    if process.poll() is None:
+        process.terminate()
+        try:
+            process.wait(timeout=1)
+        except subprocess.TimeoutExpired:
+            process.kill()
+    return 0
+
+
+def run_manifest_dict(manifest: dict[str, Any]) -> int:
+    """Run safe-by-default commands from a certification manifest dictionary."""
     if manifest["requires_live_agent"]:
         missing = [
             name for name in manifest["required_environment"]
@@ -303,6 +523,11 @@ def run_manifest(profile: str) -> int:
                 continue
             return handled
         print(f"==> {command['id']} ({cwd})")
+        if command.get("stdin_jsonl"):
+            result_code = _run_stdio_jsonrpc_sequence(command, cwd)
+            if result_code != 0:
+                return int(result_code)
+            continue
         try:
             result = subprocess.run(  # nosec B603
                 command["argv"],
@@ -318,6 +543,28 @@ def run_manifest(profile: str) -> int:
         if result.returncode != 0:
             return int(result.returncode)
     return 0
+
+
+def run_manifest(profile: str) -> int:
+    """Run safe-by-default commands for a certification profile."""
+    return run_manifest_dict(build_manifest(profile))
+
+
+def _build_registry_agent_manifest(agent_profile: str) -> dict[str, Any]:
+    """Build a manifest for an agent registry entry."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.agent_registry import (
+        classify_agent_entrypoint,
+        get_agent_registry,
+    )
+
+    registry = get_agent_registry()
+    entry = registry.get_entry(agent_profile)
+    if entry is None:
+        raise ValueError(f"Unknown ACP agent profile: {agent_profile}")
+    classification = classify_agent_entrypoint(entry)
+    return build_agent_profile_manifest(
+        classification.as_dict() | {"type": entry.type, "name": entry.name}
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -339,7 +586,18 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Run the manifest commands instead of printing them.",
     )
+    parser.add_argument(
+        "--agent-profile",
+        help="Render or run a registry-backed agent profile manifest.",
+    )
     args = parser.parse_args(argv)
+
+    if args.agent_profile:
+        manifest = _build_registry_agent_manifest(args.agent_profile)
+        if args.run:
+            return run_manifest_dict(manifest)
+        print(render_manifest_dict(manifest, output_format=args.format))
+        return 0
 
     if args.run:
         return run_manifest(args.profile)

--- a/Helper_Scripts/Testing-related/acp_certification_smoke.py
+++ b/Helper_Scripts/Testing-related/acp_certification_smoke.py
@@ -27,6 +27,8 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 _STDOUT_EOF = object()
 _ERROR_MESSAGE_LIMIT = 240
+_STDOUT_LINE_LIMIT = 64 * 1024
+_STDOUT_QUEUE_MAXSIZE = 32
 
 
 _MANIFESTS: dict[str, dict[str, Any]] = {
@@ -414,6 +416,17 @@ def _close_pipe(pipe: Any) -> None:
         pass
 
 
+def _wait_for_process(process: subprocess.Popen[str], timeout: float) -> bool:
+    """Return True when a process exits before timeout."""
+    try:
+        process.wait(timeout=timeout)
+        return True
+    except subprocess.TimeoutExpired:
+        return False
+    except OSError:
+        return True
+
+
 def _cleanup_stdio_process(process: subprocess.Popen[str], *, force_kill: bool) -> None:
     """Close stdio, stop the subprocess, and wait so failure paths do not leak."""
     is_running = True
@@ -422,6 +435,12 @@ def _cleanup_stdio_process(process: subprocess.Popen[str], *, force_kill: bool) 
             is_running = process.poll() is None
         except OSError:
             is_running = True
+
+    if not force_kill:
+        _close_pipe(getattr(process, "stdin", None))
+        if _wait_for_process(process, 1):
+            _close_pipe(getattr(process, "stdout", None))
+            return
 
     if is_running:
         try:
@@ -452,30 +471,74 @@ def _cleanup_stdio_process(process: subprocess.Popen[str], *, force_kill: bool) 
         _close_pipe(getattr(process, "stdout", None))
 
 
+def _enqueue_stdout_payload(responses: queue.Queue[object], payload: object) -> None:
+    """Bound stdout queue memory while preserving the first queued response."""
+    try:
+        responses.put_nowait(payload)
+    except queue.Full:
+        return
+
+
+def _drain_stdout_payloads(responses: queue.Queue[object]) -> None:
+    """Discard stale queued responses before advancing to the next request id."""
+    while True:
+        try:
+            responses.get_nowait()
+        except queue.Empty:
+            return
+
+
 def _stdout_reader(
     stdout: Any,
     responses: queue.Queue[object],
     stop_event: threading.Event,
+    expected_response: dict[str, Any],
+    expected_response_condition: threading.Condition,
 ) -> None:
     """Read complete stdout lines in a daemon thread."""
     while not stop_event.is_set():
+        with expected_response_condition:
+            while expected_response.get("matched") and not stop_event.is_set():
+                expected_response_condition.wait(timeout=0.01)
         try:
-            line = stdout.readline()
+            try:
+                line = stdout.readline(_STDOUT_LINE_LIMIT + 1)
+            except TypeError:
+                line = stdout.readline()
         except (OSError, ValueError):
-            responses.put(_STDOUT_EOF)
+            _enqueue_stdout_payload(responses, _STDOUT_EOF)
             return
         if not line:
-            responses.put(_STDOUT_EOF)
+            _enqueue_stdout_payload(responses, _STDOUT_EOF)
+            return
+        if len(line) > _STDOUT_LINE_LIMIT:
+            _enqueue_stdout_payload(
+                responses,
+                {"_reader_error": {"message": "JSON-RPC stdout line exceeds maximum length"}},
+            )
             return
         try:
             payload = json.loads(line)
         except json.JSONDecodeError:
-            responses.put({"_reader_error": {"message": "invalid JSON-RPC response"}})
+            _enqueue_stdout_payload(
+                responses,
+                {"_reader_error": {"message": "invalid JSON-RPC response"}},
+            )
             continue
         if not isinstance(payload, dict):
-            responses.put({"_reader_error": {"message": "JSON-RPC response is not an object"}})
+            _enqueue_stdout_payload(
+                responses,
+                {"_reader_error": {"message": "JSON-RPC response is not an object"}},
+            )
             continue
-        responses.put(payload)
+        with expected_response_condition:
+            expected_id = expected_response.get("id")
+        if payload.get("id") != expected_id:
+            continue
+        _enqueue_stdout_payload(responses, payload)
+        with expected_response_condition:
+            expected_response["matched"] = True
+            expected_response_condition.notify_all()
 
 
 def _finish_stdio_process(
@@ -554,20 +617,32 @@ def _run_stdio_jsonrpc_sequence(command: dict[str, Any], cwd: Path) -> int:
         handled = _handle_missing_prerequisite(command, str(exc))
         return 127 if handled is None else handled
 
-    responses: queue.Queue[object] = queue.Queue()
+    frames = list(command.get("stdin_jsonl", []))
+    responses: queue.Queue[object] = queue.Queue(maxsize=_STDOUT_QUEUE_MAXSIZE)
     if process.stdout is None:
         _finish_stdio_process(process, force_kill=True)
         print(f"FAIL {command_id}: subprocess stdout is unavailable", file=sys.stderr)
         return 1
     reader_stop = threading.Event()
+    expected_response: dict[str, Any] = {
+        "id": frames[0].get("id") if frames else None,
+        "matched": False,
+    }
+    expected_response_condition = threading.Condition()
     reader_thread = threading.Thread(
         target=_stdout_reader,
-        args=(process.stdout, responses, reader_stop),
+        args=(
+            process.stdout,
+            responses,
+            reader_stop,
+            expected_response,
+            expected_response_condition,
+        ),
         daemon=True,
     )
     reader_thread.start()
 
-    for frame in command.get("stdin_jsonl", []):
+    for frame in frames:
         remaining = deadline - time.monotonic()
         if remaining <= 0:
             _finish_stdio_process(
@@ -587,10 +662,14 @@ def _run_stdio_jsonrpc_sequence(command: dict[str, Any], cwd: Path) -> int:
             )
             print(f"FAIL {command_id}: subprocess stdin is unavailable", file=sys.stderr)
             return 1
+        with expected_response_condition:
+            expected_response["id"] = frame.get("id")
+            expected_response["matched"] = False
+            expected_response_condition.notify_all()
         try:
             process.stdin.write(json.dumps(frame) + "\n")
             process.stdin.flush()
-        except BrokenPipeError:
+        except (BrokenPipeError, OSError, ValueError):
             _finish_stdio_process(
                 process,
                 force_kill=True,
@@ -623,6 +702,7 @@ def _run_stdio_jsonrpc_sequence(command: dict[str, Any], cwd: Path) -> int:
                 file=sys.stderr,
             )
             return 1
+        _drain_stdout_payloads(responses)
 
     _finish_stdio_process(
         process,

--- a/Helper_Scripts/Testing-related/acp_certification_smoke.py
+++ b/Helper_Scripts/Testing-related/acp_certification_smoke.py
@@ -401,30 +401,41 @@ def _handle_missing_prerequisite(command: dict[str, Any], reason: str) -> int | 
     return 127
 
 
-def _read_jsonrpc_response(process: subprocess.Popen[str], timeout_seconds: float) -> dict[str, Any] | None:
-    """Read one JSON-RPC line from a process stdout within a timeout."""
+def _read_jsonrpc_response(
+    process: subprocess.Popen[str],
+    request_id: Any,
+    deadline: float,
+) -> dict[str, Any] | None:
+    """Read the matching JSON-RPC response for a request id before the deadline."""
     stdout = process.stdout
     if stdout is None:
         return None
 
-    if hasattr(stdout, "fileno"):
-        try:
-            readable, _, _ = select.select([stdout], [], [], timeout_seconds)
-        except (OSError, ValueError):
-            readable = [stdout]
-        if not readable:
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
             return None
 
-    line = stdout.readline()
-    if not line:
-        return None
-    try:
-        payload = json.loads(line)
-    except json.JSONDecodeError:
-        return {"error": {"message": f"invalid JSON-RPC response: {line.strip()}"}}
-    if not isinstance(payload, dict):
-        return {"error": {"message": "JSON-RPC response is not an object"}}
-    return payload
+        if hasattr(stdout, "fileno"):
+            try:
+                readable, _, _ = select.select([stdout], [], [], remaining)
+            except (OSError, ValueError):
+                readable = [stdout]
+            if not readable:
+                return None
+
+        line = stdout.readline()
+        if not line:
+            return None
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            return {"id": request_id, "error": {"message": f"invalid JSON-RPC response: {line.strip()}"}}
+        if not isinstance(payload, dict):
+            return {"id": request_id, "error": {"message": "JSON-RPC response is not an object"}}
+        if payload.get("id") != request_id:
+            continue
+        return payload
 
 
 def _run_stdio_jsonrpc_sequence(command: dict[str, Any], cwd: Path) -> int:
@@ -463,7 +474,7 @@ def _run_stdio_jsonrpc_sequence(command: dict[str, Any], cwd: Path) -> int:
             print(f"FAIL {command_id}: subprocess closed stdin before {frame.get('method')}", file=sys.stderr)
             return 1
 
-        response = _read_jsonrpc_response(process, remaining)
+        response = _read_jsonrpc_response(process, frame.get("id"), deadline)
         if response is None:
             process.kill()
             print(f"FAIL {command_id}: timed out waiting for {frame.get('method')} response", file=sys.stderr)

--- a/Helper_Scripts/Testing-related/acp_certification_smoke.py
+++ b/Helper_Scripts/Testing-related/acp_certification_smoke.py
@@ -10,11 +10,12 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import select
+import queue
 import shlex
 # subprocess is intentionally used to run static manifest argv with shell=False.
 import subprocess  # nosec B404
 import sys
+import threading
 import time
 from copy import deepcopy
 from pathlib import Path
@@ -24,6 +25,8 @@ from typing import Any
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+_STDOUT_EOF = object()
+_ERROR_MESSAGE_LIMIT = 240
 
 
 _MANIFESTS: dict[str, dict[str, Any]] = {
@@ -401,38 +404,133 @@ def _handle_missing_prerequisite(command: dict[str, Any], reason: str) -> int | 
     return 127
 
 
-def _read_jsonrpc_response(
+def _close_pipe(pipe: Any) -> None:
+    """Close a subprocess pipe if it exposes close()."""
+    if pipe is None or not hasattr(pipe, "close"):
+        return
+    try:
+        pipe.close()
+    except OSError:
+        pass
+
+
+def _cleanup_stdio_process(process: subprocess.Popen[str], *, force_kill: bool) -> None:
+    """Close stdio, stop the subprocess, and wait so failure paths do not leak."""
+    is_running = True
+    if hasattr(process, "poll"):
+        try:
+            is_running = process.poll() is None
+        except OSError:
+            is_running = True
+
+    if is_running:
+        try:
+            if force_kill:
+                process.kill()
+            elif hasattr(process, "terminate"):
+                process.terminate()
+            else:
+                process.kill()
+        except OSError:
+            pass
+
+    try:
+        process.wait(timeout=1)
+    except subprocess.TimeoutExpired:
+        try:
+            process.kill()
+        except OSError:
+            pass
+        try:
+            process.wait(timeout=1)
+        except (OSError, subprocess.TimeoutExpired):
+            pass
+    except OSError:
+        pass
+    finally:
+        _close_pipe(getattr(process, "stdin", None))
+        _close_pipe(getattr(process, "stdout", None))
+
+
+def _stdout_reader(
+    stdout: Any,
+    responses: queue.Queue[object],
+    stop_event: threading.Event,
+) -> None:
+    """Read complete stdout lines in a daemon thread."""
+    while not stop_event.is_set():
+        try:
+            line = stdout.readline()
+        except (OSError, ValueError):
+            responses.put(_STDOUT_EOF)
+            return
+        if not line:
+            responses.put(_STDOUT_EOF)
+            return
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            responses.put({"_reader_error": {"message": "invalid JSON-RPC response"}})
+            continue
+        if not isinstance(payload, dict):
+            responses.put({"_reader_error": {"message": "JSON-RPC response is not an object"}})
+            continue
+        responses.put(payload)
+
+
+def _finish_stdio_process(
     process: subprocess.Popen[str],
+    *,
+    force_kill: bool,
+    reader_stop: threading.Event | None = None,
+    reader_thread: threading.Thread | None = None,
+) -> None:
+    """Stop the stdout reader and clean up the subprocess."""
+    if reader_stop is not None:
+        reader_stop.set()
+    _cleanup_stdio_process(process, force_kill=force_kill)
+    if reader_thread is not None:
+        reader_thread.join(timeout=0.1)
+
+
+def _format_error_message(message: Any) -> str:
+    """Return a bounded single-line error message."""
+    text = str(message or "JSON-RPC error").replace("\r", " ").replace("\n", " ")
+    if len(text) > _ERROR_MESSAGE_LIMIT:
+        return text[: _ERROR_MESSAGE_LIMIT - 3] + "..."
+    return text
+
+
+def _sanitize_jsonrpc_error(error: Any) -> dict[str, Any]:
+    """Keep stable JSON-RPC error fields without printing arbitrary error data."""
+    if not isinstance(error, dict):
+        return {"message": _format_error_message(error)}
+    sanitized: dict[str, Any] = {"message": _format_error_message(error.get("message"))}
+    if "code" in error:
+        sanitized["code"] = error["code"]
+    return sanitized
+
+
+def _read_jsonrpc_response(
+    responses: queue.Queue[object],
     request_id: Any,
     deadline: float,
 ) -> dict[str, Any] | None:
     """Read the matching JSON-RPC response for a request id before the deadline."""
-    stdout = process.stdout
-    if stdout is None:
-        return None
-
     while True:
         remaining = deadline - time.monotonic()
         if remaining <= 0:
             return None
-
-        if hasattr(stdout, "fileno"):
-            try:
-                readable, _, _ = select.select([stdout], [], [], remaining)
-            except (OSError, ValueError):
-                readable = [stdout]
-            if not readable:
-                return None
-
-        line = stdout.readline()
-        if not line:
-            return None
         try:
-            payload = json.loads(line)
-        except json.JSONDecodeError:
-            return {"id": request_id, "error": {"message": f"invalid JSON-RPC response: {line.strip()}"}}
+            payload = responses.get(timeout=remaining)
+        except queue.Empty:
+            return None
+        if payload is _STDOUT_EOF:
+            return None
         if not isinstance(payload, dict):
-            return {"id": request_id, "error": {"message": "JSON-RPC response is not an object"}}
+            continue
+        if payload.get("_reader_error"):
+            return {"id": request_id, "error": payload["_reader_error"]}
         if payload.get("id") != request_id:
             continue
         return payload
@@ -456,50 +554,82 @@ def _run_stdio_jsonrpc_sequence(command: dict[str, Any], cwd: Path) -> int:
         handled = _handle_missing_prerequisite(command, str(exc))
         return 127 if handled is None else handled
 
+    responses: queue.Queue[object] = queue.Queue()
+    if process.stdout is None:
+        _finish_stdio_process(process, force_kill=True)
+        print(f"FAIL {command_id}: subprocess stdout is unavailable", file=sys.stderr)
+        return 1
+    reader_stop = threading.Event()
+    reader_thread = threading.Thread(
+        target=_stdout_reader,
+        args=(process.stdout, responses, reader_stop),
+        daemon=True,
+    )
+    reader_thread.start()
+
     for frame in command.get("stdin_jsonl", []):
         remaining = deadline - time.monotonic()
         if remaining <= 0:
-            process.kill()
+            _finish_stdio_process(
+                process,
+                force_kill=True,
+                reader_stop=reader_stop,
+                reader_thread=reader_thread,
+            )
             print(f"FAIL {command_id}: timed out before {frame.get('method')}", file=sys.stderr)
             return 124
         if process.stdin is None:
-            process.kill()
+            _finish_stdio_process(
+                process,
+                force_kill=True,
+                reader_stop=reader_stop,
+                reader_thread=reader_thread,
+            )
             print(f"FAIL {command_id}: subprocess stdin is unavailable", file=sys.stderr)
             return 1
         try:
             process.stdin.write(json.dumps(frame) + "\n")
             process.stdin.flush()
         except BrokenPipeError:
-            process.kill()
+            _finish_stdio_process(
+                process,
+                force_kill=True,
+                reader_stop=reader_stop,
+                reader_thread=reader_thread,
+            )
             print(f"FAIL {command_id}: subprocess closed stdin before {frame.get('method')}", file=sys.stderr)
             return 1
 
-        response = _read_jsonrpc_response(process, frame.get("id"), deadline)
+        response = _read_jsonrpc_response(responses, frame.get("id"), deadline)
         if response is None:
-            process.kill()
+            _finish_stdio_process(
+                process,
+                force_kill=True,
+                reader_stop=reader_stop,
+                reader_thread=reader_thread,
+            )
             print(f"FAIL {command_id}: timed out waiting for {frame.get('method')} response", file=sys.stderr)
             return 124
         if response.get("error"):
-            process.kill()
+            _finish_stdio_process(
+                process,
+                force_kill=True,
+                reader_stop=reader_stop,
+                reader_thread=reader_thread,
+            )
             print(
                 f"FAIL {command_id}: {frame.get('method')} returned error: "
-                + json.dumps(response["error"], sort_keys=True),
+                + json.dumps(_sanitize_jsonrpc_error(response["error"]), sort_keys=True),
                 file=sys.stderr,
             )
             return 1
 
-    if process.stdin is not None:
-        try:
-            process.stdin.close()
-        except OSError:
-            pass
-
-    if process.poll() is None:
-        process.terminate()
-        try:
-            process.wait(timeout=1)
-        except subprocess.TimeoutExpired:
-            process.kill()
+    _finish_stdio_process(
+        process,
+        force_kill=False,
+        reader_stop=reader_stop,
+        reader_thread=reader_thread,
+    )
     return 0
 
 

--- a/Helper_Scripts/Testing-related/acp_certification_smoke.py
+++ b/Helper_Scripts/Testing-related/acp_certification_smoke.py
@@ -194,11 +194,7 @@ def build_agent_profile_manifest(entrypoint: dict[str, Any]) -> dict[str, Any]:
         "support_state": "documented_unverified",
         "verification_level": "documented_only",
         "requires_live_agent": True,
-        "required_environment": [
-            "TLDW_E2E_SERVER_URL",
-            "TLDW_E2E_API_KEY",
-            "ACP_AGENT_PROFILE",
-        ],
+        "required_environment": [],
         "entrypoint": {
             "entrypoint_strategy": entrypoint.get("entrypoint_strategy"),
             "probe_state": entrypoint.get("probe_state"),
@@ -705,6 +701,17 @@ def _run_stdio_jsonrpc_sequence(command: dict[str, Any], cwd: Path) -> int:
             )
             return 1
         _drain_stdout_payloads(responses)
+
+    exit_code = process.poll()
+    if exit_code not in (None, 0):
+        _finish_stdio_process(
+            process,
+            force_kill=False,
+            reader_stop=reader_stop,
+            reader_thread=reader_thread,
+        )
+        print(f"FAIL {command_id}: subprocess exited with status {exit_code}", file=sys.stderr)
+        return int(exit_code)
 
     _finish_stdio_process(
         process,

--- a/backlog/tasks/task-286 - Design-ACP-downstream-entrypoint-strategy-architecture.md
+++ b/backlog/tasks/task-286 - Design-ACP-downstream-entrypoint-strategy-architecture.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-286
 title: Design ACP downstream entrypoint strategy architecture
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-12 03:35'
+updated_date: '2026-05-12 03:51'
 labels:
   - ACP
   - design
@@ -37,6 +38,12 @@ Create a design spec for an architecture-first ACP downstream entrypoint strateg
 - [x] #6 Design spec is reviewed and committed on an isolated branch.
 <!-- AC:END -->
 
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Created and reviewed the ACP downstream entrypoint strategy design. The spec defines native ACP, adapter ACP, documented candidate, and custom template strategies; requires explicit `acp_command` for certifiable native/adapter rows; scopes the first implementation to registry strategy metadata, classifier, profile manifests, and setup/status alignment; and keeps live certification, agent installation, adapter implementation, and issue closeout as follow-on work. The spec review loop approved the final revision.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [x] #1 Acceptance criteria completed
@@ -58,9 +65,3 @@ Create a design spec for an architecture-first ACP downstream entrypoint strateg
 - Verification: `git diff --check` passed.
 - Bandit: skipped because this task changed only Markdown/Backlog design artifacts and no Python code.
 <!-- SECTION:NOTES:END -->
-
-## Final Summary
-
-<!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Created and reviewed the ACP downstream entrypoint strategy design. The spec defines native ACP, adapter ACP, documented candidate, and custom template strategies; requires explicit `acp_command` for certifiable native/adapter rows; scopes the first implementation to registry strategy metadata, classifier, profile manifests, and setup/status alignment; and keeps live certification, agent installation, adapter implementation, and issue closeout as follow-on work. The spec review loop approved the final revision.
-<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-286 - Design-ACP-downstream-entrypoint-strategy-architecture.md
+++ b/backlog/tasks/task-286 - Design-ACP-downstream-entrypoint-strategy-architecture.md
@@ -1,0 +1,66 @@
+---
+id: TASK-286
+title: Design ACP downstream entrypoint strategy architecture
+status: In Progress
+assignee: []
+created_date: '2026-05-12 03:35'
+labels:
+  - ACP
+  - design
+  - compatibility
+  - certification
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1563'
+  - 'https://github.com/rmusser01/tldw_server/issues/1564'
+documentation:
+  - Docs/Development/ACP_Compatibility_Matrix.md
+  - Docs/Development/ACP_Certification_Checklist.md
+  - Docs/Development/Agent_Client_Protocol.md
+  - tldw_Server_API/Config_Files/agents.yaml
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create a design spec for an architecture-first ACP downstream entrypoint strategy. The spec should distinguish native ACP commands, adapter-backed ACP commands, documented candidates, and custom templates; define how registry metadata, classifier output, probe manifests, certification evidence, setup surfaces, and issue closeout rules should work; and preserve the rule that unsuccessful live certification keeps #1563/#1564 open.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Design defines entrypoint strategy categories for native ACP, adapter ACP, documented candidates, and custom templates.
+- [x] #2 Design explains registry metadata fields, classifier responsibilities, probe manifest generation, evidence recording, and setup/API/UI status consumption.
+- [x] #3 Design includes status and error-handling rules that prevent blocker-documentation PRs from closing unsuccessful live-certification issues.
+- [x] #4 Design identifies initial target classifications for OpenCode, Goose, Codex, Claude Code, Aider, Continue, and custom profiles.
+- [x] #5 Design includes testing expectations and staged implementation boundaries without installing agents or implementing adapters in the design task.
+- [x] #6 Design spec is reviewed and committed on an isolated branch.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Wrote design spec at `Docs/superpowers/specs/2026-05-12-acp-downstream-entrypoint-strategy-design.md`.
+- Spec review pass 1 found two blockers: `acp_command` required-vs-inferred was unresolved, and live certification/adapters were in the first implementation scope.
+- Spec review pass 2 found one blocker: Codex/Claude were marked `adapter_acp` without concrete `acp_command` values.
+- Spec review pass 3 approved the revised spec with no blocking issues.
+- Post-approval design critique found two implementation risks and patched the spec: YAML-only strategy fields would miss API/DB-backed dynamic agents, and existing MCP `protocol`/transport fields could be confused with ACP entrypoint metadata.
+- Verification: `git diff --check` passed.
+- Bandit: skipped because this task changed only Markdown/Backlog design artifacts and no Python code.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Created and reviewed the ACP downstream entrypoint strategy design. The spec defines native ACP, adapter ACP, documented candidate, and custom template strategies; requires explicit `acp_command` for certifiable native/adapter rows; scopes the first implementation to registry strategy metadata, classifier, profile manifests, and setup/status alignment; and keeps live certification, agent installation, adapter implementation, and issue closeout as follow-on work. The spec review loop approved the final revision.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-287 - Implement-ACP-downstream-entrypoint-strategy-stages-1-3.md
+++ b/backlog/tasks/task-287 - Implement-ACP-downstream-entrypoint-strategy-stages-1-3.md
@@ -4,7 +4,7 @@ title: Implement ACP downstream entrypoint strategy stages 1-3
 status: In Progress
 assignee: []
 created_date: '2026-05-12 03:51'
-updated_date: '2026-05-12 05:20'
+updated_date: '2026-05-12 05:34'
 labels:
   - ACP
   - implementation
@@ -55,6 +55,10 @@ Task 3 red evidence: focused helper pytest initially failed with 4 missing-helpe
 Task 3 follow-up review fix plan: add regression coverage for interleaved JSON-RPC notifications before matching responses; verify red against current stdio runner; update runner to wait for the response id matching the just-sent frame while ignoring notifications and other ids within the existing timeout; re-run focused helper tests and commit a scoped follow-up.
 
 Task 3 follow-up red evidence: helper pytest failed with len(written)==2 after an interleaved notification before initialize error, proving session/new was written too early. Follow-up green evidence: helper pytest now reports 14 passed, 5 warnings. The stdio reader now waits for a matching JSON-RPC response id and ignores notifications and other ids inside the existing timeout. Scoped Bandit on acp_certification_smoke.py reports 0 results and git diff --check is clean.
+
+Task 3 code-quality follow-up plan: add red tests for partial-line timeout cleanup, JSON-RPC error cleanup with sanitized stderr, and broken-pipe cleanup; replace select/readline main-thread response reading with a reader-thread queue bounded by the existing deadline; add one cleanup helper that closes stdio, terminates or kills, waits, and is used on all timeout/error/broken-pipe paths; re-run focused helper tests, Bandit, and diff checks before committing.
+
+Task 3 code-quality follow-up red evidence: helper pytest failed 3 tests for partial-line timeout and missing cleanup on JSON-RPC error and broken pipe. Final green evidence: helper pytest reports 17 passed, 5 warnings in 2.87s. Bandit on acp_certification_smoke.py reports 0 findings. git diff --check is clean. Implementation now uses a daemon stdout reader thread plus queue/deadline matching, central cleanup for kill or terminate plus wait and stdio close, and sanitized bounded JSON-RPC error output that omits error.data.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-287 - Implement-ACP-downstream-entrypoint-strategy-stages-1-3.md
+++ b/backlog/tasks/task-287 - Implement-ACP-downstream-entrypoint-strategy-stages-1-3.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-287
 title: Implement ACP downstream entrypoint strategy stages 1-3
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-12 03:51'
-updated_date: '2026-05-12 06:46'
+updated_date: '2026-05-12 10:27'
 labels:
   - ACP
   - implementation
@@ -30,11 +30,11 @@ Implement the approved ACP downstream entrypoint strategy design for the first p
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Registry entries, YAML rows, API registration/update schemas, and DB-backed dynamic registrations preserve entrypoint strategy metadata with conservative defaults for legacy rows.
-- [ ] #2 A deterministic classifier reports probe state, ACP command/args, primary blocker, blockers, status message, and docs URL without running live agent commands.
+- [x] #1 Registry entries, YAML rows, API registration/update schemas, and DB-backed dynamic registrations preserve entrypoint strategy metadata with conservative defaults for legacy rows.
+- [x] #2 A deterministic classifier reports probe state, ACP command/args, primary blocker, blockers, status message, and docs URL without running live agent commands.
 - [x] #3 Certification smoke helper can render profile-specific dry-run manifests for native, adapter-backed, documented-candidate, and custom-template profiles and refuses unsafe live runs without required env.
 - [x] #4 ACP agents, health, and setup-guide surfaces expose strategy and blocker metadata consistently for YAML, API-backed, runner, and static fallback rows.
-- [ ] #5 Focused unit, helper, integration, docs, and security checks pass for the touched scope.
+- [x] #5 Focused unit, helper, integration, docs, and security checks pass for the touched scope.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -69,12 +69,18 @@ Task 4 execution plan recorded before edits: add failing ACP endpoint tests for 
 Task 4 red evidence: focused ACP endpoint pytest failed 5 tests for missing entrypoint metadata in health, setup-guide, /agents registry, runner normalization, and static fallback. Task 4 green evidence: focused ACP endpoint pytest reports 41 passed and 5 warnings. git diff --check is clean. Scoped Bandit on agent_client_protocol endpoint and schema reports 0 findings. Implementation exposes classifier-backed entrypoint readiness metadata across health, setup-guide, registry/static/runner agent listing, and preserves dynamic registration forwarding.
 <!-- SECTION:NOTES:END -->
 
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented ACP downstream entrypoint strategy metadata, deterministic probe classification, profile-specific certification manifests, and setup/status/API exposure. Verification: focused ACP registry/API/helper tests passed, git diff --check clean, docs grep confirmed strategy/blocker coverage, and Bandit on touched Python scope showed no new findings beyond existing ACP_Sessions_DB baseline warnings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-287 - Implement-ACP-downstream-entrypoint-strategy-stages-1-3.md
+++ b/backlog/tasks/task-287 - Implement-ACP-downstream-entrypoint-strategy-stages-1-3.md
@@ -1,0 +1,56 @@
+---
+id: TASK-287
+title: Implement ACP downstream entrypoint strategy stages 1-3
+status: In Progress
+assignee: []
+created_date: '2026-05-12 03:51'
+updated_date: '2026-05-12 04:03'
+labels:
+  - ACP
+  - implementation
+  - certification
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1563'
+  - 'https://github.com/rmusser01/tldw_server/issues/1564'
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-05-12-acp-downstream-entrypoint-strategy-design.md
+  - Docs/Development/ACP_Compatibility_Matrix.md
+  - Docs/Development/ACP_Certification_Checklist.md
+  - tldw_Server_API/Config_Files/agents.yaml
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the approved ACP downstream entrypoint strategy design for the first product slice. This work adds explicit ACP entrypoint strategy metadata, classification, profile-specific certification manifests, and setup/status/API visibility while keeping live certification, downstream agent installation, and adapter implementation out of scope.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Registry entries, YAML rows, API registration/update schemas, and DB-backed dynamic registrations preserve entrypoint strategy metadata with conservative defaults for legacy rows.
+- [ ] #2 A deterministic classifier reports probe state, ACP command/args, primary blocker, blockers, status message, and docs URL without running live agent commands.
+- [ ] #3 Certification smoke helper can render profile-specific dry-run manifests for native, adapter-backed, documented-candidate, and custom-template profiles and refuses unsafe live runs without required env.
+- [ ] #4 ACP agents, health, and setup-guide surfaces expose strategy and blocker metadata consistently for YAML, API-backed, runner, and static fallback rows.
+- [ ] #5 Focused unit, helper, integration, docs, and security checks pass for the touched scope.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implementation plan saved at Docs/superpowers/plans/2026-05-12-acp-entrypoint-strategy-implementation-plan.md.
+
+Plan review completed after two fix rounds. Added explicit no-inference guardrail tests, legacy DB migration/default coverage, dynamic API parity tests, and initialize-gated session/new plus session/prompt manifest sequencing. Final reviewer status: approved.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-287 - Implement-ACP-downstream-entrypoint-strategy-stages-1-3.md
+++ b/backlog/tasks/task-287 - Implement-ACP-downstream-entrypoint-strategy-stages-1-3.md
@@ -4,7 +4,7 @@ title: Implement ACP downstream entrypoint strategy stages 1-3
 status: In Progress
 assignee: []
 created_date: '2026-05-12 03:51'
-updated_date: '2026-05-12 06:00'
+updated_date: '2026-05-12 06:19'
 labels:
   - ACP
   - implementation
@@ -61,6 +61,8 @@ Task 3 code-quality follow-up plan: add red tests for partial-line timeout clean
 Task 3 code-quality follow-up red evidence: helper pytest failed 3 tests for partial-line timeout and missing cleanup on JSON-RPC error and broken pipe. Final green evidence: helper pytest reports 17 passed, 5 warnings in 2.87s. Bandit on acp_certification_smoke.py reports 0 findings. git diff --check is clean. Implementation now uses a daemon stdout reader thread plus queue/deadline matching, central cleanup for kill or terminate plus wait and stdio close, and sanitized bounded JSON-RPC error output that omits error.data.
 
 Task 3 final robustness follow-up red evidence: helper pytest failed 4 tests before implementation for bounded stdout queue behavior, write OSError cleanup, flush ValueError cleanup, and success cleanup ordering. Final green evidence: helper pytest reports 22 passed and 5 warnings in 38.12s. Bandit on acp_certification_smoke.py reports 0 findings. git diff --check is clean. Implementation bounds stdout line and queue size, drops notifications and wrong-id responses before enqueueing, pauses read-ahead after matching the expected id, handles OSError and ValueError write or flush failures through centralized cleanup, and closes stdin before waiting on successful probe shutdown.
+
+Task 3 custom-template blocker follow-up red evidence: requested pytest failed 2 tests after updating expectations because custom-template classification and manifests omitted explicit blocker metadata. Final green evidence: requested pytest reports 45 passed and 5 warnings. git diff --check is clean. Bandit on acp_certification_smoke.py and agent_registry.py reports 0 findings. Implementation now uses custom_template as the explicit blocker and lists the required named custom profile evidence bundle in the classifier status.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-287 - Implement-ACP-downstream-entrypoint-strategy-stages-1-3.md
+++ b/backlog/tasks/task-287 - Implement-ACP-downstream-entrypoint-strategy-stages-1-3.md
@@ -4,7 +4,7 @@ title: Implement ACP downstream entrypoint strategy stages 1-3
 status: In Progress
 assignee: []
 created_date: '2026-05-12 03:51'
-updated_date: '2026-05-12 05:02'
+updated_date: '2026-05-12 05:12'
 labels:
   - ACP
   - implementation
@@ -32,7 +32,7 @@ Implement the approved ACP downstream entrypoint strategy design for the first p
 <!-- AC:BEGIN -->
 - [ ] #1 Registry entries, YAML rows, API registration/update schemas, and DB-backed dynamic registrations preserve entrypoint strategy metadata with conservative defaults for legacy rows.
 - [ ] #2 A deterministic classifier reports probe state, ACP command/args, primary blocker, blockers, status message, and docs URL without running live agent commands.
-- [ ] #3 Certification smoke helper can render profile-specific dry-run manifests for native, adapter-backed, documented-candidate, and custom-template profiles and refuses unsafe live runs without required env.
+- [x] #3 Certification smoke helper can render profile-specific dry-run manifests for native, adapter-backed, documented-candidate, and custom-template profiles and refuses unsafe live runs without required env.
 - [ ] #4 ACP agents, health, and setup-guide surfaces expose strategy and blocker metadata consistently for YAML, API-backed, runner, and static fallback rows.
 - [ ] #5 Focused unit, helper, integration, docs, and security checks pass for the touched scope.
 <!-- AC:END -->
@@ -47,6 +47,10 @@ Plan review completed after two fix rounds. Added explicit no-inference guardrai
 Task 1 complete. Added registry/API/DB ACP entrypoint strategy metadata, built-in YAML seeds, migration/default handling, and focused tests. Reviews: spec compliant and code quality approved after null-clearing and mutable-default fixes. Final scoped Task 1 tests: 67 passed, 5 warnings. Bandit reports only existing ACP_Sessions_DB.py baseline findings outside changed lines.
 
 Task 2 complete. Added deterministic classify_agent_entrypoint output, immutable AgentEntrypointClassification value object, blocker precedence tests, no acp_command inference tests, and caveat taxonomy rows. Reviews: spec compliant and code quality approved after tuple immutability fix. Focused classifier tests: 19 passed, 5 warnings; Bandit on agent_registry.py reported 0 findings.
+
+Task 3 execution plan recorded before edits: add requested failing helper tests; run focused pytest with shared venv for red evidence; implement only certification smoke profile manifest and stdio runner changes; re-run focused pytest plus scoped Bandit and diff review; commit only Task 3 helper and test files.
+
+Task 3 red evidence: focused helper pytest initially failed with 4 missing-helper failures for build_agent_profile_manifest, run_manifest_dict, and _run_stdio_jsonrpc_sequence while 8 existing tests passed. Task 3 green evidence: focused helper pytest now reports 12 passed, 5 warnings. Scoped Bandit on acp_certification_smoke.py reports 0 results. git diff --check on Task 3 files is clean.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-287 - Implement-ACP-downstream-entrypoint-strategy-stages-1-3.md
+++ b/backlog/tasks/task-287 - Implement-ACP-downstream-entrypoint-strategy-stages-1-3.md
@@ -4,7 +4,7 @@ title: Implement ACP downstream entrypoint strategy stages 1-3
 status: In Progress
 assignee: []
 created_date: '2026-05-12 03:51'
-updated_date: '2026-05-12 05:12'
+updated_date: '2026-05-12 05:20'
 labels:
   - ACP
   - implementation
@@ -51,6 +51,10 @@ Task 2 complete. Added deterministic classify_agent_entrypoint output, immutable
 Task 3 execution plan recorded before edits: add requested failing helper tests; run focused pytest with shared venv for red evidence; implement only certification smoke profile manifest and stdio runner changes; re-run focused pytest plus scoped Bandit and diff review; commit only Task 3 helper and test files.
 
 Task 3 red evidence: focused helper pytest initially failed with 4 missing-helper failures for build_agent_profile_manifest, run_manifest_dict, and _run_stdio_jsonrpc_sequence while 8 existing tests passed. Task 3 green evidence: focused helper pytest now reports 12 passed, 5 warnings. Scoped Bandit on acp_certification_smoke.py reports 0 results. git diff --check on Task 3 files is clean.
+
+Task 3 follow-up review fix plan: add regression coverage for interleaved JSON-RPC notifications before matching responses; verify red against current stdio runner; update runner to wait for the response id matching the just-sent frame while ignoring notifications and other ids within the existing timeout; re-run focused helper tests and commit a scoped follow-up.
+
+Task 3 follow-up red evidence: helper pytest failed with len(written)==2 after an interleaved notification before initialize error, proving session/new was written too early. Follow-up green evidence: helper pytest now reports 14 passed, 5 warnings. The stdio reader now waits for a matching JSON-RPC response id and ignores notifications and other ids inside the existing timeout. Scoped Bandit on acp_certification_smoke.py reports 0 results and git diff --check is clean.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-287 - Implement-ACP-downstream-entrypoint-strategy-stages-1-3.md
+++ b/backlog/tasks/task-287 - Implement-ACP-downstream-entrypoint-strategy-stages-1-3.md
@@ -4,7 +4,7 @@ title: Implement ACP downstream entrypoint strategy stages 1-3
 status: In Progress
 assignee: []
 created_date: '2026-05-12 03:51'
-updated_date: '2026-05-12 04:43'
+updated_date: '2026-05-12 05:02'
 labels:
   - ACP
   - implementation
@@ -45,6 +45,8 @@ Implementation plan saved at Docs/superpowers/plans/2026-05-12-acp-entrypoint-st
 Plan review completed after two fix rounds. Added explicit no-inference guardrail tests, legacy DB migration/default coverage, dynamic API parity tests, and initialize-gated session/new plus session/prompt manifest sequencing. Final reviewer status: approved.
 
 Task 1 complete. Added registry/API/DB ACP entrypoint strategy metadata, built-in YAML seeds, migration/default handling, and focused tests. Reviews: spec compliant and code quality approved after null-clearing and mutable-default fixes. Final scoped Task 1 tests: 67 passed, 5 warnings. Bandit reports only existing ACP_Sessions_DB.py baseline findings outside changed lines.
+
+Task 2 complete. Added deterministic classify_agent_entrypoint output, immutable AgentEntrypointClassification value object, blocker precedence tests, no acp_command inference tests, and caveat taxonomy rows. Reviews: spec compliant and code quality approved after tuple immutability fix. Focused classifier tests: 19 passed, 5 warnings; Bandit on agent_registry.py reported 0 findings.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-287 - Implement-ACP-downstream-entrypoint-strategy-stages-1-3.md
+++ b/backlog/tasks/task-287 - Implement-ACP-downstream-entrypoint-strategy-stages-1-3.md
@@ -4,7 +4,7 @@ title: Implement ACP downstream entrypoint strategy stages 1-3
 status: In Progress
 assignee: []
 created_date: '2026-05-12 03:51'
-updated_date: '2026-05-12 06:19'
+updated_date: '2026-05-12 06:46'
 labels:
   - ACP
   - implementation
@@ -33,7 +33,7 @@ Implement the approved ACP downstream entrypoint strategy design for the first p
 - [ ] #1 Registry entries, YAML rows, API registration/update schemas, and DB-backed dynamic registrations preserve entrypoint strategy metadata with conservative defaults for legacy rows.
 - [ ] #2 A deterministic classifier reports probe state, ACP command/args, primary blocker, blockers, status message, and docs URL without running live agent commands.
 - [x] #3 Certification smoke helper can render profile-specific dry-run manifests for native, adapter-backed, documented-candidate, and custom-template profiles and refuses unsafe live runs without required env.
-- [ ] #4 ACP agents, health, and setup-guide surfaces expose strategy and blocker metadata consistently for YAML, API-backed, runner, and static fallback rows.
+- [x] #4 ACP agents, health, and setup-guide surfaces expose strategy and blocker metadata consistently for YAML, API-backed, runner, and static fallback rows.
 - [ ] #5 Focused unit, helper, integration, docs, and security checks pass for the touched scope.
 <!-- AC:END -->
 
@@ -63,6 +63,10 @@ Task 3 code-quality follow-up red evidence: helper pytest failed 3 tests for par
 Task 3 final robustness follow-up red evidence: helper pytest failed 4 tests before implementation for bounded stdout queue behavior, write OSError cleanup, flush ValueError cleanup, and success cleanup ordering. Final green evidence: helper pytest reports 22 passed and 5 warnings in 38.12s. Bandit on acp_certification_smoke.py reports 0 findings. git diff --check is clean. Implementation bounds stdout line and queue size, drops notifications and wrong-id responses before enqueueing, pauses read-ahead after matching the expected id, handles OSError and ValueError write or flush failures through centralized cleanup, and closes stdin before waiting on successful probe shutdown.
 
 Task 3 custom-template blocker follow-up red evidence: requested pytest failed 2 tests after updating expectations because custom-template classification and manifests omitted explicit blocker metadata. Final green evidence: requested pytest reports 45 passed and 5 warnings. git diff --check is clean. Bandit on acp_certification_smoke.py and agent_registry.py reports 0 findings. Implementation now uses custom_template as the explicit blocker and lists the required named custom profile evidence bundle in the classifier status.
+
+Task 4 execution plan recorded before edits: add failing ACP endpoint tests for agents, setup-guide, health, dynamic register forwarding, and runner/static entrypoint normalization; run focused pytest for red evidence; implement only schema and endpoint classifier wiring needed to pass; re-run focused pytest, git diff --check, scoped Bandit, and commit the Task 4 slice.
+
+Task 4 red evidence: focused ACP endpoint pytest failed 5 tests for missing entrypoint metadata in health, setup-guide, /agents registry, runner normalization, and static fallback. Task 4 green evidence: focused ACP endpoint pytest reports 41 passed and 5 warnings. git diff --check is clean. Scoped Bandit on agent_client_protocol endpoint and schema reports 0 findings. Implementation exposes classifier-backed entrypoint readiness metadata across health, setup-guide, registry/static/runner agent listing, and preserves dynamic registration forwarding.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-287 - Implement-ACP-downstream-entrypoint-strategy-stages-1-3.md
+++ b/backlog/tasks/task-287 - Implement-ACP-downstream-entrypoint-strategy-stages-1-3.md
@@ -4,7 +4,7 @@ title: Implement ACP downstream entrypoint strategy stages 1-3
 status: In Progress
 assignee: []
 created_date: '2026-05-12 03:51'
-updated_date: '2026-05-12 04:03'
+updated_date: '2026-05-12 04:43'
 labels:
   - ACP
   - implementation
@@ -43,6 +43,8 @@ Implement the approved ACP downstream entrypoint strategy design for the first p
 Implementation plan saved at Docs/superpowers/plans/2026-05-12-acp-entrypoint-strategy-implementation-plan.md.
 
 Plan review completed after two fix rounds. Added explicit no-inference guardrail tests, legacy DB migration/default coverage, dynamic API parity tests, and initialize-gated session/new plus session/prompt manifest sequencing. Final reviewer status: approved.
+
+Task 1 complete. Added registry/API/DB ACP entrypoint strategy metadata, built-in YAML seeds, migration/default handling, and focused tests. Reviews: spec compliant and code quality approved after null-clearing and mutable-default fixes. Final scoped Task 1 tests: 67 passed, 5 warnings. Bandit reports only existing ACP_Sessions_DB.py baseline findings outside changed lines.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-287 - Implement-ACP-downstream-entrypoint-strategy-stages-1-3.md
+++ b/backlog/tasks/task-287 - Implement-ACP-downstream-entrypoint-strategy-stages-1-3.md
@@ -4,7 +4,7 @@ title: Implement ACP downstream entrypoint strategy stages 1-3
 status: In Progress
 assignee: []
 created_date: '2026-05-12 03:51'
-updated_date: '2026-05-12 05:34'
+updated_date: '2026-05-12 06:00'
 labels:
   - ACP
   - implementation
@@ -59,6 +59,8 @@ Task 3 follow-up red evidence: helper pytest failed with len(written)==2 after a
 Task 3 code-quality follow-up plan: add red tests for partial-line timeout cleanup, JSON-RPC error cleanup with sanitized stderr, and broken-pipe cleanup; replace select/readline main-thread response reading with a reader-thread queue bounded by the existing deadline; add one cleanup helper that closes stdio, terminates or kills, waits, and is used on all timeout/error/broken-pipe paths; re-run focused helper tests, Bandit, and diff checks before committing.
 
 Task 3 code-quality follow-up red evidence: helper pytest failed 3 tests for partial-line timeout and missing cleanup on JSON-RPC error and broken pipe. Final green evidence: helper pytest reports 17 passed, 5 warnings in 2.87s. Bandit on acp_certification_smoke.py reports 0 findings. git diff --check is clean. Implementation now uses a daemon stdout reader thread plus queue/deadline matching, central cleanup for kill or terminate plus wait and stdio close, and sanitized bounded JSON-RPC error output that omits error.data.
+
+Task 3 final robustness follow-up red evidence: helper pytest failed 4 tests before implementation for bounded stdout queue behavior, write OSError cleanup, flush ValueError cleanup, and success cleanup ordering. Final green evidence: helper pytest reports 22 passed and 5 warnings in 38.12s. Bandit on acp_certification_smoke.py reports 0 findings. git diff --check is clean. Implementation bounds stdout line and queue size, drops notifications and wrong-id responses before enqueueing, pauses read-ahead after matching the expected id, handles OSError and ValueError write or flush failures through centralized cleanup, and closes stdin before waiting on successful probe shutdown.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-299 - Address-ACP-entrypoint-PR-1607-review-feedback.md
+++ b/backlog/tasks/task-299 - Address-ACP-entrypoint-PR-1607-review-feedback.md
@@ -4,7 +4,7 @@ title: 'Address ACP entrypoint PR #1607 review feedback'
 status: Done
 assignee: []
 created_date: '2026-05-12 13:51'
-updated_date: '2026-05-12 14:01'
+updated_date: '2026-05-12 14:06'
 labels:
   - ACP
   - PR-review
@@ -44,12 +44,14 @@ Review threads addressed in PR #1607:
 - Added DB-backed persistence coverage for entrypoint metadata and invalid-strategy coercion.
 - Replaced timing-sensitive partial-line timeout coverage with event-driven cleanup coverage.
 - Aggregated multiple classifier blockers and added requested docstrings.
+
+Follow-up refresh after push found one new Cubic finding. Fixed YAML null acp_command coercion so it remains an empty missing entrypoint instead of the literal string "None", with regression coverage for blocked classification.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Addressed the actionable PR #1607 review feedback across ACP entrypoint classification, API status normalization, certification smoke manifests, and focused regression tests. Verification: 148 focused ACP tests passed, prior 89-test focused slice passed, git diff --check passed, and scoped Bandit on touched production files reported no findings. Review-fix commit is being pushed to the PR branch.
+Addressed the actionable PR #1607 review feedback across ACP entrypoint classification, API status normalization, certification smoke manifests, YAML null command handling, and focused regression tests. Verification: 149 focused ACP tests passed after the follow-up fix, prior 89-test focused slice passed, git diff --check passed, and scoped Bandit on touched production files reported no findings. Review-fix commits were pushed to the PR branch.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-299 - Address-ACP-entrypoint-PR-1607-review-feedback.md
+++ b/backlog/tasks/task-299 - Address-ACP-entrypoint-PR-1607-review-feedback.md
@@ -1,0 +1,63 @@
+---
+id: TASK-299
+title: 'Address ACP entrypoint PR #1607 review feedback'
+status: Done
+assignee: []
+created_date: '2026-05-12 13:51'
+updated_date: '2026-05-12 14:01'
+labels:
+  - ACP
+  - PR-review
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1607'
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-05-12-acp-downstream-entrypoint-strategy-design.md
+  - >-
+    Docs/superpowers/plans/2026-05-12-acp-entrypoint-strategy-implementation-plan.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve actionable review feedback on PR #1607 for ACP entrypoint strategy readiness surfaces. Scope: CodeRabbit stdio manifest/env, child exit code, docs URL normalization, persistence-test coverage, deterministic timeout test; Qodo docstrings; Gemini multi-blocker classifier feedback where compatible with the approved architecture.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 All actionable PR #1607 review threads are addressed or technically justified.
+- [x] #2 Focused ACP registry/helper/API tests pass after review fixes.
+- [x] #3 git diff --check passes.
+- [x] #4 Scoped Bandit on touched production files passes or only reports existing baseline findings.
+- [x] #5 Review-fix commit is pushed to PR #1607.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Review threads addressed in PR #1607:
+- Removed unrelated E2E env requirements from direct ACP agent-profile manifests while keeping them marked live-agent.
+- Made stdio JSON-RPC probes return a child nonzero exit status after successful frames.
+- Normalized registry entrypoint docs URLs through the served docs-static path.
+- Added DB-backed persistence coverage for entrypoint metadata and invalid-strategy coercion.
+- Replaced timing-sensitive partial-line timeout coverage with event-driven cleanup coverage.
+- Aggregated multiple classifier blockers and added requested docstrings.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed the actionable PR #1607 review feedback across ACP entrypoint classification, API status normalization, certification smoke manifests, and focused regression tests. Verification: 148 focused ACP tests passed, prior 89-test focused slice passed, git diff --check passed, and scoped Bandit on touched production files reported no findings. Review-fix commit is being pushed to the PR branch.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/Config_Files/agents.yaml
+++ b/tldw_Server_API/Config_Files/agents.yaml
@@ -19,6 +19,10 @@
 #     stub_smoke_tested, live_e2e_tested, sandbox_tested, production_supported
 #   compatibility_notes: Release-facing compatibility caveat
 #   compatibility_docs_url: Compatibility matrix or evidence document
+#   entrypoint_strategy: ACP entrypoint strategy; one of native_acp,
+#     adapter_acp, documented_candidate, custom_template
+#   acp_command: ACP stdio command to probe; not inferred from command
+#   acp_args: ACP stdio command arguments
 
 agents:
   - type: claude_code
@@ -36,6 +40,10 @@ agents:
     verification_level: documented_only
     compatibility_notes: "Configured-agent setup is documented, but live Claude Code ACP compatibility remains blocked until credentials and an ACP-compatible stdio command are verified."
     compatibility_docs_url: "/docs-static/Development/ACP_Compatibility_Matrix.md"
+    entrypoint_strategy: documented_candidate
+    acp_command: ""
+    acp_args: []
+    certification_blocker: adapter_required
 
   - type: codex
     name: OpenAI Codex CLI
@@ -51,6 +59,10 @@ agents:
     verification_level: documented_only
     compatibility_notes: "Configured-agent setup is documented, but live Codex ACP compatibility remains blocked until an ACP-compatible stdio command and provider credentials are verified."
     compatibility_docs_url: "/docs-static/Development/ACP_Compatibility_Matrix.md"
+    entrypoint_strategy: documented_candidate
+    acp_command: ""
+    acp_args: []
+    certification_blocker: adapter_required
 
   - type: aider
     name: Aider
@@ -64,6 +76,10 @@ agents:
     verification_level: documented_only
     compatibility_notes: "Configured-agent setup is documented, but live Aider ACP compatibility remains blocked until an ACP-compatible Aider command is installed and verified."
     compatibility_docs_url: "/docs-static/Development/ACP_Compatibility_Matrix.md"
+    entrypoint_strategy: documented_candidate
+    acp_command: ""
+    acp_args: []
+    certification_blocker: entrypoint_strategy_missing
 
   - type: goose
     name: Goose
@@ -78,6 +94,10 @@ agents:
     verification_level: documented_only
     compatibility_notes: "Configured-agent setup is documented, but live Goose ACP compatibility remains blocked until an ACP-compatible Goose command is installed and verified."
     compatibility_docs_url: "/docs-static/Development/ACP_Compatibility_Matrix.md"
+    entrypoint_strategy: native_acp
+    acp_command: goose
+    acp_args:
+      - acp
 
   - type: continue_dev
     name: Continue
@@ -92,6 +112,10 @@ agents:
     verification_level: documented_only
     compatibility_notes: "Configured-agent setup is documented, but live Continue ACP compatibility remains blocked until an ACP-compatible Continue command is installed and verified."
     compatibility_docs_url: "/docs-static/Development/ACP_Compatibility_Matrix.md"
+    entrypoint_strategy: documented_candidate
+    acp_command: ""
+    acp_args: []
+    certification_blocker: entrypoint_strategy_missing
 
   - type: opencode
     name: OpenCode
@@ -108,6 +132,10 @@ agents:
     verification_level: documented_only
     compatibility_notes: "Configured-agent setup is documented, but live OpenCode ACP compatibility remains blocked until an ACP-compatible OpenCode command is installed and verified."
     compatibility_docs_url: "/docs-static/Development/ACP_Compatibility_Matrix.md"
+    entrypoint_strategy: native_acp
+    acp_command: opencode
+    acp_args:
+      - acp
 
   - type: custom
     name: Custom Agent
@@ -121,3 +149,6 @@ agents:
     verification_level: documented_only
     compatibility_notes: "Custom ACP profiles require a named command, workspace policy, and certification evidence before release claims."
     compatibility_docs_url: "/docs-static/Development/ACP_Compatibility_Matrix.md"
+    entrypoint_strategy: custom_template
+    acp_command: ""
+    acp_args: []

--- a/tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py
+++ b/tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py
@@ -2040,6 +2040,12 @@ async def acp_register_agent(
         mcp_llm_model=request.mcp_llm_model,
         mcp_max_iterations=request.mcp_max_iterations,
         mcp_refresh_tools=request.mcp_refresh_tools,
+        entrypoint_strategy=request.entrypoint_strategy,
+        acp_command=request.acp_command,
+        acp_args=request.acp_args,
+        adapter_source=request.adapter_source,
+        adapter_docs_url=request.adapter_docs_url,
+        certification_blocker=request.certification_blocker,
     )
     _acp_record_audit_event(
         action="agent_registered",
@@ -2102,7 +2108,7 @@ async def acp_update_agent(
     from tldw_Server_API.app.core.Agent_Client_Protocol.agent_registry import get_agent_registry
 
     registry = get_agent_registry()
-    updates = request.model_dump(exclude_unset=True, exclude_none=True)
+    updates = request.model_dump(exclude_unset=True)
     entry = registry.update_agent(agent_type, **updates)
     if entry is None:
         raise HTTPException(

--- a/tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py
+++ b/tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py
@@ -1636,7 +1636,9 @@ def _string_list(value: Any) -> list[str]:
 
 def _entrypoint_status_from_entry(reg_entry: Any) -> dict[str, Any]:
     """Build ACP entrypoint status from a registry entry classifier."""
-    return classify_agent_entrypoint(reg_entry).as_dict()
+    status = classify_agent_entrypoint(reg_entry).as_dict()
+    status["docs_url"] = _normalize_docs_url(status.get("docs_url"))
+    return status
 
 
 def _entrypoint_status_from_dict(item: dict[str, Any]) -> dict[str, Any]:

--- a/tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py
+++ b/tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py
@@ -58,6 +58,7 @@ from tldw_Server_API.app.core.Agent_Client_Protocol.runner_client import (
     ACPGovernanceDeniedError,
     get_runner_client,
 )
+from tldw_Server_API.app.core.Agent_Client_Protocol.agent_registry import classify_agent_entrypoint
 from tldw_Server_API.app.services.acp_runtime_policy_service import ACPRuntimePolicyService
 from tldw_Server_API.app.services.admin_acp_sessions_service import get_acp_session_store
 from tldw_Server_API.app.core.Agent_Client_Protocol.stdio_client import ACPResponseError
@@ -1593,6 +1594,140 @@ def _check_runner_binary() -> dict[str, Any]:
     }
 
 
+_ACP_ENTRYPOINT_STRATEGIES = frozenset({
+    "native_acp",
+    "adapter_acp",
+    "documented_candidate",
+    "custom_template",
+})
+_ACP_PROBE_STATES = frozenset({
+    "ready_to_probe",
+    "blocked",
+    "custom_template",
+    "documented_only",
+})
+_ACP_ENTRYPOINT_STEP_MAP = {
+    "adapter_required": "Select and install a concrete ACP adapter command before live certification.",
+    "adapter_missing": "Select and install a concrete ACP adapter command before live certification.",
+    "binary_missing": "Install the ACP entrypoint command and ensure it is on PATH.",
+    "credentials_missing": "Set the required provider credential before live certification.",
+    "entrypoint_strategy_missing": "Identify and configure a concrete ACP stdio entrypoint before live certification.",
+    "shell_builtin_collision": "Use an executable ACP command, not a shell builtin or alias.",
+    "custom_template": "Create a named custom ACP profile with command, args, env, workspace policy, and evidence bundle.",
+}
+
+
+def _normalize_docs_url(value: Any) -> str | None:
+    """Return a docs URL using the served docs-static path for repo docs."""
+    if value is None:
+        return ACP_COMPATIBILITY_DOCS_URL
+    docs_url = str(value)
+    if docs_url.startswith("Docs/"):
+        return f"/docs-static/{docs_url.removeprefix('Docs/')}"
+    return docs_url
+
+
+def _string_list(value: Any) -> list[str]:
+    """Normalize arbitrary list-like values into strings."""
+    if isinstance(value, (list, tuple)):
+        return [str(item) for item in value]
+    return []
+
+
+def _entrypoint_status_from_entry(reg_entry: Any) -> dict[str, Any]:
+    """Build ACP entrypoint status from a registry entry classifier."""
+    return classify_agent_entrypoint(reg_entry).as_dict()
+
+
+def _entrypoint_status_from_dict(item: dict[str, Any]) -> dict[str, Any]:
+    """Normalize runner/static ACP entrypoint metadata with conservative defaults."""
+    raw_entrypoint = item.get("entrypoint")
+    source = raw_entrypoint if isinstance(raw_entrypoint, dict) else item
+    profile_key = str(
+        source.get("profile_key")
+        or item.get("profile_key")
+        or item.get("type")
+        or item.get("agent_type")
+        or ""
+    )
+
+    strategy = str(
+        source.get("entrypoint_strategy")
+        or item.get("entrypoint_strategy")
+        or "documented_candidate"
+    )
+    if strategy not in _ACP_ENTRYPOINT_STRATEGIES:
+        strategy = "documented_candidate"
+
+    default_probe_state = "custom_template" if strategy == "custom_template" else "documented_only"
+    if strategy in {"native_acp", "adapter_acp"}:
+        default_probe_state = "blocked"
+    probe_state = str(source.get("probe_state") or item.get("probe_state") or default_probe_state)
+    if probe_state not in _ACP_PROBE_STATES:
+        probe_state = default_probe_state
+
+    primary_blocker_raw = (
+        source.get("primary_blocker")
+        if source.get("primary_blocker") is not None
+        else item.get("primary_blocker")
+    )
+    if primary_blocker_raw is None:
+        primary_blocker_raw = source.get("certification_blocker") or item.get("certification_blocker")
+    if primary_blocker_raw is None and strategy == "custom_template":
+        primary_blocker_raw = "custom_template"
+    primary_blocker = str(primary_blocker_raw) if primary_blocker_raw else None
+
+    blockers = _string_list(source.get("blockers") or item.get("blockers"))
+    if not blockers and primary_blocker:
+        blockers = [primary_blocker]
+
+    status_message = str(source.get("status_message") or item.get("status_message") or "")
+    if not status_message:
+        if primary_blocker == "custom_template":
+            status_message = _ACP_ENTRYPOINT_STEP_MAP["custom_template"]
+        elif strategy == "documented_candidate":
+            status_message = "Agent is documented as a candidate and is not eligible for live ACP probing yet."
+        elif probe_state == "blocked":
+            status_message = "ACP entrypoint readiness is blocked until setup is complete."
+        elif probe_state == "ready_to_probe":
+            status_message = "Configured ACP entrypoint is ready for a bounded initialize probe."
+
+    return {
+        "profile_key": profile_key,
+        "entrypoint_strategy": strategy,
+        "probe_state": probe_state,
+        "acp_command": str(source.get("acp_command") or item.get("acp_command") or ""),
+        "acp_args": _string_list(source.get("acp_args") or item.get("acp_args")),
+        "primary_blocker": primary_blocker,
+        "blockers": blockers,
+        "status_message": status_message,
+        "docs_url": _normalize_docs_url(
+            source.get("docs_url")
+            or item.get("docs_url")
+            or item.get("compatibility_docs_url")
+            or ACP_COMPATIBILITY_DOCS_URL
+        ),
+    }
+
+
+def _entrypoint_setup_steps(entrypoint: dict[str, Any]) -> list[str]:
+    """Return setup guide steps for ACP entrypoint readiness blockers."""
+    keys = []
+    primary_blocker = entrypoint.get("primary_blocker")
+    if primary_blocker:
+        keys.append(str(primary_blocker))
+    keys.extend(_string_list(entrypoint.get("blockers")))
+    if entrypoint.get("entrypoint_strategy") == "custom_template":
+        keys.append("custom_template")
+
+    steps: list[str] = []
+    for key in keys:
+        step = _ACP_ENTRYPOINT_STEP_MAP.get(key)
+        if step and step not in steps:
+            steps.append(step)
+    return steps
+
+
 def _check_agent_availability(agent_type: str) -> dict[str, Any]:
     """Check if a downstream agent binary and API keys are available."""
     from tldw_Server_API.app.core.Agent_Client_Protocol.agent_registry import get_agent_registry
@@ -1609,9 +1744,11 @@ def _check_agent_availability(agent_type: str) -> dict[str, Any]:
             "verification_level": "documented_only",
             "compatibility_notes": "Agent is not present in the registry; live-agent ACP compatibility has not been certified.",
             "compatibility_docs_url": ACP_COMPATIBILITY_DOCS_URL,
+            "entrypoint": _entrypoint_status_from_dict({"agent_type": agent_type}),
         }
     result = entry.check_availability()
     result["agent_type"] = agent_type
+    result["entrypoint"] = _entrypoint_status_from_entry(entry)
     return result
 
 
@@ -1629,9 +1766,7 @@ def _build_agent_compatibility_status(source: Any) -> ACPAgentCompatibilityStatu
         get_value("compatibility_notes")
         or "Configured locally; live-agent ACP compatibility has not been certified."
     )
-    docs_url = get_value("compatibility_docs_url") or ACP_COMPATIBILITY_DOCS_URL
-    if str(docs_url).startswith("Docs/"):
-        docs_url = f"/docs-static/{str(docs_url).removeprefix('Docs/')}"
+    docs_url = _normalize_docs_url(get_value("compatibility_docs_url") or ACP_COMPATIBILITY_DOCS_URL)
     return ACPAgentCompatibilityStatus(
         support_state=support_state,
         verification_level=verification_level,
@@ -1698,6 +1833,7 @@ async def acp_health(
             "verification_level": avail.get("verification_level", "documented_only"),
             "compatibility_notes": avail.get("compatibility_notes", ""),
             "compatibility_docs_url": avail.get("compatibility_docs_url"),
+            "entrypoint": _entrypoint_status_from_entry(entry),
         })
     result["agents"] = agents_status
 
@@ -1808,11 +1944,13 @@ async def acp_setup_guide(
 
     for reg_entry in target_entries:
         avail = reg_entry.check_availability()
+        entrypoint = _entrypoint_status_from_entry(reg_entry)
         guide_item: dict[str, Any] = {
             "agent_type": reg_entry.type,
             "name": reg_entry.name,
             "status": avail.get("status", "unknown"),
             "compatibility": _build_agent_compatibility_status(reg_entry),
+            "entrypoint": entrypoint,
             "steps": [],
         }
 
@@ -1825,6 +1963,7 @@ async def acp_setup_guide(
         if not avail.get("api_key_set", True) and reg_entry.requires_api_key:
             guide_item["steps"].append(f"Set {reg_entry.requires_api_key} environment variable or add to .env file")
 
+        guide_item["steps"].extend(_entrypoint_setup_steps(entrypoint))
         guide_item["steps"].extend(_compatibility_setup_steps(guide_item["compatibility"]))
 
         if not guide_item["steps"]:
@@ -1856,6 +1995,11 @@ def _get_static_agents() -> tuple[list[ACPAgentInfo], str]:
             support_state="documented_unverified",
             verification_level="documented_only",
             compatibility_notes="Static fallback only; live Claude Code ACP compatibility has not been certified.",
+            entrypoint=_entrypoint_status_from_dict({
+                "type": "claude_code",
+                "entrypoint_strategy": "documented_candidate",
+                "certification_blocker": "adapter_required",
+            }),
         )
     )
 
@@ -1870,6 +2014,11 @@ def _get_static_agents() -> tuple[list[ACPAgentInfo], str]:
             support_state="documented_unverified",
             verification_level="documented_only",
             compatibility_notes="Static fallback only; live Codex ACP compatibility has not been certified.",
+            entrypoint=_entrypoint_status_from_dict({
+                "type": "codex",
+                "entrypoint_strategy": "documented_candidate",
+                "certification_blocker": "adapter_required",
+            }),
         )
     )
 
@@ -1883,6 +2032,13 @@ def _get_static_agents() -> tuple[list[ACPAgentInfo], str]:
             support_state="documented_unverified",
             verification_level="documented_only",
             compatibility_notes="Static fallback only; live OpenCode ACP compatibility has not been certified.",
+            entrypoint=_entrypoint_status_from_dict({
+                "type": "opencode",
+                "entrypoint_strategy": "native_acp",
+                "acp_command": "opencode",
+                "acp_args": ["acp"],
+                "primary_blocker": "binary_missing",
+            }),
         )
     )
 
@@ -1896,6 +2052,10 @@ def _get_static_agents() -> tuple[list[ACPAgentInfo], str]:
             support_state="documented_unverified",
             verification_level="documented_only",
             compatibility_notes="Custom agent profiles require certification evidence before release claims.",
+            entrypoint=_entrypoint_status_from_dict({
+                "type": "custom",
+                "entrypoint_strategy": "custom_template",
+            }),
         )
     )
 
@@ -1913,6 +2073,12 @@ def _get_registry_agents() -> tuple[list[ACPAgentInfo], str] | None:
         agents: list[ACPAgentInfo] = []
         for item in available:
             compatibility = _build_agent_compatibility_status(item)
+            reg_entry = registry.get_entry(str(item["type"]))
+            entrypoint = (
+                _entrypoint_status_from_entry(reg_entry)
+                if reg_entry is not None
+                else _entrypoint_status_from_dict(item)
+            )
             agents.append(
                 ACPAgentInfo(
                     type=str(item["type"]),
@@ -1924,6 +2090,7 @@ def _get_registry_agents() -> tuple[list[ACPAgentInfo], str] | None:
                     verification_level=compatibility.verification_level,
                     compatibility_notes=compatibility.notes,
                     compatibility_docs_url=compatibility.docs_url,
+                    entrypoint=entrypoint,
                 )
             )
         return agents, registry.default_type
@@ -1974,6 +2141,7 @@ async def _get_available_agents() -> tuple[list[ACPAgentInfo], str]:
                 verification_level=compatibility.verification_level,
                 compatibility_notes=compatibility.notes,
                 compatibility_docs_url=compatibility.docs_url,
+                entrypoint=_entrypoint_status_from_dict(item),
             )
         except ValidationError:
             logger.warning("Skipping invalid ACP runner agent entry: {}", agent_type)

--- a/tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py
+++ b/tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Literal, Union
+from typing import Any, ClassVar, Literal, Union
 
 from pydantic import BaseModel, Field, model_validator
 from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
@@ -37,6 +37,13 @@ ACPVerificationLevel = Literal[
     "sandbox_tested",
     "production_supported",
 ]
+ACPEntryPointStrategy = Literal[
+    "native_acp",
+    "adapter_acp",
+    "documented_candidate",
+    "custom_template",
+]
+ACPProbeState = Literal["ready_to_probe", "blocked", "custom_template", "documented_only"]
 
 
 class ACPAgentInfo(BaseModel):
@@ -133,6 +140,12 @@ class ACPAgentRegisterRequest(BaseModel):
     requires_api_key: str | None = Field(default=None, description="Required API key env var")
     install_instructions: list[str] = Field(default_factory=list, description="Installation steps")
     docs_url: str | None = Field(default=None, description="Documentation URL")
+    entrypoint_strategy: ACPEntryPointStrategy = Field(default="documented_candidate")
+    acp_command: str = Field(default="")
+    acp_args: list[str] = Field(default_factory=list)
+    adapter_source: str | None = Field(default=None)
+    adapter_docs_url: str | None = Field(default=None)
+    certification_blocker: str | None = Field(default=None)
     mcp_orchestration: Literal["agent_driven", "llm_driven"] = Field(
         default="agent_driven",
         description="MCP orchestration mode when protocol='mcp'",
@@ -153,6 +166,19 @@ class ACPAgentRegisterRequest(BaseModel):
 
 class ACPAgentUpdateRequest(BaseModel):
     """Request to update an existing agent."""
+    NON_NULLABLE_FIELDS: ClassVar[frozenset[str]] = frozenset({
+        "name",
+        "description",
+        "command",
+        "entrypoint_strategy",
+        "acp_command",
+        "mcp_orchestration",
+        "mcp_entry_tool",
+        "mcp_structured_response",
+        "mcp_max_iterations",
+        "mcp_refresh_tools",
+    })
+
     name: str | None = None
     description: str | None = None
     command: str | None = None
@@ -161,6 +187,12 @@ class ACPAgentUpdateRequest(BaseModel):
     requires_api_key: str | None = None
     install_instructions: list[str] | None = None
     docs_url: str | None = None
+    entrypoint_strategy: ACPEntryPointStrategy | None = None
+    acp_command: str | None = None
+    acp_args: list[str] | None = None
+    adapter_source: str | None = None
+    adapter_docs_url: str | None = None
+    certification_blocker: str | None = None
     mcp_orchestration: Literal["agent_driven", "llm_driven"] | None = None
     mcp_entry_tool: str | None = None
     mcp_structured_response: bool | None = None
@@ -168,6 +200,21 @@ class ACPAgentUpdateRequest(BaseModel):
     mcp_llm_model: str | None = None
     mcp_max_iterations: int | None = None
     mcp_refresh_tools: bool | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def reject_null_for_non_nullable_fields(cls, data: Any) -> Any:
+        """Reject explicit null for scalar fields that are non-null at runtime."""
+        if not isinstance(data, dict):
+            return data
+        null_fields = sorted(
+            field for field in cls.NON_NULLABLE_FIELDS
+            if field in data and data[field] is None
+        )
+        if null_fields:
+            joined = ", ".join(null_fields)
+            raise ValueError(f"Explicit null is not allowed for: {joined}")
+        return data
 
 
 # -----------------------------------------------------------------------------

--- a/tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py
+++ b/tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py
@@ -46,6 +46,19 @@ ACPEntryPointStrategy = Literal[
 ACPProbeState = Literal["ready_to_probe", "blocked", "custom_template", "documented_only"]
 
 
+class ACPAgentEntrypointStatus(BaseModel):
+    """ACP stdio entrypoint readiness metadata for one downstream agent."""
+    profile_key: str = Field(..., description="Registry profile key this metadata describes")
+    entrypoint_strategy: ACPEntryPointStrategy = Field(default="documented_candidate")
+    probe_state: ACPProbeState = Field(default="documented_only")
+    acp_command: str = Field(default="")
+    acp_args: list[str] = Field(default_factory=list)
+    primary_blocker: str | None = Field(default=None)
+    blockers: list[str] = Field(default_factory=list)
+    status_message: str = Field(default="")
+    docs_url: str | None = Field(default=ACP_COMPATIBILITY_DOCS_URL)
+
+
 class ACPAgentInfo(BaseModel):
     """Information about an available agent."""
     type: ACPAgentType = Field(..., description="Agent type identifier")
@@ -73,6 +86,10 @@ class ACPAgentInfo(BaseModel):
     compatibility_docs_url: str | None = Field(
         default=ACP_COMPATIBILITY_DOCS_URL,
         description="Documentation path or URL for compatibility details.",
+    )
+    entrypoint: ACPAgentEntrypointStatus = Field(
+        ...,
+        description="ACP stdio entrypoint readiness metadata.",
     )
 
 
@@ -120,6 +137,10 @@ class ACPSetupGuideAgent(BaseModel):
     )
     steps: list[str] = Field(default_factory=list, description="Actionable setup or certification steps")
     docs_url: str | None = Field(default=None, description="Agent documentation URL")
+    entrypoint: ACPAgentEntrypointStatus = Field(
+        ...,
+        description="ACP stdio entrypoint readiness metadata.",
+    )
 
 
 class ACPSetupGuideResponse(BaseModel):

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py
@@ -344,7 +344,7 @@ class AgentRegistry:
                 ),
                 compatibility_docs_url=item.get("compatibility_docs_url", ACP_COMPATIBILITY_DOCS_URL),
                 entrypoint_strategy=_coerce_entrypoint_strategy(item.get("entrypoint_strategy")),
-                acp_command=str(item.get("acp_command", "")),
+                acp_command=str(item.get("acp_command") or ""),
                 acp_args=list(item.get("acp_args", [])),
                 adapter_source=item.get("adapter_source"),
                 adapter_docs_url=item.get("adapter_docs_url"),

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py
@@ -46,11 +46,15 @@ class AgentEntrypointClassification:
     entrypoint_strategy: AgentEntrypointStrategy
     probe_state: AgentProbeState
     acp_command: str
-    acp_args: list[str]
+    acp_args: tuple[str, ...]
     primary_blocker: str | None
-    blockers: list[str]
+    blockers: tuple[str, ...]
     status_message: str
     docs_url: str | None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "acp_args", tuple(self.acp_args))
+        object.__setattr__(self, "blockers", tuple(self.blockers))
 
     def as_dict(self) -> dict[str, Any]:
         return {
@@ -182,13 +186,13 @@ def classify_agent_entrypoint(
         command: str = acp_command,
         args: list[str] | None = None,
     ) -> AgentEntrypointClassification:
-        blockers = [blocker] if blocker else []
+        blockers = (blocker,) if blocker else ()
         return AgentEntrypointClassification(
             profile_key=entry.type,
             entrypoint_strategy=strategy,
             probe_state=probe_state,
             acp_command=command,
-            acp_args=list(args if args is not None else acp_args),
+            acp_args=tuple(args if args is not None else acp_args),
             primary_blocker=blocker,
             blockers=blockers,
             status_message=status_message,

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py
@@ -202,7 +202,11 @@ def classify_agent_entrypoint(
     if strategy == "custom_template":
         return classification(
             "custom_template",
-            status_message="Custom agent templates require operator-supplied ACP entrypoint metadata.",
+            blocker="custom_template",
+            status_message=(
+                "Create a named custom ACP profile with command, args, env, "
+                "workspace policy, and evidence bundle."
+            ),
             command="",
             args=[],
         )

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py
@@ -35,6 +35,7 @@ _SHELL_BUILTIN_COMMANDS = frozenset({"alias", "cd", "export", "set", "source", "
 
 
 def _coerce_entrypoint_strategy(value: Any) -> AgentEntrypointStrategy:
+    """Return a valid entrypoint strategy, defaulting unknown input conservatively."""
     if value in {"native_acp", "adapter_acp", "documented_candidate", "custom_template"}:
         return value
     return "documented_candidate"
@@ -42,6 +43,7 @@ def _coerce_entrypoint_strategy(value: Any) -> AgentEntrypointStrategy:
 
 @dataclass(frozen=True)
 class AgentEntrypointClassification:
+    """Deterministic ACP entrypoint readiness without launching the agent."""
     profile_key: str
     entrypoint_strategy: AgentEntrypointStrategy
     probe_state: AgentProbeState
@@ -181,28 +183,45 @@ def classify_agent_entrypoint(
     def classification(
         probe_state: AgentProbeState,
         *,
-        blocker: str | None = None,
+        blockers: tuple[str, ...] = (),
         status_message: str,
         command: str = acp_command,
         args: list[str] | None = None,
     ) -> AgentEntrypointClassification:
-        blockers = (blocker,) if blocker else ()
+        normalized_blockers = tuple(dict.fromkeys(str(blocker) for blocker in blockers if blocker))
+        primary_blocker = normalized_blockers[0] if normalized_blockers else None
         return AgentEntrypointClassification(
             profile_key=entry.type,
             entrypoint_strategy=strategy,
             probe_state=probe_state,
             acp_command=command,
             acp_args=tuple(args if args is not None else acp_args),
-            primary_blocker=blocker,
-            blockers=blockers,
+            primary_blocker=primary_blocker,
+            blockers=normalized_blockers,
             status_message=status_message,
             docs_url=docs_url,
         )
 
+    def blocked_status(blockers: list[str]) -> str:
+        """Return a readable status for one or more deterministic blockers."""
+        messages = {
+            "entrypoint_strategy_missing": "Registry entry has no explicit ACP stdio command.",
+            "shell_builtin_collision": "Configured ACP command matches a shell builtin or alias-like value.",
+            "credentials_missing": "Required API key or credential environment variable is missing.",
+            "adapter_missing": "Configured ACP adapter command is not available on PATH.",
+            "binary_missing": "Configured ACP entrypoint command is not available on PATH.",
+        }
+        if not blockers:
+            return "ACP entrypoint readiness is blocked."
+        status_message = messages.get(blockers[0], "ACP entrypoint readiness is blocked.")
+        if len(blockers) > 1:
+            status_message += " Additional blockers: " + ", ".join(blockers[1:]) + "."
+        return status_message
+
     if strategy == "custom_template":
         return classification(
             "custom_template",
-            blocker="custom_template",
+            blockers=("custom_template",),
             status_message=(
                 "Create a named custom ACP profile with command, args, env, "
                 "workspace policy, and evidence bundle."
@@ -214,39 +233,32 @@ def classify_agent_entrypoint(
     if strategy == "documented_candidate":
         return classification(
             "documented_only",
-            blocker=entry.certification_blocker,
+            blockers=(entry.certification_blocker,) if entry.certification_blocker else (),
             status_message="Agent is documented as a candidate and is not eligible for live ACP probing yet.",
             command="",
             args=[],
         )
 
+    blockers: list[str] = []
     if not acp_command:
-        return classification(
-            "blocked",
-            blocker="entrypoint_strategy_missing",
-            status_message="Registry entry has no explicit ACP stdio command.",
-        )
+        blockers.append("entrypoint_strategy_missing")
 
-    if acp_command in _SHELL_BUILTIN_COMMANDS:
-        return classification(
-            "blocked",
-            blocker="shell_builtin_collision",
-            status_message="Configured ACP command matches a shell builtin or alias-like value.",
-        )
+    shell_builtin_collision = bool(acp_command and acp_command in _SHELL_BUILTIN_COMMANDS)
+    if shell_builtin_collision:
+        blockers.append("shell_builtin_collision")
 
     if entry.requires_api_key and not env_getter(entry.requires_api_key):
-        return classification(
-            "blocked",
-            blocker="credentials_missing",
-            status_message="Required API key or credential environment variable is missing.",
-        )
+        blockers.append("credentials_missing")
 
-    if not command_resolver(acp_command):
+    if acp_command and not shell_builtin_collision and not command_resolver(acp_command):
         blocker = "adapter_missing" if strategy == "adapter_acp" else "binary_missing"
+        blockers.append(blocker)
+
+    if blockers:
         return classification(
             "blocked",
-            blocker=blocker,
-            status_message="Configured ACP entrypoint command is not available on PATH.",
+            blockers=tuple(blockers),
+            status_message=blocked_status(blockers),
         )
 
     return classification(

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py
@@ -30,12 +30,40 @@ AgentEntrypointStrategy = Literal[
     "documented_candidate",
     "custom_template",
 ]
+AgentProbeState = Literal["ready_to_probe", "blocked", "custom_template", "documented_only"]
+_SHELL_BUILTIN_COMMANDS = frozenset({"alias", "cd", "export", "set", "source", "unset"})
 
 
 def _coerce_entrypoint_strategy(value: Any) -> AgentEntrypointStrategy:
     if value in {"native_acp", "adapter_acp", "documented_candidate", "custom_template"}:
         return value
     return "documented_candidate"
+
+
+@dataclass(frozen=True)
+class AgentEntrypointClassification:
+    profile_key: str
+    entrypoint_strategy: AgentEntrypointStrategy
+    probe_state: AgentProbeState
+    acp_command: str
+    acp_args: list[str]
+    primary_blocker: str | None
+    blockers: list[str]
+    status_message: str
+    docs_url: str | None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "profile_key": self.profile_key,
+            "entrypoint_strategy": self.entrypoint_strategy,
+            "probe_state": self.probe_state,
+            "acp_command": self.acp_command,
+            "acp_args": list(self.acp_args),
+            "primary_blocker": self.primary_blocker,
+            "blockers": list(self.blockers),
+            "status_message": self.status_message,
+            "docs_url": self.docs_url,
+        }
 
 
 @dataclass
@@ -132,6 +160,91 @@ class AgentRegistryEntry:
 
         result["is_configured"] = result["status"] == "available"
         return result
+
+
+def classify_agent_entrypoint(
+    entry: AgentRegistryEntry,
+    *,
+    command_resolver: Callable[[str], str | None] = shutil.which,
+    env_getter: Callable[[str], str | None] = os.getenv,
+) -> AgentEntrypointClassification:
+    """Classify ACP entrypoint readiness without starting the agent."""
+    strategy = entry.entrypoint_strategy
+    acp_command = entry.acp_command
+    acp_args = list(entry.acp_args)
+    docs_url = entry.compatibility_docs_url or entry.docs_url
+
+    def classification(
+        probe_state: AgentProbeState,
+        *,
+        blocker: str | None = None,
+        status_message: str,
+        command: str = acp_command,
+        args: list[str] | None = None,
+    ) -> AgentEntrypointClassification:
+        blockers = [blocker] if blocker else []
+        return AgentEntrypointClassification(
+            profile_key=entry.type,
+            entrypoint_strategy=strategy,
+            probe_state=probe_state,
+            acp_command=command,
+            acp_args=list(args if args is not None else acp_args),
+            primary_blocker=blocker,
+            blockers=blockers,
+            status_message=status_message,
+            docs_url=docs_url,
+        )
+
+    if strategy == "custom_template":
+        return classification(
+            "custom_template",
+            status_message="Custom agent templates require operator-supplied ACP entrypoint metadata.",
+            command="",
+            args=[],
+        )
+
+    if strategy == "documented_candidate":
+        return classification(
+            "documented_only",
+            blocker=entry.certification_blocker,
+            status_message="Agent is documented as a candidate and is not eligible for live ACP probing yet.",
+            command="",
+            args=[],
+        )
+
+    if not acp_command:
+        return classification(
+            "blocked",
+            blocker="entrypoint_strategy_missing",
+            status_message="Registry entry has no explicit ACP stdio command.",
+        )
+
+    if acp_command in _SHELL_BUILTIN_COMMANDS:
+        return classification(
+            "blocked",
+            blocker="shell_builtin_collision",
+            status_message="Configured ACP command matches a shell builtin or alias-like value.",
+        )
+
+    if entry.requires_api_key and not env_getter(entry.requires_api_key):
+        return classification(
+            "blocked",
+            blocker="credentials_missing",
+            status_message="Required API key or credential environment variable is missing.",
+        )
+
+    if not command_resolver(acp_command):
+        blocker = "adapter_missing" if strategy == "adapter_acp" else "binary_missing"
+        return classification(
+            "blocked",
+            blocker=blocker,
+            status_message="Configured ACP entrypoint command is not available on PATH.",
+        )
+
+    return classification(
+        "ready_to_probe",
+        status_message="Configured ACP entrypoint is ready for a bounded initialize probe.",
+    )
 
 
 class AgentRegistry:

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py
@@ -11,6 +11,7 @@ import os
 import shutil
 import threading
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
@@ -23,6 +24,18 @@ except ImportError:
 
 
 ACP_COMPATIBILITY_DOCS_URL = "/docs-static/Development/ACP_Compatibility_Matrix.md"
+AgentEntrypointStrategy = Literal[
+    "native_acp",
+    "adapter_acp",
+    "documented_candidate",
+    "custom_template",
+]
+
+
+def _coerce_entrypoint_strategy(value: Any) -> AgentEntrypointStrategy:
+    if value in {"native_acp", "adapter_acp", "documented_candidate", "custom_template"}:
+        return value
+    return "documented_candidate"
 
 
 @dataclass
@@ -54,6 +67,12 @@ class AgentRegistryEntry:
     ] = "documented_only"
     compatibility_notes: str = "Configured locally; live-agent ACP compatibility has not been certified."
     compatibility_docs_url: str | None = ACP_COMPATIBILITY_DOCS_URL
+    entrypoint_strategy: AgentEntrypointStrategy = "documented_candidate"
+    acp_command: str = ""
+    acp_args: list[str] = field(default_factory=list)
+    adapter_source: str | None = None
+    adapter_docs_url: str | None = None
+    certification_blocker: str | None = None
 
     # Protocol adapter fields (new for agent workspace harness)
     protocol: Literal["stdio", "mcp", "openai_tool_use"] = "stdio"
@@ -191,6 +210,12 @@ class AgentRegistry:
                     )
                 ),
                 compatibility_docs_url=item.get("compatibility_docs_url", ACP_COMPATIBILITY_DOCS_URL),
+                entrypoint_strategy=_coerce_entrypoint_strategy(item.get("entrypoint_strategy")),
+                acp_command=str(item.get("acp_command", "")),
+                acp_args=list(item.get("acp_args", [])),
+                adapter_source=item.get("adapter_source"),
+                adapter_docs_url=item.get("adapter_docs_url"),
+                certification_blocker=item.get("certification_blocker"),
                 mcp_orchestration=item.get("mcp_orchestration", "agent_driven"),
                 mcp_entry_tool=str(item.get("mcp_entry_tool", "execute")),
                 mcp_structured_response=bool(item.get("mcp_structured_response", False)),
@@ -265,6 +290,14 @@ class AgentRegistry:
                     verification_level="documented_only",
                     compatibility_notes="Registered dynamically; live-agent ACP compatibility has not been certified.",
                     compatibility_docs_url=ACP_COMPATIBILITY_DOCS_URL,
+                    entrypoint_strategy=_coerce_entrypoint_strategy(
+                        row.get("entrypoint_strategy")
+                    ),
+                    acp_command=row.get("acp_command", ""),
+                    acp_args=self._load_json(row.get("acp_args"), []),
+                    adapter_source=row.get("adapter_source"),
+                    adapter_docs_url=row.get("adapter_docs_url"),
+                    certification_blocker=row.get("certification_blocker"),
                     mcp_orchestration=row.get("mcp_orchestration", "agent_driven"),
                     mcp_entry_tool=row.get("mcp_entry_tool", "execute"),
                     mcp_structured_response=bool(row.get("mcp_structured_response", 0)),
@@ -330,9 +363,16 @@ class AgentRegistry:
         mcp_llm_model: str | None = None,
         mcp_max_iterations: int = 20,
         mcp_refresh_tools: bool = False,
+        entrypoint_strategy: AgentEntrypointStrategy = "documented_candidate",
+        acp_command: str = "",
+        acp_args: list[str] | None = None,
+        adapter_source: str | None = None,
+        adapter_docs_url: str | None = None,
+        certification_blocker: str | None = None,
     ) -> AgentRegistryEntry:
         """Register or update a dynamic agent entry."""
         with self._lock:
+            normalized_entrypoint_strategy = _coerce_entrypoint_strategy(entrypoint_strategy)
             entry = AgentRegistryEntry(
                 type=type,
                 name=name,
@@ -350,6 +390,12 @@ class AgentRegistry:
                 mcp_llm_model=mcp_llm_model,
                 mcp_max_iterations=mcp_max_iterations,
                 mcp_refresh_tools=mcp_refresh_tools,
+                entrypoint_strategy=normalized_entrypoint_strategy,
+                acp_command=acp_command,
+                acp_args=acp_args or [],
+                adapter_source=adapter_source,
+                adapter_docs_url=adapter_docs_url,
+                certification_blocker=certification_blocker,
             )
             if self._db is not None:
                 self._db.save_agent_entry({
@@ -369,6 +415,12 @@ class AgentRegistry:
                     "mcp_llm_model": mcp_llm_model,
                     "mcp_max_iterations": mcp_max_iterations,
                     "mcp_refresh_tools": mcp_refresh_tools,
+                    "entrypoint_strategy": normalized_entrypoint_strategy,
+                    "acp_command": acp_command,
+                    "acp_args": json.dumps(acp_args or []),
+                    "adapter_source": adapter_source,
+                    "adapter_docs_url": adapter_docs_url,
+                    "certification_blocker": certification_blocker,
                     "source": "api",
                 })
             self._api_entries = [e for e in self._api_entries if e.type != type]
@@ -388,12 +440,30 @@ class AgentRegistry:
     _UPDATABLE_FIELDS = frozenset({
         "name", "description", "command", "args", "env",
         "requires_api_key", "install_instructions", "docs_url",
+        "entrypoint_strategy", "acp_command", "acp_args", "adapter_source",
+        "adapter_docs_url", "certification_blocker",
         "mcp_orchestration", "mcp_entry_tool", "mcp_structured_response",
         "mcp_llm_provider", "mcp_llm_model", "mcp_max_iterations", "mcp_refresh_tools",
     })
 
     # Defaults for fields that must never be None at runtime
-    _FIELD_DEFAULTS: dict[str, Any] = {"args": [], "env": {}, "install_instructions": []}
+    _FIELD_DEFAULT_FACTORIES: dict[str, Callable[[], Any]] = {
+        "args": list,
+        "env": dict,
+        "install_instructions": list,
+        "acp_args": list,
+    }
+    _NON_NULLABLE_SCALAR_FIELDS = frozenset({
+        "name",
+        "description",
+        "command",
+        "acp_command",
+        "mcp_orchestration",
+        "mcp_entry_tool",
+        "mcp_structured_response",
+        "mcp_max_iterations",
+        "mcp_refresh_tools",
+    })
 
     def update_agent(self, agent_type: str, **kwargs: Any) -> AgentRegistryEntry | None:
         """Update fields on an existing dynamic agent entry."""
@@ -408,8 +478,12 @@ class AgentRegistry:
             for key, value in kwargs.items():
                 if key in self._UPDATABLE_FIELDS:
                     # Normalize None → safe default for collection fields
-                    if value is None and key in self._FIELD_DEFAULTS:
-                        value = self._FIELD_DEFAULTS[key]
+                    if value is None and key in self._FIELD_DEFAULT_FACTORIES:
+                        value = self._FIELD_DEFAULT_FACTORIES[key]()
+                    elif value is None and key in self._NON_NULLABLE_SCALAR_FIELDS:
+                        continue
+                    if key == "entrypoint_strategy":
+                        value = _coerce_entrypoint_strategy(value)
                     setattr(existing, key, value)
             if self._db is not None:
                 self._db.save_agent_entry({
@@ -429,6 +503,12 @@ class AgentRegistry:
                     "mcp_llm_model": existing.mcp_llm_model,
                     "mcp_max_iterations": existing.mcp_max_iterations,
                     "mcp_refresh_tools": existing.mcp_refresh_tools,
+                    "entrypoint_strategy": existing.entrypoint_strategy,
+                    "acp_command": existing.acp_command,
+                    "acp_args": json.dumps(existing.acp_args),
+                    "adapter_source": existing.adapter_source,
+                    "adapter_docs_url": existing.adapter_docs_url,
+                    "certification_blocker": existing.certification_blocker,
                     "source": "api",
                 })
             return existing

--- a/tldw_Server_API/app/core/DB_Management/ACP_Sessions_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ACP_Sessions_DB.py
@@ -18,7 +18,7 @@ from tldw_Server_API.app.core.DB_Management.sqlite_policy import (
     configure_sqlite_connection,
 )
 
-_SCHEMA_VERSION = 13
+_SCHEMA_VERSION = 14
 
 _SCHEMA_SQL = """\
 CREATE TABLE IF NOT EXISTS sessions (
@@ -91,6 +91,12 @@ CREATE TABLE IF NOT EXISTS agent_registry (
     mcp_llm_model TEXT,
     mcp_max_iterations INTEGER NOT NULL DEFAULT 20,
     mcp_refresh_tools INTEGER NOT NULL DEFAULT 0,
+    entrypoint_strategy TEXT NOT NULL DEFAULT 'documented_candidate',
+    acp_command TEXT NOT NULL DEFAULT '',
+    acp_args TEXT NOT NULL DEFAULT '[]',
+    adapter_source TEXT,
+    adapter_docs_url TEXT,
+    certification_blocker TEXT,
     source TEXT NOT NULL DEFAULT 'api',
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL
@@ -203,6 +209,12 @@ _ALLOWED_MIGRATION_COLUMNS = {
         "mcp_llm_model": "mcp_llm_model TEXT",
         "mcp_max_iterations": "mcp_max_iterations INTEGER NOT NULL DEFAULT 20",
         "mcp_refresh_tools": "mcp_refresh_tools INTEGER NOT NULL DEFAULT 0",
+        "entrypoint_strategy": "entrypoint_strategy TEXT NOT NULL DEFAULT 'documented_candidate'",
+        "acp_command": "acp_command TEXT NOT NULL DEFAULT ''",
+        "acp_args": "acp_args TEXT NOT NULL DEFAULT '[]'",
+        "adapter_source": "adapter_source TEXT",
+        "adapter_docs_url": "adapter_docs_url TEXT",
+        "certification_blocker": "certification_blocker TEXT",
     },
     "permission_policies": {
         "conditions_json": "conditions_json TEXT",
@@ -321,6 +333,12 @@ class ACPSessionsDB:
                         mcp_llm_model TEXT,
                         mcp_max_iterations INTEGER NOT NULL DEFAULT 20,
                         mcp_refresh_tools INTEGER NOT NULL DEFAULT 0,
+                        entrypoint_strategy TEXT NOT NULL DEFAULT 'documented_candidate',
+                        acp_command TEXT NOT NULL DEFAULT '',
+                        acp_args TEXT NOT NULL DEFAULT '[]',
+                        adapter_source TEXT,
+                        adapter_docs_url TEXT,
+                        certification_blocker TEXT,
                         source TEXT NOT NULL DEFAULT 'api',
                         created_at TEXT NOT NULL,
                         updated_at TEXT NOT NULL
@@ -529,6 +547,43 @@ class ACPSessionsDB:
                 )
             if current_version < 13:
                 _ensure_config_template_unique_index(conn)
+            if current_version < 14:
+                _ensure_column(
+                    conn,
+                    "agent_registry",
+                    "entrypoint_strategy",
+                    "entrypoint_strategy TEXT NOT NULL DEFAULT 'documented_candidate'",
+                )
+                _ensure_column(
+                    conn,
+                    "agent_registry",
+                    "acp_command",
+                    "acp_command TEXT NOT NULL DEFAULT ''",
+                )
+                _ensure_column(
+                    conn,
+                    "agent_registry",
+                    "acp_args",
+                    "acp_args TEXT NOT NULL DEFAULT '[]'",
+                )
+                _ensure_column(
+                    conn,
+                    "agent_registry",
+                    "adapter_source",
+                    "adapter_source TEXT",
+                )
+                _ensure_column(
+                    conn,
+                    "agent_registry",
+                    "adapter_docs_url",
+                    "adapter_docs_url TEXT",
+                )
+                _ensure_column(
+                    conn,
+                    "agent_registry",
+                    "certification_blocker",
+                    "certification_blocker TEXT",
+                )
             conn.execute(f"PRAGMA user_version={_SCHEMA_VERSION}")
             conn.commit()
             self._initialized = True
@@ -1555,6 +1610,12 @@ class ACPSessionsDB:
         mcp_llm_model = entry_dict.get("mcp_llm_model")
         mcp_max_iterations = int(entry_dict.get("mcp_max_iterations", 20))
         mcp_refresh_tools = int(bool(entry_dict.get("mcp_refresh_tools", 0)))
+        entrypoint_strategy = entry_dict.get("entrypoint_strategy", "documented_candidate")
+        acp_command = entry_dict.get("acp_command", "")
+        acp_args = entry_dict.get("acp_args", "[]")
+        adapter_source = entry_dict.get("adapter_source")
+        adapter_docs_url = entry_dict.get("adapter_docs_url")
+        certification_blocker = entry_dict.get("certification_blocker")
         source = entry_dict.get("source", "api")
 
         conn.execute(
@@ -1564,8 +1625,10 @@ class ACPSessionsDB:
                 requires_api_key, is_default, install_instructions, docs_url,
                 mcp_orchestration, mcp_entry_tool, mcp_structured_response,
                 mcp_llm_provider, mcp_llm_model, mcp_max_iterations, mcp_refresh_tools,
+                entrypoint_strategy, acp_command, acp_args,
+                adapter_source, adapter_docs_url, certification_blocker,
                 source, created_at, updated_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(agent_type) DO UPDATE SET
                 name = excluded.name,
                 description = excluded.description,
@@ -1583,6 +1646,12 @@ class ACPSessionsDB:
                 mcp_llm_model = excluded.mcp_llm_model,
                 mcp_max_iterations = excluded.mcp_max_iterations,
                 mcp_refresh_tools = excluded.mcp_refresh_tools,
+                entrypoint_strategy = excluded.entrypoint_strategy,
+                acp_command = excluded.acp_command,
+                acp_args = excluded.acp_args,
+                adapter_source = excluded.adapter_source,
+                adapter_docs_url = excluded.adapter_docs_url,
+                certification_blocker = excluded.certification_blocker,
                 source = excluded.source,
                 updated_at = excluded.updated_at
             """,
@@ -1591,6 +1660,8 @@ class ACPSessionsDB:
                 requires_api_key, is_default, install_instructions, docs_url,
                 mcp_orchestration, mcp_entry_tool, mcp_structured_response,
                 mcp_llm_provider, mcp_llm_model, mcp_max_iterations, mcp_refresh_tools,
+                entrypoint_strategy, acp_command, acp_args,
+                adapter_source, adapter_docs_url, certification_blocker,
                 source, now, now,
             ),
         )

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_endpoints.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_endpoints.py
@@ -308,6 +308,52 @@ def test_acp_agent_registration_records_sanitized_audit_event(
     assert "/private/bin/audit-agent" not in serialized
 
 
+def test_acp_agent_registration_forwards_entrypoint_kwargs(
+    client_user_only,
+    monkeypatch,
+):
+    """Dynamic registration forwards ACP entrypoint metadata into the registry."""
+    import tldw_Server_API.app.api.v1.endpoints.agent_client_protocol as acp_endpoints
+    import tldw_Server_API.app.core.Agent_Client_Protocol.agent_registry as registry_mod
+
+    captured: dict[str, object] = {}
+
+    class _Registry:
+        def register_agent(self, **kwargs):
+            captured.update(kwargs)
+            return types.SimpleNamespace(type=kwargs["type"], name=kwargs["name"])
+
+    async def _admin_user():
+        return types.SimpleNamespace(id=1, is_admin=True)
+
+    monkeypatch.setattr(registry_mod, "get_agent_registry", lambda: _Registry())
+    client_user_only.app.dependency_overrides[acp_endpoints.get_request_user] = _admin_user
+    try:
+        response = client_user_only.post(
+            "/api/v1/acp/agents/register",
+            json={
+                "agent_type": "adapter_agent",
+                "name": "Adapter Agent",
+                "entrypoint_strategy": "adapter_acp",
+                "acp_command": "adapter-agent-acp",
+                "acp_args": ["--stdio"],
+                "adapter_source": "https://example.test/adapter",
+                "adapter_docs_url": "https://example.test/adapter/docs",
+                "certification_blocker": "adapter_missing",
+            },
+        )
+    finally:
+        client_user_only.app.dependency_overrides.pop(acp_endpoints.get_request_user, None)
+
+    assert response.status_code == 200
+    assert captured["entrypoint_strategy"] == "adapter_acp"
+    assert captured["acp_command"] == "adapter-agent-acp"
+    assert captured["acp_args"] == ["--stdio"]
+    assert captured["adapter_source"] == "https://example.test/adapter"
+    assert captured["adapter_docs_url"] == "https://example.test/adapter/docs"
+    assert captured["certification_blocker"] == "adapter_missing"
+
+
 def test_acp_list_audit_events_reads_persisted_rows(tmp_path, monkeypatch):
     import tldw_Server_API.app.api.v1.endpoints.agent_client_protocol as acp_endpoints
     import tldw_Server_API.app.core.DB_Management.ACP_Audit_DB as audit_db_mod

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_health.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_health.py
@@ -205,6 +205,21 @@ def test_acp_health_agents_detection(client_user_only, stub_runner_client):
         assert "verification_level" in agent
 
 
+def test_acp_health_includes_custom_entrypoint_metadata(client_user_only, stub_runner_client):
+    """Health endpoint exposes classifier entrypoint metadata for custom profiles."""
+    resp = client_user_only.get("/api/v1/acp/health")
+    assert resp.status_code == 200
+    data = resp.json()
+    custom = next(agent for agent in data["agents"] if agent["agent_type"] == "custom")
+
+    entrypoint = custom["entrypoint"]
+    assert entrypoint["entrypoint_strategy"] == "custom_template"
+    assert entrypoint["probe_state"] == "custom_template"
+    assert entrypoint["primary_blocker"] == "custom_template"
+    assert "custom_template" in entrypoint["blockers"]
+    assert "custom ACP profile" in entrypoint["status_message"]
+
+
 def test_acp_health_runner_probe_with_running_client(client_user_only, stub_runner_client):
     """Health endpoint probes running runner client."""
     # stub_runner_client has is_running = True
@@ -261,6 +276,33 @@ def test_acp_setup_guide_marks_configured_but_unverified_agents(client_user_only
     assert any("certification checklist" in step.lower() for step in guide["steps"])
 
 
+def test_acp_setup_guide_codex_includes_entrypoint_blocker_steps(client_user_only, stub_runner_client):
+    """Setup guide surfaces documented-candidate ACP adapter blockers."""
+    resp = client_user_only.get("/api/v1/acp/setup-guide?agent_type=codex")
+    assert resp.status_code == 200
+    data = resp.json()
+    guide = data["guides"][0]
+
+    entrypoint = guide["entrypoint"]
+    assert entrypoint["entrypoint_strategy"] == "documented_candidate"
+    assert entrypoint["primary_blocker"] == "adapter_required"
+    assert any("adapter" in step.lower() for step in guide["steps"])
+
+
+def test_acp_agents_includes_opencode_entrypoint_metadata(client_user_only, stub_runner_client):
+    """Agent list exposes native ACP command metadata separately from compatibility support."""
+    resp = client_user_only.get("/api/v1/acp/agents")
+    assert resp.status_code == 200
+    data = resp.json()
+    opencode = next(agent for agent in data["agents"] if agent["type"] == "opencode")
+
+    entrypoint = opencode["entrypoint"]
+    assert entrypoint["entrypoint_strategy"] == "native_acp"
+    assert entrypoint["acp_command"] == "opencode"
+    assert entrypoint["acp_args"] == ["acp"]
+    assert entrypoint["probe_state"] in {"ready_to_probe", "blocked"}
+
+
 def test_acp_agents_normalizes_invalid_runner_compatibility_values(
     client_user_only,
     stub_runner_client,
@@ -280,6 +322,17 @@ def test_acp_agents_normalizes_invalid_runner_compatibility_values(
                     "support_state": "not-a-real-state",
                     "verification_level": "not-a-real-level",
                     "compatibility_docs_url": "/docs-static/Development/ACP_Compatibility_Matrix.md",
+                    "entrypoint": {
+                        "profile_key": "runner_agent",
+                        "entrypoint_strategy": "adapter_acp",
+                        "probe_state": "blocked",
+                        "acp_command": "runner-acp",
+                        "acp_args": ["--stdio"],
+                        "primary_blocker": "adapter_missing",
+                        "blockers": ["adapter_missing"],
+                        "status_message": "Adapter command is not installed.",
+                        "docs_url": "/docs-static/Development/ACP_Compatibility_Matrix.md",
+                    },
                 }
             ],
             "defaultAgentType": "runner_agent",
@@ -295,6 +348,33 @@ def test_acp_agents_normalizes_invalid_runner_compatibility_values(
     assert agent["support_state"] == "documented_unverified"
     assert agent["verification_level"] == "documented_only"
     assert agent["compatibility_docs_url"] == "/docs-static/Development/ACP_Compatibility_Matrix.md"
+    assert agent["entrypoint"]["entrypoint_strategy"] == "adapter_acp"
+    assert agent["entrypoint"]["primary_blocker"] == "adapter_missing"
+    assert agent["entrypoint"]["blockers"] == ["adapter_missing"]
+
+
+def test_acp_agents_static_fallback_includes_conservative_entrypoint_metadata(
+    client_user_only,
+    monkeypatch,
+):
+    """Static fallback rows include conservative entrypoint readiness metadata."""
+    import tldw_Server_API.app.api.v1.endpoints.agent_client_protocol as acp_mod
+
+    async def _runner_unavailable():
+        raise RuntimeError("runner unavailable")
+
+    monkeypatch.setattr(acp_mod, "_get_registry_agents", lambda: None)
+    monkeypatch.setattr(acp_mod, "get_runner_client", _runner_unavailable)
+
+    resp = client_user_only.get("/api/v1/acp/agents")
+    assert resp.status_code == 200
+    data = resp.json()
+    custom = next(agent for agent in data["agents"] if agent["type"] == "custom")
+
+    entrypoint = custom["entrypoint"]
+    assert entrypoint["profile_key"] == "custom"
+    assert entrypoint["entrypoint_strategy"] == "custom_template"
+    assert entrypoint["primary_blocker"] == "custom_template"
 
 
 def test_acp_setup_guide_filter_agent(client_user_only, stub_runner_client):

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_health.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_health.py
@@ -303,6 +303,24 @@ def test_acp_agents_includes_opencode_entrypoint_metadata(client_user_only, stub
     assert entrypoint["probe_state"] in {"ready_to_probe", "blocked"}
 
 
+def test_entrypoint_status_from_entry_normalizes_docs_url() -> None:
+    """Registry-backed entrypoint status uses served docs-static URLs."""
+    import tldw_Server_API.app.api.v1.endpoints.agent_client_protocol as acp_mod
+    from tldw_Server_API.app.core.Agent_Client_Protocol.agent_registry import AgentRegistryEntry
+
+    status = acp_mod._entrypoint_status_from_entry(
+        AgentRegistryEntry(
+            type="docs_agent",
+            name="Docs Agent",
+            entrypoint_strategy="documented_candidate",
+            certification_blocker="adapter_required",
+            compatibility_docs_url="Docs/Development/ACP_Compatibility_Matrix.md",
+        )
+    )
+
+    assert status["docs_url"] == "/docs-static/Development/ACP_Compatibility_Matrix.md"
+
+
 def test_acp_agents_normalizes_invalid_runner_compatibility_values(
     client_user_only,
     stub_runner_client,

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sessions_db.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sessions_db.py
@@ -1,11 +1,13 @@
 """Tests for ACP Sessions SQLite persistence."""
 import json
 import os
+import sqlite3
 import tempfile
 from datetime import datetime, timezone
 
 import pytest
 
+from tldw_Server_API.app.core.Agent_Client_Protocol.agent_registry import AgentRegistry
 from tldw_Server_API.app.core.DB_Management.ACP_Sessions_DB import ACPSessionsDB, _ensure_column
 
 
@@ -494,6 +496,79 @@ class TestAgentRegistry:
         db.save_agent_entry({"agent_type": "a1", "name": "Updated", "source": "api"})
         entry = db.get_agent_entry("a1")
         assert entry["name"] == "Updated"
+
+    def test_agent_entrypoint_strategy_fields_round_trip(self, db):
+        saved = db.save_agent_entry({
+            "agent_type": "adapter",
+            "name": "Adapter",
+            "entrypoint_strategy": "adapter_acp",
+            "acp_command": "adapter-acp",
+            "acp_args": '["--stdio"]',
+            "adapter_source": "example/adapter",
+            "adapter_docs_url": "https://example.test/adapter",
+            "certification_blocker": "adapter_missing",
+            "source": "api",
+        })
+
+        assert saved["entrypoint_strategy"] == "adapter_acp"
+        assert saved["acp_command"] == "adapter-acp"
+        assert saved["acp_args"] == '["--stdio"]'
+        assert saved["adapter_source"] == "example/adapter"
+        assert saved["certification_blocker"] == "adapter_missing"
+
+
+def test_legacy_agent_registry_rows_get_entrypoint_defaults(tmp_path):
+    db_path = tmp_path / "legacy_acp_sessions.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE agent_registry (
+            agent_type TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            description TEXT NOT NULL DEFAULT '',
+            command TEXT NOT NULL DEFAULT '',
+            args TEXT NOT NULL DEFAULT '[]',
+            env TEXT NOT NULL DEFAULT '{}',
+            requires_api_key TEXT,
+            is_default INTEGER NOT NULL DEFAULT 0,
+            install_instructions TEXT NOT NULL DEFAULT '[]',
+            docs_url TEXT,
+            mcp_orchestration TEXT NOT NULL DEFAULT 'agent_driven',
+            mcp_entry_tool TEXT NOT NULL DEFAULT 'execute',
+            mcp_structured_response INTEGER NOT NULL DEFAULT 0,
+            mcp_llm_provider TEXT,
+            mcp_llm_model TEXT,
+            mcp_max_iterations INTEGER NOT NULL DEFAULT 20,
+            mcp_refresh_tools INTEGER NOT NULL DEFAULT 0,
+            source TEXT NOT NULL DEFAULT 'api',
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        );
+        INSERT INTO agent_registry (
+            agent_type, name, command, source, created_at, updated_at
+        ) VALUES ('legacy_api', 'Legacy API', 'legacy-cli', 'api', '2026-01-01', '2026-01-01');
+        PRAGMA user_version=13;
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    db = ACPSessionsDB(db_path=str(db_path))
+    try:
+        row = db.get_agent_entry("legacy_api")
+        assert row["entrypoint_strategy"] == "documented_candidate"
+        assert row["acp_command"] == ""
+        assert row["acp_args"] == "[]"
+
+        registry = AgentRegistry(yaml_path="/missing.yaml", db=db)
+        registry._load_api_entries()
+        entry = registry.get_entry("legacy_api")
+        assert entry is not None
+        assert entry.entrypoint_strategy == "documented_candidate"
+        assert entry.acp_command == ""
+        assert entry.acp_args == []
+    finally:
+        db.close()
 
 
 class TestHealthHistory:

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_registry_entrypoint_strategy.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_registry_entrypoint_strategy.py
@@ -6,6 +6,7 @@ from tldw_Server_API.app.core.DB_Management.ACP_Sessions_DB import ACPSessionsDB
 from tldw_Server_API.app.core.Agent_Client_Protocol.agent_registry import (
     AgentRegistry,
     AgentRegistryEntry,
+    classify_agent_entrypoint,
 )
 
 pytestmark = pytest.mark.unit
@@ -182,3 +183,178 @@ def test_update_agent_collection_defaults_are_fresh_instances() -> None:
     assert second is not None
     assert second.acp_args == []
     assert second.acp_args is not first.acp_args
+
+
+def test_classifier_ready_to_probe_native_entrypoint(monkeypatch) -> None:
+    entry = AgentRegistryEntry(
+        type="opencode",
+        name="OpenCode",
+        entrypoint_strategy="native_acp",
+        acp_command="opencode",
+        acp_args=["acp"],
+    )
+
+    result = classify_agent_entrypoint(
+        entry,
+        command_resolver=lambda command: f"/usr/bin/{command}",
+        env_getter=lambda _name: "present",
+    )
+
+    assert result.probe_state == "ready_to_probe"
+    assert result.acp_command == "opencode"
+    assert result.acp_args == ["acp"]
+    assert result.primary_blocker is None
+    assert result.blockers == []
+
+
+def test_classifier_blocks_native_entrypoint_missing_command() -> None:
+    entry = AgentRegistryEntry(
+        type="goose",
+        name="Goose",
+        entrypoint_strategy="native_acp",
+        acp_command="goose",
+        acp_args=["acp"],
+    )
+
+    result = classify_agent_entrypoint(entry, command_resolver=lambda _command: None)
+
+    assert result.probe_state == "blocked"
+    assert result.primary_blocker == "binary_missing"
+    assert "binary_missing" in result.blockers
+
+
+def test_classifier_blocks_missing_required_credentials() -> None:
+    entry = AgentRegistryEntry(
+        type="commercial_agent",
+        name="Commercial Agent",
+        entrypoint_strategy="native_acp",
+        acp_command="commercial-agent",
+        requires_api_key="COMMERCIAL_AGENT_API_KEY",
+    )
+
+    result = classify_agent_entrypoint(
+        entry,
+        command_resolver=lambda command: f"/usr/bin/{command}",
+        env_getter=lambda _name: None,
+    )
+
+    assert result.probe_state == "blocked"
+    assert result.primary_blocker == "credentials_missing"
+    assert "credentials_missing" in result.blockers
+
+
+def test_classifier_does_not_infer_native_acp_command_from_command() -> None:
+    entry = AgentRegistryEntry(
+        type="opencode",
+        name="OpenCode",
+        command="opencode",
+        entrypoint_strategy="native_acp",
+        acp_command="",
+    )
+
+    result = classify_agent_entrypoint(
+        entry,
+        command_resolver=lambda command: f"/usr/bin/{command}",
+    )
+
+    assert result.probe_state == "blocked"
+    assert result.primary_blocker == "entrypoint_strategy_missing"
+    assert result.acp_command == ""
+
+
+def test_classifier_does_not_infer_adapter_acp_command_from_command() -> None:
+    entry = AgentRegistryEntry(
+        type="codex",
+        name="Codex",
+        command="codex",
+        entrypoint_strategy="adapter_acp",
+        acp_command="",
+        adapter_source="example/codex-acp",
+    )
+
+    result = classify_agent_entrypoint(
+        entry,
+        command_resolver=lambda command: f"/usr/bin/{command}",
+    )
+
+    assert result.probe_state == "blocked"
+    assert result.primary_blocker == "entrypoint_strategy_missing"
+    assert result.acp_command == ""
+
+
+def test_classifier_documented_candidate_keeps_command_separate_from_acp_command() -> None:
+    entry = AgentRegistryEntry(
+        type="codex",
+        name="Codex",
+        command="codex",
+        entrypoint_strategy="documented_candidate",
+        acp_command="",
+        certification_blocker="adapter_required",
+    )
+
+    result = classify_agent_entrypoint(
+        entry,
+        command_resolver=lambda command: f"/usr/bin/{command}",
+    )
+
+    assert result.probe_state == "documented_only"
+    assert result.primary_blocker == "adapter_required"
+    assert result.acp_command == ""
+
+
+def test_classifier_documented_candidate_is_documented_only() -> None:
+    entry = AgentRegistryEntry(
+        type="codex",
+        name="Codex",
+        entrypoint_strategy="documented_candidate",
+        certification_blocker="adapter_required",
+    )
+
+    result = classify_agent_entrypoint(entry)
+
+    assert result.probe_state == "documented_only"
+    assert result.primary_blocker == "adapter_required"
+    assert result.acp_command == ""
+
+
+def test_classifier_adapter_requires_adapter_command() -> None:
+    entry = AgentRegistryEntry(
+        type="adapter",
+        name="Adapter",
+        entrypoint_strategy="adapter_acp",
+        acp_command="adapter-acp",
+        acp_args=[],
+        adapter_source="example/adapter",
+    )
+
+    result = classify_agent_entrypoint(entry, command_resolver=lambda _command: None)
+
+    assert result.probe_state == "blocked"
+    assert result.primary_blocker == "adapter_missing"
+
+
+def test_classifier_custom_template_is_never_probe_ready() -> None:
+    entry = AgentRegistryEntry(
+        type="custom",
+        name="Custom Agent",
+        entrypoint_strategy="custom_template",
+    )
+
+    result = classify_agent_entrypoint(entry)
+
+    assert result.probe_state == "custom_template"
+    assert result.acp_command == ""
+
+
+def test_classifier_rejects_shell_builtin_entrypoint() -> None:
+    entry = AgentRegistryEntry(
+        type="bad",
+        name="Bad",
+        entrypoint_strategy="native_acp",
+        acp_command="cd",
+    )
+
+    result = classify_agent_entrypoint(entry, command_resolver=lambda _command: "/bin/cd")
+
+    assert result.probe_state == "blocked"
+    assert result.primary_blocker == "shell_builtin_collision"

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_registry_entrypoint_strategy.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_registry_entrypoint_strategy.py
@@ -4,6 +4,7 @@ import pytest
 
 from tldw_Server_API.app.core.DB_Management.ACP_Sessions_DB import ACPSessionsDB
 from tldw_Server_API.app.core.Agent_Client_Protocol.agent_registry import (
+    AgentEntrypointClassification,
     AgentRegistry,
     AgentRegistryEntry,
     classify_agent_entrypoint,
@@ -185,7 +186,7 @@ def test_update_agent_collection_defaults_are_fresh_instances() -> None:
     assert second.acp_args is not first.acp_args
 
 
-def test_classifier_ready_to_probe_native_entrypoint(monkeypatch) -> None:
+def test_classifier_ready_to_probe_native_entrypoint() -> None:
     entry = AgentRegistryEntry(
         type="opencode",
         name="OpenCode",
@@ -202,9 +203,39 @@ def test_classifier_ready_to_probe_native_entrypoint(monkeypatch) -> None:
 
     assert result.probe_state == "ready_to_probe"
     assert result.acp_command == "opencode"
-    assert result.acp_args == ["acp"]
+    assert result.acp_args == ("acp",)
     assert result.primary_blocker is None
-    assert result.blockers == []
+    assert result.blockers == ()
+    assert result.as_dict()["acp_args"] == ["acp"]
+    assert result.as_dict()["blockers"] == []
+
+
+def test_classification_is_immutable_against_source_and_as_dict_mutation() -> None:
+    source_args = ["acp"]
+    source_blockers = ["binary_missing"]
+    result = AgentEntrypointClassification(
+        profile_key="goose",
+        entrypoint_strategy="native_acp",
+        probe_state="blocked",
+        acp_command="goose",
+        acp_args=source_args,
+        primary_blocker="binary_missing",
+        blockers=source_blockers,
+        status_message="blocked",
+        docs_url=None,
+    )
+
+    source_args.append("--mutated")
+    source_blockers.append("credentials_missing")
+
+    serialized = result.as_dict()
+    serialized["acp_args"].append("--dict-mutated")
+    serialized["blockers"].append("dict_mutated")
+
+    assert result.acp_args == ("acp",)
+    assert result.blockers == ("binary_missing",)
+    assert result.as_dict()["acp_args"] == ["acp"]
+    assert result.as_dict()["blockers"] == ["binary_missing"]
 
 
 def test_classifier_blocks_native_entrypoint_missing_command() -> None:

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_registry_entrypoint_strategy.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_registry_entrypoint_strategy.py
@@ -57,6 +57,32 @@ agents:
     assert entry.acp_args == ["acp"]
 
 
+def test_registry_loads_null_yaml_acp_command_as_missing_entrypoint(tmp_path) -> None:
+    yaml_file = tmp_path / "agents.yaml"
+    yaml_file.write_text(
+        """
+agents:
+  - type: null_command_agent
+    name: Null Command Agent
+    command: null-command-agent
+    entrypoint_strategy: native_acp
+    acp_command:
+"""
+    )
+
+    registry = AgentRegistry(yaml_path=str(yaml_file))
+    registry.load()
+
+    entry = registry.get_entry("null_command_agent")
+    assert entry is not None
+    assert entry.acp_command == ""
+
+    result = classify_agent_entrypoint(entry)
+    assert result.probe_state == "blocked"
+    assert result.primary_blocker == "entrypoint_strategy_missing"
+    assert "binary_missing" not in result.blockers
+
+
 def test_dynamic_registration_preserves_entrypoint_strategy_fields(acp_db) -> None:
     registry = AgentRegistry(yaml_path="/missing.yaml", db=acp_db)
 

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_registry_entrypoint_strategy.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_registry_entrypoint_strategy.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.ACP_Sessions_DB import ACPSessionsDB
+from tldw_Server_API.app.core.Agent_Client_Protocol.agent_registry import (
+    AgentRegistry,
+    AgentRegistryEntry,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def acp_db(tmp_path):
+    db = ACPSessionsDB(db_path=str(tmp_path / "acp_sessions.db"))
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def test_entrypoint_strategy_defaults_to_documented_candidate() -> None:
+    entry = AgentRegistryEntry(type="legacy", name="Legacy")
+
+    assert entry.entrypoint_strategy == "documented_candidate"
+    assert entry.acp_command == ""
+    assert entry.acp_args == []
+    assert entry.adapter_source is None
+    assert entry.adapter_docs_url is None
+    assert entry.certification_blocker is None
+
+
+def test_registry_loads_entrypoint_strategy_fields_from_yaml(tmp_path) -> None:
+    yaml_file = tmp_path / "agents.yaml"
+    yaml_file.write_text(
+        """
+agents:
+  - type: opencode
+    name: OpenCode
+    command: opencode
+    entrypoint_strategy: native_acp
+    acp_command: opencode
+    acp_args: ["acp"]
+"""
+    )
+
+    registry = AgentRegistry(yaml_path=str(yaml_file))
+    registry.load()
+
+    entry = registry.get_entry("opencode")
+    assert entry is not None
+    assert entry.entrypoint_strategy == "native_acp"
+    assert entry.acp_command == "opencode"
+    assert entry.acp_args == ["acp"]
+
+
+def test_dynamic_registration_preserves_entrypoint_strategy_fields(acp_db) -> None:
+    registry = AgentRegistry(yaml_path="/missing.yaml", db=acp_db)
+
+    entry = registry.register_agent(
+        type="adapter_agent",
+        name="Adapter Agent",
+        command="agent-cli",
+        entrypoint_strategy="adapter_acp",
+        acp_command="agent-acp",
+        acp_args=["--stdio"],
+        adapter_source="example/agent-acp",
+        adapter_docs_url="https://example.test/agent-acp",
+        certification_blocker="adapter_missing",
+    )
+
+    assert entry.entrypoint_strategy == "adapter_acp"
+    assert entry.acp_command == "agent-acp"
+    assert entry.acp_args == ["--stdio"]
+
+    reloaded = AgentRegistry(yaml_path="/missing.yaml", db=acp_db)
+    reloaded._load_api_entries()
+    persisted = reloaded.get_entry("adapter_agent")
+    assert persisted is not None
+    assert persisted.entrypoint_strategy == "adapter_acp"
+    assert persisted.acp_command == "agent-acp"
+    assert persisted.acp_args == ["--stdio"]
+    assert persisted.adapter_source == "example/agent-acp"
+
+
+def test_update_agent_clears_nullable_entrypoint_metadata(acp_db) -> None:
+    registry = AgentRegistry(yaml_path="/missing.yaml", db=acp_db)
+    registry.register_agent(
+        type="adapter_agent",
+        name="Adapter Agent",
+        adapter_source="example/agent-acp",
+        adapter_docs_url="https://example.test/agent-acp",
+        certification_blocker="adapter_missing",
+    )
+
+    updated = registry.update_agent(
+        "adapter_agent",
+        adapter_source=None,
+        adapter_docs_url=None,
+        certification_blocker=None,
+    )
+
+    assert updated is not None
+    assert updated.adapter_source is None
+    assert updated.adapter_docs_url is None
+    assert updated.certification_blocker is None
+
+    persisted = acp_db.get_agent_entry("adapter_agent")
+    assert persisted is not None
+    assert persisted["adapter_source"] is None
+    assert persisted["adapter_docs_url"] is None
+    assert persisted["certification_blocker"] is None
+
+
+def test_update_agent_ignores_none_for_required_name_without_db_failure(acp_db) -> None:
+    registry = AgentRegistry(yaml_path="/missing.yaml", db=acp_db)
+    registry.register_agent(type="named_agent", name="Named Agent")
+
+    updated = registry.update_agent("named_agent", name=None)
+
+    assert updated is not None
+    assert updated.name == "Named Agent"
+    persisted = acp_db.get_agent_entry("named_agent")
+    assert persisted is not None
+    assert persisted["name"] == "Named Agent"
+
+
+def test_register_agent_coerces_invalid_entrypoint_strategy(acp_db) -> None:
+    registry = AgentRegistry(yaml_path="/missing.yaml", db=acp_db)
+
+    entry = registry.register_agent(
+        type="bad_strategy",
+        name="Bad Strategy",
+        entrypoint_strategy="maybe_acp",  # type: ignore[arg-type]
+    )
+
+    assert entry.entrypoint_strategy == "documented_candidate"
+
+    reloaded = AgentRegistry(yaml_path="/missing.yaml", db=acp_db)
+    reloaded._load_api_entries()
+    persisted = reloaded.get_entry("bad_strategy")
+    assert persisted is not None
+    assert persisted.entrypoint_strategy == "documented_candidate"
+
+
+def test_update_agent_coerces_invalid_entrypoint_strategy() -> None:
+    registry = AgentRegistry(yaml_path="/missing.yaml")
+    registry.register_agent(
+        type="bad_update_strategy",
+        name="Bad Update Strategy",
+        entrypoint_strategy="native_acp",
+    )
+
+    updated = registry.update_agent(
+        "bad_update_strategy",
+        entrypoint_strategy="maybe_acp",
+    )
+
+    assert updated is not None
+    assert updated.entrypoint_strategy == "documented_candidate"
+
+
+def test_update_agent_collection_defaults_are_fresh_instances() -> None:
+    registry = AgentRegistry(yaml_path="/missing.yaml")
+    first = registry.register_agent(
+        type="first",
+        name="First",
+        acp_args=["initial"],
+    )
+    second = registry.register_agent(
+        type="second",
+        name="Second",
+        acp_args=["initial"],
+    )
+
+    first = registry.update_agent("first", acp_args=None)
+    assert first is not None
+    first.acp_args.append("--first-only")
+    second = registry.update_agent("second", acp_args=None)
+
+    assert second is not None
+    assert second.acp_args == []
+    assert second.acp_args is not first.acp_args

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_registry_entrypoint_strategy.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_registry_entrypoint_strategy.py
@@ -375,6 +375,9 @@ def test_classifier_custom_template_is_never_probe_ready() -> None:
 
     assert result.probe_state == "custom_template"
     assert result.acp_command == ""
+    assert result.primary_blocker == "custom_template"
+    assert result.blockers == ("custom_template",)
+    assert "command, args, env, workspace policy, and evidence bundle" in result.status_message
 
 
 def test_classifier_rejects_shell_builtin_entrypoint() -> None:

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_registry_entrypoint_strategy.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_registry_entrypoint_strategy.py
@@ -84,6 +84,8 @@ def test_dynamic_registration_preserves_entrypoint_strategy_fields(acp_db) -> No
     assert persisted.acp_command == "agent-acp"
     assert persisted.acp_args == ["--stdio"]
     assert persisted.adapter_source == "example/agent-acp"
+    assert persisted.adapter_docs_url == "https://example.test/agent-acp"
+    assert persisted.certification_blocker == "adapter_missing"
 
 
 def test_update_agent_clears_nullable_entrypoint_metadata(acp_db) -> None:
@@ -146,8 +148,8 @@ def test_register_agent_coerces_invalid_entrypoint_strategy(acp_db) -> None:
     assert persisted.entrypoint_strategy == "documented_candidate"
 
 
-def test_update_agent_coerces_invalid_entrypoint_strategy() -> None:
-    registry = AgentRegistry(yaml_path="/missing.yaml")
+def test_update_agent_coerces_invalid_entrypoint_strategy(acp_db) -> None:
+    registry = AgentRegistry(yaml_path="/missing.yaml", db=acp_db)
     registry.register_agent(
         type="bad_update_strategy",
         name="Bad Update Strategy",
@@ -161,6 +163,12 @@ def test_update_agent_coerces_invalid_entrypoint_strategy() -> None:
 
     assert updated is not None
     assert updated.entrypoint_strategy == "documented_candidate"
+
+    reloaded = AgentRegistry(yaml_path="/missing.yaml", db=acp_db)
+    reloaded._load_api_entries()
+    persisted = reloaded.get_entry("bad_update_strategy")
+    assert persisted is not None
+    assert persisted.entrypoint_strategy == "documented_candidate"
 
 
 def test_update_agent_collection_defaults_are_fresh_instances() -> None:
@@ -272,6 +280,27 @@ def test_classifier_blocks_missing_required_credentials() -> None:
     assert result.probe_state == "blocked"
     assert result.primary_blocker == "credentials_missing"
     assert "credentials_missing" in result.blockers
+
+
+def test_classifier_reports_multiple_applicable_blockers() -> None:
+    entry = AgentRegistryEntry(
+        type="commercial_agent",
+        name="Commercial Agent",
+        entrypoint_strategy="native_acp",
+        acp_command="commercial-agent",
+        requires_api_key="COMMERCIAL_AGENT_API_KEY",
+    )
+
+    result = classify_agent_entrypoint(
+        entry,
+        command_resolver=lambda _command: None,
+        env_getter=lambda _name: None,
+    )
+
+    assert result.probe_state == "blocked"
+    assert result.primary_blocker == "credentials_missing"
+    assert result.blockers == ("credentials_missing", "binary_missing")
+    assert "binary_missing" in result.status_message
 
 
 def test_classifier_does_not_infer_native_acp_command_from_command() -> None:

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_registry_mcp_fields.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_registry_mcp_fields.py
@@ -1,7 +1,10 @@
 """Tests for MCP orchestration fields on AgentRegistryEntry (Phase B)."""
 from __future__ import annotations
 
+import types
+
 import pytest
+from pydantic import ValidationError
 
 from tldw_Server_API.app.api.v1.schemas.agent_client_protocol import (
     ACPAgentRegisterRequest,
@@ -92,4 +95,66 @@ def test_agent_update_request_preserves_mcp_fields():
         "mcp_llm_model": "gpt-4o-mini",
         "mcp_max_iterations": 8,
         "mcp_refresh_tools": True,
+    }
+
+
+def test_agent_register_request_exposes_entrypoint_strategy_fields():
+    request = ACPAgentRegisterRequest(
+        agent_type="native",
+        name="Native",
+        entrypoint_strategy="native_acp",
+        acp_command="native-agent",
+        acp_args=["acp"],
+    )
+
+    assert request.entrypoint_strategy == "native_acp"
+    assert request.acp_command == "native-agent"
+    assert request.acp_args == ["acp"]
+
+
+def test_agent_register_request_rejects_invalid_entrypoint_strategy():
+    with pytest.raises(ValidationError):
+        ACPAgentRegisterRequest(
+            agent_type="bad",
+            name="Bad",
+            entrypoint_strategy="maybe_acp",
+        )
+
+
+def test_agent_update_request_rejects_explicit_null_for_required_scalar():
+    with pytest.raises(ValidationError):
+        ACPAgentUpdateRequest(name=None)
+
+
+async def test_update_endpoint_preserves_explicit_nullable_fields(monkeypatch):
+    import tldw_Server_API.app.api.v1.endpoints.agent_client_protocol as acp_endpoints
+    import tldw_Server_API.app.core.Agent_Client_Protocol.agent_registry as registry_mod
+
+    captured_updates: dict[str, object] = {}
+
+    class _Registry:
+        def update_agent(self, agent_type: str, **kwargs):
+            captured_updates.update(kwargs)
+            return types.SimpleNamespace(type=agent_type, name="Updated")
+
+    monkeypatch.setattr(registry_mod, "get_agent_registry", lambda: _Registry())
+
+    request = ACPAgentUpdateRequest(
+        name="Updated",
+        adapter_source=None,
+        adapter_docs_url=None,
+        certification_blocker=None,
+        acp_args=None,
+    )
+    user = types.SimpleNamespace(id=1, is_admin=True)
+
+    response = await acp_endpoints.acp_update_agent("adapter_agent", request, user)
+
+    assert response.status == "updated"
+    assert captured_updates == {
+        "name": "Updated",
+        "acp_args": None,
+        "adapter_source": None,
+        "adapter_docs_url": None,
+        "certification_blocker": None,
     }

--- a/tldw_Server_API/tests/Helper_Scripts/test_acp_certification_smoke.py
+++ b/tldw_Server_API/tests/Helper_Scripts/test_acp_certification_smoke.py
@@ -492,7 +492,7 @@ def test_stdio_sequence_runner_times_out_on_partial_line_and_cleans_up(monkeypat
     elapsed = time.monotonic() - started
 
     assert rc == 124
-    assert elapsed < 0.15
+    assert elapsed < 0.35
     assert process.killed is True
     assert process.wait_calls >= 1
     assert process.stdin.closed is True
@@ -633,3 +633,344 @@ def test_stdio_sequence_runner_cleans_up_after_broken_pipe(monkeypatch) -> None:
     assert process.wait_calls >= 1
     assert process.stdin.closed is True
     assert process.stdout.closed is True
+
+
+def test_stdio_sequence_runner_drops_noisy_notifications_without_unbounded_queue(
+    monkeypatch,
+) -> None:
+    module = _load_module()
+    queue_sizes = []
+    lines = [
+        '{"jsonrpc":"2.0","method":"log/message","params":{"index":%d}}\n' % index
+        for index in range(200)
+    ]
+    lines.append('{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"1"}}\n')
+    responses = iter(lines)
+
+    class _TrackingQueue(module.queue.Queue):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            queue_sizes.append(self.maxsize)
+
+    class _Pipe:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    class _Stdin(_Pipe):
+        def write(self, _text):
+            return None
+
+        def flush(self):
+            return None
+
+        def close(self):
+            self.closed = True
+
+    class _Stdout(_Pipe):
+        def readline(self, _limit=-1):
+            return next(responses, "")
+
+    class _Process:
+        def __init__(self):
+            self.stdin = _Stdin()
+            self.stdout = _Stdout()
+            self.terminated = False
+            self.killed = False
+            self.wait_calls = 0
+
+        def poll(self):
+            return None
+
+        def terminate(self):
+            self.terminated = True
+
+        def wait(self, timeout=None):
+            self.wait_calls += 1
+            return 0
+
+        def kill(self):
+            self.killed = True
+
+    process = _Process()
+    monkeypatch.setattr(module.queue, "Queue", _TrackingQueue)
+    monkeypatch.setattr(module.subprocess, "Popen", lambda *_args, **_kwargs: process)
+
+    rc = module._run_stdio_jsonrpc_sequence({
+        "id": "acp_initialize_probe",
+        "cwd": ".",
+        "argv": ["opencode", "acp"],
+        "stdin_jsonl": [
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+        ],
+        "timeout_seconds": 10,
+    }, module.ROOT)
+
+    assert rc == 0
+    assert queue_sizes
+    assert queue_sizes[0] > 0
+    assert queue_sizes[0] <= 64
+    assert process.killed is False
+    assert process.stdin.closed is True
+    assert process.stdout.closed is True
+
+
+def test_stdio_sequence_runner_fails_and_cleans_up_on_overlong_stdout_line(monkeypatch) -> None:
+    module = _load_module()
+
+    class _Pipe:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    class _Stdin(_Pipe):
+        def write(self, _text):
+            return None
+
+        def flush(self):
+            return None
+
+    class _Stdout(_Pipe):
+        def readline(self, limit=-1):
+            return "{" * max(limit, 1)
+
+    class _Process:
+        def __init__(self):
+            self.stdin = _Stdin()
+            self.stdout = _Stdout()
+            self.killed = False
+            self.wait_calls = 0
+
+        def poll(self):
+            return None
+
+        def terminate(self):
+            return None
+
+        def wait(self, timeout=None):
+            self.wait_calls += 1
+            return 1
+
+        def kill(self):
+            self.killed = True
+
+    process = _Process()
+    monkeypatch.setattr(module.subprocess, "Popen", lambda *_args, **_kwargs: process)
+
+    rc = module._run_stdio_jsonrpc_sequence({
+        "id": "acp_initialize_probe",
+        "cwd": ".",
+        "argv": ["opencode", "acp"],
+        "stdin_jsonl": [
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+        ],
+        "timeout_seconds": 10,
+    }, module.ROOT)
+
+    assert rc != 0
+    assert process.killed is True
+    assert process.wait_calls >= 1
+    assert process.stdin.closed is True
+    assert process.stdout.closed is True
+
+
+def test_stdio_sequence_runner_cleans_up_after_write_oserror(monkeypatch) -> None:
+    module = _load_module()
+
+    class _Pipe:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    class _Stdin(_Pipe):
+        def write(self, _text):
+            raise OSError("write failed")
+
+        def flush(self):
+            return None
+
+    class _Stdout(_Pipe):
+        def readline(self, _limit=-1):
+            return ""
+
+    class _Process:
+        def __init__(self):
+            self.stdin = _Stdin()
+            self.stdout = _Stdout()
+            self.killed = False
+            self.wait_calls = 0
+
+        def poll(self):
+            return None
+
+        def terminate(self):
+            return None
+
+        def wait(self, timeout=None):
+            self.wait_calls += 1
+            return 1
+
+        def kill(self):
+            self.killed = True
+
+    process = _Process()
+    monkeypatch.setattr(module.subprocess, "Popen", lambda *_args, **_kwargs: process)
+
+    rc = module._run_stdio_jsonrpc_sequence({
+        "id": "acp_initialize_probe",
+        "cwd": ".",
+        "argv": ["opencode", "acp"],
+        "stdin_jsonl": [
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+        ],
+        "timeout_seconds": 10,
+    }, module.ROOT)
+
+    assert rc != 0
+    assert process.killed is True
+    assert process.wait_calls >= 1
+    assert process.stdin.closed is True
+    assert process.stdout.closed is True
+
+
+def test_stdio_sequence_runner_cleans_up_after_flush_valueerror(monkeypatch) -> None:
+    module = _load_module()
+
+    class _Pipe:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    class _Stdin(_Pipe):
+        def write(self, _text):
+            return None
+
+        def flush(self):
+            raise ValueError("flush failed")
+
+    class _Stdout(_Pipe):
+        def readline(self, _limit=-1):
+            return ""
+
+    class _Process:
+        def __init__(self):
+            self.stdin = _Stdin()
+            self.stdout = _Stdout()
+            self.killed = False
+            self.wait_calls = 0
+
+        def poll(self):
+            return None
+
+        def terminate(self):
+            return None
+
+        def wait(self, timeout=None):
+            self.wait_calls += 1
+            return 1
+
+        def kill(self):
+            self.killed = True
+
+    process = _Process()
+    monkeypatch.setattr(module.subprocess, "Popen", lambda *_args, **_kwargs: process)
+
+    rc = module._run_stdio_jsonrpc_sequence({
+        "id": "acp_initialize_probe",
+        "cwd": ".",
+        "argv": ["opencode", "acp"],
+        "stdin_jsonl": [
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+        ],
+        "timeout_seconds": 10,
+    }, module.ROOT)
+
+    assert rc != 0
+    assert process.killed is True
+    assert process.wait_calls >= 1
+    assert process.stdin.closed is True
+    assert process.stdout.closed is True
+
+
+def test_stdio_sequence_runner_success_closes_stdin_before_terminating(monkeypatch) -> None:
+    module = _load_module()
+    events = []
+    responses = iter(['{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"1"}}\n'])
+
+    class _Pipe:
+        def __init__(self, name):
+            self.name = name
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+            events.append(f"{self.name}.close")
+
+    class _Stdin(_Pipe):
+        def __init__(self):
+            super().__init__("stdin")
+
+        def write(self, _text):
+            return None
+
+        def flush(self):
+            return None
+
+    class _Stdout(_Pipe):
+        def __init__(self):
+            super().__init__("stdout")
+
+        def readline(self, _limit=-1):
+            return next(responses, "")
+
+    class _Process:
+        def __init__(self):
+            self.stdin = _Stdin()
+            self.stdout = _Stdout()
+            self.terminated = False
+            self.killed = False
+            self.wait_calls = 0
+
+        def poll(self):
+            return None
+
+        def terminate(self):
+            self.terminated = True
+            events.append("terminate")
+
+        def wait(self, timeout=None):
+            self.wait_calls += 1
+            events.append("wait")
+            return 0
+
+        def kill(self):
+            self.killed = True
+            events.append("kill")
+
+    process = _Process()
+    monkeypatch.setattr(module.subprocess, "Popen", lambda *_args, **_kwargs: process)
+
+    rc = module._run_stdio_jsonrpc_sequence({
+        "id": "acp_initialize_probe",
+        "cwd": ".",
+        "argv": ["opencode", "acp"],
+        "stdin_jsonl": [
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+        ],
+        "timeout_seconds": 10,
+    }, module.ROOT)
+
+    assert rc == 0
+    assert events.index("stdin.close") < events.index("wait")
+    assert "terminate" not in events
+    assert "kill" not in events
+    assert process.terminated is False
+    assert process.killed is False

--- a/tldw_Server_API/tests/Helper_Scripts/test_acp_certification_smoke.py
+++ b/tldw_Server_API/tests/Helper_Scripts/test_acp_certification_smoke.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import time
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
@@ -429,3 +430,206 @@ def test_stdio_sequence_runner_ignores_notification_before_initialize_success(mo
         "session/new",
         "session/prompt",
     ]
+
+
+def test_stdio_sequence_runner_times_out_on_partial_line_and_cleans_up(monkeypatch) -> None:
+    module = _load_module()
+    written = []
+
+    class _Pipe:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    class _Stdin(_Pipe):
+        def write(self, text):
+            written.append(text)
+
+        def flush(self):
+            return None
+
+    class _Stdout(_Pipe):
+        def readline(self):
+            time.sleep(0.2)
+            return '{"jsonrpc":"2.0","id":1'
+
+    class _Process:
+        def __init__(self):
+            self.stdin = _Stdin()
+            self.stdout = _Stdout()
+            self.killed = False
+            self.wait_calls = 0
+
+        def poll(self):
+            return None
+
+        def terminate(self):
+            return None
+
+        def wait(self, timeout=None):
+            self.wait_calls += 1
+            return 1
+
+        def kill(self):
+            self.killed = True
+
+    process = _Process()
+    monkeypatch.setattr(module.subprocess, "Popen", lambda *_args, **_kwargs: process)
+
+    started = time.monotonic()
+    rc = module._run_stdio_jsonrpc_sequence({
+        "id": "acp_initialize_probe",
+        "cwd": ".",
+        "argv": ["opencode", "acp"],
+        "stdin_jsonl": [
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+            {"jsonrpc": "2.0", "id": 2, "method": "session/new", "params": {}},
+        ],
+        "timeout_seconds": 0.01,
+    }, module.ROOT)
+    elapsed = time.monotonic() - started
+
+    assert rc == 124
+    assert elapsed < 0.15
+    assert process.killed is True
+    assert process.wait_calls >= 1
+    assert process.stdin.closed is True
+    assert process.stdout.closed is True
+    assert len(written) == 1
+
+
+def test_stdio_sequence_runner_sanitizes_error_output_and_cleans_up(
+    monkeypatch,
+    capsys,
+) -> None:
+    module = _load_module()
+
+    class _Pipe:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    class _Stdin(_Pipe):
+        def write(self, _text):
+            return None
+
+        def flush(self):
+            return None
+
+    class _Stdout(_Pipe):
+        def readline(self):
+            return (
+                '{"jsonrpc":"2.0","id":1,'
+                '"error":{"code":-32000,"message":"bad secret-token-value",'
+                '"data":{"token":"SECRET_DATA_SHOULD_NOT_PRINT"}}}\n'
+            )
+
+    class _Process:
+        def __init__(self):
+            self.stdin = _Stdin()
+            self.stdout = _Stdout()
+            self.killed = False
+            self.wait_calls = 0
+
+        def poll(self):
+            return None
+
+        def terminate(self):
+            return None
+
+        def wait(self, timeout=None):
+            self.wait_calls += 1
+            return 1
+
+        def kill(self):
+            self.killed = True
+
+    process = _Process()
+    monkeypatch.setattr(module.subprocess, "Popen", lambda *_args, **_kwargs: process)
+
+    rc = module._run_stdio_jsonrpc_sequence({
+        "id": "acp_initialize_probe",
+        "cwd": ".",
+        "argv": ["opencode", "acp"],
+        "stdin_jsonl": [
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+            {"jsonrpc": "2.0", "id": 2, "method": "session/new", "params": {}},
+        ],
+        "timeout_seconds": 10,
+    }, module.ROOT)
+    captured = capsys.readouterr()
+
+    assert rc != 0
+    assert process.killed is True
+    assert process.wait_calls >= 1
+    assert process.stdin.closed is True
+    assert process.stdout.closed is True
+    assert "code" in captured.err
+    assert "bad secret-token-value" in captured.err
+    assert "SECRET_DATA_SHOULD_NOT_PRINT" not in captured.err
+    assert "data" not in captured.err
+
+
+def test_stdio_sequence_runner_cleans_up_after_broken_pipe(monkeypatch) -> None:
+    module = _load_module()
+
+    class _Pipe:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    class _Stdin(_Pipe):
+        def write(self, _text):
+            raise BrokenPipeError("closed")
+
+        def flush(self):
+            return None
+
+    class _Stdout(_Pipe):
+        def readline(self):
+            return ""
+
+    class _Process:
+        def __init__(self):
+            self.stdin = _Stdin()
+            self.stdout = _Stdout()
+            self.killed = False
+            self.wait_calls = 0
+
+        def poll(self):
+            return None
+
+        def terminate(self):
+            return None
+
+        def wait(self, timeout=None):
+            self.wait_calls += 1
+            return 1
+
+        def kill(self):
+            self.killed = True
+
+    process = _Process()
+    monkeypatch.setattr(module.subprocess, "Popen", lambda *_args, **_kwargs: process)
+
+    rc = module._run_stdio_jsonrpc_sequence({
+        "id": "acp_initialize_probe",
+        "cwd": ".",
+        "argv": ["opencode", "acp"],
+        "stdin_jsonl": [
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+        ],
+        "timeout_seconds": 10,
+    }, module.ROOT)
+
+    assert rc != 0
+    assert process.killed is True
+    assert process.wait_calls >= 1
+    assert process.stdin.closed is True
+    assert process.stdout.closed is True

--- a/tldw_Server_API/tests/Helper_Scripts/test_acp_certification_smoke.py
+++ b/tldw_Server_API/tests/Helper_Scripts/test_acp_certification_smoke.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
-import time
+import threading
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
@@ -194,6 +194,8 @@ def test_profile_manifest_renders_native_acp_entrypoint(monkeypatch) -> None:
     )
 
     assert manifest["profile"] == "opencode"
+    assert manifest["requires_live_agent"] is True
+    assert manifest["required_environment"] == []
     assert manifest["entrypoint"]["entrypoint_strategy"] == "native_acp"
     initialize = next(command for command in manifest["commands"] if command["id"] == "acp_initialize_probe")
     assert initialize["argv"] == ["opencode", "acp"]
@@ -224,6 +226,7 @@ def test_profile_manifest_refuses_documented_candidate() -> None:
     )
 
     assert manifest["requires_live_agent"] is True
+    assert manifest["required_environment"] == []
     assert manifest["commands"] == []
     assert "adapter_required" in manifest["blockers"]
 
@@ -248,6 +251,7 @@ def test_profile_manifest_refuses_blocked_entrypoint() -> None:
 
     assert manifest["profile"] == "claude-code"
     assert manifest["requires_live_agent"] is True
+    assert manifest["required_environment"] == []
     assert manifest["commands"] == []
     assert manifest["blockers"] == ["adapter_missing"]
     assert manifest["entrypoint"]["entrypoint_strategy"] == "adapter_acp"
@@ -583,8 +587,16 @@ def test_stdio_sequence_runner_times_out_on_partial_line_and_cleans_up(monkeypat
             return None
 
     class _Stdout(_Pipe):
-        def readline(self):
-            time.sleep(0.2)
+        def __init__(self):
+            super().__init__()
+            self.closed_event = threading.Event()
+
+        def close(self):
+            super().close()
+            self.closed_event.set()
+
+        def readline(self, _limit=-1):
+            self.closed_event.wait()
             return '{"jsonrpc":"2.0","id":1'
 
     class _Process:
@@ -610,7 +622,6 @@ def test_stdio_sequence_runner_times_out_on_partial_line_and_cleans_up(monkeypat
     process = _Process()
     monkeypatch.setattr(module.subprocess, "Popen", lambda *_args, **_kwargs: process)
 
-    started = time.monotonic()
     rc = module._run_stdio_jsonrpc_sequence({
         "id": "acp_initialize_probe",
         "cwd": ".",
@@ -621,10 +632,8 @@ def test_stdio_sequence_runner_times_out_on_partial_line_and_cleans_up(monkeypat
         ],
         "timeout_seconds": 0.01,
     }, module.ROOT)
-    elapsed = time.monotonic() - started
 
     assert rc == 124
-    assert elapsed < 0.35
     assert process.killed is True
     assert process.wait_calls >= 1
     assert process.stdin.closed is True
@@ -1106,3 +1115,65 @@ def test_stdio_sequence_runner_success_closes_stdin_before_terminating(monkeypat
     assert "kill" not in events
     assert process.terminated is False
     assert process.killed is False
+
+
+def test_stdio_sequence_runner_returns_child_nonzero_exit_after_success(monkeypatch, capsys) -> None:
+    module = _load_module()
+    responses = iter(['{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"1"}}\n'])
+
+    class _Pipe:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    class _Stdin(_Pipe):
+        def write(self, _text):
+            return None
+
+        def flush(self):
+            return None
+
+    class _Stdout(_Pipe):
+        def readline(self, _limit=-1):
+            return next(responses, "")
+
+    class _Process:
+        def __init__(self):
+            self.stdin = _Stdin()
+            self.stdout = _Stdout()
+            self.wait_calls = 0
+
+        def poll(self):
+            return 7
+
+        def terminate(self):
+            return None
+
+        def wait(self, timeout=None):
+            self.wait_calls += 1
+            return 7
+
+        def kill(self):
+            return None
+
+    process = _Process()
+    monkeypatch.setattr(module.subprocess, "Popen", lambda *_args, **_kwargs: process)
+
+    rc = module._run_stdio_jsonrpc_sequence({
+        "id": "acp_initialize_probe",
+        "cwd": ".",
+        "argv": ["opencode", "acp"],
+        "stdin_jsonl": [
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+        ],
+        "timeout_seconds": 10,
+    }, module.ROOT)
+
+    captured = capsys.readouterr()
+    assert rc == 7
+    assert "subprocess exited with status 7" in captured.err
+    assert process.wait_calls >= 1
+    assert process.stdin.closed is True
+    assert process.stdout.closed is True

--- a/tldw_Server_API/tests/Helper_Scripts/test_acp_certification_smoke.py
+++ b/tldw_Server_API/tests/Helper_Scripts/test_acp_certification_smoke.py
@@ -172,3 +172,143 @@ def test_run_manifest_skips_optional_missing_executable(
 
     assert rc == 0
     assert "SKIP optional_missing_browser" in captured.out
+
+
+def test_profile_manifest_renders_native_acp_entrypoint(monkeypatch) -> None:
+    module = _load_module()
+
+    manifest = module.build_agent_profile_manifest(
+        {
+            "type": "opencode",
+            "name": "OpenCode",
+            "entrypoint_strategy": "native_acp",
+            "acp_command": "opencode",
+            "acp_args": ["acp"],
+            "probe_state": "ready_to_probe",
+            "primary_blocker": None,
+            "blockers": [],
+            "status_message": "Ready to probe native ACP entrypoint.",
+            "docs_url": "/docs-static/Development/ACP_Compatibility_Matrix.md",
+        }
+    )
+
+    assert manifest["profile"] == "opencode"
+    assert manifest["entrypoint"]["entrypoint_strategy"] == "native_acp"
+    initialize = next(command for command in manifest["commands"] if command["id"] == "acp_initialize_probe")
+    assert initialize["argv"] == ["opencode", "acp"]
+    assert initialize["safe_to_run_by_default"] is False
+    assert [frame["method"] for frame in initialize["stdin_jsonl"]] == [
+        "initialize",
+        "session/new",
+        "session/prompt",
+    ]
+
+
+def test_profile_manifest_refuses_documented_candidate() -> None:
+    module = _load_module()
+
+    manifest = module.build_agent_profile_manifest(
+        {
+            "type": "codex",
+            "name": "Codex",
+            "entrypoint_strategy": "documented_candidate",
+            "acp_command": "",
+            "acp_args": [],
+            "probe_state": "documented_only",
+            "primary_blocker": "adapter_required",
+            "blockers": ["adapter_required"],
+            "status_message": "Codex requires an ACP adapter.",
+            "docs_url": "/docs-static/Development/ACP_Compatibility_Matrix.md",
+        }
+    )
+
+    assert manifest["requires_live_agent"] is True
+    assert manifest["commands"] == []
+    assert "adapter_required" in manifest["blockers"]
+
+
+def test_run_profile_manifest_uses_stdio_sequence_runner(monkeypatch) -> None:
+    module = _load_module()
+    sequences = []
+
+    monkeypatch.setenv("TLDW_E2E_SERVER_URL", "http://127.0.0.1:8000")
+    monkeypatch.setenv("TLDW_E2E_API_KEY", "test")
+    monkeypatch.setenv("ACP_AGENT_PROFILE", "opencode")
+    monkeypatch.setattr(module, "_missing_executable_reason", lambda *_args: None)
+    monkeypatch.setattr(
+        module,
+        "_run_stdio_jsonrpc_sequence",
+        lambda command, cwd: sequences.append((command, cwd)) or 0,
+    )
+
+    rc = module.run_manifest_dict({
+        "profile": "opencode",
+        "requires_live_agent": True,
+        "required_environment": ["TLDW_E2E_SERVER_URL", "TLDW_E2E_API_KEY", "ACP_AGENT_PROFILE"],
+        "commands": [{
+            "id": "acp_initialize_probe",
+            "cwd": ".",
+            "argv": ["opencode", "acp"],
+            "safe_to_run_by_default": False,
+            "stdin_jsonl": [
+                {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+                {"jsonrpc": "2.0", "id": 2, "method": "session/new", "params": {}},
+                {"jsonrpc": "2.0", "id": 3, "method": "session/prompt", "params": {"prompt": "Reply ok."}},
+            ],
+            "timeout_seconds": 10,
+        }],
+    })
+
+    assert rc == 0
+    assert sequences
+    command, _cwd = sequences[0]
+    assert [frame["method"] for frame in command["stdin_jsonl"]] == [
+        "initialize",
+        "session/new",
+        "session/prompt",
+    ]
+    assert command["timeout_seconds"] == 10
+
+
+def test_stdio_sequence_runner_stops_after_failed_initialize(monkeypatch) -> None:
+    module = _load_module()
+    written = []
+
+    class _Stdin:
+        def write(self, text):
+            written.append(text)
+
+        def flush(self):
+            return None
+
+    class _Stdout:
+        def readline(self):
+            return '{"jsonrpc":"2.0","id":1,"error":{"message":"init failed"}}\n'
+
+    class _Process:
+        stdin = _Stdin()
+        stdout = _Stdout()
+
+        def wait(self, timeout=None):
+            return 1
+
+        def kill(self):
+            return None
+
+    monkeypatch.setattr(module.subprocess, "Popen", lambda *_args, **_kwargs: _Process())
+
+    rc = module._run_stdio_jsonrpc_sequence({
+        "id": "acp_initialize_probe",
+        "cwd": ".",
+        "argv": ["opencode", "acp"],
+        "stdin_jsonl": [
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+            {"jsonrpc": "2.0", "id": 2, "method": "session/new", "params": {}},
+            {"jsonrpc": "2.0", "id": 3, "method": "session/prompt", "params": {}},
+        ],
+        "timeout_seconds": 10,
+    }, module.ROOT)
+
+    assert rc != 0
+    assert len(written) == 1
+    assert '"method": "initialize"' in written[0]

--- a/tldw_Server_API/tests/Helper_Scripts/test_acp_certification_smoke.py
+++ b/tldw_Server_API/tests/Helper_Scripts/test_acp_certification_smoke.py
@@ -268,18 +268,22 @@ def test_profile_manifest_refuses_custom_template() -> None:
             "probe_state": "custom_template",
             "primary_blocker": None,
             "blockers": [],
-            "status_message": "Custom agent templates require operator-supplied ACP entrypoint metadata.",
+            "status_message": (
+                "Create a named custom ACP profile with command, args, env, "
+                "workspace policy, and evidence bundle."
+            ),
             "docs_url": "/docs-static/Development/ACP_Compatibility_Matrix.md",
         }
     )
 
     assert manifest["profile"] == "custom"
     assert manifest["commands"] == []
-    assert manifest["blockers"] == []
+    assert manifest["blockers"] == ["custom_template"]
+    assert manifest["entrypoint"]["primary_blocker"] == "custom_template"
     assert manifest["entrypoint"]["entrypoint_strategy"] == "custom_template"
     assert manifest["entrypoint"]["probe_state"] == "custom_template"
     assert manifest["entrypoint"]["acp_command"] == ""
-    assert "operator-supplied ACP entrypoint metadata" in manifest["notes"][0]
+    assert "command, args, env, workspace policy, and evidence bundle" in manifest["notes"][0]
 
 
 def test_render_manifest_dict_prints_stdin_jsonl_and_blockers() -> None:

--- a/tldw_Server_API/tests/Helper_Scripts/test_acp_certification_smoke.py
+++ b/tldw_Server_API/tests/Helper_Scripts/test_acp_certification_smoke.py
@@ -228,6 +228,134 @@ def test_profile_manifest_refuses_documented_candidate() -> None:
     assert "adapter_required" in manifest["blockers"]
 
 
+def test_profile_manifest_refuses_blocked_entrypoint() -> None:
+    module = _load_module()
+
+    manifest = module.build_agent_profile_manifest(
+        {
+            "type": "claude-code",
+            "name": "Claude Code",
+            "entrypoint_strategy": "adapter_acp",
+            "acp_command": "tldw-acp-claude",
+            "acp_args": ["--stdio"],
+            "probe_state": "blocked",
+            "primary_blocker": "adapter_missing",
+            "blockers": [],
+            "status_message": "Configured ACP adapter command is not available on PATH.",
+            "docs_url": "/docs-static/Development/ACP_Compatibility_Matrix.md",
+        }
+    )
+
+    assert manifest["profile"] == "claude-code"
+    assert manifest["requires_live_agent"] is True
+    assert manifest["commands"] == []
+    assert manifest["blockers"] == ["adapter_missing"]
+    assert manifest["entrypoint"]["entrypoint_strategy"] == "adapter_acp"
+    assert manifest["entrypoint"]["probe_state"] == "blocked"
+    assert manifest["entrypoint"]["acp_command"] == "tldw-acp-claude"
+
+
+def test_profile_manifest_refuses_custom_template() -> None:
+    module = _load_module()
+
+    manifest = module.build_agent_profile_manifest(
+        {
+            "type": "custom",
+            "name": "Custom",
+            "entrypoint_strategy": "custom_template",
+            "acp_command": "",
+            "acp_args": [],
+            "probe_state": "custom_template",
+            "primary_blocker": None,
+            "blockers": [],
+            "status_message": "Custom agent templates require operator-supplied ACP entrypoint metadata.",
+            "docs_url": "/docs-static/Development/ACP_Compatibility_Matrix.md",
+        }
+    )
+
+    assert manifest["profile"] == "custom"
+    assert manifest["commands"] == []
+    assert manifest["blockers"] == []
+    assert manifest["entrypoint"]["entrypoint_strategy"] == "custom_template"
+    assert manifest["entrypoint"]["probe_state"] == "custom_template"
+    assert manifest["entrypoint"]["acp_command"] == ""
+    assert "operator-supplied ACP entrypoint metadata" in manifest["notes"][0]
+
+
+def test_render_manifest_dict_prints_stdin_jsonl_and_blockers() -> None:
+    module = _load_module()
+    manifest = module.build_agent_profile_manifest(
+        {
+            "type": "opencode",
+            "name": "OpenCode",
+            "entrypoint_strategy": "native_acp",
+            "acp_command": "opencode",
+            "acp_args": ["acp"],
+            "probe_state": "ready_to_probe",
+            "primary_blocker": "manual_review_required",
+            "blockers": [],
+            "status_message": "Ready to probe native ACP entrypoint.",
+            "docs_url": "/docs-static/Development/ACP_Compatibility_Matrix.md",
+        }
+    )
+
+    rendered = module.render_manifest_dict(manifest)
+
+    assert "- blockers: `manual_review_required`" in rendered
+    assert "## Blockers" in rendered
+    assert "- manual_review_required" in rendered
+    assert "stdin_jsonl:" in rendered
+    assert "```jsonl" in rendered
+    assert '"method": "initialize"' in rendered
+    assert '"method": "session/new"' in rendered
+    assert '"method": "session/prompt"' in rendered
+
+
+def test_agent_profile_cli_uses_registry_classification_path(monkeypatch, capsys) -> None:
+    module = _load_module()
+    from tldw_Server_API.app.core.Agent_Client_Protocol import agent_registry
+
+    calls = []
+    entry = SimpleNamespace(type="opencode", name="OpenCode")
+
+    class _Registry:
+        def get_entry(self, profile):
+            calls.append(("get_entry", profile))
+            return entry
+
+    class _Classification:
+        def as_dict(self):
+            calls.append(("as_dict",))
+            return {
+                "entrypoint_strategy": "native_acp",
+                "acp_command": "opencode",
+                "acp_args": ["acp"],
+                "probe_state": "ready_to_probe",
+                "primary_blocker": None,
+                "blockers": [],
+                "status_message": "Configured ACP entrypoint is ready for a bounded initialize probe.",
+                "docs_url": "/docs-static/Development/ACP_Compatibility_Matrix.md",
+            }
+
+    def _classify_agent_entrypoint(received_entry):
+        calls.append(("classify", received_entry.type))
+        return _Classification()
+
+    monkeypatch.setattr(agent_registry, "get_agent_registry", lambda: _Registry())
+    monkeypatch.setattr(agent_registry, "classify_agent_entrypoint", _classify_agent_entrypoint)
+
+    rc = module.main(["--agent-profile", "opencode", "--format", "json"])
+    captured = capsys.readouterr()
+    manifest = json.loads(captured.out)
+
+    assert rc == 0
+    assert calls == [("get_entry", "opencode"), ("classify", "opencode"), ("as_dict",)]
+    assert manifest["profile"] == "opencode"
+    assert manifest["name"] == "OpenCode"
+    assert manifest["entrypoint"]["entrypoint_strategy"] == "native_acp"
+    assert manifest["commands"][0]["argv"] == ["opencode", "acp"]
+
+
 def test_run_profile_manifest_uses_stdio_sequence_runner(monkeypatch) -> None:
     module = _load_module()
     sequences = []

--- a/tldw_Server_API/tests/Helper_Scripts/test_acp_certification_smoke.py
+++ b/tldw_Server_API/tests/Helper_Scripts/test_acp_certification_smoke.py
@@ -312,3 +312,120 @@ def test_stdio_sequence_runner_stops_after_failed_initialize(monkeypatch) -> Non
     assert rc != 0
     assert len(written) == 1
     assert '"method": "initialize"' in written[0]
+
+
+def test_stdio_sequence_runner_ignores_notification_before_initialize_error(monkeypatch) -> None:
+    module = _load_module()
+    written = []
+    responses = iter(
+        [
+            '{"jsonrpc":"2.0","method":"log/message","params":{"message":"starting"}}\n',
+            '{"jsonrpc":"2.0","id":99,"result":{"ignored":true}}\n',
+            '{"jsonrpc":"2.0","id":1,"error":{"message":"init failed"}}\n',
+        ]
+    )
+
+    class _Stdin:
+        def write(self, text):
+            written.append(text)
+
+        def flush(self):
+            return None
+
+    class _Stdout:
+        def readline(self):
+            return next(responses, "")
+
+    class _Process:
+        stdin = _Stdin()
+        stdout = _Stdout()
+
+        def wait(self, timeout=None):
+            return 1
+
+        def kill(self):
+            return None
+
+    monkeypatch.setattr(module.subprocess, "Popen", lambda *_args, **_kwargs: _Process())
+
+    rc = module._run_stdio_jsonrpc_sequence({
+        "id": "acp_initialize_probe",
+        "cwd": ".",
+        "argv": ["opencode", "acp"],
+        "stdin_jsonl": [
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+            {"jsonrpc": "2.0", "id": 2, "method": "session/new", "params": {}},
+            {"jsonrpc": "2.0", "id": 3, "method": "session/prompt", "params": {}},
+        ],
+        "timeout_seconds": 10,
+    }, module.ROOT)
+
+    assert rc != 0
+    assert len(written) == 1
+    assert '"method": "initialize"' in written[0]
+    assert '"method": "session/new"' not in "".join(written)
+
+
+def test_stdio_sequence_runner_ignores_notification_before_initialize_success(monkeypatch) -> None:
+    module = _load_module()
+    written = []
+    responses = iter(
+        [
+            '{"jsonrpc":"2.0","method":"log/message","params":{"message":"starting"}}\n',
+            '{"jsonrpc":"2.0","id":99,"result":{"ignored":true}}\n',
+            '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"1"}}\n',
+            '{"jsonrpc":"2.0","id":2,"result":{"sessionId":"session-1"}}\n',
+            '{"jsonrpc":"2.0","id":3,"result":{"content":[]}}\n',
+        ]
+    )
+
+    class _Stdin:
+        def write(self, text):
+            written.append(text)
+
+        def flush(self):
+            return None
+
+        def close(self):
+            return None
+
+    class _Stdout:
+        def readline(self):
+            return next(responses, "")
+
+    class _Process:
+        stdin = _Stdin()
+        stdout = _Stdout()
+
+        def poll(self):
+            return None
+
+        def terminate(self):
+            return None
+
+        def wait(self, timeout=None):
+            return 0
+
+        def kill(self):
+            return None
+
+    monkeypatch.setattr(module.subprocess, "Popen", lambda *_args, **_kwargs: _Process())
+
+    rc = module._run_stdio_jsonrpc_sequence({
+        "id": "acp_initialize_probe",
+        "cwd": ".",
+        "argv": ["opencode", "acp"],
+        "stdin_jsonl": [
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+            {"jsonrpc": "2.0", "id": 2, "method": "session/new", "params": {}},
+            {"jsonrpc": "2.0", "id": 3, "method": "session/prompt", "params": {}},
+        ],
+        "timeout_seconds": 10,
+    }, module.ROOT)
+
+    assert rc == 0
+    assert [json.loads(frame)["method"] for frame in written] == [
+        "initialize",
+        "session/new",
+        "session/prompt",
+    ]


### PR DESCRIPTION
## Summary
- Adds explicit ACP entrypoint strategy metadata across the registry, YAML seeds, dynamic registration persistence, and API schemas.
- Adds deterministic entrypoint readiness classification plus profile-specific certification manifests for dry-run and env-gated live probes.
- Exposes entrypoint readiness metadata in ACP agents, health, and setup-guide surfaces without turning compatibility metadata into live support claims.

## Scope Notes
- Codex and Claude remain `documented_candidate` profiles until concrete ACP adapter commands are selected and certified.
- This adds dry-run/live-gated profile manifests but does not install adapters, certify downstream agents, or close live certification work.
- #1563 and #1564 should stay open for live certification/evidence unless replaced by narrower per-agent certification issues.

## Test Plan
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/test_registry_entrypoint_strategy.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sessions_db.py tldw_Server_API/tests/Agent_Client_Protocol/test_registry_mcp_fields.py tldw_Server_API/tests/Helper_Scripts/test_acp_certification_smoke.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_health.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_endpoints.py -q` -> 145 passed, 5 warnings
- [x] `git diff --check`
- [x] `rg -n "entrypoint_strategy|adapter_required|adapter_missing|shell_builtin_collision" tldw_Server_API/Config_Files/agents.yaml Docs/Development/ACP_Compatibility_Matrix.md Docs/superpowers/specs/2026-05-12-acp-downstream-entrypoint-strategy-design.md`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py tldw_Server_API/app/core/DB_Management/ACP_Sessions_DB.py tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py Helper_Scripts/Testing-related/acp_certification_smoke.py -f json -o /tmp/bandit_acp_entrypoint_strategy.json` -> no new findings; only existing ACP_Sessions_DB baseline warnings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds explicit ACP entrypoint strategy metadata with deterministic readiness classification, and surfaces it in registry, API, health, and setup-guide without implying live support. Also hardens stdio probes, expands the certification helper, and fixes null `acp_command` handling; addresses TASK-286, TASK-287, and TASK-299 while GitHub #1563/#1564 remain open for live certification.

- **New Features**
  - Registry/YAML: add `entrypoint_strategy` (`native_acp` | `adapter_acp` | `documented_candidate` | `custom_template`), `acp_command`, `acp_args`, optional adapter docs/source, and `certification_blocker`.
  - Deterministic classifier maps profiles to probe state (`ready_to_probe`, `blocked`, `documented_only`, `custom_template`) with blockers like `adapter_required`, `adapter_missing`, `binary_missing`, `acp_initialize_failed`, `shell_builtin_collision`.
  - API/health/setup: expose entrypoint readiness on health/setup and dynamic registration; schemas include strategy and command fields with clear status messages.
  - DB: schema v14 persists entrypoint fields and blocker metadata across sessions/registry.
  - Certification helper: adds profile-specific manifests; gates probes on matching ACP responses; bounds stdio IO and truncates error output; improves cleanup; includes custom-template blockers; normalizes docs URLs; adds persistence and timeout coverage.
  - Fix: handle null or empty `acp_command` values safely and classify as `documented_candidate`.

- **Migration**
  - Update `tldw_Server_API/Config_Files/agents.yaml` with `entrypoint_strategy`, `acp_command`, and `acp_args` per profile; `codex` and `claude` remain `documented_candidate`.
  - Allow the service to apply DB schema v14; no adapter installation or live certification included in this PR.

<sup>Written for commit 7beba2b680b7d9d8dec3112c44c562607aa5454b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

