### PR TITLE
Distinguish Persona runtime circuit-open diagnostics

### DIFF
--- a/backlog/tasks/task-329 - Distinguish-Persona-runtime-explorer-circuit-open-diagnostics.md
+++ b/backlog/tasks/task-329 - Distinguish-Persona-runtime-explorer-circuit-open-diagnostics.md
@@ -1,0 +1,55 @@
+---
+id: TASK-329
+title: Distinguish Persona runtime explorer circuit-open diagnostics
+status: Done
+assignee: []
+created_date: '2026-05-14 02:09'
+updated_date: '2026-05-14 02:13'
+labels:
+  - persona
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1510'
+  - 'https://github.com/rmusser01/tldw_server/issues/1652'
+  - 'https://github.com/rmusser01/tldw_server/pull/1647'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add a persona-only runtime diagnostics slice for #1652. The optional Persona Live runtime explorer already exposes circuit-open state in core results, but websocket notice routing currently collapses circuit-open fallback into the generic runtime fallback reason. Keep this focused on trace-safe diagnostics and avoid Buddy renderer/runtime, Persona Garden, visual-pack, VN/CYOA, runtime response gating, or live response mutation changes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Circuit-open runtime explorer diagnostics emit a distinct RUNTIME_EXPLORER_CIRCUIT_OPEN websocket notice reason.
+- [x] #2 Ordinary soft fallback and safe-denial runtime explorer notices keep their existing reason codes and trace-safe payload shape.
+- [x] #3 Focused regression tests cover the circuit-open websocket notice path and existing runtime diagnostics tests still pass.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Red verification: `python -m pytest tldw_Server_API/tests/Persona/test_persona_ws_dialogue_tree_runtime.py::test_runtime_explorer_circuit_open_notice_has_distinct_reason -q --tb=short` failed because no `RUNTIME_EXPLORER_CIRCUIT_OPEN` notice was emitted; circuit-open diagnostics were still routed through generic fallback.
+
+Green verification: the same focused regression test passed after adding distinct circuit-open notice routing. Focused runtime suite `python -m pytest tldw_Server_API/tests/Persona/test_persona_ws_dialogue_tree_runtime.py tldw_Server_API/tests/Persona/test_runtime_explorer.py -q` passed with 30 tests.
+
+Final verification: `python -m pytest tldw_Server_API/tests/Persona/test_persona_ws_dialogue_tree_runtime.py tldw_Server_API/tests/Persona/test_runtime_explorer.py -q` passed with 30 tests. `git diff --check` passed. Bandit on `tldw_Server_API/app/api/v1/endpoints/persona.py` exited 0 with no findings.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added distinct Persona Live runtime explorer circuit-open diagnostics for #1652. Circuit-open runtime explorer results now emit `RUNTIME_EXPLORER_CIRCUIT_OPEN` with a bounded user-facing fallback message, while ordinary soft fallback and safe-denial reason codes remain unchanged. Added focused websocket regression coverage and updated the Persona README notice taxonomy.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -401,7 +401,9 @@ def _runtime_explorer_notice_reason_code(diagnostics: dict[str, Any]) -> str | N
     fallback = str(diagnostics.get("fallback") or "")
     if fallback == "hard_safe_denial" or bool(diagnostics.get("safe_denial")):
         return "RUNTIME_EXPLORER_SAFE_DENIAL"
-    if fallback in {"soft_existing_behavior", "circuit_open"}:
+    if fallback == "circuit_open" or bool(diagnostics.get("circuit_open")):
+        return "RUNTIME_EXPLORER_CIRCUIT_OPEN"
+    if fallback == "soft_existing_behavior":
         return "RUNTIME_EXPLORER_FALLBACK"
     return None
 
@@ -410,6 +412,8 @@ def _runtime_explorer_notice_message(diagnostics: dict[str, Any]) -> str:
     reason_code = _runtime_explorer_notice_reason_code(diagnostics)
     if reason_code == "RUNTIME_EXPLORER_SAFE_DENIAL":
         return "Persona runtime explorer selected a safe denial."
+    if reason_code == "RUNTIME_EXPLORER_CIRCUIT_OPEN":
+        return "Persona runtime explorer is temporarily paused after repeated failures; using existing planning."
     return "Persona runtime explorer fell back to existing planning."
 
 

--- a/tldw_Server_API/app/core/Persona/README.md
+++ b/tldw_Server_API/app/core/Persona/README.md
@@ -92,7 +92,7 @@
 - Local Dev Tips:
   - connect to `/api/v1/persona/stream` with a websocket client and send `{ "type": "user_message", "text": "<query>" }`
   - inspect persisted persona sessions via `/api/v1/persona/sessions`
-  - when the optional runtime explorer is enabled, fallback and safe-denial paths emit a `notice` event with `RUNTIME_EXPLORER_*` reason codes and bounded `runtime_explorer` diagnostics; disabled mode emits no runtime-explorer notice
+  - when the optional runtime explorer is enabled, fallback, circuit-open, and safe-denial paths emit a `notice` event with `RUNTIME_EXPLORER_*` reason codes and bounded `runtime_explorer` diagnostics; disabled mode emits no runtime-explorer notice
 - Pitfalls & Gotchas:
   - personas are created from characters conceptually, but evolve independently after creation
   - do not store exemplar text snapshots in turn metadata when compact IDs/reasons are sufficient

--- a/tldw_Server_API/tests/Persona/test_persona_ws_dialogue_tree_runtime.py
+++ b/tldw_Server_API/tests/Persona/test_persona_ws_dialogue_tree_runtime.py
@@ -444,7 +444,10 @@ def test_runtime_explorer_fallback_notice_is_bounded_and_trace_safe(monkeypatch)
     assert "provider-secret" not in serialized_notice
 
 
