### PR TITLE
Add Persona Visual V2 archive preview diagnostics

### DIFF
--- a/Docs/Code_Documentation/Persona_Visual_Packs.md
+++ b/Docs/Code_Documentation/Persona_Visual_Packs.md
@@ -83,6 +83,16 @@ commit eligibility, and activation eligibility. It does not parse archives,
 create asset rows, activate packs, or load renderer runtimes; the current V1
 archive preview and commit flow remains unchanged.
 
+Archive import preview now routes Manifest V2 renderer metadata through that
+validator and places the result in `proposed_plan.renderer_import_preview`.
+Known disabled renderers such as `live2d`, and unknown renderers, can therefore
+return review diagnostics without being treated as malformed V1 sprite-frame
+manifests. If the renderer preview is not commit-eligible, the preview row is
+stored with `status: "blocked"` and includes `commit_eligible: false`,
+`activation_eligible: false`, and `commit_blockers` in the proposed plan. This
+is still a review-only path: no asset rows or pack rows are committed, no pack is
+activated, no runtime renderer is loaded, and no MCP provider behavior is added.
+
 ### Sprite Atlas Frames
 
 Sprite atlases are represented as `sprite_frames` packs. In this slice,

--- a/Docs/superpowers/plans/2026-05-13-persona-visual-v2-archive-preview.md
+++ b/Docs/superpowers/plans/2026-05-13-persona-visual-v2-archive-preview.md
@@ -1,0 +1,17 @@
+## Stage 1: Archive Preview Diagnostics
+**Goal**: Extend Persona Visual archive preview so Manifest V2 renderer metadata is routed through the existing renderer import-preview validator instead of failing as a malformed V1 visual manifest.
+**Success Criteria**: Disabled known renderers and unknown renderers return structured renderer diagnostics, blockers, normalized role categories, and non-activation/non-commit eligibility.
+**Tests**: Add focused previewer tests for disabled `live2d`, unknown renderer, missing required role category, and existing V1 regression coverage.
+**Status**: Complete
+
+## Stage 2: Preview Status Wiring
+**Goal**: Preserve V1 completed preview behavior while storing V2 renderer-blocked previews as non-committable review results.
+**Success Criteria**: Background import-preview jobs complete validation, but blocked preview rows are not accepted by the import-commit path.
+**Tests**: Focused unit coverage plus existing Persona visual portability tests.
+**Status**: Complete
+
+## Stage 3: Documentation And Tracker Closeout
+**Goal**: Document the V2 preview behavior and explicitly keep this slice out of runtime activation, MCP provider execution, frontend changes, and VN/CYOA code.
+**Success Criteria**: Docs and Backlog task note the backend-only preview boundary and verification results.
+**Tests**: Focused pytest and Bandit on touched Python scope.
+**Status**: Complete

