### PR TITLE
Surface Persona runtime explorer fallback diagnostics

### DIFF
--- a/backlog/tasks/task-322 - Surface-Persona-runtime-explorer-diagnostics.md
+++ b/backlog/tasks/task-322 - Surface-Persona-runtime-explorer-diagnostics.md
@@ -1,0 +1,52 @@
+---
+id: TASK-322
+title: Surface Persona runtime explorer diagnostics
+status: Done
+assignee: []
+created_date: '2026-05-14 01:13'
+updated_date: '2026-05-14 01:22'
+labels:
+  - persona
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1510'
+  - 'https://github.com/rmusser01/tldw_server/issues/1644'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Expose trace-safe Persona runtime explorer diagnostics from the optional Persona Live planning path so fallback, circuit-open, and safe-denial outcomes are visible to clients/operators without changing Buddy rendering, visual-pack behavior, VN/CYOA behavior, or normal disabled-mode runtime behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Enabled runtime explorer planning emits bounded diagnostics for fallback or safe-denial outcomes.
+- [x] #2 Diagnostics never include raw user messages, prompts, memory, candidate text, plan args, provider exceptions, or exemplar content.
+- [x] #3 Disabled runtime explorer behavior remains unchanged and emits no runtime-explorer notice.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Red verification: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_ws_dialogue_tree_runtime.py::test_runtime_explorer_fallback_notice_is_bounded_and_trace_safe tldw_Server_API/tests/Persona/test_persona_ws_dialogue_tree_runtime.py::test_runtime_explorer_disabled_emits_no_runtime_diagnostic_notice -q --tb=short failed because no RUNTIME_EXPLORER_FALLBACK notice was emitted.
+
+Green verification: focused runtime websocket/explorer tests passed: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_ws_dialogue_tree_runtime.py tldw_Server_API/tests/Persona/test_runtime_explorer.py -q (26 passed). git diff --check passed. Bandit on tldw_Server_API/app/api/v1/endpoints/persona.py exited 0 with no findings in /tmp/bandit_persona_runtime_diagnostics.json.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added a persona-only runtime explorer diagnostics slice for #1644. When the optional runtime explorer is enabled, fallback/circuit-open/safe-denial outcomes now emit bounded Persona Live notice diagnostics without exposing raw prompts, messages, memory, candidate text, plan args, provider exception messages, or exemplar content. Disabled mode still emits no runtime-explorer notice. Updated the Persona README and focused websocket runtime tests.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-322 - Surface-Persona-runtime-explorer-diagnostics.md
+++ b/backlog/tasks/task-322 - Surface-Persona-runtime-explorer-diagnostics.md
@@ -4,13 +4,14 @@ title: Surface Persona runtime explorer diagnostics
 status: Done
 assignee: []
 created_date: '2026-05-14 01:13'
-updated_date: '2026-05-14 01:22'
+updated_date: '2026-05-14 01:25'
 labels:
   - persona
 dependencies: []
 references:
   - 'https://github.com/rmusser01/tldw_server/issues/1510'
   - 'https://github.com/rmusser01/tldw_server/issues/1644'
+  - 'https://github.com/rmusser01/tldw_server/pull/1647'
 priority: medium
 ---
 

--- a/backlog/tasks/task-322 - Surface-Persona-runtime-explorer-diagnostics.md
+++ b/backlog/tasks/task-322 - Surface-Persona-runtime-explorer-diagnostics.md
@@ -4,7 +4,7 @@ title: Surface Persona runtime explorer diagnostics
 status: Done
 assignee: []
 created_date: '2026-05-14 01:13'
-updated_date: '2026-05-14 01:25'
+updated_date: '2026-05-14 01:36'
 labels:
   - persona
 dependencies: []
