### PR TITLE
Add VN script authoring graph API

### DIFF
--- a/Docs/API/VN.md
+++ b/Docs/API/VN.md
@@ -200,6 +200,10 @@ Each outline label includes:
 - `terminal`: one of `terminal`, `continues`, or `unknown`.
 - `summary`: compact text for display.
 
+Reachability is derived from the emitted static graph edges. When a response is
+truncated by node or edge limits, labels that would only be reachable through
+omitted edges are reported as unreachable in that partial graph.
+
 `graph` is the detailed layer for advanced clients. It contains label nodes,
 operation nodes, and static edges. Node IDs are deterministic:
 
@@ -237,6 +241,11 @@ conditions such as missing edge targets, unreachable labels, invalid label
 bodies, omitted edge targets, or output truncation. These diagnostics are
 intended to help authoring tools render partial structure from incomplete
 drafts.
+
+When a label could rely on implicit fallthrough to the next label,
+diagnostics include `graph_fallthrough_not_inferred` with the candidate
+`next_label`. Treat this as a static-analysis limitation marker, not a
+validation error.
 
 `validation_diagnostics` come from the VN script validator and remain the
 authoritative publish/runtime compatibility signal. A graph response can be

--- a/Docs/API/VN.md
+++ b/Docs/API/VN.md
@@ -205,7 +205,14 @@ operation nodes, and static edges. Node IDs are deterministic:
 
 - Labels: `label:<percent-encoded-label>`.
 - Operations: `op:<percent-encoded-label>:<zero-based-index>`.
-- Edges: `edge:<source-id>:<edge-type>:<target-id-or-missing-key>`.
+
+Edge IDs are deterministic but opaque API identifiers. They usually include
+the source node, edge type, and target or missing-target key, and they may also
+include disambiguators such as a choice index when multiple static edges share
+the same operation and target. Example:
+`edge:op:start:0:choice:choice:1:label:end`. Clients must use the explicit
+edge fields (`type`, `source_id`, `target_id`, `target_label`,
+`missing_target`, and `metadata`) instead of parsing the edge ID.
 
 Labels are percent-encoded in IDs because raw labels can contain separators
 such as `.`, `:`, `/`, or spaces. Use the `label` field for display. Source

--- a/Docs/API/VN.md
+++ b/Docs/API/VN.md
@@ -87,3 +87,178 @@ version options with generation metadata for custom frontends:
 
 Setup warnings include missing or unavailable generation profile snapshots and
 incompatible generated output schemas.
+
+## Script Authoring Graph
+
+Custom frontends can request a computed authoring graph for VN scripts when
+`GET /api/v1/vn/vn-capabilities` returns:
+
+```json
+{
+  "features": {
+    "script_authoring_graph": true
+  }
+}
+```
+
+The graph API is read-only. It exposes backend-owned script structure without
+executing the script, calling models, mutating drafts, persisting graph
+snapshots, or providing a node-editor implementation.
+
+### Endpoints
+
+- `GET /api/v1/vn/vn-scripts/scripts/{script_id}/draft/graph`
+- `POST /api/v1/vn/vn-scripts/scripts/{script_id}/draft/graph-preview`
+- `GET /api/v1/vn/vn-scripts/scripts/{script_id}/versions/{version_id}/graph`
+
+The draft graph endpoint reads the stored draft and returns
+`source: "stored_draft"` with the stored `base_revision`. It computes live
+validation diagnostics but does not persist them.
+
+The graph-preview endpoint accepts an unsaved draft and computes a graph
+without saving it:
+
+```json
+{
+  "draft_revision": 4,
+  "draft": {
+    "schema_version": "vn_script_program.v1",
+    "entry_label": "start",
+    "labels": {
+      "start": [
+        {"op": "narrate", "text": "Opening."},
+        {"op": "end"}
+      ]
+    }
+  }
+}
+```
+
+Preview responses use `source: "supplied_draft"` and still include the current
+stored `base_revision` for client conflict awareness. A stale
+`draft_revision` can produce a graph warning, but preview remains read-only and
+does not fail like draft mutation endpoints.
+
+The version graph endpoint reads an immutable published script version and
+returns `source: "published_version"` with `version_id`. Version validation
+uses published-version snapshot context when available, reported as
+`validation_context_source: "published_version_snapshot"`.
+
+### Response Envelope
+
+All graph endpoints return the same envelope:
+
+```json
+{
+  "schema_version": "vn_script_authoring_graph.v1",
+  "graph_semantics_version": "vn_script_authoring_graph_edges.v1",
+  "program_schema_version": "vn_script_program.v1",
+  "script_id": 12,
+  "source": "stored_draft",
+  "base_revision": 4,
+  "version_id": null,
+  "content_hash": "sha256:...",
+  "validation_context_source": "current_draft_context",
+  "truncated": false,
+  "limits": {
+    "max_labels": 500,
+    "max_ops": 5000,
+    "max_edges": 10000,
+    "max_supplied_draft_bytes": 1048576
+  },
+  "outline": {"entry_label": "start", "labels": []},
+  "graph": {"nodes": [], "edges": []},
+  "diagnostics": {"errors": [], "warnings": []},
+  "validation_diagnostics": {"valid": true, "errors": [], "warnings": []}
+}
+```
+
+Key fields:
+
+- `schema_version` identifies the response shape.
+- `graph_semantics_version` identifies static edge and reachability rules.
+- `source` is one of `stored_draft`, `supplied_draft`, or
+  `published_version`.
+- `content_hash` is a SHA-256 hash over the source program,
+  `program_schema_version`, and `graph_semantics_version`; it does not hash
+  diagnostics wording or the full response.
+- `validation_context_source` is `current_draft_context` for stored and
+  supplied drafts, or `published_version_snapshot` for version graphs.
+- `truncated` is true when a graph limit produced partial output; the
+  graph diagnostics explain which limit was reached.
+
+### Outline And Graph Layers
+
+`outline` is the compact layer for simple tree, sidebar, and label-list UIs.
+Each outline label includes:
+
+- `id`: stable API ID such as `label:start`.
+- `label`: raw display label.
+- `source_path`: bracket JSON path such as `$.labels['intro.scene']`.
+- `op_count`, `incoming_edge_count`, and `outgoing_edge_count`.
+- `reachable`: static reachability from `entry_label`.
+- `terminal`: one of `terminal`, `continues`, or `unknown`.
+- `summary`: compact text for display.
+
+`graph` is the detailed layer for advanced clients. It contains label nodes,
+operation nodes, and static edges. Node IDs are deterministic:
+
+- Labels: `label:<percent-encoded-label>`.
+- Operations: `op:<percent-encoded-label>:<zero-based-index>`.
+- Edges: `edge:<source-id>:<edge-type>:<target-id-or-missing-key>`.
+
+Labels are percent-encoded in IDs because raw labels can contain separators
+such as `.`, `:`, `/`, or spaces. Use the `label` field for display. Source
+paths always use bracket notation so label names with dots or dashes are not
+misread as object paths.
+
+V1 extracts only statically knowable control-flow edges:
+
+- `jump.target`
+- `choice.choices[].target`
+- `generate.on_generated_choice`
+- `generate.on_cancel`
+
+It does not infer random branches, conditionals, model-generated choices, or
+runtime fallthrough. Missing targets remain visible as edges with
+`target_id: null` and `missing_target: true`.
+
+### Diagnostics
+
+`diagnostics` are graph-construction diagnostics. They cover graph-specific
+conditions such as missing edge targets, unreachable labels, invalid label
+bodies, omitted edge targets, or output truncation. These diagnostics are
+intended to help authoring tools render partial structure from incomplete
+drafts.
+
+`validation_diagnostics` come from the VN script validator and remain the
+authoritative publish/runtime compatibility signal. A graph response can be
+useful even when validation is invalid, and graph diagnostics are not a
+replacement for validation diagnostics.
+
+### Limits And Truncation
+
+Graph output is bounded by:
+
+- `max_labels`: 500
+- `max_ops`: 5000
+- `max_edges`: 10000
+- `max_supplied_draft_bytes`: 1048576
+
+If a graph limit is reached, the response sets `truncated: true`, returns the
+partial graph, and includes a graph warning with the affected limit. Oversized
+supplied drafts are rejected before graph construction.
+
+### Custom Frontend Flow
+
+1. Read `GET /api/v1/vn/vn-capabilities` and check
+   `features.script_authoring_graph`.
+2. Fetch `GET /api/v1/vn/vn-scripts/scripts/{script_id}/draft/graph` for the
+   saved draft, or call `draft/graph-preview` while the user edits unsaved JSON.
+3. Compare `content_hash` and `graph_semantics_version` before reusing cached
+   graph layout state.
+4. Render `outline` for simple navigation and `graph` for advanced views.
+5. Show `diagnostics` as graph-authoring hints and
+   `validation_diagnostics` as validation status.
+6. Use existing draft update and publish endpoints for mutations; graph
+   endpoints never save or execute script content.

