### PR TITLE
Define Persona Visual external MCP provider contract

### DIFF
--- a/Docs/Code_Documentation/Persona_Visual_Packs.md
+++ b/Docs/Code_Documentation/Persona_Visual_Packs.md
@@ -218,6 +218,40 @@ Core implementation points:
 5. `PersonaVisualsModule` for MCP discovery and draft reuse on top of the same
    reference-backed service semantics.
 
+## External MCP-Compatible Pack Providers
+
+External MCP-compatible Persona Visual pack providers are review-input sources,
+not Persona Visual storage owners or runtime plugins. The contract is documented
+in
+`Docs/Design/2026-05-13-persona-visual-external-mcp-provider-contract.md`.
+
+Provider output can describe one of four durable review inputs:
+
+1. a `.tldw-persona-vpack` portable archive for import preview.
+2. a generated-candidate payload for an existing draft pack.
+3. a proposed manifest patch for an existing draft pack.
+4. a request to create a new inactive draft pack.
+
+Every provider result must be treated as untrusted until the tldw server
+validates it. Provider output must not activate a pack, mutate an active pack,
+write assets directly, bypass import preview, submit runtime renderer code, or
+grant renderer support by assertion. Renderer support still comes from the
+server renderer capability registry, and non-sprite proposals still need the
+Manifest V2 static fallback and renderer diagnostics described above.
+
+Portable archive provider results enter the same staged import flow as user
+uploads: preview first, explicit conflict choices where needed, commit to a
+reviewed draft only, and separate user activation later. Generated-candidate
+and manifest-patch provider results should use the same review semantics as
+local generation: provider asset handles are intake placeholders until the
+server validates metadata, copies bytes through approved storage paths, and
+assigns real asset ids.
+
+Provider provenance is metadata only. It must not override user ownership,
+persona scope, activation state, or personal-library source references. The
+personal library remains reference-backed and must not gain source display
+snapshots from provider metadata.
+
 ## Import Preview And Commit
 
 Import is staged:

--- a/Docs/Code_Documentation/Persona_Visual_Packs.md
+++ b/Docs/Code_Documentation/Persona_Visual_Packs.md
@@ -249,8 +249,10 @@ assigns real asset ids.
 
 Provider provenance is metadata only. It must not override user ownership,
 persona scope, activation state, or personal-library source references. The
-personal library remains reference-backed and must not gain source display
-snapshots from provider metadata.
+server must sanitize provenance before storage and reject secrets, API keys,
+tokens, host-local identifiers, or local filesystem paths in provider-supplied
+metadata. The personal library remains reference-backed and must not gain source
+display snapshots from provider metadata.
 
 ## Import Preview And Commit
 

--- a/Docs/Design/2026-05-13-persona-visual-external-mcp-provider-contract.md
+++ b/Docs/Design/2026-05-13-persona-visual-external-mcp-provider-contract.md
@@ -138,7 +138,10 @@ intake adapters can show consistent provenance and diagnostics.
     "status": "ready_for_import_preview",
     "blockers": [],
     "warnings": [
-      "listening falls back to idle"
+      {
+        "code": "state_fallback",
+        "message": "listening falls back to idle"
+      }
     ]
   },
   "provenance": {
@@ -151,7 +154,7 @@ intake adapters can show consistent provenance and diagnostics.
     "archive": {
       "mcp_resource_uri": "mcp://local-sprite-pose-maker/resources/expr-pack-2026-05-13.tldw-persona-vpack",
       "sha256": "2f3a6c2c4b0b0c7f9f7ad3e2c0f9f95543e3013d6a45b69822ad0f01f54415be",
-      "media_type": "application/vnd.tldw.persona-visual-pack"
+      "media_type": "application/vnd.tldw.persona.visual-pack+zip"
     }
   }
 }
@@ -170,6 +173,11 @@ Rules:
    copied into the Persona Visual manifest as a remote asset URL.
 7. `provenance` is advisory metadata. It must not override user ownership,
    persona scope, validation results, or library source references.
+8. `portable_archive` media types should use
+   `application/vnd.tldw.persona.visual-pack+zip` for Persona Visual archives.
+   Existing exports may still be served as `application/zip`, so intake
+   implementations should treat both as zip archive payloads and rely on
+   archive validation rather than media type alone.
 
 ## Allowed Result Types
 
@@ -332,6 +340,9 @@ Provider intake must reject or block:
    status, or ownership by assertion.
 10. unsupported renderer claims that contradict the server renderer capability
     registry.