--- a/backlog/tasks/task-319 - Implement-Persona-Visual-Manifest-V2-archive-import-preview-diagnostics.md
+++ b/backlog/tasks/task-319 - Implement-Persona-Visual-Manifest-V2-archive-import-preview-diagnostics.md
@@ -1,0 +1,68 @@
+---
+id: TASK-319
+title: Implement Persona Visual Manifest V2 archive import-preview diagnostics
+status: Done
+assignee:
+  - codex
+created_date: '2026-05-13 15:09'
+updated_date: '2026-05-13 15:25'
+labels:
+  - persona
+  - buddy
+  - visual-packs
+  - backend
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1510'
+  - 'https://github.com/rmusser01/tldw_server/issues/1638'
+documentation:
+  - Docs/Design/2026-05-13-persona-visual-manifest-v2-contract.md
+  - Docs/Code_Documentation/Persona_Visual_Packs.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Wire Manifest V2/non-sprite Persona Visual archive metadata into the backend import-preview path so review diagnostics can be returned before asset rows, pack rows, activation, runtime renderer support, MCP provider exposure, or UI changes exist. Preserve the existing V1 sprite_frames preview and commit behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 V2-style archive preview can report unsupported or blocked renderer diagnostics without the old generic malformed_visual_manifest failure
+- [x] #2 Known disabled renderers such as live2d return renderer preview diagnostics, normalized role categories, and non-activation status
+- [x] #3 Unknown renderers return safe unsupported diagnostics
+- [x] #4 Existing V1 sprite_frames archive preview and validator tests still pass
+- [x] #5 Tests cover V2 disabled renderer, unknown renderer, missing required role category, and V1 regression behavior
+- [x] #6 Docs or task notes clarify this slice still does not commit assets, activate packs, add runtime renderers, MCP provider behavior, UI changes, or VN/CYOA behavior
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented Manifest V2 archive preview routing through the existing renderer import-preview validator for non-V1 manifests. Known disabled renderers such as live2d now return proposed_plan.renderer_import_preview diagnostics and blocked preview status instead of malformed_visual_manifest.
+
+Updated the import-preview worker to persist result.status so renderer-blocked previews remain non-committable through the existing commit status gate.
+
+Verification: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_portability.py tldw_Server_API/tests/Persona/test_persona_visual_import_preview_validators.py tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py -q => 29 passed, 5 warnings.
+
+Verification: git diff --check => passed. Bandit: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Persona/visual_portability/preview.py tldw_Server_API/app/core/Persona/visual_jobs_worker.py -f json -o /tmp/bandit_persona_visual_v2_archive_preview.json => 0 findings.
+
+No runtime activation, MCP provider execution, frontend, or VN/CYOA behavior was added in this slice.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented backend-only Persona Visual Manifest V2 archive import-preview diagnostics. V2 renderer metadata now uses the renderer capability import-preview validator, returns structured diagnostics under proposed_plan.renderer_import_preview, marks non-committable renderer previews as blocked, and preserves V1 sprite_frames preview behavior. Added focused previewer and worker regression tests plus documentation for the review-only boundary.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-319 - Implement-Persona-Visual-Manifest-V2-archive-import-preview-diagnostics.md
+++ b/backlog/tasks/task-319 - Implement-Persona-Visual-Manifest-V2-archive-import-preview-diagnostics.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - codex
 created_date: '2026-05-13 15:09'
-updated_date: '2026-05-13 15:25'
+updated_date: '2026-05-14 00:29'
 labels:
   - persona
   - buddy
@@ -44,17 +44,27 @@ Implemented Manifest V2 archive preview routing through the existing renderer im
 
 Updated the import-preview worker to persist result.status so renderer-blocked previews remain non-committable through the existing commit status gate.
 
-Verification: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_portability.py tldw_Server_API/tests/Persona/test_persona_visual_import_preview_validators.py tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py -q => 29 passed, 5 warnings.
+Verification: python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_portability.py tldw_Server_API/tests/Persona/test_persona_visual_import_preview_validators.py tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py -q => 29 passed, 5 warnings.
 
-Verification: git diff --check => passed. Bandit: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Persona/visual_portability/preview.py tldw_Server_API/app/core/Persona/visual_jobs_worker.py -f json -o /tmp/bandit_persona_visual_v2_archive_preview.json => 0 findings.
+Verification: git diff --check => passed. Bandit scanned the touched backend files tldw_Server_API/app/core/Persona/visual_portability/preview.py and tldw_Server_API/app/core/Persona/visual_jobs_worker.py with python -m bandit -r tldw_Server_API/app/core/Persona/visual_portability/preview.py tldw_Server_API/app/core/Persona/visual_jobs_worker.py -f json -o /tmp/bandit_persona_visual_v2_archive_preview.json => 0 findings.
 
 No runtime activation, MCP provider execution, frontend, or VN/CYOA behavior was added in this slice.
