### PR TITLE
Migrate workspace agent handoff alerts to design-system Alert

### DIFF
--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/WorkspaceAgentTaskHandoffModal.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/WorkspaceAgentTaskHandoffModal.tsx
@@ -1,8 +1,9 @@
 import React from "react"
 import { useTranslation } from "react-i18next"
-import { Alert, Button, Input, Modal } from "antd"
+import { Button, Input, Modal } from "antd"
 import { ExternalLink } from "lucide-react"
 
+import { Alert } from "@/components/ui"
 import { useCanonicalConnectionConfig } from "@/hooks/useCanonicalConnectionConfig"
 import { buildACPAuthHeaders } from "@/services/acp/connection"
 import {
@@ -401,27 +402,27 @@ export const WorkspaceAgentTaskHandoffModal: React.FC<
       <div className="space-y-4">
         {error && (
           <Alert
-            type="error"
-            title={error}
-            showIcon
-          />
+            variant="error"
+          >
+            {error}
+          </Alert>
         )}
         {createdTask && (
           <Alert
-            type="success"
+            variant="success"
             title={t(
               "playground:workspace.agentTaskCreated",
               "Agent task created"
             )}
-            description={
-              <div className="flex flex-wrap gap-2 text-sm">
-                <span>ACP workspace #{createdTask.acpWorkspaceId}</span>
-                <span>Project #{createdTask.projectId}</span>
-                <span>Task #{createdTask.taskId}</span>
-              </div>
-            }
-            showIcon
-          />
+            role="status"
+            aria-live="polite"
+          >
+            <div className="flex flex-wrap gap-2 text-sm">
+              <span>ACP workspace #{createdTask.acpWorkspaceId}</span>
+              <span>Project #{createdTask.projectId}</span>
+              <span>Task #{createdTask.taskId}</span>
+            </div>
+          </Alert>
         )}
 
         <div className="space-y-1.5">

--- a/backlog/tasks/task-315 - Migrate-Workspace-agent-handoff-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-315 - Migrate-Workspace-agent-handoff-alerts-to-design-system-Alert.md
@@ -1,0 +1,59 @@
+---
+id: TASK-315
+title: Migrate Workspace agent handoff alerts to design-system Alert
+status: Done
+assignee: []
+created_date: '2026-05-13 06:10'
+updated_date: '2026-05-13 06:12'
+labels:
+  - design-system
+  - frontend
+  - workspace-playground
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Restore the design-system product-state guard on current dev by replacing unbaselined AntD product-state Alerts in WorkspaceAgentTaskHandoffModal with the canonical UI Alert primitive. Scope is limited to the handoff modal success/error callouts and guard verification.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The current failing design-system product-state verifier no longer reports WorkspaceAgentTaskHandoffModal AntD Alert findings.
+- [x] #2 WorkspaceAgentTaskHandoffModal success and error callouts render through the design-system Alert primitive without changing visible success/error copy.
+- [x] #3 Focused WorkspaceHeader modal coverage and the product-state guard pass after migration.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Use the current failing verify:design-system-state output as the red check for the unbaselined WorkspaceAgentTaskHandoffModal AntD Alert findings. 2. Replace the modal's AntD Alert usage with the design-system Alert primitive while preserving success/error text and details. 3. Run focused WorkspaceHeader handoff coverage, product-state guard, verify:design-system-state, JSON/diff checks, touched-path TypeScript filtering, and frontend-only Bandit skip documentation before PR.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the guard-restoration slice by replacing WorkspaceAgentTaskHandoffModal AntD Alert usage with the design-system Alert primitive for both error and success callouts. The error message remains visible as the Alert body. The success callout keeps the existing title and created task identifiers, with role="status" and aria-live="polite" for non-urgent completion feedback.
+
+Verification: initial red check was bun run verify:design-system-state failing on two unbaselined WorkspaceAgentTaskHandoffModal AntD Alert findings. After migration: bun run test src/components/Option/WorkspacePlayground/__tests__/WorkspaceHeader.test.tsx --reporter=dot (pass, 30 tests; existing jsdom navigation not-implemented messages only); bun run test src/design-system/__tests__/product-state-guard.test.ts --reporter=dot (pass, 52 tests); bun run verify:design-system-state (pass, 504 baseline exceptions / 24 canonical-state-label); node JSON parse for design-system-product-state-baseline.json (pass); git diff --check (pass); touched-path TypeScript filter over bunx tsc --noEmit --pretty false (tsc exited 2 for existing repo-wide diagnostics, no diagnostics matched WorkspaceAgentTaskHandoffModal.tsx).
+
+Bandit: skipped because touched implementation/test files are frontend TypeScript plus this task record, with no Python runtime surface.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Restored the design-system product-state guard on current dev by moving WorkspaceAgentTaskHandoffModal success/error callouts from AntD Alert to the canonical UI Alert primitive. The visible success/error copy and created task identifiers are preserved, no baseline debt was added, and focused WorkspaceHeader coverage plus the product-state verifier pass.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Replaces WorkspaceAgentTaskHandoffModal success/error AntD Alerts with the canonical design-system Alert primitive.
- Preserves the visible success/error copy and created task identifiers.
- Restores the design-system product-state verifier without adding baseline debt.

## Verification
- bun run test src/components/Option/WorkspacePlayground/__tests__/WorkspaceHeader.test.tsx --reporter=dot
- bun run test src/design-system/__tests__/product-state-guard.test.ts --reporter=dot
- bun run verify:design-system-state
- node JSON parse for apps/packages/ui/scripts/design-system-product-state-baseline.json
- git diff --check
- touched-path TypeScript filter over bunx tsc --noEmit --pretty false: tsc exited 2 for existing repo-wide diagnostics; no diagnostics matched WorkspaceAgentTaskHandoffModal.tsx

## Notes
- Bandit skipped because this slice touches frontend TypeScript plus the Backlog task record, with no Python runtime surface.
- Human-authored Change summary is still required before merge per repo policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated Workspace agent handoff alerts from `antd` to the design-system `Alert` to restore product-state compliance while keeping the same user-facing messages. Addresses TASK-315 and re-enables the product-state guard without adding baseline debt.

- **Refactors**
  - Swapped `antd` `Alert` for design-system `Alert` from `@/components/ui` in `WorkspaceAgentTaskHandoffModal`.
  - Preserved success/error copy and task IDs; added role="status" and aria-live="polite" to the success alert.
  - Product-state guard and focused tests now pass.

<sup>Written for commit 638f10f5f1d2a62ff2e2fa038164e5a3490575b1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