+11. secrets, API keys, bearer tokens, session cookies, local filesystem paths,
+    host identifiers, or other sensitive material in provider-supplied
+    metadata, diagnostics, provenance, manifests, or archive member names.
 
 Provider intake should require:
 
@@ -340,7 +351,8 @@ Provider intake should require:
 2. renderer capability resolution before import preview or candidate review.
 3. static fallback for non-sprite renderer proposals.
 4. stable diagnostics with machine-readable blocker and warning codes.
-5. provenance that is stored as pack/asset metadata only after server review.
+5. sanitized provenance that is bounded, free of secrets and host-local
+   identifiers, and stored as pack/asset metadata only after server review.
 
 ## Relationship To Existing MCP Tools
 

--- a/Docs/Design/2026-05-13-persona-visual-external-mcp-provider-contract.md
+++ b/Docs/Design/2026-05-13-persona-visual-external-mcp-provider-contract.md
@@ -1,0 +1,393 @@
+# Persona Visual External MCP Provider Contract
+
+Tracks GitHub issue #1682 under the Persona/Buddy reliability epic #1510.
+
+## Decision Summary
+
+External MCP-compatible Persona Visual pack providers should be treated as
+review-input sources, not runtime plugins. A provider can offer generated
+candidates, manifest patches, draft-pack requests, or portable pack archives,
+but the tldw server remains the trust boundary for validation, storage,
+preview, commit, and activation.
+
+This contract is design-only. It does not add provider execution, Live2D
+runtime support, a marketplace, shared libraries, or any automatic activation
+path. The first implementation target after this contract should be an intake
+adapter that converts provider output into the existing Persona Visual import
+preview or generated-candidate review flows.
+
+## Current Baseline
+
+Persona Visual Packs already have the required local safety model:
+
+1. Packs are user-owned and attached to one persona by default.
+2. V1 activation is limited to `sprite_frames`.
+3. Renderer support is reported by the renderer capability registry.
+4. Manifest V2 design defines the non-sprite renderer envelope and static
+   fallback requirement.
+5. Archive import preview can report renderer blockers before commit.
+6. Personal-library entries are reference-backed and do not store source
+   display snapshots.
+7. Durable MCP actions create drafts, manifest updates, generation jobs, or
+   library draft copies; they do not activate packs.
+
+External providers must reuse these boundaries instead of creating a parallel
+asset model.
+
+## Product Invariants
+
+Every external provider integration must preserve these invariants:
+
+1. Provider output is untrusted until the tldw server validates it.
+2. Provider output cannot activate or replace an active pack.
+3. Provider output cannot write assets directly to Persona Visual storage.
+4. Provider output cannot become runtime renderer code.
+5. Provider output cannot include remote asset references inside manifests or
+   renderer-specific source files.
+6. Imported assets remain user-owned and persona-scoped after commit.
+7. Review and explicit activation stay separate user decisions.
+8. Reference-backed personal-library semantics must not gain display snapshots
+   through provider metadata.
+
+## Provider Discovery
+
+An external MCP server that wants to offer Persona Visual packs should advertise
+a capability named `tldw.persona_visual_pack_provider.v1`.
+
+Suggested discovery shape:
+
+```json
+{
+  "capability": "tldw.persona_visual_pack_provider.v1",
+  "provider": {
+    "id": "local-sprite-pose-maker",
+    "display_name": "Local Sprite Pose Maker",
+    "version": "1.0.0",
+    "homepage": null
+  },
+  "outputs": [
+    "portable_archive",
+    "generated_candidate",
+    "manifest_patch",
+    "draft_pack_request"
+  ],
+  "renderer_targets": [
+    {
+      "renderer_type": "sprite_frames",
+      "manifest_versions": [1],
+      "requires_static_fallback": false
+    },
+    {
+      "renderer_type": "live2d",
+      "manifest_versions": [2],
+      "renderer_contract_versions": [1],
+      "requires_static_fallback": true,
+      "runtime_supported_by_provider": false
+    }
+  ],
+  "visual_states": [
+    "idle",
+    "listening",
+    "thinking",
+    "speaking",
+    "error"
+  ],
+  "limits": {
+    "max_archive_bytes": 52428800,
+    "max_asset_count": 128,
+    "max_texture_pixels": 16777216
+  },
+  "review_required": true,
+  "activation_allowed": false
+}
+```
+
+The provider capability is descriptive. tldw must still compare advertised
+renderer targets against its own renderer capability registry before preview,
+commit, or activation. A provider advertising `live2d` does not make Live2D
+supported on the target server.
+
+## Provider Result Envelope
+
+Provider results should use one common envelope so Persona Garden and future
+intake adapters can show consistent provenance and diagnostics.
+
+```json
+{
+  "contract_version": 1,
+  "result_type": "portable_archive",
+  "review_required": true,
+  "activation_allowed": false,
+  "import_preview_required": true,
+  "provider": {
+    "id": "local-sprite-pose-maker",
+    "display_name": "Local Sprite Pose Maker",
+    "version": "1.0.0"
+  },
+  "pack": {
+    "title": "Research Buddy Expressions",
+    "renderer_type": "sprite_frames",
+    "manifest_version": 1,
+    "renderer_contract_version": null,
+    "states_offered": ["idle", "thinking", "speaking", "error"],
+    "static_fallback_available": true,
+    "asset_count": 12,
+    "total_bytes": 1843200
+  },
+  "diagnostics": {
+    "status": "ready_for_import_preview",
+    "blockers": [],
+    "warnings": [
+      "listening falls back to idle"
+    ]
+  },
+  "provenance": {
+    "source": "mcp_provider",
+    "provider_pack_id": "expr-pack-2026-05-13",
+    "author": "local-user",
+    "license_label": "user-provided"
+  },
+  "payload": {
+    "archive": {
+      "mcp_resource_uri": "mcp://local-sprite-pose-maker/resources/expr-pack-2026-05-13.tldw-persona-vpack",
+      "sha256": "2f3a6c2c4b0b0c7f9f7ad3e2c0f9f95543e3013d6a45b69822ad0f01f54415be",
+      "media_type": "application/vnd.tldw.persona-visual-pack"
+    }
+  }
+}
+```
+
+Rules:
+
+1. `contract_version` is the tldw provider-contract version.
+2. `result_type` must be one of `portable_archive`, `generated_candidate`,
+   `manifest_patch`, or `draft_pack_request`.
+3. `review_required` must be true for every durable provider result.
+4. `activation_allowed` must be false. Activation is a tldw user action after
+   server validation.
+5. `import_preview_required` must be true for `portable_archive` results.
+6. `mcp_resource_uri` is a retrieval handle for the intake step. It must not be
+   copied into the Persona Visual manifest as a remote asset URL.
+7. `provenance` is advisory metadata. It must not override user ownership,
+   persona scope, validation results, or library source references.
+
+## Allowed Result Types
+
+### Portable Archive
+
+Use this when the provider can produce a `.tldw-persona-vpack` archive.
+
+Handoff:
+
+1. tldw retrieves the MCP resource through an authenticated MCP client path.
+2. tldw runs the existing archive import preview flow.
+3. Preview records warnings, blockers, conflicts, quota estimates, renderer
+   diagnostics, and proposed commit plan.
+4. Commit creates or replaces a reviewed draft only when the preview is
+   eligible and required choices are supplied.
+5. Activation remains separate.
+
+### Generated Candidate
+
+Use this when the provider proposes new assets or manifest patches for an
+existing draft pack.
+
+Minimum shape:
+
+```json
+{
+  "contract_version": 1,
+  "result_type": "generated_candidate",
+  "review_required": true,
+  "activation_allowed": false,
+  "pack": {
+    "target_pack_id": "pack-draft-123",
+    "target_state": "speaking",
+    "renderer_type": "sprite_frames",
+    "manifest_version": 1
+  },
+  "payload": {
+    "assets": [
+      {
+        "provider_asset_id": "speaking-frame-1",
+        "media_type": "image/png",
+        "sha256": "6cc8f5c53f086c0cde01f76cf1efcc5d01f05c6b49d11a62c0dbff4d61d80b70",
+        "byte_size": 204800,
+        "mcp_resource_uri": "mcp://local-sprite-pose-maker/resources/speaking-frame-1.png"
+      }
+    ],
+    "manifest_patch": {
+      "animations": {
+        "speaking_provider_candidate": {
+          "frame_rate": 8,
+          "frames": [
+            {
+              "asset_id": "provider_asset:speaking-frame-1",
+              "duration_ms": 120
+            }
+          ]
+        }
+      },
+      "states": {
+        "speaking": {
+          "animation_id": "speaking_provider_candidate"
+        }
+      }
+    }
+  }
+}
+```
+
+The `provider_asset:` identifier is only an intake placeholder. The server must
+replace it with real asset ids after validation and storage. Providers cannot
+choose final database asset ids.
+
+### Manifest Patch
+
+Use this when the provider proposes JSON changes for an existing draft pack
+without supplying new assets.
+
+Rules:
+
+1. The target pack must already be a draft owned by the current user.
+2. The patch cannot target an active pack.
+3. The patch must be reviewed through Persona Garden or an equivalent reviewed
+   candidate flow.
+4. Renderer-specific payloads must remain bounded JSON objects and must be
+   validated before candidate acceptance or activation.
+
+### Draft Pack Request
+
+Use this when the provider can describe a pack but still needs the user to
+review or fill missing pieces.
+
+Rules:
+
+1. The request can create an inactive draft only.
+2. Missing assets, missing fallback, unsupported renderer, or licensing
+   blockers must remain visible diagnostics.
+3. Draft creation must not imply import-preview success or activation
+   eligibility.
+
+## Blocked Diagnostics Example
+
+Providers should return explicit diagnostics when they already know a result is
+not ready for import or review.
+
+```json
+{
+  "contract_version": 1,
+  "result_type": "portable_archive",
+  "review_required": true,
+  "activation_allowed": false,
+  "import_preview_required": true,
+  "pack": {
+    "title": "Expressive Live2D Buddy",
+    "renderer_type": "live2d",
+    "manifest_version": 2,
+    "renderer_contract_version": 1,
+    "static_fallback_available": false
+  },
+  "diagnostics": {
+    "status": "blocked_before_import_preview",
+    "blockers": [
+      {
+        "code": "fallback_missing",
+        "message": "Manifest V2 provider results require a bounded raster static fallback."
+      }
+    ],
+    "warnings": [
+      {
+        "code": "runtime_not_claimed",
+        "message": "The provider can produce a Live2D archive but does not provide runtime support."
+      }
+    ]
+  },
+  "payload": null
+}
+```
+
+tldw may display this result for review, but it must not commit it until a
+future intake step has valid payload data and the server-side import preview
+passes.
+
+## Safety Rules
+
+Provider intake must reject or block:
+
+1. runtime JavaScript, HTML, arbitrary web components, executable scripts, or
+   dynamic renderer code.
+2. remote URLs inside manifests or renderer source files.
+3. base64/Data URI embedded binary payloads in manifests.
+4. absolute paths, path traversal, duplicate archive members, symlinks,
+   hardlinks, or ambiguous case-colliding archive paths.
+5. asset writes outside the existing Persona Visual upload/import/generation
+   storage paths.
+6. provider-selected database ids for assets, packs, personas, users, jobs, or
+   library items.
+7. cross-user or cross-persona reuse without the existing reviewed duplicate,
+   import, or library semantics.
+8. source display snapshots in personal-library entries.
+9. license or author metadata that attempts to grant support status, activation
+   status, or ownership by assertion.
+10. unsupported renderer claims that contradict the server renderer capability
+    registry.
+
+Provider intake should require:
+
+1. declared media type, byte size, checksum, and source handle for every
+   provider-supplied asset.
+2. renderer capability resolution before import preview or candidate review.
+3. static fallback for non-sprite renderer proposals.
+4. stable diagnostics with machine-readable blocker and warning codes.
+5. provenance that is stored as pack/asset metadata only after server review.
+
+## Relationship To Existing MCP Tools
+
+The internal `persona_visuals` module remains the tldw-owned Persona Visual MCP
+surface. It exposes current user/persona-scoped actions such as capabilities,
+library item listing, transient state triggers, draft creation, manifest update,
+library reuse, and generation enqueue.
+
+External pack providers are different:
+
+1. They describe or supply candidate content.
+2. They do not own Persona Visual storage.
+3. They do not trigger runtime state.
+4. They do not activate packs.
+5. They do not replace `persona_visuals` authorization checks.
+
+Future tldw intake tools can consume provider envelopes, but they should route
+durable work through the existing import preview, generated candidate, or draft
+review paths rather than trusting provider output directly.
+
+## Implementation Slices
+
+Recommended sequence:
+
+1. Contract docs and examples: this slice.
+2. Provider discovery/intake adapter: list provider offers and normalize result
+   envelopes without persisting assets.
+3. Portable archive intake: retrieve a provider archive resource and enqueue the
+   existing import-preview job.
+4. Generated-candidate intake: retrieve provider assets, validate metadata, and
+   create a reviewed candidate for an existing draft.
+5. Persona Garden provider review UI: show provider offers, diagnostics,
+   provenance, and handoff actions.
+6. Optional Live2D provider fixture only after the Live2D runtime spike has its
+   own feature gate and fallback rules.
+
+## Non-Goals
+
+This contract does not add:
+
+1. a new MCP server implementation,
+2. provider execution inside tldw,
+3. Live2D, Rive, Lottie, Spine, or other renderer runtime support,
+4. automatic activation,
+5. active-pack mutation,
+6. direct asset writes,
+7. shared marketplace behavior,
+8. cross-user sharing,
+9. VN/CYOA behavior,
+10. live chat response mutation.

