### PR TITLE
Add ACP Agent Tasks workspace filter

### DIFF
--- a/Docs/superpowers/plans/2026-05-13-acp-agent-tasks-workspace-filter-plan.md
+++ b/Docs/superpowers/plans/2026-05-13-acp-agent-tasks-workspace-filter-plan.md
@@ -1,0 +1,23 @@
+## Stage 1: Contract And Red Tests
+**Goal**: Lock the Agent Tasks workspace-native behavior before implementation.
+**Success Criteria**: Tests fail for workspace query handoff, canonical workspace project filtering, and missing execution workspace setup guidance.
+**Tests**: Focused Vitest for `AgentTasksPage` plus `WorkspaceHeader` navigation handoff.
+**Status**: Complete
+
+## Stage 2: Agent Tasks Workspace Filter
+**Goal**: Derive workspace filter options from backend `canonical_workspace` metadata and incoming route query params without changing existing project/task APIs.
+**Success Criteria**: Projects and selected tasks narrow to the chosen canonical workspace, unfiltered behavior remains unchanged, and selected project state is corrected when filters change.
+**Tests**: Focused Vitest verifies filtered project list and only the filtered project task endpoint is requested.
+**Status**: Complete
+
+## Stage 3: Workspace Setup Gap Surfacing
+**Goal**: Show actionable setup gaps when the selected canonical workspace has no usable ACP execution workspace context or a non-linked bridge status.
+**Success Criteria**: Agent Tasks presents root/env/MCP readiness guidance and links users back to WorkspacePlayground/ACP setup surfaces before dispatch.
+**Tests**: Focused Vitest covers URL-provided workspace with no linked project and conflict/unlinked metadata.
+**Status**: Complete
+
+## Stage 4: Verification And Closeout
+**Goal**: Verify the focused slice and record the outcome for #1540 continuation.
+**Success Criteria**: Focused Vitest, targeted static check or documented lint fallback, `git diff --check`, and Bandit touched-scope rationale are recorded in `TASK-314`.
+**Tests**: `bunx vitest run` targeted files, `git diff --check`, and backend Bandit skip rationale if no Python is touched.
+**Status**: Complete

--- a/apps/packages/ui/src/components/Option/AgentTasks/__tests__/AgentTasksPage.connection.test.tsx
+++ b/apps/packages/ui/src/components/Option/AgentTasks/__tests__/AgentTasksPage.connection.test.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { MemoryRouter, useLocation } from "react-router-dom"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import AgentTasksPage from "../index"
@@ -145,6 +146,31 @@ vi.mock("antd", () => {
   }
 })
 
