### PR TITLE
Migrate AgentRegistry status labels to design-system registry

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -5137,28 +5137,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "canonical-state-label:src/components/Option/AgentRegistry/index.tsx:Ready",
-    "path": "src/components/Option/AgentRegistry/index.tsx",
-    "rule": "canonical-state-label",
-    "subject": "Ready",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing hardcoded \"Ready\" state label in src/components/Option/AgentRegistry/index.tsx before the guard.",
-    "replacement": "getDesignSystemState(...)",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "canonical-state-label:src/components/Option/AgentRegistry/index.tsx:Unavailable",
-    "path": "src/components/Option/AgentRegistry/index.tsx",
-    "rule": "canonical-state-label",
-    "subject": "Unavailable",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing hardcoded \"Unavailable\" state label in src/components/Option/AgentRegistry/index.tsx before the guard.",
-    "replacement": "getDesignSystemState(...)",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "canonical-state-label:src/components/Option/CompanionHome/CompanionHomePage.tsx:Setup required#label-setup-required-companionhomepage-line-119-ne2x8o",
     "path": "src/components/Option/CompanionHome/CompanionHomePage.tsx",
     "rule": "canonical-state-label",

--- a/apps/packages/ui/src/components/Option/AgentRegistry/__tests__/AgentRegistryPage.connection.test.tsx
+++ b/apps/packages/ui/src/components/Option/AgentRegistry/__tests__/AgentRegistryPage.connection.test.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { render, screen, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
+import { getDesignSystemState } from "@/design-system"
 import { AgentRegistryPage } from "../index"
 
 const storageMocks = vi.hoisted(() => ({
@@ -20,6 +21,18 @@ const acpMocks = vi.hoisted(() => ({
   }>,
   getAvailableAgents: vi.fn()
 }))
+
+vi.mock("@/design-system", async (importActual) => {
+  const actual = await importActual<typeof import("@/design-system")>()
+
+  return {
+    ...actual,
+    getDesignSystemState: vi.fn(
+      (key: Parameters<typeof actual.getDesignSystemState>[0]) =>
+        actual.getDesignSystemState(key)
+    )
+  }
+})
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -202,6 +215,37 @@ describe("AgentRegistryPage connection config", () => {
           })
         })
       )
+    })
+  })
+
+  it("uses design-system state labels for runtime setup states", async () => {
+    acpMocks.getAvailableAgents.mockResolvedValue({
+      agents: [
+        {
+          type: "planner",
+          name: "Planner Agent",
+          description: "Plans work",
+          is_configured: true
+        },
+        {
+          type: "local-runner",
+          name: "Local Runner",
+          description: "Requires local setup",
+          is_configured: false
+        }
+      ]
+    })
+
+    render(<AgentRegistryPage />)
+
+    expect(await screen.findByText("Planner Agent")).toBeInTheDocument()
+    expect(screen.getByText("Local Runner")).toBeInTheDocument()
+    expect(screen.getByText("Ready")).toBeInTheDocument()
+    expect(screen.getByText("Setup required")).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(getDesignSystemState).toHaveBeenCalledWith("ready")
+      expect(getDesignSystemState).toHaveBeenCalledWith("setup_required")
     })
   })
 

