### PR TITLE
Harden Persona Visual import commit guard follow-up

### DIFF
--- a/backlog/tasks/task-332 - Harden-Persona-Visual-import-commit-eligibility-revalidation.md
+++ b/backlog/tasks/task-332 - Harden-Persona-Visual-import-commit-eligibility-revalidation.md
@@ -4,6 +4,7 @@ title: Harden Persona Visual import-commit eligibility revalidation
 status: Done
 assignee: []
 created_date: '2026-05-14 03:21'
+updated_date: '2026-05-14 05:56'
 labels:
   - persona
   - visual-packs
@@ -34,24 +35,17 @@ Implement GitHub issue #1657 as a focused Persona/Buddy visual-pack hardening sl
 - [x] #5 Focused backend regression tests cover stale stored ineligible preview metadata and revalidation-to-blocked behavior.
 <!-- AC:END -->
 
-## Definition of Done
-<!-- DOD:BEGIN -->
-- [x] #1 Acceptance criteria completed
-- [x] #2 Tests or verification recorded
-- [x] #3 Documentation updated when relevant
-- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [x] #5 Final summary added
-- [x] #6 Known skips or blockers documented
-<!-- DOD:END -->
-
 ## Implementation Plan
 
+<!-- SECTION:PLAN:BEGIN -->
 1. Add server-side API queueing guard for completed import previews whose stored proposed plan explicitly marks commit_eligible false.
 2. Add importer-side guard before any pack or asset creation so stored previews and revalidated archive previews must be completed and commit-eligible.
 3. Add focused regression coverage for stored ineligible preview metadata and revalidation-to-blocked behavior.
+<!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 - Added a stored preview commit-eligibility helper in the Persona API endpoint before import-commit jobs are created.
 - Added shared importer validation that accepts legacy previews with no commit_eligible flag but rejects blocked previews or explicit commit_eligible false results.
 - Added regression coverage proving blocked revalidation fails the job with no additional draft pack created.
@@ -59,6 +53,8 @@ Implement GitHub issue #1657 as a focused Persona/Buddy visual-pack hardening sl
 - Review follow-up: aligned API `blocked` preview reporting with worker `import_preview_not_commit_eligible` handling.
 - Review follow-up: malformed or non-object stored `proposed_plan_json` now fails closed before job enqueueing or worker revalidation, while valid object metadata without `commit_eligible` remains eligible.
 - Review follow-up: verification commands in this task use repo-relative invocations instead of machine-local absolute paths.
+- PR #1684 review follow-up: added `replace_import_preview_proposed_plan_json()` so intentionally corrupted stored-plan fixture writes stay centralized in the DB repository instead of raw SQL in tests.
+- PR #1684 review follow-up: normalized the API completion-status recheck with `.strip()`, made stored-plan JSON parsing bytes-safe, and restored importer top-level blank-line spacing.
 
 ## Verification
 
@@ -70,11 +66,37 @@ Implement GitHub issue #1657 as a focused Persona/Buddy visual-pack hardening sl
 - Syntax: `python -m py_compile tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/app/core/Persona/visual_portability/importer.py` passed.
 - Whitespace: `git diff --check` passed.
 - Bandit: `python -m bandit -r tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/app/core/Persona/visual_portability/importer.py -f json -o /tmp/bandit_persona_visual_commit_guards_review.json` reported zero findings.
+- PR #1684 review regression: `python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_import_commit_eligibility.py tldw_Server_API/tests/Persona/test_persona_visuals_api.py tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py -q` passed with 66 tests.
+- PR #1684 review syntax: `python -m py_compile tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/app/core/Persona/visual_portability/importer.py tldw_Server_API/app/core/Persona/visual_portability/commit_eligibility.py tldw_Server_API/app/core/DB_Management/PersonaVisualPortability_DB.py` passed.
+- PR #1684 review style: `python -m ruff check tldw_Server_API/app/core/Persona/visual_portability/importer.py --select E305 --preview` passed.
+- PR #1684 review whitespace: `git diff --check` passed.
+- PR #1684 review Bandit: `python -m bandit -r tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/app/core/Persona/visual_portability/importer.py tldw_Server_API/app/core/Persona/visual_portability/commit_eligibility.py tldw_Server_API/app/core/DB_Management/PersonaVisualPortability_DB.py -f json -o /tmp/bandit_persona_visual_commit_guards_review2.json` reported zero findings.
 
 ## Known Skips
 
 - Optional Ruff full-file check on the touched files still reports existing I001 import-order findings in legacy modules; this narrow backend guard slice did not auto-sort large unrelated import blocks.
 
+PR #1684 review closeout refresh: rebased codex/persona-visual-commit-guards onto latest origin/dev so the PR diff is scoped back to Persona Visual import-commit guard files plus TASK-332.
+
+Added docstrings to the newly introduced regression tests and local test doubles to address the remaining CodeRabbit docstring coverage warning while leaving existing unrelated tests unchanged.
+
+Post-rebase verification: focused Persona pytest suite passed 66 tests; py_compile passed for changed API/core/tests; git diff --check passed; Ruff E305 passed for importer spacing; Bandit on touched production Python paths reported no findings.
+<!-- SECTION:NOTES:END -->
+
 ## Final Summary
 
-Hardened Persona Visual import-commit so stored previews with explicit `commit_eligible: false`, blocked status, malformed stored plan JSON, or non-object stored plan JSON are rejected before job queueing or worker revalidation. Worker-side revalidation also rejects blocked or non-commit-eligible previews before draft pack or asset creation. Added focused API and worker regressions while preserving existing eligible preview behavior for valid plan objects without `commit_eligible`.
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Hardened Persona Visual import-commit so stored previews with explicit `commit_eligible: false`, blocked status, malformed stored plan JSON, or non-object stored plan JSON are rejected before job queueing or worker revalidation. Worker-side revalidation also rejects blocked or non-commit-eligible previews before draft pack or asset creation. Added focused API and worker regressions while preserving existing eligible preview behavior for valid plan objects without `commit_eligible`. PR #1684 review follow-up also centralizes corrupted stored-plan fixture writes in the DB repository, normalizes API status checks consistently, and supports bytes-backed stored JSON parsing.
+
+Post-rebase review closeout added docstrings for new regression tests, verified the PR diff is scoped to Persona Visual import-commit guard files, and reran focused pytest, py_compile, git diff --check, Ruff E305, and Bandit with no failures/findings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-332 - Harden-Persona-Visual-import-commit-eligibility-revalidation.md
+++ b/backlog/tasks/task-332 - Harden-Persona-Visual-import-commit-eligibility-revalidation.md
@@ -12,6 +12,7 @@ dependencies: []
 references:
   - 'https://github.com/rmusser01/tldw_server/issues/1657'
   - 'https://github.com/rmusser01/tldw_server/issues/1510'
