### PR TITLE
Surface ACP execution health in Agent Registry

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -1100,28 +1100,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/AgentRegistry/index.tsx:Alert#antd-alert-agentregistrypage-type-warning-health-check-u-9wmva4",
-    "path": "src/components/Option/AgentRegistry/index.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/AgentRegistry/index.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/AgentRegistry/index.tsx:Alert#antd-alert-agentregistrypage-type-error-line-211-1w95fyt",
-    "path": "src/components/Option/AgentRegistry/index.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/AgentRegistry/index.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/AgentTasks/index.tsx:Alert#antd-alert-agenttaskspage-type-warning-line-744-ocj46l",
     "path": "src/components/Option/AgentTasks/index.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/assets/locale/en/option.json
+++ b/apps/packages/ui/src/assets/locale/en/option.json
@@ -365,6 +365,64 @@
     "noMatchesDescription": "Try a different search term.",
     "noMatchesList": "No matches in this source."
   },
+  "agentRegistry": {
+    "health": {
+      "title": "ACP System Health",
+      "runnerBinary": "Runner Binary",
+      "agentStatus": "Agent Status",
+      "apiKeys": "API Keys",
+      "unavailableTitle": "Health check unavailable",
+      "unavailableBody": "Could not reach the ACP health endpoint. Ensure the server is running."
+    },
+    "executionHealth": {
+      "title": "ACP Execution Health",
+      "unavailableTitle": "Execution health summary unavailable",
+      "unavailableBody": "The admin summary endpoint may require newer backend support or elevated permissions.",
+      "sessions": "Sessions",
+      "sessionWindowSingular": "{{total}} session in {{days}}d",
+      "sessionWindowPlural": "{{total}} sessions in {{days}}d",
+      "statusCount": "{{count}} {{status}}",
+      "noSessions": "No sessions recorded",
+      "compatibility": "Compatibility",
+      "liveCertificationRequired": "Live certification required",
+      "noLiveCertificationBlocker": "No live-certification blocker",
+      "supportStateCount": "{{count}} {{state}}",
+      "unverifiedAgents": "Unverified agents: {{agents}}",
+      "noDocumentedUnverifiedAgents": "No documented-unverified agents",
+      "executionEvidenceDocs": "Execution evidence docs",
+      "retentionAndRedaction": "Retention and redaction",
+      "retentionSummary": "Retention {{sessionDays}}d sessions / {{auditDays}}d audit",
+      "redactedDrillThroughEnabled": "Redacted drill-through enabled",
+      "reviewRedactionSettings": "Review redaction settings",
+      "failureBucketsTitle": "Failure buckets",
+      "noRecentFailureBuckets": "No recent failure buckets",
+      "setupHealthTitle": "Setup health",
+      "setupStatus": "{{label}} {{status}}",
+      "evidenceCount": "{{count}} evidence",
+      "setupBlockers": "{{label}} {{status}}: {{blockers}}",
+      "noSetupBlockers": "No setup blockers in this window",
+      "failureBuckets": {
+        "setupBlockers": "Setup blockers",
+        "runnerSessionFailures": "Runner/session failures",
+        "reviewerRejections": "Reviewer rejections",
+        "reviewerFailures": "Reviewer failures",
+        "governanceDenials": "Governance denials",
+        "structuredCompletionFailures": "Structured completion failures",
+        "sandboxRuntimeErrors": "Sandbox runtime errors",
+        "retentionRedactionActions": "Retention/redaction actions"
+      },
+      "setupDimensions": {
+        "agent": "Agent",
+        "workspace": "Workspace",
+        "sandboxRuntime": "Sandbox runtime",
+        "mcpInjection": "MCP injection",
+        "schedulerTriggerPath": "Scheduler trigger path"
+      }
+    },
+    "loadFailedTitle": "Agent registry could not load",
+    "registeredAgents": "Registered Agents",
+    "empty": "No agents registered"
+  },
   "promptStudio": {
     "title": "Prompt Studio Playground",
     "subtitle": "Manage Prompt Studio projects, prompts, executions, test cases, and evaluations.",

--- a/apps/packages/ui/src/components/Option/AgentRegistry/__tests__/AgentRegistryPage.connection.test.tsx
+++ b/apps/packages/ui/src/components/Option/AgentRegistry/__tests__/AgentRegistryPage.connection.test.tsx
@@ -4,6 +4,86 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { AgentRegistryPage } from "../index"
 
+const baseACPHealthPayload = {
+  runner: "ok",
+  agent: "ok",
+  api_keys: "ok"
+}
+
+const baseExecutionHealthSummaryPayload = {
+  timestamp: "2026-05-14T09:00:00Z",
+  range_days: 30,
+  sessions: {
+    total: 0,
+    by_status: {}
+  },
+  failure_buckets: {
+    setup_blockers: 0,
+    runner_session_failures: 0,
+    reviewer_rejections: 0,
+    reviewer_failures: 0,
+    governance_denials: 0,
+    structured_completion_failures: 0,
+    sandbox_runtime_errors: 0,
+    retention_redaction_actions: 0
+  },
+  setup_health: {
+    agent: { status: "unknown", blockers: [], evidence_count: 0 },
+    workspace: { status: "unknown", blockers: [], evidence_count: 0 },
+    sandbox_runtime: { status: "unknown", blockers: [], evidence_count: 0 },
+    mcp_injection: { status: "unknown", blockers: [], evidence_count: 0 },
+    scheduler_trigger_path: { status: "unknown", blockers: [], evidence_count: 0 }
+  },
+  agents: [],
+  compatibility: {
+    by_support_state: {},
+    documented_unverified_agents: [],
+    live_certification_required: false,
+    docs_url: "/docs-static/Development/ACP_Compatibility_Matrix.md"
+  },
+  retention: {
+    session_retention_days: 30,
+    audit_retention_days: 30,
+    policy: "closed_error_sessions_and_audit_events_purged_after_retention"
+  },
+  redaction: {
+    detail_events_artifacts_redacted_views: true,
+    diagnostics_sanitized: true,
+    audit_metadata_sanitized: true
+  }
+}
+
+const installACPFetchMock = ({
+  healthPayload = baseACPHealthPayload,
+  summaryPayload = baseExecutionHealthSummaryPayload,
+  summaryOk = true,
+  summaryStatus = summaryOk ? 200 : 403
+}: {
+  healthPayload?: Record<string, unknown>
+  summaryPayload?: Record<string, unknown>
+  summaryOk?: boolean
+  summaryStatus?: number
+} = {}) => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes("/api/v1/admin/acp/execution-health/summary")) {
+        return {
+          ok: summaryOk,
+          status: summaryStatus,
+          json: async () => summaryPayload
+        }
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => healthPayload
+      }
+    })
+  )
+}
+
 const storageMocks = vi.hoisted(() => ({
   useStorage: vi.fn()
 }))
@@ -162,17 +242,7 @@ describe("AgentRegistryPage connection config", () => {
       ]
     })
 
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => ({
-        ok: true,
-        json: async () => ({
-          runner: "ok",
-          agent: "ok",
-          api_keys: "ok"
-        })
-      }))
-    )
+    installACPFetchMock()
   })
 
   afterEach(() => {
@@ -198,6 +268,14 @@ describe("AgentRegistryPage connection config", () => {
           })
         })
       )