--- a/Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md
+++ b/Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md
@@ -6,7 +6,7 @@ Feature: User-owned animated 2D visual packs for Persona Buddy and Persona Live
 Location: WebUI Persona Garden and shared Persona Buddy shell
 Status: Draft product record
 Owner: Product / WebUI / Persona
-Last Updated: 2026-05-12
+Last Updated: 2026-05-13
 
 ---
 
@@ -41,13 +41,14 @@ leaving the Persona workflow.
 
 The implementation now covers the core data model, renderer, API, editor, Jobs
 flow, MCP module, E2E runtime behavior, Buddy entry point, diagnostics, setup
-states, ownership/help copy, duplicate-to-persona drafts, and a reference-backed
+states, ownership/help copy, duplicate-to-persona drafts, a reference-backed
 personal pack library, import conflict choices, and reusable Persona Garden
 affordances. PR #1608 also added the renderer capability contract and Buddy
 renderer registry while keeping `sprite_frames` as the only enabled V1 runtime
-renderer. The remaining product gap is optional Phase 3 externalization:
-external visual providers, shared/cross-device libraries, non-sprite manifest
-design, and future renderer adapters.
+renderer. The optional Phase 3 externalization track now has contracts for
+non-sprite Manifest V2 and external MCP-compatible pack providers; remaining
+work is implementation of those contracts, shared/cross-device libraries, and
+future renderer adapters.
 
 ---
 
