### PR TITLE
Migrate Chat and Playground state labels

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -5148,17 +5148,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "canonical-state-label:src/components/Option/Playground/PlaygroundForm.tsx:Degraded",
-    "path": "src/components/Option/Playground/PlaygroundForm.tsx",
-    "rule": "canonical-state-label",
-    "subject": "Degraded",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing hardcoded \"Degraded\" state label in src/components/Option/Playground/PlaygroundForm.tsx before the guard.",
-    "replacement": "getDesignSystemState(...)",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "canonical-state-label:src/components/Option/PresentationStudio/ExtensionStartPanel.tsx:Ready#label-ready-extensionstartpanel-line-398-1k4mwwz",
     "path": "src/components/Option/PresentationStudio/ExtensionStartPanel.tsx",
     "rule": "canonical-state-label",
@@ -5254,17 +5243,6 @@
     "state": "allowed_legacy_exception",
     "owner": "design-system",
     "reason": "Existing hardcoded \"Ready\" state label in src/components/Option/WritingPlayground/index.tsx before the guard.",
-    "replacement": "getDesignSystemState(...)",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "canonical-state-label:src/routes/sidepanel-chat.tsx:Ready",
-    "path": "src/routes/sidepanel-chat.tsx",
-    "rule": "canonical-state-label",
-    "subject": "Ready",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing hardcoded \"Ready\" state label in src/routes/sidepanel-chat.tsx before the guard.",
     "replacement": "getDesignSystemState(...)",
     "migrationQueue": "shared-product-state"
   },

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx
@@ -1400,7 +1400,7 @@ export const PlaygroundForm = ({
     if (connectionUxState === "connected_degraded") {
       return t(
         "playground:composer.providerStatusDegraded",
-        getDesignSystemState("degraded").label,
+        getDesignSystemState("degraded")?.label ?? "",
       );
     }
     return t("playground:composer.providerStatusHealthy", "Healthy");

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx
@@ -12,6 +12,7 @@ import { ProviderIcons } from "@/components/Common/ProviderIcon";
 import { type KnowledgeTab } from "@/components/Knowledge";
 import type { SlashCommandItem } from "@/components/Sidepanel/Chat/SlashCommandMenu";
 import { isFirefoxTarget } from "@/config/platform";
+import { getDesignSystemState } from "@/design-system";
 import { getAllPrompts } from "@/db/dexie/helpers";
 import { useChatSettingsRecord } from "@/hooks/chat/useChatSettingsRecord";
 import {
@@ -1397,7 +1398,10 @@ export const PlaygroundForm = ({
       return t("playground:composer.providerStatusOffline", "Offline");
     }
     if (connectionUxState === "connected_degraded") {
-      return t("playground:composer.providerStatusDegraded", "Degraded");
+      return t(
+        "playground:composer.providerStatusDegraded",
+        getDesignSystemState("degraded").label,
+      );
     }
     return t("playground:composer.providerStatusHealthy", "Healthy");
   }, [connectionUxState, isConnectionReady, t]);

--- a/apps/packages/ui/src/design-system/__tests__/product-state-guard.chat-playground-migration.test.ts
+++ b/apps/packages/ui/src/design-system/__tests__/product-state-guard.chat-playground-migration.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+
+const guard = await import("../../../scripts/design-system-product-state-rules.mjs")
+
+const testDir = path.dirname(fileURLToPath(import.meta.url))
+const srcDir = path.resolve(testDir, "../..")
+
+const analyzeLiveSource = (relativePath: string) =>
+  guard.analyzeSource({
+    relativePath,
+    source: readFileSync(
+      path.resolve(srcDir, relativePath.replace(/^src\//, "")),
+      "utf8"
+    )
+  })
+
+describe("Chat and Playground product-state migration guard", () => {
+  it("keeps migrated Chat and Playground state labels out of the legacy baseline", () => {
+    const findings = [
+      ...analyzeLiveSource("src/components/Option/Playground/PlaygroundForm.tsx"),
+      ...analyzeLiveSource("src/routes/sidepanel-chat.tsx")
+    ]
+
+    const migratedFindings = findings.filter(
+      (finding) =>
+        finding.rule === "canonical-state-label" &&
+        ((finding.path === "src/components/Option/Playground/PlaygroundForm.tsx" &&
+          finding.subject === "Degraded") ||
+          (finding.path === "src/routes/sidepanel-chat.tsx" &&
+            finding.subject === "Ready"))
+    )
+
+    expect(migratedFindings).toEqual([])
+  })
+})

--- a/apps/packages/ui/src/design-system/__tests__/product-state-guard.chat-playground-migration.test.ts
+++ b/apps/packages/ui/src/design-system/__tests__/product-state-guard.chat-playground-migration.test.ts
@@ -11,11 +11,11 @@ const srcDir = path.resolve(testDir, "../..")
 const analyzeLiveSource = (relativePath: string) =>
   guard.analyzeSource({
     relativePath,
-    source: readFileSync(
-      path.resolve(srcDir, relativePath.replace(/^src\//, "")),
-      "utf8"
-    )
+    source: readLiveSource(relativePath)
   })
+
+const readLiveSource = (relativePath: string) =>
+  readFileSync(path.resolve(srcDir, relativePath.replace(/^src\//, "")), "utf8")
 
 describe("Chat and Playground product-state migration guard", () => {
   it("keeps migrated Chat and Playground state labels out of the legacy baseline", () => {
@@ -34,5 +34,27 @@ describe("Chat and Playground product-state migration guard", () => {
     )
 
     expect(migratedFindings).toEqual([])
+  })
+
+  it("does not directly dereference reviewed design-system state labels", () => {
+    expect(
+      readLiveSource("src/components/Option/Playground/PlaygroundForm.tsx")
+    ).not.toContain('getDesignSystemState("degraded").label')
+    expect(readLiveSource("src/routes/sidepanel-chat.tsx")).not.toContain(
+      'getDesignSystemState("ready").label'
+    )
+  })
+
+  it("keeps Workspace ACP history load errors on canonical recovery UI", () => {
+    const findings = analyzeLiveSource(
+      "src/components/Option/WorkspacePlayground/WorkspaceACPHistoryModal.tsx"
+    )
+
+    expect(findings).not.toContainEqual(
+      expect.objectContaining({
+        rule: "antd-product-state-import",
+        subject: "Alert"
+      })
+    )
   })
 })

--- a/apps/packages/ui/src/routes/sidepanel-chat.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-chat.tsx
@@ -10,6 +10,7 @@ import {
   saveHistory,
   saveMessage
 } from "@/db/dexie/helpers"
+import { getDesignSystemState } from "@/design-system"
 import useBackgroundMessage from "@/hooks/useBackgroundMessage"
 import { useMigration } from "@/hooks/useMigration"
 import { useSmartScroll } from "@/hooks/useSmartScroll"
@@ -2197,7 +2198,10 @@ const SidepanelChat = () => {
       case "running":
         return t("sidepanel:ingest.running", "Processing")
       case "completed":
-        return t("sidepanel:ingest.completed", "Ready")
+        return t(
+          "sidepanel:ingest.completed",
+          getDesignSystemState("ready").label
+        )
       case "failed":
         return t("sidepanel:ingest.failed", "Failed")
       case "cancelled":

--- a/apps/packages/ui/src/routes/sidepanel-chat.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-chat.tsx
@@ -2200,7 +2200,7 @@ const SidepanelChat = () => {
       case "completed":
         return t(
           "sidepanel:ingest.completed",
-          getDesignSystemState("ready").label
+          getDesignSystemState("ready")?.label ?? ""
         )
       case "failed":
         return t("sidepanel:ingest.failed", "Failed")

--- a/backlog/tasks/task-45.44.1 - Migrate-design-system-product-state-Chat-and-Playground.md
+++ b/backlog/tasks/task-45.44.1 - Migrate-design-system-product-state-Chat-and-Playground.md
@@ -4,7 +4,7 @@ title: 'Migrate design-system product state: Chat and Playground'
 status: In Progress
 assignee: []
 created_date: '2026-05-14 03:18'
-updated_date: '2026-05-14 04:28'
+updated_date: '2026-05-14 04:44'
 labels:
   - design-system
   - webui
@@ -45,6 +45,8 @@ Mirror the linked GitHub product-area migration issue. Closure requires zero cur
 Continuation after tracker PR #1679 merged. Starting first product-area slice for GitHub issue #1658 / TASK-45.44.1 in isolated worktree .worktrees/design-system-chat-playground-migration.
 
 Migrated Chat and Playground target labels. Target guard findings are now zero and target baseline entries are now zero. Focused guard suite passes. Full design-system verifier still fails on inherited WorkspaceACPHistoryModal Alert outside this task. Bandit skipped for UI-only changes.
+
+PR #1683 opened as a draft against dev and issue #1658 body updated with current count 0 and PR link. Before this slice: 2 Chat/Playground baseline exceptions. After this slice: 0 Chat/Playground baseline exceptions. No narrower implementation PR task was needed because the area contained only the two target canonical-state-label findings.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.44.1 - Migrate-design-system-product-state-Chat-and-Playground.md
+++ b/backlog/tasks/task-45.44.1 - Migrate-design-system-product-state-Chat-and-Playground.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-45.44.1
 title: 'Migrate design-system product state: Chat and Playground'
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-05-14 03:18'
+updated_date: '2026-05-14 04:21'
 labels:
   - design-system
   - webui
@@ -31,6 +32,18 @@ Mirror the linked GitHub product-area migration issue. Closure requires zero cur
 - [ ] #2 Implementation PR tasks are created under this child when the area is too broad for one PR.
 - [ ] #3 Backlog notes record PR links and before/after count evidence.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Inspect the two current Chat and Playground product-state baseline entries and their owning files. 2. Add a focused failing regression test for canonical design-system state labels in the affected Chat/Playground surface. 3. Migrate the affected UI text to the canonical design-system state registry or shared primitive without changing unrelated behavior. 4. Remove the resolved Chat and Playground baseline entries only after the verifier reports zero findings for this product area. 5. Run focused Vitest, bun run verify:design-system-state from apps/packages/ui, git diff --check, and document Bandit as skipped for UI-only work.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Continuation after tracker PR #1679 merged. Starting first product-area slice for GitHub issue #1658 / TASK-45.44.1 in isolated worktree .worktrees/design-system-chat-playground-migration.
+<!-- SECTION:NOTES:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->

--- a/backlog/tasks/task-45.44.1 - Migrate-design-system-product-state-Chat-and-Playground.md
+++ b/backlog/tasks/task-45.44.1 - Migrate-design-system-product-state-Chat-and-Playground.md
@@ -4,7 +4,7 @@ title: 'Migrate design-system product state: Chat and Playground'
 status: In Progress
 assignee: []
 created_date: '2026-05-14 03:18'
-updated_date: '2026-05-14 04:44'
+updated_date: '2026-05-14 06:35'
 labels:
   - design-system
   - webui
@@ -42,11 +42,13 @@ Mirror the linked GitHub product-area migration issue. Closure requires zero cur
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Continuation after tracker PR #1679 merged. Starting first product-area slice for GitHub issue #1658 / TASK-45.44.1 in isolated worktree .worktrees/design-system-chat-playground-migration.
+Continuation after tracker PR #1679 merged. Started first product-area slice for GitHub issue #1658 / TASK-45.44.1 in isolated worktree .worktrees/design-system-chat-playground-migration.
 
-Migrated Chat and Playground target labels. Target guard findings are now zero and target baseline entries are now zero. Focused guard suite passes. Full design-system verifier still fails on inherited WorkspaceACPHistoryModal Alert outside this task. Bandit skipped for UI-only changes.
+Migrated Chat and Playground target labels. Target guard findings are now zero and target baseline entries are now zero. Focused guard suite passes. Bandit skipped for UI-only changes.
 
-PR #1683 opened as a draft against dev and issue #1658 body updated with current count 0 and PR link. Before this slice: 2 Chat/Playground baseline exceptions. After this slice: 0 Chat/Playground baseline exceptions. No narrower implementation PR task was needed because the area contained only the two target canonical-state-label findings.
+PR #1683 opened against dev and issue #1658 body updated with current count 0 and PR link. Before this slice: 2 Chat/Playground baseline exceptions. After this slice: 0 Chat/Playground baseline exceptions. No narrower implementation PR task was needed because the area contained only the two target canonical-state-label findings.
+
+PR #1683 review fixes: added defensive optional state-label access for the reviewed getDesignSystemState call sites. After rebasing onto current dev, WorkspaceACPHistoryModal uses the shared design-system Alert primitive instead of AntD Alert. Full bun run verify:design-system-state now exits 0.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.44.1 - Migrate-design-system-product-state-Chat-and-Playground.md
+++ b/backlog/tasks/task-45.44.1 - Migrate-design-system-product-state-Chat-and-Playground.md
@@ -4,7 +4,7 @@ title: 'Migrate design-system product state: Chat and Playground'
 status: In Progress
 assignee: []
 created_date: '2026-05-14 03:18'
-updated_date: '2026-05-14 04:21'
+updated_date: '2026-05-14 04:28'
 labels:
   - design-system
   - webui
@@ -43,6 +43,8 @@ Mirror the linked GitHub product-area migration issue. Closure requires zero cur
 
 <!-- SECTION:NOTES:BEGIN -->
 Continuation after tracker PR #1679 merged. Starting first product-area slice for GitHub issue #1658 / TASK-45.44.1 in isolated worktree .worktrees/design-system-chat-playground-migration.
+
+Migrated Chat and Playground target labels. Target guard findings are now zero and target baseline entries are now zero. Focused guard suite passes. Full design-system verifier still fails on inherited WorkspaceACPHistoryModal Alert outside this task. Bandit skipped for UI-only changes.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.44.4 - Migrate-design-system-product-state-MCP-and-ACP.md
+++ b/backlog/tasks/task-45.44.4 - Migrate-design-system-product-state-MCP-and-ACP.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-45.44.4
 title: 'Migrate design-system product state: MCP and ACP'
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-05-14 03:19'
+updated_date: '2026-05-14 06:35'
 labels:
   - design-system
   - webui
@@ -31,6 +32,20 @@ Mirror the linked GitHub product-area migration issue. Closure requires zero cur
 - [ ] #2 Implementation PR tasks are created under this child when the area is too broad for one PR.
 - [ ] #3 Backlog notes record PR links and before/after count evidence.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Review-driven unblock from PR #1683: replace the unbaselined WorkspaceACPHistoryModal AntD Alert product-state error with the shared design-system recovery primitive, then rerun the full design-system verifier. Keep the broader MCP/ACP migration task open for the remaining baseline debt.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+PR #1683 review surfaced a full-verifier blocker in WorkspaceACPHistoryModal. This narrow change is being handled inside the Chat/Playground PR only to restore verifier pass status; it does not complete the broader MCP/ACP migration area.
+
+PR #1683 review unblock completed: after rebasing onto current dev, WorkspaceACPHistoryModal uses the shared design-system Alert primitive for the load-error product state. Full bun run verify:design-system-state exits 0. The broader MCP/ACP baseline migration remains open.
+<!-- SECTION:NOTES:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->


### PR DESCRIPTION
## Change summary

Human-authored change summary required before merge.

## Summary

- Migrates the Playground degraded status fallback and sidepanel ingest completed fallback to `getDesignSystemState(...)` labels.
- Adds a guard-driven regression test for the Chat/Playground product-state migration targets.
- Removes the two resolved Chat/Playground canonical-state-label baseline entries.
- Addresses review feedback by using defensive optional state-label access and preserving the shared design-system `Alert` primitive for the Workspace ACP history load-error state after rebasing onto current `dev`.

Closes #1658.

## Test plan

- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts src/design-system/__tests__/product-state-guard.chat-playground-migration.test.ts`
- `node --input-type=module -e "...target guard count check..."` -> `liveTargetFindings: 0`, `baselineTargetEntries: 0`
- `git diff --check`
- `bun run verify:design-system-state`

## Notes

The full design-system verifier no longer reports stale Chat/Playground entries after this branch. The review-surfaced Workspace ACP blocker has also been moved to the shared recovery primitive so the verifier exits 0.