@@ -31,15 +31,19 @@ Expose trace-safe Persona runtime explorer diagnostics from the optional Persona
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Red verification: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_ws_dialogue_tree_runtime.py::test_runtime_explorer_fallback_notice_is_bounded_and_trace_safe tldw_Server_API/tests/Persona/test_persona_ws_dialogue_tree_runtime.py::test_runtime_explorer_disabled_emits_no_runtime_diagnostic_notice -q --tb=short failed because no RUNTIME_EXPLORER_FALLBACK notice was emitted.
+Red verification: `python -m pytest tldw_Server_API/tests/Persona/test_persona_ws_dialogue_tree_runtime.py::test_runtime_explorer_fallback_notice_is_bounded_and_trace_safe tldw_Server_API/tests/Persona/test_persona_ws_dialogue_tree_runtime.py::test_runtime_explorer_disabled_emits_no_runtime_diagnostic_notice -q --tb=short` failed because no `RUNTIME_EXPLORER_FALLBACK` notice was emitted.
 
-Green verification: focused runtime websocket/explorer tests passed: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_ws_dialogue_tree_runtime.py tldw_Server_API/tests/Persona/test_runtime_explorer.py -q (26 passed). git diff --check passed. Bandit on tldw_Server_API/app/api/v1/endpoints/persona.py exited 0 with no findings in /tmp/bandit_persona_runtime_diagnostics.json.
+Green verification: focused runtime websocket/explorer tests passed: `python -m pytest tldw_Server_API/tests/Persona/test_persona_ws_dialogue_tree_runtime.py tldw_Server_API/tests/Persona/test_runtime_explorer.py -q` (26 passed). `git diff --check` passed. Bandit on `tldw_Server_API/app/api/v1/endpoints/persona.py` exited 0 with no findings.
+
+Review sweep for PR #1647 found still-valid comments from Gemini and CodeRabbit: defensively handle malformed runtime budget diagnostics, normalize non-string safe_denial sentinels, decouple fallback-notice test assertions from tool_plan event ordering, and remove local absolute paths from task notes. Red review verification failed for missing/null budget fields and boolean safe_denial sentinel before the fix. Focused review regression tests passed after the fix.
+
+Review-fix verification: `python -m pytest tldw_Server_API/tests/Persona/test_persona_ws_dialogue_tree_runtime.py tldw_Server_API/tests/Persona/test_runtime_explorer.py -q` passed with 29 tests. `git diff --check` passed. Bandit on `tldw_Server_API/app/api/v1/endpoints/persona.py` exited 0 with no findings.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added a persona-only runtime explorer diagnostics slice for #1644. When the optional runtime explorer is enabled, fallback/circuit-open/safe-denial outcomes now emit bounded Persona Live notice diagnostics without exposing raw prompts, messages, memory, candidate text, plan args, provider exception messages, or exemplar content. Disabled mode still emits no runtime-explorer notice. Updated the Persona README and focused websocket runtime tests.
+Added a persona-only runtime explorer diagnostics slice for #1644. When the optional runtime explorer is enabled, fallback/circuit-open/safe-denial outcomes now emit bounded Persona Live notice diagnostics without exposing raw prompts, messages, memory, candidate text, plan args, provider exception messages, or exemplar content. Disabled mode still emits no runtime-explorer notice. PR review fixes also harden malformed budget diagnostics, normalize non-string safe_denial sentinels, decouple fallback-notice tests from tool_plan event ordering, and remove machine-specific paths from task notes.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -356,6 +356,24 @@ def _runtime_explorer_safe_token(value: Any, *, fallback: str = "other") -> str:
     return fallback
 
 