@@ -68,6 +69,9 @@ design, and future renderer adapters.
 7. Allow MCP to control transient runtime states and create draft/review changes
    without silently replacing the active pack.
 8. Ensure broken or missing visual assets never block Persona Live controls.
+9. Let external MCP-compatible providers propose visual-pack content through a
+   review-first handoff that reuses import preview, generated-candidate review,
+   or inactive draft creation.
 
 ---
 
@@ -82,12 +86,14 @@ design, and future renderer adapters.
 6. Do not let MCP tools silently activate generated or imported packs.
 7. Do not require microphone, TTS provider, or external image generation
    availability for baseline runtime tests.
+8. Do not treat external MCP pack providers as runtime renderer plugins,
+   trusted asset stores, marketplaces, or shared-library publishers.
 
 ---
 
 ## 5. Current Implementation Snapshot
 
-As of 2026-05-12:
+As of 2026-05-13:
 
 1. The durable implementation from PR #1393 is merged into `dev`.
 2. The closeout documentation and E2E verification from PR #1400 is merged into
@@ -100,7 +106,7 @@ As of 2026-05-12:
 5. PR #1608 is merged and adds the Persona visual renderer capability registry,
    authenticated renderer capability API, and local Buddy renderer registry.
 
-Implemented foundations include:
+Implemented and documented foundations include:
 
 1. Backend visual-pack persistence in the persona/ChaChaNotes data layer.
 2. `PersonaVisualService` for upload validation, asset storage, activation, and
