### PR TITLE
Add Persona Visual V2 import-preview validators

### DIFF
--- a/Docs/Code_Documentation/Persona_Visual_Packs.md
+++ b/Docs/Code_Documentation/Persona_Visual_Packs.md
@@ -74,6 +74,15 @@ capability list with `can_validate: false`, `can_activate: false`,
 `runtime_adapter_not_implemented`; that is an explicit future/disabled state,
 not a runtime support claim.
 
+Renderer import-preview diagnostics are also split from archive parsing. The
+fixture-level validator in
+`tldw_Server_API/app/core/Persona/visual_import_preview_validators.py` accepts
+already-normalized manifest and asset metadata, resolves the renderer capability
+registry, and returns structured blockers, warnings, normalized role categories,
+commit eligibility, and activation eligibility. It does not parse archives,
+create asset rows, activate packs, or load renderer runtimes; the current V1
+archive preview and commit flow remains unchanged.
+
 ### Sprite Atlas Frames
 
 Sprite atlases are represented as `sprite_frames` packs. In this slice,

--- a/Docs/Design/2026-05-13-persona-visual-manifest-v2-contract.md
+++ b/Docs/Design/2026-05-13-persona-visual-manifest-v2-contract.md
@@ -224,6 +224,11 @@ Import preview statuses:
    failed validation.
 8. `fallback_missing`: no valid static fallback asset is available.
 
+The first implemented V2 preview seam is fixture-only:
+`preview_renderer_import()` consumes normalized manifest and asset metadata and
+returns renderer diagnostics without reading archives, persisting assets, or
+activating packs. Archive parsing and commit remain separate future slices.
+
 ## Validation Stages
 
 V2 needs different validation strictness at each lifecycle stage:
@@ -397,8 +402,8 @@ Recommended follow-up sequence:
 
 1. Manifest V2 schema and renderer capability docs.
 2. Backend renderer capability expansion for V2 statuses and asset-role limits.
-3. Import-preview validator interface for renderer-specific archives, with
-   fixture-only tests and no new runtime renderer.
+3. Import-preview validator interface for renderer-specific metadata, with
+   fixture-only tests and no new archive parser or runtime renderer.
 4. Persona Garden preview UI copy for unsupported, feature-gated,
    dependency-missing, license-review, and fallback-missing V2 packs.
 5. MCP capability update to expose renderer support and draft/import boundaries.

--- a/Docs/superpowers/plans/2026-05-13-persona-visual-v2-import-preview-validator.md
+++ b/Docs/superpowers/plans/2026-05-13-persona-visual-v2-import-preview-validator.md
@@ -1,0 +1,46 @@
+# Persona Visual V2 Import Preview Validator Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a backend renderer-specific import-preview validation seam for Manifest V2 Persona Visual packs without enabling archive parsing, commit, or runtime renderer support.
+
+**Architecture:** Keep the existing V1 portability preview path unchanged. Add a pure, fixture-driven validator module that takes already-normalized manifest/assets metadata, resolves the renderer capability registry, and returns structured preview diagnostics for blocked or unsupported V2 renderers. This gives later archive-parser and UI slices a stable contract without writing assets or activating packs.
+
+**Tech Stack:** Python dataclasses, existing Persona visual renderer capability registry, pytest, Bandit.
+
+---
+
+## Stage 1: Fixture Preview Contract
+**Goal**: Define the minimal import-preview result contract for renderer-specific Manifest V2 validation.
+**Success Criteria**: Tests can call the validator directly with fixture manifests/assets and receive deterministic statuses, blockers, warnings, normalized role categories, and activation eligibility.
+**Tests**: Focused pytest coverage in `tldw_Server_API/tests/Persona/test_persona_visual_import_preview_validators.py`.
+**Status**: Complete
+
+### Task 1: Validator Interface and Result Model
+**Files:**
+- Create: `tldw_Server_API/app/core/Persona/visual_import_preview_validators.py`
+- Test: `tldw_Server_API/tests/Persona/test_persona_visual_import_preview_validators.py`
+
+- [x] Write failing tests for known disabled `live2d`, unknown renderer, missing required fallback/source categories, and non-activatable preview diagnostics.
+- [x] Run focused tests and verify they fail because the interface does not exist.
+- [x] Add dataclasses for preview assets and preview results.
+- [x] Add `preview_renderer_import()` that uses the renderer capability registry and returns deterministic diagnostics without parsing archives or writing assets.
+- [x] Re-run focused tests and verify green.
+
+## Stage 2: V1 Boundary and Docs
+**Goal**: Preserve existing V1 import behavior while documenting the new fixture-only V2 seam.
+**Success Criteria**: Existing portability preview tests still pass; docs state this is not archive parsing, runtime renderer support, or activation support.
+**Tests**: Existing persona visual portability tests plus focused validator tests.
+**Status**: Complete
+
+### Task 2: Boundary Verification and Documentation
+**Files:**
+- Modify: `Docs/Code_Documentation/Persona_Visual_Packs.md`
+- Modify: `Docs/Design/2026-05-13-persona-visual-manifest-v2-contract.md`
+- Modify: `backlog/tasks/task-317 - Implement-Persona-Visual-Manifest-V2-import-preview-validator-interface.md` via Backlog tooling
+
+- [x] Update docs with the fixture-only validator boundary.
+- [x] Run focused validator and portability tests.
+- [x] Run `git diff --check`.
+- [x] Run Bandit on touched backend files.
+- [x] Update TASK-317 with verification and final summary.

