### PR TITLE
Clarify Persona Buddy atlas region bounds wording

### DIFF
--- a/Docs/Code_Documentation/Persona_Visual_Packs.md
+++ b/Docs/Code_Documentation/Persona_Visual_Packs.md
@@ -112,9 +112,9 @@ frames:
 
 The referenced asset row should use `asset_role: "sprite_sheet"` and must still
 be a bounded raster image accepted by the normal visual upload/import path.
-Backend validation rejects non-integer regions, negative x/y coordinates,
-non-positive width/height dimensions, or out-of-bounds regions when source
-dimensions are known. When dimensions are not yet available, draft validation
+Backend validation rejects non-integer coordinates or dimensions, negative x/y
+coordinates, or non-positive width/height dimensions. It also rejects out-of-bounds
+regions when source dimensions are known. When dimensions are not yet available, draft validation
 can accept integer regions with non-negative x/y coordinates and positive
 width/height dimensions, and the Buddy renderer remains fail-soft at runtime if
 a region cannot be rendered safely.

--- a/Docs/Code_Documentation/Persona_Visual_Packs.md
+++ b/Docs/Code_Documentation/Persona_Visual_Packs.md
@@ -112,10 +112,12 @@ frames:
 
 The referenced asset row should use `asset_role: "sprite_sheet"` and must still
 be a bounded raster image accepted by the normal visual upload/import path.
-Backend validation rejects non-integer, non-positive, or out-of-bounds regions
-when source dimensions are known. When dimensions are not yet available, draft
-validation can accept positive integer regions and the Buddy renderer remains
-fail-soft at runtime if a region cannot be rendered safely.
+Backend validation rejects non-integer regions, negative x/y coordinates,
+non-positive width/height dimensions, or out-of-bounds regions when source
+dimensions are known. When dimensions are not yet available, draft validation
+can accept integer regions with non-negative x/y coordinates and positive
+width/height dimensions, and the Buddy renderer remains fail-soft at runtime if
+a region cannot be rendered safely.
 
 ## Personal Library
 

--- a/backlog/tasks/task-309 - Clarify-Persona-Buddy-atlas-region-validation-wording.md
+++ b/backlog/tasks/task-309 - Clarify-Persona-Buddy-atlas-region-validation-wording.md
@@ -1,0 +1,53 @@
+---
+id: TASK-309
+title: Clarify Persona Buddy atlas region validation wording
+status: Done
+assignee: []
+created_date: '2026-05-13 01:37'
+updated_date: '2026-05-13 01:38'
+labels:
+  - persona
+  - buddy
+  - visual-packs
+  - docs
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1619'
+documentation:
+  - Docs/Code_Documentation/Persona_Visual_Packs.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Clarify the Persona Buddy visual-pack documentation after PR 1619 so atlas region validation wording matches backend behavior: x and y may be zero, negative coordinates are rejected, and width/height must be positive.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Docs describe invalid atlas regions as negative coordinates or non-positive dimensions.
+- [x] #2 Docs no longer imply that x=0 or y=0 are rejected.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verified backend behavior in tldw_Server_API/app/core/Persona/visuals.py: region x/y reject only negative values while width/height reject zero or negative values. Updated Persona_Visual_Packs.md wording and searched for the stale atlas-region phrasing. Verification: git diff --check passed; rg found no stale 'non-positive regions' wording. Tests and Bandit skipped because this is docs-only plus Backlog task metadata.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Clarified Persona visual-pack atlas region documentation to state that backend validation rejects negative x/y coordinates and non-positive width/height dimensions, rather than implying x=0 or y=0 are invalid.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
Change summary: AI-authored follow-up to PR #1619; human requester should replace this with a human-written rationale before merge per repo policy. This clarifies that atlas region validation rejects negative x/y coordinates and non-positive width/height dimensions, matching the backend validator. Verification: git diff --check; rg found no stale atlas-region wording. Tests/Bandit: skipped because this is docs-only plus Backlog task metadata.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies Persona Buddy atlas-region docs to mirror backend validation: rejects non-integer values, negative x/y, and non-positive width/height; x=0 and y=0 are valid, and out-of-bounds regions are rejected when source dimensions are known. Adds draft-validation rules (allow integer regions with non-negative x/y and positive width/height) and notes the Buddy renderer is fail-soft at runtime; aligns with TASK-309.

<sup>Written for commit 92edc7d87ef258aafe4d812984939f882fe1dbc5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

