### PR TITLE
Migrate HealthStatus labels to design-system state registry

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -3487,7 +3487,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Settings/health-status.tsx:Alert#antd-alert-healthstatus-type-info-line-563-rfgqka",
+    "id": "antd-product-state-import:src/components/Option/Settings/health-status.tsx:Alert#antd-alert-healthstatus-type-info-line-568-oxkbbj",
     "path": "src/components/Option/Settings/health-status.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -3498,7 +3498,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Settings/health-status.tsx:Alert#antd-alert-healthstatus-type-success-line-604-c2d4ax",
+    "id": "antd-product-state-import:src/components/Option/Settings/health-status.tsx:Alert#antd-alert-healthstatus-type-success-line-609-f48qxm",
     "path": "src/components/Option/Settings/health-status.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -3509,7 +3509,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Settings/health-status.tsx:Alert#antd-alert-healthstatus-type-warning-line-612-6okffr",
+    "id": "antd-product-state-import:src/components/Option/Settings/health-status.tsx:Alert#antd-alert-healthstatus-type-warning-line-617-5ameyw",
     "path": "src/components/Option/Settings/health-status.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -3520,7 +3520,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Settings/health-status.tsx:Alert#antd-alert-healthstatus-type-warning-line-863-1gpwrdl",
+    "id": "antd-product-state-import:src/components/Option/Settings/health-status.tsx:Alert#antd-alert-healthstatus-type-warning-line-868-1i3urug",
     "path": "src/components/Option/Settings/health-status.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -5144,72 +5144,6 @@
     "state": "allowed_legacy_exception",
     "owner": "design-system",
     "reason": "Existing hardcoded \"Ready\" state label in src/components/Option/PresentationStudio/ExtensionStartPanel.tsx before the stable duplicate-id guard.",
-    "replacement": "getDesignSystemState(...)",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "canonical-state-label:src/components/Option/Settings/health-status.tsx:Degraded#label-degraded-healthstatus-line-346-idc6cq",
-    "path": "src/components/Option/Settings/health-status.tsx",
-    "rule": "canonical-state-label",
-    "subject": "Degraded",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing hardcoded \"Degraded\" state label in src/components/Option/Settings/health-status.tsx before the stable duplicate-id guard.",
-    "replacement": "getDesignSystemState(...)",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "canonical-state-label:src/components/Option/Settings/health-status.tsx:Degraded#label-degraded-healthstatus-line-738-qo07n",
-    "path": "src/components/Option/Settings/health-status.tsx",
-    "rule": "canonical-state-label",
-    "subject": "Degraded",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing hardcoded \"Degraded\" state label in src/components/Option/Settings/health-status.tsx before the stable duplicate-id guard.",
-    "replacement": "getDesignSystemState(...)",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "canonical-state-label:src/components/Option/Settings/health-status.tsx:Loading#label-loading-healthstatus-line-348-14s3xnw",
-    "path": "src/components/Option/Settings/health-status.tsx",
-    "rule": "canonical-state-label",
-    "subject": "Loading",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing hardcoded \"Loading\" state label in src/components/Option/Settings/health-status.tsx before the stable duplicate-id guard.",
-    "replacement": "getDesignSystemState(...)",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "canonical-state-label:src/components/Option/Settings/health-status.tsx:Loading#label-loading-healthstatus-line-740-jk8l6w",
-    "path": "src/components/Option/Settings/health-status.tsx",
-    "rule": "canonical-state-label",
-    "subject": "Loading",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing hardcoded \"Loading\" state label in src/components/Option/Settings/health-status.tsx before the stable duplicate-id guard.",
-    "replacement": "getDesignSystemState(...)",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "canonical-state-label:src/components/Option/Settings/health-status.tsx:Ready#label-ready-healthstatus-line-343-1p80k7i",
-    "path": "src/components/Option/Settings/health-status.tsx",
-    "rule": "canonical-state-label",
-    "subject": "Ready",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing hardcoded \"Ready\" state label in src/components/Option/Settings/health-status.tsx before the stable duplicate-id guard.",
-    "replacement": "getDesignSystemState(...)",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "canonical-state-label:src/components/Option/Settings/health-status.tsx:Ready#label-ready-healthstatus-line-735-1b7c2s7",
-    "path": "src/components/Option/Settings/health-status.tsx",
-    "rule": "canonical-state-label",
-    "subject": "Ready",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing hardcoded \"Ready\" state label in src/components/Option/Settings/health-status.tsx before the stable duplicate-id guard.",
     "replacement": "getDesignSystemState(...)",
     "migrationQueue": "shared-product-state"
   },