--- a/backlog/tasks/task-317 - Implement-Persona-Visual-Manifest-V2-import-preview-validator-interface.md
+++ b/backlog/tasks/task-317 - Implement-Persona-Visual-Manifest-V2-import-preview-validator-interface.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - codex
 created_date: '2026-05-13 14:28'
-updated_date: '2026-05-13 14:36'
+updated_date: '2026-05-13 14:49'
 labels:
   - persona
   - buddy
@@ -43,12 +43,18 @@ Implement the next Manifest V2 foundation slice for Persona/Buddy visual packs: 
 Implementation plan created: Docs/superpowers/plans/2026-05-13-persona-visual-v2-import-preview-validator.md. Plan reviewer subagent was not dispatched because this session only allows subagents when explicitly requested; proceeding with an inline self-review and TDD implementation.
 
 Implemented fixture-only renderer import-preview validator and documented the boundary. Verification: initial red pytest failed on missing visual_import_preview_validators module; focused validator tests passed; persona visual boundary suite passed; git diff --check passed; Bandit JSON reported zero findings.
+
+PR #1634 review sweep started. Actionable findings verified: sanitize unknown-renderer blocker text, avoid float version truncation, treat missing required manifest/contract versions as blockers, and make asset attribute reads robust.
+
+PR #1634 review fixes implemented and verified: unknown renderer blocker text is escaped/capped, version coercion no longer truncates floats, missing manifest/contract versions now block supported renderers, and asset text extraction tolerates unexpected objects. Verification: 38 persona visual tests passed, git diff --check passed, Bandit reported zero findings.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Added a backend Persona Visual renderer import-preview validator interface for normalized manifest/assets metadata. The slice reports known disabled live2d blockers, unknown renderer diagnostics, required role-category gaps, and supported sprite_frames eligibility without parsing archives, writing assets, activating packs, or changing the existing V1 portability path.
+
+Review sweep: addressed Qodo and Gemini findings with sanitizer, strict integer version parsing, required version blockers, robust asset attribute access, and focused regression tests.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-317 - Implement-Persona-Visual-Manifest-V2-import-preview-validator-interface.md
+++ b/backlog/tasks/task-317 - Implement-Persona-Visual-Manifest-V2-import-preview-validator-interface.md
@@ -1,0 +1,62 @@
+---
+id: TASK-317
+title: Implement Persona Visual Manifest V2 import-preview validator interface
+status: Done
+assignee:
+  - codex
+created_date: '2026-05-13 14:28'
+updated_date: '2026-05-13 14:36'
+labels:
+  - persona
+  - buddy
+  - visual-packs
+  - backend
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1510'
+  - 'https://github.com/rmusser01/tldw_server/issues/1632'
+documentation:
+  - Docs/Design/2026-05-13-persona-visual-manifest-v2-contract.md
+  - Docs/Code_Documentation/Persona_Visual_Packs.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the next Manifest V2 foundation slice for Persona/Buddy visual packs: a backend renderer-specific import-preview validator interface with fixture-only validation diagnostics. This must not add an archive parser, runtime renderer, activatable non-sprite pack, asset writes, external MCP provider behavior, VN/CYOA behavior, or live response mutation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A backend renderer import-preview validator interface exists and is covered by focused tests.
+- [x] #2 Fixture-only V2 preview validation can report unsupported or blocked renderer diagnostics without committing assets.
+- [x] #3 sprite_frames import and activation behavior remains unchanged.
+- [x] #4 live2d or other V2 future renderer preview state remains non-activatable and clearly blocked.
+- [x] #5 Tests cover known renderer, unknown renderer, missing required fallback/source categories, and fixture diagnostics where applicable.
+- [x] #6 Docs explain this is a validation seam only, not archive parsing or runtime renderer support.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implementation plan created: Docs/superpowers/plans/2026-05-13-persona-visual-v2-import-preview-validator.md. Plan reviewer subagent was not dispatched because this session only allows subagents when explicitly requested; proceeding with an inline self-review and TDD implementation.
+
+Implemented fixture-only renderer import-preview validator and documented the boundary. Verification: initial red pytest failed on missing visual_import_preview_validators module; focused validator tests passed; persona visual boundary suite passed; git diff --check passed; Bandit JSON reported zero findings.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added a backend Persona Visual renderer import-preview validator interface for normalized manifest/assets metadata. The slice reports known disabled live2d blockers, unknown renderer diagnostics, required role-category gaps, and supported sprite_frames eligibility without parsing archives, writing assets, activating packs, or changing the existing V1 portability path.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/Persona/visual_import_preview_validators.py
+++ b/tldw_Server_API/app/core/Persona/visual_import_preview_validators.py
@@ -9,6 +9,7 @@ capability registry.
 
 from __future__ import annotations
 