@@ -150,6 +156,11 @@ Implemented foundations include:
     for V1 validation, activation, import/export, and Buddy runtime rendering.
 20. Buddy rendering and diagnostics route through the local renderer registry
     instead of separate hardcoded renderer checks.
+21. External MCP-compatible pack-provider contract documentation defines
+    provider discovery, result envelopes, diagnostics, provenance, safety rules,
+    and review-first handoff through existing Persona Visual flows. No external
+    provider execution, runtime renderer activation, or marketplace behavior is
+    implemented by that contract.
 
 ---
 
@@ -344,6 +355,17 @@ duration-limited, and auditable.
 MCP durable actions MUST create drafts, manifest updates, generation jobs, or
 review items. They MUST NOT silently activate packs.
 
+### FR-14: External MCP Pack Provider Contract
+
+External MCP-compatible visual providers MAY propose portable archives,
+generated candidates, manifest patches, or inactive draft-pack requests. tldw
+MUST treat provider output as untrusted review input, resolve renderer support
+through the server capability registry, and route durable results through
+import preview, generated-candidate review, or inactive draft creation. Provider
+output MUST NOT activate packs, mutate active packs, write assets directly,
+submit runtime code, bypass Persona Garden review, or introduce personal-library
+display snapshots.
+
 ---
 
 ## 10. Non-Functional Requirements
@@ -472,6 +494,12 @@ Rules:
    derives source display names from live rows, and using a library item creates
    an inactive target-persona draft through duplicate semantics.
 
+External MCP-compatible pack providers are separate from the internal
+`persona_visuals` module. The provider contract is documented in
+`Docs/Design/2026-05-13-persona-visual-external-mcp-provider-contract.md`.
+Providers advertise candidate content and diagnostics; tldw owns validation,
+storage, review, commit, and activation decisions.
+
 ---
 
 ## 13. Pack Portability
