### PR TITLE
Surface Persona Visual import-preview diagnostics

### DIFF
--- a/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
@@ -65,6 +65,7 @@ import type {
   PersonaVisualPack,
   PersonaVisualPackExportResponse,
   PersonaVisualPortabilityJobResponse,
+  PersonaVisualRendererImportPreview,
   PersonaVisualStateId
 } from "@/types/persona-visuals"
 import { getDesignSystemState } from "@/design-system"
@@ -328,6 +329,101 @@ const formatPreviewList = (items: unknown[] | null | undefined): string =>
     .filter(Boolean)
     .join(" ")
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value && typeof value === "object" && !Array.isArray(value))
+
+const previewString = (value: unknown): string | null => {
+  if (typeof value !== "string") return null
+  const trimmed = value.trim()
+  return trimmed || null
+}
+
+const previewNumber = (value: unknown): number | null =>
+  typeof value === "number" && Number.isFinite(value) ? value : null
+
+const previewBoolean = (value: unknown): boolean | null =>
+  typeof value === "boolean" ? value : null
+
+const previewStringList = (value: unknown): string[] =>
+  Array.isArray(value)
+    ? value
+        .map(previewString)
+        .filter((item): item is string => Boolean(item))
+    : []
+
+const previewRoleCategories = (
+  value: unknown
+): Record<string, string[]> | undefined => {
+  if (!isRecord(value)) return undefined
+  const categories = Object.entries(value).reduce<Record<string, string[]>>(
+    (nextCategories, [category, sourceAssetIds]) => {
+      const normalizedCategory = previewString(category)
+      const normalizedIds = previewStringList(sourceAssetIds)
+      if (normalizedCategory && normalizedIds.length) {
+        nextCategories[normalizedCategory] = normalizedIds
+      }
+      return nextCategories
+    },
+    {}
+  )
+  return Object.keys(categories).length ? categories : undefined
+}
+
+const getRendererImportPreview = (
+  preview: PersonaVisualImportPreviewResponse | null
+): PersonaVisualRendererImportPreview | null => {
+  const rawPreview = preview?.proposed_plan?.renderer_import_preview
+  if (!isRecord(rawPreview)) return null
+  return {
+    status: previewString(rawPreview.status),
+    renderer_type: previewString(rawPreview.renderer_type),
+    manifest_version: previewNumber(rawPreview.manifest_version),
+    renderer_contract_version: previewNumber(rawPreview.renderer_contract_version),
+    can_commit: previewBoolean(rawPreview.can_commit),
+    activation_eligible: previewBoolean(rawPreview.activation_eligible),
+    blockers: previewStringList(rawPreview.blockers),
+    warnings: previewStringList(rawPreview.warnings),
+    normalized_role_categories: previewRoleCategories(
+      rawPreview.normalized_role_categories
+    ),
+    setup_status: previewString(rawPreview.setup_status),
+    setup_blockers: previewStringList(rawPreview.setup_blockers),
+    disabled_reason: previewString(rawPreview.disabled_reason)
+  }
+}
+
+const getRendererImportPreviewRoleSummary = (
+  rendererPreview: PersonaVisualRendererImportPreview | null
+): string => {
+  const categories = rendererPreview?.normalized_role_categories || {}
+  return Object.entries(categories)
+    .map(([category, sourceAssetIds]) => `${category}: ${sourceAssetIds.join(", ")}`)
+    .join(" ")
+}
+
+const getImportCommitBlockers = (
+  preview: PersonaVisualImportPreviewResponse | null,
+  rendererPreview: PersonaVisualRendererImportPreview | null
+): string[] => {
+  const planBlockers = previewStringList(preview?.proposed_plan?.commit_blockers)
+  const rendererBlockers = [
+    ...(rendererPreview?.blockers || []),
+    ...(rendererPreview?.setup_blockers || []),
+    rendererPreview?.disabled_reason || null
+  ].filter((item): item is string => Boolean(item))
+  return Array.from(new Set([...planBlockers, ...rendererBlockers]))
+}
+
+const isImportPreviewCommitEligible = (
+  preview: PersonaVisualImportPreviewResponse | null,
+  rendererPreview: PersonaVisualRendererImportPreview | null
+): boolean => {
+  if (!preview || preview.status !== "completed") return false
+  if (preview.proposed_plan?.commit_eligible === false) return false
+  if (rendererPreview?.can_commit === false) return false
+  return true
+}
+
 const isFullImportPreview = (
   preview: PersonaVisualImportPreviewStartResponse | PersonaVisualImportPreviewResponse | null
 ): preview is PersonaVisualImportPreviewResponse =>
