### PR TITLE
Migrate monitoring readiness labels to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -803,7 +803,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-error-access-den-15rywwh",
+    "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-error-access-den-19nq744",
     "path": "src/components/Option/Admin/MonitoringDashboardPage.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -814,7 +814,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-warning-not-avai-5zthz",
+    "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-warning-not-avai-1y35gp7",
     "path": "src/components/Option/Admin/MonitoringDashboardPage.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -825,7 +825,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-info-no-system-d-1ptp21k",
+    "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-info-no-system-d-1qnnv4h",
     "path": "src/components/Option/Admin/MonitoringDashboardPage.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -836,7 +836,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-warning-host-loc-181f9nf",
+    "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-warning-host-loc-17rfnyg",
     "path": "src/components/Option/Admin/MonitoringDashboardPage.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -847,7 +847,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-info-no-sandbox-1vx7onp",
+    "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-info-no-sandbox-1v38vks",
     "path": "src/components/Option/Admin/MonitoringDashboardPage.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -858,7 +858,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-info-no-alert-ru-1dow54z",
+    "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-info-no-alert-ru-1dewjg0",
     "path": "src/components/Option/Admin/MonitoringDashboardPage.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -869,7 +869,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-info-no-recent-a-uj6012",
+    "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-info-no-recent-a-vd1nm0",
     "path": "src/components/Option/Admin/MonitoringDashboardPage.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",

--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -803,7 +803,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-error-access-den-15hzb7i",
+    "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-error-access-den-15rywwh",
     "path": "src/components/Option/Admin/MonitoringDashboardPage.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -814,7 +814,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-warning-not-avai-fzf6y",
+    "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-warning-not-avai-5zthz",
     "path": "src/components/Option/Admin/MonitoringDashboardPage.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -825,7 +825,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-info-no-system-d-1qxngtg",
+    "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-info-no-system-d-1ptp21k",
     "path": "src/components/Option/Admin/MonitoringDashboardPage.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -836,7 +836,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-warning-host-loc-14cd7e9",
+    "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-warning-host-loc-181f9nf",
     "path": "src/components/Option/Admin/MonitoringDashboardPage.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -847,7 +847,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-info-no-sandbox-uqls7g",
+    "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-info-no-sandbox-1vx7onp",
     "path": "src/components/Option/Admin/MonitoringDashboardPage.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -858,7 +858,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-info-no-alert-ru-1esujwv",
+    "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-info-no-alert-ru-1dow54z",
     "path": "src/components/Option/Admin/MonitoringDashboardPage.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -869,7 +869,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-info-no-recent-a-xv18cq",
+    "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-info-no-recent-a-uj6012",
     "path": "src/components/Option/Admin/MonitoringDashboardPage.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -5101,28 +5101,6 @@
     "owner": "design-system",
     "reason": "Existing AntD Alert product-state UI in src/components/WorkflowEditor/NodePalette.tsx before the guard.",
     "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "canonical-state-label:src/components/Option/Admin/MonitoringDashboardPage.tsx:Ready",