+def _runtime_explorer_budget_int(budget: Any, field_name: str) -> int:
+    """Return a non-negative budget diagnostic integer with malformed fields as zero."""
+    raw_value = getattr(budget, field_name, 0) if budget is not None else 0
+    try:
+        return max(0, int(raw_value or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _runtime_explorer_safe_denial_text(value: Any) -> str:
+    """Normalize runtime explorer safe-denial sentinels to user-facing text."""
+    if isinstance(value, str):
+        text = value.strip()
+        if text:
+            return text
+    return _PERSONA_RUNTIME_SAFE_DENIAL_TEXT
+
+
 def _runtime_explorer_diagnostics_payload(result: RuntimeExplorationResult) -> dict[str, Any]:
     """Build the websocket-safe runtime explorer diagnostics envelope."""
     diagnostics = dict(result.diagnostics or {})
@@ -366,11 +384,11 @@ def _runtime_explorer_diagnostics_payload(result: RuntimeExplorationResult) -> d
             fallback="other",
         ),
         "reason": _runtime_explorer_safe_token(diagnostics.get("reason"), fallback=reason_fallback),
-        "provider_calls": max(0, int(result.budget.provider_calls)),
-        "candidates_considered": max(0, int(result.budget.candidates_considered)),
-        "hard_prunes": max(0, int(result.budget.hard_prunes)),
-        "soft_prunes": max(0, int(result.budget.soft_prunes)),
-        "elapsed_ms": max(0, int(result.budget.elapsed_ms)),
+        "provider_calls": _runtime_explorer_budget_int(result.budget, "provider_calls"),
+        "candidates_considered": _runtime_explorer_budget_int(result.budget, "candidates_considered"),
+        "hard_prunes": _runtime_explorer_budget_int(result.budget, "hard_prunes"),
+        "soft_prunes": _runtime_explorer_budget_int(result.budget, "soft_prunes"),
+        "elapsed_ms": _runtime_explorer_budget_int(result.budget, "elapsed_ms"),
         "circuit_open": bool(result.circuit_open),
         "safe_denial": bool(result.safe_denial),
     }