+const LocationProbe = () => {
+  const location = useLocation()
+  return (
+    <div data-testid="agent-tasks-route">
+      {location.pathname}
+      {location.search}
+    </div>
+  )
+}
+
+const renderAgentTasksPage = (route = "/agent-tasks") =>
+  render(
+    <MemoryRouter initialEntries={[route]}>
+      <AgentTasksPage />
+    </MemoryRouter>
+  )
+
+const renderAgentTasksPageWithRouteProbe = (route = "/agent-tasks") =>
+  render(
+    <MemoryRouter initialEntries={[route]}>
+      <AgentTasksPage />
+      <LocationProbe />
+    </MemoryRouter>
+  )
+
 describe("AgentTasksPage connection and payload normalization", () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -240,7 +266,7 @@ describe("AgentTasksPage connection and payload normalization", () => {
   })
 
   it("loads projects and tasks from canonical config-backed requests even when legacy storage is stale", async () => {
-    render(<AgentTasksPage />)
+    renderAgentTasksPage()
 
     const projectButton = await screen.findByText("Research Project")
     expect(projectButton).toBeInTheDocument()
@@ -266,7 +292,7 @@ describe("AgentTasksPage connection and payload normalization", () => {
       }))
     )
 
-    render(<AgentTasksPage />)
+    renderAgentTasksPage()
 
     expect(await screen.findByText("Agent orchestration unavailable")).toBeInTheDocument()
     expect(
@@ -302,7 +328,7 @@ describe("AgentTasksPage connection and payload normalization", () => {
     })
     vi.stubGlobal("fetch", fetchMock)
 
-    render(<AgentTasksPage />)
+    renderAgentTasksPage()
 
     expect(await screen.findByText("Agent orchestration unavailable")).toBeInTheDocument()
     expect(fetchMock).toHaveBeenCalledTimes(2)
@@ -355,7 +381,7 @@ describe("AgentTasksPage connection and payload normalization", () => {
     })
     vi.stubGlobal("fetch", fetchMock)
 
-    render(<AgentTasksPage />)
+    renderAgentTasksPage()
 
     expect(await screen.findByText("ACP setup needs attention")).toBeInTheDocument()
     expect(screen.getByText("Runner is missing")).toBeInTheDocument()
@@ -403,7 +429,7 @@ describe("AgentTasksPage connection and payload normalization", () => {
     })
     vi.stubGlobal("fetch", fetchMock)
 
-    render(<AgentTasksPage />)
+    renderAgentTasksPage()
 
     expect(await screen.findByText("No projects yet")).toBeInTheDocument()
     expect(fetchMock).toHaveBeenCalledWith(
@@ -537,7 +563,7 @@ describe("AgentTasksPage connection and payload normalization", () => {
     })
     vi.stubGlobal("fetch", fetchMock)
 
-    render(<AgentTasksPage />)
+    renderAgentTasksPage()
 
     const projectButton = await screen.findByText("Research Project")
     fireEvent.click(projectButton)
@@ -555,7 +581,6 @@ describe("AgentTasksPage connection and payload normalization", () => {
   })
 
   it("uses the route workspace filter to show only linked canonical workspace projects and tasks", async () => {
-    window.location.hash = "#/agent-tasks?workspace=workspace-alpha"
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input)
       if (url === "http://127.0.0.1:8000/openapi.json") {
@@ -645,9 +670,12 @@ describe("AgentTasksPage connection and payload normalization", () => {
     })
     vi.stubGlobal("fetch", fetchMock)
 
-    render(<AgentTasksPage />)
+    renderAgentTasksPageWithRouteProbe("/agent-tasks?workspace=workspace-alpha")
 
     expect(await screen.findByText("Alpha Project")).toBeInTheDocument()
+    expect(screen.getByTestId("agent-tasks-route")).toHaveTextContent(
+      "/agent-tasks?workspace=workspace-alpha"
+    )
     expect(screen.queryByText("Beta Project")).toBeNull()
     expect(screen.getAllByText("Workspace: workspace-alpha").length).toBeGreaterThan(0)
 
@@ -658,10 +686,19 @@ describe("AgentTasksPage connection and payload normalization", () => {
       "http://127.0.0.1:8000/api/v1/agent-orchestration/projects/8/tasks",
       expect.anything()
     )
+
+    fireEvent.change(screen.getByLabelText("Workspace filter"), {
+      target: { value: "workspace-beta" }
+    })
+
+    expect(screen.getByTestId("agent-tasks-route")).toHaveTextContent(
+      "/agent-tasks?workspace=workspace-beta"
+    )
+    expect(await screen.findByText("Beta Project")).toBeInTheDocument()
+    expect(screen.queryByText("Alpha Project")).toBeNull()
   })
 
   it("surfaces workspace setup gaps when the selected canonical workspace has no linked ACP execution project", async () => {
-    window.location.hash = "#/agent-tasks?workspace=workspace-missing"
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input)
       if (url === "http://127.0.0.1:8000/openapi.json") {
@@ -694,7 +731,7 @@ describe("AgentTasksPage connection and payload normalization", () => {
     })
     vi.stubGlobal("fetch", fetchMock)
 
-    render(<AgentTasksPage />)
+    renderAgentTasksPage("/agent-tasks?workspace=workspace-missing")
 
     expect(await screen.findByText("Workspace setup needs attention")).toBeInTheDocument()
     expect(
@@ -707,5 +744,116 @@ describe("AgentTasksPage connection and payload normalization", () => {
     ).toBeInTheDocument()
     expect(screen.getByRole("button", { name: /open workspaceplayground/i })).toBeInTheDocument()
     expect(screen.getByRole("button", { name: /open acp playground/i })).toBeInTheDocument()
+  })
+
+  it("does not report missing workspace setup when project loading failed", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url === "http://127.0.0.1:8000/openapi.json") {
+        return {
+          ok: true,
+          json: async () => ({
+            paths: {
+              "/api/v1/agent-orchestration/projects": {},
+            }
+          })
+        }
+      }
+      if (url === "http://127.0.0.1:8000/api/v1/acp/health") {
+        return {
+          ok: true,
+          json: async () => ({
+            runner: "ok",
+            agent: "ok",
+            api_keys: "ok"
+          })
+        }
+      }
+      if (url === "http://127.0.0.1:8000/api/v1/agent-orchestration/projects") {
+        return {
+          ok: false,
+          status: 503,
+          json: async () => ({
+            detail: "Project API unavailable"
+          })
+        }
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    renderAgentTasksPage("/agent-tasks?workspace=workspace-alpha")
+
+    expect(await screen.findByText("Project API unavailable")).toBeInTheDocument()
+    expect(screen.queryByText("Workspace setup needs attention")).toBeNull()
+    expect(
+      screen.queryByText("No ACP execution workspace is linked to workspace-alpha")
+    ).toBeNull()
+  })
+
+  it("does not show an unlinked workspace warning when another matching project is linked", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url === "http://127.0.0.1:8000/openapi.json") {
+        return {
+          ok: true,
+          json: async () => ({
+            paths: {
+              "/api/v1/agent-orchestration/projects": {},
+            }
+          })
+        }
+      }
+      if (url === "http://127.0.0.1:8000/api/v1/acp/health") {
+        return {
+          ok: true,
+          json: async () => ({
+            runner: "ok",
+            agent: "ok",
+            api_keys: "ok"
+          })
+        }
+      }
+      if (url === "http://127.0.0.1:8000/api/v1/agent-orchestration/projects") {
+        return {
+          ok: true,
+          json: async () => [
+            {
+              id: 7,
+              name: "Linked Alpha Project",
+              user_id: 1,
+              created_at: "2026-03-20T19:00:00Z",
+              canonical_workspace: {
+                acp_workspace_id: 33,
+                canonical_workspace_id: "workspace-alpha",
+                canonical_workspace_source: "workspace_playground",
+                link_status: "linked"
+              }
+            },
+            {
+              id: 8,
+              name: "Stale Alpha Project",
+              user_id: 1,
+              created_at: "2026-03-20T19:00:00Z",
+              canonical_workspace: {
+                acp_workspace_id: 34,
+                canonical_workspace_id: "workspace-alpha",
+                canonical_workspace_source: "workspace_playground",
+                link_status: "conflict"
+              }
+            }
+          ]
+        }
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    renderAgentTasksPage("/agent-tasks?workspace=workspace-alpha")
+
+    expect(await screen.findByText("Linked Alpha Project")).toBeInTheDocument()
+    expect(screen.getByText("Stale Alpha Project")).toBeInTheDocument()
+    expect(screen.queryByText("Workspace setup needs attention")).toBeNull()
+    expect(screen.queryByText("ACP execution workspace link is conflict")).toBeNull()
   })
 })

--- a/apps/packages/ui/src/components/Option/AgentTasks/__tests__/AgentTasksPage.connection.test.tsx
+++ b/apps/packages/ui/src/components/Option/AgentTasks/__tests__/AgentTasksPage.connection.test.tsx
@@ -111,7 +111,34 @@ vi.mock("antd", () => {
       TextArea: () => <textarea />
     }),
     Modal: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
-    Select: () => <select aria-label="select" />,
+    Select: ({
+      options = [],
+      value,
+      onChange,
+      placeholder,
+      "aria-label": ariaLabel
+    }: {
+      options?: Array<{ value: string | number; label: React.ReactNode }>
+      value?: string | number
+      onChange?: (value: string | number | undefined) => void
+      placeholder?: React.ReactNode
+      "aria-label"?: string
+    }) => (
+      <select
+        aria-label={
+          ariaLabel || (typeof placeholder === "string" ? placeholder : "select")
+        }
+        value={value ?? ""}
+        onChange={(event) => onChange?.(event.target.value || undefined)}
+      >
+        {placeholder ? <option value="">{placeholder}</option> : null}
+        {options.map((option) => (
+          <option key={String(option.value)} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    ),
     Spin: () => <div>Loading...</div>,
     Tag: ({ children }: { children?: React.ReactNode }) => <span>{children}</span>,
     Tooltip: ({ children }: { children?: React.ReactNode }) => <>{children}</>
@@ -122,6 +149,7 @@ describe("AgentTasksPage connection and payload normalization", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     deploymentMocks.isHostedTldwDeployment.mockReturnValue(false)
+    window.location.hash = ""
 
     storageMocks.useStorage.mockImplementation((key: string, fallback: string) => {
       if (key === "serverUrl") return ["http://localhost:8000", vi.fn()]
@@ -524,5 +552,160 @@ describe("AgentTasksPage connection and payload normalization", () => {
     expect(screen.getByRole("button", { name: /open diagnostics/i })).toBeInTheDocument()
     expect(screen.getByRole("button", { name: /open artifacts/i })).toBeInTheDocument()
     expect(screen.getByText("Needs citations")).toBeInTheDocument()
+  })
+
+  it("uses the route workspace filter to show only linked canonical workspace projects and tasks", async () => {
+    window.location.hash = "#/agent-tasks?workspace=workspace-alpha"
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url === "http://127.0.0.1:8000/openapi.json") {
+        return {
+          ok: true,
+          json: async () => ({
+            paths: {
+              "/api/v1/agent-orchestration/projects": {},
+            }
+          })
+        }
+      }
+      if (url === "http://127.0.0.1:8000/api/v1/acp/health") {
+        return {
+          ok: true,
+          json: async () => ({
+            runner: "ok",
+            agent: "ok",
+            api_keys: "ok"
+          })
+        }
+      }
+      if (url === "http://127.0.0.1:8000/api/v1/agent-orchestration/projects") {
+        return {
+          ok: true,
+          json: async () => [
+            {
+              id: 7,
+              name: "Alpha Project",
+              user_id: 1,
+              created_at: "2026-03-20T19:00:00Z",
+              canonical_workspace: {
+                acp_workspace_id: 33,
+                canonical_workspace_id: "workspace-alpha",
+                canonical_workspace_source: "workspace_playground",
+                link_status: "linked"
+              },
+              task_summary: {
+                total_tasks: 1,
+                status_counts: {
+                  todo: 1
+                }
+              }
+            },
+            {
+              id: 8,
+              name: "Beta Project",
+              user_id: 1,
+              created_at: "2026-03-20T19:00:00Z",
+              canonical_workspace: {
+                acp_workspace_id: 34,
+                canonical_workspace_id: "workspace-beta",
+                canonical_workspace_source: "workspace_playground",
+                link_status: "linked"
+              },
+              task_summary: {
+                total_tasks: 1,
+                status_counts: {
+                  todo: 1
+                }
+              }
+            }
+          ]
+        }
+      }
+      if (url === "http://127.0.0.1:8000/api/v1/agent-orchestration/projects/7/tasks") {
+        return {
+          ok: true,
+          json: async () => [
+            {
+              id: 11,
+              project_id: 7,
+              title: "Alpha task",
+              status: "todo",
+              review_count: 0,
+              max_review_attempts: 3,
+              created_at: "2026-03-20T19:00:00Z",
+              updated_at: "2026-03-20T19:00:00Z"
+            }
+          ]
+        }
+      }
+      if (url === "http://127.0.0.1:8000/api/v1/agent-orchestration/projects/8/tasks") {
+        throw new Error("filtered workspace should not request beta tasks")
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    render(<AgentTasksPage />)
+
+    expect(await screen.findByText("Alpha Project")).toBeInTheDocument()
+    expect(screen.queryByText("Beta Project")).toBeNull()
+    expect(screen.getAllByText("Workspace: workspace-alpha").length).toBeGreaterThan(0)
+
+    fireEvent.click(screen.getByText("Alpha Project"))
+
+    expect(await screen.findByText("Alpha task")).toBeInTheDocument()
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      "http://127.0.0.1:8000/api/v1/agent-orchestration/projects/8/tasks",
+      expect.anything()
+    )
+  })
+
+  it("surfaces workspace setup gaps when the selected canonical workspace has no linked ACP execution project", async () => {
+    window.location.hash = "#/agent-tasks?workspace=workspace-missing"
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url === "http://127.0.0.1:8000/openapi.json") {
+        return {
+          ok: true,
+          json: async () => ({
+            paths: {
+              "/api/v1/agent-orchestration/projects": {},
+            }
+          })
+        }
+      }
+      if (url === "http://127.0.0.1:8000/api/v1/acp/health") {
+        return {
+          ok: true,
+          json: async () => ({
+            runner: "ok",
+            agent: "ok",
+            api_keys: "ok"
+          })
+        }
+      }
+      if (url === "http://127.0.0.1:8000/api/v1/agent-orchestration/projects") {
+        return {
+          ok: true,
+          json: async () => []
+        }
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    render(<AgentTasksPage />)
+
+    expect(await screen.findByText("Workspace setup needs attention")).toBeInTheDocument()
+    expect(
+      screen.getByText("No ACP execution workspace is linked to workspace-missing")
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        "Create an agent task from WorkspacePlayground so the execution root, environment, and MCP readiness can be validated before dispatch."
+      )
+    ).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /open workspaceplayground/i })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /open acp playground/i })).toBeInTheDocument()
   })
 })

