### PR TITLE
Harden Persona Visual import commit guards

### DIFF
--- a/backlog/tasks/task-332 - Harden-Persona-Visual-import-commit-eligibility-revalidation.md
+++ b/backlog/tasks/task-332 - Harden-Persona-Visual-import-commit-eligibility-revalidation.md
@@ -12,6 +12,7 @@ dependencies: []
 references:
   - 'https://github.com/rmusser01/tldw_server/issues/1657'
   - 'https://github.com/rmusser01/tldw_server/issues/1510'
+  - 'https://github.com/rmusser01/tldw_server/pull/1677'
 documentation:
   - Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md
   - Docs/Code_Documentation/Persona_Visual_Packs.md

--- a/backlog/tasks/task-332 - Harden-Persona-Visual-import-commit-eligibility-revalidation.md
+++ b/backlog/tasks/task-332 - Harden-Persona-Visual-import-commit-eligibility-revalidation.md
@@ -56,15 +56,20 @@ Implement GitHub issue #1657 as a focused Persona/Buddy visual-pack hardening sl
 - Added shared importer validation that accepts legacy previews with no commit_eligible flag but rejects blocked previews or explicit commit_eligible false results.
 - Added regression coverage proving blocked revalidation fails the job with no additional draft pack created.
 - No docs changes were needed because the existing docs already describe blocked previews as commit-ineligible review results.
+- Review follow-up: aligned API `blocked` preview reporting with worker `import_preview_not_commit_eligible` handling.
+- Review follow-up: malformed or non-object stored `proposed_plan_json` now fails closed before job enqueueing or worker revalidation, while valid object metadata without `commit_eligible` remains eligible.
+- Review follow-up: verification commands in this task use repo-relative invocations instead of machine-local absolute paths.
 
 ## Verification
 
-- RED: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_visuals_api.py::test_start_import_commit_rejects_ineligible_completed_preview tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py::test_persona_visual_import_commit_worker_rejects_revalidated_blocked_preview -q` failed with the API returning 202 and the worker not raising the new guard error.
+- RED: `python -m pytest tldw_Server_API/tests/Persona/test_persona_visuals_api.py::test_start_import_commit_rejects_ineligible_completed_preview tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py::test_persona_visual_import_commit_worker_rejects_revalidated_blocked_preview -q` failed with the API returning 202 and the worker not raising the new guard error.
 - GREEN: same focused two-test command passed with 2 tests.
-- Focused regression: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_visuals_api.py tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py -q` passed with 51 tests.
-- Syntax: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/app/core/Persona/visual_portability/importer.py` passed.
+- Review RED: `python -m pytest tldw_Server_API/tests/Persona/test_persona_visuals_api.py::test_start_import_commit_reports_blocked_preview_as_not_commit_eligible tldw_Server_API/tests/Persona/test_persona_visuals_api.py::test_start_import_commit_rejects_invalid_stored_preview_plan tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py::test_persona_visual_import_commit_worker_rejects_invalid_stored_plan_before_revalidation -q` failed with 5 failing review-regression cases.
+- Review GREEN: same review-regression command passed with 5 tests.
+- Focused regression: `python -m pytest tldw_Server_API/tests/Persona/test_persona_visuals_api.py tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py -q` passed with 56 tests.
+- Syntax: `python -m py_compile tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/app/core/Persona/visual_portability/importer.py` passed.
 - Whitespace: `git diff --check` passed.
-- Bandit: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/app/core/Persona/visual_portability/importer.py -f json -o /tmp/bandit_persona_visual_commit_guards.json` reported zero findings.
+- Bandit: `python -m bandit -r tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/app/core/Persona/visual_portability/importer.py -f json -o /tmp/bandit_persona_visual_commit_guards_review.json` reported zero findings.
 
 ## Known Skips
 
@@ -72,4 +77,4 @@ Implement GitHub issue #1657 as a focused Persona/Buddy visual-pack hardening sl
 
 ## Final Summary
 
-Hardened Persona Visual import-commit so stored previews with explicit `commit_eligible: false` are rejected before job queueing, and worker-side revalidation rejects blocked or non-commit-eligible previews before draft pack or asset creation. Added focused API and worker regressions while preserving existing eligible preview behavior.
+Hardened Persona Visual import-commit so stored previews with explicit `commit_eligible: false`, blocked status, malformed stored plan JSON, or non-object stored plan JSON are rejected before job queueing or worker revalidation. Worker-side revalidation also rejects blocked or non-commit-eligible previews before draft pack or asset creation. Added focused API and worker regressions while preserving existing eligible preview behavior for valid plan objects without `commit_eligible`.