+  - 'https://github.com/rmusser01/tldw_server/pull/1677'
 documentation:
   - Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md
   - Docs/Code_Documentation/Persona_Visual_Packs.md

--- a/backlog/tasks/task-332 - Harden-Persona-Visual-import-commit-eligibility-revalidation.md
+++ b/backlog/tasks/task-332 - Harden-Persona-Visual-import-commit-eligibility-revalidation.md
@@ -56,15 +56,20 @@ Implement GitHub issue #1657 as a focused Persona/Buddy visual-pack hardening sl
 - Added shared importer validation that accepts legacy previews with no commit_eligible flag but rejects blocked previews or explicit commit_eligible false results.
 - Added regression coverage proving blocked revalidation fails the job with no additional draft pack created.
 - No docs changes were needed because the existing docs already describe blocked previews as commit-ineligible review results.
+- Review follow-up: aligned API `blocked` preview reporting with worker `import_preview_not_commit_eligible` handling.
+- Review follow-up: malformed or non-object stored `proposed_plan_json` now fails closed before job enqueueing or worker revalidation, while valid object metadata without `commit_eligible` remains eligible.
+- Review follow-up: verification commands in this task use repo-relative invocations instead of machine-local absolute paths.
 
 ## Verification
 
-- RED: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_visuals_api.py::test_start_import_commit_rejects_ineligible_completed_preview tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py::test_persona_visual_import_commit_worker_rejects_revalidated_blocked_preview -q` failed with the API returning 202 and the worker not raising the new guard error.
+- RED: `python -m pytest tldw_Server_API/tests/Persona/test_persona_visuals_api.py::test_start_import_commit_rejects_ineligible_completed_preview tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py::test_persona_visual_import_commit_worker_rejects_revalidated_blocked_preview -q` failed with the API returning 202 and the worker not raising the new guard error.
 - GREEN: same focused two-test command passed with 2 tests.
-- Focused regression: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_visuals_api.py tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py -q` passed with 51 tests.
-- Syntax: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/app/core/Persona/visual_portability/importer.py` passed.
+- Review RED: `python -m pytest tldw_Server_API/tests/Persona/test_persona_visuals_api.py::test_start_import_commit_reports_blocked_preview_as_not_commit_eligible tldw_Server_API/tests/Persona/test_persona_visuals_api.py::test_start_import_commit_rejects_invalid_stored_preview_plan tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py::test_persona_visual_import_commit_worker_rejects_invalid_stored_plan_before_revalidation -q` failed with 5 failing review-regression cases.
+- Review GREEN: same review-regression command passed with 5 tests.
+- Focused regression: `python -m pytest tldw_Server_API/tests/Persona/test_persona_visuals_api.py tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py -q` passed with 56 tests.
+- Syntax: `python -m py_compile tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/app/core/Persona/visual_portability/importer.py` passed.
 - Whitespace: `git diff --check` passed.
-- Bandit: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/app/core/Persona/visual_portability/importer.py -f json -o /tmp/bandit_persona_visual_commit_guards.json` reported zero findings.
+- Bandit: `python -m bandit -r tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/app/core/Persona/visual_portability/importer.py -f json -o /tmp/bandit_persona_visual_commit_guards_review.json` reported zero findings.
 
 ## Known Skips
 
@@ -72,4 +77,4 @@ Implement GitHub issue #1657 as a focused Persona/Buddy visual-pack hardening sl
 
 ## Final Summary
 
-Hardened Persona Visual import-commit so stored previews with explicit `commit_eligible: false` are rejected before job queueing, and worker-side revalidation rejects blocked or non-commit-eligible previews before draft pack or asset creation. Added focused API and worker regressions while preserving existing eligible preview behavior.
+Hardened Persona Visual import-commit so stored previews with explicit `commit_eligible: false`, blocked status, malformed stored plan JSON, or non-object stored plan JSON are rejected before job queueing or worker revalidation. Worker-side revalidation also rejects blocked or non-commit-eligible previews before draft pack or asset creation. Added focused API and worker regressions while preserving existing eligible preview behavior for valid plan objects without `commit_eligible`.

--- a/backlog/tasks/task-332 - Harden-Persona-Visual-import-commit-eligibility-revalidation.md
+++ b/backlog/tasks/task-332 - Harden-Persona-Visual-import-commit-eligibility-revalidation.md
@@ -12,7 +12,7 @@ dependencies: []
 references:
   - 'https://github.com/rmusser01/tldw_server/issues/1657'
   - 'https://github.com/rmusser01/tldw_server/issues/1510'
-  - 'https://github.com/rmusser01/tldw_server/pull/1677'
+  - 'https://github.com/rmusser01/tldw_server/pull/1684'
 documentation:
   - Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md
   - Docs/Code_Documentation/Persona_Visual_Packs.md

