### PR TITLE
Add Persona Visual starter pack catalog

### DIFF
--- a/Docs/superpowers/specs/2026-05-08-persona-visual-packs-design.md
+++ b/Docs/superpowers/specs/2026-05-08-persona-visual-packs-design.md
@@ -228,6 +228,18 @@ Recommended endpoint shape, adjusted to match existing route naming conventions 
 - `POST /api/v1/persona/profiles/{persona_id}/visual-packs/{pack_id}/generated-candidates/{candidate_id}/accept`
 - `POST /api/v1/persona/profiles/{persona_id}/visual-packs/{pack_id}/generated-candidates/{candidate_id}/reject`
 
+Bundled first-run defaults are exposed as a server-owned starter catalog rather than
+global mutable packs:
+
+- `GET /api/v1/persona/visual-starter-packs`
+- `POST /api/v1/persona/visual-starter-packs/{starter_pack_id}/use`
+
+Using a starter pack copies its bundled manifest-referenced assets through the same
+Persona Visual service validation and storage path used by user uploads and
+same-user duplication. The result is a user-owned draft pack for the target
+persona; it is not activated automatically and must pass the existing explicit
+activation step before Buddy runtime rendering can use it.
+
 Activation should be explicit. A draft pack can be saved while invalid, but activation should require every baseline state to resolve to a valid animation or valid fallback.
 
 ### Jobs Integration