--- a/backlog/tasks/task-332 - Harden-Persona-Visual-import-commit-eligibility-revalidation.md
+++ b/backlog/tasks/task-332 - Harden-Persona-Visual-import-commit-eligibility-revalidation.md
@@ -1,0 +1,74 @@
+---
+id: TASK-332
+title: Harden Persona Visual import-commit eligibility revalidation
+status: Done
+assignee: []
+created_date: '2026-05-14 03:21'
+labels:
+  - persona
+  - visual-packs
+  - backend
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1657'
+  - 'https://github.com/rmusser01/tldw_server/issues/1510'
+documentation:
+  - Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md
+  - Docs/Code_Documentation/Persona_Visual_Packs.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement GitHub issue #1657 as a focused Persona/Buddy visual-pack hardening slice. Import-commit must fail closed when stored or revalidated Persona Visual import previews are blocked or not commit-eligible, so stale completed previews or capability-state changes cannot create draft packs/assets before manifest validation fails. Scope stays backend/server-side only unless an existing API contract requires a minimal response adjustment.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Import-commit rejects stored preview metadata that is not commit-eligible before starting draft pack or asset creation.
+- [x] #2 Import-commit revalidates archive previews and rejects any non-completed or non-commit-eligible revalidation result before draft pack or asset creation.
+- [x] #3 Blocked renderer preview commit attempts leave no partial draft packs/assets behind.
+- [x] #4 Existing API-level completed-preview behavior remains intact for eligible previews.
+- [x] #5 Focused backend regression tests cover stale stored ineligible preview metadata and revalidation-to-blocked behavior.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Plan
+
+1. Add server-side API queueing guard for completed import previews whose stored proposed plan explicitly marks commit_eligible false.
+2. Add importer-side guard before any pack or asset creation so stored previews and revalidated archive previews must be completed and commit-eligible.
+3. Add focused regression coverage for stored ineligible preview metadata and revalidation-to-blocked behavior.
+
+## Implementation Notes
+
+- Added a stored preview commit-eligibility helper in the Persona API endpoint before import-commit jobs are created.
+- Added shared importer validation that accepts legacy previews with no commit_eligible flag but rejects blocked previews or explicit commit_eligible false results.
+- Added regression coverage proving blocked revalidation fails the job with no additional draft pack created.
+- No docs changes were needed because the existing docs already describe blocked previews as commit-ineligible review results.
+
+## Verification
+
+- RED: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_visuals_api.py::test_start_import_commit_rejects_ineligible_completed_preview tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py::test_persona_visual_import_commit_worker_rejects_revalidated_blocked_preview -q` failed with the API returning 202 and the worker not raising the new guard error.
+- GREEN: same focused two-test command passed with 2 tests.
+- Focused regression: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_visuals_api.py tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py -q` passed with 51 tests.
+- Syntax: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/app/core/Persona/visual_portability/importer.py` passed.
+- Whitespace: `git diff --check` passed.
+- Bandit: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/app/core/Persona/visual_portability/importer.py -f json -o /tmp/bandit_persona_visual_commit_guards.json` reported zero findings.
+
+## Known Skips
+
+- Optional Ruff full-file check on the touched files still reports existing I001 import-order findings in legacy modules; this narrow backend guard slice did not auto-sort large unrelated import blocks.
+
+## Final Summary
+
+Hardened Persona Visual import-commit so stored previews with explicit `commit_eligible: false` are rejected before job queueing, and worker-side revalidation rejects blocked or non-commit-eligible previews before draft pack or asset creation. Added focused API and worker regressions while preserving existing eligible preview behavior.

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -2272,6 +2272,14 @@ def _persona_visual_json_field(row: dict[str, Any], key: str, default: Any) -> A
         return default
 
 
