### PR TITLE
Refresh Persona Buddy renderer capability docs

### DIFF
--- a/Docs/Code_Documentation/Persona_Visual_Packs.md
+++ b/Docs/Code_Documentation/Persona_Visual_Packs.md
@@ -45,16 +45,20 @@ duplicate-to-persona, import/export, and shared-library workflows without
 changing the core pack format.
 
 V1 validation and Buddy runtime support are intentionally limited to
-`sprite_frames`. Reserved renderer labels in API/UI types are not support
-claims until backend manifest validation, import preview, Buddy runtime
-rendering, and capability reporting all agree on the new renderer contract.
+`sprite_frames`. PR #1608 added the renderer capability contract and authenticated
+`GET /api/v1/persona/visual-renderers` endpoint, with `sprite_frames` as the only
+enabled V1 activatable and Buddy-runtime renderer. Reserved renderer labels in
+API/UI types are still not support claims until backend manifest validation,
+import preview, Buddy runtime rendering, and capability reporting all agree on
+that renderer.
 
 Future renderer/provider adapter work is evaluated in
 `Docs/Design/2026-05-10-persona-visual-renderer-provider-adapter-evaluation.md`.
 That evaluation keeps Live2D, Rive, Lottie, Spine, and external MCP-compatible
-pack providers separate from the current V1 activation path. The recommended
-next step is a renderer capability contract and safe sprite atlas extension
-before any non-sprite adapter implementation.
+pack providers separate from the current V1 activation path. The renderer
+capability contract is now in place; sprite-sheet frame regions are supported
+inside `sprite_frames`, and any future non-sprite adapter should reuse the
+registry instead of adding another hardcoded renderer path.
 
 ## Personal Library
 

--- a/Docs/Design/2026-05-10-persona-visual-renderer-provider-adapter-evaluation.md
+++ b/Docs/Design/2026-05-10-persona-visual-renderer-provider-adapter-evaluation.md
@@ -5,18 +5,26 @@ Tracks GitHub issue #1497 under the Persona/Buddy visual-pack epic #1449.
 ## Decision Summary
 
 Do not implement Live2D or another non-sprite renderer as the next code slice.
-The current Persona/Buddy system should first add a renderer/provider capability
-contract that keeps V1 `sprite_frames` behavior unchanged, then pursue a
-feature-flagged Live2D spike only after licensing, bundle validation, and
-fallback rules are explicit.
+The Persona/Buddy system should keep using the renderer/provider capability
+contract introduced in PR #1608 and keep V1 `sprite_frames` behavior unchanged.
+Only pursue a feature-flagged Live2D spike after licensing, bundle validation,
+and fallback rules are explicit.
+
+Status update as of 2026-05-12: PR #1608 completed the renderer capability
+registry, authenticated capability endpoint, and local Buddy renderer registry.
+`sprite_frames` remains the only enabled V1 activatable and Buddy-runtime
+renderer. Sprite-sheet frame regions already work inside `sprite_frames`; future
+renderer work should reuse the registry and stay behind explicit validation,
+dependency, licensing, and fallback gates.
 
 Recommended sequencing:
 
 1. Keep `sprite_frames` as the only activatable runtime renderer for V1.
-2. Add a renderer registry/capabilities contract before accepting new
+2. Use the renderer registry/capabilities contract before accepting new
    `renderer_type` values in manifests or imports.
-3. Add a sprite atlas/sprite-sheet performance extension inside the existing
-   sprite family before adding skeletal/model renderers.
+3. Treat any further sprite atlas/sprite-sheet work as an optimization or
+   authoring improvement inside the existing sprite family before adding
+   skeletal/model renderers.
 4. Run a Live2D adapter spike behind a feature flag, using local bundled assets
    only and preserving review-before-activation.
 5. Treat external providers as draft-pack or generated-candidate producers, not
@@ -29,11 +37,12 @@ explicit.
 
 ## Current Persona/Buddy Contract
 
-The implementation is already renderer-named but not renderer-pluggable:
+The implementation is registry-backed but intentionally exposes only the
+sprite/frame renderer:
 
 1. `tldw_Server_API/app/core/Persona/visuals.py` defines the supported visual
-   states, validates manifest version `1`, and only accepts
-   `renderer_type == "sprite_frames"` for activatable manifests.
+   states, validates manifest version `1`, and consults the renderer capability
+   registry before activation/import-preview validation.
 2. `tldw_Server_API/app/core/Persona/visual_service.py` validates uploads as
    raster images, validates manifests during activation and candidate accept,
    and creates duplicated packs as inactive drafts.
@@ -44,9 +53,12 @@ The implementation is already renderer-named but not renderer-pluggable:
    renders state-resolved frame sequences or sprite-sheet regions and falls
    back to text when an animation, asset, or region is invalid.
 5. `apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellDock.tsx`