@@ -506,8 +534,12 @@ Current and future portability/library work:
    (#1496).
 6. Future shared user libraries should be layered on top of the manifest-backed
    pack format rather than replacing it.
-7. Future cross-device sync, signed community packs, and external
-   MCP-compatible pack providers remain out of scope for V1.
+7. Future cross-device sync and signed community packs remain out of scope for
+   V1.
+8. External MCP-compatible pack providers have a contract-level design in
+   `Docs/Design/2026-05-13-persona-visual-external-mcp-provider-contract.md`.
+   Future implementation must route provider output through import preview,
+   generated-candidate review, or inactive draft creation.
 
 ---
 
@@ -579,7 +611,11 @@ baseline. The first reference-backed V1 slices are now covered:
 5. MCP reusable-pack semantics: complete for listing reference-backed personal
    library entries and creating inactive target-persona drafts (#1496).
 6. Shared/cross-device libraries remain future work.
-7. External MCP-compatible visual providers remain future work.
+7. External MCP-compatible visual provider implementation remains future work.
+   The contract is defined by #1682 and
+   `Docs/Design/2026-05-13-persona-visual-external-mcp-provider-contract.md`;
+   providers are review-input sources, not runtime plugins or trusted asset
+   stores.
 8. Renderer/provider adapter evaluation for Live2D and other future paths is
    tracked by #1497 and the 2026-05-10 design evaluation.
 9. Renderer capability registry/API and Buddy renderer registry are complete in
@@ -626,6 +662,12 @@ baseline. The first reference-backed V1 slices are now covered:
 6. Risk: The editor becomes a full image editor.
    - Mitigation: Keep V1 focused on upload, preview, state mapping, timing,
      review, activation, and portability.
+
+7. Risk: External MCP providers are treated as trusted asset stores or runtime
+   plugins.
+   - Mitigation: Keep providers as review-input sources. Route provider output
+     through import preview, generated-candidate review, or inactive draft
+     creation, and keep activation as a separate user action.
 
 ---
 
@@ -675,8 +717,8 @@ E2E:
 5. Should users be able to mark packs as reusable templates before shared
    libraries exist, or does the personal reference-backed library cover that
    near-term need?
-6. Which visual state names should become externally documented for future MCP
-   providers?
+6. Which provider intake surface should ship first: portable archive import,
+   generated-candidate intake, or read-only provider offer listing?
 
 ---
 
@@ -705,3 +747,6 @@ E2E:
     `Docs/Design/2026-05-10-persona-visual-renderer-provider-adapter-evaluation.md`
 17. PR #1608: Persona Buddy renderer capability registry.
 18. Issue #1609: Renderer capability docs and tracker refresh after PR #1608.
+19. Issue #1682: Persona Visual external MCP pack-provider contract.
+20. External MCP provider contract:
+    `Docs/Design/2026-05-13-persona-visual-external-mcp-provider-contract.md`

--- a/Docs/superpowers/plans/2026-05-13-persona-visual-external-mcp-provider-contract.md
+++ b/Docs/superpowers/plans/2026-05-13-persona-visual-external-mcp-provider-contract.md
@@ -1,0 +1,56 @@
+# Persona Visual External MCP Provider Contract Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Define the external MCP-compatible Persona Visual pack-provider contract without adding runtime renderer activation, provider execution, or shared-library behavior.
+
+**Architecture:** Keep the current server as the trust boundary. External providers may describe proposed packs, generated candidates, manifest patches, or portable archives, but every durable result must enter the existing Persona Visual review flow before commit and must remain inactive until explicit user activation.
+
+**Tech Stack:** Markdown product/design documentation, existing Persona Visual import-preview and renderer capability vocabulary, Backlog task tracking, docs-only verification.
+
+---
+
+## Stage 1: Contract Design Document
+**Goal**: Add a durable design document for external MCP-compatible Persona Visual pack providers.
+**Success Criteria**: The document defines provider discovery, provider result envelopes, allowed outputs, blocked diagnostics, safety rules, and the import-preview/review handoff.
+**Tests**: `git diff --check` and targeted text scans for forbidden runtime/activation claims.
+**Status**: Complete
+
+### Task 1: Write the Provider Contract
+**Files:**
+- Create: `Docs/Design/2026-05-13-persona-visual-external-mcp-provider-contract.md`
+
+- [x] Define provider-facing goals and non-goals.
+- [x] Define provider discovery and pack-offer response shapes.
+- [x] Add valid, blocked, and review-handoff examples.
+- [x] State that providers cannot activate packs, submit runtime code, write assets directly, or bypass import preview.
+
+## Stage 2: Product And Code Documentation Alignment
+**Goal**: Update existing Persona Visual documentation so external MCP providers are no longer only an undefined future item.
+**Success Criteria**: PRD and code docs point to the new contract and preserve the reference-backed, user-owned, review-first model.
+**Tests**: Targeted `rg` checks for reference-backed/no-snapshot language and provider boundaries.
+**Status**: Complete
+
+### Task 2: Update Existing Docs
+**Files:**
+- Modify: `Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md`
+- Modify: `Docs/Code_Documentation/Persona_Visual_Packs.md`
+
+- [x] Add the external provider contract to the Phase 3 implementation snapshot and follow-up list.
+- [x] Add provider-specific product requirements and MCP boundary notes.
+- [x] Add code documentation for provider outputs and review-first import-preview handoff.
+- [x] Ensure docs do not imply Live2D, runtime adapter, marketplace, or silent activation support.
+
+## Stage 3: Tracking And Verification
+**Goal**: Close the docs-only slice cleanly with task notes and deterministic verification.
+**Success Criteria**: Backlog task records verification and acceptance criteria; docs-only skip decisions are explicit.
+**Tests**: `git diff --check`, targeted `rg` scans, and no Bandit run because no Python code is touched.
+**Status**: Complete
+
+### Task 3: Verify And Record Results
+**Files:**
+- Modify: `backlog/tasks/task-335 - Define-external-MCP-Persona-Visual-pack-provider-contract.md`
+
+- [x] Run `git diff --check`.
+- [x] Run targeted `rg` checks for provider boundaries, no automatic activation, no runtime plugin behavior, and no snapshot reintroduction.
+- [x] Update TASK-335 acceptance criteria and final summary.

--- a/backlog/tasks/task-335 - Define-external-MCP-Persona-Visual-pack-provider-contract.md
+++ b/backlog/tasks/task-335 - Define-external-MCP-Persona-Visual-pack-provider-contract.md
@@ -1,0 +1,70 @@
+---
+id: TASK-335
+title: Define external MCP Persona Visual pack-provider contract
+status: Done
+assignee:
+  - codex
+created_date: '2026-05-14 04:37'
+updated_date: '2026-05-13 21:58'
+labels:
+  - persona
+  - buddy
+  - mcp
+  - visual-packs
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1682'
+  - 'https://github.com/rmusser01/tldw_server/issues/1510'
+documentation:
+  - Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md
+  - Docs/Code_Documentation/Persona_Visual_Packs.md
+  - >-
+    tldw_Server_API/app/core/MCP_unified/modules/implementations/persona_visuals_module.py
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create the contract/design slice for external MCP-compatible Persona Visual pack providers. The goal is to let local or third-party tools propose Persona/Buddy visual packs with poses, animations, renderer metadata, diagnostics, and provenance into the existing review-first Persona Visual import flow. This task is contract-first: provider discovery and handoff must be specified without adding runtime renderer activation, Live2D support, VN/CYOA behavior, or silent MCP activation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 PRD/design documentation explains the external MCP pack-provider flow and how it connects to existing Persona Visual import preview and reviewed draft commit behavior.
+- [x] #2 Contract separates provider discovery/listing from import-preview and commit; provider output cannot auto-activate a pack.
+- [x] #3 Provider examples cover a valid pack, blocked diagnostics, renderer capability metadata, provenance, and review handoff fields.
+- [x] #4 Safety rules document no executable scripts, bounded asset metadata, MIME and size constraints, sanitized provenance, no secrets, no cross-user access, and no auto-trust.
+- [x] #5 Documentation preserves the reference-backed user-owned personal library model with no snapshot reintroduction.
+- [x] #6 Verification records that this slice is contract-only and introduces no runtime renderer or activation behavior.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implementation plan created: Docs/superpowers/plans/2026-05-13-persona-visual-external-mcp-provider-contract.md.
+
+Added a design-only external MCP provider contract. The contract keeps providers as review-input sources and defines discovery metadata, result envelopes, portable archive handoff, generated-candidate handoff, manifest patch handoff, draft-pack requests, blocked diagnostics, safety rules, and the relationship to the internal persona_visuals MCP module.
+
+Updated the Persona Live Visual Packs PRD and Persona Visual Packs code documentation to point at the provider contract, preserve reference-backed personal-library semantics, and keep the slice out of runtime renderer activation, provider execution, Live2D support, marketplace behavior, VN/CYOA behavior, and silent activation.
+
+Verification: git diff --check passed. Targeted scans found no activation_allowed=true, runtime_supported_by_provider=true, snapshot-field reintroduction, or provider-output activation claims. Positive scans confirmed review-required, activation_allowed=false, import-preview-required, review-input, reference-backed, and no-snapshot boundary language.
+
+Bandit was not run because this slice touched only Markdown documentation and Backlog task text.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Defined the external MCP-compatible Persona Visual pack-provider contract for review-first provider output. The docs now describe provider discovery, result envelopes, examples for archive/candidate/patch/draft request flows, blocked diagnostics, safety rules, and PRD/code-doc alignment while preserving user-owned reference-backed packs and explicit activation.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-335 - Define-external-MCP-Persona-Visual-pack-provider-contract.md
+++ b/backlog/tasks/task-335 - Define-external-MCP-Persona-Visual-pack-provider-contract.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - codex
 created_date: '2026-05-14 04:37'
-updated_date: '2026-05-13 21:58'
+updated_date: '2026-05-14 05:46'
 labels:
   - persona
   - buddy
@@ -51,12 +51,14 @@ Updated the Persona Live Visual Packs PRD and Persona Visual Packs code document
 Verification: git diff --check passed. Targeted scans found no activation_allowed=true, runtime_supported_by_provider=true, snapshot-field reintroduction, or provider-output activation claims. Positive scans confirmed review-required, activation_allowed=false, import-preview-required, review-input, reference-backed, and no-snapshot boundary language.
 
 Bandit was not run because this slice touched only Markdown documentation and Backlog task text.
+
+PR #1685 review sweep addressed still-valid Qodo, Gemini, and CodeRabbit findings: provider diagnostics examples now use machine-readable warning objects, portable archive examples use the existing Persona Visual vendor zip media type while documenting `application/zip` compatibility, safety rules explicitly reject secrets and require sanitized provenance, and TASK-335 timestamp metadata now satisfies updated_date >= created_date.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Defined the external MCP-compatible Persona Visual pack-provider contract for review-first provider output. The docs now describe provider discovery, result envelopes, examples for archive/candidate/patch/draft request flows, blocked diagnostics, safety rules, and PRD/code-doc alignment while preserving user-owned reference-backed packs and explicit activation.
+Defined the external MCP-compatible Persona Visual pack-provider contract for review-first provider output. The docs now describe provider discovery, result envelopes, examples for archive/candidate/patch/draft request flows, blocked diagnostics, safety rules, sanitized provenance/no-secret requirements, canonical archive media-type guidance, and PRD/code-doc alignment while preserving user-owned reference-backed packs and explicit activation.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary

- Adds a design contract for external MCP-compatible Persona Visual pack providers.
- Documents provider discovery, result envelopes, review handoff, blocked diagnostics, provenance, and safety rules.
- Updates the Persona Visual PRD and code docs so provider output stays review-first, reference-backed, and separate from runtime renderer activation.
- Records TASK-335 with verification and docs-only Bandit skip rationale.

## Review Boundaries

- Contract/docs only.
- No provider execution.
- No runtime renderer or Live2D adapter.
- No automatic activation.
- No marketplace/shared-library behavior.
- No VN/CYOA behavior.

## Validation

- [x] `git diff --check`
- [x] Negative boundary scan for `activation_allowed": true`, `runtime_supported_by_provider": true`, snapshot field reintroduction, and provider-output activation claims.
- [x] Positive boundary scan for vendor `+zip`, `application/zip`, sanitized provenance, no-secrets language, structured warning code, review-input, `activation_allowed=false`, import-preview-required, reference-backed, and no-snapshot language.
- [x] Bandit skipped because this slice only changes Markdown documentation and Backlog task text.

## UX Audit

- [x] Not applicable: this is a documentation/contract-only PR and does not change WebUI behavior.

## Watchlists Accessibility/Scale

- [x] Not applicable: this PR does not touch Watchlists, UI rendering, data tables, pagination, or runtime queries.

## Risk

- Risk level: Low.
- Primary risk is future implementers misreading provider output as trusted runtime input; the contract now repeatedly states providers are untrusted review-input sources and cannot activate packs, write assets, or bypass import preview.
- Security-sensitive contract language explicitly rejects secrets, API keys, tokens, host-local identifiers, unsanitized provenance, executable code, remote URLs, and cross-user access.

## Rollback Plan

- Revert this docs-only PR if the provider contract direction changes.
- No database migration, runtime behavior, API execution path, or persisted user data is changed by this PR.

## Change Summary

Pending human-authored change summary before merge, per the project AI-generated PR policy.

Closes #1682