--- a/Docs/superpowers/plans/2026-05-14-vn-script-authoring-graph-api-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-14-vn-script-authoring-graph-api-implementation-plan.md
@@ -1,0 +1,727 @@
+# VN Script Authoring Graph API Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a backend-only computed VN script authoring graph API for stored drafts, supplied draft previews, and published versions.
+
+**Architecture:** Implement a pure `authoring_graph.py` builder that accepts parsed script programs and emits outline, graph, graph diagnostics, deterministic IDs, bracket JSON paths, limits, and content hashes without DB access. Add service methods that own script lookup, ownership, source selection, non-mutating validation, and published-version snapshot context. Expose the result through VN Scripts endpoints and advertise `features.script_authoring_graph`.
+
+**Tech Stack:** FastAPI, Pydantic v2, existing `VNScriptService`, existing VN script validator, SQLite-backed `VNScriptsRepository`, pytest, Bandit.
+
+---
+
+## Reference Documents
+
+- Spec: `Docs/superpowers/specs/2026-05-14-vn-script-authoring-graph-design.md`
+- API docs: `Docs/API/VN.md`
+- Existing authoring catalog plan: `Docs/superpowers/plans/2026-05-12-vn-script-authoring-catalog.md`
+- Existing backend tests:
+  - `tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_catalog.py`
+  - `tldw_Server_API/tests/VN_Scripts/test_vn_scripts_api.py`
+
+## File Structure
+
+- Create `tldw_Server_API/app/core/VN_Scripts/authoring_graph.py`
+  - Pure graph builder.
+  - Graph response constants and limits.
+  - Percent-encoded stable ID helpers.
+  - Bracket JSON path helpers.
+  - Static edge extraction.
+  - Reachability and terminal classification.
+  - Graph diagnostics.
+  - Canonical content hash helper.
+- Modify `tldw_Server_API/app/core/VN_Scripts/validator.py`
+  - Add public helper for graph-relevant static label edges or expose existing reachability behavior safely.
+  - Keep validator diagnostics authoritative.
+- Modify `tldw_Server_API/app/core/VN_Scripts/service.py`
+  - Add `get_draft_graph()`, `preview_draft_graph()`, and `get_version_graph()`.
+  - Use non-mutating validation for graph responses.
+  - Use published-version pinned context for version graphs.
+- Modify `tldw_Server_API/app/api/v1/schemas/vn_script_schemas.py`
+  - Add graph request/response schemas with `extra="forbid"`.
+- Modify `tldw_Server_API/app/api/v1/endpoints/vn_scripts.py`
+  - Add the three graph routes.
+  - Map graph-specific value errors into existing VN error envelopes.
+- Modify `tldw_Server_API/app/core/VN_Platform/capabilities.py`
+  - Add `features.script_authoring_graph`.
+- Modify `tldw_Server_API/app/api/v1/schemas/vn_capabilities_schemas.py`
+  - Add the feature field if the schema currently enumerates capability feature keys.
+- Modify `Docs/API/VN.md`
+  - Document routes, response shape, source modes, diagnostics, limits, and custom frontend flow.
+- Create `tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_graph.py`
+  - Pure builder and service tests.
+- Modify `tldw_Server_API/tests/VN_Scripts/test_vn_scripts_api.py`
+  - Endpoint and capability tests.
+
+## Task 1: Pure Authoring Graph Builder
+
+**Files:**
+- Create: `tldw_Server_API/app/core/VN_Scripts/authoring_graph.py`
+- Modify: `tldw_Server_API/app/core/VN_Scripts/validator.py`
+- Test: `tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_graph.py`
+
+- [ ] **Step 1: Write failing tests for stable IDs, paths, graph layers, and hash**
+
+Add tests like:
+
+```python
+def test_build_script_authoring_graph_returns_outline_graph_and_hash() -> None:
+    program = {
+        "schema_version": "vn_script_program.v1",
+        "entry_label": "intro.scene",
+        "labels": {
+            "intro.scene": [
+                {"op": "narrate", "text": "Opening."},
+                {"op": "jump", "target": "end label"},
+            ],
+            "end label": [{"op": "end"}],
+        },
+    }
+
+    result = build_script_authoring_graph(program)
+
+    assert result["schema_version"] == "vn_script_authoring_graph.v1"
+    assert result["graph_semantics_version"] == "vn_script_authoring_graph_edges.v1"
+    assert result["content_hash"].startswith("sha256:")
+    assert result["outline"]["entry_label"] == "intro.scene"
+    assert result["outline"]["labels"][0]["id"] == "label:intro%2Escene"
+    assert result["outline"]["labels"][0]["source_path"] == "$.labels['intro.scene']"
+    assert result["graph"]["nodes"][1]["id"] == "op:intro%2Escene:0"
+    assert result["graph"]["nodes"][2]["source_path"] == "$.labels['intro.scene'][1]"
+    assert result["graph"]["edges"][0]["type"] == "jump"
+    assert result["graph"]["edges"][0]["target_id"] == "label:end%20label"
+```
+
+Add a separate test for label separators:
+
+```python
+def test_label_ids_are_percent_encoded_but_display_label_remains_raw() -> None:
+    result = build_script_authoring_graph({
+        "schema_version": "vn_script_program.v1",
+        "entry_label": "route:1/a",
+        "labels": {"route:1/a": [{"op": "end"}]},
+    })
+
+    assert result["outline"]["labels"][0]["id"] == "label:route%3A1%2Fa"
+    assert result["outline"]["labels"][0]["label"] == "route:1/a"
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_graph.py -q
+```
+
+Expected: fail because `authoring_graph.py` does not exist.
+
+- [ ] **Step 3: Implement graph constants, helpers, and basic builder**
+
+In `authoring_graph.py`, add:
+
+```python
+SCHEMA_VERSION = "vn_script_authoring_graph.v1"
+GRAPH_SEMANTICS_VERSION = "vn_script_authoring_graph_edges.v1"
+PROGRAM_SCHEMA_VERSION = "vn_script_program.v1"
+MAX_SUPPLIED_DRAFT_BYTES = 1_048_576
+MAX_LABELS = 500
+MAX_OPS = 5000
+MAX_EDGES = 10000
+MAX_SUMMARY_LENGTH = 240
+```
+
+Add helpers:
+
+```python
+def encoded_label_id(label: str) -> str:
+    return "label:" + quote(label, safe="")
+
+def operation_id(label: str, index: int) -> str:
+    return f"op:{quote(label, safe='')}:{index}"
+
+def bracket_label_path(label: str) -> str:
+    escaped = label.replace("\\", "\\\\").replace("'", "\\'")
+    return f"$.labels['{escaped}']"
+```
+
+Add `build_script_authoring_graph(program, *, source="stored_draft", script_id=None, base_revision=None, version_id=None, validation_diagnostics=None, validation_context_source="current_draft_context") -> dict[str, Any]`.
+
+Build label nodes, operation nodes, an empty diagnostics envelope, deterministic limits, `truncated=False`, and `content_hash`.
+
+- [ ] **Step 4: Run tests to verify GREEN for the basic graph**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_graph.py -q
+```
+
+Expected: initial graph shape tests pass.
+
+- [ ] **Step 5: Add edge extraction tests**
+
+Add tests for:
+
+```python
+def test_graph_extracts_jump_choice_generate_and_cancel_edges() -> None:
+    program = {
+        "schema_version": "vn_script_program.v1",
+        "entry_label": "start",
+        "labels": {
+            "start": [
+                {"op": "choice", "choices": [{"id": "left", "text": "Left", "target": "left"}]},
+                {"op": "generate", "output_schema": "choice_set", "on_generated_choice": "generated", "on_cancel": "cancel"},
+                {"op": "jump", "target": "done"},
+            ],
+            "left": [{"op": "end"}],
+            "generated": [{"op": "end"}],
+            "cancel": [{"op": "end"}],
+            "done": [{"op": "end"}],
+        },
+    }
+
+    result = build_script_authoring_graph(program)
+    edge_types = [edge["type"] for edge in result["graph"]["edges"]]
+
+    assert edge_types == ["choice", "generated_choice_handler", "generation_cancel", "jump"]
+```
+
+Also test missing target edges:
+
+```python
+def test_missing_targets_emit_edges_and_diagnostics() -> None:
+    result = build_script_authoring_graph({
+        "schema_version": "vn_script_program.v1",
+        "entry_label": "start",
+        "labels": {"start": [{"op": "jump", "target": "missing"}]},
+    })
+
+    assert result["graph"]["edges"][0]["target_id"] is None
+    assert result["graph"]["edges"][0]["missing_target"] is True
+    assert result["diagnostics"]["errors"][0]["code"] == "graph_target_missing"
+```
+
+- [ ] **Step 6: Implement static edge extraction**
+
+Extract only:
+
+- `jump.target`
+- `choice.choices[].target`
+- `generate.on_generated_choice`
+- `generate.on_cancel`
+
+Do not infer `random`, conditionals, model output, or fallthrough.
+
+Use deterministic edge IDs:
+
+```python
+edge_id = f"edge:{source_id}:{edge_type}:{target_id or 'missing:' + encoded_missing_target}"
+```
+
+- [ ] **Step 7: Add reachability and terminal classification tests**
+
+Add tests proving:
+
+- reachable labels match graph edges.
+- unreachable labels emit `graph_label_unreachable`.
+- `end` produces `terminal`.
+- labels with `random`, `return`, conditions, malformed bodies, or dynamic flow produce `unknown`.
+
+Also compare with validator warnings:
+
+```python
+def test_graph_reachability_matches_validator_unreachable_warnings() -> None:
+    program = program_with_unreachable_label()
+    graph = build_script_authoring_graph(program)
+    validation = validate_script_program(program, VNScriptValidationContext()).to_dict()
+
+    graph_unreachable = {diag["details"]["label"] for diag in graph["diagnostics"]["warnings"] if diag["code"] == "graph_label_unreachable"}
+    validator_unreachable = {diag["details"]["label"] for diag in validation["warnings"] if diag["code"] == "label_unreachable"}
+
+    assert graph_unreachable == validator_unreachable
+```
+
+- [ ] **Step 8: Implement reachability and conservative terminal states**
+
+Use graph edges for reachability. If needed, add a validator helper that both validator and graph tests can rely on, such as:
+
+```python
+def static_reachable_labels(entry_label: str, labels: Mapping[str, Any]) -> set[str]:
+    ...
+```
+
+Keep behavior aligned with existing `_reachable_labels()` for `jump`, `choice`, `generate.on_cancel`, and `generate.on_generated_choice`.
+
+Terminal classification:
+
+- `terminal`: last meaningful op is `end`.
+- `continues`: label has at least one static outgoing edge.
+- `unknown`: malformed, dynamic, conditional, `random`, `return`, or ambiguous.
+
+- [ ] **Step 9: Add malformed and limit tests**
+
+Add tests for:
+
+- non-list label body.
+- non-object op.
+- missing `labels`.
+- invalid choice arrays.
+- malformed generate handlers.
+- `MAX_LABELS`, `MAX_OPS`, and `MAX_EDGES` truncation.
+- canonical-equivalent programs produce the same content hash.
+
+- [ ] **Step 10: Implement malformed tolerance, sorting, limits, and content hash**
+
+Use canonical JSON:
+
+```python
+json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+```
+
+Hash only source program, `PROGRAM_SCHEMA_VERSION`, and `GRAPH_SEMANTICS_VERSION`.
+
+Set `truncated=True` and add `graph_node_limit_exceeded` or `graph_edge_limit_exceeded` diagnostics when graph output is partial.
+
+- [ ] **Step 11: Run focused graph tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_graph.py -q
+```
+
+Expected: pass.
+
+- [ ] **Step 12: Commit graph builder slice**
+
+Run:
+
+```bash
+git add tldw_Server_API/app/core/VN_Scripts/authoring_graph.py tldw_Server_API/app/core/VN_Scripts/validator.py tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_graph.py
+git commit -m "Add VN script authoring graph builder"
+```
+
+## Task 2: Service Graph Methods
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/VN_Scripts/service.py`
+- Test: `tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_graph.py`
+
+- [ ] **Step 1: Write failing service tests**
+
+Add tests using the existing `CharactersRAGDB` fixture pattern:
+
+```python
+def test_service_get_draft_graph_is_non_mutating(chacha_db: CharactersRAGDB) -> None:
+    service = _service(chacha_db)
+    script = _create_script(service, draft=graph_program())
+    before = service.get_draft(script["id"])
+
+    result = service.get_draft_graph(script["id"])
+    after = service.get_draft(script["id"])
+
+    assert result["source"] == "stored_draft"
+    assert result["base_revision"] == before["revision"]
+    assert result["validation_context_source"] == "current_draft_context"
+    assert after == before
+```
+
+```python
+def test_service_preview_draft_graph_accepts_stale_revision_with_warning(chacha_db: CharactersRAGDB) -> None:
+    service = _service(chacha_db)
+    script = _create_script(service, draft=graph_program())
+
+    result = service.preview_draft_graph(script["id"], graph_program(), draft_revision=0)
+
+    assert result["source"] == "supplied_draft"
+    assert result["base_revision"] == 1
+    assert any(diag["code"] == "graph_preview_revision_stale" for diag in result["diagnostics"]["warnings"])
+```
+
+```python
+def test_service_version_graph_uses_published_version_snapshot_context(chacha_db: CharactersRAGDB) -> None:
+    service = _service(chacha_db)
+    script = _create_script(service, draft=graph_program())
+    published = service.publish_script(script["id"], draft_revision=1, idempotency_key="publish-graph")
+
+    result = service.get_version_graph(script["id"], published["version_id"])
+
+    assert result["source"] == "published_version"
+    assert result["version_id"] == published["version_id"]
+    assert result["validation_context_source"] == "published_version_snapshot"
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_graph.py -q
+```
+
+Expected: fail because service methods do not exist.
+
+- [ ] **Step 3: Implement draft graph methods**
+
+Add to `VNScriptService`:
+
+```python
+def get_draft_graph(self, script_id: int) -> dict[str, Any]:
+    script = self._require_script(script_id)
+    draft_row = self.get_draft(script_id)
+    diagnostics = self.validate_draft_payload(script, draft_row["draft"])
+    return build_script_authoring_graph(
+        draft_row["draft"],
+        source="stored_draft",
+        script_id=script_id,
+        base_revision=int(draft_row["revision"]),
+        validation_diagnostics=diagnostics,
+        validation_context_source="current_draft_context",
+    )
+```
+
+```python
+def preview_draft_graph(self, script_id: int, draft: Mapping[str, Any], *, draft_revision: int | None = None) -> dict[str, Any]:
+    script = self._require_script(script_id)
+    current_revision = int(self.get_draft(script_id)["revision"])
+    diagnostics = self.validate_draft_payload(script, draft)
+    result = build_script_authoring_graph(
+        draft,
+        source="supplied_draft",
+        script_id=script_id,
+        base_revision=current_revision,
+        validation_diagnostics=diagnostics,
+        validation_context_source="current_draft_context",
+    )
+    if draft_revision is not None and int(draft_revision) != current_revision:
+        result["diagnostics"]["warnings"].append(...)
+    return result
+```
+
+Do not call `repo.replace_draft()` or any method that stores diagnostics.
+
+- [ ] **Step 4: Implement version graph method**
+
+Use `self.get_version(script_id, version_id)` and any existing version snapshot helpers. Pass `version["program"]` to the graph builder.
+
+Resolve validation context from pinned version data. If a current helper cannot validate a version without mutable context, add a small private helper in `service.py` such as `_validate_version_program_payload(version)` and keep it local to this service task.
+
+- [ ] **Step 5: Add supplied draft size guard**
+
+Before graphing supplied drafts, measure canonical JSON bytes. If greater than `MAX_SUPPLIED_DRAFT_BYTES`, raise `ValueError("supplied_draft_too_large")`.
+
+If the draft is not a mapping, raise `ValueError("supplied_draft_invalid_shape")`.
+
+- [ ] **Step 6: Run service graph tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_graph.py -q
+```
+
+Expected: pass.
+
+- [ ] **Step 7: Commit service slice**
+
+Run:
+
+```bash
+git add tldw_Server_API/app/core/VN_Scripts/service.py tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_graph.py
+git commit -m "Add VN script authoring graph service"
+```
+
+## Task 3: API Schemas And Endpoints
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/schemas/vn_script_schemas.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/vn_scripts.py`
+- Test: `tldw_Server_API/tests/VN_Scripts/test_vn_scripts_api.py`
+
+- [ ] **Step 1: Write failing API tests**
+
+Add endpoint tests:
+
+```python
+def test_draft_graph_endpoint_returns_stored_graph(client: TestClient, chacha_dbs: dict[int, CharactersRAGDB]) -> None:
+    asset_pack_id, _ = _create_asset_pack(chacha_dbs[42])
+    script_id = _create_script(client, asset_pack_id=asset_pack_id)
+    client.put(f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft", json={"if_revision": 0, "draft": graph_program(asset_pack_id)})
+
+    response = client.get(f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft/graph")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["source"] == "stored_draft"
+    assert payload["base_revision"] == 1
+    assert payload["outline"]["labels"]
+```
+
+```python
+def test_graph_preview_does_not_persist_supplied_draft(client: TestClient, chacha_dbs: dict[int, CharactersRAGDB]) -> None:
+    asset_pack_id, _ = _create_asset_pack(chacha_dbs[42])
+    script_id = _create_script(client, asset_pack_id=asset_pack_id)
+    stored = graph_program(asset_pack_id)
+    supplied = graph_program(asset_pack_id)
+    supplied["labels"]["start"][0]["text"] = "Unsaved."
+    client.put(f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft", json={"if_revision": 0, "draft": stored})
+
+    response = client.post(f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft/graph-preview", json={"draft": supplied, "draft_revision": 1})
+    draft_after = client.get(f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft").json()
+
+    assert response.status_code == 200
+    assert response.json()["source"] == "supplied_draft"
+    assert draft_after["draft"] == stored
+```
+
+Also add tests for:
+
+- version graph endpoint.
+- malformed supplied draft shape -> `400`.
+- oversized supplied draft -> `413`.
+- graph problems return `200` with diagnostics.
+- no full op payloads or provider secrets in output.
+
+- [ ] **Step 2: Run API tests to verify RED**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/VN_Scripts/test_vn_scripts_api.py -q
+```
+
+Expected: fail because schemas/routes are missing.
+
+- [ ] **Step 3: Add Pydantic schemas**
+
+In `vn_script_schemas.py`, add models with `ConfigDict(extra="forbid")`:
+
+- `VNScriptGraphPreviewRequest`
+- `VNScriptGraphDiagnostic`
+- `VNScriptGraphDiagnostics`
+- `VNScriptGraphOutlineLabel`
+- `VNScriptGraphOutline`
+- `VNScriptGraphNode`
+- `VNScriptGraphEdge`
+- `VNScriptGraphBody`
+- `VNScriptAuthoringGraphResponse`
+
+Use `Literal` for stable enums where practical:
+
+```python
+source: Literal["stored_draft", "supplied_draft", "published_version"]
+terminal: Literal["terminal", "continues", "unknown"]
+```
+
+Keep `draft: dict[str, Any]`.
+
+- [ ] **Step 4: Add endpoints**
+
+In `vn_scripts.py`, add:
+
+```python
+@router.get("/scripts/{script_id}/draft/graph", response_model=VNScriptAuthoringGraphResponse)
+async def get_draft_graph(...):
+    ...
+```
+
+```python
+@router.post("/scripts/{script_id}/draft/graph-preview", response_model=VNScriptAuthoringGraphResponse)
+async def preview_draft_graph(...):
+    ...
+```
+
+```python
+@router.get("/scripts/{script_id}/versions/{version_id}/graph", response_model=VNScriptAuthoringGraphResponse)
+async def get_version_graph(...):
+    ...
+```
+
+Map:
+
+- `supplied_draft_invalid_shape` -> `400 ERROR_INVALID_REQUEST`
+- `supplied_draft_too_large` -> `413 ERROR_INVALID_REQUEST`
+- `script_version_not_found` -> existing not-found mapping
+- `script_not_found` / `draft_not_found` -> existing not-found mapping
+
+- [ ] **Step 5: Run API tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/VN_Scripts/test_vn_scripts_api.py -q
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Commit API slice**
+
+Run:
+
+```bash
+git add tldw_Server_API/app/api/v1/schemas/vn_script_schemas.py tldw_Server_API/app/api/v1/endpoints/vn_scripts.py tldw_Server_API/tests/VN_Scripts/test_vn_scripts_api.py
+git commit -m "Expose VN script authoring graph API"
+```
+
+## Task 4: Capabilities And Documentation
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/VN_Platform/capabilities.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/vn_capabilities_schemas.py`
+- Modify: `Docs/API/VN.md`
+- Test: `tldw_Server_API/tests/VN_Platform/test_vn_capabilities_api.py`
+- Test: `tldw_Server_API/tests/VN_Scripts/test_vn_scripts_api.py`
+
+- [ ] **Step 1: Write failing capability test**
+
+Add or update:
+
+```python
+def test_vn_capabilities_advertises_script_authoring_graph(client: TestClient) -> None:
+    response = client.get("/api/v1/vn/vn-capabilities")
+
+    assert response.status_code == 200
+    assert response.json()["features"]["script_authoring_graph"] is True
+```
+
+- [ ] **Step 2: Run capability tests to verify RED**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/VN_Platform/test_vn_capabilities_api.py -q
+```
+
+Expected: fail until feature flag is added.
+
+- [ ] **Step 3: Add capability flag**
+
+In `capabilities.py`, set:
+
+```python
+script_authoring_graph_enabled = enabled_modules["scripts"]
+```
+
+Add to `features`:
+
+```python
+"script_authoring_graph": script_authoring_graph_enabled,
+```
+
+If `vn_capabilities_schemas.py` has a concrete features schema, add `script_authoring_graph: bool = False`.
+
+- [ ] **Step 4: Update API docs**
+
+In `Docs/API/VN.md`, document:
+
+- the three graph endpoints.
+- source modes.
+- response envelope.
+- outline and graph layers.
+- diagnostics vs validation diagnostics.
+- limits and truncation.
+- content hash and graph semantics version.
+- custom frontend usage.
+- non-goals: no execution, model calls, mutation, persistence, or node editor.
+
+- [ ] **Step 5: Run focused docs/capability checks**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/VN_Platform/test_vn_capabilities_api.py tldw_Server_API/tests/VN_Scripts/test_vn_scripts_api.py -q
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Commit docs/capability slice**
+
+Run:
+
+```bash
+git add tldw_Server_API/app/core/VN_Platform/capabilities.py tldw_Server_API/app/api/v1/schemas/vn_capabilities_schemas.py Docs/API/VN.md tldw_Server_API/tests/VN_Platform/test_vn_capabilities_api.py tldw_Server_API/tests/VN_Scripts/test_vn_scripts_api.py
+git commit -m "Document VN script authoring graph capability"
+```
+
+## Task 5: Final Verification And PR Prep
+
+**Files:**
+- Modify: `backlog/tasks/<implementation-task>.md`
+- Review all changed files.
+
+- [ ] **Step 1: Run focused VN script tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/VN_Scripts -q
+```
+
+Expected: pass.
+
+- [ ] **Step 2: Run VN platform capability tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/VN_Platform/test_vn_capabilities_api.py -q
+```
+
+Expected: pass.
+
+- [ ] **Step 3: Run compile verification**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m compileall tldw_Server_API/app/core/VN_Scripts tldw_Server_API/app/api/v1/endpoints/vn_scripts.py tldw_Server_API/app/api/v1/schemas/vn_script_schemas.py tldw_Server_API/tests/VN_Scripts
+```
+
+Expected: no compile failures.
+
+- [ ] **Step 4: Run Bandit on touched backend scope**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/VN_Scripts tldw_Server_API/app/api/v1/endpoints/vn_scripts.py tldw_Server_API/app/api/v1/schemas/vn_script_schemas.py tldw_Server_API/app/core/VN_Platform/capabilities.py -f json -o /tmp/bandit_vn_script_authoring_graph.json
+```
+
+Expected: no new findings in touched code.
+
+- [ ] **Step 5: Run whitespace check**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output.
+
+- [ ] **Step 6: Update Backlog task**
+
+Record:
+
+- implementation summary.
+- focused test results.
+- compile result.
+- Bandit output path and result.
+- known skips or blockers.
+- PR URL once opened.
+
+- [ ] **Step 7: Squash if requested**
+
+If the user requests one commit, squash task commits into one after all verification passes.
+
+- [ ] **Step 8: Create PR against `dev`**
+
+Run:
+
+```bash
+git push -u origin codex/vn-script-authoring-graph-api
+gh pr create --base dev --head codex/vn-script-authoring-graph-api --title "Add VN script authoring graph API" --body-file /tmp/vn_script_authoring_graph_pr.md
+```
+
+Expected: PR created with a human-editable `Change summary` section.

--- a/Docs/superpowers/specs/2026-05-14-vn-script-authoring-graph-design.md
+++ b/Docs/superpowers/specs/2026-05-14-vn-script-authoring-graph-design.md
@@ -1,0 +1,455 @@
+# VN Script Authoring Graph API Design
+
+Date: 2026-05-14
+
+## Summary
+
+Add a backend-owned VN script authoring graph API that computes a stable outline and detailed graph from VN script drafts and published versions. This is the next backend-first authoring contract after starter templates and guided snippet editing.
+
+V1 is intentionally static. It does not execute scripts, run model calls, simulate random branches, mutate drafts, persist graph snapshots, or build a visual node editor. Its job is to give custom frontends and the bundled WebUI a server-shaped view of script structure: labels, operation summaries, statically knowable edges, reachability, missing targets, and validation diagnostics.
+
+## Goals
+
+- Support stored drafts, supplied unsaved drafts, and published versions.
+- Return both a simple outline layer and an advanced graph layer in one response.
+- Keep graph construction tolerant so incomplete drafts return partial structure plus diagnostics.
+- Keep validation and publish/runtime checks authoritative.
+- Reuse or mirror the validator's reachability rules through tested helper boundaries.
+- Give clients stable IDs, bracket JSON paths, compact operation summaries, content hashes, and graph semantics versions.
+- Expose capability discovery through `features.script_authoring_graph`.
+- Avoid frontend-owned VN traversal rules.
+
+## Non-Goals
+
+- No dry-run or playtest execution in this sprint.
+- No model calls, generation jobs, or prompt construction.
+- No runtime session creation or mutation.
+- No graph persistence tables, cache invalidation, or migrations.
+- No visual node editor.
+- No text DSL.
+- No full operation payload echoing in graph nodes.
+- No policy engine replacement.
+
+## API Surface
+
+Add routes under the existing VN Scripts resource:
+
+- `GET /api/v1/vn/vn-scripts/scripts/{script_id}/draft/graph`
+- `POST /api/v1/vn/vn-scripts/scripts/{script_id}/draft/graph-preview`
+- `GET /api/v1/vn/vn-scripts/scripts/{script_id}/versions/{version_id}/graph`
+
+The `GET` draft route computes from the stored draft. The `POST` preview route computes from a supplied draft without persistence. The version route computes from the immutable published version program and its pinned snapshots.
+
+The VN capabilities endpoint adds:
+
+```json
+{
+  "features": {
+    "script_authoring_graph": true
+  }
+}
+```
+
+Clients must treat the feature as optional and fall back to existing JSON draft endpoints when absent.
+
+## Response Shape
+
+Every graph response uses the same envelope:
+
+```json
+{
+  "schema_version": "vn_script_authoring_graph.v1",
+  "graph_semantics_version": "vn_script_authoring_graph_edges.v1",
+  "program_schema_version": "vn_script_program.v1",
+  "script_id": 12,
+  "source": "stored_draft",
+  "base_revision": 4,
+  "version_id": null,
+  "content_hash": "sha256:...",
+  "validation_context_source": "current_draft_context",
+  "truncated": false,
+  "limits": {
+    "max_labels": 500,
+    "max_ops": 5000,
+    "max_edges": 10000,
+    "max_supplied_draft_bytes": 1048576
+  },
+  "outline": {
+    "entry_label": "start",
+    "labels": []
+  },
+  "graph": {
+    "nodes": [],
+    "edges": []
+  },
+  "diagnostics": {
+    "errors": [],
+    "warnings": []
+  },
+  "validation_diagnostics": {
+    "valid": false,
+    "errors": [],
+    "warnings": []
+  }
+}
+```
+
+`schema_version` covers response shape. `graph_semantics_version` covers edge extraction and reachability semantics. This allows future traversal-rule changes without pretending the JSON response shape changed.
+
+`content_hash` is the SHA-256 of a canonical JSON serialization of:
+
+- the source program only
+- `program_schema_version`
+- `graph_semantics_version`
+
+It must not hash diagnostics wording or the full response. Clients can use it to detect whether a graph result still corresponds to the same source and semantics.
+
+`validation_context_source` tells clients which metadata context was used for `validation_diagnostics`:
+
+- `current_draft_context` for stored and supplied drafts.
+- `published_version_snapshot` for published versions.
+
+`truncated` is `true` when the server returns partial graph output because an internal graph limit was reached. Truncated responses must include a graph diagnostic explaining which limit was hit.
+
+Array ordering is deterministic:
+
+- `outline.labels` follows source label order with the entry label first when present.
+- `graph.nodes` follows source label order, with each label node immediately followed by operation nodes in index order.
+- `graph.edges` follows source operation order, then edge type order for multiple edges from the same operation.
+- diagnostics are sorted by source path, severity, and code when they are not naturally emitted in source order.
+
+## Source Modes
+
+### Stored Draft
+
+`GET /scripts/{script_id}/draft/graph` reads the stored draft and returns `source="stored_draft"` plus `base_revision`.
+
+Graph calls must not persist diagnostics as a side effect. Stored draft graph responses should compute `validation_diagnostics` live through the same non-mutating validation helper path used by snippet preview, not reuse potentially stale stored draft diagnostics.
+
+### Supplied Draft Preview
+
+`POST /scripts/{script_id}/draft/graph-preview` accepts:
+
+```json
+{
+  "draft": {
+    "schema_version": "vn_script_program.v1"
+  },
+  "draft_revision": 4
+}
+```
+
+Rules:
+
+- The script must exist and belong to the caller.
+- The supplied draft is parsed, bounded, graphed, and validated without persistence.
+- `draft_revision` is optional metadata for client conflict awareness. V1 should not require it because graph preview is read-only, but the response should still include the current stored `base_revision`. If supplied and different from the stored draft revision, the response should still succeed and include a warning diagnostic such as `graph_preview_revision_stale`; it must not fail like snippet apply because no mutation occurs.
+- The response uses `source="supplied_draft"`.
+- Supplied draft size and complexity limits are enforced before graph construction.
+
+### Published Version
+
+`GET /scripts/{script_id}/versions/{version_id}/graph` reads the immutable version program and returns `source="published_version"` plus `version_id`.
+
+Validation diagnostics for versions must use pinned version context where available: manifest snapshots, generation profile snapshots, policy profile snapshots, script defaults, content rating, and other published-version metadata. It must not silently use current mutable script settings when version snapshots exist. The response should set `validation_context_source="published_version_snapshot"` when this path is used.
+
+## Outline Layer
+
+The outline layer is optimized for simple UIs:
+
+```json
+{
+  "entry_label": "start",
+  "labels": [
+    {
+      "id": "label:start",
+      "label": "start",
+      "source_path": "$.labels['start']",
+      "op_count": 4,
+      "incoming_edge_count": 0,
+      "outgoing_edge_count": 2,
+      "reachable": true,
+      "terminal": "unknown",
+      "summary": "Narration, generated choice set, and 2 outgoing edges."
+    }
+  ]
+}
+```
+
+`terminal` is conservative:
+
+- `terminal` when the label mechanically ends with `end` and has no statically extracted outgoing edge after that point.
+- `continues` when the graph can mechanically see outgoing control flow.
+- `unknown` for labels involving unsupported dynamic semantics, malformed bodies, `return`, `random`, conditions, or ambiguous fallthrough.
+
+V1 must not over-promise dead-end detection. It should report missing targets and malformed structures, but avoid claiming non-terminal dead ends except where mechanically certain.
+
+## Graph Layer
+
+The graph layer is optimized for advanced clients and future node editors:
+
+```json
+{
+  "nodes": [
+    {
+      "id": "label:start",
+      "type": "label",
+      "label": "start",
+      "source_path": "$.labels['start']",
+      "reachable": true,
+      "terminal": "unknown",
+      "summary": "4 operations"
+    },
+    {
+      "id": "op:start:1",
+      "type": "operation",
+      "label": "start",
+      "op_index": 1,
+      "op": "generate",
+      "source_path": "$.labels['start'][1]",
+      "summary": "Generate choice_set using profile default."
+    }
+  ],
+  "edges": [
+    {
+      "id": "edge:op:start:1:on_generated_choice:label:generated_choice",
+      "type": "generated_choice_handler",
+      "source_id": "op:start:1",
+      "target_id": "label:generated_choice",
+      "source_path": "$.labels['start'][1].on_generated_choice",
+      "target_label": "generated_choice",
+      "metadata": {
+        "output_schema": "choice_set"
+      }
+    }
+  ]
+}
+```
+
+Node and edge IDs must be deterministic and stable for the same source program and graph semantics:
+
+- label nodes: `label:<encoded_label_name>`
+- operation nodes: `op:<encoded_label_name>:<zero_based_index>`
+- edge IDs: `edge:<source_id>:<edge_type>:<target_id_or_missing_key>`
+
+IDs are API identifiers, not database IDs.
+
+Label names in IDs must be encoded because labels can contain separators such as `:`, `/`, `.`, or spaces. V1 should use one explicit encoding helper everywhere, for example URL percent-encoding with uppercase hex. The raw label text remains available in the `label` field; clients must not decode IDs to recover display text.
+
+Edges to missing labels should still be represented when useful for graph rendering:
+
+```json
+{
+  "id": "edge:op:start:1:jump:missing:missing_target",
+  "type": "jump",
+  "source_id": "op:start:1",
+  "target_id": null,
+  "target_label": "missing_target",
+  "source_path": "$.labels['start'][1].target",
+  "missing_target": true
+}
+```
+
+Missing-target edges must also emit graph diagnostics.
+
+All source paths use bracket notation such as `$.labels['intro.scene'][0]`. Dot notation must not be used for label names because labels may contain dots, dashes, or other valid non-identifier characters.
+
+Graph nodes contain compact summaries only. They must not echo full operation payloads.
+
+## Edge Semantics
+
+V1 extracts only statically knowable edges:
+
+- `jump.target`
+- authored `choice.choices[].target`
+- `generate.on_generated_choice`
+- `generate.on_cancel`
+- terminal markers for `end`
+
+The graph builder must not approximate runtime behavior for `random`, conditional `if`, variable-dependent control flow, model output content, or ambiguous fallthrough. Unsupported or dynamic structures can produce diagnostics or `unknown` terminal state.
+
+Reachability must reuse or mirror the same edge families used by the current script validator's reachability behavior: `jump`, authored `choice`, `generate.on_cancel`, and `generate.on_generated_choice`. Tests must compare graph reachability with validator unreachable-label diagnostics for representative programs so the two do not drift.
+
+## Diagnostics
+
+The response has two diagnostic channels:
+
+- `diagnostics`: graph-specific diagnostics.
+- `validation_diagnostics`: the existing script validation result shape.
+
+Graph diagnostics use stable code, severity, message, source path, and details:
+
+```json
+{
+  "code": "graph_target_missing",
+  "severity": "error",
+  "message": "Target label was not found.",
+  "path": "$.labels['start'][1].target",
+  "details": {
+    "target_label": "missing",
+    "edge_type": "jump"
+  }
+}
+```
+
+Expected graph diagnostic codes include:
+
+- `graph_labels_missing`
+- `graph_label_body_invalid`
+- `graph_opcode_invalid`
+- `graph_target_missing`
+- `graph_generated_choice_handler_missing`
+- `graph_cancel_target_missing`
+- `graph_label_unreachable`
+- `graph_edge_limit_exceeded`
+- `graph_node_limit_exceeded`
+- `graph_preview_revision_stale`
+- `graph_unsupported_dynamic_flow`
+
+Existing validator diagnostics remain the authoritative source for publish/runtime validity. Graph diagnostics exist to help clients render structure and recover from malformed-but-parseable drafts.
+
+Graph problems inside a parseable draft should return `200` with diagnostics. Transport errors are reserved for access, missing resources, malformed request bodies, and hard limits.
+
+## Error Model
+
+Expected transport errors:
+
+- `404 script_not_found`
+- `404 draft_not_found`
+- `404 version_not_found`
+- `403 permission_denied`
+- `400 supplied_draft_invalid_shape`
+- `413 supplied_draft_too_large`
+- `422 request_validation_error` for Pydantic request-shape failures
+
+Malformed graph-relevant script content should not become a transport failure if the server can parse the draft as JSON and stay within limits. It should produce partial graph output and graph diagnostics.
+
+## Limits
+
+V1 should define explicit conservative limits:
+
+- `max_supplied_draft_bytes`: 1 MiB
+- `max_labels`: 500
+- `max_ops`: 5000
+- `max_edges`: 10000
+- `max_label_length`: align with current script validator/catalog rules
+- `max_summary_length`: 240 characters
+
+If supplied draft byte size exceeds `max_supplied_draft_bytes`, return `413 supplied_draft_too_large` before parsing. If label, operation, node, or edge limits are exceeded after parsing, return `200` with `truncated=true`, partial graph output, and `graph_node_limit_exceeded` or `graph_edge_limit_exceeded` diagnostics. Stored drafts and published versions should follow the same truncation behavior because a persisted large script should still be inspectable enough for recovery.
+
+These values can become config later, but V1 should document them and expose them in responses.
+
+## Security And Privacy
+
+- Preserve existing script ownership checks.
+- Do not expose raw prompt internals, provider routing, API keys, base URLs, or provider config.
+- Do not echo full operation payloads.
+- Do not log raw draft text at info level.
+- Do not run model calls, file ingestion, jobs, or network operations.
+- Do not mutate sessions, branches, drafts, versions, or diagnostics.
+- Do not persist graph snapshots.
+- Use existing VN error envelopes.
+
+The graph builder may surface existing validator diagnostics for raw provider/model/API-key fields, but it must not become a separate policy engine.
+
+## Backend Components
+
+Suggested implementation boundaries:
+
+- `tldw_Server_API/app/core/VN_Scripts/authoring_graph.py`
+  - pure graph builder
+  - graph diagnostics
+  - stable ID/path helpers
+  - canonical hash helper
+  - limits
+- `tldw_Server_API/app/core/VN_Scripts/service.py`
+  - `get_draft_graph(script_id)`
+  - `preview_draft_graph(script_id, draft, draft_revision=None)`
+  - `get_version_graph(script_id, version_id)`
+  - validation context resolution
+- `tldw_Server_API/app/api/v1/schemas/vn_script_schemas.py`
+  - graph request/response schemas
+- `tldw_Server_API/app/api/v1/endpoints/vn_scripts.py`
+  - graph endpoints and error mapping
+- `tldw_Server_API/app/core/VN_Platform/capabilities.py`
+  - `features.script_authoring_graph`
+
+The pure builder should accept parsed program mappings and never call the database. Service methods own script lookup, ownership, source selection, snapshot context, and non-mutating validation.
+
+## Testing
+
+Backend graph-builder tests:
+
+- stored program returns outline and graph layers.
+- stable node IDs and bracket JSON paths.
+- encoded node IDs for labels containing separators or whitespace.
+- deterministic outline, graph node, graph edge, and diagnostics ordering.
+- authored choice edges.
+- jump edges.
+- generated choice handler edges.
+- generation cancel edges.
+- terminal `end` classification.
+- conservative `unknown` classification for `return`, `random`, conditions, and malformed flow.
+- missing target diagnostics.
+- unreachable label diagnostics.
+- graph reachability matches validator unreachable-label diagnostics for representative programs.
+- malformed-but-parseable drafts return partial graph plus diagnostics for:
+  - non-list label bodies
+  - non-object operations
+  - missing labels
+  - invalid choice arrays
+  - malformed generate handlers
+- content hash is stable for canonical-equivalent programs and changes when program content or graph semantics version changes.
+- graph output does not include raw provider routing secrets or full operation payloads.
+- supplied draft limits reject oversized or overly complex drafts.
+- stale supplied `draft_revision` returns a graph warning without failing the read-only preview.
+
+Service and endpoint tests:
+
+- `GET /draft/graph` returns stored draft graph and does not persist diagnostics.
+- `POST /draft/graph-preview` accepts supplied draft and does not persist draft or diagnostics.
+- `GET /versions/{version_id}/graph` uses published-version pinned context.
+- missing script, draft, and version errors map to existing VN error envelopes.
+- malformed supplied draft shape returns `400`.
+- oversized supplied draft returns `413`.
+- `vn-capabilities` includes `features.script_authoring_graph = true`.
+
+Docs tests or verification:
+
+- API docs list all graph routes.
+- Examples show custom frontend flow and graph diagnostics behavior.
+- Non-goals are documented to prevent clients from expecting execution or model calls.
+
+## Rollout Plan
+
+1. Write pure graph builder and focused tests.
+2. Add service methods using non-mutating validation and published-version snapshot context.
+3. Add Pydantic schemas and endpoints.
+4. Add capability flag.
+5. Update VN API docs.
+6. Run focused VN script tests, compile checks, Bandit for touched Python scope, and `git diff --check`.
+
+No WebUI changes should land in this sprint. A later sprint can consume the graph API in a read-only outline panel or visual editor.
+
+## Risks And Mitigations
+
+- Risk: graph reachability drifts from validator warnings.
+  - Mitigation: extract shared edge/reachability helpers or add tests comparing graph and validator behavior.
+- Risk: clients treat graph diagnostics as publish authority.
+  - Mitigation: keep `validation_diagnostics` separate and document validator/publish authority clearly.
+- Risk: terminal/dead-end semantics are wrong.
+  - Mitigation: use conservative `terminal | continues | unknown` states and defer dry-run semantics.
+- Risk: graph preview becomes expensive on large unsaved drafts.
+  - Mitigation: enforce byte, label, op, and edge limits.
+- Risk: published-version graph accidentally uses mutable current context.
+  - Mitigation: service tests must assert pinned snapshot context is used where available.
+- Risk: frontend reimplements traversal while waiting for UI work.
+  - Mitigation: document graph as the custom frontend contract and include both outline and detailed graph layers.
+
+## Deferred Decisions
+
+- Dry-run/playtest route shape.
+- JSON Patch output for graph deltas.
+- Persisted graph snapshots for immutable versions.
+- Visual node editor UX.
+- Advisory authoring hints beyond graph and validation diagnostics.

--- a/backlog/tasks/task-326 - Design-VN-script-authoring-graph-API.md
+++ b/backlog/tasks/task-326 - Design-VN-script-authoring-graph-API.md
@@ -1,0 +1,74 @@
+---
+id: TASK-326
+title: Design VN script authoring graph API
+status: Done
+assignee: []
+created_date: '2026-05-14 01:32'
+updated_date: '2026-05-14 01:45'
+labels:
+  - vn
+  - scripts
+  - design
+  - api
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1391'
+  - 'https://github.com/rmusser01/tldw_server/issues/1610'
+  - 'https://github.com/rmusser01/tldw_server/pull/1641'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Write a backend-first design spec for a computed VN script authoring graph API under the existing VN Scripts surface. The spec must capture the approved choices: static graph before dry-run execution; support stored drafts, supplied drafts, and published versions; return both outline and detailed graph layers; include graph diagnostics plus existing validation diagnostics; compute on demand with no persistence; use strict statically knowable edge semantics; expose stable IDs, bracket JSON paths, compact op summaries, content hashes, and a script_authoring_graph capability flag. The design should include the critique amendments about validator reachability reuse, conservative terminal semantics, supplied-draft limits, content-hash definition, non-mutating validation, pinned published-version context, malformed-draft tolerance, and route naming.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Design spec is written under Docs/superpowers/specs with the approved V1 graph API contract and critique amendments included.
+- [x] #2 Spec defines routes, response schemas, graph/outline data model, diagnostics, error behavior, security boundaries, limits, hashing, validation context, and non-goals.
+- [x] #3 Spec includes testing and rollout guidance for a backend-only first sprint.
+- [x] #4 Spec receives a review pass and any identified issues are addressed before implementation planning.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Write the design spec in the isolated worktree on branch `codex/vn-script-authoring-graph-design`.
+2. Review the spec against current VN script validator/service/API behavior on `origin/dev`.
+3. Patch any design gaps found in review.
+4. Run documentation hygiene checks and record verification.
+<!-- SECTION:PLAN:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Created `Docs/superpowers/specs/2026-05-14-vn-script-authoring-graph-design.md`.
+- Scope is backend-only design for computed authoring graph/outline APIs; no runtime code or WebUI implementation in this task.
+- Review pass found and patched spec gaps for encoded IDs, explicit truncation, deterministic ordering, non-mutating live validation, stale preview revision behavior, and published-version validation context.
+<!-- SECTION:NOTES:END -->
+
+## Verification
+
+<!-- SECTION:VERIFICATION:BEGIN -->
+- Reviewed the spec against current `origin/dev` VN script validator/service/API behavior.
+- `git diff --check` -> passed.
+- Bandit skipped because this task only changes Markdown design/task files.
+<!-- SECTION:VERIFICATION:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Wrote the backend-first VN script authoring graph API design spec. The spec defines read-only graph routes for stored drafts, supplied draft previews, and published versions; a combined outline/detail response; graph diagnostics plus validation diagnostics; conservative static edge semantics; content hashing; graph semantics versioning; encoded stable IDs; bracket JSON paths; explicit limits/truncation behavior; non-mutating validation; and backend-only rollout/testing guidance.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-327 - Plan-VN-script-authoring-graph-API-implementation.md
+++ b/backlog/tasks/task-327 - Plan-VN-script-authoring-graph-API-implementation.md
@@ -1,0 +1,73 @@
+---
+id: TASK-327
+title: Plan VN script authoring graph API implementation
+status: Done
+assignee: []
+created_date: '2026-05-14 01:37'
+updated_date: '2026-05-14 01:52'
+labels:
+  - vn
+  - scripts
+  - plan
+  - api
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1391'
+  - 'https://github.com/rmusser01/tldw_server/pull/1641'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create a detailed implementation plan from the approved VN script authoring graph API design. The plan must be backend-only, TDD-oriented, and scoped to a future implementation PR that adds computed graph/outline APIs for stored drafts, supplied draft previews, and published versions without WebUI changes or graph persistence.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Implementation plan is written under Docs/superpowers/plans and references the approved graph design spec.
+- [x] #2 Plan decomposes the work into bite-sized backend tasks with exact files, tests, commands, and expected results.
+- [x] #3 Plan preserves the design constraints: no model calls, no mutation, no graph persistence, conservative static edge semantics, encoded stable IDs, bracket JSON paths, limits, content hashes, and pinned published-version context.
+- [x] #4 Plan includes final verification commands for VN script tests, compile checks, Bandit on touched Python scope, docs hygiene, and git diff checks.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Write `Docs/superpowers/plans/2026-05-14-vn-script-authoring-graph-api-implementation-plan.md`.
+2. Review the plan against the approved design and current VN script files.
+3. Patch any gaps found during review.
+4. Run markdown/diff hygiene checks and record verification.
+<!-- SECTION:PLAN:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Planning is being done on branch `codex/vn-script-authoring-graph-design` after the design spec commit.
+- Created `Docs/superpowers/plans/2026-05-14-vn-script-authoring-graph-api-implementation-plan.md`.
+- Review pass corrected the label ID encoding helper example and the published-version service test shape to match current `publish_script()` return data.
+<!-- SECTION:NOTES:END -->
+
+## Verification
+
+<!-- SECTION:VERIFICATION:BEGIN -->
+- Reviewed the plan against `Docs/superpowers/specs/2026-05-14-vn-script-authoring-graph-design.md` and current VN script service/API behavior.
+- `git diff --check` -> passed.
+- Bandit skipped because this task only changes Markdown plan/task files.
+<!-- SECTION:VERIFICATION:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Wrote the backend-only VN script authoring graph API implementation plan. The plan breaks implementation into pure graph builder, service methods, API schemas/endpoints, capability/docs, and final verification tasks, with TDD steps and exact commands for focused pytest, compileall, Bandit, and diff hygiene.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-328 - Implement-VN-script-authoring-graph-API.md
+++ b/backlog/tasks/task-328 - Implement-VN-script-authoring-graph-API.md
@@ -70,11 +70,13 @@ Task 3 API schemas/endpoints completed and accepted after review. Commit b02d27d
 
 Task 4 capabilities/docs completed. Commits 22e0224ed and 89a221561 add route-gated features.script_authoring_graph capability discovery, API docs for graph endpoints/source modes/response shape/diagnostics/limits/hashing/custom frontend flow/non-goals, and a regression test that keeps the graph feature disabled when only partial scripts routes are registered.
 
-Final verification: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest -q tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_graph.py tldw_Server_API/tests/VN_Scripts/test_vn_scripts_api.py tldw_Server_API/tests/VN_Platform/test_vn_capabilities_api.py -> 60 passed, 8 warnings; targeted VN capabilities pytest -> 3 passed, 8 warnings; compileall on touched VN modules passed; Bandit on touched backend VN modules reported 0 findings; git diff --check and git diff --cached --check passed.
+PR review fixes added on 2026-05-14: graph draft endpoints now resolve AuthNZ profile rows and accessible audio refs before validation; graph reachability is derived from emitted bounded edges so truncated responses stay internally consistent; capabilities now require exact graph route path+method pairs; supplied_draft_invalid_shape has explicit 400 mapping; helper docstrings and wrapped long lines added. Regression coverage added for custom AuthNZ graph validation context, method-aware capability gating, emitted-edge reachability under edge truncation, and static fallthrough warning diagnostics.
+
+Final verification after review fixes: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/VN_Scripts -q -> 123 passed, 5 warnings; /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/VN_Platform/test_vn_capabilities_api.py -q -> 4 passed, 8 warnings; compileall on touched VN modules passed; Bandit on touched backend VN modules reported 0 findings; git diff --check passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL:BEGIN -->
-Opened PR #1656 for the backend-only VN script authoring graph API. Implemented deterministic pure graph construction, non-mutating service methods for stored draft/supplied draft preview/published version graph responses, VN Scripts schemas/endpoints, route-gated features.script_authoring_graph capability discovery, and API documentation. CI state on PR #1656 is pending at creation time.
+Opened PR #1656 for the backend-only VN script authoring graph API and addressed live PR review feedback. The API now computes deterministic authoring graphs for stored drafts, supplied draft previews, and published versions; keeps graph responses non-mutating; validates draft graph responses with the same resolved profile/audio context as existing VN Scripts validation; uses emitted bounded edges for reachability; advertises features.script_authoring_graph only when the exact graph routes and methods are registered; and documents graph behavior for custom frontend clients.
 <!-- SECTION:FINAL:END -->

--- a/backlog/tasks/task-328 - Implement-VN-script-authoring-graph-API.md
+++ b/backlog/tasks/task-328 - Implement-VN-script-authoring-graph-API.md
@@ -1,0 +1,80 @@
+---
+id: TASK-328
+title: Implement VN script authoring graph API
+status: Done
+assignee: []
+created_date: '2026-05-14 01:45'
+updated_date: '2026-05-14 03:08'
+labels:
+  - vn
+  - scripts
+  - api
+  - backend
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1391'
+  - 'https://github.com/rmusser01/tldw_server/pull/1641'
+  - 'https://github.com/rmusser01/tldw_server/pull/1656'
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the backend-only VN script authoring graph API from Docs/superpowers/specs/2026-05-14-vn-script-authoring-graph-design.md and Docs/superpowers/plans/2026-05-14-vn-script-authoring-graph-api-implementation-plan.md. Scope includes a pure computed graph builder, service methods, VN Scripts schemas/endpoints, capability flag, API docs, focused backend tests, compile verification, Bandit, and PR preparation. No WebUI changes, no model calls, no runtime session mutation, and no graph persistence.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Pure graph builder returns deterministic outline and graph layers with encoded stable IDs, bracket JSON paths, content hashes, graph semantics version, limits, truncation behavior, conservative terminal states, and graph diagnostics.
+- [x] #2 Service methods support stored draft graph, supplied draft graph preview, and published-version graph without persisting drafts or diagnostics; published-version graphs use pinned version context where available.
+- [x] #3 VN Scripts API exposes draft graph, draft graph-preview, and version graph endpoints with Pydantic schemas, existing VN error envelopes, and capability discovery through features.script_authoring_graph.
+- [x] #4 API documentation covers endpoints, source modes, response shape, diagnostics, limits, hashing, custom frontend flow, and non-goals.
+- [x] #5 Focused VN script/platform tests, compile checks, Bandit on touched Python scope, and git diff checks are run and recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Subagent-driven execution on branch `codex/vn-script-authoring-graph-api` in worktree `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/vn-script-authoring-graph-design`.
+
+Implementation sequence from `Docs/superpowers/plans/2026-05-14-vn-script-authoring-graph-api-implementation-plan.md`:
+
+1. Pure authoring graph builder: create `authoring_graph.py`, add/adjust validator reachability helper, add `test_vn_script_authoring_graph.py` builder coverage, commit graph builder slice.
+2. Service graph methods: add `get_draft_graph`, `preview_draft_graph`, `get_version_graph`, supplied draft guards, non-mutating validation behavior, version snapshot context tests, commit service slice.
+3. API schemas and endpoints: add graph request/response schemas, draft graph/preview/version graph routes, error mapping, endpoint tests, commit API slice.
+4. Capabilities and docs: add `features.script_authoring_graph`, update capability schema if needed, update `Docs/API/VN.md` and tests, commit docs/capability slice.
+5. Final verification: focused VN_Scripts tests, VN capabilities tests, compileall, Bandit on touched Python scope, `git diff --check`, update Backlog task, prepare PR.
+
+Constraints: backend-only; no WebUI changes; no model calls; no runtime session mutation; no graph persistence; graph preview and stored graph must not persist diagnostics; edge semantics remain statically knowable only; use encoded stable IDs and bracket JSON paths; preserve existing VN error envelope style.
+<!-- SECTION:PLAN:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Task 1 pure graph builder completed and accepted after review. Commit 85068f2da adds authoring_graph.py and focused graph tests. Verification: focused graph pytest passed with 16 tests; spec compliance review approved; code quality review initially found omitted-target, duplicate edge ID, and mutable diagnostics issues, all fixed with regression tests; re-review approved. The worktree lacks its own .venv, so verification used /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python.
+
+Task 2 service graph methods completed and accepted after review. Commit d0d05dfea4 adds get_draft_graph, preview_draft_graph, and get_version_graph plus service tests. Code quality review found a published-version snapshot drift bug where validation could recompute from live character metadata; fixed by using stored version validation for version graph responses, with regression coverage. Verification: focused graph pytest passed with 22 tests; publish snapshot tests passed; spec and quality re-reviews approved.
+
+Task 3 API schemas/endpoints completed and accepted after review. Commit b02d27df89 adds graph request/response schemas, draft graph, draft graph-preview, and version graph endpoints, plus API tests. Verification: VN script API tests passed with 36 tests; spec compliance review approved; code quality review approved with no findings.
+
+Task 4 capabilities/docs completed. Commits 22e0224ed and 89a221561 add route-gated features.script_authoring_graph capability discovery, API docs for graph endpoints/source modes/response shape/diagnostics/limits/hashing/custom frontend flow/non-goals, and a regression test that keeps the graph feature disabled when only partial scripts routes are registered.
+
+Final verification: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest -q tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_graph.py tldw_Server_API/tests/VN_Scripts/test_vn_scripts_api.py tldw_Server_API/tests/VN_Platform/test_vn_capabilities_api.py -> 60 passed, 8 warnings; targeted VN capabilities pytest -> 3 passed, 8 warnings; compileall on touched VN modules passed; Bandit on touched backend VN modules reported 0 findings; git diff --check and git diff --cached --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL:BEGIN -->
+Opened PR #1656 for the backend-only VN script authoring graph API. Implemented deterministic pure graph construction, non-mutating service methods for stored draft/supplied draft preview/published version graph responses, VN Scripts schemas/endpoints, route-gated features.script_authoring_graph capability discovery, and API documentation. CI state on PR #1656 is pending at creation time.
+<!-- SECTION:FINAL:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/vn_scripts.py
+++ b/tldw_Server_API/app/api/v1/endpoints/vn_scripts.py
@@ -235,31 +235,76 @@ async def get_draft(script_id: int, service: VNScriptService = Depends(_service)
         raise _handle_value_error(exc) from exc
 
 
-@router.get("/scripts/{script_id}/draft/graph", response_model=VNScriptAuthoringGraphResponse)
+@router.get(
+    "/scripts/{script_id}/draft/graph",
+    response_model=VNScriptAuthoringGraphResponse,
+)
 async def get_draft_graph(
     script_id: int,
     service: VNScriptService = Depends(_service),
+    files_repo: AuthnzGeneratedFilesRepo = Depends(_generated_files_repo),
+    profile_store: VNPolicyProfileStore = Depends(_profile_store),
 ) -> VNScriptAuthoringGraphResponse:
     """Compute the authoring graph for the stored draft without persistence."""
     try:
-        return VNScriptAuthoringGraphResponse.model_validate(service.get_draft_graph(script_id))
+        script = service.get_script(script_id)
+        policy_profile, generation_profile, generation_profiles = await _resolve_script_profiles(
+            script,
+            profile_store=profile_store,
+        )
+        draft = service.get_draft(script_id)["draft"]
+        audio_refs = await _resolve_accessible_audio_refs(
+            draft,
+            files_repo=files_repo,
+            owner_user_id=service.owner_user_id,
+        )
+        return VNScriptAuthoringGraphResponse.model_validate(
+            service.get_draft_graph(
+                script_id,
+                audio_refs=audio_refs,
+                policy_profile=policy_profile,
+                generation_profile=generation_profile,
+                generation_profiles=generation_profiles,
+            )
+        )
     except ValueError as exc:
         raise _handle_value_error(exc) from exc
 
 
-@router.post("/scripts/{script_id}/draft/graph-preview", response_model=VNScriptAuthoringGraphResponse)
+@router.post(
+    "/scripts/{script_id}/draft/graph-preview",
+    response_model=VNScriptAuthoringGraphResponse,
+)
 async def preview_draft_graph(
     script_id: int,
     request: VNScriptGraphPreviewRequest,
     service: VNScriptService = Depends(_service),
+    files_repo: AuthnzGeneratedFilesRepo = Depends(_generated_files_repo),
+    profile_store: VNPolicyProfileStore = Depends(_profile_store),
 ) -> VNScriptAuthoringGraphResponse:
     """Compute the authoring graph for a supplied draft without persistence."""
     try:
+        script = service.get_script(script_id)
+        policy_profile, generation_profile, generation_profiles = await _resolve_script_profiles(
+            script,
+            profile_store=profile_store,
+        )
+        audio_refs = {}
+        if isinstance(request.draft, Mapping):
+            audio_refs = await _resolve_accessible_audio_refs(
+                request.draft,
+                files_repo=files_repo,
+                owner_user_id=service.owner_user_id,
+            )
         return VNScriptAuthoringGraphResponse.model_validate(
             service.preview_draft_graph(
                 script_id,
                 request.draft,
                 draft_revision=request.draft_revision,
+                audio_refs=audio_refs,
+                policy_profile=policy_profile,
+                generation_profile=generation_profile,
+                generation_profiles=generation_profiles,
             )
         )
     except ValueError as exc:
@@ -524,7 +569,10 @@ async def get_version(
         raise _handle_value_error(exc) from exc
 
 
-@router.get("/scripts/{script_id}/versions/{version_id}/graph", response_model=VNScriptAuthoringGraphResponse)
+@router.get(
+    "/scripts/{script_id}/versions/{version_id}/graph",
+    response_model=VNScriptAuthoringGraphResponse,
+)
 async def get_version_graph(
     script_id: int,
     version_id: int,
@@ -532,7 +580,9 @@ async def get_version_graph(
 ) -> VNScriptAuthoringGraphResponse:
     """Compute the authoring graph for an immutable published script version."""
     try:
-        return VNScriptAuthoringGraphResponse.model_validate(service.get_version_graph(script_id, version_id))
+        return VNScriptAuthoringGraphResponse.model_validate(
+            service.get_version_graph(script_id, version_id)
+        )
     except ValueError as exc:
         raise _handle_value_error(exc) from exc
 
@@ -753,6 +803,11 @@ def _handle_value_error(
     if reason == "supplied_draft_too_large":
         return HTTPException(
             status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=vn_error_detail(ERROR_INVALID_REQUEST, reason, details={"reason": reason}),
+        )
+    if reason == "supplied_draft_invalid_shape":
+        return HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
             detail=vn_error_detail(ERROR_INVALID_REQUEST, reason, details={"reason": reason}),
         )
     if reason in {"draft_revision_conflict", "idempotency_key_conflict"}:

--- a/tldw_Server_API/app/api/v1/endpoints/vn_scripts.py
+++ b/tldw_Server_API/app/api/v1/endpoints/vn_scripts.py
@@ -12,12 +12,14 @@ from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_
 from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
 from tldw_Server_API.app.api.v1.schemas.vn_script_schemas import (
     VNScriptAuthoringCatalogResponse,
+    VNScriptAuthoringGraphResponse,
     VNScriptCreate,
     VNScriptCreateFromTemplateRequest,
     VNScriptCreateFromTemplateResponse,
     VNScriptDiagnosticsResponse,
     VNScriptDraftPutRequest,
     VNScriptDraftResponse,
+    VNScriptGraphPreviewRequest,
     VNScriptListResponse,
     VNScriptManifestSnapshotResponse,
     VNScriptPatch,
@@ -229,6 +231,37 @@ async def get_draft(script_id: int, service: VNScriptService = Depends(_service)
     """Read mutable draft."""
     try:
         return VNScriptDraftResponse.model_validate(service.get_draft(script_id))
+    except ValueError as exc:
+        raise _handle_value_error(exc) from exc
+
+
+@router.get("/scripts/{script_id}/draft/graph", response_model=VNScriptAuthoringGraphResponse)
+async def get_draft_graph(
+    script_id: int,
+    service: VNScriptService = Depends(_service),
+) -> VNScriptAuthoringGraphResponse:
+    """Compute the authoring graph for the stored draft without persistence."""
+    try:
+        return VNScriptAuthoringGraphResponse.model_validate(service.get_draft_graph(script_id))
+    except ValueError as exc:
+        raise _handle_value_error(exc) from exc
+
+
+@router.post("/scripts/{script_id}/draft/graph-preview", response_model=VNScriptAuthoringGraphResponse)
+async def preview_draft_graph(
+    script_id: int,
+    request: VNScriptGraphPreviewRequest,
+    service: VNScriptService = Depends(_service),
+) -> VNScriptAuthoringGraphResponse:
+    """Compute the authoring graph for a supplied draft without persistence."""
+    try:
+        return VNScriptAuthoringGraphResponse.model_validate(
+            service.preview_draft_graph(
+                script_id,
+                request.draft,
+                draft_revision=request.draft_revision,
+            )
+        )
     except ValueError as exc:
         raise _handle_value_error(exc) from exc
 
@@ -491,6 +524,19 @@ async def get_version(
         raise _handle_value_error(exc) from exc
 
 
+@router.get("/scripts/{script_id}/versions/{version_id}/graph", response_model=VNScriptAuthoringGraphResponse)
+async def get_version_graph(
+    script_id: int,
+    version_id: int,
+    service: VNScriptService = Depends(_service),
+) -> VNScriptAuthoringGraphResponse:
+    """Compute the authoring graph for an immutable published script version."""
+    try:
+        return VNScriptAuthoringGraphResponse.model_validate(service.get_version_graph(script_id, version_id))
+    except ValueError as exc:
+        raise _handle_value_error(exc) from exc
+
+
 @router.get(
     "/scripts/{script_id}/versions/{version_id}/manifest-snapshot",
     response_model=VNScriptManifestSnapshotResponse,
@@ -699,10 +745,15 @@ def _handle_value_error(
     script_id: int | None = None,
 ) -> HTTPException:
     reason = str(exc) or "invalid_request"
-    if reason in {"script_not_found", "script_version_not_found", "template_not_found"}:
+    if reason in {"script_not_found", "draft_not_found", "script_version_not_found", "template_not_found"}:
         return HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=vn_error_detail(ERROR_NOT_FOUND, reason, details={"reason": reason}),
+        )
+    if reason == "supplied_draft_too_large":
+        return HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=vn_error_detail(ERROR_INVALID_REQUEST, reason, details={"reason": reason}),
         )
     if reason in {"draft_revision_conflict", "idempotency_key_conflict"}:
         details: dict[str, Any] = {"reason": reason}

--- a/tldw_Server_API/app/api/v1/schemas/vn_script_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/vn_script_schemas.py
@@ -235,6 +235,124 @@ class VNScriptSnippetApplyResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class VNScriptGraphPreviewRequest(BaseModel):
+    """Compute an authoring graph for a supplied draft without persistence."""
+
+    draft: Any
+    draft_revision: int | None = Field(default=None, ge=0)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class VNScriptGraphDiagnostic(BaseModel):
+    """Graph-specific authoring diagnostic."""
+
+    code: str
+    severity: Literal["error", "warning"]
+    message: str
+    path: str
+    details: dict[str, Any] = Field(default_factory=dict)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class VNScriptGraphDiagnostics(BaseModel):
+    """Graph diagnostics grouped by severity."""
+
+    errors: list[VNScriptGraphDiagnostic] = Field(default_factory=list)
+    warnings: list[VNScriptGraphDiagnostic] = Field(default_factory=list)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class VNScriptGraphOutlineLabel(BaseModel):
+    """Compact label summary for outline-style clients."""
+
+    id: str
+    label: str
+    source_path: str
+    op_count: int = Field(..., ge=0)
+    incoming_edge_count: int = Field(..., ge=0)
+    outgoing_edge_count: int = Field(..., ge=0)
+    reachable: bool
+    terminal: Literal["terminal", "continues", "unknown"]
+    summary: str
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class VNScriptGraphOutline(BaseModel):
+    """Authoring graph outline layer."""
+
+    entry_label: str | None = None
+    labels: list[VNScriptGraphOutlineLabel] = Field(default_factory=list)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class VNScriptGraphNode(BaseModel):
+    """Authoring graph node."""
+
+    id: str
+    type: Literal["label", "operation"]
+    label: str
+    source_path: str
+    reachable: bool | None = None
+    terminal: Literal["terminal", "continues", "unknown"] | None = None
+    op_index: int | None = Field(default=None, ge=0)
+    op: str | None = None
+    summary: str
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class VNScriptGraphEdge(BaseModel):
+    """Authoring graph edge."""
+
+    id: str
+    type: Literal["jump", "choice", "generated_choice_handler", "generation_cancel"]
+    source_id: str
+    target_id: str | None = None
+    source_path: str
+    target_label: str
+    metadata: dict[str, Any] | None = None
+    missing_target: bool = False
+    omitted_target: bool = False
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class VNScriptGraphBody(BaseModel):
+    """Detailed authoring graph layer."""
+
+    nodes: list[VNScriptGraphNode] = Field(default_factory=list)
+    edges: list[VNScriptGraphEdge] = Field(default_factory=list)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class VNScriptAuthoringGraphResponse(BaseModel):
+    """Computed VN script authoring graph response."""
+
+    schema_version: Literal["vn_script_authoring_graph.v1"]
+    graph_semantics_version: Literal["vn_script_authoring_graph_edges.v1"]
+    program_schema_version: Literal["vn_script_program.v1"]
+    script_id: int | None = None
+    source: Literal["stored_draft", "supplied_draft", "published_version"]
+    base_revision: int | None = None
+    version_id: int | None = None
+    content_hash: str
+    validation_context_source: Literal["current_draft_context", "published_version_snapshot"]
+    truncated: bool
+    limits: dict[str, int]
+    outline: VNScriptGraphOutline
+    graph: VNScriptGraphBody
+    diagnostics: VNScriptGraphDiagnostics
+    validation_diagnostics: dict[str, Any]
+
+    model_config = ConfigDict(extra="forbid")
+
+
 class VNScriptCreateFromTemplateRequest(BaseModel):
     """Create request for a VN script starter template."""
 

--- a/tldw_Server_API/app/core/VN_Platform/capabilities.py
+++ b/tldw_Server_API/app/core/VN_Platform/capabilities.py
@@ -21,6 +21,11 @@ VN_RESOURCE_PATHS = {
     "policy": f"{VN_BASE_PATH}/vn-policy",
     "audio": f"{VN_BASE_PATH}/vn-audio",
 }
+VN_SCRIPT_AUTHORING_GRAPH_PATHS = (
+    f"{VN_RESOURCE_PATHS['scripts']}/scripts/{{script_id}}/draft/graph",
+    f"{VN_RESOURCE_PATHS['scripts']}/scripts/{{script_id}}/draft/graph-preview",
+    f"{VN_RESOURCE_PATHS['scripts']}/scripts/{{script_id}}/versions/{{version_id}}/graph",
+)
 VN_SUPPORTED_IMAGE_MEDIA_TYPES = ["image/png", "image/jpeg", "image/webp"]
 VN_SUPPORTED_AUDIO_MEDIA_TYPES = ["audio/mpeg", "audio/wav", "audio/ogg"]
 
@@ -34,7 +39,10 @@ def build_vn_capabilities(routes: Iterable[Any]) -> dict[str, Any]:
     }
     scripted_generation_enabled = enabled_modules["scripts"] and enabled_modules["play"]
     script_authoring_catalog_enabled = enabled_modules["scripts"]
-    script_authoring_graph_enabled = enabled_modules["scripts"]
+    script_authoring_graph_enabled = _has_registered_paths(
+        route_paths,
+        VN_SCRIPT_AUTHORING_GRAPH_PATHS,
+    )
 
     return {
         "schema_version": "vn_capabilities.v1",
@@ -114,3 +122,7 @@ def _route_paths(routes: Iterable[Any]) -> set[str]:
 def _has_registered_resource(paths: set[str], resource_path: str) -> bool:
     prefix = resource_path.rstrip("/")
     return any(path == prefix or path.startswith(f"{prefix}/") for path in paths)
+
+
+def _has_registered_paths(paths: set[str], required_paths: Iterable[str]) -> bool:
+    return all(path in paths for path in required_paths)

--- a/tldw_Server_API/app/core/VN_Platform/capabilities.py
+++ b/tldw_Server_API/app/core/VN_Platform/capabilities.py
@@ -34,6 +34,7 @@ def build_vn_capabilities(routes: Iterable[Any]) -> dict[str, Any]:
     }
     scripted_generation_enabled = enabled_modules["scripts"] and enabled_modules["play"]
     script_authoring_catalog_enabled = enabled_modules["scripts"]
+    script_authoring_graph_enabled = enabled_modules["scripts"]
 
     return {
         "schema_version": "vn_capabilities.v1",
@@ -51,6 +52,7 @@ def build_vn_capabilities(routes: Iterable[Any]) -> dict[str, Any]:
             "scripted_generation_history": enabled_modules["play"],
             "scripted_generation_debug_detail": enabled_modules["play"],
             "script_authoring_catalog": script_authoring_catalog_enabled,
+            "script_authoring_graph": script_authoring_graph_enabled,
             "story_start": enabled_modules["play"],
             "tts_jobs": enabled_modules["audio"],
             "realtime_image_generation": False,

--- a/tldw_Server_API/app/core/VN_Platform/capabilities.py
+++ b/tldw_Server_API/app/core/VN_Platform/capabilities.py
@@ -26,6 +26,11 @@ VN_SCRIPT_AUTHORING_GRAPH_PATHS = (
     f"{VN_RESOURCE_PATHS['scripts']}/scripts/{{script_id}}/draft/graph-preview",
     f"{VN_RESOURCE_PATHS['scripts']}/scripts/{{script_id}}/versions/{{version_id}}/graph",
 )
+VN_SCRIPT_AUTHORING_GRAPH_ROUTES = (
+    (VN_SCRIPT_AUTHORING_GRAPH_PATHS[0], "GET"),
+    (VN_SCRIPT_AUTHORING_GRAPH_PATHS[1], "POST"),
+    (VN_SCRIPT_AUTHORING_GRAPH_PATHS[2], "GET"),
+)
 VN_SUPPORTED_IMAGE_MEDIA_TYPES = ["image/png", "image/jpeg", "image/webp"]
 VN_SUPPORTED_AUDIO_MEDIA_TYPES = ["audio/mpeg", "audio/wav", "audio/ogg"]
 
@@ -33,15 +38,16 @@ VN_SUPPORTED_AUDIO_MEDIA_TYPES = ["audio/mpeg", "audio/wav", "audio/ogg"]
 def build_vn_capabilities(routes: Iterable[Any]) -> dict[str, Any]:
     """Build a route-aware capabilities payload for the current FastAPI app."""
     route_paths = _route_paths(routes)
+    route_methods = _route_methods(routes)
     enabled_modules = {
         key: _has_registered_resource(route_paths, path)
         for key, path in VN_RESOURCE_PATHS.items()
     }
     scripted_generation_enabled = enabled_modules["scripts"] and enabled_modules["play"]
     script_authoring_catalog_enabled = enabled_modules["scripts"]
-    script_authoring_graph_enabled = _has_registered_paths(
-        route_paths,
-        VN_SCRIPT_AUTHORING_GRAPH_PATHS,
+    script_authoring_graph_enabled = _has_registered_route_methods(
+        route_methods,
+        VN_SCRIPT_AUTHORING_GRAPH_ROUTES,
     )
 
     return {
@@ -112,6 +118,7 @@ def build_vn_capabilities(routes: Iterable[Any]) -> dict[str, Any]:
 
 
 def _route_paths(routes: Iterable[Any]) -> set[str]:
+    """Return the FastAPI route paths registered in the current app."""
     return {
         path
         for route in routes
@@ -119,10 +126,29 @@ def _route_paths(routes: Iterable[Any]) -> set[str]:
     }
 
 
+def _route_methods(routes: Iterable[Any]) -> set[tuple[str, str]]:
+    """Return registered (path, HTTP method) pairs for FastAPI routes."""
+    pairs: set[tuple[str, str]] = set()
+    for route in routes:
+        path = getattr(route, "path", None)
+        methods = getattr(route, "methods", None)
+        if not isinstance(path, str) or not isinstance(methods, Iterable):
+            continue
+        for method in methods:
+            if isinstance(method, str):
+                pairs.add((path, method.upper()))
+    return pairs
+
+
 def _has_registered_resource(paths: set[str], resource_path: str) -> bool:
+    """Return whether any registered route belongs to a resource prefix."""
     prefix = resource_path.rstrip("/")
     return any(path == prefix or path.startswith(f"{prefix}/") for path in paths)
 
 
-def _has_registered_paths(paths: set[str], required_paths: Iterable[str]) -> bool:
-    return all(path in paths for path in required_paths)
+def _has_registered_route_methods(
+    route_methods: set[tuple[str, str]],
+    required_routes: Iterable[tuple[str, str]],
+) -> bool:
+    """Return whether all required route paths exist with their expected methods."""
+    return all((path, method.upper()) in route_methods for path, method in required_routes)

--- a/tldw_Server_API/app/core/VN_Scripts/authoring_graph.py
+++ b/tldw_Server_API/app/core/VN_Scripts/authoring_graph.py
@@ -1,0 +1,592 @@
+"""Pure VN script authoring graph builder."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import hashlib
+import json
+from typing import Any
+from urllib.parse import quote
+
+SCHEMA_VERSION = "vn_script_authoring_graph.v1"
+GRAPH_SEMANTICS_VERSION = "vn_script_authoring_graph_edges.v1"
+PROGRAM_SCHEMA_VERSION = "vn_script_program.v1"
+MAX_SUPPLIED_DRAFT_BYTES = 1_048_576
+MAX_LABELS = 500
+MAX_OPS = 5000
+MAX_EDGES = 10000
+MAX_SUMMARY_LENGTH = 240
+
+_DYNAMIC_FLOW_OPS = {"random", "return"}
+
+
+def encoded_label_id(label: str) -> str:
+    """Return a deterministic graph node ID for a label."""
+    return "label:" + _quote_label(label)
+
+
+def operation_id(label: str, index: int) -> str:
+    """Return a deterministic graph node ID for an operation."""
+    return f"op:{_quote_label(label)}:{index}"
+
+
+def bracket_label_path(label: str) -> str:
+    """Return the bracket-notation JSON path for a label."""
+    escaped = label.replace("\\", "\\\\").replace("'", "\\'")
+    return f"$.labels['{escaped}']"
+
+
+def content_hash_for_program(
+    program: Mapping[str, Any],
+    *,
+    graph_semantics_version: str = GRAPH_SEMANTICS_VERSION,
+    program_schema_version: str = PROGRAM_SCHEMA_VERSION,
+) -> str:
+    """Return the canonical authoring graph content hash for a source program."""
+    payload = {
+        "graph_semantics_version": graph_semantics_version,
+        "program": program,
+        "program_schema_version": program_schema_version,
+    }
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def build_script_authoring_graph(
+    program: Mapping[str, Any],
+    *,
+    source: str = "stored_draft",
+    script_id: int | None = None,
+    base_revision: int | None = None,
+    version_id: int | None = None,
+    validation_diagnostics: Mapping[str, Any] | None = None,
+    validation_context_source: str = "current_draft_context",
+    limits: Mapping[str, int] | None = None,
+) -> dict[str, Any]:
+    """Build a static authoring graph from a parsed VN script program."""
+    active_limits = _active_limits(limits)
+    diagnostics: dict[str, list[dict[str, Any]]] = {"errors": [], "warnings": []}
+    truncated = False
+    labels = program.get("labels")
+    entry_label = program.get("entry_label") if isinstance(program.get("entry_label"), str) else None
+    label_items = _ordered_label_items(labels, entry_label) if isinstance(labels, Mapping) else []
+
+    if not isinstance(labels, Mapping) or not labels:
+        _append_diag(
+            diagnostics["errors"],
+            "graph_labels_missing",
+            "error",
+            "Script must define at least one label.",
+            "$.labels",
+        )
+
+    if len(label_items) > active_limits["max_labels"]:
+        label_items = label_items[: active_limits["max_labels"]]
+        truncated = True
+        _append_diag(
+            diagnostics["warnings"],
+            "graph_node_limit_exceeded",
+            "warning",
+            "Graph label limit was reached; output is partial.",
+            "$.labels",
+            {"limit": active_limits["max_labels"]},
+        )
+
+    label_names = {label for label, _ in label_items}
+    all_label_names = {str(label) for label in labels} if isinstance(labels, Mapping) else set()
+    nodes: list[dict[str, Any]] = []
+    edges: list[dict[str, Any]] = []
+    outgoing_counts: dict[str, int] = {label: 0 for label, _ in label_items}
+    incoming_counts: dict[str, int] = {label: 0 for label, _ in label_items}
+    op_count_seen = 0
+
+    for label, raw_ops in label_items:
+        label_path = bracket_label_path(label)
+        nodes.append(
+            {
+                "id": encoded_label_id(label),
+                "type": "label",
+                "label": label,
+                "source_path": label_path,
+                "reachable": False,
+                "terminal": "unknown",
+                "summary": _clip_summary(_label_node_summary(raw_ops)),
+            }
+        )
+        if not isinstance(raw_ops, list):
+            _append_diag(
+                diagnostics["errors"],
+                "graph_label_body_invalid",
+                "error",
+                "Label body must be a list of opcodes.",
+                label_path,
+                {"label": label},
+            )
+            continue
+
+        for index, opcode in enumerate(raw_ops):
+            if op_count_seen >= active_limits["max_ops"]:
+                truncated = True
+                _append_diag(
+                    diagnostics["warnings"],
+                    "graph_node_limit_exceeded",
+                    "warning",
+                    "Graph operation limit was reached; output is partial.",
+                    f"{label_path}[{index}]",
+                    {"limit": active_limits["max_ops"]},
+                )
+                break
+            op_count_seen += 1
+            op_path = f"{label_path}[{index}]"
+            op_name = _op_name(opcode) if isinstance(opcode, Mapping) else ""
+            if not isinstance(opcode, Mapping):
+                _append_diag(
+                    diagnostics["errors"],
+                    "graph_opcode_invalid",
+                    "error",
+                    "Opcode must be an object.",
+                    op_path,
+                    {"label": label, "op_index": index},
+                )
+                nodes.append(_operation_node(label, index, "invalid", op_path, "Invalid opcode."))
+                continue
+
+            nodes.append(_operation_node(label, index, op_name or "unknown", op_path, _operation_summary(opcode)))
+            if opcode.get("if") is not None or op_name in _DYNAMIC_FLOW_OPS:
+                _append_diag(
+                    diagnostics["warnings"],
+                    "graph_unsupported_dynamic_flow",
+                    "warning",
+                    "Operation uses dynamic or conditional flow; terminal state is unknown.",
+                    op_path,
+                    {"label": label, "op_index": index, "op": op_name},
+                )
+
+            extracted = _extract_static_edges(label, index, opcode, label_names, all_label_names, diagnostics)
+            for edge in extracted:
+                if len(edges) >= active_limits["max_edges"]:
+                    truncated = True
+                    _append_diag(
+                        diagnostics["warnings"],
+                        "graph_edge_limit_exceeded",
+                        "warning",
+                        "Graph edge limit was reached; output is partial.",
+                        edge["source_path"],
+                        {"limit": active_limits["max_edges"]},
+                    )
+                    break
+                edges.append(edge)
+                outgoing_counts[label] = outgoing_counts.get(label, 0) + 1
+                target_label = edge["target_label"]
+                if edge["target_id"] is not None:
+                    if target_label in incoming_counts:
+                        incoming_counts[target_label] += 1
+
+    reachable = _reachable_labels(entry_label, labels) if entry_label and isinstance(labels, Mapping) else set()
+    for label in sorted(label_names - reachable):
+        if label != entry_label:
+            _append_diag(
+                diagnostics["warnings"],
+                "graph_label_unreachable",
+                "warning",
+                "Label is never reached from the entry label.",
+                bracket_label_path(label),
+                {"label": label},
+            )
+
+    terminal_by_label = {label: _terminal_state(raw_ops, outgoing_counts.get(label, 0)) for label, raw_ops in label_items}
+    reachable_by_label = {label: label in reachable for label, _ in label_items}
+    for node in nodes:
+        label = str(node["label"])
+        if node["type"] == "label":
+            node["reachable"] = reachable_by_label.get(label, False)
+            node["terminal"] = terminal_by_label.get(label, "unknown")
+
+    outline_labels = [
+        _outline_label(
+            label,
+            raw_ops,
+            incoming_counts.get(label, 0),
+            outgoing_counts.get(label, 0),
+            reachable_by_label.get(label, False),
+            terminal_by_label.get(label, "unknown"),
+        )
+        for label, raw_ops in label_items
+    ]
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "graph_semantics_version": GRAPH_SEMANTICS_VERSION,
+        "program_schema_version": PROGRAM_SCHEMA_VERSION,
+        "source": source,
+        "script_id": script_id,
+        "base_revision": base_revision,
+        "version_id": version_id,
+        "content_hash": content_hash_for_program(program),
+        "validation_context_source": validation_context_source,
+        "truncated": truncated,
+        "limits": {
+            "max_labels": active_limits["max_labels"],
+            "max_ops": active_limits["max_ops"],
+            "max_edges": active_limits["max_edges"],
+            "max_supplied_draft_bytes": active_limits["max_supplied_draft_bytes"],
+        },
+        "outline": {"entry_label": entry_label, "labels": outline_labels},
+        "graph": {"nodes": nodes, "edges": edges},
+        "diagnostics": diagnostics,
+        "validation_diagnostics": _validation_diagnostics(validation_diagnostics),
+    }
+
+
+def _active_limits(overrides: Mapping[str, int] | None) -> dict[str, int]:
+    limits = {
+        "max_labels": MAX_LABELS,
+        "max_ops": MAX_OPS,
+        "max_edges": MAX_EDGES,
+        "max_supplied_draft_bytes": MAX_SUPPLIED_DRAFT_BYTES,
+    }
+    if overrides:
+        for key in ("max_labels", "max_ops", "max_edges", "max_supplied_draft_bytes"):
+            if key in overrides:
+                limits[key] = max(0, int(overrides[key]))
+    return limits
+
+
+def _ordered_label_items(labels: Mapping[str, Any], entry_label: str | None) -> list[tuple[str, Any]]:
+    items = [(str(label), raw_ops) for label, raw_ops in labels.items()]
+    if not entry_label:
+        return items
+    entry_items = [(label, raw_ops) for label, raw_ops in items if label == entry_label]
+    return entry_items + [(label, raw_ops) for label, raw_ops in items if label != entry_label]
+
+
+def _operation_node(label: str, index: int, op_name: str, source_path: str, summary: str) -> dict[str, Any]:
+    return {
+        "id": operation_id(label, index),
+        "type": "operation",
+        "label": label,
+        "op_index": index,
+        "op": op_name,
+        "source_path": source_path,
+        "summary": _clip_summary(summary),
+    }
+
+
+def _outline_label(
+    label: str,
+    raw_ops: Any,
+    incoming_edge_count: int,
+    outgoing_edge_count: int,
+    reachable: bool,
+    terminal: str,
+) -> dict[str, Any]:
+    op_count = len(raw_ops) if isinstance(raw_ops, list) else 0
+    return {
+        "id": encoded_label_id(label),
+        "label": label,
+        "source_path": bracket_label_path(label),
+        "op_count": op_count,
+        "incoming_edge_count": incoming_edge_count,
+        "outgoing_edge_count": outgoing_edge_count,
+        "reachable": reachable,
+        "terminal": terminal,
+        "summary": _clip_summary(_outline_summary(op_count, outgoing_edge_count)),
+    }
+
+
+def _label_node_summary(raw_ops: Any) -> str:
+    if not isinstance(raw_ops, list):
+        return "Invalid label body."
+    return _outline_summary(len(raw_ops), 0)
+
+
+def _outline_summary(op_count: int, outgoing_edge_count: int) -> str:
+    op_word = "operation" if op_count == 1 else "operations"
+    if outgoing_edge_count:
+        edge_word = "edge" if outgoing_edge_count == 1 else "edges"
+        return f"{op_count} {op_word} and {outgoing_edge_count} outgoing {edge_word}."
+    return f"{op_count} {op_word}."
+
+
+def _operation_summary(opcode: Mapping[str, Any]) -> str:
+    op = _op_name(opcode)
+    if op == "generate":
+        output_schema = (
+            opcode.get("output_schema")
+            if isinstance(opcode.get("output_schema"), str)
+            else "narrative_dialogue"
+        )
+        profile_key = (
+            opcode.get("profile_key")
+            if isinstance(opcode.get("profile_key"), str)
+            else "default"
+        )
+        return f"Generate {output_schema} using profile {profile_key}."
+    if op == "choice":
+        choices = opcode.get("choices")
+        count = len(choices) if isinstance(choices, list) else 0
+        choice_word = "choice" if count == 1 else "choices"
+        return f"Authored choice with {count} {choice_word}."
+    if op == "jump":
+        target = opcode.get("target")
+        return f"Jump to {target}." if isinstance(target, str) else "Jump with invalid target."
+    if op == "end":
+        return "End script."
+    if op == "narrate":
+        return "Narration."
+    if op == "say":
+        return "Dialogue."
+    return f"{op} operation."
+
+
+def _extract_static_edges(
+    label: str,
+    index: int,
+    opcode: Mapping[str, Any],
+    emitted_label_names: set[str],
+    all_label_names: set[str],
+    diagnostics: dict[str, list[dict[str, Any]]],
+) -> list[dict[str, Any]]:
+    op = opcode.get("op")
+    if op == "jump":
+        return [
+            _edge(
+                label,
+                index,
+                "jump",
+                opcode.get("target"),
+                f"{bracket_label_path(label)}[{index}].target",
+                emitted_label_names,
+                all_label_names,
+                diagnostics,
+                missing_code="graph_target_missing",
+            )
+        ]
+    if op == "choice":
+        choices = opcode.get("choices")
+        if not isinstance(choices, list):
+            _append_diag(
+                diagnostics["errors"],
+                "graph_choice_options_invalid",
+                "error",
+                "Choice opcode requires a list of options.",
+                f"{bracket_label_path(label)}[{index}].choices",
+                {"label": label, "op_index": index},
+            )
+            return []
+        edges: list[dict[str, Any]] = []
+        for choice_index, choice in enumerate(choices):
+            choice_path = f"{bracket_label_path(label)}[{index}].choices[{choice_index}]"
+            if not isinstance(choice, Mapping):
+                _append_diag(
+                    diagnostics["errors"],
+                    "graph_choice_options_invalid",
+                    "error",
+                    "Choice option must be an object.",
+                    choice_path,
+                    {"label": label, "op_index": index, "choice_index": choice_index},
+                )
+                continue
+            edges.append(
+                _edge(
+                    label,
+                    index,
+                    "choice",
+                    choice.get("target"),
+                    f"{choice_path}.target",
+                    emitted_label_names,
+                    all_label_names,
+                    diagnostics,
+                    missing_code="graph_target_missing",
+                    discriminator=f"choice:{choice_index}",
+                    metadata={"choice_index": choice_index},
+                )
+            )
+        return edges
+    if op == "generate":
+        edges = []
+        if "on_generated_choice" in opcode or opcode.get("output_schema") == "choice_set":
+            edges.append(
+                _edge(
+                    label,
+                    index,
+                    "generated_choice_handler",
+                    opcode.get("on_generated_choice"),
+                    f"{bracket_label_path(label)}[{index}].on_generated_choice",
+                    emitted_label_names,
+                    all_label_names,
+                    diagnostics,
+                    missing_code="graph_generated_choice_handler_missing",
+                    metadata={
+                        "output_schema": opcode.get("output_schema")
+                        if isinstance(opcode.get("output_schema"), str)
+                        else None
+                    },
+                )
+            )
+        if "on_cancel" in opcode:
+            edges.append(
+                _edge(
+                    label,
+                    index,
+                    "generation_cancel",
+                    opcode.get("on_cancel"),
+                    f"{bracket_label_path(label)}[{index}].on_cancel",
+                    emitted_label_names,
+                    all_label_names,
+                    diagnostics,
+                    missing_code="graph_cancel_target_missing",
+                )
+            )
+        return edges
+    return []
+
+
+def _edge(
+    label: str,
+    index: int,
+    edge_type: str,
+    raw_target: Any,
+    source_path: str,
+    emitted_label_names: set[str],
+    all_label_names: set[str],
+    diagnostics: dict[str, list[dict[str, Any]]],
+    *,
+    missing_code: str,
+    discriminator: str | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    source_id = operation_id(label, index)
+    target_label = raw_target if isinstance(raw_target, str) else ""
+    target_id = encoded_label_id(target_label) if target_label in emitted_label_names else None
+    missing_key = "missing:" + _quote_label(target_label or "invalid")
+    edge_id_parts = ["edge", source_id, edge_type]
+    if discriminator is not None:
+        edge_id_parts.append(discriminator)
+    edge_id_parts.append(target_id or missing_key)
+    edge = {
+        "id": ":".join(edge_id_parts),
+        "type": edge_type,
+        "source_id": source_id,
+        "target_id": target_id,
+        "source_path": source_path,
+        "target_label": target_label,
+    }
+    compact_metadata = {key: value for key, value in dict(metadata or {}).items() if value is not None}
+    if compact_metadata:
+        edge["metadata"] = compact_metadata
+    if target_id is None and target_label in all_label_names:
+        edge["omitted_target"] = True
+        _append_diag(
+            diagnostics["warnings"],
+            "graph_target_omitted",
+            "warning",
+            "Target label was omitted because the graph node limit was reached.",
+            source_path,
+            {"target_label": target_label, "edge_type": edge_type},
+        )
+    elif target_id is None:
+        edge["missing_target"] = True
+        _append_diag(
+            diagnostics["errors"],
+            missing_code,
+            "error",
+            "Target label was not found.",
+            source_path,
+            {"target_label": target_label, "edge_type": edge_type},
+        )
+    return edge
+
+
+def _validation_diagnostics(validation_diagnostics: Mapping[str, Any] | None) -> dict[str, Any]:
+    if validation_diagnostics is None:
+        return {"valid": False, "errors": [], "warnings": []}
+    return {
+        "valid": bool(validation_diagnostics.get("valid", False)),
+        "errors": list(validation_diagnostics.get("errors") or []),
+        "warnings": list(validation_diagnostics.get("warnings") or []),
+    }
+
+
+def _reachable_labels(entry_label: str, labels: Mapping[str, Any]) -> set[str]:
+    reachable: set[str] = set()
+    stack = [entry_label]
+    while stack:
+        label = stack.pop()
+        if label in reachable:
+            continue
+        reachable.add(label)
+        raw_ops = labels.get(label)
+        if not isinstance(raw_ops, list):
+            continue
+        for opcode in raw_ops:
+            if not isinstance(opcode, Mapping):
+                continue
+            if opcode.get("op") == "jump" and isinstance(opcode.get("target"), str):
+                stack.append(str(opcode["target"]))
+            elif opcode.get("op") == "generate":
+                if isinstance(opcode.get("on_cancel"), str):
+                    stack.append(str(opcode["on_cancel"]))
+                if isinstance(opcode.get("on_generated_choice"), str):
+                    stack.append(str(opcode["on_generated_choice"]))
+            elif opcode.get("op") == "choice" and isinstance(opcode.get("choices"), list):
+                for choice in opcode["choices"]:
+                    if isinstance(choice, Mapping) and isinstance(choice.get("target"), str):
+                        stack.append(str(choice["target"]))
+    return reachable
+
+
+def _terminal_state(raw_ops: Any, outgoing_edge_count: int) -> str:
+    if not isinstance(raw_ops, list):
+        return "unknown"
+    malformed = False
+    dynamic_or_conditional = False
+    last_op = ""
+    for opcode in raw_ops:
+        if not isinstance(opcode, Mapping):
+            malformed = True
+            continue
+        last_op = _op_name(opcode)
+        if opcode.get("if") is not None or last_op in _DYNAMIC_FLOW_OPS:
+            dynamic_or_conditional = True
+    if malformed or dynamic_or_conditional:
+        return "unknown"
+    if last_op == "end" and outgoing_edge_count == 0:
+        return "terminal"
+    if outgoing_edge_count > 0:
+        return "continues"
+    return "unknown"
+
+
+def _append_diag(
+    target: list[dict[str, Any]],
+    code: str,
+    severity: str,
+    message: str,
+    path: str,
+    details: Mapping[str, Any] | None = None,
+) -> None:
+    target.append(
+        {
+            "code": code,
+            "severity": severity,
+            "message": message,
+            "path": path,
+            "details": dict(details or {}),
+        }
+    )
+
+
+def _clip_summary(summary: str) -> str:
+    if len(summary) <= MAX_SUMMARY_LENGTH:
+        return summary
+    return summary[: MAX_SUMMARY_LENGTH - 3].rstrip() + "..."
+
+
+def _quote_label(label: str) -> str:
+    return quote(label, safe="").replace(".", "%2E")
+
+
+def _op_name(opcode: Mapping[str, Any]) -> str:
+    op = opcode.get("op")
+    return op if isinstance(op, str) and op else "unknown"

--- a/tldw_Server_API/app/core/VN_Scripts/authoring_graph.py
+++ b/tldw_Server_API/app/core/VN_Scripts/authoring_graph.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping
 import hashlib
 import json
 from typing import Any
-from urllib.parse import quote
+from urllib.parse import quote, unquote
 
 SCHEMA_VERSION = "vn_script_authoring_graph.v1"
 GRAPH_SEMANTICS_VERSION = "vn_script_authoring_graph_edges.v1"
@@ -182,7 +182,7 @@ def build_script_authoring_graph(
                     if target_label in incoming_counts:
                         incoming_counts[target_label] += 1
 
-    reachable = _reachable_labels(entry_label, labels) if entry_label and isinstance(labels, Mapping) else set()
+    reachable = _reachable_labels(entry_label, edges) if entry_label else set()
     for label in sorted(label_names - reachable):
         if label != entry_label:
             _append_diag(
@@ -194,7 +194,11 @@ def build_script_authoring_graph(
                 {"label": label},
             )
 
-    terminal_by_label = {label: _terminal_state(raw_ops, outgoing_counts.get(label, 0)) for label, raw_ops in label_items}
+    terminal_by_label = {
+        label: _terminal_state(raw_ops, outgoing_counts.get(label, 0))
+        for label, raw_ops in label_items
+    }
+    _append_fallthrough_limitations(label_items, outgoing_counts, terminal_by_label, diagnostics)
     reachable_by_label = {label: label in reachable for label, _ in label_items}
     for node in nodes:
         label = str(node["label"])
@@ -508,7 +512,17 @@ def _validation_diagnostics(validation_diagnostics: Mapping[str, Any] | None) ->
     }
 
 
-def _reachable_labels(entry_label: str, labels: Mapping[str, Any]) -> set[str]:
+def _reachable_labels(entry_label: str, edges: list[dict[str, Any]]) -> set[str]:
+    """Return labels reachable through emitted static graph edges."""
+    adjacency: dict[str, list[str]] = {}
+    for edge in edges:
+        if edge.get("target_id") is None:
+            continue
+        source_label = _edge_source_label(edge)
+        target_label = edge.get("target_label")
+        if isinstance(source_label, str) and isinstance(target_label, str):
+            adjacency.setdefault(source_label, []).append(target_label)
+
     reachable: set[str] = set()
     stack = [entry_label]
     while stack:
@@ -516,24 +530,42 @@ def _reachable_labels(entry_label: str, labels: Mapping[str, Any]) -> set[str]:
         if label in reachable:
             continue
         reachable.add(label)
-        raw_ops = labels.get(label)
+        stack.extend(reversed(adjacency.get(label, [])))
+    return reachable
+
+
+def _edge_source_label(edge: Mapping[str, Any]) -> str | None:
+    """Extract the encoded source label from an emitted operation edge ID."""
+    source_id = edge.get("source_id")
+    if not isinstance(source_id, str):
+        return None
+    parts = source_id.split(":")
+    if len(parts) < 3 or parts[0] != "op":
+        return None
+    return unquote(parts[1])
+
+
+def _append_fallthrough_limitations(
+    label_items: list[tuple[str, Any]],
+    outgoing_counts: Mapping[str, int],
+    terminal_by_label: Mapping[str, str],
+    diagnostics: dict[str, list[dict[str, Any]]],
+) -> None:
+    """Append warnings for labels whose possible fallthrough is intentionally static-only."""
+    for index, (label, raw_ops) in enumerate(label_items[:-1]):
         if not isinstance(raw_ops, list):
             continue
-        for opcode in raw_ops:
-            if not isinstance(opcode, Mapping):
-                continue
-            if opcode.get("op") == "jump" and isinstance(opcode.get("target"), str):
-                stack.append(str(opcode["target"]))
-            elif opcode.get("op") == "generate":
-                if isinstance(opcode.get("on_cancel"), str):
-                    stack.append(str(opcode["on_cancel"]))
-                if isinstance(opcode.get("on_generated_choice"), str):
-                    stack.append(str(opcode["on_generated_choice"]))
-            elif opcode.get("op") == "choice" and isinstance(opcode.get("choices"), list):
-                for choice in opcode["choices"]:
-                    if isinstance(choice, Mapping) and isinstance(choice.get("target"), str):
-                        stack.append(str(choice["target"]))
-    return reachable
+        if outgoing_counts.get(label, 0) > 0 or terminal_by_label.get(label) != "unknown":
+            continue
+        next_label = label_items[index + 1][0]
+        _append_diag(
+            diagnostics["warnings"],
+            "graph_fallthrough_not_inferred",
+            "warning",
+            "Static graph reachability does not infer implicit fallthrough to the next label.",
+            bracket_label_path(label),
+            {"label": label, "next_label": next_label},
+        )
 
 
 def _terminal_state(raw_ops: Any, outgoing_edge_count: int) -> str:

--- a/tldw_Server_API/app/core/VN_Scripts/service.py
+++ b/tldw_Server_API/app/core/VN_Scripts/service.py
@@ -19,6 +19,10 @@ from tldw_Server_API.app.core.VN_Assets.service import VNAssetPackService
 from tldw_Server_API.app.core.VN_Platform.idempotency import canonical_payload_hash
 from tldw_Server_API.app.core.VN_Policy.service import evaluate_character_safety_definition
 from tldw_Server_API.app.core.VN_Scripts.authoring_catalog import list_authoring_catalog
+from tldw_Server_API.app.core.VN_Scripts.authoring_graph import (
+    MAX_SUPPLIED_DRAFT_BYTES,
+    build_script_authoring_graph,
+)
 from tldw_Server_API.app.core.VN_Scripts.snippet_patcher import SnippetPatchResult, apply_snippet_patch
 from tldw_Server_API.app.core.VN_Scripts.templates import instantiate_template, list_template_catalog
 from tldw_Server_API.app.core.VN_Scripts.validator import VNScriptValidationContext, validate_script_program
@@ -284,6 +288,59 @@ class VNScriptService:
             raise ValueError("script_not_found")
         return draft
 
+    def get_draft_graph(self, script_id: int) -> dict[str, Any]:
+        """Return a computed authoring graph for the stored draft without persistence."""
+        script = self._require_script(script_id)
+        draft_row = self.get_draft(script_id)
+        validation = self.validate_draft_payload(script, draft_row["draft"])
+        return build_script_authoring_graph(
+            draft_row["draft"],
+            source="stored_draft",
+            script_id=script_id,
+            base_revision=int(draft_row["revision"]),
+            validation_diagnostics=validation,
+            validation_context_source="current_draft_context",
+        )
+
+    def preview_draft_graph(
+        self,
+        script_id: int,
+        draft: Mapping[str, Any],
+        *,
+        draft_revision: int | None = None,
+    ) -> dict[str, Any]:
+        """Return a computed authoring graph for a supplied draft without persistence."""
+        script = self._require_script(script_id)
+        if not isinstance(draft, Mapping):
+            raise ValueError("supplied_draft_invalid_shape")
+        if _payload_size_bytes(draft) > MAX_SUPPLIED_DRAFT_BYTES:
+            raise ValueError("supplied_draft_too_large")
+        draft_row = self.get_draft(script_id)
+        current_revision = int(draft_row["revision"])
+        validation = self.validate_draft_payload(script, draft)
+        result = build_script_authoring_graph(
+            draft,
+            source="supplied_draft",
+            script_id=script_id,
+            base_revision=current_revision,
+            validation_diagnostics=validation,
+            validation_context_source="current_draft_context",
+        )
+        if draft_revision is not None and int(draft_revision) != current_revision:
+            result["diagnostics"]["warnings"].append(
+                {
+                    "code": "graph_preview_revision_stale",
+                    "severity": "warning",
+                    "message": "Supplied draft revision does not match the current stored draft revision.",
+                    "path": "$.draft_revision",
+                    "details": {
+                        "supplied_draft_revision": int(draft_revision),
+                        "current_revision": current_revision,
+                    },
+                }
+            )
+        return result
+
     def replace_draft(
         self,
         script_id: int,
@@ -509,6 +566,18 @@ class VNScriptService:
             raise ValueError("script_version_not_found")
         return version
 
+    def get_version_graph(self, script_id: int, version_id: int) -> dict[str, Any]:
+        """Return a computed authoring graph for an immutable published version."""
+        version = self.get_version(script_id, version_id)
+        return build_script_authoring_graph(
+            version["program"],
+            source="published_version",
+            script_id=script_id,
+            version_id=version_id,
+            validation_diagnostics=_stored_version_validation(version),
+            validation_context_source="published_version_snapshot",
+        )
+
     def get_manifest_snapshot(self, script_id: int, version_id: int) -> dict[str, Any]:
         """Return the manifest snapshot pinned to a version."""
         self._require_script(script_id)
@@ -641,6 +710,21 @@ def _approved_slot_keys(manifest: Mapping[str, Any]) -> set[str]:
 
 def _empty_audio_refs(program: Mapping[str, Any]) -> Mapping[str, Mapping[str, Any]]:
     return {}
+
+
+def _payload_size_bytes(payload: Mapping[str, Any]) -> int:
+    return len(json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8"))
+
+
+def _stored_version_validation(version: Mapping[str, Any]) -> dict[str, Any]:
+    validation = version.get("validation")
+    if isinstance(validation, Mapping):
+        return {
+            "valid": bool(validation.get("valid")),
+            "errors": list(validation.get("errors") or []),
+            "warnings": list(validation.get("warnings") or []),
+        }
+    return {"valid": False, "errors": [], "warnings": []}
 
 
 def _script_metadata_payload(

--- a/tldw_Server_API/app/core/VN_Scripts/service.py
+++ b/tldw_Server_API/app/core/VN_Scripts/service.py
@@ -288,11 +288,26 @@ class VNScriptService:
             raise ValueError("script_not_found")
         return draft
 
-    def get_draft_graph(self, script_id: int) -> dict[str, Any]:
+    def get_draft_graph(
+        self,
+        script_id: int,
+        *,
+        audio_refs: Mapping[str, Mapping[str, Any]] | None = None,
+        policy_profile: ProfileRow | None = None,
+        generation_profile: ProfileRow | None = None,
+        generation_profiles: Mapping[str, ProfileRow] | None = None,
+    ) -> dict[str, Any]:
         """Return a computed authoring graph for the stored draft without persistence."""
         script = self._require_script(script_id)
         draft_row = self.get_draft(script_id)
-        validation = self.validate_draft_payload(script, draft_row["draft"])
+        validation = self.validate_draft_payload(
+            script,
+            draft_row["draft"],
+            audio_refs=audio_refs,
+            policy_profile=policy_profile,
+            generation_profile=generation_profile,
+            generation_profiles=generation_profiles,
+        )
         return build_script_authoring_graph(
             draft_row["draft"],
             source="stored_draft",
@@ -308,6 +323,10 @@ class VNScriptService:
         draft: Mapping[str, Any],
         *,
         draft_revision: int | None = None,
+        audio_refs: Mapping[str, Mapping[str, Any]] | None = None,
+        policy_profile: ProfileRow | None = None,
+        generation_profile: ProfileRow | None = None,
+        generation_profiles: Mapping[str, ProfileRow] | None = None,
     ) -> dict[str, Any]:
         """Return a computed authoring graph for a supplied draft without persistence."""
         script = self._require_script(script_id)
@@ -317,7 +336,14 @@ class VNScriptService:
             raise ValueError("supplied_draft_too_large")
         draft_row = self.get_draft(script_id)
         current_revision = int(draft_row["revision"])
-        validation = self.validate_draft_payload(script, draft)
+        validation = self.validate_draft_payload(
+            script,
+            draft,
+            audio_refs=audio_refs,
+            policy_profile=policy_profile,
+            generation_profile=generation_profile,
+            generation_profiles=generation_profiles,
+        )
         result = build_script_authoring_graph(
             draft,
             source="supplied_draft",
@@ -713,10 +739,19 @@ def _empty_audio_refs(program: Mapping[str, Any]) -> Mapping[str, Mapping[str, A
 
 
 def _payload_size_bytes(payload: Mapping[str, Any]) -> int:
-    return len(json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8"))
+    """Return the canonical JSON byte size used for supplied-draft limits."""
+    return len(
+        json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        ).encode("utf-8")
+    )
 
 
 def _stored_version_validation(version: Mapping[str, Any]) -> dict[str, Any]:
+    """Return validation diagnostics pinned to a published script version."""
     validation = version.get("validation")
     if isinstance(validation, Mapping):
         return {
@@ -884,7 +919,9 @@ def _script_metadata_consistency_errors(script: Mapping[str, Any], program: Mapp
     return errors
 
 
-def _policy_profile_validation_issues(policy_decision: Mapping[str, Any]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+def _policy_profile_validation_issues(
+    policy_decision: Mapping[str, Any],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     errors: list[dict[str, Any]] = []
     warnings: list[dict[str, Any]] = []
     reasons = policy_decision.get("reasons")

--- a/tldw_Server_API/tests/VN_Platform/test_vn_capabilities_api.py
+++ b/tldw_Server_API/tests/VN_Platform/test_vn_capabilities_api.py
@@ -110,3 +110,29 @@ def test_vn_capabilities_require_graph_routes_for_script_authoring_graph() -> No
     assert body["enabled_modules"]["scripts"] is True
     assert body["features"]["script_authoring_catalog"] is True
     assert body["features"]["script_authoring_graph"] is False
+
+
+def test_vn_capabilities_require_graph_route_methods_for_script_authoring_graph() -> None:
+    partial_scripts_router = APIRouter(prefix="/vn-scripts")
+
+    @partial_scripts_router.get("/scripts/{script_id}/draft/graph")
+    async def draft_graph_stub(script_id: int) -> dict[str, int]:
+        return {"script_id": script_id}
+
+    @partial_scripts_router.get("/scripts/{script_id}/draft/graph-preview")
+    async def wrong_method_preview_graph_stub(script_id: int) -> dict[str, int]:
+        return {"script_id": script_id}
+
+    @partial_scripts_router.get("/scripts/{script_id}/versions/{version_id}/graph")
+    async def version_graph_stub(script_id: int, version_id: int) -> dict[str, int]:
+        return {"script_id": script_id, "version_id": version_id}
+
+    app = FastAPI()
+    app.include_router(vn_capabilities_router, prefix="/api/v1/vn")
+    app.include_router(partial_scripts_router, prefix="/api/v1/vn")
+    response = TestClient(app).get("/api/v1/vn/vn-capabilities")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["enabled_modules"]["scripts"] is True
+    assert body["features"]["script_authoring_graph"] is False

--- a/tldw_Server_API/tests/VN_Platform/test_vn_capabilities_api.py
+++ b/tldw_Server_API/tests/VN_Platform/test_vn_capabilities_api.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import pytest
-from fastapi import FastAPI
+from fastapi import APIRouter, FastAPI
 from fastapi.testclient import TestClient
 
 from tldw_Server_API.app.api.v1.endpoints.vn_assets import router as vn_assets_router
@@ -91,3 +91,22 @@ def test_vn_capabilities_disable_scripted_generation_details_without_scripts() -
     assert body["scripted_generation"]["dynamic_choice_supported"] is False
     assert body["scripted_generation"]["scene_update_supported"] is False
     assert body["scripted_generation"]["moderation_blocked_raw_reveal_supported"] is False
+
+
+def test_vn_capabilities_require_graph_routes_for_script_authoring_graph() -> None:
+    partial_scripts_router = APIRouter(prefix="/vn-scripts")
+
+    @partial_scripts_router.get("/vn-authoring-catalog")
+    async def authoring_catalog_stub() -> dict[str, str]:
+        return {"schema_version": "vn_script_authoring_catalog.v1"}
+
+    app = FastAPI()
+    app.include_router(vn_capabilities_router, prefix="/api/v1/vn")
+    app.include_router(partial_scripts_router, prefix="/api/v1/vn")
+    response = TestClient(app).get("/api/v1/vn/vn-capabilities")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["enabled_modules"]["scripts"] is True
+    assert body["features"]["script_authoring_catalog"] is True
+    assert body["features"]["script_authoring_graph"] is False

--- a/tldw_Server_API/tests/VN_Platform/test_vn_capabilities_api.py
+++ b/tldw_Server_API/tests/VN_Platform/test_vn_capabilities_api.py
@@ -49,6 +49,7 @@ def test_vn_capabilities_returns_canonical_paths(client: TestClient) -> None:
     assert body["features"]["scripted_generation_revision_activation"] is True
     assert body["features"]["scripted_generation_history"] is True
     assert body["features"]["scripted_generation_debug_detail"] is True
+    assert body["features"]["script_authoring_graph"] is True
     assert body["features"]["tts_jobs"] is False
     assert body["features"]["realtime_image_generation"] is False
     assert body["limits"]["max_automatic_generation_batch_count"] == 1
@@ -84,6 +85,7 @@ def test_vn_capabilities_disable_scripted_generation_details_without_scripts() -
     assert body["enabled_modules"]["play"] is True
     assert body["enabled_modules"]["scripts"] is False
     assert body["features"]["scripted_generation"] is False
+    assert body["features"]["script_authoring_graph"] is False
     assert body["scripted_generation"]["enabled"] is False
     assert body["scripted_generation"]["confirmation_supported"] is False
     assert body["scripted_generation"]["dynamic_choice_supported"] is False

--- a/tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_graph.py
+++ b/tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_graph.py
@@ -1,0 +1,480 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+from typing import Any
+
+from tldw_Server_API.app.core.VN_Scripts.authoring_graph import (
+    GRAPH_SEMANTICS_VERSION,
+    MAX_EDGES,
+    MAX_LABELS,
+    MAX_OPS,
+    MAX_SUPPLIED_DRAFT_BYTES,
+    PROGRAM_SCHEMA_VERSION,
+    SCHEMA_VERSION,
+    build_script_authoring_graph,
+    content_hash_for_program,
+)
+from tldw_Server_API.app.core.VN_Scripts.validator import (
+    VNScriptValidationContext,
+    validate_script_program,
+)
+
+
+def _program() -> dict[str, Any]:
+    return {
+        "schema_version": PROGRAM_SCHEMA_VERSION,
+        "primary_asset_pack_id": 7,
+        "entry_label": "intro.scene",
+        "labels": {
+            "intro.scene": [
+                {"op": "narrate", "text": "Opening."},
+                {"op": "jump", "target": "end label"},
+            ],
+            "end label": [{"op": "end"}],
+        },
+    }
+
+
+def _diagnostic_codes(result: dict[str, Any], severity: str) -> list[str]:
+    return [diagnostic["code"] for diagnostic in result["diagnostics"][severity]]
+
+
+def test_build_script_authoring_graph_returns_envelope_outline_graph_and_hash() -> None:
+    result = build_script_authoring_graph(
+        _program(),
+        source="supplied_draft",
+        script_id=12,
+        base_revision=4,
+        validation_diagnostics={"valid": True, "errors": [], "warnings": []},
+    )
+
+    assert result["schema_version"] == SCHEMA_VERSION
+    assert result["graph_semantics_version"] == GRAPH_SEMANTICS_VERSION
+    assert result["program_schema_version"] == PROGRAM_SCHEMA_VERSION
+    assert result["source"] == "supplied_draft"
+    assert result["script_id"] == 12
+    assert result["base_revision"] == 4
+    assert result["version_id"] is None
+    assert result["content_hash"].startswith("sha256:")
+    assert result["validation_context_source"] == "current_draft_context"
+    assert result["truncated"] is False
+    assert result["limits"] == {
+        "max_labels": MAX_LABELS,
+        "max_ops": MAX_OPS,
+        "max_edges": MAX_EDGES,
+        "max_supplied_draft_bytes": MAX_SUPPLIED_DRAFT_BYTES,
+    }
+    assert result["validation_diagnostics"] == {"valid": True, "errors": [], "warnings": []}
+
+    assert result["outline"]["entry_label"] == "intro.scene"
+    assert result["outline"]["labels"][0] == {
+        "id": "label:intro%2Escene",
+        "label": "intro.scene",
+        "source_path": "$.labels['intro.scene']",
+        "op_count": 2,
+        "incoming_edge_count": 0,
+        "outgoing_edge_count": 1,
+        "reachable": True,
+        "terminal": "continues",
+        "summary": "2 operations and 1 outgoing edge.",
+    }
+    assert result["graph"]["nodes"][0]["id"] == "label:intro%2Escene"
+    assert result["graph"]["nodes"][1]["id"] == "op:intro%2Escene:0"
+    assert result["graph"]["nodes"][2]["source_path"] == "$.labels['intro.scene'][1]"
+    assert result["graph"]["edges"][0]["type"] == "jump"
+    assert result["graph"]["edges"][0]["target_id"] == "label:end%20label"
+    assert result["graph"]["edges"][0]["source_path"] == "$.labels['intro.scene'][1].target"
+
+
+def test_label_ids_are_percent_encoded_but_display_label_remains_raw() -> None:
+    result = build_script_authoring_graph(
+        {
+            "schema_version": PROGRAM_SCHEMA_VERSION,
+            "entry_label": "route:1/a",
+            "labels": {"route:1/a": [{"op": "end"}]},
+        }
+    )
+
+    assert result["outline"]["labels"][0]["id"] == "label:route%3A1%2Fa"
+    assert result["outline"]["labels"][0]["label"] == "route:1/a"
+    assert result["graph"]["nodes"][1]["id"] == "op:route%3A1%2Fa:0"
+
+
+def test_bracket_paths_escape_label_quotes_and_backslashes() -> None:
+    result = build_script_authoring_graph(
+        {
+            "schema_version": PROGRAM_SCHEMA_VERSION,
+            "entry_label": "intro'\\scene",
+            "labels": {"intro'\\scene": [{"op": "end"}]},
+        }
+    )
+
+    assert result["outline"]["labels"][0]["source_path"] == "$.labels['intro\\'\\\\scene']"
+    assert result["graph"]["nodes"][1]["source_path"] == "$.labels['intro\\'\\\\scene'][0]"
+
+
+def test_graph_extracts_only_static_jump_choice_generate_and_cancel_edges() -> None:
+    program = {
+        "schema_version": PROGRAM_SCHEMA_VERSION,
+        "entry_label": "start",
+        "labels": {
+            "start": [
+                {"op": "choice", "choices": [{"id": "left", "text": "Left", "target": "left"}]},
+                {
+                    "op": "generate",
+                    "output_schema": "choice_set",
+                    "on_generated_choice": "generated",
+                    "on_cancel": "cancel",
+                },
+                {"op": "random", "branches": [{"target": "ignored"}]},
+                {"op": "jump", "target": "done"},
+            ],
+            "left": [{"op": "end"}],
+            "generated": [{"op": "end"}],
+            "cancel": [{"op": "end"}],
+            "done": [{"op": "end"}],
+            "ignored": [{"op": "end"}],
+        },
+    }
+
+    result = build_script_authoring_graph(program)
+
+    assert [edge["type"] for edge in result["graph"]["edges"]] == [
+        "choice",
+        "generated_choice_handler",
+        "generation_cancel",
+        "jump",
+    ]
+    assert [edge["source_path"] for edge in result["graph"]["edges"]] == [
+        "$.labels['start'][0].choices[0].target",
+        "$.labels['start'][1].on_generated_choice",
+        "$.labels['start'][1].on_cancel",
+        "$.labels['start'][3].target",
+    ]
+    assert all(edge["target_label"] != "ignored" for edge in result["graph"]["edges"])
+
+
+def test_missing_targets_emit_edges_and_diagnostics() -> None:
+    result = build_script_authoring_graph(
+        {
+            "schema_version": PROGRAM_SCHEMA_VERSION,
+            "entry_label": "start",
+            "labels": {"start": [{"op": "jump", "target": "missing"}]},
+        }
+    )
+
+    assert result["graph"]["edges"][0]["target_id"] is None
+    assert result["graph"]["edges"][0]["missing_target"] is True
+    assert result["graph"]["edges"][0]["id"] == "edge:op:start:0:jump:missing:missing"
+    assert result["diagnostics"]["errors"][0]["code"] == "graph_target_missing"
+    assert result["diagnostics"]["errors"][0]["severity"] == "error"
+    assert result["diagnostics"]["errors"][0]["path"] == "$.labels['start'][0].target"
+    assert result["diagnostics"]["errors"][0]["details"] == {
+        "target_label": "missing",
+        "edge_type": "jump",
+    }
+
+
+def test_graph_reachability_matches_validator_unreachable_warnings() -> None:
+    program = {
+        "schema_version": PROGRAM_SCHEMA_VERSION,
+        "primary_asset_pack_id": 7,
+        "entry_label": "start",
+        "labels": {
+            "start": [{"op": "choice", "choices": [{"text": "A", "target": "choice_target"}]}],
+            "choice_target": [{"op": "generate", "on_cancel": "cancel", "on_generated_choice": "generated"}],
+            "cancel": [{"op": "end"}],
+            "generated": [{"op": "jump", "target": "done"}],
+            "done": [{"op": "end"}],
+            "orphan": [{"op": "end"}],
+        },
+    }
+
+    graph = build_script_authoring_graph(program)
+    validation = validate_script_program(program, VNScriptValidationContext()).to_dict()
+
+    graph_unreachable = {
+        diagnostic["details"]["label"]
+        for diagnostic in graph["diagnostics"]["warnings"]
+        if diagnostic["code"] == "graph_label_unreachable"
+    }
+    validator_unreachable = {
+        diagnostic["details"]["label"]
+        for diagnostic in validation["warnings"]
+        if diagnostic["code"] == "label_unreachable"
+    }
+
+    assert graph_unreachable == validator_unreachable == {"orphan"}
+    assert {label["label"] for label in graph["outline"]["labels"] if label["reachable"]} == {
+        "start",
+        "choice_target",
+        "cancel",
+        "generated",
+        "done",
+    }
+
+
+def test_terminal_classification_is_conservative() -> None:
+    result = build_script_authoring_graph(
+        {
+            "schema_version": PROGRAM_SCHEMA_VERSION,
+            "entry_label": "start",
+            "labels": {
+                "start": [{"op": "jump", "target": "terminal"}],
+                "terminal": [{"op": "narrate", "text": "Bye."}, {"op": "end"}],
+                "returning": [{"op": "return"}],
+                "randomized": [{"op": "random", "branches": [{"target": "terminal"}]}],
+                "conditional": [{"op": "jump", "target": "terminal", "if": {"var": "x", "op": "eq", "value": 1}}],
+                "malformed": ["not an opcode"],
+                "ambiguous": [{"op": "narrate", "text": "No explicit control flow."}],
+            },
+        }
+    )
+
+    terminal_by_label = {label["label"]: label["terminal"] for label in result["outline"]["labels"]}
+
+    assert terminal_by_label["start"] == "continues"
+    assert terminal_by_label["terminal"] == "terminal"
+    assert terminal_by_label["returning"] == "unknown"
+    assert terminal_by_label["randomized"] == "unknown"
+    assert terminal_by_label["conditional"] == "unknown"
+    assert terminal_by_label["malformed"] == "unknown"
+    assert terminal_by_label["ambiguous"] == "unknown"
+    assert "graph_unsupported_dynamic_flow" in _diagnostic_codes(result, "warnings")
+
+
+def test_malformed_but_parseable_drafts_return_partial_graph_and_diagnostics() -> None:
+    result = build_script_authoring_graph(
+        {
+            "schema_version": PROGRAM_SCHEMA_VERSION,
+            "entry_label": "start",
+            "labels": {
+                "start": [
+                    "bad op",
+                    {"op": "choice", "choices": {"bad": "shape"}},
+                    {"op": "generate", "on_generated_choice": 123, "on_cancel": None},
+                ],
+                "broken": {"not": "a list"},
+            },
+        }
+    )
+
+    assert result["truncated"] is False
+    assert result["outline"]["labels"][0]["label"] == "start"
+    assert result["outline"]["labels"][1]["label"] == "broken"
+    assert _diagnostic_codes(result, "errors") == [
+        "graph_opcode_invalid",
+        "graph_choice_options_invalid",
+        "graph_generated_choice_handler_missing",
+        "graph_cancel_target_missing",
+        "graph_label_body_invalid",
+    ]
+
+
+def test_missing_labels_returns_empty_partial_graph_with_diagnostic() -> None:
+    result = build_script_authoring_graph({"schema_version": PROGRAM_SCHEMA_VERSION, "entry_label": "start"})
+
+    assert result["outline"]["labels"] == []
+    assert result["graph"]["nodes"] == []
+    assert result["graph"]["edges"] == []
+    assert result["diagnostics"]["errors"][0]["code"] == "graph_labels_missing"
+
+
+def test_content_hash_is_canonical_stable_and_semantics_scoped() -> None:
+    left = {
+        "labels": {"start": [{"text": "Opening.", "op": "narrate"}, {"op": "end"}]},
+        "entry_label": "start",
+        "schema_version": PROGRAM_SCHEMA_VERSION,
+    }
+    right = json.loads(json.dumps(left, indent=2))
+
+    assert build_script_authoring_graph(left)["content_hash"] == build_script_authoring_graph(right)["content_hash"]
+    assert content_hash_for_program(left) != content_hash_for_program(left, graph_semantics_version="future.v2")
+
+    changed = deepcopy(left)
+    changed["labels"]["start"][0]["text"] = "Changed."
+    assert build_script_authoring_graph(left)["content_hash"] != build_script_authoring_graph(changed)["content_hash"]
+
+
+def test_builder_does_not_mutate_input_or_leak_full_operation_payloads() -> None:
+    program = {
+        "schema_version": PROGRAM_SCHEMA_VERSION,
+        "entry_label": "start",
+        "labels": {
+            "start": [
+                {
+                    "op": "generate",
+                    "output_schema": "choice_set",
+                    "profile_key": "safe_profile",
+                    "on_generated_choice": "generated",
+                    "api_key": "sk-secret",
+                    "model": "gpt-secret",
+                    "provider_config": {"base_url": "https://provider.invalid"},
+                }
+            ],
+            "generated": [{"op": "end"}],
+        },
+    }
+    original = deepcopy(program)
+
+    result = build_script_authoring_graph(program)
+    serialized = json.dumps(result, sort_keys=True)
+
+    assert program == original
+    assert "sk-secret" not in serialized
+    assert "gpt-secret" not in serialized
+    assert "https://provider.invalid" not in serialized
+    assert all("payload" not in node and "operation" not in node for node in result["graph"]["nodes"])
+    assert result["graph"]["nodes"][1] == {
+        "id": "op:start:0",
+        "type": "operation",
+        "label": "start",
+        "op_index": 0,
+        "op": "generate",
+        "source_path": "$.labels['start'][0]",
+        "summary": "Generate choice_set using profile safe_profile.",
+    }
+
+
+def test_ordering_is_deterministic_with_entry_label_first_and_source_order_afterward() -> None:
+    result = build_script_authoring_graph(
+        {
+            "schema_version": PROGRAM_SCHEMA_VERSION,
+            "entry_label": "middle",
+            "labels": {
+                "alpha": [{"op": "end"}],
+                "middle": [
+                    {"op": "generate", "on_cancel": "omega", "on_generated_choice": "alpha"},
+                    {"op": "choice", "choices": [{"target": "alpha"}, {"target": "omega"}]},
+                ],
+                "omega": [{"op": "end"}],
+            },
+        }
+    )
+
+    assert [label["label"] for label in result["outline"]["labels"]] == ["middle", "alpha", "omega"]
+    assert [node["id"] for node in result["graph"]["nodes"]] == [
+        "label:middle",
+        "op:middle:0",
+        "op:middle:1",
+        "label:alpha",
+        "op:alpha:0",
+        "label:omega",
+        "op:omega:0",
+    ]
+    assert [edge["type"] for edge in result["graph"]["edges"]] == [
+        "generated_choice_handler",
+        "generation_cancel",
+        "choice",
+        "choice",
+    ]
+
+
+def test_graph_limits_return_partial_truncated_graph_with_diagnostics() -> None:
+    label_limited = build_script_authoring_graph(
+        {
+            "schema_version": PROGRAM_SCHEMA_VERSION,
+            "entry_label": "start",
+            "labels": {"start": [{"op": "jump", "target": "second"}], "second": [{"op": "end"}]},
+        },
+        limits={"max_labels": 1, "max_ops": 10, "max_edges": 10},
+    )
+
+    assert label_limited["truncated"] is True
+    assert [label["label"] for label in label_limited["outline"]["labels"]] == ["start"]
+    assert "graph_node_limit_exceeded" in _diagnostic_codes(label_limited, "warnings")
+
+    op_limited = build_script_authoring_graph(
+        {
+            "schema_version": PROGRAM_SCHEMA_VERSION,
+            "entry_label": "start",
+            "labels": {"start": [{"op": "narrate"}, {"op": "end"}]},
+        },
+        limits={"max_labels": 10, "max_ops": 1, "max_edges": 10},
+    )
+
+    assert op_limited["truncated"] is True
+    assert [node["id"] for node in op_limited["graph"]["nodes"]] == ["label:start", "op:start:0"]
+    assert op_limited["diagnostics"]["warnings"][-1]["code"] == "graph_node_limit_exceeded"
+
+    edge_limited = build_script_authoring_graph(
+        {
+            "schema_version": PROGRAM_SCHEMA_VERSION,
+            "entry_label": "start",
+            "labels": {
+                "start": [
+                    {
+                        "op": "choice",
+                        "choices": [
+                            {"target": "a"},
+                            {"target": "b"},
+                        ],
+                    }
+                ],
+                "a": [{"op": "end"}],
+                "b": [{"op": "end"}],
+            },
+        },
+        limits={"max_labels": 10, "max_ops": 10, "max_edges": 1},
+    )
+
+    assert edge_limited["truncated"] is True
+    assert len(edge_limited["graph"]["edges"]) == 1
+    assert edge_limited["diagnostics"]["warnings"][-1]["code"] == "graph_edge_limit_exceeded"
+
+
+def test_label_limit_truncation_does_not_emit_edges_to_omitted_label_nodes() -> None:
+    result = build_script_authoring_graph(
+        {
+            "schema_version": PROGRAM_SCHEMA_VERSION,
+            "entry_label": "start",
+            "labels": {
+                "start": [{"op": "jump", "target": "omitted"}],
+                "omitted": [{"op": "end"}],
+            },
+        },
+        limits={"max_labels": 1, "max_ops": 10, "max_edges": 10},
+    )
+
+    emitted_node_ids = {node["id"] for node in result["graph"]["nodes"]}
+
+    assert "label:omitted" not in emitted_node_ids
+    assert result["graph"]["edges"][0]["target_id"] is None
+    assert result["graph"]["edges"][0]["omitted_target"] is True
+    assert result["diagnostics"]["warnings"][-1]["code"] == "graph_target_omitted"
+
+
+def test_duplicate_static_edges_from_same_operation_have_unique_ids() -> None:
+    result = build_script_authoring_graph(
+        {
+            "schema_version": PROGRAM_SCHEMA_VERSION,
+            "entry_label": "start",
+            "labels": {
+                "start": [
+                    {
+                        "op": "choice",
+                        "choices": [
+                            {"id": "left", "text": "Left", "target": "done"},
+                            {"id": "right", "text": "Right", "target": "done"},
+                        ],
+                    }
+                ],
+                "done": [{"op": "end"}],
+            },
+        }
+    )
+
+    edge_ids = [edge["id"] for edge in result["graph"]["edges"]]
+
+    assert len(edge_ids) == 2
+    assert len(set(edge_ids)) == 2
+
+
+def test_default_validation_diagnostics_are_fresh_for_each_result() -> None:
+    first = build_script_authoring_graph(_program())
+    first["validation_diagnostics"]["errors"].append({"code": "mutated"})
+
+    second = build_script_authoring_graph(_program())
+
+    assert second["validation_diagnostics"] == {"valid": False, "errors": [], "warnings": []}

--- a/tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_graph.py
+++ b/tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_graph.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
+from collections.abc import Generator, Mapping
 from copy import deepcopy
 import json
 from typing import Any
 
+import pytest
+
+from tldw_Server_API.app.api.v1.schemas.vn_asset_schemas import VNAssetPackCreate
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+from tldw_Server_API.app.core.VN_Assets.service import VNAssetPackService
 from tldw_Server_API.app.core.VN_Scripts.authoring_graph import (
     GRAPH_SEMANTICS_VERSION,
     MAX_EDGES,
@@ -15,6 +21,7 @@ from tldw_Server_API.app.core.VN_Scripts.authoring_graph import (
     build_script_authoring_graph,
     content_hash_for_program,
 )
+from tldw_Server_API.app.core.VN_Scripts.service import VNScriptService
 from tldw_Server_API.app.core.VN_Scripts.validator import (
     VNScriptValidationContext,
     validate_script_program,
@@ -34,6 +41,65 @@ def _program() -> dict[str, Any]:
             "end label": [{"op": "end"}],
         },
     }
+
+
+def _manifest(*, pack_id: int = 7, slot_key: str = "background.archive.default") -> dict[str, Any]:
+    return {
+        "schema_version": "vn_asset_manifest.v1",
+        "pack_id": pack_id,
+        "title": f"Pack {pack_id}",
+        "primary_character_id": None,
+        "content_rating": "general",
+        "assets": {
+            "backgrounds": [{"slot_key": slot_key, "item_id": 100, "mime_type": "image/png"}],
+            "sprites": [],
+            "depth_companions": [],
+            "cgs": [],
+        },
+    }
+
+
+def _service(chacha_db: CharactersRAGDB, *, owner_user_id: int = 42) -> VNScriptService:
+    return VNScriptService(
+        chacha_db,
+        owner_user_id=owner_user_id,
+        manifest_resolver=lambda asset_pack_id: _manifest(pack_id=asset_pack_id),
+    )
+
+
+def _create_script(service: VNScriptService, draft: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    return service.create_script(
+        title="Archive Door",
+        primary_asset_pack_id=7,
+        policy_profile_id="local_default",
+        generation_profile_id="story_default",
+        content_rating="general",
+        initial_draft=draft or _program(),
+        initial_diagnostics={"valid": False, "errors": [{"code": "stale_stored"}], "warnings": []},
+    )
+
+
+def _create_character_pack(chacha_db: CharactersRAGDB, *, age_status: str = "adult") -> tuple[int, int]:
+    character_id = chacha_db.add_character_card(
+        {
+            "name": "Adult Mira",
+            "description": "A careful archivist.",
+            "personality": "Patient and exacting.",
+            "scenario": "Cataloging an orbital library.",
+            "extensions": {"safety_metadata": {"age_status": age_status}},
+        }
+    )
+    pack = VNAssetPackService(chacha_db, owner_user_id=42).create_pack(
+        VNAssetPackCreate(title="Character Pack", primary_character_id=character_id)
+    )
+    return pack.id, character_id
+
+
+@pytest.fixture
+def chacha_db() -> Generator[CharactersRAGDB, None, None]:
+    database = CharactersRAGDB(":memory:", client_id="vn-script-authoring-graph-test-client")
+    yield database
+    database.close_connection()
 
 
 def _diagnostic_codes(result: dict[str, Any], severity: str) -> list[str]:
@@ -478,3 +544,148 @@ def test_default_validation_diagnostics_are_fresh_for_each_result() -> None:
     second = build_script_authoring_graph(_program())
 
     assert second["validation_diagnostics"] == {"valid": False, "errors": [], "warnings": []}
+
+
+def test_service_get_draft_graph_is_non_mutating_and_uses_live_validation(chacha_db: CharactersRAGDB) -> None:
+    service = _service(chacha_db)
+    script = _create_script(service, draft=_program())
+    before = service.get_draft(script["id"])
+
+    result = service.get_draft_graph(script["id"])
+    after = service.get_draft(script["id"])
+
+    assert result["source"] == "stored_draft"
+    assert result["script_id"] == script["id"]
+    assert result["base_revision"] == before["revision"]
+    assert result["validation_context_source"] == "current_draft_context"
+    assert result["validation_diagnostics"]["valid"] is True
+    assert "stale_stored" not in {
+        error["code"] for error in result["validation_diagnostics"].get("errors", [])
+    }
+    assert after == before
+
+
+def test_service_graph_methods_require_ownership(chacha_db: CharactersRAGDB) -> None:
+    owner_service = _service(chacha_db, owner_user_id=42)
+    other_service = _service(chacha_db, owner_user_id=7)
+    script = _create_script(owner_service, draft=_program())
+
+    with pytest.raises(ValueError, match="script_not_found"):
+        other_service.get_draft_graph(script["id"])
+
+    with pytest.raises(ValueError, match="script_not_found"):
+        other_service.preview_draft_graph(script["id"], _program())
+
+
+def test_service_preview_draft_graph_accepts_stale_revision_with_warning(chacha_db: CharactersRAGDB) -> None:
+    service = _service(chacha_db)
+    script = _create_script(service, draft=_program())
+    before = service.get_draft(script["id"])
+
+    supplied = _program()
+    supplied["labels"]["intro.scene"][0]["text"] = "Unsaved opening."
+    result = service.preview_draft_graph(script["id"], supplied, draft_revision=-1)
+    after = service.get_draft(script["id"])
+
+    assert result["source"] == "supplied_draft"
+    assert result["script_id"] == script["id"]
+    assert result["base_revision"] == before["revision"] == 1
+    assert result["content_hash"] == content_hash_for_program(supplied)
+    assert result["validation_context_source"] == "current_draft_context"
+    assert any(
+        diagnostic["code"] == "graph_preview_revision_stale"
+        for diagnostic in result["diagnostics"]["warnings"]
+    )
+    assert after == before
+
+
+def test_service_preview_draft_graph_rejects_invalid_shape_and_oversized_drafts(
+    chacha_db: CharactersRAGDB,
+) -> None:
+    service = _service(chacha_db)
+    script = _create_script(service, draft=_program())
+
+    with pytest.raises(ValueError, match="supplied_draft_invalid_shape"):
+        service.preview_draft_graph(script["id"], ["not", "a", "mapping"])  # type: ignore[arg-type]
+
+    oversized_draft = {"schema_version": PROGRAM_SCHEMA_VERSION, "blob": "x" * MAX_SUPPLIED_DRAFT_BYTES}
+    with pytest.raises(ValueError, match="supplied_draft_too_large"):
+        service.preview_draft_graph(script["id"], oversized_draft)
+
+
+def test_service_version_graph_uses_published_version_snapshot_context(chacha_db: CharactersRAGDB) -> None:
+    service = _service(chacha_db)
+    script = _create_script(service, draft=_program())
+    published = service.publish_script(
+        script["id"],
+        draft_revision=1,
+        label="v1",
+        idempotency_key="publish-graph",
+        acknowledgements=["character_safety_missing"],
+    )
+    service.update_script(
+        script["id"],
+        {
+            "primary_asset_pack_id": 8,
+            "policy_profile_id": "strict_hosted",
+            "content_rating": "mature",
+        },
+    )
+    mutated_draft = _program()
+    mutated_draft["primary_asset_pack_id"] = 8
+    mutated_draft["labels"]["intro.scene"][0]["text"] = "Mutable draft changed."
+    service.replace_draft(script["id"], if_revision=1, draft=mutated_draft)
+
+    result = service.get_version_graph(script["id"], published["version_id"])
+
+    assert result["source"] == "published_version"
+    assert result["script_id"] == script["id"]
+    assert result["base_revision"] is None
+    assert result["version_id"] == published["version_id"]
+    assert result["content_hash"] == content_hash_for_program(_program())
+    assert result["validation_context_source"] == "published_version_snapshot"
+    assert result["validation_diagnostics"]["valid"] is True
+    assert "primary_asset_pack_mismatch" not in {
+        error["code"] for error in result["validation_diagnostics"].get("errors", [])
+    }
+
+
+def test_service_version_graph_reuses_published_validation_after_live_character_changes(
+    chacha_db: CharactersRAGDB,
+) -> None:
+    pack_id, character_id = _create_character_pack(chacha_db, age_status="adult")
+    service = VNScriptService(chacha_db, owner_user_id=42)
+    program = _program()
+    program["primary_asset_pack_id"] = pack_id
+    script = service.create_script(
+        title="Archive Door",
+        primary_asset_pack_id=pack_id,
+        policy_profile_id="strict_hosted",
+        generation_profile_id="story_default",
+        content_rating="general",
+        initial_draft=program,
+        initial_diagnostics={"valid": True, "errors": [], "warnings": []},
+    )
+    published = service.publish_script(
+        script["id"],
+        draft_revision=1,
+        label="adult",
+        idempotency_key="publish-adult-character",
+        acknowledgements=[],
+    )
+    version = service.get_version(script["id"], published["version_id"])
+    original_validation = dict(version["validation"])
+    character = chacha_db.get_character_card_by_id(character_id)
+
+    assert original_validation["valid"] is True
+    assert character is not None
+    assert chacha_db.update_character_card(
+        character_id,
+        {"extensions": {"safety_metadata": {"age_status": "missing"}}},
+        int(character["version"]),
+    )
+
+    result = service.get_version_graph(script["id"], published["version_id"])
+
+    assert result["validation_context_source"] == "published_version_snapshot"
+    assert result["validation_diagnostics"] == original_validation

--- a/tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_graph.py
+++ b/tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_graph.py
@@ -281,6 +281,34 @@ def test_graph_reachability_matches_validator_unreachable_warnings() -> None:
     }
 
 
+def test_graph_warns_that_static_reachability_does_not_infer_fallthrough() -> None:
+    result = build_script_authoring_graph(
+        {
+            "schema_version": PROGRAM_SCHEMA_VERSION,
+            "entry_label": "start",
+            "labels": {
+                "start": [{"op": "narrate", "text": "Opening."}],
+                "next": [{"op": "end"}],
+            },
+        }
+    )
+
+    fallthrough_warnings = [
+        diagnostic
+        for diagnostic in result["diagnostics"]["warnings"]
+        if diagnostic["code"] == "graph_fallthrough_not_inferred"
+    ]
+    assert fallthrough_warnings == [
+        {
+            "code": "graph_fallthrough_not_inferred",
+            "severity": "warning",
+            "message": "Static graph reachability does not infer implicit fallthrough to the next label.",
+            "path": "$.labels['start']",
+            "details": {"label": "start", "next_label": "next"},
+        }
+    ]
+
+
 def test_terminal_classification_is_conservative() -> None:
     result = build_script_authoring_graph(
         {
@@ -487,7 +515,16 @@ def test_graph_limits_return_partial_truncated_graph_with_diagnostics() -> None:
 
     assert edge_limited["truncated"] is True
     assert len(edge_limited["graph"]["edges"]) == 1
-    assert edge_limited["diagnostics"]["warnings"][-1]["code"] == "graph_edge_limit_exceeded"
+    assert "graph_edge_limit_exceeded" in _diagnostic_codes(edge_limited, "warnings")
+    assert {label["label"] for label in edge_limited["outline"]["labels"] if label["reachable"]} == {
+        "start",
+        "a",
+    }
+    assert "b" in {
+        diagnostic["details"]["label"]
+        for diagnostic in edge_limited["diagnostics"]["warnings"]
+        if diagnostic["code"] == "graph_label_unreachable"
+    }
 
 
 def test_label_limit_truncation_does_not_emit_edges_to_omitted_label_nodes() -> None:

--- a/tldw_Server_API/tests/VN_Scripts/test_vn_scripts_api.py
+++ b/tldw_Server_API/tests/VN_Scripts/test_vn_scripts_api.py
@@ -539,6 +539,195 @@ def test_snippet_apply_stale_revision_conflicts_before_anchor_validation(
     assert details["current_revision"] == 2
 
 
+def test_draft_graph_endpoint_returns_stored_graph(
+    client: TestClient,
+    chacha_dbs: dict[int, CharactersRAGDB],
+) -> None:
+    asset_pack_id, _ = _create_asset_pack(chacha_dbs[42])
+    script_id = _create_script(client, asset_pack_id=asset_pack_id)
+    client.put(
+        f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft",
+        json={"if_revision": 0, "draft": _program(asset_pack_id)},
+    )
+
+    response = client.get(f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft/graph")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["schema_version"] == "vn_script_authoring_graph.v1"
+    assert payload["graph_semantics_version"] == "vn_script_authoring_graph_edges.v1"
+    assert payload["source"] == "stored_draft"
+    assert payload["script_id"] == script_id
+    assert payload["base_revision"] == 1
+    assert payload["version_id"] is None
+    assert payload["outline"]["entry_label"] == "start"
+    assert payload["outline"]["labels"]
+    assert payload["graph"]["nodes"][0]["id"] == "label:start"
+    assert payload["validation_context_source"] == "current_draft_context"
+
+
+def test_graph_preview_accepts_supplied_draft_without_persisting(
+    client: TestClient,
+    chacha_dbs: dict[int, CharactersRAGDB],
+) -> None:
+    asset_pack_id, _ = _create_asset_pack(chacha_dbs[42])
+    script_id = _create_script(client, asset_pack_id=asset_pack_id)
+    stored = _program(asset_pack_id)
+    supplied = _program(asset_pack_id)
+    supplied["labels"]["start"][0]["text"] = "Unsaved opening."
+    client.put(
+        f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft",
+        json={"if_revision": 0, "draft": stored},
+    )
+
+    response = client.post(
+        f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft/graph-preview",
+        json={"draft": supplied, "draft_revision": 1},
+    )
+    draft_after = client.get(f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft").json()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["source"] == "supplied_draft"
+    assert payload["base_revision"] == 1
+    assert payload["outline"]["labels"][0]["summary"] == "2 operations."
+    assert draft_after["revision"] == 1
+    assert draft_after["draft"] == stored
+
+
+def test_version_graph_endpoint_returns_published_version_graph(
+    client: TestClient,
+    chacha_dbs: dict[int, CharactersRAGDB],
+) -> None:
+    asset_pack_id, slot_key = _create_asset_pack(chacha_dbs[42])
+    script_id = _create_script(client, asset_pack_id=asset_pack_id)
+    client.put(
+        f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft",
+        json={"if_revision": 0, "draft": _program(asset_pack_id, slot_key=slot_key)},
+    )
+    publish_response = client.post(
+        f"/api/v1/vn/vn-scripts/scripts/{script_id}/publish",
+        json={
+            "draft_revision": 1,
+            "label": "v1",
+            "idempotency_key": "publish-graph-v1",
+            "acknowledgements": ["character_safety_missing"],
+        },
+    )
+    version_id = publish_response.json()["version_id"]
+
+    response = client.get(f"/api/v1/vn/vn-scripts/scripts/{script_id}/versions/{version_id}/graph")
+
+    assert publish_response.status_code == 201
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["source"] == "published_version"
+    assert payload["script_id"] == script_id
+    assert payload["version_id"] == version_id
+    assert payload["base_revision"] is None
+    assert payload["validation_context_source"] == "published_version_snapshot"
+    assert payload["validation_diagnostics"]["valid"] is True
+
+
+def test_graph_preview_malformed_supplied_draft_shape_returns_vn_error(
+    client: TestClient,
+    chacha_dbs: dict[int, CharactersRAGDB],
+) -> None:
+    asset_pack_id, _ = _create_asset_pack(chacha_dbs[42])
+    script_id = _create_script(client, asset_pack_id=asset_pack_id)
+
+    response = client.post(
+        f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft/graph-preview",
+        json={"draft": ["not", "a", "mapping"]},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["details"]["reason"] == "supplied_draft_invalid_shape"
+
+
+def test_graph_preview_oversized_supplied_draft_returns_vn_error(
+    client: TestClient,
+    chacha_dbs: dict[int, CharactersRAGDB],
+) -> None:
+    asset_pack_id, _ = _create_asset_pack(chacha_dbs[42])
+    script_id = _create_script(client, asset_pack_id=asset_pack_id)
+    oversized = {"schema_version": "vn_script_program.v1", "blob": "x" * 1_048_576}
+
+    response = client.post(
+        f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft/graph-preview",
+        json={"draft": oversized},
+    )
+
+    assert response.status_code == 413
+    assert response.json()["detail"]["details"]["reason"] == "supplied_draft_too_large"
+
+
+def test_graph_problems_return_success_with_diagnostics(
+    client: TestClient,
+    chacha_dbs: dict[int, CharactersRAGDB],
+) -> None:
+    asset_pack_id, _ = _create_asset_pack(chacha_dbs[42])
+    script_id = _create_script(client, asset_pack_id=asset_pack_id)
+    supplied = _program(asset_pack_id)
+    supplied["labels"]["start"][1] = {"op": "jump", "target": "missing"}
+
+    response = client.post(
+        f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft/graph-preview",
+        json={"draft": supplied},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["diagnostics"]["errors"][0]["code"] == "graph_target_missing"
+    assert payload["graph"]["edges"][0]["missing_target"] is True
+    assert payload["validation_diagnostics"]["valid"] is False
+
+
+def test_graph_response_does_not_leak_full_op_payloads_or_provider_secrets(
+    client: TestClient,
+    chacha_dbs: dict[int, CharactersRAGDB],
+) -> None:
+    asset_pack_id, _ = _create_asset_pack(chacha_dbs[42])
+    script_id = _create_script(client, asset_pack_id=asset_pack_id)
+    supplied = _program(asset_pack_id)
+    supplied["labels"]["start"] = [
+        {
+            "op": "generate",
+            "prompt": "secret prompt text",
+            "raw_prompt": "raw secret prompt",
+            "provider": "secret-provider",
+            "model": "secret-model",
+            "api_key": "sk-secret",
+            "provider_config": {"base_url": "https://secret.example"},
+            "output_schema": "choice_set",
+            "on_generated_choice": "after_generation",
+        }
+    ]
+    supplied["labels"]["after_generation"] = [{"op": "end"}]
+
+    response = client.post(
+        f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft/graph-preview",
+        json={"draft": supplied},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    operation_nodes = [node for node in payload["graph"]["nodes"] if node["type"] == "operation"]
+    assert operation_nodes
+    assert all("prompt" not in node for node in operation_nodes)
+    assert all("provider_config" not in node for node in operation_nodes)
+    serialized = response.text
+    for leaked_value in (
+        "secret prompt text",
+        "raw secret prompt",
+        "secret-provider",
+        "secret-model",
+        "sk-secret",
+        "https://secret.example",
+    ):
+        assert leaked_value not in serialized
+
+
 def test_vn_capabilities_include_script_authoring_catalog_when_scripts_routes_registered(
     client: TestClient,
 ) -> None:

--- a/tldw_Server_API/tests/VN_Scripts/test_vn_scripts_api.py
+++ b/tldw_Server_API/tests/VN_Scripts/test_vn_scripts_api.py
@@ -595,6 +595,63 @@ def test_graph_preview_accepts_supplied_draft_without_persisting(
     assert draft_after["draft"] == stored
 
 
+def test_graph_endpoints_use_resolved_authnz_profile_context(
+    client: TestClient,
+    chacha_dbs: dict[int, CharactersRAGDB],
+    authnz_pool: DatabasePool,
+) -> None:
+    asset_pack_id, _ = _create_asset_pack(chacha_dbs[42])
+
+    async def seed_profiles() -> None:
+        store = VNPolicyProfileStore(authnz_pool)
+        await store.initialize()
+        await store.create_policy_profile(
+            profile_id="custom_local",
+            display_name="Custom Local",
+            description=None,
+            definition=LOCAL_DEFAULT_POLICY_DEFINITION,
+            created_by_user_id=42,
+        )
+        await store.create_generation_profile(
+            profile_id="custom_story",
+            display_name="Custom Story",
+            description=None,
+            definition=STORY_DEFAULT_GENERATION_DEFINITION,
+            created_by_user_id=42,
+        )
+
+    asyncio.run(seed_profiles())
+    create_response = client.post(
+        "/api/v1/vn/vn-scripts/scripts",
+        json={
+            "title": "Archive Door",
+            "primary_asset_pack_id": asset_pack_id,
+            "policy_profile_id": "custom_local",
+            "generation_profile_id": "custom_story",
+            "content_rating": "general",
+        },
+    )
+    script_id = int(create_response.json()["id"])
+    draft = _program(asset_pack_id)
+    draft["generation_defaults"]["profile_id"] = "custom_story"
+    client.put(
+        f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft",
+        json={"if_revision": 0, "draft": draft},
+    )
+
+    stored_graph_response = client.get(f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft/graph")
+    preview_graph_response = client.post(
+        f"/api/v1/vn/vn-scripts/scripts/{script_id}/draft/graph-preview",
+        json={"draft": draft, "draft_revision": 1},
+    )
+
+    assert create_response.status_code == 201
+    assert stored_graph_response.status_code == 200
+    assert stored_graph_response.json()["validation_diagnostics"]["valid"] is True
+    assert preview_graph_response.status_code == 200
+    assert preview_graph_response.json()["validation_diagnostics"]["valid"] is True
+
+
 def test_version_graph_endpoint_returns_published_version_graph(
     client: TestClient,
     chacha_dbs: dict[int, CharactersRAGDB],


### PR DESCRIPTION
## Change summary

- Adds a backend-only VN script authoring graph API for stored drafts, supplied draft previews, and published versions.
- Builds deterministic static graph output with stable encoded IDs, graph layers, diagnostics, content hashes, limits, and conservative terminal-state semantics without persisting graph data.
- Exposes `features.script_authoring_graph` only when the required graph routes are registered and documents endpoint contracts for custom frontend consumers.

## Implementation notes

- No WebUI changes, model calls, runtime session mutation, or graph persistence.
- Graph preview and stored graph methods are non-mutating and keep diagnostics out of persisted drafts.
- Edge IDs are documented as opaque; clients should use explicit edge fields instead of parsing IDs.

## Verification

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest -q tldw_Server_API/tests/VN_Scripts/test_vn_script_authoring_graph.py tldw_Server_API/tests/VN_Scripts/test_vn_scripts_api.py tldw_Server_API/tests/VN_Platform/test_vn_capabilities_api.py` -> 60 passed, 8 warnings
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest -q tldw_Server_API/tests/VN_Platform/test_vn_capabilities_api.py` -> 3 passed, 8 warnings
- `python -m compileall` on touched VN graph/API/capability modules -> passed
- `python -m bandit -q -r` on touched backend VN graph/API/capability modules -> 0 findings
- `git diff --check` and `git diff --cached --check` -> passed

## Tracking

- Issue: #1391
- Backlog: TASK-328

## Human merge note

This PR is code-complete from local verification. Per the AI-generated PR policy, a human-owned change summary/rationale should be confirmed before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a backend-only VN script authoring graph API that computes a deterministic, read-only outline and graph for stored drafts, supplied draft previews, and published versions. Capability detection is hardened to only advertise `features.script_authoring_graph` when all graph routes and methods are registered (addresses #1391).

- **New Features**
  - Pure graph builder that computes outline/graph with stable encoded IDs, bracket JSON paths, diagnostics, limits, and content hashes; no persistence, mutations, or model calls.
  - Endpoints: GET /api/v1/vn/vn-scripts/scripts/{script_id}/draft/graph, POST /api/v1/vn/vn-scripts/scripts/{script_id}/draft/graph-preview, GET /api/v1/vn/vn-scripts/scripts/{script_id}/versions/{version_id}/graph.
  - Versioned response fields (`schema_version`, `graph_semantics_version`); new schemas for graph responses and diagnostics; docs/specs expanded and tests added for endpoints and capability flag.

<sup>Written for commit def49472ac7e87543548f3326443cb589523ff72. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

