### PR TITLE
Add VZ helper launchd operator commands

### DIFF
--- a/Docs/Sandbox/macos-runtime-operator-notes.md
+++ b/Docs/Sandbox/macos-runtime-operator-notes.md
@@ -397,7 +397,7 @@ automated repair endpoint.
 - No APFS clone execution path yet
 - No allowlist networking for the new macOS runtimes
 - No `vz_macos` warm-session VM reuse yet
-- Managed helper lifecycle is available through `tools/macos-vz-helper/scripts/vz-helperctl.py`, but it remains operator-driven and does not install or load launchd services automatically
+- Managed helper lifecycle is available through `tools/macos-vz-helper/scripts/vz-helperctl.py`, including explicit `launchd` operator commands, but it remains operator-driven and does not install or load launchd services automatically
 - No automatic orphan VM termination during diagnostics or repair; orphan termination is explicit repair-only behavior and is limited to owned `vz_linux` helper VMs
 
 Current diagnostics are mixed-mode:
@@ -475,6 +475,34 @@ tools/macos-vz-helper/scripts/vz-helperctl.py start
 tools/macos-vz-helper/scripts/vz-helperctl.py restart-drill
 tools/macos-vz-helper/scripts/vz-helperctl.py stop
 ```
+
+`launchd` is available when operators want to manage the helper through a
+LaunchAgent instead of the direct pid-file wrapper. Treat it as an explicit
+procedure: run `--dry-run` first, write the plist only with `--write-plist`, and
+create runtime/log directories only with `--create-dirs`.
+
+```bash
+tools/macos-vz-helper/scripts/vz-helperctl.py launchd status --dry-run
+tools/macos-vz-helper/scripts/vz-helperctl.py launchd bootstrap \
+  --write-plist \
+  --create-dirs \
+  --dry-run
+tools/macos-vz-helper/scripts/vz-helperctl.py launchd bootstrap \
+  --write-plist \
+  --create-dirs
+tools/macos-vz-helper/scripts/vz-helperctl.py launchd kickstart
+tools/macos-vz-helper/scripts/vz-helperctl.py launchd status
+tools/macos-vz-helper/scripts/vz-helperctl.py status
+tools/macos-vz-helper/scripts/vz-helperctl.py smoke \
+  --bundle /path/to/canonical/bundle \
+  --entitlements /path/to/helper.entitlements
+tools/macos-vz-helper/scripts/vz-helperctl.py launchd bootout
+```
+
+The launchd path does not run from diagnostics, server startup, `status`,
+`plist`, or `smoke`. It also does not validate host reboot behavior; reboot
+testing remains a manual operator drill until a prepared runner can preserve
+logs and tolerate disruptive host lifecycle changes.
 
 Manual failure drills are opt-in and remain disabled for default smoke and
 scheduled host-gated runs. To include them, pass:

--- a/Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
+++ b/Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
@@ -112,7 +112,11 @@ a fresh VM and completes. Scheduled runs must not enable these drills by default
 
 Host reboot and launchd-managed restart are not part of the current host-gated
 CI contract. Maintainers validating those paths should treat them as manual
-operator procedures: restore or verify helper readiness first, inspect
+operator procedures. `tools/macos-vz-helper/scripts/vz-helperctl.py launchd ...`
+can inspect, bootstrap, kickstart, and bootout the helper through explicit
+operator commands, but host-gated CI should not run those actions unless the
+prepared runner is intentionally configured for LaunchAgent validation. Restore
+or verify helper readiness first, inspect
 `/api/v1/sandbox/admin/macos-diagnostics`, run reconciliation repair in dry-run
 mode before any mutation, and then run the real host smoke. A host reboot drill
 must not be added to scheduled CI until a dedicated prepared runner can tolerate
@@ -140,8 +144,10 @@ These are expected and should not block ordinary PRs:
   `include_failure_drills=true`
 - managed helper `restart-drill` skipped because no helper was started through
   the local `vz-helperctl.py start` workflow
-- host reboot or launchd-managed restart validation handled through a manual
-  operator procedure rather than the workflow
+- launchd operator validation skipped because the helper is managed through
+  direct `vz-helperctl.py start` or no LaunchAgent plist has been prepared
+- host reboot validation handled through a manual operator procedure rather
+  than the workflow
 
 A manual run that fails before VM execution because the runner is missing the
 configured bundle path is an operator setup failure, not a sandbox runtime

--- a/Docs/superpowers/plans/2026-05-13-vz-helper-launchd-operator.md
+++ b/Docs/superpowers/plans/2026-05-13-vz-helper-launchd-operator.md
@@ -1,0 +1,76 @@
+# VZ Helper Launchd Operator Commands Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add explicit `vz-helperctl.py launchd` operator commands for inspecting and invoking helper LaunchAgent lifecycle actions.
+
+**Architecture:** Keep launchd support inside the existing helper lifecycle wrapper and reuse current plist, path-hardening, and dry-run conventions. Mutating launchctl actions must be explicit subcommands, never side effects of `plist`, `status`, `smoke`, or server startup.
+
+**Tech Stack:** Python 3 CLI, macOS `launchctl` command construction, existing pytest coverage in `tools/macos-vz-helper/Tests/test_vz_helperctl.py`.
+
+---
+
+### Task 1: Launchd Command Model
+
+**Files:**
+- Modify: `tools/macos-vz-helper/scripts/vz-helperctl.py`
+- Test: `tools/macos-vz-helper/Tests/test_vz_helperctl.py`
+
+- [x] **Step 1: Write failing tests for launchd target and argv construction**
+
+Cover `gui/<uid>`, `gui/<uid>/<label>`, `bootstrap`, `bootout`, `kickstart`, and `status`/`print` command shapes.
+
+- [x] **Step 2: Run focused test and verify red**
+
+Run: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -k 'launchd' -q`
+
+- [x] **Step 3: Implement minimal command construction helpers**
+
+Add small helpers for launchd domain/target/argv and no subprocess execution yet.
+
+- [x] **Step 4: Run focused test and verify green**
+
+Run the same focused pytest command.
+
+### Task 2: Launchd CLI Execution
+
+**Files:**
+- Modify: `tools/macos-vz-helper/scripts/vz-helperctl.py`
+- Test: `tools/macos-vz-helper/Tests/test_vz_helperctl.py`
+
+- [x] **Step 1: Write failing tests for CLI behavior**
+
+Cover dry-run printing, bootstrap missing plist failure, explicit `--write-plist --create-dirs`, and JSON result output.
+
+- [x] **Step 2: Run focused test and verify red**
+
+Run the focused launchd pytest selection.
+
+- [x] **Step 3: Implement `launchd` subcommand**
+
+Add `launchd {status,bootstrap,kickstart,bootout}` with `--dry-run`, `--write-plist`, `--create-dirs`, helper/socket/log/plist/label/uid options, and an injectable command runner for tests.
+
+- [x] **Step 4: Run full helperctl tests**
+
+Run: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -q`
+
+### Task 3: Docs And Verification
+
+**Files:**
+- Modify: `tools/macos-vz-helper/README.md`
+- Modify: `Docs/Sandbox/macos-runtime-operator-notes.md`
+- Modify: `Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md`
+- Modify: `tldw_Server_API/app/core/Sandbox/README.md`
+- Modify: `backlog/tasks/task-318 - Add-explicit-VZ-helper-launchd-operator-commands.md`
+
+- [x] **Step 1: Update operator docs**
+
+Document the explicit launchd flow, dry-run first expectation, and host reboot out-of-scope boundary.
+
+- [x] **Step 2: Run verification**
+
+Run helperctl tests, `git diff --check`, and Bandit on touched helper script/tests with expected test-file skips.
+
+- [x] **Step 3: Close task and commit**
+
+Update `TASK-318`, stage all touched files, and commit.

--- a/backlog/tasks/task-318 - Add-explicit-VZ-helper-launchd-operator-commands.md
+++ b/backlog/tasks/task-318 - Add-explicit-VZ-helper-launchd-operator-commands.md
@@ -1,0 +1,60 @@
+---
+id: TASK-318
+title: Add explicit VZ helper launchd operator commands
+status: Done
+assignee: []
+created_date: '2026-05-13 14:42'
+updated_date: '2026-05-13 14:52'
+labels:
+  - sandbox
+  - vz-linux
+  - operator-workflow
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1485'
+documentation:
+  - Docs/Sandbox/macos-runtime-operator-notes.md
+  - Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
+  - tools/macos-vz-helper/README.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add explicit operator-owned launchd scaffolding for the macOS VZ helper lifecycle. The goal is to let operators inspect and invoke launchctl bootstrap, bootout, kickstart, and status/print flows through vz-helperctl without auto-installing services, hiding mutations, or expanding into host reboot automation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 vz-helperctl exposes explicit launchd status/bootstrap/kickstart/bootout actions with dry-run support.
+- [x] #2 Mutating launchd actions remain operator-invoked and do not run from plist generation, smoke, status, or startup paths automatically.
+- [x] #3 Launchd bootstrap reuses existing plist and private runtime/log/serial directory validation, and writes a plist only when explicitly requested.
+- [x] #4 Portable unit tests cover command construction, dry-run behavior, missing plist failures, and explicit write-plist behavior without requiring launchd.
+- [x] #5 Operator docs explain the launchd flow and keep host reboot validation out of scope.
+- [x] #6 Focused tests, diff check, and touched-scope Bandit pass.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Plan: Docs/superpowers/plans/2026-05-13-vz-helper-launchd-operator.md
+
+Verification: python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -k 'launchd' -q -> 6 passed, 93 deselected; python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -q -> 98 passed, 1 skipped; git diff --check -> clean; Bandit script/tests -> empty errors/results.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added explicit vz-helperctl launchd operator commands for status/bootstrap/kickstart/bootout with dry-run support, explicit write-plist/create-dirs gates, private directory validation reuse, portable unit coverage, and operator documentation that keeps launchd and host reboot validation manual.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-318 - Add-explicit-VZ-helper-launchd-operator-commands.md
+++ b/backlog/tasks/task-318 - Add-explicit-VZ-helper-launchd-operator-commands.md
@@ -4,7 +4,7 @@ title: Add explicit VZ helper launchd operator commands
 status: Done
 assignee: []
 created_date: '2026-05-13 14:42'
-updated_date: '2026-05-13 14:52'
+updated_date: '2026-05-14 01:25'
 labels:
   - sandbox
   - vz-linux
@@ -41,12 +41,16 @@ Add explicit operator-owned launchd scaffolding for the macOS VZ helper lifecycl
 Plan: Docs/superpowers/plans/2026-05-13-vz-helper-launchd-operator.md
 
 Verification: python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -k 'launchd' -q -> 6 passed, 93 deselected; python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -q -> 98 passed, 1 skipped; git diff --check -> clean; Bandit script/tests -> empty errors/results.
+
+PR review pass: reopened to address live PR #1636 review findings from CodeRabbit/Qodo/Gemini.
+
+Review-fix verification: red tests confirmed the directory existence, launchctl availability, CLI portability, and custom-label status issues; after fixes, python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -k 'launchd or custom_launchd_label' -q -> 9 passed, 93 deselected; python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -q -> 101 passed, 1 skipped; git diff --check -> clean; Bandit script/tests -> empty errors/results.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added explicit vz-helperctl launchd operator commands for status/bootstrap/kickstart/bootout with dry-run support, explicit write-plist/create-dirs gates, private directory validation reuse, portable unit coverage, and operator documentation that keeps launchd and host reboot validation manual.
+Added explicit vz-helperctl launchd operator commands and addressed PR review findings by requiring existing runtime/log/serial/plist directories when --write-plist is used without --create-dirs, prechecking real launchctl availability before filesystem mutation, preserving test portability for monkeypatched runners, and threading custom launchd labels through status plist validation.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/core/Sandbox/README.md
+++ b/tldw_Server_API/app/core/Sandbox/README.md
@@ -140,7 +140,7 @@ Current limitations:
 - The generic admin startup warning endpoint is `GET /api/v1/admin/startup-warnings`.
   It exposes current-process warning records only; there is no
   cross-process aggregation or persistence in this slice.
-- `tools/macos-vz-helper/scripts/vz-helperctl.py` is the preferred operator helper lifecycle command for `check`, `build`, `sign`, `start`, `status`, `restart-drill`, `stop`, `plist`, and `smoke`; it can generate launchd plist scaffolding but does not install or load services automatically.
+- `tools/macos-vz-helper/scripts/vz-helperctl.py` is the preferred operator helper lifecycle command for `check`, `build`, `sign`, `start`, `status`, `restart-drill`, `stop`, `plist`, `launchd`, and `smoke`; it can generate launchd plist scaffolding and run explicit launchd operator actions but does not install or load services automatically.
 - helper-backed template validation now distinguishes canonical bundles from
   raw-disk compatibility mode through `boot_mode` and `validation_strength`.
 - `SandboxImageStore` persists template manifests under
@@ -178,6 +178,11 @@ Current limitations:
   `tools/macos-vz-helper/scripts/vz-helperctl.py restart-drill` after the helper
   has been started through the managed wrapper. This is a local operator drill,
   not launchd automation or host reboot validation.
+- Manual LaunchAgent lifecycle checks can be run through
+  `tools/macos-vz-helper/scripts/vz-helperctl.py launchd ...`. The command
+  supports explicit `status`, `bootstrap`, `kickstart`, and `bootout` actions,
+  expects dry-run inspection before mutation, and only writes plist/runtime
+  scaffolding when `--write-plist` and `--create-dirs` are passed.
 - The host-gated CI acceptance policy for real `vz_linux` smoke lives in
   `Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md`. It defines
   manual/nightly gates, expected skips, artifact upload expectations, branch

--- a/tools/macos-vz-helper/README.md
+++ b/tools/macos-vz-helper/README.md
@@ -43,6 +43,7 @@ tools/macos-vz-helper/scripts/vz-helperctl.py status
 tools/macos-vz-helper/scripts/vz-helperctl.py restart-drill
 tools/macos-vz-helper/scripts/vz-helperctl.py stop
 tools/macos-vz-helper/scripts/vz-helperctl.py plist
+tools/macos-vz-helper/scripts/vz-helperctl.py launchd status --dry-run
 ```
 
 The command uses stable user-owned defaults under