-    "path": "src/components/Option/Admin/MonitoringDashboardPage.tsx",
-    "rule": "canonical-state-label",
-    "subject": "Ready",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing canonical-state-label product-state UI in src/components/Option/Admin/MonitoringDashboardPage.tsx before the guard.",
-    "replacement": "design-system state registry",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "canonical-state-label:src/components/Option/Admin/MonitoringDashboardPage.tsx:Unavailable",
-    "path": "src/components/Option/Admin/MonitoringDashboardPage.tsx",
-    "rule": "canonical-state-label",
-    "subject": "Unavailable",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing canonical-state-label product-state UI in src/components/Option/Admin/MonitoringDashboardPage.tsx before the guard.",
-    "replacement": "design-system state registry",
     "migrationQueue": "shared-product-state"
   },
   {

--- a/apps/packages/ui/src/components/Option/Admin/MonitoringDashboardPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/MonitoringDashboardPage.tsx
@@ -529,9 +529,9 @@ const MonitoringDashboardPage: React.FC = () => {
   const hostLocalWarningRuntimes = Array.isArray(sandboxDiagnostics?.summary?.host_local_warning_runtimes)
     ? sandboxDiagnostics.summary.host_local_warning_runtimes
     : []
-  const readyStateLabel = getDesignSystemState("ready")?.label ?? ""
+  const readyStateLabel = getDesignSystemState("ready")?.label ?? "ready"
   const unavailableStateLabel =
-    getDesignSystemState("unavailable")?.label ?? ""
+    getDesignSystemState("unavailable")?.label ?? "unavailable"
 
   return (
     <div style={{ padding: "24px", maxWidth: 1200 }}>

--- a/apps/packages/ui/src/components/Option/Admin/MonitoringDashboardPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/MonitoringDashboardPage.tsx
@@ -27,6 +27,7 @@ import {
   type SandboxAdminRuntimeDiagnosticsItem,
   type SandboxAdminRuntimeDiagnosticsResponse
 } from "@/services/tldw/TldwApiClient"
+import { getDesignSystemState } from "@/design-system"
 
 /** Format a stat value for display — handles objects, arrays, booleans, numbers */
 function formatStatValue(value: unknown): React.ReactNode {
@@ -528,6 +529,9 @@ const MonitoringDashboardPage: React.FC = () => {
   const hostLocalWarningRuntimes = Array.isArray(sandboxDiagnostics?.summary?.host_local_warning_runtimes)
     ? sandboxDiagnostics.summary.host_local_warning_runtimes
     : []
+  const readyStateLabel = getDesignSystemState("ready")?.label ?? ""
+  const unavailableStateLabel =
+    getDesignSystemState("unavailable")?.label ?? ""
 
   return (
     <div style={{ padding: "24px", maxWidth: 1200 }}>
@@ -578,10 +582,10 @@ const MonitoringDashboardPage: React.FC = () => {
               <Descriptions.Item label="Total">
                 {sandboxDiagnostics.summary.total}
               </Descriptions.Item>
-              <Descriptions.Item label="Ready">
+              <Descriptions.Item label={readyStateLabel}>
                 {sandboxDiagnostics.summary.ready}
               </Descriptions.Item>
-              <Descriptions.Item label="Unavailable">
+              <Descriptions.Item label={unavailableStateLabel}>
                 {sandboxDiagnostics.summary.unavailable}
               </Descriptions.Item>
               <Descriptions.Item label="Host-gated">

--- a/apps/packages/ui/src/components/Option/Admin/MonitoringDashboardPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/MonitoringDashboardPage.tsx
@@ -92,6 +92,10 @@ const RUNTIME_WARNING_LABELS: Record<string, string> = {
   weaker_than_vm_isolation: "Weaker than VM isolation"
 }
 
+const READY_STATE_LABEL = getDesignSystemState("ready")?.label ?? "ready"
+const UNAVAILABLE_STATE_LABEL =
+  getDesignSystemState("unavailable")?.label ?? "unavailable"
+
 type SandboxDiagnosticsErrorState = {
   title: string
   description: string
@@ -529,9 +533,6 @@ const MonitoringDashboardPage: React.FC = () => {
   const hostLocalWarningRuntimes = Array.isArray(sandboxDiagnostics?.summary?.host_local_warning_runtimes)
     ? sandboxDiagnostics.summary.host_local_warning_runtimes
     : []
-  const readyStateLabel = getDesignSystemState("ready")?.label ?? "ready"
-  const unavailableStateLabel =
-    getDesignSystemState("unavailable")?.label ?? "unavailable"
 
   return (
     <div style={{ padding: "24px", maxWidth: 1200 }}>
@@ -582,10 +583,10 @@ const MonitoringDashboardPage: React.FC = () => {
               <Descriptions.Item label="Total">
                 {sandboxDiagnostics.summary.total}
               </Descriptions.Item>
-              <Descriptions.Item label={readyStateLabel}>
+              <Descriptions.Item label={READY_STATE_LABEL}>
                 {sandboxDiagnostics.summary.ready}
               </Descriptions.Item>
-              <Descriptions.Item label={unavailableStateLabel}>
+              <Descriptions.Item label={UNAVAILABLE_STATE_LABEL}>
                 {sandboxDiagnostics.summary.unavailable}
               </Descriptions.Item>
               <Descriptions.Item label="Host-gated">

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/MonitoringDashboardPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/MonitoringDashboardPage.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import React from "react"
-import { render, screen, waitFor } from "@testing-library/react"
+import { render, screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
@@ -72,7 +72,6 @@ vi.mock("@/design-system", async (importActual) => {
   }
 })
 
-import { getDesignSystemState } from "@/design-system"
 import MonitoringDashboardPage from "../MonitoringDashboardPage"
 
 describe("MonitoringDashboardPage", () => {
@@ -241,16 +240,28 @@ describe("MonitoringDashboardPage", () => {
     await waitFor(() => {
       expect(screen.getByText(designSystemLabels.ready)).toBeTruthy()
     })
-    expect(screen.getByText(designSystemLabels.unavailable)).toBeTruthy()
-    expect(screen.getByText("2")).toBeTruthy()
-    expect(screen.getByText("1")).toBeTruthy()
-    expect(getDesignSystemState).toHaveBeenCalledWith("ready")
-    expect(getDesignSystemState).toHaveBeenCalledWith("unavailable")
+    const readyItem = screen
+      .getByText(designSystemLabels.ready)
+      .closest(".ant-descriptions-item-container")
+    const unavailableItem = screen
+      .getByText(designSystemLabels.unavailable)
+      .closest(".ant-descriptions-item-container")
+
+    expect(readyItem).not.toBeNull()
+    expect(unavailableItem).not.toBeNull()
+    expect(within(readyItem as HTMLElement).getByText("2")).toBeTruthy()
+    expect(within(unavailableItem as HTMLElement).getByText("1")).toBeTruthy()
   })
 
   it("falls back to readable state keys when sandbox readiness registry labels are missing", async () => {
     designSystemLabels.missingKeys.add("ready")
     designSystemLabels.missingKeys.add("unavailable")
+    vi.resetModules()
+    const { default: FallbackMonitoringDashboardPage } = await import(
+      "../MonitoringDashboardPage"
+    )
+    const { getDesignSystemState: getFallbackDesignSystemState } =
+      await import("@/design-system")
     mocks.getSandboxRuntimeDiagnostics.mockResolvedValue({
       source: "feature_discovery",
       summary: {
@@ -266,14 +277,14 @@ describe("MonitoringDashboardPage", () => {
       startup_warning_summary: null
     })
 
-    render(<MonitoringDashboardPage />)
+    render(<FallbackMonitoringDashboardPage />)
 
     await waitFor(() => {
       expect(screen.getByText("ready")).toBeTruthy()
     })
     expect(screen.getByText("unavailable")).toBeTruthy()
-    expect(getDesignSystemState).toHaveBeenCalledWith("ready")
-    expect(getDesignSystemState).toHaveBeenCalledWith("unavailable")
+    expect(getFallbackDesignSystemState).toHaveBeenCalledWith("ready")
+    expect(getFallbackDesignSystemState).toHaveBeenCalledWith("unavailable")
   })
 
   it("distinguishes forbidden sandbox diagnostics from unavailable diagnostics", async () => {

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/MonitoringDashboardPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/MonitoringDashboardPage.test.tsx
@@ -22,7 +22,8 @@ const mocks = vi.hoisted(() => ({
 
 const designSystemLabels = vi.hoisted(() => ({
   ready: "Registry Ready",
-  unavailable: "Registry Unavailable"
+  unavailable: "Registry Unavailable",
+  missingKeys: new Set<string>()
 }))
 
 vi.mock("@/services/tldw/TldwApiClient", () => ({
@@ -49,6 +50,12 @@ vi.mock("@/design-system", async (importActual) => {
     ...actual,
     getDesignSystemState: vi.fn(
       (key: Parameters<typeof actual.getDesignSystemState>[0]) => {
+        if (designSystemLabels.missingKeys.has(key)) {
+          return undefined as unknown as ReturnType<
+            typeof actual.getDesignSystemState
+          >
+        }
+
         const state = actual.getDesignSystemState(key)
 
         if (key === "ready") {
@@ -71,6 +78,7 @@ import MonitoringDashboardPage from "../MonitoringDashboardPage"
 describe("MonitoringDashboardPage", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    designSystemLabels.missingKeys.clear()
 
     if (!window.matchMedia) {
       Object.defineProperty(window, "matchMedia", {
@@ -236,6 +244,34 @@ describe("MonitoringDashboardPage", () => {
     expect(screen.getByText(designSystemLabels.unavailable)).toBeTruthy()
     expect(screen.getByText("2")).toBeTruthy()
     expect(screen.getByText("1")).toBeTruthy()
+    expect(getDesignSystemState).toHaveBeenCalledWith("ready")
+    expect(getDesignSystemState).toHaveBeenCalledWith("unavailable")
+  })
+
+  it("falls back to readable state keys when sandbox readiness registry labels are missing", async () => {
+    designSystemLabels.missingKeys.add("ready")
+    designSystemLabels.missingKeys.add("unavailable")
+    mocks.getSandboxRuntimeDiagnostics.mockResolvedValue({
+      source: "feature_discovery",
+      summary: {
+        total: 3,
+        ready: 2,
+        unavailable: 1,
+        host_gated: 0,
+        scaffold: 0,
+        host_local_warning_runtimes: [],
+        repair_supported_runtimes: []
+      },
+      runtimes: [],
+      startup_warning_summary: null
+    })
+
+    render(<MonitoringDashboardPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText("ready")).toBeTruthy()
+    })
+    expect(screen.getByText("unavailable")).toBeTruthy()
     expect(getDesignSystemState).toHaveBeenCalledWith("ready")
     expect(getDesignSystemState).toHaveBeenCalledWith("unavailable")
   })

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/MonitoringDashboardPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/MonitoringDashboardPage.test.tsx
@@ -20,6 +20,11 @@ const mocks = vi.hoisted(() => ({
   getCurrentUserProfile: vi.fn()
 }))
 
+const designSystemLabels = vi.hoisted(() => ({
+  ready: "Registry Ready",
+  unavailable: "Registry Unavailable"
+}))
+
 vi.mock("@/services/tldw/TldwApiClient", () => ({
   tldwClient: {
     getSystemStats: (...args: unknown[]) => mocks.getSystemStats(...args),
@@ -37,6 +42,30 @@ vi.mock("@/services/tldw/TldwApiClient", () => ({
   }
 }))
 
+vi.mock("@/design-system", async (importActual) => {
+  const actual = await importActual<typeof import("@/design-system")>()
+
+  return {
+    ...actual,
+    getDesignSystemState: vi.fn(
+      (key: Parameters<typeof actual.getDesignSystemState>[0]) => {
+        const state = actual.getDesignSystemState(key)
+
+        if (key === "ready") {
+          return { ...state, label: designSystemLabels.ready }
+        }
+
+        if (key === "unavailable") {
+          return { ...state, label: designSystemLabels.unavailable }
+        }
+
+        return state
+      }
+    )
+  }
+})
+
+import { getDesignSystemState } from "@/design-system"
 import MonitoringDashboardPage from "../MonitoringDashboardPage"
 
 describe("MonitoringDashboardPage", () => {
@@ -181,6 +210,34 @@ describe("MonitoringDashboardPage", () => {
     expect(screen.getByText("seatbelt")).toBeTruthy()
     expect(screen.getByText("worktree")).toBeTruthy()
     expect(screen.getByText(/not VM-grade isolation/i)).toBeTruthy()
+  })
+
+  it("uses design-system state labels for sandbox readiness summary counts", async () => {
+    mocks.getSandboxRuntimeDiagnostics.mockResolvedValue({
+      source: "feature_discovery",
+      summary: {
+        total: 3,
+        ready: 2,
+        unavailable: 1,
+        host_gated: 0,
+        scaffold: 0,
+        host_local_warning_runtimes: [],
+        repair_supported_runtimes: []
+      },
+      runtimes: [],
+      startup_warning_summary: null
+    })
+
+    render(<MonitoringDashboardPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText(designSystemLabels.ready)).toBeTruthy()
+    })
+    expect(screen.getByText(designSystemLabels.unavailable)).toBeTruthy()
+    expect(screen.getByText("2")).toBeTruthy()
+    expect(screen.getByText("1")).toBeTruthy()
+    expect(getDesignSystemState).toHaveBeenCalledWith("ready")
+    expect(getDesignSystemState).toHaveBeenCalledWith("unavailable")
   })
 
   it("distinguishes forbidden sandbox diagnostics from unavailable diagnostics", async () => {

--- a/backlog/tasks/task-45.45 - Migrate-MonitoringDashboardPage-sandbox-readiness-labels-to-design-system-state-registry.md
+++ b/backlog/tasks/task-45.45 - Migrate-MonitoringDashboardPage-sandbox-readiness-labels-to-design-system-state-registry.md
@@ -7,7 +7,7 @@ status: Done
 assignee:
   - Codex
 created_date: '2026-05-14 07:30'
-updated_date: '2026-05-14 19:22'
+updated_date: '2026-05-14 19:33'
 labels:
   - design-system
   - frontend
@@ -56,6 +56,8 @@ Implemented the MonitoringDashboardPage readiness summary through getDesignSyste
 PR review follow-up: Gemini flagged empty-string state-label fallbacks as confusing if the registry lookup fails. Reopened the task to change the fallback to descriptive lowercase keys and add focused coverage for missing registry entries.
 
 Review follow-up implemented: ready/unavailable fallbacks now use descriptive lowercase state keys instead of empty strings, with focused coverage for missing registry entries.
+
+Second PR review follow-up implemented: moved readiness label lookups to module-scope constants and tightened readiness count assertions so each count is checked inside its matching design-system label container.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
@@ -66,6 +68,10 @@ Migrated the admin MonitoringDashboardPage sandbox readiness summary labels for 
 Review follow-up: addressed Gemini feedback by replacing empty-string missing-registry fallbacks with readable lowercase state-key fallbacks and adding regression coverage for missing ready/unavailable registry entries.
 
 Verification: RED focused Vitest failed on the mocked registry labels before implementation and failed again on the missing-registry fallback test before the review fix; GREEN focused Vitest passed 10/10; product-state guard tests passed 52/52; bun run verify:design-system-state passed with 494 allowed legacy exceptions and canonical-state-label at 15; git diff --check passed. Broad bunx tsc --noEmit --pretty false still exits 2 on existing repo-wide UI/test type debt, with no observed MonitoringDashboardPage, design-system baseline, or touched-file errors in the output. Bandit skipped because this slice only touches UI TypeScript, JSON baseline data, and Backlog metadata.
+
+Second review follow-up: addressed CodeRabbit comments by resolving ready/unavailable labels once at module scope and binding the readiness count assertions to their corresponding summary label containers.
+
+Post-review verification: focused MonitoringDashboardPage Vitest passed 10/10 after the module-scope and count-binding changes; product-state guard tests passed 52/52; bun run verify:design-system-state passed after refreshing only MonitoringDashboardPage AntD Alert baseline IDs; git diff --check passed.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.45 - Migrate-MonitoringDashboardPage-sandbox-readiness-labels-to-design-system-state-registry.md
+++ b/backlog/tasks/task-45.45 - Migrate-MonitoringDashboardPage-sandbox-readiness-labels-to-design-system-state-registry.md
@@ -1,0 +1,73 @@
+---
+id: TASK-45.45
+title: >-
+  Migrate MonitoringDashboardPage sandbox readiness labels to design-system
+  state registry
+status: Done
+assignee:
+  - Codex
+created_date: '2026-05-14 07:30'
+updated_date: '2026-05-14 07:35'
+labels:
+  - design-system
+  - frontend
+  - product-state
+dependencies: []
+references:
+  - apps/packages/ui/src/components/Option/Admin/MonitoringDashboardPage.tsx
+  - >-
+    apps/packages/ui/src/components/Option/Admin/__tests__/MonitoringDashboardPage.test.tsx
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+documentation:
+  - Docs/Design/tldw_web_design_system_contract.md
+parent_task_id: TASK-45
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replace the admin MonitoringDashboardPage sandbox runtime summary labels for ready and unavailable readiness counts with the canonical design-system state registry labels while preserving the existing diagnostics layout and count values. This continues the design-system product-state migration against the current green verifier baseline on origin/dev.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 MonitoringDashboardPage resolves ready and unavailable sandbox readiness labels through getDesignSystemState instead of hardcoded product-state literals.
+- [x] #2 Focused component coverage proves mocked design-system ready and unavailable labels render in the sandbox runtime isolation summary.
+- [x] #3 The canonical-state-label baseline entries for MonitoringDashboardPage Ready and Unavailable are removed and the design-system product-state verifier passes.
+- [x] #4 Verification records focused Vitest, product-state guard/verifier status, diff check, and TypeScript/Bandit applicability.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused MonitoringDashboardPage coverage that mocks getDesignSystemState('ready') and getDesignSystemState('unavailable') to distinct labels and expects those labels in the sandbox runtime isolation summary.
+2. Confirm the focused test fails before implementation because MonitoringDashboardPage still renders hardcoded Ready/Unavailable labels.
+3. Import getDesignSystemState in MonitoringDashboardPage and use registry labels for the sandbox diagnostics summary items, with empty-string fallbacks so hardcoded canonical labels do not remain in product-state code.
+4. Remove the two MonitoringDashboardPage canonical-state-label baseline entries and refresh the existing MonitoringDashboardPage AntD Alert baseline IDs that changed only because this touched file line numbers moved.
+5. Verify with focused MonitoringDashboardPage Vitest, product-state guard tests, bun run verify:design-system-state, git diff --check, and broad TypeScript touched-file review; document Bandit as skipped because the final touched scope is UI TypeScript/JSON/Backlog only.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the MonitoringDashboardPage readiness summary through getDesignSystemState for ready and unavailable. The RED Vitest failed on the mocked registry labels before implementation, then passed after wiring the labels through the registry. The product-state verifier also required removing hardcoded fallback literals and refreshing existing MonitoringDashboardPage AntD Alert baseline IDs that changed due to line movement; no AntD Alert migration was included in this slice.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated the admin MonitoringDashboardPage sandbox readiness summary labels for ready and unavailable counts to the design-system state registry. Added focused test coverage with mocked registry labels so the component is no longer coupled to hardcoded product-state literals. Removed the two MonitoringDashboardPage canonical-state-label baseline entries and refreshed only the existing MonitoringDashboardPage AntD Alert baseline IDs whose generated hashes changed because the file moved lines.
+
+Verification: RED focused Vitest failed on the mocked registry labels before implementation; GREEN focused Vitest passed 9/9; product-state guard tests passed 52/52; bun run verify:design-system-state passed with 494 allowed legacy exceptions and canonical-state-label reduced to 15; git diff --check passed. Broad bunx tsc --noEmit --pretty false still exits 2 on existing repo-wide UI/test type debt, with no observed MonitoringDashboardPage, design-system baseline, or touched-file errors in the output. Bandit skipped because this slice only touches UI TypeScript, JSON baseline data, and Backlog metadata.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.45 - Migrate-MonitoringDashboardPage-sandbox-readiness-labels-to-design-system-state-registry.md
+++ b/backlog/tasks/task-45.45 - Migrate-MonitoringDashboardPage-sandbox-readiness-labels-to-design-system-state-registry.md
@@ -7,7 +7,7 @@ status: Done
 assignee:
   - Codex
 created_date: '2026-05-14 07:30'
-updated_date: '2026-05-14 07:35'
+updated_date: '2026-05-14 19:22'
 labels:
   - design-system
   - frontend
@@ -41,9 +41,9 @@ Replace the admin MonitoringDashboardPage sandbox runtime summary labels for rea
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-1. Add focused MonitoringDashboardPage coverage that mocks getDesignSystemState('ready') and getDesignSystemState('unavailable') to distinct labels and expects those labels in the sandbox runtime isolation summary.
+1. Add focused MonitoringDashboardPage coverage that mocks getDesignSystemState("ready") and getDesignSystemState("unavailable") to distinct labels and expects those labels in the sandbox runtime isolation summary.
 2. Confirm the focused test fails before implementation because MonitoringDashboardPage still renders hardcoded Ready/Unavailable labels.
-3. Import getDesignSystemState in MonitoringDashboardPage and use registry labels for the sandbox diagnostics summary items, with empty-string fallbacks so hardcoded canonical labels do not remain in product-state code.
+3. Import getDesignSystemState in MonitoringDashboardPage and use registry labels for the sandbox diagnostics summary items, with readable lowercase state-key fallbacks if the registry lookup is unavailable.
 4. Remove the two MonitoringDashboardPage canonical-state-label baseline entries and refresh the existing MonitoringDashboardPage AntD Alert baseline IDs that changed only because this touched file line numbers moved.
 5. Verify with focused MonitoringDashboardPage Vitest, product-state guard tests, bun run verify:design-system-state, git diff --check, and broad TypeScript touched-file review; document Bandit as skipped because the final touched scope is UI TypeScript/JSON/Backlog only.
 <!-- SECTION:PLAN:END -->
@@ -52,6 +52,10 @@ Replace the admin MonitoringDashboardPage sandbox runtime summary labels for rea
 
 <!-- SECTION:NOTES:BEGIN -->
 Implemented the MonitoringDashboardPage readiness summary through getDesignSystemState for ready and unavailable. The RED Vitest failed on the mocked registry labels before implementation, then passed after wiring the labels through the registry. The product-state verifier also required removing hardcoded fallback literals and refreshing existing MonitoringDashboardPage AntD Alert baseline IDs that changed due to line movement; no AntD Alert migration was included in this slice.
+
+PR review follow-up: Gemini flagged empty-string state-label fallbacks as confusing if the registry lookup fails. Reopened the task to change the fallback to descriptive lowercase keys and add focused coverage for missing registry entries.
+
+Review follow-up implemented: ready/unavailable fallbacks now use descriptive lowercase state keys instead of empty strings, with focused coverage for missing registry entries.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
@@ -59,7 +63,9 @@ Implemented the MonitoringDashboardPage readiness summary through getDesignSyste
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Migrated the admin MonitoringDashboardPage sandbox readiness summary labels for ready and unavailable counts to the design-system state registry. Added focused test coverage with mocked registry labels so the component is no longer coupled to hardcoded product-state literals. Removed the two MonitoringDashboardPage canonical-state-label baseline entries and refreshed only the existing MonitoringDashboardPage AntD Alert baseline IDs whose generated hashes changed because the file moved lines.
 
-Verification: RED focused Vitest failed on the mocked registry labels before implementation; GREEN focused Vitest passed 9/9; product-state guard tests passed 52/52; bun run verify:design-system-state passed with 494 allowed legacy exceptions and canonical-state-label reduced to 15; git diff --check passed. Broad bunx tsc --noEmit --pretty false still exits 2 on existing repo-wide UI/test type debt, with no observed MonitoringDashboardPage, design-system baseline, or touched-file errors in the output. Bandit skipped because this slice only touches UI TypeScript, JSON baseline data, and Backlog metadata.
+Review follow-up: addressed Gemini feedback by replacing empty-string missing-registry fallbacks with readable lowercase state-key fallbacks and adding regression coverage for missing ready/unavailable registry entries.
+
+Verification: RED focused Vitest failed on the mocked registry labels before implementation and failed again on the missing-registry fallback test before the review fix; GREEN focused Vitest passed 10/10; product-state guard tests passed 52/52; bun run verify:design-system-state passed with 494 allowed legacy exceptions and canonical-state-label at 15; git diff --check passed. Broad bunx tsc --noEmit --pretty false still exits 2 on existing repo-wide UI/test type debt, with no observed MonitoringDashboardPage, design-system baseline, or touched-file errors in the output. Bandit skipped because this slice only touches UI TypeScript, JSON baseline data, and Backlog metadata.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary

- Route the admin MonitoringDashboardPage sandbox readiness summary labels through `getDesignSystemState`.
- Use readable lowercase state-key fallbacks if ready/unavailable registry labels are missing.
- Resolve readiness labels once at module scope and bind readiness count assertions to their matching label containers.
- Remove the two stale MonitoringDashboardPage canonical-state-label baseline entries and refresh existing MonitoringDashboardPage AntD Alert baseline IDs caused by line movement.

## Verification

- `bunx vitest run src/components/Option/Admin/__tests__/MonitoringDashboardPage.test.tsx --reporter=dot`
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot`
- `bun run verify:design-system-state`
- `git diff --check`
- `bunx tsc --noEmit --pretty false` exits 2 on existing repo-wide UI/test type debt; no MonitoringDashboardPage/design-system baseline touched-file errors were observed in the output.

## Validation

- [x] Focused MonitoringDashboardPage Vitest passed.
- [x] Product-state guard tests passed.
- [x] Design-system product-state verifier passed with the existing legacy baseline count.
- [x] Diff whitespace check passed.
- [x] Bandit not applicable; touched scope is UI TypeScript, JSON baseline data, and Backlog metadata.
- [ ] Broad TypeScript is not clean due to existing repo-wide UI/test type debt outside this slice.

## UX Audit Checklist

- [x] No layout or interaction pattern changes; this only changes the label source and tests.
- [x] Missing registry labels still render readable fallback labels.
- [x] Readiness counts remain paired with their visible labels.

## Watchlists Checklist

- [x] Not applicable; this PR touches admin monitoring readiness labels only.

## Risk & Rollback

Risk level: Low. The change is limited to two admin monitoring summary labels, focused tests, Backlog metadata, and the product-state baseline IDs affected by line movement.

Rollback plan: Revert the PR commits to restore the previous hardcoded labels and baseline entries.

## Change Summary

Maintainer: replace this section with your own human-written change summary before merge, per the AI-generated PR merge gate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates MonitoringDashboardPage sandbox readiness labels to the design-system state registry and adds readable fallbacks when labels are missing. Adds focused tests and cleans up product-state baseline entries.

- **Refactors**
  - Use `getDesignSystemState("ready")` and `getDesignSystemState("unavailable")` for summary labels, with lowercase key fallbacks if registry labels are missing.
  - Resolve the labels at module scope and reuse the constants in the dashboard render path.
  - Add tests that mock registry labels, verify labels/counts render together, and include missing-key fallback coverage.
  - Remove two `canonical-state-label` baseline entries and refresh related AntD Alert baseline IDs due to line shifts.

<sup>Written for commit 217241ea1e3d1660727bd3e19b489c720ccf64c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->
