### PR TITLE
Harden Persona Buddy sprite atlas support

### DIFF
--- a/Docs/Code_Documentation/Persona_Visual_Packs.md
+++ b/Docs/Code_Documentation/Persona_Visual_Packs.md
@@ -60,6 +60,63 @@ capability contract is now in place; sprite-sheet frame regions are supported
 inside `sprite_frames`, and any future non-sprite adapter should reuse the
 registry instead of adding another hardcoded renderer path.
 
+### Sprite Atlas Frames
+
+Sprite atlases are represented as `sprite_frames` packs. In this slice,
+`sprite_sheet` is an asset role, not a separate `renderer_type`; manifests that
+set `renderer_type: "sprite_sheet"` are still unsupported for activation.
+
+Atlas-backed animations reference the atlas asset from each frame and include a
+pixel `region` rectangle. The same atlas asset can be reused across multiple
+frames:
+
+```json
+{
+  "manifest_version": 1,
+  "renderer_type": "sprite_frames",
+  "states": {
+    "idle": { "animation_id": "idle_loop" },
+    "listening": { "animation_id": "idle_loop" },
+    "thinking": { "animation_id": "idle_loop" },
+    "speaking": { "animation_id": "speak_loop" },
+    "error": { "animation_id": "idle_loop" }
+  },
+  "animations": {
+    "idle_loop": {
+      "frame_rate": 8,
+      "frames": [
+        {
+          "asset_id": "atlas-main",
+          "region": { "x": 0, "y": 0, "width": 128, "height": 128 },
+          "duration_ms": 120
+        },
+        {
+          "asset_id": "atlas-main",
+          "region": { "x": 128, "y": 0, "width": 128, "height": 128 },
+          "duration_ms": 120
+        }
+      ]
+    },
+    "speak_loop": {
+      "frame_rate": 12,
+      "frames": [
+        {
+          "asset_id": "atlas-main",
+          "region": { "x": 0, "y": 128, "width": 128, "height": 128 }
+        }
+      ]
+    }
+  }
+}
+```
+
+The referenced asset row should use `asset_role: "sprite_sheet"` and must still
+be a bounded raster image accepted by the normal visual upload/import path.
+Backend validation rejects non-integer, non-positive, or out-of-bounds regions
+when source dimensions are known. When dimensions are not yet available, draft
+validation can accept positive integer regions and the Buddy renderer remains
+fail-soft at runtime if a region cannot be rendered safely.
+
 ## Personal Library
 
 The personal library is a user-scoped metadata layer over existing Persona

--- a/Docs/Design/2026-05-10-persona-visual-renderer-provider-adapter-evaluation.md
+++ b/Docs/Design/2026-05-10-persona-visual-renderer-provider-adapter-evaluation.md
@@ -108,8 +108,9 @@ Recommendation:
 
 Extend the existing renderer family before adding new renderer engines:
 
-1. Add optional `sprite_sheet`/atlas capability metadata only after backend
-   validation and Buddy rendering agree on the support boundary.
+1. Keep sprite atlas support under `renderer_type: "sprite_frames"` and use
+   `asset_role: "sprite_sheet"` plus frame-level `region` rectangles for atlas
+   assets. `sprite_sheet` is not an activatable renderer in this V1.1 slice.
 2. Keep it within the same raster-safe validation model: bounded dimensions,
    byte size, region bounds, checksums, no executable content.
 3. Treat this as the lowest-risk bridge between current sprite packs and richer

--- a/Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md
+++ b/Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md
@@ -584,7 +584,10 @@ baseline. The first reference-backed V1 slices are now covered:
    tracked by #1497 and the 2026-05-10 design evaluation.
 9. Renderer capability registry/API and Buddy renderer registry are complete in
    PR #1608, with `sprite_frames` still the only enabled V1 runtime renderer.
-10. Live2D or other renderer adapter implementation remains future work after
+10. Sprite atlas V1.1 remains inside `sprite_frames`: atlas assets use
+    `asset_role: "sprite_sheet"` and frame-level `region` rectangles, not a
+    separate `sprite_sheet` renderer or manifest version bump.
+11. Live2D or other renderer adapter implementation remains future work after
     non-sprite manifest V2, import-preview validation hooks, dependency gates,
     licensing review, and fallback requirements are separately scoped.
 