--- a/apps/packages/ui/src/components/Option/Settings/__tests__/health-status.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/__tests__/health-status.design-system.test.tsx
@@ -21,6 +21,11 @@ const connectionStateMock = vi.hoisted(() => ({
   lastStatusCode: null as number | null,
   lastError: null as string | null
 }))
+const designSystemLabels = vi.hoisted(() => ({
+  ready: "Registry Ready",
+  degraded: "Registry Degraded",
+  loading: "Registry Loading"
+}))
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -85,6 +90,33 @@ vi.mock("@/hooks/useServerCapabilities", () => ({
   })
 }))
 
+vi.mock("@/design-system", async (importActual) => {
+  const actual = await importActual<typeof import("@/design-system")>()
+
+  return {
+    ...actual,
+    getDesignSystemState: vi.fn(
+      (key: Parameters<typeof actual.getDesignSystemState>[0]) => {
+        const state = actual.getDesignSystemState(key)
+
+        if (key === "ready") {
+          return { ...state, label: designSystemLabels.ready }
+        }
+
+        if (key === "degraded") {
+          return { ...state, label: designSystemLabels.degraded }
+        }
+
+        if (key === "loading") {
+          return { ...state, label: designSystemLabels.loading }
+        }
+
+        return state
+      }
+    )
+  }
+})
+
 const mockMatchMedia = () => {
   Object.defineProperty(window, "matchMedia", {
     writable: true,
@@ -133,8 +165,11 @@ describe("HealthStatus design-system states", () => {
     await renderHealth()
 
     await waitFor(() => {
-      expect(screen.getAllByText("Ready").length).toBeGreaterThan(0)
+      expect(screen.getAllByText(designSystemLabels.ready).length).toBeGreaterThan(0)
     })
+    expect(
+      screen.getByRole("group", { name: `Core API: ${designSystemLabels.ready}` })
+    ).toBeInTheDocument()
     expect(screen.getAllByText("/api/v1/health").length).toBeGreaterThan(0)
     expect(screen.getAllByText(/Raw response from/).length).toBeGreaterThan(0)
   })
@@ -151,9 +186,22 @@ describe("HealthStatus design-system states", () => {
     await renderHealth()
 
     await waitFor(() => {
-      expect(screen.getAllByText("Degraded").length).toBeGreaterThan(0)
+      expect(screen.getAllByText(designSystemLabels.degraded).length).toBeGreaterThan(0)
     })
+    expect(
+      screen.getByRole("group", { name: `RAG: ${designSystemLabels.degraded}` })
+    ).toBeInTheDocument()
     expect(screen.getByText(/RAG offline/)).toBeInTheDocument()
+  })
+
+  it("renders Loading through the design-system state registry while checks are pending", async () => {
+    apiSendMock.mockReturnValue(new Promise(() => {}))
+
+    render(<HealthStatus />)
+
+    await waitFor(() => {
+      expect(screen.getAllByText(designSystemLabels.loading).length).toBeGreaterThan(0)
+    })
   })
 
   it("renders Unavailable for unreachable connection callouts", async () => {

--- a/apps/packages/ui/src/components/Option/Settings/health-status.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/health-status.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/hooks/useConnectionState"
 import { cleanUrl } from "@/libs/clean-url"
 import { useServerCapabilities } from "@/hooks/useServerCapabilities"
+import { getDesignSystemState } from "@/design-system"
 
 type Check = {
   key: string
@@ -107,6 +108,10 @@ const makeChecks = (t: TFunction): Check[] => {
     }
   ]
 }
+
+const READY_STATE_LABEL = getDesignSystemState("ready").label
+const DEGRADED_STATE_LABEL = getDesignSystemState("degraded").label
+const LOADING_STATE_LABEL = getDesignSystemState("loading").label
 
 type Result = { status: 'unknown'|'healthy'|'unhealthy', detail?: any, statusCode?: number, durationMs?: number }
 
@@ -340,12 +345,12 @@ export default function HealthStatus() {
 
   const describeStatus = (status: Result['status']): string => {
     if (status === 'healthy') {
-      return t('healthPage.statusReady', 'Ready')
+      return t('healthPage.statusReady', READY_STATE_LABEL)
     }
     if (status === 'unhealthy') {
-      return t('healthPage.statusDegraded', 'Degraded')
+      return t('healthPage.statusDegraded', DEGRADED_STATE_LABEL)
     }
-    return t('healthPage.statusLoading', 'Loading')
+    return t('healthPage.statusLoading', LOADING_STATE_LABEL)
   }
 
   const showAuthCallout =
@@ -732,12 +737,12 @@ export default function HealthStatus() {
                 <Space size="middle" className="flex flex-wrap">
                   {r.status === 'healthy' ? (
                     <Tag color="green" className={recentHealthy.has(c.key) ? 'animate-pulse ring-2 ring-emerald-400' : undefined}>
-                      {t('healthPage.ready', 'Ready')}
+                      {t('healthPage.ready', READY_STATE_LABEL)}
                     </Tag>
                   ) : r.status === 'unhealthy' ? (
-                    <Tag color="red">{t('healthPage.degraded', 'Degraded')}</Tag>
+                    <Tag color="red">{t('healthPage.degraded', DEGRADED_STATE_LABEL)}</Tag>
                   ) : (
-                    <Tag>{t('healthPage.loadingState', 'Loading')}</Tag>
+                    <Tag>{t('healthPage.loadingState', LOADING_STATE_LABEL)}</Tag>
                   )}
                   <Typography.Text type="secondary">{c.path}</Typography.Text>
                   {typeof r.statusCode !== 'undefined' && (

--- a/apps/packages/ui/src/components/Option/Settings/health-status.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/health-status.tsx
@@ -109,9 +109,9 @@ const makeChecks = (t: TFunction): Check[] => {
   ]
 }
 
-const READY_STATE_LABEL = getDesignSystemState("ready").label
-const DEGRADED_STATE_LABEL = getDesignSystemState("degraded").label
-const LOADING_STATE_LABEL = getDesignSystemState("loading").label
+const READY_STATE_LABEL = getDesignSystemState("ready")?.label
+const DEGRADED_STATE_LABEL = getDesignSystemState("degraded")?.label
+const LOADING_STATE_LABEL = getDesignSystemState("loading")?.label
 
 type Result = { status: 'unknown'|'healthy'|'unhealthy', detail?: any, statusCode?: number, durationMs?: number }
 

--- a/backlog/tasks/task-45.44.6.1 - Migrate-HealthStatus-ready-degraded-loading-labels-to-design-system-state-registry.md
+++ b/backlog/tasks/task-45.44.6.1 - Migrate-HealthStatus-ready-degraded-loading-labels-to-design-system-state-registry.md
@@ -1,0 +1,81 @@
+---
+id: TASK-45.44.6.1
+title: >-
+  Migrate HealthStatus ready degraded loading labels to design-system state
+  registry
+status: Done
+assignee:
+  - Codex
+created_date: '2026-05-14 19:46'
+updated_date: '2026-05-14 19:51'
+labels:
+  - design-system
+  - webui
+  - extension
+  - product-state
+dependencies: []
+references:
+  - apps/packages/ui/src/components/Option/Settings/health-status.tsx
+  - >-
+    apps/packages/ui/src/components/Option/Settings/__tests__/health-status.design-system.test.tsx
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-05-14-design-system-remaining-work-tracker-design.md
+parent_task_id: TASK-45.44.6
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replace the remaining HealthStatus hardcoded ready, degraded, and loading product-state labels with the canonical design-system state registry while preserving existing translated copy behavior, health-check rendering, and product-state baseline enforcement.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 HealthStatus resolves ready, degraded, and loading labels through getDesignSystemState instead of hardcoded canonical literals.
+- [x] #2 Focused HealthStatus coverage proves mocked design-system labels render for summary and per-check status labels.
+- [x] #3 The six HealthStatus canonical-state-label baseline entries are removed and the design-system product-state verifier passes.
+- [x] #4 Verification records focused Vitest, product-state guard/verifier status, diff check, and TypeScript/Bandit applicability.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Extend the focused HealthStatus design-system test to mock getDesignSystemState for ready, degraded, and loading labels and assert those mocked labels render in both summary and per-check status surfaces.
+2. Run the focused test to confirm it fails before implementation because HealthStatus still uses hardcoded fallback labels.
+3. Import getDesignSystemState in health-status.tsx and create module-scope state label constants for ready, degraded, and loading. Use those labels as translation fallbacks in describeStatus and the per-check Tag labels.
+4. Remove the six HealthStatus canonical-state-label baseline entries from design-system-product-state-baseline.json.
+5. Verify with the focused HealthStatus Vitest, product-state guard tests, bun run verify:design-system-state, git diff --check, and document Bandit as skipped because the touched runtime scope is UI TypeScript/JSON/Backlog only.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implementation replaced HealthStatus ready/degraded/loading translation fallback literals with getDesignSystemState labels and added focused coverage that mocks registry labels for summary plus per-check status surfaces.
+
+Verified red before implementation: focused HealthStatus design-system test failed for per-check Ready, per-check Degraded, and Loading registry labels while HealthStatus still used hardcoded fallbacks.
+
+Verification passing: bunx vitest run src/components/Option/Settings/__tests__/health-status.design-system.test.tsx --reporter=dot; bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot; bun run verify:design-system-state; git diff --check.
+
+TypeScript note: bunx tsc --noEmit --pretty false exits 2 on existing package-wide type debt in unrelated tests/modules; no touched HealthStatus files appeared in the reported errors.
+
+Bandit not run: touched runtime scope is UI TypeScript plus JSON baseline and Backlog metadata, with no Python execution path.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated HealthStatus ready, degraded, and loading product-state label fallbacks to the design-system state registry, added focused registry-label assertions, removed the six resolved HealthStatus canonical-state-label baseline entries, and refreshed four shifted HealthStatus AntD Alert baseline ids caused by nearby line movement.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Route HealthStatus ready, degraded, and loading fallback labels through getDesignSystemState.
- Add focused HealthStatus coverage that proves registry labels render in summary and per-check status surfaces.
- Remove the resolved HealthStatus canonical-label baseline entries and refresh shifted legacy Alert baseline ids.

## Verification
- bunx vitest run src/components/Option/Settings/__tests__/health-status.design-system.test.tsx --reporter=dot
- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot
- bun run verify:design-system-state
- git diff --cached --check
- bunx tsc --noEmit --pretty false: exits 2 on existing package-wide type debt in unrelated files; no touched HealthStatus files reported.
- Bandit: skipped because touched runtime scope is UI TypeScript/JSON/Backlog only.

## Change summary
TODO: human-authored change summary required before merge per Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes HealthStatus Ready, Degraded, and Loading labels through `getDesignSystemState` to unify copy, support translations, and remove hardcoded fallbacks. Adds focused tests for summary and per-check tags, including pending Loading, and updates product-state baselines.

- **Refactors**
  - Use `getDesignSystemState` labels as i18n fallbacks in summary and per-check Tag labels.
  - Extend tests to mock registry labels and assert they render (Ready, Degraded, Loading) in both surfaces.
  - Remove six canonical-state-label baseline entries and refresh four shifted AntD Alert ids in `design-system-product-state-baseline.json`.

<sup>Written for commit 5ef0a8bb599adfc26f74bf346b6336e8333eca93. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