@@ -722,7 +740,7 @@ def _apply_persona_runtime_explorer_to_plan(
     result = provider.get(config).explore(runtime_context)
     runtime_diagnostics = _runtime_explorer_diagnostics_payload(result) if include_diagnostics else None
     if result.safe_denial:
-        safe_plan = _runtime_safe_denial_plan(result.safe_denial)
+        safe_plan = _runtime_safe_denial_plan(_runtime_explorer_safe_denial_text(result.safe_denial))
         if runtime_diagnostics:
             safe_plan[_PERSONA_RUNTIME_EXPLORER_DIAGNOSTICS_KEY] = runtime_diagnostics
         return safe_plan

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -217,6 +217,7 @@ from tldw_Server_API.app.core.Persona.policy_evaluator import (
 from tldw_Server_API.app.core.Persona.dialogue_tree_context import build_runtime_tree_context
 from tldw_Server_API.app.core.Persona.runtime_explorer import (
     PersonaRuntimeExplorer,
+    RuntimeExplorationResult,
     RuntimeExplorerConfig,
     RuntimeScorer,
 )
@@ -304,7 +305,9 @@ _PERSONA_STATE_FIELD_LABELS = {
     "heartbeat_md": "heartbeat",
 }
 _PERSONA_RUNTIME_EXPLORER_SELECTED_KEY = "_runtime_explorer_selected"
+_PERSONA_RUNTIME_EXPLORER_DIAGNOSTICS_KEY = "_runtime_explorer_diagnostics"
 _PERSONA_RUNTIME_SAFE_DENIAL_TEXT = RuntimeExplorerConfig().safe_denial_text
+_PERSONA_RUNTIME_EXPLORER_TOKEN_RE = re.compile(r"^[A-Za-z0-9_.:-]{1,64}$")
 
 
 def _bounded_label(value: Any, *, allowed: set[str], fallback: str) -> str:
@@ -343,6 +346,53 @@ def _metric_reason_bucket(reason_code: Any) -> str:
     if candidate in allowed:
         return candidate.lower()
     return "other"
+
+
+def _runtime_explorer_safe_token(value: Any, *, fallback: str = "other") -> str:
+    """Return a bounded identifier token for trace-safe runtime diagnostics."""
+    token = str(value or "").strip()
+    if _PERSONA_RUNTIME_EXPLORER_TOKEN_RE.fullmatch(token):
+        return token
+    return fallback
+
+
+def _runtime_explorer_diagnostics_payload(result: RuntimeExplorationResult) -> dict[str, Any]:
+    """Build the websocket-safe runtime explorer diagnostics envelope."""
+    diagnostics = dict(result.diagnostics or {})
+    reason_fallback = "selected_candidate" if result.selected_candidate else "none"
+    payload: dict[str, Any] = {
+        "fallback": _runtime_explorer_safe_token(
+            result.fallback.value if result.fallback else "none",
+            fallback="other",
+        ),
+        "reason": _runtime_explorer_safe_token(diagnostics.get("reason"), fallback=reason_fallback),
+        "provider_calls": max(0, int(result.budget.provider_calls)),
+        "candidates_considered": max(0, int(result.budget.candidates_considered)),
+        "hard_prunes": max(0, int(result.budget.hard_prunes)),
+        "soft_prunes": max(0, int(result.budget.soft_prunes)),
+        "elapsed_ms": max(0, int(result.budget.elapsed_ms)),
+        "circuit_open": bool(result.circuit_open),
+        "safe_denial": bool(result.safe_denial),
+    }
+    if diagnostics.get("error_type"):
+        payload["error_type"] = _runtime_explorer_safe_token(diagnostics.get("error_type"), fallback="Exception")
+    return payload
+
+
+def _runtime_explorer_notice_reason_code(diagnostics: dict[str, Any]) -> str | None:
+    fallback = str(diagnostics.get("fallback") or "")
+    if fallback == "hard_safe_denial" or bool(diagnostics.get("safe_denial")):
+        return "RUNTIME_EXPLORER_SAFE_DENIAL"
+    if fallback in {"soft_existing_behavior", "circuit_open"}:
+        return "RUNTIME_EXPLORER_FALLBACK"
+    return None
+
+
+def _runtime_explorer_notice_message(diagnostics: dict[str, Any]) -> str:
+    reason_code = _runtime_explorer_notice_reason_code(diagnostics)
+    if reason_code == "RUNTIME_EXPLORER_SAFE_DENIAL":
+        return "Persona runtime explorer selected a safe denial."
+    return "Persona runtime explorer fell back to existing planning."
 
 
 def _increment_persona_metric(metric_name: str, labels: dict[str, str]) -> None:
@@ -630,6 +680,7 @@ def _apply_persona_runtime_explorer_to_plan(
     companion_usage: dict[str, Any],
     persona_exemplar_selection: dict[str, Any],
     runtime_explorer_provider: PersonaRuntimeExplorerProvider | None = None,
+    include_diagnostics: bool = False,
 ) -> dict[str, Any]:
     config = _get_persona_runtime_explorer_config()
     if not config.enabled:
@@ -669,19 +720,31 @@ def _apply_persona_runtime_explorer_to_plan(
     }
     provider = runtime_explorer_provider or PersonaRuntimeExplorerProvider()
     result = provider.get(config).explore(runtime_context)
+    runtime_diagnostics = _runtime_explorer_diagnostics_payload(result) if include_diagnostics else None
     if result.safe_denial:
-        return _runtime_safe_denial_plan(result.safe_denial)
+        safe_plan = _runtime_safe_denial_plan(result.safe_denial)
+        if runtime_diagnostics:
+            safe_plan[_PERSONA_RUNTIME_EXPLORER_DIAGNOSTICS_KEY] = runtime_diagnostics
+        return safe_plan
     if result.selected_candidate:
         candidate_metadata = result.selected_candidate.get("metadata")
         if isinstance(candidate_metadata, dict) and candidate_metadata.get("source") == "existing_persona_planner":
             selected_base_plan = dict(base_plan)
             selected_base_plan[_PERSONA_RUNTIME_EXPLORER_SELECTED_KEY] = True
+            if runtime_diagnostics:
+                selected_base_plan[_PERSONA_RUNTIME_EXPLORER_DIAGNOSTICS_KEY] = runtime_diagnostics
             return selected_base_plan
         selected_plan = result.selected_candidate.get("plan")
         sanitized_selected_plan = _sanitize_persona_runtime_plan(selected_plan)
         if sanitized_selected_plan.get("steps"):
             sanitized_selected_plan[_PERSONA_RUNTIME_EXPLORER_SELECTED_KEY] = True
+            if runtime_diagnostics:
+                sanitized_selected_plan[_PERSONA_RUNTIME_EXPLORER_DIAGNOSTICS_KEY] = runtime_diagnostics
             return sanitized_selected_plan
+    if runtime_diagnostics:
+        fallback_plan = dict(base_plan)
+        fallback_plan[_PERSONA_RUNTIME_EXPLORER_DIAGNOSTICS_KEY] = runtime_diagnostics
+        return fallback_plan
     return base_plan
 
 
@@ -9064,8 +9127,20 @@ async def persona_stream(
                 companion_usage=companion_usage,
                 persona_exemplar_selection=persona_exemplar_selection,
                 runtime_explorer_provider=runtime_explorer_provider,
+                include_diagnostics=True,
             )
+            runtime_explorer_diagnostics = plan.pop(_PERSONA_RUNTIME_EXPLORER_DIAGNOSTICS_KEY, None)
             runtime_explorer_selected_plan = bool(plan.pop(_PERSONA_RUNTIME_EXPLORER_SELECTED_KEY, False))
+            if isinstance(runtime_explorer_diagnostics, dict):
+                runtime_notice_reason = _runtime_explorer_notice_reason_code(runtime_explorer_diagnostics)
+                if runtime_notice_reason:
+                    await _emit_notice(
+                        session_id=session_id,
+                        level="warning",
+                        message=_runtime_explorer_notice_message(runtime_explorer_diagnostics),
+                        reason_code=runtime_notice_reason,
+                        runtime_explorer=runtime_explorer_diagnostics,
+                    )
             plan_id = uuid.uuid4().hex
             max_tool_steps = _get_persona_max_tool_steps()
             proposed_steps = list(plan.get("steps", []))

--- a/tldw_Server_API/app/core/Persona/README.md
+++ b/tldw_Server_API/app/core/Persona/README.md
@@ -92,6 +92,7 @@
 - Local Dev Tips:
   - connect to `/api/v1/persona/stream` with a websocket client and send `{ "type": "user_message", "text": "<query>" }`
   - inspect persisted persona sessions via `/api/v1/persona/sessions`
+  - when the optional runtime explorer is enabled, fallback and safe-denial paths emit a `notice` event with `RUNTIME_EXPLORER_*` reason codes and bounded `runtime_explorer` diagnostics; disabled mode emits no runtime-explorer notice
 - Pitfalls & Gotchas:
   - personas are created from characters conceptually, but evolve independently after creation
   - do not store exemplar text snapshots in turn metadata when compact IDs/reasons are sufficient

--- a/tldw_Server_API/tests/Persona/test_persona_ws_dialogue_tree_runtime.py
+++ b/tldw_Server_API/tests/Persona/test_persona_ws_dialogue_tree_runtime.py
@@ -63,6 +63,20 @@ def _mock_persona_ws_runtime(monkeypatch):
 
 
 def _plan_for_text(text: str, *, session_id: str = "sess_runtime") -> dict:
+    events = _events_for_text(text, session_id=session_id)
+    for event in reversed(events):
+        if event.get("event") == "tool_plan":
+            return event
+    raise AssertionError("Expected tool_plan event")
+
+
+def _events_for_text(text: str, *, session_id: str = "sess_runtime") -> list[dict]:
+    events: list[dict] = []
+
+    def _capture_until_tool_plan(data: dict) -> bool:
+        events.append(data)
+        return data.get("event") == "tool_plan"
+
     with TestClient(fastapi_app) as client:
         with client.websocket_connect("/api/v1/persona/stream") as ws:
             _ = json.loads(ws.receive_text())
@@ -78,7 +92,8 @@ def _plan_for_text(text: str, *, session_id: str = "sess_runtime") -> dict:
                     }
                 )
             )