--- a/Docs/superpowers/plans/2026-05-13-persona-buddy-sprite-atlas-v11.md
+++ b/Docs/superpowers/plans/2026-05-13-persona-buddy-sprite-atlas-v11.md
@@ -1,0 +1,72 @@
+# Persona Buddy Sprite Atlas V1.1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Harden Persona/Buddy sprite atlas support under the existing `sprite_frames` renderer.
+
+**Architecture:** Keep atlas support as raster frame rendering, not a new renderer. Backend validation continues to validate `frames[].region` against known asset dimensions, while Buddy renders region-backed frames through the existing renderer registry and fails soft when a region is invalid at runtime.
+
+**Tech Stack:** Python manifest validation tests, React/Vitest Buddy renderer tests, Markdown product/code documentation.
+
+---
+
+### Task 1: Backend Atlas Validation Contract
+
+**Files:**
+- Modify: `tldw_Server_API/tests/Persona/test_persona_visuals_core.py`
+
+- [x] **Step 1: Add an activatable atlas-manifest test**
+
+Add a test that uses `renderer_type: "sprite_frames"`, a `sprite_sheet`-style atlas asset ID, required visual states, and `frames[].region` rectangles. Validate with `require_activatable=True` and known dimensions.
+
+- [x] **Step 2: Add a missing-dimension behavior test**
+
+Add a test showing that region bounds are only rejected when source dimensions are known; when dimensions are unavailable, validation still accepts positive integer regions so drafts/import previews can remain fail-open until asset metadata exists.
+
+- [x] **Step 3: Run backend focused tests**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Persona/test_persona_visuals_core.py -q`
+
+Expected: all tests pass.
+
+### Task 2: Buddy Renderer And Diagnostics Contract
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/personaVisualRenderers.test.tsx`
+- Modify: `apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/personaVisualDiagnostics.test.ts`
+
+- [x] **Step 1: Add registry-path atlas rendering coverage**
+
+Add a `PersonaVisualRendererHost` test proving a pack with `asset_role: "sprite_sheet"` and `frames[].region` renders as a cropped background through the registered `sprite_frames` renderer.
+
+- [x] **Step 2: Add unsupported-region diagnostics coverage**
+
+Add coverage showing `unsupported_region` render errors produce a fail-soft warning diagnostic instead of blocking Buddy.
+
+- [x] **Step 3: Run frontend focused tests**
+
+Run: `bunx vitest run apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/personaVisualRenderers.test.tsx apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/personaVisualDiagnostics.test.ts`
+
+Expected: all tests pass.
+
+### Task 3: Documentation And Tracker Closeout
+
+**Files:**
+- Modify: `Docs/Code_Documentation/Persona_Visual_Packs.md`
+- Modify: `Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md`
+- Modify: `Docs/Design/2026-05-10-persona-visual-renderer-provider-adapter-evaluation.md`
+- Modify: `backlog/tasks/task-308 - Harden-Persona-Buddy-sprite-atlas-support-under-sprite_frames.md`
+
+- [x] **Step 1: Add a minimal atlas-backed manifest example**
+
+Document a `sprite_frames` manifest using a `sprite_sheet` asset role plus frame-level `region` rectangles. State that `sprite_sheet` is an asset role in this slice, not an activatable renderer.
+
+- [x] **Step 2: Refresh roadmap/evaluation wording**
+
+Mark sprite atlas V1.1 as the current hardening slice and keep Live2D, non-sprite manifest V2, external providers, and shared libraries as future work.
+
+- [x] **Step 3: Run final checks**
+
+Run: `git diff --check`
+
+Run focused backend and frontend tests from Tasks 1 and 2. Run Bandit on touched Python source only if source code changes; otherwise record a non-code skip for Bandit.

--- a/apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/personaVisualDiagnostics.test.ts
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/personaVisualDiagnostics.test.ts
@@ -165,6 +165,20 @@ describe("resolvePersonaVisualDiagnostics", () => {
     )
   })
 