-   gates runtime rendering on `visualPack.renderer_type === "sprite_frames"`.
+   renders through the local Buddy renderer registry and falls back cleanly when
+   a pack uses an unsupported renderer.
 6. `apps/packages/ui/src/components/Common/PersonaBuddy/personaVisualState.ts`
    resolves named Persona visual states independently of renderer format.
+7. `GET /api/v1/persona/visual-renderers` reports the server-supported renderer
+   capabilities to authenticated clients.
 
 The TypeScript and Pydantic renderer unions already include reserved labels such
 as `static_image`, `sprite_sheet`, and `live2d`, but those are not support
@@ -365,11 +377,13 @@ All renderer/provider follow-ups should enforce:
 ## Follow-Up Issue Slices
 
 1. Renderer capability registry for Persona Visual Packs:
-   define backend/frontend/MCP capability reporting while preserving
-   `sprite_frames` as the only activatable renderer.
+   completed by PR #1608 for backend capability reporting, Persona API
+   exposure, and local Buddy renderer selection while preserving `sprite_frames`
+   as the only activatable renderer.
 2. Sprite atlas/sprite-sheet V1.1:
-   formalize atlas validation and Buddy rendering as a safe performance
-   extension.
+   keep any remaining work focused on optimization, authoring ergonomics, and
+   import/export clarity inside `sprite_frames`; region validation and Buddy
+   rendering already exist.
 3. Non-sprite manifest V2 design:
    define renderer-specific asset roles, fallback requirements, and import
    preview validation hooks.

--- a/Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md
+++ b/Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md
@@ -6,7 +6,7 @@ Feature: User-owned animated 2D visual packs for Persona Buddy and Persona Live
 Location: WebUI Persona Garden and shared Persona Buddy shell
 Status: Draft product record
 Owner: Product / WebUI / Persona
-Last Updated: 2026-05-10
+Last Updated: 2026-05-12
 
 ---
 
@@ -43,9 +43,11 @@ The implementation now covers the core data model, renderer, API, editor, Jobs
 flow, MCP module, E2E runtime behavior, Buddy entry point, diagnostics, setup
 states, ownership/help copy, duplicate-to-persona drafts, and a reference-backed
 personal pack library, import conflict choices, and reusable Persona Garden
-affordances. The remaining product gap is optional Phase 3 externalization:
-external visual providers, shared/cross-device libraries, and future renderer
-adapters.
+affordances. PR #1608 also added the renderer capability contract and Buddy
+renderer registry while keeping `sprite_frames` as the only enabled V1 runtime
+renderer. The remaining product gap is optional Phase 3 externalization:
+external visual providers, shared/cross-device libraries, non-sprite manifest
+design, and future renderer adapters.
 
 ---
 
@@ -85,7 +87,7 @@ adapters.
 
 ## 5. Current Implementation Snapshot
 
-As of 2026-05-10:
+As of 2026-05-12:
 
 1. The durable implementation from PR #1393 is merged into `dev`.
 2. The closeout documentation and E2E verification from PR #1400 is merged into