--- a/backlog/tasks/task-344 - Add-bundled-Persona-Visual-starter-pack-catalog.md
+++ b/backlog/tasks/task-344 - Add-bundled-Persona-Visual-starter-pack-catalog.md
@@ -1,0 +1,58 @@
+---
+id: TASK-344
+title: Add bundled Persona Visual starter pack catalog
+status: Done
+assignee: []
+created_date: '2026-05-14 19:49'
+updated_date: '2026-05-14 19:54'
+labels:
+  - persona-visuals
+  - backend
+  - starter-packs
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1694'
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement GitHub issue #1694: add backend-owned bundled Persona Visual starter packs that can be listed and copied into user-owned draft storage for a selected persona. The copied pack must remain inactive until the existing explicit activation flow is used. Keep the path aligned with existing Persona Visual manifest validation, personal library/storage ownership, and import/review semantics. Do not add Live2D runtime support, marketplace/library sharing, external MCP provider execution, or VN/CYOA behavior in this slice.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Backend can list available bundled sprite_frames starter packs with enough metadata for custom frontends to present a default choice.
+- [x] #2 Copying a bundled starter pack for a target persona creates a user-owned draft visual pack and owned asset records/storage references.
+- [x] #3 Copied starter packs are not activated automatically and require the existing explicit activation step.
+- [x] #4 Bundled starter pack validation rejects malformed manifest or asset data before copy-to-draft succeeds.
+- [x] #5 Tests cover list, copy-to-draft, non-activation, validation success, and malformed bundled data rejection.
+- [x] #6 Documentation or task notes explain that bundled defaults are copied into user-owned draft storage rather than referenced as global mutable state.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented backend Persona Visual starter catalog endpoints: GET /api/v1/persona/visual-starter-packs and POST /api/v1/persona/visual-starter-packs/{starter_pack_id}/use. The copy path creates an inactive user-owned draft by validating bundled manifest assets, copying image bytes through PersonaVisualService storage, remapping manifest asset IDs, and preserving explicit activation.
+
+Verification: targeted starter tests passed; full test_persona_visuals_api.py passed with 49 tests; test_persona_visual_service.py passed with 14 tests; py_compile passed for touched Python files; git diff --check passed; Bandit on touched Python paths produced zero findings in /tmp/bandit_persona_visual_starter_packs.json.
+
+Known skips/blockers: none. No frontend setup flow or E2E coverage is included here; those are intentionally left to the follow-up first-run setup and happy-path coverage issues (#1695 and #1698).
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added a backend-owned Persona Visual starter pack catalog and copy-to-draft path for issue #1694. Bundled defaults are listed through /api/v1/persona/visual-starter-packs and copied through /api/v1/persona/visual-starter-packs/{starter_pack_id}/use into user-owned draft visual pack storage. The copied draft remains inactive until explicit activation, uses existing manifest validation/storage semantics, and documents that bundled defaults are copied rather than referenced as global mutable state.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-348 - Address-Persona-Visual-starter-pack-PR-review-comments.md
+++ b/backlog/tasks/task-348 - Address-Persona-Visual-starter-pack-PR-review-comments.md
@@ -1,0 +1,54 @@
+---
+id: TASK-348
+title: Address Persona Visual starter pack PR review comments
+status: Done
+assignee: []
+created_date: '2026-05-15 01:08'
+updated_date: '2026-05-15 01:12'
+labels:
+  - persona-visuals
+  - review-fix
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1700'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the still-actionable PR #1700 review feedback for the Persona Visual starter pack catalog without expanding feature scope. Focus on API model/helper documentation, starter catalog immutability, duplicate bundled asset ID validation, and validating starter manifests before file/database copy side effects.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Starter pack response schemas and conversion helper have concise docstrings.
+- [x] #2 Starter catalog helpers do not expose mutable global manifest objects to callers.
+- [x] #3 Starter pack copy rejects duplicate bundled asset IDs with a clear invalid_starter_pack error.
+- [x] #4 Starter manifest structure is validated before creating user-owned packs or copying bundled assets.
+- [x] #5 Focused persona visual starter-pack tests pass.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented PR #1700 review fixes: starter-pack API docstrings, isolated catalog manifest copies, duplicate bundled asset ID rejection, and pre-copy starter manifest validation.
+
+Verification: focused starter-pack pytest selection passed (6 passed); full tldw_Server_API/tests/Persona/test_persona_visuals_api.py passed (52 passed); py_compile passed for touched backend modules; git diff --check passed; Bandit passed for touched backend modules with JSON output at /tmp/bandit_persona_visual_starter_review.json.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Resolved PR #1700 starter-pack review comments by documenting the new starter-pack API models/helper, isolating mutable catalog manifests with deep copies, rejecting duplicate bundled asset IDs before mapping, and prevalidating starter manifests before any pack or asset copy side effects.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -2004,12 +2004,14 @@ def _persona_visual_asset_to_response(asset: dict[str, Any]) -> PersonaVisualAss
 
 
 def _persona_visual_starter_pack_to_response(starter_pack: Any) -> PersonaVisualStarterPackResponse:
+    """Convert one bundled starter-pack catalog entry into its public API summary."""
+
     return PersonaVisualStarterPackResponse(
-        id=str(starter_pack.id),
-        title=str(starter_pack.title),
-        description=str(starter_pack.description or "") or None,
-        renderer_type=str(starter_pack.renderer_type or "sprite_frames"),
-        manifest_version=int(starter_pack.manifest_version),
+        id=starter_pack.id,
+        title=starter_pack.title,
+        description=starter_pack.description or None,
+        renderer_type=starter_pack.renderer_type,
+        manifest_version=starter_pack.manifest_version,
         asset_count=len(starter_pack.assets),
     )
 

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -105,6 +105,9 @@ from tldw_Server_API.app.api.v1.schemas.persona import (
     PersonaVisualPortabilityJobResponse,
     PersonaVisualRendererCapabilitiesResponse,
     PersonaVisualRendererCapabilityResponse,
+    PersonaVisualStarterPackListResponse,
+    PersonaVisualStarterPackResponse,
+    PersonaVisualStarterPackUseRequest,
 )
 from tldw_Server_API.app.api.v1.schemas.voice_assistant_schemas import (
     VoiceActionType,
@@ -178,6 +181,9 @@ from tldw_Server_API.app.core.Persona.visual_service import (
     MAX_VISUAL_UPLOAD_BYTES,
     PersonaVisualService,
     PersonaVisualServiceError,
+)
+from tldw_Server_API.app.core.Persona.visual_starter_catalog import (
+    list_persona_visual_starter_packs,
 )
 from tldw_Server_API.app.core.Persona.visual_library_service import (
     PersonaVisualLibraryService,
@@ -1997,6 +2003,17 @@ def _persona_visual_asset_to_response(asset: dict[str, Any]) -> PersonaVisualAss
     )
 
 
+def _persona_visual_starter_pack_to_response(starter_pack: Any) -> PersonaVisualStarterPackResponse:
+    return PersonaVisualStarterPackResponse(
+        id=str(starter_pack.id),
+        title=str(starter_pack.title),
+        description=str(starter_pack.description or "") or None,
+        renderer_type=str(starter_pack.renderer_type or "sprite_frames"),
+        manifest_version=int(starter_pack.manifest_version),
+        asset_count=len(starter_pack.assets),
+    )
+
+
 def get_persona_visual_job_manager() -> JobManager:
     db_url = (os.getenv("JOBS_DB_URL") or "").strip()
     db_path = (os.getenv("JOBS_DB_PATH") or "").strip()
@@ -2223,7 +2240,13 @@ def _persona_visual_generated_assets_for_candidate(
 
 def _persona_visual_service_error_to_http(exc: PersonaVisualServiceError) -> HTTPException:
     status_code = status.HTTP_400_BAD_REQUEST
-    if exc.code in {"pack_not_found", "asset_not_found", "candidate_not_found", "target_persona_not_found"}:
+    if exc.code in {
+        "pack_not_found",
+        "asset_not_found",
+        "candidate_not_found",
+        "target_persona_not_found",
+        "starter_pack_not_found",
+    }:
         status_code = status.HTTP_404_NOT_FOUND
     elif exc.code in {"forbidden"}:
         status_code = status.HTTP_403_FORBIDDEN
@@ -3798,6 +3821,63 @@ async def list_persona_visual_renderers(
             for capability in list_persona_visual_renderer_capabilities()
         ]
     )
+
+
+@router.get(
+    "/visual-starter-packs",
+    response_model=PersonaVisualStarterPackListResponse,
+    tags=["persona"],
+    status_code=status.HTTP_200_OK,
+    dependencies=[Depends(check_rate_limit)],
+)
+async def list_persona_visual_starter_pack_catalog(
+    _current_user: User = Depends(get_request_user),
+) -> PersonaVisualStarterPackListResponse:
+    """List immutable bundled Persona Visual starter packs available for copying."""
+    if not is_persona_enabled():
+        raise HTTPException(status_code=404, detail="Persona disabled")
+    _require_current_user_id(_current_user)
+    return PersonaVisualStarterPackListResponse(
+        items=[
+            _persona_visual_starter_pack_to_response(starter_pack)
+            for starter_pack in list_persona_visual_starter_packs()
+        ]
+    )
+
+
+@router.post(
+    "/visual-starter-packs/{starter_pack_id}/use",
+    response_model=PersonaVisualPackResponse,
+    tags=["persona"],
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(check_rate_limit)],
+)
+async def use_persona_visual_starter_pack(
+    starter_pack_id: str,
+    payload: PersonaVisualStarterPackUseRequest,
+    _current_user: User = Depends(get_request_user),
+    visual_service: PersonaVisualService = Depends(get_persona_visual_service),
+) -> PersonaVisualPackResponse:
+    """Copy a bundled starter pack into user-owned draft storage for one persona."""
+    if not is_persona_enabled():
+        raise HTTPException(status_code=404, detail="Persona disabled")
+    user_id = _require_current_user_id(_current_user)
+    try:
+        copied = await _run_persona_db_call(
+            visual_service.copy_starter_pack_to_persona,
+            starter_pack_id=starter_pack_id,
+            user_id=user_id,
+            target_persona_id=payload.target_persona_id,
+            title=payload.title,
+        )
+        return _persona_visual_pack_to_response(
+            copied,
+            assets=list(copied.get("assets") or []),
+        )
+    except PersonaVisualServiceError as exc:
+        raise _persona_visual_service_error_to_http(exc) from exc
+    except (InputError, ConflictError, CharactersRAGDBError) as exc:
+        raise _to_http_exception(exc, action="use persona visual starter pack") from exc
 
 
 @router.get(

--- a/tldw_Server_API/app/api/v1/schemas/persona.py
+++ b/tldw_Server_API/app/api/v1/schemas/persona.py
@@ -186,6 +186,42 @@ class PersonaVisualLibraryUseRequest(BaseModel):
         return normalized
 
 
+class PersonaVisualStarterPackResponse(BaseModel):
+    id: str
+    title: str
+    description: str | None = None
+    renderer_type: PersonaVisualRendererType
+    manifest_version: int = 1
+    asset_count: int = 0
+
+
+class PersonaVisualStarterPackListResponse(BaseModel):
+    items: list[PersonaVisualStarterPackResponse] = Field(default_factory=list)
+
+
+class PersonaVisualStarterPackUseRequest(BaseModel):
+    target_persona_id: str = Field(min_length=1, max_length=128)
+    title: str | None = Field(default=None, max_length=200)
+
+    @field_validator("target_persona_id")
+    @classmethod
+    def normalize_target_persona_id(cls, value: str) -> str:
+        normalized = str(value or "").strip()
+        if not normalized:
+            raise ValueError("target_persona_id is required")
+        return normalized
+
+    @field_validator("title")
+    @classmethod
+    def normalize_title(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = str(value).strip()
+        if not normalized:
+            raise ValueError("title cannot be empty")
+        return normalized
+
+
 class PersonaVisualManifestUpdate(BaseModel):
     manifest: dict[str, Any] = Field(default_factory=dict)
     expected_version: int | None = Field(default=None, ge=1)

--- a/tldw_Server_API/app/api/v1/schemas/persona.py
+++ b/tldw_Server_API/app/api/v1/schemas/persona.py
@@ -187,6 +187,8 @@ class PersonaVisualLibraryUseRequest(BaseModel):
 
 
 class PersonaVisualStarterPackResponse(BaseModel):
+    """Summary of one server-bundled Persona Visual starter pack."""
+
     id: str
     title: str
     description: str | None = None
@@ -196,10 +198,14 @@ class PersonaVisualStarterPackResponse(BaseModel):
 
 
 class PersonaVisualStarterPackListResponse(BaseModel):
+    """List response for server-bundled Persona Visual starter packs."""
+
     items: list[PersonaVisualStarterPackResponse] = Field(default_factory=list)
 
 
 class PersonaVisualStarterPackUseRequest(BaseModel):
+    """Request body for copying a starter pack into a user-owned draft."""
+
     target_persona_id: str = Field(min_length=1, max_length=128)
     title: str | None = Field(default=None, max_length=200)
 

--- a/tldw_Server_API/app/core/Persona/visual_service.py
+++ b/tldw_Server_API/app/core/Persona/visual_service.py
@@ -433,8 +433,34 @@ class PersonaVisualService:
                 details={"target_persona_id": target_persona_id},
             )
 
-        source_manifest = starter_pack.manifest if isinstance(starter_pack.manifest, dict) else {}
-        starter_assets_by_id = {str(asset.id): asset for asset in starter_pack.assets}
+        if not isinstance(starter_pack.manifest, dict):
+            raise PersonaVisualServiceError(
+                "invalid_starter_pack",
+                "Persona visual starter manifest must be an object.",
+                details={"starter_pack_id": starter_pack.id},
+            )
+        source_manifest = deepcopy(starter_pack.manifest)
+        seen_asset_ids: set[str] = set()
+        duplicate_asset_ids: set[str] = set()
+        starter_assets_by_id: dict[str, Any] = {}
+        for asset in starter_pack.assets:
+            source_asset_id = str(asset.id or "").strip()
+            if not source_asset_id:
+                raise PersonaVisualServiceError(
+                    "invalid_starter_pack",
+                    "Persona visual starter pack contains a bundled asset without an ID.",
+                    details={"starter_pack_id": starter_pack.id},
+                )
+            if source_asset_id in seen_asset_ids:
+                duplicate_asset_ids.add(source_asset_id)
+            seen_asset_ids.add(source_asset_id)
+            starter_assets_by_id[source_asset_id] = asset
+        if duplicate_asset_ids:
+            raise PersonaVisualServiceError(
+                "invalid_starter_pack",
+                "Persona visual starter pack contains duplicate bundled asset IDs.",
+                details={"starter_pack_id": starter_pack.id, "asset_ids": sorted(duplicate_asset_ids)},
+            )
         referenced_asset_ids = collect_visual_manifest_asset_ids(source_manifest)
         missing_asset_ids = sorted(referenced_asset_ids - set(starter_assets_by_id))
         if missing_asset_ids:
@@ -449,6 +475,18 @@ class PersonaVisualService:
                 "Persona visual starter manifest does not reference any bundled assets.",
                 details={"starter_pack_id": starter_pack.id},
             )
+        try:
+            validate_visual_manifest(
+                source_manifest,
+                available_asset_ids=referenced_asset_ids,
+                require_activatable=False,
+            )
+        except PersonaVisualManifestError as exc:
+            raise PersonaVisualServiceError(
+                "invalid_starter_pack",
+                str(exc),
+                details={"starter_pack_id": starter_pack.id},
+            ) from exc
 
         title_value = str(title or "").strip() or starter_pack.title
         target_pack = self._db.create_persona_visual_pack(

--- a/tldw_Server_API/app/core/Persona/visual_service.py
+++ b/tldw_Server_API/app/core/Persona/visual_service.py
@@ -24,6 +24,9 @@ from tldw_Server_API.app.core.Persona.visual_manifest_assets import (
     collect_visual_manifest_asset_ids,
     remap_visual_manifest_assets,
 )
+from tldw_Server_API.app.core.Persona.visual_starter_catalog import (
+    get_persona_visual_starter_pack,
+)
 from tldw_Server_API.app.core.Persona.visuals import (
     PersonaVisualManifestError,
     validate_visual_manifest,
@@ -388,6 +391,154 @@ class PersonaVisualService:
                 except OSError as cleanup_error:  # pragma: no cover - defensive cleanup logging
                     logger.warning(
                         "Failed to unlink partially duplicated persona visual asset {}: {}",
+                        path,
+                        cleanup_error,
+                    )
+            raise
+
+        assets = self._db.list_persona_visual_assets(
+            pack_id=str(target_pack["id"]),
+            persona_id=target_persona_id,
+            user_id=user_id,
+        )
+        finalized["assets"] = assets
+        finalized["assets_by_id"] = {str(asset["id"]): asset for asset in assets}
+        return finalized
+
+    def copy_starter_pack_to_persona(
+        self,
+        *,
+        starter_pack_id: str,
+        user_id: str,
+        target_persona_id: str,
+        title: str | None = None,
+    ) -> dict[str, Any]:
+        """Copy an immutable bundled starter pack into a user-owned draft pack."""
+        starter_pack = get_persona_visual_starter_pack(starter_pack_id)
+        if starter_pack is None:
+            raise PersonaVisualServiceError(
+                "starter_pack_not_found",
+                "Persona visual starter pack not found.",
+                details={"starter_pack_id": starter_pack_id},
+            )
+
+        target_persona = self._db.get_persona_profile(
+            persona_id=target_persona_id,
+            user_id=user_id,
+        )
+        if not target_persona:
+            raise PersonaVisualServiceError(
+                "target_persona_not_found",
+                "Target persona not found for user.",
+                details={"target_persona_id": target_persona_id},
+            )
+
+        source_manifest = starter_pack.manifest if isinstance(starter_pack.manifest, dict) else {}
+        starter_assets_by_id = {str(asset.id): asset for asset in starter_pack.assets}
+        referenced_asset_ids = collect_visual_manifest_asset_ids(source_manifest)
+        missing_asset_ids = sorted(referenced_asset_ids - set(starter_assets_by_id))
+        if missing_asset_ids:
+            raise PersonaVisualServiceError(
+                "invalid_starter_pack",
+                "Persona visual starter manifest references bundled assets that are missing.",
+                details={"starter_pack_id": starter_pack.id, "asset_ids": missing_asset_ids},
+            )
+        if not referenced_asset_ids:
+            raise PersonaVisualServiceError(
+                "invalid_starter_pack",
+                "Persona visual starter manifest does not reference any bundled assets.",
+                details={"starter_pack_id": starter_pack.id},
+            )
+
+        title_value = str(title or "").strip() or starter_pack.title
+        target_pack = self._db.create_persona_visual_pack(
+            persona_id=target_persona_id,
+            user_id=user_id,
+            title=title_value,
+            renderer_type=starter_pack.renderer_type,
+            status="failed",
+            provenance="imported",
+            manifest={
+                "manifest_version": starter_pack.manifest_version,
+                "renderer_type": starter_pack.renderer_type,
+                "states": {},
+                "animations": {},
+            },
+        )
+        copied_file_paths: list[Path] = []
+        try:
+            asset_id_map: dict[str, str] = {}
+            copied_assets: list[dict[str, Any]] = []
+            for source_asset_id in sorted(referenced_asset_ids):
+                source_asset = starter_assets_by_id[source_asset_id]
+                copied = self.create_asset_from_upload(
+                    persona_id=target_persona_id,
+                    user_id=user_id,
+                    pack_id=str(target_pack["id"]),
+                    content=source_asset.content,
+                    mime_type=source_asset.mime_type,
+                    original_filename=source_asset.filename,
+                    asset_role=source_asset.asset_role,
+                    provenance="imported",
+                )
+                if copied.get("storage_path"):
+                    copied_file_paths.append(Path(str(copied["storage_path"])))
+                asset_id_map[source_asset_id] = str(copied["id"])
+                copied_assets.append(copied)
+
+            remapped_manifest = remap_visual_manifest_assets(source_manifest, asset_id_map)
+            asset_ids = {str(asset["id"]) for asset in copied_assets}
+            asset_dimensions = {
+                str(asset["id"]): (int(asset["width"]), int(asset["height"]))
+                for asset in copied_assets
+                if asset.get("width") is not None and asset.get("height") is not None
+            }
+            try:
+                validation = validate_visual_manifest(
+                    remapped_manifest,
+                    available_asset_ids=asset_ids,
+                    available_asset_dimensions=asset_dimensions,
+                    require_activatable=False,
+                )
+            except PersonaVisualManifestError as exc:
+                raise PersonaVisualServiceError(
+                    "invalid_starter_pack",
+                    str(exc),
+                    details={"starter_pack_id": starter_pack.id},
+                ) from exc
+            updated_pack = self._db.update_persona_visual_pack_manifest(
+                pack_id=str(target_pack["id"]),
+                persona_id=target_persona_id,
+                user_id=user_id,
+                manifest=validation.manifest,
+                expected_version=int(target_pack["version"]),
+            )
+            finalized = self._db.update_persona_visual_pack_status(
+                pack_id=str(target_pack["id"]),
+                persona_id=target_persona_id,
+                user_id=user_id,
+                status="draft",
+                expected_version=int(updated_pack["version"]),
+            )
+        except Exception:
+            try:
+                self._db.soft_delete_persona_visual_pack_with_assets(
+                    pack_id=str(target_pack["id"]),
+                    persona_id=target_persona_id,
+                    user_id=user_id,
+                )
+            except Exception as cleanup_error:  # pragma: no cover - defensive cleanup logging
+                logger.warning(
+                    "Failed to soft-delete partially copied persona visual starter pack {}: {}",
+                    target_pack.get("id"),
+                    cleanup_error,
+                )
+            for path in copied_file_paths:
+                try:
+                    path.unlink(missing_ok=True)
+                except OSError as cleanup_error:  # pragma: no cover - defensive cleanup logging
+                    logger.warning(
+                        "Failed to unlink partially copied persona visual starter asset {}: {}",
                         path,
                         cleanup_error,
                     )

--- a/tldw_Server_API/app/core/Persona/visual_starter_catalog.py
+++ b/tldw_Server_API/app/core/Persona/visual_starter_catalog.py
@@ -7,6 +7,7 @@ assets into user-owned draft storage before any activation can happen.
 from __future__ import annotations
 
 import base64
+from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any
 
@@ -89,16 +90,16 @@ _STARTER_PACKS: tuple[PersonaVisualStarterPack, ...] = (
 
 
 def list_persona_visual_starter_packs() -> list[PersonaVisualStarterPack]:
-    """Return immutable bundled Persona Visual starter packs."""
-    return list(_STARTER_PACKS)
+    """Return bundled Persona Visual starter packs with isolated mutable fields."""
+    return [deepcopy(starter_pack) for starter_pack in _STARTER_PACKS]
 
 
 def get_persona_visual_starter_pack(starter_pack_id: str) -> PersonaVisualStarterPack | None:
-    """Return one bundled starter pack by stable ID."""
+    """Return one bundled starter pack by stable ID with isolated mutable fields."""
     normalized_id = str(starter_pack_id or "").strip()
     for starter_pack in _STARTER_PACKS:
         if starter_pack.id == normalized_id:
-            return starter_pack
+            return deepcopy(starter_pack)
     return None
 
 

--- a/tldw_Server_API/app/core/Persona/visual_starter_catalog.py
+++ b/tldw_Server_API/app/core/Persona/visual_starter_catalog.py
@@ -1,0 +1,110 @@
+"""Bundled Persona Visual starter-pack catalog.
+
+Starter packs are immutable server-bundled inputs. Runtime use copies their
+assets into user-owned draft storage before any activation can happen.
+"""
+
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class PersonaVisualStarterAsset:
+    """One immutable asset bundled with a starter pack."""
+
+    id: str
+    filename: str
+    mime_type: str
+    asset_role: str
+    content: bytes
+
+
+@dataclass(frozen=True)
+class PersonaVisualStarterPack:
+    """Immutable bundled Persona Visual pack definition."""
+
+    id: str
+    title: str
+    description: str
+    renderer_type: str
+    manifest: dict[str, Any]
+    assets: tuple[PersonaVisualStarterAsset, ...]
+
+    @property
+    def manifest_version(self) -> int:
+        return int(self.manifest.get("manifest_version") or 1)
+
+
+_RESEARCH_BUDDY_IDLE_ASSET_ID = "research-buddy-idle-frame"
+_RESEARCH_BUDDY_IDLE_PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGNg+M/wHwAEAQH/"
+    "cetH5QAAAABJRU5ErkJggg=="
+)
+
+_RESEARCH_BUDDY_MANIFEST: dict[str, Any] = {
+    "manifest_version": 1,
+    "renderer_type": "sprite_frames",
+    "states": {
+        "idle": {"animation_id": "idle"},
+        "listening": {"animation_id": "idle"},
+        "thinking": {"animation_id": "idle"},
+        "speaking": {"animation_id": "idle"},
+        "error": {"animation_id": "idle"},
+    },
+    "animations": {
+        "idle": {
+            "frames": [
+                {
+                    "asset_id": _RESEARCH_BUDDY_IDLE_ASSET_ID,
+                    "duration_ms": 1000,
+                }
+            ],
+            "frame_rate": 1,
+            "loop": True,
+        }
+    },
+}
+
+_STARTER_PACKS: tuple[PersonaVisualStarterPack, ...] = (
+    PersonaVisualStarterPack(
+        id="research-buddy-sprite-frames-v1",
+        title="Research Buddy starter",
+        description="A minimal sprite_frames starter pack for first-run Persona Buddy setup.",
+        renderer_type="sprite_frames",
+        manifest=_RESEARCH_BUDDY_MANIFEST,
+        assets=(
+            PersonaVisualStarterAsset(
+                id=_RESEARCH_BUDDY_IDLE_ASSET_ID,
+                filename="research-buddy-idle.png",
+                mime_type="image/png",
+                asset_role="frame",
+                content=_RESEARCH_BUDDY_IDLE_PNG,
+            ),
+        ),
+    ),
+)
+
+
+def list_persona_visual_starter_packs() -> list[PersonaVisualStarterPack]:
+    """Return immutable bundled Persona Visual starter packs."""
+    return list(_STARTER_PACKS)
+
+
+def get_persona_visual_starter_pack(starter_pack_id: str) -> PersonaVisualStarterPack | None:
+    """Return one bundled starter pack by stable ID."""
+    normalized_id = str(starter_pack_id or "").strip()
+    for starter_pack in _STARTER_PACKS:
+        if starter_pack.id == normalized_id:
+            return starter_pack
+    return None
+
+
+__all__ = [
+    "PersonaVisualStarterAsset",
+    "PersonaVisualStarterPack",
+    "get_persona_visual_starter_pack",
+    "list_persona_visual_starter_packs",
+]

--- a/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
@@ -180,6 +180,112 @@ def test_persona_visual_renderer_capabilities_respect_persona_feature_flag(
     assert response.json() == {"detail": "Persona disabled"}
 
 
+def test_list_persona_visual_starter_packs(persona_db: CharactersRAGDB) -> None:
+    with _client_for_user(1, persona_db) as client:
+        response = client.get("/api/v1/persona/visual-starter-packs")
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert [item["id"] for item in payload["items"]] == ["research-buddy-sprite-frames-v1"]
+    starter = payload["items"][0]
+    assert starter["title"] == "Research Buddy starter"
+    assert starter["renderer_type"] == "sprite_frames"
+    assert starter["manifest_version"] == 1
+    assert starter["asset_count"] == 1
+
+
+def test_use_persona_visual_starter_pack_creates_inactive_user_owned_draft(
+    persona_db: CharactersRAGDB,
+) -> None:
+    with _client_for_user(1, persona_db) as client:
+        persona_id = _create_persona(client, name="Starter Target")
+
+        response = client.post(
+            "/api/v1/persona/visual-starter-packs/research-buddy-sprite-frames-v1/use",
+            json={"target_persona_id": persona_id, "title": "My starter draft"},
+        )
+
+        assert response.status_code == 201, response.text
+        payload = response.json()
+        assert payload["title"] == "My starter draft"
+        assert payload["persona_id"] == persona_id
+        assert payload["status"] == "draft"
+        assert payload["provenance"] == "imported"
+        assert payload["parent_pack_id"] is None
+        assert len(payload["assets"]) == 1
+        copied_asset_id = payload["assets"][0]["id"]
+        assert payload["manifest"]["animations"]["idle"]["frames"][0]["asset_id"] == copied_asset_id
+        assert persona_db.get_active_persona_visual_pack(persona_id=persona_id, user_id="1") is None
+
+
+def test_use_persona_visual_starter_pack_rejects_other_user_target(
+    persona_db: CharactersRAGDB,
+) -> None:
+    with _client_for_user(2, persona_db) as other_client:
+        other_persona_id = _create_persona(other_client, name="Other Starter Target")
+    with _client_for_user(1, persona_db) as client:
+        response = client.post(
+            "/api/v1/persona/visual-starter-packs/research-buddy-sprite-frames-v1/use",
+            json={"target_persona_id": other_persona_id},
+        )
+
+    assert response.status_code == 404
+    assert response.json()["detail"]["code"] == "target_persona_not_found"
+
+
+def test_use_persona_visual_starter_pack_rejects_malformed_catalog_entry(
+    monkeypatch: pytest.MonkeyPatch,
+    persona_db: CharactersRAGDB,
+) -> None:
+    from tldw_Server_API.app.core.Persona import visual_service
+    from tldw_Server_API.app.core.Persona.visual_starter_catalog import (
+        PersonaVisualStarterAsset,
+        PersonaVisualStarterPack,
+    )
+
+    malformed_pack = PersonaVisualStarterPack(
+        id="broken-starter",
+        title="Broken starter",
+        description="References an asset that is not bundled.",
+        renderer_type="sprite_frames",
+        manifest={
+            "manifest_version": 1,
+            "renderer_type": "sprite_frames",
+            "states": {"idle": {"animation_id": "idle"}},
+            "animations": {
+                "idle": {
+                    "frames": [{"asset_id": "missing-source-asset", "duration_ms": 100}],
+                    "frame_rate": 1,
+                }
+            },
+        },
+        assets=(
+            PersonaVisualStarterAsset(
+                id="actual-source-asset",
+                filename="actual.png",
+                mime_type="image/png",
+                asset_role="frame",
+                content=_png_bytes(),
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        visual_service,
+        "get_persona_visual_starter_pack",
+        lambda starter_pack_id: malformed_pack if starter_pack_id == "broken-starter" else None,
+    )
+    with _client_for_user(1, persona_db) as client:
+        persona_id = _create_persona(client, name="Broken Starter Target")
+
+        response = client.post(
+            "/api/v1/persona/visual-starter-packs/broken-starter/use",
+            json={"target_persona_id": persona_id},
+        )
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["code"] == "invalid_starter_pack"
+
+
 def _upload_png(client: TestClient, persona_id: str, pack_id: str) -> dict:
     response = client.post(
         f"/api/v1/persona/profiles/{persona_id}/visual-packs/{pack_id}/assets",

--- a/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
@@ -194,6 +194,21 @@ def test_list_persona_visual_starter_packs(persona_db: CharactersRAGDB) -> None:
     assert starter["asset_count"] == 1
 
 
+def test_persona_visual_starter_catalog_returns_isolated_manifest_copies() -> None:
+    from tldw_Server_API.app.core.Persona.visual_starter_catalog import (
+        get_persona_visual_starter_pack,
+    )
+
+    first = get_persona_visual_starter_pack("research-buddy-sprite-frames-v1")
+    assert first is not None
+    first.manifest["states"]["idle"]["animation_id"] = "mutated"
+
+    second = get_persona_visual_starter_pack("research-buddy-sprite-frames-v1")
+
+    assert second is not None
+    assert second.manifest["states"]["idle"]["animation_id"] == "idle"
+
+
 def test_use_persona_visual_starter_pack_creates_inactive_user_owned_draft(
     persona_db: CharactersRAGDB,
 ) -> None:
@@ -284,6 +299,125 @@ def test_use_persona_visual_starter_pack_rejects_malformed_catalog_entry(
 
     assert response.status_code == 400
     assert response.json()["detail"]["code"] == "invalid_starter_pack"
+
+
+def test_use_persona_visual_starter_pack_rejects_duplicate_bundled_asset_ids(
+    monkeypatch: pytest.MonkeyPatch,
+    persona_db: CharactersRAGDB,
+) -> None:
+    from tldw_Server_API.app.core.Persona import visual_service
+    from tldw_Server_API.app.core.Persona.visual_starter_catalog import (
+        PersonaVisualStarterAsset,
+        PersonaVisualStarterPack,
+    )
+
+    duplicate_pack = PersonaVisualStarterPack(
+        id="duplicate-starter",
+        title="Duplicate starter",
+        description="Contains two bundled assets with the same stable ID.",
+        renderer_type="sprite_frames",
+        manifest={
+            "manifest_version": 1,
+            "renderer_type": "sprite_frames",
+            "states": {"idle": {"animation_id": "idle"}},
+            "animations": {
+                "idle": {
+                    "frames": [{"asset_id": "duplicate-source-asset", "duration_ms": 100}],
+                    "frame_rate": 1,
+                }
+            },
+        },
+        assets=(
+            PersonaVisualStarterAsset(
+                id="duplicate-source-asset",
+                filename="one.png",
+                mime_type="image/png",
+                asset_role="frame",
+                content=_png_bytes(),
+            ),
+            PersonaVisualStarterAsset(
+                id="duplicate-source-asset",
+                filename="two.png",
+                mime_type="image/png",
+                asset_role="frame",
+                content=_png_bytes(),
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        visual_service,
+        "get_persona_visual_starter_pack",
+        lambda starter_pack_id: duplicate_pack if starter_pack_id == "duplicate-starter" else None,
+    )
+    with _client_for_user(1, persona_db) as client:
+        persona_id = _create_persona(client, name="Duplicate Starter Target")
+
+        response = client.post(
+            "/api/v1/persona/visual-starter-packs/duplicate-starter/use",
+            json={"target_persona_id": persona_id},
+        )
+
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert detail["code"] == "invalid_starter_pack"
+    assert detail["details"]["asset_ids"] == ["duplicate-source-asset"]
+    assert persona_db.list_persona_visual_packs(persona_id=persona_id, user_id="1") == []
+
+
+def test_use_persona_visual_starter_pack_prevalidates_manifest_before_copy(
+    monkeypatch: pytest.MonkeyPatch,
+    persona_db: CharactersRAGDB,
+) -> None:
+    from tldw_Server_API.app.core.Persona import visual_service
+    from tldw_Server_API.app.core.Persona.visual_starter_catalog import (
+        PersonaVisualStarterAsset,
+        PersonaVisualStarterPack,
+    )
+
+    invalid_manifest_pack = PersonaVisualStarterPack(
+        id="invalid-manifest-starter",
+        title="Invalid manifest starter",
+        description="Has bundled assets but an unsupported renderer type.",
+        renderer_type="sprite_frames",
+        manifest={
+            "manifest_version": 1,
+            "renderer_type": "unsupported_renderer",
+            "states": {"idle": {"animation_id": "idle"}},
+            "animations": {
+                "idle": {
+                    "frames": [{"asset_id": "source-asset", "duration_ms": 100}],
+                    "frame_rate": 1,
+                }
+            },
+        },
+        assets=(
+            PersonaVisualStarterAsset(
+                id="source-asset",
+                filename="source.png",
+                mime_type="image/png",
+                asset_role="frame",
+                content=_png_bytes(),
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        visual_service,
+        "get_persona_visual_starter_pack",
+        lambda starter_pack_id: invalid_manifest_pack
+        if starter_pack_id == "invalid-manifest-starter"
+        else None,
+    )
+    with _client_for_user(1, persona_db) as client:
+        persona_id = _create_persona(client, name="Invalid Manifest Starter Target")
+
+        response = client.post(
+            "/api/v1/persona/visual-starter-packs/invalid-manifest-starter/use",
+            json={"target_persona_id": persona_id},
+        )
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["code"] == "invalid_starter_pack"
+    assert persona_db.list_persona_visual_packs(persona_id=persona_id, user_id="1") == []
 
 
 def _upload_png(client: TestClient, persona_id: str, pack_id: str) -> dict:


### PR DESCRIPTION
## Summary
- Add backend Persona Visual starter catalog endpoints for listing bundled defaults and copying one into a user-owned draft pack.
- Add an immutable Research Buddy sprite_frames starter pack and copy it through existing PersonaVisualService asset storage, manifest validation, and asset-id remapping.
- Document that bundled defaults are copied into user-owned draft storage and remain inactive until explicit activation.

## Verification
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Persona/test_persona_visuals_api.py -k "starter_pack" -q
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Persona/test_persona_visuals_api.py -q
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_service.py -q
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m py_compile tldw_Server_API/app/core/Persona/visual_starter_catalog.py tldw_Server_API/app/core/Persona/visual_service.py tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/app/api/v1/schemas/persona.py
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -q -r tldw_Server_API/app/core/Persona/visual_starter_catalog.py tldw_Server_API/app/core/Persona/visual_service.py tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/app/api/v1/schemas/persona.py -f json -o /tmp/bandit_persona_visual_starter_packs.json
- git diff --check

## Change summary
AI-generated draft. Human maintainer should replace this section with the required human-written change summary before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a server-owned Persona Visual starter pack catalog and a flow to copy a bundled pack into a user-owned draft. Includes a minimal Research Buddy starter; drafts stay inactive, with prevalidated manifests and immutable catalog entries.

- **New Features**
  - `GET /api/v1/persona/visual-starter-packs` lists immutable bundled starters with id, title, renderer, `manifest_version`, and `asset_count`.
  - `POST /api/v1/persona/visual-starter-packs/{starter_pack_id}/use` copies a starter to a target persona, prevalidates the manifest, rejects missing/duplicate asset IDs, copies assets via existing storage, remaps asset IDs, and creates an inactive draft.
  - Catalog in `visual_starter_catalog.py` with `research-buddy-sprite-frames-v1`; entries are deep-copied to preserve immutability.
  - Errors/tests: 404 `starter_pack_not_found`; 400 `invalid_starter_pack`; tests cover list, copy-to-draft, immutability, and prevalidation.

<sup>Written for commit 7c4b94d3581dca01b67904e61c6500cbe07e475c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