+def _persona_visual_import_preview_commit_eligible(preview: dict[str, Any]) -> bool:
+    """Return whether stored preview metadata allows queuing import commit."""
+    proposed_plan = _persona_visual_json_field(preview, "proposed_plan_json", {})
+    if not isinstance(proposed_plan, dict):
+        return True
+    return proposed_plan.get("commit_eligible") is not False
+
+
 def _persona_visual_replaceable_pack_ids(conflicts: Any) -> set[str]:
     """Return target pack ids that preview conflicts allow replacing."""
     if not isinstance(conflicts, list):
@@ -5160,6 +5168,11 @@ async def start_persona_visual_pack_import_commit(
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
                 detail="import_preview_not_completed",
+            )
+        if not _persona_visual_import_preview_commit_eligible(preview):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="import_preview_not_commit_eligible",
             )
         conflicts = _persona_visual_json_field(preview, "conflicts_json", [])
         replaceable_pack_ids = _persona_visual_replaceable_pack_ids(conflicts)

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -2272,11 +2272,34 @@ def _persona_visual_json_field(row: dict[str, Any], key: str, default: Any) -> A
         return default
 
 
+def _persona_visual_import_preview_proposed_plan(preview: dict[str, Any]) -> tuple[dict[str, Any], bool]:
+    """Return stored proposed-plan metadata and whether it decoded as an object."""
+    value = preview.get("proposed_plan_json")
+    if value in (None, ""):
+        return {}, True
+    if isinstance(value, dict):
+        return value, True
+    if isinstance(value, list):
+        return {}, False
+    try:
+        parsed = json.loads(str(value))
+    except json.JSONDecodeError:
+        return {}, False
+    if not isinstance(parsed, dict):
+        return {}, False
+    return parsed, True
+
+
 def _persona_visual_import_preview_commit_eligible(preview: dict[str, Any]) -> bool:
     """Return whether stored preview metadata allows queuing import commit."""
-    proposed_plan = _persona_visual_json_field(preview, "proposed_plan_json", {})
-    if not isinstance(proposed_plan, dict):
+    status_value = str(preview.get("status") or "").strip()
+    if status_value == "blocked":
+        return False
+    if status_value != "completed":
         return True
+    proposed_plan, proposed_plan_valid = _persona_visual_import_preview_proposed_plan(preview)
+    if not proposed_plan_valid:
+        return False
     return proposed_plan.get("commit_eligible") is not False
 
 
@@ -5164,15 +5187,15 @@ async def start_persona_visual_pack_import_commit(
         )
         if preview is None or str(preview.get("target_persona_id") or "") != persona_id:
             raise HTTPException(status_code=404, detail="import_preview_not_found")
-        if str(preview.get("status") or "") != "completed":
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail="import_preview_not_completed",
-            )
         if not _persona_visual_import_preview_commit_eligible(preview):
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
                 detail="import_preview_not_commit_eligible",
+            )
+        if str(preview.get("status") or "") != "completed":
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="import_preview_not_completed",
             )
         conflicts = _persona_visual_json_field(preview, "conflicts_json", [])
         replaceable_pack_ids = _persona_visual_replaceable_pack_ids(conflicts)

--- a/tldw_Server_API/app/core/Persona/visual_portability/importer.py
+++ b/tldw_Server_API/app/core/Persona/visual_portability/importer.py
@@ -90,6 +90,7 @@ class PersonaVisualPackImporter:
         expected_fingerprint = str(preview.get("canonical_payload_fingerprint") or "")
         if expected_fingerprint and revalidated["canonical_payload_fingerprint"] != expected_fingerprint:
             raise ValueError("import_archive_fingerprint_changed")
+        _validate_preview_commit_allowed(revalidated)
         revalidated_conflicts = revalidated.get("conflicts")
         current_conflicts = revalidated_conflicts if isinstance(revalidated_conflicts, list) else []
         if current_conflicts and not conflict_choice_explicit:
@@ -255,8 +256,7 @@ class PersonaVisualPackImporter:
             )
 
     def _validate_preview_ready(self, *, preview: dict[str, Any], archive_path: Path) -> None:
-        if str(preview.get("status") or "") != "completed":
-            raise ValueError("import_preview_not_completed")
+        _validate_preview_commit_allowed(preview)
         if not archive_path.is_file():
             raise ValueError("import_archive_not_found")
         expires_at = _parse_datetime(preview.get("expires_at"))