@@ -504,6 +600,7 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
   const { t } = useTranslation(["sidepanel", "common"])
   const loadingLabel = t("common:loading", getDesignSystemState("loading").label)
   const refreshLabel = t("common:refresh", "Refresh")
+  const unknownLabel = t("common:unknown", { defaultValue: "unknown" })
   const [packs, setPacks] = React.useState<PersonaVisualPack[]>([])
   const [selectedPackId, setSelectedPackId] = React.useState("")
   const [draftTitle, setDraftTitle] = React.useState("")
@@ -589,6 +686,7 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
   const generationReadinessRequestIdRef = React.useRef(0)
   const duplicateTargetsRequestIdRef = React.useRef(0)
   const libraryRequestIdRef = React.useRef(0)
+  const importCommitInFlightRef = React.useRef(false)
 
   const selectedPack =
     packs.find((pack) => pack.id === selectedPackId) ?? packs[0] ?? null
@@ -1259,9 +1357,12 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
   }
 
   const handleStartImportCommit = async () => {
+    if (importCommitInFlightRef.current || committingImport) return
     if (!selectedPersonaId || !fullImportPreview?.preview_id) return
     if (fullImportPreview.status !== "completed") return
+    if (!importPreviewCommitEligible) return
     if (importConflictChoiceRequired && !importTargetMode) return
+    importCommitInFlightRef.current = true
     setCommittingImport(true)
     setError(null)
     try {
@@ -1289,6 +1390,7 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
           : "Failed to queue visual pack import commit."
       )
     } finally {
+      importCommitInFlightRef.current = false
       setCommittingImport(false)
     }
   }
@@ -1847,6 +1949,13 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
     : []
   const importPreviewConflicts = fullImportPreview?.conflicts || []
   const importPreviewPlan = fullImportPreview?.proposed_plan || null
+  const rendererImportPreview = getRendererImportPreview(fullImportPreview)
+  const rendererImportRoleSummary =
+    getRendererImportPreviewRoleSummary(rendererImportPreview)
+  const importCommitBlockers = getImportCommitBlockers(
+    fullImportPreview,
+    rendererImportPreview
+  )
   const importTargetChoice = getImportTargetChoice(fullImportPreview)
   const importAllowedTargetModes = getAllowedImportTargetModes(importTargetChoice)
   const replaceableImportConflicts = getReplaceableImportConflicts(importPreviewConflicts)
@@ -1856,11 +1965,16 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
     importTargetMode === "create_new" ||
     Boolean(importReplacePackId)
   const canCommitImportPreview = fullImportPreview?.status === "completed"
+  const importPreviewCommitEligible = isImportPreviewCommitEligible(
+    fullImportPreview,
+    rendererImportPreview
+  )
   const importCommitStatus = importCommitJob?.status || null
   const importCommitIsTerminal = importCommitStatus
     ? IMPORT_COMMIT_TERMINAL_STATUSES.has(importCommitStatus)
     : false
   const canStartImportCommit =
+    importPreviewCommitEligible &&
     importConflictChoiceValid &&
     (!importCommitJob?.job_id || importCommitStatus === "failed")
   const canRefreshImportCommit =