+      expect(global.fetch).toHaveBeenCalledWith(
+        "http://127.0.0.1:8000/api/v1/admin/acp/execution-health/summary?range_days=30",
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            "X-API-KEY": "real-key"
+          })
+        })
+      )
       const authHeaders = await acpMocks.constructedConfigs[0]?.getAuthHeaders()
       expect(authHeaders).toEqual(
         expect.objectContaining({
@@ -217,6 +295,14 @@ describe("AgentRegistryPage connection config", () => {
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith(
         "/api/v1/acp/health",
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            "X-API-KEY": "real-key"
+          })
+        })
+      )
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/v1/admin/acp/execution-health/summary?range_days=30",
         expect.objectContaining({
           headers: expect.objectContaining({
             "X-API-KEY": "real-key"
@@ -253,28 +339,24 @@ describe("AgentRegistryPage connection config", () => {
   })
 
   it("normalizes structured ACP health payloads without trying to render raw objects", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => ({
-        ok: true,
-        json: async () => ({
-          runner: {
-            status: "ok",
-            path: "/opt/homebrew/bin/go",
-            source: "PATH"
-          },
-          agents: [
-            {
-              agent_type: "planner",
-              status: "available",
-              api_key_set: true
-            }
-          ],
-          overall: "ok",
-          message: null
-        })
-      }))
-    )
+    installACPFetchMock({
+      healthPayload: {
+        runner: {
+          status: "ok",
+          path: "/opt/homebrew/bin/go",
+          source: "PATH"
+        },
+        agents: [
+          {
+            agent_type: "planner",
+            status: "available",
+            api_key_set: true
+          }
+        ],
+        overall: "ok",
+        message: null
+      }
+    })
 
     render(<AgentRegistryPage />)
 
@@ -319,5 +401,76 @@ describe("AgentRegistryPage connection config", () => {
       "href",
       "/docs-static/Development/ACP_Compatibility_Matrix.md"
     )
+  })
+
+  it("renders the admin execution-health summary without overstating agent certification", async () => {
+    installACPFetchMock({
+      summaryPayload: {
+        ...baseExecutionHealthSummaryPayload,
+        range_days: 30,
+        sessions: {
+          total: 3,
+          by_status: {
+            active: 2,
+            error: 1
+          }
+        },
+        failure_buckets: {
+          setup_blockers: 1,
+          runner_session_failures: 1,
+          reviewer_rejections: 1,
+          reviewer_failures: 0,
+          governance_denials: 1,
+          structured_completion_failures: 1,
+          sandbox_runtime_errors: 1,
+          retention_redaction_actions: 1
+        },
+        setup_health: {
+          agent: { status: "blocked", blockers: ["adapter_required"], evidence_count: 1 },
+          workspace: { status: "unknown", blockers: [], evidence_count: 0 },
+          sandbox_runtime: { status: "blocked", blockers: ["sandbox_runtime_error"], evidence_count: 1 },
+          mcp_injection: { status: "unknown", blockers: [], evidence_count: 0 },
+          scheduler_trigger_path: { status: "ok", blockers: [], evidence_count: 2 }
+        },
+        compatibility: {
+          by_support_state: {
+            documented_unverified: 1,
+            supported_with_caveats: 1
+          },
+          documented_unverified_agents: ["codex"],
+          live_certification_required: true,
+          docs_url: "/docs-static/Development/ACP_Compatibility_Matrix.md"
+        },
+        retention: {
+          session_retention_days: 30,
+          audit_retention_days: 45,
+          policy: "closed_error_sessions_and_audit_events_purged_after_retention"
+        }
+      }
+    })
+
+    render(<AgentRegistryPage />)
+
+    expect(await screen.findByText("ACP Execution Health")).toBeInTheDocument()
+    expect(await screen.findByText("3 sessions in 30d")).toBeInTheDocument()
+    expect(screen.getByText("2 active")).toBeInTheDocument()
+    expect(screen.getByText("1 error")).toBeInTheDocument()
+    expect(screen.getByText("Runner/session failures")).toBeInTheDocument()
+    expect(screen.getByText("Setup blockers")).toBeInTheDocument()
+    expect(screen.getByText("Unverified agents: codex")).toBeInTheDocument()
+    expect(screen.getByText("Live certification required")).toBeInTheDocument()
+    expect(screen.getByText("Agent blocked: adapter_required")).toBeInTheDocument()
+    expect(screen.getByText("Retention 30d sessions / 45d audit")).toBeInTheDocument()
+    expect(screen.getByText("Redacted drill-through enabled")).toBeInTheDocument()
+  })
+
+  it("keeps the registry usable when the admin execution-health summary is unavailable", async () => {
+    installACPFetchMock({ summaryOk: false, summaryStatus: 403 })
+
+    render(<AgentRegistryPage />)
+
+    expect(await screen.findByText("Planner Agent")).toBeInTheDocument()
+    expect(screen.getByText("Execution health summary unavailable")).toBeInTheDocument()
+    expect(screen.getByText("Runner Binary")).toBeInTheDocument()
   })
 })

--- a/apps/packages/ui/src/components/Option/AgentRegistry/__tests__/AgentRegistryPage.connection.test.tsx
+++ b/apps/packages/ui/src/components/Option/AgentRegistry/__tests__/AgentRegistryPage.connection.test.tsx
@@ -124,7 +124,26 @@ vi.mock("@/design-system", async (importActual) => {
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
-    t: (_key: string, fallback?: string) => fallback ?? _key
+    t: (
+      key: string,
+      fallbackOrOptions?: string | Record<string, unknown>,
+      options?: Record<string, unknown>
+    ) => {
+      const values =
+        typeof fallbackOrOptions === "object" && fallbackOrOptions !== null
+          ? fallbackOrOptions
+          : options
+      const template =
+        typeof fallbackOrOptions === "string"
+          ? fallbackOrOptions
+          : typeof fallbackOrOptions?.defaultValue === "string"
+            ? String(fallbackOrOptions.defaultValue)
+            : key
+
+      return template.replace(/\{\{(\w+)}}/g, (_, token: string) =>
+        values?.[token] == null ? "" : String(values[token])
+      )
+    }
   })
 }))
 
@@ -472,5 +491,44 @@ describe("AgentRegistryPage connection config", () => {
     expect(await screen.findByText("Planner Agent")).toBeInTheDocument()
     expect(screen.getByText("Execution health summary unavailable")).toBeInTheDocument()
     expect(screen.getByText("Runner Binary")).toBeInTheDocument()
+  })
+
+  it("treats malformed admin execution-health summaries as unavailable", async () => {
+    installACPFetchMock({
+      summaryPayload: {
+        sessions: {
+          total: 1
+        }
+      }
+    })
+
+    render(<AgentRegistryPage />)
+
+    expect(await screen.findByText("Planner Agent")).toBeInTheDocument()
+    expect(screen.getByText("Execution health summary unavailable")).toBeInTheDocument()
+  })
+
+  it("uses safe defaults for partial admin execution-health summaries", async () => {
+    installACPFetchMock({
+      summaryPayload: {
+        ...baseExecutionHealthSummaryPayload,
+        sessions: {
+          total: 2
+        },
+        failure_buckets: null,
+        setup_health: null,
+        compatibility: null,
+        retention: null,
+        redaction: null
+      }
+    })
+
+    render(<AgentRegistryPage />)
+
+    expect(await screen.findByText("Planner Agent")).toBeInTheDocument()
+    expect(await screen.findByText("2 sessions in 30d")).toBeInTheDocument()
+    expect(screen.getByText("No recent failure buckets")).toBeInTheDocument()
+    expect(screen.getByText("No setup blockers in this window")).toBeInTheDocument()
+    expect(screen.getByText("Review redaction settings")).toBeInTheDocument()
   })
 })

--- a/apps/packages/ui/src/components/Option/AgentRegistry/index.tsx
+++ b/apps/packages/ui/src/components/Option/AgentRegistry/index.tsx
@@ -16,7 +16,11 @@ import { Alert as DSAlert, Badge as DSBadge } from "@/components/ui/primitives"
 import { useCanonicalConnectionConfig } from "@/hooks/useCanonicalConnectionConfig"
 import { ACPRestClient } from "@/services/acp/client"
 import { buildACPAuthHeaders, buildACPClientConfig } from "@/services/acp/connection"