@@ -282,6 +282,27 @@ def _import_preview_json_field(row: Mapping[str, Any], key: str, default: Any) -
         return json.loads(str(value))
     except json.JSONDecodeError:
         return default
+
+
+def _import_preview_proposed_plan(preview: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Return proposed-plan metadata from either a row or fresh preview payload."""
+    proposed_plan = preview.get("proposed_plan")
+    if isinstance(proposed_plan, Mapping):
+        return proposed_plan
+    stored_plan = _import_preview_json_field(preview, "proposed_plan_json", {})
+    if isinstance(stored_plan, Mapping):
+        return stored_plan
+    return {}
+
+
+def _validate_preview_commit_allowed(preview: Mapping[str, Any]) -> None:
+    """Reject previews that are not currently eligible for import commit."""
+    proposed_plan = _import_preview_proposed_plan(preview)
+    status_value = str(preview.get("status") or "").strip()
+    if status_value == "blocked" or proposed_plan.get("commit_eligible") is False:
+        raise ValueError("import_preview_not_commit_eligible")
+    if status_value != "completed":
+        raise ValueError("import_preview_not_completed")
 
 
 def _replaceable_pack_ids_from_conflicts(conflicts: Any) -> set[str]:

--- a/tldw_Server_API/app/core/Persona/visual_portability/importer.py
+++ b/tldw_Server_API/app/core/Persona/visual_portability/importer.py
@@ -284,25 +284,40 @@ def _import_preview_json_field(row: Mapping[str, Any], key: str, default: Any) -
         return default
 
 
-def _import_preview_proposed_plan(preview: Mapping[str, Any]) -> Mapping[str, Any]:
-    """Return proposed-plan metadata from either a row or fresh preview payload."""
+def _import_preview_proposed_plan(preview: Mapping[str, Any]) -> tuple[Mapping[str, Any], bool]:
+    """Return proposed-plan metadata and whether it decoded as an object."""
     proposed_plan = preview.get("proposed_plan")
     if isinstance(proposed_plan, Mapping):
-        return proposed_plan
-    stored_plan = _import_preview_json_field(preview, "proposed_plan_json", {})
-    if isinstance(stored_plan, Mapping):
-        return stored_plan
-    return {}
+        return proposed_plan, True
+    if "proposed_plan" in preview and proposed_plan is not None:
+        return {}, False
+
+    stored_plan_value = preview.get("proposed_plan_json")
+    if stored_plan_value in (None, ""):
+        return {}, True
+    if isinstance(stored_plan_value, Mapping):
+        return stored_plan_value, True
+    if isinstance(stored_plan_value, list):
+        return {}, False
+    try:
+        stored_plan = json.loads(str(stored_plan_value))
+    except json.JSONDecodeError:
+        return {}, False
+    if not isinstance(stored_plan, Mapping):
+        return {}, False
+    return stored_plan, True
 
 
 def _validate_preview_commit_allowed(preview: Mapping[str, Any]) -> None:
     """Reject previews that are not currently eligible for import commit."""
-    proposed_plan = _import_preview_proposed_plan(preview)
     status_value = str(preview.get("status") or "").strip()
-    if status_value == "blocked" or proposed_plan.get("commit_eligible") is False:
+    if status_value == "blocked":
         raise ValueError("import_preview_not_commit_eligible")
     if status_value != "completed":
         raise ValueError("import_preview_not_completed")
+    proposed_plan, proposed_plan_valid = _import_preview_proposed_plan(preview)
+    if not proposed_plan_valid or proposed_plan.get("commit_eligible") is False:
+        raise ValueError("import_preview_not_commit_eligible")
 
 
 def _replaceable_pack_ids_from_conflicts(conflicts: Any) -> set[str]:

--- a/tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py
@@ -1040,6 +1040,116 @@ async def test_persona_visual_import_commit_worker_rejects_incomplete_preview(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("stored_plan_json", ["{not-json", "[]"])
+async def test_persona_visual_import_commit_worker_rejects_invalid_stored_plan_before_revalidation(
+    db_instance: CharactersRAGDB,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    stored_plan_json: str,
+) -> None:
+    from tldw_Server_API.app.core.DB_Management.PersonaVisualPortability_DB import (
+        PersonaVisualPortabilityRepository,
+    )
+    from tldw_Server_API.app.core.Persona.visual_jobs_worker import (
+        PersonaVisualPortabilityWorker,
+    )
+    from tldw_Server_API.app.core.Persona.visual_portability import importer as importer_module
+
+    persona_id, pack, _source_asset = _create_pack_with_asset(
+        db_instance,
+        visuals_root=tmp_path / "visuals",
+        monkeypatch=monkeypatch,
+    )
+    export_result = PersonaVisualPackExporter(
+        db=db_instance,
+        user_id="user-1",
+        staging_root=tmp_path / "exports",
+    ).export_pack(
+        persona_id=persona_id,
+        pack_id=str(pack["id"]),
+        options=PersonaVisualPackExportOptions(),
+    )
+    preview_result = PersonaVisualPackImportPreviewer().create_preview(
+        archive_path=export_result.archive_path,
+        owner_user_id="user-1",
+        target_persona_id=persona_id,
+        target_packs=db_instance.list_persona_visual_packs(
+            persona_id=persona_id,
+            user_id="user-1",
+        ),
+    )
+    repo = PersonaVisualPortabilityRepository.initialized(db_instance)
+    preview = repo.create_import_preview(
+        owner_user_id="user-1",
+        job_id="job-preview-1",
+        status="completed",
+        stage="completed",
+        archive_path=str(export_result.archive_path),
+        archive_sha256=preview_result["archive_sha256"],
+        canonical_payload_fingerprint=preview_result["canonical_payload_fingerprint"],
+        schema_version=preview_result["schema_version"],
+        target_persona_id=persona_id,
+        bundle_summary=preview_result["bundle_summary"],
+        conflicts=preview_result["conflicts"],
+        proposed_plan=preview_result["proposed_plan"],
+        required_choices=preview_result["required_choices"],
+    )
+    with db_instance.transaction() as conn:
+        conn.execute(
+            """
+            UPDATE persona_visual_pack_import_previews
+               SET proposed_plan_json = ?
+             WHERE id = ?
+            """,
+            (stored_plan_json, preview["id"]),
+        )
+    portability_job = repo.create_portability_job(
+        owner_user_id="user-1",
+        job_id="job-commit-1",
+        operation="import_commit",
+        status="queued",
+        stage="queued",
+        preview_id=str(preview["id"]),
+        persona_id=persona_id,
+    )
+
+    class _UnexpectedPreviewer:
+        def create_preview(self, **_kwargs: Any) -> dict[str, Any]:
+            raise AssertionError("import commit revalidated a corrupt stored preview")
+
+    monkeypatch.setattr(
+        importer_module,
+        "PersonaVisualPackImportPreviewer",
+        _UnexpectedPreviewer,
+    )
+    worker = PersonaVisualPortabilityWorker(db=db_instance, repo=repo)
+
+    with pytest.raises(ValueError, match="import_preview_not_commit_eligible"):
+        await worker.handle_job_async(
+            {
+                "id": "job-commit-1",
+                "job_type": PERSONA_VISUAL_PACK_IMPORT_COMMIT_JOB_TYPE,
+                "owner_user_id": "user-1",
+                "payload": {
+                    "user_id": "user-1",
+                    "preview_id": str(preview["id"]),
+                    "portability_job_id": str(portability_job["id"]),
+                    "request_id": "req-commit",
+                    "target_persona_id": persona_id,
+                    "trust_mode": "untrusted_import",
+                    "target_mode": "create_new",
+                },
+            }
+        )
+
+    updated_job = repo.get_portability_job(str(portability_job["id"]), owner_user_id="user-1")
+    assert updated_job is not None
+    assert updated_job["status"] == "failed"
+    assert updated_job["error_message"] == "import_preview_not_commit_eligible"
+    assert len(db_instance.list_persona_visual_packs(persona_id=persona_id, user_id="user-1")) == 1
+
+
+@pytest.mark.asyncio
 async def test_persona_visual_import_commit_worker_rejects_revalidated_blocked_preview(
     db_instance: CharactersRAGDB,
     tmp_path: Path,

--- a/tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py
@@ -1037,3 +1037,110 @@ async def test_persona_visual_import_commit_worker_rejects_incomplete_preview(
         )
 
     assert len(db_instance.list_persona_visual_packs(persona_id=persona_id, user_id="user-1")) == 1
+
+
+@pytest.mark.asyncio
+async def test_persona_visual_import_commit_worker_rejects_revalidated_blocked_preview(
+    db_instance: CharactersRAGDB,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.core.DB_Management.PersonaVisualPortability_DB import (
+        PersonaVisualPortabilityRepository,
+    )
+    from tldw_Server_API.app.core.Persona.visual_jobs_worker import (
+        PersonaVisualPortabilityWorker,
+    )
+    from tldw_Server_API.app.core.Persona.visual_portability import importer as importer_module
+
+    persona_id, pack, _source_asset = _create_pack_with_asset(
+        db_instance,
+        visuals_root=tmp_path / "visuals",
+        monkeypatch=monkeypatch,
+    )
+    export_result = PersonaVisualPackExporter(
+        db=db_instance,
+        user_id="user-1",
+        staging_root=tmp_path / "exports",
+    ).export_pack(
+        persona_id=persona_id,
+        pack_id=str(pack["id"]),
+        options=PersonaVisualPackExportOptions(),
+    )
+    preview_result = PersonaVisualPackImportPreviewer().create_preview(
+        archive_path=export_result.archive_path,
+        owner_user_id="user-1",
+        target_persona_id=persona_id,
+        target_packs=db_instance.list_persona_visual_packs(
+            persona_id=persona_id,
+            user_id="user-1",
+        ),
+    )
+    repo = PersonaVisualPortabilityRepository.initialized(db_instance)
+    preview = repo.create_import_preview(
+        owner_user_id="user-1",
+        job_id="job-preview-1",
+        status="completed",
+        stage="completed",
+        archive_path=str(export_result.archive_path),
+        archive_sha256=preview_result["archive_sha256"],
+        canonical_payload_fingerprint=preview_result["canonical_payload_fingerprint"],
+        schema_version=preview_result["schema_version"],
+        target_persona_id=persona_id,
+        bundle_summary=preview_result["bundle_summary"],
+        conflicts=preview_result["conflicts"],
+        proposed_plan=preview_result["proposed_plan"],
+        required_choices=preview_result["required_choices"],
+    )
+    portability_job = repo.create_portability_job(
+        owner_user_id="user-1",
+        job_id="job-commit-1",
+        operation="import_commit",
+        status="queued",
+        stage="queued",
+        preview_id=str(preview["id"]),
+        persona_id=persona_id,
+    )
+
+    class _BlockedPreviewer:
+        def create_preview(self, **_kwargs: Any) -> dict[str, Any]:
+            blocked = dict(preview_result)
+            blocked["status"] = "blocked"
+            blocked["proposed_plan"] = {
+                **preview_result["proposed_plan"],
+                "commit_eligible": False,
+                "commit_blockers": ["unsupported_renderer"],
+            }
+            return blocked
+
+    monkeypatch.setattr(
+        importer_module,
+        "PersonaVisualPackImportPreviewer",
+        _BlockedPreviewer,
+    )
+    worker = PersonaVisualPortabilityWorker(db=db_instance, repo=repo)
+
+    with pytest.raises(ValueError, match="import_preview_not_commit_eligible"):
+        await worker.handle_job_async(
+            {
+                "id": "job-commit-1",
+                "job_type": PERSONA_VISUAL_PACK_IMPORT_COMMIT_JOB_TYPE,
+                "owner_user_id": "user-1",
+                "payload": {
+                    "user_id": "user-1",
+                    "preview_id": str(preview["id"]),
+                    "portability_job_id": str(portability_job["id"]),
+                    "request_id": "req-commit",
+                    "target_persona_id": persona_id,
+                    "trust_mode": "untrusted_import",
+                    "target_mode": "create_new",
+                    "conflict_choice_explicit": True,
+                },
+            }
+        )
+
+    updated_job = repo.get_portability_job(str(portability_job["id"]), owner_user_id="user-1")
+    assert updated_job is not None
+    assert updated_job["status"] == "failed"
+    assert updated_job["error_message"] == "import_preview_not_commit_eligible"
+    assert len(db_instance.list_persona_visual_packs(persona_id=persona_id, user_id="user-1")) == 1

--- a/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
@@ -1550,6 +1550,48 @@ def test_start_import_commit_rejects_incomplete_preview(
     assert manager.created == []
 
 
+def test_start_import_commit_rejects_ineligible_completed_preview(
+    persona_db: CharactersRAGDB,
+    tmp_path: Path,
+) -> None:
+    from tldw_Server_API.app.core.DB_Management.PersonaVisualPortability_DB import (
+        PersonaVisualPortabilityRepository,
+    )
+
+    manager = FakeJobManager()
+    fastapi_app.dependency_overrides[persona_ep.get_persona_visual_job_manager] = lambda: manager
+    with _client_for_user(1, persona_db) as client:
+        persona_id = _create_persona(client, name="Ineligible Import Commit Persona")
+        archive_path = tmp_path / "commit-ineligible.tldw-persona-vpack"
+        archive_path.write_bytes(b"portable visual archive")
+        repo = PersonaVisualPortabilityRepository.initialized(persona_db)
+        preview = repo.create_import_preview(
+            owner_user_id="1",
+            job_id="preview-job-ineligible",
+            status="completed",
+            stage="completed",
+            archive_path=str(archive_path),
+            archive_sha256="a" * 64,
+            canonical_payload_fingerprint="b" * 64,
+            schema_version="tldw.persona_visual_pack.v1",
+            target_persona_id=persona_id,
+            proposed_plan={
+                "target_mode": "create_new",
+                "commit_eligible": False,
+                "commit_blockers": ["unsupported_renderer"],
+            },
+        )
+
+        response = client.post(
+            f"/api/v1/persona/profiles/{persona_id}/visual-packs/import-previews/{preview['id']}/commit",
+            json={"trust_mode": "untrusted_import", "target_mode": "create_new"},
+        )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "import_preview_not_commit_eligible"
+    assert manager.created == []
+
+
 def test_deactivate_visual_pack_reverts_to_derived_buddy(persona_db: CharactersRAGDB) -> None:
     with _client_for_user(1, persona_db) as client:
         persona_id = _create_persona(client, name="Deactivate Visual API Persona")

--- a/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
@@ -1592,6 +1592,97 @@ def test_start_import_commit_rejects_ineligible_completed_preview(
     assert manager.created == []
 
 
+def test_start_import_commit_reports_blocked_preview_as_not_commit_eligible(
+    persona_db: CharactersRAGDB,
+    tmp_path: Path,
+) -> None:
+    from tldw_Server_API.app.core.DB_Management.PersonaVisualPortability_DB import (
+        PersonaVisualPortabilityRepository,
+    )
+
+    manager = FakeJobManager()
+    fastapi_app.dependency_overrides[persona_ep.get_persona_visual_job_manager] = lambda: manager
+    with _client_for_user(1, persona_db) as client:
+        persona_id = _create_persona(client, name="Blocked Import Commit Persona")
+        archive_path = tmp_path / "commit-blocked.tldw-persona-vpack"
+        archive_path.write_bytes(b"portable visual archive")
+        repo = PersonaVisualPortabilityRepository.initialized(persona_db)
+        preview = repo.create_import_preview(
+            owner_user_id="1",
+            job_id="preview-job-blocked",
+            status="blocked",
+            stage="completed",
+            archive_path=str(archive_path),
+            archive_sha256="a" * 64,
+            canonical_payload_fingerprint="b" * 64,
+            schema_version="tldw.persona_visual_pack.v1",
+            target_persona_id=persona_id,
+            proposed_plan={
+                "target_mode": "create_new",
+                "commit_eligible": False,
+                "commit_blockers": ["unsupported_renderer"],
+            },
+        )
+
+        response = client.post(
+            f"/api/v1/persona/profiles/{persona_id}/visual-packs/import-previews/{preview['id']}/commit",
+            json={"trust_mode": "untrusted_import", "target_mode": "create_new"},
+        )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "import_preview_not_commit_eligible"
+    assert manager.created == []
+
+
+@pytest.mark.parametrize("stored_plan_json", ["{not-json", "[]"])
+def test_start_import_commit_rejects_invalid_stored_preview_plan(
+    persona_db: CharactersRAGDB,
+    tmp_path: Path,
+    stored_plan_json: str,
+) -> None:
+    from tldw_Server_API.app.core.DB_Management.PersonaVisualPortability_DB import (
+        PersonaVisualPortabilityRepository,
+    )
+
+    manager = FakeJobManager()
+    fastapi_app.dependency_overrides[persona_ep.get_persona_visual_job_manager] = lambda: manager
+    with _client_for_user(1, persona_db) as client:
+        persona_id = _create_persona(client, name="Invalid Plan Import Commit Persona")
+        archive_path = tmp_path / "commit-invalid-plan.tldw-persona-vpack"
+        archive_path.write_bytes(b"portable visual archive")
+        repo = PersonaVisualPortabilityRepository.initialized(persona_db)
+        preview = repo.create_import_preview(
+            owner_user_id="1",
+            job_id="preview-job-invalid-plan",
+            status="completed",
+            stage="completed",
+            archive_path=str(archive_path),
+            archive_sha256="a" * 64,
+            canonical_payload_fingerprint="b" * 64,
+            schema_version="tldw.persona_visual_pack.v1",
+            target_persona_id=persona_id,
+            proposed_plan={"target_mode": "create_new"},
+        )
+        with persona_db.transaction() as conn:
+            conn.execute(
+                """
+                UPDATE persona_visual_pack_import_previews
+                   SET proposed_plan_json = ?
+                 WHERE id = ?
+                """,
+                (stored_plan_json, preview["id"]),
+            )
+
+        response = client.post(
+            f"/api/v1/persona/profiles/{persona_id}/visual-packs/import-previews/{preview['id']}/commit",
+            json={"trust_mode": "untrusted_import", "target_mode": "create_new"},
+        )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "import_preview_not_commit_eligible"
+    assert manager.created == []
+
+
 def test_deactivate_visual_pack_reverts_to_derived_buddy(persona_db: CharactersRAGDB) -> None:
     with _client_for_user(1, persona_db) as client:
         persona_id = _create_persona(client, name="Deactivate Visual API Persona")


### PR DESCRIPTION
## Summary
- Closes #1657.
- Reject stored Persona Visual import previews whose proposed plan explicitly marks `commit_eligible` false before enqueueing commit jobs.
- Reject revalidated blocked/non-commit-eligible previews inside the import-commit worker before draft pack or asset creation.
- Add focused API and worker regressions and TASK-332 tracking.

## Change summary
Maintainer-authored change summary required before ready-for-merge per AI-generated PR policy.

## Risk / rollback
- Risk: Low. The changes are limited to Persona Visual import-commit eligibility guards and focused regression coverage.
- Rollback: Revert this PR to restore the prior import-commit behavior. Existing stored previews and packs are not migrated by this change.

## Tests
- `python -m pytest tldw_Server_API/tests/Persona/test_persona_visuals_api.py::test_start_import_commit_reports_blocked_preview_as_not_commit_eligible tldw_Server_API/tests/Persona/test_persona_visuals_api.py::test_start_import_commit_rejects_invalid_stored_preview_plan tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py::test_persona_visual_import_commit_worker_rejects_invalid_stored_plan_before_revalidation -q`
- `python -m pytest tldw_Server_API/tests/Persona/test_persona_visuals_api.py tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py -q`
- `python -m py_compile tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/app/core/Persona/visual_portability/importer.py`
- `git diff --check`
- `python -m bandit -r tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/app/core/Persona/visual_portability/importer.py -f json -o /tmp/bandit_persona_visual_commit_guards_review.json`

## Notes
- Optional Ruff full-file check on touched files still reports existing I001 import-order findings in legacy modules; this PR does not auto-sort unrelated legacy imports.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened Persona Visual import-commit to fail closed for blocked, commit-ineligible, or invalid stored-plan previews, preventing partial draft packs/assets. Implements TASK-332 and addresses issue #1657.

- **Bug Fixes**
  - API: Reject `blocked`, `commit_eligible: false`, or malformed/non-object `proposed_plan_json` previews with 409 `import_preview_not_commit_eligible` before job enqueue; keep 409 for `import_preview_not_completed`.
  - Worker: Centralized eligibility checks; for stored and revalidated previews, reject `blocked`, `not completed`, `commit_eligible: false`, or invalid plan before any creation; fail job with `import_preview_not_commit_eligible` or `import_preview_not_completed`.
  - Tests: Added API and worker regressions for blocked and invalid stored-plan cases and revalidated-to-blocked paths; assert failed job and no drafts; eligible previews unchanged.

<sup>Written for commit 41a2a648d993fbe733fd4515ad79b2936d9be061. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