+  it("reports unsupported sprite atlas regions as fail-soft warnings", () => {
+    expect(
+      getPrimaryPersonaVisualDiagnostic({
+        pack: buildPack(),
+        renderError: "unsupported_region"
+      })
+    ).toEqual(
+      expect.objectContaining({
+        code: "unsupported_region",
+        severity: "warning"
+      })
+    )
+  })
+
   it("returns no diagnostics for a renderable sprite-frame pack", () => {
     expect(resolvePersonaVisualDiagnostics({ pack: buildPack() })).toEqual([])
   })

--- a/apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/personaVisualRenderers.test.tsx
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/personaVisualRenderers.test.tsx
@@ -124,6 +124,52 @@ describe("persona visual renderer registry", () => {
     expect(onRenderError).toHaveBeenCalledWith(null)
   })
 
+  it("renders sprite atlas regions through the registered sprite frame renderer", () => {
+    const onRenderError = vi.fn()
+
+    render(
+      <PersonaVisualRendererHost
+        pack={buildPack({
+          manifest: {
+            ...buildPack().manifest,
+            animations: {
+              idle: {
+                frames: [
+                  {
+                    asset_id: "sheet-1",
+                    region: { x: 16, y: 8, width: 24, height: 32 }
+                  }
+                ]
+              }
+            }
+          },
+          assets_by_id: {
+            "sheet-1": {
+              id: "sheet-1",
+              url: "/assets/sheet.png",
+              mime_type: "image/png",
+              asset_role: "sprite_sheet",
+              width: 96,
+              height: 64
+            }
+          }
+        })}
+        state="idle"
+        fallbackLabel="Buddy"
+        onRenderError={onRenderError}
+      />
+    )
+
+    expect(screen.getByTestId("persona-visual-frame")).toHaveStyle({
+      backgroundImage: "url(/assets/sheet.png)",
+      backgroundPosition: "-16px -8px",
+      backgroundSize: "96px 64px",
+      width: "24px",
+      height: "32px"
+    })
+    expect(onRenderError).toHaveBeenCalledWith(null)
+  })
+
   it("mounts supported renderers so they can report render errors", () => {
     const onRenderError = vi.fn()
 
@@ -148,6 +194,47 @@ describe("persona visual renderer registry", () => {
     expect(screen.getByText("Buddy")).toBeInTheDocument()
     expect(screen.queryByTestId("persona-visual-frame")).not.toBeInTheDocument()
     expect(onRenderError).toHaveBeenCalledWith("missing_asset")
+  })
+
+  it("keeps unsupported sprite atlas regions fail-soft through the registered renderer", () => {
+    const onRenderError = vi.fn()
+
+    render(
+      <PersonaVisualRendererHost
+        pack={buildPack({
+          manifest: {
+            ...buildPack().manifest,
+            animations: {
+              idle: {
+                frames: [
+                  {
+                    asset_id: "sheet-1",
+                    region: { x: 80, y: 0, width: 32, height: 32 }
+                  }
+                ]
+              }
+            }
+          },
+          assets_by_id: {
+            "sheet-1": {
+              id: "sheet-1",
+              url: "/assets/sheet.png",
+              mime_type: "image/png",
+              asset_role: "sprite_sheet",
+              width: 96,
+              height: 64
+            }
+          }
+        })}
+        state="idle"
+        fallbackLabel="Buddy"
+        onRenderError={onRenderError}
+      />
+    )
+
+    expect(screen.getByText("Buddy")).toBeInTheDocument()
+    expect(screen.queryByTestId("persona-visual-frame")).not.toBeInTheDocument()
+    expect(onRenderError).toHaveBeenCalledWith("unsupported_region")
   })
 
   it("falls back for unsupported renderer packs", () => {

--- a/backlog/tasks/task-308 - Harden-Persona-Buddy-sprite-atlas-support-under-sprite_frames.md
+++ b/backlog/tasks/task-308 - Harden-Persona-Buddy-sprite-atlas-support-under-sprite_frames.md
@@ -1,0 +1,69 @@
+---
+id: TASK-308
+title: Harden Persona Buddy sprite atlas support under sprite_frames
+status: Done
+assignee: []
+created_date: '2026-05-13 01:02'
+updated_date: '2026-05-13 01:18'
+labels:
+  - persona
+  - buddy
+  - visual-packs
+  - webui
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1611'
+documentation:
+  - Docs/Code_Documentation/Persona_Visual_Packs.md
+  - Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md
+  - >-
+    Docs/Design/2026-05-10-persona-visual-renderer-provider-adapter-evaluation.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement GitHub issue 1611 as a narrow V1.1 hardening slice. Keep sprite atlas support under renderer_type sprite_frames using sprite_sheet asset roles plus frame-level region rectangles. Do not add a sprite_sheet renderer, manifest version bump, Live2D adapter, external provider behavior, VN/CYOA behavior, image generation, automatic atlas packing, or marketplace/shared-library behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Valid sprite_frames manifests can use a sprite_sheet atlas asset with frames[].region and remain activatable when dimensions are known.
+- [x] #2 Backend validation coverage rejects invalid atlas regions when dimensions are known and documents fail-open missing-dimension behavior.
+- [x] #3 Buddy WebUI renderer coverage proves atlas-backed frames render cropped through the existing renderer registry path.
+- [x] #4 Diagnostics and fallback coverage stays fail-soft for missing assets or unsupported regions.
+- [x] #5 Docs include a minimal atlas-backed sprite_frames manifest example and clearly state sprite_sheet is an asset role, not a separate renderer in this slice.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Plan saved at Docs/superpowers/plans/2026-05-13-persona-buddy-sprite-atlas-v11.md. Scope: backend atlas validation contract tests, Buddy renderer and diagnostics tests, and docs examples. No new renderer type, manifest version, Live2D adapter, external provider behavior, VN/CYOA behavior, or automatic atlas generation.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Created implementation plan after inspecting current backend validation and Buddy renderer support. Current code already supports frames[].region cropping and known-dimension bounds checks, so this slice should mostly harden contract tests and docs unless focused tests expose a gap.
+
+Completed implementation as a contract/docs hardening slice. Added backend coverage for activatable atlas manifests with known dimensions, retained existing rejection coverage for out-of-bounds regions, and added missing-dimension fail-open coverage for draft/import metadata gaps. Added Buddy renderer registry-path atlas rendering coverage and unsupported-region diagnostics coverage. Added docs example defining sprite_sheet as an asset role under sprite_frames, not a renderer_type.
+
+Verification: git diff --check passed. Backend focused test passed with 20 tests. Frontend focused test passed with 17 tests after running from apps/packages/ui so Vitest used the UI package dependency context. Bandit against Persona visual source files reported zero findings.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Hardened Persona Buddy sprite atlas support under the existing sprite_frames renderer. Added backend tests for activatable atlas manifests and missing-dimension region behavior, WebUI tests for cropped atlas rendering through the renderer registry, and diagnostics coverage for unsupported regions. Updated docs and the renderer evaluation to show sprite_sheet as an asset role with frames[].region rectangles, not a separate renderer or manifest version. Verification: git diff --check passed, tldw_Server_API/tests/Persona/test_persona_visuals_core.py passed with 20 tests, PersonaBuddy Vitest focus passed with 17 tests, and Bandit reported zero issues across Persona visual source files.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/tests/Persona/test_persona_visuals_core.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visuals_core.py
@@ -258,6 +258,39 @@ def test_accepts_sprite_sheet_regions_and_preview_frame() -> None:
     assert result.manifest["animations"]["idle"]["preview_frame"] == 1
 
 
+def test_activatable_manifest_accepts_sprite_sheet_regions_with_known_dimensions() -> None:
+    manifest = _activatable_manifest()
+    for index, animation in enumerate(manifest["animations"].values()):
+        animation.pop("asset_ids", None)
+        animation["frames"] = [
+            {
+                "asset_id": "sheet-asset",
+                "region": {
+                    "x": index * 64,
+                    "y": 0,
+                    "width": 64,
+                    "height": 64,
+                },
+                "duration_ms": 120,
+            }
+        ]
+
+    result = validate_visual_manifest(
+        manifest,
+        available_asset_ids={"sheet-asset"},
+        available_asset_dimensions={"sheet-asset": (512, 128)},
+        require_activatable=True,
+    )
+
+    assert set(result.resolved_required_states) == REQUIRED_VISUAL_STATES
+    assert result.manifest["renderer_type"] == "sprite_frames"
+    for animation in result.manifest["animations"].values():
+        frame = animation["frames"][0]
+        assert frame["asset_id"] == "sheet-asset"
+        assert frame["region"]["width"] == 64
+        assert frame["region"]["height"] == 64
+
+
 def test_rejects_sprite_sheet_regions_outside_asset_bounds() -> None:
     manifest = {
         "manifest_version": 1,
@@ -283,6 +316,39 @@ def test_rejects_sprite_sheet_regions_outside_asset_bounds() -> None:
             available_asset_dimensions={"sheet-asset": (256, 128)},
             require_activatable=False,
         )
+
+
+def test_accepts_sprite_sheet_regions_without_dimensions_until_asset_metadata_exists() -> None:
+    manifest = {
+        "manifest_version": 1,
+        "renderer_type": "sprite_frames",
+        "states": {"idle": {"animation_id": "idle"}},
+        "animations": {
+            "idle": {
+                "frames": [
+                    {
+                        "asset_id": "sheet-asset",
+                        "region": {"x": 200, "y": 0, "width": 128, "height": 128},
+                    }
+                ],
+                "frame_rate": 8,
+            }
+        },
+    }
+
+    result = validate_visual_manifest(
+        manifest,
+        available_asset_ids={"sheet-asset"},
+        available_asset_dimensions={},
+        require_activatable=False,
+    )
+
+    assert result.manifest["animations"]["idle"]["frames"][0]["region"] == {
+        "x": 200,
+        "y": 0,
+        "width": 128,
+        "height": 128,
+    }
 
 
 def test_rejects_preview_frame_out_of_range() -> None:


### PR DESCRIPTION
## Human Change Summary

Pending human-authored summary before merge per project policy.

## AI Implementation Summary

- Adds backend contract coverage for sprite atlas frames under renderer_type sprite_frames, including activatable manifests with known dimensions and fail-open draft behavior when dimensions are unavailable.
- Adds Buddy WebUI renderer-registry coverage for cropped atlas frames and fail-soft unsupported-region diagnostics.
- Documents the atlas manifest shape and clarifies that sprite_sheet is an asset role, not a separate renderer in this slice.
- Adds TASK-308 and a focused implementation plan for the slice.

## Verification

- git diff --check
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_visuals_core.py -q
- bunx vitest run src/components/Common/PersonaBuddy/__tests__/personaVisualRenderers.test.tsx src/components/Common/PersonaBuddy/__tests__/personaVisualDiagnostics.test.ts from apps/packages/ui
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Persona/visuals.py tldw_Server_API/app/core/Persona/visual_manifest_assets.py tldw_Server_API/app/core/Persona/visual_service.py -f json -o /tmp/bandit_persona_buddy_sprite_atlas.json

Closes #1611

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened Persona Buddy sprite atlas support under the existing `sprite_frames` renderer, covering atlas frame regions end to end. Clarifies `sprite_sheet` as an asset role and keeps runtime fail-soft for unsupported regions.

- Documentation and Tests
  - Backend: adds tests for activatable manifests using atlas `frames[].region`; rejects out-of-bounds regions when dimensions are known; allows positive regions when dimensions are missing (drafts stay fail-open).
  - WebUI: adds renderer tests for cropped atlas frames and warning diagnostics for `unsupported_region`, preserving fallback behavior.
  - Docs: adds a minimal atlas-backed `sprite_frames` manifest example, clarifies that `sprite_sheet` is not a separate renderer, and updates design/PRD and the implementation plan.

<sup>Written for commit 34fad5246015696c3097c815a76134437826fea7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

