### PR TITLE
Add ACP workspace bridge contract

### DIFF
--- a/Docs/Development/Agent_Client_Protocol.md
+++ b/Docs/Development/Agent_Client_Protocol.md
@@ -483,6 +483,12 @@ For product-level workspace membership, ACP execution workspaces attach to the
 canonical workspace model rather than defining a separate product workspace.
 See `../Design/ACP_Workspace_Integration_Decision_2026_05.md` for the bridge
 contract between `/api/v1/workspaces` and `/api/v1/agent-orchestration`.
+Use `POST /api/v1/agent-orchestration/workspaces/canonical-bridge` to find or
+create the ACP execution workspace for a canonical workspace. The request must
+include the canonical workspace ID and an absolute `root_path` under the
+configured ACP workspace allowlist; the response includes a `canonical_workspace`
+bridge object with the canonical ID, source, link status, and ACP execution
+workspace ID.
 
 For the standard runner, per-session env is sent with `session/new`. For sandbox
 mode, per-session env is merged over `[ACP-SANDBOX].agent_env` and passed to the

--- a/backlog/tasks/task-307 - Implement-ACP-workspace-backend-bridge-contract-for-issue-1540.md
+++ b/backlog/tasks/task-307 - Implement-ACP-workspace-backend-bridge-contract-for-issue-1540.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - codex
 created_date: '2026-05-13 00:21'
-updated_date: '2026-05-13 00:44'
+updated_date: '2026-05-13 01:28'
 labels:
   - ACP
   - workspace
@@ -59,12 +59,18 @@ Verification:
 - git diff --check => clean.
 - source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py tldw_Server_API/app/core/DB_Management/Orchestration_DB.py -f json -o /tmp/bandit_task307.json => 0 findings.
 - Ruff focused check after import cleanup still reports pre-existing baseline issues in touched files: B904/F841/UP037/SIM118/F841 unrelated to this bridge slice.
+
+PR review sweep started for PR #1615. Actionable review findings to address: async canonical workspace lookup, atomic bridge binding, canonical link uniqueness, missing return/test type hints, and helper docstrings. Frontend Lint check log shows the job was canceled during bun install while the workflow was still running, not a code lint error from this branch.
+
+PR 1615 review sweep addressed unresolved comments for async canonical DB lookup atomic bridge binding canonical uniqueness direct canonical lookup batched project workspace lookup type hints and helper docstrings. Added relink conflict prevention for existing ACP roots.
+
+Final verification after review fixes: focused Agent Orchestration pytest 86 passed; Ruff touched-file check passed; git diff --check clean; Bandit touched backend scan 0 findings.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented the ACP workspace backend bridge contract for #1540 and opened PR #1615. The slice adds the canonical bridge endpoint, metadata helpers, response exposure for project/task details, documentation, and focused tests for ownership/missing workspace, allowlist failures, duplicate bridge behavior, trusted-root inheritance, cwd containment, and canonical response metadata. Verification: focused Agent Orchestration pytest 80 passed; git diff --check clean; Bandit on touched backend files 0 findings. Known non-blocker: focused Ruff still reports unrelated pre-existing baseline issues in touched files after import cleanup.
+Implemented the ACP workspace backend bridge contract for issue 1540 and addressed PR 1615 review feedback. Verification: focused Agent Orchestration pytest 86 passed; Ruff on touched files passed; git diff --check clean; Bandit on touched backend files 0 findings.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-307 - Implement-ACP-workspace-backend-bridge-contract-for-issue-1540.md
+++ b/backlog/tasks/task-307 - Implement-ACP-workspace-backend-bridge-contract-for-issue-1540.md
@@ -1,0 +1,78 @@
+---
+id: TASK-307
+title: Implement ACP workspace backend bridge contract for issue 1540
+status: Done
+assignee:
+  - codex
+created_date: '2026-05-13 00:21'
+updated_date: '2026-05-13 00:44'
+labels:
+  - ACP
+  - workspace
+  - backend
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1540'
+  - 'https://github.com/rmusser01/tldw_server/issues/1532'
+documentation:
+  - Docs/Design/ACP_Workspace_Integration_Decision_2026_05.md
+  - Docs/Development/Agent_Client_Protocol.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Slice 1 from Docs/Design/ACP_Workspace_Integration_Decision_2026_05.md: explicit backend bridge between canonical workspaces and ACP execution workspaces, with ownership, allowlist, trusted-root, and duplicate-bridge tests.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 ACP execution workspace metadata carries canonical_workspace_id and source when linked
+- [x] #2 Backend helper/API path can find or create a linked ACP execution workspace for a canonical workspace
+- [x] #3 Project/task detail responses expose canonical workspace metadata through the ACP execution workspace
+- [x] #4 Ownership, missing workspace, missing allowlist, trusted-root inheritance, cwd containment, and duplicate bridge behavior are covered by focused tests
+- [x] #5 Issue #1540 can be updated with implementation evidence and remaining frontend slices
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add OrchestrationDB helper coverage first: verify ACP workspaces can be found by metadata.canonical_workspace_id and that linking an existing workspace merges canonical metadata without duplicating rows.
+2. Add agent orchestration API tests for the canonical bridge path: canonical workspace must exist for the current user, root_path must pass the existing ACP allowlist validation, an existing linked workspace is reused idempotently, root conflicts fail closed when linked to another canonical workspace, and an unlinked root workspace can be linked.
+3. Add response contract tests proving project detail and task detail expose a canonical_workspace bridge object inherited from the bound ACP execution workspace.
+4. Implement minimal backend support in tldw_Server_API/app/core/DB_Management/Orchestration_DB.py and tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py, reusing existing root validation, workspace CRUD, and dispatch cwd containment helpers.
+5. Run focused pytest for the changed Agent_Orchestration tests, run Bandit on touched backend implementation files, update TASK-307 acceptance criteria/notes, and prepare the PR with #1540 remaining frontend slices still open.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implementation evidence:
+- Added ACP workspace metadata bridge helpers in OrchestrationDB: get_workspace_by_canonical_workspace_id and link_workspace_to_canonical.
+- Added POST /api/v1/agent-orchestration/workspaces/canonical-bridge to validate canonical workspace existence, enforce ACP root allowlisting, reuse existing links, link existing unlinked roots, and reject conflicting root/canonical links.
+- Project and task detail responses now expose canonical_workspace inherited through the bound ACP execution workspace.
+- Added focused tests for ownership/missing canonical workspace behavior, missing allowlist, duplicate bridge prevention, trusted-root inheritance, cwd escape rejection, and response metadata.
+
+Verification:
+- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Agent_Orchestration/test_workspace_db.py tldw_Server_API/tests/Agent_Orchestration/test_orchestration_api.py -q => 80 passed, 5 warnings.
+- git diff --check => clean.
+- source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py tldw_Server_API/app/core/DB_Management/Orchestration_DB.py -f json -o /tmp/bandit_task307.json => 0 findings.
+- Ruff focused check after import cleanup still reports pre-existing baseline issues in touched files: B904/F841/UP037/SIM118/F841 unrelated to this bridge slice.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the ACP workspace backend bridge contract for #1540 and opened PR #1615. The slice adds the canonical bridge endpoint, metadata helpers, response exposure for project/task details, documentation, and focused tests for ownership/missing workspace, allowlist failures, duplicate bridge behavior, trusted-root inheritance, cwd containment, and canonical response metadata. Verification: focused Agent Orchestration pytest 80 passed; git diff --check clean; Bandit on touched backend files 0 findings. Known non-blocker: focused Ruff still reports unrelated pre-existing baseline issues in touched files after import cleanup.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py
+++ b/tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py
@@ -13,20 +13,26 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from loguru import logger
 from pydantic import BaseModel, Field, field_validator
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, TokenScopeGuard, User
 
-from tldw_Server_API.app.core.Agent_Orchestration.models import TaskStatus
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import TokenScopeGuard, User, get_request_user
+from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
 from tldw_Server_API.app.core.Agent_Orchestration.completion_signals import (
     CompletionSignalValidationError,
     ReviewDecisionValidationError,
-    validate_task_completion_signal,
     validate_review_decision_signal,
+    validate_task_completion_signal,
 )
+from tldw_Server_API.app.core.Agent_Orchestration.models import TaskStatus
 from tldw_Server_API.app.core.Agent_Orchestration.orchestration_service import (
     CycleDependencyError,
     get_orchestration_db,
 )
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 from tldw_Server_API.app.core.DB_Management.Orchestration_DB import (
+    CANONICAL_WORKSPACE_ID_METADATA_KEY,
+    CANONICAL_WORKSPACE_LINK_STATUS_METADATA_KEY,
+    CANONICAL_WORKSPACE_LINKED_STATUS,
+    CANONICAL_WORKSPACE_SOURCE_METADATA_KEY,
     InvalidTransitionError,
     OrchestrationNotFoundError,
 )
@@ -604,6 +610,7 @@ def _resolve_dispatch_cwd(raw_cwd: str, *, workspace_root: str | None = None) ->
 
 
 _VALID_WORKSPACE_TYPES = {"manual", "discovered", "monorepo_child"}
+_VALID_CANONICAL_WORKSPACE_SOURCES = {"workspace_playground"}
 
 
 class ACPWorkspaceCreateRequest(BaseModel):
@@ -631,6 +638,46 @@ class ACPWorkspaceUpdateRequest(BaseModel):
     metadata: dict[str, Any] | None = None
 
 