@@ -52,6 +53,27 @@ The command uses stable user-owned defaults under
 `plist` prints LaunchAgent scaffolding by default and does not create runtime
 directories unless `--create-dirs` is provided. It does not call `launchctl`,
 install services, or auto-upgrade helpers.
+
+`launchd` provides explicit operator actions for a LaunchAgent-managed helper.
+Use dry-run first to inspect the `launchctl` command, then opt into plist
+creation/loading only when intended:
+
+```bash
+tools/macos-vz-helper/scripts/vz-helperctl.py launchd status --dry-run
+tools/macos-vz-helper/scripts/vz-helperctl.py launchd bootstrap \
+  --write-plist \
+  --create-dirs \
+  --dry-run
+tools/macos-vz-helper/scripts/vz-helperctl.py launchd bootstrap \
+  --write-plist \
+  --create-dirs
+tools/macos-vz-helper/scripts/vz-helperctl.py launchd kickstart
+tools/macos-vz-helper/scripts/vz-helperctl.py launchd bootout
+```
+
+These commands never run automatically from `plist`, `status`, `smoke`, or
+server startup. They are operator-owned scaffolding and do not validate host
+reboot behavior.
 
 `restart-drill` is an operator-managed lifecycle drill for helpers already
 started through `vz-helperctl.py start`. It verifies the current managed helper

