### PR TITLE
Migrate Writing diagnostics ready label to registry

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -4664,7 +4664,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/WritingPlayground/WritingPlaygroundDiagnosticsPanel.tsx:Alert#antd-alert-writingplaygrounddiagnosticspanel-type-info-l-1fyinzi",
+    "id": "antd-product-state-import:src/components/Option/WritingPlayground/WritingPlaygroundDiagnosticsPanel.tsx:Alert#antd-alert-writingplaygrounddiagnosticspanel-type-info-l-1cmka5v",
     "path": "src/components/Option/WritingPlayground/WritingPlaygroundDiagnosticsPanel.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -4675,7 +4675,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/WritingPlayground/WritingPlaygroundDiagnosticsPanel.tsx:Alert#antd-alert-writingplaygrounddiagnosticspanel-type-warnin-1703bpg",
+    "id": "antd-product-state-import:src/components/Option/WritingPlayground/WritingPlaygroundDiagnosticsPanel.tsx:Alert#antd-alert-writingplaygrounddiagnosticspanel-type-warnin-1345qhv",
     "path": "src/components/Option/WritingPlayground/WritingPlaygroundDiagnosticsPanel.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -5320,17 +5320,6 @@
     "state": "allowed_legacy_exception",
     "owner": "design-system",
     "reason": "Existing hardcoded \"Ready\" state label in src/components/Option/WritingPlayground/index.tsx before the guard.",
-    "replacement": "getDesignSystemState(...)",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "canonical-state-label:src/components/Option/WritingPlayground/WritingPlaygroundDiagnosticsPanel.tsx:Ready",
-    "path": "src/components/Option/WritingPlayground/WritingPlaygroundDiagnosticsPanel.tsx",
-    "rule": "canonical-state-label",
-    "subject": "Ready",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing hardcoded \"Ready\" state label in src/components/Option/WritingPlayground/WritingPlaygroundDiagnosticsPanel.tsx before the guard.",
     "replacement": "getDesignSystemState(...)",
     "migrationQueue": "shared-product-state"
   },

--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -4664,7 +4664,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/WritingPlayground/WritingPlaygroundDiagnosticsPanel.tsx:Alert#antd-alert-writingplaygrounddiagnosticspanel-type-info-l-1cmka5v",
+    "id": "antd-product-state-import:src/components/Option/WritingPlayground/WritingPlaygroundDiagnosticsPanel.tsx:Alert#antd-alert-writingplaygrounddiagnosticspanel-type-info-l-1cwjvuu",
     "path": "src/components/Option/WritingPlayground/WritingPlaygroundDiagnosticsPanel.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -4675,7 +4675,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/WritingPlayground/WritingPlaygroundDiagnosticsPanel.tsx:Alert#antd-alert-writingplaygrounddiagnosticspanel-type-warnin-1345qhv",
+    "id": "antd-product-state-import:src/components/Option/WritingPlayground/WritingPlaygroundDiagnosticsPanel.tsx:Alert#antd-alert-writingplaygrounddiagnosticspanel-type-warnin-12u64sw",
     "path": "src/components/Option/WritingPlayground/WritingPlaygroundDiagnosticsPanel.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",

--- a/apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundDiagnosticsPanel.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundDiagnosticsPanel.tsx
@@ -6,6 +6,8 @@ import { WritingPlaygroundTokenInspectorCard } from "./WritingPlaygroundTokenIns
 import { WritingPlaygroundWordcloudCard } from "./WritingPlaygroundWordcloudCard"
 import type { WritingPlaygroundDiagnosticsPanelProps } from "./WritingPlaygroundDiagnostics.types"
 