+class CanonicalWorkspaceBridgeRequest(BaseModel):
+    canonical_workspace_id: str = Field(..., min_length=1)
+    root_path: str = Field(..., description="Absolute filesystem path for ACP execution")
+    name: str | None = Field(
+        default=None,
+        description="Optional ACP execution workspace name",
+    )
+    description: str = Field(
+        default="",
+        description="Optional ACP execution workspace description",
+    )
+    canonical_workspace_source: str = Field(default="workspace_playground")
+    env_vars: dict[str, str] = Field(default_factory=dict)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("canonical_workspace_id")
+    @classmethod
+    def clean_canonical_workspace_id(cls, value: str) -> str:
+        canonical_id = value.strip()
+        if not canonical_id:
+            raise ValueError("canonical_workspace_id must not be empty")
+        return canonical_id
+
+    @field_validator("canonical_workspace_source")
+    @classmethod
+    def check_canonical_workspace_source(cls, value: str) -> str:
+        if value not in _VALID_CANONICAL_WORKSPACE_SOURCES:
+            raise ValueError(
+                f"canonical_workspace_source must be one of {_VALID_CANONICAL_WORKSPACE_SOURCES}"
+            )
+        return value
+
+
+class CanonicalWorkspaceLinkResponse(BaseModel):
+    acp_workspace_id: int
+    canonical_workspace_id: str
+    canonical_workspace_source: str = "workspace_playground"
+    link_status: str = CANONICAL_WORKSPACE_LINKED_STATUS
+
+
 class ACPWorkspaceResponse(BaseModel):
     id: int
     name: str
@@ -649,6 +696,7 @@ class ACPWorkspaceResponse(BaseModel):
     created_at: str = ""
     updated_at: str | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
+    canonical_workspace: CanonicalWorkspaceLinkResponse | None = None
     children: list[ACPWorkspaceResponse] | None = None
     mcp_servers: list[dict[str, Any]] | None = None
 
@@ -692,6 +740,7 @@ class ProjectResponse(BaseModel):
     metadata: dict[str, Any] = Field(default_factory=dict)
     task_summary: dict[str, Any] | None = None
     workspace: ACPWorkspaceResponse | None = None
+    canonical_workspace: CanonicalWorkspaceLinkResponse | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -726,6 +775,7 @@ class TaskResponse(BaseModel):
     created_at: str = ""
     updated_at: str | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
+    canonical_workspace: CanonicalWorkspaceLinkResponse | None = None
     runs: list[dict[str, Any]] | None = None
     reviews: list[dict[str, Any]] | None = None
 
@@ -738,6 +788,135 @@ class RunDispatchRequest(BaseModel):
 class ReviewRequest(BaseModel):
     approved: bool = Field(..., description="Whether the review is approved")
     feedback: str = Field(default="", description="Review feedback")