+
+Review follow-up started for PR #1642: verifying Qodo, CodeRabbit, and Gemini comments against current branch before minimal fixes.
+
+Review follow-up: fixed Qodo version-coercion finding by accepting integer-like floats and signed ASCII integer strings for archive preview routing, avoiding isdigit Unicode edge cases. Added regression coverage for manifest_version 2.0 and +2 routing to renderer diagnostics.
+
+Review follow-up: updated Backlog verification notes to use reproducible python -m commands and to clarify Bandit scanned preview.py and visual_jobs_worker.py specifically.
+
+Review verification: python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_portability.py tldw_Server_API/tests/Persona/test_persona_visual_import_preview_validators.py tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py -q => 31 passed, 5 warnings. git diff --check => passed. python -m bandit -r tldw_Server_API/app/core/Persona/visual_portability/preview.py tldw_Server_API/app/core/Persona/visual_jobs_worker.py -f json -o /tmp/bandit_persona_visual_v2_archive_preview_review_fix.json => 0 findings.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Implemented backend-only Persona Visual Manifest V2 archive import-preview diagnostics. V2 renderer metadata now uses the renderer capability import-preview validator, returns structured diagnostics under proposed_plan.renderer_import_preview, marks non-committable renderer previews as blocked, and preserves V1 sprite_frames preview behavior. Added focused previewer and worker regression tests plus documentation for the review-only boundary.
+
+Review follow-up fixed manifest version routing for integer-like floats and signed strings, added regression tests, and normalized task verification wording.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/core/Persona/visual_jobs_worker.py
+++ b/tldw_Server_API/app/core/Persona/visual_jobs_worker.py
@@ -384,7 +384,7 @@ class PersonaVisualPortabilityWorker:
         self._repo.update_import_preview(
             preview_id,
             {
-                "status": "completed",
+                "status": str(result.get("status") or "completed"),
                 "stage": "completed",
                 "archive_sha256": result["archive_sha256"],
                 "canonical_payload_fingerprint": result["canonical_payload_fingerprint"],

--- a/tldw_Server_API/app/core/Persona/visual_portability/preview.py
+++ b/tldw_Server_API/app/core/Persona/visual_portability/preview.py
@@ -8,6 +8,9 @@ from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
+from tldw_Server_API.app.core.Persona.visual_import_preview_validators import (
+    preview_renderer_import,
+)
 from tldw_Server_API.app.core.Persona.visuals import (
     PersonaVisualManifestError,
     validate_visual_manifest,
@@ -65,27 +68,36 @@ class PersonaVisualPackImportPreviewer:
             visual_manifest = pack.get("visual_manifest")
             if not isinstance(visual_manifest, dict):
                 raise ValueError("malformed_metadata: metadata/pack.json")
-            available_asset_ids = {
-                str(asset["source_asset_id"])
-                for asset in assets
-                if asset.get("source_asset_id") not in (None, "")
-            }
-            available_dimensions = {
-                str(asset["source_asset_id"]): (int(asset["width"]), int(asset["height"]))
-                for asset in assets
-                if asset.get("source_asset_id") not in (None, "")
-                and asset.get("width") is not None
-                and asset.get("height") is not None
-            }
-            try:
-                manifest_validation = validate_visual_manifest(
-                    visual_manifest,
-                    available_asset_ids=available_asset_ids,
-                    available_asset_dimensions=available_dimensions,
-                    require_activatable=False,
-                )
-            except PersonaVisualManifestError as exc:
-                raise ValueError("malformed_visual_manifest") from exc
+            renderer_import_preview: dict[str, Any] | None = None
+            resolved_required_states: Mapping[str, str] = {}
+            if _uses_renderer_import_preview(visual_manifest):
+                renderer_import_preview = preview_renderer_import(
+                    manifest=visual_manifest,
+                    assets=assets,
+                ).to_dict()
+            else:
+                available_asset_ids = {
+                    str(asset["source_asset_id"])
+                    for asset in assets
+                    if asset.get("source_asset_id") not in (None, "")
+                }
+                available_dimensions = {
+                    str(asset["source_asset_id"]): (int(asset["width"]), int(asset["height"]))
+                    for asset in assets
+                    if asset.get("source_asset_id") not in (None, "")
+                    and asset.get("width") is not None
+                    and asset.get("height") is not None
+                }
+                try:
+                    manifest_validation = validate_visual_manifest(
+                        visual_manifest,
+                        available_asset_ids=available_asset_ids,
+                        available_asset_dimensions=available_dimensions,
+                        require_activatable=False,
+                    )
+                except PersonaVisualManifestError as exc:
+                    raise ValueError("malformed_visual_manifest") from exc
+                resolved_required_states = manifest_validation.resolved_required_states
 
         validation_warnings = _validation_warnings(assets)
         source_persona_id = str(pack.get("source_persona_id") or "")
@@ -126,6 +138,16 @@ class PersonaVisualPackImportPreviewer:
                 "manifest": "state_and_animation_ids",
             },
         }
+        preview_status = "completed"
+        if renderer_import_preview is not None:
+            proposed_plan["renderer_import_preview"] = renderer_import_preview
+            proposed_plan["commit_eligible"] = bool(renderer_import_preview.get("can_commit"))
+            proposed_plan["activation_eligible"] = bool(
+                renderer_import_preview.get("activation_eligible")
+            )
+            proposed_plan["commit_blockers"] = list(renderer_import_preview.get("blockers") or [])
+            if not proposed_plan["commit_eligible"]:
+                preview_status = "blocked"
         quota_estimate = {
             "asset_bytes": asset_summary["present_asset_bytes"],
             "present_asset_items": asset_summary["present_asset_items"],
@@ -136,11 +158,11 @@ class PersonaVisualPackImportPreviewer:
             pack=pack,
             assets=assets,
             asset_summary=asset_summary,
-            resolved_required_states=manifest_validation.resolved_required_states,
+            resolved_required_states=resolved_required_states,
         )
         self._progress(progress, "completed", {"archive_sha256": archive_sha256})
         return {
-            "status": "completed",
+            "status": preview_status,
             "archive_sha256": archive_sha256,
             "canonical_payload_fingerprint": preview_fingerprint,
             "schema_version": PERSONA_VISUAL_PACK_SCHEMA_VERSION,
@@ -211,6 +233,26 @@ def _section_list(value: Any, *, key: str, path: str) -> list[dict[str, Any]]:
             raise ValueError(f"malformed_metadata: {path}")
         records.append(dict(item))
     return records
+
+
+def _uses_renderer_import_preview(visual_manifest: Mapping[str, Any]) -> bool:
+    """Return whether archive preview should use renderer capability diagnostics."""
+
+    manifest_version = _coerce_manifest_version(visual_manifest.get("manifest_version"))
+    return manifest_version is not None and manifest_version != 1
+
+
+def _coerce_manifest_version(value: Any) -> int | None:
+    """Normalize JSON manifest version values used for preview-path routing."""
+
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        stripped = value.strip()
+        return int(stripped) if stripped.isdigit() else None
+    return None
 
 
 def _validate_checksums(

--- a/tldw_Server_API/app/core/Persona/visual_portability/preview.py
+++ b/tldw_Server_API/app/core/Persona/visual_portability/preview.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import zipfile
 from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
@@ -27,6 +28,8 @@ from .constants import (
     TRUST_MODE_UNTRUSTED_IMPORT,
 )
 from .fingerprints import canonical_payload_fingerprint, sha256_file, sha256_stream
+
+_INTEGER_TEXT_RE = re.compile(r"^[+-]?[0-9]+$")
 
 
 class PersonaVisualPackImportPreviewer:
@@ -249,9 +252,11 @@ def _coerce_manifest_version(value: Any) -> int | None:
         return None
     if isinstance(value, int):
         return value
+    if isinstance(value, float):
+        return int(value) if value.is_integer() else None
     if isinstance(value, str):
         stripped = value.strip()
-        return int(stripped) if stripped.isdigit() else None
+        return int(stripped) if _INTEGER_TEXT_RE.fullmatch(stripped) else None
     return None
 
 

--- a/tldw_Server_API/tests/Persona/test_persona_visual_portability.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_portability.py
@@ -67,6 +67,126 @@ def _valid_manifest(asset_id: str) -> dict[str, object]:
     }
 
 
+def _json_bytes(payload: object) -> bytes:
+    return json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _live2d_v2_manifest() -> dict[str, object]:
+    return {
+        "manifest_version": 2,
+        "renderer_type": "live2d",
+        "renderer_contract_version": 1,
+        "renderer_assets": {
+            "fallback_preview_asset_id": "asset-fallback",
+            "source_manifest_asset_id": "asset-model",
+        },
+        "states": {
+            "idle": {"animation_id": "idle"},
+        },
+        "animations": {
+            "idle": {
+                "renderer_action": {
+                    "motion_group": "Idle",
+                    "loop": True,
+                },
+            },
+        },
+    }
+
+
+def _renderer_preview_archive(
+    tmp_path: Path,
+    *,
+    title: str,
+    visual_manifest: dict[str, object],
+    assets: list[dict[str, object]],
+    asset_files: dict[str, bytes] | None = None,
+) -> Path:
+    archive_path = tmp_path / f"{title.lower().replace(' ', '-')}.tldw-persona-vpack"
+    asset_files = asset_files or {}
+    archive_manifest = {
+        "schema_version": PERSONA_VISUAL_PACK_SCHEMA_VERSION,
+        "archive_profile": "backup",
+        "pack_title": title,
+        "renderer_type": visual_manifest.get("renderer_type"),
+        "counts": {
+            "assets": len(assets),
+            "assets_with_bytes": sum(
+                1
+                for asset in assets
+                if asset.get("asset_bytes_status") == ASSET_BYTES_STATUS_PRESENT
+            ),
+        },
+    }
+    pack_payload = {
+        "pack": {
+            "title": title,
+            "source_persona_id": "source-persona-v2",
+            "renderer_type": visual_manifest.get("renderer_type"),
+            "visual_manifest": visual_manifest,
+        }
+    }
+    entries: dict[str, bytes] = {
+        MANIFEST_PATH: _json_bytes(archive_manifest),
+        "metadata/pack.json": _json_bytes(pack_payload),
+        "metadata/assets.json": _json_bytes({"assets": assets}),
+        **asset_files,
+    }
+    checksums = {
+        member_path: sha256_bytes(member_bytes)
+        for member_path, member_bytes in entries.items()
+    }
+    entries[CHECKSUMS_PATH] = _json_bytes(dict(sorted(checksums.items())))
+
+    with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for member_path, member_bytes in entries.items():
+            archive.writestr(member_path, member_bytes)
+    return archive_path
+
+
+def _live2d_preview_assets(
+    *,
+    include_fallback: bool = True,
+) -> tuple[list[dict[str, object]], dict[str, bytes]]:
+    fallback_bytes = _png_bytes()
+    model_bytes = b'{"Version":3,"FileReferences":{}}'
+    assets: list[dict[str, object]] = [
+        {
+            "source_asset_id": "asset-model",
+            "asset_role": "live2d_model_manifest",
+            "asset_bytes_status": ASSET_BYTES_STATUS_PRESENT,
+            "asset_path": "assets/persona_visuals/model.model3.json",
+            "asset_sha256": sha256_bytes(model_bytes),
+            "mime_type": "application/json",
+            "original_filename": "model.model3.json",
+        },
+    ]
+    asset_files = {
+        "assets/persona_visuals/model.model3.json": model_bytes,
+    }
+    if include_fallback:
+        assets.append(
+            {
+                "source_asset_id": "asset-fallback",
+                "asset_role": "fallback_preview",
+                "asset_bytes_status": ASSET_BYTES_STATUS_PRESENT,
+                "asset_path": "assets/persona_visuals/fallback.png",
+                "asset_sha256": sha256_bytes(fallback_bytes),
+                "mime_type": "image/png",
+                "width": 2,
+                "height": 3,
+                "original_filename": "fallback.png",
+            }
+        )
+        asset_files["assets/persona_visuals/fallback.png"] = fallback_bytes
+    return assets, asset_files
+
+
 def _patch_visuals_dir(monkeypatch: pytest.MonkeyPatch, root: Path) -> None:
     def _fake_visuals_dir(user_id: str) -> Path:
         root.mkdir(parents=True, exist_ok=True)
@@ -385,6 +505,102 @@ def test_import_preview_reports_missing_asset_bytes_as_warning(
     ]
     exported_assets = preview["bundle_summary"]["assets"]
     assert exported_assets[0]["asset_bytes_status"] == ASSET_BYTES_STATUS_MISSING  # nosec B101
+
+
+def test_import_preview_reports_v2_live2d_renderer_diagnostics_without_activation(
+    tmp_path: Path,
+) -> None:
+    assets, asset_files = _live2d_preview_assets()
+    archive_path = _renderer_preview_archive(
+        tmp_path,
+        title="Live2D Preview",
+        visual_manifest=_live2d_v2_manifest(),
+        assets=assets,
+        asset_files=asset_files,
+    )
+
+    preview = PersonaVisualPackImportPreviewer().create_preview(
+        archive_path=archive_path,
+        owner_user_id="user-1",
+        target_persona_id="target-persona",
+    )
+
+    renderer_preview = preview["proposed_plan"]["renderer_import_preview"]
+    assert preview["status"] == "blocked"  # nosec B101
+    assert preview["bundle_summary"]["renderer_type"] == "live2d"  # nosec B101
+    assert preview["proposed_plan"]["commit_eligible"] is False  # nosec B101
+    assert preview["proposed_plan"]["activation_eligible"] is False  # nosec B101
+    assert renderer_preview["status"] == "unsupported_renderer"  # nosec B101
+    assert renderer_preview["setup_status"] == "unsupported_renderer"  # nosec B101
+    assert renderer_preview["can_commit"] is False  # nosec B101
+    assert renderer_preview["activation_eligible"] is False  # nosec B101
+    assert "runtime_adapter_not_implemented" in renderer_preview["blockers"]  # nosec B101
+    assert renderer_preview["normalized_role_categories"]["fallback_preview"] == [  # nosec B101
+        "asset-fallback"
+    ]
+    assert renderer_preview["normalized_role_categories"]["source_manifest"] == [  # nosec B101
+        "asset-model"
+    ]
+
+
+def test_import_preview_reports_v2_missing_required_role_category(
+    tmp_path: Path,
+) -> None:
+    assets, asset_files = _live2d_preview_assets(include_fallback=False)
+    archive_path = _renderer_preview_archive(
+        tmp_path,
+        title="Live2D Missing Fallback",
+        visual_manifest=_live2d_v2_manifest(),
+        assets=assets,
+        asset_files=asset_files,
+    )
+
+    preview = PersonaVisualPackImportPreviewer().create_preview(
+        archive_path=archive_path,
+        owner_user_id="user-1",
+        target_persona_id="target-persona",
+    )
+
+    renderer_preview = preview["proposed_plan"]["renderer_import_preview"]
+    assert preview["status"] == "blocked"  # nosec B101
+    assert "missing_required_role_category:fallback_preview" in renderer_preview["blockers"]  # nosec B101
+    assert renderer_preview["normalized_role_categories"]["fallback_preview"] == []  # nosec B101
+    assert renderer_preview["normalized_role_categories"]["source_manifest"] == [  # nosec B101
+        "asset-model"
+    ]
+
+
+def test_import_preview_reports_v2_unknown_renderer_safely(
+    tmp_path: Path,
+) -> None:
+    visual_manifest = {
+        "manifest_version": 2,
+        "renderer_type": "unknown\nrenderer\\token",
+        "renderer_contract_version": 1,
+        "states": {},
+        "animations": {},
+    }
+    archive_path = _renderer_preview_archive(
+        tmp_path,
+        title="Unknown Renderer Preview",
+        visual_manifest=visual_manifest,
+        assets=[],
+    )
+
+    preview = PersonaVisualPackImportPreviewer().create_preview(
+        archive_path=archive_path,
+        owner_user_id="user-1",
+        target_persona_id="target-persona",
+    )
+
+    renderer_preview = preview["proposed_plan"]["renderer_import_preview"]
+    assert preview["status"] == "blocked"  # nosec B101
+    assert preview["proposed_plan"]["commit_eligible"] is False  # nosec B101
+    assert renderer_preview["status"] == "unsupported_renderer"  # nosec B101
+    assert renderer_preview["blockers"] == [  # nosec B101
+        "unknown_renderer:unknown\\nrenderer\\\\token"
+    ]
+    assert "\n" not in renderer_preview["blockers"][0]  # nosec B101
 
 
 def test_import_preview_rejects_unsupported_renderer_type_in_visual_manifest(

--- a/tldw_Server_API/tests/Persona/test_persona_visual_portability.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_portability.py
@@ -543,6 +543,34 @@ def test_import_preview_reports_v2_live2d_renderer_diagnostics_without_activatio
     ]
 
 
+@pytest.mark.parametrize("manifest_version", [2.0, "+2"])
+def test_import_preview_routes_integer_like_v2_manifest_versions_to_renderer_diagnostics(
+    tmp_path: Path,
+    manifest_version: object,
+) -> None:
+    assets, asset_files = _live2d_preview_assets()
+    visual_manifest = _live2d_v2_manifest()
+    visual_manifest["manifest_version"] = manifest_version
+    archive_path = _renderer_preview_archive(
+        tmp_path,
+        title=f"Live2D Version {manifest_version}",
+        visual_manifest=visual_manifest,
+        assets=assets,
+        asset_files=asset_files,
+    )
+
+    preview = PersonaVisualPackImportPreviewer().create_preview(
+        archive_path=archive_path,
+        owner_user_id="user-1",
+        target_persona_id="target-persona",
+    )
+
+    renderer_preview = preview["proposed_plan"]["renderer_import_preview"]
+    assert preview["status"] == "blocked"  # nosec B101
+    assert renderer_preview["manifest_version"] == 2  # nosec B101
+    assert renderer_preview["status"] == "unsupported_renderer"  # nosec B101
+
+
 def test_import_preview_reports_v2_missing_required_role_category(
     tmp_path: Path,
 ) -> None:

--- a/tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py
@@ -344,6 +344,89 @@ async def test_persona_visual_import_preview_worker_updates_preview_without_muta
 
 
 @pytest.mark.asyncio
+async def test_persona_visual_import_preview_worker_persists_blocked_preview_status(
+    db_instance: CharactersRAGDB,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.core.DB_Management.PersonaVisualPortability_DB import (
+        PersonaVisualPortabilityRepository,
+    )
+    from tldw_Server_API.app.core.Persona import visual_jobs_worker as worker_module
+
+    class _BlockedPreviewer:
+        def create_preview(self, **_kwargs: Any) -> dict[str, Any]:
+            return {
+                "status": "blocked",
+                "archive_sha256": "a" * 64,
+                "canonical_payload_fingerprint": "b" * 64,
+                "schema_version": "tldw.persona_visual_pack.v1",
+                "bundle_summary": {"renderer_type": "live2d"},
+                "validation_warnings": [],
+                "conflicts": [],
+                "proposed_plan": {
+                    "renderer_import_preview": {"status": "unsupported_renderer"},
+                    "commit_eligible": False,
+                },
+                "quota_estimate": {
+                    "asset_bytes": 0,
+                    "present_asset_items": 0,
+                    "missing_asset_items": 0,
+                },
+                "required_choices": [],
+                "target_warnings": [],
+            }
+
+    archive_path = tmp_path / "incoming.tldw-persona-vpack"
+    archive_path.write_bytes(b"placeholder")
+    monkeypatch.setattr(
+        worker_module,
+        "PersonaVisualPackImportPreviewer",
+        _BlockedPreviewer,
+    )
+    repo = PersonaVisualPortabilityRepository.initialized(db_instance)
+    preview = repo.create_import_preview(
+        owner_user_id="user-1",
+        job_id="job-preview-blocked",
+        status="queued",
+        archive_path=str(archive_path),
+    )
+    portability_job = repo.create_portability_job(
+        owner_user_id="user-1",
+        job_id="job-preview-blocked",
+        operation="import_preview",
+        status="queued",
+        stage="queued",
+        preview_id=str(preview["id"]),
+        archive_path=str(archive_path),
+    )
+    worker = worker_module.PersonaVisualPortabilityWorker(db=db_instance, repo=repo)
+
+    result = await worker.handle_job_async(
+        {
+            "id": "job-preview-blocked",
+            "job_type": PERSONA_VISUAL_PACK_IMPORT_PREVIEW_JOB_TYPE,
+            "owner_user_id": "user-1",
+            "payload": {
+                "user_id": "user-1",
+                "preview_id": str(preview["id"]),
+                "archive_path": str(archive_path),
+                "request_id": "req-worker-blocked",
+            },
+        }
+    )
+
+    updated_preview = repo.get_import_preview(str(preview["id"]), owner_user_id="user-1")
+    updated_job = repo.get_portability_job(str(portability_job["id"]), owner_user_id="user-1")
+    assert result["status"] == "previewed"
+    assert updated_preview is not None
+    assert updated_preview["status"] == "blocked"
+    assert json.loads(updated_preview["proposed_plan_json"])["commit_eligible"] is False
+    assert updated_job is not None
+    assert updated_job["status"] == "completed"
+
+
+@pytest.mark.asyncio
 async def test_persona_visual_import_preview_worker_persists_target_conflicts(
     db_instance: CharactersRAGDB,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- Routes Manifest V2 renderer metadata through the existing import-preview validator.
- Stores blocked renderer previews with status: "blocked" for non-committable results.
- Adds renderer diagnostics to proposed_plan.renderer_import_preview with eligibility flags.
- Adds focused tests for disabled live2d, unknown renderers, missing role categories, and integer-like Manifest V2 version routing.

## Scope Boundaries
- Backend-only preview diagnostics.
- No asset or pack commit behavior, activation, runtime renderer loading, MCP provider behavior, frontend behavior, or VN/CYOA behavior.

## Verification
- python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_portability.py tldw_Server_API/tests/Persona/test_persona_visual_import_preview_validators.py tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py -q => 31 passed, 5 warnings.
- git diff --check
- python -m bandit -r tldw_Server_API/app/core/Persona/visual_portability/preview.py tldw_Server_API/app/core/Persona/visual_jobs_worker.py -f json -o /tmp/bandit_persona_visual_v2_archive_preview_review_fix.json => 0 findings.

## Tracking
Closes #1638
Refs #1510

## Change summary
Human owner should confirm or replace this section before merge per repository AI-generated PR policy.
