### PR TITLE
Migrate Flashcards setup label to registry

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -5115,17 +5115,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "canonical-state-label:src/components/Flashcards/FlashcardsWorkspace.tsx:Setup required",
-    "path": "src/components/Flashcards/FlashcardsWorkspace.tsx",
-    "rule": "canonical-state-label",
-    "subject": "Setup required",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing hardcoded \"Setup required\" state label in src/components/Flashcards/FlashcardsWorkspace.tsx before the guard.",
-    "replacement": "getDesignSystemState(...)",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "canonical-state-label:src/components/Option/Admin/MonitoringDashboardPage.tsx:Ready",
     "path": "src/components/Option/Admin/MonitoringDashboardPage.tsx",
     "rule": "canonical-state-label",

--- a/apps/packages/ui/src/components/Flashcards/FlashcardsWorkspace.tsx
+++ b/apps/packages/ui/src/components/Flashcards/FlashcardsWorkspace.tsx
@@ -13,6 +13,7 @@ import {
 import FeatureEmptyState from "@/components/Common/FeatureEmptyState"
 import ConnectionProblemBanner from "@/components/Common/ConnectionProblemBanner"
 import { StatusBadge } from "@/components/Common/StatusBadge"
+import { getDesignSystemState } from "@/design-system"
 import { getDemoFlashcardDecks } from "@/utils/demo-content"
 const FlipCardDemo = React.lazy(() =>
   import("./components/FlipCardDemo").then((m) => ({ default: m.FlipCardDemo }))
@@ -109,8 +110,9 @@ export const FlashcardsWorkspace: React.FC = () => {
       }
     }
     if (uxState === "unconfigured" || uxState === "configuring_url") {
+      const setupRequiredState = getDesignSystemState("setup_required")
       return {
-        badgeLabel: "Setup required",
+        badgeLabel: setupRequiredState.label,
         title: t("option:flashcards.setupTitle", {
           defaultValue: "Finish setup to use Flashcards"
         }),

--- a/apps/packages/ui/src/components/Flashcards/__tests__/FlashcardsWorkspace.connection-state.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/__tests__/FlashcardsWorkspace.connection-state.test.tsx
@@ -81,11 +81,13 @@ vi.mock("@/design-system", async (importActual) => {
     getDesignSystemState: vi.fn(
       (key: Parameters<typeof actual.getDesignSystemState>[0]) => {
         const state = actual.getDesignSystemState(key)
-        return {
-          ...state,
-          label:
-            key === "setup_required" ? mocks.setupRequiredLabel : state.label
-        }
+        return state
+          ? {
+              ...state,
+              label:
+                key === "setup_required" ? mocks.setupRequiredLabel : state.label
+            }
+          : state
       }
     )
   }

--- a/apps/packages/ui/src/components/Flashcards/__tests__/FlashcardsWorkspace.connection-state.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/__tests__/FlashcardsWorkspace.connection-state.test.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { fireEvent, render, screen } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import { getDesignSystemState } from "@/design-system"
 import { FlashcardsWorkspace } from "../FlashcardsWorkspace"
 
 const mocks = vi.hoisted(() => ({
@@ -24,7 +25,8 @@ const mocks = vi.hoisted(() => ({
   capsLoading: false,
   navigate: vi.fn(),
   scrollToServerCard: vi.fn(),
-  checkOnce: vi.fn()
+  checkOnce: vi.fn(),
+  setupRequiredLabel: "Registry Setup Required"
 }))
 
 vi.mock("react-i18next", () => ({
@@ -72,6 +74,23 @@ vi.mock("@/hooks/useScrollToServerCard", () => ({
   useScrollToServerCard: () => mocks.scrollToServerCard
 }))
 
+vi.mock("@/design-system", async (importActual) => {
+  const actual = await importActual<typeof import("@/design-system")>()
+  return {
+    ...actual,
+    getDesignSystemState: vi.fn(
+      (key: Parameters<typeof actual.getDesignSystemState>[0]) => {
+        const state = actual.getDesignSystemState(key)
+        return {
+          ...state,
+          label:
+            key === "setup_required" ? mocks.setupRequiredLabel : state.label
+        }
+      }
+    )
+  }
+})
+
 describe("FlashcardsWorkspace connection states", () => {
   beforeEach(() => {
     mocks.isOnline = true
@@ -83,6 +102,8 @@ describe("FlashcardsWorkspace connection states", () => {
     mocks.navigate.mockReset()
     mocks.scrollToServerCard.mockReset()
     mocks.checkOnce.mockReset()
+    mocks.setupRequiredLabel = "Registry Setup Required"
+    vi.mocked(getDesignSystemState).mockClear()
   })
 
   it("keeps demo preview visible while surfacing auth guidance", () => {
@@ -93,7 +114,7 @@ describe("FlashcardsWorkspace connection states", () => {
     render(<FlashcardsWorkspace />)
 
     expect(screen.getByText("Explore Flashcards in demo mode")).toBeInTheDocument()
-    expect(screen.getByText("Example decks (preview only)")).toBeInTheDocument()
+    expect(screen.getByText("Try sample flashcards")).toBeInTheDocument()
     expect(
       screen.getByText("Demo stays available, but your Flashcards credentials need attention.")
     ).toBeInTheDocument()
@@ -113,6 +134,8 @@ describe("FlashcardsWorkspace connection states", () => {
     expect(
       screen.getByText("Finish setup to use Flashcards")
     ).toBeInTheDocument()
+    expect(screen.getByText(mocks.setupRequiredLabel)).toBeInTheDocument()
+    expect(getDesignSystemState).toHaveBeenCalledWith("setup_required")
 
     fireEvent.click(screen.getByRole("button", { name: "Go to server card" }))
     expect(mocks.scrollToServerCard).toHaveBeenCalled()
@@ -125,7 +148,7 @@ describe("FlashcardsWorkspace connection states", () => {
 
     render(<FlashcardsWorkspace />)
 
-    expect(screen.getByText("Example decks (preview only)")).toBeInTheDocument()
+    expect(screen.getByText("Try sample flashcards")).toBeInTheDocument()
     expect(
       screen.getByText("Demo stays available, but your tldw server is unreachable.")
     ).toBeInTheDocument()

--- a/backlog/tasks/task-308 - Migrate-FlashcardsWorkspace-setup-required-label-to-design-system-registry.md
+++ b/backlog/tasks/task-308 - Migrate-FlashcardsWorkspace-setup-required-label-to-design-system-registry.md
@@ -1,0 +1,71 @@
+---
+id: TASK-308
+title: Migrate FlashcardsWorkspace setup-required label to design-system registry
+status: Done
+assignee: []
+created_date: '2026-05-13 00:56'
+updated_date: '2026-05-13 01:03'
+labels:
+  - design-system
+  - frontend
+  - flashcards
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replace the remaining hardcoded FlashcardsWorkspace setup-required product-state label with the canonical design-system state registry value. Scope is limited to the FlashcardsWorkspace offline/setup banner and the matching product-state baseline entry.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Focused regression coverage fails before the migration and passes after the registry-backed label is wired.
+- [x] #2 The matching FlashcardsWorkspace canonical-state-label baseline exception is removed and the design-system product-state guard passes.
+- [x] #3 FlashcardsWorkspace renders the setup-required banner label from getDesignSystemState("setup_required").label instead of a local hardcoded product-state string.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused failing regression test proving the setup-required FlashcardsWorkspace banner label comes from getDesignSystemState("setup_required").label.
+2. Replace the hardcoded setup-required badge label with the design-system registry value.
+3. Remove the matching baseline entry and run focused Flashcards plus product-state guard verification.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implementation notes:
+- Replaced FlashcardsWorkspace setup-required offline banner badge label with getDesignSystemState("setup_required").label.
+- Added a registry-backed regression assertion in FlashcardsWorkspace.connection-state.test.tsx.
+- Updated stale demo preview expectations from "Example decks (preview only)" to the current "Try sample flashcards" text exposed by current dev.
+- Removed the matching FlashcardsWorkspace canonical-state-label baseline exception.
+
+Verification:
+- Red: bun run test src/components/Flashcards/__tests__/FlashcardsWorkspace.connection-state.test.tsx --reporter=dot failed only because Registry Setup Required was not rendered.
+- Green: bun run test src/components/Flashcards/__tests__/FlashcardsWorkspace.connection-state.test.tsx --reporter=dot passed 3 tests.
+- bun run test src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed 52 tests.
+- bun run verify:design-system-state passed with baseline exceptions reduced to 506 and canonical-state-label exceptions reduced to 26.
+- bunx tsc --noEmit --pretty false 2>&1 | rg -n "FlashcardsWorkspace|design-system-product-state-baseline" returned no touched-path diagnostics.
+- git diff --check passed.
+- Baseline JSON parse check passed.
+- Bandit skipped: touched code is frontend TypeScript, JSON baseline, and task documentation only.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+FlashcardsWorkspace now reads its setup-required product-state badge label from the canonical design-system state registry, the focused connection-state test covers the registry-backed label path, and the product-state baseline no longer carries the FlashcardsWorkspace setup-required exception.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-308 - Migrate-FlashcardsWorkspace-setup-required-label-to-design-system-registry.md
+++ b/backlog/tasks/task-308 - Migrate-FlashcardsWorkspace-setup-required-label-to-design-system-registry.md
@@ -4,7 +4,7 @@ title: Migrate FlashcardsWorkspace setup-required label to design-system registr
 status: Done
 assignee: []
 created_date: '2026-05-13 00:56'
-updated_date: '2026-05-13 01:03'
+updated_date: '2026-05-13 01:29'
 labels:
   - design-system
   - frontend
@@ -52,6 +52,11 @@ Verification:
 - git diff --check passed.
 - Baseline JSON parse check passed.
 - Bandit skipped: touched code is frontend TypeScript, JSON baseline, and task documentation only.
+
+PR #1618 review fix:
+- Made the getDesignSystemState test mock defensively pass through a missing registry state instead of dereferencing state.label.
+- Fresh review-fix verification: FlashcardsWorkspace connection-state Vitest passed 3 tests; product-state guard Vitest passed 52 tests; verify:design-system-state exited 0 with baseline exceptions 506 and canonical-state-label 26; git diff --check passed.
+- Full UI tsc still exits nonzero due existing unrelated package diagnostics outside this PR touched files.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary


### PR DESCRIPTION
## Change summary
- Move the Flashcards setup-required offline banner badge label to `getDesignSystemState("setup_required").label` so this state copy is owned by the canonical design-system registry.
- Add focused regression coverage that overrides the registry label and verifies the rendered setup badge uses that value.
- Remove the matching FlashcardsWorkspace `canonical-state-label` baseline exception, reducing the shared product-state baseline by one entry.

## Verification
- `bun run test src/components/Flashcards/__tests__/FlashcardsWorkspace.connection-state.test.tsx --reporter=dot`
- `bun run test src/design-system/__tests__/product-state-guard.test.ts --reporter=dot`
- `bun run verify:design-system-state`
- `bunx tsc --noEmit --pretty false 2>&1 | rg -n "FlashcardsWorkspace|design-system-product-state-baseline"`
- `git diff --check`
- `node -e 'const fs=require("fs"); JSON.parse(fs.readFileSync("apps/packages/ui/scripts/design-system-product-state-baseline.json","utf8")); console.log("baseline json ok")'`\n\nBandit skipped: touched code is frontend TypeScript, JSON baseline, and task documentation only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the Flashcards “setup required” badge to the design-system registry and removes the baseline exception. Hardens the test registry mock and updates assertions to match current copy. Completes TASK-308.

- **Refactors**
  - Uses `getDesignSystemState("setup_required").label` for the setup badge.
  - Makes the test registry mock defensive and asserts the `setup_required` lookup; updates expectation to “Try sample flashcards”.
  - Removes the matching `canonical-state-label` baseline exception.

<sup>Written for commit c28abe0b01c4c6f6957f9be5f831e0787758d895. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