-import { normalizeACPHealthStatus, type ACPHealthStatus } from "@/services/acp/readiness"
+import {
+  normalizeACPExecutionHealthSummary,
+  normalizeACPHealthStatus,
+  type ACPHealthStatus
+} from "@/services/acp/readiness"
 import type {
   ACPExecutionHealthFailureBuckets,
   ACPExecutionHealthSetupSummary,
@@ -30,23 +34,77 @@ import { DESIGN_SYSTEM_STATES, getDesignSystemState, type DesignSystemStateKey }
 const ACP_EXECUTION_HEALTH_SUMMARY_PATH =
   "/api/v1/admin/acp/execution-health/summary?range_days=30"
 
-const FAILURE_BUCKET_LABELS: Array<[keyof ACPExecutionHealthFailureBuckets, string]> = [
-  ["setup_blockers", "Setup blockers"],
-  ["runner_session_failures", "Runner/session failures"],
-  ["reviewer_rejections", "Reviewer rejections"],
-  ["reviewer_failures", "Reviewer failures"],
-  ["governance_denials", "Governance denials"],
-  ["structured_completion_failures", "Structured completion failures"],
-  ["sandbox_runtime_errors", "Sandbox runtime errors"],
-  ["retention_redaction_actions", "Retention/redaction actions"]
+const FAILURE_BUCKET_LABELS: Array<{
+  key: keyof ACPExecutionHealthFailureBuckets
+  labelKey: string
+  fallback: string
+}> = [
+  {
+    key: "setup_blockers",
+    labelKey: "option:agentRegistry.executionHealth.failureBuckets.setupBlockers",
+    fallback: "Setup blockers"
+  },
+  {
+    key: "runner_session_failures",
+    labelKey: "option:agentRegistry.executionHealth.failureBuckets.runnerSessionFailures",
+    fallback: "Runner/session failures"
+  },
+  {
+    key: "reviewer_rejections",
+    labelKey: "option:agentRegistry.executionHealth.failureBuckets.reviewerRejections",
+    fallback: "Reviewer rejections"
+  },
+  {
+    key: "reviewer_failures",
+    labelKey: "option:agentRegistry.executionHealth.failureBuckets.reviewerFailures",
+    fallback: "Reviewer failures"
+  },
+  {
+    key: "governance_denials",
+    labelKey: "option:agentRegistry.executionHealth.failureBuckets.governanceDenials",
+    fallback: "Governance denials"
+  },
+  {
+    key: "structured_completion_failures",
+    labelKey: "option:agentRegistry.executionHealth.failureBuckets.structuredCompletionFailures",
+    fallback: "Structured completion failures"
+  },
+  {
+    key: "sandbox_runtime_errors",
+    labelKey: "option:agentRegistry.executionHealth.failureBuckets.sandboxRuntimeErrors",
+    fallback: "Sandbox runtime errors"
+  },
+  {
+    key: "retention_redaction_actions",
+    labelKey: "option:agentRegistry.executionHealth.failureBuckets.retentionRedactionActions",
+    fallback: "Retention/redaction actions"
+  }
 ]
 
-const SETUP_DIMENSION_LABELS: Record<keyof ACPExecutionHealthSetupSummary, string> = {
-  agent: "Agent",
-  workspace: "Workspace",
-  sandbox_runtime: "Sandbox runtime",
-  mcp_injection: "MCP injection",
-  scheduler_trigger_path: "Scheduler trigger path"
+const SETUP_DIMENSION_LABELS: Record<
+  keyof ACPExecutionHealthSetupSummary,
+  { labelKey: string; fallback: string }
+> = {
+  agent: {
+    labelKey: "option:agentRegistry.executionHealth.setupDimensions.agent",
+    fallback: "Agent"
+  },
+  workspace: {
+    labelKey: "option:agentRegistry.executionHealth.setupDimensions.workspace",
+    fallback: "Workspace"
+  },
+  sandbox_runtime: {
+    labelKey: "option:agentRegistry.executionHealth.setupDimensions.sandboxRuntime",
+    fallback: "Sandbox runtime"
+  },
+  mcp_injection: {
+    labelKey: "option:agentRegistry.executionHealth.setupDimensions.mcpInjection",
+    fallback: "MCP injection"
+  },
+  scheduler_trigger_path: {
+    labelKey: "option:agentRegistry.executionHealth.setupDimensions.schedulerTriggerPath",
+    fallback: "Scheduler trigger path"
+  }
 }
 type AgentEntry = {
   type: string
@@ -155,7 +213,7 @@ export const AgentRegistryPage: React.FC = () => {
       })
       const res = await fetch(transport.url, { headers: getACPHeaders(transport) })
       if (res.ok) {
-        setExecutionHealth(await res.json())
+        setExecutionHealth(normalizeACPExecutionHealthSummary(await res.json()))
       } else {
         setExecutionHealth(null)
       }
@@ -209,7 +267,7 @@ export const AgentRegistryPage: React.FC = () => {
         title={
           <span className="flex items-center gap-2">
             <Heart className="h-4 w-4" />
-            ACP System Health
+            {t("option:agentRegistry.health.title", "ACP System Health")}
           </span>
         }
         extra={
@@ -222,7 +280,7 @@ export const AgentRegistryPage: React.FC = () => {
               void fetchAgents()
             }}
           >
-            Refresh
+            {t("common:refresh", "Refresh")}
           </Button>
         }
       >
@@ -235,28 +293,43 @@ export const AgentRegistryPage: React.FC = () => {
             <div className="flex items-center gap-2 rounded-lg border border-border p-3">
               {statusIcon(health.runner)}
               <div>
-                <div className="text-xs text-muted-foreground">Runner Binary</div>
+                <div className="text-xs text-muted-foreground">
+                  {t("option:agentRegistry.health.runnerBinary", "Runner Binary")}
+                </div>
                 <Tag color={statusColor(health.runner)}>{health.runner}</Tag>
               </div>
             </div>
             <div className="flex items-center gap-2 rounded-lg border border-border p-3">
               {statusIcon(health.agent)}
               <div>
-                <div className="text-xs text-muted-foreground">Agent Status</div>
+                <div className="text-xs text-muted-foreground">
+                  {t("option:agentRegistry.health.agentStatus", "Agent Status")}
+                </div>
                 <Tag color={statusColor(health.agent)}>{health.agent}</Tag>
               </div>
             </div>
             <div className="flex items-center gap-2 rounded-lg border border-border p-3">
               {statusIcon(health.api_keys)}
               <div>
-                <div className="text-xs text-muted-foreground">API Keys</div>
+                <div className="text-xs text-muted-foreground">
+                  {t("option:agentRegistry.health.apiKeys", "API Keys")}
+                </div>
                 <Tag color={statusColor(health.api_keys)}>{health.api_keys}</Tag>
               </div>
             </div>
           </div>
         ) : (
-          <DSAlert variant="warning" title="Health check unavailable">
-            Could not reach the ACP health endpoint. Ensure the server is running.
+          <DSAlert
+            variant="warning"
+            title={t(
+              "option:agentRegistry.health.unavailableTitle",
+              "Health check unavailable"
+            )}
+          >
+            {t(
+              "option:agentRegistry.health.unavailableBody",
+              "Could not reach the ACP health endpoint. Ensure the server is running."
+            )}
           </DSAlert>
         )}
         {health?.details && (
@@ -268,7 +341,7 @@ export const AgentRegistryPage: React.FC = () => {
         title={
           <span className="flex items-center gap-2">
             <Activity className="h-4 w-4" />
-            ACP Execution Health
+            {t("option:agentRegistry.executionHealth.title", "ACP Execution Health")}
           </span>
         }
       >
@@ -279,16 +352,30 @@ export const AgentRegistryPage: React.FC = () => {
         ) : executionHealth ? (
           <ExecutionHealthSummary summary={executionHealth} />
         ) : (
-          <DSAlert variant="warning" title="Execution health summary unavailable">
-            The admin summary endpoint may require newer backend support or elevated permissions.
+          <DSAlert
+            variant="warning"
+            title={t(
+              "option:agentRegistry.executionHealth.unavailableTitle",
+              "Execution health summary unavailable"
+            )}
+          >
+            {t(
+              "option:agentRegistry.executionHealth.unavailableBody",
+              "The admin summary endpoint may require newer backend support or elevated permissions."
+            )}
           </DSAlert>
         )}
       </Card>
 
       {/* Error */}
       {error && (
-        <DSAlert variant="error" title={error} dismissible onDismiss={() => setError(null)}>
-          Agent registry could not load.
+        <DSAlert
+          variant="error"
+          title={t("option:agentRegistry.loadFailedTitle", "Agent registry could not load")}
+          dismissible
+          onDismiss={() => setError(null)}
+        >
+          {error}
         </DSAlert>
       )}
 
@@ -297,7 +384,7 @@ export const AgentRegistryPage: React.FC = () => {
         title={
           <span className="flex items-center gap-2">
             <Bot className="h-4 w-4" />
-            Registered Agents
+            {t("option:agentRegistry.registeredAgents", "Registered Agents")}
             {!loading && (
               <Badge
                 count={agents.length}
@@ -312,7 +399,9 @@ export const AgentRegistryPage: React.FC = () => {
             <Spin />
           </div>
         ) : agents.length === 0 ? (
-          <Empty description="No agents registered" />
+          <Empty
+            description={t("option:agentRegistry.empty", "No agents registered")}
+          />
         ) : (
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
             {agents.map((agent) => (
@@ -328,85 +417,158 @@ export const AgentRegistryPage: React.FC = () => {
 const ExecutionHealthSummary: React.FC<{
   summary: ACPExecutionHealthSummaryResponse
 }> = ({ summary }) => {
-  const sessionStatusEntries = Object.entries(summary.sessions.by_status ?? {})
-    .filter(([, count]) => count > 0)
-    .sort(([left], [right]) => left.localeCompare(right))
+  const { t } = useTranslation(["option", "common"])
+  const sessionStatusEntries = useMemo(
+    () =>
+      Object.entries(summary.sessions.by_status ?? {})
+        .filter(([, count]) => count > 0)
+        .sort(([left], [right]) => left.localeCompare(right)),
+    [summary.sessions.by_status]
+  )
 
-  const failureEntries = FAILURE_BUCKET_LABELS
-    .map(([key, label]) => ({
-      key,
-      label,
-      count: summary.failure_buckets[key] ?? 0
-    }))
-    .filter((entry) => entry.count > 0)
+  const failureEntries = useMemo(
+    () =>
+      FAILURE_BUCKET_LABELS
+        .map(({ key, labelKey, fallback }) => ({
+          key,
+          label: t(labelKey, fallback),
+          count: summary.failure_buckets[key] ?? 0
+        }))
+        .filter((entry) => entry.count > 0),
+    [summary.failure_buckets, t]
+  )
 
-  const setupEntries = (Object.entries(summary.setup_health) as Array<
-    [
-      keyof ACPExecutionHealthSetupSummary,
-      ACPExecutionHealthSetupSummary[keyof ACPExecutionHealthSetupSummary]
-    ]
-  >)
-    .filter(([, dimension]) => {
-      return (
-        dimension.status === "blocked" ||
-        dimension.status === "degraded" ||
-        dimension.blockers.length > 0
-      )
-    })
-    .map(([key, dimension]) => ({
-      key,
-      label: SETUP_DIMENSION_LABELS[key],
-      status: dimension.status,
-      blockers: dimension.blockers,
-      evidenceCount: dimension.evidence_count
-    }))
+  const setupEntries = useMemo(
+    () =>
+      (Object.entries(summary.setup_health) as Array<
+        [
+          keyof ACPExecutionHealthSetupSummary,
+          ACPExecutionHealthSetupSummary[keyof ACPExecutionHealthSetupSummary]
+        ]
+      >)
+        .filter(([, dimension]) => {
+          return (
+            dimension.status === "blocked" ||
+            dimension.status === "degraded" ||
+            dimension.blockers.length > 0
+          )
+        })
+        .map(([key, dimension]) => {
+          const label = SETUP_DIMENSION_LABELS[key]
+          return {
+            key,
+            label: t(label.labelKey, label.fallback),
+            status: dimension.status,
+            blockers: dimension.blockers,
+            evidenceCount: dimension.evidence_count
+          }
+        }),
+    [summary.setup_health, t]
+  )
 
-  const unverifiedAgents = summary.compatibility.documented_unverified_agents ?? []
-  const redactionEnabled =
-    summary.redaction.detail_events_artifacts_redacted_views &&
-    summary.redaction.diagnostics_sanitized &&
-    summary.redaction.audit_metadata_sanitized
+  const unverifiedAgents = useMemo(
+    () => summary.compatibility.documented_unverified_agents ?? [],
+    [summary.compatibility.documented_unverified_agents]
+  )
+  const redactionEnabled = useMemo(
+    () =>
+      summary.redaction.detail_events_artifacts_redacted_views &&
+      summary.redaction.diagnostics_sanitized &&
+      summary.redaction.audit_metadata_sanitized,
+    [summary.redaction]
+  )
+
+  const sessionWindowFallback =
+    summary.sessions.total === 1
+      ? "{{total}} session in {{days}}d"
+      : "{{total}} sessions in {{days}}d"
+  const sessionWindowKey =
+    summary.sessions.total === 1
+      ? "option:agentRegistry.executionHealth.sessionWindowSingular"
+      : "option:agentRegistry.executionHealth.sessionWindowPlural"
 
   return (
     <div className="space-y-4">
       <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
         <div className="rounded-lg border border-border p-3">
-          <div className="text-xs text-muted-foreground">Sessions</div>
+          <div className="text-xs text-muted-foreground">
+            {t("option:agentRegistry.executionHealth.sessions", "Sessions")}
+          </div>
           <div className="text-base font-medium">
-            {summary.sessions.total} sessions in {summary.range_days}d
+            {t(
+              sessionWindowKey,
+              sessionWindowFallback,
+              { total: summary.sessions.total, days: summary.range_days }
+            )}
           </div>
           <div className="mt-2 flex flex-wrap gap-1">
             {sessionStatusEntries.length > 0 ? (
               sessionStatusEntries.map(([status, count]) => (
-                <DSBadge key={status} variant="secondary">{count} {status}</DSBadge>
+                <DSBadge key={status} variant="secondary">
+                  {t(
+                    "option:agentRegistry.executionHealth.statusCount",
+                    "{{count}} {{status}}",
+                    { count, status }
+                  )}
+                </DSBadge>
               ))
             ) : (
-              <span className="text-xs text-muted-foreground">No sessions recorded</span>
+              <span className="text-xs text-muted-foreground">
+                {t(
+                  "option:agentRegistry.executionHealth.noSessions",
+                  "No sessions recorded"
+                )}
+              </span>
             )}
           </div>
         </div>
 
         <div className="rounded-lg border border-border p-3">
-          <div className="text-xs text-muted-foreground">Compatibility</div>
+          <div className="text-xs text-muted-foreground">
+            {t("option:agentRegistry.executionHealth.compatibility", "Compatibility")}
+          </div>
           <div className="mt-1 flex flex-wrap gap-1">
             {summary.compatibility.live_certification_required ? (
-              <DSBadge variant="warning">Live certification required</DSBadge>
+              <DSBadge variant="warning">
+                {t(
+                  "option:agentRegistry.executionHealth.liveCertificationRequired",
+                  "Live certification required"
+                )}
+              </DSBadge>
             ) : (
-              <DSBadge variant="success">No live-certification blocker</DSBadge>
+              <DSBadge variant="success">
+                {t(
+                  "option:agentRegistry.executionHealth.noLiveCertificationBlocker",
+                  "No live-certification blocker"
+                )}
+              </DSBadge>
             )}
             {Object.entries(summary.compatibility.by_support_state ?? {}).map(
               ([state, count]) => (
-                <DSBadge key={state} variant="secondary">{count} {state}</DSBadge>
+                <DSBadge key={state} variant="secondary">
+                  {t(
+                    "option:agentRegistry.executionHealth.supportStateCount",
+                    "{{count}} {{state}}",
+                    { count, state }
+                  )}
+                </DSBadge>
               )
             )}
           </div>
           {unverifiedAgents.length > 0 ? (
             <div className="mt-2 text-xs text-yellow-700 dark:text-yellow-400">
-              Unverified agents: {unverifiedAgents.join(", ")}
+              {t(
+                "option:agentRegistry.executionHealth.unverifiedAgents",
+                "Unverified agents: {{agents}}",
+                { agents: unverifiedAgents.join(", ") }
+              )}
             </div>
           ) : (
             <div className="mt-2 text-xs text-muted-foreground">
-              No documented-unverified agents
+              {t(
+                "option:agentRegistry.executionHealth.noDocumentedUnverifiedAgents",
+                "No documented-unverified agents"
+              )}
             </div>
           )}
           {summary.compatibility.docs_url && (
@@ -416,21 +578,41 @@ const ExecutionHealthSummary: React.FC<{
               target="_blank"
               rel="noreferrer"
             >
-              Execution evidence docs
+              {t(
+                "option:agentRegistry.executionHealth.executionEvidenceDocs",
+                "Execution evidence docs"
+              )}
             </a>
           )}
         </div>
 
         <div className="rounded-lg border border-border p-3">
-          <div className="text-xs text-muted-foreground">Retention and redaction</div>
+          <div className="text-xs text-muted-foreground">
+            {t(
+              "option:agentRegistry.executionHealth.retentionAndRedaction",
+              "Retention and redaction"
+            )}
+          </div>
           <div className="mt-1 text-sm">
-            Retention {summary.retention.session_retention_days}d sessions /{" "}
-            {summary.retention.audit_retention_days}d audit
+            {t(
+              "option:agentRegistry.executionHealth.retentionSummary",
+              "Retention {{sessionDays}}d sessions / {{auditDays}}d audit",
+              {
+                sessionDays: summary.retention.session_retention_days,
+                auditDays: summary.retention.audit_retention_days
+              }
+            )}
           </div>
           <div className="mt-2 text-xs text-muted-foreground">
             {redactionEnabled
-              ? "Redacted drill-through enabled"
-              : "Review redaction settings"}
+              ? t(
+                  "option:agentRegistry.executionHealth.redactedDrillThroughEnabled",
+                  "Redacted drill-through enabled"
+                )
+              : t(
+                  "option:agentRegistry.executionHealth.reviewRedactionSettings",
+                  "Review redaction settings"
+                )}
           </div>
         </div>
       </div>
@@ -438,7 +620,10 @@ const ExecutionHealthSummary: React.FC<{
       <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
         <div className="rounded-lg border border-border p-3">
           <div className="mb-2 text-xs font-medium text-muted-foreground">
-            Failure buckets
+            {t(
+              "option:agentRegistry.executionHealth.failureBucketsTitle",
+              "Failure buckets"
+            )}
           </div>
           {failureEntries.length > 0 ? (
             <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
@@ -453,13 +638,18 @@ const ExecutionHealthSummary: React.FC<{
               ))}
             </div>
           ) : (
-            <div className="text-sm text-muted-foreground">No recent failure buckets</div>
+            <div className="text-sm text-muted-foreground">
+              {t(
+                "option:agentRegistry.executionHealth.noRecentFailureBuckets",
+                "No recent failure buckets"
+              )}
+            </div>
           )}
         </div>
 
         <div className="rounded-lg border border-border p-3">
           <div className="mb-2 text-xs font-medium text-muted-foreground">
-            Setup health
+            {t("option:agentRegistry.executionHealth.setupHealthTitle", "Setup health")}
           </div>
           {setupEntries.length > 0 ? (
             <div className="space-y-2">
@@ -467,15 +657,31 @@ const ExecutionHealthSummary: React.FC<{
                 <div key={entry.key} className="rounded border border-border px-2 py-1.5 text-sm">
                   <div className="flex flex-wrap items-center gap-2">
                     <DSBadge variant={entry.status === "blocked" ? "danger" : "warning"}>
-                      {entry.label} {entry.status}
+                      {t(
+                        "option:agentRegistry.executionHealth.setupStatus",
+                        "{{label}} {{status}}",
+                        { label: entry.label, status: entry.status }
+                      )}
                     </DSBadge>
                     <span className="text-xs text-muted-foreground">
-                      {entry.evidenceCount} evidence
+                      {t(
+                        "option:agentRegistry.executionHealth.evidenceCount",
+                        "{{count}} evidence",
+                        { count: entry.evidenceCount }
+                      )}
                     </span>
                   </div>
                   {entry.blockers.length > 0 && (
                     <div className="mt-1 text-xs text-muted-foreground">
-                      {entry.label} {entry.status}: {entry.blockers.join(", ")}
+                      {t(
+                        "option:agentRegistry.executionHealth.setupBlockers",
+                        "{{label}} {{status}}: {{blockers}}",
+                        {
+                          label: entry.label,
+                          status: entry.status,
+                          blockers: entry.blockers.join(", ")
+                        }
+                      )}
                     </div>
                   )}
                 </div>
@@ -483,7 +689,10 @@ const ExecutionHealthSummary: React.FC<{
             </div>
           ) : (
             <div className="text-sm text-muted-foreground">
-              No setup blockers in this window
+              {t(
+                "option:agentRegistry.executionHealth.noSetupBlockers",
+                "No setup blockers in this window"
+              )}
             </div>
           )}
         </div>

--- a/apps/packages/ui/src/components/Option/AgentRegistry/index.tsx
+++ b/apps/packages/ui/src/components/Option/AgentRegistry/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useCallback, useMemo } from "react"
 import { useTranslation } from "react-i18next"
-import { Alert, Button, Card, Spin, Tag, Tooltip, Empty, Badge } from "antd"
+import { Button, Card, Spin, Tag, Tooltip, Empty, Badge } from "antd"
 import {
   Bot,
   CheckCircle,
@@ -10,14 +10,44 @@ import {
   Play,
   Settings,
   Heart,
+  Activity,
 } from "lucide-react"
+import { Alert as DSAlert, Badge as DSBadge } from "@/components/ui/primitives"
 import { useCanonicalConnectionConfig } from "@/hooks/useCanonicalConnectionConfig"
 import { ACPRestClient } from "@/services/acp/client"
 import { buildACPAuthHeaders, buildACPClientConfig } from "@/services/acp/connection"
 import { normalizeACPHealthStatus, type ACPHealthStatus } from "@/services/acp/readiness"
-import type { ACPSupportState, ACPVerificationLevel } from "@/services/acp/types"
+import type {
+  ACPExecutionHealthFailureBuckets,
+  ACPExecutionHealthSetupSummary,
+  ACPExecutionHealthSummaryResponse,
+  ACPSupportState,
+  ACPVerificationLevel
+} from "@/services/acp/types"
 import { resolveBrowserRequestTransport } from "@/services/tldw/request-core"
 import { DESIGN_SYSTEM_STATES, getDesignSystemState, type DesignSystemStateKey } from "@/design-system"
+
+const ACP_EXECUTION_HEALTH_SUMMARY_PATH =
+  "/api/v1/admin/acp/execution-health/summary?range_days=30"
+
+const FAILURE_BUCKET_LABELS: Array<[keyof ACPExecutionHealthFailureBuckets, string]> = [
+  ["setup_blockers", "Setup blockers"],
+  ["runner_session_failures", "Runner/session failures"],
+  ["reviewer_rejections", "Reviewer rejections"],
+  ["reviewer_failures", "Reviewer failures"],
+  ["governance_denials", "Governance denials"],
+  ["structured_completion_failures", "Structured completion failures"],
+  ["sandbox_runtime_errors", "Sandbox runtime errors"],
+  ["retention_redaction_actions", "Retention/redaction actions"]
+]
+
+const SETUP_DIMENSION_LABELS: Record<keyof ACPExecutionHealthSetupSummary, string> = {
+  agent: "Agent",
+  workspace: "Workspace",
+  sandbox_runtime: "Sandbox runtime",
+  mcp_injection: "MCP injection",
+  scheduler_trigger_path: "Scheduler trigger path"
+}
 type AgentEntry = {
   type: string
   name: string
@@ -45,8 +75,11 @@ export const AgentRegistryPage: React.FC = () => {
 
   const [agents, setAgents] = useState<AgentEntry[]>([])
   const [health, setHealth] = useState<ACPHealthStatus | null>(null)
+  const [executionHealth, setExecutionHealth] =
+    useState<ACPExecutionHealthSummaryResponse | null>(null)
   const [loading, setLoading] = useState(true)
   const [healthLoading, setHealthLoading] = useState(true)
+  const [executionHealthLoading, setExecutionHealthLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
   const restClient = useMemo(
@@ -54,6 +87,14 @@ export const AgentRegistryPage: React.FC = () => {
       connectionConfig
         ? new ACPRestClient(buildACPClientConfig(connectionConfig))
         : null,
+    [connectionConfig]
+  )
+
+  const getACPHeaders = useCallback(
+    (transport: { mode: string }) =>
+      transport.mode === "hosted"
+        ? { "Content-Type": "application/json" }
+        : buildACPAuthHeaders(connectionConfig, { includeContentType: true }),
     [connectionConfig]
   )
 
@@ -90,11 +131,7 @@ export const AgentRegistryPage: React.FC = () => {
         config: connectionConfig,
         path: "/api/v1/acp/health"
       })
-      const headers =
-        transport.mode === "hosted"
-          ? { "Content-Type": "application/json" }
-          : buildACPAuthHeaders(connectionConfig, { includeContentType: true })
-      const res = await fetch(transport.url, { headers })
+      const res = await fetch(transport.url, { headers: getACPHeaders(transport) })
       if (res.ok) {
         setHealth(normalizeACPHealthStatus(await res.json()))
       } else {
@@ -106,13 +143,36 @@ export const AgentRegistryPage: React.FC = () => {
     } finally {
       setHealthLoading(false)
     }
-  }, [connectionConfig])
+  }, [connectionConfig, getACPHeaders])
+
+  const fetchExecutionHealth = useCallback(async () => {
+    if (!connectionConfig) return
+    setExecutionHealthLoading(true)
+    try {
+      const transport = resolveBrowserRequestTransport({
+        config: connectionConfig,
+        path: ACP_EXECUTION_HEALTH_SUMMARY_PATH
+      })
+      const res = await fetch(transport.url, { headers: getACPHeaders(transport) })
+      if (res.ok) {
+        setExecutionHealth(await res.json())
+      } else {
+        setExecutionHealth(null)
+      }
+    } catch {
+      // The admin summary can be permission-gated; keep the registry usable.
+      setExecutionHealth(null)
+    } finally {
+      setExecutionHealthLoading(false)
+    }
+  }, [connectionConfig, getACPHeaders])
 
   useEffect(() => {
     if (!connectionConfig) return
     void fetchAgents()
     void fetchHealth()
-  }, [connectionConfig, fetchAgents, fetchHealth])
+    void fetchExecutionHealth()
+  }, [connectionConfig, fetchAgents, fetchHealth, fetchExecutionHealth])
 
   const statusIcon = (status: string) => {
     switch (status) {
@@ -158,6 +218,7 @@ export const AgentRegistryPage: React.FC = () => {
             icon={<RefreshCw className="h-3.5 w-3.5" />}
             onClick={() => {
               void fetchHealth()
+              void fetchExecutionHealth()
               void fetchAgents()
             }}
           >
@@ -194,21 +255,41 @@ export const AgentRegistryPage: React.FC = () => {
             </div>
           </div>
         ) : (
-          <Alert
-            type="warning"
-            message="Health check unavailable"
-            description="Could not reach the ACP health endpoint. Ensure the server is running."
-            showIcon
-          />
+          <DSAlert variant="warning" title="Health check unavailable">
+            Could not reach the ACP health endpoint. Ensure the server is running.
+          </DSAlert>
         )}
         {health?.details && (
           <div className="mt-2 text-xs text-muted-foreground">{health.details}</div>
         )}
       </Card>
 
+      <Card
+        title={
+          <span className="flex items-center gap-2">
+            <Activity className="h-4 w-4" />
+            ACP Execution Health
+          </span>
+        }
+      >
+        {executionHealthLoading ? (
+          <div className="flex justify-center py-4">
+            <Spin size="small" />
+          </div>
+        ) : executionHealth ? (
+          <ExecutionHealthSummary summary={executionHealth} />
+        ) : (
+          <DSAlert variant="warning" title="Execution health summary unavailable">
+            The admin summary endpoint may require newer backend support or elevated permissions.
+          </DSAlert>
+        )}
+      </Card>
+
       {/* Error */}
       {error && (
-        <Alert type="error" message={error} closable onClose={() => setError(null)} />
+        <DSAlert variant="error" title={error} dismissible onDismiss={() => setError(null)}>
+          Agent registry could not load.
+        </DSAlert>
       )}
 
       {/* Agent List */}
@@ -240,6 +321,173 @@ export const AgentRegistryPage: React.FC = () => {
           </div>
         )}
       </Card>
+    </div>
+  )
+}
+
+const ExecutionHealthSummary: React.FC<{
+  summary: ACPExecutionHealthSummaryResponse
+}> = ({ summary }) => {
+  const sessionStatusEntries = Object.entries(summary.sessions.by_status ?? {})
+    .filter(([, count]) => count > 0)
+    .sort(([left], [right]) => left.localeCompare(right))
+
+  const failureEntries = FAILURE_BUCKET_LABELS
+    .map(([key, label]) => ({
+      key,
+      label,
+      count: summary.failure_buckets[key] ?? 0
+    }))
+    .filter((entry) => entry.count > 0)
+
+  const setupEntries = (Object.entries(summary.setup_health) as Array<
+    [
+      keyof ACPExecutionHealthSetupSummary,
+      ACPExecutionHealthSetupSummary[keyof ACPExecutionHealthSetupSummary]
+    ]
+  >)
+    .filter(([, dimension]) => {
+      return (
+        dimension.status === "blocked" ||
+        dimension.status === "degraded" ||
+        dimension.blockers.length > 0
+      )
+    })
+    .map(([key, dimension]) => ({
+      key,
+      label: SETUP_DIMENSION_LABELS[key],
+      status: dimension.status,
+      blockers: dimension.blockers,
+      evidenceCount: dimension.evidence_count
+    }))
+
+  const unverifiedAgents = summary.compatibility.documented_unverified_agents ?? []
+  const redactionEnabled =
+    summary.redaction.detail_events_artifacts_redacted_views &&
+    summary.redaction.diagnostics_sanitized &&
+    summary.redaction.audit_metadata_sanitized
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+        <div className="rounded-lg border border-border p-3">
+          <div className="text-xs text-muted-foreground">Sessions</div>
+          <div className="text-base font-medium">
+            {summary.sessions.total} sessions in {summary.range_days}d
+          </div>
+          <div className="mt-2 flex flex-wrap gap-1">
+            {sessionStatusEntries.length > 0 ? (
+              sessionStatusEntries.map(([status, count]) => (
+                <DSBadge key={status} variant="secondary">{count} {status}</DSBadge>
+              ))
+            ) : (
+              <span className="text-xs text-muted-foreground">No sessions recorded</span>
+            )}
+          </div>
+        </div>
+
+        <div className="rounded-lg border border-border p-3">
+          <div className="text-xs text-muted-foreground">Compatibility</div>
+          <div className="mt-1 flex flex-wrap gap-1">
+            {summary.compatibility.live_certification_required ? (
+              <DSBadge variant="warning">Live certification required</DSBadge>
+            ) : (
+              <DSBadge variant="success">No live-certification blocker</DSBadge>
+            )}
+            {Object.entries(summary.compatibility.by_support_state ?? {}).map(
+              ([state, count]) => (
+                <DSBadge key={state} variant="secondary">{count} {state}</DSBadge>
+              )
+            )}
+          </div>
+          {unverifiedAgents.length > 0 ? (
+            <div className="mt-2 text-xs text-yellow-700 dark:text-yellow-400">
+              Unverified agents: {unverifiedAgents.join(", ")}
+            </div>
+          ) : (
+            <div className="mt-2 text-xs text-muted-foreground">
+              No documented-unverified agents
+            </div>
+          )}
+          {summary.compatibility.docs_url && (
+            <a
+              className="mt-2 inline-block text-xs text-primary hover:underline"
+              href={summary.compatibility.docs_url}
+              target="_blank"
+              rel="noreferrer"
+            >
+              Execution evidence docs
+            </a>
+          )}
+        </div>
+
+        <div className="rounded-lg border border-border p-3">
+          <div className="text-xs text-muted-foreground">Retention and redaction</div>
+          <div className="mt-1 text-sm">
+            Retention {summary.retention.session_retention_days}d sessions /{" "}
+            {summary.retention.audit_retention_days}d audit
+          </div>
+          <div className="mt-2 text-xs text-muted-foreground">
+            {redactionEnabled
+              ? "Redacted drill-through enabled"
+              : "Review redaction settings"}
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+        <div className="rounded-lg border border-border p-3">
+          <div className="mb-2 text-xs font-medium text-muted-foreground">
+            Failure buckets
+          </div>
+          {failureEntries.length > 0 ? (
+            <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+              {failureEntries.map((entry) => (
+                <div
+                  key={entry.key}
+                  className="flex items-center justify-between rounded border border-border px-2 py-1.5 text-sm"
+                >
+                  <span>{entry.label}</span>
+                  <DSBadge variant="warning">{entry.count}</DSBadge>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="text-sm text-muted-foreground">No recent failure buckets</div>
+          )}
+        </div>
+
+        <div className="rounded-lg border border-border p-3">
+          <div className="mb-2 text-xs font-medium text-muted-foreground">
+            Setup health
+          </div>
+          {setupEntries.length > 0 ? (
+            <div className="space-y-2">
+              {setupEntries.map((entry) => (
+                <div key={entry.key} className="rounded border border-border px-2 py-1.5 text-sm">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <DSBadge variant={entry.status === "blocked" ? "danger" : "warning"}>
+                      {entry.label} {entry.status}
+                    </DSBadge>
+                    <span className="text-xs text-muted-foreground">
+                      {entry.evidenceCount} evidence
+                    </span>
+                  </div>
+                  {entry.blockers.length > 0 && (
+                    <div className="mt-1 text-xs text-muted-foreground">
+                      {entry.label} {entry.status}: {entry.blockers.join(", ")}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="text-sm text-muted-foreground">
+              No setup blockers in this window
+            </div>
+          )}
+        </div>
+      </div>
     </div>
   )
 }

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/WorkspaceACPHistoryModal.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/WorkspaceACPHistoryModal.tsx
@@ -1,9 +1,10 @@
 import React from "react"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
-import { Alert, Button, Empty, Modal, Spin, Tag } from "antd"
+import { Button, Empty, Modal, Spin, Tag } from "antd"
 import { ExternalLink } from "lucide-react"
 
+import { Alert as DSAlert } from "@/components/ui/primitives"
 import { useCanonicalConnectionConfig } from "@/hooks/useCanonicalConnectionConfig"
 import { buildACPAuthHeaders } from "@/services/acp/connection"
 import {
@@ -408,15 +409,15 @@ export const WorkspaceACPHistoryModal: React.FC<
         )}
 
         {!loading && error && (
-          <Alert
-            type="error"
-            showIcon
+          <DSAlert
+            variant="error"
             title={t(
               "playground:workspace.acpRunHistoryLoadFailed",
               "Could not load ACP run history"
             )}
-            description={errorDescription}
-          />
+          >
+            {errorDescription}
+          </DSAlert>
         )}
 
         {!loading && !error && entries.length === 0 && (

--- a/apps/packages/ui/src/services/acp/readiness.ts
+++ b/apps/packages/ui/src/services/acp/readiness.ts
@@ -1,3 +1,18 @@
+import type {
+  ACPExecutionHealthAgentSummary,
+  ACPExecutionHealthCompatibilitySummary,
+  ACPExecutionHealthFailureBuckets,
+  ACPExecutionHealthRedactionSummary,
+  ACPExecutionHealthRetentionSummary,
+  ACPExecutionHealthSessionSummary,
+  ACPExecutionHealthSetupDimension,
+  ACPExecutionHealthSetupSummary,
+  ACPExecutionHealthSummaryResponse,
+  ACPSetupHealthStatus,
+  ACPSupportState,
+  ACPVerificationLevel
+} from "./types"
+
 export type ACPHealthStatus = {
   runner: string
   agent: string
@@ -12,6 +27,100 @@ export type ACPSetupIssue = {
 }
 
 const OK_STATUSES = new Set(["ok", "available", "healthy", "degraded"])
+
+const ACP_SETUP_HEALTH_STATUSES: ReadonlySet<ACPSetupHealthStatus> = new Set([
+  "ok",
+  "degraded",
+  "blocked",
+  "unknown"
+])
+
+const ACP_SUPPORT_STATES: ReadonlySet<ACPSupportState> = new Set([
+  "supported",
+  "supported_with_caveats",
+  "experimental",
+  "documented_unverified",
+  "unsupported"
+])
+
+const ACP_VERIFICATION_LEVELS: ReadonlySet<ACPVerificationLevel> = new Set([
+  "documented_only",
+  "stub_smoke_tested",
+  "live_e2e_tested",
+  "sandbox_tested",
+  "production_supported"
+])
+
+const ACP_COMPATIBILITY_DOCS_URL = "/docs-static/Development/ACP_Compatibility_Matrix.md"
+
+const FAILURE_BUCKET_KEYS: Array<keyof ACPExecutionHealthFailureBuckets> = [
+  "setup_blockers",
+  "runner_session_failures",
+  "reviewer_rejections",
+  "reviewer_failures",
+  "governance_denials",
+  "structured_completion_failures",
+  "sandbox_runtime_errors",
+  "retention_redaction_actions"
+]
+
+const SETUP_DIMENSION_KEYS: Array<keyof ACPExecutionHealthSetupSummary> = [
+  "agent",
+  "workspace",
+  "sandbox_runtime",
+  "mcp_injection",
+  "scheduler_trigger_path"
+]
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === "object" && !Array.isArray(value)
+
+const numberOrDefault = (value: unknown, fallback = 0): number =>
+  typeof value === "number" && Number.isFinite(value) ? Math.max(0, Math.trunc(value)) : fallback
+
+const booleanOrDefault = (value: unknown, fallback = false): boolean =>
+  typeof value === "boolean" ? value : fallback
+
+const stringOrDefault = (value: unknown, fallback = ""): string =>
+  typeof value === "string" ? value : fallback
+
+const stringListOrDefault = (value: unknown): string[] =>
+  Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : []
+
+const numberRecordOrDefault = (
+  value: unknown,
+  allowedKeys?: ReadonlySet<string>
+): Record<string, number> => {
+  if (!isRecord(value)) {
+    return {}
+  }
+
+  const counts: Record<string, number> = {}
+  for (const [key, count] of Object.entries(value)) {
+    if (allowedKeys && !allowedKeys.has(key)) {
+      continue
+    }
+    if (typeof count === "number" && Number.isFinite(count)) {
+      counts[key] = Math.max(0, Math.trunc(count))
+    }
+  }
+  return counts
+}
+
+const normalizeSetupHealthStatus = (value: unknown): ACPSetupHealthStatus =>
+  typeof value === "string" && ACP_SETUP_HEALTH_STATUSES.has(value as ACPSetupHealthStatus)
+    ? (value as ACPSetupHealthStatus)
+    : "unknown"
+
+const normalizeSupportState = (value: unknown): ACPSupportState =>
+  typeof value === "string" && ACP_SUPPORT_STATES.has(value as ACPSupportState)
+    ? (value as ACPSupportState)
+    : "documented_unverified"
+
+const normalizeVerificationLevel = (value: unknown): ACPVerificationLevel =>
+  typeof value === "string" && ACP_VERIFICATION_LEVELS.has(value as ACPVerificationLevel)
+    ? (value as ACPVerificationLevel)
+    : "documented_only"
 
 const formatHealthDetails = (
   message: unknown,
@@ -85,6 +194,149 @@ export const normalizeACPHealthStatus = (payload: unknown): ACPHealthStatus | nu
             : "degraded",
     api_keys: missingApiKeys ? "missing" : "ok",
     details: formatHealthDetails(record.message, runner, availableAgents, agents.length)
+  }
+}
+
+const normalizeExecutionHealthSessions = (
+  value: unknown
+): ACPExecutionHealthSessionSummary => {
+  const record = isRecord(value) ? value : {}
+  return {
+    total: numberOrDefault(record.total),
+    by_status: numberRecordOrDefault(record.by_status)
+  }
+}
+
+const normalizeExecutionHealthFailureBuckets = (
+  value: unknown
+): ACPExecutionHealthFailureBuckets => {
+  const record = isRecord(value) ? value : {}
+  return Object.fromEntries(
+    FAILURE_BUCKET_KEYS.map((key) => [key, numberOrDefault(record[key])])
+  ) as unknown as ACPExecutionHealthFailureBuckets
+}
+
+const normalizeExecutionHealthSetupDimension = (
+  value: unknown
+): ACPExecutionHealthSetupDimension => {
+  const record = isRecord(value) ? value : {}
+  return {
+    status: normalizeSetupHealthStatus(record.status),
+    blockers: stringListOrDefault(record.blockers),
+    evidence_count: numberOrDefault(record.evidence_count)
+  }
+}
+
+const normalizeExecutionHealthSetupSummary = (
+  value: unknown
+): ACPExecutionHealthSetupSummary => {
+  const record = isRecord(value) ? value : {}
+  return Object.fromEntries(
+    SETUP_DIMENSION_KEYS.map((key) => [
+      key,
+      normalizeExecutionHealthSetupDimension(record[key])
+    ])
+  ) as unknown as ACPExecutionHealthSetupSummary
+}
+
+const normalizeExecutionHealthAgent = (
+  value: unknown
+): ACPExecutionHealthAgentSummary | null => {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  const agentType = stringOrDefault(value.agent_type)
+  if (!agentType) {
+    return null
+  }
+
+  return {
+    agent_type: agentType,
+    name: stringOrDefault(value.name),
+    is_configured: booleanOrDefault(value.is_configured),
+    support_state: normalizeSupportState(value.support_state),
+    verification_level: normalizeVerificationLevel(value.verification_level),
+    setup_blocked: booleanOrDefault(value.setup_blocked),
+    primary_blocker:
+      typeof value.primary_blocker === "string" ? value.primary_blocker : null
+  }
+}
+
+const normalizeExecutionHealthAgents = (
+  value: unknown
+): ACPExecutionHealthAgentSummary[] =>
+  Array.isArray(value)
+    ? value
+        .map(normalizeExecutionHealthAgent)
+        .filter((agent): agent is ACPExecutionHealthAgentSummary => Boolean(agent))
+    : []
+
+const normalizeExecutionHealthCompatibility = (
+  value: unknown
+): ACPExecutionHealthCompatibilitySummary => {
+  const record = isRecord(value) ? value : {}
+  return {
+    by_support_state: numberRecordOrDefault(record.by_support_state, ACP_SUPPORT_STATES),
+    documented_unverified_agents: stringListOrDefault(record.documented_unverified_agents),
+    live_certification_required: booleanOrDefault(record.live_certification_required),
+    docs_url: stringOrDefault(record.docs_url, ACP_COMPATIBILITY_DOCS_URL)
+  }
+}
+
+const normalizeExecutionHealthRetention = (
+  value: unknown
+): ACPExecutionHealthRetentionSummary => {
+  const record = isRecord(value) ? value : {}
+  return {
+    session_retention_days: numberOrDefault(record.session_retention_days, 30),
+    audit_retention_days: numberOrDefault(record.audit_retention_days, 30),
+    policy: stringOrDefault(
+      record.policy,
+      "closed_error_sessions_and_audit_events_purged_after_retention"
+    )
+  }
+}
+
+const normalizeExecutionHealthRedaction = (
+  value: unknown
+): ACPExecutionHealthRedactionSummary => {
+  const record = isRecord(value) ? value : {}
+  return {
+    detail_events_artifacts_redacted_views: booleanOrDefault(
+      record.detail_events_artifacts_redacted_views
+    ),
+    diagnostics_sanitized: booleanOrDefault(record.diagnostics_sanitized),
+    audit_metadata_sanitized: booleanOrDefault(record.audit_metadata_sanitized)
+  }
+}
+
+export const normalizeACPExecutionHealthSummary = (
+  payload: unknown
+): ACPExecutionHealthSummaryResponse | null => {
+  if (!isRecord(payload)) {
+    return null
+  }
+  if (
+    typeof payload.timestamp !== "string" ||
+    payload.timestamp.trim().length === 0 ||
+    typeof payload.range_days !== "number" ||
+    !Number.isFinite(payload.range_days) ||
+    payload.range_days < 0
+  ) {
+    return null
+  }
+
+  return {
+    timestamp: stringOrDefault(payload.timestamp),
+    range_days: numberOrDefault(payload.range_days),
+    sessions: normalizeExecutionHealthSessions(payload.sessions),
+    failure_buckets: normalizeExecutionHealthFailureBuckets(payload.failure_buckets),
+    setup_health: normalizeExecutionHealthSetupSummary(payload.setup_health),
+    agents: normalizeExecutionHealthAgents(payload.agents),
+    compatibility: normalizeExecutionHealthCompatibility(payload.compatibility),
+    retention: normalizeExecutionHealthRetention(payload.retention),
+    redaction: normalizeExecutionHealthRedaction(payload.redaction)
   }
 }
 

--- a/apps/packages/ui/src/services/acp/types.ts
+++ b/apps/packages/ui/src/services/acp/types.ts
@@ -23,6 +23,8 @@ export type ACPVerificationLevel =
   | "sandbox_tested"
   | "production_supported"
 
+export type ACPSetupHealthStatus = "ok" | "degraded" | "blocked" | "unknown"
+
 export interface ACPAgentInfo {
   type: ACPAgentType
   name: string
@@ -38,6 +40,77 @@ export interface ACPAgentInfo {
 export interface ACPAgentListResponse {
   agents: ACPAgentInfo[]
   default_agent: ACPAgentType
+}
+
+export interface ACPExecutionHealthSessionSummary {
+  total: number
+  by_status: Record<string, number>
+}
+
+export interface ACPExecutionHealthFailureBuckets {
+  setup_blockers: number
+  runner_session_failures: number
+  reviewer_rejections: number
+  reviewer_failures: number
+  governance_denials: number
+  structured_completion_failures: number
+  sandbox_runtime_errors: number
+  retention_redaction_actions: number
+}
+
+export interface ACPExecutionHealthSetupDimension {
+  status: ACPSetupHealthStatus
+  blockers: string[]
+  evidence_count: number
+}
+
+export interface ACPExecutionHealthSetupSummary {
+  agent: ACPExecutionHealthSetupDimension
+  workspace: ACPExecutionHealthSetupDimension
+  sandbox_runtime: ACPExecutionHealthSetupDimension
+  mcp_injection: ACPExecutionHealthSetupDimension
+  scheduler_trigger_path: ACPExecutionHealthSetupDimension
+}
+
+export interface ACPExecutionHealthAgentSummary {
+  agent_type: string
+  name: string
+  is_configured: boolean
+  support_state: ACPSupportState
+  verification_level: ACPVerificationLevel
+  setup_blocked: boolean
+  primary_blocker?: string | null
+}
+
+export interface ACPExecutionHealthCompatibilitySummary {
+  by_support_state: Record<string, number>
+  documented_unverified_agents: string[]
+  live_certification_required: boolean
+  docs_url: string
+}
+
+export interface ACPExecutionHealthRetentionSummary {
+  session_retention_days: number
+  audit_retention_days: number
+  policy: string
+}
+
+export interface ACPExecutionHealthRedactionSummary {
+  detail_events_artifacts_redacted_views: boolean
+  diagnostics_sanitized: boolean
+  audit_metadata_sanitized: boolean
+}
+
+export interface ACPExecutionHealthSummaryResponse {
+  timestamp: string
+  range_days: number
+  sessions: ACPExecutionHealthSessionSummary
+  failure_buckets: ACPExecutionHealthFailureBuckets
+  setup_health: ACPExecutionHealthSetupSummary
+  agents: ACPExecutionHealthAgentSummary[]
+  compatibility: ACPExecutionHealthCompatibilitySummary
+  retention: ACPExecutionHealthRetentionSummary
+  redaction: ACPExecutionHealthRedactionSummary
 }
 
 // -----------------------------------------------------------------------------

--- a/backlog/tasks/task-330 - Surface-ACP-execution-health-summary-in-Agent-Registry.md
+++ b/backlog/tasks/task-330 - Surface-ACP-execution-health-summary-in-Agent-Registry.md
@@ -1,0 +1,60 @@
+---
+id: TASK-330
+title: Surface ACP execution health summary in Agent Registry
+status: Done
+assignee: []
+created_date: '2026-05-14 02:18'
+updated_date: '2026-05-14 02:31'
+labels:
+  - ACP
+  - admin
+  - frontend
+  - reporting
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1537'
+  - 'https://github.com/rmusser01/tldw_server/issues/1532'
+  - 'https://github.com/rmusser01/tldw_server/pull/1648'
+documentation:
+  - Docs/Development/Agent_Client_Protocol.md
+  - Docs/Product/ACP_Agent_Orchestration_PRD.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Expose the ACP execution-health summary contract from issue #1537 in the Agent Registry/admin setup surface so operators can see recent session totals, failures, setup-health dimensions, retention/redaction state, and compatibility warnings without digging through raw API responses.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Agent Registry fetches the ACP execution-health summary using the backend admin contract and supports the same direct/proxy transport behavior as existing ACP health calls.
+- [x] #2 The UI summarizes session totals, completion/failure counts, recent failure categories, setup-health dimensions, retention/redaction metadata, and compatibility warnings without claiming unsupported agent certification.
+- [x] #3 Unavailable, unauthorized, or failed summary fetches degrade gracefully without blocking the existing registry health view.
+- [x] #4 Focused frontend tests cover representative summary rendering and failure handling.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+TDD checkpoint: added failing Agent Registry coverage for the admin ACP execution-health summary transport/rendering and unavailable-summary behavior; implemented the summary fetch/UI; focused Vitest is now green.
+
+Verification: ./node_modules/.bin/vitest run src/components/Option/AgentRegistry/__tests__/AgentRegistryPage.connection.test.tsx --maxWorkers=1 --no-file-parallelism passed; bun run verify:design-system-state passed; git diff --check passed. Full package tsc --noEmit -p tsconfig.json still fails on existing repo-wide TypeScript baseline errors outside this slice; no Python touched, so Bandit is not applicable.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the ACP admin execution-health summary display in Agent Registry, backed by the existing browser transport/auth helpers and typed frontend models for the backend summary contract. Added focused tests for direct/proxy summary fetches, representative summary rendering, compatibility warnings, and graceful unavailable-summary handling. Also migrated the touched Agent Registry and ACP history error alerts to design-system primitives and removed stale product-state baseline entries.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-334 - Address-PR-1654-ACP-execution-health-review-comments.md
+++ b/backlog/tasks/task-334 - Address-PR-1654-ACP-execution-health-review-comments.md
@@ -1,0 +1,48 @@
+---
+id: TASK-334
+title: Address PR 1654 ACP execution-health review comments
+status: In Progress
+assignee: []
+created_date: '2026-05-14 04:29'
+labels:
+  - acp
+  - webui
+  - review-fix
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1654'
+  - 'https://github.com/rmusser01/tldw_server/issues/1537'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the actionable review feedback on PR #1654 for the ACP Agent Registry execution-health UI. The review feedback calls out missing runtime validation for the admin execution-health summary payload, hardcoded user-facing strings in the new execution-health UI/alerts, raw error text used as an alert title, and avoidable per-render recalculation in the summary component.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Execution-health summary responses are normalized or rejected before rendering so malformed/partial payloads do not crash the Agent Registry page.
+- [ ] #2 New Agent Registry execution-health labels and reviewed alerts are resolved through the existing translation fallback pattern rather than hardcoded directly in JSX.
+- [ ] #3 The Agent Registry load error alert uses a stable localized title and places the raw error detail in the alert body.
+- [ ] #4 ExecutionHealthSummary memoizes derived summary rows and booleans that are otherwise recalculated on every render.
+- [ ] #5 Focused tests cover malformed or partial execution-health summary payloads and existing execution-health rendering behavior.
+- [ ] #6 Actionable PR review threads are resolved or replied to after the fix is pushed, and verification results are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused regression tests for malformed and partial execution-health summary payloads. 2. Add a runtime normalizer for admin execution-health summary payloads and use it before updating component state. 3. Move reviewed Agent Registry execution-health strings through the existing t(..., fallback) pattern, fix the raw-error alert title, and memoize derived summary rows. 4. Run focused UI tests plus lightweight hygiene checks, push the review-fix commit, and resolve the actionable PR threads.
+<!-- SECTION:PLAN:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-334 - Address-PR-1654-ACP-execution-health-review-comments.md
+++ b/backlog/tasks/task-334 - Address-PR-1654-ACP-execution-health-review-comments.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-334
 title: Address PR 1654 ACP execution-health review comments
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-14 04:29'
+updated_date: '2026-05-14 04:33'
 labels:
   - acp
   - webui
@@ -23,12 +24,12 @@ Resolve the actionable review feedback on PR #1654 for the ACP Agent Registry ex
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Execution-health summary responses are normalized or rejected before rendering so malformed/partial payloads do not crash the Agent Registry page.
-- [ ] #2 New Agent Registry execution-health labels and reviewed alerts are resolved through the existing translation fallback pattern rather than hardcoded directly in JSX.
-- [ ] #3 The Agent Registry load error alert uses a stable localized title and places the raw error detail in the alert body.
-- [ ] #4 ExecutionHealthSummary memoizes derived summary rows and booleans that are otherwise recalculated on every render.
-- [ ] #5 Focused tests cover malformed or partial execution-health summary payloads and existing execution-health rendering behavior.
-- [ ] #6 Actionable PR review threads are resolved or replied to after the fix is pushed, and verification results are recorded.
+- [x] #1 Execution-health summary responses are normalized or rejected before rendering so malformed/partial payloads do not crash the Agent Registry page.
+- [x] #2 New Agent Registry execution-health labels and reviewed alerts are resolved through the existing translation fallback pattern rather than hardcoded directly in JSX.
+- [x] #3 The Agent Registry load error alert uses a stable localized title and places the raw error detail in the alert body.
+- [x] #4 ExecutionHealthSummary memoizes derived summary rows and booleans that are otherwise recalculated on every render.
+- [x] #5 Focused tests cover malformed or partial execution-health summary payloads and existing execution-health rendering behavior.
+- [x] #6 Actionable PR review threads are resolved or replied to after the fix is pushed, and verification results are recorded.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -37,12 +38,24 @@ Resolve the actionable review feedback on PR #1654 for the ACP Agent Registry ex
 1. Add focused regression tests for malformed and partial execution-health summary payloads. 2. Add a runtime normalizer for admin execution-health summary payloads and use it before updating component state. 3. Move reviewed Agent Registry execution-health strings through the existing t(..., fallback) pattern, fix the raw-error alert title, and memoize derived summary rows. 4. Run focused UI tests plus lightweight hygiene checks, push the review-fix commit, and resolve the actionable PR threads.
 <!-- SECTION:PLAN:END -->
 
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verification: bunx vitest run src/components/Option/AgentRegistry/__tests__/AgentRegistryPage.connection.test.tsx passed with 9 tests; git diff --check passed; bun run verify:design-system-state passed with existing baseline exceptions; bunx tsc --noEmit --pretty false still fails on existing repo-wide type baseline issues outside the touched Agent Registry/readiness files. Bandit skipped because this task touched only TypeScript/JSON/Backlog files.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed PR #1654 review feedback by adding runtime normalization for ACP execution-health summary payloads, fail-closed handling for malformed top-level summaries, safe defaults for nullable nested sections, localized Agent Registry execution-health strings, a stable load-error alert title with raw error details in the body, and memoization for derived summary rows. Added focused regression coverage for unavailable, malformed, and partial summary payloads. Resolved all actionable Gemini/Qodo review threads after pushing commit b93584d3d.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
## Change summary

TODO: Human requester must replace this before merge per the AI-generated PR change-summary policy.

## Implementation notes

- Refs #1537 and #1532.
- Surfaced `/api/v1/admin/acp/execution-health/summary?range_days=30` in Agent Registry using the same browser transport and ACP auth headers as the existing health check.
- Added frontend ACP execution-health response types that mirror the backend contract.
- Rendered recent session totals/statuses, failure buckets, setup-health blockers, compatibility evidence, retention/redaction posture, and live-certification warnings without claiming downstream agent certification.
- Gracefully degrades when the admin summary endpoint is unavailable or permission-gated.
- Migrated the touched Agent Registry and ACP workspace-history error alerts to design-system primitives and removed now-stale product-state baseline exceptions.
- Added Backlog task `TASK-330` for this reviewable slice.

## Verification

- `./node_modules/.bin/vitest run src/components/Option/AgentRegistry/__tests__/AgentRegistryPage.connection.test.tsx --maxWorkers=1 --no-file-parallelism`
- `bun run verify:design-system-state`
- `git diff --check HEAD~1 HEAD`

## Known gap

- `./node_modules/.bin/tsc --noEmit -p tsconfig.json` still fails on existing repo-wide TypeScript baseline errors outside this slice, including unrelated test fixture and route typing issues.
