### PR TITLE
Add ACP execution health summary

### DIFF
--- a/Docs/Development/Agent_Client_Protocol.md
+++ b/Docs/Development/Agent_Client_Protocol.md
@@ -136,6 +136,7 @@ source that supports the matrix.
 |`/api/v1/acp/tasks/{task_id}`|GET|Poll async ACP task status/result|
 |`/api/v1/acp/runs`|GET|List ACP run history|
 |`/api/v1/acp/runs/aggregate`|GET|Aggregate ACP usage and cost data|
+|`/api/v1/admin/acp/execution-health/summary`|GET|Admin summary of ACP session health, failure buckets, retention/redaction posture, and compatibility evidence|
 |`/api/v1/acp/sessions/{session_id}/rollback`|POST|Rollback a sandbox-backed session to a checkpoint|
 |`/api/v1/acp/sessions/{session_id}/checkpoints`|GET|List available session checkpoints|
 |`/api/v1/agent-orchestration/workspaces`|GET/POST|List or create ACP workspaces|
@@ -272,6 +273,35 @@ previews, sanitized audit metadata, sanitized diagnostics, automatic ACP
 session/audit retention maintenance, and opt-in redacted session/event/artifact
 views. Do not claim that the default drill-through endpoints are redacted; they
 remain intentionally full fidelity for authorized operators.
+
+### Admin Execution-Health Summary
+
+`GET /api/v1/admin/acp/execution-health/summary` provides the backend-owned
+admin reporting contract for ACP release readiness and future admin UI display.
+The endpoint aggregates existing ACP session history and configured agent
+metadata. It does not introduce a separate observability store.
+
+The response includes:
+
+- `sessions.total` and `sessions.by_status` for sessions considered in the
+  requested `range_days` lookback.
+- `failure_buckets.setup_blockers` for unconfigured or blocked agent setup
+  state, `runner_session_failures` for errored sessions and runner/session
+  failures, `reviewer_rejections` and `reviewer_failures` for review-loop
+  outcomes, and `governance_denials` for policy or permission-denial outcomes.
+- `agents[]` entries with per-agent setup and compatibility posture, including
+  `support_state`, `verification_level`, `setup_blocked`, and
+  `primary_blocker`.
+- `compatibility.by_support_state`, `documented_unverified_agents`, and
+  `live_certification_required` so admin reporting can distinguish documented
+  candidates from live-certified agents without overstating support.
+- `retention` and `redaction` summaries that mirror the configured ACP
+  retention policy and the support-safe redaction posture for details, events,
+  artifacts, diagnostics, and audit metadata.
+
+The initial contract intentionally stays summary-level. Operator drill-through
+continues to use the existing session detail, events, artifacts, diagnostics,
+audit, run-history, and task-detail endpoints listed above.
 
 ### Frontend Setup And Diagnostics Surfaces
 

--- a/Docs/Development/Agent_Client_Protocol.md
+++ b/Docs/Development/Agent_Client_Protocol.md
@@ -288,7 +288,16 @@ The response includes:
 - `failure_buckets.setup_blockers` for unconfigured or blocked agent setup
   state, `runner_session_failures` for errored sessions and runner/session
   failures, `reviewer_rejections` and `reviewer_failures` for review-loop
-  outcomes, and `governance_denials` for policy or permission-denial outcomes.
+  outcomes, `governance_denials` for policy or permission-denial outcomes,
+  `structured_completion_failures` for missing or invalid completion signals,
+  `sandbox_runtime_errors` for sandbox or runtime launch/execution failures,
+  and `retention_redaction_actions` for observed retention or redaction
+  lifecycle actions.
+- `setup_health` dimensions for `agent`, `workspace`, `sandbox_runtime`,
+  `mcp_injection`, and `scheduler_trigger_path`. Each dimension reports a
+  status, normalized blockers, and an evidence count so operators can separate
+  known blockers from dimensions that are simply not observed in the summary
+  window.
 - `agents[]` entries with per-agent setup and compatibility posture, including
   `support_state`, `verification_level`, `setup_blocked`, and
   `primary_blocker`.

