### PR TITLE
Add WorkspacePlayground ACP task handoff

### DIFF
--- a/Docs/Design/ACP_Workspace_Integration_Decision_2026_05.md
+++ b/Docs/Design/ACP_Workspace_Integration_Decision_2026_05.md
@@ -182,6 +182,12 @@ ACP retention and redaction rules already cover session detail, events,
 artifacts, diagnostics, and audit views. Workspace integration should consume
 those views rather than reimplement redaction.
 
+The workspace handoff should stay coordinated with the retention/export/delete
+policy tracked in #1512 and the support/audit redaction work tracked in #1513.
+Until those issues are fully closed, this integration must not introduce a
+separate workspace-level ACP retention pipeline or bypass the existing ACP
+support-safe view controls.
+
 Workspace-level history should show safe previews and link to the authenticated
 ACP detail routes. Support-safe views should prefer the existing `redacted=true`
 ACP route behavior and sanitized diagnostic/audit metadata.

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/WorkspaceAgentTaskHandoffModal.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/WorkspaceAgentTaskHandoffModal.tsx
@@ -41,7 +41,7 @@ export interface WorkspaceAgentTaskHandoffModalProps {
   workspaceId?: string | null
   workspaceName?: string | null
   workspaceTag?: string | null
-  onBeforeSubmit?: () => void
+  onBeforeSubmit?: () => Promise<void> | void
   onCancel: () => void
   onOpenAgentTasks: () => void
 }
@@ -90,7 +90,10 @@ export const WorkspaceAgentTaskHandoffModal: React.FC<
   onOpenAgentTasks
 }) => {
   const { t } = useTranslation(["playground", "common"])
-  const { config: connectionConfig } = useCanonicalConnectionConfig()
+  const {
+    config: connectionConfig,
+    loading: connectionConfigLoading
+  } = useCanonicalConnectionConfig()
   const [rootPath, setRootPath] = React.useState("")
   const [taskTitle, setTaskTitle] = React.useState("")
   const [taskDescription, setTaskDescription] = React.useState("")
@@ -151,10 +154,15 @@ export const WorkspaceAgentTaskHandoffModal: React.FC<
       const transport = buildRequestTransport(path)
       if (!transport) {
         throw new Error(
-          t(
-            "playground:workspace.agentTaskConnectionMissing",
-            "Backend connection is not configured."
-          )
+          connectionConfigLoading
+            ? t(
+                "playground:workspace.agentTaskConnectionLoading",
+                "Backend connection is still loading."
+              )
+            : t(
+                "playground:workspace.agentTaskConnectionMissing",
+                "Backend connection is not configured."
+              )
         )
       }
 
@@ -168,7 +176,35 @@ export const WorkspaceAgentTaskHandoffModal: React.FC<
       }
       return (await response.json()) as T
     },
-    [buildRequestTransport, getHeaders, t]
+    [buildRequestTransport, connectionConfigLoading, getHeaders, t]
+  )
+
+  const deleteProject = React.useCallback(
+    async (projectId: number): Promise<void> => {
+      const transport = buildRequestTransport(`${PROJECTS_PATH}/${projectId}`)
+      if (!transport) {
+        throw new Error(
+          connectionConfigLoading
+            ? t(
+                "playground:workspace.agentTaskConnectionLoading",
+                "Backend connection is still loading."
+              )
+            : t(
+                "playground:workspace.agentTaskConnectionMissing",
+                "Backend connection is not configured."
+              )
+        )
+      }
+
+      const response = await fetch(transport.url, {
+        method: "DELETE",
+        headers: getHeaders(transport)
+      })
+      if (!response.ok) {
+        throw new Error(await readApiErrorMessage(response))
+      }
+    },
+    [buildRequestTransport, connectionConfigLoading, getHeaders, t]
   )
 
   const handleSubmit = async () => {
@@ -176,6 +212,15 @@ export const WorkspaceAgentTaskHandoffModal: React.FC<
     const trimmedRootPath = rootPath.trim()
     const trimmedTitle = taskTitle.trim()
 
+    if (connectionConfigLoading) {
+      setError(
+        t(
+          "playground:workspace.agentTaskConnectionLoading",
+          "Backend connection is still loading."
+        )
+      )
+      return
+    }
     if (!canonicalWorkspaceId) {
       setError(
         t(
@@ -213,8 +258,9 @@ export const WorkspaceAgentTaskHandoffModal: React.FC<
       workspace_tag: workspaceTag?.trim() || null
     }
 
+    let createdProjectId: number | null = null
     try {
-      onBeforeSubmit?.()
+      await onBeforeSubmit?.()
       const bridge = await postJson<CanonicalBridgeResponse>(
         CANONICAL_BRIDGE_PATH,
         {
@@ -254,6 +300,7 @@ export const WorkspaceAgentTaskHandoffModal: React.FC<
           )
         )
       }
+      createdProjectId = project.id
 
       const task = await postJson<TaskResponse>(
         `${PROJECTS_PATH}/${project.id}/tasks`,
@@ -273,6 +320,7 @@ export const WorkspaceAgentTaskHandoffModal: React.FC<
           )
         )
       }
+      createdProjectId = null
 
       setCreatedTask({
         acpWorkspaceId,
@@ -280,6 +328,16 @@ export const WorkspaceAgentTaskHandoffModal: React.FC<
         taskId: task.id
       })
     } catch (err) {
+      if (createdProjectId != null) {
+        try {
+          await deleteProject(createdProjectId)
+        } catch (rollbackError) {
+          console.warn(
+            "[workspace-agent-task-handoff] Failed to roll back ACP project after task creation failure",
+            rollbackError
+          )
+        }
+      }
       setError(
         err instanceof Error
           ? err.message
@@ -293,6 +351,14 @@ export const WorkspaceAgentTaskHandoffModal: React.FC<
     }
   }
 
