### PR TITLE
Harden VZ helper create_vm contract

### DIFF
--- a/Docs/Sandbox/macos-runtime-operator-notes.md
+++ b/Docs/Sandbox/macos-runtime-operator-notes.md
@@ -217,9 +217,11 @@ item and reports `live_vm_matches_blocked_cleanup` instead of deleting files.
   direct `create_vm` requests unless `network_policy=deny_all`. The helper also
   echoes the accepted policy in VM metadata/status details for diagnostics.
   Direct `create_vm` requests are also shape-checked before boot: unsupported
-  runtimes, invalid VM ids, non-absolute or NUL-bearing paths, symlink
-  paths, oversized metadata, and out-of-range startup timeouts are rejected
-  without registering a VM.
+  runtimes, invalid VM ids, non-absolute or NUL-bearing paths, symlink leaf
+  paths or user-controlled symlinked parent components, oversized metadata, and
+  out-of-range startup timeouts are rejected without registering a VM. Root-level
+  macOS compatibility prefixes such as `/tmp` and `/var` are allowed and
+  subsequent components are still checked.
 - The current `vz_linux` Virtualization.framework configuration omits network
   device attachment; guest command transport uses vsock rather than guest
   network access.

--- a/Docs/Sandbox/macos-runtime-operator-notes.md
+++ b/Docs/Sandbox/macos-runtime-operator-notes.md
@@ -216,6 +216,10 @@ item and reports `live_vm_matches_blocked_cleanup` instead of deleting files.
   rejects unsupported policies before dispatch, and the Swift helper rejects
   direct `create_vm` requests unless `network_policy=deny_all`. The helper also
   echoes the accepted policy in VM metadata/status details for diagnostics.
+  Direct `create_vm` requests are also shape-checked before boot: unsupported
+  runtimes, invalid VM ids, non-absolute or NUL-bearing paths, symlink
+  paths, oversized metadata, and out-of-range startup timeouts are rejected
+  without registering a VM.
 - The current `vz_linux` Virtualization.framework configuration omits network
   device attachment; guest command transport uses vsock rather than guest
   network access.

--- a/Docs/Sandbox/sandbox-security-policy-matrix.md
+++ b/Docs/Sandbox/sandbox-security-policy-matrix.md
@@ -142,7 +142,7 @@ truth in the helper.
 
 | Runtime | Allowlisting expectation |
 | --- | --- |
-| `vz_linux` | Python admits only supported trust/network/runtime requests; helper independently rejects unsupported VM creation, unsafe sockets, and unsupported protocol versions. |
+| `vz_linux` | Python admits only supported trust/network/runtime requests; helper independently rejects unsupported VM creation, malformed `create_vm` request shape, unsafe sockets, and unsupported protocol versions. |
 | `vz_macos` | Must follow the same Python/helper split when real execution lands. |
 | `lima` | Python must revalidate strict policy at execution time before dispatch. |
 | `firecracker` | Runtime config paths must be validated before VM start. |

--- a/Docs/superpowers/plans/2026-05-14-vz-helper-create-vm-contract.md
+++ b/Docs/superpowers/plans/2026-05-14-vz-helper-create-vm-contract.md
@@ -1,0 +1,48 @@
+# VZ Helper Create VM Contract Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Harden the macOS VZ helper `create_vm` request boundary so malformed or unsupported direct helper requests fail before VM boot.
+
+**Architecture:** Keep Python as the sandbox policy owner and keep the helper as the live VM owner. Add matching Python client and Swift helper request-shape validation for `create_vm`, but do not introduce image-store root allowlisting, vmnet networking, automatic repair, or guest-user rewrites in this slice.
+
+**Tech Stack:** Python helper client, Swift helper daemon, pytest, Swift Testing.
+
+---
+
+## Design Review
+
+- Do not require templates or workspaces to live under a single root yet. Compatibility templates and session workspaces are intentionally flexible, so this slice validates absolute non-NUL paths and rejects symlink paths.
+- Do not move policy admission into the helper. The helper should reject unsupported runtime/network values and malformed request shape, while trust-level and user policy decisions stay in Python.
+- Do not change helper protocol version. The contract is a stricter interpretation of protocol v1 fields and remains compatible with the Python runner's existing request shape.
+- Do not require live host VM smoke for this patch. Portable Python and Swift tests prove request validation; real VZ smoke remains host-gated.
+
+## Stage 1: Python Client Contract
+
+**Goal:** Validate `create_vm` requests before fake or real helper transport.
+
+**Success Criteria:** Invalid Python client requests raise `MacOSVirtualizationHelperFailure` with stable codes and valid runner-shaped requests still serialize.
+
+**Tests:** Focused pytest in `tldw_Server_API/tests/sandbox/test_macos_virtualization_helper_client.py`.
+
+**Status:** Complete
+
+## Stage 2: Swift Helper Contract
+
+**Goal:** Validate direct Unix-socket/service `create_vm` requests before VM manager boot and registry mutation.
+
+**Success Criteria:** Invalid helper requests return stable error payloads and do not register a VM.
+
+**Tests:** Swift helper tests in `tools/macos-vz-helper/Tests/HelperServiceVMTests.swift` and `UnixSocketServerTests.swift`.
+
+**Status:** Complete
+
+## Stage 3: Docs And Verification
+
+**Goal:** Document the stricter protocol contract and verify the focused slice.
+
+**Success Criteria:** Protocol/operator docs mention the `create_vm` validation boundary; focused Python/Swift tests, diff check, and Bandit pass or record host/tooling skips.
+
+**Tests:** `pytest`, `swift test`, `git diff --check`, and Bandit over touched Python scope.
+
+**Status:** Complete

