### PR TITLE
Add VN script graph inspector

### DIFF
--- a/Docs/API/VN.md
+++ b/Docs/API/VN.md
@@ -278,3 +278,22 @@ supplied drafts are rejected before graph construction.
    `validation_diagnostics` as validation status.
 6. Use existing draft update and publish endpoints for mutations; graph
    endpoints never save or execute script content.
+
+### WebUI Graph Inspector Flow
+
+The WebUI script authoring surface consumes the same contract as custom
+frontends:
+
+- Show the graph inspector only when `features.script_authoring_graph` is true.
+- Use the saved draft graph for the last persisted draft revision.
+- Use graph preview for unsaved editor JSON so authors can inspect structure
+  before saving.
+- Use version graph from each published-version card for immutable release
+  structure.
+- Treat `content_hash`, `graph_semantics_version`, `base_revision`, and
+  `version_id` as cache/staleness keys for rendered outline state.
+- Render `outline` as the primary authoring aid and keep detailed `graph`
+  nodes/edges available for richer custom clients.
+- Keep graph diagnostics visually separate from validation diagnostics:
+  graph diagnostics explain static-analysis limitations or partial structure,
+  while validation diagnostics remain the publish/runtime readiness signal.

--- a/Docs/superpowers/plans/2026-05-14-vn-script-graph-inspector.md
+++ b/Docs/superpowers/plans/2026-05-14-vn-script-graph-inspector.md
@@ -1,0 +1,51 @@
+# VN Script Graph Inspector Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a read-only WebUI graph/outline inspector for VN script drafts and published versions using the backend-owned graph API from issue #1680.
+
+**Architecture:** The frontend adds typed graph API helpers and renders server-shaped graph data only. The existing VN script workbench remains the integration point; graph derivation, validation, cache keys, and diagnostics semantics stay owned by `/api/v1/vn/vn-scripts`.
+
+**Tech Stack:** Next.js/React, existing `apiClient`, Vitest + Testing Library, VN API docs in `Docs/API/VN.md`.
+
+---
+
+### Task 1: Typed VN Script Graph Client Contract
+
+**Files:**
+- Modify: `apps/tldw-frontend/types/vn-scripts.ts`
+- Modify: `apps/tldw-frontend/lib/api/vnScripts.ts`
+- Modify: `apps/tldw-frontend/__tests__/vn-scripts/vnScriptsApi.test.ts`
+
+- [ ] Add TypeScript interfaces for the graph response envelope, outline labels, graph nodes, graph edges, graph diagnostics, and preview request.
+- [ ] Add `getVNScriptDraftGraph`, `previewVNScriptDraftGraph`, and `getVNScriptVersionGraph` helpers.
+- [ ] Add failing API helper tests for the three endpoint paths and payload behavior.
+- [ ] Run `bunx vitest run __tests__/vn-scripts/vnScriptsApi.test.ts` from `apps/tldw-frontend` and confirm the new tests fail before implementation.
+- [ ] Implement the helpers and verify the focused API test passes.
+
+### Task 2: Read-Only Graph Inspector UI
+
+**Files:**
+- Modify: `apps/tldw-frontend/components/vn-scripts/VNScriptsWorkbench.tsx`
+- Modify: `apps/tldw-frontend/__tests__/vn-scripts/VNScriptsWorkbench.test.tsx`
+
+- [ ] Add state and loading handlers for saved draft graph, unsaved draft graph preview, and per-version graph reads.
+- [ ] Gate the panel on `vnCapabilities.features.script_authoring_graph`.
+- [ ] Render graph source metadata, cache/staleness keys, outline rows, graph diagnostics, validation diagnostics, and truncated-state warnings distinctly from existing validation/diagnostics panels.
+- [ ] Provide actions to load the saved draft graph, preview current editor JSON without saving, and load a published version graph.
+- [ ] Keep the UI read-only: do not derive edges client-side, mutate drafts, or add node-editing controls.
+- [ ] Add failing workbench tests for capability gating, saved draft graph rendering, unsaved preview payloads, version graph rendering, and graph-vs-validation diagnostics separation.
+- [ ] Run `bunx vitest run __tests__/vn-scripts/VNScriptsWorkbench.test.tsx` from `apps/tldw-frontend` and confirm the new tests fail before implementation.
+- [ ] Implement the panel and verify the focused workbench test passes.
+
+### Task 3: Documentation And Verification
+
+**Files:**
+- Modify: `Docs/API/VN.md`
+- Modify: `backlog/tasks/task-333 - Add-VN-script-graph-and-outline-inspector.md`
+
+- [ ] Update the VN API docs with a short WebUI/custom-frontend graph-inspector flow, including when to call saved draft, unsaved preview, and version graph endpoints.
+- [ ] Run focused frontend tests for VN script API and workbench.
+- [ ] Run `git diff --check`.
+- [ ] Run Bandit on touched Python scope if any backend Python is touched; otherwise record the frontend/docs-only skip in TASK-333.
+- [ ] Update TASK-333 acceptance criteria, verification notes, known skips, and final summary.