--- a/tools/macos-vz-helper/Tests/test_vz_helperctl.py
+++ b/tools/macos-vz-helper/Tests/test_vz_helperctl.py
@@ -646,6 +646,76 @@ def test_launchd_bootstrap_write_plist_creates_private_dirs_and_runs(tmp_path: P
     CASE.assertEqual((log_dir / "serial").stat().st_mode & 0o777, 0o700)
 
 
+def test_launchd_bootstrap_write_plist_without_create_dirs_requires_existing_dirs(tmp_path: Path) -> None:
+    helperctl = load_helperctl()
+    private_root = tmp_path / "private"
+    private_root.mkdir(mode=0o700)
+    private_root.chmod(0o700)
+    helper = private_root / "macos-vz-helper"
+    socket_path = private_root / "runtime" / "helper.sock"
+    log_dir = private_root / "logs"
+    plist_dir = private_root / "LaunchAgents"
+    plist_path = plist_dir / "org.tldw.macos-vz-helper.plist"
+    commands: list[list[str]] = []
+    helper.write_text("#!/bin/sh\n", encoding="utf-8")
+    helper.chmod(0o700)
+    plist_dir.mkdir(mode=0o700)
+
+    result = helperctl.run_launchd_action(
+        "bootstrap",
+        label="org.tldw.macos-vz-helper",
+        plist_path=plist_path,
+        helper_path=helper,
+        socket_path=socket_path,
+        log_dir=log_dir,
+        write_plist=True,
+        create_dirs=False,
+        uid=501,
+        command_runner=lambda argv, **kwargs: commands.append(argv) or 0,
+    )
+
+    CASE.assertEqual(
+        result,
+        helperctl.CheckResult(ok=False, reason="helper_directory_missing", message=str(socket_path.parent)),
+    )
+    CASE.assertEqual(commands, [])
+    CASE.assertFalse(plist_path.exists())
+
+
+def test_launchd_bootstrap_launchctl_unavailable_does_not_mutate_filesystem(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    helperctl = load_helperctl()
+    private_root = tmp_path / "private"
+    private_root.mkdir(mode=0o700)
+    private_root.chmod(0o700)
+    helper = private_root / "macos-vz-helper"
+    socket_path = private_root / "runtime" / "helper.sock"
+    log_dir = private_root / "logs"
+    plist_path = private_root / "LaunchAgents" / "org.tldw.macos-vz-helper.plist"
+    helper.write_text("#!/bin/sh\n", encoding="utf-8")
+    helper.chmod(0o700)
+    monkeypatch.setattr(helperctl.shutil, "which", lambda executable: None)
+
+    result = helperctl.run_launchd_action(
+        "bootstrap",
+        label="org.tldw.macos-vz-helper",
+        plist_path=plist_path,
+        helper_path=helper,
+        socket_path=socket_path,
+        log_dir=log_dir,
+        write_plist=True,
+        create_dirs=True,
+        uid=501,
+    )
+
+    CASE.assertEqual(result, helperctl.CheckResult(ok=False, reason="launchd_launchctl_unavailable"))
+    CASE.assertFalse(socket_path.parent.exists())
+    CASE.assertFalse(log_dir.exists())
+    CASE.assertFalse(plist_path.exists())
+
+
 def test_launchd_cli_dry_run_prints_command(capsys: pytest.CaptureFixture[str]) -> None:
     helperctl = load_helperctl()
 
@@ -669,6 +739,7 @@ def test_launchd_cli_dry_run_prints_command(capsys: pytest.CaptureFixture[str]) 
 def test_launchd_cli_json_result(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
     helperctl = load_helperctl()
 
+    monkeypatch.setattr(helperctl.shutil, "which", lambda executable: None)
     monkeypatch.setattr(helperctl, "run_command", lambda argv, **kwargs: 0)
 
     code = helperctl.main(
@@ -686,6 +757,42 @@ def test_launchd_cli_json_result(monkeypatch: pytest.MonkeyPatch, capsys: pytest
     output = json.loads(capsys.readouterr().out)
     CASE.assertEqual(code, 0)
     CASE.assertEqual(output, [{"name": "launchd", "ok": True, "reason": "ok", "message": ""}])
+
+
+def test_status_results_accept_custom_launchd_label(tmp_path: Path) -> None:
+    helperctl = load_helperctl()
+    private_root = tmp_path / "private"
+    private_root.mkdir(mode=0o700)
+    private_root.chmod(0o700)
+    helper = private_root / "macos-vz-helper"
+    socket_path = private_root / "runtime" / "helper.sock"
+    pid_file = private_root / "runtime" / "helper.pid"
+    log_dir = private_root / "logs"
+    plist_path = private_root / "LaunchAgents" / "org.tldw.custom-helper.plist"
+    helper.write_text("#!/bin/sh\n", encoding="utf-8")
+    helper.chmod(0o700)
+    socket_path.parent.mkdir(mode=0o700)
+    log_dir.mkdir(mode=0o700)
+    (log_dir / "serial").mkdir(mode=0o700)
+    plist_path.parent.mkdir(mode=0o700)
+    plist_path.write_text(
+        helperctl.render_launchd_plist(helper, socket_path, log_dir, label="org.tldw.custom-helper"),
+        encoding="utf-8",
+    )
+
+    results = dict(
+        helperctl.collect_status_results(
+            helper,
+            socket_path,
+            pid_file,
+            log_dir,
+            plist_path=plist_path,
+            label="org.tldw.custom-helper",
+            entitlement_checker=lambda helper_path, entitlements_path: helperctl.CheckResult(True),
+        )
+    )
+
+    CASE.assertEqual(results["launchd_plist"].reason, "launchd_plist_match")
 
 
 def test_plist_cli_rejects_unsafe_socket_parent_when_not_dry_run(tmp_path, capsys):

--- a/tools/macos-vz-helper/Tests/test_vz_helperctl.py
+++ b/tools/macos-vz-helper/Tests/test_vz_helperctl.py
@@ -563,6 +563,131 @@ def test_plist_cli_writes_explicit_output_without_creating_runtime_dirs(tmp_path
     CASE.assertFalse(log_dir.exists())
 
 
+def test_launchd_argv_shapes(tmp_path: Path) -> None:
+    helperctl = load_helperctl()
+    plist_path = tmp_path / "org.tldw.macos-vz-helper.plist"
+
+    CASE.assertEqual(helperctl.launchd_domain(501), "gui/501")
+    CASE.assertEqual(
+        helperctl.launchd_service_target("org.tldw.macos-vz-helper", uid=501),
+        "gui/501/org.tldw.macos-vz-helper",
+    )
+    CASE.assertEqual(
+        helperctl.launchd_argv(
+            "bootstrap",
+            label="org.tldw.macos-vz-helper",
+            plist_path=plist_path,
+            uid=501,
+        ),
+        ["launchctl", "bootstrap", "gui/501", str(plist_path)],
+    )
+    CASE.assertEqual(
+        helperctl.launchd_argv("status", label="org.tldw.macos-vz-helper", uid=501),
+        ["launchctl", "print", "gui/501/org.tldw.macos-vz-helper"],
+    )
+    CASE.assertEqual(
+        helperctl.launchd_argv("kickstart", label="org.tldw.macos-vz-helper", uid=501),
+        ["launchctl", "kickstart", "-k", "gui/501/org.tldw.macos-vz-helper"],
+    )
+    CASE.assertEqual(
+        helperctl.launchd_argv("bootout", label="org.tldw.macos-vz-helper", uid=501),
+        ["launchctl", "bootout", "gui/501/org.tldw.macos-vz-helper"],
+    )
+
+
+def test_launchd_bootstrap_requires_existing_plist_without_write(tmp_path: Path) -> None:
+    helperctl = load_helperctl()
+    commands: list[list[str]] = []
+
+    result = helperctl.run_launchd_action(
+        "bootstrap",
+        label="org.tldw.macos-vz-helper",
+        plist_path=tmp_path / "missing.plist",
+        uid=501,
+        command_runner=lambda argv, **kwargs: commands.append(argv) or 0,
+    )
+
+    CASE.assertIs(result.ok, False)
+    CASE.assertEqual(result.reason, "launchd_plist_missing")
+    CASE.assertEqual(commands, [])
+
+
+def test_launchd_bootstrap_write_plist_creates_private_dirs_and_runs(tmp_path: Path) -> None:
+    helperctl = load_helperctl()
+    private_root = tmp_path / "private"
+    private_root.mkdir(mode=0o700)
+    private_root.chmod(0o700)
+    helper = private_root / "macos-vz-helper"
+    socket_path = private_root / "runtime" / "helper.sock"
+    log_dir = private_root / "logs"
+    plist_path = private_root / "LaunchAgents" / "org.tldw.macos-vz-helper.plist"
+    commands: list[list[str]] = []
+    helper.write_text("#!/bin/sh\n", encoding="utf-8")
+    helper.chmod(0o700)
+
+    result = helperctl.run_launchd_action(
+        "bootstrap",
+        label="org.tldw.macos-vz-helper",
+        plist_path=plist_path,
+        helper_path=helper,
+        socket_path=socket_path,
+        log_dir=log_dir,
+        write_plist=True,
+        create_dirs=True,
+        uid=501,
+        command_runner=lambda argv, **kwargs: commands.append(argv) or 0,
+    )
+
+    CASE.assertEqual(result, helperctl.CheckResult(ok=True))
+    CASE.assertEqual(commands, [["launchctl", "bootstrap", "gui/501", str(plist_path)]])
+    CASE.assertTrue(plist_path.exists())
+    CASE.assertEqual(socket_path.parent.stat().st_mode & 0o777, 0o700)
+    CASE.assertEqual(log_dir.stat().st_mode & 0o777, 0o700)
+    CASE.assertEqual((log_dir / "serial").stat().st_mode & 0o777, 0o700)
+
+
+def test_launchd_cli_dry_run_prints_command(capsys: pytest.CaptureFixture[str]) -> None:
+    helperctl = load_helperctl()
+
+    code = helperctl.main(
+        [
+            "launchd",
+            "status",
+            "--label",
+            "org.tldw.test-helper",
+            "--uid",
+            "501",
+            "--dry-run",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    CASE.assertEqual(code, 0)
+    CASE.assertIn("launchctl print gui/501/org.tldw.test-helper", captured.out)
+
+
+def test_launchd_cli_json_result(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    helperctl = load_helperctl()
+
+    monkeypatch.setattr(helperctl, "run_command", lambda argv, **kwargs: 0)
+
+    code = helperctl.main(
+        [
+            "launchd",
+            "status",
+            "--label",
+            "org.tldw.test-helper",
+            "--uid",
+            "501",
+            "--json",
+        ]
+    )
+
+    output = json.loads(capsys.readouterr().out)
+    CASE.assertEqual(code, 0)
+    CASE.assertEqual(output, [{"name": "launchd", "ok": True, "reason": "ok", "message": ""}])
+
+
 def test_plist_cli_rejects_unsafe_socket_parent_when_not_dry_run(tmp_path, capsys):
     helperctl = load_helperctl()
     helper_path = tmp_path / "macos-vz-helper"

--- a/tools/macos-vz-helper/scripts/vz-helperctl.py
+++ b/tools/macos-vz-helper/scripts/vz-helperctl.py
@@ -43,6 +43,8 @@ else:
 
 
 INVALID_LIFECYCLE_LOCK_GRACE_SEC = 1.0
+DEFAULT_LAUNCHD_LABEL = "org.tldw.macos-vz-helper"
+LAUNCHD_ACTIONS = {"bootstrap", "bootout", "kickstart", "status"}
 
 
 @dataclass(frozen=True)
@@ -238,7 +240,7 @@ def render_launchd_plist(
     helper_path: Path,
     socket_path: Path,
     log_dir: Path,
-    label: str = "org.tldw.macos-vz-helper",
+    label: str = DEFAULT_LAUNCHD_LABEL,
 ) -> str:
     stdout_path = log_dir / "helper.stdout.log"
     stderr_path = log_dir / "helper.stderr.log"
@@ -256,6 +258,130 @@ def render_launchd_plist(
         "RunAtLoad": False,
     }
     return plistlib.dumps(payload, sort_keys=True).decode("utf-8")
+
+
+def launchd_domain(uid: int | None = None) -> str:
+    """Return the per-user launchd GUI domain used for the helper LaunchAgent."""
+    return f"gui/{os.getuid() if uid is None else uid}"
+
+
+def launchd_service_target(label: str, *, uid: int | None = None) -> str:
+    """Return the launchd service target for commands that address a loaded job."""
+    return f"{launchd_domain(uid)}/{label}"
+
+
+def launchd_argv(
+    action: str,
+    *,
+    label: str = DEFAULT_LAUNCHD_LABEL,
+    plist_path: Path | None = None,
+    uid: int | None = None,
+) -> list[str]:
+    """Build the launchctl argv for an explicit operator lifecycle action."""
+    if action not in LAUNCHD_ACTIONS:
+        raise ValueError(f"unsupported launchd action: {action}")
+    if action == "bootstrap":
+        if plist_path is None:
+            raise ValueError("bootstrap requires a plist path")
+        return ["launchctl", "bootstrap", launchd_domain(uid), str(plist_path)]
+    if action == "status":
+        return ["launchctl", "print", launchd_service_target(label, uid=uid)]
+    if action == "kickstart":
+        return ["launchctl", "kickstart", "-k", launchd_service_target(label, uid=uid)]
+    return ["launchctl", "bootout", launchd_service_target(label, uid=uid)]
+
+
+def _prepare_launchd_plist(
+    *,
+    plist_path: Path,
+    helper_path: Path,
+    socket_path: Path,
+    log_dir: Path,
+    label: str,
+    write_plist: bool,
+    create_dirs: bool,
+    dry_run: bool,
+) -> CheckResult:
+    """Validate or explicitly write the helper LaunchAgent plist before bootstrap."""
+    if not write_plist:
+        if dry_run and not plist_path.exists():
+            return CheckResult(ok=True, reason="dry_run")
+        if not plist_path.exists():
+            return CheckResult(ok=False, reason="launchd_plist_missing", message=str(plist_path))
+        return validate_plist_match(plist_path, helper_path, socket_path, log_dir, label=label)
+
+    helper_result = validate_helper_binary(helper_path)
+    if not helper_result.ok:
+        return helper_result
+    socket_result = validate_socket_path(socket_path)
+    if not socket_result.ok:
+        return socket_result
+
+    directory_dry_run = dry_run or not create_dirs
+    for directory in (socket_path.parent, log_dir, log_dir / "serial", plist_path.parent):
+        directory_result = ensure_private_dir(directory, dry_run=directory_dry_run)
+        if not directory_result.ok:
+            return directory_result
+    if not create_dirs and not dry_run and not plist_path.parent.exists():
+        return CheckResult(ok=False, reason="helper_directory_missing", message=str(plist_path.parent))
+
+    if dry_run:
+        return CheckResult(ok=True, reason="dry_run")
+
+    rendered = render_launchd_plist(helper_path, socket_path, log_dir, label=label)
+    plist_path.write_text(rendered, encoding="utf-8")
+    return CheckResult(ok=True, reason="launchd_plist_written", message=str(plist_path))
+
+
+def run_launchd_action(
+    action: str,
+    *,
+    label: str = DEFAULT_LAUNCHD_LABEL,
+    plist_path: Path | None = None,
+    helper_path: Path | None = None,
+    socket_path: Path | None = None,
+    log_dir: Path | None = None,
+    uid: int | None = None,
+    dry_run: bool = False,
+    write_plist: bool = False,
+    create_dirs: bool = False,
+    command_runner: Callable[..., int] | None = None,
+) -> CheckResult:
+    """Run one explicit launchctl action without installing or loading implicitly."""
+    runner = command_runner or run_command
+    paths = default_paths()
+    resolved_plist_path = plist_path or paths.plist_path
+    resolved_helper_path = helper_path or DEFAULT_HELPER
+    resolved_socket_path = socket_path or paths.socket_path
+    resolved_log_dir = log_dir or paths.log_dir
+
+    if action == "bootstrap":
+        plist_result = _prepare_launchd_plist(
+            plist_path=resolved_plist_path,
+            helper_path=resolved_helper_path,
+            socket_path=resolved_socket_path,
+            log_dir=resolved_log_dir,
+            label=label,
+            write_plist=write_plist,
+            create_dirs=create_dirs,
+            dry_run=dry_run,
+        )
+        if not plist_result.ok:
+            return plist_result
+
+    if not dry_run and runner is run_command and shutil.which("launchctl") is None:
+        return CheckResult(ok=False, reason="launchd_launchctl_unavailable")
+
+    try:
+        argv = launchd_argv(action, label=label, plist_path=resolved_plist_path, uid=uid)
+    except ValueError as exc:
+        return CheckResult(ok=False, reason="launchd_action_invalid", message=str(exc))
+    code = runner(argv, dry_run=dry_run)
+    if code == 0:
+        return CheckResult(ok=True, reason="dry_run" if dry_run else "ok")
+    if code == 127:
+        return CheckResult(ok=False, reason="launchd_launchctl_unavailable")
+    return CheckResult(ok=False, reason=f"launchd_{action}_failed", message=str(code))
 
 
 def host_smoke_script_path() -> Path:
@@ -978,12 +1104,19 @@ def start_helper(
         _release_lifecycle_lock(pid_file, lock_fd)
 
 
-def validate_plist_match(plist_path: Path, helper_path: Path, socket_path: Path, log_dir: Path) -> CheckResult:
+def validate_plist_match(
+    plist_path: Path,
+    helper_path: Path,
+    socket_path: Path,
+    log_dir: Path,
+    *,
+    label: str = DEFAULT_LAUNCHD_LABEL,
+) -> CheckResult:
     if not plist_path.exists():
         return CheckResult(ok=True, reason="launchd_plist_missing", message=str(plist_path))
     try:
         actual = plistlib.loads(plist_path.read_bytes())
-        expected = plistlib.loads(render_launchd_plist(helper_path, socket_path, log_dir).encode("utf-8"))
+        expected = plistlib.loads(render_launchd_plist(helper_path, socket_path, log_dir, label=label).encode("utf-8"))
     except (OSError, plistlib.InvalidFileException, ValueError) as exc:
         return CheckResult(ok=False, reason="launchd_plist_mismatch", message=str(exc))
     if actual != expected:
@@ -1464,6 +1597,24 @@ def _restart_drill_command(args: argparse.Namespace) -> int:
     return 0 if all(result.ok for _, result in results) else 1
 
 
+def _launchd_command(args: argparse.Namespace) -> int:
+    paths = default_paths()
+    result = run_launchd_action(
+        args.action,
+        label=args.label,
+        plist_path=Path(args.plist_output) if args.plist_output else paths.plist_path,
+        helper_path=Path(args.helper_path) if args.helper_path else DEFAULT_HELPER,
+        socket_path=Path(args.socket_path) if args.socket_path else paths.socket_path,
+        log_dir=Path(args.log_dir) if args.log_dir else paths.log_dir,
+        uid=args.uid,
+        dry_run=args.dry_run,
+        write_plist=args.write_plist,
+        create_dirs=args.create_dirs,
+    )
+    _print_results([("launchd", result)], as_json=args.json)
+    return 0 if result.ok else 1
+
+
 def _start_command(args: argparse.Namespace) -> int:
     paths = default_paths()
     result = start_helper(
@@ -1566,6 +1717,20 @@ def build_parser() -> argparse.ArgumentParser:
     restart_drill.add_argument("--dry-run", action="store_true")
     restart_drill.add_argument("--json", action="store_true")
     restart_drill.set_defaults(func=_restart_drill_command)
+
+    launchd = subparsers.add_parser("launchd", help="run explicit launchctl helper lifecycle actions")
+    launchd.add_argument("action", choices=sorted(LAUNCHD_ACTIONS))
+    launchd.add_argument("--helper", "--helper-path", dest="helper_path")
+    launchd.add_argument("--socket", "--socket-path", dest="socket_path")
+    launchd.add_argument("--log-dir")
+    launchd.add_argument("--plist-output")
+    launchd.add_argument("--label", default=DEFAULT_LAUNCHD_LABEL)
+    launchd.add_argument("--uid", type=int)
+    launchd.add_argument("--write-plist", action="store_true")
+    launchd.add_argument("--create-dirs", action="store_true")
+    launchd.add_argument("--dry-run", action="store_true")
+    launchd.add_argument("--json", action="store_true")
+    launchd.set_defaults(func=_launchd_command)
 
     start = subparsers.add_parser("start", help="start the helper")
     start.add_argument("--helper", "--helper-path", dest="helper_path")

--- a/tools/macos-vz-helper/scripts/vz-helperctl.py
+++ b/tools/macos-vz-helper/scripts/vz-helperctl.py
@@ -317,13 +317,16 @@ def _prepare_launchd_plist(
     if not socket_result.ok:
         return socket_result
 
+    required_dirs = (socket_path.parent, log_dir, log_dir / "serial", plist_path.parent)
     directory_dry_run = dry_run or not create_dirs
-    for directory in (socket_path.parent, log_dir, log_dir / "serial", plist_path.parent):
+    for directory in required_dirs:
         directory_result = ensure_private_dir(directory, dry_run=directory_dry_run)
         if not directory_result.ok:
             return directory_result
-    if not create_dirs and not dry_run and not plist_path.parent.exists():
-        return CheckResult(ok=False, reason="helper_directory_missing", message=str(plist_path.parent))
+    if not create_dirs and not dry_run:
+        for directory in required_dirs:
+            if not directory.exists():
+                return CheckResult(ok=False, reason="helper_directory_missing", message=str(directory))
 
     if dry_run:
         return CheckResult(ok=True, reason="dry_run")
@@ -355,6 +358,14 @@ def run_launchd_action(
     resolved_socket_path = socket_path or paths.socket_path
     resolved_log_dir = log_dir or paths.log_dir
 
+    try:
+        argv = launchd_argv(action, label=label, plist_path=resolved_plist_path, uid=uid)
+    except ValueError as exc:
+        return CheckResult(ok=False, reason="launchd_action_invalid", message=str(exc))
+
+    if not dry_run and _is_default_run_command(runner) and shutil.which("launchctl") is None:
+        return CheckResult(ok=False, reason="launchd_launchctl_unavailable")
+
     if action == "bootstrap":
         plist_result = _prepare_launchd_plist(
             plist_path=resolved_plist_path,
@@ -369,13 +380,6 @@ def run_launchd_action(
         if not plist_result.ok:
             return plist_result
 
-    if not dry_run and runner is run_command and shutil.which("launchctl") is None:
-        return CheckResult(ok=False, reason="launchd_launchctl_unavailable")
-
-    try:
-        argv = launchd_argv(action, label=label, plist_path=resolved_plist_path, uid=uid)
-    except ValueError as exc:
-        return CheckResult(ok=False, reason="launchd_action_invalid", message=str(exc))
     code = runner(argv, dry_run=dry_run)
     if code == 0:
         return CheckResult(ok=True, reason="dry_run" if dry_run else "ok")
@@ -398,6 +402,10 @@ def run_command(argv: list[str], *, dry_run: bool = False, env: dict[str, str] |
     except FileNotFoundError:
         return 127
     return int(completed.returncode)
+
+
+def _is_default_run_command(runner: Callable[..., int]) -> bool:
+    return getattr(runner, "__module__", None) == __name__ and getattr(runner, "__name__", None) == "run_command"
 
 
 def build_helper(*, dry_run: bool = False, configuration: str = "debug") -> CheckResult:
@@ -1132,6 +1140,7 @@ def collect_status_results(
     *,
     plist_path: Path | None = None,
     entitlements_path: Path | None = None,
+    label: str = DEFAULT_LAUNCHD_LABEL,
     entitlement_checker: Callable[[Path, Path | None], CheckResult] = compare_entitlements,
     ping_checker: Callable[[Path], CheckResult | PingState] = ping_helper_state,
     process_lookup: Callable[[int], ProcessInfo | None] = lookup_process,
@@ -1188,7 +1197,7 @@ def collect_status_results(
     )
 
     if plist_path is not None:
-        results.append(("launchd_plist", validate_plist_match(plist_path, helper_path, socket_path, log_dir)))
+        results.append(("launchd_plist", validate_plist_match(plist_path, helper_path, socket_path, log_dir, label=label)))
 
     entitlement_result = entitlement_checker(helper_path, entitlements_path)
     results.append(("entitlements", entitlement_result))
@@ -1264,6 +1273,7 @@ def status_helper(
     log_dir: Path | None = None,
     plist_path: Path | None = None,
     entitlements_path: Path | None = None,
+    label: str = DEFAULT_LAUNCHD_LABEL,
     entitlement_checker: Callable[[Path, Path | None], CheckResult] = compare_entitlements,
     ping_checker: Callable[[Path], CheckResult] = _ping_helper,
     process_lookup: Callable[[int], ProcessInfo | None] = lookup_process,
@@ -1276,6 +1286,7 @@ def status_helper(
         log_dir or paths.log_dir,
         plist_path=plist_path,
         entitlements_path=entitlements_path,
+        label=label,
         entitlement_checker=entitlement_checker,
         ping_checker=ping_checker,
         process_lookup=process_lookup,
@@ -1577,6 +1588,7 @@ def _status_command(args: argparse.Namespace) -> int:
         Path(args.log_dir) if args.log_dir else paths.log_dir,
         plist_path=Path(args.plist_output) if args.plist_output else paths.plist_path,
         entitlements_path=Path(args.entitlements) if args.entitlements else None,
+        label=args.label,
     )
     _print_results(results, as_json=args.json)
     return 0 if all(result.ok for _, result in results) else 1
@@ -1700,6 +1712,7 @@ def build_parser() -> argparse.ArgumentParser:
     status.add_argument("--pid-file")
     status.add_argument("--log-dir")
     status.add_argument("--plist-output")
+    status.add_argument("--label", default=DEFAULT_LAUNCHD_LABEL)
     status.add_argument("--entitlements")
     status.add_argument("--json", action="store_true")
     status.set_defaults(func=_status_command)


### PR DESCRIPTION
## Summary
- Add explicit `vz-helperctl.py launchd` operator commands for `status`, `bootstrap`, `kickstart`, and `bootout`.
- Gate LaunchAgent plist creation and directory scaffolding behind explicit `--write-plist` and `--create-dirs` flags, with dry-run support.
- Document the manual launchd operator flow while keeping host reboot validation and automatic service management out of scope.

## Validation
- `python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -k 'launchd' -q` -> 6 passed, 93 deselected\n- `python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -q` -> 98 passed, 1 skipped\n- `git diff --check origin/dev..HEAD` -> clean\n- Bandit on touched helper script/tests -> empty errors/results\n\n## Human Change Summary\nPending human-authored change summary before merge, per repo policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds explicit `launchd` subcommands to `tools/macos-vz-helper/scripts/vz-helperctl.py` for managing the helper via a LaunchAgent with safe, manual controls. Tightens validation and prechecks to prevent unintended filesystem changes or implicit service install/load.

- **New Features**
  - `launchd {status, bootstrap, kickstart, bootout}` with `--dry-run`, `--uid`, `--label`, `--plist-output`, and JSON output.
  - Validates/writes plists and private dirs before `bootstrap`, gated behind `--write-plist` and `--create-dirs`.
  - Adds `--label` to `status` and threads custom labels through plist validation.
  - Docs updated to show the explicit flow; no automatic calls from `plist`, `status`, `smoke`, or server startup.

- **Bug Fixes**
  - Prechecks `launchctl` availability and avoids filesystem mutation when missing.
  - When `--write-plist` is used without `--create-dirs`, requires existing runtime/log/serial/plist dirs; no implicit creation.

<sup>Written for commit 008766dda028ddda4f8b4b82c0b8c5d42693896d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