--- a/apps/packages/ui/src/components/Option/AgentRegistry/__tests__/AgentRegistryPage.connection.test.tsx
+++ b/apps/packages/ui/src/components/Option/AgentRegistry/__tests__/AgentRegistryPage.connection.test.tsx
@@ -2,7 +2,6 @@ import React from "react"
 import { render, screen, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
-import { getDesignSystemState } from "@/design-system"
 import { AgentRegistryPage } from "../index"
 
 const storageMocks = vi.hoisted(() => ({
@@ -24,12 +23,21 @@ const acpMocks = vi.hoisted(() => ({
 
 vi.mock("@/design-system", async (importActual) => {
   const actual = await importActual<typeof import("@/design-system")>()
+  const labelOverrides: Partial<
+    Record<Parameters<typeof actual.getDesignSystemState>[0], string>
+  > = {
+    ready: "Registry ready",
+    setup_required: "Registry setup required"
+  }
 
   return {
     ...actual,
     getDesignSystemState: vi.fn(
-      (key: Parameters<typeof actual.getDesignSystemState>[0]) =>
-        actual.getDesignSystemState(key)
+      (key: Parameters<typeof actual.getDesignSystemState>[0]) => {
+        const state = actual.getDesignSystemState(key)
+        const label = labelOverrides[key]
+        return label ? { ...state, label } : state
+      }
     )
   }
 })
@@ -240,13 +248,8 @@ describe("AgentRegistryPage connection config", () => {
 
     expect(await screen.findByText("Planner Agent")).toBeInTheDocument()
     expect(screen.getByText("Local Runner")).toBeInTheDocument()
-    expect(screen.getByText("Ready")).toBeInTheDocument()
-    expect(screen.getByText("Setup required")).toBeInTheDocument()
-
-    await waitFor(() => {
-      expect(getDesignSystemState).toHaveBeenCalledWith("ready")
-      expect(getDesignSystemState).toHaveBeenCalledWith("setup_required")
-    })
+    expect(screen.getByText("Registry ready")).toBeInTheDocument()
+    expect(screen.getByText("Registry setup required")).toBeInTheDocument()
   })
 
   it("normalizes structured ACP health payloads without trying to render raw objects", async () => {

--- a/apps/packages/ui/src/components/Option/AgentRegistry/index.tsx
+++ b/apps/packages/ui/src/components/Option/AgentRegistry/index.tsx
@@ -250,6 +250,13 @@ const AGENT_STATUS_STATE: Record<AgentEntry["status"], DesignSystemStateKey> = {
   unavailable: "unavailable"
 }
 
+const AGENT_STATUS_LABELS = Object.fromEntries(
+  Object.entries(AGENT_STATUS_STATE).map(([status, stateKey]) => [
+    status,
+    (getDesignSystemState(stateKey) ?? DESIGN_SYSTEM_STATES[stateKey]).label
+  ])
+) as Record<AgentEntry["status"], string>
+
 const AgentCard: React.FC<{ agent: AgentEntry }> = ({ agent }) => {
   const statusColor =
     agent.status === "available"
@@ -258,10 +265,7 @@ const AgentCard: React.FC<{ agent: AgentEntry }> = ({ agent }) => {
         ? "warning"
         : "error"
 
-  const statusStateKey = AGENT_STATUS_STATE[agent.status]
-  const statusState =
-    getDesignSystemState(statusStateKey) ?? DESIGN_SYSTEM_STATES[statusStateKey]
-  const statusLabel = statusState.label
+  const statusLabel = AGENT_STATUS_LABELS[agent.status]
   const showUnverifiedWarning =
     agent.status === "available" && agent.support_state === "documented_unverified"
 

--- a/apps/packages/ui/src/components/Option/AgentRegistry/index.tsx
+++ b/apps/packages/ui/src/components/Option/AgentRegistry/index.tsx
@@ -17,7 +17,7 @@ import { buildACPAuthHeaders, buildACPClientConfig } from "@/services/acp/connec
 import { normalizeACPHealthStatus, type ACPHealthStatus } from "@/services/acp/readiness"
 import type { ACPSupportState, ACPVerificationLevel } from "@/services/acp/types"
 import { resolveBrowserRequestTransport } from "@/services/tldw/request-core"
-
+import { DESIGN_SYSTEM_STATES, getDesignSystemState, type DesignSystemStateKey } from "@/design-system"
 type AgentEntry = {
   type: string
   name: string
@@ -244,6 +244,12 @@ export const AgentRegistryPage: React.FC = () => {
   )
 }
 
+const AGENT_STATUS_STATE: Record<AgentEntry["status"], DesignSystemStateKey> = {
+  available: "ready",
+  requires_setup: "setup_required",
+  unavailable: "unavailable"
+}
+
 const AgentCard: React.FC<{ agent: AgentEntry }> = ({ agent }) => {
   const statusColor =
     agent.status === "available"
@@ -252,12 +258,10 @@ const AgentCard: React.FC<{ agent: AgentEntry }> = ({ agent }) => {
         ? "warning"
         : "error"
 
-  const statusLabel =
-    agent.status === "available"
-      ? "Ready"
-      : agent.status === "requires_setup"
-        ? "Setup Required"
-        : "Unavailable"
+  const statusStateKey = AGENT_STATUS_STATE[agent.status]
+  const statusState =
+    getDesignSystemState(statusStateKey) ?? DESIGN_SYSTEM_STATES[statusStateKey]
+  const statusLabel = statusState.label
   const showUnverifiedWarning =
     agent.status === "available" && agent.support_state === "documented_unverified"
 

--- a/backlog/tasks/task-45.38 - Migrate-AgentRegistry-status-labels-to-design-system-registry.md
+++ b/backlog/tasks/task-45.38 - Migrate-AgentRegistry-status-labels-to-design-system-registry.md
@@ -1,0 +1,81 @@
+---
+id: TASK-45.38
+title: Migrate AgentRegistry status labels to design-system registry
+status: Done
+assignee:
+  - codex
+created_date: '2026-05-13 14:23'
+updated_date: '2026-05-13 14:29'
+labels:
+  - design-system
+  - webui
+  - extension
+dependencies: []
+references:
+  - apps/packages/ui/src/components/Option/AgentRegistry/index.tsx
+  - >-
+    apps/packages/ui/src/components/Option/AgentRegistry/__tests__/AgentRegistryPage.connection.test.tsx
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+documentation:
+  - Docs/Design/tldw_web_design_system_contract.md
+parent_task_id: TASK-45
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue the shared product-state design-system migration by routing AgentRegistry runtime setup/availability status labels through the canonical design-system state registry. Keep scope limited to AgentRegistry status label resolution, focused test coverage, and removal of the migrated canonical-state-label baseline entries.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 AgentRegistry status labels for available, setup-required, and unavailable states resolve through getDesignSystemState with safe fallbacks.
+- [x] #2 Focused AgentRegistry tests cover the design-system registry calls without brittle full-module mocking.
+- [x] #3 The product-state guard baseline no longer contains AgentRegistry canonical-state-label exceptions for Ready or Unavailable.
+- [x] #4 Focused tests and the design-system product-state verifier pass or any unrelated baseline failures are documented.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused AgentRegistry coverage that requires runtime status labels to use getDesignSystemState for available/setup-required states while preserving the existing module exports.
+2. Run the focused AgentRegistry test to confirm the design-system expectation fails against the current hardcoded labels.
+3. Update AgentRegistry status label resolution to map available -> ready, requires_setup -> setup_required, unavailable -> unavailable via getDesignSystemState with safe fallback labels.
+4. Remove only the migrated AgentRegistry canonical-state-label baseline entries for Ready and Unavailable.
+5. Verify with focused AgentRegistry tests, product-state guard tests, bun run verify:design-system-state, git diff --check, and document frontend-only Bandit skip if applicable.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Baseline verifier on fresh origin/dev passed with 504 allowed legacy exceptions: 480 antd-product-state-import and 24 canonical-state-label. AgentRegistry has two canonical-state-label exceptions and existing focused tests, making it a narrow next slice.
+
+RED: bunx vitest run src/components/Option/AgentRegistry/__tests__/AgentRegistryPage.connection.test.tsx --reporter=dot failed because Setup required was not rendered from the design-system registry; the component still rendered the local hardcoded Setup Required label.
+
+Implementation: AgentRegistry now maps available/requires_setup/unavailable to ready/setup_required/unavailable design-system state keys, resolves labels through getDesignSystemState with DESIGN_SYSTEM_STATES fallback definitions, and preserves the existing status color behavior.
+
+Verification: focused AgentRegistry test passed with 5 tests; combined AgentRegistry plus product-state guard tests passed with 57 tests; bun run verify:design-system-state passed with baseline exceptions reduced from 504 to 502 and canonical-state-label reduced from 24 to 22; git diff --check passed.
+
+TypeScript caveat: bunx tsc --noEmit --pretty false --project tsconfig.json still fails on existing repo-wide baseline errors in unrelated tests/components; no reported errors referenced AgentRegistry or the touched baseline file. Bandit skipped because this is a frontend-only TypeScript/JSON slice.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated AgentRegistry runtime status labels to resolve through the canonical design-system state registry. Available, setup-required, and unavailable statuses now map to ready, setup_required, and unavailable registry states with DESIGN_SYSTEM_STATES fallbacks, preserving the existing status color behavior while centralizing user-facing state copy.
+
+Added focused AgentRegistry coverage that preserves the real design-system module and spies only on getDesignSystemState. Removed the two obsolete AgentRegistry canonical-state-label baseline exceptions for Ready and Unavailable.
+
+Verification passed for focused AgentRegistry tests, AgentRegistry plus product-state guard tests, bun run verify:design-system-state, and git diff --check. Package-wide TypeScript remains blocked by unrelated existing baseline errors; no errors referenced AgentRegistry or the touched baseline file. Bandit was skipped because this is a frontend-only TypeScript/JSON change.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.38 - Migrate-AgentRegistry-status-labels-to-design-system-registry.md
+++ b/backlog/tasks/task-45.38 - Migrate-AgentRegistry-status-labels-to-design-system-registry.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - codex
 created_date: '2026-05-13 14:23'
-updated_date: '2026-05-13 14:29'
+updated_date: '2026-05-13 14:44'
 labels:
   - design-system
   - webui
@@ -58,14 +58,20 @@ Implementation: AgentRegistry now maps available/requires_setup/unavailable to r
 Verification: focused AgentRegistry test passed with 5 tests; combined AgentRegistry plus product-state guard tests passed with 57 tests; bun run verify:design-system-state passed with baseline exceptions reduced from 504 to 502 and canonical-state-label reduced from 24 to 22; git diff --check passed.
 
 TypeScript caveat: bunx tsc --noEmit --pretty false --project tsconfig.json still fails on existing repo-wide baseline errors in unrelated tests/components; no reported errors referenced AgentRegistry or the touched baseline file. Bandit skipped because this is a frontend-only TypeScript/JSON slice.
+
+PR #1633 review-fix pass: Qodo flagged the test's getDesignSystemState call-argument assertions as implementation-detail brittle; CodeRabbit flagged per-card render-time design-system label lookups. Both findings are valid for this slice and can be handled with behavior-based visible-label assertions plus module-scope status-label precomputation.
+
+Review fix implementation: AgentRegistry now precomputes AGENT_STATUS_LABELS at module scope from AGENT_STATUS_STATE and the design-system registry/fallback definitions. The focused test now verifies visible registry-derived labels by having the design-system mock return distinct ready/setup_required labels, without asserting getDesignSystemState call arguments.
+
+Review fix verification: bunx vitest run src/components/Option/AgentRegistry/__tests__/AgentRegistryPage.connection.test.tsx src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed with 57 tests; bun run verify:design-system-state passed with 502 baseline exceptions and canonical-state-label 22; git diff --check passed. Package-wide TypeScript remains blocked by unrelated existing baseline diagnostics and still reports no AgentRegistry touched-file diagnostics.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Migrated AgentRegistry runtime status labels to resolve through the canonical design-system state registry. Available, setup-required, and unavailable statuses now map to ready, setup_required, and unavailable registry states with DESIGN_SYSTEM_STATES fallbacks, preserving the existing status color behavior while centralizing user-facing state copy.
+Migrated AgentRegistry runtime status labels to resolve through the canonical design-system state registry. Available, setup-required, and unavailable statuses map to ready, setup_required, and unavailable registry states with DESIGN_SYSTEM_STATES fallbacks, preserving existing status color behavior while centralizing user-facing state copy.
 
-Added focused AgentRegistry coverage that preserves the real design-system module and spies only on getDesignSystemState. Removed the two obsolete AgentRegistry canonical-state-label baseline exceptions for Ready and Unavailable.
+Review feedback on PR #1633 was addressed by moving status-label resolution to a module-scope AGENT_STATUS_LABELS map and changing the focused test to assert visible registry-derived labels instead of getDesignSystemState call arguments. The two obsolete AgentRegistry canonical-state-label baseline exceptions remain removed.
 
 Verification passed for focused AgentRegistry tests, AgentRegistry plus product-state guard tests, bun run verify:design-system-state, and git diff --check. Package-wide TypeScript remains blocked by unrelated existing baseline errors; no errors referenced AgentRegistry or the touched baseline file. Bandit was skipped because this is a frontend-only TypeScript/JSON change.
 <!-- SECTION:FINAL_SUMMARY:END -->


### PR DESCRIPTION
## Summary
- Route AgentRegistry runtime setup/availability status labels through the canonical design-system state registry.
- Add focused AgentRegistry coverage that preserves the real design-system module and spies only on getDesignSystemState.
- Remove the two obsolete AgentRegistry canonical-state-label baseline exceptions.

## Verification
- bunx vitest run src/components/Option/AgentRegistry/__tests__/AgentRegistryPage.connection.test.tsx src/design-system/__tests__/product-state-guard.test.ts --reporter=dot
- bun run verify:design-system-state
- git diff --check

## Notes
- Package-wide TypeScript still fails on unrelated existing baseline errors; no reported errors referenced AgentRegistry or the touched baseline file.
- Bandit skipped: frontend-only TypeScript/JSON change.
- Per the AI-generated PR merge policy, a human-written Change summary is still required before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated AgentRegistry runtime status labels to the canonical `@/design-system` state registry to centralize copy and remove hardcoded strings. Satisfies TASK-45.38.

- **Refactors**
  - Map AgentRegistry statuses to design-system keys (available → `ready`, requires_setup → `setup_required`, unavailable → `unavailable`) and precompute labels at module scope via `getDesignSystemState` with `DESIGN_SYSTEM_STATES` fallback.
  - Update focused tests to wrap the real `@/design-system` module, override `ready`/`setup_required` labels, and assert visible registry-derived labels (no call-argument assertions).
  - Remove two obsolete AgentRegistry `canonical-state-label` baseline exceptions from `design-system-product-state-baseline.json`.

<sup>Written for commit 981fcdeb30a4bdd5eacd86be325853ec64b0048c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