@@ -2357,6 +2471,75 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
                         {stringifyPreviewValue(importPreviewPlan)}
                       </div>
                     ) : null}
+                    {rendererImportPreview ? (
+                      <div
+                        data-testid="persona-visual-import-renderer-diagnostics"
+                        className="rounded border border-border bg-bg p-2"
+                      >
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className="font-medium text-text">
+                            {t(
+                              "sidepanel:personaGarden.visuals.rendererDiagnosticsTitle",
+                              { defaultValue: "Renderer diagnostics" }
+                            )}
+                          </span>
+                          <Tag>
+                            {rendererImportPreview.renderer_type || unknownLabel}
+                          </Tag>
+                          <Tag>{rendererImportPreview.status || unknownLabel}</Tag>
+                          {rendererImportPreview.setup_status ? (
+                            <Tag>{rendererImportPreview.setup_status}</Tag>
+                          ) : null}
+                        </div>
+                        <div className="mt-1">
+                          {t("sidepanel:personaGarden.visuals.manifestVersion", {
+                            defaultValue: "Manifest v"
+                          })}
+                          {rendererImportPreview.manifest_version ?? unknownLabel}
+                          {" / "}
+                          {t("sidepanel:personaGarden.visuals.contractVersion", {
+                            defaultValue: "Contract v"
+                          })}
+                          {rendererImportPreview.renderer_contract_version ??
+                            unknownLabel}
+                        </div>
+                        <div className="mt-1">
+                          {rendererImportPreview.activation_eligible
+                            ? t(
+                                "sidepanel:personaGarden.visuals.activationEligible",
+                                { defaultValue: "Activation eligible" }
+                              )
+                            : t(
+                                "sidepanel:personaGarden.visuals.activationUnavailable",
+                                { defaultValue: "Activation unavailable" }
+                              )}
+                        </div>
+                        {importCommitBlockers.length ? (
+                          <div className="mt-1">
+                            {t("sidepanel:personaGarden.visuals.commitBlockers", {
+                              defaultValue: "Commit blockers"
+                            })}
+                            : {formatPreviewList(importCommitBlockers)}
+                          </div>
+                        ) : null}
+                        {rendererImportPreview.warnings?.length ? (
+                          <div className="mt-1">
+                            {t("sidepanel:personaGarden.visuals.rendererWarnings", {
+                              defaultValue: "Warnings"
+                            })}
+                            : {formatPreviewList(rendererImportPreview.warnings)}
+                          </div>
+                        ) : null}
+                        {rendererImportRoleSummary ? (
+                          <div className="mt-1">
+                            {t("sidepanel:personaGarden.visuals.assetRoles", {
+                              defaultValue: "Asset roles"
+                            })}
+                            : {rendererImportRoleSummary}
+                          </div>
+                        ) : null}
+                      </div>
+                    ) : null}
                     {canCommitImportPreview ? (
                       <div className="mt-2 border-t border-border pt-2">
                         <div className="flex flex-wrap items-center justify-between gap-2">
@@ -2368,6 +2551,23 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
                         <div className="mt-1 text-text-muted">
                           Commit creates a new draft pack. Activation remains separate.
                         </div>
+                        {!importPreviewCommitEligible ? (
+                          <div
+                            data-testid="persona-visual-import-commit-blocked"
+                            className="mt-2 rounded border border-border bg-bg p-2 text-text-muted"
+                          >
+                            {t(
+                              "sidepanel:personaGarden.visuals.importCommitBlocked",
+                              {
+                                defaultValue:
+                                  "Commit unavailable until preview blockers are resolved"
+                              }
+                            )}
+                            {importCommitBlockers.length
+                              ? `: ${formatPreviewList(importCommitBlockers)}`
+                              : "."}
+                          </div>
+                        ) : null}
                         {importConflictChoiceRequired ? (
                           <div
                             data-testid="persona-visual-import-conflict-choice"

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
@@ -1941,6 +1941,7 @@ describe("VisualPackEditor", () => {
       version: 1
     }
     let importCommitted = false
+    let importCommitStarts = 0
 
     mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string; body?: any }) => {
       const method = init?.method || "GET"
@@ -2004,6 +2005,7 @@ describe("VisualPackEditor", () => {
           "/api/v1/persona/profiles/persona-1/visual-packs/import-previews/preview-1/commit" &&
         method === "POST"
       ) {
+        importCommitStarts += 1
         expect(parseJsonBody(init?.body)).toMatchObject({
           trust_mode: "untrusted_import",
           target_mode: "create_new"
@@ -2092,13 +2094,16 @@ describe("VisualPackEditor", () => {
       "create_new"
     )
 
-    expect(screen.getByTestId("persona-visual-import-commit-button")).toBeEnabled()
-    fireEvent.click(screen.getByTestId("persona-visual-import-commit-button"))
+    const commitButton = screen.getByTestId("persona-visual-import-commit-button")
+    expect(commitButton).toBeEnabled()
+    fireEvent.click(commitButton)
+    fireEvent.click(commitButton)
     await waitFor(() =>
       expect(screen.getByTestId("persona-visual-import-commit-status")).toHaveTextContent(
         "queued"
       )
     )
+    expect(importCommitStarts).toBe(1)
     expect(screen.getByTestId("persona-visual-import-commit-stage")).toHaveTextContent(
       "queued"
     )
@@ -2121,6 +2126,192 @@ describe("VisualPackEditor", () => {
     )
     expect(
       calls.some((call) => call.includes("/activate") || call.includes("/manifest"))
+    ).toBe(false)
+  })
+
+  it("surfaces blocked renderer import diagnostics and disables commit", async () => {
+    const calls: string[] = []
+    const pack = {
+      id: "pack-1",
+      persona_id: "persona-1",
+      title: "Animated pack",
+      renderer_type: "sprite_frames",
+      status: "draft",
+      manifest: structuredClone(baseManifest),
+      assets: visualAssets,
+      version: 3
+    }
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string; body?: any }) => {
+      const method = init?.method || "GET"
+      calls.push(`${method} ${path}`)
+      if (path === "/api/v1/persona/profiles/persona-1/visual-packs" && method === "GET") {
+        return okResponse([pack])
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/pack-1/generated-candidates" &&
+        method === "GET"
+      ) {
+        return okResponse({ candidates: [] })
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/import-previews" &&
+        method === "POST"
+      ) {
+        return okResponse({
+          preview_id: "preview-live2d",
+          job_id: "preview-job-live2d",
+          portability_job_id: "portability-preview-live2d",
+          operation: "import_preview",
+          target_persona_id: "persona-1",
+          status: "queued",
+          stage: "queued"
+        })
+      }
+      if (
+        path ===
+          "/api/v1/persona/profiles/persona-1/visual-packs/import-previews/preview-live2d" &&
+        method === "GET"
+      ) {
+        return okResponse({
+          preview_id: "preview-live2d",
+          job_id: "preview-job-live2d",
+          portability_job_id: "portability-preview-live2d",
+          operation: "import_preview",
+          target_persona_id: "persona-1",
+          status: "completed",
+          visual_status: "blocked",
+          stage: "blocked",
+          archive_sha256: "sha-live2d-preview",
+          canonical_payload_fingerprint: "fingerprint-live2d-preview",
+          schema_version: "persona_visual_pack.v2",
+          bundle_summary: {
+            pack_title: "Imported Live2D Visuals",
+            asset_count: 2,
+            assets_with_bytes: 2
+          },
+          validation_warnings: [],
+          conflicts: [],
+          proposed_plan: {
+            target_mode: "create_new",
+            commit_eligible: false,
+            activation_eligible: false,
+            commit_blockers: ["runtime_adapter_not_implemented"],
+            renderer_import_preview: {
+              status: "feature_gated",
+              renderer_type: "live2d",
+              manifest_version: 2,
+              renderer_contract_version: 1,
+              can_commit: false,
+              activation_eligible: false,
+              blockers: ["runtime_adapter_not_implemented"],
+              warnings: ["requires_license_ack"],
+              normalized_role_categories: {
+                model: ["source-model"],
+                texture: ["source-texture"]
+              },
+              setup_status: "feature_gated",
+              setup_blockers: [],
+              disabled_reason: "runtime_adapter_not_implemented"
+            }
+          },
+          quota_estimate: { asset_bytes: 2048 },
+          required_choices: [],
+          target_warnings: []
+        })
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        error: `Unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(
+      <VisualPackEditor
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Garden Helper"
+        isActive
+      />
+    )
+
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-pack-status")).toHaveTextContent(
+        "draft"
+      )
+    )
+    const archive = new File(["portable archive"], "portable.tldw-persona-vpack", {
+      type: "application/octet-stream"
+    })
+    fireEvent.change(screen.getByTestId("persona-visual-import-preview-input"), {
+      target: { files: [archive] }
+    })
+    fireEvent.click(screen.getByTestId("persona-visual-import-preview-button"))
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-import-preview-status")).toHaveTextContent(
+        "queued"
+      )
+    )
+
+    fireEvent.click(screen.getByTestId("persona-visual-import-preview-refresh-button"))
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-import-preview-status")).toHaveTextContent(
+        "completed"
+      )
+    )
+
+    const diagnostics = screen.getByTestId(
+      "persona-visual-import-renderer-diagnostics"
+    )
+    expect(diagnostics).toHaveTextContent("live2d")
+    expect(diagnostics).toHaveTextContent("feature_gated")
+    expect(diagnostics).toHaveTextContent("runtime_adapter_not_implemented")
+    expect(diagnostics).toHaveTextContent("requires_license_ack")
+    expect(diagnostics).toHaveTextContent("source-model")
+    expect(diagnostics).toHaveTextContent("Activation unavailable")
+    expect(mocks.translate).toHaveBeenCalledWith(
+      "sidepanel:personaGarden.visuals.rendererDiagnosticsTitle",
+      { defaultValue: "Renderer diagnostics" }
+    )
+    expect(mocks.translate).toHaveBeenCalledWith("common:unknown", {
+      defaultValue: "unknown"
+    })
+    expect(mocks.translate).toHaveBeenCalledWith(
+      "sidepanel:personaGarden.visuals.manifestVersion",
+      { defaultValue: "Manifest v" }
+    )
+    expect(mocks.translate).toHaveBeenCalledWith(
+      "sidepanel:personaGarden.visuals.contractVersion",
+      { defaultValue: "Contract v" }
+    )
+    expect(mocks.translate).toHaveBeenCalledWith(
+      "sidepanel:personaGarden.visuals.activationUnavailable",
+      { defaultValue: "Activation unavailable" }
+    )
+    expect(mocks.translate).toHaveBeenCalledWith(
+      "sidepanel:personaGarden.visuals.commitBlockers",
+      { defaultValue: "Commit blockers" }
+    )
+    expect(mocks.translate).toHaveBeenCalledWith(
+      "sidepanel:personaGarden.visuals.rendererWarnings",
+      { defaultValue: "Warnings" }
+    )
+    expect(mocks.translate).toHaveBeenCalledWith(
+      "sidepanel:personaGarden.visuals.assetRoles",
+      { defaultValue: "Asset roles" }
+    )
+    expect(mocks.translate).toHaveBeenCalledWith(
+      "sidepanel:personaGarden.visuals.importCommitBlocked",
+      {
+        defaultValue: "Commit unavailable until preview blockers are resolved"
+      }
+    )
+
+    expect(screen.getByTestId("persona-visual-import-commit-button")).toBeDisabled()
+    fireEvent.click(screen.getByTestId("persona-visual-import-commit-button"))
+    expect(
+      calls.some((call) => call.includes("/commit"))
     ).toBe(false)
   })
 

--- a/apps/packages/ui/src/types/persona-visuals.ts
+++ b/apps/packages/ui/src/types/persona-visuals.ts
@@ -342,6 +342,31 @@ export interface PersonaVisualImportRequiredChoice {
   replaceable_pack_ids?: string[]
 }
 
+export interface PersonaVisualRendererImportPreview {
+  status?: string | null
+  renderer_type?: string | null
+  manifest_version?: number | null
+  renderer_contract_version?: number | null
+  can_commit?: boolean | null
+  activation_eligible?: boolean | null
+  blockers?: string[]
+  warnings?: string[]
+  normalized_role_categories?: Record<string, string[]>
+  setup_status?: string | null
+  setup_blockers?: string[]
+  disabled_reason?: string | null
+}
+
+export interface PersonaVisualImportProposedPlan extends Record<string, unknown> {
+  target_mode?: PersonaVisualImportTargetMode | string
+  target_modes?: Array<PersonaVisualImportTargetMode | string>
+  default_target_mode?: PersonaVisualImportTargetMode | string
+  commit_eligible?: boolean
+  activation_eligible?: boolean
+  commit_blockers?: string[]
+  renderer_import_preview?: PersonaVisualRendererImportPreview
+}
+
 export interface PersonaVisualImportPreviewResponse {
   preview_id: string
   job_id: string
@@ -357,7 +382,7 @@ export interface PersonaVisualImportPreviewResponse {
   bundle_summary: Record<string, unknown>
   validation_warnings: unknown[]
   conflicts: PersonaVisualImportConflict[]
-  proposed_plan: Record<string, unknown>
+  proposed_plan: PersonaVisualImportProposedPlan
   quota_estimate: Record<string, unknown>
   required_choices: PersonaVisualImportRequiredChoice[]
   target_warnings: unknown[]

--- a/backlog/tasks/task-325 - Surface-Persona-Visual-import-preview-renderer-diagnostics-in-Persona-Garden.md
+++ b/backlog/tasks/task-325 - Surface-Persona-Visual-import-preview-renderer-diagnostics-in-Persona-Garden.md
@@ -1,0 +1,81 @@
+---
+id: TASK-325
+title: Surface Persona Visual import-preview renderer diagnostics in Persona Garden
+status: Done
+assignee: []
+created_date: '2026-05-14 01:20'
+updated_date: '2026-05-14 01:41'
+labels:
+  - persona
+  - buddy
+  - webui
+  - visual-packs
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1510'
+  - 'https://github.com/rmusser01/tldw_server/issues/1645'
+  - 'https://github.com/rmusser01/tldw_server/pull/1642'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add the next narrow Buddy/Persona visual-pack slice under GitHub issue #1645. PR #1642 added backend diagnostics for Manifest V2/non-sprite renderer import previews while keeping V1 sprite_frames as the only activatable renderer. Persona Garden should make those diagnostics understandable in the import-preview review panel and avoid offering commit when backend eligibility says the preview is blocked. Scope stays frontend review UX only: no Live2D runtime renderer, no V2 activation, no MCP provider expansion, and no VN/CYOA behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Renderer import-preview diagnostics returned in proposed_plan are typed or normalized before UI use.
+- [x] #2 Blocked Manifest V2/non-sprite renderer previews show renderer status, blockers, warnings, and activation eligibility in Persona Garden import preview.
+- [x] #3 Import commit controls are disabled or withheld when the preview is not backend commit-eligible or renderer diagnostics mark it uncommittable.
+- [x] #4 Existing V1 sprite_frames import preview and commit flow remains unchanged.
+- [x] #5 Focused frontend tests cover blocked renderer diagnostics display and commit gating.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implementation:
+- Typed and normalized proposed_plan.renderer_import_preview in the Persona Visual frontend contract.
+- Rendered renderer import diagnostics in Persona Garden import previews, including status, blockers, warnings, role categories, and activation eligibility.
+- Gated import commit on backend commit_eligible and renderer can_commit signals while preserving existing sprite_frames import behavior.
+
+Verification:
+- PASS: bunx vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx --testNamePattern "surfaces blocked renderer import diagnostics"
+- PASS: bunx vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+- PASS: git diff --check
+- BASELINE FAIL: bun run verify:design-system-state reports unrelated existing blocked product-state findings in AgentTasks and other files outside this task.
+- BASELINE FAIL: bunx tsc --noEmit --project tsconfig.json reports unrelated existing type errors outside the touched Persona Visual files.
+- SKIP: Bandit not applicable; this slice touches TypeScript UI and Backlog metadata only.
+
+Review fix pass:
+- Address Gemini localization threads for new renderer diagnostics copy.
+- Address Qodo double-submit reliability thread for import commit enqueue.
+
+Review fixes implemented:
+- Added a synchronous import-commit in-flight ref guard and readability short-circuit to prevent duplicate commit enqueue before UI disabled state propagates.
+- Localized new renderer diagnostics labels, fallback unknown text, activation status text, blocker labels, warning labels, asset-role labels, and commit-blocked copy.
+- Extended VisualPackEditor coverage for localized diagnostics keys and duplicate click commit guarding.
+
+Review fix verification:
+- PASS: bunx vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx --testNamePattern "import-preview|blocked renderer"
+- PASS: bunx vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+- PASS: git diff --check
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Surface Persona Garden import-preview renderer diagnostics, gate blocked commits, localize new diagnostics copy, and guard import commit enqueue against duplicate rapid submits.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Change summary

Required before merge: the human requester should replace this section with a human-written summary of what changed and why these implementation choices were made.

## What changed

- Typed and normalized `proposed_plan.renderer_import_preview` in the Persona Visual frontend contract.
- Added a Persona Garden import-preview diagnostics block for renderer status, blockers, warnings, role categories, and activation eligibility.
- Gated import commit on backend `commit_eligible` and renderer `can_commit` signals while preserving existing V1 `sprite_frames` import behavior.
- Added `TASK-325` tracking for #1645 under the Persona/Buddy epic.

Closes #1645

## Scope boundaries

- No Live2D runtime renderer.
- No V2/non-`sprite_frames` activation support.
- No MCP provider/import-source expansion.
- No VN/CYOA behavior.

## Verification

- PASS: `bunx vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx --testNamePattern "surfaces blocked renderer import diagnostics"`
- PASS: `bunx vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx`
- PASS: `git diff --check origin/dev...HEAD`
- BASELINE FAIL: `bun run verify:design-system-state` reports unrelated existing product-state findings in `AgentTasks` and other files outside this PR.
- BASELINE FAIL: `bunx tsc --noEmit --project tsconfig.json` reports unrelated existing type errors outside the touched Persona Visual files.
- SKIP: Bandit is not applicable; this PR touches TypeScript UI and Backlog metadata only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces renderer import-preview diagnostics in Persona Garden and blocks commit when a preview isn’t eligible. Adds i18n’d diagnostics UI and a duplicate-click guard; aligns with TASK-325 and #1645 while keeping V1 `sprite_frames` import/commit unchanged.

- **New Features**
  - Typed and normalized `proposed_plan.renderer_import_preview` and `proposed_plan` fields in the Persona Visual contract.
  - Show renderer status, setup state, manifest and contract versions, blockers, warnings, role categories, and activation eligibility in the import-preview panel.
  - Gate commit on backend `commit_eligible` and renderer `can_commit`; display merged commit blockers when disabled.
  - Prevent duplicate commit enqueue with an in-flight guard.
  - Localized diagnostics labels and fallback text; added tests for diagnostics, commit gating, i18n keys, and double-click protection.

<sup>Written for commit 757da7fdde3fb7244c6640836422e6e8fd5e6f1d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

