### PR TITLE
Migrate Quiz setup label to registry

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -5335,17 +5335,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "canonical-state-label:src/components/Quiz/QuizWorkspace.tsx:Setup required",
-    "path": "src/components/Quiz/QuizWorkspace.tsx",
-    "rule": "canonical-state-label",
-    "subject": "Setup required",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing hardcoded \"Setup required\" state label in src/components/Quiz/QuizWorkspace.tsx before the guard.",
-    "replacement": "getDesignSystemState(...)",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "canonical-state-label:src/routes/sidepanel-chat.tsx:Ready",
     "path": "src/routes/sidepanel-chat.tsx",
     "rule": "canonical-state-label",

--- a/apps/packages/ui/src/components/Quiz/QuizWorkspace.tsx
+++ b/apps/packages/ui/src/components/Quiz/QuizWorkspace.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from "react-router-dom"
 import { useServerOnline } from "@/hooks/useServerOnline"
 import { useServerCapabilities } from "@/hooks/useServerCapabilities"
 import { useDemoMode } from "@/context/demo-mode"
+import { getDesignSystemState } from "@/design-system"
 import { useScrollToServerCard } from "@/hooks/useScrollToServerCard"
 import {
   useConnectionActions,
@@ -527,8 +528,10 @@ export const QuizWorkspace: React.FC = () => {
       }
     }
     if (uxState === "unconfigured" || uxState === "configuring_url") {
+      const setupRequiredState = getDesignSystemState("setup_required")
+
       return {
-        badgeLabel: "Setup required",
+        badgeLabel: setupRequiredState.label,
         title: t("option:quiz.setupTitle", {
           defaultValue: "Finish setup to use Quiz Playground"
         }),

--- a/apps/packages/ui/src/components/Quiz/QuizWorkspace.tsx
+++ b/apps/packages/ui/src/components/Quiz/QuizWorkspace.tsx
@@ -531,7 +531,7 @@ export const QuizWorkspace: React.FC = () => {
       const setupRequiredState = getDesignSystemState("setup_required")
 
       return {
-        badgeLabel: setupRequiredState.label,
+        badgeLabel: setupRequiredState?.label ?? "",
         title: t("option:quiz.setupTitle", {
           defaultValue: "Finish setup to use Quiz Playground"
         }),

--- a/apps/packages/ui/src/components/Quiz/__tests__/QuizWorkspace.connection-state.test.tsx
+++ b/apps/packages/ui/src/components/Quiz/__tests__/QuizWorkspace.connection-state.test.tsx
@@ -28,7 +28,8 @@ const mocks = vi.hoisted(() => ({
   navigate: vi.fn(),
   scrollToServerCard: vi.fn(),
   checkOnce: vi.fn(),
-  setupRequiredLabel: "Registry Setup Required"
+  setupRequiredLabel: "Registry Setup Required",
+  missingDesignSystemStateKeys: new Set<string>()
 }))
 
 const interpolate = (template: string, values?: Record<string, unknown>) =>
@@ -91,6 +92,10 @@ vi.mock("@/design-system", async (importActual) => {
     ...actual,
     getDesignSystemState: vi.fn(
       (key: Parameters<typeof actual.getDesignSystemState>[0]) => {
+        if (mocks.missingDesignSystemStateKeys.has(key)) {
+          return undefined as unknown as ReturnType<typeof actual.getDesignSystemState>
+        }
+
         const state = actual.getDesignSystemState(key)
         return state
           ? {
@@ -125,6 +130,7 @@ describe("QuizWorkspace connection and availability states", () => {
     mocks.scrollToServerCard.mockReset()
     mocks.checkOnce.mockReset()
     mocks.setupRequiredLabel = "Registry Setup Required"
+    mocks.missingDesignSystemStateKeys.clear()
     vi.mocked(getDesignSystemState).mockClear()
   })
 
@@ -195,6 +201,21 @@ describe("QuizWorkspace connection and availability states", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Go to server card" }))
     expect(mocks.scrollToServerCard).toHaveBeenCalled()
+  })
+
+  it("keeps setup guidance renderable when the setup state registry entry is unavailable", () => {
+    mocks.isOnline = false
+    mocks.demoEnabled = false
+    mocks.uxState = "unconfigured"
+    mocks.hasCompletedFirstRun = false
+    mocks.missingDesignSystemStateKeys.add("setup_required")
+
+    expect(() => render(<QuizWorkspace />)).not.toThrow()
+
+    expect(
+      screen.getByText("Finish setup to use Quiz Playground")
+    ).toBeInTheDocument()
+    expect(getDesignSystemState).toHaveBeenCalledWith("setup_required")
   })
 
   it("shows unreachable guidance without hiding the demo preview", () => {

--- a/apps/packages/ui/src/components/Quiz/__tests__/QuizWorkspace.connection-state.test.tsx
+++ b/apps/packages/ui/src/components/Quiz/__tests__/QuizWorkspace.connection-state.test.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import { getDesignSystemState } from "@/design-system"
 import { QuizWorkspace } from "../QuizWorkspace"
 
 const mocks = vi.hoisted(() => ({
@@ -26,7 +27,8 @@ const mocks = vi.hoisted(() => ({
   capsLoading: false,
   navigate: vi.fn(),
   scrollToServerCard: vi.fn(),
-  checkOnce: vi.fn()
+  checkOnce: vi.fn(),
+  setupRequiredLabel: "Registry Setup Required"
 }))
 
 const interpolate = (template: string, values?: Record<string, unknown>) =>
@@ -83,6 +85,25 @@ vi.mock("@/hooks/useConnectionState", () => ({
   })
 }))
 
+vi.mock("@/design-system", async (importActual) => {
+  const actual = await importActual<typeof import("@/design-system")>()
+  return {
+    ...actual,
+    getDesignSystemState: vi.fn(
+      (key: Parameters<typeof actual.getDesignSystemState>[0]) => {
+        const state = actual.getDesignSystemState(key)
+        return state
+          ? {
+              ...state,
+              label:
+                key === "setup_required" ? mocks.setupRequiredLabel : state.label
+            }
+          : state
+      }
+    )
+  }
+})
+
 vi.mock("../hooks", () => ({
   useQuizzesQuery: () => ({ data: undefined, isLoading: false }),
   useAttemptsQuery: () => ({ data: { count: 0 } })
@@ -103,6 +124,8 @@ describe("QuizWorkspace connection and availability states", () => {
     mocks.navigate.mockReset()
     mocks.scrollToServerCard.mockReset()
     mocks.checkOnce.mockReset()
+    mocks.setupRequiredLabel = "Registry Setup Required"
+    vi.mocked(getDesignSystemState).mockClear()
   })
 
   it("renders an interactive local demo quiz flow when offline demo mode is enabled", async () => {
@@ -167,6 +190,8 @@ describe("QuizWorkspace connection and availability states", () => {
     expect(
       screen.getByText("Finish setup to use Quiz Playground")
     ).toBeInTheDocument()
+    expect(screen.getByText(mocks.setupRequiredLabel)).toBeInTheDocument()
+    expect(getDesignSystemState).toHaveBeenCalledWith("setup_required")
 
     fireEvent.click(screen.getByRole("button", { name: "Go to server card" }))
     expect(mocks.scrollToServerCard).toHaveBeenCalled()

--- a/backlog/tasks/task-310 - Migrate-QuizWorkspace-setup-required-label-to-design-system-registry.md
+++ b/backlog/tasks/task-310 - Migrate-QuizWorkspace-setup-required-label-to-design-system-registry.md
@@ -4,7 +4,7 @@ title: Migrate QuizWorkspace setup-required label to design-system registry
 status: Done
 assignee: []
 created_date: '2026-05-13 01:40'
-updated_date: '2026-05-13 02:02'
+updated_date: '2026-05-13 02:12'
 labels:
   - design-system
   - frontend
@@ -55,12 +55,18 @@ Verification:
 - Bandit skipped: touched code is frontend TypeScript, JSON baseline, and task documentation only.
 
 Pull request: https://github.com/rmusser01/tldw_server/pull/1622
+
+Review follow-up plan: add a regression test that simulates getDesignSystemState("setup_required") returning undefined, then make QuizWorkspace tolerate that missing registry value without crashing while preserving the existing registry-backed path. Re-run the focused Quiz test, product-state guard test, verify:design-system-state, diff checks, and touched-path TypeScript filter before closing the PR thread.
+
+Review follow-up verification: added a regression test for a missing setup_required registry entry; red run failed at QuizWorkspace.tsx with Cannot read properties of undefined (reading 'label'); after optional chaining fallback, bun run test src/components/Quiz/__tests__/QuizWorkspace.connection-state.test.tsx --reporter=dot passed 7 tests. Also passed product-state guard unit tests, verify:design-system-state, baseline JSON parse, git diff --check, and touched-path TypeScript filtering with no diagnostics for QuizWorkspace or its connection-state test. Bandit skipped again because touched files are frontend TypeScript and Backlog task docs only.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 QuizWorkspace now reads its setup-required product-state badge label from the canonical design-system state registry, the focused connection-state test covers the registry-backed label path, and the product-state baseline no longer carries the QuizWorkspace setup-required exception.
+
+Review follow-up: QuizWorkspace now tolerates a missing setup_required registry result by using optional chaining with an empty label fallback, and the connection-state regression test covers that path.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-310 - Migrate-QuizWorkspace-setup-required-label-to-design-system-registry.md
+++ b/backlog/tasks/task-310 - Migrate-QuizWorkspace-setup-required-label-to-design-system-registry.md
@@ -1,0 +1,74 @@
+---
+id: TASK-310
+title: Migrate QuizWorkspace setup-required label to design-system registry
+status: Done
+assignee: []
+created_date: '2026-05-13 01:40'
+updated_date: '2026-05-13 02:02'
+labels:
+  - design-system
+  - frontend
+  - quiz
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1622'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replace the remaining hardcoded QuizWorkspace setup-required product-state label with the canonical design-system state registry value. Scope is limited to the QuizWorkspace offline/setup banner and the matching product-state baseline entry.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Focused regression coverage fails before the migration and passes after the registry-backed label is wired.
+- [x] #2 The matching QuizWorkspace canonical-state-label baseline exception is removed and the design-system product-state guard passes.
+- [x] #3 QuizWorkspace renders the setup-required banner label from getDesignSystemState("setup_required").label instead of a local hardcoded product-state string.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused failing regression test proving the setup-required QuizWorkspace banner label comes from getDesignSystemState("setup_required").label.
+2. Replace the hardcoded setup-required badge label with the design-system registry value.
+3. Remove the matching baseline entry and run focused Quiz plus product-state guard verification.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implementation notes:
+- Replaced QuizWorkspace setup-required offline banner badge label with getDesignSystemState("setup_required").label.
+- Added a registry-backed regression assertion in QuizWorkspace.connection-state.test.tsx.
+- Removed the matching QuizWorkspace canonical-state-label baseline exception.
+
+Verification:
+- Red: bun run test src/components/Quiz/__tests__/QuizWorkspace.connection-state.test.tsx --reporter=dot failed only because Registry Setup Required was not rendered.
+- Green: bun run test src/components/Quiz/__tests__/QuizWorkspace.connection-state.test.tsx --reporter=dot passed 6 tests.
+- bun run test src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed 52 tests.
+- bun run verify:design-system-state passed with baseline exceptions reduced to 505 and canonical-state-label exceptions reduced to 25.
+- Baseline JSON parse check passed.
+- git diff --check passed.
+- Touched-path TypeScript filter returned no QuizWorkspace or baseline diagnostics.
+- Bandit skipped: touched code is frontend TypeScript, JSON baseline, and task documentation only.
+
+Pull request: https://github.com/rmusser01/tldw_server/pull/1622
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+QuizWorkspace now reads its setup-required product-state badge label from the canonical design-system state registry, the focused connection-state test covers the registry-backed label path, and the product-state baseline no longer carries the QuizWorkspace setup-required exception.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Change summary
- Move the Quiz setup-required offline banner badge label to `getDesignSystemState("setup_required").label` so this state copy is owned by the canonical design-system registry.
- Add focused regression coverage that overrides the registry label and verifies the rendered setup badge uses that value.
- Remove the matching QuizWorkspace `canonical-state-label` baseline exception, reducing the shared product-state baseline by one entry.

## Verification
- `bun run test src/components/Quiz/__tests__/QuizWorkspace.connection-state.test.tsx --reporter=dot`
- `bun run test src/design-system/__tests__/product-state-guard.test.ts --reporter=dot`
- `bun run verify:design-system-state`
- `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('apps/packages/ui/scripts/design-system-product-state-baseline.json','utf8'));"`
- `node -e "const {spawnSync}=require('child_process'); const r=spawnSync('bunx',['tsc','--noEmit','--pretty','false'],{encoding:'utf8'}); const out=(r.stdout||'')+(r.stderr||''); const lines=out.split(/\n/).filter((line)=>/QuizWorkspace|design-system-product-state-baseline/.test(line)); if (lines.length) { console.log(lines.join('\n')); process.exit(1); }"`
- `git diff --check origin/dev...HEAD`

Bandit skipped: touched code is frontend TypeScript, JSON baseline, and task documentation only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the Quiz setup-required badge to the design-system registry via `getDesignSystemState("setup_required").label` and adds tests. Adds a safe fallback when the registry entry is missing so the setup guidance still renders.

- **Refactors**
  - Replace hardcoded label in `QuizWorkspace` with `getDesignSystemState("setup_required").label`.
  - Remove the matching baseline exception in `design-system-product-state-baseline.json`.

- **Bug Fixes**
  - Handle missing `setup_required` registry entry with `?.label ?? ""` to avoid crashes.
  - Extend tests to mock the registry label and missing-entry path; verify the badge renders and `getDesignSystemState("setup_required")` is called.

<sup>Written for commit ae6ed60c77dfed4a248e213cd4242e528f0fbef5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

