### PR TITLE
Harden Persona Visual import commit eligibility

### DIFF
--- a/backlog/tasks/task-331 - Harden-Persona-Visual-import-commit-eligibility-revalidation.md
+++ b/backlog/tasks/task-331 - Harden-Persona-Visual-import-commit-eligibility-revalidation.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - codex
 created_date: '2026-05-14 03:19'
-updated_date: '2026-05-14 03:49'
+updated_date: '2026-05-14 04:05'
 labels:
   - persona
 dependencies: []
@@ -57,15 +57,29 @@ Implemented shared import preview commit eligibility guards for API enqueue and 
 
 Verification: red tests first confirmed stale blocked revalidation still created packs and commit-ineligible completed preview still queued a job before the fix.
 
-Verification after fix: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py -q --tb=short` passed 11 tests.
+Verification after fix: `python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py -q --tb=short` passed 11 tests.
 
-Verification after fix: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_visuals_api.py -q --tb=short` passed 40 tests.
+Verification after fix: `python -m pytest tldw_Server_API/tests/Persona/test_persona_visuals_api.py -q --tb=short` passed 40 tests.
 
-Verification after fix: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_portability.py tldw_Server_API/tests/Persona/test_persona_visual_import_preview_validators.py -q --tb=short` passed 21 tests.
+Verification after fix: `python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_portability.py tldw_Server_API/tests/Persona/test_persona_visual_import_preview_validators.py -q --tb=short` passed 21 tests.
 
 Verification after fix: `git diff --check` passed.
 
-Verification after fix: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit tldw_Server_API/app/core/Persona/visual_portability/commit_eligibility.py tldw_Server_API/app/core/Persona/visual_portability/importer.py tldw_Server_API/app/api/v1/endpoints/persona.py` reported no issues.
+Verification after fix: `python -m bandit tldw_Server_API/app/core/Persona/visual_portability/commit_eligibility.py tldw_Server_API/app/core/Persona/visual_portability/importer.py tldw_Server_API/app/api/v1/endpoints/persona.py` reported no issues.
 
 Draft PR opened: https://github.com/rmusser01/tldw_server/pull/1678. GitHub checks were pending at creation time; human-authored Change summary remains required before merge per repo policy.