-def test_runtime_explorer_circuit_open_notice_has_distinct_reason(monkeypatch) -> None:
+def test_runtime_explorer_circuit_open_notice_has_distinct_reason(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify circuit-open runtime fallback emits a distinct websocket notice."""
     class _FakeExplorer:
         def explore(self, _context: dict) -> RuntimeExplorationResult:
             return RuntimeExplorationResult(

--- a/tldw_Server_API/tests/Persona/test_persona_ws_dialogue_tree_runtime.py
+++ b/tldw_Server_API/tests/Persona/test_persona_ws_dialogue_tree_runtime.py
@@ -63,8 +63,11 @@ def _mock_persona_ws_runtime(monkeypatch):
 
     monkeypatch.setattr(persona_ep, "_resolve_authenticated_user_id", _fake_resolve)
     monkeypatch.setattr(persona_ep, "is_persona_enabled", lambda: True)
+    fastapi_app.dependency_overrides.clear()
     if hasattr(fastapi_app.state, "persona_runtime_explorer_provider"):
         delattr(fastapi_app.state, "persona_runtime_explorer_provider")
+    yield
+    fastapi_app.dependency_overrides.clear()
 
 
 def _plan_for_text(text: str, *, session_id: str = "sess_runtime") -> dict:
@@ -439,6 +442,46 @@ def test_runtime_explorer_fallback_notice_is_bounded_and_trace_safe(monkeypatch)
     assert diagnostics["provider_calls"] == 1
     assert "user-secret" not in serialized_notice
     assert "provider-secret" not in serialized_notice
+
+
+def test_runtime_explorer_circuit_open_notice_has_distinct_reason(monkeypatch) -> None:
+    class _FakeExplorer:
+        def explore(self, _context: dict) -> RuntimeExplorationResult:
+            return RuntimeExplorationResult(
+                selected_candidate=None,
+                fallback=ExplorationFallback.CIRCUIT_OPEN,
+                safe_denial=None,
+                budget=RuntimeBudgetUsage(),
+                diagnostics={"reason": "runtime_explorer_circuit_open"},
+                circuit_open=True,
+            )
+
+    class _FakeProvider:
+        def get(self, _config: RuntimeExplorerConfig) -> _FakeExplorer:
+            return _FakeExplorer()
+
+    monkeypatch.setattr(
+        persona_ep,
+        "_get_persona_runtime_explorer_config",
+        lambda: RuntimeExplorerConfig(enabled=True),
+        raising=False,
+    )
+    fastapi_app.dependency_overrides[persona_ep.get_persona_runtime_explorer_provider] = (
+        lambda: _FakeProvider()
+    )
+
+    notice = _notice_for_text(
+        "find runtime notes while circuit is open",
+        reason_code="RUNTIME_EXPLORER_CIRCUIT_OPEN",
+        session_id="sess_runtime_circuit_open_notice",
+    )
+
+    diagnostics = notice["runtime_explorer"]
+    assert diagnostics["fallback"] == "circuit_open"
+    assert diagnostics["reason"] == "runtime_explorer_circuit_open"
+    assert diagnostics["provider_calls"] == 0
+    assert diagnostics["circuit_open"] is True
+    assert "temporarily" in str(notice.get("message", "")).lower()
 
 
 def test_runtime_explorer_enabled_selects_highest_scoring_safe_plan(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Add a distinct `RUNTIME_EXPLORER_CIRCUIT_OPEN` Persona Live notice reason for runtime explorer circuit-open fallback.
- Keep ordinary soft fallback and safe-denial notice routing unchanged.
- Add focused websocket regression coverage and update the Persona runtime README taxonomy.

## Scope
- Persona-only runtime diagnostics.
- No Buddy renderer/runtime changes, Persona Garden changes, visual-pack changes, VN/CYOA behavior, response gating, or live response mutation.

## Test Plan
- `python -m pytest tldw_Server_API/tests/Persona/test_persona_ws_dialogue_tree_runtime.py::test_runtime_explorer_circuit_open_notice_has_distinct_reason -q --tb=short` (red before fix, green after fix)
- `python -m pytest tldw_Server_API/tests/Persona/test_persona_ws_dialogue_tree_runtime.py tldw_Server_API/tests/Persona/test_runtime_explorer.py -q`
- `git diff --check`
- `python -m bandit -r tldw_Server_API/app/api/v1/endpoints/persona.py -f json`

## Tracking
- Closes #1652
- Backlog: TASK-329

## Merge Gate
This PR is AI-authored and will need a human-written Change summary before merge under the repo policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a distinct `RUNTIME_EXPLORER_CIRCUIT_OPEN` notice and message when the Persona runtime explorer circuit is open, instead of collapsing into generic fallback. Keeps `RUNTIME_EXPLORER_FALLBACK` and `RUNTIME_EXPLORER_SAFE_DENIAL` unchanged.

- New Features
  - Emits `RUNTIME_EXPLORER_CIRCUIT_OPEN` when `fallback == "circuit_open"` or `diagnostics.circuit_open` is true; notice message explains the explorer is temporarily paused after repeated failures.
  - Adds a focused websocket regression test for circuit-open reason/message and diagnostics; stabilizes the WS fixture by clearing FastAPI dependency overrides; updates the Persona README taxonomy. Satisfies Linear `TASK-329`; addresses #1652.

<sup>Written for commit 921d55805425a6d834bdf9dd7bfe80fa6341f505. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