+import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any
@@ -17,6 +18,9 @@ from tldw_Server_API.app.core.Persona.visual_renderer_capabilities import (
     PersonaVisualRendererCapability,
     get_persona_visual_renderer_capability,
 )
+
+MAX_BLOCKER_TEXT_LENGTH = 100
+_INTEGER_TEXT_RE = re.compile(r"^[+-]?\d+$")
 
 
 @dataclass(frozen=True)
@@ -88,7 +92,7 @@ def preview_renderer_import(
             renderer_contract_version=renderer_contract_version,
             can_commit=False,
             activation_eligible=False,
-            blockers=[f"unknown_renderer:{renderer_type or 'missing'}"],
+            blockers=[f"unknown_renderer:{_format_text_for_blocker(renderer_type)}"],
             normalized_role_categories=_normalize_role_categories(None, assets),
         )
 
@@ -134,11 +138,10 @@ def _capability_blockers(
         _append_unique(blockers, blocker)
     if capability.disabled_reason:
         _append_unique(blockers, capability.disabled_reason)
-    if manifest_version is not None and manifest_version not in capability.manifest_versions:
+    if capability.manifest_versions and manifest_version not in capability.manifest_versions:
         _append_unique(blockers, f"unsupported_manifest_version:{manifest_version}")
     if (
-        renderer_contract_version is not None
-        and capability.renderer_contract_versions
+        capability.renderer_contract_versions
         and renderer_contract_version not in capability.renderer_contract_versions
     ):
         _append_unique(
@@ -206,16 +209,33 @@ def _asset_text(
 ) -> str:
     if isinstance(asset, Mapping):
         return str(asset.get(field_name) or "")
-    return str(getattr(asset, field_name) or "")
+    return str(getattr(asset, field_name, "") or "")
 
 
 def _coerce_int(value: Any) -> int | None:
     if isinstance(value, bool) or value is None:
         return None
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value) if value.is_integer() else None
+    if isinstance(value, str):
+        stripped = value.strip()
+        return int(stripped) if _INTEGER_TEXT_RE.fullmatch(stripped) else None
+    return None
+
+
+def _format_text_for_blocker(value: Any) -> str:
+    text = str(value or "")
+    text = (
+        text.replace("\\", "\\\\")
+        .replace("\r", "\\r")
+        .replace("\n", "\\n")
+        .replace("\t", "\\t")
+    )
+    if len(text) > MAX_BLOCKER_TEXT_LENGTH:
+        return text[:MAX_BLOCKER_TEXT_LENGTH] + "..."
+    return text or "missing"
 
 
 def _append_unique(values: list[str], value: str) -> None:

--- a/tldw_Server_API/app/core/Persona/visual_import_preview_validators.py
+++ b/tldw_Server_API/app/core/Persona/visual_import_preview_validators.py
@@ -1,0 +1,230 @@
+"""Fixture-level import-preview validation for Persona Visual renderer metadata.
+
+The helpers in this module operate on already-normalized manifest and asset
+metadata. They do not parse archives, write asset rows, activate packs, or load
+renderer runtimes. The goal is to give future Manifest V2 archive and UI slices
+a deterministic diagnostics contract that is backed by the backend renderer
+capability registry.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+from tldw_Server_API.app.core.Persona.visual_renderer_capabilities import (
+    PersonaVisualRendererCapability,
+    get_persona_visual_renderer_capability,
+)
+
+
+@dataclass(frozen=True)
+class PersonaVisualImportPreviewAsset:
+    """Normalized asset metadata available to renderer import-preview checks."""
+
+    source_asset_id: str
+    asset_role: str
+    mime_type: str | None = None
+    width: int | None = None
+    height: int | None = None
+
+
+@dataclass
+class PersonaVisualRendererImportPreviewResult:
+    """Structured diagnostics for a renderer import-preview validation pass."""
+
+    status: str
+    renderer_type: str
+    manifest_version: int | None
+    renderer_contract_version: int | None
+    can_commit: bool
+    activation_eligible: bool
+    blockers: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    normalized_role_categories: dict[str, list[str]] = field(default_factory=dict)
+    setup_status: str | None = None
+    setup_blockers: list[str] = field(default_factory=list)
+    disabled_reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation of the preview result."""
+
+        return {
+            "status": self.status,
+            "renderer_type": self.renderer_type,
+            "manifest_version": self.manifest_version,
+            "renderer_contract_version": self.renderer_contract_version,
+            "can_commit": self.can_commit,
+            "activation_eligible": self.activation_eligible,
+            "blockers": list(self.blockers),
+            "warnings": list(self.warnings),
+            "normalized_role_categories": {
+                category: list(source_asset_ids)
+                for category, source_asset_ids in self.normalized_role_categories.items()
+            },
+            "setup_status": self.setup_status,
+            "setup_blockers": list(self.setup_blockers),
+            "disabled_reason": self.disabled_reason,
+        }
+
+
+def preview_renderer_import(
+    *,
+    manifest: Mapping[str, Any],
+    assets: Sequence[PersonaVisualImportPreviewAsset | Mapping[str, Any]],
+) -> PersonaVisualRendererImportPreviewResult:
+    """Validate renderer metadata for an import preview without committing assets."""
+
+    renderer_type = str(manifest.get("renderer_type") or "")
+    manifest_version = _coerce_int(manifest.get("manifest_version"))
+    renderer_contract_version = _coerce_int(manifest.get("renderer_contract_version"))
+    capability = get_persona_visual_renderer_capability(renderer_type)
+    if capability is None:
+        return PersonaVisualRendererImportPreviewResult(
+            status="unsupported_renderer",
+            renderer_type=renderer_type,
+            manifest_version=manifest_version,
+            renderer_contract_version=renderer_contract_version,
+            can_commit=False,
+            activation_eligible=False,
+            blockers=[f"unknown_renderer:{renderer_type or 'missing'}"],
+            normalized_role_categories=_normalize_role_categories(None, assets),
+        )
+
+    normalized_role_categories = _normalize_role_categories(capability, assets)
+    blockers = _capability_blockers(
+        capability=capability,
+        manifest_version=manifest_version,
+        renderer_contract_version=renderer_contract_version,
+        normalized_role_categories=normalized_role_categories,
+    )
+    status = _preview_status(capability, blockers)
+    can_commit = capability.import_supported and status == "supported" and not blockers
+    activation_eligible = (
+        capability.can_activate
+        and capability.buddy_runtime_supported
+        and status == "supported"
+        and not blockers
+    )
+    return PersonaVisualRendererImportPreviewResult(
+        status=status,
+        renderer_type=renderer_type,
+        manifest_version=manifest_version,
+        renderer_contract_version=renderer_contract_version,
+        can_commit=can_commit,
+        activation_eligible=activation_eligible,
+        blockers=blockers,
+        normalized_role_categories=normalized_role_categories,
+        setup_status=capability.setup_status,
+        setup_blockers=list(capability.setup_blockers),
+        disabled_reason=capability.disabled_reason,
+    )
+
+
+def _capability_blockers(
+    *,
+    capability: PersonaVisualRendererCapability,
+    manifest_version: int | None,
+    renderer_contract_version: int | None,
+    normalized_role_categories: Mapping[str, Sequence[str]],
+) -> list[str]:
+    blockers: list[str] = []
+    for blocker in capability.setup_blockers:
+        _append_unique(blockers, blocker)
+    if capability.disabled_reason:
+        _append_unique(blockers, capability.disabled_reason)
+    if manifest_version is not None and manifest_version not in capability.manifest_versions:
+        _append_unique(blockers, f"unsupported_manifest_version:{manifest_version}")
+    if (
+        renderer_contract_version is not None
+        and capability.renderer_contract_versions
+        and renderer_contract_version not in capability.renderer_contract_versions
+    ):
+        _append_unique(
+            blockers,
+            f"unsupported_renderer_contract_version:{renderer_contract_version}",
+        )
+    for category in capability.required_role_categories:
+        if not normalized_role_categories.get(category):
+            _append_unique(blockers, f"missing_required_role_category:{category}")
+    return blockers
+
+
+def _preview_status(
+    capability: PersonaVisualRendererCapability,
+    blockers: Sequence[str],
+) -> str:
+    if capability.setup_status != "supported":
+        return capability.setup_status
+    if blockers:
+        return "invalid_renderer_assets"
+    return "supported"
+
+
+def _normalize_role_categories(
+    capability: PersonaVisualRendererCapability | None,
+    assets: Sequence[PersonaVisualImportPreviewAsset | Mapping[str, Any]],
+) -> dict[str, list[str]]:
+    role_categories = _role_categories_by_role(capability)
+    normalized: dict[str, list[str]] = {
+        category: []
+        for category in (capability.required_role_categories if capability else ())
+    }
+
+    for asset in assets:
+        source_asset_id = _asset_text(asset, "source_asset_id")
+        asset_role = _asset_text(asset, "asset_role")
+        if not source_asset_id or not asset_role:
+            continue
+        categories = role_categories.get(asset_role) or (asset_role,)
+        for category in categories:
+            normalized.setdefault(category, []).append(source_asset_id)
+    return normalized
+
+
+def _role_categories_by_role(
+    capability: PersonaVisualRendererCapability | None,
+) -> dict[str, tuple[str, ...]]:
+    if capability is None:
+        return {}
+
+    categories_by_role: dict[str, list[str]] = {}
+    for category, roles in capability.role_category_map.items():
+        categories_by_role.setdefault(category, []).append(category)
+        for role in roles:
+            categories_by_role.setdefault(role, []).append(category)
+    return {
+        role: tuple(dict.fromkeys(categories))
+        for role, categories in categories_by_role.items()
+    }
+
+
+def _asset_text(
+    asset: PersonaVisualImportPreviewAsset | Mapping[str, Any],
+    field_name: str,
+) -> str:
+    if isinstance(asset, Mapping):
+        return str(asset.get(field_name) or "")
+    return str(getattr(asset, field_name) or "")
+
+
+def _coerce_int(value: Any) -> int | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _append_unique(values: list[str], value: str) -> None:
+    if value and value not in values:
+        values.append(value)
+
+
+__all__ = [
+    "PersonaVisualImportPreviewAsset",
+    "PersonaVisualRendererImportPreviewResult",
+    "preview_renderer_import",
+]

--- a/tldw_Server_API/tests/Persona/test_persona_visual_import_preview_validators.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_import_preview_validators.py
@@ -99,9 +99,30 @@ def test_preview_renderer_import_reports_unknown_renderer_without_asset_writes()
     assert result.warnings == []
 
 
+def test_preview_renderer_import_sanitizes_unknown_renderer_blocker() -> None:
+    unsafe_renderer_type = "not_real\n\tsecret\\path" + ("x" * 120)
+    manifest = _live2d_manifest()
+    manifest["renderer_type"] = unsafe_renderer_type
+
+    result = preview_renderer_import(manifest=manifest, assets=[])
+
+    assert result.renderer_type == unsafe_renderer_type
+    assert len(result.blockers) == 1
+    blocker = result.blockers[0]
+    assert "\n" not in blocker
+    assert "\t" not in blocker
+    assert "\r" not in blocker
+    assert "not_real\\n\\tsecret\\\\path" in blocker
+    assert blocker.endswith("...")
+
+
 def test_preview_renderer_import_keeps_sprite_frames_supported() -> None:
     result = preview_renderer_import(
-        manifest={"manifest_version": 1, "renderer_type": "sprite_frames"},
+        manifest={
+            "manifest_version": 1,
+            "renderer_type": "sprite_frames",
+            "renderer_contract_version": 1,
+        },
         assets=[
             PersonaVisualImportPreviewAsset(
                 source_asset_id="asset-idle",
@@ -118,3 +139,60 @@ def test_preview_renderer_import_keeps_sprite_frames_supported() -> None:
     assert result.activation_eligible is True
     assert result.blockers == []
     assert result.normalized_role_categories["frame"] == ["asset-idle"]
+
+
+def test_preview_renderer_import_blocks_missing_required_versions() -> None:
+    result = preview_renderer_import(
+        manifest={"renderer_type": "sprite_frames"},
+        assets=[
+            PersonaVisualImportPreviewAsset(
+                source_asset_id="asset-idle",
+                asset_role="frame",
+                mime_type="image/png",
+            )
+        ],
+    )
+
+    assert result.status == "invalid_renderer_assets"
+    assert result.can_commit is False
+    assert result.activation_eligible is False
+    assert "unsupported_manifest_version:None" in result.blockers
+    assert "unsupported_renderer_contract_version:None" in result.blockers
+
+
+def test_preview_renderer_import_rejects_non_integer_version_values() -> None:
+    result = preview_renderer_import(
+        manifest={
+            "manifest_version": 1.9,
+            "renderer_type": "sprite_frames",
+            "renderer_contract_version": 1.9,
+        },
+        assets=[
+            PersonaVisualImportPreviewAsset(
+                source_asset_id="asset-idle",
+                asset_role="frame",
+                mime_type="image/png",
+            )
+        ],
+    )
+
+    assert result.manifest_version is None
+    assert result.renderer_contract_version is None
+    assert result.status == "invalid_renderer_assets"
+    assert result.can_commit is False
+    assert "unsupported_manifest_version:None" in result.blockers
+    assert "unsupported_renderer_contract_version:None" in result.blockers
+
+
+def test_preview_renderer_import_ignores_unexpected_asset_objects() -> None:
+    result = preview_renderer_import(
+        manifest={
+            "manifest_version": 1,
+            "renderer_type": "sprite_frames",
+            "renderer_contract_version": 1,
+        },
+        assets=[object()],  # type: ignore[list-item]
+    )
+
+    assert result.status == "supported"
+    assert result.normalized_role_categories == {}

--- a/tldw_Server_API/tests/Persona/test_persona_visual_import_preview_validators.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_import_preview_validators.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.core.Persona.visual_import_preview_validators import (
+    PersonaVisualImportPreviewAsset,
+    preview_renderer_import,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+def _live2d_manifest() -> dict[str, object]:
+    return {
+        "manifest_version": 2,
+        "renderer_type": "live2d",
+        "renderer_contract_version": 1,
+        "renderer_assets": {
+            "fallback_preview_asset_id": "asset-fallback",
+            "source_manifest_asset_id": "asset-model",
+        },
+        "states": {"idle": {"animation_id": "idle"}},
+        "animations": {"idle": {"renderer_action": {"motion_group": "Idle"}}},
+    }
+
+
+def test_preview_renderer_import_reports_live2d_as_blocked_fixture_only() -> None:
+    result = preview_renderer_import(
+        manifest=_live2d_manifest(),
+        assets=[
+            PersonaVisualImportPreviewAsset(
+                source_asset_id="asset-fallback",
+                asset_role="fallback_preview",
+                mime_type="image/png",
+                width=256,
+                height=256,
+            ),
+            PersonaVisualImportPreviewAsset(
+                source_asset_id="asset-model",
+                asset_role="live2d_model_manifest",
+                mime_type="application/json",
+            ),
+        ],
+    )
+
+    assert result.status == "unsupported_renderer"
+    assert result.renderer_type == "live2d"
+    assert result.manifest_version == 2
+    assert result.can_commit is False
+    assert result.activation_eligible is False
+    assert "runtime_adapter_not_implemented" in result.blockers
+    assert result.normalized_role_categories == {
+        "fallback_preview": ["asset-fallback"],
+        "source_manifest": ["asset-model"],
+    }
+
+
+def test_preview_renderer_import_reports_missing_required_role_categories() -> None:
+    result = preview_renderer_import(
+        manifest=_live2d_manifest(),
+        assets=[
+            PersonaVisualImportPreviewAsset(
+                source_asset_id="asset-model",
+                asset_role="live2d_model_manifest",
+                mime_type="application/json",
+            ),
+        ],
+    )
+
+    assert result.status == "unsupported_renderer"
+    assert "missing_required_role_category:fallback_preview" in result.blockers
+    assert "runtime_adapter_not_implemented" in result.blockers
+    assert result.normalized_role_categories == {
+        "fallback_preview": [],
+        "source_manifest": ["asset-model"],
+    }
+
+
+def test_preview_renderer_import_reports_unknown_renderer_without_asset_writes() -> None:
+    manifest = _live2d_manifest()
+    manifest["renderer_type"] = "not_real"
+
+    result = preview_renderer_import(
+        manifest=manifest,
+        assets=[
+            PersonaVisualImportPreviewAsset(
+                source_asset_id="asset-model",
+                asset_role="renderer_metadata",
+                mime_type="application/json",
+            )
+        ],
+    )
+
+    assert result.status == "unsupported_renderer"
+    assert result.can_commit is False
+    assert result.activation_eligible is False
+    assert result.blockers == ["unknown_renderer:not_real"]
+    assert result.warnings == []
+
+
+def test_preview_renderer_import_keeps_sprite_frames_supported() -> None:
+    result = preview_renderer_import(
+        manifest={"manifest_version": 1, "renderer_type": "sprite_frames"},
+        assets=[
+            PersonaVisualImportPreviewAsset(
+                source_asset_id="asset-idle",
+                asset_role="frame",
+                mime_type="image/png",
+                width=64,
+                height=64,
+            )
+        ],
+    )
+
+    assert result.status == "supported"
+    assert result.can_commit is True
+    assert result.activation_eligible is True
+    assert result.blockers == []
+    assert result.normalized_role_categories["frame"] == ["asset-idle"]


### PR DESCRIPTION
## Summary
- Add a fixture-level Persona Visual renderer import-preview validator for normalized manifest/assets metadata.
- Report disabled `live2d`, unknown renderer, missing required role categories, and `sprite_frames` activation eligibility without archive parsing or asset writes.
- Document that this is a validation seam only and leaves the existing V1 portability path unchanged.

## Why
This gives the Manifest V2 import-preview work a backend-owned diagnostics contract before archive parsing, non-sprite runtime support, MCP provider behavior, or UI commit flows are added.

## Test Plan
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_import_preview_validators.py tldw_Server_API/tests/Persona/test_persona_visual_portability.py tldw_Server_API/tests/Persona/test_persona_visuals_core.py -q`
- [x] `git diff --check`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Persona/visual_import_preview_validators.py -f json -o /tmp/bandit_persona_visual_v2_import_preview.json`

Resolves #1632
Part of #1510

Draft note: this PR still needs the human-authored Change summary required by the AI-generated PR merge gate before it is merge-ready.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a fixture-only Manifest V2 import-preview validator for Persona Visual packs that returns renderer diagnostics from normalized manifest/asset metadata without reading archives or writing assets. Hardens diagnostics with sanitized unknown-renderer text, strict integer version checks, and resilient asset handling; V1 preview/activation remains unchanged. Resolves #1632; part of #1510.

- **Bug Fixes**
  - Sanitizes unknown renderer blocker text and caps length.
  - Treats missing or non-integer manifest/contract versions as blockers and tolerates unexpected asset objects during reads.

<sup>Written for commit 802f5d238193c23bb600eb176dc1a572905f264f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