@@ -95,6 +97,8 @@ As of 2026-05-10:
 4. PR #1447 is merged and closes the ordered Product Hardening tracker from
    #1428: reliability diagnostics (#1430), generation/setup UX (#1431), and
    ownership/help copy (#1429).
+5. PR #1608 is merged and adds the Persona visual renderer capability registry,
+   authenticated renderer capability API, and local Buddy renderer registry.
 
 Implemented foundations include:
 
@@ -141,6 +145,11 @@ Implemented foundations include:
     draft, personal library, import archive preview, and duplicate-to-persona
     actions into the existing controls while preserving draft/review-before-
     activation semantics.
+19. Renderer capability reporting through
+    `GET /api/v1/persona/visual-renderers`, with only `sprite_frames` enabled
+    for V1 validation, activation, import/export, and Buddy runtime rendering.
+20. Buddy rendering and diagnostics route through the local renderer registry
+    instead of separate hardcoded renderer checks.
 
 ---
 
@@ -432,6 +441,7 @@ Current persona-scoped API routes include:
 19. `PATCH /api/v1/persona/visual-library/{item_id}`
 20. `DELETE /api/v1/persona/visual-library/{item_id}`
 21. `POST /api/v1/persona/visual-library/{item_id}/use`
+22. `GET /api/v1/persona/visual-renderers`
 
 ---
 
@@ -572,8 +582,11 @@ baseline. The first reference-backed V1 slices are now covered:
 7. External MCP-compatible visual providers remain future work.
 8. Renderer/provider adapter evaluation for Live2D and other future paths is
    tracked by #1497 and the 2026-05-10 design evaluation.
-9. Live2D or other renderer adapter implementation remains future work after the
-   sprite/frame path and renderer capability contract are stable.
+9. Renderer capability registry/API and Buddy renderer registry are complete in
+   PR #1608, with `sprite_frames` still the only enabled V1 runtime renderer.
+10. Live2D or other renderer adapter implementation remains future work after
+    non-sprite manifest V2, import-preview validation hooks, dependency gates,
+    licensing review, and fallback requirements are separately scoped.
 
 ---
 
@@ -591,7 +604,9 @@ baseline. The first reference-backed V1 slices are now covered:
      loading.
 
 4. Risk: Future renderer types force a schema rewrite.
-   - Mitigation: Keep manifest versioned and renderer typed.
+   - Mitigation: Keep manifests versioned and route renderer support through
+     the capability registry before activation/import/runtime support is
+     exposed.
 
 5. Risk: Cross-persona asset leakage.
    - Mitigation: Enforce user/persona/pack ownership checks at API, service, and
@@ -677,3 +692,5 @@ E2E:
 15. Issue #1497: Persona visual-pack renderer/provider adapter evaluation.
 16. Renderer/provider adapter evaluation:
     `Docs/Design/2026-05-10-persona-visual-renderer-provider-adapter-evaluation.md`
+17. PR #1608: Persona Buddy renderer capability registry.
+18. Issue #1609: Renderer capability docs and tracker refresh after PR #1608.

--- a/backlog/tasks/task-300 - Refresh-Persona-Buddy-renderer-capability-docs-after-PR-1608.md
+++ b/backlog/tasks/task-300 - Refresh-Persona-Buddy-renderer-capability-docs-after-PR-1608.md
@@ -1,0 +1,65 @@
+---
+id: TASK-300
+title: Refresh Persona Buddy renderer capability docs after PR 1608
+status: Done
+assignee: []
+created_date: '2026-05-12 14:25'
+updated_date: '2026-05-12 14:35'
+labels:
+  - persona
+  - buddy
+  - visual-packs
+  - docs
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1609'
+  - 'https://github.com/rmusser01/tldw_server/pull/1608'
+documentation:
+  - Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md
+  - Docs/Code_Documentation/Persona_Visual_Packs.md
+  - >-
+    Docs/Design/2026-05-10-persona-visual-renderer-provider-adapter-evaluation.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Refresh Persona/Buddy visual-pack product and code documentation after PR #1608 added the renderer capability registry and Buddy renderer registry. Keep the change documentation-only: no runtime behavior, renderer adapters, Live2D, VN/CYOA, or new API work.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Docs no longer describe the renderer capability contract itself as a future prerequisite.
+- [x] #2 Docs record that sprite_frames remains the only enabled V1 activatable and Buddy-runtime renderer.
+- [x] #3 Remaining future renderer work is accurately scoped to non-sprite manifest V2, feature-gated Live2D adapter spike, external MCP pack-provider contract, and shared/cross-device library work.
+- [x] #4 Verification confirms documentation references are consistent and no local absolute paths are introduced.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Refresh Persona visual-pack code docs so PR 1608 renderer capability support is current state, not future prerequisite. 2. Refresh the WebUI PRD and renderer/provider adapter evaluation with the new registry/API status while preserving sprite_frames as the only enabled V1 runtime renderer. 3. Run docs-only verification and record applicable skips.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implementation notes: PR 1608 is merged, so documentation was changed from future capability wording to current registry wording. Scope stayed docs-only and records sprite_frames as the only enabled V1 renderer. Verification: git diff --check passed. Stale future-prerequisite wording probe found no matches. Local absolute path probe found no matches. Bandit skipped because the touched scope is documentation and Backlog metadata only.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Refreshed Persona Buddy visual-pack docs after PR 1608 so the renderer capability registry and visual-renderers endpoint are treated as existing foundations, while sprite_frames remains the only enabled V1 runtime renderer. Updated the PRD, code documentation, and renderer provider adapter evaluation to keep future work focused on non-sprite manifest V2, feature-gated Live2D exploration, external MCP providers, and shared library work. Verification: git diff --check passed. Stale wording and local path scans returned no matches. Bandit was not applicable for this docs-only change.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Human Change Summary

Pending human-authored summary before merge per project policy.

## AI Implementation Summary

- Updates Persona Visual Packs docs to treat PR #1608 renderer capability registry and GET /api/v1/persona/visual-renderers endpoint as current state.
- Aligns the PRD and renderer/provider adapter evaluation around sprite_frames as the only enabled V1 Buddy runtime renderer.
- Adds TASK-300 Backlog record and links this docs refresh to the Persona/Buddy tracker.

## Verification

- git diff --check
- stale future-prerequisite wording scan returned no matches
- local absolute path scan returned no matches
- Bandit skipped because the touched scope is docs and Backlog metadata only

Closes #1609

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes Persona Buddy visual-pack docs to reflect the renderer capability registry from PR #1608 and the `GET /api/v1/persona/visual-renderers` API. Clarifies that `sprite_frames` remains the only enabled V1 runtime renderer and adds TASK-300; closes #1609.

<sup>Written for commit acaf3e2e32c279e37493ef4a795aa3431f18a728. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