+  const handleCancel = React.useCallback(() => {
+    if (submitting) return
+    onCancel()
+  }, [onCancel, submitting])
+
+  const createTaskDisabled =
+    submitting || Boolean(createdTask) || connectionConfigLoading
+
   return (
     <Modal
       title={t(
@@ -300,10 +366,11 @@ export const WorkspaceAgentTaskHandoffModal: React.FC<
         "Create agent task"
       )}
       open={open}
-      onCancel={onCancel}
+      onCancel={handleCancel}
+      closable={!submitting}
       destroyOnHidden
       footer={[
-        <Button key="cancel" onClick={onCancel}>
+        <Button key="cancel" onClick={handleCancel} disabled={submitting}>
           {t("common:cancel", "Cancel")}
         </Button>,
         createdTask ? (
@@ -320,6 +387,7 @@ export const WorkspaceAgentTaskHandoffModal: React.FC<
             key="create-task"
             type="primary"
             loading={submitting}
+            disabled={createTaskDisabled}
             onClick={() => void handleSubmit()}
           >
             {t("playground:workspace.createAgentTaskSubmit", "Create task")}
@@ -328,6 +396,7 @@ export const WorkspaceAgentTaskHandoffModal: React.FC<
       ]}
       centered
       maskClosable={!submitting}
+      keyboard={!submitting}
     >
       <div className="space-y-4">
         {error && (

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/WorkspaceAgentTaskHandoffModal.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/WorkspaceAgentTaskHandoffModal.tsx
@@ -1,0 +1,428 @@
+import React from "react"
+import { useTranslation } from "react-i18next"
+import { Alert, Button, Input, Modal } from "antd"
+import { ExternalLink } from "lucide-react"
+
+import { useCanonicalConnectionConfig } from "@/hooks/useCanonicalConnectionConfig"
+import { buildACPAuthHeaders } from "@/services/acp/connection"
+import {
+  resolveBrowserRequestTransport,
+  type BrowserRequestTransport
+} from "@/services/tldw/request-core"
+
+const AGENT_ORCHESTRATION_BASE_PATH = "/api/v1/agent-orchestration"
+const CANONICAL_BRIDGE_PATH =
+  `${AGENT_ORCHESTRATION_BASE_PATH}/workspaces/canonical-bridge`
+const PROJECTS_PATH = `${AGENT_ORCHESTRATION_BASE_PATH}/projects`
+
+type CanonicalBridgeResponse = {
+  id?: number
+  canonical_workspace?: {
+    acp_workspace_id?: number
+  } | null
+}
+
+type ProjectResponse = {
+  id?: number
+}
+
+type TaskResponse = {
+  id?: number
+}
+
+type CreatedAgentTask = {
+  acpWorkspaceId: number
+  projectId: number
+  taskId: number
+}
+
+export interface WorkspaceAgentTaskHandoffModalProps {
+  open: boolean
+  workspaceId?: string | null
+  workspaceName?: string | null
+  workspaceTag?: string | null
+  onBeforeSubmit?: () => void
+  onCancel: () => void
+  onOpenAgentTasks: () => void
+}
+
+const readApiErrorMessage = async (response: Response): Promise<string> => {
+  const payload = await response.json().catch(() => null)
+  const detail =
+    payload && typeof payload === "object"
+      ? (payload as { detail?: unknown }).detail
+      : null
+
+  if (typeof detail === "string" && detail.trim()) {
+    return detail
+  }
+  if (detail && typeof detail === "object") {
+    const detailRecord = detail as Record<string, unknown>
+    if (typeof detailRecord.message === "string" && detailRecord.message.trim()) {
+      return detailRecord.message
+    }
+    if (typeof detailRecord.code === "string" && detailRecord.code.trim()) {
+      return detailRecord.code
+    }
+  }
+  return `HTTP ${response.status}`
+}
+
+const getAcpWorkspaceId = (payload: CanonicalBridgeResponse): number | null => {
+  const candidate =
+    typeof payload.id === "number"
+      ? payload.id
+      : payload.canonical_workspace?.acp_workspace_id
+  return typeof candidate === "number" && Number.isFinite(candidate)
+    ? candidate
+    : null
+}
+
+export const WorkspaceAgentTaskHandoffModal: React.FC<
+  WorkspaceAgentTaskHandoffModalProps
+> = ({
+  open,
+  workspaceId,
+  workspaceName,
+  workspaceTag,
+  onBeforeSubmit,
+  onCancel,
+  onOpenAgentTasks
+}) => {
+  const { t } = useTranslation(["playground", "common"])
+  const { config: connectionConfig } = useCanonicalConnectionConfig()
+  const [rootPath, setRootPath] = React.useState("")
+  const [taskTitle, setTaskTitle] = React.useState("")
+  const [taskDescription, setTaskDescription] = React.useState("")
+  const [agentType, setAgentType] = React.useState("codex")
+  const [submitting, setSubmitting] = React.useState(false)
+  const [error, setError] = React.useState<string | null>(null)
+  const [createdTask, setCreatedTask] = React.useState<CreatedAgentTask | null>(
+    null
+  )
+  const wasOpenRef = React.useRef(false)
+
+  const workspaceDisplayName = workspaceName?.trim() || "Workspace"
+
+  React.useEffect(() => {
+    if (!open) {
+      wasOpenRef.current = false
+      return
+    }
+    if (wasOpenRef.current) return
+    wasOpenRef.current = true
+    setRootPath("")
+    setTaskTitle(
+      t("playground:workspace.agentTaskDefaultTitle", {
+        defaultValue: "Continue {{workspace}} work",
+        workspace: workspaceDisplayName
+      })
+    )
+    setTaskDescription("")
+    setAgentType("codex")
+    setSubmitting(false)
+    setError(null)
+    setCreatedTask(null)
+  }, [open, t, workspaceDisplayName])
+
+  const buildRequestTransport = React.useCallback(
+    (path: string): BrowserRequestTransport | null => {
+      if (!connectionConfig) return null
+      return resolveBrowserRequestTransport({
+        config: connectionConfig,
+        path
+      })
+    },
+    [connectionConfig]
+  )
+
+  const getHeaders = React.useCallback(
+    (transport: BrowserRequestTransport | null) => {
+      if (transport?.mode === "hosted") {
+        return { "Content-Type": "application/json" }
+      }
+      return buildACPAuthHeaders(connectionConfig, { includeContentType: true })
+    },
+    [connectionConfig]
+  )
+
+  const postJson = React.useCallback(
+    async <T,>(path: string, payload: unknown): Promise<T> => {
+      const transport = buildRequestTransport(path)
+      if (!transport) {
+        throw new Error(
+          t(
+            "playground:workspace.agentTaskConnectionMissing",
+            "Backend connection is not configured."
+          )
+        )
+      }
+
+      const response = await fetch(transport.url, {
+        method: "POST",
+        headers: getHeaders(transport),
+        body: JSON.stringify(payload)
+      })
+      if (!response.ok) {
+        throw new Error(await readApiErrorMessage(response))
+      }
+      return (await response.json()) as T
+    },
+    [buildRequestTransport, getHeaders, t]
+  )
+
+  const handleSubmit = async () => {
+    const canonicalWorkspaceId = workspaceId?.trim()
+    const trimmedRootPath = rootPath.trim()
+    const trimmedTitle = taskTitle.trim()
+
+    if (!canonicalWorkspaceId) {
+      setError(
+        t(
+          "playground:workspace.agentTaskMissingWorkspace",
+          "Select or save a workspace before creating an agent task."
+        )
+      )
+      return
+    }
+    if (!trimmedRootPath) {
+      setError(
+        t(
+          "playground:workspace.agentTaskMissingRoot",
+          "Enter an execution root path."
+        )
+      )
+      return
+    }
+    if (!trimmedTitle) {
+      setError(
+        t("playground:workspace.agentTaskMissingTitle", "Enter a task title.")
+      )
+      return
+    }
+
+    setSubmitting(true)
+    setError(null)
+    setCreatedTask(null)
+
+    const baseMetadata = {
+      created_from: "workspace_playground",
+      canonical_workspace_id: canonicalWorkspaceId,
+      canonical_workspace_source: "workspace_playground",
+      workspace_name: workspaceName?.trim() || null,
+      workspace_tag: workspaceTag?.trim() || null
+    }
+
+    try {
+      onBeforeSubmit?.()
+      const bridge = await postJson<CanonicalBridgeResponse>(
+        CANONICAL_BRIDGE_PATH,
+        {
+          canonical_workspace_id: canonicalWorkspaceId,
+          canonical_workspace_source: "workspace_playground",
+          root_path: trimmedRootPath,
+          name: `${workspaceDisplayName} execution`,
+          description: `ACP execution workspace linked from ${workspaceDisplayName}.`,
+          metadata: baseMetadata
+        }
+      )
+      const acpWorkspaceId = getAcpWorkspaceId(bridge)
+      if (acpWorkspaceId == null) {
+        throw new Error(
+          t(
+            "playground:workspace.agentTaskBridgeMissingId",
+            "Canonical bridge did not return an ACP workspace ID."
+          )
+        )
+      }
+
+      const metadata = {
+        ...baseMetadata,
+        acp_workspace_id: acpWorkspaceId
+      }
+      const project = await postJson<ProjectResponse>(PROJECTS_PATH, {
+        name: `${workspaceDisplayName} agent work`,
+        description: `Agent tasks created from ${workspaceDisplayName}.`,
+        workspace_id: acpWorkspaceId,
+        metadata
+      })
+      if (typeof project.id !== "number") {
+        throw new Error(
+          t(
+            "playground:workspace.agentTaskProjectMissingId",
+            "Agent project creation did not return a project ID."
+          )
+        )
+      }
+
+      const task = await postJson<TaskResponse>(
+        `${PROJECTS_PATH}/${project.id}/tasks`,
+        {
+          title: trimmedTitle,
+          description: taskDescription.trim(),
+          agent_type: agentType.trim() || undefined,
+          max_review_attempts: 3,
+          metadata
+        }
+      )
+      if (typeof task.id !== "number") {
+        throw new Error(
+          t(
+            "playground:workspace.agentTaskTaskMissingId",
+            "Agent task creation did not return a task ID."
+          )
+        )
+      }
+
+      setCreatedTask({
+        acpWorkspaceId,
+        projectId: project.id,
+        taskId: task.id
+      })
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : t(
+              "playground:workspace.agentTaskCreateFailed",
+              "Failed to create agent task."
+            )
+      )
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Modal
+      title={t(
+        "playground:workspace.agentTaskModalTitle",
+        "Create agent task"
+      )}
+      open={open}
+      onCancel={onCancel}
+      destroyOnHidden
+      footer={[
+        <Button key="cancel" onClick={onCancel}>
+          {t("common:cancel", "Cancel")}
+        </Button>,
+        createdTask ? (
+          <Button
+            key="open-agent-tasks"
+            type="primary"
+            icon={<ExternalLink className="h-4 w-4" />}
+            onClick={onOpenAgentTasks}
+          >
+            {t("playground:workspace.openAgentTasks", "Open Agent Tasks")}
+          </Button>
+        ) : (
+          <Button
+            key="create-task"
+            type="primary"
+            loading={submitting}
+            onClick={() => void handleSubmit()}
+          >
+            {t("playground:workspace.createAgentTaskSubmit", "Create task")}
+          </Button>
+        )
+      ]}
+      centered
+      maskClosable={!submitting}
+    >
+      <div className="space-y-4">
+        {error && (
+          <Alert
+            type="error"
+            title={error}
+            showIcon
+          />
+        )}
+        {createdTask && (
+          <Alert
+            type="success"
+            title={t(
+              "playground:workspace.agentTaskCreated",
+              "Agent task created"
+            )}
+            description={
+              <div className="flex flex-wrap gap-2 text-sm">
+                <span>ACP workspace #{createdTask.acpWorkspaceId}</span>
+                <span>Project #{createdTask.projectId}</span>
+                <span>Task #{createdTask.taskId}</span>
+              </div>
+            }
+            showIcon
+          />
+        )}
+
+        <div className="space-y-1.5">
+          <label
+            htmlFor="workspace-agent-task-root-path"
+            className="block text-sm font-medium text-text"
+          >
+            {t(
+              "playground:workspace.agentTaskRootPath",
+              "Execution root path"
+            )}
+          </label>
+          <Input
+            id="workspace-agent-task-root-path"
+            value={rootPath}
+            onChange={(event) => setRootPath(event.target.value)}
+            placeholder="/Users/name/src/project"
+            disabled={submitting || Boolean(createdTask)}
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <label
+            htmlFor="workspace-agent-task-title"
+            className="block text-sm font-medium text-text"
+          >
+            {t("playground:workspace.agentTaskTitle", "Task title")}
+          </label>
+          <Input
+            id="workspace-agent-task-title"
+            value={taskTitle}
+            onChange={(event) => setTaskTitle(event.target.value)}
+            disabled={submitting || Boolean(createdTask)}
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <label
+            htmlFor="workspace-agent-task-description"
+            className="block text-sm font-medium text-text"
+          >
+            {t(
+              "playground:workspace.agentTaskDescription",
+              "Task description"
+            )}
+          </label>
+          <Input.TextArea
+            id="workspace-agent-task-description"
+            value={taskDescription}
+            onChange={(event) => setTaskDescription(event.target.value)}
+            autoSize={{ minRows: 3, maxRows: 6 }}
+            disabled={submitting || Boolean(createdTask)}
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <label
+            htmlFor="workspace-agent-task-agent-type"
+            className="block text-sm font-medium text-text"
+          >
+            {t("playground:workspace.agentTaskAgentType", "Agent type")}
+          </label>
+          <Input
+            id="workspace-agent-task-agent-type"
+            value={agentType}
+            onChange={(event) => setAgentType(event.target.value)}
+            disabled={submitting || Boolean(createdTask)}
+          />
+        </div>
+      </div>
+    </Modal>
+  )
+}

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/WorkspaceHeader.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/WorkspaceHeader.tsx
@@ -33,7 +33,8 @@ import {
   Settings,
   Star,
   Share2,
-  CircleHelp
+  CircleHelp,
+  Bot
 } from "lucide-react"
 import type {
   SavedWorkspace,
@@ -88,6 +89,7 @@ import {
   normalizeRolloutPercentage
 } from "@/utils/feature-rollout"
 import { WorkspaceShortcutsModal } from "./WorkspaceShortcutsModal"
+import { WorkspaceAgentTaskHandoffModal } from "./WorkspaceAgentTaskHandoffModal"
 
 interface WorkspaceHeaderProps {
   leftPaneOpen: boolean
@@ -171,6 +173,7 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
   const [editName, setEditName] = React.useState("")
   const [workspaceBrowserOpen, setWorkspaceBrowserOpen] = React.useState(false)
   const [shortcutsModalOpen, setShortcutsModalOpen] = React.useState(false)
+  const [agentTaskModalOpen, setAgentTaskModalOpen] = React.useState(false)
   const [deleteConfirmOpen, setDeleteConfirmOpen] = React.useState(false)
   const [deleteConfirmInput, setDeleteConfirmInput] = React.useState("")
   const [deleteTargetWorkspace, setDeleteTargetWorkspace] = React.useState<{
@@ -516,6 +519,19 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
     // Save current workspace before navigating
     saveCurrentWorkspace()
     navigate("/")
+  }
+
+  const handleOpenAgentTaskModal = () => {
+    setAgentTaskModalOpen(true)
+  }
+
+  const handleCloseAgentTaskModal = () => {
+    setAgentTaskModalOpen(false)
+  }
+
+  const handleOpenAgentTasksPage = () => {
+    setAgentTaskModalOpen(false)
+    navigate("/agent-tasks")
   }
 
   const handleCreateNewWorkspace = () => {
@@ -1443,6 +1459,15 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
     ...(workspaceId
       ? [
           {
+            key: "create-agent-task",
+            icon: <Bot className="h-4 w-4" />,
+            label: t(
+              "playground:workspace.createAgentTask",
+              "Create agent task"
+            ),
+            onClick: handleOpenAgentTaskModal
+          },
+          {
             key: "duplicate-current",
             icon: <Copy className="h-4 w-4" />,
             label: t(
@@ -1729,6 +1754,16 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
           </Tooltip>
         </Dropdown>
       </div>
+
+      <WorkspaceAgentTaskHandoffModal
+        open={agentTaskModalOpen}
+        workspaceId={workspaceId}
+        workspaceName={workspaceName}
+        workspaceTag={workspaceTag}
+        onBeforeSubmit={saveCurrentWorkspace}
+        onCancel={handleCloseAgentTaskModal}
+        onOpenAgentTasks={handleOpenAgentTasksPage}
+      />
 
       <input
         ref={importFileInputRef}

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/WorkspaceHeader.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/WorkspaceHeader.tsx
@@ -2491,7 +2491,7 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
         }}
         centered
         maskClosable={false}
-        destroyOnClose
+        destroyOnHidden
       >
         {deleteTargetWorkspace && (
           <div className="space-y-3">

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/WorkspaceHeader.test.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/WorkspaceHeader.test.tsx
@@ -44,14 +44,25 @@ const registryStateOverrides = vi.hoisted(() => ({
   degradedLabel: "Registry Degraded",
   missingDegraded: false
 }))
-const connectionConfigState = vi.hoisted(() => ({
-  config: {
-    serverUrl: "http://127.0.0.1:8000",
-    authMode: "single-user" as const,
-    apiKey: "test-api-key",
-    accessToken: ""
-  }
-}))
+const connectionConfigState = vi.hoisted(
+  (): {
+    loading: boolean
+    config: {
+      serverUrl: string
+      authMode: "single-user"
+      apiKey: string
+      accessToken: string
+    } | null
+  } => ({
+    loading: false,
+    config: {
+      serverUrl: "http://127.0.0.1:8000",
+      authMode: "single-user" as const,
+      apiKey: "test-api-key",
+      accessToken: ""
+    }
+  })
+)
 const fetchMockState = vi.hoisted(() => ({
   fetch: vi.fn()
 }))
@@ -204,7 +215,7 @@ vi.mock("@/store/connection", () => ({
 vi.mock("@/hooks/useCanonicalConnectionConfig", () => ({
   useCanonicalConnectionConfig: () => ({
     config: connectionConfigState.config,
-    loading: false
+    loading: connectionConfigState.loading
   })
 }))
 
@@ -288,6 +299,13 @@ describe("WorkspaceHeader workspace browser modal", () => {
     vi.clearAllMocks()
     window.localStorage.clear()
     clearWorkspaceUndoActionsForTests()
+    connectionConfigState.loading = false
+    connectionConfigState.config = {
+      serverUrl: "http://127.0.0.1:8000",
+      authMode: "single-user",
+      apiKey: "test-api-key",
+      accessToken: ""
+    }
     mockStoreState.savedWorkspaces = [
       {
         id: "workspace-alpha",
@@ -1375,6 +1393,228 @@ describe("WorkspaceHeader workspace browser modal", () => {
       expect(
         within(modal).getByText("Root path is outside the configured ACP allowlist.")
       ).toBeInTheDocument()
+    })
+  })
+
+  it("waits for connection configuration before enabling task creation", async () => {
+    connectionConfigState.loading = true
+    connectionConfigState.config = null
+
+    render(
+      <WorkspaceHeader
+        leftPaneOpen={true}
+        rightPaneOpen={true}
+        onToggleLeftPane={vi.fn()}
+        onToggleRightPane={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Workspace settings" }))
+    fireEvent.click(await screen.findByText("Create agent task"))
+
+    const modal = await screen.findByRole("dialog", {
+      name: "Create agent task"
+    })
+    const createTaskButton = within(modal).getByRole("button", {
+      name: "Create task"
+    })
+
+    expect(createTaskButton).toBeDisabled()
+    fireEvent.click(createTaskButton)
+    expect(fetchMockState.fetch).not.toHaveBeenCalled()
+  })
+
+  it("rolls back a created ACP project when task creation fails", async () => {
+    fetchMockState.fetch.mockImplementation(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input)
+
+        if (
+          url ===
+          "http://127.0.0.1:8000/api/v1/agent-orchestration/workspaces/canonical-bridge"
+        ) {
+          return {
+            ok: true,
+            json: async () => ({
+              id: 33,
+              canonical_workspace: {
+                acp_workspace_id: 33
+              }
+            })
+          } as Response
+        }
+
+        if (
+          url ===
+          "http://127.0.0.1:8000/api/v1/agent-orchestration/projects"
+        ) {
+          return {
+            ok: true,
+            json: async () => ({
+              id: 44,
+              name: "Alpha Research agent work",
+              workspace_id: 33
+            })
+          } as Response
+        }
+
+        if (
+          url ===
+          "http://127.0.0.1:8000/api/v1/agent-orchestration/projects/44/tasks"
+        ) {
+          return {
+            ok: false,
+            status: 500,
+            json: async () => ({
+              detail: "Task creation failed."
+            })
+          } as Response
+        }
+
+        if (
+          url ===
+          "http://127.0.0.1:8000/api/v1/agent-orchestration/projects/44"
+        ) {
+          expect(init?.method).toBe("DELETE")
+          return {
+            ok: true,
+            json: async () => ({})
+          } as Response
+        }
+
+        throw new Error(`unexpected fetch: ${url}`)
+      }
+    )
+
+    render(
+      <WorkspaceHeader
+        leftPaneOpen={true}
+        rightPaneOpen={true}
+        onToggleLeftPane={vi.fn()}
+        onToggleRightPane={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Workspace settings" }))
+    fireEvent.click(await screen.findByText("Create agent task"))
+
+    const modal = await screen.findByRole("dialog", {
+      name: "Create agent task"
+    })
+    fireEvent.change(within(modal).getByLabelText("Execution root path"), {
+      target: { value: "/Users/macbook-dev/src/alpha" }
+    })
+    fireEvent.change(within(modal).getByLabelText("Task title"), {
+      target: { value: "Summarize workspace blockers" }
+    })
+    fireEvent.click(within(modal).getByRole("button", { name: "Create task" }))
+
+    await waitFor(() => {
+      expect(fetchMockState.fetch).toHaveBeenCalledTimes(4)
+      expect(within(modal).getByText("Task creation failed.")).toBeInTheDocument()
+    })
+    expect(
+      fetchMockState.fetch.mock.calls.some(
+        ([input, init]) =>
+          String(input) ===
+            "http://127.0.0.1:8000/api/v1/agent-orchestration/projects/44" &&
+          init?.method === "DELETE"
+      )
+    ).toBe(true)
+    expect(within(modal).queryByText("Agent task created")).not.toBeInTheDocument()
+  })
+
+  it("keeps the task handoff modal open while submission is in flight", async () => {
+    let resolveBridge: (response: Response) => void = () => {}
+
+    fetchMockState.fetch.mockImplementation(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input)
+
+        if (
+          url ===
+          "http://127.0.0.1:8000/api/v1/agent-orchestration/workspaces/canonical-bridge"
+        ) {
+          return new Promise<Response>((resolve) => {
+            resolveBridge = resolve
+          })
+        }
+
+        if (
+          url ===
+          "http://127.0.0.1:8000/api/v1/agent-orchestration/projects"
+        ) {
+          return {
+            ok: true,
+            json: async () => ({
+              id: 44,
+              workspace_id: 33
+            })
+          } as Response
+        }
+
+        if (
+          url ===
+          "http://127.0.0.1:8000/api/v1/agent-orchestration/projects/44/tasks"
+        ) {
+          expect(init?.method).toBe("POST")
+          return {
+            ok: true,
+            json: async () => ({
+              id: 55
+            })
+          } as Response
+        }
+
+        throw new Error(`unexpected fetch: ${url}`)
+      }
+    )
+
+    render(
+      <WorkspaceHeader
+        leftPaneOpen={true}
+        rightPaneOpen={true}
+        onToggleLeftPane={vi.fn()}
+        onToggleRightPane={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Workspace settings" }))
+    fireEvent.click(await screen.findByText("Create agent task"))
+
+    const modal = await screen.findByRole("dialog", {
+      name: "Create agent task"
+    })
+    fireEvent.change(within(modal).getByLabelText("Execution root path"), {
+      target: { value: "/Users/macbook-dev/src/alpha" }
+    })
+    const createTaskButton = within(modal).getByRole("button", {
+      name: "Create task"
+    })
+    fireEvent.click(createTaskButton)
+
+    const cancelButton = within(modal).getByRole("button", { name: "Cancel" })
+    await waitFor(() => {
+      expect(cancelButton).toBeDisabled()
+      expect(createTaskButton).toBeDisabled()
+    })
+    fireEvent.click(cancelButton)
+    expect(
+      screen.getByRole("dialog", { name: "Create agent task" })
+    ).toBeInTheDocument()
+
+    resolveBridge({
+      ok: true,
+      json: async () => ({
+        id: 33,
+        canonical_workspace: {
+          acp_workspace_id: 33
+        }
+      })
+    } as Response)
+
+    await waitFor(() => {
+      expect(within(modal).getByText("Agent task created")).toBeInTheDocument()
     })
   })
 })

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/WorkspaceHeader.test.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/WorkspaceHeader.test.tsx
@@ -44,6 +44,17 @@ const registryStateOverrides = vi.hoisted(() => ({
   degradedLabel: "Registry Degraded",
   missingDegraded: false
 }))
+const connectionConfigState = vi.hoisted(() => ({
+  config: {
+    serverUrl: "http://127.0.0.1:8000",
+    authMode: "single-user" as const,
+    apiKey: "test-api-key",
+    accessToken: ""
+  }
+}))
+const fetchMockState = vi.hoisted(() => ({
+  fetch: vi.fn()
+}))
 
 const now = new Date("2026-02-18T12:00:00.000Z")
 
@@ -188,6 +199,13 @@ vi.mock("@/store/connection", () => ({
   useConnectionStore: (
     selector: (state: typeof mockConnectionStoreState) => unknown
   ) => selector(mockConnectionStoreState)
+}))
+
+vi.mock("@/hooks/useCanonicalConnectionConfig", () => ({
+  useCanonicalConnectionConfig: () => ({
+    config: connectionConfigState.config,
+    loading: false
+  })
 }))
 
 vi.mock("@/design-system", async (importActual) => {
@@ -454,6 +472,16 @@ describe("WorkspaceHeader workspace browser modal", () => {
       bytes: 16000,
       updatedAt: new Date("2026-02-25T10:00:00.000Z")
     })
+    connectionConfigState.config = {
+      serverUrl: "http://127.0.0.1:8000",
+      authMode: "single-user",
+      apiKey: "test-api-key",
+      accessToken: ""
+    }
+    fetchMockState.fetch.mockImplementation(async (input: RequestInfo | URL) => {
+      throw new Error(`unexpected fetch: ${String(input)}`)
+    })
+    vi.stubGlobal("fetch", fetchMockState.fetch)
   })
 
   it("opens view-all modal and filters workspaces by search query", async () => {
@@ -1176,5 +1204,177 @@ describe("WorkspaceHeader workspace browser modal", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Workspace settings" }))
     expect(screen.queryByText("Telemetry summary")).not.toBeInTheDocument()
+  })
+
+  it("creates an ACP-backed agent task for the current workspace", async () => {
+    fetchMockState.fetch.mockImplementation(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input)
+        const body =
+          typeof init?.body === "string" ? JSON.parse(init.body) : undefined
+
+        if (
+          url ===
+          "http://127.0.0.1:8000/api/v1/agent-orchestration/workspaces/canonical-bridge"
+        ) {
+          expect(init?.method).toBe("POST")
+          expect((init?.headers as Record<string, string>)["X-API-KEY"]).toBe(
+            "test-api-key"
+          )
+          expect(body).toMatchObject({
+            canonical_workspace_id: "workspace-alpha",
+            canonical_workspace_source: "workspace_playground",
+            root_path: "/Users/macbook-dev/src/alpha",
+            metadata: {
+              created_from: "workspace_playground",
+              canonical_workspace_id: "workspace-alpha"
+            }
+          })
+          return {
+            ok: true,
+            json: async () => ({
+              id: 33,
+              name: "Alpha Research execution",
+              root_path: "/Users/macbook-dev/src/alpha",
+              canonical_workspace: {
+                acp_workspace_id: 33,
+                canonical_workspace_id: "workspace-alpha",
+                canonical_workspace_source: "workspace_playground",
+                link_status: "linked"
+              }
+            })
+          } as Response
+        }
+
+        if (
+          url ===
+          "http://127.0.0.1:8000/api/v1/agent-orchestration/projects"
+        ) {
+          expect(init?.method).toBe("POST")
+          expect(body).toMatchObject({
+            name: "Alpha Research agent work",
+            workspace_id: 33,
+            metadata: {
+              created_from: "workspace_playground",
+              canonical_workspace_id: "workspace-alpha",
+              acp_workspace_id: 33
+            }
+          })
+          return {
+            ok: true,
+            json: async () => ({
+              id: 44,
+              name: "Alpha Research agent work",
+              workspace_id: 33
+            })
+          } as Response
+        }
+
+        if (
+          url ===
+          "http://127.0.0.1:8000/api/v1/agent-orchestration/projects/44/tasks"
+        ) {
+          expect(init?.method).toBe("POST")
+          expect(body).toMatchObject({
+            title: "Summarize workspace blockers",
+            description: "Review the current sources and identify blockers.",
+            agent_type: "codex",
+            metadata: {
+              created_from: "workspace_playground",
+              canonical_workspace_id: "workspace-alpha",
+              acp_workspace_id: 33
+            }
+          })
+          return {
+            ok: true,
+            json: async () => ({
+              id: 55,
+              project_id: 44,
+              title: "Summarize workspace blockers"
+            })
+          } as Response
+        }
+
+        throw new Error(`unexpected fetch: ${url}`)
+      }
+    )
+
+    render(
+      <WorkspaceHeader
+        leftPaneOpen={true}
+        rightPaneOpen={true}
+        onToggleLeftPane={vi.fn()}
+        onToggleRightPane={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Workspace settings" }))
+    fireEvent.click(await screen.findByText("Create agent task"))
+
+    const modal = await screen.findByRole("dialog", {
+      name: "Create agent task"
+    })
+    fireEvent.change(within(modal).getByLabelText("Execution root path"), {
+      target: { value: "/Users/macbook-dev/src/alpha" }
+    })
+    fireEvent.change(within(modal).getByLabelText("Task title"), {
+      target: { value: "Summarize workspace blockers" }
+    })
+    fireEvent.change(within(modal).getByLabelText("Task description"), {
+      target: { value: "Review the current sources and identify blockers." }
+    })
+    fireEvent.change(within(modal).getByLabelText("Agent type"), {
+      target: { value: "codex" }
+    })
+    fireEvent.click(within(modal).getByRole("button", { name: "Create task" }))
+
+    await waitFor(() => {
+      expect(fetchMockState.fetch).toHaveBeenCalledTimes(3)
+      expect(within(modal).getByText("Agent task created")).toBeInTheDocument()
+      expect(within(modal).getByText("ACP workspace #33")).toBeInTheDocument()
+    })
+
+    fireEvent.click(within(modal).getByRole("button", { name: "Open Agent Tasks" }))
+    expect(mockNavigate).toHaveBeenCalledWith("/agent-tasks")
+  })
+
+  it("surfaces ACP bridge setup failures without creating project or task records", async () => {
+    fetchMockState.fetch.mockResolvedValue({
+      ok: false,
+      status: 409,
+      json: async () => ({
+        detail: {
+          code: "workspace_root_not_allowed",
+          message: "Root path is outside the configured ACP allowlist."
+        }
+      })
+    } as Response)
+
+    render(
+      <WorkspaceHeader
+        leftPaneOpen={true}
+        rightPaneOpen={true}
+        onToggleLeftPane={vi.fn()}
+        onToggleRightPane={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Workspace settings" }))
+    fireEvent.click(await screen.findByText("Create agent task"))
+
+    const modal = await screen.findByRole("dialog", {
+      name: "Create agent task"
+    })
+    fireEvent.change(within(modal).getByLabelText("Execution root path"), {
+      target: { value: "/private/not-allowed" }
+    })
+    fireEvent.click(within(modal).getByRole("button", { name: "Create task" }))
+
+    await waitFor(() => {
+      expect(fetchMockState.fetch).toHaveBeenCalledTimes(1)
+      expect(
+        within(modal).getByText("Root path is outside the configured ACP allowlist.")
+      ).toBeInTheDocument()
+    })
   })
 })

--- a/backlog/tasks/task-311 - Implement-WorkspacePlayground-ACP-task-handoff.md
+++ b/backlog/tasks/task-311 - Implement-WorkspacePlayground-ACP-task-handoff.md
@@ -1,0 +1,59 @@
+---
+id: TASK-311
+title: Implement WorkspacePlayground ACP task handoff
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-05-13 02:10'
+updated_date: '2026-05-13 02:42'
+labels:
+  - ACP
+  - workspace
+  - frontend
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1540'
+  - 'https://github.com/rmusser01/tldw_server/pull/1615'
+documentation:
+  - Docs/Design/ACP_Workspace_Integration_Decision_2026_05.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Slice 2 from Docs/Design/ACP_Workspace_Integration_Decision_2026_05.md for issue 1540. WorkspacePlayground should let a user start an ACP agent task from the current canonical workspace without inventing a parallel ACP workspace model. The flow must use the backend canonical bridge endpoint from PR 1615 to find or create the ACP execution workspace before creating the AgentProject and AgentTask.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 WorkspacePlayground exposes a create-agent-task action for the current canonical workspace
+- [x] #2 The flow calls the canonical bridge endpoint and uses the returned ACP execution workspace ID when creating the agent project/task
+- [x] #3 Created project/task state exposes the canonical workspace link and gives the user a clear path to Agent Tasks or ACP diagnostics
+- [x] #4 Missing root/allowlist/setup failures are surfaced as actionable setup gaps rather than silent task creation failures
+- [x] #5 Focused frontend tests cover successful handoff and bridge/setup failure behavior
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented WorkspacePlayground ACP handoff slice in isolated worktree .worktrees/acp-workspace-task-handoff-1540. Added Workspace settings action and modal that calls canonical bridge, creates an AgentProject bound to returned ACP workspace ID, then creates the AgentTask with workspace metadata.
+
+Verification: bunx vitest run src/components/Option/WorkspacePlayground/__tests__/WorkspaceHeader.test.tsx src/components/Option/AgentTasks/__tests__/AgentTasksPage.connection.test.tsx passed from apps/packages/ui. git diff --check passed. Bandit skipped/documented because touched source is TypeScript/TSX frontend only.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added a WorkspacePlayground create-agent-task handoff that uses the canonical ACP workspace bridge, creates an AgentProject bound to the returned ACP execution workspace, then creates the AgentTask with canonical workspace metadata and a direct path to Agent Tasks. Verification passed for the focused WorkspaceHeader/AgentTasks Vitest set, git diff --check, and Bandit on the touched frontend path with zero Python findings because the touched source is TS/TSX.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-311 - Implement-WorkspacePlayground-ACP-task-handoff.md
+++ b/backlog/tasks/task-311 - Implement-WorkspacePlayground-ACP-task-handoff.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-311
 title: Implement WorkspacePlayground ACP task handoff
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-05-13 02:10'
-updated_date: '2026-05-13 04:47'
+updated_date: '2026-05-13 04:52'
 labels:
   - ACP
   - workspace
@@ -47,12 +47,14 @@ Verification: bunx vitest run src/components/Option/WorkspacePlayground/__tests_
 PR #1625 review-fix pass reopened this task in the branch worktree. Scope: resolve still-actionable Gemini, CodeRabbit, and Qodo review threads; preserve Ant Design v6 title/destroyOnHidden props where local tests and guardrails prove those are the current API; add regression tests for config loading, rollback, and in-flight cancellation guards.
 
 Review fixes now also document that WorkspacePlayground ACP history/retention must coordinate with #1512 and #1513 rather than creating a separate retention/redaction path.
+
+Review-fix verification: focused Vitest passed for WorkspaceHeader, AgentTasks connection, and AntD modal prop guards (40 tests). bun run lint from apps/tldw-frontend exited 0 with existing warnings only. Targeted ESLint on changed package files exited 0 with warnings only. git diff --check passed. Bandit on the touched frontend path wrote /tmp/bandit_task311_pr1625_review_frontend_path.json with zero findings and loc=0 because no Python files were touched.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added a WorkspacePlayground create-agent-task handoff that uses the canonical ACP workspace bridge, creates an AgentProject bound to the returned ACP execution workspace, then creates the AgentTask with canonical workspace metadata and a direct path to Agent Tasks. Verification passed for the focused WorkspaceHeader/AgentTasks Vitest set, git diff --check, and Bandit on the touched frontend path with zero Python findings because the touched source is TS/TSX.
+Implemented PR #1625 review fixes for WorkspacePlayground ACP task handoff. The modal now awaits async pre-submit persistence, respects connection-config loading before enabling task creation, rolls back an ACP AgentProject if downstream AgentTask creation fails, and blocks cancel/close/keyboard dismissal while submission is in flight. The touched WorkspaceHeader modal now uses Ant Design v6 destroyOnHidden, and the ACP workspace decision doc explicitly ties retention/redaction behavior to #1512 and #1513. Verification passed for the focused Vitest set, frontend lint, targeted ESLint, git diff --check, and Bandit frontend-path scan.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-311 - Implement-WorkspacePlayground-ACP-task-handoff.md
+++ b/backlog/tasks/task-311 - Implement-WorkspacePlayground-ACP-task-handoff.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-311
 title: Implement WorkspacePlayground ACP task handoff
-status: Done
+status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-05-13 02:10'
-updated_date: '2026-05-13 02:42'
+updated_date: '2026-05-13 04:47'
 labels:
   - ACP
   - workspace
@@ -14,6 +14,9 @@ dependencies: []
 references:
   - 'https://github.com/rmusser01/tldw_server/issues/1540'
   - 'https://github.com/rmusser01/tldw_server/pull/1615'
+  - 'https://github.com/rmusser01/tldw_server/pull/1625'
+  - 'https://github.com/rmusser01/tldw_server/issues/1512'
+  - 'https://github.com/rmusser01/tldw_server/issues/1513'
 documentation:
   - Docs/Design/ACP_Workspace_Integration_Decision_2026_05.md
 priority: high
@@ -40,6 +43,10 @@ Implement Slice 2 from Docs/Design/ACP_Workspace_Integration_Decision_2026_05.md
 Implemented WorkspacePlayground ACP handoff slice in isolated worktree .worktrees/acp-workspace-task-handoff-1540. Added Workspace settings action and modal that calls canonical bridge, creates an AgentProject bound to returned ACP workspace ID, then creates the AgentTask with workspace metadata.
 
 Verification: bunx vitest run src/components/Option/WorkspacePlayground/__tests__/WorkspaceHeader.test.tsx src/components/Option/AgentTasks/__tests__/AgentTasksPage.connection.test.tsx passed from apps/packages/ui. git diff --check passed. Bandit skipped/documented because touched source is TypeScript/TSX frontend only.
+
+PR #1625 review-fix pass reopened this task in the branch worktree. Scope: resolve still-actionable Gemini, CodeRabbit, and Qodo review threads; preserve Ant Design v6 title/destroyOnHidden props where local tests and guardrails prove those are the current API; add regression tests for config loading, rollback, and in-flight cancellation guards.
+
+Review fixes now also document that WorkspacePlayground ACP history/retention must coordinate with #1512 and #1513 rather than creating a separate retention/redaction path.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary


### PR DESCRIPTION
## Summary
- Adds a WorkspacePlayground settings action and modal for creating an ACP-backed agent task from the current canonical workspace.
- Calls the canonical ACP workspace bridge first, then creates an AgentProject bound to the returned ACP workspace ID and an AgentTask with canonical workspace metadata.
- Adds Backlog task TASK-311 plus focused tests for successful handoff and bridge/setup failure handling.

## Test Plan
- `bunx vitest run src/components/Option/WorkspacePlayground/__tests__/WorkspaceHeader.test.tsx src/components/Option/AgentTasks/__tests__/AgentTasksPage.connection.test.tsx`
- `git diff --check`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r apps/packages/ui/src/components/Option/WorkspacePlayground -f json -o /tmp/bandit_task311.json`

## Tracking
- Refs #1540

## Change summary
Human-authored change summary is required before merge per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a WorkspacePlayground settings action and modal to hand off the current canonical workspace to ACP and create a linked agent task. Bridges to the ACP execution workspace, then creates the bound project and task with workspace metadata (implements #1540).

- **New Features**
  - Workspace settings adds “Create agent task”, opening `WorkspaceAgentTaskHandoffModal` with root path, title, description, and agent type.
  - Calls `/api/v1/agent-orchestration/workspaces/canonical-bridge`, then `POST` to `/projects` and `/projects/{id}/tasks` using the returned `acp_workspace_id`.
  - Awaits workspace save, validates inputs, gates on connection config, blocks close/cancel while submitting, and rolls back the project if task creation fails.
  - Shows success with IDs and an “Open Agent Tasks” CTA; docs align with retention/redaction in #1512 and #1513; focused tests cover success, bridge/setup errors, rollback, config-loading gating, and in‑flight guards.

<sup>Written for commit 2ca8474212ef881eaf232106a010e6dfc6e9c859. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