+const READY_STATE_LABEL = getDesignSystemState("ready").label
+
 export const WritingPlaygroundDiagnosticsPanel: FC<
   WritingPlaygroundDiagnosticsPanelProps
 > = ({
@@ -22,7 +24,6 @@ export const WritingPlaygroundDiagnosticsPanel: FC<
   const { enabled: responseEnabled, ...responseCardProps } = response
   const { enabled: tokenEnabled, ...tokenCardProps } = token
   const { enabled: wordcloudEnabled, ...wordcloudCardProps } = wordcloud
-  const readyState = status === "ready" ? getDesignSystemState("ready") : null
 
   return (
     <Card
@@ -34,7 +35,7 @@ export const WritingPlaygroundDiagnosticsPanel: FC<
             ? t("option:writingPlayground.diagnosticsWarning", "Warning")
             : status === "busy"
               ? t("option:writingPlayground.diagnosticsBusy", "Busy")
-              : t("option:writingPlayground.diagnosticsReady", readyState?.label ?? "")}
+              : t("option:writingPlayground.diagnosticsReady", READY_STATE_LABEL)}
         </Tag>
         {showOffline ? (
           <Alert

--- a/apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundDiagnosticsPanel.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundDiagnosticsPanel.tsx
@@ -1,5 +1,6 @@
 import type { FC } from "react"
 import { Alert, Card, Empty, Tag } from "antd"
+import { getDesignSystemState } from "@/design-system"
 import { WritingPlaygroundResponseInspectorCard } from "./WritingPlaygroundResponseInspectorCard"
 import { WritingPlaygroundTokenInspectorCard } from "./WritingPlaygroundTokenInspectorCard"
 import { WritingPlaygroundWordcloudCard } from "./WritingPlaygroundWordcloudCard"
@@ -21,6 +22,7 @@ export const WritingPlaygroundDiagnosticsPanel: FC<
   const { enabled: responseEnabled, ...responseCardProps } = response
   const { enabled: tokenEnabled, ...tokenCardProps } = token
   const { enabled: wordcloudEnabled, ...wordcloudCardProps } = wordcloud
+  const readyState = status === "ready" ? getDesignSystemState("ready") : null
 
   return (
     <Card
@@ -32,7 +34,7 @@ export const WritingPlaygroundDiagnosticsPanel: FC<
             ? t("option:writingPlayground.diagnosticsWarning", "Warning")
             : status === "busy"
               ? t("option:writingPlayground.diagnosticsBusy", "Busy")
-              : t("option:writingPlayground.diagnosticsReady", "Ready")}
+              : t("option:writingPlayground.diagnosticsReady", readyState?.label ?? "")}
         </Tag>
         {showOffline ? (
           <Alert

--- a/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlaygroundDiagnosticsPanel.design-system-state.test.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlaygroundDiagnosticsPanel.design-system-state.test.tsx
@@ -5,7 +5,9 @@ import { getDesignSystemState } from "@/design-system"
 import { WritingPlaygroundDiagnosticsPanel } from "../WritingPlaygroundDiagnosticsPanel"
 import type { WritingPlaygroundDiagnosticsPanelProps } from "../WritingPlaygroundDiagnostics.types"
 
-const registryReadyLabel = "Registry Ready"
+const { registryReadyLabel } = vi.hoisted(() => ({
+  registryReadyLabel: "Registry Ready"
+}))
 
 vi.mock("@/design-system", async (importActual) => {
   const actual = await importActual<typeof import("@/design-system")>()

--- a/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlaygroundDiagnosticsPanel.design-system-state.test.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlaygroundDiagnosticsPanel.design-system-state.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { getDesignSystemState } from "@/design-system"
+import { WritingPlaygroundDiagnosticsPanel } from "../WritingPlaygroundDiagnosticsPanel"
+import type { WritingPlaygroundDiagnosticsPanelProps } from "../WritingPlaygroundDiagnostics.types"
+
+const registryReadyLabel = "Registry Ready"
+
+vi.mock("@/design-system", async (importActual) => {
+  const actual = await importActual<typeof import("@/design-system")>()
+  return {
+    ...actual,
+    getDesignSystemState: vi.fn(
+      (key: Parameters<typeof actual.getDesignSystemState>[0]) => {
+        const state = actual.getDesignSystemState(key)
+        return key === "ready" ? { ...state, label: registryReadyLabel } : state
+      }
+    )
+  }
+})
+
+const t: WritingPlaygroundDiagnosticsPanelProps["t"] = (_key, defaultValue) =>
+  defaultValue
+
+const makeProps = (): WritingPlaygroundDiagnosticsPanelProps => ({
+  title: "Diagnostics",
+  t,
+  status: "ready",
+  showOffline: false,
+  showUnsupported: false,
+  hasActiveSession: false,
+  response: {
+    enabled: false,
+    responseInspectorRowsCount: 0,
+    responseLogprobsCount: 0,
+    settingsLogprobsEnabled: false,
+    settingsDisabled: false,
+    responseLogprobRowsCount: 0,
+    responseLogprobTruncated: false,
+    onCopyResponseInspectorJson: vi.fn(),
+    onExportResponseInspectorCsv: vi.fn(),
+    onClearResponseInspector: vi.fn()
+  },
+  token: {
+    enabled: false,
+    tokenizerName: null,
+    serverSupportsTokenCount: false,
+    canCountTokens: false,
+    isCountingTokens: false,
+    onCountTokens: vi.fn(),
+    serverSupportsTokenize: false,
+    canTokenizePreview: false,
+    isTokenizingText: false,
+    onTokenizePreview: vi.fn(),
+    hasTokenCountResult: false,
+    tokenCountValue: null,
+    hasTokenizeResult: false,
+    tokenInspectorError: null,
+    tokenInspectorBusy: false,
+    tokenInspectorUnavailableReason: null,
+    onClearTokenInspector: vi.fn(),
+    tokenPreviewRowsCount: 0,
+    tokenPreviewTotal: 0
+  },
+  wordcloud: {
+    enabled: false,
+    wordcloudStatus: null,
+    wordcloudStatusColor: "default",
+    canGenerateWordcloud: false,
+    isGeneratingWordcloud: false,
+    onGenerateWordcloud: vi.fn(),
+    wordcloudError: null,
+    onClearWordcloud: vi.fn(),
+    wordcloudWords: []
+  }
+})
+
+describe("WritingPlaygroundDiagnosticsPanel design-system state labels", () => {
+  it("renders the ready diagnostics label from the design-system registry", () => {
+    render(<WritingPlaygroundDiagnosticsPanel {...makeProps()} />)
+
+    expect(screen.getByText(registryReadyLabel)).toBeInTheDocument()
+    expect(getDesignSystemState).toHaveBeenCalledWith("ready")
+  })
+})

--- a/backlog/tasks/task-312 - Migrate-WritingPlayground-diagnostics-Ready-label-to-design-system-registry.md
+++ b/backlog/tasks/task-312 - Migrate-WritingPlayground-diagnostics-Ready-label-to-design-system-registry.md
@@ -1,0 +1,59 @@
+---
+id: TASK-312
+title: Migrate WritingPlayground diagnostics Ready label to design-system registry
+status: Done
+assignee: []
+created_date: '2026-05-13 03:53'
+updated_date: '2026-05-13 04:05'
+labels:
+  - design-system
+  - frontend
+  - writing-playground
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replace the remaining hardcoded WritingPlaygroundDiagnosticsPanel Ready product-state label with the canonical design-system state registry value. Scope is limited to the diagnostics panel ready status label and the matching product-state baseline entry.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Focused regression coverage fails before the migration and passes after the registry-backed Ready label is wired.
+- [x] #2 The matching WritingPlaygroundDiagnosticsPanel canonical-state-label baseline exception is removed and the design-system product-state guard passes.
+- [x] #3 WritingPlaygroundDiagnosticsPanel renders the ready status label from getDesignSystemState("ready").label instead of a local hardcoded product-state string.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused failing regression test proving the ready diagnostics label comes from getDesignSystemState("ready").label. 2. Replace the hardcoded ready diagnostics label with the design-system registry value without changing warning/busy behavior. 3. Remove the matching WritingPlaygroundDiagnosticsPanel canonical-state-label baseline exception. 4. Run focused WritingPlayground test coverage, the product-state guard test, bun run verify:design-system-state, JSON/diff checks, and touched-path TypeScript filtering before opening a PR.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented WritingPlaygroundDiagnosticsPanel ready-label migration to getDesignSystemState("ready").label with optional fallback. Added focused Vitest coverage that mocks the registry ready label to "Registry Ready" and verifies the panel renders it. Removed the matching canonical-state-label baseline entry and refreshed the two existing AntD Alert baseline IDs shifted by the import.
+
+Verification: bun run test src/components/Option/WritingPlayground/__tests__/WritingPlaygroundDiagnosticsPanel.design-system-state.test.tsx --reporter=dot (pass); bun run test src/design-system/__tests__/product-state-guard.test.ts --reporter=dot (pass); bun run verify:design-system-state (pass, 504 baseline exceptions / 24 canonical-state-label); node JSON parse for design-system-product-state-baseline.json (pass); git diff --check (pass); touched-path TypeScript filter over bunx tsc --noEmit --pretty false (tsc exited 2 for existing repo-wide diagnostics, no diagnostics matched touched paths).
+
+Bandit: skipped because touched implementation/test files are frontend TypeScript/JSON plus this task record, with no Python runtime surface.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated the WritingPlayground diagnostics Ready label to the design-system state registry and added a focused regression test proving the rendered label follows getDesignSystemState("ready").label. Removed the corresponding canonical-state-label baseline exception while preserving the existing AntD product-state baseline entries for later migration. Verification passed for focused Vitest, product-state guard, design-system state verifier, baseline JSON parse, diff check, and touched-path TypeScript filtering.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-312 - Migrate-WritingPlayground-diagnostics-Ready-label-to-design-system-registry.md
+++ b/backlog/tasks/task-312 - Migrate-WritingPlayground-diagnostics-Ready-label-to-design-system-registry.md
@@ -4,7 +4,7 @@ title: Migrate WritingPlayground diagnostics Ready label to design-system regist
 status: Done
 assignee: []
 created_date: '2026-05-13 03:53'
-updated_date: '2026-05-13 04:05'
+updated_date: '2026-05-13 05:37'
 labels:
   - design-system
   - frontend
@@ -40,12 +40,18 @@ Implemented WritingPlaygroundDiagnosticsPanel ready-label migration to getDesign
 Verification: bun run test src/components/Option/WritingPlayground/__tests__/WritingPlaygroundDiagnosticsPanel.design-system-state.test.tsx --reporter=dot (pass); bun run test src/design-system/__tests__/product-state-guard.test.ts --reporter=dot (pass); bun run verify:design-system-state (pass, 504 baseline exceptions / 24 canonical-state-label); node JSON parse for design-system-product-state-baseline.json (pass); git diff --check (pass); touched-path TypeScript filter over bunx tsc --noEmit --pretty false (tsc exited 2 for existing repo-wide diagnostics, no diagnostics matched touched paths).
 
 Bandit: skipped because touched implementation/test files are frontend TypeScript/JSON plus this task record, with no Python runtime surface.
+
+PR review follow-up: live review scan found Gemini/Qodo feedback that the component should use getDesignSystemState("ready").label directly instead of a nullable readyState plus empty fallback. CodeRabbit edge-case coverage depends on the nullable fallback and will be obsolete after this change; memoization is low value for the direct registry label accessor.
+
+PR review follow-up implemented: replaced nullable readyState with module-level READY_STATE_LABEL = getDesignSystemState("ready").label, matching the established WorkspaceStatusStrip pattern and preserving the prior ready fallback behavior. Updated the regression test to use vi.hoisted for the mock label because the registry lookup now happens at module import time. Refreshed the two shifted AntD Alert baseline IDs after the module-level constant moved line context.
+
+Follow-up verification: bun run test src/components/Option/WritingPlayground/__tests__/WritingPlaygroundDiagnosticsPanel.design-system-state.test.tsx --reporter=dot (pass after vi.hoisted test fix); bun run test src/design-system/__tests__/product-state-guard.test.ts --reporter=dot (pass); bun run verify:design-system-state (pass, 504 baseline exceptions / 24 canonical-state-label); node JSON parse for design-system-product-state-baseline.json (pass); git diff --check (pass); touched-path TypeScript filter over bunx tsc --noEmit --pretty false (tsc exited 2 for existing repo-wide diagnostics, no diagnostics matched touched paths).
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Migrated the WritingPlayground diagnostics Ready label to the design-system state registry and added a focused regression test proving the rendered label follows getDesignSystemState("ready").label. Removed the corresponding canonical-state-label baseline exception while preserving the existing AntD product-state baseline entries for later migration. Verification passed for focused Vitest, product-state guard, design-system state verifier, baseline JSON parse, diff check, and touched-path TypeScript filtering.
+Migrated the WritingPlayground diagnostics Ready label to a direct design-system registry label constant, added focused regression coverage for registry-backed rendering, removed the matching canonical-state-label baseline exception, and addressed PR review feedback by eliminating the nullable ready label fallback. Verification passed for focused Vitest, product-state guard, design-system state verifier, baseline JSON parse, diff check, and touched-path TypeScript filtering.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary
- Migrates the WritingPlayground diagnostics Ready tag to use getDesignSystemState("ready").label.
- Adds focused regression coverage that mocks the registry ready label and verifies the panel renders it.
- Removes the matching canonical-state-label baseline exception and refreshes the two shifted existing AntD Alert baseline IDs.

## Verification
- bun run test src/components/Option/WritingPlayground/__tests__/WritingPlaygroundDiagnosticsPanel.design-system-state.test.tsx --reporter=dot
- bun run test src/design-system/__tests__/product-state-guard.test.ts --reporter=dot
- bun run verify:design-system-state
- node JSON parse for apps/packages/ui/scripts/design-system-product-state-baseline.json
- git diff --check
- touched-path TypeScript filter over bunx tsc --noEmit --pretty false: tsc exited 2 for existing repo-wide diagnostics; no diagnostics matched touched paths

## Notes
- Bandit skipped because this slice touches frontend TypeScript/JSON plus the Backlog task record, with no Python runtime surface.
- Human-authored Change summary is still required before merge per repo policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated the WritingPlayground diagnostics Ready label to the design-system registry and aligned the implementation with review feedback. Added focused test coverage and removed the legacy baseline exception.

- **Refactors**
  - Use a module-level `READY_STATE_LABEL = getDesignSystemState("ready").label` from `@/design-system` in `WritingPlaygroundDiagnosticsPanel`.
  - Add a focused test that mocks the registry Ready label and verifies it renders (hoisted mock for import-time lookup).
  - Remove the `canonical-state-label` baseline exception and refresh two AntD Alert baseline IDs.

<sup>Written for commit 42a9dfa45e833237cc8d0996e7208952855c5d37. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

