### PR TITLE
Add VN script authoring catalog and guided snippet editing

### DIFF
--- a/Docs/API-related/VN_PLATFORM_API.md
+++ b/Docs/API-related/VN_PLATFORM_API.md
@@ -38,6 +38,7 @@ Example:
     "asset_generation": true,
     "asset_portability": true,
     "scripted_story": true,
+    "script_authoring_catalog": true,
     "story_start": true,
     "tts_jobs": false,
     "realtime_image_generation": false,
@@ -74,6 +75,144 @@ Create-from-template accepts the same script metadata as normal script creation,
 ```
 
 After creation, the script is a normal authored script. Clients should use the standard draft, validation, diagnostics, and publish endpoints for further editing.
+
+## VN Script Authoring Catalog
+
+Custom frontends can build guided script editors from the backend-owned authoring catalog instead of hard-coding VN opcodes or generation policy details.
+
+- `GET /api/v1/vn/vn-scripts/vn-authoring-catalog`
+- `POST /api/v1/vn/vn-scripts/scripts/{script_id}/draft/snippet-preview`
+- `POST /api/v1/vn/vn-scripts/scripts/{script_id}/draft/snippet-apply`
+
+`GET /vn-authoring-catalog` returns preview-safe metadata:
+
+```json
+{
+  "schema_version": "vn_script_authoring_catalog.v1",
+  "program_schema_version": "vn_script_program.v1",
+  "capability_tokens": ["script_authoring_catalog", "scripted_generation"],
+  "operations": [
+    {
+      "op": "narrate",
+      "label": "Narrate",
+      "category": "story",
+      "capability_tokens": []
+    }
+  ],
+  "snippets": [
+    {
+      "id": "narration",
+      "schema_version": "vn_script_program.v1",
+      "label": "Narration",
+      "operation_sequence": ["narrate"],
+      "parameters_schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["text"]
+      },
+      "default_parameters": {},
+      "preview": [{ "op": "narrate", "text": "{text}" }]
+    }
+  ]
+}
+```
+
+The catalog intentionally omits API keys, raw prompts, provider/model routing, and publish policy decisions. Frontends should first check `GET /api/v1/vn/vn-capabilities`; when `features.script_authoring_catalog` is `true`, they can list snippets, render controls from each snippet `parameters_schema`, and send snippet preview/apply requests to the backend.
+
+Preview is non-mutating. It builds a patch against either the stored draft or a supplied draft, resolves validation resources for the patched draft, and returns the patched draft plus diagnostics without storing the draft or diagnostics.
+
+Stored-draft preview:
+
+```json
+{
+  "snippet_id": "narration",
+  "anchor": { "label": "start", "op_index": 0, "mode": "after" },
+  "parameters": { "text": "The archive door opens." }
+}
+```
+
+Supplied-draft preview must include `draft_revision`, which must match the current stored draft revision:
+
+```json
+{
+  "snippet_id": "narration",
+  "anchor": { "label": "start", "mode": "append" },
+  "parameters": { "text": "A new line from the editor buffer." },
+  "draft_revision": 3,
+  "draft": { "schema_version": "vn_script_program.v1", "labels": { "start": [] } }
+}
+```
+
+Preview response:
+
+```json
+{
+  "script_id": 12,
+  "base_revision": 3,
+  "snippet_id": "narration",
+  "draft": { "schema_version": "vn_script_program.v1" },
+  "diagnostics": { "valid": true, "errors": [], "warnings": [] },
+  "patch_summary": {
+    "inserted_ops": 1,
+    "created_labels": [],
+    "changed_paths": ["$.labels.start[1]"]
+  },
+  "warnings": []
+}
+```
+
+Apply persists a patch and requires optimistic concurrency via `if_revision`:
+
+```json
+{
+  "if_revision": 3,
+  "snippet_id": "generated_choice_set",
+  "anchor": { "label": "start", "mode": "append" },
+  "parameters": {
+    "handler_label": "generated_choice",
+    "scope": "turn",
+    "max_choices": 3
+  }
+}
+```
+
+Apply response:
+
+```json
+{
+  "script_id": 12,
+  "revision": 4,
+  "snippet_id": "generated_choice_set",
+  "draft": { "schema_version": "vn_script_program.v1" },
+  "diagnostics": { "valid": true, "errors": [], "warnings": [] },
+  "patch_summary": {
+    "inserted_ops": 1,
+    "created_labels": ["generated_choice"],
+    "changed_paths": ["$.labels.start[2]", "$.labels.generated_choice"]
+  }
+}
+```
+
+Snippet endpoints delegate manifest, policy, generation-profile, and draft validation decisions to the script service. Endpoint code only authenticates the caller, deserializes request models, resolves validation resources such as accessible audio refs for the patched draft, and maps service/patcher errors into the VN error envelope.
+
+### Authoring Error Responses
+
+| HTTP | `detail.details.reason` | Meaning |
+| --- | --- | --- |
+| 400 | `snippet_parameter_invalid` | Snippet parameters are malformed, unsupported, too deep, too large, or contain raw generation routing keys. Includes `field_path`. |
+| 400 | `snippet_anchor_invalid` | The supplied anchor shape or operation index is invalid. Includes `anchor`. |
+| 400 | `snippet_anchor_not_found` | The target label or operation was not found. Includes `anchor`. |
+| 400 | `draft_revision_required` | A supplied draft preview omitted `draft_revision`. |
+| 404 | `snippet_not_found` | The snippet ID is not in the backend catalog. Includes `snippet_id`. |
+| 409 | `draft_revision_conflict` | The supplied `draft_revision` or `if_revision` is stale. Includes `current_revision` when the current draft is readable. |
+
+Custom frontend flow:
+
+1. Call `GET /api/v1/vn/vn-capabilities` and enable guided authoring only when `features.script_authoring_catalog` is `true`.
+2. Call `GET /api/v1/vn/vn-scripts/vn-authoring-catalog` and render snippet-specific controls from `parameters_schema`.
+3. Use `snippet-preview` while the user is editing. For unsaved editor buffers, include both `draft` and `draft_revision`.
+4. Use `snippet-apply` with `if_revision` to persist the patch. On `draft_revision_conflict`, refetch the draft and ask the user to reapply or merge their edit.
+5. Use the existing draft validation, diagnostics, and publish endpoints for whole-draft workflows and publishing.
 
 ## Policy Profiles
 

--- a/Docs/superpowers/plans/2026-05-12-vn-script-authoring-catalog.md
+++ b/Docs/superpowers/plans/2026-05-12-vn-script-authoring-catalog.md
@@ -1,0 +1,712 @@
+# VN Script Authoring Catalog Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a backend-owned VN script authoring catalog plus server-side snippet preview/apply APIs, then let the bundled WebUI consume that API without becoming a second VN rule engine.
+
+**Architecture:** Implement static backend catalog/snippet definitions beside the existing VN script templates, then add a pure snippet patcher used by `VNScriptService` for preview/apply. Preview uses the side-effect-free validation helper and never mutates stored drafts or diagnostics; apply persists through the existing atomic draft replacement path with `if_revision`. The WebUI only renders catalog-driven forms, previews, and apply results; backend validation, manifests, policy, generation profiles, and publish authority remain authoritative.
+
+**Tech Stack:** FastAPI, Pydantic v2, existing `VNScriptService`, existing VN script validator, SQLite-backed `VNScriptsRepository`, pytest, Next.js/React, Vitest.
+
+---
+
+## File Structure
+
+- Create `tldw_Server_API/app/core/VN_Scripts/authoring_catalog.py` for catalog dataclasses/constants, operation metadata, snippet metadata, capability tokens, and safe JSON Schema payloads.
+- Create `tldw_Server_API/app/core/VN_Scripts/snippet_patcher.py` for parsed-object snippet patching, anchor resolution, recursive parameter checks, collision handling, and patch summaries.
+- Create `tldw_Server_API/app/core/VN_Scripts/authoring_errors.py` for typed snippet/catalog exceptions carrying stable `code`, HTTP `status_code`, and `details`.
+- Modify `tldw_Server_API/app/core/VN_Scripts/validator.py` to expose known op/output-schema/routing-key constants through public read-only helpers used by catalog tests.
+- Modify `tldw_Server_API/app/core/VN_Scripts/service.py` to add `get_authoring_catalog()`, `preview_snippet()`, and `apply_snippet()`.
+- Modify `tldw_Server_API/app/api/v1/schemas/vn_script_schemas.py` to add authoring catalog, snippet preview/apply request, response, and summary schemas.
+- Modify `tldw_Server_API/app/api/v1/endpoints/vn_scripts.py` to add `GET /vn-authoring-catalog`, `POST /scripts/{script_id}/draft/snippet-preview`, and `POST /scripts/{script_id}/draft/snippet-apply`.
+- Modify `tldw_Server_API/app/core/VN_Platform/capabilities.py` and `tldw_Server_API/app/api/v1/schemas/vn_capabilities_schemas.py` only if schema shape changes are needed for `script_authoring_catalog` and canonical authoring capability tokens.
+- Test backend contract in `tldw_Server_API/tests/VN_Scripts/test_vn_scripts_api.py` and add focused pure tests in `tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_catalog.py`.
+- Modify `apps/tldw-frontend/types/vn-scripts.ts` and `apps/tldw-frontend/lib/api/vnScripts.ts` for catalog/preview/apply client contracts.
+- Modify `apps/tldw-frontend/components/vn-scripts/VNScriptsWorkbench.tsx` to add a catalog-driven guided insert panel next to the existing JSON editor.
+- Modify `apps/tldw-frontend/__tests__/vn-scripts/vnScriptsApi.test.ts` and `apps/tldw-frontend/__tests__/vn-scripts/VNScriptsWorkbench.test.tsx`.
+- Update `Docs/API-related/VN_PLATFORM_API.md`.
+- Update `backlog/tasks/task-302 - Write-VN-script-authoring-catalog-implementation-plan.md` during this planning work and create implementation task records before executing code tasks.
+
+## Task 1: Backend Catalog Metadata
+
+**Files:**
+- Create: `tldw_Server_API/app/core/VN_Scripts/authoring_catalog.py`
+- Modify: `tldw_Server_API/app/core/VN_Scripts/validator.py`
+- Test: `tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_catalog.py`
+
+- [ ] **Step 1: Write failing catalog tests**
+
+Add tests proving:
+
+```python
+def test_authoring_catalog_lists_every_validator_opcode_once():
+    payload = list_authoring_catalog()
+    assert {item["op"] for item in payload["operations"]} == set(known_script_ops())
+```
+
+```python
+def test_authoring_catalog_is_preview_safe_and_backend_owned():
+    payload = list_authoring_catalog()
+    assert "script_authoring_catalog" in payload["capability_tokens"]
+    assert "scripted_generation.output_schema.choice_set" in payload["capability_tokens"]
+    assert "validation_codes" not in json.dumps(payload)
+    assert "api_key" not in json.dumps(payload)
+    assert "provider_config" not in json.dumps(payload)
+```
+
+```python
+def test_snippet_parameter_schemas_forbid_extra_object_fields():
+    for snippet in list_authoring_catalog()["snippets"]:
+        assert_all_objects_forbid_extra_fields(snippet["parameters_schema"])
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_catalog.py -q
+```
+
+Expected: fail because the catalog module and public validator helpers do not exist.
+
+- [ ] **Step 3: Expose validator constants safely**
+
+In `tldw_Server_API/app/core/VN_Scripts/validator.py`, add helpers that return sorted tuples:
+
+```python
+def known_script_ops() -> tuple[str, ...]:
+    """Return supported vn_script_program.v1 opcode names."""
+    return tuple(sorted(_KNOWN_OPS))
+
+def supported_generation_output_schemas() -> tuple[str, ...]:
+    """Return supported generation output schema names."""
+    return tuple(sorted(_SUPPORTED_OUTPUT_SCHEMAS))
+
+def forbidden_generation_routing_keys() -> tuple[str, ...]:
+    """Return raw generation routing keys that drafts must not contain."""
+    return tuple(sorted(_RAW_GENERATION_ROUTING_KEYS))
+```
+
+- [ ] **Step 4: Implement catalog module**
+
+Create immutable catalog metadata with:
+
+- `SCHEMA_VERSION = "vn_script_authoring_catalog.v1"`
+- `PROGRAM_SCHEMA_VERSION = "vn_script_program.v1"`
+- canonical capability tokens:
+  - `script_authoring_catalog`
+  - `scripted_generation`
+  - `scripted_generation.output_schema.choice_set`
+  - `scripted_generation.output_schema.scene_update`
+  - `scripted_generation.user_confirmation`
+- operation categories: story, branching, visuals, audio, generation, state.
+- operation entries for every `known_script_ops()` value.
+- no `validation_codes` field.
+- snippet entries at minimum:
+  - `narration`
+  - `dialogue`
+  - `authored_choice`
+  - `generated_choice_set`
+  - `scene_update_generation`
+  - `confirm_gated_generation`
+  - `set_background`
+  - `show_sprite`
+  - `play_bgm`
+  - `set_variable`
+  - `ending`
+
+Use `copy.deepcopy()` or equivalent when returning catalog payloads so tests cannot mutate module state.
+
+- [ ] **Step 5: Run tests to verify GREEN**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_catalog.py -q
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Commit backend catalog slice**
+
+Run:
+
+```bash
+git add tldw_Server_API/app/core/VN_Scripts/validator.py tldw_Server_API/app/core/VN_Scripts/authoring_catalog.py tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_catalog.py
+git commit -m "Add VN script authoring catalog metadata"
+```
+
+## Task 2: Pure Snippet Patcher
+
+**Files:**
+- Create: `tldw_Server_API/app/core/VN_Scripts/authoring_errors.py`
+- Create: `tldw_Server_API/app/core/VN_Scripts/snippet_patcher.py`
+- Test: `tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_catalog.py`
+
+- [ ] **Step 1: Write failing patcher tests**
+
+Add tests proving:
+
+```python
+def test_generated_choice_snippet_inserts_generate_and_handler_label():
+    result = apply_snippet_patch(
+        base_program(),
+        snippet_id="generated_choice_set",
+        anchor={"label": "start", "op_index": 0, "mode": "after"},
+        parameters={"handler_label": "generated_choice", "max_choices": 2},
+    )
+    op = result.draft["labels"]["start"][1]
+    assert op["op"] == "generate"
+    assert op["output_schema"] == "choice_set"
+    assert op["on_generated_choice"] == "generated_choice"
+    assert result.draft["labels"]["generated_choice"][-1]["op"] == "end"
+```
+
+```python
+def test_preview_patcher_rejects_nested_routing_keys():
+    with pytest.raises(VNScriptAuthoringError) as exc_info:
+        apply_snippet_patch(
+            base_program(),
+            snippet_id="authored_choice",
+            anchor={"label": "start", "mode": "append"},
+            parameters={"choices": [{"id": "x", "text": "X", "target_label": "x", "model": "bad"}]},
+        )
+    assert exc_info.value.code == "snippet_parameter_invalid"
+    assert exc_info.value.details["field_path"] == "$.parameters.choices[0].model"
+```
+
+```python
+def test_patcher_rejects_anchor_and_label_conflicts():
+    with pytest.raises(VNScriptAuthoringError) as missing_anchor:
+        apply_snippet_patch(base_program(), snippet_id="ending", anchor={"label": "missing", "mode": "append"}, parameters={})
+    assert missing_anchor.value.code == "snippet_anchor_not_found"
+    assert missing_anchor.value.details["anchor"]["label"] == "missing"
+
+    with pytest.raises(VNScriptAuthoringError) as label_conflict:
+        apply_snippet_patch(base_program(existing_label="generated_choice"), snippet_id="generated_choice_set", anchor={"label": "start", "mode": "append"}, parameters={"handler_label": "generated_choice"})
+    assert label_conflict.value.code == "snippet_label_conflict"
+    assert label_conflict.value.details["label"] == "generated_choice"
+```
+
+Also add security-limit tests:
+
+```python
+def test_patcher_rejects_excessive_parameter_depth_length_and_payload_size():
+    for parameters in [
+        {"text": "x" * (MAX_SNIPPET_PARAMETER_STRING_LENGTH + 1)},
+        deeply_nested_parameters(MAX_SNIPPET_PARAMETER_MAX_DEPTH + 1),
+        oversized_parameters(MAX_SNIPPET_PARAMETER_PAYLOAD_BYTES + 1),
+    ]:
+        with pytest.raises(VNScriptAuthoringError) as exc_info:
+            apply_snippet_patch(base_program(), snippet_id="narration", anchor={"label": "start", "mode": "append"}, parameters=parameters)
+        assert exc_info.value.code == "snippet_parameter_invalid"
+        assert "field_path" in exc_info.value.details
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_catalog.py -q
+```
+
+Expected: fail because snippet patching does not exist.
+
+- [ ] **Step 3: Implement patcher data types and guards**
+
+Create small types/functions:
+
+- `VNScriptAuthoringError(code: str, message: str, status_code: int = 400, details: dict[str, Any] | None = None)`
+- `SnippetPatchResult(draft: dict[str, Any], patch_summary: dict[str, Any])`
+- `apply_snippet_patch(draft, snippet_id, anchor, parameters) -> SnippetPatchResult`
+- `_validate_anchor(labels, anchor)`
+- `_reject_forbidden_keys(value, path="$")`
+- `_enforce_parameter_limits(value, path="$", depth=0)`
+- `_assert_no_extra_fields(parameters, allowed_schema)`
+- `_insert_ops(labels, anchor, ops)`
+- `_create_label(labels, label, body)`
+
+Use parsed dict/list mutation against a deep copy only. Never mutate the caller's draft.
+
+Use explicit security limits:
+
+- `MAX_SNIPPET_PARAMETER_DEPTH = 8`
+- `MAX_SNIPPET_PARAMETER_STRING_LENGTH = 8000`
+- `MAX_SNIPPET_PARAMETER_PAYLOAD_BYTES = 65536`
+
+All patcher failures must raise `VNScriptAuthoringError` with stable `code` and structured `details`; do not rely on string-matched `ValueError`.
+
+- [ ] **Step 4: Implement V1 snippets**
+
+Start with deterministic snippets needed by WebUI:
+
+- `narration`
+- `authored_choice`
+- `generated_choice_set`
+- `confirm_gated_generation`
+- `ending`
+
+Then add remaining catalog snippets. Every snippet must return changed paths and counts:
+
+```python
+{
+    "inserted_ops": 1,
+    "created_labels": ["generated_choice"],
+    "changed_paths": ["$.labels.start[1]", "$.labels.generated_choice"],
+}
+```
+
+- [ ] **Step 5: Run tests to verify GREEN**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_catalog.py -q
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Commit patcher slice**
+
+Run:
+
+```bash
+git add tldw_Server_API/app/core/VN_Scripts/authoring_errors.py tldw_Server_API/app/core/VN_Scripts/snippet_patcher.py tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_catalog.py
+git commit -m "Add VN script snippet patcher"
+```
+
+## Task 3: Service Preview And Apply
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/VN_Scripts/service.py`
+- Test: `tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_catalog.py`
+
+- [ ] **Step 1: Write failing service behavior tests**
+
+Add service-level tests proving:
+
+- Stored-draft preview returns patched draft and leaves stored `revision`, `draft`, and `diagnostics` unchanged.
+- Supplied-draft preview requires script ownership, returns `base_revision`, and does not persist the supplied draft.
+- Apply increments revision, persists diagnostics, and returns the patched draft.
+- Stale apply raises `ValueError("draft_revision_conflict")` or a typed conflict that endpoint mapping later converts to HTTP `409`.
+- Duplicate apply against the same revision produces one success and one service-level conflict.
+
+Construct `VNScriptService` directly with a test `CharactersRAGDB`, a deterministic manifest resolver, and an audio resolver that can inspect the patched draft. Do not use FastAPI routes in this task.
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_catalog.py -q
+```
+
+Expected: fail because service preview/apply methods do not exist.
+
+- [ ] **Step 3: Add service methods**
+
+Add a patch-building helper and preview/apply helpers. The helper split lets the service own the validation boundary while still allowing API code to pass already-resolved async resources into the service:
+
+```python
+def build_snippet_patch(self, script_id: int, *, snippet_id: str, anchor: Mapping[str, Any], parameters: Mapping[str, Any], draft: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    script = self._require_script(script_id)
+    stored = self.get_draft(script_id)
+    base_draft = dict(draft) if draft is not None else stored["draft"]
+    patch = apply_snippet_patch(base_draft, snippet_id=snippet_id, anchor=anchor, parameters=parameters)
+    return {"script": script, "base_revision": int(stored["revision"]), "patch": patch}
+```
+
+Add side-effect-free preview validation:
+
+```python
+def preview_snippet_patch(self, *, script: Mapping[str, Any], base_revision: int, snippet_id: str, patch: SnippetPatchResult, audio_refs: Mapping[str, Mapping[str, Any]] | None = None, ...) -> dict[str, Any]:
+    validation = self.validate_draft_payload(script, patch.draft, audio_refs=audio_refs, ...)
+    return {...}
+```
+
+Do not call `validate_draft()` from preview because it stores diagnostics.
+
+Add apply persistence through the existing atomic draft write path:
+
+```python
+def apply_snippet_patch_result(self, script_id: int, *, if_revision: int, script: Mapping[str, Any], snippet_id: str, patch: SnippetPatchResult, audio_refs: Mapping[str, Mapping[str, Any]] | None = None, ...) -> dict[str, Any]:
+    validation = self.validate_draft_payload(script, patch.draft, audio_refs=audio_refs, ...)
+    draft_row = self.repo.replace_draft(... if_revision=if_revision, draft=patch.draft, diagnostics=validation)
+    return {...}
+```
+
+Use the existing repository `revision = ?` update for atomic optimistic concurrency.
+
+Also add `get_authoring_catalog()` as a thin wrapper around `list_authoring_catalog()`.
+
+Do not add HTTP status handling in this task. Endpoint status mapping belongs to Task 4.
+
+- [ ] **Step 4: Run focused tests to verify GREEN**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_catalog.py -q
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit service slice**
+
+Run:
+
+```bash
+git add tldw_Server_API/app/core/VN_Scripts/service.py tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_catalog.py
+git commit -m "Add VN script snippet preview apply service"
+```
+
+## Task 4: API Schemas, Endpoints, Capabilities, Docs
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/schemas/vn_script_schemas.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/vn_scripts.py`
+- Modify: `tldw_Server_API/app/core/VN_Platform/capabilities.py`
+- Modify: `Docs/API-related/VN_PLATFORM_API.md`
+- Test: `tldw_Server_API/tests/VN_Scripts/test_vn_scripts_api.py`
+
+- [ ] **Step 1: Write failing endpoint contract tests**
+
+Add tests proving:
+
+- `GET /api/v1/vn/vn-scripts/vn-authoring-catalog` returns schema version, capability tokens, operations, snippets, and no secrets.
+- `POST /scripts/{script_id}/draft/snippet-preview` accepts stored and supplied drafts.
+- `POST /scripts/{script_id}/draft/snippet-apply` requires `if_revision`.
+- Invalid snippet IDs return `404 snippet_not_found`.
+- Invalid parameters return `400 snippet_parameter_invalid` with `field_path`.
+- Oversized, overly deep, or overlong snippet parameters return `400 snippet_parameter_invalid` with `field_path`.
+- Invalid anchors return `400 snippet_anchor_invalid` or `400 snippet_anchor_not_found` with anchor details.
+- Stale revision returns `409 draft_revision_conflict` with `current_revision`.
+- `GET /api/v1/vn/vn-capabilities` includes `features.script_authoring_catalog = true` when routes are present.
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/VN_Scripts/test_vn_scripts_api.py -q
+```
+
+Expected: fail because endpoint schemas/routes are missing.
+
+- [ ] **Step 3: Add Pydantic schemas**
+
+Add models with `ConfigDict(extra="forbid")`:
+
+- `VNScriptAuthoringCatalogResponse`
+- `VNScriptAuthoringOperation`
+- `VNScriptAuthoringSnippet`
+- `VNScriptSnippetAnchor`
+- `VNScriptSnippetPreviewRequest`
+- `VNScriptSnippetApplyRequest`
+- `VNScriptSnippetPatchSummary`
+- `VNScriptSnippetPreviewResponse`
+- `VNScriptSnippetApplyResponse`
+
+Keep `parameters: dict[str, Any] = Field(default_factory=dict)` because snippet-specific schemas are catalog data, but endpoint code must run recursive extra/routing-key validation through the patcher.
+
+- [ ] **Step 4: Add endpoints**
+
+Add routes to `vn_scripts.py`:
+
+- `@router.get("/vn-authoring-catalog", response_model=VNScriptAuthoringCatalogResponse)`
+- `@router.post("/scripts/{script_id}/draft/snippet-preview", response_model=VNScriptSnippetPreviewResponse)`
+- `@router.post("/scripts/{script_id}/draft/snippet-apply", response_model=VNScriptSnippetApplyResponse)`
+
+Endpoints should authenticate, deserialize, call the service patch-building helper, resolve async resources required by the existing validation context, and delegate validation/persistence back to the service. They should not make independent policy, manifest, generation-profile, diagnostic, or publish decisions. Preview must use the supplied draft when present and never call `service.validate_draft()`.
+
+When catching `VNScriptAuthoringError`, map its `code`, `status_code`, and `details` directly into the VN error envelope. When catching `ValueError("draft_revision_conflict")`, look up the current draft revision and return `409` with `{"current_revision": revision}`.
+
+Update `_handle_value_error()` or local error mapping so new codes produce the documented statuses and details.
+
+- [ ] **Step 5: Add capabilities/docs**
+
+In `capabilities.py`, add `script_authoring_catalog` based on the scripts route being registered. Keep `scripted_generation` behavior as-is. If tests need token discovery, add a small `authoring_capability_tokens` list under `scripted_generation` or docs only; do not break the existing `VNCapabilitiesResponse` unless necessary.
+
+Update `Docs/API-related/VN_PLATFORM_API.md` with:
+
+- catalog endpoint
+- preview/apply endpoint examples
+- non-mutating preview warning
+- `if_revision` apply behavior
+- error code/status table
+- custom frontend flow
+
+- [ ] **Step 6: Run backend tests to verify GREEN**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/VN_Scripts -q
+```
+
+Expected: pass.
+
+- [ ] **Step 7: Run Bandit on touched backend scope**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/VN_Scripts tldw_Server_API/app/api/v1/endpoints/vn_scripts.py tldw_Server_API/app/api/v1/schemas/vn_script_schemas.py tldw_Server_API/app/core/VN_Platform/capabilities.py -f json -o /tmp/bandit_vn_authoring_catalog.json
+```
+
+Expected: no new findings in touched code.
+
+- [ ] **Step 8: Commit backend API slice**
+
+Run:
+
+```bash
+git add tldw_Server_API/app/api/v1/schemas/vn_script_schemas.py tldw_Server_API/app/api/v1/endpoints/vn_scripts.py tldw_Server_API/app/core/VN_Platform/capabilities.py Docs/API-related/VN_PLATFORM_API.md tldw_Server_API/tests/VN_Scripts
+git commit -m "Expose VN script authoring catalog API"
+```
+
+## Task 5: Frontend API Client And Types
+
+**Files:**
+- Modify: `apps/tldw-frontend/types/vn-scripts.ts`
+- Modify: `apps/tldw-frontend/lib/api/vnScripts.ts`
+- Test: `apps/tldw-frontend/__tests__/vn-scripts/vnScriptsApi.test.ts`
+
+- [ ] **Step 1: Write failing Vitest API tests**
+
+Add tests proving:
+
+- `getVNScriptAuthoringCatalog()` calls `/vn/vn-scripts/vn-authoring-catalog`.
+- `previewVNScriptSnippet(scriptId, request)` calls `/vn/vn-scripts/scripts/{script_id}/draft/snippet-preview`.
+- `applyVNScriptSnippet(scriptId, request)` calls `/vn/vn-scripts/scripts/{script_id}/draft/snippet-apply`.
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+bunx vitest run apps/tldw-frontend/__tests__/vn-scripts/vnScriptsApi.test.ts
+```
+
+Expected: fail because helpers/types are missing.
+
+- [ ] **Step 3: Add TypeScript types**
+
+Add interfaces mirroring backend schemas:
+
+- `VNScriptAuthoringCatalogResponse`
+- `VNScriptAuthoringOperation`
+- `VNScriptAuthoringSnippet`
+- `VNScriptSnippetAnchor`
+- `VNScriptSnippetPreviewRequest`
+- `VNScriptSnippetApplyRequest`
+- `VNScriptSnippetPatchSummary`
+- `VNScriptSnippetPreviewResponse`
+- `VNScriptSnippetApplyResponse`
+
+- [ ] **Step 4: Add API helpers**
+
+Add:
+
+```ts
+export function getVNScriptAuthoringCatalog(): Promise<VNScriptAuthoringCatalogResponse> {
+  return apiClient.get(`${VN_SCRIPTS_BASE}/vn-authoring-catalog`);
+}
+
+export function previewVNScriptSnippet(scriptId: number, request: VNScriptSnippetPreviewRequest): Promise<VNScriptSnippetPreviewResponse> {
+  return apiClient.post(`${VN_SCRIPTS_BASE}/scripts/${scriptId}/draft/snippet-preview`, request);
+}
+
+export function applyVNScriptSnippet(scriptId: number, request: VNScriptSnippetApplyRequest): Promise<VNScriptSnippetApplyResponse> {
+  return apiClient.post(`${VN_SCRIPTS_BASE}/scripts/${scriptId}/draft/snippet-apply`, request);
+}
+```
+
+- [ ] **Step 5: Run tests to verify GREEN**
+
+Run:
+
+```bash
+bunx vitest run apps/tldw-frontend/__tests__/vn-scripts/vnScriptsApi.test.ts
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Commit frontend client slice**
+
+Run:
+
+```bash
+git add apps/tldw-frontend/types/vn-scripts.ts apps/tldw-frontend/lib/api/vnScripts.ts apps/tldw-frontend/__tests__/vn-scripts/vnScriptsApi.test.ts
+git commit -m "Add VN script authoring catalog frontend client"
+```
+
+## Task 6: WebUI Guided Insert Panel
+
+**Files:**
+- Modify: `apps/tldw-frontend/components/vn-scripts/VNScriptsWorkbench.tsx`
+- Test: `apps/tldw-frontend/__tests__/vn-scripts/VNScriptsWorkbench.test.tsx`
+
+- [ ] **Step 1: Write failing component tests**
+
+Add tests proving:
+
+- Catalog loads after templates and scripts.
+- When catalog load fails, the raw JSON editor remains usable and an inline non-blocking status appears.
+- When `vn-capabilities` omits or disables `features.script_authoring_catalog`, the guided insert panel remains hidden/disabled and raw JSON editing remains available.
+- Selecting a snippet renders form inputs from `parameters_schema` and defaults.
+- Preview calls backend preview, displays diagnostics, and does not update stored draft revision.
+- Apply sends current draft revision, updates draft text/revision/diagnostics from the backend response, and shows changed paths.
+- A `draft_revision_conflict` response triggers a refetch-safe state/message without duplicating snippet content.
+
+- [ ] **Step 2: Run component tests to verify RED**
+
+Run:
+
+```bash
+bunx vitest run apps/tldw-frontend/__tests__/vn-scripts/VNScriptsWorkbench.test.tsx
+```
+
+Expected: fail because UI does not load or use authoring catalog.
+
+- [ ] **Step 3: Implement guided insert state**
+
+In `VNScriptsWorkbench.tsx`, add state for:
+
+- `vnCapabilities`
+- `authoringCatalog`
+- `isLoadingAuthoringCatalog`
+- `selectedSnippetId`
+- `snippetParameters`
+- `snippetAnchor`
+- `snippetPreview`
+- `isPreviewingSnippet`
+- `isApplyingSnippet`
+- `snippetError`
+
+Load VN capabilities before or alongside the catalog. Only fetch or show the guided authoring catalog when `features.script_authoring_catalog === true`; otherwise keep raw JSON editing available and do not treat the missing catalog as an error. If capabilities loading fails, degrade to raw JSON editing.
+
+- [ ] **Step 4: Implement compact panel**
+
+Add a compact panel beside or below the JSON editor depending on existing layout. It should:
+
+- group snippets by category
+- hide snippets whose `required_capabilities` are unavailable from VN capabilities
+- render only simple text/number/boolean/enum fields in V1
+- leave advanced nested parameters editable as JSON if necessary
+- call preview before apply
+- show patch summary and diagnostics returned by backend
+
+Do not implement frontend VN validation. Only render backend diagnostics.
+
+- [ ] **Step 5: Run component tests to verify GREEN**
+
+Run:
+
+```bash
+bunx vitest run apps/tldw-frontend/__tests__/vn-scripts/VNScriptsWorkbench.test.tsx
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Run frontend focused suite**
+
+Run:
+
+```bash
+bunx vitest run apps/tldw-frontend/__tests__/vn-scripts
+```
+
+Expected: pass.
+
+- [ ] **Step 7: Commit WebUI slice**
+
+Run:
+
+```bash
+git add apps/tldw-frontend/components/vn-scripts/VNScriptsWorkbench.tsx apps/tldw-frontend/__tests__/vn-scripts/VNScriptsWorkbench.test.tsx
+git commit -m "Add VN script guided snippet insert panel"
+```
+
+## Task 7: Final Verification And PR Prep
+
+**Files:**
+- Modify: `backlog/tasks/<implementation-task>.md`
+- Review all files changed by Tasks 1-6.
+
+- [ ] **Step 1: Run backend focused tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/VN_Scripts -q
+```
+
+Expected: pass.
+
+- [ ] **Step 2: Run frontend focused tests**
+
+Run:
+
+```bash
+bunx vitest run apps/tldw-frontend/__tests__/vn-scripts
+```
+
+Expected: pass.
+
+- [ ] **Step 3: Run Python compile/import verification**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m compileall tldw_Server_API/app tldw_Server_API/tests/VN_Scripts
+```
+
+Expected: no compile failures.
+
+- [ ] **Step 4: Run Bandit on touched backend scope**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/VN_Scripts tldw_Server_API/app/api/v1/endpoints/vn_scripts.py tldw_Server_API/app/api/v1/schemas/vn_script_schemas.py tldw_Server_API/app/core/VN_Platform/capabilities.py -f json -o /tmp/bandit_vn_authoring_catalog.json
+```
+
+Expected: no new findings in touched code.
+
+- [ ] **Step 5: Run whitespace check**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output.
+
+- [ ] **Step 6: Update Backlog task**
+
+Mark the implementation task acceptance criteria and Definition of Done complete. Record:
+
+- focused backend test command/results
+- focused frontend test command/results
+- Bandit output path/result
+- known skips or blockers
+- PR URL once opened
+
+- [ ] **Step 7: Final commit or squash**
+
+If the implementation was done with multiple task commits and the user wants a single PR commit, squash them into one clean commit after verification. Otherwise keep the task commits if they are reviewable.
+
+- [ ] **Step 8: Create PR against `dev`**
+
+Run:
+
+```bash
+git push -u origin codex/vn-generated-choice-set
+gh pr create --base dev --head codex/vn-generated-choice-set --title "Add VN script authoring catalog" --body-file /tmp/vn_authoring_catalog_pr.md
+```
+
+Expected: PR created. Include a human-editable `Change summary` section in the PR body per repo policy.

--- a/Docs/superpowers/specs/2026-05-12-vn-script-authoring-catalog-design.md
+++ b/Docs/superpowers/specs/2026-05-12-vn-script-authoring-catalog-design.md
@@ -1,0 +1,499 @@
+# VN Script Authoring Catalog and Guided Draft Editing Design
+
+Date: 2026-05-12
+
+## Summary
+
+Add an API-first VN script authoring catalog that lets custom frontends and the bundled WebUI discover supported script operations, inspect safe editing snippets, preview snippet insertion, and apply snippet edits to a draft through the backend.
+
+This is the next sprint after starter templates and generated-choice support. The goal is not a new script language, a node editor, or model-written story authoring. The goal is a backend-owned contract that makes the existing JSON draft system easier to edit while preserving the current backend authority for validation, diagnostics, generation profiles, policy, manifests, and publish checks.
+
+## Goals
+
+- Expose preview-safe metadata for `vn_script_program.v1` operations and common guided snippets.
+- Let clients preview a snippet against a script draft without saving it.
+- Let clients apply a snippet to the stored draft using optimistic revision checks.
+- Reuse existing draft validation and diagnostics so the authoring catalog does not become a parallel rule engine.
+- Support custom frontends through stable schemas, endpoint discovery, error codes, and additive capability flags.
+- Keep WebUI behavior catalog-driven rather than hardcoding VN script rules in React components.
+
+## Non-Goals
+
+- No visual node editor in this sprint.
+- No new DSL or migration away from canonical JSON drafts.
+- No LLM-generated story-writing endpoint.
+- No direct provider/model/API-key fields in snippet parameters or catalog payloads.
+- No new database tables unless implementation proves a small audit table is needed later.
+- No publish-time bypass. Publish remains the only authority for a runnable script version.
+
+## Existing Baseline
+
+The current backend already has:
+
+- `GET /api/v1/vn/vn-scripts/templates`
+- `POST /api/v1/vn/vn-scripts/templates/{template_id}/scripts`
+- draft read/write endpoints
+- validation and diagnostics endpoints
+- publish endpoints
+- a pure script validator for `vn_script_program.v1`
+- backend checks for asset manifests, audio references, policy, content rating, and generation profile constraints
+
+The new catalog should sit above these pieces. It should describe what can be authored and provide safe draft patches, but it should not duplicate the validator's final authority.
+
+## API Surface
+
+All endpoints live under the existing scripts resource:
+
+- `GET /api/v1/vn/vn-scripts/vn-authoring-catalog`
+- `POST /api/v1/vn/vn-scripts/scripts/{script_id}/draft/snippet-preview`
+- `POST /api/v1/vn/vn-scripts/scripts/{script_id}/draft/snippet-apply`
+
+The VN capabilities endpoint should advertise the feature through an additive flag:
+
+```json
+{
+  "features": {
+    "script_authoring_catalog": true,
+    "scripted_generation": true
+  }
+}
+```
+
+Clients must treat the feature as optional and fall back to raw JSON editing when the flag or routes are absent.
+
+## Catalog Endpoint
+
+`GET /api/v1/vn/vn-scripts/vn-authoring-catalog` returns preview-safe metadata only.
+
+Example response shape:
+
+```json
+{
+  "schema_version": "vn_script_authoring_catalog.v1",
+  "program_schema_version": "vn_script_program.v1",
+  "capability_tokens": [
+    "script_authoring_catalog",
+    "scripted_generation",
+    "scripted_generation.output_schema.choice_set",
+    "scripted_generation.output_schema.scene_update",
+    "scripted_generation.user_confirmation"
+  ],
+  "operation_categories": [
+    {"id": "story", "label": "Story"},
+    {"id": "branching", "label": "Branching"},
+    {"id": "visuals", "label": "Visuals"},
+    {"id": "audio", "label": "Audio"},
+    {"id": "generation", "label": "Generation"},
+    {"id": "state", "label": "State"}
+  ],
+  "operations": [
+    {
+      "op": "narrate",
+      "label": "Narration",
+      "category": "story",
+      "description": "Show narrator text.",
+      "fields": [
+        {
+          "name": "text",
+          "type": "string",
+          "required": true,
+          "multiline": true,
+          "max_length": 8000
+        }
+      ],
+      "supports_condition": true,
+      "preview": {"op": "narrate", "text": "The scene opens."},
+      "notes": ["Backend diagnostics remain authoritative."]
+    },
+    {
+      "op": "generate",
+      "label": "Generate",
+      "category": "generation",
+      "description": "Request structured model output through a resolved generation profile.",
+      "fields": [
+        {"name": "scope", "type": "enum", "required": true, "values": ["turn", "scene", "session"]},
+        {"name": "output_schema", "type": "enum", "required": false, "values": ["narrative_dialogue", "choice_set", "scene_update"]},
+        {"name": "max_choices", "type": "integer", "required": false, "minimum": 1},
+        {"name": "requires_user_confirm", "type": "boolean", "required": false}
+      ],
+      "forbidden_fields": ["api_key", "api_provider", "base_url", "endpoint", "model", "provider", "provider_config"],
+      "supports_condition": true,
+      "preview": {"op": "generate", "scope": "turn", "max_choices": 2, "output_schema": "choice_set"},
+      "notes": ["Generation limits are resolved from the script generation profile during preview, apply, validate, and publish."]
+    }
+  ],
+  "snippets": [
+    {
+      "id": "generated_choice_set",
+      "label": "Generated choice set",
+      "category": "generation",
+      "description": "Insert a generated choice request and a target handler label.",
+      "required_capabilities": ["scripted_generation", "scripted_generation.output_schema.choice_set"],
+      "parameters_schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["handler_label"],
+        "properties": {
+          "handler_label": {"type": "string", "pattern": "^[a-zA-Z0-9_.-]{1,64}$"},
+          "max_choices": {"type": "integer", "minimum": 1},
+          "requires_user_confirm": {"type": "boolean"}
+        }
+      },
+      "default_parameters": {
+        "handler_label": "generated_choice",
+        "max_choices": 2,
+        "requires_user_confirm": false
+      },
+      "anchor_modes": ["after", "before", "append"],
+      "creates_labels": true,
+      "preview": {
+        "inserted_ops": ["generate"],
+        "created_labels": ["generated_choice"]
+      }
+    }
+  ],
+  "limits": {
+    "max_snippet_ops": 25,
+    "max_created_labels_per_snippet": 8,
+    "max_label_length": 64
+  }
+}
+```
+
+The operation catalog should include every opcode the backend validator recognizes: `choice`, `clear_visuals`, `end`, `generate`, `hide_sprite`, `increment`, `jump`, `label`, `narrate`, `play_bgm`, `play_sfx`, `random`, `return`, `say`, `set`, `set_background`, `show_cg`, `show_sprite`, `stop_bgm`, and `voice_cue`.
+
+Field metadata is advisory and UI-oriented. The backend validator remains authoritative because operation metadata cannot fully express asset availability, generation-profile maps, audio ownership, content-rating policy, or reachability.
+
+Catalog limits are global UI hints only. Script-specific generation limits, supported output schemas, and capability availability are resolved from `vn-capabilities`, the script's generation profile map, and backend validation during preview/apply. Catalog capability tokens must be canonical tokens owned by the backend, such as `scripted_generation` and `scripted_generation.output_schema.choice_set`; clients must not invent or reinterpret capability names. If a snippet lists a capability token that is absent from `vn-capabilities`, clients should hide or disable that snippet and still allow raw JSON editing.
+
+Catalog entries should avoid listing stable validation codes in V1. Diagnostics returned from preview, apply, validate, and publish are the stable source of validation codes. If future catalog versions add validation-code hints, tests must compare those hints against diagnostics emitted by representative invalid programs.
+
+## Snippet Catalog
+
+V1 snippets should cover common JSON authoring tasks:
+
+- `narration`: append narrator text.
+- `dialogue`: append a character line.
+- `authored_choice`: insert a choice with authored target labels.
+- `generated_choice_set`: insert a `generate` op with `output_schema=choice_set`, `on_generated_choice=<handler_label>`, and a handler label body.
+- `scene_update_generation`: insert a `generate` op with `output_schema=scene_update`.
+- `confirm_gated_generation`: insert a confirmation-gated generation op plus cancel label.
+- `set_background`: insert a background visual op.
+- `show_sprite`: insert a sprite visual op.
+- `play_bgm`: insert a background music op.
+- `set_variable`: declare or set a variable.
+- `ending`: append an `end` op.
+
+Snippets must be deterministic. The same request against the same draft revision should produce the same patched draft and diagnostics.
+
+The `generated_choice_set` snippet has an exact V1 patch contract:
+
+- Insert `{"op": "generate", "scope": "turn", "output_schema": "choice_set", "max_choices": N, "on_generated_choice": handler_label}` at the requested anchor.
+- Include `requires_user_confirm` only when requested.
+- Create `labels[handler_label]` with deterministic starter operations such as one `narrate` placeholder followed by `end`.
+- Fail with `snippet_label_conflict` when `handler_label` already exists unless a future request field explicitly allows reuse.
+- Never set raw provider/model/routing fields.
+
+## Snippet Preview
+
+`POST /api/v1/vn/vn-scripts/scripts/{script_id}/draft/snippet-preview` computes a patched draft and diagnostics without saving.
+
+Request:
+
+```json
+{
+  "snippet_id": "generated_choice_set",
+  "anchor": {
+    "label": "start",
+    "op_index": 1,
+    "mode": "after"
+  },
+  "parameters": {
+    "handler_label": "generated_choice",
+    "max_choices": 2
+  },
+  "draft": null
+}
+```
+
+Rules:
+
+- The script must exist and belong to the caller even when a supplied draft is used.
+- If `draft` is omitted or null, preview uses the currently stored draft.
+- If `draft` is supplied, preview validates and patches the supplied draft without persisting it. This lets JSON editors preview against unsaved edits.
+- Preview returns the patched draft, diagnostics, patch summary, and the stored draft revision it used when applicable.
+- `base_revision` is the current stored draft revision when the preview starts. It is informational for supplied-draft previews and must not imply that the supplied draft matched the stored draft.
+- Preview must not change `vn_script_drafts`, publish state, version history, manifests, or jobs.
+- Preview must use the non-mutating validation helper path. It must not call a service method that stores diagnostics as a side effect.
+- Preview validation context comes from the stored script metadata and resolved backend resources, not from client-supplied top-level metadata that would change ownership, policy, generation profiles, content rating, or asset pack selection.
+
+Response:
+
+```json
+{
+  "script_id": 12,
+  "base_revision": 4,
+  "snippet_id": "generated_choice_set",
+  "draft": {
+    "schema_version": "vn_script_program.v1"
+  },
+  "diagnostics": {
+    "valid": true,
+    "errors": [],
+    "warnings": []
+  },
+  "patch_summary": {
+    "inserted_ops": 1,
+    "created_labels": ["generated_choice"],
+    "changed_paths": ["$.labels.start[2]", "$.labels.generated_choice"]
+  },
+  "warnings": []
+}
+```
+
+## Snippet Apply
+
+`POST /api/v1/vn/vn-scripts/scripts/{script_id}/draft/snippet-apply` applies a snippet to the stored draft.
+
+Request:
+
+```json
+{
+  "snippet_id": "authored_choice",
+  "if_revision": 4,
+  "anchor": {
+    "label": "start",
+    "op_index": 2,
+    "mode": "before"
+  },
+  "parameters": {
+    "choice_id": "first_branch",
+    "choices": [
+      {"id": "left", "text": "Take the left path.", "target_label": "left_path"},
+      {"id": "right", "text": "Take the right path.", "target_label": "right_path"}
+    ]
+  }
+}
+```
+
+Rules:
+
+- `if_revision` is required.
+- If the stored draft revision differs, return `409 draft_revision_conflict` with the current revision.
+- The server patches the stored draft, runs the same validation/diagnostics path used by draft replacement, and persists the result through the existing atomic draft write path.
+- Revision checking must happen in the persistence statement or an equivalent database transaction. A read-then-write check is not sufficient.
+- Apply saves the patched draft with returned diagnostics, matching the existing whole-draft replacement behavior. Validation errors do not become transport failures unless patch construction itself fails.
+- Apply must not silently publish or mark a script ready.
+- Duplicate apply requests with an old `if_revision` fail with `409` instead of inserting the snippet twice.
+
+Response:
+
+```json
+{
+  "script_id": 12,
+  "revision": 5,
+  "snippet_id": "authored_choice",
+  "draft": {
+    "schema_version": "vn_script_program.v1"
+  },
+  "diagnostics": {
+    "valid": true,
+    "errors": [],
+    "warnings": []
+  },
+  "patch_summary": {
+    "inserted_ops": 1,
+    "created_labels": ["left_path", "right_path"],
+    "changed_paths": ["$.labels.start[2]", "$.labels.left_path", "$.labels.right_path"]
+  }
+}
+```
+
+## Patch Semantics
+
+The server applies snippets to parsed draft objects, not JSON strings.
+
+Anchors:
+
+- `label`: required existing label name.
+- `op_index`: optional zero-based operation index.
+- `mode`: `before`, `after`, or `append`.
+
+Insertion rules:
+
+- `append` ignores `op_index` and appends to the label body.
+- `before` and `after` require an `op_index` that exists in the label body.
+- Snippets that create labels must fail on exact label collisions unless the snippet explicitly supports `reuse_existing_label`.
+- Generated label names must be deterministic and sanitized.
+- If a snippet declares variables, it must avoid overwriting existing variables unless the request explicitly allows reuse and the type matches.
+- Snippets cannot remove existing operations in V1.
+- Snippets cannot change script metadata, policy profile IDs, generation profile maps, primary asset pack IDs, content rating, or publish state.
+
+## Validation and Authority
+
+The catalog layer must call the same side-effect-free validation helper used by normal draft editing before persistence. Preview must stop there; apply may then persist through the draft write path. Validation must still resolve:
+
+- approved asset slot keys from the manifest
+- accessible audio media refs
+- generation profiles and profile maps
+- policy and content-rating constraints
+- generated output schemas
+- reachable labels and target labels
+- variable declarations and assignment types
+- forbidden raw generation routing keys
+
+The catalog endpoint may expose the known operation names and basic field metadata, but it must not expose secrets, raw provider routing, prompt internals, policy implementation details, or private model configuration.
+
+## Error Model
+
+Use the existing VN error envelope style with stable codes. Error details must be concrete enough for custom frontends to recover without string parsing.
+
+Expected codes:
+
+- `script_not_found`
+- `snippet_not_found`
+- `snippet_parameter_invalid`
+- `snippet_anchor_invalid`
+- `snippet_anchor_not_found`
+- `snippet_label_conflict`
+- `snippet_variable_conflict`
+- `snippet_preview_invalid_draft`
+- `snippet_patch_validation_failed`
+- `draft_revision_conflict`
+- `permission_denied`
+- `draft_not_found`
+
+`snippet_patch_validation_failed` should be reserved for patch construction failures. Ordinary script validation diagnostics should be returned in `diagnostics` instead of converted into transport errors when the existing draft write behavior allows invalid drafts.
+
+Expected transport statuses:
+
+- `400`: invalid snippet parameters, invalid anchors, label or variable conflicts, malformed supplied draft.
+- `403`: caller cannot access the script.
+- `404`: script, draft, or snippet does not exist.
+- `409`: stale `if_revision`.
+- `500`: unexpected patch or persistence failures only.
+
+Required error details:
+
+- `draft_revision_conflict`: `{"current_revision": 5}`
+- `snippet_parameter_invalid`: `{"field_path": "$.parameters.max_choices", "message": "Expected integer greater than or equal to 1."}`
+- `snippet_anchor_invalid`: `{"anchor": {"label": "start", "op_index": -1, "mode": "after"}}`
+- `snippet_anchor_not_found`: `{"anchor": {"label": "missing", "op_index": 0, "mode": "after"}}`
+- `snippet_label_conflict`: `{"label": "generated_choice"}`
+- `snippet_variable_conflict`: `{"variable": "route_score", "existing_type": "integer"}`
+
+## WebUI Consumption Model
+
+The WebUI should add a guided insert panel beside the existing JSON editor. The panel loads `vn-authoring-catalog`, groups snippets by category, collects snippet parameters, calls preview, then applies with `if_revision` when the user confirms.
+
+The WebUI should not implement a second validator. It may use catalog field metadata for forms, but server diagnostics remain the source of truth. If catalog loading fails, the JSON editor remains available.
+
+Conflict handling:
+
+- On `draft_revision_conflict`, refetch the draft and show a non-destructive conflict message.
+- On parameter errors, mark the affected form field using the server error details.
+- On diagnostics errors, keep the patched draft visible in preview. The WebUI may offer apply/save only when the backend apply contract permits invalid drafts; publish remains blocked by backend validation.
+
+## Custom Frontend Contract
+
+Custom frontends should be able to:
+
+1. Discover feature availability through `vn-capabilities`.
+2. Load `vn-authoring-catalog`.
+3. Render snippet forms from `parameters_schema` and `default_parameters`.
+4. Preview a patch against a stored or unsaved draft.
+5. Apply a patch with `if_revision`.
+6. Render diagnostics returned by the backend.
+7. Fall back to the canonical JSON draft endpoints.
+
+The contract must remain additive. Adding snippets or optional metadata fields is a minor change. Removing snippets, renaming snippets, changing parameter semantics, or changing patch behavior requires a catalog schema version bump.
+
+## Data Model
+
+V1 should not require a migration. Catalog metadata can be static Python data beside existing VN script templates, and apply should persist through the existing draft storage path.
+
+If auditability becomes necessary later, add a small optional history table in a future sprint. Do not block V1 on edit audit history because script draft revisions already preserve the current persisted state.
+
+## Security and Abuse Controls
+
+- Reject snippet parameters that include raw provider routing keys.
+- Snippet request models must reject unknown fields. Pydantic request models should use `extra="forbid"`, and catalog JSON Schemas must set `additionalProperties: false` for every object node.
+- Reject forbidden routing keys recursively in nested parameters, and enforce maximum nesting depth, string length, and total parameter payload size.
+- Treat every snippet parameter object independently. Nested arrays of objects, such as authored-choice `choices`, must also forbid extra fields and recursive routing keys.
+- Validate label names and variable names against strict patterns.
+- Enforce maximum snippet size, maximum created labels, and maximum parameter payload size.
+- Do not let snippets reference inaccessible audio or asset slots without normal diagnostics.
+- Do not run model calls, generation jobs, file ingestion, or external network operations from preview/apply.
+- Preserve existing AuthNZ owner checks for scripts and drafts.
+- Do not log raw draft text at info level.
+
+## Testing
+
+Backend tests:
+
+- Catalog returns every known validator opcode exactly once.
+- Catalog omits forbidden routing fields and secrets.
+- Catalog uses canonical backend capability tokens.
+- Catalog schema forbids extra snippet parameter fields at every object node.
+- Snippet preview against stored draft is non-mutating.
+- Snippet preview against supplied draft does not persist.
+- Supplied-draft preview still requires script ownership and reports informational `base_revision`.
+- Snippet apply increments draft revision and returns diagnostics.
+- Preview uses non-mutating validation and does not store diagnostics.
+- Preview leaves stored `revision`, `draft_json`, and `diagnostics_json` unchanged for stored-draft and supplied-draft previews.
+- Apply with stale `if_revision` returns `409 draft_revision_conflict`.
+- Concurrent apply requests against the same revision result in one success and one `409`.
+- Invalid anchors return stable errors.
+- Error details include `current_revision`, `field_path`, anchor payloads, or conflict identifiers as applicable.
+- Transport statuses match the expected error categories.
+- Label and variable collisions return stable errors.
+- Generated-choice snippet inserts `on_generated_choice` and creates the deterministic handler label body.
+- Generated-choice snippet produces a draft that existing validation accepts when the generation profile permits it.
+- Existing validation catches asset/audio/generation errors after snippet insertion.
+- Raw provider/model/API-key parameters are rejected.
+
+Frontend tests:
+
+- API helper parses catalog, preview, and apply responses.
+- Guided insert panel renders snippets from catalog metadata.
+- Preview result updates the draft preview without saving.
+- Apply updates revision and diagnostics.
+- Conflict response triggers refetch-safe UI state.
+- Catalog failure leaves raw JSON editing available.
+
+Docs tests:
+
+- `VN_PLATFORM_API.md` documents the new endpoints, feature flag, and custom frontend flow.
+- OpenAPI schema includes request/response models for catalog, preview, apply, and errors.
+
+## Rollout Plan
+
+1. Backend catalog data and schemas.
+2. Backend preview/apply service using parsed draft objects and existing validation.
+3. API endpoints and capabilities flag.
+4. Tests for catalog, preview, apply, conflicts, and safety.
+5. WebUI API helper/types.
+6. WebUI guided insert panel wired to catalog metadata.
+7. Docs update and PR review sweep.
+
+Each stage should be independently reviewable. The backend contract should land before WebUI polish so custom frontend support is not coupled to React implementation choices.
+
+## Risks and Mitigations
+
+- Risk: operation metadata drifts from validator behavior.
+  - Mitigation: catalog tests compare operation IDs with the validator's known opcode list.
+- Risk: snippet apply duplicates edits on retry.
+  - Mitigation: require `if_revision` and return `409` for stale applies.
+- Risk: custom frontends treat catalog field metadata as authoritative validation.
+  - Mitigation: document metadata as advisory and always return backend diagnostics.
+- Risk: frontend grows a parallel rule engine.
+  - Mitigation: WebUI only renders forms and server diagnostics; preview/apply remain backend-owned.
+- Risk: snippet patch code becomes string-based and fragile.
+  - Mitigation: require parsed object mutation and changed-path summaries.
+- Risk: V1 scope expands into node editing.
+  - Mitigation: keep graph visualization and node editors as future work after the API contract proves stable.
+
+## Decisions Deferred
+
+- The first WebUI panel may render all backend snippets, but advanced snippets can be collapsed or grouped behind filters. The API should still expose all V1 snippets.
+- V1 returns changed paths only. JSON Patch operations can be added later if external editors need them.

--- a/apps/tldw-frontend/__tests__/vn-scripts/VNScriptsWorkbench.test.tsx
+++ b/apps/tldw-frontend/__tests__/vn-scripts/VNScriptsWorkbench.test.tsx
@@ -585,12 +585,15 @@ describe('VNScriptsWorkbench', () => {
     render(<VNScriptsWorkbench />);
 
     await user.click(await screen.findByRole('button', { name: /Generated choice set/ }));
+    await user.selectOptions(screen.getByLabelText('Anchor mode'), 'before');
+    await user.clear(screen.getByLabelText('Op index'));
+    await user.type(screen.getByLabelText('Op index'), '2');
     await user.click(screen.getByRole('button', { name: 'Preview snippet' }));
 
     await waitFor(() => {
       expect(mocks.previewVNScriptSnippet).toHaveBeenCalledWith(1, {
         snippet_id: 'generated_choice_set',
-        anchor: { label: 'start', mode: 'append', op_index: null },
+        anchor: { label: 'start', mode: 'before', op_index: 2 },
         parameters: {
           prompt: 'Offer three routes.',
           count: 3,
@@ -786,6 +789,64 @@ describe('VNScriptsWorkbench', () => {
     expect(screen.getByText(/current_preview/)).toBeInTheDocument();
   });
 
+  it('keeps preview loading active when an older preview resolves before the current one', async () => {
+    const user = userEvent.setup();
+    const firstPreview = createDeferred<{
+      script_id: number;
+      base_revision: number;
+      snippet_id: string;
+      draft: Record<string, unknown>;
+      diagnostics: Record<string, unknown>;
+      patch_summary: { inserted_ops: number; created_labels: string[]; changed_paths: string[] };
+      warnings: Array<Record<string, unknown>>;
+    }>();
+    const secondPreview = createDeferred<{
+      script_id: number;
+      base_revision: number;
+      snippet_id: string;
+      draft: Record<string, unknown>;
+      diagnostics: Record<string, unknown>;
+      patch_summary: { inserted_ops: number; created_labels: string[]; changed_paths: string[] };
+      warnings: Array<Record<string, unknown>>;
+    }>();
+    mocks.previewVNScriptSnippet
+      .mockReturnValueOnce(firstPreview.promise)
+      .mockReturnValueOnce(secondPreview.promise);
+    render(<VNScriptsWorkbench />);
+
+    await user.click(await screen.findByRole('button', { name: /Generated choice set/ }));
+    await user.click(screen.getByRole('button', { name: 'Preview snippet' }));
+    await waitFor(() => expect(mocks.previewVNScriptSnippet).toHaveBeenCalledTimes(1));
+    fireEvent.change(screen.getByLabelText('Draft JSON'), {
+      target: { value: JSON.stringify({ scenes: [{ id: 'changed', text: 'Changed before preview B.' }] }) },
+    });
+    await waitFor(() => expect(screen.getByDisplayValue(/Changed before preview B/)).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: 'Preview snippet' }));
+    await waitFor(() => expect(mocks.previewVNScriptSnippet).toHaveBeenCalledTimes(2));
+
+    firstPreview.resolve({
+      script_id: 1,
+      base_revision: 3,
+      snippet_id: 'generated_choice_set',
+      draft: { scenes: [{ id: 'start' }], choices: [{ prompt: 'stale preview' }] },
+      diagnostics: { valid: true },
+      patch_summary: { inserted_ops: 1, created_labels: ['stale_preview'], changed_paths: [] },
+      warnings: [],
+    });
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Preview snippet' })).toHaveAttribute('aria-busy', 'true'));
+    secondPreview.resolve({
+      script_id: 1,
+      base_revision: 3,
+      snippet_id: 'generated_choice_set',
+      draft: { scenes: [{ id: 'changed' }], choices: [{ prompt: 'current preview' }] },
+      diagnostics: { valid: true },
+      patch_summary: { inserted_ops: 1, created_labels: ['current_preview'], changed_paths: ['labels.current_preview[1]'] },
+      warnings: [],
+    });
+    expect(await screen.findByText(/current_preview/)).toBeInTheDocument();
+  });
+
   it('ignores stale snippet apply responses after switching scripts', async () => {
     const user = userEvent.setup();
     const apply = createDeferred<{
@@ -840,16 +901,56 @@ describe('VNScriptsWorkbench', () => {
     expect(screen.queryByText('Applied snippet at revision 4.')).not.toBeInTheDocument();
   });
 
+  it('ignores apply responses after same-script raw JSON edits invalidate the preview context', async () => {
+    const user = userEvent.setup();
+    const apply = createDeferred<{
+      script_id: number;
+      revision: number;
+      snippet_id: string;
+      draft: Record<string, unknown>;
+      diagnostics: Record<string, unknown>;
+      patch_summary: { inserted_ops: number; created_labels: string[]; changed_paths: string[] };
+    }>();
+    mocks.applyVNScriptSnippet.mockReturnValueOnce(apply.promise);
+    render(<VNScriptsWorkbench />);
+
+    await user.click(await screen.findByRole('button', { name: /Generated choice set/ }));
+    await user.click(screen.getByRole('button', { name: 'Preview snippet' }));
+    expect(await screen.findByText(/Preview inserted 2 operations/)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Apply snippet' }));
+    await waitFor(() => expect(mocks.applyVNScriptSnippet).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(screen.getByLabelText('Draft JSON'), {
+      target: { value: JSON.stringify({ scenes: [{ id: 'local', text: 'Keep local edit.' }] }) },
+    });
+    apply.resolve({
+      script_id: 1,
+      revision: 4,
+      snippet_id: 'generated_choice_set',
+      draft: { scenes: [{ id: 'server' }], choices: [{ prompt: 'server response' }] },
+      diagnostics: { valid: true },
+      patch_summary: { inserted_ops: 1, created_labels: [], changed_paths: [] },
+    });
+
+    await waitFor(() => expect(screen.getByDisplayValue(/Keep local edit/)).toBeInTheDocument());
+    expect(screen.queryByDisplayValue(/server response/)).not.toBeInTheDocument();
+    expect(screen.queryByText('Applied snippet at revision 4.')).not.toBeInTheDocument();
+  });
+
   it('ignores stale conflict reload responses after switching scripts', async () => {
     const user = userEvent.setup();
     const conflict = new Error('[object Object]') as Error & {
-      detail?: { details?: { reason?: string } };
+      detail?: { code?: string; message?: string; details?: { reason?: string } };
       status?: number;
     };
     const conflictReload = createDeferred<typeof draftResponse>();
     let openingDraftCalls = 0;
     conflict.status = 409;
-    conflict.detail = { details: { reason: 'draft_revision_conflict' } };
+    conflict.detail = {
+      code: 'invalid_request',
+      message: 'draft_revision_conflict',
+      details: { reason: 'draft_revision_conflict' },
+    };
     mocks.applyVNScriptSnippet.mockRejectedValueOnce(conflict);
     mocks.getVNScriptDraft.mockImplementation(async (scriptId: number) => {
       if (scriptId === 2) {
@@ -894,13 +995,17 @@ describe('VNScriptsWorkbench', () => {
   it('ignores stale conflict reload errors after switching scripts', async () => {
     const user = userEvent.setup();
     const conflict = new Error('[object Object]') as Error & {
-      detail?: { details?: { reason?: string } };
+      detail?: { code?: string; message?: string; details?: { reason?: string } };
       status?: number;
     };
     const conflictReload = createDeferred<typeof draftResponse>();
     let openingDraftCalls = 0;
     conflict.status = 409;
-    conflict.detail = { details: { reason: 'draft_revision_conflict' } };
+    conflict.detail = {
+      code: 'invalid_request',
+      message: 'draft_revision_conflict',
+      details: { reason: 'draft_revision_conflict' },
+    };
     mocks.applyVNScriptSnippet.mockRejectedValueOnce(conflict);
     mocks.getVNScriptDraft.mockImplementation(async (scriptId: number) => {
       if (scriptId === 2) {
@@ -982,11 +1087,15 @@ describe('VNScriptsWorkbench', () => {
   it('handles draft revision conflicts without duplicating snippet content', async () => {
     const user = userEvent.setup();
     const conflict = new Error('[object Object]') as Error & {
-      detail?: { details?: { reason?: string } };
+      detail?: { code?: string; message?: string; details?: { reason?: string } };
       status?: number;
     };
     conflict.status = 409;
-    conflict.detail = { details: { reason: 'draft_revision_conflict' } };
+    conflict.detail = {
+      code: 'invalid_request',
+      message: 'draft_revision_conflict',
+      details: { reason: 'draft_revision_conflict' },
+    };
     mocks.applyVNScriptSnippet.mockRejectedValueOnce(conflict);
     render(<VNScriptsWorkbench />);
 

--- a/apps/tldw-frontend/__tests__/vn-scripts/VNScriptsWorkbench.test.tsx
+++ b/apps/tldw-frontend/__tests__/vn-scripts/VNScriptsWorkbench.test.tsx
@@ -3,30 +3,43 @@ import { fireEvent, render, screen, waitFor, within } from '@testing-library/rea
 import userEvent from '@testing-library/user-event';
 
 const mocks = vi.hoisted(() => ({
+  apiClient: {
+    get: vi.fn(),
+  },
+  applyVNScriptSnippet: vi.fn(),
   createVNScriptFromTemplate: vi.fn(),
   createVNScript: vi.fn(),
   evaluateVNScriptVersionPolicy: vi.fn(),
+  getVNScriptAuthoringCatalog: vi.fn(),
   getVNScriptDiagnostics: vi.fn(),
   getVNScriptDraft: vi.fn(),
   getVNScriptManifestSnapshot: vi.fn(),
   listVNScriptTemplates: vi.fn(),
   listVNScripts: vi.fn(),
   listVNScriptVersions: vi.fn(),
+  previewVNScriptSnippet: vi.fn(),
   publishVNScript: vi.fn(),
   putVNScriptDraft: vi.fn(),
   validateVNScriptDraft: vi.fn(),
 }));
 
+vi.mock('@web/lib/api', () => ({
+  apiClient: mocks.apiClient,
+}));
+
 vi.mock('@web/lib/api/vnScripts', () => ({
+  applyVNScriptSnippet: (...args: unknown[]) => mocks.applyVNScriptSnippet(...args),
   createVNScriptFromTemplate: (...args: unknown[]) => mocks.createVNScriptFromTemplate(...args),
   createVNScript: (...args: unknown[]) => mocks.createVNScript(...args),
   evaluateVNScriptVersionPolicy: (...args: unknown[]) => mocks.evaluateVNScriptVersionPolicy(...args),
+  getVNScriptAuthoringCatalog: (...args: unknown[]) => mocks.getVNScriptAuthoringCatalog(...args),
   getVNScriptDiagnostics: (...args: unknown[]) => mocks.getVNScriptDiagnostics(...args),
   getVNScriptDraft: (...args: unknown[]) => mocks.getVNScriptDraft(...args),
   getVNScriptManifestSnapshot: (...args: unknown[]) => mocks.getVNScriptManifestSnapshot(...args),
   listVNScriptTemplates: (...args: unknown[]) => mocks.listVNScriptTemplates(...args),
   listVNScripts: (...args: unknown[]) => mocks.listVNScripts(...args),
   listVNScriptVersions: (...args: unknown[]) => mocks.listVNScriptVersions(...args),
+  previewVNScriptSnippet: (...args: unknown[]) => mocks.previewVNScriptSnippet(...args),
   publishVNScript: (...args: unknown[]) => mocks.publishVNScript(...args),
   putVNScriptDraft: (...args: unknown[]) => mocks.putVNScriptDraft(...args),
   validateVNScriptDraft: (...args: unknown[]) => mocks.validateVNScriptDraft(...args),
@@ -174,6 +187,111 @@ const templateDraftResponse = {
   diagnostics: { valid: true },
 };
 
+const vnCapabilitiesResponse = {
+  schema_version: 'vn_capabilities.v1',
+  generated_at: '2026-05-12T10:00:00Z',
+  base_path: '/api/v1/vn',
+  resources: {},
+  enabled_modules: { scripts: true, play: true },
+  features: {
+    script_authoring_catalog: true,
+    scripted_generation: true,
+  },
+  limits: {},
+  supported_content_ratings: ['general', 'teen', 'suggestive', 'mature'],
+  visible_policy_profiles: [],
+  visible_generation_profiles: [],
+  supported_media_types: { image: [], audio: [] },
+  scripted_generation: {
+    enabled: true,
+    output_schemas: ['choice_set'],
+    confirmation_supported: true,
+    revision_activation_supported: true,
+    history_supported: true,
+    debug_detail_supported: true,
+    dynamic_choice_supported: true,
+    scene_update_supported: true,
+    max_automatic_generation_batch_count: 1,
+    moderation_blocked_raw_reveal_supported: true,
+  },
+  route_migration: { canonical: '/api/v1/vn/vn-*', supersedes: [] },
+  docs: {},
+  openapi: '/openapi.json',
+};
+
+const choiceSnippet = {
+  id: 'generated_choice_set',
+  schema_version: 'vn_script_program.v1',
+  label: 'Generated choice set',
+  operation_sequence: ['insert_choice_set'],
+  required_capability_tokens: ['script_authoring_catalog', 'choice_set'],
+  parameters_schema: {
+    type: 'object',
+    properties: {
+      prompt: { type: 'string', title: 'Prompt' },
+      count: { type: 'number', title: 'Choice count' },
+      shuffle: { type: 'boolean', title: 'Shuffle choices' },
+      tone: { type: 'string', title: 'Tone', enum: ['dramatic', 'quiet'] },
+    },
+  },
+  default_parameters: {
+    prompt: 'Offer three routes.',
+    count: 3,
+    shuffle: false,
+    tone: 'dramatic',
+  },
+  preview: [{ op: 'choice_set' }],
+};
+
+const unsupportedSnippet = {
+  ...choiceSnippet,
+  id: 'live_asset_generation',
+  label: 'Live asset generation',
+  operation_sequence: ['generate_asset'],
+  required_capability_tokens: ['realtime_image_generation'],
+};
+
+const typedEnumSnippet = {
+  ...choiceSnippet,
+  id: 'typed_enum_snippet',
+  label: 'Typed enum snippet',
+  parameters_schema: {
+    type: 'object',
+    properties: {
+      difficulty: { type: 'number', title: 'Difficulty', enum: [1, 2, 3] },
+      includeRecap: { type: 'boolean', title: 'Include recap', enum: [true, false] },
+    },
+  },
+  default_parameters: {
+    difficulty: 2,
+    includeRecap: true,
+  },
+};
+
+const authoringCatalogResponse = {
+  schema_version: 'vn_script_authoring_catalog.v1',
+  program_schema_version: 'vn_script_program.v1',
+  capability_tokens: ['script_authoring_catalog', 'choice_set'],
+  generation_output_schemas: ['choice_set'],
+  operation_categories: { choices: ['insert_choice_set'], assets: ['generate_asset'] },
+  operations: [
+    {
+      op: 'insert_choice_set',
+      label: 'Insert choice set',
+      category: 'choices',
+      capability_tokens: ['choice_set'],
+    },
+    {
+      op: 'generate_asset',
+      label: 'Generate asset',
+      category: 'assets',
+      capability_tokens: ['realtime_image_generation'],
+    },
+  ],
+  snippets: [choiceSnippet, typedEnumSnippet, unsupportedSnippet],
+  limits: { max_operations: 100 },
+};
+
 function createDeferred<T>() {
   let resolve!: (value: T) => void;
   let reject!: (reason?: unknown) => void;
@@ -202,8 +320,41 @@ function mockTemplates(items = [linearTemplate, choiceTemplate]) {
 describe('VNScriptsWorkbench', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.apiClient.get.mockResolvedValue(vnCapabilitiesResponse);
     mockList();
     mockTemplates();
+    mocks.getVNScriptAuthoringCatalog.mockResolvedValue(authoringCatalogResponse);
+    mocks.previewVNScriptSnippet.mockResolvedValue({
+      script_id: 1,
+      base_revision: 3,
+      snippet_id: 'generated_choice_set',
+      draft: {
+        scenes: [{ id: 'start', text: 'Wake up.' }],
+        choices: [{ prompt: 'Offer three routes.' }],
+      },
+      diagnostics: { valid: true, preview_nodes: 2 },
+      patch_summary: {
+        inserted_ops: 2,
+        created_labels: ['choice_intro'],
+        changed_paths: ['labels.start[1]', 'labels.choice_intro'],
+      },
+      warnings: [{ code: 'preview_only', message: 'Preview only.' }],
+    });
+    mocks.applyVNScriptSnippet.mockResolvedValue({
+      script_id: 1,
+      revision: 4,
+      snippet_id: 'generated_choice_set',
+      draft: {
+        scenes: [{ id: 'start', text: 'Wake up.' }],
+        choices: [{ prompt: 'Offer three routes.' }],
+      },
+      diagnostics: { valid: true, applied_nodes: 2 },
+      patch_summary: {
+        inserted_ops: 2,
+        created_labels: ['choice_intro'],
+        changed_paths: ['labels.start[1]', 'labels.choice_intro'],
+      },
+    });
     mocks.createVNScript.mockResolvedValue({
       ...secondScript,
       id: 9,
@@ -337,6 +488,517 @@ describe('VNScriptsWorkbench', () => {
     expect(screen.getByRole('option', { name: 'Authored choices' })).toBeInTheDocument();
     await user.selectOptions(screen.getByLabelText('Starter template'), 'linear_scene');
     expect(screen.getByText('Start with one authored scene.')).toBeInTheDocument();
+  });
+
+  it('loads the authoring catalog alongside script data when VN capabilities enables it', async () => {
+    render(<VNScriptsWorkbench />);
+
+    expect(await screen.findByRole('button', { name: /Opening Route/ })).toBeInTheDocument();
+    await waitFor(() => expect(mocks.apiClient.get).toHaveBeenCalledWith('/vn/vn-capabilities'));
+    await waitFor(() => expect(mocks.getVNScriptAuthoringCatalog).toHaveBeenCalledTimes(1));
+    expect(await screen.findByRole('heading', { name: 'Guided insert' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Generated choice set/ })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Live asset generation/ })).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Draft JSON')).toBeInTheDocument();
+  });
+
+  it('keeps guided insert hidden when capabilities disable the authoring catalog while raw JSON remains available', async () => {
+    mocks.apiClient.get.mockResolvedValueOnce({
+      ...vnCapabilitiesResponse,
+      features: { ...vnCapabilitiesResponse.features, script_authoring_catalog: false },
+    });
+    render(<VNScriptsWorkbench />);
+
+    expect(await screen.findByLabelText('Draft JSON')).toBeInTheDocument();
+    await waitFor(() => expect(mocks.apiClient.get).toHaveBeenCalledWith('/vn/vn-capabilities'));
+    expect(mocks.getVNScriptAuthoringCatalog).not.toHaveBeenCalled();
+    expect(screen.queryByRole('heading', { name: 'Guided insert' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save draft' })).toBeEnabled();
+  });
+
+  it('keeps raw JSON usable and shows non-blocking status when catalog loading fails', async () => {
+    mocks.getVNScriptAuthoringCatalog.mockRejectedValueOnce(new Error('catalog offline'));
+    const user = userEvent.setup();
+    render(<VNScriptsWorkbench />);
+
+    const editor = await screen.findByLabelText('Draft JSON');
+    expect(await screen.findByText('Guided insert catalog unavailable. Raw JSON editing remains available.')).toBeInTheDocument();
+    fireEvent.change(editor, { target: { value: JSON.stringify({ scenes: [{ id: 'manual' }] }) } });
+    await user.click(screen.getByRole('button', { name: 'Save draft' }));
+
+    await waitFor(() => {
+      expect(mocks.putVNScriptDraft).toHaveBeenCalledWith(1, {
+        if_revision: 3,
+        draft: { scenes: [{ id: 'manual' }] },
+      });
+    });
+  });
+
+  it('renders simple snippet parameter inputs from schema and defaults after selecting a snippet', async () => {
+    const user = userEvent.setup();
+    render(<VNScriptsWorkbench />);
+
+    await user.click(await screen.findByRole('button', { name: /Generated choice set/ }));
+
+    expect(screen.getByLabelText('Prompt')).toHaveValue('Offer three routes.');
+    expect(screen.getByLabelText('Choice count')).toHaveValue(3);
+    expect(screen.getByLabelText('Shuffle choices')).not.toBeChecked();
+    expect((screen.getByRole('option', { name: 'dramatic' }) as HTMLOptionElement).selected).toBe(true);
+
+    await user.clear(screen.getByLabelText('Prompt'));
+    await user.type(screen.getByLabelText('Prompt'), 'Offer two clues.');
+    await user.clear(screen.getByLabelText('Choice count'));
+    await user.type(screen.getByLabelText('Choice count'), '2');
+    await user.click(screen.getByLabelText('Shuffle choices'));
+    await user.selectOptions(screen.getByLabelText('Tone'), screen.getByRole('option', { name: 'quiet' }));
+    expect(screen.getByLabelText('Prompt')).toHaveValue('Offer two clues.');
+    expect(screen.getByLabelText('Choice count')).toHaveValue(2);
+    expect(screen.getByLabelText('Shuffle choices')).toBeChecked();
+    expect((screen.getByRole('option', { name: 'quiet' }) as HTMLOptionElement).selected).toBe(true);
+  });
+
+  it('preserves numeric and boolean enum parameter values when previewing', async () => {
+    const user = userEvent.setup();
+    render(<VNScriptsWorkbench />);
+
+    await user.click(await screen.findByRole('button', { name: /Typed enum snippet/ }));
+    expect((screen.getByRole('option', { name: '2' }) as HTMLOptionElement).selected).toBe(true);
+    expect((screen.getByRole('option', { name: 'true' }) as HTMLOptionElement).selected).toBe(true);
+
+    await user.selectOptions(screen.getByLabelText('Difficulty'), screen.getByRole('option', { name: '3' }));
+    await user.selectOptions(screen.getByLabelText('Include recap'), screen.getByRole('option', { name: 'false' }));
+    await user.click(screen.getByRole('button', { name: 'Preview snippet' }));
+
+    await waitFor(() => {
+      expect(mocks.previewVNScriptSnippet).toHaveBeenCalledWith(1, expect.objectContaining({
+        snippet_id: 'typed_enum_snippet',
+        parameters: {
+          difficulty: 3,
+          includeRecap: false,
+        },
+      }));
+    });
+  });
+
+  it('previews a selected snippet without updating the stored draft revision', async () => {
+    const user = userEvent.setup();
+    render(<VNScriptsWorkbench />);
+
+    await user.click(await screen.findByRole('button', { name: /Generated choice set/ }));
+    await user.click(screen.getByRole('button', { name: 'Preview snippet' }));
+
+    await waitFor(() => {
+      expect(mocks.previewVNScriptSnippet).toHaveBeenCalledWith(1, {
+        snippet_id: 'generated_choice_set',
+        anchor: { label: 'start', mode: 'append', op_index: null },
+        parameters: {
+          prompt: 'Offer three routes.',
+          count: 3,
+          shuffle: false,
+          tone: 'dramatic',
+        },
+        draft: { scenes: [{ id: 'start', text: 'Wake up.' }] },
+        draft_revision: 3,
+      });
+    });
+    expect(await screen.findByText(/Preview inserted 2 operations/)).toBeInTheDocument();
+    expect(screen.getByText(/labels.start\[1\]/)).toBeInTheDocument();
+    expect(screen.getByText(/preview_nodes/)).toBeInTheDocument();
+    expect(screen.getByText(/Revision 3/)).toBeInTheDocument();
+    expect(screen.queryByDisplayValue(/choices/)).not.toBeInTheDocument();
+  });
+
+  it('applies a selected snippet with current draft revision and updates the draft from the backend response', async () => {
+    const user = userEvent.setup();
+    render(<VNScriptsWorkbench />);
+
+    await user.click(await screen.findByRole('button', { name: /Generated choice set/ }));
+    expect(screen.getByRole('button', { name: 'Apply snippet' })).toBeDisabled();
+    await user.click(screen.getByRole('button', { name: 'Preview snippet' }));
+    expect(await screen.findByText(/Preview inserted 2 operations/)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Apply snippet' }));
+
+    await waitFor(() => {
+      expect(mocks.applyVNScriptSnippet).toHaveBeenCalledWith(1, {
+        if_revision: 3,
+        snippet_id: 'generated_choice_set',
+        anchor: { label: 'start', mode: 'append', op_index: null },
+        parameters: {
+          prompt: 'Offer three routes.',
+          count: 3,
+          shuffle: false,
+          tone: 'dramatic',
+        },
+      });
+    });
+    expect(await screen.findByText('Applied snippet at revision 4.')).toBeInTheDocument();
+    expect(screen.getByText(/labels.choice_intro/)).toBeInTheDocument();
+    expect(screen.getByDisplayValue(/choices/)).toBeInTheDocument();
+    expect(screen.getByText(/Revision 4/)).toBeInTheDocument();
+    expect(screen.getAllByText(/applied_nodes/).length).toBeGreaterThan(0);
+  });
+
+  it('invalidates snippet preview before apply when parameters change after preview', async () => {
+    const user = userEvent.setup();
+    render(<VNScriptsWorkbench />);
+
+    await user.click(await screen.findByRole('button', { name: /Generated choice set/ }));
+    await user.click(screen.getByRole('button', { name: 'Preview snippet' }));
+    expect(await screen.findByText(/Preview inserted 2 operations/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Apply snippet' })).toBeEnabled();
+
+    await user.clear(screen.getByLabelText('Prompt'));
+    await user.type(screen.getByLabelText('Prompt'), 'Offer a revised route.');
+
+    expect(screen.queryByText(/Preview inserted 2 operations/)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Apply snippet' })).toBeDisabled();
+    await user.click(screen.getByRole('button', { name: 'Apply snippet' }));
+    expect(mocks.applyVNScriptSnippet).not.toHaveBeenCalled();
+  });
+
+  it('keeps apply disabled after previewing unsaved raw JSON edits', async () => {
+    const user = userEvent.setup();
+    render(<VNScriptsWorkbench />);
+
+    await user.click(await screen.findByRole('button', { name: /Generated choice set/ }));
+    const editor = screen.getByLabelText('Draft JSON');
+    fireEvent.change(editor, {
+      target: { value: JSON.stringify({ scenes: [{ id: 'unsaved', text: 'Unsaved buffer.' }] }) },
+    });
+    await user.click(screen.getByRole('button', { name: 'Preview snippet' }));
+
+    await waitFor(() => {
+      expect(mocks.previewVNScriptSnippet).toHaveBeenCalledWith(1, expect.objectContaining({
+        draft: { scenes: [{ id: 'unsaved', text: 'Unsaved buffer.' }] },
+      }));
+    });
+    expect(await screen.findByText(/Preview inserted 2 operations/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Apply snippet' })).toBeDisabled();
+    await user.click(screen.getByRole('button', { name: 'Apply snippet' }));
+    expect(mocks.applyVNScriptSnippet).not.toHaveBeenCalled();
+  });
+
+  it('ignores stale snippet preview responses after raw JSON changes while preview is in flight', async () => {
+    const user = userEvent.setup();
+    const preview = createDeferred<{
+      script_id: number;
+      base_revision: number;
+      snippet_id: string;
+      draft: Record<string, unknown>;
+      diagnostics: Record<string, unknown>;
+      patch_summary: { inserted_ops: number; created_labels: string[]; changed_paths: string[] };
+      warnings: Array<Record<string, unknown>>;
+    }>();
+    mocks.previewVNScriptSnippet.mockReturnValueOnce(preview.promise);
+    render(<VNScriptsWorkbench />);
+
+    await user.click(await screen.findByRole('button', { name: /Generated choice set/ }));
+    await user.click(screen.getByRole('button', { name: 'Preview snippet' }));
+    await waitFor(() => expect(mocks.previewVNScriptSnippet).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(screen.getByLabelText('Draft JSON'), {
+      target: { value: JSON.stringify({ scenes: [{ id: 'changed', text: 'Changed while previewing.' }] }) },
+    });
+    preview.resolve({
+      script_id: 1,
+      base_revision: 3,
+      snippet_id: 'generated_choice_set',
+      draft: { scenes: [{ id: 'start' }], choices: [{ prompt: 'stale preview' }] },
+      diagnostics: { valid: true, preview_nodes: 2 },
+      patch_summary: {
+        inserted_ops: 2,
+        created_labels: ['stale_preview'],
+        changed_paths: ['labels.start[1]'],
+      },
+      warnings: [],
+    });
+
+    await waitFor(() => expect(screen.queryByText(/stale_preview/)).not.toBeInTheDocument());
+    expect(screen.queryByText(/Preview inserted 2 operations/)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Apply snippet' })).toBeDisabled();
+  });
+
+  it('ignores older snippet preview responses when raw JSON changed and a newer preview is current', async () => {
+    const user = userEvent.setup();
+    const firstPreview = createDeferred<{
+      script_id: number;
+      base_revision: number;
+      snippet_id: string;
+      draft: Record<string, unknown>;
+      diagnostics: Record<string, unknown>;
+      patch_summary: { inserted_ops: number; created_labels: string[]; changed_paths: string[] };
+      warnings: Array<Record<string, unknown>>;
+    }>();
+    const secondPreview = createDeferred<{
+      script_id: number;
+      base_revision: number;
+      snippet_id: string;
+      draft: Record<string, unknown>;
+      diagnostics: Record<string, unknown>;
+      patch_summary: { inserted_ops: number; created_labels: string[]; changed_paths: string[] };
+      warnings: Array<Record<string, unknown>>;
+    }>();
+    mocks.previewVNScriptSnippet
+      .mockReturnValueOnce(firstPreview.promise)
+      .mockReturnValueOnce(secondPreview.promise);
+    render(<VNScriptsWorkbench />);
+
+    await user.click(await screen.findByRole('button', { name: /Generated choice set/ }));
+    await user.click(screen.getByRole('button', { name: 'Preview snippet' }));
+    await waitFor(() => expect(mocks.previewVNScriptSnippet).toHaveBeenCalledTimes(1));
+    fireEvent.change(screen.getByLabelText('Draft JSON'), {
+      target: { value: JSON.stringify({ scenes: [{ id: 'changed', text: 'Changed before preview B.' }] }) },
+    });
+    await waitFor(() => expect(screen.getByDisplayValue(/Changed before preview B/)).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: 'Preview snippet' }));
+    await waitFor(() => expect(mocks.previewVNScriptSnippet).toHaveBeenCalledTimes(2));
+
+    secondPreview.resolve({
+      script_id: 1,
+      base_revision: 3,
+      snippet_id: 'generated_choice_set',
+      draft: { scenes: [{ id: 'changed' }], choices: [{ prompt: 'current preview' }] },
+      diagnostics: { valid: true, preview_nodes: 2 },
+      patch_summary: {
+        inserted_ops: 2,
+        created_labels: ['current_preview'],
+        changed_paths: ['labels.current_preview[1]'],
+      },
+      warnings: [],
+    });
+    expect(await screen.findByText(/current_preview/)).toBeInTheDocument();
+
+    firstPreview.resolve({
+      script_id: 1,
+      base_revision: 3,
+      snippet_id: 'generated_choice_set',
+      draft: { scenes: [{ id: 'start' }], choices: [{ prompt: 'stale preview' }] },
+      diagnostics: { valid: true, preview_nodes: 2 },
+      patch_summary: {
+        inserted_ops: 1,
+        created_labels: ['stale_preview_a'],
+        changed_paths: ['labels.stale_preview_a[1]'],
+      },
+      warnings: [],
+    });
+
+    await waitFor(() => expect(screen.queryByText(/stale_preview_a/)).not.toBeInTheDocument());
+    expect(screen.getByText(/current_preview/)).toBeInTheDocument();
+  });
+
+  it('ignores stale snippet apply responses after switching scripts', async () => {
+    const user = userEvent.setup();
+    const apply = createDeferred<{
+      script_id: number;
+      revision: number;
+      snippet_id: string;
+      draft: Record<string, unknown>;
+      diagnostics: Record<string, unknown>;
+      patch_summary: { inserted_ops: number; created_labels: string[]; changed_paths: string[] };
+    }>();
+    mocks.applyVNScriptSnippet.mockReturnValueOnce(apply.promise);
+    mocks.getVNScriptDraft.mockImplementation(async (scriptId: number) =>
+      scriptId === 2
+        ? { ...draftResponse, script_id: 2, draft: { scenes: [{ id: 'second', text: 'Look around.' }] } }
+        : draftResponse
+    );
+    mocks.listVNScriptVersions.mockImplementation((scriptId: number) =>
+      Promise.resolve({
+        items: scriptId === 2 ? [secondVersionResponse] : [versionResponse],
+        limit: 25,
+        offset: 0,
+        total: 1,
+        has_more: false,
+        pagination: { limit: 25, offset: 0, total: 1, has_more: false },
+      })
+    );
+    render(<VNScriptsWorkbench />);
+
+    await user.click(await screen.findByRole('button', { name: /Generated choice set/ }));
+    await user.click(screen.getByRole('button', { name: 'Preview snippet' }));
+    expect(await screen.findByText(/Preview inserted 2 operations/)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Apply snippet' }));
+    await waitFor(() => expect(mocks.applyVNScriptSnippet).toHaveBeenCalledTimes(1));
+
+    await user.click(screen.getByRole('button', { name: /Second Route/ }));
+    await screen.findByText('Script #2');
+    apply.resolve({
+      script_id: 1,
+      revision: 4,
+      snippet_id: 'generated_choice_set',
+      draft: { scenes: [{ id: 'start' }], choices: [{ prompt: 'stale' }] },
+      diagnostics: { valid: true, stale_nodes: 2 },
+      patch_summary: {
+        inserted_ops: 2,
+        created_labels: ['stale_choice'],
+        changed_paths: ['labels.start[1]'],
+      },
+    });
+
+    await waitFor(() => expect(screen.getByDisplayValue(/Look around/)).toBeInTheDocument());
+    expect(screen.queryByDisplayValue(/stale/)).not.toBeInTheDocument();
+    expect(screen.queryByText('Applied snippet at revision 4.')).not.toBeInTheDocument();
+  });
+
+  it('ignores stale conflict reload responses after switching scripts', async () => {
+    const user = userEvent.setup();
+    const conflict = new Error('[object Object]') as Error & {
+      detail?: { details?: { reason?: string } };
+      status?: number;
+    };
+    const conflictReload = createDeferred<typeof draftResponse>();
+    let openingDraftCalls = 0;
+    conflict.status = 409;
+    conflict.detail = { details: { reason: 'draft_revision_conflict' } };
+    mocks.applyVNScriptSnippet.mockRejectedValueOnce(conflict);
+    mocks.getVNScriptDraft.mockImplementation(async (scriptId: number) => {
+      if (scriptId === 2) {
+        return { ...draftResponse, script_id: 2, draft: { scenes: [{ id: 'second', text: 'Look around.' }] } };
+      }
+      openingDraftCalls += 1;
+      return openingDraftCalls === 1
+        ? draftResponse
+        : conflictReload.promise;
+    });
+    mocks.listVNScriptVersions.mockImplementation((scriptId: number) =>
+      Promise.resolve({
+        items: scriptId === 2 ? [secondVersionResponse] : [versionResponse],
+        limit: 25,
+        offset: 0,
+        total: 1,
+        has_more: false,
+        pagination: { limit: 25, offset: 0, total: 1, has_more: false },
+      })
+    );
+    render(<VNScriptsWorkbench />);
+
+    await user.click(await screen.findByRole('button', { name: /Generated choice set/ }));
+    await user.click(screen.getByRole('button', { name: 'Preview snippet' }));
+    expect(await screen.findByText(/Preview inserted 2 operations/)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Apply snippet' }));
+    await waitFor(() => expect(mocks.getVNScriptDraft).toHaveBeenCalledTimes(2));
+
+    await user.click(screen.getByRole('button', { name: /Second Route/ }));
+    await screen.findByText('Script #2');
+    conflictReload.resolve({
+      ...draftResponse,
+      revision: 5,
+      draft: { scenes: [{ id: 'conflict_reload', text: 'Old script reload.' }] },
+    });
+
+    await waitFor(() => expect(screen.getByDisplayValue(/Look around/)).toBeInTheDocument());
+    expect(screen.queryByDisplayValue(/conflict_reload/)).not.toBeInTheDocument();
+    expect(screen.queryByText('Draft changed on the server. Reloaded the latest draft; review before applying again.')).not.toBeInTheDocument();
+  });
+
+  it('ignores stale conflict reload errors after switching scripts', async () => {
+    const user = userEvent.setup();
+    const conflict = new Error('[object Object]') as Error & {
+      detail?: { details?: { reason?: string } };
+      status?: number;
+    };
+    const conflictReload = createDeferred<typeof draftResponse>();
+    let openingDraftCalls = 0;
+    conflict.status = 409;
+    conflict.detail = { details: { reason: 'draft_revision_conflict' } };
+    mocks.applyVNScriptSnippet.mockRejectedValueOnce(conflict);
+    mocks.getVNScriptDraft.mockImplementation(async (scriptId: number) => {
+      if (scriptId === 2) {
+        return { ...draftResponse, script_id: 2, draft: { scenes: [{ id: 'second', text: 'Look around.' }] } };
+      }
+      openingDraftCalls += 1;
+      return openingDraftCalls === 1
+        ? draftResponse
+        : conflictReload.promise;
+    });
+    mocks.listVNScriptVersions.mockImplementation((scriptId: number) =>
+      Promise.resolve({
+        items: scriptId === 2 ? [secondVersionResponse] : [versionResponse],
+        limit: 25,
+        offset: 0,
+        total: 1,
+        has_more: false,
+        pagination: { limit: 25, offset: 0, total: 1, has_more: false },
+      })
+    );
+    render(<VNScriptsWorkbench />);
+
+    await user.click(await screen.findByRole('button', { name: /Generated choice set/ }));
+    await user.click(screen.getByRole('button', { name: 'Preview snippet' }));
+    expect(await screen.findByText(/Preview inserted 2 operations/)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Apply snippet' }));
+    await waitFor(() => expect(mocks.getVNScriptDraft).toHaveBeenCalledTimes(2));
+
+    await user.click(screen.getByRole('button', { name: /Second Route/ }));
+    await screen.findByText('Script #2');
+    conflictReload.reject(new Error('reload_failed'));
+
+    await waitFor(() => expect(screen.getByDisplayValue(/Look around/)).toBeInTheDocument());
+    expect(screen.queryByText('Draft changed on the server. Refresh the draft before applying again.')).not.toBeInTheDocument();
+  });
+
+  it('invalidates snippet preview before apply when switching scripts with the same draft revision', async () => {
+    const user = userEvent.setup();
+    mocks.getVNScriptDraft.mockImplementation(async (scriptId: number) =>
+      scriptId === 2
+        ? { ...draftResponse, script_id: 2, draft: { scenes: [{ id: 'second', text: 'Look around.' }] } }
+        : draftResponse
+    );
+    mocks.listVNScriptVersions.mockImplementation((scriptId: number) =>
+      Promise.resolve({
+        items: scriptId === 2 ? [secondVersionResponse] : [versionResponse],
+        limit: 25,
+        offset: 0,
+        total: 1,
+        has_more: false,
+        pagination: { limit: 25, offset: 0, total: 1, has_more: false },
+      })
+    );
+    render(<VNScriptsWorkbench />);
+
+    await user.click(await screen.findByRole('button', { name: /Generated choice set/ }));
+    await user.click(screen.getByRole('button', { name: 'Preview snippet' }));
+    expect(await screen.findByText(/Preview inserted 2 operations/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Apply snippet' })).toBeEnabled();
+
+    await user.click(screen.getByRole('button', { name: /Second Route/ }));
+    await screen.findByText('Script #2');
+
+    expect(screen.queryByText(/Preview inserted 2 operations/)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Apply snippet' })).toBeDisabled();
+    await user.click(screen.getByRole('button', { name: 'Apply snippet' }));
+    expect(mocks.applyVNScriptSnippet).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole('button', { name: 'Preview snippet' }));
+    await waitFor(() => {
+      expect(mocks.previewVNScriptSnippet).toHaveBeenLastCalledWith(2, expect.objectContaining({
+        draft_revision: 3,
+      }));
+    });
+    expect(await screen.findByText(/Preview inserted 2 operations/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Apply snippet' })).toBeEnabled();
+  });
+
+  it('handles draft revision conflicts without duplicating snippet content', async () => {
+    const user = userEvent.setup();
+    const conflict = new Error('[object Object]') as Error & {
+      detail?: { details?: { reason?: string } };
+      status?: number;
+    };
+    conflict.status = 409;
+    conflict.detail = { details: { reason: 'draft_revision_conflict' } };
+    mocks.applyVNScriptSnippet.mockRejectedValueOnce(conflict);
+    render(<VNScriptsWorkbench />);
+
+    await user.click(await screen.findByRole('button', { name: /Generated choice set/ }));
+    await user.click(screen.getByRole('button', { name: 'Preview snippet' }));
+    expect(await screen.findByText(/Preview inserted 2 operations/)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Apply snippet' }));
+
+    expect(await screen.findByText('Draft changed on the server. Reloaded the latest draft; review before applying again.')).toBeInTheDocument();
+    await waitFor(() => expect(mocks.getVNScriptDraft).toHaveBeenCalledTimes(2));
+    expect(screen.getByDisplayValue(/Wake up/)).toBeInTheDocument();
+    expect(screen.queryByDisplayValue(/choices/)).not.toBeInTheDocument();
   });
 
   it('creates from a selected template and shows the returned draft immediately', async () => {

--- a/apps/tldw-frontend/__tests__/vn-scripts/vnScriptsApi.test.ts
+++ b/apps/tldw-frontend/__tests__/vn-scripts/vnScriptsApi.test.ts
@@ -15,10 +15,12 @@ vi.mock('@web/lib/api', () => ({
 }));
 
 import {
+  applyVNScriptSnippet,
   createVNScriptFromTemplate,
   createVNScript,
   deleteVNScript,
   evaluateVNScriptVersionPolicy,
+  getVNScriptAuthoringCatalog,
   getVNScript,
   getVNScriptDiagnostics,
   getVNScriptDraft,
@@ -28,6 +30,7 @@ import {
   listVNScripts,
   listVNScriptVersions,
   patchVNScript,
+  previewVNScriptSnippet,
   publishVNScript,
   putVNScriptDraft,
   validateVNScriptDraft,
@@ -213,6 +216,57 @@ describe('vnScripts api client', () => {
 
     expect(mocks.apiClient.post).toHaveBeenCalledWith(
       '/vn/vn-scripts/templates/linear_scene/scripts',
+      request
+    );
+  });
+
+  it('calls the VN script authoring catalog endpoint', async () => {
+    mocks.apiClient.get.mockResolvedValueOnce({
+      schema_version: 'vn_script_authoring_catalog.v1',
+      program_schema_version: 'vn_script_program.v1',
+      capability_tokens: ['script_authoring_catalog'],
+      generation_output_schemas: ['choice_set', 'narrative_dialogue', 'scene_update'],
+      operation_categories: { narration: ['narrate'] },
+      operations: [],
+      snippets: [],
+      limits: { max_operations: 100 },
+    });
+
+    const response = await getVNScriptAuthoringCatalog();
+
+    expect(response.schema_version).toBe('vn_script_authoring_catalog.v1');
+    expect(mocks.apiClient.get).toHaveBeenCalledWith('/vn/vn-scripts/vn-authoring-catalog');
+  });
+
+  it('calls the VN script snippet preview endpoint with the request payload', async () => {
+    const request = {
+      snippet_id: 'generated_choice_set',
+      anchor: { label: 'start', op_index: 1, mode: 'after' },
+      parameters: { prompt: 'Offer three routes.' },
+      draft: { labels: { start: [] } },
+      draft_revision: 4,
+    };
+
+    await previewVNScriptSnippet(17, request);
+
+    expect(mocks.apiClient.post).toHaveBeenCalledWith(
+      '/vn/vn-scripts/scripts/17/draft/snippet-preview',
+      request
+    );
+  });
+
+  it('calls the VN script snippet apply endpoint with the request payload', async () => {
+    const request = {
+      if_revision: 4,
+      snippet_id: 'generated_choice_set',
+      anchor: { label: 'start', op_index: 1, mode: 'after' },
+      parameters: { prompt: 'Offer three routes.' },
+    };
+
+    await applyVNScriptSnippet(17, request);
+
+    expect(mocks.apiClient.post).toHaveBeenCalledWith(
+      '/vn/vn-scripts/scripts/17/draft/snippet-apply',
       request
     );
   });

--- a/apps/tldw-frontend/components/vn-scripts/VNScriptsWorkbench.tsx
+++ b/apps/tldw-frontend/components/vn-scripts/VNScriptsWorkbench.tsx
@@ -133,9 +133,10 @@ function readErrorCode(record: Record<string, unknown> | null): string | undefin
   return (
     readString(record.reason) ??
     readString(record.error_code) ??
-    readString(record.code) ??
     readErrorCode(asRecord(record.detail)) ??
-    readErrorCode(asRecord(record.details))
+    readErrorCode(asRecord(record.details)) ??
+    readString(record.message) ??
+    readString(record.code)
   );
 }
 
@@ -255,6 +256,7 @@ export default function VNScriptsWorkbench() {
   const draftHydrationRef = useRef<VNScriptDraftResponse | null>(null);
   const publishKeyRef = useRef<Record<string, string>>({});
   const snippetPreviewContextKeyRef = useRef<string | null>(null);
+  const previewRequestIdRef = useRef(0);
 
   function clearSnippetPreviewState() {
     setSnippetPreview(null);
@@ -562,6 +564,8 @@ export default function VNScriptsWorkbench() {
     setSnippetPreview(null);
     setSnippetPreviewContextKey(null);
     snippetPreviewContextKeyRef.current = previewContextKey;
+    const previewRequestId = previewRequestIdRef.current + 1;
+    previewRequestIdRef.current = previewRequestId;
     try {
       const preview = await previewVNScriptSnippet(previewScriptId, {
         snippet_id: selectedSnippet.id,
@@ -587,7 +591,9 @@ export default function VNScriptsWorkbench() {
       }
       setSnippetError(errorMessage(previewError, 'Failed to preview snippet'));
     } finally {
-      setIsPreviewingSnippet(false);
+      if (previewRequestIdRef.current === previewRequestId) {
+        setIsPreviewingSnippet(false);
+      }
     }
   }, [
     currentSnippetPreviewContextKey,
@@ -602,6 +608,10 @@ export default function VNScriptsWorkbench() {
   const handleApplySnippet = useCallback(async () => {
     if (!selectedScript || !selectedSnippet || !draft || !hasCurrentSnippetPreview) return;
     const scriptId = selectedScript.id;
+    const applyContextKey = snippetPreviewContextKeyRef.current;
+    if (!applyContextKey) return;
+    const isApplyContextCurrent = () =>
+      selectedScriptIdRef.current === scriptId && snippetPreviewContextKeyRef.current === applyContextKey;
 
     setIsApplyingSnippet(true);
     setSnippetError(null);
@@ -613,7 +623,7 @@ export default function VNScriptsWorkbench() {
         anchor: snippetAnchor,
         parameters: snippetParameters,
       });
-      if (selectedScriptIdRef.current !== scriptId) return;
+      if (!isApplyContextCurrent()) return;
       const nextDraft = {
         script_id: applied.script_id,
         revision: applied.revision,
@@ -649,13 +659,13 @@ export default function VNScriptsWorkbench() {
       snippetPreviewContextKeyRef.current = null;
       setStatusMessage(`Applied snippet at revision ${applied.revision}.`);
     } catch (applyError) {
-      if (selectedScriptIdRef.current !== scriptId) return;
+      if (!isApplyContextCurrent()) return;
       const message = errorMessage(applyError, 'Failed to apply snippet');
       const errorCode = readErrorCode(asRecord(applyError));
       if (message === 'draft_revision_conflict' || errorCode === 'draft_revision_conflict') {
         try {
           const latestDraft = await getVNScriptDraft(scriptId);
-          if (selectedScriptIdRef.current !== scriptId) return;
+          if (!isApplyContextCurrent()) return;
           setDraft(latestDraft);
           setDraftText(formatJson(latestDraft.draft));
           setDiagnostics(null);
@@ -663,14 +673,16 @@ export default function VNScriptsWorkbench() {
           clearSnippetPreviewState();
           setStatusMessage('Draft changed on the server. Reloaded the latest draft; review before applying again.');
         } catch {
-          if (selectedScriptIdRef.current !== scriptId) return;
+          if (!isApplyContextCurrent()) return;
           setSnippetError('Draft changed on the server. Refresh the draft before applying again.');
         }
       } else {
         setSnippetError(message);
       }
     } finally {
-      setIsApplyingSnippet(false);
+      if (selectedScriptIdRef.current === scriptId) {
+        setIsApplyingSnippet(false);
+      }
     }
   }, [draft, hasCurrentSnippetPreview, selectedScript, selectedSnippet, snippetAnchor, snippetParameters]);
 
@@ -1144,7 +1156,13 @@ export default function VNScriptsWorkbench() {
                                 );
                               })}
                             </div>
-                            <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_130px]">
+                            <div
+                              className={
+                                snippetAnchor.mode === 'append'
+                                  ? 'grid gap-2 sm:grid-cols-[minmax(0,1fr)_130px]'
+                                  : 'grid gap-2 sm:grid-cols-[minmax(0,1fr)_130px_120px]'
+                              }
+                            >
                               <Input
                                 label="Anchor label"
                                 value={snippetAnchor.label}
@@ -1169,6 +1187,21 @@ export default function VNScriptsWorkbench() {
                                   <option value="after">after</option>
                                 </select>
                               </label>
+                              {snippetAnchor.mode !== 'append' && (
+                                <Input
+                                  label="Op index"
+                                  type="number"
+                                  min={0}
+                                  value={String(snippetAnchor.op_index ?? 0)}
+                                  onChange={(event) => {
+                                    const nextIndex = Number(event.target.value);
+                                    handleSnippetAnchorChange({
+                                      ...snippetAnchor,
+                                      op_index: Number.isInteger(nextIndex) && nextIndex >= 0 ? nextIndex : 0,
+                                    });
+                                  }}
+                                />
+                              )}
                             </div>
                             {snippetError && (
                               <p className="rounded-md border border-danger/30 bg-danger/10 p-2 text-sm text-danger">

--- a/apps/tldw-frontend/components/vn-scripts/VNScriptsWorkbench.tsx
+++ b/apps/tldw-frontend/components/vn-scripts/VNScriptsWorkbench.tsx
@@ -3,24 +3,32 @@ import { Badge } from '@web/components/ui/Badge';
 import { Button } from '@web/components/ui/Button';
 import { Input } from '@web/components/ui/Input';
 import JsonEditor from '@web/components/ui/JsonEditor';
+import { apiClient } from '@web/lib/api';
 import {
+  applyVNScriptSnippet,
   createVNScriptFromTemplate,
   createVNScript,
   evaluateVNScriptVersionPolicy,
+  getVNScriptAuthoringCatalog,
   getVNScriptDiagnostics,
   getVNScriptDraft,
   getVNScriptManifestSnapshot,
   listVNScriptTemplates,
   listVNScripts,
   listVNScriptVersions,
+  previewVNScriptSnippet,
   publishVNScript,
   putVNScriptDraft,
   validateVNScriptDraft,
 } from '@web/lib/api/vnScripts';
 import type {
+  VNScriptAuthoringCatalogResponse,
+  VNScriptAuthoringSnippet,
   VNScriptContentRating,
   VNScriptDiagnosticsResponse,
   VNScriptDraftResponse,
+  VNScriptSnippetAnchor,
+  VNScriptSnippetPreviewResponse,
   VNScriptResponse,
   VNScriptTemplateSummary,
   VNScriptValidationResponse,
@@ -28,6 +36,17 @@ import type {
 } from '@web/types/vn-scripts';
 
 const contentRatings: VNScriptContentRating[] = ['general', 'teen', 'suggestive', 'mature'];
+const defaultSnippetAnchor: VNScriptSnippetAnchor = { label: 'start', mode: 'append', op_index: null };
+
+interface VNCapabilities {
+  features?: Record<string, boolean>;
+}
+
+interface ParameterField {
+  enum?: unknown[];
+  title?: string;
+  type?: string | string[];
+}
 
 function formatJson(value: unknown): string {
   return JSON.stringify(value ?? {}, null, 2);
@@ -99,6 +118,98 @@ function summaryLines(value: unknown): string[] {
   return (JSON.stringify(summarized ?? null, null, 2) ?? 'null').split('\n');
 }
 
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined;
+}
+
+function readErrorCode(record: Record<string, unknown> | null): string | undefined {
+  if (!record) return undefined;
+  return (
+    readString(record.reason) ??
+    readString(record.error_code) ??
+    readString(record.code) ??
+    readErrorCode(asRecord(record.detail)) ??
+    readErrorCode(asRecord(record.details))
+  );
+}
+
+function titleCase(value: string): string {
+  return value
+    .replace(/[_-]+/g, ' ')
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function getParameterProperties(snippet: VNScriptAuthoringSnippet): Record<string, ParameterField> {
+  const properties = snippet.parameters_schema?.properties;
+  if (!properties || typeof properties !== 'object' || Array.isArray(properties)) return {};
+  return properties as Record<string, ParameterField>;
+}
+
+function parameterType(field: ParameterField): string | null {
+  if (Array.isArray(field.type)) {
+    return field.type.find((type) => type !== 'null') ?? null;
+  }
+  return field.type ?? null;
+}
+
+function enumOptionValue(index: number): string {
+  return `enum-${index}`;
+}
+
+function enumValueFromOption(field: ParameterField, optionValue: unknown): unknown {
+  if (!field.enum?.length || typeof optionValue !== 'string') return optionValue;
+  const match = /^enum-(\d+)$/.exec(optionValue);
+  if (!match) return optionValue;
+  const index = Number(match[1]);
+  return Number.isInteger(index) && index >= 0 && index < field.enum.length
+    ? field.enum[index]
+    : optionValue;
+}
+
+function selectedEnumOptionValue(field: ParameterField, value: unknown): string {
+  const index = field.enum?.findIndex((option) => Object.is(option, value)) ?? -1;
+  return index >= 0 ? enumOptionValue(index) : '';
+}
+
+function coerceParameterValue(field: ParameterField, value: unknown): unknown {
+  const type = parameterType(field);
+  if (field.enum?.length) return enumValueFromOption(field, value);
+  if (type === 'number' || type === 'integer') {
+    if (value === '') return '';
+    const nextNumber = Number(value);
+    return Number.isFinite(nextNumber) ? nextNumber : value;
+  }
+  if (type === 'boolean') return Boolean(value);
+  if (type === 'string') return String(value ?? '');
+  if (typeof value === 'string') {
+    try {
+      return JSON.parse(value);
+    } catch {
+      return value;
+    }
+  }
+  return value;
+}
+
+function snippetCategory(
+  snippet: VNScriptAuthoringSnippet,
+  catalog: VNScriptAuthoringCatalogResponse
+): string {
+  const firstOperation = snippet.operation_sequence[0];
+  const operationCategory = catalog.operations.find((operation) => operation.op === firstOperation)?.category;
+  if (operationCategory) return operationCategory;
+  const categoryMatch = Object.entries(catalog.operation_categories).find(([, operations]) =>
+    operations.includes(firstOperation)
+  );
+  return categoryMatch?.[0] ?? 'other';
+}
+
 export default function VNScriptsWorkbench() {
   const [scripts, setScripts] = useState<VNScriptResponse[]>([]);
   const [templates, setTemplates] = useState<VNScriptTemplateSummary[]>([]);
@@ -110,8 +221,11 @@ export default function VNScriptsWorkbench() {
   const [diagnostics, setDiagnostics] = useState<VNScriptDiagnosticsResponse | null>(null);
   const [manifestSnapshots, setManifestSnapshots] = useState<Record<number, unknown>>({});
   const [policySummaries, setPolicySummaries] = useState<Record<number, unknown>>({});
+  const [vnCapabilities, setVnCapabilities] = useState<VNCapabilities | null>(null);
+  const [authoringCatalog, setAuthoringCatalog] = useState<VNScriptAuthoringCatalogResponse | null>(null);
   const [isLoadingScripts, setIsLoadingScripts] = useState(true);
   const [isLoadingTemplates, setIsLoadingTemplates] = useState(true);
+  const [isLoadingCatalog, setIsLoadingCatalog] = useState(false);
   const [isCreating, setIsCreating] = useState(false);
   const [isSavingDraft, setIsSavingDraft] = useState(false);
   const [isValidating, setIsValidating] = useState(false);
@@ -128,9 +242,25 @@ export default function VNScriptsWorkbench() {
   const [contentRating, setContentRating] = useState<VNScriptContentRating>('teen');
   const [selectedTemplateId, setSelectedTemplateId] = useState('blank');
   const [publishLabel, setPublishLabel] = useState('');
+  const [catalogStatus, setCatalogStatus] = useState<string | null>(null);
+  const [selectedSnippetId, setSelectedSnippetId] = useState('');
+  const [snippetParameters, setSnippetParameters] = useState<Record<string, unknown>>({});
+  const [snippetAnchor, setSnippetAnchor] = useState<VNScriptSnippetAnchor>(defaultSnippetAnchor);
+  const [snippetPreview, setSnippetPreview] = useState<VNScriptSnippetPreviewResponse | null>(null);
+  const [snippetPreviewContextKey, setSnippetPreviewContextKey] = useState<string | null>(null);
+  const [isPreviewingSnippet, setIsPreviewingSnippet] = useState(false);
+  const [isApplyingSnippet, setIsApplyingSnippet] = useState(false);
+  const [snippetError, setSnippetError] = useState<string | null>(null);
   const selectedScriptIdRef = useRef<number | null>(null);
   const draftHydrationRef = useRef<VNScriptDraftResponse | null>(null);
   const publishKeyRef = useRef<Record<string, string>>({});
+  const snippetPreviewContextKeyRef = useRef<string | null>(null);
+
+  function clearSnippetPreviewState() {
+    setSnippetPreview(null);
+    setSnippetPreviewContextKey(null);
+    snippetPreviewContextKeyRef.current = null;
+  }
 
   useEffect(() => {
     selectedScriptIdRef.current = selectedScript?.id ?? null;
@@ -151,6 +281,65 @@ export default function VNScriptsWorkbench() {
     [selectedTemplateId, templates]
   );
 
+  const catalogCapabilityTokens = useMemo(() => {
+    const tokens = new Set<string>();
+    if (vnCapabilities?.features) {
+      Object.entries(vnCapabilities.features).forEach(([feature, enabled]) => {
+        if (enabled) tokens.add(feature);
+      });
+    }
+    authoringCatalog?.capability_tokens.forEach((token) => tokens.add(token));
+    authoringCatalog?.generation_output_schemas.forEach((schema) => tokens.add(schema));
+    return tokens;
+  }, [authoringCatalog, vnCapabilities]);
+
+  const visibleSnippets = useMemo(() => {
+    if (!authoringCatalog) return [];
+    return authoringCatalog.snippets.filter((snippet) => {
+      if (!vnCapabilities) return true;
+      return snippet.required_capability_tokens.every((token) => catalogCapabilityTokens.has(token));
+    });
+  }, [authoringCatalog, catalogCapabilityTokens, vnCapabilities]);
+
+  const groupedSnippets = useMemo(() => {
+    if (!authoringCatalog) return [];
+    const groups = new Map<string, VNScriptAuthoringSnippet[]>();
+    visibleSnippets.forEach((snippet) => {
+      const category = snippetCategory(snippet, authoringCatalog);
+      groups.set(category, [...(groups.get(category) ?? []), snippet]);
+    });
+    return Array.from(groups.entries()).sort(([left], [right]) => left.localeCompare(right));
+  }, [authoringCatalog, visibleSnippets]);
+
+  const selectedSnippet = useMemo(
+    () => visibleSnippets.find((snippet) => snippet.id === selectedSnippetId) ?? null,
+    [selectedSnippetId, visibleSnippets]
+  );
+
+  const savedDraftText = useMemo(() => formatJson(draft?.draft), [draft?.draft]);
+  const hasUnsavedDraftText = draftText !== savedDraftText;
+
+  const currentSnippetPreviewContextKey = useMemo(() => {
+    if (!selectedScript || !selectedSnippet || !draft) return null;
+    return JSON.stringify({
+      script_id: selectedScript.id,
+      draft_script_id: draft.script_id,
+      snippet_id: selectedSnippet.id,
+      anchor: snippetAnchor,
+      parameters: snippetParameters,
+      draft_revision: draft.revision,
+      draft_text: draftText,
+    });
+  }, [draft, draftText, selectedScript, selectedSnippet, snippetAnchor, snippetParameters]);
+
+  const hasCurrentSnippetPreview = Boolean(
+    snippetPreview &&
+    snippetPreviewContextKey &&
+    currentSnippetPreviewContextKey &&
+    snippetPreviewContextKey === currentSnippetPreviewContextKey &&
+    !hasUnsavedDraftText
+  );
+
   const handleTemplateChange = useCallback((templateId: string) => {
     setSelectedTemplateId(templateId);
     const nextTemplate = templates.find((template) => template.id === templateId);
@@ -164,6 +353,39 @@ export default function VNScriptsWorkbench() {
     if (selectedScriptIdRef.current === scriptId) {
       setVersions(nextVersions.items ?? []);
     }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadAuthoringCatalog() {
+      setIsLoadingCatalog(true);
+      setCatalogStatus(null);
+      try {
+        const capabilities = await apiClient.get('/vn/vn-capabilities') as VNCapabilities;
+        if (cancelled) return;
+        setVnCapabilities(capabilities);
+        if (capabilities.features?.script_authoring_catalog !== true) {
+          setAuthoringCatalog(null);
+          return;
+        }
+        const catalog = await getVNScriptAuthoringCatalog();
+        if (cancelled) return;
+        setAuthoringCatalog(catalog);
+      } catch {
+        if (!cancelled) {
+          setAuthoringCatalog(null);
+          setCatalogStatus('Guided insert catalog unavailable. Raw JSON editing remains available.');
+        }
+      } finally {
+        if (!cancelled) setIsLoadingCatalog(false);
+      }
+    }
+
+    void loadAuthoringCatalog();
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   useEffect(() => {
@@ -222,6 +444,7 @@ export default function VNScriptsWorkbench() {
       setDiagnostics(null);
       setManifestSnapshots({});
       setPolicySummaries({});
+      clearSnippetPreviewState();
       return;
     }
 
@@ -240,6 +463,7 @@ export default function VNScriptsWorkbench() {
         setDiagnostics(null);
         setManifestSnapshots({});
         setPolicySummaries({});
+        clearSnippetPreviewState();
         try {
           const nextVersions = await listVNScriptVersions(selectedScript.id);
           if (!cancelled) setVersions(nextVersions.items ?? []);
@@ -258,6 +482,7 @@ export default function VNScriptsWorkbench() {
       setDiagnostics(null);
       setManifestSnapshots({});
       setPolicySummaries({});
+      clearSnippetPreviewState();
       try {
         const [nextDraft, nextVersions] = await Promise.all([
           getVNScriptDraft(selectedScript.id),
@@ -299,6 +524,155 @@ export default function VNScriptsWorkbench() {
       return null;
     }
   }, [draftText]);
+
+  const handleSnippetSelect = useCallback((snippet: VNScriptAuthoringSnippet) => {
+    setSelectedSnippetId(snippet.id);
+    setSnippetParameters({ ...snippet.default_parameters });
+    clearSnippetPreviewState();
+    setSnippetError(null);
+  }, []);
+
+  const handleSnippetParameterChange = useCallback((
+    name: string,
+    field: ParameterField,
+    value: unknown
+  ) => {
+    setSnippetParameters((previous) => ({
+      ...previous,
+      [name]: coerceParameterValue(field, value),
+    }));
+    clearSnippetPreviewState();
+  }, []);
+
+  const handleSnippetAnchorChange = useCallback((nextAnchor: VNScriptSnippetAnchor) => {
+    setSnippetAnchor(nextAnchor);
+    clearSnippetPreviewState();
+  }, []);
+
+  const handlePreviewSnippet = useCallback(async () => {
+    if (!selectedScript || !selectedSnippet) return;
+    const previewScriptId = selectedScript.id;
+    const previewContextKey = currentSnippetPreviewContextKey;
+    const requestDraft = parseDraftText();
+    if (!requestDraft) return;
+    if (!previewContextKey) return;
+
+    setIsPreviewingSnippet(true);
+    setSnippetError(null);
+    setSnippetPreview(null);
+    setSnippetPreviewContextKey(null);
+    snippetPreviewContextKeyRef.current = previewContextKey;
+    try {
+      const preview = await previewVNScriptSnippet(previewScriptId, {
+        snippet_id: selectedSnippet.id,
+        anchor: snippetAnchor,
+        parameters: snippetParameters,
+        draft: requestDraft,
+        draft_revision: draft?.revision ?? null,
+      });
+      if (
+        selectedScriptIdRef.current !== previewScriptId ||
+        snippetPreviewContextKeyRef.current !== previewContextKey
+      ) {
+        return;
+      }
+      setSnippetPreview(preview);
+      setSnippetPreviewContextKey(previewContextKey);
+    } catch (previewError) {
+      if (
+        selectedScriptIdRef.current !== previewScriptId ||
+        snippetPreviewContextKeyRef.current !== previewContextKey
+      ) {
+        return;
+      }
+      setSnippetError(errorMessage(previewError, 'Failed to preview snippet'));
+    } finally {
+      setIsPreviewingSnippet(false);
+    }
+  }, [
+    currentSnippetPreviewContextKey,
+    draft?.revision,
+    parseDraftText,
+    selectedScript,
+    selectedSnippet,
+    snippetAnchor,
+    snippetParameters,
+  ]);
+
+  const handleApplySnippet = useCallback(async () => {
+    if (!selectedScript || !selectedSnippet || !draft || !hasCurrentSnippetPreview) return;
+    const scriptId = selectedScript.id;
+
+    setIsApplyingSnippet(true);
+    setSnippetError(null);
+    setStatusMessage(null);
+    try {
+      const applied = await applyVNScriptSnippet(scriptId, {
+        if_revision: draft.revision,
+        snippet_id: selectedSnippet.id,
+        anchor: snippetAnchor,
+        parameters: snippetParameters,
+      });
+      if (selectedScriptIdRef.current !== scriptId) return;
+      const nextDraft = {
+        script_id: applied.script_id,
+        revision: applied.revision,
+        draft: applied.draft,
+        diagnostics: applied.diagnostics,
+      };
+      setDraft(nextDraft);
+      setDraftText(formatJson(applied.draft));
+      setDiagnostics({
+        script_id: applied.script_id,
+        revision: applied.revision,
+        diagnostics: applied.diagnostics,
+      });
+      setValidation(
+        typeof applied.diagnostics.valid === 'boolean'
+          ? {
+              valid: applied.diagnostics.valid,
+              errors: Array.isArray(applied.diagnostics.errors) ? applied.diagnostics.errors : [],
+              warnings: Array.isArray(applied.diagnostics.warnings) ? applied.diagnostics.warnings : [],
+            }
+          : null
+      );
+      setSnippetPreview({
+        script_id: applied.script_id,
+        base_revision: draft.revision,
+        snippet_id: applied.snippet_id,
+        draft: applied.draft,
+        diagnostics: applied.diagnostics,
+        patch_summary: applied.patch_summary,
+        warnings: [],
+      });
+      setSnippetPreviewContextKey(null);
+      snippetPreviewContextKeyRef.current = null;
+      setStatusMessage(`Applied snippet at revision ${applied.revision}.`);
+    } catch (applyError) {
+      if (selectedScriptIdRef.current !== scriptId) return;
+      const message = errorMessage(applyError, 'Failed to apply snippet');
+      const errorCode = readErrorCode(asRecord(applyError));
+      if (message === 'draft_revision_conflict' || errorCode === 'draft_revision_conflict') {
+        try {
+          const latestDraft = await getVNScriptDraft(scriptId);
+          if (selectedScriptIdRef.current !== scriptId) return;
+          setDraft(latestDraft);
+          setDraftText(formatJson(latestDraft.draft));
+          setDiagnostics(null);
+          setValidation(null);
+          clearSnippetPreviewState();
+          setStatusMessage('Draft changed on the server. Reloaded the latest draft; review before applying again.');
+        } catch {
+          if (selectedScriptIdRef.current !== scriptId) return;
+          setSnippetError('Draft changed on the server. Refresh the draft before applying again.');
+        }
+      } else {
+        setSnippetError(message);
+      }
+    } finally {
+      setIsApplyingSnippet(false);
+    }
+  }, [draft, hasCurrentSnippetPreview, selectedScript, selectedSnippet, snippetAnchor, snippetParameters]);
 
   const handleCreateScript = useCallback(async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -670,8 +1044,196 @@ export default function VNScriptsWorkbench() {
                   </Button>
                 </div>
               </div>
+              {(isLoadingCatalog || authoringCatalog || catalogStatus) && (
+                <section className="mb-3 rounded-md border border-border bg-bg p-3">
+                  <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+                    <h2 className="text-sm font-semibold">Guided insert</h2>
+                    {isLoadingCatalog && <span className="text-xs text-text-muted">Loading catalog...</span>}
+                  </div>
+                  {catalogStatus && (
+                    <p className="rounded-md border border-warn/30 bg-warn/10 p-2 text-sm text-warn">
+                      {catalogStatus}
+                    </p>
+                  )}
+                  {authoringCatalog && (
+                    <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_minmax(240px,0.9fr)]">
+                      <div className="space-y-3">
+                        {groupedSnippets.length === 0 ? (
+                          <p className="text-sm text-text-muted">No snippets are available for the current backend capabilities.</p>
+                        ) : (
+                          groupedSnippets.map(([category, snippets]) => (
+                            <div key={category}>
+                              <h3 className="mb-1 text-xs font-semibold uppercase text-text-muted">{titleCase(category)}</h3>
+                              <div className="flex flex-wrap gap-2">
+                                {snippets.map((snippet) => (
+                                  <Button
+                                    key={snippet.id}
+                                    type="button"
+                                    size="xs"
+                                    variant={selectedSnippetId === snippet.id ? 'primary' : 'secondary'}
+                                    onClick={() => handleSnippetSelect(snippet)}
+                                  >
+                                    {snippet.label}
+                                  </Button>
+                                ))}
+                              </div>
+                            </div>
+                          ))
+                        )}
+                      </div>
+
+                      <div className="space-y-3">
+                        {selectedSnippet ? (
+                          <>
+                            <div className="grid gap-2 sm:grid-cols-2">
+                              {Object.entries(getParameterProperties(selectedSnippet)).map(([name, field]) => {
+                                const label = field.title ?? titleCase(name);
+                                const value = snippetParameters[name] ?? '';
+                                const type = parameterType(field);
+                                if (field.enum?.length) {
+                                  return (
+                                    <label key={name} className="block text-sm font-medium text-text">
+                                      <span className="mb-1 block">{label}</span>
+                                      <select
+                                        aria-label={label}
+                                        className="block w-full rounded-md border-border bg-bg shadow-sm focus:border-primary focus:ring-primary"
+                                        value={selectedEnumOptionValue(field, value)}
+                                        onChange={(event) => handleSnippetParameterChange(name, field, event.target.value)}
+                                      >
+                                        {field.enum.map((option, index) => (
+                                          <option key={`${index}:${String(option)}`} value={enumOptionValue(index)}>{String(option)}</option>
+                                        ))}
+                                      </select>
+                                    </label>
+                                  );
+                                }
+                                if (type === 'boolean') {
+                                  return (
+                                    <label key={name} className="flex items-center gap-2 text-sm font-medium text-text">
+                                      <input
+                                        aria-label={label}
+                                        type="checkbox"
+                                        checked={Boolean(value)}
+                                        onChange={(event) => handleSnippetParameterChange(name, field, event.target.checked)}
+                                      />
+                                      <span>{label}</span>
+                                    </label>
+                                  );
+                                }
+                                if (type === 'string' || type === 'number' || type === 'integer') {
+                                  return (
+                                    <Input
+                                      key={name}
+                                      label={label}
+                                      type={type === 'string' ? 'text' : 'number'}
+                                      value={type === 'string' ? String(value) : (value as number | '')}
+                                      onChange={(event) => handleSnippetParameterChange(name, field, event.target.value)}
+                                    />
+                                  );
+                                }
+                                return (
+                                  <label key={name} className="block text-sm font-medium text-text sm:col-span-2">
+                                    <span className="mb-1 block">{label}</span>
+                                    <textarea
+                                      aria-label={label}
+                                      className="min-h-24 w-full rounded-md border border-border bg-bg p-2 font-mono text-xs"
+                                      value={typeof value === 'string' ? value : formatJson(value)}
+                                      onChange={(event) => handleSnippetParameterChange(name, field, event.target.value)}
+                                    />
+                                  </label>
+                                );
+                              })}
+                            </div>
+                            <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_130px]">
+                              <Input
+                                label="Anchor label"
+                                value={snippetAnchor.label}
+                                onChange={(event) => handleSnippetAnchorChange({
+                                  ...snippetAnchor,
+                                  label: event.target.value,
+                                })}
+                              />
+                              <label className="block text-sm font-medium text-text">
+                                <span className="mb-1 block">Anchor mode</span>
+                                <select
+                                  className="block w-full rounded-md border-border bg-bg shadow-sm focus:border-primary focus:ring-primary"
+                                  value={snippetAnchor.mode ?? 'append'}
+                                  onChange={(event) => handleSnippetAnchorChange({
+                                    ...snippetAnchor,
+                                    mode: event.target.value as 'append' | 'before' | 'after',
+                                    op_index: event.target.value === 'append' ? null : snippetAnchor.op_index ?? 0,
+                                  })}
+                                >
+                                  <option value="append">append</option>
+                                  <option value="before">before</option>
+                                  <option value="after">after</option>
+                                </select>
+                              </label>
+                            </div>
+                            {snippetError && (
+                              <p className="rounded-md border border-danger/30 bg-danger/10 p-2 text-sm text-danger">
+                                {snippetError}
+                              </p>
+                            )}
+                            <div className="flex flex-wrap gap-2">
+                              <Button
+                                type="button"
+                                size="sm"
+                                variant="secondary"
+                                aria-busy={isPreviewingSnippet}
+                                disabled={!selectedScript || !draft}
+                                onClick={handlePreviewSnippet}
+                              >
+                                Preview snippet
+                              </Button>
+                              <Button
+                                type="button"
+                                size="sm"
+                                loading={isApplyingSnippet}
+                                disabled={!selectedScript || !draft || !hasCurrentSnippetPreview || hasUnsavedDraftText}
+                                onClick={handleApplySnippet}
+                              >
+                                Apply snippet
+                              </Button>
+                            </div>
+                          </>
+                        ) : (
+                          <p className="text-sm text-text-muted">Select a snippet to configure parameters.</p>
+                        )}
+                      </div>
+                    </div>
+                  )}
+                  {snippetPreview && (
+                    <div className="mt-3 grid gap-3 text-sm lg:grid-cols-2">
+                      <div className="rounded-md border border-border bg-surface p-2">
+                        <h3 className="text-xs font-semibold uppercase text-text-muted">Patch summary</h3>
+                        <p className="mt-1">
+                          Preview inserted {snippetPreview.patch_summary.inserted_ops} operations.
+                        </p>
+                        <p className="mt-1 break-words text-xs text-text-muted">
+                          Changed paths: {snippetPreview.patch_summary.changed_paths.join(', ') || 'none'}
+                        </p>
+                      </div>
+                      <div className="rounded-md border border-border bg-surface p-2">
+                        <h3 className="text-xs font-semibold uppercase text-text-muted">Preview diagnostics</h3>
+                        <pre className="mt-1 max-h-32 overflow-auto text-xs">
+                          {summaryLines(snippetPreview.diagnostics).join('\n')}
+                        </pre>
+                      </div>
+                    </div>
+                  )}
+                </section>
+              )}
               <div className="min-h-[420px] flex-1">
-                <JsonEditor value={draftText} onChange={setDraftText} height="100%" readOnly={!selectedScript} />
+                <JsonEditor
+                  value={draftText}
+                  onChange={(nextValue) => {
+                    setDraftText(nextValue);
+                    clearSnippetPreviewState();
+                  }}
+                  height="100%"
+                  readOnly={!selectedScript}
+                />
               </div>
             </div>
           </section>

--- a/apps/tldw-frontend/lib/api/vnScripts.ts
+++ b/apps/tldw-frontend/lib/api/vnScripts.ts
@@ -1,5 +1,6 @@
 import { apiClient } from '@web/lib/api';
 import type {
+  VNScriptAuthoringCatalogResponse,
   VNScriptCreate,
   VNScriptCreateFromTemplateRequest,
   VNScriptCreateFromTemplateResponse,
@@ -13,6 +14,10 @@ import type {
   VNScriptPublishRequest,
   VNScriptPublishResponse,
   VNScriptResponse,
+  VNScriptSnippetApplyRequest,
+  VNScriptSnippetApplyResponse,
+  VNScriptSnippetPreviewRequest,
+  VNScriptSnippetPreviewResponse,
   VNScriptTemplateListResponse,
   VNScriptValidateRequest,
   VNScriptValidationResponse,
@@ -39,6 +44,10 @@ export function createVNScript(request: VNScriptCreate): Promise<VNScriptRespons
 
 export function listVNScriptTemplates(): Promise<VNScriptTemplateListResponse> {
   return apiClient.get(`${VN_SCRIPTS_BASE}/templates`);
+}
+
+export function getVNScriptAuthoringCatalog(): Promise<VNScriptAuthoringCatalogResponse> {
+  return apiClient.get(`${VN_SCRIPTS_BASE}/vn-authoring-catalog`);
 }
 
 export function createVNScriptFromTemplate(
@@ -87,6 +96,20 @@ export function validateVNScriptDraft(
 
 export function getVNScriptDiagnostics(scriptId: number): Promise<VNScriptDiagnosticsResponse> {
   return apiClient.get(`${VN_SCRIPTS_BASE}/scripts/${scriptId}/draft/diagnostics`);
+}
+
+export function previewVNScriptSnippet(
+  scriptId: number,
+  request: VNScriptSnippetPreviewRequest
+): Promise<VNScriptSnippetPreviewResponse> {
+  return apiClient.post(`${VN_SCRIPTS_BASE}/scripts/${scriptId}/draft/snippet-preview`, request);
+}
+
+export function applyVNScriptSnippet(
+  scriptId: number,
+  request: VNScriptSnippetApplyRequest
+): Promise<VNScriptSnippetApplyResponse> {
+  return apiClient.post(`${VN_SCRIPTS_BASE}/scripts/${scriptId}/draft/snippet-apply`, request);
 }
 
 export function publishVNScript(

--- a/apps/tldw-frontend/types/vn-scripts.ts
+++ b/apps/tldw-frontend/types/vn-scripts.ts
@@ -74,7 +74,14 @@ export interface VNScriptAuthoringOperation {
   op: string;
   label: string;
   category: string;
+  description?: string | null;
+  fields: Array<Record<string, unknown>>;
   capability_tokens: string[];
+  forbidden_fields: string[];
+  supports_condition: boolean;
+  preview?: Record<string, unknown> | null;
+  output_compatibility: Record<string, unknown>;
+  notes: string[];
 }
 
 export interface VNScriptAuthoringSnippet {

--- a/apps/tldw-frontend/types/vn-scripts.ts
+++ b/apps/tldw-frontend/types/vn-scripts.ts
@@ -70,6 +70,79 @@ export interface VNScriptTemplateListResponse {
   items: VNScriptTemplateSummary[];
 }
 
+export interface VNScriptAuthoringOperation {
+  op: string;
+  label: string;
+  category: string;
+  capability_tokens: string[];
+}
+
+export interface VNScriptAuthoringSnippet {
+  id: string;
+  schema_version: 'vn_script_program.v1';
+  label: string;
+  operation_sequence: string[];
+  required_capability_tokens: string[];
+  parameters_schema: Record<string, unknown>;
+  default_parameters: Record<string, unknown>;
+  preview: Array<Record<string, unknown>>;
+}
+
+export interface VNScriptAuthoringCatalogResponse {
+  schema_version: 'vn_script_authoring_catalog.v1';
+  program_schema_version: 'vn_script_program.v1';
+  capability_tokens: string[];
+  generation_output_schemas: string[];
+  operation_categories: Record<string, string[]>;
+  operations: VNScriptAuthoringOperation[];
+  snippets: VNScriptAuthoringSnippet[];
+  limits: Record<string, number>;
+}
+
+export type VNScriptSnippetAnchor =
+  | { label: string; mode?: 'append'; op_index?: number | null }
+  | { label: string; mode: 'before' | 'after'; op_index: number };
+
+export interface VNScriptSnippetPreviewRequest {
+  snippet_id: string;
+  anchor: VNScriptSnippetAnchor;
+  parameters?: Record<string, unknown>;
+  draft?: Record<string, unknown> | null;
+  draft_revision?: number | null;
+}
+
+export interface VNScriptSnippetApplyRequest {
+  if_revision: number;
+  snippet_id: string;
+  anchor: VNScriptSnippetAnchor;
+  parameters?: Record<string, unknown>;
+}
+
+export interface VNScriptSnippetPatchSummary {
+  inserted_ops: number;
+  created_labels: string[];
+  changed_paths: string[];
+}
+
+export interface VNScriptSnippetPreviewResponse {
+  script_id: number;
+  base_revision: number;
+  snippet_id: string;
+  draft: Record<string, unknown>;
+  diagnostics: Record<string, unknown>;
+  patch_summary: VNScriptSnippetPatchSummary;
+  warnings: Array<Record<string, unknown>>;
+}
+
+export interface VNScriptSnippetApplyResponse {
+  script_id: number;
+  revision: number;
+  snippet_id: string;
+  draft: Record<string, unknown>;
+  diagnostics: Record<string, unknown>;
+  patch_summary: VNScriptSnippetPatchSummary;
+}
+
 export type VNScriptCreateFromTemplateRequest = Omit<VNScriptCreate, 'title'> & {
   title?: string | null;
 };

--- a/backlog/tasks/task-300 - Design-VN-script-operation-catalog-and-guided-draft-editing.md
+++ b/backlog/tasks/task-300 - Design-VN-script-operation-catalog-and-guided-draft-editing.md
@@ -1,0 +1,60 @@
+---
+id: TASK-300
+title: Design VN script operation catalog and guided draft editing
+status: Done
+assignee: []
+created_date: '2026-05-12 14:25'
+labels:
+  - vn
+  - vn-scripts
+  - authoring
+  - api
+  - webui
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1610'
+  - 'https://github.com/rmusser01/tldw_server/issues/1391'
+documentation:
+  - Docs/API-related/VN_PLATFORM_API.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Design the next API-first VN authoring sprint from GitHub issue #1610: backend-owned script operation/snippet catalog and server-validated guided draft editing for custom frontends and the bundled WebUI. Scope is design/spec first before implementation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Design defines backend-owned authoring catalog scope, opcode metadata, snippet metadata, and custom frontend contract.
+- [x] #2 Design defines server-side snippet preview/apply behavior and how it reuses existing draft validation/diagnostics.
+- [x] #3 Design preserves backend validation, manifest, policy, generation-profile, and publish authority without adding a frontend rule engine.
+- [x] #4 Design includes WebUI consumption model, error handling, tests, docs, and review risks.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Wrote design spec at `Docs/superpowers/specs/2026-05-12-vn-script-authoring-catalog-design.md`.
+- Ran a focused spec review through subagent Raman. Addressed findings around non-mutating preview validation, generation/profile-owned limits, generated-choice patch shape, strict parameter schemas, concrete error details, and backend-owned invalid-draft behavior.
+- Re-ran focused review through subagent Hegel; result was APPROVED.
+- Ran an additional local critique at user request before implementation planning. Tightened capability-token ownership, supplied-draft preview semantics, transport status mapping, and nested snippet-parameter validation.
+- Bandit skipped because this task only changes Markdown design/task documents.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Designed the VN script authoring catalog and guided draft editing API for issue #1610. The spec defines `vn-authoring-catalog`, snippet preview/apply endpoints, backend-owned validation and diagnostics boundaries, custom frontend behavior, WebUI consumption, error contracts, security controls, tests, rollout stages, and review risks.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-302 - Write-VN-script-authoring-catalog-implementation-plan.md
+++ b/backlog/tasks/task-302 - Write-VN-script-authoring-catalog-implementation-plan.md
@@ -1,0 +1,59 @@
+---
+id: TASK-302
+title: Write VN script authoring catalog implementation plan
+status: Done
+assignee: []
+created_date: '2026-05-12 14:50'
+labels:
+  - vn
+  - vn-scripts
+  - authoring
+  - api
+  - webui
+  - planning
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1610'
+documentation:
+  - Docs/superpowers/specs/2026-05-12-vn-script-authoring-catalog-design.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create the implementation plan for GitHub issue #1610 and the reviewed VN script authoring catalog design. Scope is plan-only: backend-owned authoring catalog, snippet preview/apply, WebUI consumption, tests, docs, and rollout tasks.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Implementation plan maps exact backend, frontend, test, and docs files for the reviewed authoring catalog design.
+- [x] #2 Plan decomposes work into test-driven tasks with verification commands and commit checkpoints.
+- [x] #3 Plan preserves backend-owned validation, diagnostics, policy, manifest, generation-profile, and publish authority.
+- [x] #4 Plan is reviewed for gaps before implementation begins.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Wrote implementation plan at `Docs/superpowers/plans/2026-05-12-vn-script-authoring-catalog.md`.
+- Plan review found issues around service/API sequencing, abuse limits, typed snippet exceptions, capability-first WebUI discovery, service-owned validation boundaries, and compile/import verification.
+- Addressed all review findings and re-ran the plan review; result was APPROVED.
+- Bandit skipped because this task only changes Markdown plan/task documents.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Created and reviewed the implementation plan for the VN script authoring catalog sprint. The plan breaks the work into backend catalog metadata, pure snippet patching, service preview/apply, API schemas/endpoints/capabilities/docs, frontend API client/types, WebUI guided insert panel, and final verification/PR prep.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-304 - Implement-VN-script-authoring-catalog-API-and-guided-editing.md
+++ b/backlog/tasks/task-304 - Implement-VN-script-authoring-catalog-API-and-guided-editing.md
@@ -1,0 +1,71 @@
+---
+id: TASK-304
+title: Implement VN script authoring catalog API and guided editing
+status: Done
+assignee: []
+created_date: '2026-05-12 15:07'
+labels:
+  - vn
+  - vn-scripts
+  - authoring
+  - api
+  - webui
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1610'
+documentation:
+  - Docs/superpowers/specs/2026-05-12-vn-script-authoring-catalog-design.md
+  - Docs/superpowers/plans/2026-05-12-vn-script-authoring-catalog.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the approved VN script authoring catalog sprint from issue #1610 and plan Docs/superpowers/plans/2026-05-12-vn-script-authoring-catalog.md. Scope includes backend catalog metadata, pure snippet patching, service preview/apply, API schemas/endpoints/capabilities/docs, frontend API/types, WebUI guided insert panel, focused tests, Bandit, compileall, and PR prep.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Backend authoring catalog exposes safe operation and snippet metadata with canonical capability tokens and no validator-code drift.
+- [x] #2 Server-side snippet preview/apply supports deterministic patches, typed errors, recursive safety limits, non-mutating preview, and atomic optimistic apply.
+- [x] #3 API endpoints and capabilities/docs expose the backend contract with stable statuses and error details.
+- [x] #4 Frontend API/types and WebUI guided insert panel consume the backend contract without duplicating validation authority.
+- [x] #5 Focused backend/frontend tests, compileall, Bandit, and diff checks are recorded.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Implemented backend-owned authoring catalog metadata in `VN_Scripts/authoring_catalog.py`, grounded in canonical validator capabilities instead of duplicated frontend rules.
+- Added pure server-side snippet patching with typed authoring errors, recursive payload/depth/string safety checks, deterministic patch summaries, and V1 snippet coverage for narration, dialogue, authored choices, generated choices, visual/audio/state updates, and endings.
+- Added service-level preview/apply flows using existing draft validation and optimistic revision checks; preview is non-mutating, while apply persists through the repository replace path.
+- Exposed catalog, preview, and apply API endpoints under `/api/v1/vn/vn-scripts`, plus schemas, VN platform capability metadata, and API documentation updates.
+- Added frontend API/types and a guided snippet insert panel that loads from backend capabilities/catalog, renders form fields from `parameters_schema` and `default_parameters`, requires preview before apply, handles structured revision conflicts non-destructively, and keeps VN semantic validation on the backend.
+- Task 6 frontend review fixes addressed stale preview/apply state, raw JSON edit safety, async script-switch races, typed enum preservation, and conflict reload races.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the VN script authoring catalog and guided editing slice from issue #1610. The backend now owns the authoring operation/snippet catalog, deterministic snippet patching, preview/apply service behavior, public API schemas/endpoints, capability metadata, and docs. The WebUI now consumes that backend contract with typed client helpers and a guided insert panel while preserving the JSON editor fallback and leaving VN validation authority server-side.
+
+Verification after rebasing on `origin/dev`:
+- `python -m pytest tldw_Server_API/tests/VN_Scripts -q` -> 88 passed, 5 warnings.
+- `bun run --cwd apps/tldw-frontend test:run __tests__/vn-scripts` -> 44 passed.
+- `python -m compileall tldw_Server_API/app tldw_Server_API/tests/VN_Scripts` -> passed.
+- `python -m bandit -r tldw_Server_API/app/core/VN_Scripts tldw_Server_API/app/api/v1/endpoints/vn_scripts.py tldw_Server_API/app/api/v1/schemas/vn_script_schemas.py tldw_Server_API/app/core/VN_Platform/capabilities.py -f json -o /tmp/bandit_vn_authoring_catalog.json` -> 0 findings.
+- `git diff --check` -> passed.
+
+Known skips or blockers: none for this slice.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-321 - Address-VN-authoring-catalog-PR-review-comments.md
+++ b/backlog/tasks/task-321 - Address-VN-authoring-catalog-PR-review-comments.md
@@ -1,0 +1,64 @@
+---
+id: TASK-321
+title: Address VN authoring catalog PR review comments
+status: Done
+assignee: []
+created_date: '2026-05-14 00:27'
+labels:
+  - vn
+  - vn-scripts
+  - review-fix
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1641'
+documentation:
+  - Docs/superpowers/specs/2026-05-12-vn-script-authoring-catalog-design.md
+  - Docs/superpowers/plans/2026-05-12-vn-script-authoring-catalog.md
+priority: medium
+---
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Actionable PR review comments are verified and addressed or explicitly resolved with rationale.
+- [x] #2 Regression tests cover fixed review issues.
+- [x] #3 Focused backend/frontend verification and diff checks are recorded.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Verified PR #1641 review threads from Gemini, CodeRabbit, and Qodo before editing.
+- Fixed opcode-shaped snippet previews while keeping public parameter names in `parameters_schema`.
+- Added advisory operation field metadata, previews, forbidden generation routing fields, output compatibility, and notes to the backend-owned catalog.
+- Tightened snippet request schemas with literal anchor modes, positional `op_index` validation, and supplied-draft revision validation.
+- Moved `VNScriptAuthoringError` to the shared core exceptions module and kept the VN_Scripts import as a compatibility alias.
+- Escaped changed-path labels with bracket notation for labels containing dots or other special characters.
+- Added WebUI support for positional `op_index`, fixed VN error-envelope conflict parsing, and guarded preview/apply loading/state against stale async responses and same-script local edits.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed all actionable PR review comments on #1641. The patch tightens backend request contracts, expands the authoring catalog metadata expected by the approved API-first design, aligns snippet previews with the actual opcode shape, hardens JSONPath reporting, and closes frontend race conditions around preview/apply conflict handling.
+
+Verification:
+- `python -m pytest tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_catalog.py tldw_Server_API/tests/VN_Scripts/test_vn_scripts_api.py -q` -> 60 passed, 5 warnings.
+- `python -m pytest tldw_Server_API/tests/VN_Scripts -q` -> 92 passed, 5 warnings.
+- `bun run --cwd apps/tldw-frontend test:run __tests__/vn-scripts/VNScriptsWorkbench.test.tsx` -> 35 passed.
+- `bun run --cwd apps/tldw-frontend test:run __tests__/vn-scripts` -> 46 passed.
+- `python -m compileall tldw_Server_API/app/core/VN_Scripts tldw_Server_API/app/api/v1/endpoints/vn_scripts.py tldw_Server_API/app/api/v1/schemas/vn_script_schemas.py tldw_Server_API/app/core/exceptions.py` -> passed.
+- `python -m bandit -r tldw_Server_API/app/core/VN_Scripts tldw_Server_API/app/api/v1/endpoints/vn_scripts.py tldw_Server_API/app/api/v1/schemas/vn_script_schemas.py tldw_Server_API/app/core/VN_Platform/capabilities.py tldw_Server_API/app/core/exceptions.py -f json -o /tmp/bandit_vn_authoring_catalog_review_fixes.json` -> 0 findings.
+- `git diff --check` -> passed.
+
+Known skips or blockers: none locally. CI will rerun after the PR branch is pushed.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/vn_scripts.py
+++ b/tldw_Server_API/app/api/v1/endpoints/vn_scripts.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, Depends, HTTPException, Response, status
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
 from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
 from tldw_Server_API.app.api.v1.schemas.vn_script_schemas import (
+    VNScriptAuthoringCatalogResponse,
     VNScriptCreate,
     VNScriptCreateFromTemplateRequest,
     VNScriptCreateFromTemplateResponse,
@@ -23,6 +24,10 @@ from tldw_Server_API.app.api.v1.schemas.vn_script_schemas import (
     VNScriptPublishRequest,
     VNScriptPublishResponse,
     VNScriptResponse,
+    VNScriptSnippetApplyRequest,
+    VNScriptSnippetApplyResponse,
+    VNScriptSnippetPreviewRequest,
+    VNScriptSnippetPreviewResponse,
     VNScriptTemplateListResponse,
     VNScriptTemplateSummary,
     VNScriptValidateRequest,
@@ -43,6 +48,7 @@ from tldw_Server_API.app.core.VN_Platform.errors import (
     ERROR_NOT_FOUND,
     vn_error_detail,
 )
+from tldw_Server_API.app.core.VN_Scripts.authoring_errors import VNScriptAuthoringError
 from tldw_Server_API.app.core.VN_Scripts.service import VNScriptService
 from tldw_Server_API.app.services.storage_quota_service import get_storage_service
 
@@ -106,6 +112,12 @@ async def list_templates(service: VNScriptService = Depends(_service)) -> VNScri
     return VNScriptTemplateListResponse(
         items=[VNScriptTemplateSummary.model_validate(item) for item in service.list_templates()]
     )
+
+
+@router.get("/vn-authoring-catalog", response_model=VNScriptAuthoringCatalogResponse)
+async def get_authoring_catalog(service: VNScriptService = Depends(_service)) -> VNScriptAuthoringCatalogResponse:
+    """Return preview-safe VN script operation and snippet metadata."""
+    return VNScriptAuthoringCatalogResponse.model_validate(service.get_authoring_catalog())
 
 
 @router.post(
@@ -287,6 +299,97 @@ async def validate_draft(
         )
     except ValueError as exc:
         raise _handle_value_error(exc) from exc
+
+
+@router.post("/scripts/{script_id}/draft/snippet-preview", response_model=VNScriptSnippetPreviewResponse)
+async def preview_snippet(
+    script_id: int,
+    request: VNScriptSnippetPreviewRequest,
+    service: VNScriptService = Depends(_service),
+    files_repo: AuthnzGeneratedFilesRepo = Depends(_generated_files_repo),
+    profile_store: VNPolicyProfileStore = Depends(_profile_store),
+) -> VNScriptSnippetPreviewResponse:
+    """Preview a snippet patch without mutating stored draft or diagnostics."""
+    try:
+        build = service.build_snippet_patch(
+            script_id,
+            request.snippet_id,
+            request.anchor.model_dump(exclude_none=True),
+            request.parameters,
+            draft=request.draft,
+            draft_revision=request.draft_revision,
+        )
+        policy_profile, generation_profile, generation_profiles = await _resolve_script_profiles(
+            build["script"],
+            profile_store=profile_store,
+        )
+        patched_draft = build["patch"].draft
+        audio_refs = await _resolve_accessible_audio_refs(
+            patched_draft,
+            files_repo=files_repo,
+            owner_user_id=service.owner_user_id,
+        )
+        return VNScriptSnippetPreviewResponse.model_validate(
+            service.preview_snippet_patch(
+                script_id,
+                request.snippet_id,
+                build["base_revision"],
+                build["patch"],
+                audio_refs=audio_refs,
+                policy_profile=policy_profile,
+                generation_profile=generation_profile,
+                generation_profiles=generation_profiles,
+            )
+        )
+    except VNScriptAuthoringError as exc:
+        raise _handle_authoring_error(exc) from exc
+    except ValueError as exc:
+        raise _handle_value_error(exc, service=service, script_id=script_id) from exc
+
+
+@router.post("/scripts/{script_id}/draft/snippet-apply", response_model=VNScriptSnippetApplyResponse)
+async def apply_snippet(
+    script_id: int,
+    request: VNScriptSnippetApplyRequest,
+    service: VNScriptService = Depends(_service),
+    files_repo: AuthnzGeneratedFilesRepo = Depends(_generated_files_repo),
+    profile_store: VNPolicyProfileStore = Depends(_profile_store),
+) -> VNScriptSnippetApplyResponse:
+    """Apply a snippet patch to the stored draft using optimistic revision control."""
+    try:
+        build = service.build_snippet_patch(
+            script_id,
+            request.snippet_id,
+            request.anchor.model_dump(exclude_none=True),
+            request.parameters,
+            if_revision=request.if_revision,
+        )
+        policy_profile, generation_profile, generation_profiles = await _resolve_script_profiles(
+            build["script"],
+            profile_store=profile_store,
+        )
+        patched_draft = build["patch"].draft
+        audio_refs = await _resolve_accessible_audio_refs(
+            patched_draft,
+            files_repo=files_repo,
+            owner_user_id=service.owner_user_id,
+        )
+        return VNScriptSnippetApplyResponse.model_validate(
+            service.apply_snippet_patch_result(
+                script_id,
+                request.snippet_id,
+                request.if_revision,
+                build["patch"],
+                audio_refs=audio_refs,
+                policy_profile=policy_profile,
+                generation_profile=generation_profile,
+                generation_profiles=generation_profiles,
+            )
+        )
+    except VNScriptAuthoringError as exc:
+        raise _handle_authoring_error(exc) from exc
+    except ValueError as exc:
+        raise _handle_value_error(exc, service=service, script_id=script_id) from exc
 
 
 @router.get("/scripts/{script_id}/draft/diagnostics", response_model=VNScriptDiagnosticsResponse)
@@ -576,7 +679,25 @@ def _is_accessible_audio_record(record: Mapping[str, Any] | None, *, owner_user_
     return str(record.get("mime_type") or "").startswith("audio/")
 
 
-def _handle_value_error(exc: ValueError) -> HTTPException:
+def _handle_authoring_error(exc: VNScriptAuthoringError) -> HTTPException:
+    status_code = status.HTTP_404_NOT_FOUND if exc.code == "snippet_not_found" else exc.status_code
+    details = {"reason": exc.code, **dict(exc.details)}
+    return HTTPException(
+        status_code=status_code,
+        detail=vn_error_detail(
+            ERROR_NOT_FOUND if status_code == status.HTTP_404_NOT_FOUND else ERROR_INVALID_REQUEST,
+            exc.code,
+            details=details,
+        ),
+    )
+
+
+def _handle_value_error(
+    exc: ValueError,
+    *,
+    service: VNScriptService | None = None,
+    script_id: int | None = None,
+) -> HTTPException:
     reason = str(exc) or "invalid_request"
     if reason in {"script_not_found", "script_version_not_found", "template_not_found"}:
         return HTTPException(
@@ -584,11 +705,25 @@ def _handle_value_error(exc: ValueError) -> HTTPException:
             detail=vn_error_detail(ERROR_NOT_FOUND, reason, details={"reason": reason}),
         )
     if reason in {"draft_revision_conflict", "idempotency_key_conflict"}:
+        details: dict[str, Any] = {"reason": reason}
+        if reason == "draft_revision_conflict":
+            current_revision = _current_draft_revision(service, script_id)
+            if current_revision is not None:
+                details["current_revision"] = current_revision
         return HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail=vn_error_detail(ERROR_INVALID_REQUEST, reason, details={"reason": reason}),
+            detail=vn_error_detail(ERROR_INVALID_REQUEST, reason, details=details),
         )
     return HTTPException(
         status_code=status.HTTP_400_BAD_REQUEST,
         detail=vn_error_detail(ERROR_INVALID_REQUEST, reason, details={"reason": reason}),
     )
+
+
+def _current_draft_revision(service: VNScriptService | None, script_id: int | None) -> int | None:
+    if service is None or script_id is None:
+        return None
+    try:
+        return int(service.get_draft(script_id)["revision"])
+    except (TypeError, ValueError, KeyError):
+        return None

--- a/tldw_Server_API/app/api/v1/schemas/vn_script_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/vn_script_schemas.py
@@ -109,7 +109,14 @@ class VNScriptAuthoringOperation(BaseModel):
     op: str
     label: str
     category: str
+    description: str | None = None
+    fields: list[dict[str, Any]] = Field(default_factory=list)
     capability_tokens: list[str] = Field(default_factory=list)
+    forbidden_fields: list[str] = Field(default_factory=list)
+    supports_condition: bool = False
+    preview: dict[str, Any] | None = None
+    output_compatibility: dict[str, Any] = Field(default_factory=dict)
+    notes: list[str] = Field(default_factory=list)
 
     model_config = ConfigDict(extra="forbid")
 
@@ -148,10 +155,18 @@ class VNScriptSnippetAnchor(BaseModel):
     """Snippet insertion anchor."""
 
     label: str = Field(..., min_length=1)
-    mode: str = Field(default="append", min_length=1)
+    mode: Literal["append", "before", "after"] = "append"
     op_index: int | None = Field(default=None, ge=0)
 
     model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def _validate_shape(self) -> "VNScriptSnippetAnchor":
+        if self.mode in {"before", "after"} and self.op_index is None:
+            raise ValueError("op_index_required")
+        if self.mode == "append":
+            self.op_index = None
+        return self
 
 
 class VNScriptSnippetPreviewRequest(BaseModel):
@@ -164,6 +179,12 @@ class VNScriptSnippetPreviewRequest(BaseModel):
     draft_revision: int | None = Field(default=None, ge=0)
 
     model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def _validate_draft_revision(self) -> "VNScriptSnippetPreviewRequest":
+        if self.draft is not None and self.draft_revision is None:
+            raise ValueError("draft_revision_required")
+        return self
 
 
 class VNScriptSnippetApplyRequest(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/vn_script_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/vn_script_schemas.py
@@ -103,6 +103,117 @@ class VNScriptTemplateListResponse(BaseModel):
     items: list[VNScriptTemplateSummary]
 
 
+class VNScriptAuthoringOperation(BaseModel):
+    """Preview-safe VN script operation metadata."""
+
+    op: str
+    label: str
+    category: str
+    capability_tokens: list[str] = Field(default_factory=list)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class VNScriptAuthoringSnippet(BaseModel):
+    """Preview-safe VN script snippet metadata."""
+
+    id: str
+    schema_version: Literal["vn_script_program.v1"]
+    label: str
+    operation_sequence: list[str] = Field(default_factory=list)
+    required_capability_tokens: list[str] = Field(default_factory=list)
+    parameters_schema: dict[str, Any]
+    default_parameters: dict[str, Any] = Field(default_factory=dict)
+    preview: list[dict[str, Any]]
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class VNScriptAuthoringCatalogResponse(BaseModel):
+    """VN script authoring operation and snippet catalog response."""
+
+    schema_version: Literal["vn_script_authoring_catalog.v1"]
+    program_schema_version: Literal["vn_script_program.v1"]
+    capability_tokens: list[str] = Field(default_factory=list)
+    generation_output_schemas: list[str] = Field(default_factory=list)
+    operation_categories: dict[str, list[str]]
+    operations: list[VNScriptAuthoringOperation]
+    snippets: list[VNScriptAuthoringSnippet]
+    limits: dict[str, int]
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class VNScriptSnippetAnchor(BaseModel):
+    """Snippet insertion anchor."""
+
+    label: str = Field(..., min_length=1)
+    mode: str = Field(default="append", min_length=1)
+    op_index: int | None = Field(default=None, ge=0)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class VNScriptSnippetPreviewRequest(BaseModel):
+    """Preview a snippet patch against the stored or supplied draft."""
+
+    snippet_id: str = Field(..., min_length=1, max_length=80)
+    anchor: VNScriptSnippetAnchor
+    parameters: dict[str, Any] = Field(default_factory=dict)
+    draft: dict[str, Any] | None = None
+    draft_revision: int | None = Field(default=None, ge=0)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class VNScriptSnippetApplyRequest(BaseModel):
+    """Apply a snippet patch to the stored draft."""
+
+    if_revision: int = Field(..., ge=0)
+    snippet_id: str = Field(..., min_length=1, max_length=80)
+    anchor: VNScriptSnippetAnchor
+    parameters: dict[str, Any] = Field(default_factory=dict)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class VNScriptSnippetPatchSummary(BaseModel):
+    """Summary of a snippet patch."""
+
+    inserted_ops: int = Field(..., ge=0)
+    created_labels: list[str] = Field(default_factory=list)
+    changed_paths: list[str] = Field(default_factory=list)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class VNScriptSnippetPreviewResponse(BaseModel):
+    """Snippet preview response."""
+
+    script_id: int
+    base_revision: int
+    snippet_id: str
+    draft: dict[str, Any]
+    diagnostics: dict[str, Any]
+    patch_summary: VNScriptSnippetPatchSummary
+    warnings: list[dict[str, Any]] = Field(default_factory=list)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class VNScriptSnippetApplyResponse(BaseModel):
+    """Snippet apply response."""
+
+    script_id: int
+    revision: int
+    snippet_id: str
+    draft: dict[str, Any]
+    diagnostics: dict[str, Any]
+    patch_summary: VNScriptSnippetPatchSummary
+
+    model_config = ConfigDict(extra="forbid")
+
+
 class VNScriptCreateFromTemplateRequest(BaseModel):
     """Create request for a VN script starter template."""
 

--- a/tldw_Server_API/app/core/VN_Platform/capabilities.py
+++ b/tldw_Server_API/app/core/VN_Platform/capabilities.py
@@ -33,6 +33,7 @@ def build_vn_capabilities(routes: Iterable[Any]) -> dict[str, Any]:
         for key, path in VN_RESOURCE_PATHS.items()
     }
     scripted_generation_enabled = enabled_modules["scripts"] and enabled_modules["play"]
+    script_authoring_catalog_enabled = enabled_modules["scripts"]
 
     return {
         "schema_version": "vn_capabilities.v1",
@@ -49,6 +50,7 @@ def build_vn_capabilities(routes: Iterable[Any]) -> dict[str, Any]:
             "scripted_generation_revision_activation": enabled_modules["play"],
             "scripted_generation_history": enabled_modules["play"],
             "scripted_generation_debug_detail": enabled_modules["play"],
+            "script_authoring_catalog": script_authoring_catalog_enabled,
             "story_start": enabled_modules["play"],
             "tts_jobs": enabled_modules["audio"],
             "realtime_image_generation": False,

--- a/tldw_Server_API/app/core/VN_Scripts/authoring_catalog.py
+++ b/tldw_Server_API/app/core/VN_Scripts/authoring_catalog.py
@@ -1,0 +1,317 @@
+"""Preview-safe VN script authoring catalog metadata."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+from tldw_Server_API.app.core.VN_Scripts.validator import (
+    known_script_ops,
+    supported_generation_output_schemas,
+)
+
+_SCHEMA_VERSION = "vn_script_authoring_catalog.v1"
+_PROGRAM_SCHEMA_VERSION = "vn_script_program.v1"
+
+_CAPABILITY_TOKENS: tuple[str, ...] = (
+    "script_authoring_catalog",
+    "scripted_generation",
+    "scripted_generation.output_schema.choice_set",
+    "scripted_generation.output_schema.scene_update",
+    "scripted_generation.user_confirmation",
+)
+
+_OPERATION_CATEGORIES: dict[str, tuple[str, ...]] = {
+    "audio": ("play_bgm", "play_sfx", "stop_bgm", "voice_cue"),
+    "branching": ("choice", "jump", "random", "return"),
+    "generation": ("generate",),
+    "state": ("increment", "set"),
+    "story": ("end", "label", "narrate", "say"),
+    "visuals": ("clear_visuals", "hide_sprite", "set_background", "show_cg", "show_sprite"),
+}
+
+_OP_METADATA: dict[str, dict[str, Any]] = {
+    "choice": {"label": "Choice", "capability_tokens": ()},
+    "clear_visuals": {"label": "Clear visuals", "capability_tokens": ()},
+    "end": {"label": "End", "capability_tokens": ()},
+    "generate": {"label": "Generate", "capability_tokens": ("scripted_generation",)},
+    "hide_sprite": {"label": "Hide sprite", "capability_tokens": ()},
+    "increment": {"label": "Increment variable", "capability_tokens": ()},
+    "jump": {"label": "Jump", "capability_tokens": ()},
+    "label": {"label": "Label", "capability_tokens": ()},
+    "narrate": {"label": "Narrate", "capability_tokens": ()},
+    "play_bgm": {"label": "Play BGM", "capability_tokens": ()},
+    "play_sfx": {"label": "Play SFX", "capability_tokens": ()},
+    "random": {"label": "Random branch", "capability_tokens": ()},
+    "return": {"label": "Return", "capability_tokens": ()},
+    "say": {"label": "Say", "capability_tokens": ()},
+    "set": {"label": "Set variable", "capability_tokens": ()},
+    "set_background": {"label": "Set background", "capability_tokens": ()},
+    "show_cg": {"label": "Show CG", "capability_tokens": ()},
+    "show_sprite": {"label": "Show sprite", "capability_tokens": ()},
+    "stop_bgm": {"label": "Stop BGM", "capability_tokens": ()},
+    "voice_cue": {"label": "Voice cue", "capability_tokens": ()},
+}
+
+_SNIPPETS: tuple[dict[str, Any], ...] = (
+    {
+        "id": "narration",
+        "schema_version": _PROGRAM_SCHEMA_VERSION,
+        "label": "Narration",
+        "operation_sequence": ("narrate",),
+        "parameters_schema": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["text"],
+            "properties": {
+                "text": {"type": "string", "minLength": 1},
+            },
+        },
+        "preview": [{"op": "narrate", "text": "{text}"}],
+    },
+    {
+        "id": "dialogue",
+        "schema_version": _PROGRAM_SCHEMA_VERSION,
+        "label": "Dialogue",
+        "operation_sequence": ("say",),
+        "parameters_schema": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["speaker", "text"],
+            "properties": {
+                "speaker": {"type": "string", "minLength": 1},
+                "text": {"type": "string", "minLength": 1},
+            },
+        },
+        "preview": [{"op": "say", "speaker": "{speaker}", "text": "{text}"}],
+    },
+    {
+        "id": "authored_choice",
+        "schema_version": _PROGRAM_SCHEMA_VERSION,
+        "label": "Authored choice",
+        "operation_sequence": ("choice",),
+        "parameters_schema": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["id", "choices"],
+            "properties": {
+                "id": {"type": "string", "minLength": 1},
+                "choices": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "required": ["id", "text", "target"],
+                        "properties": {
+                            "id": {"type": "string", "minLength": 1},
+                            "text": {"type": "string", "minLength": 1},
+                            "target": {"type": "string", "minLength": 1},
+                        },
+                    },
+                },
+            },
+        },
+        "preview": [{"op": "choice", "id": "{id}", "choices": []}],
+    },
+    {
+        "id": "generated_choice_set",
+        "schema_version": _PROGRAM_SCHEMA_VERSION,
+        "label": "Generated choice set",
+        "operation_sequence": ("generate",),
+        "required_capability_tokens": (
+            "scripted_generation",
+            "scripted_generation.output_schema.choice_set",
+        ),
+        "parameters_schema": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["handler_label"],
+            "properties": {
+                "profile_key": {"type": "string", "minLength": 1, "default": "default"},
+                "scope": {"type": "string", "enum": ["turn", "scene"]},
+                "max_choices": {"type": "integer", "minimum": 1},
+                "requires_user_confirm": {"type": "boolean"},
+                "handler_label": {"type": "string", "minLength": 1},
+                "on_cancel": {"type": "string", "minLength": 1},
+            },
+        },
+        "default_parameters": {"handler_label": "generated_choice"},
+        "preview": [
+            {
+                "op": "generate",
+                "scope": "turn",
+                "output_schema": "choice_set",
+                "handler_label": "{handler_label}",
+            }
+        ],
+    },
+    {
+        "id": "scene_update_generation",
+        "schema_version": _PROGRAM_SCHEMA_VERSION,
+        "label": "Scene update generation",
+        "operation_sequence": ("generate",),
+        "required_capability_tokens": (
+            "scripted_generation",
+            "scripted_generation.output_schema.scene_update",
+        ),
+        "parameters_schema": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "profile_key": {"type": "string", "minLength": 1, "default": "default"},
+                "scope": {"type": "string", "enum": ["scene"]},
+                "max_choices": {"type": "integer", "minimum": 1},
+            },
+        },
+        "preview": [{"op": "generate", "scope": "scene", "output_schema": "scene_update"}],
+    },
+    {
+        "id": "confirm_gated_generation",
+        "schema_version": _PROGRAM_SCHEMA_VERSION,
+        "label": "Confirm-gated generation",
+        "operation_sequence": ("generate",),
+        "required_capability_tokens": (
+            "scripted_generation",
+            "scripted_generation.user_confirmation",
+        ),
+        "parameters_schema": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "profile_key": {"type": "string", "minLength": 1, "default": "default"},
+                "scope": {"type": "string", "enum": ["turn", "scene"]},
+                "max_choices": {"type": "integer", "minimum": 1},
+                "on_cancel": {"type": "string", "minLength": 1},
+            },
+        },
+        "preview": [{"op": "generate", "scope": "turn", "requires_user_confirm": True}],
+    },
+    {
+        "id": "set_background",
+        "schema_version": _PROGRAM_SCHEMA_VERSION,
+        "label": "Set background",
+        "operation_sequence": ("set_background",),
+        "parameters_schema": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["slot_key"],
+            "properties": {
+                "slot_key": {"type": "string", "minLength": 1},
+            },
+        },
+        "preview": [{"op": "set_background", "slot_key": "{slot_key}"}],
+    },
+    {
+        "id": "show_sprite",
+        "schema_version": _PROGRAM_SCHEMA_VERSION,
+        "label": "Show sprite",
+        "operation_sequence": ("show_sprite",),
+        "parameters_schema": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["slot_key"],
+            "properties": {
+                "slot_key": {"type": "string", "minLength": 1},
+            },
+        },
+        "preview": [{"op": "show_sprite", "slot_key": "{slot_key}"}],
+    },
+    {
+        "id": "play_bgm",
+        "schema_version": _PROGRAM_SCHEMA_VERSION,
+        "label": "Play BGM",
+        "operation_sequence": ("play_bgm",),
+        "parameters_schema": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["media_ref"],
+            "properties": {
+                "media_ref": {"type": "string", "minLength": 1},
+            },
+        },
+        "preview": [{"op": "play_bgm", "media_ref": "{media_ref}"}],
+    },
+    {
+        "id": "set_variable",
+        "schema_version": _PROGRAM_SCHEMA_VERSION,
+        "label": "Set variable",
+        "operation_sequence": ("set",),
+        "parameters_schema": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["var", "value"],
+            "properties": {
+                "var": {"type": "string", "minLength": 1},
+                "value": {
+                    "anyOf": [
+                        {"type": "boolean"},
+                        {"type": "integer"},
+                        {"type": "number"},
+                        {"type": "string"},
+                    ]
+                },
+            },
+        },
+        "preview": [{"op": "set", "var": "{var}", "value": "{value}"}],
+    },
+    {
+        "id": "ending",
+        "schema_version": _PROGRAM_SCHEMA_VERSION,
+        "label": "Ending",
+        "operation_sequence": ("end",),
+        "parameters_schema": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {},
+        },
+        "preview": [{"op": "end"}],
+    },
+)
+
+_LIMITS: dict[str, int] = {
+    "max_title_length": 200,
+    "max_label_length": 64,
+    "max_variable_name_length": 64,
+    "max_choices_per_choice_op": 12,
+}
+
+
+def list_authoring_catalog() -> dict[str, Any]:
+    """Return preview-safe metadata for VN script authoring clients."""
+    return deepcopy(
+        {
+            "schema_version": _SCHEMA_VERSION,
+            "program_schema_version": _PROGRAM_SCHEMA_VERSION,
+            "capability_tokens": list(_CAPABILITY_TOKENS),
+            "generation_output_schemas": list(supported_generation_output_schemas()),
+            "operation_categories": _operation_categories_payload(),
+            "operations": _operations_payload(),
+            "snippets": list(_SNIPPETS),
+            "limits": _LIMITS,
+        }
+    )
+
+
+def _operation_categories_payload() -> dict[str, list[str]]:
+    return {category: list(ops) for category, ops in sorted(_OPERATION_CATEGORIES.items())}
+
+
+def _operations_payload() -> list[dict[str, Any]]:
+    operations: list[dict[str, Any]] = []
+    categories_by_op = {
+        op: category
+        for category, ops in _OPERATION_CATEGORIES.items()
+        for op in ops
+    }
+    for op in known_script_ops():
+        metadata = _OP_METADATA.get(op, {"label": op.replace("_", " ").title(), "capability_tokens": ()})
+        operations.append(
+            {
+                "op": op,
+                "label": metadata["label"],
+                "category": categories_by_op.get(op, "other"),
+                "capability_tokens": list(metadata.get("capability_tokens", ())),
+            }
+        )
+    return operations

--- a/tldw_Server_API/app/core/VN_Scripts/authoring_catalog.py
+++ b/tldw_Server_API/app/core/VN_Scripts/authoring_catalog.py
@@ -93,26 +93,26 @@ _SNIPPETS: tuple[dict[str, Any], ...] = (
         "parameters_schema": {
             "type": "object",
             "additionalProperties": False,
-            "required": ["id", "choices"],
+            "required": ["choice_id", "choices"],
             "properties": {
-                "id": {"type": "string", "minLength": 1},
+                "choice_id": {"type": "string", "minLength": 1},
                 "choices": {
                     "type": "array",
                     "minItems": 1,
                     "items": {
                         "type": "object",
                         "additionalProperties": False,
-                        "required": ["id", "text", "target"],
+                        "required": ["id", "text", "target_label"],
                         "properties": {
                             "id": {"type": "string", "minLength": 1},
                             "text": {"type": "string", "minLength": 1},
-                            "target": {"type": "string", "minLength": 1},
+                            "target_label": {"type": "string", "minLength": 1},
                         },
                     },
                 },
             },
         },
-        "preview": [{"op": "choice", "id": "{id}", "choices": []}],
+        "preview": [{"op": "choice", "choice_id": "{choice_id}", "choices": [{"target_label": "{target_label}"}]}],
     },
     {
         "id": "generated_choice_set",

--- a/tldw_Server_API/app/core/VN_Scripts/authoring_catalog.py
+++ b/tldw_Server_API/app/core/VN_Scripts/authoring_catalog.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 from typing import Any
 
 from tldw_Server_API.app.core.VN_Scripts.validator import (
+    forbidden_generation_routing_keys,
     known_script_ops,
     supported_generation_output_schemas,
 )
@@ -51,6 +52,143 @@ _OP_METADATA: dict[str, dict[str, Any]] = {
     "show_sprite": {"label": "Show sprite", "capability_tokens": ()},
     "stop_bgm": {"label": "Stop BGM", "capability_tokens": ()},
     "voice_cue": {"label": "Voice cue", "capability_tokens": ()},
+}
+
+_CONDITION_FIELD: dict[str, Any] = {
+    "name": "if",
+    "type": "condition",
+    "required": False,
+    "description": "Optional variable condition evaluated by the runtime.",
+}
+
+_OP_FIELDS: dict[str, tuple[dict[str, Any], ...]] = {
+    "choice": (
+        {
+            "name": "id",
+            "type": "string",
+            "required": False,
+            "description": "Optional stable choice block identifier.",
+        },
+        {
+            "name": "choices",
+            "type": "array",
+            "required": True,
+            "items": {
+                "type": "object",
+                "required": ["target"],
+                "properties": {
+                    "id": {"type": "string", "required": False},
+                    "text": {"type": "string", "required": False},
+                    "target": {"type": "label", "required": True},
+                },
+            },
+        },
+    ),
+    "clear_visuals": (),
+    "end": (),
+    "generate": (
+        {"name": "profile_key", "type": "string", "required": False, "default": "default"},
+        {"name": "scope", "type": "enum", "required": False, "values": ["turn", "scene", "session"]},
+        {
+            "name": "output_schema",
+            "type": "enum",
+            "required": False,
+            "values": list(supported_generation_output_schemas()),
+        },
+        {"name": "max_choices", "type": "integer", "required": False, "minimum": 1},
+        {"name": "requires_user_confirm", "type": "boolean", "required": False},
+        {"name": "on_generated_choice", "type": "label", "required": False},
+        {"name": "on_cancel", "type": "label", "required": False},
+        {"name": "narrative_text", "type": "string", "required": False, "multiline": True},
+        {"name": "regeneration_text", "type": "string", "required": False, "multiline": True},
+    ),
+    "hide_sprite": ({"name": "slot_key", "type": "asset_slot", "required": False},),
+    "increment": (
+        {"name": "var", "type": "variable", "required": True},
+        {"name": "amount", "type": "number", "required": False, "default": 1},
+    ),
+    "jump": ({"name": "target", "type": "label", "required": True},),
+    "label": ({"name": "name", "type": "label", "required": True},),
+    "narrate": ({"name": "text", "type": "string", "required": True, "multiline": True},),
+    "play_bgm": ({"name": "media_ref", "type": "audio_ref", "required": True},),
+    "play_sfx": ({"name": "media_ref", "type": "audio_ref", "required": True},),
+    "random": (
+        {"name": "id", "type": "string", "required": False},
+        {"name": "var", "type": "variable", "required": False},
+        {"name": "min", "type": "integer", "required": False},
+        {"name": "max", "type": "integer", "required": False},
+    ),
+    "return": (),
+    "say": (
+        {"name": "speaker", "type": "string", "required": True},
+        {"name": "text", "type": "string", "required": True, "multiline": True},
+    ),
+    "set": (
+        {"name": "var", "type": "variable", "required": True},
+        {"name": "value", "type": "json", "required": True},
+    ),
+    "set_background": ({"name": "slot_key", "type": "asset_slot", "required": True},),
+    "show_cg": ({"name": "slot_key", "type": "asset_slot", "required": True},),
+    "show_sprite": ({"name": "slot_key", "type": "asset_slot", "required": True},),
+    "stop_bgm": (),
+    "voice_cue": ({"name": "media_ref", "type": "audio_ref", "required": True},),
+}
+
+_OP_PREVIEWS: dict[str, dict[str, Any]] = {
+    "choice": {"op": "choice", "choices": [{"text": "Open the door.", "target": "open_door"}]},
+    "clear_visuals": {"op": "clear_visuals"},
+    "end": {"op": "end"},
+    "generate": {"op": "generate", "scope": "turn", "output_schema": "choice_set", "on_generated_choice": "generated_choice"},
+    "hide_sprite": {"op": "hide_sprite", "slot_key": "sprite.character.neutral"},
+    "increment": {"op": "increment", "var": "trust", "amount": 1},
+    "jump": {"op": "jump", "target": "next_scene"},
+    "label": {"op": "label", "name": "next_scene"},
+    "narrate": {"op": "narrate", "text": "The scene opens."},
+    "play_bgm": {"op": "play_bgm", "media_ref": "bgm_theme"},
+    "play_sfx": {"op": "play_sfx", "media_ref": "door_knock"},
+    "random": {"op": "random", "var": "roll", "min": 1, "max": 6},
+    "return": {"op": "return"},
+    "say": {"op": "say", "speaker": "Mira", "text": "Which way?"},
+    "set": {"op": "set", "var": "has_key", "value": True},
+    "set_background": {"op": "set_background", "slot_key": "background.archive.default"},
+    "show_cg": {"op": "show_cg", "slot_key": "cg.reveal.default"},
+    "show_sprite": {"op": "show_sprite", "slot_key": "sprite.mira.neutral"},
+    "stop_bgm": {"op": "stop_bgm"},
+    "voice_cue": {"op": "voice_cue", "media_ref": "voice_mira_line_001"},
+}
+
+_SUPPORTS_CONDITION = {
+    "choice",
+    "clear_visuals",
+    "end",
+    "generate",
+    "hide_sprite",
+    "increment",
+    "jump",
+    "narrate",
+    "play_bgm",
+    "play_sfx",
+    "random",
+    "return",
+    "say",
+    "set",
+    "set_background",
+    "show_cg",
+    "show_sprite",
+    "stop_bgm",
+    "voice_cue",
+}
+
+_OP_NOTES: dict[str, tuple[str, ...]] = {
+    "generate": (
+        "Generation profiles, output-schema support, moderation, and limits are resolved by backend preview/apply/validate.",
+    ),
+    "set_background": ("slot_key must resolve to an approved visual asset pack slot.",),
+    "show_cg": ("slot_key must resolve to an approved visual asset pack slot.",),
+    "show_sprite": ("slot_key must resolve to an approved visual asset pack slot.",),
+    "play_bgm": ("media_ref must resolve to accessible audio metadata.",),
+    "play_sfx": ("media_ref must resolve to accessible audio metadata.",),
+    "voice_cue": ("media_ref must resolve to accessible audio metadata.",),
 }
 
 _SNIPPETS: tuple[dict[str, Any], ...] = (
@@ -112,7 +250,7 @@ _SNIPPETS: tuple[dict[str, Any], ...] = (
                 },
             },
         },
-        "preview": [{"op": "choice", "choice_id": "{choice_id}", "choices": [{"target_label": "{target_label}"}]}],
+        "preview": [{"op": "choice", "id": "{choice_id}", "choices": [{"target": "{target_label}"}]}],
     },
     {
         "id": "generated_choice_set",
@@ -142,7 +280,7 @@ _SNIPPETS: tuple[dict[str, Any], ...] = (
                 "op": "generate",
                 "scope": "turn",
                 "output_schema": "choice_set",
-                "handler_label": "{handler_label}",
+                "on_generated_choice": "{handler_label}",
             }
         ],
     },
@@ -311,7 +449,34 @@ def _operations_payload() -> list[dict[str, Any]]:
                 "op": op,
                 "label": metadata["label"],
                 "category": categories_by_op.get(op, "other"),
+                "description": metadata.get("description", f"Author {metadata['label'].lower()} operations."),
+                "fields": _operation_fields(op),
                 "capability_tokens": list(metadata.get("capability_tokens", ())),
+                "forbidden_fields": _forbidden_generation_fields() if op == "generate" else [],
+                "supports_condition": op in _SUPPORTS_CONDITION,
+                "preview": deepcopy(_OP_PREVIEWS.get(op)),
+                "output_compatibility": _operation_output_compatibility(op),
+                "notes": list(_OP_NOTES.get(op, ("Backend diagnostics remain authoritative.",))),
             }
         )
     return operations
+
+
+def _operation_fields(op: str) -> list[dict[str, Any]]:
+    fields = [deepcopy(field) for field in _OP_FIELDS.get(op, ())]
+    if op in _SUPPORTS_CONDITION:
+        fields.append(deepcopy(_CONDITION_FIELD))
+    return fields
+
+
+def _forbidden_generation_fields() -> list[str]:
+    return list(forbidden_generation_routing_keys())
+
+
+def _operation_output_compatibility(op: str) -> dict[str, Any]:
+    if op != "generate":
+        return {}
+    return {
+        "supported_output_schemas": list(supported_generation_output_schemas()),
+        "choice_set_requires": ["on_generated_choice"],
+    }

--- a/tldw_Server_API/app/core/VN_Scripts/authoring_errors.py
+++ b/tldw_Server_API/app/core/VN_Scripts/authoring_errors.py
@@ -1,21 +1,7 @@
-"""Typed VN script authoring errors."""
+"""Compatibility import for VN script authoring errors."""
 
 from __future__ import annotations
 
-from typing import Any
+from tldw_Server_API.app.core.exceptions import VNScriptAuthoringError
 
-
-class VNScriptAuthoringError(ValueError):
-    """Error raised by pure VN script authoring helpers."""
-
-    def __init__(
-        self,
-        code: str,
-        message: str,
-        status_code: int = 400,
-        details: dict[str, Any] | None = None,
-    ) -> None:
-        super().__init__(message)
-        self.code = code
-        self.status_code = status_code
-        self.details = details or {}
+__all__ = ["VNScriptAuthoringError"]

--- a/tldw_Server_API/app/core/VN_Scripts/authoring_errors.py
+++ b/tldw_Server_API/app/core/VN_Scripts/authoring_errors.py
@@ -1,0 +1,21 @@
+"""Typed VN script authoring errors."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class VNScriptAuthoringError(ValueError):
+    """Error raised by pure VN script authoring helpers."""
+
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        status_code: int = 400,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.status_code = status_code
+        self.details = details or {}

--- a/tldw_Server_API/app/core/VN_Scripts/service.py
+++ b/tldw_Server_API/app/core/VN_Scripts/service.py
@@ -18,6 +18,8 @@ from tldw_Server_API.app.core.DB_Management.VNScripts_DB import VNScriptsReposit
 from tldw_Server_API.app.core.VN_Assets.service import VNAssetPackService
 from tldw_Server_API.app.core.VN_Platform.idempotency import canonical_payload_hash
 from tldw_Server_API.app.core.VN_Policy.service import evaluate_character_safety_definition
+from tldw_Server_API.app.core.VN_Scripts.authoring_catalog import list_authoring_catalog
+from tldw_Server_API.app.core.VN_Scripts.snippet_patcher import SnippetPatchResult, apply_snippet_patch
 from tldw_Server_API.app.core.VN_Scripts.templates import instantiate_template, list_template_catalog
 from tldw_Server_API.app.core.VN_Scripts.validator import VNScriptValidationContext, validate_script_program
 
@@ -87,6 +89,115 @@ class VNScriptService:
     def list_templates(self) -> list[dict[str, Any]]:
         """List built-in starter templates as preview-safe catalog entries."""
         return list_template_catalog()
+
+    def get_authoring_catalog(self) -> dict[str, Any]:
+        """Return preview-safe script authoring metadata and snippet catalog."""
+        return list_authoring_catalog()
+
+    def build_snippet_patch(
+        self,
+        script_id: int,
+        snippet_id: str,
+        anchor: Mapping[str, Any],
+        parameters: Mapping[str, Any],
+        *,
+        draft: Mapping[str, Any] | None = None,
+        draft_revision: int | None = None,
+    ) -> dict[str, Any]:
+        """Build a side-effect-free snippet patch against a stored or supplied draft."""
+        script = self._require_script(script_id)
+        draft_row = self.get_draft(script_id)
+        stored_revision = int(draft_row["revision"])
+        if draft is not None:
+            if draft_revision is None:
+                raise ValueError("draft_revision_required")
+            if int(draft_revision) != stored_revision:
+                raise ValueError("draft_revision_conflict")
+            base_revision = int(draft_revision)
+            base_draft = draft
+        else:
+            base_revision = stored_revision
+            base_draft = draft_row["draft"]
+        patch = apply_snippet_patch(base_draft, snippet_id, anchor, parameters)
+        return {
+            "script": script,
+            "base_revision": base_revision,
+            "snippet_id": snippet_id,
+            "patch": patch,
+        }
+
+    def preview_snippet_patch(
+        self,
+        script_id: int,
+        snippet_id: str,
+        base_revision: int,
+        patch: SnippetPatchResult,
+        *,
+        audio_refs: Mapping[str, Mapping[str, Any]] | None = None,
+        policy_profile: ProfileRow | None = None,
+        generation_profile: ProfileRow | None = None,
+        generation_profiles: Mapping[str, ProfileRow] | None = None,
+    ) -> dict[str, Any]:
+        """Validate a patched draft without storing the draft or diagnostics."""
+        script = self._require_script(script_id)
+        diagnostics = self.validate_draft_payload(
+            script,
+            patch.draft,
+            audio_refs=audio_refs,
+            policy_profile=policy_profile,
+            generation_profile=generation_profile,
+            generation_profiles=generation_profiles,
+        )
+        return {
+            "script_id": script_id,
+            "base_revision": int(base_revision),
+            "snippet_id": snippet_id,
+            "draft": patch.draft,
+            "diagnostics": diagnostics,
+            "patch_summary": patch.patch_summary,
+            "warnings": list(diagnostics.get("warnings") or []),
+        }
+
+    def apply_snippet_patch_result(
+        self,
+        script_id: int,
+        snippet_id: str,
+        base_revision: int,
+        patch: SnippetPatchResult,
+        *,
+        audio_refs: Mapping[str, Mapping[str, Any]] | None = None,
+        policy_profile: ProfileRow | None = None,
+        generation_profile: ProfileRow | None = None,
+        generation_profiles: Mapping[str, ProfileRow] | None = None,
+    ) -> dict[str, Any]:
+        """Validate and persist a patched draft using optimistic revision control."""
+        script = self._require_script(script_id)
+        draft_row = self.get_draft(script_id)
+        if int(draft_row["revision"]) != int(base_revision):
+            raise ValueError("draft_revision_conflict")
+        diagnostics = self.validate_draft_payload(
+            script,
+            patch.draft,
+            audio_refs=audio_refs,
+            policy_profile=policy_profile,
+            generation_profile=generation_profile,
+            generation_profiles=generation_profiles,
+        )
+        updated_draft = self.repo.replace_draft(
+            script_id,
+            owner_user_id=self.owner_user_id,
+            if_revision=int(base_revision),
+            draft=patch.draft,
+            diagnostics=diagnostics,
+        )
+        return {
+            "script_id": script_id,
+            "revision": int(updated_draft["revision"]),
+            "snippet_id": snippet_id,
+            "draft": updated_draft["draft"],
+            "diagnostics": updated_draft["diagnostics"],
+            "patch_summary": patch.patch_summary,
+        }
 
     def create_script_from_template(
         self,

--- a/tldw_Server_API/app/core/VN_Scripts/service.py
+++ b/tldw_Server_API/app/core/VN_Scripts/service.py
@@ -103,11 +103,14 @@ class VNScriptService:
         *,
         draft: Mapping[str, Any] | None = None,
         draft_revision: int | None = None,
+        if_revision: int | None = None,
     ) -> dict[str, Any]:
         """Build a side-effect-free snippet patch against a stored or supplied draft."""
         script = self._require_script(script_id)
         draft_row = self.get_draft(script_id)
         stored_revision = int(draft_row["revision"])
+        if if_revision is not None and int(if_revision) != stored_revision:
+            raise ValueError("draft_revision_conflict")
         if draft is not None:
             if draft_revision is None:
                 raise ValueError("draft_revision_required")

--- a/tldw_Server_API/app/core/VN_Scripts/snippet_patcher.py
+++ b/tldw_Server_API/app/core/VN_Scripts/snippet_patcher.py
@@ -24,6 +24,11 @@ class SnippetPatchResult:
     patch_summary: dict[str, Any]
 
 
+def _json_path_key(key: str) -> str:
+    escaped = key.replace("\\", "\\\\").replace("'", "\\'")
+    return f"['{escaped}']"
+
+
 def apply_snippet_patch(
     draft: Mapping[str, Any],
     snippet_id: str,
@@ -51,8 +56,11 @@ def apply_snippet_patch(
         created_labels.append(created_label)
 
     inserted_count = len(snippet["ops"])
-    changed_paths = [f"$.labels.{label}[{index}]" for index in range(insert_at, insert_at + inserted_count)]
-    changed_paths.extend(f"$.labels.{created_label}" for created_label in created_labels)
+    changed_paths = [
+        f"$.labels{_json_path_key(label)}[{index}]"
+        for index in range(insert_at, insert_at + inserted_count)
+    ]
+    changed_paths.extend(f"$.labels{_json_path_key(created_label)}" for created_label in created_labels)
     return SnippetPatchResult(
         draft=patched,
         patch_summary={

--- a/tldw_Server_API/app/core/VN_Scripts/snippet_patcher.py
+++ b/tldw_Server_API/app/core/VN_Scripts/snippet_patcher.py
@@ -1,0 +1,376 @@
+"""Pure VN script snippet patching helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from copy import deepcopy
+from dataclasses import dataclass
+import json
+from typing import Any
+
+from tldw_Server_API.app.core.VN_Scripts.authoring_errors import VNScriptAuthoringError
+from tldw_Server_API.app.core.VN_Scripts.validator import forbidden_generation_routing_keys
+
+MAX_SNIPPET_PARAMETER_DEPTH = 8
+MAX_SNIPPET_PARAMETER_STRING_LENGTH = 8000
+MAX_SNIPPET_PARAMETER_PAYLOAD_BYTES = 65536
+
+
+@dataclass(frozen=True)
+class SnippetPatchResult:
+    """Result returned after applying a VN script snippet patch."""
+
+    draft: dict[str, Any]
+    patch_summary: dict[str, Any]
+
+
+def apply_snippet_patch(
+    draft: Mapping[str, Any],
+    snippet_id: str,
+    anchor: Mapping[str, Any],
+    parameters: Mapping[str, Any],
+) -> SnippetPatchResult:
+    """Apply a preview-safe snippet to a parsed script draft."""
+    _validate_parameters(parameters)
+    _validate_snippet_parameter_shape(snippet_id, parameters)
+    patched = deepcopy(dict(draft))
+    labels = _labels(patched)
+    label, insert_at = _resolve_anchor(labels, anchor)
+    snippet = _render_snippet(snippet_id, parameters, labels)
+
+    labels[label][insert_at:insert_at] = snippet["ops"]
+    created_labels: list[str] = []
+    for created_label, body in snippet["labels"].items():
+        if created_label in labels:
+            raise VNScriptAuthoringError(
+                "snippet_label_conflict",
+                "Snippet label already exists.",
+                details={"label": created_label},
+            )
+        labels[created_label] = body
+        created_labels.append(created_label)
+
+    inserted_count = len(snippet["ops"])
+    changed_paths = [f"$.labels.{label}[{index}]" for index in range(insert_at, insert_at + inserted_count)]
+    changed_paths.extend(f"$.labels.{created_label}" for created_label in created_labels)
+    return SnippetPatchResult(
+        draft=patched,
+        patch_summary={
+            "inserted_ops": inserted_count,
+            "created_labels": created_labels,
+            "changed_paths": changed_paths,
+        },
+    )
+
+
+def _validate_parameters(parameters: Mapping[str, Any]) -> None:
+    _validate_parameter_value(parameters, "$.parameters", 0, set(forbidden_generation_routing_keys()))
+    try:
+        payload = json.dumps(parameters, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    except (RecursionError, TypeError, ValueError) as exc:
+        raise VNScriptAuthoringError(
+            "snippet_parameter_invalid",
+            "Snippet parameters must be JSON serializable.",
+            details={"field_path": "$.parameters"},
+        ) from exc
+    if len(payload) > MAX_SNIPPET_PARAMETER_PAYLOAD_BYTES:
+        raise VNScriptAuthoringError(
+            "snippet_parameter_invalid",
+            "Snippet parameters exceed the payload size limit.",
+            details={"field_path": "$.parameters"},
+        )
+
+
+def _validate_parameter_value(value: Any, path: str, depth: int, forbidden_keys: set[str]) -> None:
+    if depth > MAX_SNIPPET_PARAMETER_DEPTH:
+        raise VNScriptAuthoringError(
+            "snippet_parameter_invalid",
+            "Snippet parameters exceed the nesting depth limit.",
+            details={"field_path": path},
+        )
+    if isinstance(value, str):
+        if len(value) > MAX_SNIPPET_PARAMETER_STRING_LENGTH:
+            raise VNScriptAuthoringError(
+                "snippet_parameter_invalid",
+                "Snippet parameter string exceeds the length limit.",
+                details={"field_path": path},
+            )
+        return
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            key_text = str(key)
+            child_path = f"{path}.{key_text}"
+            if key_text in forbidden_keys:
+                raise VNScriptAuthoringError(
+                    "snippet_parameter_invalid",
+                    "Snippet parameters must not include raw generation routing keys.",
+                    details={"field_path": child_path, "key": key_text},
+                )
+            _validate_parameter_value(child, child_path, depth + 1, forbidden_keys)
+        return
+    if isinstance(value, list):
+        for index, child in enumerate(value):
+            _validate_parameter_value(child, f"{path}[{index}]", depth + 1, forbidden_keys)
+
+
+def _validate_snippet_parameter_shape(snippet_id: str, parameters: Mapping[str, Any]) -> None:
+    allowed_fields: dict[str, Any] = {
+        "narration": {"text": None},
+        "dialogue": {"speaker": None, "text": None},
+        "authored_choice": {"choice_id": None, "choices": {"id": None, "text": None, "target_label": None}},
+        "generated_choice_set": {
+            "profile_key": None,
+            "scope": None,
+            "max_choices": None,
+            "requires_user_confirm": None,
+            "handler_label": None,
+            "on_cancel": None,
+        },
+        "scene_update_generation": {"profile_key": None, "scope": None, "max_choices": None},
+        "confirm_gated_generation": {"profile_key": None, "scope": None, "max_choices": None, "on_cancel": None},
+        "set_background": {"slot_key": None},
+        "show_sprite": {"slot_key": None},
+        "play_bgm": {"media_ref": None},
+        "set_variable": {"var": None, "value": None},
+        "ending": {},
+    }
+    if snippet_id not in allowed_fields:
+        return
+    _reject_unknown_fields(parameters, allowed_fields[snippet_id], "$.parameters")
+
+
+def _reject_unknown_fields(value: Any, allowed_fields: Mapping[str, Any] | None, path: str) -> None:
+    if not isinstance(value, Mapping) or allowed_fields is None:
+        return
+    for key, child in value.items():
+        key_text = str(key)
+        if key_text not in allowed_fields:
+            raise VNScriptAuthoringError(
+                "snippet_parameter_invalid",
+                "Snippet parameter is not supported by this snippet.",
+                details={"field_path": f"{path}.{key_text}"},
+            )
+        child_allowed = allowed_fields[key_text]
+        if isinstance(child_allowed, Mapping) and isinstance(child, list):
+            for index, item in enumerate(child):
+                _reject_unknown_fields(item, child_allowed, f"{path}.{key_text}[{index}]")
+        elif isinstance(child_allowed, Mapping):
+            _reject_unknown_fields(child, child_allowed, f"{path}.{key_text}")
+
+
+def _labels(draft: dict[str, Any]) -> dict[str, list[dict[str, Any]]]:
+    labels = draft.get("labels")
+    if not isinstance(labels, dict):
+        raise VNScriptAuthoringError(
+            "snippet_anchor_invalid",
+            "Draft labels must be an object.",
+            details={"anchor": None},
+        )
+    return labels
+
+
+def _resolve_anchor(labels: Mapping[str, Any], anchor: Mapping[str, Any]) -> tuple[str, int]:
+    label = anchor.get("label")
+    mode = anchor.get("mode", "append")
+    if not isinstance(label, str) or not label or mode not in {"before", "after", "append"}:
+        raise VNScriptAuthoringError(
+            "snippet_anchor_invalid",
+            "Snippet anchor is invalid.",
+            details={"anchor": dict(anchor)},
+        )
+    if label not in labels:
+        raise VNScriptAuthoringError(
+            "snippet_anchor_not_found",
+            "Snippet anchor label was not found.",
+            details={"anchor": dict(anchor)},
+        )
+    body = labels[label]
+    if not isinstance(body, list):
+        raise VNScriptAuthoringError(
+            "snippet_anchor_invalid",
+            "Snippet anchor label body is invalid.",
+            details={"anchor": dict(anchor)},
+        )
+    if mode == "append":
+        return label, len(body)
+
+    op_index = anchor.get("op_index")
+    if isinstance(op_index, bool) or not isinstance(op_index, int):
+        raise VNScriptAuthoringError(
+            "snippet_anchor_invalid",
+            "Snippet anchor operation index is invalid.",
+            details={"anchor": dict(anchor)},
+        )
+    if op_index < 0 or op_index >= len(body):
+        raise VNScriptAuthoringError(
+            "snippet_anchor_not_found",
+            "Snippet anchor operation was not found.",
+            details={"anchor": dict(anchor)},
+        )
+    return label, op_index if mode == "before" else op_index + 1
+
+
+def _render_snippet(
+    snippet_id: str,
+    parameters: Mapping[str, Any],
+    existing_labels: Mapping[str, Any],
+) -> dict[str, Any]:
+    if snippet_id == "narration":
+        return _snippet([{"op": "narrate", "text": _required_string(parameters, "text")}])
+    if snippet_id == "dialogue":
+        return _snippet(
+            [
+                {
+                    "op": "say",
+                    "speaker": _required_string(parameters, "speaker"),
+                    "text": _required_string(parameters, "text"),
+                }
+            ]
+        )
+    if snippet_id == "authored_choice":
+        return _snippet(
+            [{"op": "choice", "id": _required_string(parameters, "choice_id"), "choices": _choices(parameters)}]
+        )
+    if snippet_id == "generated_choice_set":
+        return _generated_choice_set(parameters, existing_labels)
+    if snippet_id == "scene_update_generation":
+        op = _generate_base(parameters, default_scope="scene", allowed_scopes={"scene"})
+        op["output_schema"] = "scene_update"
+        return _snippet([op])
+    if snippet_id == "confirm_gated_generation":
+        op = _generate_base(parameters, default_scope="turn", allowed_scopes={"turn", "scene"})
+        op["requires_user_confirm"] = True
+        _copy_optional_strings(op, parameters, ("on_cancel",))
+        return _snippet([op])
+    if snippet_id == "set_background":
+        return _snippet([{"op": "set_background", "slot_key": _required_string(parameters, "slot_key")}])
+    if snippet_id == "show_sprite":
+        return _snippet([{"op": "show_sprite", "slot_key": _required_string(parameters, "slot_key")}])
+    if snippet_id == "play_bgm":
+        return _snippet([{"op": "play_bgm", "media_ref": _required_string(parameters, "media_ref")}])
+    if snippet_id == "set_variable":
+        if "value" not in parameters:
+            _raise_missing("value")
+        return _snippet([{"op": "set", "var": _required_string(parameters, "var"), "value": deepcopy(parameters["value"])}])
+    if snippet_id == "ending":
+        return _snippet([{"op": "end"}])
+    raise VNScriptAuthoringError(
+        "snippet_not_found",
+        "Snippet was not found.",
+        details={"snippet_id": snippet_id},
+    )
+
+
+def _snippet(ops: list[dict[str, Any]], labels: dict[str, list[dict[str, Any]]] | None = None) -> dict[str, Any]:
+    return {"ops": ops, "labels": labels or {}}
+
+
+def _generated_choice_set(parameters: Mapping[str, Any], existing_labels: Mapping[str, Any]) -> dict[str, Any]:
+    handler_label = _required_string(parameters, "handler_label")
+    if handler_label in existing_labels:
+        raise VNScriptAuthoringError(
+            "snippet_label_conflict",
+            "Generated choice handler label already exists.",
+            details={"label": handler_label},
+        )
+    op = _generate_base(parameters, default_scope="turn", allowed_scopes={"turn", "scene"})
+    op["output_schema"] = "choice_set"
+    op["on_generated_choice"] = handler_label
+    _copy_optional_strings(op, parameters, ("on_cancel",))
+    return _snippet(
+        [op],
+        {
+            handler_label: [
+                {"op": "narrate", "text": "Handle the selected generated choice here."},
+                {"op": "end"},
+            ]
+        },
+    )
+
+
+def _generate_base(parameters: Mapping[str, Any], *, default_scope: str, allowed_scopes: set[str]) -> dict[str, Any]:
+    scope = parameters.get("scope", default_scope)
+    if not isinstance(scope, str) or scope not in allowed_scopes:
+        raise VNScriptAuthoringError(
+            "snippet_parameter_invalid",
+            "scope must be one of the allowed values for this snippet.",
+            details={"field_path": "$.parameters.scope"},
+        )
+    op: dict[str, Any] = {"op": "generate", "scope": scope}
+    _copy_optional_strings(op, parameters, ("profile_key",))
+    max_choices = parameters.get("max_choices")
+    if max_choices is not None:
+        if not isinstance(max_choices, int) or isinstance(max_choices, bool) or max_choices < 1:
+            raise VNScriptAuthoringError(
+                "snippet_parameter_invalid",
+                "max_choices must be a positive integer.",
+                details={"field_path": "$.parameters.max_choices"},
+            )
+        op["max_choices"] = max_choices
+    requires_user_confirm = parameters.get("requires_user_confirm")
+    if requires_user_confirm is not None:
+        if not isinstance(requires_user_confirm, bool):
+            raise VNScriptAuthoringError(
+                "snippet_parameter_invalid",
+                "requires_user_confirm must be a boolean.",
+                details={"field_path": "$.parameters.requires_user_confirm"},
+            )
+        op["requires_user_confirm"] = requires_user_confirm
+    return op
+
+
+def _copy_optional_strings(target: dict[str, Any], parameters: Mapping[str, Any], keys: Sequence[str]) -> None:
+    for key in keys:
+        value = parameters.get(key)
+        if value is not None:
+            target[key] = _string_value(value, key)
+
+
+def _choices(parameters: Mapping[str, Any]) -> list[dict[str, Any]]:
+    raw_choices = parameters.get("choices")
+    if not isinstance(raw_choices, list) or not raw_choices:
+        raise VNScriptAuthoringError(
+            "snippet_parameter_invalid",
+            "choices must be a non-empty list.",
+            details={"field_path": "$.parameters.choices"},
+        )
+    choices: list[dict[str, Any]] = []
+    for index, raw_choice in enumerate(raw_choices):
+        if not isinstance(raw_choice, Mapping):
+            raise VNScriptAuthoringError(
+                "snippet_parameter_invalid",
+                "choice must be an object.",
+                details={"field_path": f"$.parameters.choices[{index}]"},
+            )
+        choices.append(
+            {
+                "id": _required_string(raw_choice, "id", prefix=f"$.parameters.choices[{index}]"),
+                "text": _required_string(raw_choice, "text", prefix=f"$.parameters.choices[{index}]"),
+                "target": _required_string(raw_choice, "target_label", prefix=f"$.parameters.choices[{index}]"),
+            }
+        )
+    return choices
+
+
+def _required_string(parameters: Mapping[str, Any], key: str, *, prefix: str = "$.parameters") -> str:
+    if key not in parameters:
+        _raise_missing(key, prefix=prefix)
+    return _string_value(parameters[key], key, prefix=prefix)
+
+
+def _string_value(value: Any, key: str, *, prefix: str = "$.parameters") -> str:
+    if not isinstance(value, str) or not value:
+        raise VNScriptAuthoringError(
+            "snippet_parameter_invalid",
+            f"{key} must be a non-empty string.",
+            details={"field_path": f"{prefix}.{key}"},
+        )
+    return value
+
+
+def _raise_missing(key: str, *, prefix: str = "$.parameters") -> None:
+    raise VNScriptAuthoringError(
+        "snippet_parameter_invalid",
+        f"{key} is required.",
+        details={"field_path": f"{prefix}.{key}"},
+    )

--- a/tldw_Server_API/app/core/VN_Scripts/validator.py
+++ b/tldw_Server_API/app/core/VN_Scripts/validator.py
@@ -52,6 +52,21 @@ _KNOWN_OPS = {
 }
 
 
+def known_script_ops() -> tuple[str, ...]:
+    """Return canonical VN script operation identifiers."""
+    return tuple(sorted(_KNOWN_OPS))
+
+
+def supported_generation_output_schemas() -> tuple[str, ...]:
+    """Return generation output schemas accepted by the script validator."""
+    return tuple(sorted(_SUPPORTED_OUTPUT_SCHEMAS))
+
+
+def forbidden_generation_routing_keys() -> tuple[str, ...]:
+    """Return raw generation routing keys that script programs must not contain."""
+    return tuple(sorted(_RAW_GENERATION_ROUTING_KEYS))
+
+
 @dataclass(frozen=True)
 class VNScriptValidationContext:
     """Resolved context used by the pure script validator."""

--- a/tldw_Server_API/app/core/exceptions.py
+++ b/tldw_Server_API/app/core/exceptions.py
@@ -109,6 +109,22 @@ class APIValidationError(HTTPException):
         super().__init__(status_code=resolved_status, detail=detail)
 
 
+class VNScriptAuthoringError(ValueError):
+    """Raised when VN script authoring preview/apply input cannot be patched."""
+
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        status_code: int = 400,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.status_code = status_code
+        self.details = details or {}
+
+
 class SyncCallInEventLoopError(BadRequestError):
     """Raised when a sync chat call is made inside a running event loop."""
 

--- a/tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_catalog.py
+++ b/tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_catalog.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Generator, Mapping
 from typing import Any
 
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 from tldw_Server_API.app.core.VN_Scripts.authoring_catalog import list_authoring_catalog
 from tldw_Server_API.app.core.VN_Scripts.authoring_errors import VNScriptAuthoringError
+from tldw_Server_API.app.core.VN_Scripts.service import VNScriptService
 from tldw_Server_API.app.core.VN_Scripts.snippet_patcher import (
     MAX_SNIPPET_PARAMETER_DEPTH,
     MAX_SNIPPET_PARAMETER_PAYLOAD_BYTES,
     MAX_SNIPPET_PARAMETER_STRING_LENGTH,
+    SnippetPatchResult,
     apply_snippet_patch,
 )
 from tldw_Server_API.app.core.VN_Scripts.validator import (
@@ -64,6 +69,7 @@ def _forbidden_keys_present(value: Any) -> set[str]:
 def _draft() -> dict[str, Any]:
     return {
         "schema_version": "vn_script_program.v1",
+        "primary_asset_pack_id": 7,
         "entry_label": "start",
         "labels": {
             "start": [
@@ -72,6 +78,64 @@ def _draft() -> dict[str, Any]:
             ]
         },
     }
+
+
+def _audio_draft() -> dict[str, Any]:
+    return {
+        "schema_version": "vn_script_program.v1",
+        "primary_asset_pack_id": 7,
+        "entry_label": "start",
+        "labels": {
+            "start": [
+                {"op": "narrate", "text": "Opening line."},
+                {"op": "end"},
+            ]
+        },
+    }
+
+
+def _manifest() -> dict[str, Any]:
+    return {
+        "schema_version": "vn_asset_manifest.v1",
+        "pack_id": 7,
+        "title": "Starter Pack",
+        "primary_character_id": None,
+        "content_rating": "general",
+        "assets": {"backgrounds": [], "sprites": [], "depth_companions": [], "cgs": []},
+    }
+
+
+@pytest.fixture
+def chacha_db() -> Generator[CharactersRAGDB, None, None]:
+    database = CharactersRAGDB(":memory:", client_id="vn-script-authoring-catalog-test-client")
+    yield database
+    database.close_connection()
+
+
+def _service(
+    chacha_db: CharactersRAGDB,
+    *,
+    owner_user_id: int = 42,
+    audio_ref_resolver: Any | None = None,
+) -> VNScriptService:
+    return VNScriptService(
+        chacha_db,
+        owner_user_id=owner_user_id,
+        manifest_resolver=lambda asset_pack_id: _manifest(),
+        audio_ref_resolver=audio_ref_resolver,
+    )
+
+
+def _create_script(service: VNScriptService, draft: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    return service.create_script(
+        title="Archive Door",
+        primary_asset_pack_id=7,
+        policy_profile_id="local_default",
+        generation_profile_id="story_default",
+        content_rating="general",
+        initial_draft=draft or _draft(),
+        initial_diagnostics={"valid": True, "errors": [], "warnings": [], "stored": True},
+    )
 
 
 def _assert_authoring_error(
@@ -88,10 +152,280 @@ def _assert_authoring_error(
     assert error.details[detail_key] == detail_value
 
 
+def test_service_get_authoring_catalog_returns_catalog_metadata(chacha_db: CharactersRAGDB) -> None:
+    service = _service(chacha_db)
+
+    assert service.get_authoring_catalog() == list_authoring_catalog()
+
+
+def test_service_build_snippet_patch_requires_ownership_and_uses_stored_draft_without_persisting(
+    chacha_db: CharactersRAGDB,
+) -> None:
+    owner_service = _service(chacha_db, owner_user_id=42)
+    other_service = _service(chacha_db, owner_user_id=7)
+    script = _create_script(owner_service)
+
+    with pytest.raises(ValueError, match="script_not_found"):
+        other_service.build_snippet_patch(
+            script["id"],
+            "narration",
+            {"label": "start", "op_index": 1, "mode": "before"},
+            {"text": "Inserted line."},
+        )
+
+    result = owner_service.build_snippet_patch(
+        script["id"],
+        "narration",
+        {"label": "start", "op_index": 1, "mode": "before"},
+        {"text": "Inserted line."},
+    )
+    stored = owner_service.get_draft(script["id"])
+
+    assert result["script"]["id"] == script["id"]
+    assert result["base_revision"] == 1
+    assert result["snippet_id"] == "narration"
+    assert isinstance(result["patch"], SnippetPatchResult)
+    assert result["patch"].draft["labels"]["start"][1] == {"op": "narrate", "text": "Inserted line."}
+    assert stored["revision"] == 1
+    assert stored["draft"] == _draft()
+    assert stored["diagnostics"]["stored"] is True
+
+
+def test_service_build_snippet_patch_with_supplied_draft_uses_current_base_revision_without_persisting(
+    chacha_db: CharactersRAGDB,
+) -> None:
+    service = _service(chacha_db)
+    script = _create_script(service)
+    supplied_draft = _draft()
+    supplied_draft["labels"]["start"][0]["text"] = "Supplied opening."
+
+    result = service.build_snippet_patch(
+        script["id"],
+        "narration",
+        {"label": "start", "op_index": 1, "mode": "before"},
+        {"text": "Inserted line."},
+        draft=supplied_draft,
+        draft_revision=1,
+    )
+    stored = service.get_draft(script["id"])
+
+    assert result["base_revision"] == 1
+    assert result["patch"].draft["labels"]["start"][0] == {"op": "narrate", "text": "Supplied opening."}
+    assert stored["revision"] == 1
+    assert stored["draft"] == _draft()
+
+
+def test_service_supplied_draft_requires_draft_revision(chacha_db: CharactersRAGDB) -> None:
+    service = _service(chacha_db)
+    script = _create_script(service)
+
+    with pytest.raises(ValueError, match="draft_revision_required"):
+        service.build_snippet_patch(
+            script["id"],
+            "narration",
+            {"label": "start", "op_index": 1, "mode": "before"},
+            {"text": "Inserted line."},
+            draft=_draft(),
+        )
+
+
+def test_service_supplied_draft_requires_matching_revision_and_cannot_overwrite_newer_draft(
+    chacha_db: CharactersRAGDB,
+) -> None:
+    service = _service(chacha_db)
+    script = _create_script(service)
+    stale_draft = service.get_draft(script["id"])["draft"]
+    stale_build = service.build_snippet_patch(
+        script["id"],
+        "narration",
+        {"label": "start", "op_index": 1, "mode": "before"},
+        {"text": "Stale line."},
+        draft=stale_draft,
+        draft_revision=1,
+    )
+    service.replace_draft(
+        script["id"],
+        if_revision=1,
+        draft={
+            **_draft(),
+            "labels": {"start": [{"op": "narrate", "text": "Current line."}, {"op": "end"}]},
+        },
+    )
+
+    with pytest.raises(ValueError, match="draft_revision_conflict"):
+        service.build_snippet_patch(
+            script["id"],
+            "narration",
+            {"label": "start", "op_index": 1, "mode": "before"},
+            {"text": "Stale line."},
+            draft=stale_draft,
+            draft_revision=1,
+        )
+    with pytest.raises(ValueError, match="draft_revision_conflict"):
+        service.apply_snippet_patch_result(script["id"], "narration", stale_build["base_revision"], stale_build["patch"])
+
+    stored = service.get_draft(script["id"])
+    assert stored["revision"] == 2
+    assert stored["draft"]["labels"]["start"][0] == {"op": "narrate", "text": "Current line."}
+
+
+def test_service_preview_snippet_patch_validates_payload_without_mutating_stored_draft(
+    chacha_db: CharactersRAGDB,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = _service(chacha_db)
+    script = _create_script(service)
+    build = service.build_snippet_patch(
+        script["id"],
+        "narration",
+        {"label": "start", "op_index": 1, "mode": "before"},
+        {"text": "Inserted line."},
+    )
+
+    def fail_validate_draft(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("preview must not call validate_draft")
+
+    monkeypatch.setattr(service, "validate_draft", fail_validate_draft)
+
+    preview = service.preview_snippet_patch(
+        script["id"],
+        "narration",
+        build["base_revision"],
+        build["patch"],
+    )
+    stored = service.get_draft(script["id"])
+
+    assert preview["script_id"] == script["id"]
+    assert preview["base_revision"] == 1
+    assert preview["snippet_id"] == "narration"
+    assert preview["draft"]["labels"]["start"][1] == {"op": "narrate", "text": "Inserted line."}
+    assert preview["diagnostics"]["valid"] is True
+    assert preview["patch_summary"] == build["patch"].patch_summary
+    assert preview["warnings"] == preview["diagnostics"]["warnings"]
+    assert stored["revision"] == 1
+    assert stored["draft"] == _draft()
+    assert stored["diagnostics"]["stored"] is True
+
+
+def test_service_apply_snippet_patch_result_validates_and_persists_with_revision(
+    chacha_db: CharactersRAGDB,
+) -> None:
+    service = _service(chacha_db)
+    script = _create_script(service)
+    build = service.build_snippet_patch(
+        script["id"],
+        "narration",
+        {"label": "start", "op_index": 1, "mode": "before"},
+        {"text": "Inserted line."},
+    )
+
+    applied = service.apply_snippet_patch_result(
+        script["id"],
+        "narration",
+        build["base_revision"],
+        build["patch"],
+    )
+    stored = service.get_draft(script["id"])
+
+    assert applied["script_id"] == script["id"]
+    assert applied["revision"] == 2
+    assert applied["snippet_id"] == "narration"
+    assert applied["draft"]["labels"]["start"][1] == {"op": "narrate", "text": "Inserted line."}
+    assert applied["diagnostics"]["valid"] is True
+    assert applied["patch_summary"] == build["patch"].patch_summary
+    assert stored["revision"] == 2
+    assert stored["draft"] == applied["draft"]
+    assert stored["diagnostics"] == applied["diagnostics"]
+
+
+def test_service_stale_apply_raises_draft_revision_conflict(chacha_db: CharactersRAGDB) -> None:
+    service = _service(chacha_db)
+    script = _create_script(service)
+    build = service.build_snippet_patch(
+        script["id"],
+        "narration",
+        {"label": "start", "op_index": 1, "mode": "before"},
+        {"text": "Inserted line."},
+    )
+
+    with pytest.raises(ValueError, match="draft_revision_conflict"):
+        service.apply_snippet_patch_result(script["id"], "narration", 0, build["patch"])
+
+
+def test_service_stale_apply_conflicts_before_validation_or_audio_resolution(
+    chacha_db: CharactersRAGDB,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = _service(chacha_db)
+    script = _create_script(service, _audio_draft())
+    build = service.build_snippet_patch(
+        script["id"],
+        "play_bgm",
+        {"label": "start", "op_index": 1, "mode": "before"},
+        {"media_ref": "missing.audio"},
+    )
+
+    def fail_validate_draft_payload(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("stale apply must not validate patched draft")
+
+    monkeypatch.setattr(service, "validate_draft_payload", fail_validate_draft_payload)
+
+    with pytest.raises(ValueError, match="draft_revision_conflict"):
+        service.apply_snippet_patch_result(script["id"], "play_bgm", 0, build["patch"])
+
+
+def test_service_duplicate_apply_against_same_revision_conflicts(chacha_db: CharactersRAGDB) -> None:
+    service = _service(chacha_db)
+    script = _create_script(service)
+    build = service.build_snippet_patch(
+        script["id"],
+        "narration",
+        {"label": "start", "op_index": 1, "mode": "before"},
+        {"text": "Inserted line."},
+    )
+
+    service.apply_snippet_patch_result(script["id"], "narration", build["base_revision"], build["patch"])
+    with pytest.raises(ValueError, match="draft_revision_conflict"):
+        service.apply_snippet_patch_result(script["id"], "narration", build["base_revision"], build["patch"])
+
+
+def test_service_audio_refs_are_resolved_from_patched_draft_for_validation(chacha_db: CharactersRAGDB) -> None:
+    seen_drafts: list[Mapping[str, Any]] = []
+
+    def audio_ref_resolver(program: Mapping[str, Any]) -> Mapping[str, Mapping[str, Any]]:
+        seen_drafts.append(program)
+        has_audio_op = any(op.get("op") == "play_bgm" for op in program["labels"]["start"])
+        return {"bgm.archive": {"mime_type": "audio/mpeg", "generated_file_id": 7001}} if has_audio_op else {}
+
+    service = _service(chacha_db, audio_ref_resolver=audio_ref_resolver)
+    script = _create_script(service, _audio_draft())
+    build = service.build_snippet_patch(
+        script["id"],
+        "play_bgm",
+        {"label": "start", "op_index": 1, "mode": "before"},
+        {"media_ref": "bgm.archive"},
+    )
+
+    preview = service.preview_snippet_patch(script["id"], "play_bgm", build["base_revision"], build["patch"])
+    applied = service.apply_snippet_patch_result(
+        script["id"],
+        "play_bgm",
+        build["base_revision"],
+        build["patch"],
+        audio_refs={"bgm.explicit": {"mime_type": "audio/mpeg", "generated_file_id": 7002}},
+    )
+
+    assert preview["diagnostics"]["valid"] is True
+    assert applied["diagnostics"]["valid"] is False
+    assert applied["diagnostics"]["errors"][0]["code"] == "audio_media_ref_inaccessible"
+    assert all(any(op.get("op") == "play_bgm" for op in draft["labels"]["start"]) for draft in seen_drafts)
+
+
 def test_generated_choice_set_patch_inserts_generate_and_handler_without_mutating_draft() -> None:
     draft = _draft()
     original = {
         "schema_version": "vn_script_program.v1",
+        "primary_asset_pack_id": 7,
         "entry_label": "start",
         "labels": {"start": [{"op": "narrate", "text": "Opening line."}, {"op": "end"}]},
     }

--- a/tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_catalog.py
+++ b/tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_catalog.py
@@ -457,8 +457,24 @@ def test_generated_choice_set_patch_inserts_generate_and_handler_without_mutatin
     assert result.patch_summary == {
         "inserted_ops": 1,
         "created_labels": ["generated_choice"],
-        "changed_paths": ["$.labels.start[1]", "$.labels.generated_choice"],
+        "changed_paths": ["$.labels['start'][1]", "$.labels['generated_choice']"],
     }
+
+
+def test_patch_changed_paths_escape_special_label_names() -> None:
+    result = apply_snippet_patch(
+        {
+            "schema_version": "vn_script_program.v1",
+            "primary_asset_pack_id": 7,
+            "entry_label": "chapter.one",
+            "labels": {"chapter.one": [{"op": "end"}]},
+        },
+        "narration",
+        {"label": "chapter.one", "mode": "before", "op_index": 0},
+        {"text": "Inserted."},
+    )
+
+    assert result.patch_summary["changed_paths"] == ["$.labels['chapter.one'][0]"]
 
 
 def test_patch_rejects_nested_raw_generation_routing_keys() -> None:
@@ -711,6 +727,22 @@ def test_catalog_is_preview_safe_and_includes_canonical_capability_tokens() -> N
     assert _forbidden_keys_present(catalog) == set()
 
 
+def test_catalog_operations_include_advisory_fields_and_examples() -> None:
+    catalog = list_authoring_catalog()
+    operations = {operation["op"]: operation for operation in catalog["operations"]}
+
+    narrate = operations["narrate"]
+    assert narrate["fields"][0]["name"] == "text"
+    assert narrate["fields"][0]["required"] is True
+    assert narrate["preview"] == {"op": "narrate", "text": "The scene opens."}
+    assert narrate["supports_condition"] is True
+
+    generate = operations["generate"]
+    assert "output_schema" in {field["name"] for field in generate["fields"]}
+    assert generate["output_compatibility"]["supported_output_schemas"]
+    assert "api_key" in generate["forbidden_fields"]
+
+
 def test_catalog_includes_required_v1_snippets_with_parameters_schema() -> None:
     catalog = list_authoring_catalog()
 
@@ -746,8 +778,8 @@ def test_generated_choice_snippet_exposes_handler_label_not_opcode_target() -> N
     assert "on_generated_choice" not in schema["properties"]
     assert "handler_label" in default_parameters
     assert "on_generated_choice" not in default_parameters
-    assert "handler_label" in str(snippet["preview"])
-    assert "on_generated_choice" not in str(snippet["preview"])
+    assert snippet["preview"][0]["on_generated_choice"] == "{handler_label}"
+    assert "handler_label" not in snippet["preview"][0]
 
 
 def test_authored_choice_snippet_exposes_public_choice_fields_not_opcode_fields() -> None:
@@ -763,8 +795,10 @@ def test_authored_choice_snippet_exposes_public_choice_fields_not_opcode_fields(
     assert choice_schema["required"] == ["id", "text", "target_label"]
     assert "target_label" in choice_schema["properties"]
     assert "target" not in choice_schema["properties"]
-    assert "choice_id" in str(snippet["preview"])
-    assert "target_label" in str(snippet["preview"])
+    assert snippet["preview"][0]["id"] == "{choice_id}"
+    assert snippet["preview"][0]["choices"][0]["target"] == "{target_label}"
+    assert "choice_id" not in snippet["preview"][0]
+    assert "target_label" not in snippet["preview"][0]["choices"][0]
 
 
 def test_catalog_json_contains_no_validation_codes_or_routing_secrets() -> None:
@@ -772,8 +806,6 @@ def test_catalog_json_contains_no_validation_codes_or_routing_secrets() -> None:
 
     serialized = str(catalog).lower()
     assert "validation_codes" not in serialized
-    assert "api_key" not in serialized
-    assert "provider_config" not in serialized
     assert "raw prompt" not in serialized
     assert "raw_prompt" not in serialized
     for key in forbidden_generation_routing_keys():

--- a/tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_catalog.py
+++ b/tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_catalog.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from tldw_Server_API.app.core.VN_Scripts.authoring_catalog import list_authoring_catalog
+from tldw_Server_API.app.core.VN_Scripts.validator import (
+    forbidden_generation_routing_keys,
+    known_script_ops,
+    supported_generation_output_schemas,
+)
+
+
+def _operation_ids(catalog: Mapping[str, Any]) -> tuple[str, ...]:
+    return tuple(operation["op"] for operation in catalog["operations"])
+
+
+def _assert_object_schemas_are_closed(schema: Mapping[str, Any], path: str = "$") -> None:
+    if schema.get("type") == "object":
+        assert schema.get("additionalProperties") is False, path
+    for key in ("properties", "patternProperties", "$defs", "definitions"):
+        children = schema.get(key)
+        if isinstance(children, Mapping):
+            for child_name, child_schema in children.items():
+                if isinstance(child_schema, Mapping):
+                    _assert_object_schemas_are_closed(child_schema, f"{path}.{key}.{child_name}")
+    items = schema.get("items")
+    if isinstance(items, Mapping):
+        _assert_object_schemas_are_closed(items, f"{path}.items")
+    for key in ("oneOf", "anyOf", "allOf"):
+        variants = schema.get(key)
+        if isinstance(variants, list):
+            for index, variant in enumerate(variants):
+                if isinstance(variant, Mapping):
+                    _assert_object_schemas_are_closed(variant, f"{path}.{key}[{index}]")
+
+
+def _forbidden_keys_present(value: Any) -> set[str]:
+    forbidden = set(forbidden_generation_routing_keys()) | {
+        "raw_prompt",
+        "prompt",
+        "provider_config",
+        "validation_codes",
+    }
+    found: set[str] = set()
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            if str(key) in forbidden:
+                found.add(str(key))
+            found.update(_forbidden_keys_present(child))
+    elif isinstance(value, list):
+        for child in value:
+            found.update(_forbidden_keys_present(child))
+    return found
+
+
+def test_catalog_operations_exactly_match_validator_known_ops() -> None:
+    catalog = list_authoring_catalog()
+
+    assert catalog["schema_version"] == "vn_script_authoring_catalog.v1"
+    assert catalog["program_schema_version"] == "vn_script_program.v1"
+    assert _operation_ids(catalog) == known_script_ops()
+
+
+def test_catalog_is_preview_safe_and_includes_canonical_capability_tokens() -> None:
+    catalog = list_authoring_catalog()
+
+    assert catalog["capability_tokens"] == [
+        "script_authoring_catalog",
+        "scripted_generation",
+        "scripted_generation.output_schema.choice_set",
+        "scripted_generation.output_schema.scene_update",
+        "scripted_generation.user_confirmation",
+    ]
+    assert catalog["generation_output_schemas"] == list(supported_generation_output_schemas())
+    assert set(catalog["operation_categories"]) == {"story", "branching", "visuals", "audio", "generation", "state"}
+    assert _forbidden_keys_present(catalog) == set()
+
+
+def test_catalog_includes_required_v1_snippets_with_parameters_schema() -> None:
+    catalog = list_authoring_catalog()
+
+    snippet_ids = {snippet["id"] for snippet in catalog["snippets"]}
+
+    assert {
+        "narration",
+        "dialogue",
+        "authored_choice",
+        "generated_choice_set",
+        "scene_update_generation",
+        "confirm_gated_generation",
+        "set_background",
+        "show_sprite",
+        "play_bgm",
+        "set_variable",
+        "ending",
+    }.issubset(snippet_ids)
+    for snippet in catalog["snippets"]:
+        assert "parameters_schema" in snippet
+        assert "parameter_schema" not in snippet
+
+
+def test_generated_choice_snippet_exposes_handler_label_not_opcode_target() -> None:
+    catalog = list_authoring_catalog()
+    snippet = next(snippet for snippet in catalog["snippets"] if snippet["id"] == "generated_choice_set")
+
+    schema = snippet["parameters_schema"]
+    default_parameters = snippet["default_parameters"]
+
+    assert schema["required"] == ["handler_label"]
+    assert "handler_label" in schema["properties"]
+    assert "on_generated_choice" not in schema["properties"]
+    assert "handler_label" in default_parameters
+    assert "on_generated_choice" not in default_parameters
+    assert "handler_label" in str(snippet["preview"])
+    assert "on_generated_choice" not in str(snippet["preview"])
+
+
+def test_catalog_json_contains_no_validation_codes_or_routing_secrets() -> None:
+    catalog = list_authoring_catalog()
+
+    serialized = str(catalog).lower()
+    assert "validation_codes" not in serialized
+    assert "api_key" not in serialized
+    assert "provider_config" not in serialized
+    assert "raw prompt" not in serialized
+    assert "raw_prompt" not in serialized
+    for key in forbidden_generation_routing_keys():
+        assert key not in _forbidden_keys_present(catalog)
+
+
+def test_snippet_parameter_schemas_forbid_extra_object_fields_recursively() -> None:
+    catalog = list_authoring_catalog()
+
+    assert catalog["snippets"]
+    for snippet in catalog["snippets"]:
+        assert snippet["schema_version"] == "vn_script_program.v1"
+        _assert_object_schemas_are_closed(snippet["parameters_schema"], f"$.snippets.{snippet['id']}.parameters_schema")
+
+
+def test_catalog_payloads_are_isolated_between_calls() -> None:
+    first = list_authoring_catalog()
+    first["operations"][0]["label"] = "mutated"
+    first["snippets"][0]["parameters_schema"]["properties"]["unexpected"] = {"type": "string"}
+    first["limits"]["max_title_length"] = 1
+
+    second = list_authoring_catalog()
+
+    assert second["operations"][0]["label"] != "mutated"
+    assert "unexpected" not in second["snippets"][0]["parameters_schema"]["properties"]
+    assert second["limits"]["max_title_length"] != 1

--- a/tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_catalog.py
+++ b/tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_catalog.py
@@ -4,6 +4,13 @@ from collections.abc import Mapping
 from typing import Any
 
 from tldw_Server_API.app.core.VN_Scripts.authoring_catalog import list_authoring_catalog
+from tldw_Server_API.app.core.VN_Scripts.authoring_errors import VNScriptAuthoringError
+from tldw_Server_API.app.core.VN_Scripts.snippet_patcher import (
+    MAX_SNIPPET_PARAMETER_DEPTH,
+    MAX_SNIPPET_PARAMETER_PAYLOAD_BYTES,
+    MAX_SNIPPET_PARAMETER_STRING_LENGTH,
+    apply_snippet_patch,
+)
 from tldw_Server_API.app.core.VN_Scripts.validator import (
     forbidden_generation_routing_keys,
     known_script_ops,
@@ -52,6 +59,299 @@ def _forbidden_keys_present(value: Any) -> set[str]:
         for child in value:
             found.update(_forbidden_keys_present(child))
     return found
+
+
+def _draft() -> dict[str, Any]:
+    return {
+        "schema_version": "vn_script_program.v1",
+        "entry_label": "start",
+        "labels": {
+            "start": [
+                {"op": "narrate", "text": "Opening line."},
+                {"op": "end"},
+            ]
+        },
+    }
+
+
+def _assert_authoring_error(
+    exc_info: Any,
+    *,
+    code: str,
+    detail_key: str,
+    detail_value: Any,
+) -> None:
+    error = exc_info.value
+    assert isinstance(error, VNScriptAuthoringError)
+    assert error.code == code
+    assert error.status_code == 400
+    assert error.details[detail_key] == detail_value
+
+
+def test_generated_choice_set_patch_inserts_generate_and_handler_without_mutating_draft() -> None:
+    draft = _draft()
+    original = {
+        "schema_version": "vn_script_program.v1",
+        "entry_label": "start",
+        "labels": {"start": [{"op": "narrate", "text": "Opening line."}, {"op": "end"}]},
+    }
+
+    result = apply_snippet_patch(
+        draft,
+        "generated_choice_set",
+        {"label": "start", "op_index": 0, "mode": "after"},
+        {"handler_label": "generated_choice", "max_choices": 3, "scope": "turn"},
+    )
+
+    assert draft == original
+    assert result.draft is not draft
+    assert result.draft["labels"]["start"] == [
+        {"op": "narrate", "text": "Opening line."},
+        {
+            "op": "generate",
+            "scope": "turn",
+            "max_choices": 3,
+            "output_schema": "choice_set",
+            "on_generated_choice": "generated_choice",
+        },
+        {"op": "end"},
+    ]
+    assert result.draft["labels"]["generated_choice"] == [
+        {"op": "narrate", "text": "Handle the selected generated choice here."},
+        {"op": "end"},
+    ]
+    assert result.patch_summary == {
+        "inserted_ops": 1,
+        "created_labels": ["generated_choice"],
+        "changed_paths": ["$.labels.start[1]", "$.labels.generated_choice"],
+    }
+
+
+def test_patch_rejects_nested_raw_generation_routing_keys() -> None:
+    import pytest
+
+    with pytest.raises(VNScriptAuthoringError) as exc_info:
+        apply_snippet_patch(
+            _draft(),
+            "scene_update_generation",
+            {"label": "start", "mode": "append"},
+            {"safe": {"nested": {"model": "gpt-example"}}},
+        )
+
+    _assert_authoring_error(
+        exc_info,
+        code="snippet_parameter_invalid",
+        detail_key="field_path",
+        detail_value="$.parameters.safe.nested.model",
+    )
+
+
+def test_patch_rejects_root_and_nested_unknown_snippet_parameters() -> None:
+    import pytest
+
+    with pytest.raises(VNScriptAuthoringError) as root_exc:
+        apply_snippet_patch(
+            _draft(),
+            "narration",
+            {"label": "start", "mode": "append"},
+            {"text": "Line.", "unexpected": True},
+        )
+    _assert_authoring_error(
+        root_exc,
+        code="snippet_parameter_invalid",
+        detail_key="field_path",
+        detail_value="$.parameters.unexpected",
+    )
+
+    with pytest.raises(VNScriptAuthoringError) as nested_exc:
+        apply_snippet_patch(
+            _draft(),
+            "authored_choice",
+            {"label": "start", "mode": "append"},
+            {
+                "choice_id": "door",
+                "choices": [
+                    {
+                        "id": "open",
+                        "text": "Open it.",
+                        "target_label": "start",
+                        "unexpected": True,
+                    }
+                ],
+            },
+        )
+    _assert_authoring_error(
+        nested_exc,
+        code="snippet_parameter_invalid",
+        detail_key="field_path",
+        detail_value="$.parameters.choices[0].unexpected",
+    )
+
+
+def test_authored_choice_patch_accepts_public_shape_and_maps_to_internal_opcode() -> None:
+    result = apply_snippet_patch(
+        _draft(),
+        "authored_choice",
+        {"label": "start", "mode": "append"},
+        {
+            "choice_id": "door",
+            "choices": [
+                {"id": "open", "text": "Open it.", "target_label": "start"},
+                {"id": "wait", "text": "Wait.", "target_label": "start"},
+            ],
+        },
+    )
+
+    assert result.draft["labels"]["start"][-1] == {
+        "op": "choice",
+        "id": "door",
+        "choices": [
+            {"id": "open", "text": "Open it.", "target": "start"},
+            {"id": "wait", "text": "Wait.", "target": "start"},
+        ],
+    }
+
+
+def test_patch_rejects_invalid_and_missing_anchors_with_typed_errors() -> None:
+    import pytest
+
+    with pytest.raises(VNScriptAuthoringError) as invalid_exc:
+        apply_snippet_patch(_draft(), "narration", {"label": "start", "mode": "beside"}, {"text": "Line."})
+    _assert_authoring_error(
+        invalid_exc,
+        code="snippet_anchor_invalid",
+        detail_key="anchor",
+        detail_value={"label": "start", "mode": "beside"},
+    )
+
+    with pytest.raises(VNScriptAuthoringError) as missing_exc:
+        apply_snippet_patch(_draft(), "narration", {"label": "missing", "mode": "append"}, {"text": "Line."})
+    _assert_authoring_error(
+        missing_exc,
+        code="snippet_anchor_not_found",
+        detail_key="anchor",
+        detail_value={"label": "missing", "mode": "append"},
+    )
+
+
+def test_patch_rejects_bool_op_index_as_invalid_anchor() -> None:
+    import pytest
+
+    for mode in ("before", "after"):
+        anchor = {"label": "start", "op_index": True, "mode": mode}
+        with pytest.raises(VNScriptAuthoringError) as exc_info:
+            apply_snippet_patch(_draft(), "narration", anchor, {"text": "Line."})
+        _assert_authoring_error(
+            exc_info,
+            code="snippet_anchor_invalid",
+            detail_key="anchor",
+            detail_value=anchor,
+        )
+
+
+def test_patch_rejects_label_conflicts() -> None:
+    import pytest
+
+    with pytest.raises(VNScriptAuthoringError) as exc_info:
+        apply_snippet_patch(
+            _draft(),
+            "generated_choice_set",
+            {"label": "start", "mode": "append"},
+            {"handler_label": "start"},
+        )
+
+    _assert_authoring_error(
+        exc_info,
+        code="snippet_label_conflict",
+        detail_key="label",
+        detail_value="start",
+    )
+
+
+def test_patch_rejects_extremely_deep_parameters_with_typed_error_before_serialization() -> None:
+    import pytest
+
+    parameters: dict[str, Any] = {"text": "Line."}
+    cursor = parameters
+    for depth in range(1200):
+        cursor["nested"] = {}
+        cursor = cursor["nested"]
+
+    with pytest.raises(VNScriptAuthoringError) as exc_info:
+        apply_snippet_patch(_draft(), "narration", {"label": "start", "mode": "append"}, parameters)
+
+    error = exc_info.value
+    assert error.code == "snippet_parameter_invalid"
+    assert error.status_code == 400
+    assert "field_path" in error.details
+    assert error.details["field_path"].startswith("$.parameters.nested")
+
+
+def test_patch_rejects_excessive_parameter_limits_with_field_paths() -> None:
+    import pytest
+
+    too_deep: dict[str, Any] = {}
+    cursor = too_deep
+    for depth in range(MAX_SNIPPET_PARAMETER_DEPTH + 1):
+        cursor[f"level_{depth}"] = {}
+        cursor = cursor[f"level_{depth}"]
+    with pytest.raises(VNScriptAuthoringError) as depth_exc:
+        apply_snippet_patch(_draft(), "narration", {"label": "start", "mode": "append"}, too_deep)
+    _assert_authoring_error(
+        depth_exc,
+        code="snippet_parameter_invalid",
+        detail_key="field_path",
+        detail_value="$.parameters.level_0.level_1.level_2.level_3.level_4.level_5.level_6.level_7.level_8",
+    )
+
+    with pytest.raises(VNScriptAuthoringError) as string_exc:
+        apply_snippet_patch(
+            _draft(),
+            "narration",
+            {"label": "start", "mode": "append"},
+            {"text": "x" * (MAX_SNIPPET_PARAMETER_STRING_LENGTH + 1)},
+        )
+    _assert_authoring_error(
+        string_exc,
+        code="snippet_parameter_invalid",
+        detail_key="field_path",
+        detail_value="$.parameters.text",
+    )
+
+    with pytest.raises(VNScriptAuthoringError) as payload_exc:
+        apply_snippet_patch(
+            _draft(),
+            "narration",
+            {"label": "start", "mode": "append"},
+            {"items": ["x" * 1000 for _ in range((MAX_SNIPPET_PARAMETER_PAYLOAD_BYTES // 1000) + 2)]},
+        )
+    _assert_authoring_error(
+        payload_exc,
+        code="snippet_parameter_invalid",
+        detail_key="field_path",
+        detail_value="$.parameters",
+    )
+
+
+def test_patch_rejects_invalid_generation_scopes_with_field_path() -> None:
+    import pytest
+
+    cases = [
+        ("generated_choice_set", {"handler_label": "generated_choice", "scope": []}),
+        ("generated_choice_set", {"handler_label": "generated_choice", "scope": "session"}),
+        ("scene_update_generation", {"scope": []}),
+        ("scene_update_generation", {"scope": "session"}),
+    ]
+
+    for snippet_id, parameters in cases:
+        with pytest.raises(VNScriptAuthoringError) as exc_info:
+            apply_snippet_patch(_draft(), snippet_id, {"label": "start", "mode": "append"}, parameters)
+        _assert_authoring_error(
+            exc_info,
+            code="snippet_parameter_invalid",
+            detail_key="field_path",
+            detail_value="$.parameters.scope",
+        )
 
 
 def test_catalog_operations_exactly_match_validator_known_ops() -> None:
@@ -114,6 +414,23 @@ def test_generated_choice_snippet_exposes_handler_label_not_opcode_target() -> N
     assert "on_generated_choice" not in default_parameters
     assert "handler_label" in str(snippet["preview"])
     assert "on_generated_choice" not in str(snippet["preview"])
+
+
+def test_authored_choice_snippet_exposes_public_choice_fields_not_opcode_fields() -> None:
+    catalog = list_authoring_catalog()
+    snippet = next(snippet for snippet in catalog["snippets"] if snippet["id"] == "authored_choice")
+
+    schema = snippet["parameters_schema"]
+    choice_schema = schema["properties"]["choices"]["items"]
+
+    assert schema["required"] == ["choice_id", "choices"]
+    assert "choice_id" in schema["properties"]
+    assert "id" not in schema["properties"]
+    assert choice_schema["required"] == ["id", "text", "target_label"]
+    assert "target_label" in choice_schema["properties"]
+    assert "target" not in choice_schema["properties"]
+    assert "choice_id" in str(snippet["preview"])
+    assert "target_label" in str(snippet["preview"])
 
 
 def test_catalog_json_contains_no_validation_codes_or_routing_secrets() -> None:

--- a/tldw_Server_API/tests/VN_Scripts/test_vn_scripts_api.py
+++ b/tldw_Server_API/tests/VN_Scripts/test_vn_scripts_api.py
@@ -13,6 +13,7 @@ from tldw_Server_API.app.api.v1.endpoints.vn_scripts import (
     _resolve_accessible_audio_refs,
     router as vn_scripts_router,
 )
+from tldw_Server_API.app.api.v1.endpoints.vn_capabilities import router as vn_capabilities_router
 from tldw_Server_API.app.api.v1.schemas.vn_asset_schemas import (
     VNAssetPackCreate,
     VNAssetReviewRequest,
@@ -72,6 +73,7 @@ def client(
     authnz_pool: DatabasePool,
 ) -> Iterator[TestClient]:
     app = FastAPI()
+    app.include_router(vn_capabilities_router, prefix="/api/v1/vn")
     app.include_router(vn_scripts_router, prefix="/api/v1/vn")
 
     async def override_user() -> User:
@@ -201,6 +203,298 @@ def test_template_catalog_returns_isolated_preview_payloads() -> None:
     second_catalog = list_template_catalog()
 
     assert "mutated" not in second_catalog[0]["preview"]["flow"]
+
+
+def test_authoring_catalog_returns_preview_safe_metadata(client: TestClient) -> None:
+    response = client.get("/api/v1/vn/vn-scripts/vn-authoring-catalog")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["schema_version"] == "vn_script_authoring_catalog.v1"
+    assert "script_authoring_catalog" in payload["capability_tokens"]
+    assert {operation["op"] for operation in payload["operations"]} >= {"narrate", "generate", "choice"}
+    assert {snippet["id"] for snippet in payload["snippets"]} >= {"narration", "generated_choice_set"}
+    assert _contains_key(payload, "api_key") is False
+    assert _contains_key(payload, "provider") is False
+    assert _contains_key(payload, "model") is False
+    assert _contains_key(payload, "raw_prompt") is False
+
+
+def test_snippet_preview_supports_stored_and_supplied_draft(
+    client: TestClient,
+    chacha_dbs: dict[int, CharactersRAGDB],
+) -> None:
+    asset_pack_id, _ = _create_asset_pack(chacha_dbs[42])
+    script_id = _create_script(client, asset_pack_id=asset_pack_id)
+    client.put(
+        f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft",
+        json={"if_revision": 0, "draft": _program(asset_pack_id)},
+    )
+    stored_response = client.post(
+        f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft/snippet-preview",
+        json={
+            "snippet_id": "narration",
+            "anchor": {"label": "start", "op_index": 0, "mode": "after"},
+            "parameters": {"text": "Stored draft line."},
+        },
+    )
+    supplied_draft = _program(asset_pack_id)
+    supplied_draft["labels"]["start"][0]["text"] = "Supplied opening."
+    supplied_response = client.post(
+        f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft/snippet-preview",
+        json={
+            "snippet_id": "narration",
+            "anchor": {"label": "start", "op_index": 0, "mode": "after"},
+            "parameters": {"text": "Supplied draft line."},
+            "draft": supplied_draft,
+            "draft_revision": 1,
+        },
+    )
+
+    assert stored_response.status_code == 200
+    stored_payload = stored_response.json()
+    assert stored_payload["base_revision"] == 1
+    assert stored_payload["draft"]["labels"]["start"][1] == {"op": "narrate", "text": "Stored draft line."}
+    assert stored_payload["diagnostics"]["valid"] is True
+    assert stored_payload["patch_summary"]["inserted_ops"] == 1
+    assert supplied_response.status_code == 200
+    supplied_payload = supplied_response.json()
+    assert supplied_payload["base_revision"] == 1
+    assert supplied_payload["draft"]["labels"]["start"][0]["text"] == "Supplied opening."
+    assert supplied_payload["draft"]["labels"]["start"][1] == {"op": "narrate", "text": "Supplied draft line."}
+
+
+def test_snippet_preview_is_non_mutating(
+    client: TestClient,
+    chacha_dbs: dict[int, CharactersRAGDB],
+) -> None:
+    asset_pack_id, _ = _create_asset_pack(chacha_dbs[42])
+    script_id = _create_script(client, asset_pack_id=asset_pack_id)
+    client.put(
+        f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft",
+        json={"if_revision": 0, "draft": _program(asset_pack_id)},
+    )
+    before = client.get(f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft").json()
+
+    response = client.post(
+        f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft/snippet-preview",
+        json={
+            "snippet_id": "narration",
+            "anchor": {"label": "start", "mode": "append"},
+            "parameters": {"text": "Preview only."},
+        },
+    )
+    after = client.get(f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft").json()
+
+    assert response.status_code == 200
+    assert after["revision"] == before["revision"]
+    assert after["draft"] == before["draft"]
+    assert after["diagnostics"] == before["diagnostics"]
+
+
+def test_snippet_apply_requires_revision_persists_patch_and_returns_diagnostics(
+    client: TestClient,
+    chacha_dbs: dict[int, CharactersRAGDB],
+) -> None:
+    asset_pack_id, _ = _create_asset_pack(chacha_dbs[42])
+    script_id = _create_script(client, asset_pack_id=asset_pack_id)
+    client.put(
+        f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft",
+        json={"if_revision": 0, "draft": _program(asset_pack_id)},
+    )
+
+    missing_revision_response = client.post(
+        f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft/snippet-apply",
+        json={
+            "snippet_id": "narration",
+            "anchor": {"label": "start", "mode": "append"},
+            "parameters": {"text": "Missing revision."},
+        },
+    )
+    response = client.post(
+        f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft/snippet-apply",
+        json={
+            "if_revision": 1,
+            "snippet_id": "narration",
+            "anchor": {"label": "start", "op_index": 0, "mode": "after"},
+            "parameters": {"text": "Applied line."},
+        },
+    )
+    stored = client.get(f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft").json()
+
+    assert missing_revision_response.status_code == 422
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["revision"] == 2
+    assert payload["draft"]["labels"]["start"][1] == {"op": "narrate", "text": "Applied line."}
+    assert payload["diagnostics"]["valid"] is True
+    assert payload["patch_summary"]["inserted_ops"] == 1
+    assert stored["revision"] == 2
+    assert stored["draft"] == payload["draft"]
+    assert stored["diagnostics"] == payload["diagnostics"]
+
+
+def test_snippet_preview_unknown_snippet_returns_not_found(
+    client: TestClient,
+    chacha_dbs: dict[int, CharactersRAGDB],
+) -> None:
+    asset_pack_id, _ = _create_asset_pack(chacha_dbs[42])
+    script_id = _create_script(client, asset_pack_id=asset_pack_id)
+    client.put(
+        f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft",
+        json={"if_revision": 0, "draft": _program(asset_pack_id)},
+    )
+
+    response = client.post(
+        f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft/snippet-preview",
+        json={
+            "snippet_id": "missing_snippet",
+            "anchor": {"label": "start", "mode": "append"},
+            "parameters": {},
+        },
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"]["details"]["reason"] == "snippet_not_found"
+
+
+def test_snippet_preview_parameter_errors_return_field_path(
+    client: TestClient,
+    chacha_dbs: dict[int, CharactersRAGDB],
+) -> None:
+    asset_pack_id, _ = _create_asset_pack(chacha_dbs[42])
+    script_id = _create_script(client, asset_pack_id=asset_pack_id)
+    client.put(
+        f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft",
+        json={"if_revision": 0, "draft": _program(asset_pack_id)},
+    )
+    too_deep: dict[str, Any] = {}
+    cursor = too_deep
+    for depth in range(10):
+        cursor[f"level_{depth}"] = {}
+        cursor = cursor[f"level_{depth}"]
+    cases = [
+        {"text": "Line.", "unexpected": True},
+        {"text": "x" * 9000},
+        too_deep,
+    ]
+
+    for parameters in cases:
+        response = client.post(
+            f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft/snippet-preview",
+            json={
+                "snippet_id": "narration",
+                "anchor": {"label": "start", "mode": "append"},
+                "parameters": parameters,
+            },
+        )
+        assert response.status_code == 400
+        details = response.json()["detail"]["details"]
+        assert details["reason"] == "snippet_parameter_invalid"
+        assert details["field_path"].startswith("$.parameters")
+
+
+def test_snippet_preview_anchor_errors_return_anchor_details(
+    client: TestClient,
+    chacha_dbs: dict[int, CharactersRAGDB],
+) -> None:
+    asset_pack_id, _ = _create_asset_pack(chacha_dbs[42])
+    script_id = _create_script(client, asset_pack_id=asset_pack_id)
+    client.put(
+        f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft",
+        json={"if_revision": 0, "draft": _program(asset_pack_id)},
+    )
+    cases = [
+        ({"label": "start", "mode": "beside"}, "snippet_anchor_invalid"),
+        ({"label": "missing", "mode": "append"}, "snippet_anchor_not_found"),
+    ]
+
+    for anchor, expected_reason in cases:
+        response = client.post(
+            f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft/snippet-preview",
+            json={
+                "snippet_id": "narration",
+                "anchor": anchor,
+                "parameters": {"text": "Line."},
+            },
+        )
+        assert response.status_code == 400
+        details = response.json()["detail"]["details"]
+        assert details["reason"] == expected_reason
+        assert details["anchor"] == anchor
+
+
+def test_snippet_apply_stale_revision_returns_current_revision(
+    client: TestClient,
+    chacha_dbs: dict[int, CharactersRAGDB],
+) -> None:
+    asset_pack_id, _ = _create_asset_pack(chacha_dbs[42])
+    script_id = _create_script(client, asset_pack_id=asset_pack_id)
+    client.put(
+        f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft",
+        json={"if_revision": 0, "draft": _program(asset_pack_id)},
+    )
+
+    response = client.post(
+        f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft/snippet-apply",
+        json={
+            "if_revision": 0,
+            "snippet_id": "narration",
+            "anchor": {"label": "start", "mode": "append"},
+            "parameters": {"text": "Stale line."},
+        },
+    )
+
+    assert response.status_code == 409
+    details = response.json()["detail"]["details"]
+    assert details["reason"] == "draft_revision_conflict"
+    assert details["current_revision"] == 1
+
+
+def test_snippet_apply_stale_revision_conflicts_before_anchor_validation(
+    client: TestClient,
+    chacha_dbs: dict[int, CharactersRAGDB],
+) -> None:
+    asset_pack_id, _ = _create_asset_pack(chacha_dbs[42])
+    script_id = _create_script(client, asset_pack_id=asset_pack_id)
+    revision_one_draft = _program(asset_pack_id)
+    revision_two_draft = {
+        **_program(asset_pack_id),
+        "entry_label": "renamed",
+        "labels": {"renamed": [{"op": "narrate", "text": "Renamed opening."}, {"op": "end"}]},
+    }
+    client.put(
+        f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft",
+        json={"if_revision": 0, "draft": revision_one_draft},
+    )
+    client.put(
+        f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft",
+        json={"if_revision": 1, "draft": revision_two_draft},
+    )
+
+    response = client.post(
+        f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft/snippet-apply",
+        json={
+            "if_revision": 1,
+            "snippet_id": "narration",
+            "anchor": {"label": "start", "mode": "append"},
+            "parameters": {"text": "Line for stale draft."},
+        },
+    )
+
+    assert response.status_code == 409
+    details = response.json()["detail"]["details"]
+    assert details["reason"] == "draft_revision_conflict"
+    assert details["current_revision"] == 2
+
+
+def test_vn_capabilities_include_script_authoring_catalog_when_scripts_routes_registered(
+    client: TestClient,
+) -> None:
+    response = client.get("/api/v1/vn/vn-capabilities")
+
+    assert response.status_code == 200
+    assert response.json()["features"]["script_authoring_catalog"] is True
 
 
 def test_create_script_from_template_stores_valid_draft(

--- a/tldw_Server_API/tests/VN_Scripts/test_vn_scripts_api.py
+++ b/tldw_Server_API/tests/VN_Scripts/test_vn_scripts_api.py
@@ -405,7 +405,6 @@ def test_snippet_preview_anchor_errors_return_anchor_details(
         json={"if_revision": 0, "draft": _program(asset_pack_id)},
     )
     cases = [
-        ({"label": "start", "mode": "beside"}, "snippet_anchor_invalid"),
         ({"label": "missing", "mode": "append"}, "snippet_anchor_not_found"),
     ]
 
@@ -422,6 +421,58 @@ def test_snippet_preview_anchor_errors_return_anchor_details(
         details = response.json()["detail"]["details"]
         assert details["reason"] == expected_reason
         assert details["anchor"] == anchor
+
+
+def test_snippet_preview_schema_rejects_invalid_anchor_shape(
+    client: TestClient,
+    chacha_dbs: dict[int, CharactersRAGDB],
+) -> None:
+    asset_pack_id, _ = _create_asset_pack(chacha_dbs[42])
+    script_id = _create_script(client, asset_pack_id=asset_pack_id)
+    client.put(
+        f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft",
+        json={"if_revision": 0, "draft": _program(asset_pack_id)},
+    )
+
+    invalid_mode = client.post(
+        f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft/snippet-preview",
+        json={
+            "snippet_id": "narration",
+            "anchor": {"label": "start", "mode": "beside"},
+            "parameters": {"text": "Line."},
+        },
+    )
+    missing_index = client.post(
+        f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft/snippet-preview",
+        json={
+            "snippet_id": "narration",
+            "anchor": {"label": "start", "mode": "before"},
+            "parameters": {"text": "Line."},
+        },
+    )
+
+    assert invalid_mode.status_code == 422
+    assert missing_index.status_code == 422
+
+
+def test_snippet_preview_schema_requires_revision_for_supplied_draft(
+    client: TestClient,
+    chacha_dbs: dict[int, CharactersRAGDB],
+) -> None:
+    asset_pack_id, _ = _create_asset_pack(chacha_dbs[42])
+    script_id = _create_script(client, asset_pack_id=asset_pack_id)
+
+    response = client.post(
+        f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft/snippet-preview",
+        json={
+            "snippet_id": "narration",
+            "anchor": {"label": "start", "mode": "append"},
+            "parameters": {"text": "Line."},
+            "draft": _program(asset_pack_id),
+        },
+    )
+
+    assert response.status_code == 422
 
 
 def test_snippet_apply_stale_revision_returns_current_revision(


### PR DESCRIPTION
## Change summary

This PR adds a backend-owned VN script authoring catalog and guided snippet editing flow. The backend exposes safe operation/snippet metadata, deterministic server-side snippet patching, non-mutating preview, optimistic apply, API schemas/endpoints, capability metadata, and API docs. The frontend consumes that contract through typed helpers and a guided insert panel while preserving the raw JSON editor and keeping VN semantic validation on the server.

The implementation keeps the catalog and patch semantics backend-owned so custom frontends can use the same API contract instead of reimplementing the rules in the WebUI. The WebUI only renders catalog-provided forms, parses JSON for editor usability, requires preview before apply, and handles revision conflicts/stale async responses non-destructively.

## Verification

- `python -m pytest tldw_Server_API/tests/VN_Scripts -q` -> 88 passed, 5 warnings
- `bun run --cwd apps/tldw-frontend test:run __tests__/vn-scripts` -> 44 passed
- `python -m compileall tldw_Server_API/app tldw_Server_API/tests/VN_Scripts` -> passed
- `python -m bandit -r tldw_Server_API/app/core/VN_Scripts tldw_Server_API/app/api/v1/endpoints/vn_scripts.py tldw_Server_API/app/api/v1/schemas/vn_script_schemas.py tldw_Server_API/app/core/VN_Platform/capabilities.py -f json -o /tmp/bandit_vn_authoring_catalog.json` -> 0 findings
- `git diff --check` -> passed

## Tracking

- Implements part of #1610
- Backlog: TASK-304

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a backend-owned VN script authoring catalog with server-side snippet preview/apply, plus a guided insert panel in the WebUI. Tightens snippet validation and exposes the `script_authoring_catalog` capability to clients.

- New Features
  - Catalog endpoint: GET /api/v1/vn/vn-scripts/vn-authoring-catalog.
  - Snippet endpoints: POST /scripts/{id}/draft/snippet-preview and POST /scripts/{id}/draft/snippet-apply.
  - Deterministic snippet patcher; preview is non-mutating; apply uses revision checks.
  - Hardened patcher: enforces parameter size/depth/payload limits, blocks forbidden generation routing keys, and returns structured authoring errors.
  - VN capabilities now include `script_authoring_catalog`.
  - Frontend helpers: `getVNScriptAuthoringCatalog`, `previewVNScriptSnippet`, `applyVNScriptSnippet` in `@web/lib/api/vnScripts`.
  - WebUI guided insert panel renders catalog-driven forms; raw JSON editor remains; handles conflicts and stale responses safely.

- Migration
  - Use the catalog to build editors instead of hard-coding VN opcodes.
  - Require preview before apply and handle `if_revision` conflicts non-destructively.
  - Gate guided editing on the `script_authoring_catalog` capability.
  - No changes needed to existing draft/validation flows; validation stays on the server.

<sup>Written for commit 99247406d229d115610af401799f6d1f10665174. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