--- a/backlog/tasks/task-332 - Harden-Persona-Visual-import-commit-eligibility-revalidation.md
+++ b/backlog/tasks/task-332 - Harden-Persona-Visual-import-commit-eligibility-revalidation.md
@@ -1,0 +1,74 @@
+---
+id: TASK-332
+title: Harden Persona Visual import-commit eligibility revalidation
+status: Done
+assignee: []
+created_date: '2026-05-14 03:21'
+labels:
+  - persona
+  - visual-packs
+  - backend
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1657'
+  - 'https://github.com/rmusser01/tldw_server/issues/1510'
+documentation:
+  - Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md
+  - Docs/Code_Documentation/Persona_Visual_Packs.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement GitHub issue #1657 as a focused Persona/Buddy visual-pack hardening slice. Import-commit must fail closed when stored or revalidated Persona Visual import previews are blocked or not commit-eligible, so stale completed previews or capability-state changes cannot create draft packs/assets before manifest validation fails. Scope stays backend/server-side only unless an existing API contract requires a minimal response adjustment.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Import-commit rejects stored preview metadata that is not commit-eligible before starting draft pack or asset creation.
+- [x] #2 Import-commit revalidates archive previews and rejects any non-completed or non-commit-eligible revalidation result before draft pack or asset creation.
+- [x] #3 Blocked renderer preview commit attempts leave no partial draft packs/assets behind.
+- [x] #4 Existing API-level completed-preview behavior remains intact for eligible previews.
+- [x] #5 Focused backend regression tests cover stale stored ineligible preview metadata and revalidation-to-blocked behavior.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Plan
+
+1. Add server-side API queueing guard for completed import previews whose stored proposed plan explicitly marks commit_eligible false.
+2. Add importer-side guard before any pack or asset creation so stored previews and revalidated archive previews must be completed and commit-eligible.
+3. Add focused regression coverage for stored ineligible preview metadata and revalidation-to-blocked behavior.
+
+## Implementation Notes
+
+- Added a stored preview commit-eligibility helper in the Persona API endpoint before import-commit jobs are created.
+- Added shared importer validation that accepts legacy previews with no commit_eligible flag but rejects blocked previews or explicit commit_eligible false results.
+- Added regression coverage proving blocked revalidation fails the job with no additional draft pack created.
+- No docs changes were needed because the existing docs already describe blocked previews as commit-ineligible review results.
+
+## Verification
+
+- RED: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_visuals_api.py::test_start_import_commit_rejects_ineligible_completed_preview tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py::test_persona_visual_import_commit_worker_rejects_revalidated_blocked_preview -q` failed with the API returning 202 and the worker not raising the new guard error.
+- GREEN: same focused two-test command passed with 2 tests.
+- Focused regression: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_visuals_api.py tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py -q` passed with 51 tests.
+- Syntax: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/app/core/Persona/visual_portability/importer.py` passed.
+- Whitespace: `git diff --check` passed.
+- Bandit: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/app/core/Persona/visual_portability/importer.py -f json -o /tmp/bandit_persona_visual_commit_guards.json` reported zero findings.
+
+## Known Skips
+
+- Optional Ruff full-file check on the touched files still reports existing I001 import-order findings in legacy modules; this narrow backend guard slice did not auto-sort large unrelated import blocks.
+
+## Final Summary
+
+Hardened Persona Visual import-commit so stored previews with explicit `commit_eligible: false` are rejected before job queueing, and worker-side revalidation rejects blocked or non-commit-eligible previews before draft pack or asset creation. Added focused API and worker regressions while preserving existing eligible preview behavior.

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -163,6 +163,7 @@ from tldw_Server_API.app.core.Persona.visual_portability.archive import (
     DEFAULT_MAX_ARCHIVE_SIZE_BYTES,
 )
 from tldw_Server_API.app.core.Persona.visual_portability.commit_eligibility import (
+    import_preview_plan_from_stored_json,
     is_import_preview_plan_committable,
 )
 from tldw_Server_API.app.core.Persona.visual_portability.constants import (
@@ -2273,6 +2274,16 @@ def _persona_visual_json_field(row: dict[str, Any], key: str, default: Any) -> A
         return json.loads(str(value))
     except json.JSONDecodeError:
         return default
+
+
+def _persona_visual_import_preview_commit_eligible(preview: dict[str, Any]) -> bool:
+    """Return whether stored preview metadata allows queuing import commit."""
+    if str(preview.get("status") or "").strip() == "blocked":
+        return False
+    proposed_plan, proposed_plan_valid = import_preview_plan_from_stored_json(
+        preview.get("proposed_plan_json")
+    )
+    return proposed_plan_valid and is_import_preview_plan_committable(proposed_plan)
 
 
 def _persona_visual_replaceable_pack_ids(conflicts: Any) -> set[str]:
@@ -5159,16 +5170,15 @@ async def start_persona_visual_pack_import_commit(
         )
         if preview is None or str(preview.get("target_persona_id") or "") != persona_id:
             raise HTTPException(status_code=404, detail="import_preview_not_found")
+        if not _persona_visual_import_preview_commit_eligible(preview):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="import_preview_not_commit_eligible",
+            )
         if str(preview.get("status") or "") != "completed":
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
                 detail="import_preview_not_completed",
-            )
-        proposed_plan = _persona_visual_json_field(preview, "proposed_plan_json", {})
-        if not is_import_preview_plan_committable(proposed_plan):
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail="import_preview_not_committable",
             )
         conflicts = _persona_visual_json_field(preview, "conflicts_json", [])
         replaceable_pack_ids = _persona_visual_replaceable_pack_ids(conflicts)

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -5178,7 +5178,7 @@ async def start_persona_visual_pack_import_commit(
                 status_code=status.HTTP_409_CONFLICT,
                 detail="import_preview_not_commit_eligible",
             )
-        if str(preview.get("status") or "") != "completed":
+        if str(preview.get("status") or "").strip() != "completed":
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
                 detail="import_preview_not_completed",

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -2278,8 +2278,11 @@ def _persona_visual_json_field(row: dict[str, Any], key: str, default: Any) -> A
 
 def _persona_visual_import_preview_commit_eligible(preview: dict[str, Any]) -> bool:
     """Return whether stored preview metadata allows queuing import commit."""
-    if str(preview.get("status") or "").strip() == "blocked":
+    status_value = str(preview.get("status") or "").strip()
+    if status_value == "blocked":
         return False
+    if status_value != "completed":
+        return True
     proposed_plan, proposed_plan_valid = import_preview_plan_from_stored_json(
         preview.get("proposed_plan_json")
     )

--- a/tldw_Server_API/app/core/DB_Management/PersonaVisualPortability_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/PersonaVisualPortability_DB.py
@@ -418,6 +418,34 @@ class PersonaVisualPortabilityRepository:
             )
         return self.get_import_preview(preview_id, owner_user_id=owner_user_id)
 
+    def replace_import_preview_proposed_plan_json(
+        self,
+        preview_id: str,
+        proposed_plan_json: str | bytes,
+        *,
+        owner_user_id: str | None = None,
+    ) -> dict[str, Any] | None:
+        """Overwrite stored preview plan JSON text through the repository layer."""
+        self._ensure_schema_initialized()
+        current = self.get_import_preview(preview_id, owner_user_id=owner_user_id)
+        if current is None:
+            return None
+
+        with self.db.transaction() as conn:
+            where_clause = "id = ?"
+            where_params: list[Any] = [str(preview_id)]
+            if owner_user_id is not None:
+                where_clause += " AND owner_user_id = ?"
+                where_params.append(str(owner_user_id))
+            _execute_portability_update(
+                conn,
+                table_name="persona_visual_pack_import_previews",
+                update_values=[("proposed_plan_json", proposed_plan_json)],
+                where_clause=where_clause,
+                where_params=where_params,
+            )
+        return self.get_import_preview(preview_id, owner_user_id=owner_user_id)
+
     def _ensure_schema_initialized(self) -> None:
         if not self._schema_initialized:
             self.initialize_schema()

--- a/tldw_Server_API/app/core/Persona/visual_portability/commit_eligibility.py
+++ b/tldw_Server_API/app/core/Persona/visual_portability/commit_eligibility.py
@@ -7,6 +7,7 @@ any visual pack records are created.
 
 from __future__ import annotations
 
+import json
 from collections.abc import Mapping
 from typing import Any
 
@@ -21,6 +22,23 @@ def is_import_preview_result_committable(preview_result: Mapping[str, Any]) -> b
     if str(preview_result.get("status") or "") != "completed":
         return False
     return is_import_preview_plan_committable(preview_result.get("proposed_plan"))