+
+PR review follow-up: added helper-level regression coverage for malformed proposed plans, missing revalidated proposed plans, null blocker filtering, and legacy renderer previews without `can_commit`. The shared guard now fails closed for non-mapping plans, ignores null blocker values, and only treats `renderer_import_preview.can_commit` as a blocker when that key is explicitly present and not true.
+
+Verification after review fix: `python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_import_commit_eligibility.py -q --tb=short` passed 4 tests.
+
+Verification after review fix: `python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py -q --tb=short` passed 11 tests.
+
+Verification after review fix: `python -m pytest tldw_Server_API/tests/Persona/test_persona_visuals_api.py -q --tb=short` passed 40 tests.
+
+Verification after review fix: `python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_portability.py tldw_Server_API/tests/Persona/test_persona_visual_import_preview_validators.py -q --tb=short` passed 21 tests.
+
+Verification after review fix: `git diff --check` passed.
+
+Verification after review fix: `python -m bandit tldw_Server_API/app/core/Persona/visual_portability/commit_eligibility.py tldw_Server_API/app/core/Persona/visual_portability/importer.py tldw_Server_API/app/api/v1/endpoints/persona.py` reported no issues.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-331 - Harden-Persona-Visual-import-commit-eligibility-revalidation.md
+++ b/backlog/tasks/task-331 - Harden-Persona-Visual-import-commit-eligibility-revalidation.md
@@ -1,0 +1,71 @@
+---
+id: TASK-331
+title: Harden Persona Visual import-commit eligibility revalidation
+status: In Progress
+assignee:
+  - codex
+created_date: '2026-05-14 03:19'
+updated_date: '2026-05-14 03:49'
+labels:
+  - persona
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1510'
+  - 'https://github.com/rmusser01/tldw_server/issues/1657'
+  - 'https://github.com/rmusser01/tldw_server/pull/1678'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add a narrow Persona/Buddy visual-pack hardening slice for GitHub #1657. Current origin/dev rejects blocked Manifest V2 renderer import previews at the API because their preview status is blocked, but the import-commit worker revalidates the archive and does not fail closed when the revalidated result is blocked or non-committable. Harden the server-side commit path so stale completed previews or capability-state changes cannot create partial draft packs/assets for unsupported renderer imports. Keep this scoped to Persona Visual Pack import-commit safety; do not add Live2D runtime activation, new renderer implementations, Persona Garden UI changes unless required by API contract, MCP provider expansion, VN/CYOA behavior, or live response mutation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Import-commit worker/importer fails closed when revalidated preview status is not completed or proposed_plan.commit_eligible is false.
+- [x] #2 Stored preview metadata that already indicates commit ineligible is rejected before queuing a commit job when available.
+- [x] #3 Blocked or non-committable renderer previews do not create draft visual packs or imported assets during failed commit attempts.
+- [x] #4 Focused backend regression tests cover the stale completed/non-committable revalidation path and the API prequeue guard.
+- [x] #5 Relevant Persona visual-pack docs or task notes are updated only if behavior/contract wording changes.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add red regression coverage in Persona visual import-commit tests for a stale completed preview whose archive revalidates as blocked/non-committable, asserting no draft pack/assets are created.
+2. Add API regression coverage for a stored completed preview whose proposed_plan marks commit_eligible=false, asserting the commit request is rejected before queuing a job.
+3. Add a small shared eligibility guard for preview metadata and apply it in the API prequeue path plus importer revalidation path.
+4. Keep behavior limited to Persona Visual Pack import-commit safety; do not change renderer capabilities, activation, Persona Garden UI, MCP provider behavior, VN/CYOA, or live responses.
+5. Run focused Persona visual portability/API tests, git diff checks, and Bandit on touched backend code before PR.
+<!-- SECTION:PLAN:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Notes
+<!-- SECTION:NOTES:BEGIN -->
+Implemented shared import preview commit eligibility guards for API enqueue and worker revalidation paths.
+
+Verification: red tests first confirmed stale blocked revalidation still created packs and commit-ineligible completed preview still queued a job before the fix.
+
+Verification after fix: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py -q --tb=short` passed 11 tests.
+
+Verification after fix: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_visuals_api.py -q --tb=short` passed 40 tests.
+
+Verification after fix: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_portability.py tldw_Server_API/tests/Persona/test_persona_visual_import_preview_validators.py -q --tb=short` passed 21 tests.
+
+Verification after fix: `git diff --check` passed.
+
+Verification after fix: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit tldw_Server_API/app/core/Persona/visual_portability/commit_eligibility.py tldw_Server_API/app/core/Persona/visual_portability/importer.py tldw_Server_API/app/api/v1/endpoints/persona.py` reported no issues.
+
+Draft PR opened: https://github.com/rmusser01/tldw_server/pull/1678. GitHub checks were pending at creation time; human-authored Change summary remains required before merge per repo policy.
+<!-- SECTION:NOTES:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -162,6 +162,9 @@ from tldw_Server_API.app.core.Persona.visual_jobs import (
 from tldw_Server_API.app.core.Persona.visual_portability.archive import (
     DEFAULT_MAX_ARCHIVE_SIZE_BYTES,
 )
+from tldw_Server_API.app.core.Persona.visual_portability.commit_eligibility import (
+    is_import_preview_plan_committable,
+)
 from tldw_Server_API.app.core.Persona.visual_portability.constants import (
     PERSONA_VISUAL_PACK_EXTENSION,
 )
@@ -5160,6 +5163,12 @@ async def start_persona_visual_pack_import_commit(
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
                 detail="import_preview_not_completed",
+            )
+        proposed_plan = _persona_visual_json_field(preview, "proposed_plan_json", {})
+        if not is_import_preview_plan_committable(proposed_plan):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="import_preview_not_committable",
             )
         conflicts = _persona_visual_json_field(preview, "conflicts_json", [])
         replaceable_pack_ids = _persona_visual_replaceable_pack_ids(conflicts)