--- a/Docs/Product/ACP_Agent_Orchestration_PRD.md
+++ b/Docs/Product/ACP_Agent_Orchestration_PRD.md
@@ -57,6 +57,7 @@ parallel ACP-only workspace product.
 | Governance, RBAC, and audit | Shipped by [#1476](https://github.com/rmusser01/tldw_server/issues/1476) | ACP control surfaces use token scope guards where applicable, prompt/permission flows use shared governance coordination, and audit events are sanitized. |
 | Workspace and sandbox readiness | Shipped with runtime caveats by [#1477](https://github.com/rmusser01/tldw_server/issues/1477) | Workspace roots fail closed; workspace MCP servers and env flow into sessions; sandbox mode merges configured and per-session env. Docker/Lima/VZ runtime verification remains host-specific. |
 | Schedules and triggers | Shipped by [#1474](https://github.com/rmusser01/tldw_server/issues/1474) | ACP schedules route through APScheduler to the core Scheduler `acp_run` handler; triggers sanitize secrets and expose operator state. |
+| Admin execution-health reporting | Backend contract added under [#1537](https://github.com/rmusser01/tldw_server/issues/1537) | `/api/v1/admin/acp/execution-health/summary` summarizes ACP sessions, failure buckets, setup blockers, retention/redaction posture, and downstream-agent compatibility evidence for admin display. |
 | Frontend setup/run/diagnose UX | Shipped by [#1473](https://github.com/rmusser01/tldw_server/issues/1473) | Agent Tasks, Agent Registry, and ACP Playground share connection/auth handling; Agent Tasks shows setup gaps and task diagnostics without manual ID copying. |
 | Production readiness closeout | Remaining under [#1472](https://github.com/rmusser01/tldw_server/issues/1472) | Final release signoff still needs the readiness matrix closeout, broader live-backend E2E, Go runner verification, and accepted runtime caveats. |
 
@@ -149,6 +150,10 @@ All paths below are mounted below `/api/v1`.
 - `GET /acp/sessions/{session_id}/checkpoints`
 - `WS /acp/sessions/{session_id}/stream`
 - `WS /acp/sessions/{session_id}/ssh`
+
+### Admin Reporting
+
+- `GET /admin/acp/execution-health/summary`
 
 ### Agent Orchestration
 
@@ -260,6 +265,9 @@ The current implementation exposes enough state to derive:
 - average runs and reviews per task
 - run duration and failure reasons
 - token usage and run cost aggregates from ACP run history
+- ACP execution-health buckets for setup blockers, runner/session failures,
+  reviewer outcomes, governance denials, retention/redaction posture, and
+  documented-unverified compatibility
 - schedule queued, skipped, disabled, and error states
 - audit event volume by action and session
 

--- a/Docs/Product/ACP_Agent_Orchestration_PRD.md
+++ b/Docs/Product/ACP_Agent_Orchestration_PRD.md
@@ -266,8 +266,9 @@ The current implementation exposes enough state to derive:
 - run duration and failure reasons
 - token usage and run cost aggregates from ACP run history
 - ACP execution-health buckets for setup blockers, runner/session failures,
-  reviewer outcomes, governance denials, retention/redaction posture, and
-  documented-unverified compatibility
+  reviewer outcomes, governance denials, structured completion failures,
+  sandbox/runtime errors, retention/redaction actions, setup-health dimensions,
+  and documented-unverified compatibility
 - schedule queued, skipped, disabled, and error states
 - audit event volume by action and session
 

--- a/backlog/tasks/task-325 - Implement-ACP-execution-health-summary-contract-for-issue-1537.md
+++ b/backlog/tasks/task-325 - Implement-ACP-execution-health-summary-contract-for-issue-1537.md
@@ -1,0 +1,64 @@
+---
+id: TASK-325
+title: Implement ACP execution health summary contract for issue 1537
+status: Done
+assignee:
+  - codex
+created_date: '2026-05-14 01:14'
+updated_date: '2026-05-14 01:31'
+labels:
+  - ACP
+  - admin
+  - reporting
+  - backend
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1537'
+  - 'https://github.com/rmusser01/tldw_server/issues/1532'
+documentation:
+  - Docs/Development/Agent_Client_Protocol.md
+  - Docs/Product/ACP_Agent_Orchestration_PRD.md
+  - Docs/Development/ACP_Compatibility_Matrix.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the first #1537 slice as a backend-owned ACP execution-health summary contract that admins/operators and future UI surfaces can consume. The slice should aggregate existing ACP/session/orchestration/registry signals without inventing a separate observability system, and should keep downstream UI work as a follow-up once the API contract is stable.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 ACP execution-health summary metrics and failure buckets are documented in a durable ACP development/product doc.
+- [x] #2 A backend API/service path exposes summary data for ACP sessions/runs/reviews/setup-health using existing storage and status sources where available.
+- [x] #3 Summary output distinguishes setup blockers, runner/session failures, reviewer rejections, governance denials, retention/redaction status, and documented-unverified live-agent compatibility states without overstating support.
+- [x] #4 Focused tests cover the summary contract, empty-state behavior, representative failure buckets, and redaction/retention status fields.
+- [x] #5 Issue #1537 can be updated with backend contract evidence and clearly split follow-up frontend/admin display work.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented backend ACP execution-health summary contract with session status counts, failure buckets, retention/redaction posture, compatibility support-state rollup, and fail-closed compatibility enum coercion.
+
+Verification: focused execution-health pytest 3 passed; full admin ACP endpoint pytest 20 passed; git diff --check passed; Bandit touched backend scope reported 0 findings; OpenAPI schema generation exposed /api/v1/admin/acp/execution-health/summary with fake test SINGLE_USER_API_KEY.
+
+PR: https://github.com/rmusser01/tldw_server/pull/1648. Issue update: https://github.com/rmusser01/tldw_server/issues/1537#issuecomment-4446577031.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented ACP execution-health backend summary contract and opened draft PR #1648. The contract exposes /api/v1/admin/acp/execution-health/summary with session status counts, normalized failure buckets, retention/redaction posture, per-agent setup and compatibility summary, documented-unverified live-certification flags, and fail-closed enum handling. Validation: admin ACP endpoint pytest 20 passed, git diff --check clean, Bandit touched backend scope 0 findings, OpenAPI registration verified with fake test SINGLE_USER_API_KEY. Issue #1537 was updated with PR evidence and remaining frontend/admin display follow-up.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-325 - Implement-ACP-execution-health-summary-contract-for-issue-1537.md
+++ b/backlog/tasks/task-325 - Implement-ACP-execution-health-summary-contract-for-issue-1537.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - codex
 created_date: '2026-05-14 01:14'
-updated_date: '2026-05-14 01:31'
+updated_date: '2026-05-14 01:58'
 labels:
   - ACP
   - admin
@@ -15,6 +15,9 @@ dependencies: []
 references:
   - 'https://github.com/rmusser01/tldw_server/issues/1537'
   - 'https://github.com/rmusser01/tldw_server/issues/1532'
+  - 'https://github.com/rmusser01/tldw_server/issues/1512'
+  - 'https://github.com/rmusser01/tldw_server/issues/1513'
+  - 'https://github.com/rmusser01/tldw_server/issues/1529'
 documentation:
   - Docs/Development/Agent_Client_Protocol.md
   - Docs/Product/ACP_Agent_Orchestration_PRD.md
@@ -45,12 +48,22 @@ Implemented backend ACP execution-health summary contract with session status co
 Verification: focused execution-health pytest 3 passed; full admin ACP endpoint pytest 20 passed; git diff --check passed; Bandit touched backend scope reported 0 findings; OpenAPI schema generation exposed /api/v1/admin/acp/execution-health/summary with fake test SINGLE_USER_API_KEY.
 
 PR: https://github.com/rmusser01/tldw_server/pull/1648. Issue update: https://github.com/rmusser01/tldw_server/issues/1537#issuecomment-4446577031.
+
+Review-fix pass for PR #1648: addressing Qodo/Gemini comments on failure bucket taxonomy, setup-health dimensions, Backlog dependency/follow-up links, endpoint type/logging/style issues, aggregation placement, lookback filtering, pagination, and N+1 session loads.
+
+Review-fix coordination links added for #1512 retention, #1513 redacted views, and #1529 admin/deployment baseline.
+
+Trackable follow-up split: backend aggregation hardening covers DB/pre-aggregated execution-health metrics beyond the summary contract; frontend display covers admin UI cards/tables and drill-through entry points; docs/verification covers release evidence, OpenAPI examples, and compatibility matrix signoff. These follow-ups coordinate under #1537 and the linked ACP-adjacent issues rather than being claimed complete by this backend contract slice.
+
+Review-fix verification: PASS pytest tldw_Server_API/tests/Admin/test_admin_acp_new_endpoints.py -q (23 passed); PASS git diff --check; PASS py_compile touched backend files; PASS OpenAPI route/schema smoke for execution-health setup_health; Bandit touched backend scope reports only pre-existing baseline findings in ACP_Sessions_DB.py, with 0 findings in the new execution_health.py and admin endpoint/service changes.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Implemented ACP execution-health backend summary contract and opened draft PR #1648. The contract exposes /api/v1/admin/acp/execution-health/summary with session status counts, normalized failure buckets, retention/redaction posture, per-agent setup and compatibility summary, documented-unverified live-certification flags, and fail-closed enum handling. Validation: admin ACP endpoint pytest 20 passed, git diff --check clean, Bandit touched backend scope 0 findings, OpenAPI registration verified with fake test SINGLE_USER_API_KEY. Issue #1537 was updated with PR evidence and remaining frontend/admin display follow-up.
+
+Review-fix pass added core execution-health aggregation, DB-filtered paginated/batched session loading, expanded failure/setup-health taxonomy, fail-closed timestamp handling, Backlog coordination links, and focused regression tests.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_acp_agents.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_acp_agents.py
@@ -5,7 +5,8 @@ configurations, and tool permission policy management.
 """
 from __future__ import annotations
 
-from typing import Any
+from datetime import datetime, timedelta, timezone
+from typing import Any, cast, get_args
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from loguru import logger
@@ -20,6 +21,15 @@ from tldw_Server_API.app.api.v1.schemas.agent_client_protocol import (
     ACPAgentMetricsListResponse,
     ACPAgentUsageItem,
     ACPAgentUsageResponse,
+    ACPExecutionHealthAgentSummary,
+    ACPExecutionHealthCompatibilitySummary,
+    ACPExecutionHealthFailureBuckets,
+    ACPExecutionHealthRedactionSummary,
+    ACPExecutionHealthRetentionSummary,
+    ACPExecutionHealthSessionSummary,
+    ACPExecutionHealthSummaryResponse,
+    ACPSupportState,
+    ACPVerificationLevel,
     ACPPermissionPolicyCreate,
     ACPPermissionPolicyListResponse,
     ACPPermissionPolicyResponse,
@@ -45,6 +55,152 @@ _NONCRITICAL = (
     TypeError,
     ValueError,
 )
+
+_REVIEW_REJECTION_REASONS = frozenset({
+    "review_rejected",
+    "reviewer_rejected",
+    "review_rejected_retry",
+    "manual_review_rejected_retry",
+    "review_rejected_max_attempts",
+    "manual_review_rejected_max_attempts",
+})
+_REVIEW_FAILURE_REASONS = frozenset({
+    "reviewer_failed",
+    "review_decision_invalid",
+})
+_GOVERNANCE_DENIAL_REASONS = frozenset({
+    "governance_denied",
+    "permission_denied",
+    "policy_denied",
+    "tool_denied",
+    "denied",
+})
+_SETUP_BLOCKER_REASONS = frozenset({
+    "setup_blocked",
+    "runner_missing",
+    "binary_missing",
+    "api_key_missing",
+    "adapter_required",
+})
+_SUPPORT_STATES = frozenset(get_args(ACPSupportState))
+_VERIFICATION_LEVELS = frozenset(get_args(ACPVerificationLevel))
+
+
+async def _get_available_agents():
+    """Return configured ACP agents through the public ACP endpoint helper."""
+    from tldw_Server_API.app.api.v1.endpoints.agent_client_protocol import (
+        _get_available_agents as _acp_get_available_agents,
+    )
+
+    return await _acp_get_available_agents()
+
+
+def _now_iso() -> str:
+    """Return the current UTC time in ISO 8601 format."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _parse_iso(value: str | None) -> datetime | None:
+    """Parse an ISO timestamp and return None for absent or malformed values."""
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _session_within_range(record: Any, *, since: datetime) -> bool:
+    """Return whether a session record falls inside the requested lookback."""
+    created = _parse_iso(getattr(record, "created_at", None))
+    if created is None:
+        return True
+    if created.tzinfo is None:
+        created = created.replace(tzinfo=timezone.utc)
+    return created >= since
+
+
+def _collect_reason_codes(payload: Any, reasons: set[str]) -> None:
+    """Collect normalized failure/status codes from nested ACP payload data."""
+    if isinstance(payload, dict):
+        for key in ("reason_code", "error_type", "status", "code"):
+            value = payload.get(key)
+            if value is not None:
+                reasons.add(str(value).lower())
+        for value in payload.values():
+            _collect_reason_codes(value, reasons)
+    elif isinstance(payload, (list, tuple)):
+        for item in payload:
+            _collect_reason_codes(item, reasons)
+
+
+def _iter_session_reason_codes(record: Any) -> set[str]:
+    """Extract outcome reason codes from non-user session messages."""
+    reasons: set[str] = set()
+    for message in getattr(record, "messages", []) or []:
+        if not isinstance(message, dict):
+            continue
+        if str(message.get("role") or "").lower() == "user":
+            continue
+        _collect_reason_codes(message.get("content"), reasons)
+        _collect_reason_codes(message.get("raw_result"), reasons)
+    return reasons
+
+
+def _increment_failure_buckets(record: Any, buckets: dict[str, int]) -> None:
+    """Increment normalized execution-health buckets for one ACP session."""
+    status_value = str(getattr(record, "status", "") or "").lower()
+    reasons = _iter_session_reason_codes(record)
+    if status_value == "error" or any("runner" in reason or "session_failed" in reason for reason in reasons):
+        buckets["runner_session_failures"] += 1
+    if reasons & _REVIEW_REJECTION_REASONS:
+        buckets["reviewer_rejections"] += 1
+    if reasons & _REVIEW_FAILURE_REASONS:
+        buckets["reviewer_failures"] += 1
+    if reasons & _GOVERNANCE_DENIAL_REASONS:
+        buckets["governance_denials"] += 1
+    if reasons & _SETUP_BLOCKER_REASONS:
+        buckets["setup_blockers"] += 1
+
+
+def _agent_setup_blocked(agent: Any) -> tuple[bool, str | None]:
+    """Return whether an agent contributes an admin-visible setup blocker."""
+    entrypoint = getattr(agent, "entrypoint", None)
+    primary_blocker = getattr(entrypoint, "primary_blocker", None)
+    probe_state = getattr(entrypoint, "probe_state", None)
+    is_configured = bool(getattr(agent, "is_configured", False))
+    setup_blocked = (not is_configured) or bool(primary_blocker) or str(probe_state) == "blocked"
+    return setup_blocked, str(primary_blocker) if primary_blocker else None
+
+
+def _coerce_support_state(value: Any) -> ACPSupportState:
+    """Validate support state values and fail closed to documented-unverified."""
+    support_state = str(value or "documented_unverified")
+    if support_state in _SUPPORT_STATES:
+        return cast(ACPSupportState, support_state)
+    return "documented_unverified"
+
+
+def _coerce_verification_level(value: Any) -> ACPVerificationLevel:
+    """Validate verification level values and fail closed to documented-only."""
+    verification_level = str(value or "documented_only")
+    if verification_level in _VERIFICATION_LEVELS:
+        return cast(ACPVerificationLevel, verification_level)
+    return "documented_only"
+
+
+def _retention_summary() -> ACPExecutionHealthRetentionSummary:
+    """Return the configured ACP retention posture, falling back to defaults."""
+    try:
+        from tldw_Server_API.app.core.Agent_Client_Protocol.config import load_acp_sandbox_config
+
+        config = load_acp_sandbox_config()
+        return ACPExecutionHealthRetentionSummary(
+            session_retention_days=int(getattr(config, "session_retention_days", 30)),
+            audit_retention_days=int(getattr(config, "audit_retention_days", 30)),
+        )
+    except _NONCRITICAL:
+        return ACPExecutionHealthRetentionSummary()
 
 
 # ---------------------------------------------------------------------------
@@ -213,6 +369,86 @@ async def get_acp_agent_metrics() -> ACPAgentMetricsListResponse:
     metrics = await store.get_agent_metrics()
     return ACPAgentMetricsListResponse(
         items=[ACPAgentMetrics(**m) for m in metrics],
+    )
+
+
+@router.get("/acp/execution-health/summary", response_model=ACPExecutionHealthSummaryResponse)
+async def get_acp_execution_health_summary(
+    range_days: int = Query(30, ge=1, le=180),
+    _: object = Depends(get_auth_principal),
+    __: None = Depends(check_rate_limit),
+) -> ACPExecutionHealthSummaryResponse:
+    """Return a compact ACP execution-health rollup for admin reporting."""
+    store = await get_acp_session_store()
+    records, _total = await store.list_sessions(limit=1000, offset=0)
+    since = datetime.now(timezone.utc) - timedelta(days=range_days)
+
+    session_records = [
+        await store.get_session(record.session_id)
+        for record in records
+        if _session_within_range(record, since=since)
+    ]
+    sessions = [record for record in session_records if record is not None]
+
+    status_counts: dict[str, int] = {}
+    buckets = {
+        "setup_blockers": 0,
+        "runner_session_failures": 0,
+        "reviewer_rejections": 0,
+        "reviewer_failures": 0,
+        "governance_denials": 0,
+    }
+    for record in sessions:
+        status_value = str(getattr(record, "status", "unknown") or "unknown")
+        status_counts[status_value] = status_counts.get(status_value, 0) + 1
+        _increment_failure_buckets(record, buckets)
+
+    try:
+        agents, _default_agent = await _get_available_agents()
+    except _NONCRITICAL as exc:
+        logger.warning("Unable to include ACP agent compatibility in execution-health summary: {}", exc)
+        agents = []
+
+    agent_summaries: list[ACPExecutionHealthAgentSummary] = []
+    support_counts: dict[str, int] = {}
+    documented_unverified: list[str] = []
+    for agent in agents:
+        support_state = _coerce_support_state(getattr(agent, "support_state", "documented_unverified"))
+        verification_level = _coerce_verification_level(getattr(agent, "verification_level", "documented_only"))
+        support_counts[support_state] = support_counts.get(support_state, 0) + 1
+        if support_state == "documented_unverified":
+            documented_unverified.append(str(getattr(agent, "type", "")))
+        setup_blocked, primary_blocker = _agent_setup_blocked(agent)
+        if setup_blocked:
+            buckets["setup_blockers"] += 1
+        agent_summaries.append(
+            ACPExecutionHealthAgentSummary(
+                agent_type=str(getattr(agent, "type", "custom")),
+                name=str(getattr(agent, "name", "")),
+                is_configured=bool(getattr(agent, "is_configured", False)),
+                support_state=support_state,
+                verification_level=verification_level,
+                setup_blocked=setup_blocked,
+                primary_blocker=primary_blocker,
+            )
+        )
+
+    return ACPExecutionHealthSummaryResponse(
+        timestamp=_now_iso(),
+        range_days=range_days,
+        sessions=ACPExecutionHealthSessionSummary(
+            total=len(sessions),
+            by_status=status_counts,
+        ),
+        failure_buckets=ACPExecutionHealthFailureBuckets(**buckets),
+        agents=agent_summaries,
+        compatibility=ACPExecutionHealthCompatibilitySummary(
+            by_support_state=support_counts,
+            documented_unverified_agents=documented_unverified,
+            live_certification_required=bool(documented_unverified),
+        ),
+        retention=_retention_summary(),
+        redaction=ACPExecutionHealthRedactionSummary(),
     )
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_acp_agents.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_acp_agents.py
@@ -6,7 +6,6 @@ configurations, and tool permission policy management.
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
-from typing import Any, cast, get_args
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from loguru import logger
@@ -17,19 +16,17 @@ from tldw_Server_API.app.api.v1.schemas.agent_client_protocol import (
     ACPAgentConfigCreate,
     ACPAgentConfigListResponse,
     ACPAgentConfigResponse,
+    ACPAgentInfo,
     ACPAgentMetrics,
     ACPAgentMetricsListResponse,
     ACPAgentUsageItem,
     ACPAgentUsageResponse,
-    ACPExecutionHealthAgentSummary,
-    ACPExecutionHealthCompatibilitySummary,
     ACPExecutionHealthFailureBuckets,
     ACPExecutionHealthRedactionSummary,
     ACPExecutionHealthRetentionSummary,
     ACPExecutionHealthSessionSummary,
+    ACPExecutionHealthSetupSummary,
     ACPExecutionHealthSummaryResponse,
-    ACPSupportState,
-    ACPVerificationLevel,
     ACPPermissionPolicyCreate,
     ACPPermissionPolicyListResponse,
     ACPPermissionPolicyResponse,
@@ -39,6 +36,9 @@ from tldw_Server_API.app.api.v1.schemas.agent_client_protocol import (
     ACPSessionListResponse,
     ACPSessionUsageResponse,
     ACPTokenUsage,
+)
+from tldw_Server_API.app.core.Agent_Client_Protocol.execution_health import (
+    summarize_execution_health,
 )
 from tldw_Server_API.app.core.Usage.pricing_catalog import compute_token_cost
 from tldw_Server_API.app.services.admin_acp_sessions_service import get_acp_session_store
@@ -56,37 +56,8 @@ _NONCRITICAL = (
     ValueError,
 )
 
-_REVIEW_REJECTION_REASONS = frozenset({
-    "review_rejected",
-    "reviewer_rejected",
-    "review_rejected_retry",
-    "manual_review_rejected_retry",
-    "review_rejected_max_attempts",
-    "manual_review_rejected_max_attempts",
-})
-_REVIEW_FAILURE_REASONS = frozenset({
-    "reviewer_failed",
-    "review_decision_invalid",
-})
-_GOVERNANCE_DENIAL_REASONS = frozenset({
-    "governance_denied",
-    "permission_denied",
-    "policy_denied",
-    "tool_denied",
-    "denied",
-})
-_SETUP_BLOCKER_REASONS = frozenset({
-    "setup_blocked",
-    "runner_missing",
-    "binary_missing",
-    "api_key_missing",
-    "adapter_required",
-})
-_SUPPORT_STATES = frozenset(get_args(ACPSupportState))
-_VERIFICATION_LEVELS = frozenset(get_args(ACPVerificationLevel))
 
-
-async def _get_available_agents():
+async def _get_available_agents() -> tuple[list[ACPAgentInfo], str | None]:
     """Return configured ACP agents through the public ACP endpoint helper."""
     from tldw_Server_API.app.api.v1.endpoints.agent_client_protocol import (
         _get_available_agents as _acp_get_available_agents,
@@ -100,95 +71,6 @@ def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
-def _parse_iso(value: str | None) -> datetime | None:
-    """Parse an ISO timestamp and return None for absent or malformed values."""
-    if not value:
-        return None
-    try:
-        return datetime.fromisoformat(value)
-    except (TypeError, ValueError):
-        return None
-
-
-def _session_within_range(record: Any, *, since: datetime) -> bool:
-    """Return whether a session record falls inside the requested lookback."""
-    created = _parse_iso(getattr(record, "created_at", None))
-    if created is None:
-        return True
-    if created.tzinfo is None:
-        created = created.replace(tzinfo=timezone.utc)
-    return created >= since
-
-
-def _collect_reason_codes(payload: Any, reasons: set[str]) -> None:
-    """Collect normalized failure/status codes from nested ACP payload data."""
-    if isinstance(payload, dict):
-        for key in ("reason_code", "error_type", "status", "code"):
-            value = payload.get(key)
-            if value is not None:
-                reasons.add(str(value).lower())
-        for value in payload.values():
-            _collect_reason_codes(value, reasons)
-    elif isinstance(payload, (list, tuple)):
-        for item in payload:
-            _collect_reason_codes(item, reasons)
-
-
-def _iter_session_reason_codes(record: Any) -> set[str]:
-    """Extract outcome reason codes from non-user session messages."""
-    reasons: set[str] = set()
-    for message in getattr(record, "messages", []) or []:
-        if not isinstance(message, dict):
-            continue
-        if str(message.get("role") or "").lower() == "user":
-            continue
-        _collect_reason_codes(message.get("content"), reasons)
-        _collect_reason_codes(message.get("raw_result"), reasons)
-    return reasons
-
-
-def _increment_failure_buckets(record: Any, buckets: dict[str, int]) -> None:
-    """Increment normalized execution-health buckets for one ACP session."""
-    status_value = str(getattr(record, "status", "") or "").lower()
-    reasons = _iter_session_reason_codes(record)
-    if status_value == "error" or any("runner" in reason or "session_failed" in reason for reason in reasons):
-        buckets["runner_session_failures"] += 1
-    if reasons & _REVIEW_REJECTION_REASONS:
-        buckets["reviewer_rejections"] += 1
-    if reasons & _REVIEW_FAILURE_REASONS:
-        buckets["reviewer_failures"] += 1
-    if reasons & _GOVERNANCE_DENIAL_REASONS:
-        buckets["governance_denials"] += 1
-    if reasons & _SETUP_BLOCKER_REASONS:
-        buckets["setup_blockers"] += 1
-
-
-def _agent_setup_blocked(agent: Any) -> tuple[bool, str | None]:
-    """Return whether an agent contributes an admin-visible setup blocker."""
-    entrypoint = getattr(agent, "entrypoint", None)
-    primary_blocker = getattr(entrypoint, "primary_blocker", None)
-    probe_state = getattr(entrypoint, "probe_state", None)
-    is_configured = bool(getattr(agent, "is_configured", False))
-    setup_blocked = (not is_configured) or bool(primary_blocker) or str(probe_state) == "blocked"
-    return setup_blocked, str(primary_blocker) if primary_blocker else None
-
-
-def _coerce_support_state(value: Any) -> ACPSupportState:
-    """Validate support state values and fail closed to documented-unverified."""
-    support_state = str(value or "documented_unverified")
-    if support_state in _SUPPORT_STATES:
-        return cast(ACPSupportState, support_state)
-    return "documented_unverified"
-
-
-def _coerce_verification_level(value: Any) -> ACPVerificationLevel:
-    """Validate verification level values and fail closed to documented-only."""
-    verification_level = str(value or "documented_only")
-    if verification_level in _VERIFICATION_LEVELS:
-        return cast(ACPVerificationLevel, verification_level)
-    return "documented_only"
-
-
 def _retention_summary() -> ACPExecutionHealthRetentionSummary:
     """Return the configured ACP retention posture, falling back to defaults."""
     try:
@@ -199,7 +81,11 @@ def _retention_summary() -> ACPExecutionHealthRetentionSummary:
             session_retention_days=int(getattr(config, "session_retention_days", 30)),
             audit_retention_days=int(getattr(config, "audit_retention_days", 30)),
         )
-    except _NONCRITICAL:
+    except _NONCRITICAL as exc:
+        logger.warning(
+            "Unable to load ACP retention config for execution-health summary; using defaults: {}",
+            type(exc).__name__,
+        )
         return ACPExecutionHealthRetentionSummary()
 
 
@@ -380,73 +266,28 @@ async def get_acp_execution_health_summary(
 ) -> ACPExecutionHealthSummaryResponse:
     """Return a compact ACP execution-health rollup for admin reporting."""
     store = await get_acp_session_store()
-    records, _total = await store.list_sessions(limit=1000, offset=0)
     since = datetime.now(timezone.utc) - timedelta(days=range_days)
-
-    session_records = [
-        await store.get_session(record.session_id)
-        for record in records
-        if _session_within_range(record, since=since)
-    ]
-    sessions = [record for record in session_records if record is not None]
-
-    status_counts: dict[str, int] = {}
-    buckets = {
-        "setup_blockers": 0,
-        "runner_session_failures": 0,
-        "reviewer_rejections": 0,
-        "reviewer_failures": 0,
-        "governance_denials": 0,
-    }
-    for record in sessions:
-        status_value = str(getattr(record, "status", "unknown") or "unknown")
-        status_counts[status_value] = status_counts.get(status_value, 0) + 1
-        _increment_failure_buckets(record, buckets)
+    sessions = await store.list_sessions_with_messages_since(since=since, page_size=1000)
 
     try:
         agents, _default_agent = await _get_available_agents()
     except _NONCRITICAL as exc:
-        logger.warning("Unable to include ACP agent compatibility in execution-health summary: {}", exc)
+        logger.warning(
+            "Unable to include ACP agent compatibility in execution-health summary: {}",
+            exc,
+        )
         agents = []
 
-    agent_summaries: list[ACPExecutionHealthAgentSummary] = []
-    support_counts: dict[str, int] = {}
-    documented_unverified: list[str] = []
-    for agent in agents:
-        support_state = _coerce_support_state(getattr(agent, "support_state", "documented_unverified"))
-        verification_level = _coerce_verification_level(getattr(agent, "verification_level", "documented_only"))
-        support_counts[support_state] = support_counts.get(support_state, 0) + 1
-        if support_state == "documented_unverified":
-            documented_unverified.append(str(getattr(agent, "type", "")))
-        setup_blocked, primary_blocker = _agent_setup_blocked(agent)
-        if setup_blocked:
-            buckets["setup_blockers"] += 1
-        agent_summaries.append(
-            ACPExecutionHealthAgentSummary(
-                agent_type=str(getattr(agent, "type", "custom")),
-                name=str(getattr(agent, "name", "")),
-                is_configured=bool(getattr(agent, "is_configured", False)),
-                support_state=support_state,
-                verification_level=verification_level,
-                setup_blocked=setup_blocked,
-                primary_blocker=primary_blocker,
-            )
-        )
+    summary = summarize_execution_health(sessions=sessions, agents=agents)
 
     return ACPExecutionHealthSummaryResponse(
         timestamp=_now_iso(),
         range_days=range_days,
-        sessions=ACPExecutionHealthSessionSummary(
-            total=len(sessions),
-            by_status=status_counts,
-        ),
-        failure_buckets=ACPExecutionHealthFailureBuckets(**buckets),
-        agents=agent_summaries,
-        compatibility=ACPExecutionHealthCompatibilitySummary(
-            by_support_state=support_counts,
-            documented_unverified_agents=documented_unverified,
-            live_certification_required=bool(documented_unverified),
-        ),
+        sessions=ACPExecutionHealthSessionSummary(**summary["sessions"]),
+        failure_buckets=ACPExecutionHealthFailureBuckets(**summary["failure_buckets"]),
+        setup_health=ACPExecutionHealthSetupSummary(**summary["setup_health"]),
+        agents=summary["agents"],
+        compatibility=summary["compatibility"],
         retention=_retention_summary(),
         redaction=ACPExecutionHealthRedactionSummary(),
     )

--- a/tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py
+++ b/tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py
@@ -670,6 +670,66 @@ class ACPAgentMetricsListResponse(BaseModel):
     items: list[ACPAgentMetrics] = Field(default_factory=list)
 
 
+class ACPExecutionHealthSessionSummary(BaseModel):
+    """Aggregated ACP session status counts for admin execution-health reporting."""
+    total: int = Field(default=0, description="Total ACP sessions considered in this summary")
+    by_status: dict[str, int] = Field(default_factory=dict, description="Session count by persisted status")
+
+
+class ACPExecutionHealthFailureBuckets(BaseModel):
+    """Normalized ACP execution-health failure buckets for admin reporting."""
+    setup_blockers: int = Field(default=0, description="Agents or sessions blocked by setup/certification gaps")
+    runner_session_failures: int = Field(default=0, description="Sessions or events that indicate runner/session failure")
+    reviewer_rejections: int = Field(default=0, description="Sessions with reviewer rejection outcomes")
+    reviewer_failures: int = Field(default=0, description="Sessions with reviewer execution or decision failures")
+    governance_denials: int = Field(default=0, description="Sessions with governance or permission-denial outcomes")
+
+
+class ACPExecutionHealthAgentSummary(BaseModel):
+    """Compatibility and setup posture for one configured ACP agent."""
+    agent_type: str = Field(..., description="Agent type identifier")
+    name: str = Field(default="", description="Human-readable agent name")
+    is_configured: bool = Field(default=False, description="Whether local prerequisites appear configured")
+    support_state: ACPSupportState = Field(default="documented_unverified")
+    verification_level: ACPVerificationLevel = Field(default="documented_only")
+    setup_blocked: bool = Field(default=False, description="Whether this agent contributes a setup blocker")
+    primary_blocker: str | None = Field(default=None, description="Primary setup or entrypoint blocker, if known")
+
+
+class ACPExecutionHealthCompatibilitySummary(BaseModel):
+    """Downstream-agent compatibility evidence summary for ACP admin reporting."""
+    by_support_state: dict[str, int] = Field(default_factory=dict)
+    documented_unverified_agents: list[str] = Field(default_factory=list)
+    live_certification_required: bool = Field(default=False)
+    docs_url: str = Field(default=ACP_COMPATIBILITY_DOCS_URL)
+
+
+class ACPExecutionHealthRetentionSummary(BaseModel):
+    """Configured ACP retention posture for admin execution-health reporting."""
+    session_retention_days: int = Field(default=30)
+    audit_retention_days: int = Field(default=30)
+    policy: str = Field(default="closed_error_sessions_and_audit_events_purged_after_retention")
+
+
+class ACPExecutionHealthRedactionSummary(BaseModel):
+    """Redaction posture for support-safe ACP drill-through surfaces."""
+    detail_events_artifacts_redacted_views: bool = Field(default=True)
+    diagnostics_sanitized: bool = Field(default=True)
+    audit_metadata_sanitized: bool = Field(default=True)
+
+
+class ACPExecutionHealthSummaryResponse(BaseModel):
+    """Admin ACP execution-health rollup across sessions, agents, and support posture."""
+    timestamp: str = Field(..., description="ISO 8601 timestamp for this summary")
+    range_days: int = Field(..., description="Lookback window used for session aggregation")
+    sessions: ACPExecutionHealthSessionSummary = Field(default_factory=ACPExecutionHealthSessionSummary)
+    failure_buckets: ACPExecutionHealthFailureBuckets = Field(default_factory=ACPExecutionHealthFailureBuckets)
+    agents: list[ACPExecutionHealthAgentSummary] = Field(default_factory=list)
+    compatibility: ACPExecutionHealthCompatibilitySummary = Field(default_factory=ACPExecutionHealthCompatibilitySummary)
+    retention: ACPExecutionHealthRetentionSummary = Field(default_factory=ACPExecutionHealthRetentionSummary)
+    redaction: ACPExecutionHealthRedactionSummary = Field(default_factory=ACPExecutionHealthRedactionSummary)
+
+
 class ACPAgentUsageItem(BaseModel):
     """Aggregated usage statistics for a single agent type."""
     agent_type: str

--- a/tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py
+++ b/tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py
@@ -44,6 +44,7 @@ ACPEntryPointStrategy = Literal[
     "custom_template",
 ]
 ACPProbeState = Literal["ready_to_probe", "blocked", "custom_template", "documented_only"]
+ACPSetupHealthStatus = Literal["unknown", "ready", "blocked", "not_configured", "partial"]
 
 
 class ACPAgentEntrypointStatus(BaseModel):
@@ -678,11 +679,70 @@ class ACPExecutionHealthSessionSummary(BaseModel):
 
 class ACPExecutionHealthFailureBuckets(BaseModel):
     """Normalized ACP execution-health failure buckets for admin reporting."""
-    setup_blockers: int = Field(default=0, description="Agents or sessions blocked by setup/certification gaps")
-    runner_session_failures: int = Field(default=0, description="Sessions or events that indicate runner/session failure")
-    reviewer_rejections: int = Field(default=0, description="Sessions with reviewer rejection outcomes")
-    reviewer_failures: int = Field(default=0, description="Sessions with reviewer execution or decision failures")
-    governance_denials: int = Field(default=0, description="Sessions with governance or permission-denial outcomes")
+    setup_blockers: int = Field(
+        default=0,
+        description="Agents or sessions blocked by setup/certification gaps",
+    )
+    runner_session_failures: int = Field(
+        default=0,
+        description="Sessions or events that indicate runner/session failure",
+    )
+    reviewer_rejections: int = Field(
+        default=0,
+        description="Sessions with reviewer rejection outcomes",
+    )
+    reviewer_failures: int = Field(
+        default=0,
+        description="Sessions with reviewer execution or decision failures",
+    )
+    governance_denials: int = Field(
+        default=0,
+        description="Sessions with governance or permission-denial outcomes",
+    )
+    structured_completion_failures: int = Field(
+        default=0,
+        description="Sessions with invalid or missing structured completion signals",
+    )
+    sandbox_runtime_errors: int = Field(
+        default=0,
+        description="Sessions with sandbox/runtime launch or execution errors",
+    )
+    retention_redaction_actions: int = Field(
+        default=0,
+        description="Sessions with retention or redaction actions observed",
+    )
+
+
+class ACPExecutionHealthSetupDimension(BaseModel):
+    """Setup-health status for one ACP readiness dimension."""
+    status: ACPSetupHealthStatus = Field(default="unknown", description="Dimension status")
+    blockers: list[str] = Field(
+        default_factory=list,
+        description="Normalized blocker codes for this setup dimension",
+    )
+    evidence_count: int = Field(
+        default=0,
+        description="Number of observed records contributing evidence to this dimension",
+    )
+
+
+class ACPExecutionHealthSetupSummary(BaseModel):
+    """ACP setup-health dimensions for admin readiness reporting."""
+    agent: ACPExecutionHealthSetupDimension = Field(
+        default_factory=ACPExecutionHealthSetupDimension,
+    )
+    workspace: ACPExecutionHealthSetupDimension = Field(
+        default_factory=ACPExecutionHealthSetupDimension,
+    )
+    sandbox_runtime: ACPExecutionHealthSetupDimension = Field(
+        default_factory=ACPExecutionHealthSetupDimension,
+    )
+    mcp_injection: ACPExecutionHealthSetupDimension = Field(
+        default_factory=ACPExecutionHealthSetupDimension,
+    )
+    scheduler_trigger_path: ACPExecutionHealthSetupDimension = Field(
+        default_factory=ACPExecutionHealthSetupDimension,
+    )
 
 
 class ACPExecutionHealthAgentSummary(BaseModel):
@@ -722,8 +782,15 @@ class ACPExecutionHealthSummaryResponse(BaseModel):
     """Admin ACP execution-health rollup across sessions, agents, and support posture."""
     timestamp: str = Field(..., description="ISO 8601 timestamp for this summary")
     range_days: int = Field(..., description="Lookback window used for session aggregation")
-    sessions: ACPExecutionHealthSessionSummary = Field(default_factory=ACPExecutionHealthSessionSummary)
-    failure_buckets: ACPExecutionHealthFailureBuckets = Field(default_factory=ACPExecutionHealthFailureBuckets)
+    sessions: ACPExecutionHealthSessionSummary = Field(
+        default_factory=ACPExecutionHealthSessionSummary,
+    )
+    failure_buckets: ACPExecutionHealthFailureBuckets = Field(
+        default_factory=ACPExecutionHealthFailureBuckets,
+    )
+    setup_health: ACPExecutionHealthSetupSummary = Field(
+        default_factory=ACPExecutionHealthSetupSummary,
+    )
     agents: list[ACPExecutionHealthAgentSummary] = Field(default_factory=list)
     compatibility: ACPExecutionHealthCompatibilitySummary = Field(default_factory=ACPExecutionHealthCompatibilitySummary)
     retention: ACPExecutionHealthRetentionSummary = Field(default_factory=ACPExecutionHealthRetentionSummary)

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/execution_health.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/execution_health.py
@@ -1,0 +1,446 @@
+"""ACP execution-health summary aggregation.
+
+The admin endpoint owns routing and auth. This module owns the reusable
+classification and aggregation rules for ACP session health reporting.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Iterable
+
+REASON_KEYS = ("reason_code", "error_type", "status", "code")
+MAX_REASON_NODES = 10_000
+
+SUPPORT_STATES = frozenset({
+    "supported",
+    "supported_with_caveats",
+    "experimental",
+    "documented_unverified",
+    "unsupported",
+})
+VERIFICATION_LEVELS = frozenset({
+    "documented_only",
+    "stub_smoke_tested",
+    "live_e2e_tested",
+    "sandbox_tested",
+    "production_supported",
+})
+
+REVIEW_REJECTION_REASONS = frozenset({
+    "review_rejected",
+    "reviewer_rejected",
+    "review_rejected_retry",
+    "manual_review_rejected_retry",
+    "review_rejected_max_attempts",
+    "manual_review_rejected_max_attempts",
+})
+REVIEW_FAILURE_REASONS = frozenset({
+    "reviewer_failed",
+    "review_decision_invalid",
+})
+GOVERNANCE_DENIAL_REASONS = frozenset({
+    "governance_denied",
+    "permission_denied",
+    "policy_denied",
+    "tool_denied",
+    "denied",
+})
+SETUP_BLOCKER_REASONS = frozenset({
+    "setup_blocked",
+    "runner_missing",
+    "binary_missing",
+    "api_key_missing",
+    "adapter_required",
+})
+RUNNER_SESSION_FAILURE_REASONS = frozenset({
+    "agent_run_failed",
+    "run_failed",
+    "runner_crashed",
+    "runner_error",
+    "runner_failed",
+    "runner_timeout",
+    "session_error",
+    "session_failed",
+    "session_failed_retry",
+    "task_failed",
+})
+STRUCTURED_COMPLETION_FAILURE_REASONS = frozenset({
+    "completion_schema_invalid",
+    "completion_signal_invalid",
+    "completion_signal_missing",
+    "completion_validation_failed",
+    "invalid_completion_signal",
+    "missing_completion_signal",
+    "structured_completion_failed",
+    "structured_completion_invalid",
+})
+SANDBOX_RUNTIME_ERROR_REASONS = frozenset({
+    "runtime_error",
+    "runtime_unavailable",
+    "sandbox_launch_failed",
+    "sandbox_runner_failed",
+    "sandbox_runtime_error",
+    "sandbox_start_failed",
+    "sandbox_timeout",
+    "sandbox_unavailable",
+})
+RETENTION_REDACTION_ACTION_REASONS = frozenset({
+    "audit_retention_purged",
+    "redacted_view_requested",
+    "redaction_applied",
+    "retention_applied",
+    "retention_purged",
+    "session_retention_purged",
+})
+MCP_INJECTION_FAILURE_REASONS = frozenset({
+    "mcp_injection_failed",
+    "mcp_server_unavailable",
+    "mcp_tool_registration_failed",
+})
+SCHEDULER_TRIGGER_FAILURE_REASONS = frozenset({
+    "schedule_enqueue_failed",
+    "scheduler_trigger_failed",
+    "trigger_dispatch_failed",
+    "webhook_trigger_failed",
+})
+
+
+def _get_field(obj: Any, key: str, default: Any = None) -> Any:
+    """Read a key from dict-like or attribute-like objects."""
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _normalize_utc(value: datetime) -> datetime:
+    """Return an aware UTC datetime."""
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def parse_iso(value: Any) -> datetime | None:
+    """Parse an ISO timestamp, including trailing Z, and fail closed on errors."""
+    if isinstance(value, datetime):
+        return _normalize_utc(value)
+    if not isinstance(value, str) or not value.strip():
+        return None
+    normalized = value.strip()
+    if normalized.endswith("Z"):
+        normalized = f"{normalized[:-1]}+00:00"
+    try:
+        return _normalize_utc(datetime.fromisoformat(normalized))
+    except (TypeError, ValueError):
+        return None
+
+
+def session_reference_datetime(record: Any) -> datetime | None:
+    """Return the best timestamp available for lookback filtering."""
+    parsed_values: list[datetime] = []
+    for field_name in ("created_at", "last_activity_at"):
+        parsed = parse_iso(_get_field(record, field_name))
+        if parsed is not None:
+            parsed_values.append(parsed)
+    return max(parsed_values) if parsed_values else None
+
+
+def session_within_range(record: Any, *, since: datetime) -> bool:
+    """Return whether a session falls inside the requested lookback window."""
+    reference_time = session_reference_datetime(record)
+    if reference_time is None:
+        return False
+    return reference_time >= _normalize_utc(since)
+
+
+def collect_reason_codes(payload: Any, reasons: set[str]) -> None:
+    """Collect normalized failure/status codes from nested ACP payload data."""
+    stack: list[Any] = [payload]
+    seen_containers: set[int] = set()
+    visited = 0
+
+    while stack and visited < MAX_REASON_NODES:
+        current = stack.pop()
+        visited += 1
+
+        if isinstance(current, dict):
+            identity = id(current)
+            if identity in seen_containers:
+                continue
+            seen_containers.add(identity)
+            for key in REASON_KEYS:
+                value = current.get(key)
+                if value is not None:
+                    reasons.add(str(value).strip().lower())
+            stack.extend(current.values())
+        elif isinstance(current, (list, tuple)):
+            identity = id(current)
+            if identity in seen_containers:
+                continue
+            seen_containers.add(identity)
+            stack.extend(current)
+
+
+def iter_session_reason_codes(record: Any) -> set[str]:
+    """Extract outcome reason codes from non-user session messages."""
+    reasons: set[str] = set()
+    for message in _get_field(record, "messages", []) or []:
+        if not isinstance(message, dict):
+            continue
+        if str(message.get("role") or "").lower() == "user":
+            continue
+        collect_reason_codes(message.get("content"), reasons)
+        collect_reason_codes(message.get("raw_result"), reasons)
+        collect_reason_codes(message.get("raw_data"), reasons)
+    return reasons
+
+
+def default_failure_buckets() -> dict[str, int]:
+    """Return zeroed ACP execution-health failure buckets."""
+    return {
+        "setup_blockers": 0,
+        "runner_session_failures": 0,
+        "reviewer_rejections": 0,
+        "reviewer_failures": 0,
+        "governance_denials": 0,
+        "structured_completion_failures": 0,
+        "sandbox_runtime_errors": 0,
+        "retention_redaction_actions": 0,
+    }
+
+
+def _has_runner_session_failure(status_value: str, reasons: set[str]) -> bool:
+    if status_value == "error":
+        return True
+    if reasons & RUNNER_SESSION_FAILURE_REASONS:
+        return True
+    return any(
+        reason.startswith("runner_") and reason not in SETUP_BLOCKER_REASONS
+        for reason in reasons
+    )
+
+
+def increment_failure_buckets(
+    *,
+    status_value: str,
+    reasons: set[str],
+    buckets: dict[str, int],
+) -> None:
+    """Increment normalized execution-health buckets for one ACP session."""
+    if _has_runner_session_failure(status_value, reasons):
+        buckets["runner_session_failures"] += 1
+    if reasons & REVIEW_REJECTION_REASONS:
+        buckets["reviewer_rejections"] += 1
+    if reasons & REVIEW_FAILURE_REASONS:
+        buckets["reviewer_failures"] += 1
+    if reasons & GOVERNANCE_DENIAL_REASONS:
+        buckets["governance_denials"] += 1
+    if reasons & SETUP_BLOCKER_REASONS:
+        buckets["setup_blockers"] += 1
+    if reasons & STRUCTURED_COMPLETION_FAILURE_REASONS:
+        buckets["structured_completion_failures"] += 1
+    if reasons & SANDBOX_RUNTIME_ERROR_REASONS:
+        buckets["sandbox_runtime_errors"] += 1
+    if reasons & RETENTION_REDACTION_ACTION_REASONS:
+        buckets["retention_redaction_actions"] += 1
+
+
+def agent_setup_blocked(agent: Any) -> tuple[bool, str | None]:
+    """Return whether an agent contributes an admin-visible setup blocker."""
+    entrypoint = _get_field(agent, "entrypoint")
+    primary_blocker = _get_field(entrypoint, "primary_blocker") if entrypoint else None
+    probe_state = _get_field(entrypoint, "probe_state") if entrypoint else None
+    is_configured = bool(_get_field(agent, "is_configured", False))
+    setup_blocked = (
+        (not is_configured)
+        or bool(primary_blocker)
+        or str(probe_state) == "blocked"
+    )
+    return setup_blocked, str(primary_blocker) if primary_blocker else None
+
+
+def coerce_support_state(value: Any) -> str:
+    """Validate support state values and fail closed to documented-unverified."""
+    support_state = str(value or "documented_unverified")
+    if support_state in SUPPORT_STATES:
+        return support_state
+    return "documented_unverified"
+
+
+def coerce_verification_level(value: Any) -> str:
+    """Validate verification level values and fail closed to documented-only."""
+    verification_level = str(value or "documented_only")
+    if verification_level in VERIFICATION_LEVELS:
+        return verification_level
+    return "documented_only"
+
+
+def _setup_dimension(
+    status_value: str,
+    *,
+    blockers: Iterable[str] = (),
+    evidence_count: int = 0,
+) -> dict[str, Any]:
+    """Build one setup-health dimension summary."""
+    return {
+        "status": status_value,
+        "blockers": sorted({blocker for blocker in blockers if blocker}),
+        "evidence_count": max(0, int(evidence_count)),
+    }
+
+
+def _session_has_workspace_evidence(record: Any) -> bool:
+    return bool(
+        _get_field(record, "workspace_id")
+        or _get_field(record, "workspace_group_id")
+        or _get_field(record, "scope_snapshot_id")
+    )
+
+
+def _session_has_mcp_evidence(record: Any) -> bool:
+    return bool(_get_field(record, "mcp_servers") or [])
+
+
+def build_setup_health_summary(
+    *,
+    sessions: list[Any],
+    agent_summaries: list[dict[str, Any]],
+    buckets: dict[str, int],
+    reason_sets: list[set[str]],
+) -> dict[str, Any]:
+    """Summarize readiness blockers across ACP setup dimensions."""
+    agent_blockers = [
+        str(agent.get("primary_blocker"))
+        for agent in agent_summaries
+        if agent.get("setup_blocked") and agent.get("primary_blocker")
+    ]
+    blocked_agent_count = sum(
+        1 for agent in agent_summaries if agent.get("setup_blocked")
+    )
+    session_setup_blocked = buckets.get("setup_blockers", 0) > blocked_agent_count
+    agent_status = (
+        "blocked"
+        if blocked_agent_count or session_setup_blocked
+        else "ready"
+        if agent_summaries
+        else "unknown"
+    )
+    if session_setup_blocked:
+        agent_blockers.append("session_setup_blockers")
+
+    workspace_evidence = sum(
+        1 for session in sessions if _session_has_workspace_evidence(session)
+    )
+    mcp_evidence = sum(1 for session in sessions if _session_has_mcp_evidence(session))
+    mcp_failures = sum(
+        1 for reasons in reason_sets if reasons & MCP_INJECTION_FAILURE_REASONS
+    )
+    scheduler_failures = sum(
+        1 for reasons in reason_sets if reasons & SCHEDULER_TRIGGER_FAILURE_REASONS
+    )
+
+    return {
+        "agent": _setup_dimension(
+            agent_status,
+            blockers=agent_blockers,
+            evidence_count=(
+                blocked_agent_count
+                if agent_status == "blocked"
+                else len(agent_summaries)
+            ),
+        ),
+        "workspace": _setup_dimension(
+            "ready" if workspace_evidence else "unknown",
+            evidence_count=workspace_evidence,
+        ),
+        "sandbox_runtime": _setup_dimension(
+            "blocked" if buckets.get("sandbox_runtime_errors", 0) else "unknown",
+            blockers=(
+                ["sandbox_runtime_errors"]
+                if buckets.get("sandbox_runtime_errors", 0)
+                else ()
+            ),
+            evidence_count=buckets.get("sandbox_runtime_errors", 0),
+        ),
+        "mcp_injection": _setup_dimension(
+            "blocked" if mcp_failures else "ready" if mcp_evidence else "unknown",
+            blockers=["mcp_injection_failures"] if mcp_failures else (),
+            evidence_count=mcp_failures or mcp_evidence,
+        ),
+        "scheduler_trigger_path": _setup_dimension(
+            "blocked" if scheduler_failures else "unknown",
+            blockers=["scheduler_or_trigger_failures"] if scheduler_failures else (),
+            evidence_count=scheduler_failures,
+        ),
+    }
+
+
+def summarize_execution_health(
+    *,
+    sessions: Iterable[Any],
+    agents: Iterable[Any],
+) -> dict[str, Any]:
+    """Aggregate ACP sessions and agent metadata into the admin summary contract."""
+    session_list = list(sessions)
+    buckets = default_failure_buckets()
+    status_counts: dict[str, int] = {}
+    reason_sets: list[set[str]] = []
+
+    for record in session_list:
+        status_value = str(_get_field(record, "status", "unknown") or "unknown")
+        status_counts[status_value] = status_counts.get(status_value, 0) + 1
+        normalized_status = status_value.lower()
+        reasons = iter_session_reason_codes(record)
+        reason_sets.append(reasons)
+        increment_failure_buckets(
+            status_value=normalized_status,
+            reasons=reasons,
+            buckets=buckets,
+        )
+
+    agent_summaries: list[dict[str, Any]] = []
+    support_counts: dict[str, int] = {}
+    documented_unverified: list[str] = []
+
+    for agent in agents:
+        support_state = coerce_support_state(
+            _get_field(agent, "support_state", "documented_unverified")
+        )
+        verification_level = coerce_verification_level(
+            _get_field(agent, "verification_level", "documented_only")
+        )
+        support_counts[support_state] = support_counts.get(support_state, 0) + 1
+        agent_type = str(_get_field(agent, "type", "custom"))
+        if support_state == "documented_unverified":
+            documented_unverified.append(agent_type)
+        setup_blocked, primary_blocker = agent_setup_blocked(agent)
+        if setup_blocked:
+            buckets["setup_blockers"] += 1
+        agent_summaries.append({
+            "agent_type": agent_type,
+            "name": str(_get_field(agent, "name", "")),
+            "is_configured": bool(_get_field(agent, "is_configured", False)),
+            "support_state": support_state,
+            "verification_level": verification_level,
+            "setup_blocked": setup_blocked,
+            "primary_blocker": primary_blocker,
+        })
+
+    return {
+        "sessions": {
+            "total": len(session_list),
+            "by_status": status_counts,
+        },
+        "failure_buckets": buckets,
+        "agents": agent_summaries,
+        "compatibility": {
+            "by_support_state": support_counts,
+            "documented_unverified_agents": documented_unverified,
+            "live_certification_required": bool(documented_unverified),
+        },
+        "setup_health": build_setup_health_summary(
+            sessions=session_list,
+            agent_summaries=agent_summaries,
+            buckets=buckets,
+            reason_sets=reason_sets,
+        ),
+    }

--- a/tldw_Server_API/app/core/DB_Management/ACP_Sessions_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ACP_Sessions_DB.py
@@ -862,6 +862,29 @@ class ACPSessionsDB:
 
         return [self._row_to_dict(r) for r in rows], total
 
+    def list_sessions_since(
+        self,
+        *,
+        since_iso: str,
+        limit: int = 1000,
+        offset: int = 0,
+    ) -> tuple[list[dict[str, Any]], int]:
+        """List sessions created or active at or after an ISO timestamp."""
+        conn = self._get_conn()
+        count_row = conn.execute(
+            "SELECT COUNT(*) FROM sessions "
+            "WHERE (created_at >= ? OR COALESCE(last_activity_at, '') >= ?)",
+            (since_iso, since_iso),
+        ).fetchone()
+        total = count_row[0] if count_row else 0
+        rows = conn.execute(
+            "SELECT * FROM sessions "
+            "WHERE (created_at >= ? OR COALESCE(last_activity_at, '') >= ?) "
+            "ORDER BY created_at DESC LIMIT ? OFFSET ?",
+            (since_iso, since_iso, limit, offset),
+        ).fetchall()
+        return [self._row_to_dict(r) for r in rows], total
+
     def aggregate_metrics_by_agent(self) -> list[dict[str, Any]]:
         """Aggregate session metrics grouped by agent_type.
 
@@ -1212,6 +1235,55 @@ class ACPSessionsDB:
                     pass
             results.append(d)
         return results
+
+    def get_messages_for_sessions(
+        self,
+        session_ids: list[str],
+        *,
+        chunk_size: int = 500,
+    ) -> dict[str, list[dict[str, Any]]]:
+        """Return ordered messages grouped by session ID for multiple sessions."""
+        if not session_ids:
+            return {}
+
+        conn = self._get_conn()
+        grouped: dict[str, list[dict[str, Any]]] = {
+            session_id: [] for session_id in session_ids
+        }
+        safe_chunk_size = max(1, int(chunk_size))
+        conn.execute(
+            "CREATE TEMP TABLE IF NOT EXISTS temp_acp_message_session_ids "
+            "(session_id TEXT PRIMARY KEY)"
+        )
+
+        for start in range(0, len(session_ids), safe_chunk_size):
+            chunk = session_ids[start:start + safe_chunk_size]
+            conn.execute("DELETE FROM temp_acp_message_session_ids")
+            conn.executemany(
+                "INSERT INTO temp_acp_message_session_ids(session_id) VALUES (?)",
+                [(session_id,) for session_id in chunk],
+            )
+            rows = conn.execute(
+                """
+                SELECT m.session_id, m.role, m.content, m.timestamp, m.raw_data
+                FROM session_messages AS m
+                JOIN temp_acp_message_session_ids AS ids
+                  ON ids.session_id = m.session_id
+                ORDER BY m.session_id, m.message_index
+                """
+            ).fetchall()
+            for row in rows:
+                d = dict(row)
+                session_id = str(d.pop("session_id"))
+                if d.get("raw_data"):
+                    try:
+                        d["raw_data"] = json.loads(d["raw_data"])
+                    except (json.JSONDecodeError, TypeError):
+                        pass
+                grouped.setdefault(session_id, []).append(d)
+
+        conn.execute("DELETE FROM temp_acp_message_session_ids")
+        return grouped
 
     def update_token_usage(
         self,

--- a/tldw_Server_API/app/services/admin_acp_sessions_service.py
+++ b/tldw_Server_API/app/services/admin_acp_sessions_service.py
@@ -640,6 +640,63 @@ class ACPSessionStore:
         records = [self._dict_to_record(d) for d in rows]
         return records, total
 
+    async def list_sessions_with_messages_since(
+        self,
+        *,
+        since: datetime,
+        page_size: int = 1000,
+    ) -> list[SessionRecord]:
+        """List sessions in the lookback window with messages batch-loaded."""
+        return await asyncio.to_thread(
+            self._list_sessions_with_messages_since_sync,
+            since,
+            page_size,
+        )
+
+    def _list_sessions_with_messages_since_sync(
+        self,
+        since: datetime,
+        page_size: int,
+    ) -> list[SessionRecord]:
+        """Synchronously page filtered sessions and batch-load messages."""
+        from tldw_Server_API.app.core.Agent_Client_Protocol.execution_health import (
+            session_within_range,
+        )
+
+        if since.tzinfo:
+            since_iso = since.astimezone(timezone.utc).isoformat()
+        else:
+            since_iso = since.replace(tzinfo=timezone.utc).isoformat()
+        safe_page_size = max(1, min(int(page_size), 1000))
+        offset = 0
+        rows_in_range: list[dict[str, Any]] = []
+
+        while True:
+            rows, total = self._db.list_sessions_since(
+                since_iso=since_iso,
+                limit=safe_page_size,
+                offset=offset,
+            )
+            if not rows:
+                break
+            rows_in_range.extend(row for row in rows if session_within_range(row, since=since))
+            offset += len(rows)
+            if offset >= total:
+                break
+
+        messages_by_id = self._db.get_messages_for_sessions([
+            str(row["session_id"]) for row in rows_in_range
+        ])
+        return [
+            self._dict_to_record(
+                row,
+                self._db_messages_to_record_messages(
+                    messages_by_id.get(str(row["session_id"]), []),
+                ),
+            )
+            for row in rows_in_range
+        ]
+
     async def get_agent_usage_stats(self, *, range_days: int = 7) -> list[dict[str, Any]]:
         """Return per-agent aggregated token usage for the last *range_days* days."""
         cutoff = (datetime.now(timezone.utc) - timedelta(days=range_days)).isoformat()

--- a/tldw_Server_API/tests/Admin/test_admin_acp_new_endpoints.py
+++ b/tldw_Server_API/tests/Admin/test_admin_acp_new_endpoints.py
@@ -6,6 +6,8 @@ using isolated ACPSessionStore instances backed by temporary SQLite files.
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 from typing import Any
 from unittest import mock
 
@@ -353,7 +355,17 @@ class TestACPExecutionHealthSummary:
             await store.record_prompt(
                 "s-review",
                 [{"role": "user", "content": "review this"}],
-                {"role": "assistant", "content": {"reason_code": "reviewer_rejected"}},
+                {
+                    "role": "assistant",
+                    "content": {
+                        "reason_code": "reviewer_rejected",
+                        "diagnostics": [
+                            {"reason_code": "structured_completion_failed"},
+                            {"error_type": "sandbox_runtime_error"},
+                            {"code": "redaction_applied"},
+                        ],
+                    },
+                },
             )
 
             await _register_session(store, "s-governance", agent_type="codex")
@@ -384,10 +396,101 @@ class TestACPExecutionHealthSummary:
             assert resp.failure_buckets.runner_session_failures == 1
             assert resp.failure_buckets.reviewer_rejections == 1
             assert resp.failure_buckets.governance_denials == 1
+            assert resp.failure_buckets.structured_completion_failures == 1
+            assert resp.failure_buckets.sandbox_runtime_errors == 1
+            assert resp.failure_buckets.retention_redaction_actions == 1
             assert resp.failure_buckets.setup_blockers == 1
+            assert resp.setup_health.agent.status == "blocked"
+            assert resp.setup_health.agent.evidence_count == 1
+            assert resp.setup_health.workspace.status == "unknown"
+            assert resp.setup_health.sandbox_runtime.status == "blocked"
             assert resp.compatibility.by_support_state["documented_unverified"] == 1
             assert resp.compatibility.documented_unverified_agents == ["codex"]
             assert resp.compatibility.live_certification_required is True
+
+        _run(_run_test())
+
+    def test_execution_health_summary_uses_batched_session_loader(self, monkeypatch):
+        """The summary does not perform per-session get_session detail loads."""
+
+        class _FakeStore:
+            called = False
+
+            async def list_sessions_with_messages_since(
+                self,
+                *,
+                since: datetime,
+                page_size: int = 1000,
+            ):
+                self.called = True
+                assert page_size == 1000
+                assert since.tzinfo is not None
+                return [
+                    SimpleNamespace(
+                        session_id="s-batched",
+                        status="error",
+                        created_at=datetime.now(timezone.utc).isoformat(),
+                        last_activity_at=None,
+                        workspace_id="workspace-1",
+                        mcp_servers=[{"name": "filesystem"}],
+                        messages=[],
+                    )
+                ]
+
+            async def get_session(self, session_id: str):  # pragma: no cover - should not be called
+                raise AssertionError(f"unexpected per-session load for {session_id}")
+
+        store = _FakeStore()
+
+        async def _run_test():
+            monkeypatch.setattr(
+                "tldw_Server_API.app.api.v1.endpoints.admin.admin_acp_agents.get_acp_session_store",
+                mock.AsyncMock(return_value=store),
+            )
+            monkeypatch.setattr(
+                "tldw_Server_API.app.api.v1.endpoints.admin.admin_acp_agents._get_available_agents",
+                mock.AsyncMock(return_value=([], None)),
+            )
+
+            from tldw_Server_API.app.api.v1.endpoints.admin.admin_acp_agents import (
+                get_acp_execution_health_summary,
+            )
+
+            resp = await get_acp_execution_health_summary(range_days=30)
+
+            assert store.called is True
+            assert resp.sessions.total == 1
+            assert resp.failure_buckets.runner_session_failures == 1
+            assert resp.setup_health.workspace.status == "ready"
+            assert resp.setup_health.mcp_injection.status == "ready"
+
+        _run(_run_test())
+
+    def test_execution_health_store_loader_paginates_and_loads_messages(self, tmp_path):
+        """The store loader exhausts all in-range pages and batch-loads messages."""
+        store = _make_store(tmp_path)
+
+        async def _run_test():
+            for index in range(3):
+                session_id = f"s-page-{index}"
+                await _register_session(store, session_id, agent_type="stub")
+                await store.record_prompt(
+                    session_id,
+                    [{"role": "user", "content": "run"}],
+                    {"role": "assistant", "content": {"reason_code": "reviewer_rejected"}},
+                )
+
+            sessions = await store.list_sessions_with_messages_since(
+                since=datetime.now(timezone.utc) - timedelta(days=1),
+                page_size=1,
+            )
+
+            assert {session.session_id for session in sessions} == {
+                "s-page-0",
+                "s-page-1",
+                "s-page-2",
+            }
+            assert all(session.messages for session in sessions)
 
         _run(_run_test())
 
@@ -429,6 +532,41 @@ class TestACPExecutionHealthSummary:
             assert resp.agents[0].verification_level == "documented_only"
 
         _run(_run_test())
+
+    def test_execution_health_helpers_fail_closed_and_iterate_deep_payloads(self):
+        """Timestamp filtering fails closed and reason extraction is stack based."""
+        from tldw_Server_API.app.core.Agent_Client_Protocol.execution_health import (
+            collect_reason_codes,
+            session_within_range,
+        )
+
+        since = datetime.now(timezone.utc) - timedelta(days=1)
+        assert session_within_range(
+            SimpleNamespace(created_at=None, last_activity_at=None),
+            since=since,
+        ) is False
+        assert session_within_range(
+            SimpleNamespace(
+                created_at=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                last_activity_at=None,
+            ),
+            since=since,
+        ) is True
+        assert session_within_range(
+            SimpleNamespace(
+                created_at="not-a-date",
+                last_activity_at=datetime.now(timezone.utc).isoformat(),
+            ),
+            since=since,
+        ) is True
+
+        payload: Any = {"reason_code": "structured_completion_failed"}
+        for _ in range(1200):
+            payload = {"nested": [payload]}
+
+        reasons: set[str] = set()
+        collect_reason_codes(payload, reasons)
+        assert "structured_completion_failed" in reasons
 
 
 # ===========================================================================

--- a/tldw_Server_API/tests/Admin/test_admin_acp_new_endpoints.py
+++ b/tldw_Server_API/tests/Admin/test_admin_acp_new_endpoints.py
@@ -268,6 +268,170 @@ class TestACPAgentMetrics:
 
 
 # ===========================================================================
+# 2b. GET /admin/acp/execution-health/summary
+# ===========================================================================
+
+
+class TestACPExecutionHealthSummary:
+    """Tests for the ACP admin execution-health summary endpoint."""
+
+    def test_execution_health_summary_empty_store(self, monkeypatch, tmp_path):
+        """An empty ACP store still reports configured retention/redaction posture."""
+        store = _make_store(tmp_path)
+
+        async def _run_test():
+            monkeypatch.setattr(
+                "tldw_Server_API.app.api.v1.endpoints.admin.admin_acp_agents.get_acp_session_store",
+                mock.AsyncMock(return_value=store),
+            )
+            from tldw_Server_API.app.api.v1.endpoints.admin.admin_acp_agents import (
+                get_acp_execution_health_summary,
+            )
+
+            resp = await get_acp_execution_health_summary(range_days=30)
+
+            assert resp.sessions.total == 0
+            assert resp.sessions.by_status == {}
+            assert resp.failure_buckets.runner_session_failures == 0
+            assert resp.failure_buckets.reviewer_rejections == 0
+            assert resp.failure_buckets.governance_denials == 0
+            assert resp.retention.session_retention_days >= 0
+            assert resp.retention.audit_retention_days >= 0
+            assert resp.redaction.detail_events_artifacts_redacted_views is True
+            assert resp.redaction.diagnostics_sanitized is True
+            assert resp.redaction.audit_metadata_sanitized is True
+
+        _run(_run_test())
+
+    def test_execution_health_summary_buckets_failures_and_compatibility(self, monkeypatch, tmp_path):
+        """Representative sessions and agents are bucketed without overstating support."""
+        store = _make_store(tmp_path)
+
+        async def _fake_agents():
+            from tldw_Server_API.app.api.v1.schemas.agent_client_protocol import (
+                ACPAgentEntrypointStatus,
+                ACPAgentInfo,
+            )
+
+            return [
+                ACPAgentInfo(
+                    type="stub",
+                    name="In-repo ACP stub",
+                    is_configured=True,
+                    support_state="supported_with_caveats",
+                    verification_level="stub_smoke_tested",
+                    compatibility_notes="Stub protocol evidence only.",
+                    entrypoint=ACPAgentEntrypointStatus(
+                        profile_key="stub",
+                        entrypoint_strategy="native_acp",
+                        probe_state="ready_to_probe",
+                        primary_blocker=None,
+                    ),
+                ),
+                ACPAgentInfo(
+                    type="codex",
+                    name="Codex CLI",
+                    is_configured=False,
+                    support_state="documented_unverified",
+                    verification_level="documented_only",
+                    compatibility_notes="Live ACP stdio certification is blocked.",
+                    entrypoint=ACPAgentEntrypointStatus(
+                        profile_key="codex",
+                        entrypoint_strategy="documented_candidate",
+                        probe_state="blocked",
+                        primary_blocker="adapter_required",
+                    ),
+                ),
+            ], "stub"
+
+        async def _run_test():
+            await _register_session(store, "s-error", agent_type="stub")
+            await _add_usage(store, "s-error", 10, 5)
+            store._db.set_session_status("s-error", "error")
+
+            await _register_session(store, "s-review", agent_type="stub")
+            await store.record_prompt(
+                "s-review",
+                [{"role": "user", "content": "review this"}],
+                {"role": "assistant", "content": {"reason_code": "reviewer_rejected"}},
+            )
+
+            await _register_session(store, "s-governance", agent_type="codex")
+            await store.record_prompt(
+                "s-governance",
+                [{"role": "user", "content": "run tool"}],
+                {"role": "assistant", "content": {"reason_code": "governance_denied"}},
+            )
+
+            monkeypatch.setattr(
+                "tldw_Server_API.app.api.v1.endpoints.admin.admin_acp_agents.get_acp_session_store",
+                mock.AsyncMock(return_value=store),
+            )
+            monkeypatch.setattr(
+                "tldw_Server_API.app.api.v1.endpoints.admin.admin_acp_agents._get_available_agents",
+                _fake_agents,
+            )
+
+            from tldw_Server_API.app.api.v1.endpoints.admin.admin_acp_agents import (
+                get_acp_execution_health_summary,
+            )
+
+            resp = await get_acp_execution_health_summary(range_days=30)
+
+            assert resp.sessions.total == 3
+            assert resp.sessions.by_status["error"] == 1
+            assert resp.sessions.by_status["active"] == 2
+            assert resp.failure_buckets.runner_session_failures == 1
+            assert resp.failure_buckets.reviewer_rejections == 1
+            assert resp.failure_buckets.governance_denials == 1
+            assert resp.failure_buckets.setup_blockers == 1
+            assert resp.compatibility.by_support_state["documented_unverified"] == 1
+            assert resp.compatibility.documented_unverified_agents == ["codex"]
+            assert resp.compatibility.live_certification_required is True
+
+        _run(_run_test())
+
+    def test_execution_health_summary_fails_closed_for_unknown_compatibility_values(self, monkeypatch, tmp_path):
+        """Unknown compatibility enums fall back to documented-unverified support."""
+        store = _make_store(tmp_path)
+
+        class _FakeAgent:
+            type = "legacy"
+            name = "Legacy agent"
+            is_configured = True
+            support_state = "vendor_promised"
+            verification_level = "not_checked"
+            entrypoint = None
+
+        async def _fake_agents():
+            return [_FakeAgent()], "legacy"
+
+        async def _run_test():
+            monkeypatch.setattr(
+                "tldw_Server_API.app.api.v1.endpoints.admin.admin_acp_agents.get_acp_session_store",
+                mock.AsyncMock(return_value=store),
+            )
+            monkeypatch.setattr(
+                "tldw_Server_API.app.api.v1.endpoints.admin.admin_acp_agents._get_available_agents",
+                _fake_agents,
+            )
+
+            from tldw_Server_API.app.api.v1.endpoints.admin.admin_acp_agents import (
+                get_acp_execution_health_summary,
+            )
+
+            resp = await get_acp_execution_health_summary(range_days=30)
+
+            assert resp.compatibility.by_support_state["documented_unverified"] == 1
+            assert resp.compatibility.documented_unverified_agents == ["legacy"]
+            assert resp.compatibility.live_certification_required is True
+            assert resp.agents[0].support_state == "documented_unverified"
+            assert resp.agents[0].verification_level == "documented_only"
+
+        _run(_run_test())
+
+
+# ===========================================================================
 # 3. PATCH /admin/acp/sessions/{session_id}/budget
 # ===========================================================================
 


### PR DESCRIPTION
## Summary

- What changed:
  - Added a backend-owned ACP admin execution-health summary endpoint at `/api/v1/admin/acp/execution-health/summary`.
  - Added response schemas for session status counts, normalized failure buckets, per-agent compatibility/setup posture, retention, and redaction status.
  - Documented the route and reporting contract in the ACP development guide and PRD.
  - Added focused admin endpoint tests for empty state, representative failure buckets, compatibility caveats, and fail-closed compatibility enum handling.
- Why:
  - Issue #1537 needs a stable backend contract before frontend/admin display work can be built cleanly.
  - The summary reuses existing ACP session and agent registry data instead of creating a parallel observability store.

Human change summary required before merge:

- This PR was authored by Codex. Per project policy, the requester should replace or confirm this section with a human-written rationale before merge.

## Validation

- [x] Tests added/updated for behavior changes
- [x] Relevant unit/integration tests pass locally
- [x] Docs updated (if behavior, routes, or config changed)

Commands run:

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Admin/test_admin_acp_new_endpoints.py -q`
- `git diff --check HEAD~1..HEAD`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/endpoints/admin/admin_acp_agents.py tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py -f json -o /tmp/bandit_acp_1537_rebased.json`
- `SINGLE_USER_API_KEY=THIS-IS-A-SECURE-KEY-123-FAKE-KEY /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -c "from tldw_Server_API.app.main import app; schema=app.openapi(); path='/api/v1/admin/acp/execution-health/summary'; assert path in schema['paths']; print(schema['paths'][path]['get']['operationId'])"`

## UX Audit Checklist (v2 Stage 5)

- [ ] `npm run e2e:smoke:stage5` passes
- [ ] `npx playwright test e2e/smoke/all-pages.spec.ts --reporter=line` passes (or failures documented)
- [ ] No listed AntD deprecations in console output: `Drawer.width`, `Space.direction`, `Alert.message`, `List`
- [ ] No `Maximum update depth exceeded` warnings on audited routes
- [ ] No unresolved `{{...}}` placeholders on audited routes
- [ ] WebUI/extension parity validated for shared UI fixes
- [ ] For Flashcards UI changes: tabs remain `Study` / `Manage` / `Transfer` and secondary create CTAs route through manager create-entry path
- [ ] For Flashcards drawer changes: use `FLASHCARDS_DRAWER_WIDTH_PX` and keep footer action order `Cancel -> secondary -> primary`
- [ ] For Flashcards help/copy/import UX changes: update `Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md` and keep in-app help links pointed at guide section anchors

Not applicable: this PR does not change frontend UI routes, Flashcards, or WebUI/extension shared UI behavior.

## Watchlists Accessibility Checklist (Group 09 Stage 5)

- [ ] If Watchlists UI behavior changed: `cd apps/packages/ui && bun run test:watchlists:a11y` passes locally
- [ ] If Watchlists UI behavior changed: keyboard-only path still works for Overview -> Feeds -> Monitors -> Activity -> Articles -> Reports
- [ ] If Watchlists UI behavior changed: list/table labels and live-region copy remain localized (no new hardcoded assistive text)
- [ ] If Watchlists UI behavior changed: monitor/feed active state is not color-only (explicit text or icon signal is present)
- [ ] If Watchlists UI behavior changed: known assistive-tech constraints reviewed in `Docs/Plans/WATCHLISTS_ASSISTIVE_TECH_AUDIT_2026_02_24.md`

Not applicable: no Watchlists UI behavior changed.

## Watchlists Scale Checklist (Group 10 Stage 5)

- [ ] If Watchlists UI behavior changed: `cd apps/packages/ui && bun run test:watchlists:scale` passes locally
- [ ] If Watchlists polling/notifications behavior changed: no duplicate terminal notifications during in-flight polling overlap
- [ ] If Watchlists Activity polling changed: auto-refresh is gated to active + visible Activity context (no background tab polling churn)
- [ ] If Watchlists batch triage behavior changed: partial-failure retry path remains available and updates only failed IDs
- [ ] If Watchlists scale behavior changed: constraints/mitigations reviewed in `Docs/Plans/WATCHLISTS_SCALE_READINESS_RUNBOOK_2026_02_24.md`

Not applicable: no Watchlists scale behavior changed.

## Risk & Rollback

- Risk level: Low
- Rollback plan: Revert this single commit to remove the new admin summary route, schemas, tests, and docs.

Closes part of #1537.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a backend-owned ACP admin execution-health summary endpoint that rolls up session health, expanded failure buckets, setup-health dimensions, compatibility, and retention/redaction posture. Uses paged, batched loading to avoid N+1 and provides a stable contract for the admin UI; supports #1537.

- New Features
  - Added `GET /api/v1/admin/acp/execution-health/summary` with `range_days` (1–180, default 30) and a response `timestamp`.
  - Response includes session totals/by_status and failure buckets: `setup_blockers`, `runner_session_failures`, `reviewer_rejections`, `reviewer_failures`, `governance_denials`, `structured_completion_failures`, `sandbox_runtime_errors`, `retention_redaction_actions`.
  - Added `setup_health` dimensions with status, blockers, and `evidence_count`: `agent`, `workspace`, `sandbox_runtime`, `mcp_injection`, `scheduler_trigger_path`.
  - Per‑agent summary (`support_state`, `verification_level`, `setup_blocked`, `primary_blocker`) and compatibility rollups (`by_support_state`, `documented_unverified_agents`, `live_certification_required`) with fail‑closed enum coercion.
  - Includes retention and redaction posture.

- Refactors
  - Reuses existing ACP session store and agent registry; no new observability store.
  - Implemented paged lookback loading and batched message fetch to avoid N+1 (`list_sessions_since`, `get_messages_for_sessions`, `list_sessions_with_messages_since`).
  - Lookback filters by `created_at`/`last_activity_at`; deep reason-code extraction with guardrails.
  - Docs updated and tests added for empty state, bucket mapping, setup_health, enum fallback, and pagination/batching.

<sup>Written for commit 48001bc58f9d2eb9e89e154bf7151116e17bb1e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