+
+
+def import_preview_plan_from_stored_json(value: Any) -> tuple[Mapping[str, Any], bool]:
+    """Parse stored proposed-plan JSON while preserving corrupted-row signal."""
+    if value in (None, ""):
+        return {}, True
+    if isinstance(value, Mapping):
+        return value, True
+    if isinstance(value, list):
+        return {}, False
+    try:
+        parsed = json.loads(str(value))
+    except json.JSONDecodeError:
+        return {}, False
+    if not isinstance(parsed, Mapping):
+        return {}, False
+    return parsed, True
 
 
 def import_preview_commit_blockers(proposed_plan: Any) -> list[str]:

--- a/tldw_Server_API/app/core/Persona/visual_portability/commit_eligibility.py
+++ b/tldw_Server_API/app/core/Persona/visual_portability/commit_eligibility.py
@@ -33,8 +33,8 @@ def import_preview_plan_from_stored_json(value: Any) -> tuple[Mapping[str, Any],
     if isinstance(value, list):
         return {}, False
     try:
-        parsed = json.loads(str(value))
-    except json.JSONDecodeError:
+        parsed = json.loads(value)
+    except (json.JSONDecodeError, TypeError):
         return {}, False
     if not isinstance(parsed, Mapping):
         return {}, False

--- a/tldw_Server_API/app/core/Persona/visual_portability/importer.py
+++ b/tldw_Server_API/app/core/Persona/visual_portability/importer.py
@@ -273,7 +273,6 @@ class PersonaVisualPackImporter:
         if progress is not None:
             progress(stage, payload)
 
-
 def _import_preview_proposed_plan(preview: Mapping[str, Any]) -> tuple[Mapping[str, Any], bool]:
     """Return proposed-plan metadata from either a row or fresh preview payload."""
     if "proposed_plan" in preview:

--- a/tldw_Server_API/app/core/Persona/visual_portability/importer.py
+++ b/tldw_Server_API/app/core/Persona/visual_portability/importer.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import contextlib
-import json
 import zipfile
 from collections.abc import Mapping
 from datetime import datetime, timezone
@@ -15,8 +14,8 @@ from tldw_Server_API.app.core.DB_Management.PersonaVisualPortability_DB import (
 )
 from tldw_Server_API.app.core.Persona.visual_portability.archive import normalize_member_name
 from tldw_Server_API.app.core.Persona.visual_portability.commit_eligibility import (
+    import_preview_plan_from_stored_json,
     is_import_preview_plan_committable,
-    is_import_preview_result_committable,
 )
 from tldw_Server_API.app.core.Persona.visual_portability.constants import (
     ASSET_BYTES_STATUS_PRESENT,
@@ -94,8 +93,7 @@ class PersonaVisualPackImporter:
         expected_fingerprint = str(preview.get("canonical_payload_fingerprint") or "")
         if expected_fingerprint and revalidated["canonical_payload_fingerprint"] != expected_fingerprint:
             raise ValueError("import_archive_fingerprint_changed")
-        if not is_import_preview_result_committable(revalidated):
-            raise ValueError("import_preview_not_committable")
+        _validate_preview_commit_allowed(revalidated)
         revalidated_conflicts = revalidated.get("conflicts")
         current_conflicts = revalidated_conflicts if isinstance(revalidated_conflicts, list) else []
         if current_conflicts and not conflict_choice_explicit:
@@ -261,11 +259,7 @@ class PersonaVisualPackImporter:
             )
 
     def _validate_preview_ready(self, *, preview: dict[str, Any], archive_path: Path) -> None:
-        if str(preview.get("status") or "") != "completed":
-            raise ValueError("import_preview_not_completed")
-        proposed_plan = _import_preview_json_field(preview, "proposed_plan_json", {})
-        if not is_import_preview_plan_committable(proposed_plan):
-            raise ValueError("import_preview_not_committable")
+        _validate_preview_commit_allowed(preview)
         if not archive_path.is_file():
             raise ValueError("import_archive_not_found")
         expires_at = _parse_datetime(preview.get("expires_at"))
@@ -280,17 +274,26 @@ class PersonaVisualPackImporter:
             progress(stage, payload)
 
 
-def _import_preview_json_field(row: Mapping[str, Any], key: str, default: Any) -> Any:
-    """Read a JSON-backed import preview column with a typed fallback."""
-    value = row.get(key)
-    if value in (None, ""):
-        return default
-    if isinstance(value, (dict, list)):
-        return value
-    try:
-        return json.loads(str(value))
-    except json.JSONDecodeError:
-        return default
+def _import_preview_proposed_plan(preview: Mapping[str, Any]) -> tuple[Mapping[str, Any], bool]:
+    """Return proposed-plan metadata from either a row or fresh preview payload."""
+    if "proposed_plan" in preview:
+        proposed_plan = preview.get("proposed_plan")
+        if isinstance(proposed_plan, Mapping):
+            return proposed_plan, True
+        return {}, False
+    return import_preview_plan_from_stored_json(preview.get("proposed_plan_json"))
+
+
+def _validate_preview_commit_allowed(preview: Mapping[str, Any]) -> None:
+    """Reject previews that are not currently eligible for import commit."""
+    status_value = str(preview.get("status") or "").strip()
+    if status_value == "blocked":
+        raise ValueError("import_preview_not_commit_eligible")
+    if status_value != "completed":
+        raise ValueError("import_preview_not_completed")
+    proposed_plan, proposed_plan_valid = _import_preview_proposed_plan(preview)
+    if not proposed_plan_valid or not is_import_preview_plan_committable(proposed_plan):
+        raise ValueError("import_preview_not_commit_eligible")
 
 
 def _replaceable_pack_ids_from_conflicts(conflicts: Any) -> set[str]:

--- a/tldw_Server_API/app/core/Persona/visual_portability/importer.py
+++ b/tldw_Server_API/app/core/Persona/visual_portability/importer.py
@@ -273,6 +273,7 @@ class PersonaVisualPackImporter:
         if progress is not None:
             progress(stage, payload)
 
+
 def _import_preview_proposed_plan(preview: Mapping[str, Any]) -> tuple[Mapping[str, Any], bool]:
     """Return proposed-plan metadata from either a row or fresh preview payload."""
     if "proposed_plan" in preview:

--- a/tldw_Server_API/tests/Persona/test_persona_visual_import_commit_eligibility.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_import_commit_eligibility.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from tldw_Server_API.app.core.Persona.visual_portability.commit_eligibility import (
     import_preview_commit_blockers,
+    import_preview_plan_from_stored_json,
     is_import_preview_plan_committable,
     is_import_preview_result_committable,
 )
@@ -17,6 +18,21 @@ def test_import_preview_plan_rejects_non_mapping_plan() -> None:
 def test_import_preview_result_rejects_missing_plan() -> None:
     assert not is_import_preview_result_committable({"status": "completed"})
     assert not is_import_preview_result_committable({"status": "completed", "proposed_plan": []})
+
+
+def test_import_preview_plan_from_stored_json_allows_empty_legacy_plan() -> None:
+    plan, valid = import_preview_plan_from_stored_json("")
+
+    assert valid is True
+    assert plan == {}
+
+
+def test_import_preview_plan_from_stored_json_rejects_corrupted_or_non_object_plan() -> None:
+    for raw_value in ("{not-json", "[]"):
+        plan, valid = import_preview_plan_from_stored_json(raw_value)
+
+        assert valid is False
+        assert plan == {}
 
 
 def test_renderer_import_preview_without_can_commit_does_not_block_plan() -> None:

--- a/tldw_Server_API/tests/Persona/test_persona_visual_import_commit_eligibility.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_import_commit_eligibility.py
@@ -21,13 +21,23 @@ def test_import_preview_result_rejects_missing_plan() -> None:
 
 
 def test_import_preview_plan_from_stored_json_allows_empty_legacy_plan() -> None:
+    """Treat missing legacy proposed-plan JSON as valid empty metadata."""
     plan, valid = import_preview_plan_from_stored_json("")
 
     assert valid is True
     assert plan == {}
 
 
+def test_import_preview_plan_from_stored_json_accepts_bytes_json() -> None:
+    """Parse byte-encoded proposed-plan JSON without coercing through repr text."""
+    plan, valid = import_preview_plan_from_stored_json(b'{"target_mode": "create_new"}')
+
+    assert valid is True
+    assert plan == {"target_mode": "create_new"}
+
+
 def test_import_preview_plan_from_stored_json_rejects_corrupted_or_non_object_plan() -> None:
+    """Reject malformed or non-object proposed-plan JSON from stored previews."""
     for raw_value in ("{not-json", "[]"):
         plan, valid = import_preview_plan_from_stored_json(raw_value)
 

--- a/tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py
@@ -1153,6 +1153,116 @@ async def test_persona_visual_import_commit_worker_rejects_incomplete_preview(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("stored_plan_json", ["{not-json", "[]"])
+async def test_persona_visual_import_commit_worker_rejects_invalid_stored_plan_before_revalidation(
+    db_instance: CharactersRAGDB,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    stored_plan_json: str,
+) -> None:
+    from tldw_Server_API.app.core.DB_Management.PersonaVisualPortability_DB import (
+        PersonaVisualPortabilityRepository,
+    )
+    from tldw_Server_API.app.core.Persona.visual_jobs_worker import (
+        PersonaVisualPortabilityWorker,
+    )
+    from tldw_Server_API.app.core.Persona.visual_portability import importer as importer_module
+
+    persona_id, pack, _source_asset = _create_pack_with_asset(
+        db_instance,
+        visuals_root=tmp_path / "visuals",
+        monkeypatch=monkeypatch,
+    )
+    export_result = PersonaVisualPackExporter(
+        db=db_instance,
+        user_id="user-1",
+        staging_root=tmp_path / "exports",
+    ).export_pack(
+        persona_id=persona_id,
+        pack_id=str(pack["id"]),
+        options=PersonaVisualPackExportOptions(),
+    )
+    preview_result = PersonaVisualPackImportPreviewer().create_preview(
+        archive_path=export_result.archive_path,
+        owner_user_id="user-1",
+        target_persona_id=persona_id,
+        target_packs=db_instance.list_persona_visual_packs(
+            persona_id=persona_id,
+            user_id="user-1",
+        ),
+    )
+    repo = PersonaVisualPortabilityRepository.initialized(db_instance)
+    preview = repo.create_import_preview(
+        owner_user_id="user-1",
+        job_id="job-preview-1",
+        status="completed",
+        stage="completed",
+        archive_path=str(export_result.archive_path),
+        archive_sha256=preview_result["archive_sha256"],
+        canonical_payload_fingerprint=preview_result["canonical_payload_fingerprint"],
+        schema_version=preview_result["schema_version"],
+        target_persona_id=persona_id,
+        bundle_summary=preview_result["bundle_summary"],
+        conflicts=preview_result["conflicts"],
+        proposed_plan=preview_result["proposed_plan"],
+        required_choices=preview_result["required_choices"],
+    )
+    with db_instance.transaction() as conn:
+        conn.execute(
+            """
+            UPDATE persona_visual_pack_import_previews
+               SET proposed_plan_json = ?
+             WHERE id = ?
+            """,
+            (stored_plan_json, preview["id"]),
+        )
+    portability_job = repo.create_portability_job(
+        owner_user_id="user-1",
+        job_id="job-commit-1",
+        operation="import_commit",
+        status="queued",
+        stage="queued",
+        preview_id=str(preview["id"]),
+        persona_id=persona_id,
+    )
+
+    class _UnexpectedPreviewer:
+        def create_preview(self, **_kwargs: Any) -> dict[str, Any]:
+            raise AssertionError("import commit revalidated a corrupt stored preview")
+
+    monkeypatch.setattr(
+        importer_module,
+        "PersonaVisualPackImportPreviewer",
+        _UnexpectedPreviewer,
+    )
+    worker = PersonaVisualPortabilityWorker(db=db_instance, repo=repo)
+
+    with pytest.raises(ValueError, match="import_preview_not_commit_eligible"):
+        await worker.handle_job_async(
+            {
+                "id": "job-commit-1",
+                "job_type": PERSONA_VISUAL_PACK_IMPORT_COMMIT_JOB_TYPE,
+                "owner_user_id": "user-1",
+                "payload": {
+                    "user_id": "user-1",
+                    "preview_id": str(preview["id"]),
+                    "portability_job_id": str(portability_job["id"]),
+                    "request_id": "req-commit",
+                    "target_persona_id": persona_id,
+                    "trust_mode": "untrusted_import",
+                    "target_mode": "create_new",
+                },
+            }
+        )
+
+    updated_job = repo.get_portability_job(str(portability_job["id"]), owner_user_id="user-1")
+    assert updated_job is not None
+    assert updated_job["status"] == "failed"
+    assert updated_job["error_message"] == "import_preview_not_commit_eligible"
+    assert len(db_instance.list_persona_visual_packs(persona_id=persona_id, user_id="user-1")) == 1
+
+
+@pytest.mark.asyncio
 async def test_persona_visual_import_commit_worker_rejects_revalidated_blocked_preview(
     db_instance: CharactersRAGDB,
     tmp_path: Path,

--- a/tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py
@@ -1160,6 +1160,7 @@ async def test_persona_visual_import_commit_worker_rejects_invalid_stored_plan_b
     monkeypatch: pytest.MonkeyPatch,
     stored_plan_json: str,
 ) -> None:
+    """Fail import-commit jobs before revalidation when stored plan JSON is invalid."""
     from tldw_Server_API.app.core.DB_Management.PersonaVisualPortability_DB import (
         PersonaVisualPortabilityRepository,
     )
@@ -1207,15 +1208,11 @@ async def test_persona_visual_import_commit_worker_rejects_invalid_stored_plan_b
         proposed_plan=preview_result["proposed_plan"],
         required_choices=preview_result["required_choices"],
     )
-    with db_instance.transaction() as conn:
-        conn.execute(
-            """
-            UPDATE persona_visual_pack_import_previews
-               SET proposed_plan_json = ?
-             WHERE id = ?
-            """,
-            (stored_plan_json, preview["id"]),
-        )
+    repo.replace_import_preview_proposed_plan_json(
+        str(preview["id"]),
+        stored_plan_json,
+        owner_user_id="user-1",
+    )
     portability_job = repo.create_portability_job(
         owner_user_id="user-1",
         job_id="job-commit-1",
@@ -1228,6 +1225,7 @@ async def test_persona_visual_import_commit_worker_rejects_invalid_stored_plan_b
 
     class _UnexpectedPreviewer:
         def create_preview(self, **_kwargs: Any) -> dict[str, Any]:
+            """Fail the test if invalid stored plans reach archive revalidation."""
             raise AssertionError("import commit revalidated a corrupt stored preview")
 
     monkeypatch.setattr(
@@ -1268,6 +1266,7 @@ async def test_persona_visual_import_commit_worker_rejects_revalidated_blocked_p
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Fail import-commit jobs when archive revalidation returns a blocked preview."""
     from tldw_Server_API.app.core.DB_Management.PersonaVisualPortability_DB import (
         PersonaVisualPortabilityRepository,
     )
@@ -1327,6 +1326,7 @@ async def test_persona_visual_import_commit_worker_rejects_revalidated_blocked_p
 
     class _BlockedPreviewer:
         def create_preview(self, **_kwargs: Any) -> dict[str, Any]:
+            """Return a blocked revalidation result for the commit worker path."""
             blocked = dict(preview_result)
             blocked["status"] = "blocked"
             blocked["proposed_plan"] = {

--- a/tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py
@@ -714,7 +714,7 @@ async def test_persona_visual_import_commit_worker_rejects_blocked_revalidation_
     )
     worker = worker_module.PersonaVisualPortabilityWorker(db=db_instance, repo=repo)
 
-    with pytest.raises(ValueError, match="import_preview_not_committable"):
+    with pytest.raises(ValueError, match="import_preview_not_commit_eligible"):
         await worker.handle_job_async(
             {
                 "id": "job-commit-blocked-revalidation",
@@ -1149,4 +1149,111 @@ async def test_persona_visual_import_commit_worker_rejects_incomplete_preview(
             }
         )
 
+    assert len(db_instance.list_persona_visual_packs(persona_id=persona_id, user_id="user-1")) == 1
+
+
+@pytest.mark.asyncio
+async def test_persona_visual_import_commit_worker_rejects_revalidated_blocked_preview(
+    db_instance: CharactersRAGDB,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.core.DB_Management.PersonaVisualPortability_DB import (
+        PersonaVisualPortabilityRepository,
+    )
+    from tldw_Server_API.app.core.Persona.visual_jobs_worker import (
+        PersonaVisualPortabilityWorker,
+    )
+    from tldw_Server_API.app.core.Persona.visual_portability import importer as importer_module
+
+    persona_id, pack, _source_asset = _create_pack_with_asset(
+        db_instance,
+        visuals_root=tmp_path / "visuals",
+        monkeypatch=monkeypatch,
+    )
+    export_result = PersonaVisualPackExporter(
+        db=db_instance,
+        user_id="user-1",
+        staging_root=tmp_path / "exports",
+    ).export_pack(
+        persona_id=persona_id,
+        pack_id=str(pack["id"]),
+        options=PersonaVisualPackExportOptions(),
+    )
+    preview_result = PersonaVisualPackImportPreviewer().create_preview(
+        archive_path=export_result.archive_path,
+        owner_user_id="user-1",
+        target_persona_id=persona_id,
+        target_packs=db_instance.list_persona_visual_packs(
+            persona_id=persona_id,
+            user_id="user-1",
+        ),
+    )
+    repo = PersonaVisualPortabilityRepository.initialized(db_instance)
+    preview = repo.create_import_preview(
+        owner_user_id="user-1",
+        job_id="job-preview-1",
+        status="completed",
+        stage="completed",
+        archive_path=str(export_result.archive_path),
+        archive_sha256=preview_result["archive_sha256"],
+        canonical_payload_fingerprint=preview_result["canonical_payload_fingerprint"],
+        schema_version=preview_result["schema_version"],
+        target_persona_id=persona_id,
+        bundle_summary=preview_result["bundle_summary"],
+        conflicts=preview_result["conflicts"],
+        proposed_plan=preview_result["proposed_plan"],
+        required_choices=preview_result["required_choices"],
+    )
+    portability_job = repo.create_portability_job(
+        owner_user_id="user-1",
+        job_id="job-commit-1",
+        operation="import_commit",
+        status="queued",
+        stage="queued",
+        preview_id=str(preview["id"]),
+        persona_id=persona_id,
+    )
+
+    class _BlockedPreviewer:
+        def create_preview(self, **_kwargs: Any) -> dict[str, Any]:
+            blocked = dict(preview_result)
+            blocked["status"] = "blocked"
+            blocked["proposed_plan"] = {
+                **preview_result["proposed_plan"],
+                "commit_eligible": False,
+                "commit_blockers": ["unsupported_renderer"],
+            }
+            return blocked
+
+    monkeypatch.setattr(
+        importer_module,
+        "PersonaVisualPackImportPreviewer",
+        _BlockedPreviewer,
+    )
+    worker = PersonaVisualPortabilityWorker(db=db_instance, repo=repo)
+
+    with pytest.raises(ValueError, match="import_preview_not_commit_eligible"):
+        await worker.handle_job_async(
+            {
+                "id": "job-commit-1",
+                "job_type": PERSONA_VISUAL_PACK_IMPORT_COMMIT_JOB_TYPE,
+                "owner_user_id": "user-1",
+                "payload": {
+                    "user_id": "user-1",
+                    "preview_id": str(preview["id"]),
+                    "portability_job_id": str(portability_job["id"]),
+                    "request_id": "req-commit",
+                    "target_persona_id": persona_id,
+                    "trust_mode": "untrusted_import",
+                    "target_mode": "create_new",
+                    "conflict_choice_explicit": True,
+                },
+            }
+        )
+
+    updated_job = repo.get_portability_job(str(portability_job["id"]), owner_user_id="user-1")
+    assert updated_job is not None
+    assert updated_job["status"] == "failed"
+    assert updated_job["error_message"] == "import_preview_not_commit_eligible"
     assert len(db_instance.list_persona_visual_packs(persona_id=persona_id, user_id="user-1")) == 1

--- a/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
@@ -1636,6 +1636,97 @@ def test_start_import_commit_rejects_ineligible_completed_preview(
     assert manager.created == []
 
 
+def test_start_import_commit_reports_blocked_preview_as_not_commit_eligible(
+    persona_db: CharactersRAGDB,
+    tmp_path: Path,
+) -> None:
+    from tldw_Server_API.app.core.DB_Management.PersonaVisualPortability_DB import (
+        PersonaVisualPortabilityRepository,
+    )
+
+    manager = FakeJobManager()
+    fastapi_app.dependency_overrides[persona_ep.get_persona_visual_job_manager] = lambda: manager
+    with _client_for_user(1, persona_db) as client:
+        persona_id = _create_persona(client, name="Blocked Import Commit Persona")
+        archive_path = tmp_path / "commit-blocked.tldw-persona-vpack"
+        archive_path.write_bytes(b"portable visual archive")
+        repo = PersonaVisualPortabilityRepository.initialized(persona_db)
+        preview = repo.create_import_preview(
+            owner_user_id="1",
+            job_id="preview-job-blocked",
+            status="blocked",
+            stage="completed",
+            archive_path=str(archive_path),
+            archive_sha256="a" * 64,
+            canonical_payload_fingerprint="b" * 64,
+            schema_version="tldw.persona_visual_pack.v1",
+            target_persona_id=persona_id,
+            proposed_plan={
+                "target_mode": "create_new",
+                "commit_eligible": False,
+                "commit_blockers": ["unsupported_renderer"],
+            },
+        )
+
+        response = client.post(
+            f"/api/v1/persona/profiles/{persona_id}/visual-packs/import-previews/{preview['id']}/commit",
+            json={"trust_mode": "untrusted_import", "target_mode": "create_new"},
+        )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "import_preview_not_commit_eligible"
+    assert manager.created == []
+
+
+@pytest.mark.parametrize("stored_plan_json", ["{not-json", "[]"])
+def test_start_import_commit_rejects_invalid_stored_preview_plan(
+    persona_db: CharactersRAGDB,
+    tmp_path: Path,
+    stored_plan_json: str,
+) -> None:
+    from tldw_Server_API.app.core.DB_Management.PersonaVisualPortability_DB import (
+        PersonaVisualPortabilityRepository,
+    )
+
+    manager = FakeJobManager()
+    fastapi_app.dependency_overrides[persona_ep.get_persona_visual_job_manager] = lambda: manager
+    with _client_for_user(1, persona_db) as client:
+        persona_id = _create_persona(client, name="Invalid Plan Import Commit Persona")
+        archive_path = tmp_path / "commit-invalid-plan.tldw-persona-vpack"
+        archive_path.write_bytes(b"portable visual archive")
+        repo = PersonaVisualPortabilityRepository.initialized(persona_db)
+        preview = repo.create_import_preview(
+            owner_user_id="1",
+            job_id="preview-job-invalid-plan",
+            status="completed",
+            stage="completed",
+            archive_path=str(archive_path),
+            archive_sha256="a" * 64,
+            canonical_payload_fingerprint="b" * 64,
+            schema_version="tldw.persona_visual_pack.v1",
+            target_persona_id=persona_id,
+            proposed_plan={"target_mode": "create_new"},
+        )
+        with persona_db.transaction() as conn:
+            conn.execute(
+                """
+                UPDATE persona_visual_pack_import_previews
+                   SET proposed_plan_json = ?
+                 WHERE id = ?
+                """,
+                (stored_plan_json, preview["id"]),
+            )
+
+        response = client.post(
+            f"/api/v1/persona/profiles/{persona_id}/visual-packs/import-previews/{preview['id']}/commit",
+            json={"trust_mode": "untrusted_import", "target_mode": "create_new"},
+        )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "import_preview_not_commit_eligible"
+    assert manager.created == []
+
+
 def test_deactivate_visual_pack_reverts_to_derived_buddy(persona_db: CharactersRAGDB) -> None:
     with _client_for_user(1, persona_db) as client:
         persona_id = _create_persona(client, name="Deactivate Visual API Persona")

--- a/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
@@ -1391,7 +1391,7 @@ def test_start_import_commit_rejects_commit_ineligible_preview(
         )
 
     assert response.status_code == 409, response.text
-    assert response.json()["detail"] == "import_preview_not_committable"
+    assert response.json()["detail"] == "import_preview_not_commit_eligible"
     assert manager.created == []
 
 
@@ -1591,6 +1591,48 @@ def test_start_import_commit_rejects_incomplete_preview(
         )
 
     assert response.status_code == 409
+    assert manager.created == []
+
+
+def test_start_import_commit_rejects_ineligible_completed_preview(
+    persona_db: CharactersRAGDB,
+    tmp_path: Path,
+) -> None:
+    from tldw_Server_API.app.core.DB_Management.PersonaVisualPortability_DB import (
+        PersonaVisualPortabilityRepository,
+    )
+
+    manager = FakeJobManager()
+    fastapi_app.dependency_overrides[persona_ep.get_persona_visual_job_manager] = lambda: manager
+    with _client_for_user(1, persona_db) as client:
+        persona_id = _create_persona(client, name="Ineligible Import Commit Persona")
+        archive_path = tmp_path / "commit-ineligible.tldw-persona-vpack"
+        archive_path.write_bytes(b"portable visual archive")
+        repo = PersonaVisualPortabilityRepository.initialized(persona_db)
+        preview = repo.create_import_preview(
+            owner_user_id="1",
+            job_id="preview-job-ineligible",
+            status="completed",
+            stage="completed",
+            archive_path=str(archive_path),
+            archive_sha256="a" * 64,
+            canonical_payload_fingerprint="b" * 64,
+            schema_version="tldw.persona_visual_pack.v1",
+            target_persona_id=persona_id,
+            proposed_plan={
+                "target_mode": "create_new",
+                "commit_eligible": False,
+                "commit_blockers": ["unsupported_renderer"],
+            },
+        )
+
+        response = client.post(
+            f"/api/v1/persona/profiles/{persona_id}/visual-packs/import-previews/{preview['id']}/commit",
+            json={"trust_mode": "untrusted_import", "target_mode": "create_new"},
+        )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "import_preview_not_commit_eligible"
     assert manager.created == []
 
 

--- a/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
@@ -1351,6 +1351,44 @@ def test_start_import_commit_creates_jobs_backed_portability_row(
     assert row["persona_id"] == persona_id
 
 
+def test_start_import_commit_normalizes_completed_preview_status(
+    persona_db: CharactersRAGDB,
+    tmp_path: Path,
+) -> None:
+    """Accept completed previews even when stored status has surrounding whitespace."""
+    from tldw_Server_API.app.core.DB_Management.PersonaVisualPortability_DB import (
+        PersonaVisualPortabilityRepository,
+    )
+
+    manager = FakeJobManager()
+    fastapi_app.dependency_overrides[persona_ep.get_persona_visual_job_manager] = lambda: manager
+    with _client_for_user(1, persona_db) as client:
+        persona_id = _create_persona(client, name="Whitespace Status Import Persona")
+        archive_path = tmp_path / "commit-status-spaces.tldw-persona-vpack"
+        archive_path.write_bytes(b"portable visual archive")
+        repo = PersonaVisualPortabilityRepository.initialized(persona_db)
+        preview = repo.create_import_preview(
+            owner_user_id="1",
+            job_id="preview-job-spaced-status",
+            status=" completed ",
+            stage="completed",
+            archive_path=str(archive_path),
+            archive_sha256="a" * 64,
+            canonical_payload_fingerprint="b" * 64,
+            schema_version="tldw.persona_visual_pack.v1",
+            target_persona_id=persona_id,
+            proposed_plan={"target_mode": "create_new"},
+        )
+
+        response = client.post(
+            f"/api/v1/persona/profiles/{persona_id}/visual-packs/import-previews/{preview['id']}/commit",
+            json={"trust_mode": "untrusted_import", "target_mode": "create_new"},
+        )
+
+    assert response.status_code == 202, response.text
+    assert manager.created
+
+
 def test_start_import_commit_rejects_commit_ineligible_preview(
     persona_db: CharactersRAGDB,
     tmp_path: Path,
@@ -1598,6 +1636,7 @@ def test_start_import_commit_rejects_ineligible_completed_preview(
     persona_db: CharactersRAGDB,
     tmp_path: Path,
 ) -> None:
+    """Reject completed previews whose stored plan is explicitly not commit eligible."""
     from tldw_Server_API.app.core.DB_Management.PersonaVisualPortability_DB import (
         PersonaVisualPortabilityRepository,
     )
@@ -1640,6 +1679,7 @@ def test_start_import_commit_reports_blocked_preview_as_not_commit_eligible(
     persona_db: CharactersRAGDB,
     tmp_path: Path,
 ) -> None:
+    """Return the commit-eligibility error for blocked import previews."""
     from tldw_Server_API.app.core.DB_Management.PersonaVisualPortability_DB import (
         PersonaVisualPortabilityRepository,
     )
@@ -1684,6 +1724,7 @@ def test_start_import_commit_rejects_invalid_stored_preview_plan(
     tmp_path: Path,
     stored_plan_json: str,
 ) -> None:
+    """Reject commit requests when the persisted proposed plan is malformed."""
     from tldw_Server_API.app.core.DB_Management.PersonaVisualPortability_DB import (
         PersonaVisualPortabilityRepository,
     )
@@ -1707,15 +1748,11 @@ def test_start_import_commit_rejects_invalid_stored_preview_plan(
             target_persona_id=persona_id,
             proposed_plan={"target_mode": "create_new"},
         )
-        with persona_db.transaction() as conn:
-            conn.execute(
-                """
-                UPDATE persona_visual_pack_import_previews
-                   SET proposed_plan_json = ?
-                 WHERE id = ?
-                """,
-                (stored_plan_json, preview["id"]),
-            )
+        repo.replace_import_preview_proposed_plan_json(
+            str(preview["id"]),
+            stored_plan_json,
+            owner_user_id="1",
+        )
 
         response = client.post(
             f"/api/v1/persona/profiles/{persona_id}/visual-packs/import-previews/{preview['id']}/commit",


### PR DESCRIPTION
## Summary
- Supersedes closed PR #1677, which GitHub would not reopen after the branch was rebased.
- Builds on merged PR #1678 by making stored Persona Visual import previews fail closed when `proposed_plan_json` is malformed or not a JSON object.
- Keeps API and worker import-commit failures aligned on `import_preview_not_commit_eligible` for blocked, corrupted, or explicitly ineligible previews.
- Adds focused API, worker, and shared helper regressions plus TASK-332 tracking.

## Change summary
Maintainer-authored change summary required before ready-for-merge per AI-generated PR policy.

## Risk / rollback
- Risk: Low. The changes are limited to Persona Visual import-commit eligibility guards and focused regression coverage.
- Rollback: Revert this PR to restore the current merged import-commit behavior. Existing stored previews and packs are not migrated by this change.

## Tests
- `python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_import_commit_eligibility.py tldw_Server_API/tests/Persona/test_persona_visuals_api.py tldw_Server_API/tests/Persona/test_persona_visual_portability_worker.py -q`
- `python -m py_compile tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/app/core/Persona/visual_portability/importer.py tldw_Server_API/app/core/Persona/visual_portability/commit_eligibility.py`
- `git diff --check`
- `python -m bandit -r tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/app/core/Persona/visual_portability/importer.py tldw_Server_API/app/core/Persona/visual_portability/commit_eligibility.py -f json -o /tmp/bandit_persona_visual_commit_guards_rebased2.json`

## Notes
- PR #1677 had all review threads resolved before it was closed, but it remained unmerged. This PR carries the rebased branch state on top of current `dev`.
- Optional Ruff full-file check was not rerun after the final rebase; earlier full-file Ruff checks in this area reported existing import-order baseline noise, so this slice sticks to focused backend verification.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened Persona Visual import-commit to fail closed for blocked previews and invalid or non-object stored plan JSON, preventing partial draft packs/assets. API and worker now consistently return 409 import_preview_not_commit_eligible; added status whitespace normalization and bytes-safe plan parsing. Addresses TASK-332.

- **Bug Fixes**
  - Added `import_preview_plan_from_stored_json` to safely parse stored `proposed_plan_json` (supports bytes; treats empty as legacy-valid; rejects malformed or non-object).
  - API checks `_persona_visual_import_preview_commit_eligible` before enqueueing; returns 409 `import_preview_not_commit_eligible` for blocked, invalid stored-plan, or `commit_eligible: false`; keeps 409 `import_preview_not_completed` for non-completed; normalizes status with `.strip()`.
  - Worker/importer `_validate_preview_commit_allowed` rejects blocked, non-completed, invalid stored-plan, or ineligible previews before revalidation or any pack/asset creation; blocked revalidation fails with `import_preview_not_commit_eligible`.
  - Added `replace_import_preview_proposed_plan_json()` for centralized test fixture writes; expanded API/worker tests for whitespace-normalized status, invalid stored plans (pre-revalidation), blocked revalidation, and consistent error responses.

<sup>Written for commit 4087be1a78e2579b30ce490aea35a6a65779a3ff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