-            return _recv_until(ws, lambda data: data.get("event") == "tool_plan")
+            _recv_until(ws, _capture_until_tool_plan)
+    return events
 
 
 def test_runtime_explorer_provider_reuses_matching_explorer_instances() -> None:
@@ -268,6 +283,57 @@ def test_runtime_explorer_disabled_preserves_existing_plan_without_debug_metadat
     assert plan["steps"][0]["tool"] == "rag_search"
     assert "runtime_explorer" not in plan
     assert "candidate" not in json.dumps(plan).lower()
+
+
+def test_runtime_explorer_disabled_emits_no_runtime_diagnostic_notice(monkeypatch) -> None:
+    monkeypatch.setattr(
+        persona_ep,
+        "_get_persona_runtime_explorer_config",
+        lambda: RuntimeExplorerConfig(enabled=False),
+        raising=False,
+    )
+
+    events = _events_for_text("find notes about runtime explorer", session_id="sess_runtime_disabled_notice")
+
+    assert not [
+        event
+        for event in events
+        if event.get("event") == "notice"
+        and str(event.get("reason_code") or "").startswith("RUNTIME_EXPLORER_")
+    ]
+
+
+def test_runtime_explorer_fallback_notice_is_bounded_and_trace_safe(monkeypatch) -> None:
+    def _timeout(_context: dict) -> list[dict]:
+        raise TimeoutError("provider token=provider-secret")
+
+    monkeypatch.setattr(
+        persona_ep,
+        "_get_persona_runtime_explorer_config",
+        lambda: RuntimeExplorerConfig(enabled=True, timeout_ms=1, max_provider_calls=1),
+        raising=False,
+    )
+    monkeypatch.setattr(persona_ep, "_persona_runtime_candidate_generator", _timeout, raising=False)
+
+    events = _events_for_text(
+        "Authorization: Bearer user-secret find runtime notes",
+        session_id="sess_runtime_fallback_notice",
+    )
+
+    notice = next(
+        event
+        for event in events
+        if event.get("event") == "notice"
+        and event.get("reason_code") == "RUNTIME_EXPLORER_FALLBACK"
+    )
+    diagnostics = notice["runtime_explorer"]
+    serialized_notice = json.dumps(notice, sort_keys=True)
+    assert diagnostics["fallback"] == "soft_existing_behavior"
+    assert diagnostics["reason"] == "candidate_generation_timeout"
+    assert diagnostics["error_type"] == "TimeoutError"
+    assert diagnostics["provider_calls"] == 1
+    assert "user-secret" not in serialized_notice
+    assert "provider-secret" not in serialized_notice
 
 
 def test_runtime_explorer_enabled_selects_highest_scoring_safe_plan(monkeypatch) -> None:

--- a/tldw_Server_API/tests/Persona/test_persona_ws_dialogue_tree_runtime.py
+++ b/tldw_Server_API/tests/Persona/test_persona_ws_dialogue_tree_runtime.py
@@ -12,7 +12,12 @@ from starlette.datastructures import State
 
 from tldw_Server_API.app.api.v1.endpoints import persona as persona_ep
 from tldw_Server_API.app.core.Persona.dialogue_tree_scorers import ScoreResult, ScoreSeverity
-from tldw_Server_API.app.core.Persona.runtime_explorer import RuntimeExplorerConfig
+from tldw_Server_API.app.core.Persona.runtime_explorer import (
+    ExplorationFallback,
+    RuntimeBudgetUsage,
+    RuntimeExplorationResult,
+    RuntimeExplorerConfig,
+)
 
 
 pytestmark = pytest.mark.unit
@@ -96,6 +101,29 @@ def _events_for_text(text: str, *, session_id: str = "sess_runtime") -> list[dic
     return events
 
 
+def _notice_for_text(text: str, *, reason_code: str, session_id: str = "sess_runtime") -> dict:
+    with TestClient(fastapi_app) as client:
+        with client.websocket_connect("/api/v1/persona/stream") as ws:
+            _ = json.loads(ws.receive_text())
+            ws.send_text(
+                json.dumps(
+                    {
+                        "type": "user_message",
+                        "session_id": session_id,
+                        "text": text,
+                        "use_memory_context": False,
+                        "use_companion_context": False,
+                        "use_persona_state_context": False,
+                    }
+                )
+            )
+            return _recv_until(
+                ws,
+                lambda data: data.get("event") == "notice"
+                and data.get("reason_code") == reason_code,
+            )
+
+
 def test_runtime_explorer_provider_reuses_matching_explorer_instances() -> None:
     provider = persona_ep.PersonaRuntimeExplorerProvider()
     config = RuntimeExplorerConfig(enabled=True, max_provider_calls=1)
@@ -142,6 +170,50 @@ def test_runtime_explorer_config_clamps_numeric_settings(monkeypatch) -> None:
     assert config.max_provider_calls == 100
     assert config.timeout_ms == 100
     assert config.max_tokens == 16
+
+
+def test_runtime_explorer_diagnostics_payload_defaults_missing_budget() -> None:
+    result = RuntimeExplorationResult(
+        selected_candidate=None,
+        fallback=ExplorationFallback.SOFT_EXISTING_BEHAVIOR,
+        safe_denial=None,
+        budget=None,  # type: ignore[arg-type]
+        diagnostics={"reason": "candidate_generation_timeout", "error_type": "TimeoutError"},
+    )
+
+    payload = persona_ep._runtime_explorer_diagnostics_payload(result)
+
+    assert payload["provider_calls"] == 0
+    assert payload["candidates_considered"] == 0
+    assert payload["hard_prunes"] == 0
+    assert payload["soft_prunes"] == 0
+    assert payload["elapsed_ms"] == 0
+    assert payload["reason"] == "candidate_generation_timeout"
+    assert payload["error_type"] == "TimeoutError"
+
+
+def test_runtime_explorer_diagnostics_payload_defaults_null_budget_fields() -> None:
+    result = RuntimeExplorationResult(
+        selected_candidate=None,
+        fallback=ExplorationFallback.SOFT_EXISTING_BEHAVIOR,
+        safe_denial=None,
+        budget=RuntimeBudgetUsage(
+            provider_calls=None,  # type: ignore[arg-type]
+            candidates_considered=None,  # type: ignore[arg-type]
+            hard_prunes=None,  # type: ignore[arg-type]
+            soft_prunes=None,  # type: ignore[arg-type]
+            elapsed_ms=None,  # type: ignore[arg-type]
+        ),
+        diagnostics={"reason": "candidate_generation_timeout"},
+    )
+
+    payload = persona_ep._runtime_explorer_diagnostics_payload(result)
+
+    assert payload["provider_calls"] == 0
+    assert payload["candidates_considered"] == 0
+    assert payload["hard_prunes"] == 0
+    assert payload["soft_prunes"] == 0
+    assert payload["elapsed_ms"] == 0
 
 
 def test_runtime_explorer_provider_context_is_minimized_and_redacted(monkeypatch) -> None:
@@ -269,6 +341,44 @@ def test_runtime_explorer_default_generator_can_select_safe_alternative(monkeypa
     assert plan["steps"][0]["policy"]["allow"] is True
 
 
+def test_runtime_explorer_boolean_safe_denial_uses_default_message(monkeypatch) -> None:
+    class _FakeExplorer:
+        def explore(self, _context: dict) -> RuntimeExplorationResult:
+            return RuntimeExplorationResult(
+                selected_candidate=None,
+                fallback=ExplorationFallback.HARD_SAFE_DENIAL,
+                safe_denial=True,  # type: ignore[arg-type]
+                budget=RuntimeBudgetUsage(),
+            )
+
+    class _FakeProvider:
+        def get(self, _config: RuntimeExplorerConfig) -> _FakeExplorer:
+            return _FakeExplorer()
+
+    monkeypatch.setattr(
+        persona_ep,
+        "_get_persona_runtime_explorer_config",
+        lambda: RuntimeExplorerConfig(enabled=True, max_provider_calls=1),
+        raising=False,
+    )
+
+    plan = persona_ep._apply_persona_runtime_explorer_to_plan(
+        base_plan={"steps": []},
+        user_message="unsafe request",
+        session_id="sess_runtime_bool_safe_denial",
+        persona_id="persona-default",
+        runtime_mode="global",
+        memory_context=[],
+        persona_state_fields=[],
+        companion_usage={},
+        persona_exemplar_selection={},
+        runtime_explorer_provider=_FakeProvider(),  # type: ignore[arg-type]
+    )
+
+    assert plan["steps"][0]["args"]["text"] == RuntimeExplorerConfig().safe_denial_text
+    assert plan["steps"][0]["args"]["text"] != "True"
+
+
 def test_runtime_explorer_disabled_preserves_existing_plan_without_debug_metadata(monkeypatch) -> None:
     monkeypatch.setattr(
         persona_ep,
@@ -315,17 +425,12 @@ def test_runtime_explorer_fallback_notice_is_bounded_and_trace_safe(monkeypatch)
     )
     monkeypatch.setattr(persona_ep, "_persona_runtime_candidate_generator", _timeout, raising=False)
 
-    events = _events_for_text(
+    notice = _notice_for_text(
         "Authorization: Bearer user-secret find runtime notes",
+        reason_code="RUNTIME_EXPLORER_FALLBACK",
         session_id="sess_runtime_fallback_notice",
     )
 
-    notice = next(
-        event
-        for event in events
-        if event.get("event") == "notice"
-        and event.get("reason_code") == "RUNTIME_EXPLORER_FALLBACK"
-    )
     diagnostics = notice["runtime_explorer"]
     serialized_notice = json.dumps(notice, sort_keys=True)
     assert diagnostics["fallback"] == "soft_existing_behavior"


### PR DESCRIPTION
## Summary
- add bounded Persona Live notice diagnostics for optional runtime explorer fallback, circuit-open, and safe-denial outcomes
- keep disabled runtime explorer behavior quiet and strip internal diagnostics before tool plans are emitted
- document the notice contract and add focused websocket regression coverage

## Tracking
- Closes #1644
- Parent: #1510
- Backlog: TASK-322

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_ws_dialogue_tree_runtime.py tldw_Server_API/tests/Persona/test_runtime_explorer.py -q
- git diff --check
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/endpoints/persona.py -f json -o /tmp/bandit_persona_runtime_diagnostics.json

## Change summary
Pending human-authored change summary before this AI-authored PR is merge-ready.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces trace-safe Persona runtime explorer diagnostics as notice events. When enabled, we emit bounded `runtime_explorer` details for fallback, circuit-open, and safe-denial; disabled mode stays quiet and tool plans remain clean. Implements TASK-322 and addresses #1644.

- **New Features**
  - Emits `notice` events with `RUNTIME_EXPLORER_FALLBACK` (includes circuit-open) or `RUNTIME_EXPLORER_SAFE_DENIAL` and a bounded `runtime_explorer` payload (fallback, reason, error_type, provider_calls, candidates_considered, hard_prunes, soft_prunes, elapsed_ms, circuit_open, safe_denial).
  - Sanitizes diagnostics (tokenized values only); no raw user text, prompts, memory, candidate text, plan args, or provider exception messages.
  - Attaches diagnostics internally, then strips them from tool plans before emit; adds focused websocket tests and a README note.

- **Bug Fixes**
  - Defaults missing/malformed budget fields to 0 and normalizes non-string `safe_denial` to the configured text.
  - Adds bounded token validation and updates tests to assert trace-safety and decouple from event ordering.

<sup>Written for commit b200af8e7648df28e6eb5d759b02913785b88a70. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