--- a/tldw_Server_API/app/core/Persona/visual_portability/commit_eligibility.py
+++ b/tldw_Server_API/app/core/Persona/visual_portability/commit_eligibility.py
@@ -1,0 +1,45 @@
+"""Shared commit eligibility checks for persona visual import previews.
+
+These helpers keep the REST enqueue path and background import worker aligned so
+stored preview metadata and archive revalidation results both fail closed before
+any visual pack records are created.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def is_import_preview_plan_committable(proposed_plan: Any) -> bool:
+    """Return whether a preview plan can be committed into a visual pack."""
+    return not import_preview_commit_blockers(proposed_plan)
+
+
+def is_import_preview_result_committable(preview_result: Mapping[str, Any]) -> bool:
+    """Return whether a revalidated preview result is safe to commit."""
+    if str(preview_result.get("status") or "") != "completed":
+        return False
+    return is_import_preview_plan_committable(preview_result.get("proposed_plan"))
+
+
+def import_preview_commit_blockers(proposed_plan: Any) -> list[str]:
+    """Normalize reasons that an import preview plan must not be committed."""
+    if not isinstance(proposed_plan, Mapping):
+        return []
+
+    blockers = _string_list(proposed_plan.get("commit_blockers"))
+    if "commit_eligible" in proposed_plan and proposed_plan.get("commit_eligible") is not True:
+        blockers.append("commit_eligible_not_true")
+
+    renderer_preview = proposed_plan.get("renderer_import_preview")
+    if isinstance(renderer_preview, Mapping) and renderer_preview.get("can_commit") is not True:
+        blockers.append("renderer_import_preview_not_committable")
+
+    return blockers
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if str(item).strip()]

--- a/tldw_Server_API/app/core/Persona/visual_portability/commit_eligibility.py
+++ b/tldw_Server_API/app/core/Persona/visual_portability/commit_eligibility.py
@@ -26,20 +26,25 @@ def is_import_preview_result_committable(preview_result: Mapping[str, Any]) -> b
 def import_preview_commit_blockers(proposed_plan: Any) -> list[str]:
     """Normalize reasons that an import preview plan must not be committed."""
     if not isinstance(proposed_plan, Mapping):
-        return []
+        return ["missing_or_invalid_plan"]
 
     blockers = _string_list(proposed_plan.get("commit_blockers"))
     if "commit_eligible" in proposed_plan and proposed_plan.get("commit_eligible") is not True:
         blockers.append("commit_eligible_not_true")
 
     renderer_preview = proposed_plan.get("renderer_import_preview")
-    if isinstance(renderer_preview, Mapping) and renderer_preview.get("can_commit") is not True:
+    if (
+        isinstance(renderer_preview, Mapping)
+        and "can_commit" in renderer_preview
+        and renderer_preview.get("can_commit") is not True
+    ):
         blockers.append("renderer_import_preview_not_committable")
 
     return blockers
 
 
 def _string_list(value: Any) -> list[str]:
+    """Return non-empty string values from a JSON list while ignoring nulls."""
     if not isinstance(value, list):
         return []
-    return [str(item) for item in value if str(item).strip()]
+    return [str(item) for item in value if item is not None and str(item).strip()]

--- a/tldw_Server_API/app/core/Persona/visual_portability/importer.py
+++ b/tldw_Server_API/app/core/Persona/visual_portability/importer.py
@@ -14,6 +14,10 @@ from tldw_Server_API.app.core.DB_Management.PersonaVisualPortability_DB import (
     PersonaVisualPortabilityRepository,
 )
 from tldw_Server_API.app.core.Persona.visual_portability.archive import normalize_member_name
+from tldw_Server_API.app.core.Persona.visual_portability.commit_eligibility import (
+    is_import_preview_plan_committable,
+    is_import_preview_result_committable,
+)
 from tldw_Server_API.app.core.Persona.visual_portability.constants import (
     ASSET_BYTES_STATUS_PRESENT,
     TRUST_MODE_TRUSTED_RESTORE,
@@ -90,6 +94,8 @@ class PersonaVisualPackImporter:
         expected_fingerprint = str(preview.get("canonical_payload_fingerprint") or "")
         if expected_fingerprint and revalidated["canonical_payload_fingerprint"] != expected_fingerprint:
             raise ValueError("import_archive_fingerprint_changed")
+        if not is_import_preview_result_committable(revalidated):
+            raise ValueError("import_preview_not_committable")
         revalidated_conflicts = revalidated.get("conflicts")
         current_conflicts = revalidated_conflicts if isinstance(revalidated_conflicts, list) else []
         if current_conflicts and not conflict_choice_explicit:
@@ -257,6 +263,9 @@ class PersonaVisualPackImporter:
     def _validate_preview_ready(self, *, preview: dict[str, Any], archive_path: Path) -> None:
         if str(preview.get("status") or "") != "completed":
             raise ValueError("import_preview_not_completed")
+        proposed_plan = _import_preview_json_field(preview, "proposed_plan_json", {})
+        if not is_import_preview_plan_committable(proposed_plan):
+            raise ValueError("import_preview_not_committable")
         if not archive_path.is_file():
             raise ValueError("import_archive_not_found")
         expires_at = _parse_datetime(preview.get("expires_at"))

--- a/tldw_Server_API/tests/Persona/test_persona_visual_import_commit_eligibility.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_import_commit_eligibility.py
@@ -1,0 +1,45 @@
+"""Regression tests for persona visual import commit eligibility guards."""
+
+from __future__ import annotations
+
+from tldw_Server_API.app.core.Persona.visual_portability.commit_eligibility import (
+    import_preview_commit_blockers,
+    is_import_preview_plan_committable,
+    is_import_preview_result_committable,
+)
+
+
+def test_import_preview_plan_rejects_non_mapping_plan() -> None:
+    assert not is_import_preview_plan_committable([])
+    assert import_preview_commit_blockers([]) == ["missing_or_invalid_plan"]
+
+
+def test_import_preview_result_rejects_missing_plan() -> None:
+    assert not is_import_preview_result_committable({"status": "completed"})
+    assert not is_import_preview_result_committable({"status": "completed", "proposed_plan": []})
+
+
+def test_renderer_import_preview_without_can_commit_does_not_block_plan() -> None:
+    plan = {
+        "renderer_import_preview": {
+            "status": "legacy_preview",
+        },
+    }
+
+    assert is_import_preview_plan_committable(plan)
+
+
+def test_import_preview_commit_blockers_ignore_null_entries() -> None:
+    plan = {
+        "commit_blockers": [
+            None,
+            "runtime_adapter_not_implemented",
+            " ",
+        ],
+        "commit_eligible": False,
+    }
+
+    assert import_preview_commit_blockers(plan) == [
+        "runtime_adapter_not_implemented",
+        "commit_eligible_not_true",
+    ]

--- a/tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py
@@ -631,6 +631,119 @@ async def test_persona_visual_import_commit_worker_creates_pack_and_remaps_asset
 
 
 @pytest.mark.asyncio
+async def test_persona_visual_import_commit_worker_rejects_blocked_revalidation_without_pack(
+    db_instance: CharactersRAGDB,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ensure stale completed previews cannot commit after blocked revalidation."""
+
+    from tldw_Server_API.app.core.DB_Management.PersonaVisualPortability_DB import (
+        PersonaVisualPortabilityRepository,
+    )
+    from tldw_Server_API.app.core.Persona import visual_jobs_worker as worker_module
+    from tldw_Server_API.app.core.Persona.visual_portability import importer as importer_module
+
+    class _BlockedPreviewer:
+        def create_preview(self, **_kwargs: Any) -> dict[str, Any]:
+            return {
+                "status": "blocked",
+                "archive_sha256": "a" * 64,
+                "canonical_payload_fingerprint": "b" * 64,
+                "schema_version": "tldw.persona_visual_pack.v1",
+                "bundle_summary": {"renderer_type": "live2d"},
+                "validation_warnings": [],
+                "conflicts": [],
+                "proposed_plan": {
+                    "renderer_import_preview": {"status": "unsupported_renderer"},
+                    "commit_eligible": False,
+                    "commit_blockers": ["runtime_adapter_not_implemented"],
+                },
+                "quota_estimate": {
+                    "asset_bytes": 0,
+                    "present_asset_items": 0,
+                    "missing_asset_items": 0,
+                },
+                "required_choices": [],
+                "target_warnings": [],
+            }
+
+    persona_id, pack, _source_asset = _create_pack_with_asset(
+        db_instance,
+        visuals_root=tmp_path / "visuals",
+        monkeypatch=monkeypatch,
+    )
+    export_result = PersonaVisualPackExporter(
+        db=db_instance,
+        user_id="user-1",
+        staging_root=tmp_path / "exports",
+    ).export_pack(
+        persona_id=persona_id,
+        pack_id=str(pack["id"]),
+        options=PersonaVisualPackExportOptions(),
+    )
+    repo = PersonaVisualPortabilityRepository.initialized(db_instance)
+    preview = repo.create_import_preview(
+        owner_user_id="user-1",
+        job_id="job-preview-blocked-revalidation",
+        status="completed",
+        stage="completed",
+        archive_path=str(export_result.archive_path),
+        archive_sha256=export_result.archive_sha256,
+        canonical_payload_fingerprint="b" * 64,
+        schema_version="tldw.persona_visual_pack.v1",
+        target_persona_id=persona_id,
+    )
+    portability_job = repo.create_portability_job(
+        owner_user_id="user-1",
+        job_id="job-commit-blocked-revalidation",
+        operation="import_commit",
+        status="queued",
+        stage="queued",
+        preview_id=str(preview["id"]),
+        persona_id=persona_id,
+    )
+    packs_before = db_instance.list_persona_visual_packs(
+        persona_id=persona_id,
+        user_id="user-1",
+    )
+    monkeypatch.setattr(
+        importer_module,
+        "PersonaVisualPackImportPreviewer",
+        _BlockedPreviewer,
+    )
+    worker = worker_module.PersonaVisualPortabilityWorker(db=db_instance, repo=repo)
+
+    with pytest.raises(ValueError, match="import_preview_not_committable"):
+        await worker.handle_job_async(
+            {
+                "id": "job-commit-blocked-revalidation",
+                "job_type": PERSONA_VISUAL_PACK_IMPORT_COMMIT_JOB_TYPE,
+                "owner_user_id": "user-1",
+                "payload": {
+                    "user_id": "user-1",
+                    "preview_id": str(preview["id"]),
+                    "portability_job_id": str(portability_job["id"]),
+                    "request_id": "req-commit-blocked-revalidation",
+                    "target_persona_id": persona_id,
+                    "trust_mode": "untrusted_import",
+                    "target_mode": "create_new",
+                    "conflict_choice_explicit": True,
+                },
+            }
+        )
+
+    updated_job = repo.get_portability_job(str(portability_job["id"]), owner_user_id="user-1")
+    assert updated_job is not None
+    assert updated_job["status"] == "failed"
+    assert updated_job["error_code"] == "import_commit_failed"
+    assert db_instance.list_persona_visual_packs(
+        persona_id=persona_id,
+        user_id="user-1",
+    ) == packs_before
+
+
+@pytest.mark.asyncio
 async def test_persona_visual_import_commit_worker_replaces_selected_draft_only(
     db_instance: CharactersRAGDB,
     tmp_path: Path,

--- a/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
@@ -1351,6 +1351,50 @@ def test_start_import_commit_creates_jobs_backed_portability_row(
     assert row["persona_id"] == persona_id
 
 
+def test_start_import_commit_rejects_commit_ineligible_preview(
+    persona_db: CharactersRAGDB,
+    tmp_path: Path,
+) -> None:
+    """Ensure stored renderer preview blockers prevent commit job enqueue."""
+
+    from tldw_Server_API.app.core.DB_Management.PersonaVisualPortability_DB import (
+        PersonaVisualPortabilityRepository,
+    )
+
+    manager = FakeJobManager()
+    fastapi_app.dependency_overrides[persona_ep.get_persona_visual_job_manager] = lambda: manager
+    with _client_for_user(1, persona_db) as client:
+        persona_id = _create_persona(client, name="Commit Ineligible Persona")
+        archive_path = tmp_path / "commit-ineligible.tldw-persona-vpack"
+        archive_path.write_bytes(b"portable visual archive")
+        repo = PersonaVisualPortabilityRepository.initialized(persona_db)
+        preview = repo.create_import_preview(
+            owner_user_id="1",
+            job_id="preview-job-ineligible",
+            status="completed",
+            stage="completed",
+            archive_path=str(archive_path),
+            archive_sha256="a" * 64,
+            canonical_payload_fingerprint="b" * 64,
+            schema_version="tldw.persona_visual_pack.v1",
+            target_persona_id=persona_id,
+            proposed_plan={
+                "renderer_import_preview": {"status": "unsupported_renderer"},
+                "commit_eligible": False,
+                "commit_blockers": ["runtime_adapter_not_implemented"],
+            },
+        )
+
+        response = client.post(
+            f"/api/v1/persona/profiles/{persona_id}/visual-packs/import-previews/{preview['id']}/commit",
+            json={"trust_mode": "untrusted_import", "target_mode": "create_new"},
+        )
+
+    assert response.status_code == 409, response.text
+    assert response.json()["detail"] == "import_preview_not_committable"
+    assert manager.created == []
+
+
 def test_start_import_commit_requires_explicit_target_mode_for_conflicts(
     persona_db: CharactersRAGDB,
     tmp_path: Path,


### PR DESCRIPTION
## Change summary

Pending human-authored summary before merge per the AI-generated PR policy.

## What changed

- Added a shared Persona Visual import-preview commit eligibility guard used by both the API enqueue path and the background importer.
- Rejected completed previews before queueing when stored `proposed_plan` metadata says commit is not allowed.
- Rejected stale import commits when archive revalidation returns a blocked or non-committable preview, before creating draft packs or assets.
- Added focused API and worker regression coverage for the rejected paths.
- Added Backlog task TASK-331 for GitHub issue #1657.

## Verification

- Red tests first confirmed the pre-fix behavior:
  - stale blocked revalidation did not raise and created a pack
  - commit-ineligible completed preview still queued a job
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py -q --tb=short`
  - 11 passed
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_visuals_api.py -q --tb=short`
  - 40 passed
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_portability.py tldw_Server_API/tests/Persona/test_persona_visual_import_preview_validators.py -q --tb=short`
  - 21 passed
- `git diff --cached --check`
  - passed
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit tldw_Server_API/app/core/Persona/visual_portability/commit_eligibility.py tldw_Server_API/app/core/Persona/visual_portability/importer.py tldw_Server_API/app/api/v1/endpoints/persona.py`
  - no issues identified

Refs #1510
Refs #1657

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened Persona Visual import-commit to fail closed for blocked or ineligible previews in both API and worker. Adds a robust shared guard to prevent stale or unsupported imports from creating draft packs or assets.

- **Bug Fixes**
  - Shared commit-eligibility guard used by API enqueue and importer revalidation.
  - API: reject completed previews with a non-committable `proposed_plan` with 409 `import_preview_not_committable`.
  - Worker: after archive revalidation, require `status=completed` and a committable plan; reject before creating draft packs/assets and validate stored `proposed_plan` during readiness checks.
  - Guard robustness: reject missing/non-mapping plans; ignore null `commit_blockers`; only treat `renderer_import_preview.can_commit` as a blocker when explicitly present and not true; added focused helper tests.

<sup>Written for commit 5b1ba5c6f90c1ed9cb7d701ab9e83a0538e01896. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