+
+
+def _canonical_workspace_link_from_workspace(workspace: Any | None) -> dict[str, Any] | None:
+    if workspace is None:
+        return None
+
+    if isinstance(workspace, dict):
+        metadata = workspace.get("metadata") or {}
+        workspace_id = workspace.get("id")
+    else:
+        metadata = getattr(workspace, "metadata", {}) or {}
+        workspace_id = getattr(workspace, "id", None)
+
+    if not isinstance(metadata, dict) or workspace_id is None:
+        return None
+
+    canonical_workspace_id = metadata.get(CANONICAL_WORKSPACE_ID_METADATA_KEY)
+    if not canonical_workspace_id:
+        return None
+
+    return {
+        "acp_workspace_id": int(workspace_id),
+        "canonical_workspace_id": str(canonical_workspace_id),
+        "canonical_workspace_source": str(
+            metadata.get(CANONICAL_WORKSPACE_SOURCE_METADATA_KEY)
+            or "workspace_playground"
+        ),
+        "link_status": str(
+            metadata.get(CANONICAL_WORKSPACE_LINK_STATUS_METADATA_KEY)
+            or CANONICAL_WORKSPACE_LINKED_STATUS
+        ),
+    }
+
+
+def _workspace_response_payload(workspace: Any) -> dict[str, Any]:
+    payload = workspace.to_dict() if hasattr(workspace, "to_dict") else dict(workspace)
+    payload["canonical_workspace"] = _canonical_workspace_link_from_workspace(workspace)
+    return payload
+
+
+def _bridge_metadata(
+    *,
+    canonical_workspace_id: str,
+    canonical_workspace_source: str,
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    merged = dict(metadata or {})
+    merged[CANONICAL_WORKSPACE_ID_METADATA_KEY] = canonical_workspace_id
+    merged[CANONICAL_WORKSPACE_SOURCE_METADATA_KEY] = canonical_workspace_source
+    merged[CANONICAL_WORKSPACE_LINK_STATUS_METADATA_KEY] = (
+        CANONICAL_WORKSPACE_LINKED_STATUS
+    )
+    return merged
+
+
+def _canonical_workspace_name(canonical_workspace: Any, fallback_id: str) -> str:
+    if isinstance(canonical_workspace, dict):
+        name = canonical_workspace.get("name")
+    else:
+        name = getattr(canonical_workspace, "name", None)
+    return str(name or fallback_id).strip() or fallback_id
+
+
+def _canonical_workspace_bridge_conflict(message: str) -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail={
+            "code": "canonical_workspace_bridge_conflict",
+            "message": message,
+        },
+    )
+
+
+def _ensure_canonical_workspace_bridge_sync(
+    *,
+    db: Any,
+    payload: CanonicalWorkspaceBridgeRequest,
+    canonical_workspace: Any,
+    validated_path: str,
+):
+    existing_link = db.get_workspace_by_canonical_workspace_id(
+        payload.canonical_workspace_id
+    )
+    if existing_link:
+        if existing_link.root_path != validated_path:
+            raise _canonical_workspace_bridge_conflict(
+                "Canonical workspace is already linked to a different ACP workspace root."
+            )
+        return existing_link
+
+    existing_root = db.get_workspace_by_root_path(validated_path)
+    if existing_root:
+        existing_canonical_id = (existing_root.metadata or {}).get(
+            CANONICAL_WORKSPACE_ID_METADATA_KEY
+        )
+        if (
+            existing_canonical_id
+            and str(existing_canonical_id) != payload.canonical_workspace_id
+        ):
+            raise _canonical_workspace_bridge_conflict(
+                "ACP workspace root is already linked to a different canonical workspace."
+            )
+        return db.link_workspace_to_canonical(
+            existing_root.id,
+            canonical_workspace_id=payload.canonical_workspace_id,
+            canonical_workspace_source=payload.canonical_workspace_source,
+            metadata=payload.metadata,
+        )
+
+    canonical_name = _canonical_workspace_name(
+        canonical_workspace,
+        payload.canonical_workspace_id,
+    )
+    workspace_name = (
+        payload.name
+        or f"ACP: {canonical_name} ({payload.canonical_workspace_id})"
+    )
+    return db.create_workspace(
+        name=workspace_name,
+        root_path=validated_path,
+        description=payload.description,
+        workspace_type="manual",
+        env_vars=payload.env_vars,
+        metadata=_bridge_metadata(
+            canonical_workspace_id=payload.canonical_workspace_id,
+            canonical_workspace_source=payload.canonical_workspace_source,
+            metadata=payload.metadata,
+        ),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -772,7 +951,7 @@ async def create_workspace(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except ValueError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
-    return ACPWorkspaceResponse(**ws.to_dict())
+    return ACPWorkspaceResponse(**_workspace_response_payload(ws))
 
 
 @router.get(
@@ -791,7 +970,41 @@ async def list_workspaces(
         workspace_type=workspace_type,
         health_status=health_status,
     ))
-    return [ACPWorkspaceResponse(**ws.to_dict()) for ws in workspaces]
+    return [ACPWorkspaceResponse(**_workspace_response_payload(ws)) for ws in workspaces]
+
+
+@router.post(
+    "/workspaces/canonical-bridge",
+    response_model=ACPWorkspaceResponse,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.manage"))],
+)
+async def ensure_canonical_workspace_bridge(
+    payload: CanonicalWorkspaceBridgeRequest,
+    user: User = Depends(get_request_user),
+    canonical_db: CharactersRAGDB = Depends(get_chacha_db_for_user),
+) -> ACPWorkspaceResponse:
+    """Find or create an ACP execution workspace linked to a canonical workspace."""
+    canonical_workspace = canonical_db.get_workspace(payload.canonical_workspace_id)
+    if not canonical_workspace:
+        raise HTTPException(status_code=404, detail="Workspace not found")
+
+    validated_path = _validate_workspace_root(payload.root_path)
+    db = get_orchestration_db(_user_id_int(user))
+    try:
+        workspace = await _run_sync(
+            lambda: _ensure_canonical_workspace_bridge_sync(
+                db=db,
+                payload=payload,
+                canonical_workspace=canonical_workspace,
+                validated_path=validated_path,
+            )
+        )
+    except OrchestrationNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return ACPWorkspaceResponse(**_workspace_response_payload(workspace))
 
 
 @router.get(
@@ -813,7 +1026,11 @@ async def get_workspace(
     mcp_servers = await _run_sync(lambda: db.list_workspace_mcp_servers(workspace_id))
 
     d = ws.to_dict()
-    d["children"] = [ACPWorkspaceResponse(**c.to_dict()).model_dump() for c in children]
+    d["canonical_workspace"] = _canonical_workspace_link_from_workspace(ws)
+    d["children"] = [
+        ACPWorkspaceResponse(**_workspace_response_payload(c)).model_dump()
+        for c in children
+    ]
     d["mcp_servers"] = mcp_servers
     return ACPWorkspaceResponse(**d)
 
@@ -842,7 +1059,7 @@ async def update_workspace(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except ValueError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
-    return ACPWorkspaceResponse(**ws.to_dict())
+    return ACPWorkspaceResponse(**_workspace_response_payload(ws))
 
 
 @router.delete(
@@ -1057,7 +1274,14 @@ async def create_project(
         ))
     except OrchestrationNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
-    return ProjectResponse(**project.to_dict())
+    d = project.to_dict()
+    if project.workspace_id:
+        ws = await _run_sync(lambda: db.get_workspace(project.workspace_id))
+        if ws:
+            workspace_payload = _workspace_response_payload(ws)
+            d["workspace"] = workspace_payload
+            d["canonical_workspace"] = workspace_payload.get("canonical_workspace")
+    return ProjectResponse(**d)
 
 
 @router.get(
@@ -1089,7 +1313,9 @@ async def list_projects(
             if p.workspace_id:
                 ws = db.get_workspace(p.workspace_id)
                 if ws:
-                    d["workspace"] = ws.to_dict()
+                    workspace_payload = _workspace_response_payload(ws)
+                    d["workspace"] = workspace_payload
+                    d["canonical_workspace"] = workspace_payload.get("canonical_workspace")
             results.append(d)
         return results
 
@@ -1117,7 +1343,9 @@ async def get_project(
     if project.workspace_id:
         ws = await _run_sync(lambda: db.get_workspace(project.workspace_id))
         if ws:
-            d["workspace"] = ws.to_dict()
+            workspace_payload = _workspace_response_payload(ws)
+            d["workspace"] = workspace_payload
+            d["canonical_workspace"] = workspace_payload.get("canonical_workspace")
     return ProjectResponse(**d)
 
 
@@ -1225,6 +1453,10 @@ async def get_task(
     runs = await _run_sync(lambda: db.list_runs(task_id))
     reviews = await _run_sync(lambda: db.list_reviews(task_id))
     d = task.to_dict()
+    project = await _run_sync(lambda: db.get_project(task.project_id))
+    if project and project.workspace_id:
+        workspace = await _run_sync(lambda: db.get_workspace(project.workspace_id))
+        d["canonical_workspace"] = _canonical_workspace_link_from_workspace(workspace)
     d["reviews"] = reviews
     d["runs"] = await _enrich_task_runs(
         runs,

--- a/tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py
+++ b/tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py
@@ -22,7 +22,7 @@ from tldw_Server_API.app.core.Agent_Orchestration.completion_signals import (
     validate_review_decision_signal,
     validate_task_completion_signal,
 )
-from tldw_Server_API.app.core.Agent_Orchestration.models import TaskStatus
+from tldw_Server_API.app.core.Agent_Orchestration.models import ACPWorkspace, TaskStatus
 from tldw_Server_API.app.core.Agent_Orchestration.orchestration_service import (
     CycleDependencyError,
     get_orchestration_db,
@@ -33,6 +33,7 @@ from tldw_Server_API.app.core.DB_Management.Orchestration_DB import (
     CANONICAL_WORKSPACE_LINK_STATUS_METADATA_KEY,
     CANONICAL_WORKSPACE_LINKED_STATUS,
     CANONICAL_WORKSPACE_SOURCE_METADATA_KEY,
+    CanonicalWorkspaceBridgeConflictError,
     InvalidTransitionError,
     OrchestrationNotFoundError,
 )
@@ -791,6 +792,7 @@ class ReviewRequest(BaseModel):
 
 
 def _canonical_workspace_link_from_workspace(workspace: Any | None) -> dict[str, Any] | None:
+    """Build the public canonical workspace link payload from an ACP workspace."""
     if workspace is None:
         return None
 
@@ -823,27 +825,14 @@ def _canonical_workspace_link_from_workspace(workspace: Any | None) -> dict[str,
 
 
 def _workspace_response_payload(workspace: Any) -> dict[str, Any]:
+    """Convert an ACP workspace to an API payload with bridge metadata included."""
     payload = workspace.to_dict() if hasattr(workspace, "to_dict") else dict(workspace)
     payload["canonical_workspace"] = _canonical_workspace_link_from_workspace(workspace)
     return payload
 
 
-def _bridge_metadata(
-    *,
-    canonical_workspace_id: str,
-    canonical_workspace_source: str,
-    metadata: dict[str, Any] | None = None,
-) -> dict[str, Any]:
-    merged = dict(metadata or {})
-    merged[CANONICAL_WORKSPACE_ID_METADATA_KEY] = canonical_workspace_id
-    merged[CANONICAL_WORKSPACE_SOURCE_METADATA_KEY] = canonical_workspace_source
-    merged[CANONICAL_WORKSPACE_LINK_STATUS_METADATA_KEY] = (
-        CANONICAL_WORKSPACE_LINKED_STATUS
-    )
-    return merged
-
-
 def _canonical_workspace_name(canonical_workspace: Any, fallback_id: str) -> str:
+    """Return a display name from a canonical workspace row or fallback ID."""
     if isinstance(canonical_workspace, dict):
         name = canonical_workspace.get("name")
     else:
@@ -852,6 +841,7 @@ def _canonical_workspace_name(canonical_workspace: Any, fallback_id: str) -> str
 
 
 def _canonical_workspace_bridge_conflict(message: str) -> HTTPException:
+    """Return the stable 409 error shape for canonical bridge conflicts."""
     return HTTPException(
         status_code=status.HTTP_409_CONFLICT,
         detail={
@@ -867,36 +857,8 @@ def _ensure_canonical_workspace_bridge_sync(
     payload: CanonicalWorkspaceBridgeRequest,
     canonical_workspace: Any,
     validated_path: str,
-):
-    existing_link = db.get_workspace_by_canonical_workspace_id(
-        payload.canonical_workspace_id
-    )
-    if existing_link:
-        if existing_link.root_path != validated_path:
-            raise _canonical_workspace_bridge_conflict(
-                "Canonical workspace is already linked to a different ACP workspace root."
-            )
-        return existing_link
-
-    existing_root = db.get_workspace_by_root_path(validated_path)
-    if existing_root:
-        existing_canonical_id = (existing_root.metadata or {}).get(
-            CANONICAL_WORKSPACE_ID_METADATA_KEY
-        )
-        if (
-            existing_canonical_id
-            and str(existing_canonical_id) != payload.canonical_workspace_id
-        ):
-            raise _canonical_workspace_bridge_conflict(
-                "ACP workspace root is already linked to a different canonical workspace."
-            )
-        return db.link_workspace_to_canonical(
-            existing_root.id,
-            canonical_workspace_id=payload.canonical_workspace_id,
-            canonical_workspace_source=payload.canonical_workspace_source,
-            metadata=payload.metadata,
-        )
-
+) -> ACPWorkspace:
+    """Delegate canonical bridge creation to the DB atomic bridge helper."""
     canonical_name = _canonical_workspace_name(
         canonical_workspace,
         payload.canonical_workspace_id,
@@ -905,17 +867,14 @@ def _ensure_canonical_workspace_bridge_sync(
         payload.name
         or f"ACP: {canonical_name} ({payload.canonical_workspace_id})"
     )
-    return db.create_workspace(
+    return db.find_or_create_canonical_workspace_bridge(
+        canonical_workspace_id=payload.canonical_workspace_id,
+        canonical_workspace_source=payload.canonical_workspace_source,
         name=workspace_name,
         root_path=validated_path,
         description=payload.description,
-        workspace_type="manual",
         env_vars=payload.env_vars,
-        metadata=_bridge_metadata(
-            canonical_workspace_id=payload.canonical_workspace_id,
-            canonical_workspace_source=payload.canonical_workspace_source,
-            metadata=payload.metadata,
-        ),
+        metadata=payload.metadata,
     )
 
 
@@ -985,7 +944,9 @@ async def ensure_canonical_workspace_bridge(
     canonical_db: CharactersRAGDB = Depends(get_chacha_db_for_user),
 ) -> ACPWorkspaceResponse:
     """Find or create an ACP execution workspace linked to a canonical workspace."""
-    canonical_workspace = canonical_db.get_workspace(payload.canonical_workspace_id)
+    canonical_workspace = await _run_sync(
+        lambda: canonical_db.get_workspace(payload.canonical_workspace_id)
+    )
     if not canonical_workspace:
         raise HTTPException(status_code=404, detail="Workspace not found")
 
@@ -1000,6 +961,8 @@ async def ensure_canonical_workspace_bridge(
                 validated_path=validated_path,
             )
         )
+    except CanonicalWorkspaceBridgeConflictError as exc:
+        raise _canonical_workspace_bridge_conflict(str(exc)) from exc
     except OrchestrationNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except ValueError as exc:
@@ -1304,6 +1267,9 @@ async def list_projects(
             projects = db.list_projects(workspace_id=None)
         else:
             projects = db.list_projects()
+        workspaces_by_id = db.get_workspaces_by_ids([
+            p.workspace_id for p in projects if p.workspace_id
+        ])
         results = []
         for p in projects:
             summary = db.get_project_summary(p.id)
@@ -1311,7 +1277,7 @@ async def list_projects(
             d["task_summary"] = summary
             # Include workspace info if bound
             if p.workspace_id:
-                ws = db.get_workspace(p.workspace_id)
+                ws = workspaces_by_id.get(p.workspace_id)
                 if ws:
                     workspace_payload = _workspace_response_payload(ws)
                     d["workspace"] = workspace_payload
@@ -1430,8 +1396,11 @@ async def list_tasks(
     if status_filter:
         try:
             task_status = TaskStatus(status_filter)
-        except ValueError:
-            raise HTTPException(status_code=400, detail=f"Invalid status: {status_filter}")
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid status: {status_filter}",
+            ) from exc
     tasks = await _run_sync(lambda: db.list_tasks(project_id, status=task_status))
     return [TaskResponse(**t.to_dict()) for t in tasks]
 
@@ -1573,7 +1542,7 @@ async def dispatch_run(
                 name=f"orchestration-task-{task_id}",
                 cwd=effective_cwd,
             )
-        except Exception as reg_exc:
+        except Exception:
             logger.warning("Failed to register orchestration ACP session")
 
     except HTTPException:
@@ -1741,7 +1710,7 @@ async def dispatch_run(
                     "feedback_present": True,
                 },
             )
-        except Exception as exc:
+        except Exception:
             review_error = REVIEWER_FAILED
             logger.exception("ACP reviewer failed")
             if review_run is None:

--- a/tldw_Server_API/app/core/DB_Management/Orchestration_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Orchestration_DB.py
@@ -19,8 +19,6 @@ from pathlib import Path
 from typing import Any
 
 from loguru import logger
-from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
-from tldw_Server_API.app.core.DB_Management.sqlite_policy import configure_sqlite_connection
 
 from tldw_Server_API.app.core.Agent_Orchestration.models import (
     ACPWorkspace,
@@ -31,6 +29,8 @@ from tldw_Server_API.app.core.Agent_Orchestration.models import (
     TaskStatus,
     is_valid_transition,
 )
+from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
+from tldw_Server_API.app.core.DB_Management.sqlite_policy import configure_sqlite_connection
 
 # ---------------------------------------------------------------------------
 # Custom exceptions
@@ -46,6 +46,10 @@ class InvalidTransitionError(ValueError):
 
 
 _SCHEMA_VERSION = 2
+CANONICAL_WORKSPACE_ID_METADATA_KEY = "canonical_workspace_id"
+CANONICAL_WORKSPACE_SOURCE_METADATA_KEY = "canonical_workspace_source"
+CANONICAL_WORKSPACE_LINK_STATUS_METADATA_KEY = "link_status"
+CANONICAL_WORKSPACE_LINKED_STATUS = "linked"
 
 # Base schema (v1) — applied to fresh databases
 _SCHEMA_V1_SQL = """\
@@ -456,6 +460,46 @@ class OrchestrationDB:
         if row is None:
             return None
         return self._row_to_workspace(row)
+
+    def get_workspace_by_canonical_workspace_id(
+        self,
+        canonical_workspace_id: str,
+    ) -> ACPWorkspace | None:
+        """Look up a workspace linked to a canonical product workspace."""
+        canonical_id = str(canonical_workspace_id or "").strip()
+        if not canonical_id:
+            return None
+        for workspace in self.list_workspaces():
+            metadata = workspace.metadata if isinstance(workspace.metadata, dict) else {}
+            linked_canonical_id = str(
+                metadata.get(CANONICAL_WORKSPACE_ID_METADATA_KEY) or ""
+            )
+            if linked_canonical_id == canonical_id:
+                return workspace
+        return None
+
+    def link_workspace_to_canonical(
+        self,
+        workspace_id: int,
+        *,
+        canonical_workspace_id: str,
+        canonical_workspace_source: str = "workspace_playground",
+        link_status: str = CANONICAL_WORKSPACE_LINKED_STATUS,
+        metadata: dict[str, Any] | None = None,
+    ) -> ACPWorkspace:
+        """Attach canonical workspace metadata to an existing ACP workspace."""
+        workspace = self.get_workspace(workspace_id)
+        if workspace is None:
+            raise OrchestrationNotFoundError(f"Workspace {workspace_id} not found")
+
+        merged_metadata = dict(workspace.metadata or {})
+        merged_metadata.update(metadata or {})
+        merged_metadata[CANONICAL_WORKSPACE_ID_METADATA_KEY] = str(canonical_workspace_id)
+        merged_metadata[CANONICAL_WORKSPACE_SOURCE_METADATA_KEY] = str(
+            canonical_workspace_source
+        )
+        merged_metadata[CANONICAL_WORKSPACE_LINK_STATUS_METADATA_KEY] = str(link_status)
+        return self.update_workspace(workspace_id, metadata=merged_metadata)
 
     def list_workspaces(
         self,

--- a/tldw_Server_API/app/core/DB_Management/Orchestration_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Orchestration_DB.py
@@ -45,7 +45,11 @@ class InvalidTransitionError(ValueError):
     """Raised when a task state transition is not allowed."""
 
 
-_SCHEMA_VERSION = 2
+class CanonicalWorkspaceBridgeConflictError(ValueError):
+    """Raised when a canonical workspace bridge would create an ambiguous link."""
+
+
+_SCHEMA_VERSION = 3
 CANONICAL_WORKSPACE_ID_METADATA_KEY = "canonical_workspace_id"
 CANONICAL_WORKSPACE_SOURCE_METADATA_KEY = "canonical_workspace_source"
 CANONICAL_WORKSPACE_LINK_STATUS_METADATA_KEY = "link_status"
@@ -155,6 +159,12 @@ CREATE TABLE IF NOT EXISTS acp_workspace_mcp_servers (
 CREATE INDEX IF NOT EXISTS idx_ws_mcp_workspace ON acp_workspace_mcp_servers(workspace_id);
 """
 
+_SCHEMA_V3_SQL = """\
+CREATE UNIQUE INDEX IF NOT EXISTS idx_acp_workspaces_user_canonical
+ON acp_workspaces(user_id, canonical_workspace_id)
+WHERE canonical_workspace_id IS NOT NULL;
+"""
+
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
@@ -167,6 +177,14 @@ def _parse_json(raw: str | None) -> dict[str, Any]:
         return json.loads(raw)
     except (json.JSONDecodeError, TypeError):
         return {}
+
+
+def _canonical_workspace_id_from_metadata(metadata: dict[str, Any] | None) -> str | None:
+    """Return a normalized canonical workspace ID from workspace metadata."""
+    if not isinstance(metadata, dict):
+        return None
+    canonical_id = str(metadata.get(CANONICAL_WORKSPACE_ID_METADATA_KEY) or "").strip()
+    return canonical_id or None
 
 
 def _parse_json_list(raw: str | None) -> list[Any]:
@@ -200,7 +218,7 @@ class OrchestrationDB:
     """Per-user SQLite store for orchestration projects, tasks, runs, reviews, workspaces."""
 
     @classmethod
-    def for_user(cls, user_id: int) -> "OrchestrationDB":
+    def for_user(cls, user_id: int) -> OrchestrationDB:
         safe_user_id = int(user_id)
         safe_db_dir = DatabasePaths.get_user_base_directory(safe_user_id)
         return cls(user_id=safe_user_id, db_dir=safe_db_dir, _trusted_db_dir=True)
@@ -227,6 +245,7 @@ class OrchestrationDB:
         self._conn_local = threading.local()
         self._initialized = False
         self._init_lock = threading.Lock()
+        self._bridge_lock = threading.Lock()
 
     # ------------------------------------------------------------------
     # Connection helpers
@@ -262,6 +281,11 @@ class OrchestrationDB:
                 self._migrate_v1_to_v2(conn)
                 current_version = 2
 
+            if current_version < 3:
+                # Migrate v2 → v3
+                self._migrate_v2_to_v3(conn)
+                current_version = 3
+
             conn.execute(f"PRAGMA user_version={_SCHEMA_VERSION}")
             conn.commit()
             self._initialized = True
@@ -277,6 +301,49 @@ class OrchestrationDB:
                 "ALTER TABLE projects ADD COLUMN workspace_id INTEGER "
                 "REFERENCES acp_workspaces(id) ON DELETE SET NULL"
             )
+        conn.commit()
+
+    def _migrate_v2_to_v3(self, conn: sqlite3.Connection) -> None:
+        """Apply v3 canonical workspace link column and uniqueness index."""
+        logger.info("Orchestration DB: migrating schema v2 → v3")
+        if not _col_exists(conn, "acp_workspaces", "canonical_workspace_id"):
+            conn.execute("ALTER TABLE acp_workspaces ADD COLUMN canonical_workspace_id TEXT")
+
+        rows = conn.execute(
+            "SELECT id, user_id, metadata, canonical_workspace_id FROM acp_workspaces"
+        ).fetchall()
+        seen: dict[tuple[int, str], int] = {}
+        duplicates: list[tuple[int, str, int, int]] = []
+        updates: list[tuple[str, int]] = []
+        for row in rows:
+            metadata = _parse_json(row["metadata"])
+            canonical_id = str(row["canonical_workspace_id"] or "").strip()
+            canonical_id = canonical_id or _canonical_workspace_id_from_metadata(metadata)
+            if not canonical_id:
+                continue
+            key = (int(row["user_id"]), canonical_id)
+            if key in seen:
+                duplicates.append((key[0], canonical_id, seen[key], int(row["id"])))
+                continue
+            seen[key] = int(row["id"])
+            updates.append((canonical_id, int(row["id"])))
+
+        if duplicates:
+            details = "; ".join(
+                f"user_id={user_id} canonical_workspace_id={canonical_id} "
+                f"workspace_ids={first_id},{duplicate_id}"
+                for user_id, canonical_id, first_id, duplicate_id in duplicates
+            )
+            raise ValueError(
+                "Duplicate canonical workspace links detected during orchestration "
+                f"schema migration; remove duplicate ACP workspace metadata before retrying: {details}"
+            )
+
+        conn.executemany(
+            "UPDATE acp_workspaces SET canonical_workspace_id = ? WHERE id = ?",
+            updates,
+        )
+        conn.executescript(_SCHEMA_V3_SQL)
         conn.commit()
 
     # ------------------------------------------------------------------
@@ -305,11 +372,12 @@ class OrchestrationDB:
         )
 
     def _row_to_project(self, row: sqlite3.Row) -> AgentProject:
+        columns = set(row.keys())
         return AgentProject(
             id=row["id"],
             name=row["name"],
             description=row["description"],
-            workspace_id=row["workspace_id"] if "workspace_id" in row.keys() else None,
+            workspace_id=row["workspace_id"] if "workspace_id" in columns else None,
             user_id=row["user_id"],
             created_at=row["created_at"],
             updated_at=row["updated_at"],
@@ -383,6 +451,8 @@ class OrchestrationDB:
     ) -> ACPWorkspace:
         self._ensure_schema()
         conn = self._get_conn()
+        metadata_payload = dict(metadata or {})
+        canonical_workspace_id = _canonical_workspace_id_from_metadata(metadata_payload)
 
         # Validate parent exists if provided
         if parent_workspace_id is not None:
@@ -399,15 +469,15 @@ class OrchestrationDB:
                 "INSERT INTO acp_workspaces "
                 "(name, root_path, description, workspace_type, parent_workspace_id, "
                 " env_vars, git_remote_url, git_default_branch, git_current_branch, "
-                " git_is_dirty, health_status, user_id, metadata, created_at) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                " git_is_dirty, health_status, user_id, metadata, canonical_workspace_id, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     name, root_path, description, workspace_type,
                     parent_workspace_id, json.dumps(env_vars or {}),
                     git_remote_url, git_default_branch, git_current_branch,
                     int(git_is_dirty) if git_is_dirty is not None else None,
                     health_status, self._user_id,
-                    json.dumps(metadata or {}), now,
+                    json.dumps(metadata_payload), canonical_workspace_id, now,
                 ),
             )
             conn.commit()
@@ -415,8 +485,8 @@ class OrchestrationDB:
             err = str(exc).lower()
             if "unique" in err:
                 raise ValueError(
-                    f"Workspace with name '{name}' or root_path '{root_path}' "
-                    f"already exists for this user"
+                    f"Workspace with name '{name}', root_path '{root_path}', or "
+                    f"canonical_workspace_id '{canonical_workspace_id}' already exists for this user"
                 ) from exc
             raise
 
@@ -435,7 +505,7 @@ class OrchestrationDB:
             health_status=health_status,
             user_id=self._user_id,
             created_at=now,
-            metadata=dict(metadata or {}),
+            metadata=metadata_payload,
         )
 
     def get_workspace(self, workspace_id: int) -> ACPWorkspace | None:
@@ -448,6 +518,20 @@ class OrchestrationDB:
         if row is None:
             return None
         return self._row_to_workspace(row)
+
+    def get_workspaces_by_ids(self, workspace_ids: list[int]) -> dict[int, ACPWorkspace]:
+        """Return current-user workspaces keyed by ID for the provided IDs."""
+        self._ensure_schema()
+        unique_ids = sorted({int(workspace_id) for workspace_id in workspace_ids})
+        if not unique_ids:
+            return {}
+        conn = self._get_conn()
+        placeholders = ",".join("?" for _ in unique_ids)
+        rows = conn.execute(
+            f"SELECT * FROM acp_workspaces WHERE user_id = ? AND id IN ({placeholders})",  # nosec B608
+            [self._user_id, *unique_ids],
+        ).fetchall()
+        return {int(row["id"]): self._row_to_workspace(row) for row in rows}
 
     def get_workspace_by_root_path(self, root_path: str) -> ACPWorkspace | None:
         """Look up a workspace by its root_path for the current user."""
@@ -469,14 +553,16 @@ class OrchestrationDB:
         canonical_id = str(canonical_workspace_id or "").strip()
         if not canonical_id:
             return None
-        for workspace in self.list_workspaces():
-            metadata = workspace.metadata if isinstance(workspace.metadata, dict) else {}
-            linked_canonical_id = str(
-                metadata.get(CANONICAL_WORKSPACE_ID_METADATA_KEY) or ""
-            )
-            if linked_canonical_id == canonical_id:
-                return workspace
-        return None
+        self._ensure_schema()
+        conn = self._get_conn()
+        row = conn.execute(
+            "SELECT * FROM acp_workspaces "
+            "WHERE canonical_workspace_id = ? AND user_id = ?",
+            (canonical_id, self._user_id),
+        ).fetchone()
+        if row is None:
+            return None
+        return self._row_to_workspace(row)
 
     def link_workspace_to_canonical(
         self,
@@ -492,14 +578,108 @@ class OrchestrationDB:
         if workspace is None:
             raise OrchestrationNotFoundError(f"Workspace {workspace_id} not found")
 
+        canonical_id = str(canonical_workspace_id).strip()
+        existing_canonical_id = _canonical_workspace_id_from_metadata(workspace.metadata)
+        if existing_canonical_id and existing_canonical_id != canonical_id:
+            raise CanonicalWorkspaceBridgeConflictError(
+                "ACP workspace root is already linked to a different canonical workspace."
+            )
+
         merged_metadata = dict(workspace.metadata or {})
         merged_metadata.update(metadata or {})
-        merged_metadata[CANONICAL_WORKSPACE_ID_METADATA_KEY] = str(canonical_workspace_id)
+        merged_metadata[CANONICAL_WORKSPACE_ID_METADATA_KEY] = canonical_id
         merged_metadata[CANONICAL_WORKSPACE_SOURCE_METADATA_KEY] = str(
             canonical_workspace_source
         )
         merged_metadata[CANONICAL_WORKSPACE_LINK_STATUS_METADATA_KEY] = str(link_status)
-        return self.update_workspace(workspace_id, metadata=merged_metadata)
+        conn = self._get_conn()
+        try:
+            cur = conn.execute(
+                "UPDATE acp_workspaces SET metadata = ?, canonical_workspace_id = ?, "
+                "updated_at = ? WHERE id = ? AND user_id = ? "
+                "AND (canonical_workspace_id IS NULL OR canonical_workspace_id = ?)",
+                (
+                    json.dumps(merged_metadata),
+                    canonical_id,
+                    _now_iso(),
+                    workspace_id,
+                    self._user_id,
+                    canonical_id,
+                ),
+            )
+            if cur.rowcount == 0:
+                conn.rollback()
+                raise CanonicalWorkspaceBridgeConflictError(
+                    "ACP workspace root is already linked to a different canonical workspace."
+                )
+            conn.commit()
+        except sqlite3.IntegrityError as exc:
+            conn.rollback()
+            raise CanonicalWorkspaceBridgeConflictError(
+                "Canonical workspace is already linked to a different ACP workspace."
+            ) from exc
+        updated = self.get_workspace(workspace_id)
+        if updated is None:
+            raise OrchestrationNotFoundError(f"Workspace {workspace_id} not found")
+        return updated
+
+    def find_or_create_canonical_workspace_bridge(
+        self,
+        *,
+        canonical_workspace_id: str,
+        canonical_workspace_source: str,
+        root_path: str,
+        name: str,
+        description: str = "",
+        env_vars: dict[str, str] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> ACPWorkspace:
+        """Atomically find or create the ACP workspace for a canonical workspace."""
+        canonical_id = str(canonical_workspace_id).strip()
+        with self._bridge_lock:
+            existing_link = self.get_workspace_by_canonical_workspace_id(canonical_id)
+            if existing_link:
+                if existing_link.root_path != root_path:
+                    raise CanonicalWorkspaceBridgeConflictError(
+                        "Canonical workspace is already linked to a different ACP workspace root."
+                    )
+                return existing_link
+
+            existing_root = self.get_workspace_by_root_path(root_path)
+            if existing_root:
+                existing_canonical_id = _canonical_workspace_id_from_metadata(
+                    existing_root.metadata
+                )
+                if existing_canonical_id and existing_canonical_id != canonical_id:
+                    raise CanonicalWorkspaceBridgeConflictError(
+                        "ACP workspace root is already linked to a different canonical workspace."
+                    )
+                return self.link_workspace_to_canonical(
+                    existing_root.id,
+                    canonical_workspace_id=canonical_id,
+                    canonical_workspace_source=canonical_workspace_source,
+                    metadata=metadata,
+                )
+
+            bridge_metadata = dict(metadata or {})
+            bridge_metadata[CANONICAL_WORKSPACE_ID_METADATA_KEY] = canonical_id
+            bridge_metadata[CANONICAL_WORKSPACE_SOURCE_METADATA_KEY] = (
+                canonical_workspace_source
+            )
+            bridge_metadata[CANONICAL_WORKSPACE_LINK_STATUS_METADATA_KEY] = (
+                CANONICAL_WORKSPACE_LINKED_STATUS
+            )
+            try:
+                return self.create_workspace(
+                    name=name,
+                    root_path=root_path,
+                    description=description,
+                    workspace_type="manual",
+                    env_vars=env_vars,
+                    metadata=bridge_metadata,
+                )
+            except ValueError as exc:
+                raise CanonicalWorkspaceBridgeConflictError(str(exc)) from exc
 
     def list_workspaces(
         self,
@@ -546,6 +726,9 @@ class OrchestrationDB:
             if key in ("env_vars", "metadata"):
                 sets.append(f"{key} = ?")
                 params.append(json.dumps(value or {}))
+                if key == "metadata":
+                    sets.append("canonical_workspace_id = ?")
+                    params.append(_canonical_workspace_id_from_metadata(value or {}))
             else:
                 sets.append(f"{key} = ?")
                 params.append(value)
@@ -568,7 +751,7 @@ class OrchestrationDB:
             err = str(exc).lower()
             if "unique" in err:
                 raise ValueError(
-                    "Workspace name or root_path conflicts with an existing workspace"
+                    "Workspace name, root_path, or canonical workspace link conflicts with an existing workspace"
                 ) from exc
             raise
 

--- a/tldw_Server_API/tests/Agent_Orchestration/test_orchestration_api.py
+++ b/tldw_Server_API/tests/Agent_Orchestration/test_orchestration_api.py
@@ -8,10 +8,10 @@ from unittest.mock import MagicMock
 import pytest
 from fastapi import HTTPException
 
+from tldw_Server_API.app.core.Agent_Orchestration.models import TaskStatus
 from tldw_Server_API.app.core.Agent_Orchestration.orchestration_service import (
     OrchestrationService,
 )
-from tldw_Server_API.app.core.Agent_Orchestration.models import TaskStatus
 from tldw_Server_API.app.core.DB_Management.Orchestration_DB import OrchestrationDB
 
 pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
@@ -272,6 +272,14 @@ class _TestUser:
     id_int = 1
 
 
+class _CanonicalWorkspaceDB:
+    def __init__(self, workspaces=None):
+        self.workspaces = dict(workspaces or {})
+
+    def get_workspace(self, workspace_id):
+        return self.workspaces.get(workspace_id)
+
+
 class _NoopSessionStore:
     async def check_session_quota(self, _user_id):
         return None
@@ -390,7 +398,7 @@ class _WorkspaceSessionCaptureClient:
         self.create_session_calls = []
 
     async def create_session(self, *_args, **kwargs):
-        self.create_session_calls.append(kwargs)
+        self.create_session_calls.append({"args": _args, "kwargs": kwargs})
         return "session-workspace-env"
 
     async def prompt(self, *_args, **_kwargs):
@@ -402,6 +410,309 @@ class _WorkspaceSessionCaptureClient:
             },
             "usage": {},
         }
+
+
+async def test_canonical_workspace_bridge_creates_linked_execution_workspace(monkeypatch, tmp_path):
+    from tldw_Server_API.app.api.v1.endpoints import agent_orchestration as orch_mod
+
+    db = OrchestrationDB(user_id=1, db_dir=tmp_path)
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    canonical_db = _CanonicalWorkspaceDB(
+        {"workspace-alpha": {"id": "workspace-alpha", "name": "Alpha Workspace"}}
+    )
+
+    monkeypatch.setattr(orch_mod, "get_orchestration_db", lambda _user_id: db)
+    monkeypatch.setattr(orch_mod, "_allowed_workspace_roots", lambda: (tmp_path.resolve(),))
+
+    try:
+        response = await orch_mod.ensure_canonical_workspace_bridge(
+            orch_mod.CanonicalWorkspaceBridgeRequest(
+                canonical_workspace_id="workspace-alpha",
+                root_path=str(workspace_root),
+                metadata={"existing": "kept"},
+            ),
+            user=_TestUser(),
+            canonical_db=canonical_db,
+        )
+
+        assert response.id > 0
+        assert response.root_path == str(workspace_root)
+        assert response.metadata["existing"] == "kept"
+        assert response.metadata["canonical_workspace_id"] == "workspace-alpha"
+        assert response.metadata["canonical_workspace_source"] == "workspace_playground"
+        assert response.metadata["link_status"] == "linked"
+        assert response.canonical_workspace.canonical_workspace_id == "workspace-alpha"
+        assert response.canonical_workspace.acp_workspace_id == response.id
+    finally:
+        db.close()
+
+
+async def test_canonical_workspace_bridge_reuses_existing_link(monkeypatch, tmp_path):
+    from tldw_Server_API.app.api.v1.endpoints import agent_orchestration as orch_mod
+
+    db = OrchestrationDB(user_id=1, db_dir=tmp_path)
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    db.create_workspace(
+        name="Linked",
+        root_path=str(workspace_root),
+        metadata={
+            "canonical_workspace_id": "workspace-alpha",
+            "canonical_workspace_source": "workspace_playground",
+            "link_status": "linked",
+        },
+    )
+    canonical_db = _CanonicalWorkspaceDB(
+        {"workspace-alpha": {"id": "workspace-alpha", "name": "Alpha Workspace"}}
+    )
+
+    monkeypatch.setattr(orch_mod, "get_orchestration_db", lambda _user_id: db)
+    monkeypatch.setattr(orch_mod, "_allowed_workspace_roots", lambda: (tmp_path.resolve(),))
+
+    try:
+        response = await orch_mod.ensure_canonical_workspace_bridge(
+            orch_mod.CanonicalWorkspaceBridgeRequest(
+                canonical_workspace_id="workspace-alpha",
+                root_path=str(workspace_root),
+            ),
+            user=_TestUser(),
+            canonical_db=canonical_db,
+        )
+
+        assert response.name == "Linked"
+        assert len(db.list_workspaces()) == 1
+    finally:
+        db.close()
+
+
+async def test_canonical_workspace_bridge_links_existing_unlinked_root(monkeypatch, tmp_path):
+    from tldw_Server_API.app.api.v1.endpoints import agent_orchestration as orch_mod
+
+    db = OrchestrationDB(user_id=1, db_dir=tmp_path)
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    existing = db.create_workspace(
+        name="Existing Root",
+        root_path=str(workspace_root),
+        metadata={"owner": "research"},
+    )
+    canonical_db = _CanonicalWorkspaceDB(
+        {"workspace-alpha": {"id": "workspace-alpha", "name": "Alpha Workspace"}}
+    )
+
+    monkeypatch.setattr(orch_mod, "get_orchestration_db", lambda _user_id: db)
+    monkeypatch.setattr(orch_mod, "_allowed_workspace_roots", lambda: (tmp_path.resolve(),))
+
+    try:
+        response = await orch_mod.ensure_canonical_workspace_bridge(
+            orch_mod.CanonicalWorkspaceBridgeRequest(
+                canonical_workspace_id="workspace-alpha",
+                root_path=str(workspace_root),
+            ),
+            user=_TestUser(),
+            canonical_db=canonical_db,
+        )
+
+        assert response.id == existing.id
+        assert response.metadata["owner"] == "research"
+        assert response.metadata["canonical_workspace_id"] == "workspace-alpha"
+        assert len(db.list_workspaces()) == 1
+    finally:
+        db.close()
+
+
+async def test_canonical_workspace_bridge_rejects_missing_canonical_workspace(monkeypatch, tmp_path):
+    from tldw_Server_API.app.api.v1.endpoints import agent_orchestration as orch_mod
+
+    db = OrchestrationDB(user_id=1, db_dir=tmp_path)
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+
+    monkeypatch.setattr(orch_mod, "get_orchestration_db", lambda _user_id: db)
+    monkeypatch.setattr(orch_mod, "_allowed_workspace_roots", lambda: (tmp_path.resolve(),))
+
+    try:
+        with pytest.raises(HTTPException) as exc_info:
+            await orch_mod.ensure_canonical_workspace_bridge(
+                orch_mod.CanonicalWorkspaceBridgeRequest(
+                    canonical_workspace_id="workspace-missing",
+                    root_path=str(workspace_root),
+                ),
+                user=_TestUser(),
+                canonical_db=_CanonicalWorkspaceDB(),
+            )
+
+        assert exc_info.value.status_code == 404
+        assert db.list_workspaces() == []
+    finally:
+        db.close()
+
+
+async def test_canonical_workspace_bridge_requires_allowed_root(monkeypatch, tmp_path):
+    from tldw_Server_API.app.api.v1.endpoints import agent_orchestration as orch_mod
+
+    db = OrchestrationDB(user_id=1, db_dir=tmp_path)
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    canonical_db = _CanonicalWorkspaceDB(
+        {"workspace-alpha": {"id": "workspace-alpha", "name": "Alpha Workspace"}}
+    )
+
+    monkeypatch.setattr(orch_mod, "get_orchestration_db", lambda _user_id: db)
+    monkeypatch.setattr(orch_mod, "_allowed_workspace_roots", lambda: ())
+
+    try:
+        with pytest.raises(HTTPException) as exc_info:
+            await orch_mod.ensure_canonical_workspace_bridge(
+                orch_mod.CanonicalWorkspaceBridgeRequest(
+                    canonical_workspace_id="workspace-alpha",
+                    root_path=str(workspace_root),
+                ),
+                user=_TestUser(),
+                canonical_db=canonical_db,
+            )
+
+        assert exc_info.value.status_code == 503
+        assert db.list_workspaces() == []
+    finally:
+        db.close()
+
+
+async def test_canonical_workspace_bridge_rejects_root_linked_to_other_workspace(
+    monkeypatch,
+    tmp_path,
+):
+    from tldw_Server_API.app.api.v1.endpoints import agent_orchestration as orch_mod
+
+    db = OrchestrationDB(user_id=1, db_dir=tmp_path)
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    db.create_workspace(
+        name="Linked Elsewhere",
+        root_path=str(workspace_root),
+        metadata={
+            "canonical_workspace_id": "workspace-other",
+            "canonical_workspace_source": "workspace_playground",
+            "link_status": "linked",
+        },
+    )
+    canonical_db = _CanonicalWorkspaceDB(
+        {"workspace-alpha": {"id": "workspace-alpha", "name": "Alpha Workspace"}}
+    )
+
+    monkeypatch.setattr(orch_mod, "get_orchestration_db", lambda _user_id: db)
+    monkeypatch.setattr(orch_mod, "_allowed_workspace_roots", lambda: (tmp_path.resolve(),))
+
+    try:
+        with pytest.raises(HTTPException) as exc_info:
+            await orch_mod.ensure_canonical_workspace_bridge(
+                orch_mod.CanonicalWorkspaceBridgeRequest(
+                    canonical_workspace_id="workspace-alpha",
+                    root_path=str(workspace_root),
+                ),
+                user=_TestUser(),
+                canonical_db=canonical_db,
+            )
+
+        assert exc_info.value.status_code == 409
+        assert exc_info.value.detail["code"] == "canonical_workspace_bridge_conflict"
+    finally:
+        db.close()
+
+
+async def test_project_and_task_detail_include_canonical_workspace(monkeypatch, tmp_path):
+    from tldw_Server_API.app.api.v1.endpoints import agent_orchestration as orch_mod
+
+    db = OrchestrationDB(user_id=1, db_dir=tmp_path)
+    workspace = db.create_workspace(
+        name="Linked",
+        root_path=str(tmp_path / "workspace"),
+        metadata={
+            "canonical_workspace_id": "workspace-alpha",
+            "canonical_workspace_source": "workspace_playground",
+            "link_status": "linked",
+        },
+    )
+    project = db.create_project(name="P1", workspace_id=workspace.id)
+    task = db.create_task(project.id, title="T1", description="Dispatch me", agent_type="codex")
+
+    monkeypatch.setattr(orch_mod, "get_orchestration_db", lambda _user_id: db)
+
+    try:
+        project_detail = await orch_mod.get_project(project.id, user=_TestUser())
+        task_detail = await orch_mod.get_task(task.id, user=_TestUser())
+
+        assert project_detail.workspace.canonical_workspace.canonical_workspace_id == "workspace-alpha"
+        assert project_detail.canonical_workspace.canonical_workspace_id == "workspace-alpha"
+        assert project_detail.canonical_workspace.acp_workspace_id == workspace.id
+        assert task_detail.canonical_workspace.canonical_workspace_id == "workspace-alpha"
+        assert task_detail.canonical_workspace.acp_workspace_id == workspace.id
+    finally:
+        db.close()
+
+
+async def test_dispatch_run_inherits_trusted_root_from_canonical_bridge(monkeypatch, tmp_path):
+    from tldw_Server_API.app.api.v1.endpoints import agent_orchestration as orch_mod
+
+    db = OrchestrationDB(user_id=1, db_dir=tmp_path)
+    workspace_root = tmp_path / "workspace"
+    (workspace_root / "src").mkdir(parents=True)
+    workspace = db.create_workspace(
+        name="Linked",
+        root_path=str(workspace_root),
+        metadata={
+            "canonical_workspace_id": "workspace-alpha",
+            "canonical_workspace_source": "workspace_playground",
+            "link_status": "linked",
+        },
+    )
+    project = db.create_project(name="P1", workspace_id=workspace.id)
+    task = db.create_task(project.id, title="T1", description="Dispatch me", agent_type="codex")
+    client = _WorkspaceSessionCaptureClient()
+
+    async def fake_store():
+        return _NoopSessionStore()
+
+    async def fake_client():
+        return client
+
+    monkeypatch.setattr(orch_mod, "get_orchestration_db", lambda _user_id: db)
+    monkeypatch.setattr(orch_mod, "_allowed_workspace_roots", lambda: (tmp_path.resolve(),))
+    monkeypatch.setattr(
+        "tldw_Server_API.app.services.admin_acp_sessions_service.get_acp_session_store",
+        fake_store,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Agent_Client_Protocol.runner_client.get_runner_client",
+        fake_client,
+    )
+
+    try:
+        result = await orch_mod.dispatch_run(
+            task.id,
+            orch_mod.RunDispatchRequest(cwd="src"),
+            user=_TestUser(),
+        )
+
+        assert result["status"] == TaskStatus.COMPLETE
+        assert client.create_session_calls[0]["args"][0] == str(workspace_root / "src")
+
+        escape_task = db.create_task(
+            project.id,
+            title="T2",
+            description="Reject escaped cwd",
+            agent_type="codex",
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await orch_mod.dispatch_run(
+                escape_task.id,
+                orch_mod.RunDispatchRequest(cwd="../outside"),
+                user=_TestUser(),
+            )
+        assert exc_info.value.status_code == 403
+    finally:
+        db.close()
 
 
 def _clear_acp_audit_events() -> None:
@@ -826,8 +1137,8 @@ async def test_dispatch_run_injects_workspace_env_and_mcp_servers(monkeypatch, t
         )
 
         assert result["status"] == TaskStatus.COMPLETE
-        assert client.create_session_calls[0]["session_env"] == {"WORKSPACE_TOKEN": "abc"}
-        assert client.create_session_calls[0]["mcp_servers"] == [
+        assert client.create_session_calls[0]["kwargs"]["session_env"] == {"WORKSPACE_TOKEN": "abc"}
+        assert client.create_session_calls[0]["kwargs"]["mcp_servers"] == [
             {
                 "name": "workspace-files",
                 "type": "stdio",

--- a/tldw_Server_API/tests/Agent_Orchestration/test_orchestration_api.py
+++ b/tldw_Server_API/tests/Agent_Orchestration/test_orchestration_api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -98,9 +99,9 @@ async def test_multiple_runs_per_task(svc):
     project = await svc.create_project(name="P1", user_id=1)
     task = await svc.create_task(project.id, title="T1", user_id=1)
 
-    r1 = await svc.create_run(task.id, session_id="s1")
-    r2 = await svc.create_run(task.id, session_id="s2")
-    r3 = await svc.create_run(task.id, session_id="s3")
+    await svc.create_run(task.id, session_id="s1")
+    await svc.create_run(task.id, session_id="s2")
+    await svc.create_run(task.id, session_id="s3")
 
     runs = await svc.list_runs(task.id)
     assert len(runs) == 3
@@ -273,10 +274,10 @@ class _TestUser:
 
 
 class _CanonicalWorkspaceDB:
-    def __init__(self, workspaces=None):
+    def __init__(self, workspaces: dict[str, dict[str, Any]] | None = None) -> None:
         self.workspaces = dict(workspaces or {})
 
-    def get_workspace(self, workspace_id):
+    def get_workspace(self, workspace_id: str) -> dict[str, Any] | None:
         return self.workspaces.get(workspace_id)
 
 
@@ -394,10 +395,10 @@ class _ReviewerDecisionClient:
 
 
 class _WorkspaceSessionCaptureClient:
-    def __init__(self):
+    def __init__(self) -> None:
         self.create_session_calls = []
 
-    async def create_session(self, *_args, **kwargs):
+    async def create_session(self, *_args: Any, **kwargs: Any) -> str:
         self.create_session_calls.append({"args": _args, "kwargs": kwargs})
         return "session-workspace-env"
 

--- a/tldw_Server_API/tests/Agent_Orchestration/test_workspace_db.py
+++ b/tldw_Server_API/tests/Agent_Orchestration/test_workspace_db.py
@@ -4,6 +4,7 @@ import tempfile
 import pytest
 
 from tldw_Server_API.app.core.DB_Management.Orchestration_DB import (
+    CanonicalWorkspaceBridgeConflictError,
     OrchestrationDB,
     OrchestrationNotFoundError,
 )
@@ -24,7 +25,7 @@ def db():
 
 class TestSchemaMigration:
     def test_fresh_db_creates_v2_schema(self, db):
-        """A fresh DB should have all v2 tables."""
+        """A fresh DB should have all current workspace tables and columns."""
         db._ensure_schema()
         conn = db._get_conn()
         tables = {
@@ -36,9 +37,13 @@ class TestSchemaMigration:
         assert "acp_workspaces" in tables
         assert "acp_workspace_mcp_servers" in tables
         assert "projects" in tables
+        workspace_cols = {
+            r[1] for r in conn.execute("PRAGMA table_info(acp_workspaces)").fetchall()
+        }
+        assert "canonical_workspace_id" in workspace_cols
         # Check user_version
         version = conn.execute("PRAGMA user_version").fetchone()[0]
-        assert version == 2
+        assert version == 3
 
     def test_projects_has_workspace_id_column(self, db):
         """The projects table should have a workspace_id column after migration."""
@@ -47,8 +52,8 @@ class TestSchemaMigration:
         cols = {r[1] for r in conn.execute("PRAGMA table_info(projects)").fetchall()}
         assert "workspace_id" in cols
 
-    def test_v1_to_v2_migration(self):
-        """Simulate a v1 DB and verify migration to v2 works."""
+    def test_v1_to_current_migration(self):
+        """Simulate a v1 DB and verify migration to the current schema works."""
         import os
         import sqlite3
 
@@ -99,8 +104,119 @@ class TestSchemaMigration:
             assert row is not None
             assert row[1] == "test"  # name
 
+            workspace_cols = {
+                r[1] for r in c.execute("PRAGMA table_info(acp_workspaces)").fetchall()
+            }
+            assert "canonical_workspace_id" in workspace_cols
+
             version = c.execute("PRAGMA user_version").fetchone()[0]
-            assert version == 2
+            assert version == 3
+            db.close()
+
+    def test_v2_to_v3_migration_backfills_canonical_workspace_id(self):
+        """Existing metadata links should backfill the dedicated canonical column."""
+        import os
+        import sqlite3
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = os.path.join(tmp, "orchestration.db")
+            conn = sqlite3.connect(db_path)
+            conn.executescript("""
+                CREATE TABLE acp_workspaces (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT NOT NULL,
+                    root_path TEXT NOT NULL,
+                    description TEXT NOT NULL DEFAULT '',
+                    workspace_type TEXT NOT NULL DEFAULT 'manual',
+                    parent_workspace_id INTEGER,
+                    env_vars TEXT NOT NULL DEFAULT '{}',
+                    git_remote_url TEXT,
+                    git_default_branch TEXT,
+                    git_current_branch TEXT,
+                    git_is_dirty INTEGER,
+                    last_health_check TEXT,
+                    health_status TEXT NOT NULL DEFAULT 'unknown',
+                    user_id INTEGER NOT NULL,
+                    metadata TEXT NOT NULL DEFAULT '{}',
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT
+                );
+                CREATE UNIQUE INDEX idx_acp_workspaces_name ON acp_workspaces(user_id, name);
+                CREATE UNIQUE INDEX idx_acp_workspaces_root ON acp_workspaces(user_id, root_path);
+                PRAGMA user_version=2;
+            """)
+            conn.execute(
+                "INSERT INTO acp_workspaces "
+                "(name, root_path, user_id, metadata, created_at) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (
+                    "Linked",
+                    "/tmp/linked",
+                    1,
+                    '{"canonical_workspace_id":"workspace-alpha"}',
+                    "2026-01-01T00:00:00+00:00",
+                ),
+            )
+            conn.commit()
+            conn.close()
+
+            db = OrchestrationDB(user_id=1, db_dir=tmp)
+            db._ensure_schema()
+
+            found = db.get_workspace_by_canonical_workspace_id("workspace-alpha")
+            assert found is not None
+            assert found.name == "Linked"
+            db.close()
+
+    def test_v2_to_v3_migration_rejects_duplicate_canonical_links(self):
+        """Duplicate metadata links should fail migration with remediation context."""
+        import os
+        import sqlite3
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = os.path.join(tmp, "orchestration.db")
+            conn = sqlite3.connect(db_path)
+            conn.executescript("""
+                CREATE TABLE acp_workspaces (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT NOT NULL,
+                    root_path TEXT NOT NULL,
+                    description TEXT NOT NULL DEFAULT '',
+                    workspace_type TEXT NOT NULL DEFAULT 'manual',
+                    parent_workspace_id INTEGER,
+                    env_vars TEXT NOT NULL DEFAULT '{}',
+                    git_remote_url TEXT,
+                    git_default_branch TEXT,
+                    git_current_branch TEXT,
+                    git_is_dirty INTEGER,
+                    last_health_check TEXT,
+                    health_status TEXT NOT NULL DEFAULT 'unknown',
+                    user_id INTEGER NOT NULL,
+                    metadata TEXT NOT NULL DEFAULT '{}',
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT
+                );
+                PRAGMA user_version=2;
+            """)
+            for name, root_path in (("Linked A", "/tmp/a"), ("Linked B", "/tmp/b")):
+                conn.execute(
+                    "INSERT INTO acp_workspaces "
+                    "(name, root_path, user_id, metadata, created_at) "
+                    "VALUES (?, ?, ?, ?, ?)",
+                    (
+                        name,
+                        root_path,
+                        1,
+                        '{"canonical_workspace_id":"workspace-alpha"}',
+                        "2026-01-01T00:00:00+00:00",
+                    ),
+                )
+            conn.commit()
+            conn.close()
+
+            db = OrchestrationDB(user_id=1, db_dir=tmp)
+            with pytest.raises(ValueError, match="Duplicate canonical workspace links"):
+                db._ensure_schema()
             db.close()
 
 
@@ -211,6 +327,16 @@ class TestWorkspaceCRUD:
         assert found.name == "WS1"
         assert db.get_workspace_by_root_path("/tmp/nonexistent") is None
 
+    def test_get_workspaces_by_ids_returns_current_user_workspaces(self, db):
+        ws1 = db.create_workspace(name="WS1", root_path="/tmp/ws1")
+        ws2 = db.create_workspace(name="WS2", root_path="/tmp/ws2")
+
+        found = db.get_workspaces_by_ids([ws1.id, ws2.id, ws1.id, 999])
+
+        assert set(found) == {ws1.id, ws2.id}
+        assert found[ws1.id].name == "WS1"
+        assert found[ws2.id].name == "WS2"
+
     def test_workspace_with_env_vars(self, db):
         ws = db.create_workspace(
             name="WS1",
@@ -247,6 +373,20 @@ class TestWorkspaceCRUD:
         assert found.id == linked.id
         assert db.get_workspace_by_canonical_workspace_id("workspace-missing") is None
 
+    def test_duplicate_canonical_workspace_id_raises(self, db):
+        db.create_workspace(
+            name="Linked A",
+            root_path="/tmp/linked-a",
+            metadata={"canonical_workspace_id": "workspace-alpha"},
+        )
+
+        with pytest.raises(ValueError, match="canonical_workspace_id"):
+            db.create_workspace(
+                name="Linked B",
+                root_path="/tmp/linked-b",
+                metadata={"canonical_workspace_id": "workspace-alpha"},
+            )
+
     def test_link_workspace_to_canonical_merges_metadata_without_duplication(self, db):
         ws = db.create_workspace(
             name="Existing Root",
@@ -269,6 +409,45 @@ class TestWorkspaceCRUD:
         }
         assert len(db.list_workspaces()) == 1
         assert db.get_workspace_by_canonical_workspace_id("workspace-alpha").id == ws.id
+
+    def test_link_workspace_to_canonical_rejects_duplicate_canonical_id(self, db):
+        first = db.create_workspace(name="First", root_path="/tmp/first")
+        second = db.create_workspace(name="Second", root_path="/tmp/second")
+        db.link_workspace_to_canonical(
+            first.id,
+            canonical_workspace_id="workspace-alpha",
+            canonical_workspace_source="workspace_playground",
+        )
+
+        with pytest.raises(ValueError, match="already linked"):
+            db.link_workspace_to_canonical(
+                second.id,
+                canonical_workspace_id="workspace-alpha",
+                canonical_workspace_source="workspace_playground",
+            )
+
+    def test_link_workspace_to_canonical_rejects_overwriting_existing_link(self, db):
+        ws = db.create_workspace(name="Existing Root", root_path="/tmp/existing-root")
+        db.link_workspace_to_canonical(
+            ws.id,
+            canonical_workspace_id="workspace-alpha",
+            canonical_workspace_source="workspace_playground",
+        )
+
+        with pytest.raises(
+            CanonicalWorkspaceBridgeConflictError,
+            match="different canonical workspace",
+        ):
+            db.link_workspace_to_canonical(
+                ws.id,
+                canonical_workspace_id="workspace-beta",
+                canonical_workspace_source="workspace_playground",
+            )
+
+        assert (
+            db.get_workspace_by_canonical_workspace_id("workspace-alpha").id == ws.id
+        )
+        assert db.get_workspace_by_canonical_workspace_id("workspace-beta") is None
 
     def test_workspace_with_git_info(self, db):
         ws = db.create_workspace(

--- a/tldw_Server_API/tests/Agent_Orchestration/test_workspace_db.py
+++ b/tldw_Server_API/tests/Agent_Orchestration/test_workspace_db.py
@@ -3,7 +3,6 @@ import tempfile
 
 import pytest
 
-from tldw_Server_API.app.core.Agent_Orchestration.models import ACPWorkspace, TaskStatus
 from tldw_Server_API.app.core.DB_Management.Orchestration_DB import (
     OrchestrationDB,
     OrchestrationNotFoundError,
@@ -229,6 +228,47 @@ class TestWorkspaceCRUD:
             metadata={"framework": "fastapi", "version": "0.100"},
         )
         assert ws.metadata["framework"] == "fastapi"
+
+    def test_get_workspace_by_canonical_workspace_id(self, db):
+        db.create_workspace(name="Other", root_path="/tmp/other")
+        linked = db.create_workspace(
+            name="Linked",
+            root_path="/tmp/linked",
+            metadata={
+                "canonical_workspace_id": "workspace-alpha",
+                "canonical_workspace_source": "workspace_playground",
+                "link_status": "linked",
+            },
+        )
+
+        found = db.get_workspace_by_canonical_workspace_id("workspace-alpha")
+
+        assert found is not None
+        assert found.id == linked.id
+        assert db.get_workspace_by_canonical_workspace_id("workspace-missing") is None
+
+    def test_link_workspace_to_canonical_merges_metadata_without_duplication(self, db):
+        ws = db.create_workspace(
+            name="Existing Root",
+            root_path="/tmp/existing-root",
+            metadata={"existing": "kept"},
+        )
+
+        linked = db.link_workspace_to_canonical(
+            ws.id,
+            canonical_workspace_id="workspace-alpha",
+            canonical_workspace_source="workspace_playground",
+        )
+
+        assert linked.id == ws.id
+        assert linked.metadata == {
+            "existing": "kept",
+            "canonical_workspace_id": "workspace-alpha",
+            "canonical_workspace_source": "workspace_playground",
+            "link_status": "linked",
+        }
+        assert len(db.list_workspaces()) == 1
+        assert db.get_workspace_by_canonical_workspace_id("workspace-alpha").id == ws.id
 
     def test_workspace_with_git_info(self, db):
         ws = db.create_workspace(


### PR DESCRIPTION
## Summary
- Add a canonical workspace bridge endpoint at `POST /api/v1/agent-orchestration/workspaces/canonical-bridge` that validates canonical workspace ownership, enforces ACP workspace root allowlisting, reuses existing links, links existing unlinked roots, and rejects conflicting canonical/root bindings.
- Add ACP workspace metadata helpers and expose `canonical_workspace` bridge metadata on workspace, project detail, and task detail responses.
- Document the bridge endpoint and add Backlog TASK-307 with verification evidence.

## Verification
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Agent_Orchestration/test_workspace_db.py tldw_Server_API/tests/Agent_Orchestration/test_orchestration_api.py -q` => 80 passed, 5 warnings.
- `git diff --check` => clean.
- `source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py tldw_Server_API/app/core/DB_Management/Orchestration_DB.py -f json -o /tmp/bandit_task307.json` => 0 findings.
- Focused Ruff after import cleanup still reports pre-existing baseline issues in touched files: B904/F841/UP037/SIM118/F841.

Refs #1540.
Refs #1532.

## Merge Gate
Per the AI-generated PR policy, the human requester still needs to add or own the final Change summary before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an ACP canonical workspace bridge. `POST /api/v1/agent-orchestration/workspaces/canonical-bridge` links a canonical workspace to an ACP execution workspace with allowlisting and conflict checks, and returns a `canonical_workspace` link. Surfaces this link on workspace, project, and task responses. Addresses #1540 and #1532.

- **New Features**
  - Validates the canonical workspace exists for the user via `get_chacha_db_for_user`.
  - Adds atomic DB bridge `find_or_create_canonical_workspace_bridge`: reuses existing links, links unlinked roots, and rejects conflicting canonical/root pairs (409 with stable error code).
  - Enforces ACP root allowlist; dispatch inherits the trusted root and blocks cwd escapes.
  - DB helpers/constants: `get_workspaces_by_ids`, `get_workspace_by_canonical_workspace_id`, `link_workspace_to_canonical`, and canonical metadata keys; persists `canonical_workspace_id` and source in both a column and metadata.
  - Response updates: adds `canonical_workspace` link to workspace, project (list/detail), and task payloads; docs and focused API/DB tests added.

- **Migration**
  - Bumps schema to v3: adds `canonical_workspace_id` column and a partial unique index per user; migration backfills from metadata and fails if duplicate canonical links exist.

<sup>Written for commit 0a50d3185d0ba3843df68dfe4fa3cef0e322f262. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