--- a/apps/packages/ui/src/components/Option/AgentTasks/index.tsx
+++ b/apps/packages/ui/src/components/Option/AgentTasks/index.tsx
@@ -31,17 +31,28 @@ import {
   ExternalLink,
 } from "lucide-react"
 import { useCanonicalConnectionConfig } from "@/hooks/useCanonicalConnectionConfig"
+import { WORKSPACE_PLAYGROUND_PATH } from "@/routes/route-paths"
 import { buildACPAuthHeaders } from "@/services/acp/connection"
 import { buildACPSetupIssues, normalizeACPHealthStatus, type ACPSetupIssue } from "@/services/acp/readiness"
 import { resolveBrowserRequestTransport } from "@/services/tldw/request-core"
 
 // Types matching the backend orchestration API
+type CanonicalWorkspaceLink = {
+  acp_workspace_id?: number | null
+  canonical_workspace_id?: string | null
+  canonical_workspace_source?: string | null
+  link_status?: string | null
+}
+
 type ProjectSummary = {
   id: number
   name: string
   description?: string
+  workspace_id?: number | null
   user_id: number
   created_at: string
+  metadata?: Record<string, unknown>
+  canonical_workspace?: CanonicalWorkspaceLink | null
   task_summary?: {
     total_tasks: number
     status_counts: Record<string, number>
@@ -60,6 +71,8 @@ type TaskItem = {
   max_review_attempts: number
   created_at: string
   updated_at: string
+  metadata?: Record<string, unknown>
+  canonical_workspace?: CanonicalWorkspaceLink | null
   runs?: RunItem[]
 }
 
@@ -120,6 +133,8 @@ const AGENT_ORCHESTRATION_UNSUPPORTED_DESCRIPTION =
 const AGENT_ORCHESTRATION_UNSUPPORTED_CODE = "AGENT_ORCHESTRATION_UNSUPPORTED"
 const AGENT_ORCHESTRATION_PROJECTS_PATH = "/api/v1/agent-orchestration/projects"
 const AGENT_ORCHESTRATION_BASE_PATH = "/api/v1/agent-orchestration"
+const ALL_WORKSPACES_FILTER_VALUE = "__all_workspaces__"
+const LINKED_CANONICAL_WORKSPACE_STATUS = "linked"
 
 const STATUS_COLORS: Record<string, string> = {
   todo: "default",
@@ -142,6 +157,48 @@ const navigateOptionRoute = (path: string) => {
     return
   }
   window.location.hash = path
+}
+
+const normalizeWorkspaceFilterId = (value: unknown): string | null => {
+  if (typeof value !== "string") {
+    return null
+  }
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+const readWorkspaceFilterFromRoute = (): string | null => {
+  if (typeof window === "undefined") {
+    return null
+  }
+
+  const hash = window.location.hash || ""
+  const hashQueryIndex = hash.indexOf("?")
+  const params =
+    hashQueryIndex >= 0
+      ? new URLSearchParams(hash.slice(hashQueryIndex + 1))
+      : new URLSearchParams(window.location.search)
+
+  return (
+    normalizeWorkspaceFilterId(params.get("workspace")) ||
+    normalizeWorkspaceFilterId(params.get("workspace_id")) ||
+    normalizeWorkspaceFilterId(params.get("canonical_workspace_id"))
+  )
+}
+
+const getCanonicalWorkspaceId = (
+  projectOrTask: ProjectSummary | TaskItem
+): string | null => {
+  return (
+    normalizeWorkspaceFilterId(projectOrTask.canonical_workspace?.canonical_workspace_id) ||
+    normalizeWorkspaceFilterId(projectOrTask.metadata?.canonical_workspace_id)
+  )
+}
+
+const getCanonicalWorkspaceLinkStatus = (
+  project: ProjectSummary
+): string | null => {
+  return normalizeWorkspaceFilterId(project.canonical_workspace?.link_status)?.toLowerCase() ?? null
 }
 
 const normalizeListPayload = <T,>(payload: unknown, key: string): T[] => {
@@ -200,6 +257,9 @@ export const AgentTasksPage: React.FC = () => {
   const [setupLoading, setSetupLoading] = useState(false)
   const [taskDetail, setTaskDetail] = useState<TaskDetailItem | null>(null)
   const [taskDetailLoading, setTaskDetailLoading] = useState(false)
+  const [workspaceFilterId, setWorkspaceFilterId] = useState<string | null>(() =>
+    readWorkspaceFilterFromRoute()
+  )
 
   // Modal states
   const [showProjectModal, setShowProjectModal] = useState(false)
@@ -247,6 +307,19 @@ export const AgentTasksPage: React.FC = () => {
   React.useEffect(() => {
     orchestrationSupportRef.current = null
   }, [connectionConfig])
+
+  React.useEffect(() => {
+    if (typeof window === "undefined") {
+      return
+    }
+    const syncWorkspaceFilter = () => {
+      setWorkspaceFilterId(readWorkspaceFilterFromRoute())
+    }
+    window.addEventListener("hashchange", syncWorkspaceFilter)
+    return () => {
+      window.removeEventListener("hashchange", syncWorkspaceFilter)
+    }
+  }, [])
 
   const markUnsupported = useCallback(() => {
     setIsUnsupported(true)
@@ -558,7 +631,96 @@ export const AgentTasksPage: React.FC = () => {
     }
   }
 
-  const selectedProject = projects.find((p) => p.id === selectedProjectId)
+  const workspaceOptions = useMemo(() => {
+    const options = new Map<string, string>()
+    if (workspaceFilterId) {
+      options.set(workspaceFilterId, workspaceFilterId)
+    }
+    for (const project of projects) {
+      const canonicalWorkspaceId = getCanonicalWorkspaceId(project)
+      if (canonicalWorkspaceId) {
+        options.set(canonicalWorkspaceId, canonicalWorkspaceId)
+      }
+    }
+    return Array.from(options, ([value, label]) => ({ value, label }))
+  }, [projects, workspaceFilterId])
+
+  const workspaceSelectOptions = useMemo(
+    () => [
+      { value: ALL_WORKSPACES_FILTER_VALUE, label: "All workspaces" },
+      ...workspaceOptions
+    ],
+    [workspaceOptions]
+  )
+
+  const filteredProjects = useMemo(() => {
+    if (!workspaceFilterId) {
+      return projects
+    }
+    return projects.filter(
+      (project) => getCanonicalWorkspaceId(project) === workspaceFilterId
+    )
+  }, [projects, workspaceFilterId])
+
+  const visibleTasks = useMemo(() => {
+    if (!workspaceFilterId) {
+      return tasks
+    }
+    return tasks.filter((task) => {
+      const taskWorkspaceId = getCanonicalWorkspaceId(task)
+      return !taskWorkspaceId || taskWorkspaceId === workspaceFilterId
+    })
+  }, [tasks, workspaceFilterId])
+
+  const workspaceSetupIssues = useMemo<ACPSetupIssue[]>(() => {
+    if (!workspaceFilterId || loading || isUnsupported) {
+      return []
+    }
+
+    const matchingProjects = projects.filter(
+      (project) => getCanonicalWorkspaceId(project) === workspaceFilterId
+    )
+    if (matchingProjects.length === 0) {
+      return [
+        {
+          code: "canonical_workspace_bridge_missing",
+          title: `No ACP execution workspace is linked to ${workspaceFilterId}`,
+          description:
+            "Create an agent task from WorkspacePlayground so the execution root, environment, and MCP readiness can be validated before dispatch."
+        }
+      ]
+    }
+
+    const unlinkedProject = matchingProjects.find((project) => {
+      const status = getCanonicalWorkspaceLinkStatus(project)
+      return status !== null && status !== LINKED_CANONICAL_WORKSPACE_STATUS
+    })
+    if (unlinkedProject) {
+      const status = getCanonicalWorkspaceLinkStatus(unlinkedProject) || "unknown"
+      return [
+        {
+          code: "canonical_workspace_bridge_unlinked",
+          title: `ACP execution workspace link is ${status}`,
+          description:
+            "Recreate the workspace handoff from WorkspacePlayground so root, environment, and MCP readiness are checked before dispatch."
+        }
+      ]
+    }
+
+    return []
+  }, [isUnsupported, loading, projects, workspaceFilterId])
+
+  useEffect(() => {
+    if (
+      selectedProjectId !== null &&
+      !filteredProjects.some((project) => project.id === selectedProjectId)
+    ) {
+      setSelectedProjectId(null)
+      setTasks([])
+    }
+  }, [filteredProjects, selectedProjectId])
+
+  const selectedProject = filteredProjects.find((p) => p.id === selectedProjectId)
 
   return (
     <div className="space-y-6">
@@ -598,8 +760,44 @@ export const AgentTasksPage: React.FC = () => {
           showIcon
         />
       )}
+      {!isUnsupported && workspaceSetupIssues.length > 0 && (
+        <Alert
+          type="warning"
+          message="Workspace setup needs attention"
+          description={
+            <AgentTasksSetupDescription
+              body="Resolve these workspace setup items before dispatching task runs."
+              issues={workspaceSetupIssues}
+              showAgentRegistry={false}
+              showWorkspacePlayground
+            />
+          }
+          showIcon
+        />
+      )}
       {error && (
         <Alert type="error" message={error} closable onClose={() => setError(null)} />
+      )}
+
+      {(workspaceOptions.length > 0 || workspaceFilterId) && (
+        <div className="flex flex-wrap items-center gap-3 border border-border bg-surface px-4 py-3">
+          <span className="text-sm font-medium">Canonical workspace</span>
+          <Select
+            aria-label="Workspace filter"
+            value={workspaceFilterId ?? ALL_WORKSPACES_FILTER_VALUE}
+            options={workspaceSelectOptions}
+            onChange={(value) => {
+              const nextValue = String(value || "")
+              setWorkspaceFilterId(
+                nextValue === ALL_WORKSPACES_FILTER_VALUE
+                  ? null
+                  : normalizeWorkspaceFilterId(nextValue)
+              )
+            }}
+            style={{ minWidth: 240 }}
+          />
+          {workspaceFilterId && <Tag>Workspace: {workspaceFilterId}</Tag>}
+        </div>
       )}
 
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
@@ -635,9 +833,13 @@ export const AgentTasksPage: React.FC = () => {
             <div className="flex justify-center py-8">
               <Spin />
             </div>
-          ) : projects.length === 0 ? (
+          ) : filteredProjects.length === 0 ? (
             <Empty
-              description="No projects yet"
+              description={
+                workspaceFilterId
+                  ? "No projects linked to this workspace yet"
+                  : "No projects yet"
+              }
               className="py-8"
             >
               <Button type="primary" onClick={() => setShowProjectModal(true)}>
@@ -646,7 +848,7 @@ export const AgentTasksPage: React.FC = () => {
             </Empty>
           ) : (
             <div className="divide-y divide-border">
-              {projects.map((project) => (
+              {filteredProjects.map((project) => (
                 <div
                   key={project.id}
                   className={`flex cursor-pointer items-center gap-2 px-4 py-3 transition-colors hover:bg-surface-hover ${
@@ -661,6 +863,11 @@ export const AgentTasksPage: React.FC = () => {
                   />
                   <div className="min-w-0 flex-1">
                     <div className="font-medium truncate">{project.name}</div>
+                    {getCanonicalWorkspaceId(project) && (
+                      <div className="mt-0.5 text-xs text-muted-foreground">
+                        Workspace: {getCanonicalWorkspaceId(project)}
+                      </div>
+                    )}
                     {project.task_summary && (
                       <div className="flex gap-1 text-xs text-muted-foreground mt-0.5">
                         <span>{project.task_summary.total_tasks} tasks</span>
@@ -730,7 +937,7 @@ export const AgentTasksPage: React.FC = () => {
             <div className="flex justify-center py-8">
               <Spin />
             </div>
-          ) : tasks.length === 0 ? (
+          ) : visibleTasks.length === 0 ? (
             <Empty description="No tasks yet" className="py-8">
               <Button type="primary" onClick={() => setShowTaskModal(true)}>
                 Create Task
@@ -738,11 +945,11 @@ export const AgentTasksPage: React.FC = () => {
             </Empty>
           ) : (
             <div className="space-y-3">
-              {tasks.map((task) => (
+              {visibleTasks.map((task) => (
                 <TaskCard
                   key={task.id}
                   task={task}
-                  allTasks={tasks}
+                  allTasks={visibleTasks}
                   onDispatchRun={handleDispatchRun}
                   onReview={handleSubmitReview}
                   onInspectTask={handleInspectTask}
@@ -809,7 +1016,7 @@ export const AgentTasksPage: React.FC = () => {
             <Select
               placeholder="No dependency"
               allowClear
-              options={tasks.map((t) => ({
+              options={visibleTasks.map((t) => ({
                 value: t.id,
                 label: `#${t.id}: ${t.title}`,
               }))}
@@ -851,7 +1058,14 @@ export const AgentTasksPage: React.FC = () => {
 const AgentTasksSetupDescription: React.FC<{
   body: string
   issues: ACPSetupIssue[]
-}> = ({ body, issues }) => (
+  showAgentRegistry?: boolean
+  showWorkspacePlayground?: boolean
+}> = ({
+  body,
+  issues,
+  showAgentRegistry = true,
+  showWorkspacePlayground = false
+}) => (
   <div className="space-y-3">
     <div>{body}</div>
     <ul className="m-0 space-y-2 pl-4">
@@ -863,13 +1077,24 @@ const AgentTasksSetupDescription: React.FC<{
       ))}
     </ul>
     <div className="flex flex-wrap gap-2">
-      <Button
-        size="small"
-        icon={<ExternalLink className="h-3 w-3" />}
-        onClick={() => navigateOptionRoute("/agents")}
-      >
-        Open Agent Registry
-      </Button>
+      {showAgentRegistry && (
+        <Button
+          size="small"
+          icon={<ExternalLink className="h-3 w-3" />}
+          onClick={() => navigateOptionRoute("/agents")}
+        >
+          Open Agent Registry
+        </Button>
+      )}
+      {showWorkspacePlayground && (
+        <Button
+          size="small"
+          icon={<ExternalLink className="h-3 w-3" />}
+          onClick={() => navigateOptionRoute(WORKSPACE_PLAYGROUND_PATH)}
+        >
+          Open WorkspacePlayground
+        </Button>
+      )}
       <Button
         size="small"
         icon={<ExternalLink className="h-3 w-3" />}

--- a/apps/packages/ui/src/components/Option/AgentTasks/index.tsx
+++ b/apps/packages/ui/src/components/Option/AgentTasks/index.tsx
@@ -30,6 +30,7 @@ import {
   Search,
   ExternalLink,
 } from "lucide-react"
+import { useLocation, useNavigate } from "react-router-dom"
 import { useCanonicalConnectionConfig } from "@/hooks/useCanonicalConnectionConfig"
 import { WORKSPACE_PLAYGROUND_PATH } from "@/routes/route-paths"
 import { buildACPAuthHeaders } from "@/services/acp/connection"
@@ -167,18 +168,8 @@ const normalizeWorkspaceFilterId = (value: unknown): string | null => {
   return trimmed.length > 0 ? trimmed : null
 }
 
-const readWorkspaceFilterFromRoute = (): string | null => {
-  if (typeof window === "undefined") {
-    return null
-  }
-
-  const hash = window.location.hash || ""
-  const hashQueryIndex = hash.indexOf("?")
-  const params =
-    hashQueryIndex >= 0
-      ? new URLSearchParams(hash.slice(hashQueryIndex + 1))
-      : new URLSearchParams(window.location.search)
-
+const readWorkspaceFilterFromSearch = (search: string): string | null => {
+  const params = new URLSearchParams(search)
   return (
     normalizeWorkspaceFilterId(params.get("workspace")) ||
     normalizeWorkspaceFilterId(params.get("workspace_id")) ||
@@ -245,6 +236,8 @@ const ensureOrchestrationResponse = async (response: Response): Promise<void> =>
 export const AgentTasksPage: React.FC = () => {
   const { t } = useTranslation(["option", "common"])
   const { config: connectionConfig } = useCanonicalConnectionConfig()
+  const location = useLocation()
+  const navigate = useNavigate()
 
   const [projects, setProjects] = useState<ProjectSummary[]>([])
   const [selectedProjectId, setSelectedProjectId] = useState<number | null>(null)
@@ -257,8 +250,10 @@ export const AgentTasksPage: React.FC = () => {
   const [setupLoading, setSetupLoading] = useState(false)
   const [taskDetail, setTaskDetail] = useState<TaskDetailItem | null>(null)
   const [taskDetailLoading, setTaskDetailLoading] = useState(false)
-  const [workspaceFilterId, setWorkspaceFilterId] = useState<string | null>(() =>
-    readWorkspaceFilterFromRoute()
+  const [projectsLoadedSuccessfully, setProjectsLoadedSuccessfully] = useState(false)
+  const workspaceFilterId = useMemo(
+    () => readWorkspaceFilterFromSearch(location.search),
+    [location.search]
   )
 
   // Modal states
@@ -308,23 +303,11 @@ export const AgentTasksPage: React.FC = () => {
     orchestrationSupportRef.current = null
   }, [connectionConfig])
 
-  React.useEffect(() => {
-    if (typeof window === "undefined") {
-      return
-    }
-    const syncWorkspaceFilter = () => {
-      setWorkspaceFilterId(readWorkspaceFilterFromRoute())
-    }
-    window.addEventListener("hashchange", syncWorkspaceFilter)
-    return () => {
-      window.removeEventListener("hashchange", syncWorkspaceFilter)
-    }
-  }, [])
-
   const markUnsupported = useCallback(() => {
     setIsUnsupported(true)
     setError(null)
     setProjects([])
+    setProjectsLoadedSuccessfully(false)
     setTasks([])
     setSelectedProjectId(null)
   }, [])
@@ -406,6 +389,7 @@ export const AgentTasksPage: React.FC = () => {
     if (!apiBase) return
     setLoading(true)
     setError(null)
+    setProjectsLoadedSuccessfully(false)
     try {
       const supported = await hasOrchestrationSupport()
       if (!supported) {
@@ -418,10 +402,12 @@ export const AgentTasksPage: React.FC = () => {
       const data = await res.json()
       setIsUnsupported(false)
       setProjects(normalizeListPayload<ProjectSummary>(data, "projects"))
+      setProjectsLoadedSuccessfully(true)
     } catch (err) {
       if (isUnsupportedError(err)) {
         markUnsupported()
       } else {
+        setProjectsLoadedSuccessfully(false)
         setError(err instanceof Error ? err.message : "Failed to load projects")
       }
     } finally {
@@ -673,13 +659,11 @@ export const AgentTasksPage: React.FC = () => {
   }, [tasks, workspaceFilterId])
 
   const workspaceSetupIssues = useMemo<ACPSetupIssue[]>(() => {
-    if (!workspaceFilterId || loading || isUnsupported) {
+    if (!workspaceFilterId || loading || isUnsupported || !projectsLoadedSuccessfully) {
       return []
     }
 
-    const matchingProjects = projects.filter(
-      (project) => getCanonicalWorkspaceId(project) === workspaceFilterId
-    )
+    const matchingProjects = filteredProjects
     if (matchingProjects.length === 0) {
       return [
         {
@@ -691,11 +675,16 @@ export const AgentTasksPage: React.FC = () => {
       ]
     }
 
+    const hasLinkedProject = matchingProjects.some(
+      (project) =>
+        getCanonicalWorkspaceLinkStatus(project) ===
+        LINKED_CANONICAL_WORKSPACE_STATUS
+    )
     const unlinkedProject = matchingProjects.find((project) => {
       const status = getCanonicalWorkspaceLinkStatus(project)
       return status !== null && status !== LINKED_CANONICAL_WORKSPACE_STATUS
     })
-    if (unlinkedProject) {
+    if (!hasLinkedProject && unlinkedProject) {
       const status = getCanonicalWorkspaceLinkStatus(unlinkedProject) || "unknown"
       return [
         {
@@ -708,7 +697,34 @@ export const AgentTasksPage: React.FC = () => {
     }
 
     return []
-  }, [isUnsupported, loading, projects, workspaceFilterId])
+  }, [
+    filteredProjects,
+    isUnsupported,
+    loading,
+    projectsLoadedSuccessfully,
+    workspaceFilterId
+  ])
+
+  const updateWorkspaceFilter = useCallback(
+    (nextWorkspaceFilterId: string | null) => {
+      const params = new URLSearchParams(location.search)
+      params.delete("workspace")
+      params.delete("workspace_id")
+      params.delete("canonical_workspace_id")
+      if (nextWorkspaceFilterId) {
+        params.set("workspace", nextWorkspaceFilterId)
+      }
+      const search = params.toString()
+      navigate(
+        {
+          pathname: location.pathname,
+          search: search ? `?${search}` : ""
+        },
+        { replace: true }
+      )
+    },
+    [location.pathname, location.search, navigate]
+  )
 
   useEffect(() => {
     if (
@@ -788,7 +804,7 @@ export const AgentTasksPage: React.FC = () => {
             options={workspaceSelectOptions}
             onChange={(value) => {
               const nextValue = String(value || "")
-              setWorkspaceFilterId(
+              updateWorkspaceFilter(
                 nextValue === ALL_WORKSPACES_FILTER_VALUE
                   ? null
                   : normalizeWorkspaceFilterId(nextValue)
@@ -796,7 +812,6 @@ export const AgentTasksPage: React.FC = () => {
             }}
             style={{ minWidth: 240 }}
           />
-          {workspaceFilterId && <Tag>Workspace: {workspaceFilterId}</Tag>}
         </div>
       )}
 

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/WorkspaceHeader.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/WorkspaceHeader.tsx
@@ -531,7 +531,13 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
 
   const handleOpenAgentTasksPage = () => {
     setAgentTaskModalOpen(false)
-    navigate("/agent-tasks")
+    const canonicalWorkspaceId = workspaceId?.trim()
+    if (!canonicalWorkspaceId) {
+      navigate("/agent-tasks")
+      return
+    }
+    const params = new URLSearchParams({ workspace: canonicalWorkspaceId })
+    navigate(`/agent-tasks?${params.toString()}`)
   }
 
   const handleCreateNewWorkspace = () => {

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/WorkspaceHeader.test.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/WorkspaceHeader.test.tsx
@@ -1353,7 +1353,7 @@ describe("WorkspaceHeader workspace browser modal", () => {
     })
 
     fireEvent.click(within(modal).getByRole("button", { name: "Open Agent Tasks" }))
-    expect(mockNavigate).toHaveBeenCalledWith("/agent-tasks")
+    expect(mockNavigate).toHaveBeenCalledWith("/agent-tasks?workspace=workspace-alpha")
   })
 
   it("surfaces ACP bridge setup failures without creating project or task records", async () => {

--- a/backlog/tasks/task-314 - Implement-Agent-Tasks-canonical-workspace-filter-for-ACP-issue-1540.md
+++ b/backlog/tasks/task-314 - Implement-Agent-Tasks-canonical-workspace-filter-for-ACP-issue-1540.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-05-13 05:49'
-updated_date: '2026-05-13 06:08'
+updated_date: '2026-05-13 14:30'
 labels:
   - ACP
   - workspace
@@ -70,6 +70,8 @@ Verification: red run failed as expected before implementation. Final focused Vi
 Post-rebase verification on current origin/dev: focused Vitest passed again with 2 files and 38 tests; targeted TypeScript pass using /private/tmp/acp-agent-tasks-tsconfig.json passed; git diff --check origin/dev...HEAD passed.
 
 Draft PR opened: https://github.com/rmusser01/tldw_server/pull/1627. Kept draft because the AI-generated PR policy requires a human-owned Change summary before merge and #1540 has later history/diagnostic-link slices remaining.
+
+PR #1627 review sweep: addressed 6 unresolved review threads. Changes: switched Agent Tasks workspace filter parsing to React Router location/navigation for MemoryRouter compatibility; synchronized manual workspace filter changes back to router search; suppressed workspace setup warnings unless project data loaded successfully; reused filteredProjects in workspace setup calculation; only reports unlinked bridge warning when no matching linked project exists; removed redundant active-workspace Tag. Added regression tests for MemoryRouter route updates, project-load failure diagnostics, and mixed linked/stale project state. Verification: focused Vitest now 2 files/40 tests passed; targeted touched-file TypeScript passed; git diff --check passed.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-314 - Implement-Agent-Tasks-canonical-workspace-filter-for-ACP-issue-1540.md
+++ b/backlog/tasks/task-314 - Implement-Agent-Tasks-canonical-workspace-filter-for-ACP-issue-1540.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-05-13 05:49'
-updated_date: '2026-05-13 06:03'
+updated_date: '2026-05-13 06:08'
 labels:
   - ACP
   - workspace
@@ -14,6 +14,7 @@ dependencies: []
 references:
   - 'https://github.com/rmusser01/tldw_server/issues/1540'
   - 'https://github.com/rmusser01/tldw_server/pull/1625'
+  - 'https://github.com/rmusser01/tldw_server/pull/1627'
 documentation:
   - Docs/Design/ACP_Workspace_Integration_Decision_2026_05.md
 priority: high
@@ -67,6 +68,8 @@ Implementation notes: Agent Tasks now reads workspace/workspace_id/canonical_wor
 Verification: red run failed as expected before implementation. Final focused Vitest passed: bunx vitest run src/components/Option/AgentTasks/__tests__/AgentTasksPage.connection.test.tsx src/components/Option/WorkspacePlayground/__tests__/WorkspaceHeader.test.tsx --maxWorkers=1 --no-file-parallelism => 2 files, 38 tests passed. Targeted TypeScript pass used /private/tmp/acp-agent-tasks-tsconfig.json with touched files plus ambient/test globals. Full UI tsc remains blocked by existing unrelated baseline errors across many tests/services. git diff --check passed. Bandit not run because touched implementation is TypeScript/frontend docs/backlog only and no Python files are in scope.
 
 Post-rebase verification on current origin/dev: focused Vitest passed again with 2 files and 38 tests; targeted TypeScript pass using /private/tmp/acp-agent-tasks-tsconfig.json passed; git diff --check origin/dev...HEAD passed.
+
+Draft PR opened: https://github.com/rmusser01/tldw_server/pull/1627. Kept draft because the AI-generated PR policy requires a human-owned Change summary before merge and #1540 has later history/diagnostic-link slices remaining.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-314 - Implement-Agent-Tasks-canonical-workspace-filter-for-ACP-issue-1540.md
+++ b/backlog/tasks/task-314 - Implement-Agent-Tasks-canonical-workspace-filter-for-ACP-issue-1540.md
@@ -1,0 +1,80 @@
+---
+id: TASK-314
+title: Implement Agent Tasks canonical workspace filter for ACP issue 1540
+status: In Progress
+assignee:
+  - '@codex'
+created_date: '2026-05-13 05:49'
+updated_date: '2026-05-13 06:03'
+labels:
+  - ACP
+  - workspace
+  - frontend
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1540'
+  - 'https://github.com/rmusser01/tldw_server/pull/1625'
+documentation:
+  - Docs/Design/ACP_Workspace_Integration_Decision_2026_05.md
+priority: high
+---
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Agent Tasks can filter tasks by canonical workspace metadata without dropping existing project/task behavior
+- [x] #2 Agent Tasks surfaces workspace-linked setup gaps for missing root/env/MCP readiness when the selected workspace has no usable ACP execution workspace context
+- [x] #3 Focused frontend tests cover canonical workspace filter requests and setup-gap display behavior
+- [x] #4 Verification includes focused Vitest, lint or targeted ESLint, git diff --check, and Bandit touched-scope rationale
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+## Stage 1: Contract And Red Tests
+Goal: lock the Agent Tasks workspace-native behavior before implementation.
+Success Criteria: tests fail for workspace query handoff, canonical workspace project filtering, and missing execution workspace setup guidance.
+Tests: focused Vitest for AgentTasksPage plus WorkspaceHeader navigation handoff.
+Status: Complete
+
+## Stage 2: Agent Tasks Workspace Filter
+Goal: derive workspace filter options from backend canonical_workspace metadata and from incoming route query params without changing existing project/task APIs.
+Success Criteria: projects and selected tasks narrow to the chosen canonical workspace, unfiltered behavior remains unchanged, and selected project state is corrected when filters change.
+Tests: focused Vitest verifies filtered project list and only the filtered project task endpoint is requested.
+Status: Complete
+
+## Stage 3: Workspace Setup Gap Surfacing
+Goal: show actionable setup gaps when the selected canonical workspace has no usable ACP execution workspace context or a non-linked bridge status.
+Success Criteria: Agent Tasks presents root/env/MCP readiness guidance and links users back to WorkspacePlayground/ACP setup surfaces before dispatch.
+Tests: focused Vitest covers URL-provided workspace with no linked project and conflict/unlinked metadata.
+Status: Complete
+
+## Stage 4: Verification And Closeout
+Goal: verify the focused slice and record the outcome for #1540 continuation.
+Success Criteria: focused Vitest, targeted static check or documented lint fallback, git diff --check, and Bandit touched-scope rationale are recorded in TASK-314.
+Tests: bunx vitest run targeted files; git diff --check; backend Bandit skip rationale if no Python touched.
+Status: Complete
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Continuation after merged PR #1625. Implements the next #1540 slice: Agent Tasks canonical workspace filter plus setup-gap surfacing, using the backend bridge metadata from PR #1615 and WorkspacePlayground handoff from PR #1625.
+
+Red test run completed before production changes. Command: bunx vitest run src/components/Option/AgentTasks/__tests__/AgentTasksPage.connection.test.tsx src/components/Option/WorkspacePlayground/__tests__/WorkspaceHeader.test.tsx --maxWorkers=1 --no-file-parallelism. Expected failures: route workspace filter not applied, workspace setup gap alert absent, WorkspaceHeader navigates to /agent-tasks without workspace query.
+
+Implementation notes: Agent Tasks now reads workspace/workspace_id/canonical_workspace_id from the route, derives canonical workspace filter options from project metadata, filters visible projects/tasks without changing existing backend project/task endpoints, and shows workspace-specific setup guidance when the selected canonical workspace lacks a usable ACP execution project or has a non-linked bridge status. WorkspacePlayground handoff now opens /agent-tasks with the current workspace query.
+
+Verification: red run failed as expected before implementation. Final focused Vitest passed: bunx vitest run src/components/Option/AgentTasks/__tests__/AgentTasksPage.connection.test.tsx src/components/Option/WorkspacePlayground/__tests__/WorkspaceHeader.test.tsx --maxWorkers=1 --no-file-parallelism => 2 files, 38 tests passed. Targeted TypeScript pass used /private/tmp/acp-agent-tasks-tsconfig.json with touched files plus ambient/test globals. Full UI tsc remains blocked by existing unrelated baseline errors across many tests/services. git diff --check passed. Bandit not run because touched implementation is TypeScript/frontend docs/backlog only and no Python files are in scope.
+
+Post-rebase verification on current origin/dev: focused Vitest passed again with 2 files and 38 tests; targeted TypeScript pass using /private/tmp/acp-agent-tasks-tsconfig.json passed; git diff --check origin/dev...HEAD passed.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## AI-authored implementation note

This PR is materially AI-authored. Per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`, a human-owned Change summary is still required before merge.

## Summary

- Adds route-scoped canonical workspace filtering to Agent Tasks using `workspace`, `workspace_id`, or `canonical_workspace_id` query params.
- Keeps existing Agent Tasks project/task APIs intact while filtering visible projects/tasks from backend `canonical_workspace` metadata.
- Updates the WorkspacePlayground task handoff to open Agent Tasks scoped to the current workspace.
- Surfaces workspace-specific setup guidance when a selected canonical workspace has no linked ACP execution project or when none of the matching project links are currently linked.
- Records TASK-314 and the Slice 3 implementation plan for issue #1540 continuation.

## Scope

Refs #1540. This handles the Agent Tasks workspace filter and setup-gap slice. Remaining #1540 work after this PR is the workspace history/diagnostic links and final closeout pass.

## Validation Checklist

- [x] Route-scoped workspace filtering reads React Router location search params, including MemoryRouter mode.
- [x] Workspace filter UI writes the canonical `workspace` query param while preserving unrelated query params.
- [x] WorkspacePlayground opens Agent Tasks with the current canonical workspace in the URL.
- [x] Project and task lists are filtered by backend `canonical_workspace` metadata without changing the API contract.
- [x] Workspace setup warnings are suppressed until projects have loaded successfully.
- [x] Workspace setup warnings do not show an unlinked warning when another matching project is already linked.
- [x] Focused Agent Tasks and WorkspacePlayground tests cover the route filter, setup warning, load-error, and mixed linked/unlinked cases.

## UX Validation Checklist

- [x] The Agent Tasks selector has an explicit "All workspaces" option for clearing the filter.
- [x] Selected workspace state is visible in the selector and refresh/deep-link safe through the URL.
- [x] Redundant active-workspace tag was removed to avoid repeating the selector value.
- [x] Setup guidance is only shown for actionable workspace-link states, not backend load failures.

## Verification

- Red run before implementation failed in the expected spots: missing route filter, missing workspace setup alert, and bare `/agent-tasks` handoff.
- `bunx vitest run src/components/Option/AgentTasks/__tests__/AgentTasksPage.connection.test.tsx src/components/Option/WorkspacePlayground/__tests__/WorkspaceHeader.test.tsx --maxWorkers=1 --no-file-parallelism`
  - passed with 2 files and 40 tests.
- `bunx tsc --noEmit -p /private/tmp/acp-agent-tasks-tsconfig.json --pretty false`
  - passed for touched files with UI ambient/test globals.
- `git diff --check`
  - passed.

## Risk And Rollback

Risk level: low to medium. The change is confined to frontend Agent Tasks workspace filtering, WorkspacePlayground handoff routing, focused tests, and task/plan documentation. It does not change backend Agent Tasks APIs or persistence.

Rollback plan: revert this PR to restore the prior unfiltered Agent Tasks behavior and the previous WorkspacePlayground handoff URL. Because no backend data model or API contract is changed, rollback does not require migration or data repair.

## Known Baseline

- Full `bunx tsc --noEmit -p tsconfig.json --pretty false` is still blocked by unrelated existing UI package type errors across tests/services, so this PR uses the narrowed touched-file static config for the targeted gate.
- Bandit was not run because the touched implementation is TypeScript/frontend docs/backlog only and no Python files are in scope.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a canonical workspace filter to Agent Tasks so projects and tasks are scoped from the route or UI, and shows setup gaps when a workspace isn’t linked. Updates WorkspacePlayground to pass the current workspace to Agent Tasks. Aligns with #1540.

- **New Features**
  - Read `workspace`, `workspace_id`, or `canonical_workspace_id` from the router to scope Agent Tasks; UI changes keep the URL in sync.
  - Filter projects and tasks by backend `canonical_workspace` metadata without changing APIs; clear stale selections when the filter excludes them.
  - Add a “Canonical workspace” selector with “All workspaces”; options derive from loaded projects, and project rows show “Workspace: <id>”.
  - Show setup guidance only after projects load: warn when no linked ACP execution workspace exists or when none of the matches are linked, with links to WorkspacePlayground/ACP; WorkspacePlayground now opens Agent Tasks with `?workspace=<id>`.

<sup>Written for commit 68280d56f8e4e649d84c7c6b2c93b765705665ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->