--- a/apps/tldw-frontend/__tests__/vn-scripts/VNScriptsWorkbench.test.tsx
+++ b/apps/tldw-frontend/__tests__/vn-scripts/VNScriptsWorkbench.test.tsx
@@ -13,10 +13,13 @@ const mocks = vi.hoisted(() => ({
   getVNScriptAuthoringCatalog: vi.fn(),
   getVNScriptDiagnostics: vi.fn(),
   getVNScriptDraft: vi.fn(),
+  getVNScriptDraftGraph: vi.fn(),
   getVNScriptManifestSnapshot: vi.fn(),
+  getVNScriptVersionGraph: vi.fn(),
   listVNScriptTemplates: vi.fn(),
   listVNScripts: vi.fn(),
   listVNScriptVersions: vi.fn(),
+  previewVNScriptDraftGraph: vi.fn(),
   previewVNScriptSnippet: vi.fn(),
   publishVNScript: vi.fn(),
   putVNScriptDraft: vi.fn(),
@@ -35,10 +38,13 @@ vi.mock('@web/lib/api/vnScripts', () => ({
   getVNScriptAuthoringCatalog: (...args: unknown[]) => mocks.getVNScriptAuthoringCatalog(...args),
   getVNScriptDiagnostics: (...args: unknown[]) => mocks.getVNScriptDiagnostics(...args),
   getVNScriptDraft: (...args: unknown[]) => mocks.getVNScriptDraft(...args),
+  getVNScriptDraftGraph: (...args: unknown[]) => mocks.getVNScriptDraftGraph(...args),
   getVNScriptManifestSnapshot: (...args: unknown[]) => mocks.getVNScriptManifestSnapshot(...args),
+  getVNScriptVersionGraph: (...args: unknown[]) => mocks.getVNScriptVersionGraph(...args),
   listVNScriptTemplates: (...args: unknown[]) => mocks.listVNScriptTemplates(...args),
   listVNScripts: (...args: unknown[]) => mocks.listVNScripts(...args),
   listVNScriptVersions: (...args: unknown[]) => mocks.listVNScriptVersions(...args),
+  previewVNScriptDraftGraph: (...args: unknown[]) => mocks.previewVNScriptDraftGraph(...args),
   previewVNScriptSnippet: (...args: unknown[]) => mocks.previewVNScriptSnippet(...args),
   publishVNScript: (...args: unknown[]) => mocks.publishVNScript(...args),
   putVNScriptDraft: (...args: unknown[]) => mocks.putVNScriptDraft(...args),
@@ -195,6 +201,7 @@ const vnCapabilitiesResponse = {
   enabled_modules: { scripts: true, play: true },
   features: {
     script_authoring_catalog: true,
+    script_authoring_graph: true,
     scripted_generation: true,
   },
   limits: {},
@@ -292,6 +299,72 @@ const authoringCatalogResponse = {
   limits: { max_operations: 100 },
 };
 
+const graphResponse = {
+  schema_version: 'vn_script_authoring_graph.v1',
+  graph_semantics_version: 'vn_script_authoring_graph_edges.v1',
+  program_schema_version: 'vn_script_program.v1',
+  script_id: 1,
+  source: 'stored_draft',
+  base_revision: 3,
+  version_id: null,
+  content_hash: 'sha256:opening',
+  validation_context_source: 'current_draft_context',
+  truncated: false,
+  limits: {
+    max_labels: 500,
+    max_ops: 5000,
+    max_edges: 10000,
+    max_supplied_draft_bytes: 1048576,
+  },
+  outline: {
+    entry_label: 'start',
+    labels: [
+      {
+        id: 'label:start',
+        label: 'start',
+        source_path: "$.labels['start']",
+        op_count: 2,
+        incoming_edge_count: 0,
+        outgoing_edge_count: 1,
+        reachable: true,
+        terminal: 'continues',
+        summary: 'Opening label',
+      },
+    ],
+  },
+  graph: {
+    nodes: [
+      {
+        id: 'label:start',
+        type: 'label',
+        label: 'start',
+        source_path: "$.labels['start']",
+        reachable: true,
+        terminal: 'continues',
+        summary: 'Opening label',
+      },
+    ],
+    edges: [],
+  },
+  diagnostics: {
+    errors: [],
+    warnings: [
+      {
+        code: 'graph_fallthrough_not_inferred',
+        severity: 'warning',
+        message: 'Fallthrough is not inferred.',
+        path: "$.labels['start'][1]",
+        details: { next_label: 'end' },
+      },
+    ],
+  },
+  validation_diagnostics: {
+    valid: false,
+    errors: [{ code: 'missing_target', message: 'Missing target.' }],
+    warnings: [{ code: 'unused_label', message: 'Unused label.' }],
+  },
+};
+
 function createDeferred<T>() {
   let resolve!: (value: T) => void;
   let reject!: (reason?: unknown) => void;
@@ -369,6 +442,19 @@ describe('VNScriptsWorkbench', () => {
       draft: templateDraftResponse,
     });
     mocks.getVNScriptDraft.mockResolvedValue(draftResponse);
+    mocks.getVNScriptDraftGraph.mockResolvedValue(graphResponse);
+    mocks.previewVNScriptDraftGraph.mockResolvedValue({
+      ...graphResponse,
+      source: 'supplied_draft',
+      content_hash: 'sha256:preview',
+    });
+    mocks.getVNScriptVersionGraph.mockResolvedValue({
+      ...graphResponse,
+      source: 'published_version',
+      version_id: 12,
+      validation_context_source: 'published_version_snapshot',
+      content_hash: 'sha256:version',
+    });
     mocks.putVNScriptDraft.mockResolvedValue({
       ...draftResponse,
       revision: 4,
@@ -445,6 +531,70 @@ describe('VNScriptsWorkbench', () => {
     expect(screen.getByText('Policy 202')).toBeInTheDocument();
     expect(screen.getByText('Generation 303')).toBeInTheDocument();
     expect(screen.getByText(/2026-05-12T10:15:00Z/)).toBeInTheDocument();
+  });
+
+  it('loads and renders the saved draft graph outline with graph diagnostics separated from validation diagnostics', async () => {
+    const user = userEvent.setup();
+    render(<VNScriptsWorkbench />);
+
+    await screen.findByRole('button', { name: /Opening Route/ });
+    await user.click(screen.getByRole('button', { name: 'Load saved graph' }));
+
+    await waitFor(() => expect(mocks.getVNScriptDraftGraph).toHaveBeenCalledWith(1));
+    expect(screen.getByText('Script graph')).toBeInTheDocument();
+    expect(screen.getByText('stored_draft')).toBeInTheDocument();
+    expect(screen.getByText('sha256:opening')).toBeInTheDocument();
+    expect(screen.getByText('Opening label')).toBeInTheDocument();
+    expect(screen.getByText(/graph_fallthrough_not_inferred/)).toBeInTheDocument();
+    expect(screen.getByText('Graph diagnostics')).toBeInTheDocument();
+    expect(screen.getByText('Validation diagnostics')).toBeInTheDocument();
+    expect(screen.getByText(/missing_target/)).toBeInTheDocument();
+  });
+
+  it('previews the current unsaved draft graph without saving the draft', async () => {
+    const user = userEvent.setup();
+    render(<VNScriptsWorkbench />);
+
+    const editor = await screen.findByLabelText('Draft JSON');
+    fireEvent.change(editor, {
+      target: { value: '{"labels":{"start":[{"op":"narrate","text":"Changed."}]}}' },
+    });
+    await user.click(screen.getByRole('button', { name: 'Preview current JSON graph' }));
+
+    await waitFor(() => expect(mocks.previewVNScriptDraftGraph).toHaveBeenCalledWith(1, {
+      draft_revision: 3,
+      draft: { labels: { start: [{ op: 'narrate', text: 'Changed.' }] } },
+    }));
+    expect(mocks.putVNScriptDraft).not.toHaveBeenCalled();
+    expect(screen.getByText('supplied_draft')).toBeInTheDocument();
+    expect(screen.getByText('sha256:preview')).toBeInTheDocument();
+  });
+
+  it('keeps the graph inspector hidden when backend capabilities disable the graph feature', async () => {
+    mocks.apiClient.get.mockResolvedValueOnce({
+      ...vnCapabilitiesResponse,
+      features: { ...vnCapabilitiesResponse.features, script_authoring_graph: false },
+    });
+
+    render(<VNScriptsWorkbench />);
+
+    await screen.findByRole('button', { name: /Opening Route/ });
+    expect(screen.queryByRole('button', { name: 'Load saved graph' })).not.toBeInTheDocument();
+    expect(mocks.getVNScriptDraftGraph).not.toHaveBeenCalled();
+  });
+
+  it('loads a published version graph from the version card', async () => {
+    const user = userEvent.setup();
+    render(<VNScriptsWorkbench />);
+
+    await screen.findByText('Version 2');
+    await user.click(screen.getByRole('button', { name: 'Graph for version 2' }));
+
+    await waitFor(() => expect(mocks.getVNScriptVersionGraph).toHaveBeenCalledWith(1, 12));
+    const versionCard = screen.getByTestId('version-12');
+    expect(within(versionCard).getByText('published_version')).toBeInTheDocument();
+    expect(within(versionCard).getByText('sha256:version')).toBeInTheDocument();
+    expect(within(versionCard).getByText('published_version_snapshot')).toBeInTheDocument();
   });
 
   it('creates a script shell, prepends it, selects it, and loads its details', async () => {

--- a/apps/tldw-frontend/__tests__/vn-scripts/VNScriptsWorkbench.test.tsx
+++ b/apps/tldw-frontend/__tests__/vn-scripts/VNScriptsWorkbench.test.tsx
@@ -543,12 +543,98 @@ describe('VNScriptsWorkbench', () => {
     await waitFor(() => expect(mocks.getVNScriptDraftGraph).toHaveBeenCalledWith(1));
     expect(screen.getByText('Script graph')).toBeInTheDocument();
     expect(screen.getByText('stored_draft')).toBeInTheDocument();
+    expect(screen.getByText('vn_script_authoring_graph.v1')).toBeInTheDocument();
+    expect(screen.getByText('vn_script_program.v1')).toBeInTheDocument();
     expect(screen.getByText('sha256:opening')).toBeInTheDocument();
     expect(screen.getByText('Opening label')).toBeInTheDocument();
     expect(screen.getByText(/graph_fallthrough_not_inferred/)).toBeInTheDocument();
     expect(screen.getByText('Graph diagnostics')).toBeInTheDocument();
     expect(screen.getByText('Validation diagnostics')).toBeInTheDocument();
     expect(screen.getByText(/missing_target/)).toBeInTheDocument();
+  });
+
+  it('lets authors select an outline source path and highlights it near the draft editor', async () => {
+    const user = userEvent.setup();
+    render(<VNScriptsWorkbench />);
+
+    await screen.findByRole('button', { name: /Opening Route/ });
+    await user.click(screen.getByRole('button', { name: 'Load saved graph' }));
+    await user.click(await screen.findByRole('button', { name: /Select source path for start/ }));
+
+    expect(screen.getByText(/Selected graph path/)).toBeInTheDocument();
+    expect(screen.getAllByText("$.labels['start']").length).toBeGreaterThan(0);
+    expect(screen.getByText(/Selected graph path/).closest('div')).toHaveClass('bg-primary/10');
+  });
+
+  it('shows graph loading and error states for failed graph requests', async () => {
+    const user = userEvent.setup();
+    const graphRequest = createDeferred<typeof graphResponse>();
+    mocks.getVNScriptDraftGraph.mockReturnValueOnce(graphRequest.promise);
+    render(<VNScriptsWorkbench />);
+
+    await screen.findByRole('button', { name: /Opening Route/ });
+    await user.click(screen.getByRole('button', { name: 'Load saved graph' }));
+    expect(screen.getByRole('button', { name: 'Load saved graph' })).toBeDisabled();
+
+    graphRequest.reject(new Error('graph_backend_down'));
+
+    expect(await screen.findByText('graph_backend_down')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Load saved graph' })).toBeEnabled();
+  });
+
+  it('clears graph loading state when switching scripts while a graph request is in flight', async () => {
+    const user = userEvent.setup();
+    const graphRequest = createDeferred<typeof graphResponse>();
+    mocks.getVNScriptDraftGraph.mockReturnValueOnce(graphRequest.promise);
+    render(<VNScriptsWorkbench />);
+
+    await screen.findByRole('button', { name: /Opening Route/ });
+    await user.click(screen.getByRole('button', { name: 'Load saved graph' }));
+    expect(screen.getByRole('button', { name: 'Load saved graph' })).toBeDisabled();
+    await user.click(screen.getByRole('button', { name: /Second Route/ }));
+
+    await waitFor(() => expect(mocks.getVNScriptDraft).toHaveBeenCalledWith(2));
+    expect(screen.getByRole('button', { name: 'Load saved graph' })).toBeEnabled();
+  });
+
+  it('ignores stale saved graph responses after a newer preview graph response wins', async () => {
+    const user = userEvent.setup();
+    const savedRequest = createDeferred<typeof graphResponse>();
+    const previewRequest = createDeferred<typeof graphResponse>();
+    mocks.getVNScriptDraftGraph.mockReturnValueOnce(savedRequest.promise);
+    mocks.previewVNScriptDraftGraph.mockReturnValueOnce(previewRequest.promise);
+    render(<VNScriptsWorkbench />);
+
+    await screen.findByRole('button', { name: /Opening Route/ });
+    await user.click(screen.getByRole('button', { name: 'Load saved graph' }));
+    fireEvent.change(screen.getByLabelText('Draft JSON'), {
+      target: { value: '{"labels":{"start":[{"op":"narrate","text":"Changed."}]}}' },
+    });
+    await user.click(screen.getByRole('button', { name: 'Preview current JSON graph' }));
+
+    previewRequest.resolve({
+      ...graphResponse,
+      source: 'supplied_draft',
+      content_hash: 'sha256:newer-preview',
+      outline: {
+        ...graphResponse.outline,
+        labels: [{ ...graphResponse.outline.labels[0], summary: 'Newer preview label' }],
+      },
+    });
+    await screen.findByText('sha256:newer-preview');
+
+    savedRequest.resolve({
+      ...graphResponse,
+      content_hash: 'sha256:stale-saved',
+      outline: {
+        ...graphResponse.outline,
+        labels: [{ ...graphResponse.outline.labels[0], summary: 'Stale saved label' }],
+      },
+    });
+
+    await waitFor(() => expect(screen.queryByText('sha256:stale-saved')).not.toBeInTheDocument());
+    expect(screen.getByText('Newer preview label')).toBeInTheDocument();
+    expect(screen.queryByText('Stale saved label')).not.toBeInTheDocument();
   });
 
   it('previews the current unsaved draft graph without saving the draft', async () => {

--- a/apps/tldw-frontend/__tests__/vn-scripts/vnScriptsApi.test.ts
+++ b/apps/tldw-frontend/__tests__/vn-scripts/vnScriptsApi.test.ts
@@ -24,12 +24,15 @@ import {
   getVNScript,
   getVNScriptDiagnostics,
   getVNScriptDraft,
+  getVNScriptDraftGraph,
   getVNScriptManifestSnapshot,
   getVNScriptVersion,
+  getVNScriptVersionGraph,
   listVNScriptTemplates,
   listVNScripts,
   listVNScriptVersions,
   patchVNScript,
+  previewVNScriptDraftGraph,
   previewVNScriptSnippet,
   publishVNScript,
   putVNScriptDraft,
@@ -268,6 +271,59 @@ describe('vnScripts api client', () => {
     expect(mocks.apiClient.post).toHaveBeenCalledWith(
       '/vn/vn-scripts/scripts/17/draft/snippet-apply',
       request
+    );
+  });
+
+  it('calls the VN script stored draft graph endpoint', async () => {
+    mocks.apiClient.get.mockResolvedValueOnce({
+      schema_version: 'vn_script_authoring_graph.v1',
+      graph_semantics_version: 'vn_script_authoring_graph_edges.v1',
+      program_schema_version: 'vn_script_program.v1',
+      script_id: 17,
+      source: 'stored_draft',
+      base_revision: 4,
+      version_id: null,
+      content_hash: 'sha256:stored',
+      validation_context_source: 'current_draft_context',
+      truncated: false,
+      limits: { max_labels: 500 },
+      outline: { entry_label: 'start', labels: [] },
+      graph: { nodes: [], edges: [] },
+      diagnostics: { errors: [], warnings: [] },
+      validation_diagnostics: { valid: true, errors: [], warnings: [] },
+    });
+
+    const response = await getVNScriptDraftGraph(17);
+
+    expect(response.source).toBe('stored_draft');
+    expect(mocks.apiClient.get).toHaveBeenCalledWith('/vn/vn-scripts/scripts/17/draft/graph');
+  });
+
+  it('calls the VN script draft graph preview endpoint with the supplied draft payload', async () => {
+    const request = {
+      draft_revision: 4,
+      draft: {
+        schema_version: 'vn_script_program.v1',
+        entry_label: 'start',
+        labels: {
+          start: [{ op: 'end' }],
+        },
+      },
+    };
+
+    await previewVNScriptDraftGraph(17, request);
+
+    expect(mocks.apiClient.post).toHaveBeenCalledWith(
+      '/vn/vn-scripts/scripts/17/draft/graph-preview',
+      request
+    );
+  });
+
+  it('calls the VN script published version graph endpoint', async () => {
+    await getVNScriptVersionGraph(17, 9);
+
+    expect(mocks.apiClient.get).toHaveBeenCalledWith(
+      '/vn/vn-scripts/scripts/17/versions/9/graph'
     );
   });
 });

--- a/apps/tldw-frontend/components/vn-scripts/VNScriptsWorkbench.tsx
+++ b/apps/tldw-frontend/components/vn-scripts/VNScriptsWorkbench.tsx
@@ -12,10 +12,13 @@ import {
   getVNScriptAuthoringCatalog,
   getVNScriptDiagnostics,
   getVNScriptDraft,
+  getVNScriptDraftGraph,
   getVNScriptManifestSnapshot,
+  getVNScriptVersionGraph,
   listVNScriptTemplates,
   listVNScripts,
   listVNScriptVersions,
+  previewVNScriptDraftGraph,
   previewVNScriptSnippet,
   publishVNScript,
   putVNScriptDraft,
@@ -23,6 +26,7 @@ import {
 } from '@web/lib/api/vnScripts';
 import type {
   VNScriptAuthoringCatalogResponse,
+  VNScriptAuthoringGraphResponse,
   VNScriptAuthoringSnippet,
   VNScriptContentRating,
   VNScriptDiagnosticsResponse,
@@ -211,6 +215,101 @@ function snippetCategory(
   return categoryMatch?.[0] ?? 'other';
 }
 
+function diagnosticCodes(items: Array<{ code?: unknown; message?: unknown }> | undefined): string {
+  if (!items?.length) return 'none';
+  return items
+    .map((item) => readString(item.code) ?? readString(item.message) ?? 'diagnostic')
+    .join(', ');
+}
+
+function validationDiagnosticItems(value: unknown, key: 'errors' | 'warnings'): Array<Record<string, unknown>> {
+  const record = asRecord(value);
+  const items = record?.[key];
+  return Array.isArray(items) ? items.filter((item): item is Record<string, unknown> => Boolean(asRecord(item))) : [];
+}
+
+function GraphSummary({ graph }: { graph: VNScriptAuthoringGraphResponse }) {
+  const validationErrors = validationDiagnosticItems(graph.validation_diagnostics, 'errors');
+  const validationWarnings = validationDiagnosticItems(graph.validation_diagnostics, 'warnings');
+  const limits = Object.entries(graph.limits ?? {});
+
+  return (
+    <div className="space-y-3 text-sm">
+      {graph.truncated && (
+        <p className="rounded-md border border-warn/30 bg-warn/10 p-2 text-warn">
+          Graph output is truncated. Use diagnostics to see which limit was reached.
+        </p>
+      )}
+      <dl className="grid grid-cols-2 gap-2 text-xs">
+        <div className="rounded-md border border-border bg-bg p-2">
+          <dt className="text-text-muted">Source</dt>
+          <dd className="break-words font-medium">{graph.source}</dd>
+        </div>
+        <div className="rounded-md border border-border bg-bg p-2">
+          <dt className="text-text-muted">Content hash</dt>
+          <dd className="break-words font-medium">{graph.content_hash}</dd>
+        </div>
+        <div className="rounded-md border border-border bg-bg p-2">
+          <dt className="text-text-muted">Base revision</dt>
+          <dd>{graph.base_revision ?? 'n/a'}</dd>
+        </div>
+        <div className="rounded-md border border-border bg-bg p-2">
+          <dt className="text-text-muted">Validation context</dt>
+          <dd className="break-words">{graph.validation_context_source}</dd>
+        </div>
+        <div className="rounded-md border border-border bg-bg p-2">
+          <dt className="text-text-muted">Graph semantics</dt>
+          <dd className="break-words">{graph.graph_semantics_version}</dd>
+        </div>
+        <div className="rounded-md border border-border bg-bg p-2">
+          <dt className="text-text-muted">Nodes / edges</dt>
+          <dd>{graph.graph.nodes.length} / {graph.graph.edges.length}</dd>
+        </div>
+      </dl>
+      {limits.length > 0 && (
+        <p className="text-xs text-text-muted">
+          Limits: {limits.map(([key, value]) => `${key} ${value}`).join(', ')}
+        </p>
+      )}
+      <div>
+        <h3 className="mb-1 text-xs font-semibold uppercase text-text-muted">Outline</h3>
+        {graph.outline.labels.length === 0 ? (
+          <p className="text-text-muted">No outline labels returned.</p>
+        ) : (
+          <ul className="space-y-2">
+            {graph.outline.labels.map((label) => (
+              <li key={label.id} className="rounded-md border border-border bg-bg p-2">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <span className="font-medium">{label.label}</span>
+                  <span className="text-xs text-text-muted">{label.id}</span>
+                </div>
+                <p className="mt-1 text-xs">{label.summary}</p>
+                <p className="mt-1 text-xs text-text-muted">
+                  {label.op_count} ops, {label.incoming_edge_count} in, {label.outgoing_edge_count} out,
+                  {' '}{label.reachable ? 'reachable' : 'unreachable'}, {label.terminal}
+                </p>
+                <p className="mt-1 break-words font-mono text-[11px] text-text-muted">{label.source_path}</p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+      <div className="grid gap-2 lg:grid-cols-2">
+        <div className="rounded-md border border-border bg-bg p-2">
+          <h3 className="text-xs font-semibold uppercase text-text-muted">Graph diagnostics</h3>
+          <p className="mt-1 text-xs text-danger">Errors: {diagnosticCodes(graph.diagnostics.errors)}</p>
+          <p className="mt-1 text-xs text-warn">Warnings: {diagnosticCodes(graph.diagnostics.warnings)}</p>
+        </div>
+        <div className="rounded-md border border-border bg-bg p-2">
+          <h3 className="text-xs font-semibold uppercase text-text-muted">Validation diagnostics</h3>
+          <p className="mt-1 text-xs text-danger">Errors: {diagnosticCodes(validationErrors)}</p>
+          <p className="mt-1 text-xs text-warn">Warnings: {diagnosticCodes(validationWarnings)}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function VNScriptsWorkbench() {
   const [scripts, setScripts] = useState<VNScriptResponse[]>([]);
   const [templates, setTemplates] = useState<VNScriptTemplateSummary[]>([]);
@@ -252,6 +351,11 @@ export default function VNScriptsWorkbench() {
   const [isPreviewingSnippet, setIsPreviewingSnippet] = useState(false);
   const [isApplyingSnippet, setIsApplyingSnippet] = useState(false);
   const [snippetError, setSnippetError] = useState<string | null>(null);
+  const [scriptGraph, setScriptGraph] = useState<VNScriptAuthoringGraphResponse | null>(null);
+  const [versionGraphs, setVersionGraphs] = useState<Record<number, VNScriptAuthoringGraphResponse>>({});
+  const [isLoadingGraph, setIsLoadingGraph] = useState(false);
+  const [loadingVersionGraphId, setLoadingVersionGraphId] = useState<number | null>(null);
+  const [graphError, setGraphError] = useState<string | null>(null);
   const selectedScriptIdRef = useRef<number | null>(null);
   const draftHydrationRef = useRef<VNScriptDraftResponse | null>(null);
   const publishKeyRef = useRef<Record<string, string>>({});
@@ -262,6 +366,12 @@ export default function VNScriptsWorkbench() {
     setSnippetPreview(null);
     setSnippetPreviewContextKey(null);
     snippetPreviewContextKeyRef.current = null;
+  }
+
+  function clearGraphState() {
+    setScriptGraph(null);
+    setVersionGraphs({});
+    setGraphError(null);
   }
 
   useEffect(() => {
@@ -320,6 +430,7 @@ export default function VNScriptsWorkbench() {
 
   const savedDraftText = useMemo(() => formatJson(draft?.draft), [draft?.draft]);
   const hasUnsavedDraftText = draftText !== savedDraftText;
+  const graphCapabilityEnabled = vnCapabilities?.features?.script_authoring_graph === true;
 
   const currentSnippetPreviewContextKey = useMemo(() => {
     if (!selectedScript || !selectedSnippet || !draft) return null;
@@ -447,6 +558,7 @@ export default function VNScriptsWorkbench() {
       setManifestSnapshots({});
       setPolicySummaries({});
       clearSnippetPreviewState();
+      clearGraphState();
       return;
     }
 
@@ -466,6 +578,7 @@ export default function VNScriptsWorkbench() {
         setManifestSnapshots({});
         setPolicySummaries({});
         clearSnippetPreviewState();
+        clearGraphState();
         try {
           const nextVersions = await listVNScriptVersions(selectedScript.id);
           if (!cancelled) setVersions(nextVersions.items ?? []);
@@ -485,6 +598,7 @@ export default function VNScriptsWorkbench() {
       setManifestSnapshots({});
       setPolicySummaries({});
       clearSnippetPreviewState();
+      clearGraphState();
       try {
         const [nextDraft, nextVersions] = await Promise.all([
           getVNScriptDraft(selectedScript.id),
@@ -759,6 +873,7 @@ export default function VNScriptsWorkbench() {
       });
       setDraft(updated);
       setDraftText(formatJson(updated.draft));
+      clearGraphState();
       setStatusMessage(`Draft saved at revision ${updated.revision}.`);
     } catch (saveError) {
       setError(errorMessage(saveError, 'Failed to save draft'));
@@ -798,6 +913,65 @@ export default function VNScriptsWorkbench() {
       setError(errorMessage(diagnosticsError, 'Failed to load diagnostics'));
     } finally {
       setIsLoadingDiagnostics(false);
+    }
+  }, [selectedScript]);
+
+  const handleLoadDraftGraph = useCallback(async () => {
+    if (!selectedScript) return;
+    const scriptId = selectedScript.id;
+    setIsLoadingGraph(true);
+    setGraphError(null);
+    try {
+      const graph = await getVNScriptDraftGraph(scriptId);
+      if (selectedScriptIdRef.current !== scriptId) return;
+      setScriptGraph(graph);
+    } catch (graphLoadError) {
+      if (selectedScriptIdRef.current === scriptId) {
+        setGraphError(errorMessage(graphLoadError, 'Failed to load script graph'));
+      }
+    } finally {
+      if (selectedScriptIdRef.current === scriptId) setIsLoadingGraph(false);
+    }
+  }, [selectedScript]);
+
+  const handlePreviewDraftGraph = useCallback(async () => {
+    if (!selectedScript) return;
+    const requestDraft = parseDraftText();
+    if (!requestDraft) return;
+    const scriptId = selectedScript.id;
+    setIsLoadingGraph(true);
+    setGraphError(null);
+    try {
+      const graph = await previewVNScriptDraftGraph(scriptId, {
+        draft: requestDraft,
+        draft_revision: draft?.revision ?? null,
+      });
+      if (selectedScriptIdRef.current !== scriptId) return;
+      setScriptGraph(graph);
+    } catch (graphPreviewError) {
+      if (selectedScriptIdRef.current === scriptId) {
+        setGraphError(errorMessage(graphPreviewError, 'Failed to preview script graph'));
+      }
+    } finally {
+      if (selectedScriptIdRef.current === scriptId) setIsLoadingGraph(false);
+    }
+  }, [draft?.revision, parseDraftText, selectedScript]);
+
+  const handleVersionGraph = useCallback(async (version: VNScriptVersionResponse) => {
+    if (!selectedScript) return;
+    const scriptId = selectedScript.id;
+    setLoadingVersionGraphId(version.id);
+    setGraphError(null);
+    try {
+      const graph = await getVNScriptVersionGraph(scriptId, version.id);
+      if (selectedScriptIdRef.current !== scriptId) return;
+      setVersionGraphs((previous) => ({ ...previous, [version.id]: graph }));
+    } catch (versionGraphError) {
+      if (selectedScriptIdRef.current === scriptId) {
+        setGraphError(errorMessage(versionGraphError, 'Failed to load version graph'));
+      }
+    } finally {
+      if (selectedScriptIdRef.current === scriptId) setLoadingVersionGraphId(null);
     }
   }, [selectedScript]);
 
@@ -1263,6 +1437,7 @@ export default function VNScriptsWorkbench() {
                   onChange={(nextValue) => {
                     setDraftText(nextValue);
                     clearSnippetPreviewState();
+                    clearGraphState();
                   }}
                   height="100%"
                   readOnly={!selectedScript}
@@ -1329,6 +1504,51 @@ export default function VNScriptsWorkbench() {
               )}
             </section>
 
+            {graphCapabilityEnabled && (
+              <section className="rounded-md border border-border bg-surface p-3">
+                <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+                  <div>
+                    <h2 className="text-sm font-semibold">Script graph</h2>
+                    <p className="text-xs text-text-muted">Read-only outline from the backend graph API.</p>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <Button
+                      type="button"
+                      size="xs"
+                      variant="secondary"
+                      loading={isLoadingGraph}
+                      disabled={!selectedScript}
+                      onClick={handleLoadDraftGraph}
+                    >
+                      Load saved graph
+                    </Button>
+                    <Button
+                      type="button"
+                      size="xs"
+                      variant="secondary"
+                      loading={isLoadingGraph}
+                      disabled={!selectedScript}
+                      onClick={handlePreviewDraftGraph}
+                    >
+                      Preview current JSON graph
+                    </Button>
+                  </div>
+                </div>
+                {graphError && (
+                  <p className="mb-3 rounded-md border border-danger/30 bg-danger/10 p-2 text-sm text-danger">
+                    {graphError}
+                  </p>
+                )}
+                {scriptGraph ? (
+                  <GraphSummary graph={scriptGraph} />
+                ) : (
+                  <p className="text-sm text-text-muted">
+                    Load the saved draft graph or preview the current editor JSON without saving.
+                  </p>
+                )}
+              </section>
+            )}
+
             <section className="rounded-md border border-border bg-surface p-3">
               <h2 className="mb-3 text-sm font-semibold">Publish</h2>
               <div className="space-y-3">
@@ -1389,6 +1609,18 @@ export default function VNScriptsWorkbench() {
                       >
                         Policy
                       </Button>
+                      {graphCapabilityEnabled && (
+                        <Button
+                          type="button"
+                          size="xs"
+                          variant="secondary"
+                          loading={loadingVersionGraphId === version.id}
+                          aria-label={`Graph for version ${version.version_number}`}
+                          onClick={() => void handleVersionGraph(version)}
+                        >
+                          Graph
+                        </Button>
+                      )}
                     </div>
                     {manifestSnapshots[version.id] && (
                       <div className="mt-3">
@@ -1404,6 +1636,12 @@ export default function VNScriptsWorkbench() {
                         <pre className="max-h-48 overflow-auto rounded-md bg-surface2 p-2 text-xs">
                           {summaryLines(policySummaries[version.id]).join('\n')}
                         </pre>
+                      </div>
+                    )}
+                    {versionGraphs[version.id] && (
+                      <div className="mt-3">
+                        <h4 className="mb-1 text-xs font-semibold uppercase text-text-muted">Version graph</h4>
+                        <GraphSummary graph={versionGraphs[version.id]} />
                       </div>
                     )}
                   </article>

--- a/apps/tldw-frontend/components/vn-scripts/VNScriptsWorkbench.tsx
+++ b/apps/tldw-frontend/components/vn-scripts/VNScriptsWorkbench.tsx
@@ -222,12 +222,6 @@ function diagnosticCodes(items: Array<{ code?: unknown; message?: unknown }> | u
     .join(', ');
 }
 
-function validationDiagnosticItems(value: unknown, key: 'errors' | 'warnings'): Array<Record<string, unknown>> {
-  const record = asRecord(value);
-  const items = record?.[key];
-  return Array.isArray(items) ? items.filter((item): item is Record<string, unknown> => Boolean(asRecord(item))) : [];
-}
-
 function GraphSummary({
   graph,
   onSourcePathSelect,
@@ -235,8 +229,8 @@ function GraphSummary({
   graph: VNScriptAuthoringGraphResponse;
   onSourcePathSelect?: (sourcePath: string) => void;
 }) {
-  const validationErrors = validationDiagnosticItems(graph.validation_diagnostics, 'errors');
-  const validationWarnings = validationDiagnosticItems(graph.validation_diagnostics, 'warnings');
+  const validationErrors = graph.validation_diagnostics.errors;
+  const validationWarnings = graph.validation_diagnostics.warnings;
   const limits = Object.entries(graph.limits ?? {});
 
   return (
@@ -1568,7 +1562,7 @@ export default function VNScriptsWorkbench() {
                       size="xs"
                       variant="secondary"
                       loading={loadingGraphAction === 'saved'}
-                      disabled={!selectedScript}
+                      disabled={!selectedScript || loadingGraphAction !== null}
                       onClick={handleLoadDraftGraph}
                     >
                       Load saved graph
@@ -1578,7 +1572,7 @@ export default function VNScriptsWorkbench() {
                       size="xs"
                       variant="secondary"
                       loading={loadingGraphAction === 'preview'}
-                      disabled={!selectedScript}
+                      disabled={!selectedScript || loadingGraphAction !== null}
                       onClick={handlePreviewDraftGraph}
                     >
                       Preview current JSON graph
@@ -1666,6 +1660,7 @@ export default function VNScriptsWorkbench() {
                           size="xs"
                           variant="secondary"
                           loading={loadingVersionGraphId === version.id}
+                          disabled={loadingVersionGraphId !== null}
                           aria-label={`Graph for version ${version.version_number}`}
                           onClick={() => void handleVersionGraph(version)}
                         >

--- a/apps/tldw-frontend/components/vn-scripts/VNScriptsWorkbench.tsx
+++ b/apps/tldw-frontend/components/vn-scripts/VNScriptsWorkbench.tsx
@@ -228,7 +228,13 @@ function validationDiagnosticItems(value: unknown, key: 'errors' | 'warnings'): 
   return Array.isArray(items) ? items.filter((item): item is Record<string, unknown> => Boolean(asRecord(item))) : [];
 }
 
-function GraphSummary({ graph }: { graph: VNScriptAuthoringGraphResponse }) {
+function GraphSummary({
+  graph,
+  onSourcePathSelect,
+}: {
+  graph: VNScriptAuthoringGraphResponse;
+  onSourcePathSelect?: (sourcePath: string) => void;
+}) {
   const validationErrors = validationDiagnosticItems(graph.validation_diagnostics, 'errors');
   const validationWarnings = validationDiagnosticItems(graph.validation_diagnostics, 'warnings');
   const limits = Object.entries(graph.limits ?? {});
@@ -248,6 +254,14 @@ function GraphSummary({ graph }: { graph: VNScriptAuthoringGraphResponse }) {
         <div className="rounded-md border border-border bg-bg p-2">
           <dt className="text-text-muted">Content hash</dt>
           <dd className="break-words font-medium">{graph.content_hash}</dd>
+        </div>
+        <div className="rounded-md border border-border bg-bg p-2">
+          <dt className="text-text-muted">Schema</dt>
+          <dd className="break-words font-medium">{graph.schema_version}</dd>
+        </div>
+        <div className="rounded-md border border-border bg-bg p-2">
+          <dt className="text-text-muted">Program schema</dt>
+          <dd className="break-words font-medium">{graph.program_schema_version}</dd>
         </div>
         <div className="rounded-md border border-border bg-bg p-2">
           <dt className="text-text-muted">Base revision</dt>
@@ -288,7 +302,18 @@ function GraphSummary({ graph }: { graph: VNScriptAuthoringGraphResponse }) {
                   {label.op_count} ops, {label.incoming_edge_count} in, {label.outgoing_edge_count} out,
                   {' '}{label.reachable ? 'reachable' : 'unreachable'}, {label.terminal}
                 </p>
-                <p className="mt-1 break-words font-mono text-[11px] text-text-muted">{label.source_path}</p>
+                {label.source_path ? (
+                  <button
+                    type="button"
+                    aria-label={`Select source path for ${label.label}`}
+                    className="mt-1 block break-all rounded-sm font-mono text-[11px] text-primary underline-offset-2 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                    onClick={() => onSourcePathSelect?.(label.source_path)}
+                  >
+                    {label.source_path}
+                  </button>
+                ) : (
+                  <p className="mt-1 break-words font-mono text-[11px] text-text-muted">No source path.</p>
+                )}
               </li>
             ))}
           </ul>
@@ -353,11 +378,15 @@ export default function VNScriptsWorkbench() {
   const [snippetError, setSnippetError] = useState<string | null>(null);
   const [scriptGraph, setScriptGraph] = useState<VNScriptAuthoringGraphResponse | null>(null);
   const [versionGraphs, setVersionGraphs] = useState<Record<number, VNScriptAuthoringGraphResponse>>({});
-  const [isLoadingGraph, setIsLoadingGraph] = useState(false);
+  const [loadingGraphAction, setLoadingGraphAction] = useState<'saved' | 'preview' | null>(null);
   const [loadingVersionGraphId, setLoadingVersionGraphId] = useState<number | null>(null);
   const [graphError, setGraphError] = useState<string | null>(null);
+  const [selectedGraphSourcePath, setSelectedGraphSourcePath] = useState<string | null>(null);
   const selectedScriptIdRef = useRef<number | null>(null);
   const draftHydrationRef = useRef<VNScriptDraftResponse | null>(null);
+  const draftEditorRegionRef = useRef<HTMLDivElement | null>(null);
+  const graphRequestIdRef = useRef(0);
+  const versionGraphRequestIdRef = useRef(0);
   const publishKeyRef = useRef<Record<string, string>>({});
   const snippetPreviewContextKeyRef = useRef<string | null>(null);
   const previewRequestIdRef = useRef(0);
@@ -369,9 +398,14 @@ export default function VNScriptsWorkbench() {
   }
 
   function clearGraphState() {
+    graphRequestIdRef.current += 1;
+    versionGraphRequestIdRef.current += 1;
     setScriptGraph(null);
     setVersionGraphs({});
     setGraphError(null);
+    setLoadingGraphAction(null);
+    setLoadingVersionGraphId(null);
+    setSelectedGraphSourcePath(null);
   }
 
   useEffect(() => {
@@ -919,18 +953,20 @@ export default function VNScriptsWorkbench() {
   const handleLoadDraftGraph = useCallback(async () => {
     if (!selectedScript) return;
     const scriptId = selectedScript.id;
-    setIsLoadingGraph(true);
+    const requestId = graphRequestIdRef.current + 1;
+    graphRequestIdRef.current = requestId;
+    setLoadingGraphAction('saved');
     setGraphError(null);
     try {
       const graph = await getVNScriptDraftGraph(scriptId);
-      if (selectedScriptIdRef.current !== scriptId) return;
+      if (selectedScriptIdRef.current !== scriptId || graphRequestIdRef.current !== requestId) return;
       setScriptGraph(graph);
     } catch (graphLoadError) {
-      if (selectedScriptIdRef.current === scriptId) {
+      if (selectedScriptIdRef.current === scriptId && graphRequestIdRef.current === requestId) {
         setGraphError(errorMessage(graphLoadError, 'Failed to load script graph'));
       }
     } finally {
-      if (selectedScriptIdRef.current === scriptId) setIsLoadingGraph(false);
+      if (graphRequestIdRef.current === requestId) setLoadingGraphAction(null);
     }
   }, [selectedScript]);
 
@@ -939,41 +975,50 @@ export default function VNScriptsWorkbench() {
     const requestDraft = parseDraftText();
     if (!requestDraft) return;
     const scriptId = selectedScript.id;
-    setIsLoadingGraph(true);
+    const requestId = graphRequestIdRef.current + 1;
+    graphRequestIdRef.current = requestId;
+    setLoadingGraphAction('preview');
     setGraphError(null);
     try {
       const graph = await previewVNScriptDraftGraph(scriptId, {
         draft: requestDraft,
         draft_revision: draft?.revision ?? null,
       });
-      if (selectedScriptIdRef.current !== scriptId) return;
+      if (selectedScriptIdRef.current !== scriptId || graphRequestIdRef.current !== requestId) return;
       setScriptGraph(graph);
     } catch (graphPreviewError) {
-      if (selectedScriptIdRef.current === scriptId) {
+      if (selectedScriptIdRef.current === scriptId && graphRequestIdRef.current === requestId) {
         setGraphError(errorMessage(graphPreviewError, 'Failed to preview script graph'));
       }
     } finally {
-      if (selectedScriptIdRef.current === scriptId) setIsLoadingGraph(false);
+      if (graphRequestIdRef.current === requestId) setLoadingGraphAction(null);
     }
   }, [draft?.revision, parseDraftText, selectedScript]);
 
   const handleVersionGraph = useCallback(async (version: VNScriptVersionResponse) => {
     if (!selectedScript) return;
     const scriptId = selectedScript.id;
+    const requestId = versionGraphRequestIdRef.current + 1;
+    versionGraphRequestIdRef.current = requestId;
     setLoadingVersionGraphId(version.id);
     setGraphError(null);
     try {
       const graph = await getVNScriptVersionGraph(scriptId, version.id);
-      if (selectedScriptIdRef.current !== scriptId) return;
+      if (selectedScriptIdRef.current !== scriptId || versionGraphRequestIdRef.current !== requestId) return;
       setVersionGraphs((previous) => ({ ...previous, [version.id]: graph }));
     } catch (versionGraphError) {
-      if (selectedScriptIdRef.current === scriptId) {
+      if (selectedScriptIdRef.current === scriptId && versionGraphRequestIdRef.current === requestId) {
         setGraphError(errorMessage(versionGraphError, 'Failed to load version graph'));
       }
     } finally {
-      if (selectedScriptIdRef.current === scriptId) setLoadingVersionGraphId(null);
+      if (versionGraphRequestIdRef.current === requestId) setLoadingVersionGraphId(null);
     }
   }, [selectedScript]);
+
+  const handleGraphSourcePathSelect = useCallback((sourcePath: string) => {
+    setSelectedGraphSourcePath(sourcePath);
+    draftEditorRegionRef.current?.scrollIntoView?.({ block: 'nearest' });
+  }, []);
 
   const handlePublish = useCallback(async () => {
     if (!selectedScript || !draft) return;
@@ -1220,6 +1265,12 @@ export default function VNScriptsWorkbench() {
                   <p className="text-xs text-text-muted">
                     Revision {draft?.revision ?? 'n/a'}; JSON parsing only, opcode semantics stay on the API server.
                   </p>
+                  {selectedGraphSourcePath && (
+                    <div className="mt-2 rounded-md border border-primary/30 bg-primary/10 p-2 text-xs text-primary">
+                      <span className="font-semibold">Selected graph path</span>
+                      <code className="ml-2 break-all font-mono">{selectedGraphSourcePath}</code>
+                    </div>
+                  )}
                 </div>
                 <div className="flex gap-2">
                   <Button type="button" size="sm" variant="secondary" loading={isValidating} disabled={!selectedScript} onClick={handleValidate}>
@@ -1431,7 +1482,7 @@ export default function VNScriptsWorkbench() {
                   )}
                 </section>
               )}
-              <div className="min-h-[420px] flex-1">
+              <div ref={draftEditorRegionRef} className="min-h-[420px] flex-1">
                 <JsonEditor
                   value={draftText}
                   onChange={(nextValue) => {
@@ -1516,7 +1567,7 @@ export default function VNScriptsWorkbench() {
                       type="button"
                       size="xs"
                       variant="secondary"
-                      loading={isLoadingGraph}
+                      loading={loadingGraphAction === 'saved'}
                       disabled={!selectedScript}
                       onClick={handleLoadDraftGraph}
                     >
@@ -1526,7 +1577,7 @@ export default function VNScriptsWorkbench() {
                       type="button"
                       size="xs"
                       variant="secondary"
-                      loading={isLoadingGraph}
+                      loading={loadingGraphAction === 'preview'}
                       disabled={!selectedScript}
                       onClick={handlePreviewDraftGraph}
                     >
@@ -1540,7 +1591,7 @@ export default function VNScriptsWorkbench() {
                   </p>
                 )}
                 {scriptGraph ? (
-                  <GraphSummary graph={scriptGraph} />
+                  <GraphSummary graph={scriptGraph} onSourcePathSelect={handleGraphSourcePathSelect} />
                 ) : (
                   <p className="text-sm text-text-muted">
                     Load the saved draft graph or preview the current editor JSON without saving.
@@ -1641,7 +1692,7 @@ export default function VNScriptsWorkbench() {
                     {versionGraphs[version.id] && (
                       <div className="mt-3">
                         <h4 className="mb-1 text-xs font-semibold uppercase text-text-muted">Version graph</h4>
-                        <GraphSummary graph={versionGraphs[version.id]} />
+                        <GraphSummary graph={versionGraphs[version.id]} onSourcePathSelect={handleGraphSourcePathSelect} />
                       </div>
                     )}
                   </article>

--- a/apps/tldw-frontend/lib/api/vnScripts.ts
+++ b/apps/tldw-frontend/lib/api/vnScripts.ts
@@ -1,12 +1,14 @@
 import { apiClient } from '@web/lib/api';
 import type {
   VNScriptAuthoringCatalogResponse,
+  VNScriptAuthoringGraphResponse,
   VNScriptCreate,
   VNScriptCreateFromTemplateRequest,
   VNScriptCreateFromTemplateResponse,
   VNScriptDiagnosticsResponse,
   VNScriptDraftPutRequest,
   VNScriptDraftResponse,
+  VNScriptGraphPreviewRequest,
   VNScriptListQuery,
   VNScriptListResponse,
   VNScriptManifestSnapshotResponse,
@@ -80,6 +82,17 @@ export function getVNScriptDraft(scriptId: number): Promise<VNScriptDraftRespons
   return apiClient.get(`${VN_SCRIPTS_BASE}/scripts/${scriptId}/draft`);
 }
 
+export function getVNScriptDraftGraph(scriptId: number): Promise<VNScriptAuthoringGraphResponse> {
+  return apiClient.get(`${VN_SCRIPTS_BASE}/scripts/${scriptId}/draft/graph`);
+}
+
+export function previewVNScriptDraftGraph(
+  scriptId: number,
+  request: VNScriptGraphPreviewRequest
+): Promise<VNScriptAuthoringGraphResponse> {
+  return apiClient.post(`${VN_SCRIPTS_BASE}/scripts/${scriptId}/draft/graph-preview`, request);
+}
+
 export function putVNScriptDraft(
   scriptId: number,
   request: VNScriptDraftPutRequest
@@ -133,6 +146,13 @@ export function getVNScriptVersion(
   versionId: number
 ): Promise<VNScriptVersionResponse> {
   return apiClient.get(`${VN_SCRIPTS_BASE}/scripts/${scriptId}/versions/${versionId}`);
+}
+
+export function getVNScriptVersionGraph(
+  scriptId: number,
+  versionId: number
+): Promise<VNScriptAuthoringGraphResponse> {
+  return apiClient.get(`${VN_SCRIPTS_BASE}/scripts/${scriptId}/versions/${versionId}/graph`);
 }
 
 export function getVNScriptManifestSnapshot(

--- a/apps/tldw-frontend/types/vn-scripts.ts
+++ b/apps/tldw-frontend/types/vn-scripts.ts
@@ -150,6 +150,101 @@ export interface VNScriptSnippetApplyResponse {
   patch_summary: VNScriptSnippetPatchSummary;
 }
 
+export type VNScriptGraphSource = 'stored_draft' | 'supplied_draft' | 'published_version';
+export type VNScriptGraphValidationContextSource =
+  | 'current_draft_context'
+  | 'published_version_snapshot';
+export type VNScriptGraphTerminalState = 'terminal' | 'continues' | 'unknown';
+export type VNScriptGraphNodeType = 'label' | 'operation';
+export type VNScriptGraphEdgeType =
+  | 'jump'
+  | 'choice'
+  | 'generated_choice_handler'
+  | 'generation_cancel';
+export type VNScriptGraphDiagnosticSeverity = 'error' | 'warning';
+
+export interface VNScriptGraphPreviewRequest {
+  draft: unknown;
+  draft_revision?: number | null;
+}
+
+export interface VNScriptGraphDiagnostic {
+  code: string;
+  severity: VNScriptGraphDiagnosticSeverity;
+  message: string;
+  path: string;
+  details: Record<string, unknown>;
+}
+
+export interface VNScriptGraphDiagnostics {
+  errors: VNScriptGraphDiagnostic[];
+  warnings: VNScriptGraphDiagnostic[];
+}
+
+export interface VNScriptGraphOutlineLabel {
+  id: string;
+  label: string;
+  source_path: string;
+  op_count: number;
+  incoming_edge_count: number;
+  outgoing_edge_count: number;
+  reachable: boolean;
+  terminal: VNScriptGraphTerminalState;
+  summary: string;
+}
+
+export interface VNScriptGraphOutline {
+  entry_label?: string | null;
+  labels: VNScriptGraphOutlineLabel[];
+}
+
+export interface VNScriptGraphNode {
+  id: string;
+  type: VNScriptGraphNodeType;
+  label: string;
+  source_path: string;
+  reachable?: boolean | null;
+  terminal?: VNScriptGraphTerminalState | null;
+  op_index?: number | null;
+  op?: string | null;
+  summary: string;
+}
+
+export interface VNScriptGraphEdge {
+  id: string;
+  type: VNScriptGraphEdgeType;
+  source_id: string;
+  target_id?: string | null;
+  source_path: string;
+  target_label: string;
+  metadata?: Record<string, unknown> | null;
+  missing_target: boolean;
+  omitted_target: boolean;
+}
+
+export interface VNScriptGraphBody {
+  nodes: VNScriptGraphNode[];
+  edges: VNScriptGraphEdge[];
+}
+
+export interface VNScriptAuthoringGraphResponse {
+  schema_version: 'vn_script_authoring_graph.v1';
+  graph_semantics_version: 'vn_script_authoring_graph_edges.v1';
+  program_schema_version: 'vn_script_program.v1';
+  script_id?: number | null;
+  source: VNScriptGraphSource;
+  base_revision?: number | null;
+  version_id?: number | null;
+  content_hash: string;
+  validation_context_source: VNScriptGraphValidationContextSource;
+  truncated: boolean;
+  limits: Record<string, number>;
+  outline: VNScriptGraphOutline;
+  graph: VNScriptGraphBody;
+  diagnostics: VNScriptGraphDiagnostics;
+  validation_diagnostics: Record<string, unknown>;
+}
+
 export type VNScriptCreateFromTemplateRequest = Omit<VNScriptCreate, 'title'> & {
   title?: string | null;
 };

--- a/apps/tldw-frontend/types/vn-scripts.ts
+++ b/apps/tldw-frontend/types/vn-scripts.ts
@@ -242,7 +242,7 @@ export interface VNScriptAuthoringGraphResponse {
   outline: VNScriptGraphOutline;
   graph: VNScriptGraphBody;
   diagnostics: VNScriptGraphDiagnostics;
-  validation_diagnostics: Record<string, unknown>;
+  validation_diagnostics: VNScriptValidationResponse;
 }
 
 export type VNScriptCreateFromTemplateRequest = Omit<VNScriptCreate, 'title'> & {

--- a/backlog/tasks/task-333 - Add-VN-script-graph-and-outline-inspector.md
+++ b/backlog/tasks/task-333 - Add-VN-script-graph-and-outline-inspector.md
@@ -1,0 +1,69 @@
+---
+id: TASK-333
+title: Add VN script graph and outline inspector
+status: In Progress
+assignee: []
+created_date: '2026-05-14 04:15'
+labels:
+  - vn
+  - frontend
+  - scripts
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1680'
+  - 'https://github.com/rmusser01/tldw_server/issues/1391'
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement GitHub issue #1680: add a WebUI consumer for the backend-owned VN script authoring graph API so authors can inspect saved draft, unsaved draft preview, and published version graph structure without duplicating VN graph derivation or validation rules in the frontend. Keep this as a focused frontend/API-client/documentation slice; visual node editing, frontend graph derivation, new DSL work, runtime VN Play behavior changes, and backend graph semantics changes are out of scope unless a blocking integration issue is discovered.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Typed frontend helpers cover the VN script graph endpoints and use the existing backend graph contract.
+- [x] #2 VN script authoring UI exposes a read-only graph or outline inspector gated by features.script_authoring_graph.
+- [x] #3 Inspector supports saved draft graph, unsaved draft graph preview, and published version graph where available.
+- [x] #4 Graph metadata and diagnostics are displayed without mixing them up with script validation diagnostics.
+- [x] #5 Frontend does not derive graph semantics or validate script structure beyond rendering backend responses and client input states.
+- [x] #6 Focused frontend tests cover capability gating, loading and error states, stale or unsaved draft preview behavior, graph/outline rendering, and diagnostics.
+- [x] #7 Documentation explains the custom-frontend graph endpoint usage and cache/staleness fields.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Added typed VN authoring graph response/request models and frontend API helpers for saved draft, unsaved preview, and version graph endpoints.
+- Added a read-only Script graph panel to the VN script workbench gated by `features.script_authoring_graph`.
+- The panel renders backend source/hash/revision/semantics metadata, outline rows, limits, graph diagnostics, and validation diagnostics as separate UI concepts.
+- Added version-card Graph actions for published version graph inspection.
+- Frontend only renders server-shaped graph data; it does not compute graph edges or validate script op semantics.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Verification
+
+<!-- SECTION:VERIFICATION:BEGIN -->
+- `bun run test:run __tests__/vn-scripts/vnScriptsApi.test.ts __tests__/vn-scripts/VNScriptsWorkbench.test.tsx` from `apps/tldw-frontend`: 2 files passed, 53 tests passed.
+- `git diff --check`: passed.
+- `bun run lint -- components/vn-scripts/VNScriptsWorkbench.tsx lib/api/vnScripts.ts types/vn-scripts.ts __tests__/vn-scripts/vnScriptsApi.test.ts __tests__/vn-scripts/VNScriptsWorkbench.test.tsx` from `apps/tldw-frontend`: exited 0; repo-wide baseline warnings remain because the package lint script prepends `eslint .`.
+- `./node_modules/.bin/tsc --noEmit` from `apps/tldw-frontend`: failed on pre-existing shared UI type errors in `../packages/ui/src/components/Option/Evaluations/tabs/recipe-configs/EmbeddingsModelSelectionConfig.tsx` and `../packages/ui/src/components/Option/WorkspacePlayground/StudioPane/index.tsx`; no errors were reported in the touched VN script files before the baseline failures stopped the run.
+- Bandit skipped: frontend/docs/backlog-only change, no Python touched.
+<!-- SECTION:VERIFICATION:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added the VN script graph inspector WebUI slice for issue #1680. The frontend now has typed graph API helpers, a capability-gated read-only graph panel for saved drafts and unsaved draft previews, per-version graph inspection from published version cards, focused coverage for the new graph flows, and custom-frontend documentation for graph-inspector usage and staleness keys.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-333 - Add-VN-script-graph-and-outline-inspector.md
+++ b/backlog/tasks/task-333 - Add-VN-script-graph-and-outline-inspector.md
@@ -4,6 +4,7 @@ title: Add VN script graph and outline inspector
 status: In Progress
 assignee: []
 created_date: '2026-05-14 04:15'
+updated_date: '2026-05-14 05:10'
 labels:
   - vn
   - frontend
@@ -40,7 +41,25 @@ Implement GitHub issue #1680: add a WebUI consumer for the backend-owned VN scri
 - The panel renders backend source/hash/revision/semantics metadata, outline rows, limits, graph diagnostics, and validation diagnostics as separate UI concepts.
 - Added version-card Graph actions for published version graph inspection.
 - Frontend only renders server-shaped graph data; it does not compute graph edges or validate script op semantics.
+- PR #1681 review fixes added graph schema metadata rendering, source path selection, stale response guards, and loading reset on script switch.
 <!-- SECTION:NOTES:END -->
+
+## Verification
+
+<!-- SECTION:VERIFICATION:BEGIN -->
+- `bun run test:run __tests__/vn-scripts/vnScriptsApi.test.ts __tests__/vn-scripts/VNScriptsWorkbench.test.tsx` from `apps/tldw-frontend`: 2 files passed, 53 tests passed.
+- `git diff --check`: passed.
+- `bun run lint -- components/vn-scripts/VNScriptsWorkbench.tsx lib/api/vnScripts.ts types/vn-scripts.ts __tests__/vn-scripts/vnScriptsApi.test.ts __tests__/vn-scripts/VNScriptsWorkbench.test.tsx` from `apps/tldw-frontend`: exited 0; repo-wide baseline warnings remain because the package lint script prepends `eslint .`.
+- `./node_modules/.bin/tsc --noEmit` from `apps/tldw-frontend`: failed on pre-existing shared UI type errors in `../packages/ui/src/components/Option/Evaluations/tabs/recipe-configs/EmbeddingsModelSelectionConfig.tsx` and `../packages/ui/src/components/Option/WorkspacePlayground/StudioPane/index.tsx`; no errors were reported in the touched VN script files before the baseline failures stopped the run.
+- Bandit skipped: frontend/docs/backlog-only change, no Python touched.
+- PR #1681 review-fix verification: `bun run test:run __tests__/vn-scripts/VNScriptsWorkbench.test.tsx` passed 43 tests; `bun run test:run __tests__/vn-scripts/vnScriptsApi.test.ts __tests__/vn-scripts/VNScriptsWorkbench.test.tsx` passed 57 tests; `git diff --check` passed; `bun run lint -- components/vn-scripts/VNScriptsWorkbench.tsx __tests__/vn-scripts/VNScriptsWorkbench.test.tsx __tests__/vn-scripts/vnScriptsApi.test.ts` exited 0 with the repo-wide warning baseline; `bun run tsc --noEmit` still fails on the known shared UI baseline files listed above.
+<!-- SECTION:VERIFICATION:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added the VN script graph inspector WebUI slice for issue #1680. The frontend now has typed graph API helpers, a capability-gated read-only graph panel for saved drafts and unsaved draft previews, per-version graph inspection from published version cards, focused coverage for the new graph flows, and custom-frontend documentation for graph-inspector usage and staleness keys.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
@@ -51,19 +70,3 @@ Implement GitHub issue #1680: add a WebUI consumer for the backend-owned VN scri
 - [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->
-
-## Verification
-
-<!-- SECTION:VERIFICATION:BEGIN -->
-- `bun run test:run __tests__/vn-scripts/vnScriptsApi.test.ts __tests__/vn-scripts/VNScriptsWorkbench.test.tsx` from `apps/tldw-frontend`: 2 files passed, 53 tests passed.
-- `git diff --check`: passed.
-- `bun run lint -- components/vn-scripts/VNScriptsWorkbench.tsx lib/api/vnScripts.ts types/vn-scripts.ts __tests__/vn-scripts/vnScriptsApi.test.ts __tests__/vn-scripts/VNScriptsWorkbench.test.tsx` from `apps/tldw-frontend`: exited 0; repo-wide baseline warnings remain because the package lint script prepends `eslint .`.
-- `./node_modules/.bin/tsc --noEmit` from `apps/tldw-frontend`: failed on pre-existing shared UI type errors in `../packages/ui/src/components/Option/Evaluations/tabs/recipe-configs/EmbeddingsModelSelectionConfig.tsx` and `../packages/ui/src/components/Option/WorkspacePlayground/StudioPane/index.tsx`; no errors were reported in the touched VN script files before the baseline failures stopped the run.
-- Bandit skipped: frontend/docs/backlog-only change, no Python touched.
-<!-- SECTION:VERIFICATION:END -->
-
-## Final Summary
-
-<!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added the VN script graph inspector WebUI slice for issue #1680. The frontend now has typed graph API helpers, a capability-gated read-only graph panel for saved drafts and unsaved draft previews, per-version graph inspection from published version cards, focused coverage for the new graph flows, and custom-frontend documentation for graph-inspector usage and staleness keys.
-<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-333 - Add-VN-script-graph-and-outline-inspector.md
+++ b/backlog/tasks/task-333 - Add-VN-script-graph-and-outline-inspector.md
@@ -41,7 +41,7 @@ Implement GitHub issue #1680: add a WebUI consumer for the backend-owned VN scri
 - The panel renders backend source/hash/revision/semantics metadata, outline rows, limits, graph diagnostics, and validation diagnostics as separate UI concepts.
 - Added version-card Graph actions for published version graph inspection.
 - Frontend only renders server-shaped graph data; it does not compute graph edges or validate script op semantics.
-- PR #1681 review fixes added graph schema metadata rendering, source path selection, stale response guards, and loading reset on script switch.
+- PR #1681 review fixes added graph schema metadata rendering, source path selection, stale response guards, loading reset on script switch, duplicate graph-action disabling, and stricter validation diagnostics typing.
 <!-- SECTION:NOTES:END -->
 
 ## Verification
@@ -52,7 +52,7 @@ Implement GitHub issue #1680: add a WebUI consumer for the backend-owned VN scri
 - `bun run lint -- components/vn-scripts/VNScriptsWorkbench.tsx lib/api/vnScripts.ts types/vn-scripts.ts __tests__/vn-scripts/vnScriptsApi.test.ts __tests__/vn-scripts/VNScriptsWorkbench.test.tsx` from `apps/tldw-frontend`: exited 0; repo-wide baseline warnings remain because the package lint script prepends `eslint .`.
 - `./node_modules/.bin/tsc --noEmit` from `apps/tldw-frontend`: failed on pre-existing shared UI type errors in `../packages/ui/src/components/Option/Evaluations/tabs/recipe-configs/EmbeddingsModelSelectionConfig.tsx` and `../packages/ui/src/components/Option/WorkspacePlayground/StudioPane/index.tsx`; no errors were reported in the touched VN script files before the baseline failures stopped the run.
 - Bandit skipped: frontend/docs/backlog-only change, no Python touched.
-- PR #1681 review-fix verification: `bun run test:run __tests__/vn-scripts/VNScriptsWorkbench.test.tsx` passed 43 tests; `bun run test:run __tests__/vn-scripts/vnScriptsApi.test.ts __tests__/vn-scripts/VNScriptsWorkbench.test.tsx` passed 57 tests; `git diff --check` passed; `bun run lint -- components/vn-scripts/VNScriptsWorkbench.tsx __tests__/vn-scripts/VNScriptsWorkbench.test.tsx __tests__/vn-scripts/vnScriptsApi.test.ts` exited 0 with the repo-wide warning baseline; `bun run tsc --noEmit` still fails on the known shared UI baseline files listed above.
+- PR #1681 review-fix verification: `bun run test:run __tests__/vn-scripts/VNScriptsWorkbench.test.tsx` passed 43 tests; `bun run test:run __tests__/vn-scripts/vnScriptsApi.test.ts __tests__/vn-scripts/VNScriptsWorkbench.test.tsx` passed 57 tests; `git diff --check` passed; `bun run lint -- components/vn-scripts/VNScriptsWorkbench.tsx __tests__/vn-scripts/VNScriptsWorkbench.test.tsx __tests__/vn-scripts/vnScriptsApi.test.ts` exited 0 with the repo-wide warning baseline; `bun run tsc --noEmit` still fails on the known shared UI baseline files listed above. A follow-up review sweep also addressed duplicate graph-action disabling and stricter validation diagnostics typing.
 <!-- SECTION:VERIFICATION:END -->
 
 ## Final Summary


### PR DESCRIPTION
## Summary

- Add typed WebUI helpers and types for VN script authoring graph endpoints.
- Add a capability-gated read-only Script graph panel for saved draft graphs, unsaved JSON graph previews, and published version graphs.
- Update VN API docs and TASK-333 with the implementation plan, verification, and frontend/custom-frontend graph inspector flow.

## Change summary

AI-authored PR. Human maintainer must replace this section before merge with a human-written summary explaining what changed and why these implementation choices were made.

## Test Plan

- [x] `bun run test:run __tests__/vn-scripts/vnScriptsApi.test.ts __tests__/vn-scripts/VNScriptsWorkbench.test.tsx`
- [x] `git diff --check`
- [x] `bun run lint -- components/vn-scripts/VNScriptsWorkbench.tsx lib/api/vnScripts.ts types/vn-scripts.ts __tests__/vn-scripts/vnScriptsApi.test.ts __tests__/vn-scripts/VNScriptsWorkbench.test.tsx`
- [ ] `./node_modules/.bin/tsc --noEmit` currently blocked by baseline shared UI type errors outside this slice:
  - `../packages/ui/src/components/Option/Evaluations/tabs/recipe-configs/EmbeddingsModelSelectionConfig.tsx`
  - `../packages/ui/src/components/Option/WorkspacePlayground/StudioPane/index.tsx`

Closes #1680

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a capability-gated, read-only VN script graph inspector in the WebUI backed by server graph endpoints. Authors can load saved draft graphs, preview unsaved editor JSON, and inspect published version graphs with graph diagnostics shown separately from validation.

- New Features
  - Typed models and API helpers for draft graph, draft graph preview, and version graph.
  - Workbench panel gated by `features.script_authoring_graph`; outline-first rendering with schema/program/semantics metadata, validation-context, limits, and node/edge counts.
  - Actions: load saved graph, preview current JSON without saving, and open per-version graphs from version cards.
  - Outline source-path selection highlights the corresponding area near the draft editor.
  - Renders server-shaped data only; no client-side graph derivation or mutations.
  - Tests cover gating, loading/error states, saved/preview/version flows, stale-response handling, and source-path selection; docs updated with inspector flow and cache/staleness keys.

- Bug Fixes
  - Ignore stale graph responses; reset loading when switching scripts; surface errors and disable controls while requests are in flight.
  - Hide the inspector when the feature flag is off; clear graph state after saving or editing draft JSON.
  - Tightened controls to prevent duplicate graph actions and applied stricter validation diagnostics typing.

<sup>Written for commit 40f0c3ac65f4bfca257853944cc736531ef69980. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