--- a/backlog/tasks/task-341 - Harden-VZ-helper-create_vm-request-contract.md
+++ b/backlog/tasks/task-341 - Harden-VZ-helper-create_vm-request-contract.md
@@ -1,0 +1,78 @@
+---
+id: TASK-341
+title: Harden VZ helper create_vm request contract
+status: Done
+assignee: []
+created_date: '2026-05-14 16:52'
+updated_date: '2026-05-14 17:28'
+labels:
+  - sandbox
+  - vz_linux
+  - security
+dependencies: []
+documentation:
+  - Docs/Sandbox/sandbox-architecture-doctrine.md
+  - Docs/Sandbox/sandbox-security-policy-matrix.md
+  - Docs/Sandbox/macos-runtime-operator-notes.md
+  - tools/macos-vz-helper/PROTOCOL.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add a focused Phase 2 security hardening slice for the macOS VZ Linux helper. The helper and Python client should reject malformed or unsupported create_vm requests before VM boot while preserving Python as the source of policy admission and the helper as live VM truth. Keep the scope narrow: validate request shape, runtime/network support, bounded metadata, timeout, and basic path safety; do not add vmnet, OCI boot changes, automatic repair, or broader guest-user rewrites.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Python helper client validates create_vm request shape before fake or real transport and returns stable helper failure codes for invalid requests.
+- [x] #2 Swift helper validates create_vm requests before VM manager boot and maps denials to stable error payloads without registering a VM.
+- [x] #3 Validation covers unsupported runtime/network policy, missing or invalid vm id, bounded text metadata, timeout range, and absolute non-NUL template/workspace/run-manifest paths with symlink rejection.
+- [x] #4 Existing VZ Linux runner create_vm calls remain compatible and include required metadata for the hardened contract.
+- [x] #5 Helper protocol/operator docs describe the create_vm request contract and its non-goals.
+- [x] #6 Focused Python and Swift tests cover accepted requests and rejected malformed/unsupported requests.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Implementation plan: Docs/superpowers/plans/2026-05-14-vz-helper-create-vm-contract.md
+
+Stages:
+1. Python helper client create_vm request validation with focused pytest red/green.
+2. Swift helper create_vm validation before VM manager boot with Swift Testing red/green.
+3. Protocol/operator docs plus verification: focused tests, git diff --check, Bandit.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Working in /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/vz-helper-create-vm-contract on branch codex/vz-helper-create-vm-contract from origin/dev. Main checkout is dirty/diverged and intentionally untouched.
+
+Verification:
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_macos_virtualization_helper_client.py tldw_Server_API/tests/sandbox/test_macos_helper_client.py tldw_Server_API/tests/sandbox/test_vz_linux_runner.py -q` passed: 69 passed, 2 warnings.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -q` passed: 101 passed, 1 skipped, 2 warnings.
+- `env CLANG_MODULE_CACHE_PATH=/private/tmp/tldw-swift-module-cache swift test --package-path tools/macos-vz-helper` passed: 83 tests passed.
+- `git diff --check` passed.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Sandbox/macos_virtualization/helper_client.py -f json -o /tmp/bandit_vz_helper_create_vm_contract.json` passed with 0 findings.
+
+Known notes:
+- SwiftPM still warns that `tools/macos-vz-helper/Tests/test_vz_helperctl.py` is an unhandled package resource; this is pre-existing because the package directory also hosts pytest tests.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Hardened the VZ Linux helper `create_vm` boundary by adding matching Python client and Swift daemon validation before fake transport, socket transport, VM boot, or registry mutation. The contract now rejects unsupported runtimes/network policy, invalid VM ids, malformed non-string request fields, unsafe path shape, symlink paths, oversized metadata, and invalid timeouts with stable helper error codes. Protocol/operator docs and focused tests were updated to make the boundary explicit.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/tldw_Server_API/app/core/Sandbox/README.md
+++ b/tldw_Server_API/app/core/Sandbox/README.md
@@ -89,9 +89,11 @@ Current limitations:
   records the accepted policy in VM metadata/status details. The helper also
   rejects malformed direct `create_vm` requests before boot, including
   unsupported runtimes, invalid VM ids, non-absolute or NUL-bearing paths,
-  symlink paths, oversized metadata, and out-of-range startup
-  timeouts. The current Virtualization.framework configuration does not attach
-  a network device.
+  symlink leaf paths or user-controlled symlinked parent components, oversized
+  metadata, and out-of-range startup timeouts. Root-level macOS compatibility
+  prefixes such as `/tmp` and `/var` are allowed and subsequent components are
+  still checked. The current Virtualization.framework configuration does not
+  attach a network device.
 - `vz_linux` passes `SANDBOX_MAX_LOG_BYTES` to helper `exec_guest` as
   `max_output_bytes`, clamped to the helper protocol ceiling of 256 MiB, and
   also uses the effective cap when publishing stdout/stderr frames. Rebuilt

--- a/tldw_Server_API/app/core/Sandbox/README.md
+++ b/tldw_Server_API/app/core/Sandbox/README.md
@@ -86,8 +86,12 @@ Current limitations:
 - Strict allowlist networking is not implemented for `vz_linux`, `vz_macos`, `seatbelt`, or `worktree`.
 - `vz_linux` VM creation is fail-closed at both Python admission and helper
   protocol layers: only `network_policy=deny_all` is accepted, and the helper
-  records the accepted policy in VM metadata/status details. The current
-  Virtualization.framework configuration does not attach a network device.
+  records the accepted policy in VM metadata/status details. The helper also
+  rejects malformed direct `create_vm` requests before boot, including
+  unsupported runtimes, invalid VM ids, non-absolute or NUL-bearing paths,
+  symlink paths, oversized metadata, and out-of-range startup
+  timeouts. The current Virtualization.framework configuration does not attach
+  a network device.
 - `vz_linux` passes `SANDBOX_MAX_LOG_BYTES` to helper `exec_guest` as
   `max_output_bytes`, clamped to the helper protocol ceiling of 256 MiB, and
   also uses the effective cap when publishing stdout/stderr frames. Rebuilt

--- a/tldw_Server_API/app/core/Sandbox/macos_virtualization/helper_client.py
+++ b/tldw_Server_API/app/core/Sandbox/macos_virtualization/helper_client.py
@@ -37,6 +37,19 @@ _MAX_EXEC_ENV_COUNT = 128
 _MAX_EXEC_ENV_BYTES = 32 * 1024
 _MAX_EXEC_TIMEOUT_SEC = 3_600.0
 _MAX_EXEC_OUTPUT_BYTES = 256 * 1024 * 1024
+_MAX_CREATE_VM_ID_BYTES = 128
+_MAX_CREATE_VM_TEXT_BYTES = 1024
+_MAX_CREATE_VM_PATH_BYTES = 4096
+_MAX_CREATE_VM_TIMEOUT_SEC = 3_600.0
+_CREATE_VM_TEXT_FIELDS = (
+    "owner",
+    "runtime",
+    "run_id",
+    "session_id",
+    "template_id",
+    "planning_source",
+    "created_at",
+)
 
 
 class MacOSVirtualizationHelperUnavailable(RuntimeError):
@@ -98,9 +111,10 @@ class MacOSVirtualizationHelperClient:
         return self._request("validate_template", request)
 
     def create_vm(self, request: dict[str, Any]) -> HelperVMReply:
+        self._validate_create_vm_request(request)
         if is_truthy(os.getenv("TEST_MODE")):
             vm_name = str(request.get("vm_name") or "").strip() or "vm-test"
-            runtime = str(request.get("runtime") or "").strip() or "vz_linux"
+            runtime = (str(request.get("runtime") or "").strip().lower() or "vz_linux")
             network_policy = self._normalize_network_policy(request.get("network_policy"))
             if network_policy != "deny_all":
                 raise MacOSVirtualizationHelperFailure(
@@ -359,6 +373,108 @@ class MacOSVirtualizationHelperClient:
     def _network_policy_error_code(network_policy: str) -> str:
         """Return the stable helper error code for an unsupported normalized network policy."""
         return "strict_allowlist_not_supported" if network_policy == "allowlist" else "unsupported_network_policy"
+
+    @classmethod
+    def _validate_create_vm_request(cls, request: dict[str, Any]) -> None:
+        """Validate create_vm request shape before contacting or emulating the helper."""
+        if not isinstance(request, dict):
+            raise MacOSVirtualizationHelperFailure("invalid_request", "invalid_request")
+
+        runtime = cls._optional_create_vm_string(request, "runtime", default="vz_linux").strip().lower() or "vz_linux"
+        if runtime != "vz_linux":
+            raise MacOSVirtualizationHelperFailure("runtime_unsupported", runtime)
+
+        network_policy = cls._optional_create_vm_string(
+            request,
+            "network_policy",
+            default="deny_all",
+        ).strip().lower() or "deny_all"
+        if network_policy != "deny_all":
+            raise MacOSVirtualizationHelperFailure(
+                error_code=cls._network_policy_error_code(network_policy),
+                message=network_policy,
+            )
+
+        vm_id = cls._optional_create_vm_string(
+            request,
+            "vm_name",
+            default=cls._optional_create_vm_string(request, "run_id", default=""),
+        )
+        cls._validate_create_vm_id(vm_id)
+
+        template_path = cls._optional_create_vm_string(
+            request,
+            "template",
+            default=cls._optional_create_vm_string(request, "template_path", default=""),
+        )
+        cls._validate_create_vm_path(template_path, "template_path_invalid", required=True)
+
+        workspace_path = cls._optional_create_vm_string(request, "workspace_path", default="")
+        cls._validate_create_vm_path(workspace_path, "workspace_path_invalid", required=True)
+
+        run_manifest_path = cls._optional_create_vm_string(request, "run_manifest_path", default="")
+        cls._validate_create_vm_path(run_manifest_path, "run_manifest_path_invalid", required=False)
+
+        for field in _CREATE_VM_TEXT_FIELDS:
+            cls._validate_create_vm_text_field(
+                cls._optional_create_vm_string(request, field, default=""),
+                f"{field}_invalid",
+            )
+
+        if "timeout_sec" in request:
+            timeout_sec = cls._finite_positive_timeout(request.get("timeout_sec"))
+            if timeout_sec is None or timeout_sec > _MAX_CREATE_VM_TIMEOUT_SEC:
+                raise MacOSVirtualizationHelperFailure("create_vm_timeout_invalid", "timeout_out_of_range")
+
+    @staticmethod
+    def _optional_create_vm_string(request: dict[str, Any], key: str, *, default: str) -> str:
+        value = request.get(key, default)
+        if value is None:
+            return default
+        if not isinstance(value, str):
+            raise MacOSVirtualizationHelperFailure("invalid_request", "invalid_request")
+        return value
+
+    @staticmethod
+    def _raise_invalid_create_vm(reason: str) -> None:
+        raise MacOSVirtualizationHelperFailure("create_vm_request_invalid", reason)
+
+    @classmethod
+    def _validate_create_vm_id(cls, vm_id: str) -> None:
+        if not vm_id or vm_id.strip() != vm_id or "\x00" in vm_id:
+            cls._raise_invalid_create_vm("vm_id_invalid")
+        if len(vm_id.encode("utf-8")) > _MAX_CREATE_VM_ID_BYTES:
+            cls._raise_invalid_create_vm("vm_id_invalid")
+        allowed_extra = {"-", "_", "."}
+        if any(not (character.isalnum() or character in allowed_extra) for character in vm_id):
+            cls._raise_invalid_create_vm("vm_id_invalid")
+
+    @classmethod
+    def _validate_create_vm_text_field(cls, value: str, reason: str) -> None:
+        if "\x00" in value or len(value.encode("utf-8")) > _MAX_CREATE_VM_TEXT_BYTES:
+            cls._raise_invalid_create_vm(reason)
+        if any(ord(character) < 0x20 or ord(character) == 0x7F for character in value):
+            cls._raise_invalid_create_vm(reason)
+
+    @classmethod
+    def _validate_create_vm_path(cls, value: str, reason: str, *, required: bool) -> None:
+        if not value:
+            if required:
+                cls._raise_invalid_create_vm(reason)
+            return
+        if "\x00" in value or len(value.encode("utf-8")) > _MAX_CREATE_VM_PATH_BYTES:
+            cls._raise_invalid_create_vm(reason)
+        try:
+            path = Path(value)
+        except (OSError, ValueError):
+            cls._raise_invalid_create_vm(reason)
+        if not path.is_absolute():
+            cls._raise_invalid_create_vm(reason)
+        try:
+            if path.is_symlink():
+                cls._raise_invalid_create_vm(reason)
+        except (OSError, ValueError):
+            cls._raise_invalid_create_vm(reason)
 
     @classmethod
     def _validate_exec_guest_request(

--- a/tldw_Server_API/app/core/Sandbox/macos_virtualization/helper_client.py
+++ b/tldw_Server_API/app/core/Sandbox/macos_virtualization/helper_client.py
@@ -4,6 +4,7 @@ import json
 import math
 import os
 import socket
+import stat
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -41,6 +42,7 @@ _MAX_CREATE_VM_ID_BYTES = 128
 _MAX_CREATE_VM_TEXT_BYTES = 1024
 _MAX_CREATE_VM_PATH_BYTES = 4096
 _MAX_CREATE_VM_TIMEOUT_SEC = 3_600.0
+_ALLOWED_CREATE_VM_SYMLINK_PREFIXES = {Path(os.sep) / "tmp", Path(os.sep) / "var"}
 _CREATE_VM_TEXT_FIELDS = (
     "owner",
     "runtime",
@@ -380,7 +382,10 @@ class MacOSVirtualizationHelperClient:
         if not isinstance(request, dict):
             raise MacOSVirtualizationHelperFailure("invalid_request", "invalid_request")
 
-        runtime = cls._optional_create_vm_string(request, "runtime", default="vz_linux").strip().lower() or "vz_linux"
+        runtime = (
+            cls._optional_create_vm_string(request, "runtime", default="vz_linux").strip().lower()
+            or "vz_linux"
+        )
         if runtime != "vz_linux":
             raise MacOSVirtualizationHelperFailure("runtime_unsupported", runtime)
 
@@ -398,15 +403,19 @@ class MacOSVirtualizationHelperClient:
         vm_id = cls._optional_create_vm_string(
             request,
             "vm_name",
-            default=cls._optional_create_vm_string(request, "run_id", default=""),
+            default="",
         )
+        if not vm_id:
+            vm_id = cls._optional_create_vm_string(request, "run_id", default="")
         cls._validate_create_vm_id(vm_id)
 
         template_path = cls._optional_create_vm_string(
             request,
             "template",
-            default=cls._optional_create_vm_string(request, "template_path", default=""),
+            default="",
         )
+        if not template_path:
+            template_path = cls._optional_create_vm_string(request, "template_path", default="")
         cls._validate_create_vm_path(template_path, "template_path_invalid", required=True)
 
         workspace_path = cls._optional_create_vm_string(request, "workspace_path", default="")
@@ -422,16 +431,22 @@ class MacOSVirtualizationHelperClient:
             )
 
         if "timeout_sec" in request:
-            timeout_sec = cls._finite_positive_timeout(request.get("timeout_sec"))
+            raw_timeout = request.get("timeout_sec")
+            if isinstance(raw_timeout, bool) or not isinstance(raw_timeout, (int, float)):
+                raise MacOSVirtualizationHelperFailure("invalid_request", "invalid_request")
+            timeout_sec = cls._finite_positive_timeout(raw_timeout)
             if timeout_sec is None or timeout_sec > _MAX_CREATE_VM_TIMEOUT_SEC:
-                raise MacOSVirtualizationHelperFailure("create_vm_timeout_invalid", "timeout_out_of_range")
+                raise MacOSVirtualizationHelperFailure(
+                    "create_vm_timeout_invalid",
+                    "timeout_out_of_range",
+                )
 
     @staticmethod
     def _optional_create_vm_string(request: dict[str, Any], key: str, *, default: str) -> str:
-        value = request.get(key, default)
-        if value is None:
+        if key not in request:
             return default
-        if not isinstance(value, str):
+        value = request[key]
+        if value is None or not isinstance(value, str):
             raise MacOSVirtualizationHelperFailure("invalid_request", "invalid_request")
         return value
 
@@ -471,10 +486,21 @@ class MacOSVirtualizationHelperClient:
         if not path.is_absolute():
             cls._raise_invalid_create_vm(reason)
         try:
-            if path.is_symlink():
-                cls._raise_invalid_create_vm(reason)
+            cls._validate_create_vm_path_components(path, reason)
         except (OSError, ValueError):
             cls._raise_invalid_create_vm(reason)
+
+    @classmethod
+    def _validate_create_vm_path_components(cls, path: Path, reason: str) -> None:
+        current = Path(path.anchor)
+        for component in path.parts[1:]:
+            current = current / component
+            try:
+                mode = os.lstat(current).st_mode
+            except FileNotFoundError:
+                return
+            if stat.S_ISLNK(mode) and current not in _ALLOWED_CREATE_VM_SYMLINK_PREFIXES:
+                cls._raise_invalid_create_vm(reason)
 
     @classmethod
     def _validate_exec_guest_request(

--- a/tldw_Server_API/tests/sandbox/test_macos_helper_client.py
+++ b/tldw_Server_API/tests/sandbox/test_macos_helper_client.py
@@ -41,7 +41,10 @@ def test_helper_client_raises_custom_exception_when_helper_unavailable(monkeypat
             {
                 "runtime": "vz_linux",
                 "vm_name": "run-123",
+                "run_id": "run-123",
                 "template": "/tmp/template.img",
                 "workspace_path": "/tmp/workspace",
+                "network_policy": "deny_all",
+                "timeout_sec": 30,
             }
         )

--- a/tldw_Server_API/tests/sandbox/test_macos_helper_client.py
+++ b/tldw_Server_API/tests/sandbox/test_macos_helper_client.py
@@ -37,4 +37,11 @@ def test_helper_client_raises_custom_exception_when_helper_unavailable(monkeypat
     client = MacOSVirtualizationHelperClient()
 
     with pytest.raises(MacOSVirtualizationHelperUnavailable, match="macos_virtualization_helper_unavailable"):
-        client.create_vm({"runtime": "vz_linux", "vm_name": "run-123"})
+        client.create_vm(
+            {
+                "runtime": "vz_linux",
+                "vm_name": "run-123",
+                "template": "/tmp/template.img",
+                "workspace_path": "/tmp/workspace",
+            }
+        )

--- a/tldw_Server_API/tests/sandbox/test_macos_virtualization_helper_client.py
+++ b/tldw_Server_API/tests/sandbox/test_macos_virtualization_helper_client.py
@@ -80,6 +80,21 @@ def _install_fake_helper_socket(monkeypatch, responses: dict[str, object], socke
     return requests
 
 
+def _valid_create_vm_request(**overrides: object) -> dict[str, object]:
+    request: dict[str, object] = {
+        "owner": "tldw",
+        "runtime": "vz_linux",
+        "vm_name": "run-1",
+        "run_id": "run-1",
+        "template": "/tmp/template.img",
+        "workspace_path": "/tmp/workspace",
+        "network_policy": "deny_all",
+        "timeout_sec": 30,
+    }
+    request.update(overrides)
+    return request
+
+
 def test_helper_client_exports_expected_protocol_version() -> None:
     from tldw_Server_API.app.core.Sandbox.macos_virtualization.helper_client import (
         EXPECTED_HELPER_PROTOCOL_VERSION,
@@ -282,13 +297,90 @@ def test_helper_client_raw_validation_rejects_null_exec_guest_output_limit() -> 
     assert exc_info.value.error_code == "invalid_request"
 
 
+@pytest.mark.parametrize(
+    ("overrides", "expected_code", "expected_message"),
+    [
+        ({"runtime": "vz_macos"}, "runtime_unsupported", "vz_macos"),
+        ({"vm_name": "bad/name"}, "create_vm_request_invalid", "vm_id_invalid"),
+        ({"template": "relative.img"}, "create_vm_request_invalid", "template_path_invalid"),
+        ({"workspace_path": "workspace"}, "create_vm_request_invalid", "workspace_path_invalid"),
+        ({"run_manifest_path": "runs/run-1/manifest.json"}, "create_vm_request_invalid", "run_manifest_path_invalid"),
+        ({"timeout_sec": 0}, "create_vm_timeout_invalid", "timeout_out_of_range"),
+    ],
+)
+def test_helper_client_validates_create_vm_request_contract_in_test_mode(
+    monkeypatch,
+    overrides: dict[str, object],
+    expected_code: str,
+    expected_message: str,
+) -> None:
+    monkeypatch.setenv("TEST_MODE", "1")
+
+    with pytest.raises(MacOSVirtualizationHelperFailure) as exc_info:
+        MacOSVirtualizationHelperClient().create_vm(_valid_create_vm_request(**overrides))
+
+    assert exc_info.value.error_code == expected_code
+    assert exc_info.value.message == expected_message
+
+
+def test_helper_client_rejects_invalid_create_vm_before_socket_request(monkeypatch) -> None:
+    monkeypatch.delenv("TEST_MODE", raising=False)
+    requests = _install_fake_helper_socket(
+        monkeypatch,
+        {
+            "create_vm": {
+                "protocol_version": "1",
+                "helper_version": "0.1.0",
+                "vm_id": "unexpected",
+                "state": "created",
+            }
+        },
+    )
+
+    with pytest.raises(MacOSVirtualizationHelperFailure) as exc_info:
+        MacOSVirtualizationHelperClient().create_vm(_valid_create_vm_request(runtime="vz_macos"))
+
+    assert exc_info.value.error_code == "runtime_unsupported"
+    assert requests == []
+
+
+def test_helper_client_rejects_create_vm_existing_symlink_path(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("TEST_MODE", "1")
+    workspace_target = tmp_path / "workspace-target"
+    workspace_target.mkdir()
+    workspace_link = tmp_path / "workspace-link"
+    workspace_link.symlink_to(workspace_target, target_is_directory=True)
+
+    with pytest.raises(MacOSVirtualizationHelperFailure) as exc_info:
+        MacOSVirtualizationHelperClient().create_vm(
+            _valid_create_vm_request(workspace_path=str(workspace_link))
+        )
+
+    assert exc_info.value.error_code == "create_vm_request_invalid"
+    assert exc_info.value.message == "workspace_path_invalid"
+
+
+def test_helper_client_rejects_create_vm_broken_symlink_path(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("TEST_MODE", "1")
+    template_link = tmp_path / "template-link.img"
+    template_link.symlink_to(tmp_path / "missing-template.img")
+
+    with pytest.raises(MacOSVirtualizationHelperFailure) as exc_info:
+        MacOSVirtualizationHelperClient().create_vm(
+            _valid_create_vm_request(template=str(template_link))
+        )
+
+    assert exc_info.value.error_code == "create_vm_request_invalid"
+    assert exc_info.value.message == "template_path_invalid"
+
+
 def test_helper_create_vm_fails_closed_without_test_mode(monkeypatch) -> None:
     monkeypatch.delenv("TEST_MODE", raising=False)
 
     client = MacOSVirtualizationHelperClient()
 
     with pytest.raises(MacOSVirtualizationHelperUnavailable):
-        client.create_vm({"runtime": "vz_linux", "vm_name": "vz-linux-run-2"})
+        client.create_vm(_valid_create_vm_request(vm_name="vz-linux-run-2"))
 
 
 def test_fake_helper_validates_vz_linux_host_readiness(monkeypatch) -> None:
@@ -605,8 +697,10 @@ def test_socket_helper_supports_ping_validate_create_exec_status_and_terminate(m
             "runtime": "vz_linux",
             "vm_name": "run-1",
             "template_id": "vz_linux:debian-bookworm-arm64",
+            "template": "/tmp/template.img",
             "run_manifest_path": "/tmp/image-store/runs/run-1/manifest.json",
             "planning_source": "image_store",
+            "workspace_path": "/tmp/workspace",
         }
     )
     exec_reply = client.exec_guest(vm_id=vm.vm_id, request={"argv": ["/bin/echo", "ok"]})
@@ -707,7 +801,7 @@ def test_socket_helper_maps_error_payload_to_helper_failure(monkeypatch) -> None
     client = MacOSVirtualizationHelperClient()
 
     with pytest.raises(MacOSVirtualizationHelperFailure) as excinfo:
-        client.create_vm({"runtime": "vz_linux", "vm_name": "run-1"})
+        client.create_vm(_valid_create_vm_request())
 
     assert excinfo.value.error_code == "template_invalid"
     assert "template path is invalid" in str(excinfo.value)

--- a/tldw_Server_API/tests/sandbox/test_macos_virtualization_helper_client.py
+++ b/tldw_Server_API/tests/sandbox/test_macos_virtualization_helper_client.py
@@ -306,6 +306,11 @@ def test_helper_client_raw_validation_rejects_null_exec_guest_output_limit() -> 
         ({"workspace_path": "workspace"}, "create_vm_request_invalid", "workspace_path_invalid"),
         ({"run_manifest_path": "runs/run-1/manifest.json"}, "create_vm_request_invalid", "run_manifest_path_invalid"),
         ({"timeout_sec": 0}, "create_vm_timeout_invalid", "timeout_out_of_range"),
+        ({"timeout_sec": 3601}, "create_vm_timeout_invalid", "timeout_out_of_range"),
+        ({"timeout_sec": "30"}, "invalid_request", "invalid_request"),
+        ({"runtime": None}, "invalid_request", "invalid_request"),
+        ({"network_policy": None}, "invalid_request", "invalid_request"),
+        ({"vm_name": None, "run_id": "run-1"}, "invalid_request", "invalid_request"),
     ],
 )
 def test_helper_client_validates_create_vm_request_contract_in_test_mode(
@@ -344,6 +349,37 @@ def test_helper_client_rejects_invalid_create_vm_before_socket_request(monkeypat
     assert requests == []
 
 
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"vm_name": None, "run_id": "run-1"},
+        {"timeout_sec": "30"},
+    ],
+)
+def test_helper_client_rejects_malformed_create_vm_before_socket_request(
+    monkeypatch,
+    overrides: dict[str, object],
+) -> None:
+    monkeypatch.delenv("TEST_MODE", raising=False)
+    requests = _install_fake_helper_socket(
+        monkeypatch,
+        {
+            "create_vm": {
+                "protocol_version": "1",
+                "helper_version": "0.1.0",
+                "vm_id": "unexpected",
+                "state": "created",
+            }
+        },
+    )
+
+    with pytest.raises(MacOSVirtualizationHelperFailure) as exc_info:
+        MacOSVirtualizationHelperClient().create_vm(_valid_create_vm_request(**overrides))
+
+    assert exc_info.value.error_code == "invalid_request"
+    assert requests == []
+
+
 def test_helper_client_rejects_create_vm_existing_symlink_path(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("TEST_MODE", "1")
     workspace_target = tmp_path / "workspace-target"
@@ -372,6 +408,22 @@ def test_helper_client_rejects_create_vm_broken_symlink_path(monkeypatch, tmp_pa
 
     assert exc_info.value.error_code == "create_vm_request_invalid"
     assert exc_info.value.message == "template_path_invalid"
+
+
+def test_helper_client_rejects_create_vm_symlink_parent_path(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("TEST_MODE", "1")
+    workspace_target = tmp_path / "workspace-target"
+    workspace_target.mkdir()
+    workspace_link = tmp_path / "workspace-link"
+    workspace_link.symlink_to(workspace_target, target_is_directory=True)
+
+    with pytest.raises(MacOSVirtualizationHelperFailure) as exc_info:
+        MacOSVirtualizationHelperClient().create_vm(
+            _valid_create_vm_request(workspace_path=str(workspace_link / "nested-workspace"))
+        )
+
+    assert exc_info.value.error_code == "create_vm_request_invalid"
+    assert exc_info.value.message == "workspace_path_invalid"
 
 
 def test_helper_create_vm_fails_closed_without_test_mode(monkeypatch) -> None:

--- a/tools/macos-vz-helper/PROTOCOL.md
+++ b/tools/macos-vz-helper/PROTOCOL.md
@@ -152,9 +152,12 @@ The helper enforces the `create_vm` request contract before VM boot:
 - `vm_name` or `run_id` must provide a non-empty VM id using only
   alphanumeric characters, `.`, `_`, and `-`, capped at 128 UTF-8 bytes.
 - `template` or `template_path` and `workspace_path` must be absolute, non-NUL
-  paths capped at 4096 UTF-8 bytes. Symlink paths are rejected before
-  boot. The helper does not require these paths to be under one root yet because
-  compatibility templates and session workspaces remain intentionally flexible.
+  paths capped at 4096 UTF-8 bytes. Symlink leaf paths and user-controlled
+  symlinked parent components are rejected before boot; root-level macOS
+  compatibility prefixes such as `/tmp` and `/var` are allowed and subsequent
+  components are still checked. The helper does not require these paths to be
+  under one root yet because compatibility templates and session workspaces
+  remain intentionally flexible.
 - `run_manifest_path`, when present, follows the same absolute path and symlink
   rules.
 - ownership/provenance text metadata is bounded and rejects NUL/control
@@ -359,8 +362,9 @@ the unprefixed keys when `guest_*` keys are absent during mixed-version rollouts
   echoed in VM metadata and status details.
 - `vz_linux` helper VM creation also validates request shape before boot:
   unsupported runtimes, invalid VM ids, non-absolute or NUL-bearing paths,
-  symlink paths, oversized metadata, and out-of-range startup timeouts
-  are rejected without registering a VM.
+  symlink leaf paths or user-controlled symlinked parent components, oversized
+  metadata, and out-of-range startup timeouts are rejected without registering a
+  VM.
 - `vz_linux` guest-agent readiness metadata is additive in protocol version `1`.
   `guest_version`, `guest_workspace_root`, `guest_capabilities_known`, and
   `guest_capabilities` are diagnostic details only. Older guests may omit

--- a/tools/macos-vz-helper/PROTOCOL.md
+++ b/tools/macos-vz-helper/PROTOCOL.md
@@ -146,6 +146,25 @@ identifies the planner, for example `image_store`.
 `network_policy` defaults to `deny_all`; helper-side VM creation rejects any
 other value and returns `strict_allowlist_not_supported` for `allowlist`.
 
+The helper enforces the `create_vm` request contract before VM boot:
+
+- `runtime`, when present, must be `vz_linux`.
+- `vm_name` or `run_id` must provide a non-empty VM id using only
+  alphanumeric characters, `.`, `_`, and `-`, capped at 128 UTF-8 bytes.
+- `template` or `template_path` and `workspace_path` must be absolute, non-NUL
+  paths capped at 4096 UTF-8 bytes. Symlink paths are rejected before
+  boot. The helper does not require these paths to be under one root yet because
+  compatibility templates and session workspaces remain intentionally flexible.
+- `run_manifest_path`, when present, follows the same absolute path and symlink
+  rules.
+- ownership/provenance text metadata is bounded and rejects NUL/control
+  characters.
+- `timeout_sec` must be finite, positive, and no greater than 3600 seconds.
+
+Malformed JSON shape or non-string fields return `invalid_request`. Semantic
+denials return `runtime_unsupported`, `create_vm_request_invalid`, or
+`create_vm_timeout_invalid`, with `message` carrying the stable reason.
+
 Response:
 
 ```json
