### PR TITLE
Add ACP workspace run history links

### DIFF
--- a/Docs/Design/ACP_Workspace_Integration_Decision_2026_05.md
+++ b/Docs/Design/ACP_Workspace_Integration_Decision_2026_05.md
@@ -308,6 +308,13 @@ Scope:
 - Link to ACP detail/events/artifacts/diagnostics/audit routes.
 - Use redacted previews where support-safe views are required.
 
+Implementation note:
+
+- First UI pass adds WorkspacePlayground `ACP run history`, reusing existing
+  Agent Orchestration project/task/task-detail contracts and ACP Playground
+  session view routes. It intentionally does not add a new backend workspace
+  history endpoint or a parallel ACP workspace browser.
+
 ### Slice 5: Verification, Testing, And Closeout
 
 Goal: prove the integration behavior before closing #1540 and split any

--- a/Docs/superpowers/plans/2026-05-13-acp-workspace-history-diagnostic-links-plan.md
+++ b/Docs/superpowers/plans/2026-05-13-acp-workspace-history-diagnostic-links-plan.md
@@ -1,0 +1,115 @@
+# ACP Workspace History Diagnostic Links Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make recent ACP run history discoverable from WorkspacePlayground for the active canonical workspace, with links into existing Agent Tasks and ACP Playground diagnostic views.
+
+**Architecture:** Add a small WorkspacePlayground modal that reuses existing Agent Orchestration project, task, and enriched task-detail contracts. The modal filters projects by `canonical_workspace_id`, fetches task detail only for matching workspace tasks, flattens recent runs, and routes users to existing Agent Tasks and ACP Playground views instead of creating a parallel ACP workspace browser.
+
+**Tech Stack:** React, TypeScript, Ant Design, Vitest, React Testing Library, existing ACP auth/request transport helpers.
+
+---
+
+### Task 1: Red Tests For Workspace ACP History
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/WorkspaceHeader.test.tsx`
+
+- [x] **Step 1: Add a failing test for successful workspace history rendering**
+
+Add a test that opens Workspace settings, selects `ACP run history`, mocks:
+- `GET /api/v1/agent-orchestration/projects`
+- `GET /api/v1/agent-orchestration/projects/{project_id}/tasks`
+- `GET /api/v1/agent-orchestration/tasks/{task_id}`
+
+Expected assertions:
+- The modal renders a recent run for `workspace-alpha`.
+- The modal includes project/task context, status, session id, and artifact/diagnostic/audit counts.
+- `Open Agent Tasks` navigates to `/agent-tasks?workspace=workspace-alpha`.
+- `Open diagnostics` navigates to `/acp-playground?session=sess-alpha&view=diagnostics`.
+
+- [x] **Step 2: Add failing tests for empty and error states**
+
+Add tests proving:
+- A workspace with no matching ACP runs shows a non-misleading empty state.
+- A backend load error shows an error state instead of setup guidance.
+
+- [x] **Step 3: Run focused tests and verify red**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/components/Option/WorkspacePlayground/__tests__/WorkspaceHeader.test.tsx --maxWorkers=1 --no-file-parallelism
+```
+
+Expected: new tests fail because the modal/menu item does not exist yet.
+
+### Task 2: Workspace ACP History Modal
+
+**Files:**
+- Create: `apps/packages/ui/src/components/Option/WorkspacePlayground/WorkspaceACPHistoryModal.tsx`
+- Modify: `apps/packages/ui/src/components/Option/WorkspacePlayground/WorkspaceHeader.tsx`
+
+- [x] **Step 1: Implement the modal data loader**
+
+Create a component that:
+- Accepts `open`, `workspaceId`, `workspaceName`, `onCancel`, `onOpenAgentTasks`.
+- Uses `useCanonicalConnectionConfig`, `resolveBrowserRequestTransport`, and `buildACPAuthHeaders`.
+- Fetches projects from `/api/v1/agent-orchestration/projects`.
+- Filters to projects whose `canonical_workspace.canonical_workspace_id` or metadata fallback matches the active workspace.
+- Fetches tasks for matching projects.
+- Fetches enriched task detail for a bounded number of matching tasks.
+- Flattens and sorts recent runs by `started_at` or `completed_at`, newest first.
+
+- [x] **Step 2: Render recent run history and diagnostic actions**
+
+Render:
+- Loading spinner while fetching.
+- Empty state when no matching projects/tasks/runs exist.
+- Alert when orchestration is unsupported or load fails.
+- Recent run cards with project name, task title, run status, session id, counts, result/failure preview, and buttons for existing detail routes.
+
+- [x] **Step 3: Wire the settings menu entry**
+
+Add an `ACP run history` action to Workspace settings when `workspaceId` exists. Keep it near `Create agent task` because both are ACP workspace actions.
+
+- [x] **Step 4: Run focused tests and verify green**
+
+Run the same focused Vitest command. Expected: all WorkspaceHeader tests pass.
+
+### Task 3: Documentation And Task Record
+
+**Files:**
+- Modify: `Docs/Design/ACP_Workspace_Integration_Decision_2026_05.md`
+- Modify: `backlog/tasks/task-318 - Implement-ACP-workspace-history-and-diagnostic-links-for-issue-1540.md`
+
+- [x] **Step 1: Update the design doc slice status**
+
+Add a short implementation note under Slice 4 documenting that the first UI pass reuses existing Agent Orchestration and ACP Playground routes.
+
+- [x] **Step 2: Update TASK-318 notes**
+
+Record implementation details, touched files, verification commands, and Bandit rationale if no Python files were changed.
+
+### Task 4: Verification And PR Packaging
+
+**Files:**
+- Modify only if verification exposes issues.
+
+- [x] **Step 1: Run targeted verification**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/components/Option/WorkspacePlayground/__tests__/WorkspaceHeader.test.tsx --maxWorkers=1 --no-file-parallelism
+bunx tsc --noEmit -p /private/tmp/acp-workspace-history-tsconfig.json --pretty false
+git diff --check
+```
+
+If the temporary TypeScript config does not exist, create one scoped to the touched WorkspacePlayground files and existing test ambient globals.
+
+- [x] **Step 2: Commit and open PR**
+
+Commit the focused slice and open a PR against `dev` referencing #1540 and TASK-318.

--- a/apps/packages/ui/src/components/Option/ACPPlayground/__tests__/ACPPlayground.connection.test.tsx
+++ b/apps/packages/ui/src/components/Option/ACPPlayground/__tests__/ACPPlayground.connection.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render, waitFor } from "@testing-library/react"
+import { render, screen, waitFor } from "@testing-library/react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
@@ -25,6 +25,10 @@ const acpMocks = vi.hoisted(() => ({
   getSessionUsage: vi.fn()
 }))
 
+const mediaMocks = vi.hoisted(() => ({
+  isMobile: false
+}))
+
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (_key: string, fallback?: string) => fallback ?? _key
@@ -42,7 +46,7 @@ vi.mock("@/services/tldw/TldwApiClient", () => ({
 }))
 
 vi.mock("@/hooks/useMediaQuery", () => ({
-  useMobile: () => false
+  useMobile: () => mediaMocks.isMobile
 }))
 
 vi.mock("@/hooks/useACPSession", () => ({
@@ -91,8 +95,16 @@ vi.mock("@/services/acp/client", () => ({
 
 vi.mock("antd", () => ({
   Drawer: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
-  Tabs: ({ items }: { items?: Array<{ children?: React.ReactNode }> }) => (
-    <div>{items?.map((item, index) => <div key={index}>{item.children}</div>)}</div>
+  Tabs: ({
+    activeKey,
+    items
+  }: {
+    activeKey?: string
+    items?: Array<{ children?: React.ReactNode }>
+  }) => (
+    <div data-testid={`acp-tabs-${activeKey ?? "none"}`}>
+      {items?.map((item, index) => <div key={index}>{item.children}</div>)}
+    </div>
   )
 }))
 
@@ -139,6 +151,8 @@ describe("ACPPlayground canonical connection config", () => {
   beforeEach(() => {
     useACPSessionsStore.getState().reset()
     vi.clearAllMocks()
+    mediaMocks.isMobile = false
+    window.history.pushState({}, "", "/acp-playground")
     acpMocks.constructedConfigs.length = 0
 
     storageMocks.useStorage.mockImplementation((key: string, fallback: unknown) => {
@@ -179,5 +193,31 @@ describe("ACPPlayground canonical connection config", () => {
         offset: 0
       })
     })
+  })
+
+  it("activates ACP sessions and session views from history deep links", async () => {
+    mediaMocks.isMobile = true
+    window.history.pushState(
+      {},
+      "",
+      "/acp-playground?session=sess-linked&view=diagnostics"
+    )
+    acpMocks.listSessions.mockResolvedValue({
+      sessions: [
+        {
+          session_id: "sess-linked",
+          name: "Linked Session",
+          status: "active",
+          updated_at: "2026-05-13T14:00:00.000Z"
+        }
+      ]
+    })
+
+    renderPlayground()
+
+    await waitFor(() => {
+      expect(useACPSessionsStore.getState().activeSessionId).toBe("sess-linked")
+    })
+    expect(screen.getByTestId("acp-tabs-sessions")).toBeInTheDocument()
   })
 })

--- a/apps/packages/ui/src/components/Option/ACPPlayground/index.tsx
+++ b/apps/packages/ui/src/components/Option/ACPPlayground/index.tsx
@@ -29,6 +29,27 @@ const ACPPermissionModal = React.lazy(() =>
 
 const ACP_LEFT_PANE_KEY = "acp-playground-left-pane"
 const ACP_RIGHT_PANE_KEY = "acp-playground-right-pane"
+const ACP_SESSION_DETAIL_VIEWS = new Set([
+  "session",
+  "diagnostics",
+  "artifacts",
+  "audit",
+  "events"
+])
+
+const readACPPlaygroundSearch = (): string => {
+  if (typeof window === "undefined") return ""
+  if (window.location.search) return window.location.search
+
+  const hash = window.location.hash || ""
+  const queryIndex = hash.indexOf("?")
+  return queryIndex >= 0 ? hash.slice(queryIndex) : ""
+}
+
+const normalizeQueryValue = (value: string | null): string | null => {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : null
+}
 
 /**
  * ACPPlayground - Agent Client Protocol interface
@@ -80,6 +101,7 @@ export const ACPPlayground: React.FC = () => {
   const upsertSessionsFromServerList = useACPSessionsStore((s) => s.upsertSessionsFromServerList)
   const applySessionDetail = useACPSessionsStore((s) => s.applySessionDetail)
   const applySessionUsage = useACPSessionsStore((s) => s.applySessionUsage)
+  const setActiveSession = useACPSessionsStore((s) => s.setActiveSession)
   const globalError = useACPSessionsStore((s) => s.globalError)
   const setGlobalError = useACPSessionsStore((s) => s.setGlobalError)
   const cleanupExpiredSessions = useACPSessionsStore((s) => s.cleanupExpiredSessions)
@@ -195,6 +217,45 @@ export const ACPPlayground: React.FC = () => {
   useEffect(() => {
     cleanupExpiredSessions()
   }, [cleanupExpiredSessions])
+
+  // Honor deep links from Agent Tasks and workspace run history.
+  useEffect(() => {
+    const params = new URLSearchParams(readACPPlaygroundSearch())
+    const requestedSessionId = normalizeQueryValue(params.get("session"))
+    const requestedView = normalizeQueryValue(params.get("view"))?.toLowerCase()
+
+    if (requestedSessionId) {
+      setActiveSession(requestedSessionId)
+    }
+
+    if (!requestedView) {
+      return
+    }
+
+    if (requestedView === "workspace") {
+      setActiveTab("workspace")
+      setRightTab("workspace")
+      setRightPaneOpen(true)
+      return
+    }
+
+    if (requestedView === "tools") {
+      setActiveTab("tools")
+      setRightTab("tools")
+      setRightPaneOpen(true)
+      return
+    }
+
+    if (requestedView === "chat") {
+      setActiveTab("chat")
+      return
+    }
+
+    if (requestedView === "sessions" || ACP_SESSION_DETAIL_VIEWS.has(requestedView)) {
+      setActiveTab("sessions")
+      setLeftPaneOpen(true)
+    }
+  }, [setActiveSession, setLeftPaneOpen, setRightPaneOpen])
 
   // Hydrate persisted ACP sessions from backend when the page loads.
   useEffect(() => {

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/WorkspaceACPHistoryModal.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/WorkspaceACPHistoryModal.tsx
@@ -1,0 +1,459 @@
+import React from "react"
+import { useTranslation } from "react-i18next"
+import { useNavigate } from "react-router-dom"
+import { Alert, Button, Empty, Modal, Spin, Tag } from "antd"
+import { ExternalLink } from "lucide-react"
+
+import { useCanonicalConnectionConfig } from "@/hooks/useCanonicalConnectionConfig"
+import { buildACPAuthHeaders } from "@/services/acp/connection"
+import {
+  resolveBrowserRequestTransport,
+  type BrowserRequestTransport
+} from "@/services/tldw/request-core"
+
+const AGENT_ORCHESTRATION_BASE_PATH = "/api/v1/agent-orchestration"
+const PROJECTS_PATH = `${AGENT_ORCHESTRATION_BASE_PATH}/projects`
+const AGENT_ORCHESTRATION_UNSUPPORTED_MESSAGE =
+  "Agent orchestration is not available on this server."
+const MAX_TASK_DETAILS = 12
+const MAX_RECENT_RUNS = 6
+
+type CanonicalWorkspaceLink = {
+  canonical_workspace_id?: string | null
+  link_status?: string | null
+}
+
+type ProjectSummary = {
+  id: number
+  name: string
+  metadata?: Record<string, unknown> | null
+  canonical_workspace?: CanonicalWorkspaceLink | null
+}
+
+type TaskSummary = {
+  id: number
+  project_id: number
+  title: string
+  status: string
+  metadata?: Record<string, unknown> | null
+  canonical_workspace?: CanonicalWorkspaceLink | null
+}
+
+type RunItem = {
+  id: number
+  task_id: number
+  session_id?: string | null
+  agent_type?: string | null
+  status: string
+  result_summary?: string | null
+  error?: string | null
+  started_at?: string | null
+  completed_at?: string | null
+  session?: {
+    session_id?: string | null
+    available?: boolean
+    links?: Record<string, string>
+  } | null
+  history?: {
+    audit_event_count?: number
+    artifact_count?: number
+    diagnostic_count?: number
+    event_count?: number
+    result?: {
+      preview?: string | null
+    } | null
+  } | null
+  failure_context?: {
+    reason_code?: string | null
+    message?: string | null
+  } | null
+}
+
+type TaskDetail = TaskSummary & {
+  runs?: RunItem[]
+}
+
+type WorkspaceRunHistoryEntry = {
+  projectId: number
+  projectName: string
+  taskId: number
+  taskTitle: string
+  run: RunItem
+}
+
+export interface WorkspaceACPHistoryModalProps {
+  open: boolean
+  workspaceId?: string | null
+  workspaceName?: string | null
+  onCancel: () => void
+  onOpenAgentTasks: () => void
+}
+
+const normalizeListPayload = <T,>(payload: unknown, key: string): T[] => {
+  if (Array.isArray(payload)) return payload as T[]
+  if (payload && typeof payload === "object") {
+    const value = (payload as Record<string, unknown>)[key]
+    if (Array.isArray(value)) return value as T[]
+  }
+  return []
+}
+
+const normalizeWorkspaceId = (value: unknown): string | null => {
+  if (typeof value !== "string") return null
+  const trimmed = value.trim()
+  return trimmed ? trimmed : null
+}
+
+const getCanonicalWorkspaceId = (
+  item: {
+    canonical_workspace?: CanonicalWorkspaceLink | null
+    metadata?: Record<string, unknown> | null
+  }
+): string | null =>
+  normalizeWorkspaceId(item.canonical_workspace?.canonical_workspace_id) ||
+  normalizeWorkspaceId(item.metadata?.canonical_workspace_id)
+
+const readApiErrorMessage = async (response: Response): Promise<string> => {
+  const payload = await response.json().catch(() => null)
+  const detail =
+    payload && typeof payload === "object"
+      ? (payload as { detail?: unknown }).detail
+      : null
+
+  if (typeof detail === "string" && detail.trim()) {
+    return detail
+  }
+  if (detail && typeof detail === "object") {
+    const detailRecord = detail as Record<string, unknown>
+    if (typeof detailRecord.message === "string" && detailRecord.message.trim()) {
+      return detailRecord.message
+    }
+    if (typeof detailRecord.code === "string" && detailRecord.code.trim()) {
+      return detailRecord.code
+    }
+  }
+  return `HTTP ${response.status}`
+}
+
+const getRunTimestamp = (run: RunItem): number => {
+  const candidate = run.completed_at || run.started_at
+  if (!candidate) return 0
+  const timestamp = Date.parse(candidate)
+  return Number.isNaN(timestamp) ? 0 : timestamp
+}
+
+const getSessionId = (run: RunItem): string | null =>
+  normalizeWorkspaceId(run.session?.session_id) ||
+  normalizeWorkspaceId(run.session_id)
+
+const statusColor = (status: string): string => {
+  if (status === "completed" || status === "complete") return "success"
+  if (status === "failed" || status === "triage") return "error"
+  if (status === "running" || status === "inprogress") return "processing"
+  return "default"
+}
+
+export const WorkspaceACPHistoryModal: React.FC<
+  WorkspaceACPHistoryModalProps
+> = ({ open, workspaceId, workspaceName, onCancel, onOpenAgentTasks }) => {
+  const { t } = useTranslation(["playground", "common"])
+  const navigate = useNavigate()
+  const {
+    config: connectionConfig,
+    loading: connectionConfigLoading
+  } = useCanonicalConnectionConfig()
+  const [loading, setLoading] = React.useState(false)
+  const [error, setError] = React.useState<string | null>(null)
+  const [entries, setEntries] = React.useState<WorkspaceRunHistoryEntry[]>([])
+
+  const buildRequestTransport = React.useCallback(
+    (path: string): BrowserRequestTransport | null => {
+      if (!connectionConfig) return null
+      return resolveBrowserRequestTransport({
+        config: connectionConfig,
+        path
+      })
+    },
+    [connectionConfig]
+  )
+
+  const getHeaders = React.useCallback(
+    (transport: BrowserRequestTransport | null) => {
+      if (transport?.mode === "hosted") {
+        return { "Content-Type": "application/json" }
+      }
+      return buildACPAuthHeaders(connectionConfig)
+    },
+    [connectionConfig]
+  )
+
+  const fetchJson = React.useCallback(
+    async <T,>(path: string): Promise<T> => {
+      const transport = buildRequestTransport(path)
+      if (!transport) {
+        throw new Error(
+          connectionConfigLoading
+            ? "Backend connection is still loading."
+            : "Backend connection is not configured."
+        )
+      }
+
+      const response = await fetch(transport.url, {
+        headers: getHeaders(transport)
+      })
+      if (!response.ok) {
+        if (response.status === 404) {
+          throw new Error(AGENT_ORCHESTRATION_UNSUPPORTED_MESSAGE)
+        }
+        throw new Error(await readApiErrorMessage(response))
+      }
+      return (await response.json()) as T
+    },
+    [buildRequestTransport, connectionConfigLoading, getHeaders]
+  )
+
+  React.useEffect(() => {
+    if (!open) return
+
+    let cancelled = false
+
+    const loadHistory = async () => {
+      const canonicalWorkspaceId = workspaceId?.trim()
+      setLoading(true)
+      setError(null)
+      setEntries([])
+
+      try {
+        if (!canonicalWorkspaceId) {
+          throw new Error(
+            "Select or save a workspace before loading ACP run history."
+          )
+        }
+
+        const projectsPayload = await fetchJson<unknown>(PROJECTS_PATH)
+        const projects = normalizeListPayload<ProjectSummary>(
+          projectsPayload,
+          "projects"
+        )
+        const matchingProjects = projects.filter(
+          (project) => getCanonicalWorkspaceId(project) === canonicalWorkspaceId
+        )
+
+        const taskRows = (
+          await Promise.all(
+            matchingProjects.map(async (project) => {
+              const tasksPayload = await fetchJson<unknown>(
+                `${PROJECTS_PATH}/${project.id}/tasks`
+              )
+              const tasks = normalizeListPayload<TaskSummary>(
+                tasksPayload,
+                "tasks"
+              )
+              return tasks.map((task) => ({ project, task }))
+            })
+          )
+        ).flat()
+
+        const taskDetails = await Promise.all(
+          taskRows.slice(0, MAX_TASK_DETAILS).map(async ({ project, task }) => {
+            const detail = await fetchJson<TaskDetail>(
+              `${AGENT_ORCHESTRATION_BASE_PATH}/tasks/${task.id}`
+            )
+            return { project, task: detail }
+          })
+        )
+
+        const recentEntries = taskDetails
+          .flatMap(({ project, task }) =>
+            (task.runs || []).map((run) => ({
+              projectId: project.id,
+              projectName: project.name,
+              taskId: task.id,
+              taskTitle: task.title,
+              run
+            }))
+          )
+          .sort((left, right) => getRunTimestamp(right.run) - getRunTimestamp(left.run))
+          .slice(0, MAX_RECENT_RUNS)
+
+        if (!cancelled) {
+          setEntries(recentEntries)
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to load ACP run history")
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false)
+        }
+      }
+    }
+
+    void loadHistory()
+
+    return () => {
+      cancelled = true
+    }
+  }, [fetchJson, open, workspaceId])
+
+  const openSessionRoute = React.useCallback(
+    (run: RunItem, view?: string) => {
+      const sessionId = getSessionId(run)
+      if (!sessionId) return
+      const params = new URLSearchParams({ session: sessionId })
+      if (view) params.set("view", view)
+      navigate(`/acp-playground?${params.toString()}`)
+    },
+    [navigate]
+  )
+
+  return (
+    <Modal
+      title={t("playground:workspace.acpRunHistory", "ACP run history")}
+      open={open}
+      onCancel={onCancel}
+      footer={[
+        <Button key="agent-tasks" onClick={onOpenAgentTasks}>
+          {t("playground:workspace.openAgentTasks", "Open Agent Tasks")}
+        </Button>,
+        <Button key="close" type="primary" onClick={onCancel}>
+          {t("common:close", "Close")}
+        </Button>
+      ]}
+      width={760}
+    >
+      <div className="space-y-4">
+        <div className="text-sm text-muted-foreground">
+          {t("playground:workspace.acpRunHistoryWorkspace", {
+            defaultValue: "Recent agent runs linked to {{workspace}}.",
+            workspace: workspaceName?.trim() || workspaceId || "this workspace"
+          })}
+        </div>
+
+        {loading && (
+          <div className="flex justify-center py-8">
+            <Spin />
+          </div>
+        )}
+
+        {!loading && error && (
+          <Alert
+            type="error"
+            showIcon
+            title={t(
+              "playground:workspace.acpRunHistoryLoadFailed",
+              "Could not load ACP run history"
+            )}
+            description={error}
+          />
+        )}
+
+        {!loading && !error && entries.length === 0 && (
+          <Empty
+            description={t(
+              "playground:workspace.acpRunHistoryEmpty",
+              "No ACP runs linked to this workspace yet"
+            )}
+          />
+        )}
+
+        {!loading && !error && entries.length > 0 && (
+          <div className="space-y-3">
+            {entries.map((entry) => {
+              const { run } = entry
+              const sessionId = getSessionId(run)
+              const failureMessage =
+                run.failure_context?.message || run.error || null
+              const resultPreview =
+                run.result_summary || run.history?.result?.preview || null
+
+              return (
+                <div
+                  key={`${entry.taskId}-${run.id}`}
+                  className="rounded-lg border border-border p-4"
+                >
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <div className="text-sm font-medium">{entry.taskTitle}</div>
+                      <div className="text-xs text-muted-foreground">
+                        {entry.projectName}
+                      </div>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Tag color={statusColor(run.status)}>{run.status}</Tag>
+                      {run.agent_type && <Tag>{run.agent_type}</Tag>}
+                    </div>
+                  </div>
+
+                  {sessionId && (
+                    <div className="mt-2 text-xs text-muted-foreground">
+                      {sessionId}
+                    </div>
+                  )}
+
+                  <div className="mt-3 grid grid-cols-3 gap-2 text-xs text-muted-foreground">
+                    <span>{run.history?.artifact_count ?? 0} artifacts</span>
+                    <span>{run.history?.diagnostic_count ?? 0} diagnostics</span>
+                    <span>{run.history?.audit_event_count ?? 0} audit</span>
+                  </div>
+
+                  {failureMessage && (
+                    <div className="mt-3 rounded border border-red-200 bg-red-50 p-2 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-950/20 dark:text-red-300">
+                      {failureMessage}
+                    </div>
+                  )}
+                  {!failureMessage && resultPreview && (
+                    <div className="mt-3 text-sm">{resultPreview}</div>
+                  )}
+
+                  {sessionId && (
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      <Button
+                        size="small"
+                        icon={<ExternalLink className="h-3 w-3" />}
+                        onClick={() => openSessionRoute(run)}
+                      >
+                        {t("playground:workspace.openSession", "Open session")}
+                      </Button>
+                      {run.session?.links?.diagnostics && (
+                        <Button
+                          size="small"
+                          icon={<ExternalLink className="h-3 w-3" />}
+                          onClick={() => openSessionRoute(run, "diagnostics")}
+                        >
+                          {t(
+                            "playground:workspace.openDiagnostics",
+                            "Open diagnostics"
+                          )}
+                        </Button>
+                      )}
+                      {run.session?.links?.artifacts && (
+                        <Button
+                          size="small"
+                          icon={<ExternalLink className="h-3 w-3" />}
+                          onClick={() => openSessionRoute(run, "artifacts")}
+                        >
+                          {t("playground:workspace.openArtifacts", "Open artifacts")}
+                        </Button>
+                      )}
+                      {run.session?.links?.audit && (
+                        <Button
+                          size="small"
+                          icon={<ExternalLink className="h-3 w-3" />}
+                          onClick={() => openSessionRoute(run, "audit")}
+                        >
+                          {t("playground:workspace.openAudit", "Open audit")}
+                        </Button>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+    </Modal>
+  )
+}

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/WorkspaceACPHistoryModal.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/WorkspaceACPHistoryModal.tsx
@@ -15,6 +15,8 @@ const AGENT_ORCHESTRATION_BASE_PATH = "/api/v1/agent-orchestration"
 const PROJECTS_PATH = `${AGENT_ORCHESTRATION_BASE_PATH}/projects`
 const AGENT_ORCHESTRATION_UNSUPPORTED_MESSAGE =
   "Agent orchestration is not available on this server."
+const AGENT_ORCHESTRATION_UNSUPPORTED_CODE =
+  "AGENT_ORCHESTRATION_UNSUPPORTED"
 const MAX_TASK_DETAILS = 12
 const MAX_RECENT_RUNS = 6
 
@@ -35,6 +37,8 @@ type TaskSummary = {
   project_id: number
   title: string
   status: string
+  created_at?: string | null
+  updated_at?: string | null
   metadata?: Record<string, unknown> | null
   canonical_workspace?: CanonicalWorkspaceLink | null
 }
@@ -80,6 +84,10 @@ type WorkspaceRunHistoryEntry = {
   taskTitle: string
   run: RunItem
 }
+
+type WorkspaceACPHistoryError =
+  | { kind: "message"; message: string }
+  | { kind: "unsupported" }
 
 export interface WorkspaceACPHistoryModalProps {
   open: boolean
@@ -142,6 +150,13 @@ const getRunTimestamp = (run: RunItem): number => {
   return Number.isNaN(timestamp) ? 0 : timestamp
 }
 
+const getTaskTimestamp = (task: TaskSummary): number => {
+  const candidate = task.updated_at || task.created_at
+  if (!candidate) return task.id
+  const timestamp = Date.parse(candidate)
+  return Number.isNaN(timestamp) ? task.id : timestamp
+}
+
 const getSessionId = (run: RunItem): string | null =>
   normalizeWorkspaceId(run.session?.session_id) ||
   normalizeWorkspaceId(run.session_id)
@@ -153,6 +168,21 @@ const statusColor = (status: string): string => {
   return "default"
 }
 
+const createUnsupportedError = (): Error & { code: string } =>
+  Object.assign(new Error(AGENT_ORCHESTRATION_UNSUPPORTED_CODE), {
+    code: AGENT_ORCHESTRATION_UNSUPPORTED_CODE
+  })
+
+const isUnsupportedError = (
+  error: unknown
+): error is Error & { code: string } =>
+  Boolean(
+    error &&
+      typeof error === "object" &&
+      "code" in error &&
+      (error as { code?: string }).code === AGENT_ORCHESTRATION_UNSUPPORTED_CODE
+  )
+
 export const WorkspaceACPHistoryModal: React.FC<
   WorkspaceACPHistoryModalProps
 > = ({ open, workspaceId, workspaceName, onCancel, onOpenAgentTasks }) => {
@@ -163,7 +193,7 @@ export const WorkspaceACPHistoryModal: React.FC<
     loading: connectionConfigLoading
   } = useCanonicalConnectionConfig()
   const [loading, setLoading] = React.useState(false)
-  const [error, setError] = React.useState<string | null>(null)
+  const [error, setError] = React.useState<WorkspaceACPHistoryError | null>(null)
   const [entries, setEntries] = React.useState<WorkspaceRunHistoryEntry[]>([])
 
   const buildRequestTransport = React.useCallback(
@@ -188,7 +218,7 @@ export const WorkspaceACPHistoryModal: React.FC<
   )
 
   const fetchJson = React.useCallback(
-    async <T,>(path: string): Promise<T> => {
+    async <T,>(path: string, signal?: AbortSignal): Promise<T> => {
       const transport = buildRequestTransport(path)
       if (!transport) {
         throw new Error(
@@ -199,13 +229,19 @@ export const WorkspaceACPHistoryModal: React.FC<
       }
 
       const response = await fetch(transport.url, {
-        headers: getHeaders(transport)
+        headers: getHeaders(transport),
+        signal
       })
       if (!response.ok) {
-        if (response.status === 404) {
-          throw new Error(AGENT_ORCHESTRATION_UNSUPPORTED_MESSAGE)
+        const message = await readApiErrorMessage(response)
+        if (
+          response.status === 404 &&
+          path === PROJECTS_PATH &&
+          message === "Not Found"
+        ) {
+          throw createUnsupportedError()
         }
-        throw new Error(await readApiErrorMessage(response))
+        throw new Error(message)
       }
       return (await response.json()) as T
     },
@@ -216,6 +252,7 @@ export const WorkspaceACPHistoryModal: React.FC<
     if (!open) return
 
     let cancelled = false
+    const abortController = new AbortController()
 
     const loadHistory = async () => {
       const canonicalWorkspaceId = workspaceId?.trim()
@@ -230,7 +267,10 @@ export const WorkspaceACPHistoryModal: React.FC<
           )
         }
 
-        const projectsPayload = await fetchJson<unknown>(PROJECTS_PATH)
+        const projectsPayload = await fetchJson<unknown>(
+          PROJECTS_PATH,
+          abortController.signal
+        )
         const projects = normalizeListPayload<ProjectSummary>(
           projectsPayload,
           "projects"
@@ -243,7 +283,8 @@ export const WorkspaceACPHistoryModal: React.FC<
           await Promise.all(
             matchingProjects.map(async (project) => {
               const tasksPayload = await fetchJson<unknown>(
-                `${PROJECTS_PATH}/${project.id}/tasks`
+                `${PROJECTS_PATH}/${project.id}/tasks`,
+                abortController.signal
               )
               const tasks = normalizeListPayload<TaskSummary>(
                 tasksPayload,
@@ -255,12 +296,19 @@ export const WorkspaceACPHistoryModal: React.FC<
         ).flat()
 
         const taskDetails = await Promise.all(
-          taskRows.slice(0, MAX_TASK_DETAILS).map(async ({ project, task }) => {
-            const detail = await fetchJson<TaskDetail>(
-              `${AGENT_ORCHESTRATION_BASE_PATH}/tasks/${task.id}`
+          [...taskRows]
+            .sort(
+              (left, right) =>
+                getTaskTimestamp(right.task) - getTaskTimestamp(left.task)
             )
-            return { project, task: detail }
-          })
+            .slice(0, MAX_TASK_DETAILS)
+            .map(async ({ project, task }) => {
+              const detail = await fetchJson<TaskDetail>(
+                `${AGENT_ORCHESTRATION_BASE_PATH}/tasks/${task.id}`,
+                abortController.signal
+              )
+              return { project, task: detail }
+            })
         )
 
         const recentEntries = taskDetails
@@ -280,8 +328,21 @@ export const WorkspaceACPHistoryModal: React.FC<
           setEntries(recentEntries)
         }
       } catch (err) {
+        if (cancelled || abortController.signal.aborted) {
+          return
+        }
         if (!cancelled) {
-          setError(err instanceof Error ? err.message : "Failed to load ACP run history")
+          setError(
+            isUnsupportedError(err)
+              ? { kind: "unsupported" }
+              : {
+                  kind: "message",
+                  message:
+                    err instanceof Error
+                      ? err.message
+                      : "Failed to load ACP run history"
+                }
+          )
         }
       } finally {
         if (!cancelled) {
@@ -294,6 +355,7 @@ export const WorkspaceACPHistoryModal: React.FC<
 
     return () => {
       cancelled = true
+      abortController.abort()
     }
   }, [fetchJson, open, workspaceId])
 
@@ -307,6 +369,14 @@ export const WorkspaceACPHistoryModal: React.FC<
     },
     [navigate]
   )
+
+  const errorDescription =
+    error?.kind === "unsupported"
+      ? t(
+          "playground:workspace.orchestrationUnsupported",
+          AGENT_ORCHESTRATION_UNSUPPORTED_MESSAGE
+        )
+      : error?.message
 
   return (
     <Modal
@@ -345,7 +415,7 @@ export const WorkspaceACPHistoryModal: React.FC<
               "playground:workspace.acpRunHistoryLoadFailed",
               "Could not load ACP run history"
             )}
-            description={error}
+            description={errorDescription}
           />
         )}
 

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/WorkspaceHeader.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/WorkspaceHeader.tsx
@@ -34,7 +34,8 @@ import {
   Star,
   Share2,
   CircleHelp,
-  Bot
+  Bot,
+  History
 } from "lucide-react"
 import type {
   SavedWorkspace,
@@ -90,6 +91,7 @@ import {
 } from "@/utils/feature-rollout"
 import { WorkspaceShortcutsModal } from "./WorkspaceShortcutsModal"
 import { WorkspaceAgentTaskHandoffModal } from "./WorkspaceAgentTaskHandoffModal"
+import { WorkspaceACPHistoryModal } from "./WorkspaceACPHistoryModal"
 
 interface WorkspaceHeaderProps {
   leftPaneOpen: boolean
@@ -174,6 +176,7 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
   const [workspaceBrowserOpen, setWorkspaceBrowserOpen] = React.useState(false)
   const [shortcutsModalOpen, setShortcutsModalOpen] = React.useState(false)
   const [agentTaskModalOpen, setAgentTaskModalOpen] = React.useState(false)
+  const [acpHistoryModalOpen, setAcpHistoryModalOpen] = React.useState(false)
   const [deleteConfirmOpen, setDeleteConfirmOpen] = React.useState(false)
   const [deleteConfirmInput, setDeleteConfirmInput] = React.useState("")
   const [deleteTargetWorkspace, setDeleteTargetWorkspace] = React.useState<{
@@ -529,8 +532,17 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
     setAgentTaskModalOpen(false)
   }
 
+  const handleOpenAcpHistoryModal = () => {
+    setAcpHistoryModalOpen(true)
+  }
+
+  const handleCloseAcpHistoryModal = () => {
+    setAcpHistoryModalOpen(false)
+  }
+
   const handleOpenAgentTasksPage = () => {
     setAgentTaskModalOpen(false)
+    setAcpHistoryModalOpen(false)
     const canonicalWorkspaceId = workspaceId?.trim()
     if (!canonicalWorkspaceId) {
       navigate("/agent-tasks")
@@ -1474,6 +1486,15 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
             onClick: handleOpenAgentTaskModal
           },
           {
+            key: "acp-run-history",
+            icon: <History className="h-4 w-4" />,
+            label: t(
+              "playground:workspace.acpRunHistory",
+              "ACP run history"
+            ),
+            onClick: handleOpenAcpHistoryModal
+          },
+          {
             key: "duplicate-current",
             icon: <Copy className="h-4 w-4" />,
             label: t(
@@ -1768,6 +1789,14 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
         workspaceTag={workspaceTag}
         onBeforeSubmit={saveCurrentWorkspace}
         onCancel={handleCloseAgentTaskModal}
+        onOpenAgentTasks={handleOpenAgentTasksPage}
+      />
+
+      <WorkspaceACPHistoryModal
+        open={acpHistoryModalOpen}
+        workspaceId={workspaceId}
+        workspaceName={workspaceName}
+        onCancel={handleCloseAcpHistoryModal}
         onOpenAgentTasks={handleOpenAgentTasksPage}
       />
 

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/WorkspaceHeader.test.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/WorkspaceHeader.test.tsx
@@ -1488,6 +1488,155 @@ describe("WorkspaceHeader workspace browser modal", () => {
     )
   })
 
+  it("aborts ACP run history requests when the modal closes", async () => {
+    let capturedSignal: AbortSignal | undefined
+    fetchMockState.fetch.mockImplementation(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        capturedSignal = init?.signal as AbortSignal | undefined
+        return new Promise<Response>(() => undefined)
+      }
+    )
+
+    render(
+      <WorkspaceHeader
+        leftPaneOpen={true}
+        rightPaneOpen={true}
+        onToggleLeftPane={vi.fn()}
+        onToggleRightPane={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Workspace settings" }))
+    fireEvent.click(await screen.findByText("ACP run history"))
+
+    const modal = await screen.findByRole("dialog", {
+      name: "ACP run history"
+    })
+    await waitFor(() => expect(capturedSignal).toBeInstanceOf(AbortSignal))
+
+    const closeButtons = within(modal).getAllByRole("button", { name: "Close" })
+    fireEvent.click(closeButtons[closeButtons.length - 1])
+
+    expect(capturedSignal?.aborted).toBe(true)
+  })
+
+  it("prioritizes newest workspace tasks before fetching ACP run detail", async () => {
+    const detailRequests: string[] = []
+
+    fetchMockState.fetch.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (
+        url ===
+        "http://127.0.0.1:8000/api/v1/agent-orchestration/projects"
+      ) {
+        return {
+          ok: true,
+          json: async () => [
+            {
+              id: 44,
+              name: "Alpha agent work",
+              canonical_workspace: {
+                canonical_workspace_id: "workspace-alpha",
+                link_status: "linked"
+              }
+            }
+          ]
+        } as Response
+      }
+
+      if (
+        url ===
+        "http://127.0.0.1:8000/api/v1/agent-orchestration/projects/44/tasks"
+      ) {
+        return {
+          ok: true,
+          json: async () =>
+            Array.from({ length: 13 }, (_value, index) => {
+              const id = index + 1
+              return {
+                id,
+                project_id: 44,
+                title: `Task ${id}`,
+                status: "complete",
+                created_at: `2026-05-13T13:${String(id).padStart(2, "0")}:00.000Z`,
+                updated_at: `2026-05-13T13:${String(id).padStart(2, "0")}:30.000Z`,
+                canonical_workspace: {
+                  canonical_workspace_id: "workspace-alpha"
+                }
+              }
+            })
+        } as Response
+      }
+
+      if (
+        url.startsWith(
+          "http://127.0.0.1:8000/api/v1/agent-orchestration/tasks/"
+        )
+      ) {
+        detailRequests.push(url)
+        const id = Number(url.split("/").pop())
+        return {
+          ok: true,
+          json: async () => ({
+            id,
+            project_id: 44,
+            title: `Task ${id}`,
+            status: "complete",
+            runs:
+              id === 13
+                ? [
+                    {
+                      id: 130,
+                      task_id: 13,
+                      status: "completed",
+                      result_summary: "Newest task run",
+                      completed_at: "2026-05-13T14:00:00.000Z",
+                      session: {
+                        session_id: "sess-newest",
+                        links: {
+                          diagnostics: "/api/v1/acp/sessions/sess-newest/diagnostics"
+                        }
+                      },
+                      history: {
+                        artifact_count: 0,
+                        diagnostic_count: 1,
+                        audit_event_count: 0
+                      }
+                    }
+                  ]
+                : []
+          })
+        } as Response
+      }
+
+      throw new Error(`unexpected fetch: ${url}`)
+    })
+
+    render(
+      <WorkspaceHeader
+        leftPaneOpen={true}
+        rightPaneOpen={true}
+        onToggleLeftPane={vi.fn()}
+        onToggleRightPane={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Workspace settings" }))
+    fireEvent.click(await screen.findByText("ACP run history"))
+
+    const modal = await screen.findByRole("dialog", {
+      name: "ACP run history"
+    })
+    expect(await within(modal).findByText("Newest task run")).toBeInTheDocument()
+    expect(detailRequests).toContain(
+      "http://127.0.0.1:8000/api/v1/agent-orchestration/tasks/13"
+    )
+    expect(detailRequests).not.toContain(
+      "http://127.0.0.1:8000/api/v1/agent-orchestration/tasks/1"
+    )
+  })
+
   it("shows an empty ACP run history state for workspaces without runs", async () => {
     fetchMockState.fetch.mockResolvedValue({
       ok: true,
@@ -1548,6 +1697,86 @@ describe("WorkspaceHeader workspace browser modal", () => {
     ).toBeInTheDocument()
     expect(
       within(modal).queryByText("Workspace setup needs attention")
+    ).not.toBeInTheDocument()
+  })
+
+  it("surfaces missing task errors instead of treating them as unsupported orchestration", async () => {
+    fetchMockState.fetch.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (
+        url ===
+        "http://127.0.0.1:8000/api/v1/agent-orchestration/projects"
+      ) {
+        return {
+          ok: true,
+          json: async () => [
+            {
+              id: 44,
+              name: "Alpha agent work",
+              canonical_workspace: {
+                canonical_workspace_id: "workspace-alpha",
+                link_status: "linked"
+              }
+            }
+          ]
+        } as Response
+      }
+
+      if (
+        url ===
+        "http://127.0.0.1:8000/api/v1/agent-orchestration/projects/44/tasks"
+      ) {
+        return {
+          ok: true,
+          json: async () => [
+            {
+              id: 55,
+              project_id: 44,
+              title: "Deleted task",
+              status: "complete",
+              canonical_workspace: {
+                canonical_workspace_id: "workspace-alpha"
+              }
+            }
+          ]
+        } as Response
+      }
+
+      if (
+        url ===
+        "http://127.0.0.1:8000/api/v1/agent-orchestration/tasks/55"
+      ) {
+        return {
+          ok: false,
+          status: 404,
+          json: async () => ({
+            detail: "Task not found"
+          })
+        } as Response
+      }
+
+      throw new Error(`unexpected fetch: ${url}`)
+    })
+
+    render(
+      <WorkspaceHeader
+        leftPaneOpen={true}
+        rightPaneOpen={true}
+        onToggleLeftPane={vi.fn()}
+        onToggleRightPane={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Workspace settings" }))
+    fireEvent.click(await screen.findByText("ACP run history"))
+
+    const modal = await screen.findByRole("dialog", {
+      name: "ACP run history"
+    })
+    expect(await within(modal).findByText("Task not found")).toBeInTheDocument()
+    expect(
+      within(modal).queryByText("Agent orchestration is not available on this server.")
     ).not.toBeInTheDocument()
   })
 

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/WorkspaceHeader.test.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/WorkspaceHeader.test.tsx
@@ -1356,6 +1356,235 @@ describe("WorkspaceHeader workspace browser modal", () => {
     expect(mockNavigate).toHaveBeenCalledWith("/agent-tasks?workspace=workspace-alpha")
   })
 
+  it("shows recent ACP run history for the current workspace and opens diagnostics", async () => {
+    fetchMockState.fetch.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (
+        url ===
+        "http://127.0.0.1:8000/api/v1/agent-orchestration/projects"
+      ) {
+        return {
+          ok: true,
+          json: async () => [
+            {
+              id: 44,
+              name: "Alpha agent work",
+              canonical_workspace: {
+                canonical_workspace_id: "workspace-alpha",
+                link_status: "linked"
+              }
+            },
+            {
+              id: 77,
+              name: "Beta agent work",
+              canonical_workspace: {
+                canonical_workspace_id: "workspace-beta",
+                link_status: "linked"
+              }
+            }
+          ]
+        } as Response
+      }
+
+      if (
+        url ===
+        "http://127.0.0.1:8000/api/v1/agent-orchestration/projects/44/tasks"
+      ) {
+        return {
+          ok: true,
+          json: async () => [
+            {
+              id: 55,
+              project_id: 44,
+              title: "Summarize workspace blockers",
+              status: "complete",
+              canonical_workspace: {
+                canonical_workspace_id: "workspace-alpha"
+              }
+            }
+          ]
+        } as Response
+      }
+
+      if (
+        url ===
+        "http://127.0.0.1:8000/api/v1/agent-orchestration/tasks/55"
+      ) {
+        return {
+          ok: true,
+          json: async () => ({
+            id: 55,
+            project_id: 44,
+            title: "Summarize workspace blockers",
+            status: "complete",
+            runs: [
+              {
+                id: 88,
+                task_id: 55,
+                status: "completed",
+                agent_type: "codex",
+                result_summary: "Identified two release blockers.",
+                started_at: "2026-05-13T13:00:00.000Z",
+                completed_at: "2026-05-13T13:05:00.000Z",
+                session: {
+                  session_id: "sess-alpha",
+                  available: true,
+                  links: {
+                    diagnostics: "/api/v1/acp/sessions/sess-alpha/diagnostics",
+                    artifacts: "/api/v1/acp/sessions/sess-alpha/artifacts",
+                    audit: "/api/v1/acp/sessions/sess-alpha/audit"
+                  }
+                },
+                history: {
+                  audit_event_count: 2,
+                  artifact_count: 1,
+                  diagnostic_count: 3,
+                  result: {
+                    preview: "Workspace run preview"
+                  }
+                }
+              }
+            ]
+          })
+        } as Response
+      }
+
+      throw new Error(`unexpected fetch: ${url}`)
+    })
+
+    render(
+      <WorkspaceHeader
+        leftPaneOpen={true}
+        rightPaneOpen={true}
+        onToggleLeftPane={vi.fn()}
+        onToggleRightPane={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Workspace settings" }))
+    fireEvent.click(await screen.findByText("ACP run history"))
+
+    const modal = await screen.findByRole("dialog", {
+      name: "ACP run history"
+    })
+    expect(await within(modal).findByText("Alpha agent work")).toBeInTheDocument()
+    expect(
+      within(modal).getByText("Summarize workspace blockers")
+    ).toBeInTheDocument()
+    expect(within(modal).getByText("sess-alpha")).toBeInTheDocument()
+    expect(within(modal).getByText("1 artifacts")).toBeInTheDocument()
+    expect(within(modal).getByText("3 diagnostics")).toBeInTheDocument()
+    expect(
+      within(modal).getByText("Identified two release blockers.")
+    ).toBeInTheDocument()
+
+    fireEvent.click(within(modal).getByRole("button", { name: "Open Agent Tasks" }))
+    expect(mockNavigate).toHaveBeenCalledWith("/agent-tasks?workspace=workspace-alpha")
+
+    fireEvent.click(within(modal).getByRole("button", { name: "Open diagnostics" }))
+    expect(mockNavigate).toHaveBeenCalledWith(
+      "/acp-playground?session=sess-alpha&view=diagnostics"
+    )
+  })
+
+  it("shows an empty ACP run history state for workspaces without runs", async () => {
+    fetchMockState.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => []
+    } as Response)
+
+    render(
+      <WorkspaceHeader
+        leftPaneOpen={true}
+        rightPaneOpen={true}
+        onToggleLeftPane={vi.fn()}
+        onToggleRightPane={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Workspace settings" }))
+    fireEvent.click(await screen.findByText("ACP run history"))
+
+    const modal = await screen.findByRole("dialog", {
+      name: "ACP run history"
+    })
+    expect(
+      await within(modal).findByText("No ACP runs linked to this workspace yet")
+    ).toBeInTheDocument()
+    expect(
+      within(modal).queryByText("Workspace setup needs attention")
+    ).not.toBeInTheDocument()
+  })
+
+  it("shows ACP run history load errors without setup guidance", async () => {
+    fetchMockState.fetch.mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({
+        detail: "Agent orchestration is temporarily unavailable"
+      })
+    } as Response)
+
+    render(
+      <WorkspaceHeader
+        leftPaneOpen={true}
+        rightPaneOpen={true}
+        onToggleLeftPane={vi.fn()}
+        onToggleRightPane={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Workspace settings" }))
+    fireEvent.click(await screen.findByText("ACP run history"))
+
+    const modal = await screen.findByRole("dialog", {
+      name: "ACP run history"
+    })
+    expect(
+      await within(modal).findByText(
+        "Agent orchestration is temporarily unavailable"
+      )
+    ).toBeInTheDocument()
+    expect(
+      within(modal).queryByText("Workspace setup needs attention")
+    ).not.toBeInTheDocument()
+  })
+
+  it("shows unsupported ACP run history state without setup guidance", async () => {
+    fetchMockState.fetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({
+        detail: "Not Found"
+      })
+    } as Response)
+
+    render(
+      <WorkspaceHeader
+        leftPaneOpen={true}
+        rightPaneOpen={true}
+        onToggleLeftPane={vi.fn()}
+        onToggleRightPane={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Workspace settings" }))
+    fireEvent.click(await screen.findByText("ACP run history"))
+
+    const modal = await screen.findByRole("dialog", {
+      name: "ACP run history"
+    })
+    expect(
+      await within(modal).findByText(
+        "Agent orchestration is not available on this server."
+      )
+    ).toBeInTheDocument()
+    expect(
+      within(modal).queryByText("Workspace setup needs attention")
+    ).not.toBeInTheDocument()
+  })
+
   it("surfaces ACP bridge setup failures without creating project or task records", async () => {
     fetchMockState.fetch.mockResolvedValue({
       ok: false,

--- a/backlog/tasks/task-318 - Implement-ACP-workspace-history-and-diagnostic-links-for-issue-1540.md
+++ b/backlog/tasks/task-318 - Implement-ACP-workspace-history-and-diagnostic-links-for-issue-1540.md
@@ -1,0 +1,79 @@
+---
+id: TASK-318
+title: Implement ACP workspace history and diagnostic links for issue 1540
+status: Done
+assignee: []
+created_date: '2026-05-13 14:46'
+updated_date: '2026-05-13 19:19'
+labels:
+  - ACP
+  - workspace
+  - frontend
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1540'
+  - 'https://github.com/rmusser01/tldw_server/pull/1643'
+documentation:
+  - Docs/Design/ACP_Workspace_Integration_Decision_2026_05.md
+  - Docs/Plans/IMPLEMENTATION_PLAN_acp_run_history_1475.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Slice 4 from Docs/Design/ACP_Workspace_Integration_Decision_2026_05.md for issue 1540. WorkspacePlayground should make recent ACP runs discoverable from the current canonical workspace and route users to existing Agent Tasks and ACP Playground diagnostic/detail views without introducing a parallel ACP workspace browser or new backend data model.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 WorkspacePlayground exposes recent ACP run history for the current canonical workspace when linked Agent Tasks data is available
+- [x] #2 Run history entries include task/project context, status, session id when available, and counts or previews from the existing enriched task-detail contract
+- [x] #3 Users can navigate from a workspace history entry to Agent Tasks scoped to the current workspace and to ACP session detail/diagnostics/artifacts/audit views when those links are available
+- [x] #4 The implementation handles loading, empty, unsupported orchestration, and backend-error states without showing misleading setup guidance
+- [x] #5 Focused frontend tests cover successful history rendering, diagnostic navigation, empty state, and failure/unsupported behavior
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Plan: Docs/superpowers/plans/2026-05-13-acp-workspace-history-diagnostic-links-plan.md
+
+Stages:
+1. Add red WorkspaceHeader tests for recent ACP run history, diagnostic navigation, empty state, and backend-error behavior.
+2. Implement a WorkspaceACPHistoryModal that reuses existing Agent Orchestration and ACP Playground contracts.
+3. Wire Workspace settings and update docs/task evidence.
+4. Run focused Vitest, targeted TypeScript, and git diff checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Created isolated worktree .worktrees/acp-workspace-history-diagnostic-links-1540 from origin/dev after PR #1627 merged. TASK-318 covers #1540 Slice 4: workspace history and diagnostic links.
+
+Implemented WorkspaceACPHistoryModal and WorkspaceHeader menu wiring for ACP run history. The modal reuses Agent Orchestration projects/tasks/task-detail data, filters by canonical workspace id, and links to Agent Tasks plus ACP Playground session/diagnostics/artifacts/audit views.
+
+Verification: bunx vitest run src/components/Option/WorkspacePlayground/__tests__/WorkspaceHeader.test.tsx --maxWorkers=1 --no-file-parallelism passed 34 tests; bunx vitest run src/components/Option/AgentTasks/__tests__/AgentTasksPage.connection.test.tsx --maxWorkers=1 --no-file-parallelism passed 10 tests; bunx tsc --noEmit -p /private/tmp/acp-workspace-history-tsconfig.json --pretty false exited 0; git diff --check exited 0.
+
+Bandit: skipped because this slice changes TypeScript UI, tests, docs, and Backlog task metadata only; no Python backend files were touched.
+
+Known skips/blockers: no Python files were touched, so Bandit was not run. Merge readiness still depends on the repository AI-generated PR policy requiring a human-authored Change summary before merge.
+
+PR opened: https://github.com/rmusser01/tldw_server/pull/1643
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented #1540 Slice 4 by adding WorkspacePlayground ACP run history. The UI reuses existing Agent Orchestration project/task/task-detail responses, filters runs by canonical workspace id, and routes users to scoped Agent Tasks plus ACP Playground session diagnostics, artifacts, and audit views. Focused tests cover success, empty, backend-error, and unsupported endpoint states.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-321 - Address-PR-1643-ACP-workspace-history-review-comments.md
+++ b/backlog/tasks/task-321 - Address-PR-1643-ACP-workspace-history-review-comments.md
@@ -1,0 +1,53 @@
+---
+id: TASK-321
+title: Address PR 1643 ACP workspace history review comments
+status: In Progress
+assignee: []
+created_date: '2026-05-14 00:29'
+updated_date: '2026-05-14 00:58'
+labels:
+  - review-fix
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1643'
+documentation:
+  - Docs/Design/ACP_Workspace_Integration_Decision_2026_05.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address the live PR #1643 review findings for ACP workspace history: request cancellation, localized unsupported state, recent-task detail selection, scoped 404 handling, and ACP Playground query-param deep links.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 WorkspaceACPHistoryModal aborts in-flight fetches when closed or workspace changes
+- [x] #2 Unsupported orchestration 404 handling does not mask missing project/task errors
+- [x] #3 Recent run detail fetches prioritize newest tasks before applying the cap
+- [x] #4 ACP Playground honors session and view query params from history links
+- [x] #5 Focused tests and TypeScript verification cover the review fixes
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Live PR sweep found unresolved review threads from Gemini, CodeRabbit, and Qodo. Valid fixes: abortable fetches, localized unsupported error rendering, task recency sort before detail cap, scoped 404 handling, and ACP Playground query-param session/view handling.
+
+Implemented review fixes for PR #1643: abortable WorkspaceACPHistoryModal fetches, scoped unsupported 404 mapping, localized unsupported error rendering, task recency sorting before MAX_TASK_DETAILS, and ACPPlayground session/view query-param handling.
+
+Verification: bunx vitest run src/components/Option/WorkspacePlayground/__tests__/WorkspaceHeader.test.tsx --maxWorkers=1 --no-file-parallelism passed 37 tests; bunx vitest run src/components/Option/ACPPlayground/__tests__/ACPPlayground.connection.test.tsx --maxWorkers=1 --no-file-parallelism passed 2 tests; bunx tsc --noEmit -p /private/tmp/acp-workspace-history-tsconfig.json --pretty false exited 0; git diff --check exited 0.
+
+Bandit: skipped because the review-fix changes touch TypeScript UI/tests and Backlog metadata only; no Python backend files changed.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary

- Add WorkspacePlayground `ACP run history` from Workspace settings.
- Reuse existing Agent Orchestration projects/tasks/task-detail data to show recent runs for the current canonical workspace.
- Link entries to scoped Agent Tasks and ACP Playground session/diagnostics/artifacts/audit views.
- Document Slice 4 status and add Backlog task TASK-318.

## Change summary

AI-authored implementation note: this PR must receive a human-written Change summary before merge per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

## Verification

- `bunx vitest run src/components/Option/WorkspacePlayground/__tests__/WorkspaceHeader.test.tsx --maxWorkers=1 --no-file-parallelism`
- `bunx vitest run src/components/Option/AgentTasks/__tests__/AgentTasksPage.connection.test.tsx --maxWorkers=1 --no-file-parallelism`
- `bunx tsc --noEmit -p /private/tmp/acp-workspace-history-tsconfig.json --pretty false`
- `git diff --check`

## Notes

- Bandit skipped: TypeScript UI, tests, docs, and Backlog metadata only; no Python files changed.
- Tracks #1540 Slice 4 and TASK-318.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an ACP run history view to WorkspacePlayground with direct links to Agent Tasks and ACP session diagnostics. Implements Slice 4 of #1540 (TASK-318) using existing Agent Orchestration and ACP Playground routes; no backend changes.

- **New Features**
  - Added an ACP run history action in Workspace settings that opens `WorkspaceACPHistoryModal`.
  - The modal loads projects, tasks, and task details from `GET /api/v1/agent-orchestration/*`, filters by `canonical_workspace_id`, and shows recent runs.
  - Each entry shows project/task, status, session ID, and artifact/diagnostic/audit counts, with links to `/agent-tasks?workspace=…` and `/acp-playground?session=…&view={diagnostics|artifacts|audit}`.
  - `ACPPlayground` now honors `session` and `view` query params to activate the session and open the right tab/panes (sessions/diagnostics/artifacts/audit/workspace/tools/chat).

- **Bug Fixes**
  - Abort in-flight history requests when the modal closes or the workspace changes.
  - Only treat a 404 on projects (with “Not Found”) as orchestration unsupported; surface other 404s (e.g., missing task) as errors.
  - Prioritize newest tasks before applying the task-detail cap, then sort runs by most recent.

<sup>Written for commit b3b227a99008344b0d3cee6321cbb2774afca8d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