@@ -338,6 +357,10 @@ the unprefixed keys when `guest_*` keys are absent during mixed-version rollouts
 - `vz_linux` helper VM creation accepts only `network_policy=deny_all` until a
   separately verified allowlist implementation exists. The accepted policy is
   echoed in VM metadata and status details.
+- `vz_linux` helper VM creation also validates request shape before boot:
+  unsupported runtimes, invalid VM ids, non-absolute or NUL-bearing paths,
+  symlink paths, oversized metadata, and out-of-range startup timeouts
+  are rejected without registering a VM.
 - `vz_linux` guest-agent readiness metadata is additive in protocol version `1`.
   `guest_version`, `guest_workspace_root`, `guest_capabilities_known`, and
   `guest_capabilities` are diagnostic details only. Older guests may omit

--- a/tools/macos-vz-helper/Sources/Server/HelperService.swift
+++ b/tools/macos-vz-helper/Sources/Server/HelperService.swift
@@ -31,6 +31,7 @@ final class HelperService {
     private static let maxCreateVMTextBytes = 1024
     private static let maxCreateVMPathBytes = 4096
     private static let maxCreateVMTimeoutSeconds: TimeInterval = 3_600
+    private static let allowedCreateVMSymlinkPrefixes: Set<String> = ["/tmp", "/var"]
 
     private let protocolVersion = "1"
     private let helperVersion = "0.1.0"
@@ -340,17 +341,23 @@ final class HelperService {
             throw HelperServiceError.invalidCreateVMRequest(reason)
         }
 
-        var pathStat = stat()
-        let result = lstat(value, &pathStat)
-        if result == 0 {
-            let type = pathStat.st_mode & S_IFMT
-            guard type != S_IFLNK else {
+        var currentPath = ""
+        for component in value.split(separator: "/", omittingEmptySubsequences: true) {
+            currentPath += "/\(component)"
+            var pathStat = stat()
+            errno = 0
+            let result = lstat(currentPath, &pathStat)
+            if result == 0 {
+                let type = pathStat.st_mode & S_IFMT
+                guard type != S_IFLNK || Self.allowedCreateVMSymlinkPrefixes.contains(currentPath) else {
+                    throw HelperServiceError.invalidCreateVMRequest(reason)
+                }
+                continue
+            }
+            guard errno == ENOENT else {
                 throw HelperServiceError.invalidCreateVMRequest(reason)
             }
             return
-        }
-        guard errno == ENOENT else {
-            throw HelperServiceError.invalidCreateVMRequest(reason)
         }
     }
 

--- a/tools/macos-vz-helper/Sources/Server/HelperService.swift
+++ b/tools/macos-vz-helper/Sources/Server/HelperService.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 
 struct HostFacts {
@@ -6,6 +7,9 @@ struct HostFacts {
 }
 
 enum HelperServiceError: Error {
+    case unsupportedRuntime(String)
+    case invalidCreateVMRequest(String)
+    case invalidCreateVMTimeout(String)
     case unsupportedNetworkPolicy(String)
     case invalidExecArgv(String)
     case invalidExecCwd(String)
@@ -23,6 +27,10 @@ final class HelperService {
     private static let maxExecEnvBytes = 32 * 1024
     private static let maxExecTimeoutSeconds: TimeInterval = 3_600
     private static let maxExecOutputBytes = 256 * 1024 * 1024
+    private static let maxCreateVMIDBytes = 128
+    private static let maxCreateVMTextBytes = 1024
+    private static let maxCreateVMPathBytes = 4096
+    private static let maxCreateVMTimeoutSeconds: TimeInterval = 3_600
 
     private let protocolVersion = "1"
     private let helperVersion = "0.1.0"
@@ -108,6 +116,13 @@ final class HelperService {
         metadata: VMOwnershipMetadata = .unknown,
         networkPolicy: String = "deny_all"
     ) throws -> HelperVMResponse {
+        try validateCreateVMContract(
+            vmID: vmID,
+            templatePath: templatePath,
+            workspacePath: workspacePath,
+            readinessTimeoutSeconds: readinessTimeoutSeconds,
+            metadata: metadata
+        )
         let normalizedNetworkPolicy = try requireSupportedNetworkPolicy(networkPolicy)
         let normalizedMetadata = normalizeMetadata(
             metadata,
@@ -221,9 +236,10 @@ final class HelperService {
         workspacePath: String,
         networkPolicy: String
     ) -> VMOwnershipMetadata {
-        VMOwnershipMetadata(
+        let normalizedRuntime = normalizeRuntime(metadata.runtime)
+        return VMOwnershipMetadata(
             owner: metadata.owner.isEmpty ? "unknown" : metadata.owner,
-            runtime: metadata.runtime.isEmpty ? "vz_linux" : metadata.runtime,
+            runtime: normalizedRuntime.isEmpty ? "vz_linux" : normalizedRuntime,
             runID: metadata.runID,
             sessionID: metadata.sessionID,
             sessionMode: metadata.sessionMode,
@@ -250,8 +266,100 @@ final class HelperService {
         return normalized.isEmpty ? "deny_all" : normalized
     }
 
+    private func normalizeRuntime(_ runtime: String) -> String {
+        runtime.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
     private func networkPolicyErrorCode(_ networkPolicy: String) -> String {
         networkPolicy == "allowlist" ? "strict_allowlist_not_supported" : "unsupported_network_policy"
+    }
+
+    private func validateCreateVMContract(
+        vmID: String,
+        templatePath: String,
+        workspacePath: String,
+        readinessTimeoutSeconds: TimeInterval,
+        metadata: VMOwnershipMetadata
+    ) throws {
+        try validateCreateVMID(vmID)
+        try validateCreateVMPath(templatePath, reason: "template_path_invalid", required: true)
+        try validateCreateVMPath(workspacePath, reason: "workspace_path_invalid", required: true)
+        try validateCreateVMTimeout(readinessTimeoutSeconds)
+
+        let metadataRuntime = normalizeRuntime(metadata.runtime)
+        if !metadataRuntime.isEmpty, metadataRuntime != "vz_linux" {
+            throw HelperServiceError.unsupportedRuntime(metadataRuntime)
+        }
+
+        for (value, reason) in [
+            (metadata.owner, "owner_invalid"),
+            (metadata.runID, "run_id_invalid"),
+            (metadata.sessionID, "session_id_invalid"),
+            (metadata.templateID, "template_id_invalid"),
+            (metadata.planningSource, "planning_source_invalid"),
+            (metadata.createdAt, "created_at_invalid"),
+        ] {
+            try validateCreateVMText(value, reason: reason)
+        }
+        try validateCreateVMPath(metadata.templatePath, reason: "template_path_invalid", required: false)
+        try validateCreateVMPath(metadata.workspacePath, reason: "workspace_path_invalid", required: false)
+        try validateCreateVMPath(metadata.runManifestPath, reason: "run_manifest_path_invalid", required: false)
+    }
+
+    private func validateCreateVMID(_ vmID: String) throws {
+        guard !vmID.isEmpty,
+              vmID.trimmingCharacters(in: .whitespacesAndNewlines) == vmID,
+              !containsNUL(vmID),
+              vmID.utf8.count <= Self.maxCreateVMIDBytes else {
+            throw HelperServiceError.invalidCreateVMRequest("vm_id_invalid")
+        }
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "._-"))
+        guard vmID.unicodeScalars.allSatisfy({ allowed.contains($0) }) else {
+            throw HelperServiceError.invalidCreateVMRequest("vm_id_invalid")
+        }
+    }
+
+    private func validateCreateVMText(_ value: String, reason: String) throws {
+        guard !containsNUL(value),
+              !containsControlCharacter(value),
+              value.utf8.count <= Self.maxCreateVMTextBytes else {
+            throw HelperServiceError.invalidCreateVMRequest(reason)
+        }
+    }
+
+    private func validateCreateVMPath(_ value: String, reason: String, required: Bool) throws {
+        if value.isEmpty {
+            if required {
+                throw HelperServiceError.invalidCreateVMRequest(reason)
+            }
+            return
+        }
+        guard !containsNUL(value),
+              value.utf8.count <= Self.maxCreateVMPathBytes,
+              value.hasPrefix("/") else {
+            throw HelperServiceError.invalidCreateVMRequest(reason)
+        }
+
+        var pathStat = stat()
+        let result = lstat(value, &pathStat)
+        if result == 0 {
+            let type = pathStat.st_mode & S_IFMT
+            guard type != S_IFLNK else {
+                throw HelperServiceError.invalidCreateVMRequest(reason)
+            }
+            return
+        }
+        guard errno == ENOENT else {
+            throw HelperServiceError.invalidCreateVMRequest(reason)
+        }
+    }
+
+    private func validateCreateVMTimeout(_ timeoutSeconds: TimeInterval) throws {
+        guard timeoutSeconds.isFinite,
+              timeoutSeconds > 0,
+              timeoutSeconds <= Self.maxCreateVMTimeoutSeconds else {
+            throw HelperServiceError.invalidCreateVMTimeout("timeout_out_of_range")
+        }
     }
 
     private func vmDetails(for record: VMRecord) -> [String: String] {

--- a/tools/macos-vz-helper/Sources/Server/UnixSocketServer.swift
+++ b/tools/macos-vz-helper/Sources/Server/UnixSocketServer.swift
@@ -138,29 +138,43 @@ final class UnixSocketServer {
                     key: "network_policy",
                     defaultValue: "deny_all"
                 )
-                let templatePath = request.request["template"]?.stringValue
-                    ?? request.request["template_path"]?.stringValue
-                    ?? ""
-                let workspacePath = request.request["workspace_path"]?.stringValue ?? ""
+                let templatePath = try optionalStringField(
+                    request.request,
+                    key: "template",
+                    defaultValue: try optionalStringField(
+                        request.request,
+                        key: "template_path",
+                        defaultValue: ""
+                    )
+                )
+                let workspacePath = try optionalStringField(request.request, key: "workspace_path", defaultValue: "")
                 let metadata = VMOwnershipMetadata(
-                    owner: request.request["owner"]?.stringValue ?? "unknown",
-                    runtime: request.request["runtime"]?.stringValue ?? "vz_linux",
-                    runID: request.request["run_id"]?.stringValue ?? "",
-                    sessionID: request.request["session_id"]?.stringValue ?? "",
+                    owner: try optionalStringField(request.request, key: "owner", defaultValue: "unknown"),
+                    runtime: try optionalStringField(request.request, key: "runtime", defaultValue: "vz_linux"),
+                    runID: try optionalStringField(request.request, key: "run_id", defaultValue: ""),
+                    sessionID: try optionalStringField(request.request, key: "session_id", defaultValue: ""),
                     sessionMode: request.request["session_mode"]?.boolValue ?? false,
-                    templateID: request.request["template_id"]?.stringValue ?? "",
+                    templateID: try optionalStringField(request.request, key: "template_id", defaultValue: ""),
                     templatePath: templatePath,
-                    runManifestPath: request.request["run_manifest_path"]?.stringValue ?? "",
-                    planningSource: request.request["planning_source"]?.stringValue ?? "",
+                    runManifestPath: try optionalStringField(request.request, key: "run_manifest_path", defaultValue: ""),
+                    planningSource: try optionalStringField(request.request, key: "planning_source", defaultValue: ""),
                     workspacePath: workspacePath,
                     createdAt: ""
                 )
                 return try encoder.encode(
                     try service.createVM(
-                        vmID: request.request["vm_name"]?.stringValue ?? request.request["run_id"]?.stringValue ?? "",
+                        vmID: try optionalStringField(
+                            request.request,
+                            key: "vm_name",
+                            defaultValue: try optionalStringField(request.request, key: "run_id", defaultValue: "")
+                        ),
                         templatePath: templatePath,
                         workspacePath: workspacePath,
-                        readinessTimeoutSeconds: TimeInterval(request.request["timeout_sec"]?.intValue ?? 30),
+                        readinessTimeoutSeconds: try optionalTimeIntervalField(
+                            request.request,
+                            key: "timeout_sec",
+                            defaultValue: 30
+                        ),
                         metadata: metadata,
                         networkPolicy: networkPolicy
                     )
@@ -655,6 +669,12 @@ final class UnixSocketServer {
             return "helper_socket_path_too_long"
         case UnixSocketServerError.unsupportedOperation:
             return "unsupported_operation"
+        case HelperServiceError.unsupportedRuntime:
+            return "runtime_unsupported"
+        case HelperServiceError.invalidCreateVMRequest:
+            return "create_vm_request_invalid"
+        case HelperServiceError.invalidCreateVMTimeout:
+            return "create_vm_timeout_invalid"
         case HelperServiceError.unsupportedNetworkPolicy(let policy):
             return policy == "allowlist" ? "strict_allowlist_not_supported" : "unsupported_network_policy"
         case HelperServiceError.invalidExecArgv:
@@ -699,6 +719,11 @@ final class UnixSocketServer {
             return "system_error_\(code)"
         case UnixSocketServerError.invalidRequest, is DecodingError:
             return "invalid_request"
+        case HelperServiceError.unsupportedRuntime(let runtime):
+            return runtime
+        case HelperServiceError.invalidCreateVMRequest(let reason),
+             HelperServiceError.invalidCreateVMTimeout(let reason):
+            return reason
         case HelperServiceError.unsupportedNetworkPolicy(let policy):
             return policy
         case HelperServiceError.invalidExecArgv(let reason),

--- a/tools/macos-vz-helper/Tests/HelperServiceVMTests.swift
+++ b/tools/macos-vz-helper/Tests/HelperServiceVMTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import MacOSVZHelperDaemon
 
@@ -157,7 +158,7 @@ import Testing
     )
     let metadata = VMOwnershipMetadata(
         owner: "tldw",
-        runtime: "vz_linux",
+        runtime: " VZ_LINUX ",
         runID: "run-owned",
         sessionID: "session-owned",
         sessionMode: true,
@@ -181,6 +182,7 @@ import Testing
     let listed = service.listVMs().vms.first
 
     #expect(response.metadata.owner == "tldw")
+    #expect(response.metadata.runtime == "vz_linux")
     #expect(response.metadata.runID == "run-owned")
     #expect(response.metadata.sessionID == "session-owned")
     #expect(response.metadata.sessionMode == true)
@@ -225,6 +227,82 @@ import Testing
         Issue.record("expected unsupportedNetworkPolicy, got \(error)")
     }
     #expect(registry.status(vmID: "vm-allowlist") == nil)
+}
+
+@Test func helperServiceCreateVMRejectsInvalidContractBeforeRegistryMutation() throws {
+    let registry = VMRegistry()
+    let manager = VZLinuxVMManager(
+        registry: registry,
+        bootDriver: RecordingBootDriver(),
+        guestBridge: ReadyGuestBridge()
+    )
+    let service = HelperService(
+        hostFacts: HostFacts(isMacOS: true, isAppleSilicon: true),
+        registry: registry,
+        vmManager: manager
+    )
+
+    #expect(throws: HelperServiceError.self) {
+        _ = try service.createVM(
+            vmID: "bad/name",
+            templatePath: "/tmp/template.img",
+            workspacePath: "/tmp/workspace",
+            readinessTimeoutSeconds: 5
+        )
+    }
+    #expect(registry.status(vmID: "bad/name") == nil)
+
+    #expect(throws: HelperServiceError.self) {
+        _ = try service.createVM(
+            vmID: "vm-relative-workspace",
+            templatePath: "/tmp/template.img",
+            workspacePath: "workspace",
+            readinessTimeoutSeconds: 5
+        )
+    }
+    #expect(registry.status(vmID: "vm-relative-workspace") == nil)
+
+    #expect(throws: HelperServiceError.self) {
+        _ = try service.createVM(
+            vmID: "vm-timeout",
+            templatePath: "/tmp/template.img",
+            workspacePath: "/tmp/workspace",
+            readinessTimeoutSeconds: 0
+        )
+    }
+    #expect(registry.status(vmID: "vm-timeout") == nil)
+}
+
+@Test func helperServiceCreateVMRejectsExistingSymlinkWorkspaceBeforeRegistryMutation() throws {
+    let root = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appendingPathComponent("macos-vz-create-vm-\(UUID().uuidString)")
+    let target = root.appendingPathComponent("target", isDirectory: true)
+    let link = root.appendingPathComponent("workspace-link", isDirectory: true)
+    try FileManager.default.createDirectory(at: target, withIntermediateDirectories: true)
+    try FileManager.default.createSymbolicLink(atPath: link.path, withDestinationPath: target.path)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let registry = VMRegistry()
+    let manager = VZLinuxVMManager(
+        registry: registry,
+        bootDriver: RecordingBootDriver(),
+        guestBridge: ReadyGuestBridge()
+    )
+    let service = HelperService(
+        hostFacts: HostFacts(isMacOS: true, isAppleSilicon: true),
+        registry: registry,
+        vmManager: manager
+    )
+
+    #expect(throws: HelperServiceError.self) {
+        _ = try service.createVM(
+            vmID: "vm-symlink-workspace",
+            templatePath: "/tmp/template.img",
+            workspacePath: link.path,
+            readinessTimeoutSeconds: 5
+        )
+    }
+    #expect(registry.status(vmID: "vm-symlink-workspace") == nil)
 }
 
 @Test func helperServiceCreateVMDefaultsMissingOwnershipMetadataToUnknown() throws {

--- a/tools/macos-vz-helper/Tests/HelperServiceVMTests.swift
+++ b/tools/macos-vz-helper/Tests/HelperServiceVMTests.swift
@@ -305,6 +305,38 @@ import Testing
     #expect(registry.status(vmID: "vm-symlink-workspace") == nil)
 }
 
+@Test func helperServiceCreateVMRejectsSymlinkParentWorkspaceBeforeRegistryMutation() throws {
+    let root = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appendingPathComponent("macos-vz-create-vm-\(UUID().uuidString)")
+    let target = root.appendingPathComponent("target", isDirectory: true)
+    let link = root.appendingPathComponent("workspace-link", isDirectory: true)
+    try FileManager.default.createDirectory(at: target, withIntermediateDirectories: true)
+    try FileManager.default.createSymbolicLink(atPath: link.path, withDestinationPath: target.path)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let registry = VMRegistry()
+    let manager = VZLinuxVMManager(
+        registry: registry,
+        bootDriver: RecordingBootDriver(),
+        guestBridge: ReadyGuestBridge()
+    )
+    let service = HelperService(
+        hostFacts: HostFacts(isMacOS: true, isAppleSilicon: true),
+        registry: registry,
+        vmManager: manager
+    )
+
+    #expect(throws: HelperServiceError.self) {
+        _ = try service.createVM(
+            vmID: "vm-symlink-parent-workspace",
+            templatePath: "/tmp/template.img",
+            workspacePath: link.appendingPathComponent("nested-workspace").path,
+            readinessTimeoutSeconds: 5
+        )
+    }
+    #expect(registry.status(vmID: "vm-symlink-parent-workspace") == nil)
+}
+
 @Test func helperServiceCreateVMDefaultsMissingOwnershipMetadataToUnknown() throws {
     let registry = VMRegistry()
     let manager = VZLinuxVMManager(

--- a/tools/macos-vz-helper/Tests/UnixSocketServerTests.swift
+++ b/tools/macos-vz-helper/Tests/UnixSocketServerTests.swift
@@ -438,6 +438,43 @@ import Testing
     }
 }
 
+@Test func unixSocketServerRejectsSymlinkParentCreateVMPathBeforeBoot() throws {
+    let root = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appendingPathComponent("macos-vz-create-vm-\(UUID().uuidString)")
+    let target = root.appendingPathComponent("target", isDirectory: true)
+    let link = root.appendingPathComponent("workspace-link", isDirectory: true)
+    try FileManager.default.createDirectory(at: target, withIntermediateDirectories: true)
+    try FileManager.default.createSymbolicLink(atPath: link.path, withDestinationPath: target.path)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let registry = VMRegistry()
+    let manager = VZLinuxVMManager(
+        registry: registry,
+        bootDriver: RecordingBootDriver(),
+        guestBridge: ReadyGuestBridge()
+    )
+    let service = HelperService(
+        hostFacts: HostFacts(isMacOS: true, isAppleSilicon: true),
+        registry: registry,
+        vmManager: manager
+    )
+    let server = UnixSocketServer(
+        socketPath: "/tmp/macos-vz-helper.sock",
+        service: service
+    )
+    let workspacePath = link.appendingPathComponent("nested-workspace").path
+    let request = """
+    {"operation":"create_vm","protocol_version":"1","request":{"vm_name":"vm-symlink-parent","template":"/tmp/template.img","workspace_path":"\(workspacePath)"}}
+    """
+
+    let responseData = try server.handleRequestData(request.data(using: .utf8)!)
+    let json = try JSONSerialization.jsonObject(with: responseData) as? [String: Any]
+
+    #expect(json?["error_code"] as? String == "create_vm_request_invalid")
+    #expect(json?["message"] as? String == "workspace_path_invalid")
+    #expect(registry.status(vmID: "vm-symlink-parent") == nil)
+}
+
 @Test func unixSocketServerRejectsValidateHostNonStringNetworkPolicy() throws {
     let server = UnixSocketServer(
         socketPath: "/tmp/macos-vz-helper.sock",

--- a/tools/macos-vz-helper/Tests/UnixSocketServerTests.swift
+++ b/tools/macos-vz-helper/Tests/UnixSocketServerTests.swift
@@ -361,6 +361,83 @@ import Testing
     #expect(registry.status(vmID: "vm-malformed-policy") == nil)
 }
 
+@Test func unixSocketServerRejectsInvalidCreateVMContractBeforeBoot() throws {
+    let registry = VMRegistry()
+    let manager = VZLinuxVMManager(
+        registry: registry,
+        bootDriver: RecordingBootDriver(),
+        guestBridge: ReadyGuestBridge()
+    )
+    let service = HelperService(
+        hostFacts: HostFacts(isMacOS: true, isAppleSilicon: true),
+        registry: registry,
+        vmManager: manager
+    )
+    let server = UnixSocketServer(
+        socketPath: "/tmp/macos-vz-helper.sock",
+        service: service
+    )
+
+    let cases = [
+        (
+            """
+            {"operation":"create_vm","protocol_version":"1","request":{"vm_name":"vm-runtime","runtime":"vz_macos","template":"/tmp/template.img","workspace_path":"/workspace"}}
+            """,
+            "runtime_unsupported",
+            "vz_macos",
+            "vm-runtime"
+        ),
+        (
+            """
+            {"operation":"create_vm","protocol_version":"1","request":{"vm_name":"bad/name","template":"/tmp/template.img","workspace_path":"/workspace"}}
+            """,
+            "create_vm_request_invalid",
+            "vm_id_invalid",
+            "bad/name"
+        ),
+        (
+            """
+            {"operation":"create_vm","protocol_version":"1","request":{"vm_name":"vm-template","template":"relative.img","workspace_path":"/workspace"}}
+            """,
+            "create_vm_request_invalid",
+            "template_path_invalid",
+            "vm-template"
+        ),
+        (
+            """
+            {"operation":"create_vm","protocol_version":"1","request":{"vm_name":"vm-workspace","template":"/tmp/template.img","workspace_path":"workspace"}}
+            """,
+            "create_vm_request_invalid",
+            "workspace_path_invalid",
+            "vm-workspace"
+        ),
+        (
+            """
+            {"operation":"create_vm","protocol_version":"1","request":{"vm_name":"vm-timeout","template":"/tmp/template.img","workspace_path":"/workspace","timeout_sec":0}}
+            """,
+            "create_vm_timeout_invalid",
+            "timeout_out_of_range",
+            "vm-timeout"
+        ),
+        (
+            """
+            {"operation":"create_vm","protocol_version":"1","request":{"vm_name":"vm-timeout-shape","template":"/tmp/template.img","workspace_path":"/workspace","timeout_sec":"30"}}
+            """,
+            "invalid_request",
+            "invalid_request",
+            "vm-timeout-shape"
+        ),
+    ]
+
+    for (request, expectedCode, expectedMessage, vmID) in cases {
+        let responseData = try server.handleRequestData(request.data(using: .utf8)!)
+        let json = try JSONSerialization.jsonObject(with: responseData) as? [String: Any]
+        #expect(json?["error_code"] as? String == expectedCode)
+        #expect(json?["message"] as? String == expectedMessage)
+        #expect(registry.status(vmID: vmID) == nil)
+    }
+}
+
 @Test func unixSocketServerRejectsValidateHostNonStringNetworkPolicy() throws {
     let server = UnixSocketServer(
         socketPath: "/tmp/macos-vz-helper.sock",


### PR DESCRIPTION
## Summary
- Harden Python helper-client create_vm validation before fake or real helper transport.
- Add daemon-side create_vm validation before VM boot/registry mutation with stable error payloads.
- Document the create_vm contract and add focused Python/Swift coverage plus Backlog task TASK-341.

## Verification
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_macos_virtualization_helper_client.py tldw_Server_API/tests/sandbox/test_macos_helper_client.py tldw_Server_API/tests/sandbox/test_vz_linux_runner.py -q`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -q`
- `env CLANG_MODULE_CACHE_PATH=/private/tmp/tldw-swift-module-cache swift test --package-path tools/macos-vz-helper`
- `git diff --check`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Sandbox/macos_virtualization/helper_client.py -f json -o /tmp/bandit_vz_helper_create_vm_contract.json`

## Merge Gate
Human-written Change summary still required before merge per repo policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the macOS VZ helper create_vm contract so bad requests fail early. Python client and Swift helper validate request shape and types before transport/boot, normalize runtime/network, and return stable errors. Addresses TASK-341.

- **New Features**
  - Python `create_vm` preflight: requires `runtime=vz_linux`, valid `vm_name`/`run_id`, absolute `template`/`workspace_path` (no symlink leaf or parent; root prefixes `/tmp` and `/var` allowed), optional absolute `run_manifest_path`, bounded text metadata (no NUL/control), `timeout_sec` > 0 and ≤ 3600, and `network_policy=deny_all`. Type errors map to `invalid_request`; semantic denials map to `runtime_unsupported`, `create_vm_request_invalid`, `create_vm_timeout_invalid`, or policy codes.
  - Swift helper/socket: enforces the same checks before VM boot/registry updates; normalizes runtime/network in metadata; socket maps new errors to stable codes/messages. Protocol and operator docs updated; added focused pytest and Swift tests.

- **Migration**
  - Ensure requests use absolute, non-symlink `template` and `workspace_path` (root `/tmp`/`/var` prefixes allowed), a valid `vm_name` (or `run_id`), `network_policy=deny_all`, and positive `timeout_sec` ≤ 3600. Optional `run_manifest_path` must be absolute if present.

<sup>Written for commit 7f7a9b66caa72e1fa9bfbfd82d833f597374e506. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

