### PR TITLE
Add bundled Persona Visual starter catalog

### DIFF
--- a/Docs/Code_Documentation/Persona_Visual_Packs.md
+++ b/Docs/Code_Documentation/Persona_Visual_Packs.md
@@ -208,6 +208,30 @@ Runtime state triggers are transient session behavior; library reuse is a
 durable draft-creation action that must preserve review and explicit activation
 semantics.
 
+## Bundled Starter Pack Catalog
+
+Bundled starter packs are immutable server fixtures for first-run or recovery
+flows. They are not global Persona Visual pack rows, shared library entries, or
+runtime assets. Listing the catalog returns safe fixture metadata only.
+
+Copying a bundled starter pack creates a normal user-owned draft pack attached
+to the selected target persona. The copy path validates the fixture manifest and
+assets, writes new asset files through the existing Persona Visual storage
+service, remaps fixture asset keys to newly created asset ids, and stores the
+resulting manifest on the new draft pack.
+
+Starter-pack copies do not activate automatically. If the target persona already
+has an active pack, that active pack stays active until the user explicitly
+activates the copied draft through the existing activation endpoint. This keeps
+bundled defaults aligned with the same review-before-activation rule used by
+imports, library reuse, and generated candidates.
+
+Current starter-pack API routes:
+
+1. `GET /api/v1/persona/visual-starter-packs`
+2. `GET /api/v1/persona/visual-starter-packs/{starter_pack_id}`
+3. `POST /api/v1/persona/visual-starter-packs/{starter_pack_id}/copy`
+
 Core implementation points:
 
 1. `persona_visual_library_items` in the ChaChaNotes persona store.
@@ -217,6 +241,9 @@ Core implementation points:
 4. `VisualPackEditor` for save/list/edit/remove/use controls in Persona Garden.
 5. `PersonaVisualsModule` for MCP discovery and draft reuse on top of the same
    reference-backed service semantics.
+6. `PersonaVisualStarterCatalogService` for bundled fixture listing and
+   copy-to-draft creation on top of the existing asset storage and manifest
+   validation path.
 
 ## External MCP-Compatible Pack Providers
 

--- a/Docs/superpowers/plans/2026-05-14-persona-visual-starter-catalog-plan.md
+++ b/Docs/superpowers/plans/2026-05-14-persona-visual-starter-catalog-plan.md
@@ -1,0 +1,90 @@
+# Persona Visual Starter Catalog Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add bundled Persona Visual starter packs that can be listed by the backend and copied into user-owned inactive draft packs for a selected persona.
+
+**Architecture:** Keep bundled starter packs as immutable server fixtures, not shared mutable pack rows. A new backend service validates fixture manifests/assets and creates normal user-owned draft pack plus asset rows through the existing `PersonaVisualService` storage and validation paths. REST endpoints expose catalog list/detail and copy-to-draft actions beside the existing Persona Visual pack API.
+
+**Tech Stack:** FastAPI, Pydantic, SQLite-backed `CharactersRAGDB`, existing Persona Visual service/storage, pytest.
+
+---
+
+## File Structure
+
+- Create: `tldw_Server_API/app/core/Persona/visual_starter_catalog.py`
+  - Loads bundled fixture definitions, validates catalog metadata, validates sprite-frame manifests against copied assets, and copies one starter pack to a target persona as a normal draft.
+- Create: `tldw_Server_API/app/core/Persona/visual_starter_fixtures.py`
+  - Contains one small built-in sprite_frames starter fixture with embedded PNG bytes and manifest builder metadata.
+- Modify: `tldw_Server_API/app/api/v1/schemas/persona.py`
+  - Adds catalog response and copy request/response schemas.
+- Modify: `tldw_Server_API/app/api/v1/endpoints/persona.py`
+  - Adds service dependency and REST endpoints under `/visual-starter-packs`.
+- Modify: `Docs/Code_Documentation/Persona_Visual_Packs.md`
+  - Documents that bundled starters are copied into user-owned draft storage and are never activated automatically.
+- Test: `tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py`
+  - Unit tests for service behavior, validation, and malformed fixture rejection.
+- Test: `tldw_Server_API/tests/Persona/test_persona_visuals_api.py`
+  - API tests for list and copy endpoints.
+
+---
+
+## Stage 1: Service Contract And Fixture Validation
+
+**Goal:** Introduce a fixture-backed catalog service without API wiring.
+
+**Success Criteria:** The service lists the bundled starter pack, rejects malformed fixture data, and copies a fixture into a user-owned draft using existing asset storage and manifest validation.
+
+**Tests:**
+- `python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py -q`
+
+- [x] Write failing tests in `test_persona_visual_starter_catalog.py` for listing the default fixture and copying it to a target persona.
+- [x] Run the focused test and confirm it fails because `visual_starter_catalog` is missing.
+- [x] Create `visual_starter_fixtures.py` with a tiny embedded PNG starter fixture and manifest builder metadata.
+- [x] Create `visual_starter_catalog.py` with a documented service, stable error codes, list/get/copy methods, and explicit malformed-fixture validation.
+- [x] Run the focused service tests and keep them passing.
+
+## Stage 2: REST Schemas And Endpoints
+
+**Goal:** Expose catalog list/detail and copy-to-draft actions through the existing Persona API.
+
+**Success Criteria:** Authenticated users can list bundled starters and copy a starter into one of their personas as a draft; cross-user persona targets and unknown starter IDs fail with stable HTTP errors.
+
+**Tests:**
+- `python -m pytest tldw_Server_API/tests/Persona/test_persona_visuals_api.py -q`
+
+- [x] Add Pydantic schemas for starter pack summaries, detail responses, and copy requests.
+- [x] Add `get_persona_visual_starter_catalog_service()` in `endpoints/persona.py`.
+- [x] Add `GET /api/v1/persona/visual-starter-packs`.
+- [x] Add `GET /api/v1/persona/visual-starter-packs/{starter_pack_id}`.
+- [x] Add `POST /api/v1/persona/visual-starter-packs/{starter_pack_id}/copy`.
+- [x] Add API tests proving copy creates a draft and preserves the target persona's active pack.
+
+## Stage 3: Docs, Tracker, And Verification
+
+**Goal:** Document semantics and package the PR-ready branch.
+
+**Success Criteria:** Docs explain copy semantics, Backlog acceptance criteria are checked, and focused tests plus Bandit pass for touched Python scope.
+
+**Tests:**
+- `python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py tldw_Server_API/tests/Persona/test_persona_visuals_api.py -q`
+- `python -m py_compile tldw_Server_API/app/core/Persona/visual_starter_catalog.py tldw_Server_API/app/core/Persona/visual_starter_fixtures.py`
+- `python -m bandit -r tldw_Server_API/app/core/Persona/visual_starter_catalog.py tldw_Server_API/app/core/Persona/visual_starter_fixtures.py tldw_Server_API/app/api/v1/endpoints/persona.py -f json -o /tmp/bandit_persona_visual_starter_catalog.json`
+- `git diff --check`
+
+- [x] Update `Docs/Code_Documentation/Persona_Visual_Packs.md`.
+- [x] Update Backlog task notes and check completed acceptance criteria.
+- [x] Run focused pytest, py_compile, Bandit, and diff whitespace checks.
+- [ ] Commit the implementation with issue `#1694` references.
+- [ ] Open a draft PR against `dev` and link `#1694` plus epic `#1510`.
+
+---
+
+## Boundaries
+
+- No Live2D runtime adapter.
+- No marketplace/shared public library.
+- No external MCP provider execution.
+- No VN/CYOA behavior.
+- No auto-activation.
+- No global mutable pack rows or reference-backed starter rows; starters are copied into user-owned draft storage.

--- a/Docs/superpowers/plans/2026-05-14-persona-visual-starter-catalog-plan.md
+++ b/Docs/superpowers/plans/2026-05-14-persona-visual-starter-catalog-plan.md
@@ -75,8 +75,8 @@
 - [x] Update `Docs/Code_Documentation/Persona_Visual_Packs.md`.
 - [x] Update Backlog task notes and check completed acceptance criteria.
 - [x] Run focused pytest, py_compile, Bandit, and diff whitespace checks.
-- [ ] Commit the implementation with issue `#1694` references.
-- [ ] Open a draft PR against `dev` and link `#1694` plus epic `#1510`.
+- [x] Commit the implementation with issue `#1694` references.
+- [x] Open a draft PR against `dev` and link `#1694` plus epic `#1510`.
 
 ---
 

--- a/Docs/superpowers/specs/2026-05-08-persona-visual-packs-design.md
+++ b/Docs/superpowers/specs/2026-05-08-persona-visual-packs-design.md
@@ -228,6 +228,20 @@ Recommended endpoint shape, adjusted to match existing route naming conventions 
 - `POST /api/v1/persona/profiles/{persona_id}/visual-packs/{pack_id}/generated-candidates/{candidate_id}/accept`
 - `POST /api/v1/persona/profiles/{persona_id}/visual-packs/{pack_id}/generated-candidates/{candidate_id}/reject`
 
+Bundled first-run defaults should be exposed through a server-owned starter
+catalog rather than global mutable packs:
+
+- `GET /api/v1/persona/visual-starter-packs`
+- `GET /api/v1/persona/visual-starter-packs/{starter_pack_id}`
+- `POST /api/v1/persona/visual-starter-packs/{starter_pack_id}/copy`
+
+Copying a starter pack should validate the bundled manifest and assets, copy
+the referenced fixture assets through the same Persona Visual storage path used
+by user uploads, remap fixture asset keys to user-owned asset IDs, and create an
+inactive draft pack for the target persona. It must not activate automatically;
+Buddy runtime rendering should only use the copied pack after the existing
+explicit activation step succeeds.
+
 Activation should be explicit. A draft pack can be saved while invalid, but activation should require every baseline state to resolve to a valid animation or valid fallback.
 
 ### Jobs Integration

--- a/backlog/tasks/task-345 - Add-bundled-Persona-Visual-starter-pack-catalog.md
+++ b/backlog/tasks/task-345 - Add-bundled-Persona-Visual-starter-pack-catalog.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-05-14 19:57'
-updated_date: '2026-05-14 20:00'
+updated_date: '2026-05-14 20:13'
 labels:
   - persona
   - persona-visual
@@ -14,6 +14,7 @@ dependencies: []
 references:
   - 'https://github.com/rmusser01/tldw_server/issues/1694'
   - 'https://github.com/rmusser01/tldw_server/issues/1510'
+  - 'https://github.com/rmusser01/tldw_server/pull/1701'
 priority: medium
 ---
 
@@ -52,6 +53,8 @@ Stage 1 green: service tests cover listing the bundled starter fixture, copying 
 Stage 2 green: API tests cover catalog list/detail, copy-to-draft without activation, unknown starter errors, and cross-user target rejection.
 
 Verification completed: `python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py tldw_Server_API/tests/Persona/test_persona_visuals_api.py -q --tb=short --disable-warnings` -> 53 passed; `python -m py_compile tldw_Server_API/app/core/Persona/visual_starter_catalog.py tldw_Server_API/app/core/Persona/visual_starter_fixtures.py` -> passed; Bandit touched Python scope -> 0 findings in `/tmp/bandit_persona_visual_starter_catalog.json`; `git diff --check` -> passed.
+
+Draft PR opened: https://github.com/rmusser01/tldw_server/pull/1701.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-345 - Add-bundled-Persona-Visual-starter-pack-catalog.md
+++ b/backlog/tasks/task-345 - Add-bundled-Persona-Visual-starter-pack-catalog.md
@@ -1,0 +1,71 @@
+---
+id: TASK-345
+title: Add bundled Persona Visual starter pack catalog
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-05-14 19:57'
+updated_date: '2026-05-14 20:00'
+labels:
+  - persona
+  - persona-visual
+  - backend
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1694'
+  - 'https://github.com/rmusser01/tldw_server/issues/1510'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement GitHub issue #1694: provide bundled sprite_frames Persona Visual starter packs that the backend can list and copy into a user-owned draft for a selected persona. The copied pack must align with existing Persona Visual import and manifest validation behavior, preserve the personal visual library reference-backed model, and require explicit activation after copy.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A bundled default sprite_frames pack can be listed by the backend.
+- [x] #2 Copying a bundled pack creates a user-owned draft attached to the target persona.
+- [x] #3 Copied drafts are not activated automatically and still require the existing explicit activation step.
+- [x] #4 Validation covers bundled pack manifests/assets and rejects malformed bundled pack data.
+- [x] #5 Docs or task notes explain that bundled defaults are copied into user-owned draft storage rather than referenced as global mutable state.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Plan artifact: `Docs/superpowers/plans/2026-05-14-persona-visual-starter-catalog-plan.md`
+
+Stage 1: Service Contract And Fixture Validation.
+Stage 2: REST Schemas And Endpoints.
+Stage 3: Docs, Tracker, And Verification.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Planning started in isolated worktree `.worktrees/persona-visual-starter-catalog` on branch `codex/persona-visual-starter-catalog` from `origin/dev`. Key implementation direction: bundled starter packs create normal user-owned draft pack and asset rows through existing storage/validation paths rather than global mutable pack references or auto-activation.
+
+Stage 1 green: service tests cover listing the bundled starter fixture, copying into an inactive user-owned draft, preserving an existing active pack, remapping fixture asset keys, and rejecting malformed fixture manifests.
+
+Stage 2 green: API tests cover catalog list/detail, copy-to-draft without activation, unknown starter errors, and cross-user target rejection.
+
+Verification completed: `python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py tldw_Server_API/tests/Persona/test_persona_visuals_api.py -q --tb=short --disable-warnings` -> 53 passed; `python -m py_compile tldw_Server_API/app/core/Persona/visual_starter_catalog.py tldw_Server_API/app/core/Persona/visual_starter_fixtures.py` -> passed; Bandit touched Python scope -> 0 findings in `/tmp/bandit_persona_visual_starter_catalog.json`; `git diff --check` -> passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented bundled Persona Visual starter-pack catalog support for issue #1694. Added immutable fixture definitions, a starter catalog service that validates fixture manifests/assets and copies them through existing PersonaVisualService storage into inactive user-owned draft packs, REST schemas/endpoints for list/detail/copy, docs for starter-copy semantics, and focused service/API regression coverage. Verification: 53 focused Persona Visual tests passed, py_compile passed for new modules, Bandit touched Python scope reported 0 findings, and staged whitespace check passed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-348 - Address-PR-1701-Persona-Visual-starter-catalog-review-comments.md
+++ b/backlog/tasks/task-348 - Address-PR-1701-Persona-Visual-starter-catalog-review-comments.md
@@ -1,0 +1,58 @@
+---
+id: TASK-348
+title: Address PR 1701 Persona Visual starter catalog review comments
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-05-15 01:06'
+updated_date: '2026-05-15 01:09'
+labels:
+  - persona
+  - persona-visual
+  - review-fix
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1701'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Verify and address actionable review comments on PR #1701 for the bundled Persona Visual starter catalog. Scope: type hints in new tests, stable fixture validation before API response serialization, defensive DB update return guards, and verification of the manifest remapping mutability concern.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Still-valid Qodo and CodeRabbit review findings are fixed or documented as skipped with a reason.
+- [x] #2 Gemini manifest mutation concern is verified against current code and fixed only if still valid.
+- [x] #3 Focused tests and security/format checks pass after review fixes.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Qodo findings were valid: the new pytest fixture lacked a return type and list/detail responses could echo invalid fixture enum strings into FastAPI response validation. Added the fixture return type and starter fixture validation for renderer type, manifest renderer consistency, and response-safe asset roles before list/detail/copy responses are built.
+
+CodeRabbit's DB update return guard finding was valid. `copy_starter_pack_to_persona` now raises `starter_copy_failed` inside the cleanup block when either the manifest update or draft status transition returns no pack.
+
+Gemini's in-place manifest mutation concern is already mitigated by `remap_visual_manifest_assets`, which deep-copies internally; the call site now also passes a deep copy to keep the fixture boundary explicit.
+
+Verification completed: `python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py tldw_Server_API/tests/Persona/test_persona_visuals_api.py -q --tb=short --disable-warnings` -> 57 passed; `python -m py_compile ...` touched Persona Visual files -> passed; Bandit touched Python scope -> 0 findings in `/tmp/bandit_persona_visual_starter_catalog_review.json`; `git diff --check` -> passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed PR #1701 review feedback by adding return typing to the new fixture, validating bundled starter fixture enums before API response serialization, guarding failed manifest/status update returns with cleanup-safe errors, and making the manifest remap call-site explicitly copy fixture manifests. Added focused regression tests for invalid fixture enums and update-return cleanup paths. Verification: 57 focused Persona Visual tests passed, py_compile passed for touched files, Bandit reported 0 findings, and whitespace validation passed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-354 - Port-useful-PR-1700-starter-catalog-follow-ups-into-PR-1701.md
+++ b/backlog/tasks/task-354 - Port-useful-PR-1700-starter-catalog-follow-ups-into-PR-1701.md
@@ -1,0 +1,54 @@
+---
+id: TASK-354
+title: Port useful PR 1700 starter catalog follow-ups into PR 1701
+status: Done
+assignee: []
+created_date: '2026-05-15 01:59'
+updated_date: '2026-05-15 02:01'
+labels:
+  - persona
+  - persona-visual
+  - review-fix
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1700'
+  - 'https://github.com/rmusser01/tldw_server/pull/1701'
+  - 'https://github.com/rmusser01/tldw_server/issues/1694'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Follow up on PR #1701 by selectively porting non-duplicative useful pieces from overlapping PR #1700: design-spec documentation for the starter catalog placement and focused regressions that protect fixture manifest isolation and duplicate bundled asset-key validation. Keep PR #1701's separate PersonaVisualStarterCatalogService boundary and /copy route semantics unchanged.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Design spec documents the bundled starter catalog using PR #1701's actual list detail and copy routes
+- [x] #2 Starter catalog tests prove returned detail manifests are isolated from bundled fixture mutation
+- [x] #3 Starter catalog tests prove duplicate bundled asset keys are rejected with a stable starter catalog error
+- [x] #4 Focused Persona Visual starter catalog tests pass after the changes
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Ported the useful non-overlapping PR #1700 pieces into PR #1701: design-spec starter catalog placement using #1701's /copy route semantics, manifest preview isolation regression coverage, and duplicate fixture asset-key regression coverage. Verification: focused starter catalog tests passed (9 passed), focused Persona Visual starter/API slice passed (59 passed), py_compile passed, black --check passed, git diff --check passed, and Bandit with pytest assert check excluded reported 0 findings; the raw Bandit run only reported B101 pytest assert usage in the touched test file.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Ported useful PR #1700 follow-ups into PR #1701 without changing the production service boundary. Added design-spec documentation for the starter catalog routes and service semantics, plus regression tests for manifest preview isolation and duplicate fixture asset-key rejection.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -105,6 +105,9 @@ from tldw_Server_API.app.api.v1.schemas.persona import (
     PersonaVisualPortabilityJobResponse,
     PersonaVisualRendererCapabilitiesResponse,
     PersonaVisualRendererCapabilityResponse,
+    PersonaVisualStarterPackCopyRequest,
+    PersonaVisualStarterPackDetailResponse,
+    PersonaVisualStarterPackListResponse,
 )
 from tldw_Server_API.app.api.v1.schemas.voice_assistant_schemas import (
     VoiceActionType,
@@ -182,6 +185,10 @@ from tldw_Server_API.app.core.Persona.visual_service import (
 from tldw_Server_API.app.core.Persona.visual_library_service import (
     PersonaVisualLibraryService,
     PersonaVisualLibraryServiceError,
+)
+from tldw_Server_API.app.core.Persona.visual_starter_catalog import (
+    PersonaVisualStarterCatalogError,
+    PersonaVisualStarterCatalogService,
 )
 from tldw_Server_API.app.core.Persona.connections import (
     PERSONA_CONNECTION_STATUS_FIELD,
@@ -2020,6 +2027,12 @@ def get_persona_visual_library_service(
     return PersonaVisualLibraryService(db)
 
 
+def get_persona_visual_starter_catalog_service(
+    db: CharactersRAGDB = Depends(get_chacha_db_for_user),
+) -> PersonaVisualStarterCatalogService:
+    return PersonaVisualStarterCatalogService(db)
+
+
 def _build_persona_visual_generation_readiness(
     *,
     backend: str | None,
@@ -2246,6 +2259,22 @@ def _persona_visual_library_service_error_to_http(exc: PersonaVisualLibraryServi
     elif exc.code in {"source_pack_unavailable", "library_item_conflict"}:
         status_code = status.HTTP_409_CONFLICT
     elif exc.code in {"invalid_library_metadata"}:
+        status_code = status.HTTP_422_UNPROCESSABLE_ENTITY
+    return HTTPException(
+        status_code=status_code,
+        detail={"code": exc.code, "message": str(exc), "details": exc.details},
+    )
+
+
+def _persona_visual_starter_catalog_error_to_http(exc: PersonaVisualStarterCatalogError) -> HTTPException:
+    status_code = status.HTTP_400_BAD_REQUEST
+    if exc.code in {"starter_pack_not_found", "target_persona_not_found"}:
+        status_code = status.HTTP_404_NOT_FOUND
+    elif exc.code in {"invalid_starter_fixture", "duplicate_starter_fixture"}:
+        status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+    elif exc.code in {"invalid_starter_asset", "invalid_starter_manifest"}:
+        status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+    elif exc.code in {"persona_id_required", "user_id_required"}:
         status_code = status.HTTP_422_UNPROCESSABLE_ENTITY
     return HTTPException(
         status_code=status_code,
@@ -3798,6 +3827,82 @@ async def list_persona_visual_renderers(
             for capability in list_persona_visual_renderer_capabilities()
         ]
     )
+
+
+@router.get(
+    "/visual-starter-packs",
+    response_model=PersonaVisualStarterPackListResponse,
+    tags=["persona"],
+    status_code=status.HTTP_200_OK,
+    dependencies=[Depends(check_rate_limit)],
+)
+async def list_persona_visual_starter_packs(
+    _current_user: User = Depends(get_request_user),
+    starter_service: PersonaVisualStarterCatalogService = Depends(get_persona_visual_starter_catalog_service),
+) -> PersonaVisualStarterPackListResponse:
+    """List bundled Persona Visual starter packs available for draft copy."""
+    if not is_persona_enabled():
+        raise HTTPException(status_code=404, detail="Persona disabled")
+    _require_current_user_id(_current_user)
+    try:
+        starter_packs = await _run_persona_db_call(starter_service.list_starter_packs)
+        return PersonaVisualStarterPackListResponse(starter_packs=starter_packs)
+    except PersonaVisualStarterCatalogError as exc:
+        raise _persona_visual_starter_catalog_error_to_http(exc) from exc
+
+
+@router.get(
+    "/visual-starter-packs/{starter_pack_id}",
+    response_model=PersonaVisualStarterPackDetailResponse,
+    tags=["persona"],
+    status_code=status.HTTP_200_OK,
+    dependencies=[Depends(check_rate_limit)],
+)
+async def get_persona_visual_starter_pack(
+    starter_pack_id: str,
+    _current_user: User = Depends(get_request_user),
+    starter_service: PersonaVisualStarterCatalogService = Depends(get_persona_visual_starter_catalog_service),
+) -> PersonaVisualStarterPackDetailResponse:
+    """Return one bundled Persona Visual starter pack fixture preview."""
+    if not is_persona_enabled():
+        raise HTTPException(status_code=404, detail="Persona disabled")
+    _require_current_user_id(_current_user)
+    try:
+        return await _run_persona_db_call(starter_service.get_starter_pack, starter_pack_id)
+    except PersonaVisualStarterCatalogError as exc:
+        raise _persona_visual_starter_catalog_error_to_http(exc) from exc
+
+
+@router.post(
+    "/visual-starter-packs/{starter_pack_id}/copy",
+    response_model=PersonaVisualPackResponse,
+    tags=["persona"],
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(check_rate_limit)],
+)
+async def copy_persona_visual_starter_pack(
+    starter_pack_id: str,
+    payload: PersonaVisualStarterPackCopyRequest,
+    _current_user: User = Depends(get_request_user),
+    starter_service: PersonaVisualStarterCatalogService = Depends(get_persona_visual_starter_catalog_service),
+) -> PersonaVisualPackResponse:
+    """Copy a bundled starter pack to a target persona as an inactive draft."""
+    if not is_persona_enabled():
+        raise HTTPException(status_code=404, detail="Persona disabled")
+    user_id = _require_current_user_id(_current_user)
+    try:
+        copied = await _run_persona_db_call(
+            starter_service.copy_starter_pack_to_persona,
+            starter_pack_id=starter_pack_id,
+            persona_id=payload.target_persona_id,
+            user_id=user_id,
+            title=payload.title,
+        )
+        return _persona_visual_pack_to_response(copied, assets=list(copied.get("assets") or []))
+    except PersonaVisualStarterCatalogError as exc:
+        raise _persona_visual_starter_catalog_error_to_http(exc) from exc
+    except (InputError, ConflictError, CharactersRAGDBError) as exc:
+        raise _to_http_exception(exc, action="copy persona visual starter pack") from exc
 
 
 @router.get(

--- a/tldw_Server_API/app/api/v1/schemas/persona.py
+++ b/tldw_Server_API/app/api/v1/schemas/persona.py
@@ -100,6 +100,27 @@ class PersonaVisualPackDuplicateRequest(BaseModel):
         return normalized or None
 
 
+class PersonaVisualStarterPackCopyRequest(BaseModel):
+    target_persona_id: str = Field(min_length=1, max_length=128)
+    title: str | None = Field(default=None, max_length=200)
+
+    @field_validator("target_persona_id")
+    @classmethod
+    def normalize_target_persona_id(cls, value: str) -> str:
+        normalized = str(value or "").strip()
+        if not normalized:
+            raise ValueError("target_persona_id is required")
+        return normalized
+
+    @field_validator("title")
+    @classmethod
+    def normalize_title(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = str(value).strip()
+        return normalized or None
+
+
 class PersonaVisualLibrarySaveRequest(BaseModel):
     title: str | None = Field(default=None, max_length=200)
     notes: str | None = Field(default=None, max_length=4000)
@@ -259,6 +280,36 @@ class PersonaVisualPackResponse(BaseModel):
     created_at: str
     last_modified: str
     version: int = 1
+
+
+class PersonaVisualStarterAssetResponse(BaseModel):
+    asset_key: str
+    filename: str
+    mime_type: str
+    asset_role: PersonaVisualAssetRole
+    byte_size: int
+
+
+class PersonaVisualStarterPackResponse(BaseModel):
+    id: str
+    title: str
+    description: str
+    renderer_type: PersonaVisualRendererType
+    manifest_version: int = 1
+    states_offered: list[str] = Field(default_factory=list)
+    asset_count: int = 0
+    total_bytes: int = 0
+    tags: list[str] = Field(default_factory=list)
+    license_label: str = "bundled"
+
+
+class PersonaVisualStarterPackDetailResponse(PersonaVisualStarterPackResponse):
+    manifest: dict[str, Any] = Field(default_factory=dict)
+    assets: list[PersonaVisualStarterAssetResponse] = Field(default_factory=list)
+
+
+class PersonaVisualStarterPackListResponse(BaseModel):
+    starter_packs: list[PersonaVisualStarterPackResponse] = Field(default_factory=list)
 
 
 class PersonaVisualLibraryItemResponse(BaseModel):

--- a/tldw_Server_API/app/core/Persona/visual_starter_catalog.py
+++ b/tldw_Server_API/app/core/Persona/visual_starter_catalog.py
@@ -19,6 +19,9 @@ from tldw_Server_API.app.core.Persona.visual_manifest_assets import (
     collect_visual_manifest_asset_ids,
     remap_visual_manifest_assets,
 )
+from tldw_Server_API.app.core.Persona.visual_renderer_capabilities import (
+    get_persona_visual_renderer_capability,
+)
 from tldw_Server_API.app.core.Persona.visual_service import (
     PersonaVisualService,
     PersonaVisualServiceError,
@@ -34,6 +37,17 @@ from tldw_Server_API.app.core.Persona.visuals import (
 
 if TYPE_CHECKING:
     from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+
+
+_ALLOWED_STARTER_RESPONSE_ASSET_ROLES = frozenset(
+    {
+        "frame",
+        "still_pose",
+        "sprite_sheet",
+        "preview",
+        "generated_candidate",
+    }
+)
 
 
 class PersonaVisualStarterCatalogError(Exception):
@@ -61,11 +75,15 @@ class PersonaVisualStarterCatalogService:
 
     def list_starter_packs(self) -> list[dict[str, Any]]:
         """Return safe summaries for all bundled starter packs."""
-        return [self._starter_summary(starter) for starter in self._starter_packs.values()]
+        starter_packs = tuple(self._starter_packs.values())
+        for starter in starter_packs:
+            self._validate_starter_fixture(starter)
+        return [self._starter_summary(starter) for starter in starter_packs]
 
     def get_starter_pack(self, starter_pack_id: str) -> dict[str, Any]:
         """Return one starter pack summary with a manifest preview."""
         starter = self._get_starter(starter_pack_id)
+        self._validate_starter_fixture(starter)
         detail = self._starter_summary(starter)
         detail["manifest"] = deepcopy(starter.manifest)
         detail["assets"] = [
@@ -157,7 +175,7 @@ class PersonaVisualStarterCatalogService:
                 asset_id_map[starter_asset.asset_key] = str(copied["id"])
                 copied_assets.append(copied)
 
-            remapped_manifest = remap_visual_manifest_assets(starter.manifest, asset_id_map)
+            remapped_manifest = remap_visual_manifest_assets(deepcopy(starter.manifest), asset_id_map)
             asset_ids = {str(asset["id"]) for asset in copied_assets}
             asset_dimensions = {
                 str(asset["id"]): (int(asset["width"]), int(asset["height"]))
@@ -185,13 +203,31 @@ class PersonaVisualStarterCatalogService:
                 manifest=validation.manifest,
                 expected_version=int(target_pack["version"]),
             )
+            if not updated_pack:
+                raise PersonaVisualStarterCatalogError(
+                    "starter_copy_failed",
+                    "Failed to persist remapped starter manifest.",
+                    details={
+                        "starter_pack_id": starter.id,
+                        "target_pack_id": str(target_pack["id"]),
+                    },
+                )
             finalized = self._db.update_persona_visual_pack_status(
                 pack_id=str(target_pack["id"]),
                 persona_id=persona_id_value,
                 user_id=user_id_value,
                 status="draft",
-                expected_version=int(updated_pack["version"]) if updated_pack else None,
+                expected_version=int(updated_pack["version"]),
             )
+            if not finalized:
+                raise PersonaVisualStarterCatalogError(
+                    "starter_copy_failed",
+                    "Failed to transition copied starter pack to draft.",
+                    details={
+                        "starter_pack_id": starter.id,
+                        "target_pack_id": str(target_pack["id"]),
+                    },
+                )
         except Exception:
             self._cleanup_partial_pack(
                 target_pack_id=str(target_pack["id"]),
@@ -260,6 +296,32 @@ class PersonaVisualStarterCatalogService:
 
     @staticmethod
     def _validate_starter_fixture(starter: PersonaVisualStarterPack) -> None:
+        renderer_type = str(starter.renderer_type or "").strip()
+        capability = get_persona_visual_renderer_capability(renderer_type)
+        if capability is None or not capability.can_activate:
+            raise PersonaVisualStarterCatalogError(
+                "invalid_starter_fixture",
+                "Bundled starter renderer_type is not supported for starter packs.",
+                details={"starter_pack_id": starter.id, "renderer_type": renderer_type},
+            )
+        if not isinstance(starter.manifest, dict):
+            raise PersonaVisualStarterCatalogError(
+                "invalid_starter_fixture",
+                "Bundled starter manifest must be an object.",
+                details={"starter_pack_id": starter.id},
+            )
+        manifest_renderer_type = str(starter.manifest.get("renderer_type") or "").strip()
+        if manifest_renderer_type != renderer_type:
+            raise PersonaVisualStarterCatalogError(
+                "invalid_starter_fixture",
+                "Bundled starter renderer_type must match its manifest.",
+                details={
+                    "starter_pack_id": starter.id,
+                    "renderer_type": renderer_type,
+                    "manifest_renderer_type": manifest_renderer_type,
+                },
+            )
+
         asset_keys: set[str] = set()
         for asset in starter.assets:
             key = str(asset.asset_key or "").strip()
@@ -274,6 +336,20 @@ class PersonaVisualStarterCatalogService:
                     "invalid_starter_asset",
                     "Bundled starter asset keys must be unique.",
                     details={"starter_pack_id": starter.id, "asset_key": key},
+                )
+            asset_role = str(asset.asset_role or "").strip()
+            if (
+                asset_role not in capability.supported_asset_roles
+                or asset_role not in _ALLOWED_STARTER_RESPONSE_ASSET_ROLES
+            ):
+                raise PersonaVisualStarterCatalogError(
+                    "invalid_starter_fixture",
+                    "Bundled starter asset_role is not supported for starter-pack responses.",
+                    details={
+                        "starter_pack_id": starter.id,
+                        "asset_key": key,
+                        "asset_role": asset_role,
+                    },
                 )
             if not asset.content:
                 raise PersonaVisualStarterCatalogError(

--- a/tldw_Server_API/app/core/Persona/visual_starter_catalog.py
+++ b/tldw_Server_API/app/core/Persona/visual_starter_catalog.py
@@ -1,0 +1,341 @@
+"""Service for copying bundled Persona Visual starter packs into user drafts.
+
+Bundled starter packs are immutable fixtures used for first-run visual Buddy
+setup. This service lists those fixtures and creates normal user-owned draft
+packs by validating fixture manifests, copying fixture assets through
+``PersonaVisualService``, and remapping manifest asset references. It never
+activates a pack automatically and never stores global mutable pack rows.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+from tldw_Server_API.app.core.Persona.visual_manifest_assets import (
+    collect_visual_manifest_asset_ids,
+    remap_visual_manifest_assets,
+)
+from tldw_Server_API.app.core.Persona.visual_service import (
+    PersonaVisualService,
+    PersonaVisualServiceError,
+)
+from tldw_Server_API.app.core.Persona.visual_starter_fixtures import (
+    DEFAULT_PERSONA_VISUAL_STARTER_PACKS,
+    PersonaVisualStarterPack,
+)
+from tldw_Server_API.app.core.Persona.visuals import (
+    PersonaVisualManifestError,
+    validate_visual_manifest,
+)
+
+if TYPE_CHECKING:
+    from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+
+
+class PersonaVisualStarterCatalogError(Exception):
+    """Stable service error for bundled Persona Visual starter-pack operations."""
+
+    def __init__(self, code: str, message: str, *, details: dict[str, Any] | None = None) -> None:
+        super().__init__(message)
+        self.code = code
+        self.details = details or {}
+
+
+class PersonaVisualStarterCatalogService:
+    """List bundled starter packs and copy them into user-owned draft packs."""
+
+    def __init__(
+        self,
+        db: CharactersRAGDB,
+        *,
+        visual_service: PersonaVisualService | None = None,
+        starter_packs: tuple[PersonaVisualStarterPack, ...] = DEFAULT_PERSONA_VISUAL_STARTER_PACKS,
+    ) -> None:
+        self._db = db
+        self._visual_service = visual_service or PersonaVisualService(db)
+        self._starter_packs = self._index_starter_packs(starter_packs)
+
+    def list_starter_packs(self) -> list[dict[str, Any]]:
+        """Return safe summaries for all bundled starter packs."""
+        return [self._starter_summary(starter) for starter in self._starter_packs.values()]
+
+    def get_starter_pack(self, starter_pack_id: str) -> dict[str, Any]:
+        """Return one starter pack summary with a manifest preview."""
+        starter = self._get_starter(starter_pack_id)
+        detail = self._starter_summary(starter)
+        detail["manifest"] = deepcopy(starter.manifest)
+        detail["assets"] = [
+            {
+                "asset_key": asset.asset_key,
+                "filename": asset.filename,
+                "mime_type": asset.mime_type,
+                "asset_role": asset.asset_role,
+                "byte_size": len(asset.content),
+            }
+            for asset in starter.assets
+        ]
+        return detail
+
+    def copy_starter_pack_to_persona(
+        self,
+        *,
+        starter_pack_id: str,
+        persona_id: str,
+        user_id: str,
+        title: str | None = None,
+    ) -> dict[str, Any]:
+        """Copy a bundled starter into one user's persona as an inactive draft."""
+        starter = self._get_starter(starter_pack_id)
+        persona_id_value = str(persona_id or "").strip()
+        user_id_value = str(user_id or "").strip()
+        if not persona_id_value:
+            raise PersonaVisualStarterCatalogError(
+                "persona_id_required",
+                "Target persona_id is required.",
+            )
+        if not user_id_value:
+            raise PersonaVisualStarterCatalogError(
+                "user_id_required",
+                "User id is required.",
+            )
+
+        target_persona = self._db.get_persona_profile(
+            persona_id=persona_id_value,
+            user_id=user_id_value,
+        )
+        if not target_persona:
+            raise PersonaVisualStarterCatalogError(
+                "target_persona_not_found",
+                "Target persona not found for user.",
+                details={"persona_id": persona_id_value},
+            )
+
+        self._validate_starter_fixture(starter)
+        title_value = str(title or "").strip() or starter.title
+        target_pack = self._db.create_persona_visual_pack(
+            persona_id=persona_id_value,
+            user_id=user_id_value,
+            title=title_value,
+            renderer_type=starter.renderer_type,
+            status="failed",
+            provenance="imported",
+            manifest={
+                "manifest_version": 1,
+                "renderer_type": starter.renderer_type,
+                "states": {},
+                "animations": {},
+            },
+        )
+        copied_file_paths: list[Path] = []
+        try:
+            asset_id_map: dict[str, str] = {}
+            copied_assets: list[dict[str, Any]] = []
+            for starter_asset in starter.assets:
+                try:
+                    copied = self._visual_service.create_asset_from_upload(
+                        persona_id=persona_id_value,
+                        user_id=user_id_value,
+                        pack_id=str(target_pack["id"]),
+                        content=starter_asset.content,
+                        mime_type=starter_asset.mime_type,
+                        original_filename=starter_asset.filename,
+                        asset_role=starter_asset.asset_role,
+                        provenance="imported",
+                    )
+                except PersonaVisualServiceError as exc:
+                    raise PersonaVisualStarterCatalogError(
+                        "invalid_starter_asset",
+                        str(exc),
+                        details={"asset_key": starter_asset.asset_key, **exc.details},
+                    ) from exc
+                if copied.get("storage_path"):
+                    copied_file_paths.append(Path(str(copied["storage_path"])))
+                asset_id_map[starter_asset.asset_key] = str(copied["id"])
+                copied_assets.append(copied)
+
+            remapped_manifest = remap_visual_manifest_assets(starter.manifest, asset_id_map)
+            asset_ids = {str(asset["id"]) for asset in copied_assets}
+            asset_dimensions = {
+                str(asset["id"]): (int(asset["width"]), int(asset["height"]))
+                for asset in copied_assets
+                if asset.get("width") is not None and asset.get("height") is not None
+            }
+            try:
+                validation = validate_visual_manifest(
+                    remapped_manifest,
+                    available_asset_ids=asset_ids,
+                    available_asset_dimensions=asset_dimensions,
+                    require_activatable=True,
+                )
+            except PersonaVisualManifestError as exc:
+                raise PersonaVisualStarterCatalogError(
+                    "invalid_starter_manifest",
+                    str(exc),
+                    details={"starter_pack_id": starter.id},
+                ) from exc
+
+            updated_pack = self._db.update_persona_visual_pack_manifest(
+                pack_id=str(target_pack["id"]),
+                persona_id=persona_id_value,
+                user_id=user_id_value,
+                manifest=validation.manifest,
+                expected_version=int(target_pack["version"]),
+            )
+            finalized = self._db.update_persona_visual_pack_status(
+                pack_id=str(target_pack["id"]),
+                persona_id=persona_id_value,
+                user_id=user_id_value,
+                status="draft",
+                expected_version=int(updated_pack["version"]) if updated_pack else None,
+            )
+        except Exception:
+            self._cleanup_partial_pack(
+                target_pack_id=str(target_pack["id"]),
+                persona_id=persona_id_value,
+                user_id=user_id_value,
+                copied_file_paths=copied_file_paths,
+            )
+            raise
+
+        assets = self._db.list_persona_visual_assets(
+            pack_id=str(target_pack["id"]),
+            persona_id=persona_id_value,
+            user_id=user_id_value,
+        )
+        finalized["assets"] = assets
+        finalized["assets_by_id"] = {str(asset["id"]): asset for asset in assets}
+        return finalized
+
+    @staticmethod
+    def _index_starter_packs(
+        starter_packs: tuple[PersonaVisualStarterPack, ...],
+    ) -> dict[str, PersonaVisualStarterPack]:
+        indexed: dict[str, PersonaVisualStarterPack] = {}
+        for starter in starter_packs:
+            starter_id = str(starter.id or "").strip()
+            if not starter_id:
+                raise PersonaVisualStarterCatalogError(
+                    "invalid_starter_fixture",
+                    "Bundled starter pack id is required.",
+                )
+            if starter_id in indexed:
+                raise PersonaVisualStarterCatalogError(
+                    "duplicate_starter_fixture",
+                    "Bundled starter pack ids must be unique.",
+                    details={"starter_pack_id": starter_id},
+                )
+            indexed[starter_id] = starter
+        return indexed
+
+    def _get_starter(self, starter_pack_id: str) -> PersonaVisualStarterPack:
+        starter_id = str(starter_pack_id or "").strip()
+        starter = self._starter_packs.get(starter_id)
+        if starter is None:
+            raise PersonaVisualStarterCatalogError(
+                "starter_pack_not_found",
+                "Persona Visual starter pack not found.",
+                details={"starter_pack_id": starter_id},
+            )
+        return starter
+
+    @staticmethod
+    def _starter_summary(starter: PersonaVisualStarterPack) -> dict[str, Any]:
+        states = starter.manifest.get("states") if isinstance(starter.manifest, dict) else {}
+        return {
+            "id": starter.id,
+            "title": starter.title,
+            "description": starter.description,
+            "renderer_type": starter.renderer_type,
+            "manifest_version": int(starter.manifest.get("manifest_version", 1) or 1),
+            "states_offered": sorted(states) if isinstance(states, dict) else [],
+            "asset_count": len(starter.assets),
+            "total_bytes": sum(len(asset.content) for asset in starter.assets),
+            "tags": list(starter.tags),
+            "license_label": starter.license_label,
+        }
+
+    @staticmethod
+    def _validate_starter_fixture(starter: PersonaVisualStarterPack) -> None:
+        asset_keys: set[str] = set()
+        for asset in starter.assets:
+            key = str(asset.asset_key or "").strip()
+            if not key:
+                raise PersonaVisualStarterCatalogError(
+                    "invalid_starter_asset",
+                    "Bundled starter asset keys must be non-empty.",
+                    details={"starter_pack_id": starter.id},
+                )
+            if key in asset_keys:
+                raise PersonaVisualStarterCatalogError(
+                    "invalid_starter_asset",
+                    "Bundled starter asset keys must be unique.",
+                    details={"starter_pack_id": starter.id, "asset_key": key},
+                )
+            if not asset.content:
+                raise PersonaVisualStarterCatalogError(
+                    "invalid_starter_asset",
+                    "Bundled starter asset content is empty.",
+                    details={"starter_pack_id": starter.id, "asset_key": key},
+                )
+            asset_keys.add(key)
+
+        referenced_asset_ids = collect_visual_manifest_asset_ids(starter.manifest)
+        missing_asset_ids = sorted(referenced_asset_ids - asset_keys)
+        if missing_asset_ids:
+            raise PersonaVisualStarterCatalogError(
+                "invalid_starter_manifest",
+                "Bundled starter manifest references assets missing from the fixture.",
+                details={"starter_pack_id": starter.id, "asset_ids": missing_asset_ids},
+            )
+        try:
+            validate_visual_manifest(
+                deepcopy(starter.manifest),
+                available_asset_ids=asset_keys,
+                require_activatable=True,
+            )
+        except PersonaVisualManifestError as exc:
+            raise PersonaVisualStarterCatalogError(
+                "invalid_starter_manifest",
+                str(exc),
+                details={"starter_pack_id": starter.id},
+            ) from exc
+
+    def _cleanup_partial_pack(
+        self,
+        *,
+        target_pack_id: str,
+        persona_id: str,
+        user_id: str,
+        copied_file_paths: list[Path],
+    ) -> None:
+        try:
+            self._db.soft_delete_persona_visual_pack_with_assets(
+                pack_id=target_pack_id,
+                persona_id=persona_id,
+                user_id=user_id,
+            )
+        except Exception as cleanup_error:  # pragma: no cover - defensive cleanup logging
+            logger.warning(
+                "Failed to soft-delete partial starter visual pack {}: {}",
+                target_pack_id,
+                cleanup_error,
+            )
+        for path in copied_file_paths:
+            try:
+                path.unlink(missing_ok=True)
+            except OSError as cleanup_error:  # pragma: no cover - defensive cleanup logging
+                logger.warning(
+                    "Failed to unlink partial starter visual asset {}: {}",
+                    path,
+                    cleanup_error,
+                )
+
+
+__all__ = [
+    "PersonaVisualStarterCatalogError",
+    "PersonaVisualStarterCatalogService",
+]

--- a/tldw_Server_API/app/core/Persona/visual_starter_fixtures.py
+++ b/tldw_Server_API/app/core/Persona/visual_starter_fixtures.py
@@ -1,0 +1,93 @@
+"""Bundled Persona Visual starter-pack fixtures.
+
+The fixtures in this module are immutable server-owned source material. Runtime
+code must copy their assets and manifests into normal user-owned draft visual
+packs before a persona can use them.
+"""
+
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass, field
+from typing import Any
+
+
+DEFAULT_PERSONA_VISUAL_STARTER_PACK_ID = "research-buddy-starter"
+
+
+@dataclass(frozen=True)
+class PersonaVisualStarterAsset:
+    """One immutable asset included in a bundled Persona Visual starter pack."""
+
+    asset_key: str
+    filename: str
+    mime_type: str
+    content: bytes
+    asset_role: str = "frame"
+
+
+@dataclass(frozen=True)
+class PersonaVisualStarterPack:
+    """Immutable bundled starter-pack definition using local fixture asset keys."""
+
+    id: str
+    title: str
+    description: str
+    renderer_type: str
+    manifest: dict[str, Any]
+    assets: tuple[PersonaVisualStarterAsset, ...]
+    tags: tuple[str, ...] = field(default_factory=tuple)
+    license_label: str = "bundled"
+
+
+_STARTER_IDLE_PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAFUlEQVR4nGM0SFjwn4GBgYEJRIAwACC4AjN5lYLvAAAAAElFTkSuQmCC"
+)
+
+
+def _research_buddy_manifest() -> dict[str, Any]:
+    states = {
+        state: {"animation_id": "idle"}
+        for state in ("idle", "listening", "thinking", "speaking", "error")
+    }
+    return {
+        "manifest_version": 1,
+        "renderer_type": "sprite_frames",
+        "states": states,
+        "animations": {
+            "idle": {
+                "frames": [{"asset_id": "starter_idle", "duration_ms": 250}],
+                "frame_rate": 1,
+                "preview_asset_id": "starter_idle",
+            }
+        },
+    }
+
+
+DEFAULT_PERSONA_VISUAL_STARTER_PACKS: tuple[PersonaVisualStarterPack, ...] = (
+    PersonaVisualStarterPack(
+        id=DEFAULT_PERSONA_VISUAL_STARTER_PACK_ID,
+        title="Research Buddy Starter",
+        description="A minimal bundled sprite-frame visual for first-run Buddy setup.",
+        renderer_type="sprite_frames",
+        manifest=_research_buddy_manifest(),
+        assets=(
+            PersonaVisualStarterAsset(
+                asset_key="starter_idle",
+                filename="research-buddy-idle.png",
+                mime_type="image/png",
+                content=_STARTER_IDLE_PNG,
+                asset_role="frame",
+            ),
+        ),
+        tags=("starter", "sprite_frames"),
+    ),
+)
+
+
+__all__ = [
+    "DEFAULT_PERSONA_VISUAL_STARTER_PACK_ID",
+    "DEFAULT_PERSONA_VISUAL_STARTER_PACKS",
+    "PersonaVisualStarterAsset",
+    "PersonaVisualStarterPack",
+]

--- a/tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
+from tldw_Server_API.app.core.Persona.visual_manifest_assets import collect_visual_manifest_asset_ids
+from tldw_Server_API.app.core.Persona.visual_starter_catalog import (
+    PersonaVisualStarterCatalogError,
+    PersonaVisualStarterCatalogService,
+)
+from tldw_Server_API.app.core.Persona.visual_starter_fixtures import (
+    DEFAULT_PERSONA_VISUAL_STARTER_PACK_ID,
+    PersonaVisualStarterAsset,
+    PersonaVisualStarterPack,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+def _png_bytes(width: int = 2, height: int = 2) -> bytes:
+    buffer = BytesIO()
+    Image.new("RGBA", (width, height), (48, 96, 160, 255)).save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+@pytest.fixture()
+def db_instance(tmp_path: Path):
+    db = CharactersRAGDB(tmp_path / "persona_visual_starter_catalog.sqlite", "persona-visual-starter-test")
+    yield db
+    db.close_connection()
+
+
+@pytest.fixture(autouse=True)
+def visual_storage_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = tmp_path / "visuals"
+
+    def _fake_visuals_dir(user_id: str) -> Path:
+        root.mkdir(parents=True, exist_ok=True)
+        return root
+
+    monkeypatch.setattr(
+        DatabasePaths,
+        "get_user_persona_visuals_dir",
+        staticmethod(_fake_visuals_dir),
+    )
+    return root
+
+
+def test_starter_catalog_lists_bundled_sprite_pack(
+    db_instance: CharactersRAGDB,
+) -> None:
+    service = PersonaVisualStarterCatalogService(db_instance)
+
+    starters = service.list_starter_packs()
+
+    assert [starter["id"] for starter in starters] == [DEFAULT_PERSONA_VISUAL_STARTER_PACK_ID]
+    starter = starters[0]
+    assert starter["title"] == "Research Buddy Starter"
+    assert starter["renderer_type"] == "sprite_frames"
+    assert starter["manifest_version"] == 1
+    assert starter["asset_count"] >= 1
+    assert starter["total_bytes"] > 0
+    assert {"idle", "listening", "thinking", "speaking", "error"}.issubset(
+        set(starter["states_offered"])
+    )
+
+
+def test_copy_starter_pack_to_persona_creates_inactive_user_owned_draft(
+    db_instance: CharactersRAGDB,
+    visual_storage_root: Path,
+) -> None:
+    user_id = "user-1"
+    persona_id = db_instance.create_persona_profile({"user_id": user_id, "name": "Target"})
+    active_pack = db_instance.create_persona_visual_pack(
+        persona_id=persona_id,
+        user_id=user_id,
+        title="Existing active visual",
+        status="draft",
+    )
+    db_instance.activate_persona_visual_pack(
+        persona_id=persona_id,
+        user_id=user_id,
+        pack_id=active_pack["id"],
+    )
+    service = PersonaVisualStarterCatalogService(db_instance)
+
+    copied = service.copy_starter_pack_to_persona(
+        starter_pack_id=DEFAULT_PERSONA_VISUAL_STARTER_PACK_ID,
+        persona_id=persona_id,
+        user_id=user_id,
+    )
+
+    assert copied["status"] == "draft"
+    assert copied["persona_id"] == persona_id
+    assert copied["user_id"] == user_id
+    assert copied["title"] == "Research Buddy Starter"
+    assert copied["provenance"] == "imported"
+    assert copied["active_at"] is None
+    assert db_instance.get_active_persona_visual_pack(
+        persona_id=persona_id,
+        user_id=user_id,
+    )["id"] == active_pack["id"]
+
+    copied_assets = db_instance.list_persona_visual_assets(
+        pack_id=copied["id"],
+        persona_id=persona_id,
+        user_id=user_id,
+    )
+    assert copied["assets"] == copied_assets
+    assert len(copied_assets) == 1
+    assert copied_assets[0]["provenance"] == "imported"
+    assert (visual_storage_root / persona_id / copied["id"]).is_dir()
+
+    copied_asset_ids = {str(asset["id"]) for asset in copied_assets}
+    assert collect_visual_manifest_asset_ids(copied["manifest"]) == copied_asset_ids
+    assert "starter_idle" not in str(copied["manifest"])
+
+
+def test_copy_starter_pack_rejects_malformed_fixture_manifest(
+    db_instance: CharactersRAGDB,
+) -> None:
+    user_id = "user-1"
+    persona_id = db_instance.create_persona_profile({"user_id": user_id, "name": "Target"})
+    malformed = PersonaVisualStarterPack(
+        id="malformed",
+        title="Malformed starter",
+        description="Invalid test fixture",
+        renderer_type="sprite_frames",
+        manifest={
+            "manifest_version": 1,
+            "renderer_type": "sprite_frames",
+            "states": {"idle": {"animation_id": "idle"}},
+            "animations": {
+                "idle": {
+                    "frames": [{"asset_id": "missing_asset", "duration_ms": 100}],
+                    "frame_rate": 1,
+                }
+            },
+        },
+        assets=(
+            PersonaVisualStarterAsset(
+                asset_key="starter_idle",
+                filename="idle.png",
+                mime_type="image/png",
+                content=_png_bytes(),
+                asset_role="frame",
+            ),
+        ),
+    )
+    service = PersonaVisualStarterCatalogService(db_instance, starter_packs=(malformed,))
+
+    with pytest.raises(PersonaVisualStarterCatalogError) as exc_info:
+        service.copy_starter_pack_to_persona(
+            starter_pack_id="malformed",
+            persona_id=persona_id,
+            user_id=user_id,
+        )
+
+    assert exc_info.value.code == "invalid_starter_manifest"
+    assert db_instance.list_persona_visual_packs(persona_id=persona_id, user_id=user_id) == []

--- a/tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
 from io import BytesIO
 from pathlib import Path
 
@@ -30,7 +31,7 @@ def _png_bytes(width: int = 2, height: int = 2) -> bytes:
 
 
 @pytest.fixture()
-def db_instance(tmp_path: Path):
+def db_instance(tmp_path: Path) -> Iterator[CharactersRAGDB]:
     db = CharactersRAGDB(tmp_path / "persona_visual_starter_catalog.sqlite", "persona-visual-starter-test")
     yield db
     db.close_connection()
@@ -66,9 +67,7 @@ def test_starter_catalog_lists_bundled_sprite_pack(
     assert starter["manifest_version"] == 1
     assert starter["asset_count"] >= 1
     assert starter["total_bytes"] > 0
-    assert {"idle", "listening", "thinking", "speaking", "error"}.issubset(
-        set(starter["states_offered"])
-    )
+    assert {"idle", "listening", "thinking", "speaking", "error"}.issubset(set(starter["states_offered"]))
 
 
 def test_copy_starter_pack_to_persona_creates_inactive_user_owned_draft(
@@ -102,10 +101,13 @@ def test_copy_starter_pack_to_persona_creates_inactive_user_owned_draft(
     assert copied["title"] == "Research Buddy Starter"
     assert copied["provenance"] == "imported"
     assert copied["active_at"] is None
-    assert db_instance.get_active_persona_visual_pack(
-        persona_id=persona_id,
-        user_id=user_id,
-    )["id"] == active_pack["id"]
+    assert (
+        db_instance.get_active_persona_visual_pack(
+            persona_id=persona_id,
+            user_id=user_id,
+        )["id"]
+        == active_pack["id"]
+    )
 
     copied_assets = db_instance.list_persona_visual_assets(
         pack_id=copied["id"],
@@ -163,4 +165,118 @@ def test_copy_starter_pack_rejects_malformed_fixture_manifest(
         )
 
     assert exc_info.value.code == "invalid_starter_manifest"
+    assert db_instance.list_persona_visual_packs(persona_id=persona_id, user_id=user_id) == []
+
+
+def test_list_starter_packs_rejects_invalid_fixture_renderer_type(
+    db_instance: CharactersRAGDB,
+) -> None:
+    malformed = PersonaVisualStarterPack(
+        id="bad-renderer",
+        title="Bad renderer",
+        description="Invalid test fixture",
+        renderer_type="unknown_renderer",
+        manifest={
+            "manifest_version": 1,
+            "renderer_type": "unknown_renderer",
+            "states": {"idle": {"animation_id": "idle"}},
+            "animations": {
+                "idle": {
+                    "frames": [{"asset_id": "starter_idle", "duration_ms": 100}],
+                    "frame_rate": 1,
+                }
+            },
+        },
+        assets=(
+            PersonaVisualStarterAsset(
+                asset_key="starter_idle",
+                filename="idle.png",
+                mime_type="image/png",
+                content=_png_bytes(),
+                asset_role="frame",
+            ),
+        ),
+    )
+    service = PersonaVisualStarterCatalogService(db_instance, starter_packs=(malformed,))
+
+    with pytest.raises(PersonaVisualStarterCatalogError) as exc_info:
+        service.list_starter_packs()
+
+    assert exc_info.value.code == "invalid_starter_fixture"
+
+
+def test_get_starter_pack_rejects_invalid_fixture_asset_role(
+    db_instance: CharactersRAGDB,
+) -> None:
+    malformed = PersonaVisualStarterPack(
+        id="bad-asset-role",
+        title="Bad asset role",
+        description="Invalid test fixture",
+        renderer_type="sprite_frames",
+        manifest={
+            "manifest_version": 1,
+            "renderer_type": "sprite_frames",
+            "states": {"idle": {"animation_id": "idle"}},
+            "animations": {
+                "idle": {
+                    "frames": [{"asset_id": "starter_idle", "duration_ms": 100}],
+                    "frame_rate": 1,
+                }
+            },
+        },
+        assets=(
+            PersonaVisualStarterAsset(
+                asset_key="starter_idle",
+                filename="idle.png",
+                mime_type="image/png",
+                content=_png_bytes(),
+                asset_role="unsupported_role",
+            ),
+        ),
+    )
+    service = PersonaVisualStarterCatalogService(db_instance, starter_packs=(malformed,))
+
+    with pytest.raises(PersonaVisualStarterCatalogError) as exc_info:
+        service.get_starter_pack("bad-asset-role")
+
+    assert exc_info.value.code == "invalid_starter_fixture"
+
+
+def test_copy_starter_pack_cleans_up_when_manifest_update_returns_none(
+    db_instance: CharactersRAGDB,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user_id = "user-1"
+    persona_id = db_instance.create_persona_profile({"user_id": user_id, "name": "Target"})
+    service = PersonaVisualStarterCatalogService(db_instance)
+    monkeypatch.setattr(db_instance, "update_persona_visual_pack_manifest", lambda **_: None)
+
+    with pytest.raises(PersonaVisualStarterCatalogError) as exc_info:
+        service.copy_starter_pack_to_persona(
+            starter_pack_id=DEFAULT_PERSONA_VISUAL_STARTER_PACK_ID,
+            persona_id=persona_id,
+            user_id=user_id,
+        )
+
+    assert exc_info.value.code == "starter_copy_failed"
+    assert db_instance.list_persona_visual_packs(persona_id=persona_id, user_id=user_id) == []
+
+
+def test_copy_starter_pack_cleans_up_when_status_update_returns_none(
+    db_instance: CharactersRAGDB,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user_id = "user-1"
+    persona_id = db_instance.create_persona_profile({"user_id": user_id, "name": "Target"})
+    service = PersonaVisualStarterCatalogService(db_instance)
+    monkeypatch.setattr(db_instance, "update_persona_visual_pack_status", lambda **_: None)
+
+    with pytest.raises(PersonaVisualStarterCatalogError) as exc_info:
+        service.copy_starter_pack_to_persona(
+            starter_pack_id=DEFAULT_PERSONA_VISUAL_STARTER_PACK_ID,
+            persona_id=persona_id,
+            user_id=user_id,
+        )
+
+    assert exc_info.value.code == "starter_copy_failed"
     assert db_instance.list_persona_visual_packs(persona_id=persona_id, user_id=user_id) == []

--- a/tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py
@@ -70,6 +70,18 @@ def test_starter_catalog_lists_bundled_sprite_pack(
     assert {"idle", "listening", "thinking", "speaking", "error"}.issubset(set(starter["states_offered"]))
 
 
+def test_get_starter_pack_returns_isolated_manifest_preview(
+    db_instance: CharactersRAGDB,
+) -> None:
+    service = PersonaVisualStarterCatalogService(db_instance)
+    first = service.get_starter_pack(DEFAULT_PERSONA_VISUAL_STARTER_PACK_ID)
+    first["manifest"]["states"]["idle"]["animation_id"] = "mutated"
+
+    second = service.get_starter_pack(DEFAULT_PERSONA_VISUAL_STARTER_PACK_ID)
+
+    assert second["manifest"]["states"]["idle"]["animation_id"] == "idle"
+
+
 def test_copy_starter_pack_to_persona_creates_inactive_user_owned_draft(
     db_instance: CharactersRAGDB,
     visual_storage_root: Path,
@@ -203,6 +215,51 @@ def test_list_starter_packs_rejects_invalid_fixture_renderer_type(
         service.list_starter_packs()
 
     assert exc_info.value.code == "invalid_starter_fixture"
+
+
+def test_list_starter_packs_rejects_duplicate_fixture_asset_keys(
+    db_instance: CharactersRAGDB,
+) -> None:
+    malformed = PersonaVisualStarterPack(
+        id="duplicate-asset-key",
+        title="Duplicate asset key",
+        description="Invalid test fixture",
+        renderer_type="sprite_frames",
+        manifest={
+            "manifest_version": 1,
+            "renderer_type": "sprite_frames",
+            "states": {"idle": {"animation_id": "idle"}},
+            "animations": {
+                "idle": {
+                    "frames": [{"asset_id": "starter_idle", "duration_ms": 100}],
+                    "frame_rate": 1,
+                }
+            },
+        },
+        assets=(
+            PersonaVisualStarterAsset(
+                asset_key="starter_idle",
+                filename="idle-one.png",
+                mime_type="image/png",
+                content=_png_bytes(),
+                asset_role="frame",
+            ),
+            PersonaVisualStarterAsset(
+                asset_key="starter_idle",
+                filename="idle-two.png",
+                mime_type="image/png",
+                content=_png_bytes(),
+                asset_role="frame",
+            ),
+        ),
+    )
+    service = PersonaVisualStarterCatalogService(db_instance, starter_packs=(malformed,))
+
+    with pytest.raises(PersonaVisualStarterCatalogError) as exc_info:
+        service.list_starter_packs()
+
+    assert exc_info.value.code == "invalid_starter_asset"
+    assert exc_info.value.details["asset_key"] == "starter_idle"
 
 
 def test_get_starter_pack_rejects_invalid_fixture_asset_role(

--- a/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
@@ -12,6 +12,9 @@ from tldw_Server_API.app.api.v1.endpoints import persona as persona_ep
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.core.Persona.visual_library_service import PersonaVisualLibraryServiceError
+from tldw_Server_API.app.core.Persona.visual_starter_fixtures import (
+    DEFAULT_PERSONA_VISUAL_STARTER_PACK_ID,
+)
 
 
 pytestmark = pytest.mark.unit
@@ -180,6 +183,19 @@ def test_persona_visual_renderer_capabilities_respect_persona_feature_flag(
     assert response.json() == {"detail": "Persona disabled"}
 
 
+def test_get_persona_visual_starter_pack_detail(persona_db: CharactersRAGDB) -> None:
+    with _client_for_user(1, persona_db) as client:
+        response = client.get(
+            f"/api/v1/persona/visual-starter-packs/{DEFAULT_PERSONA_VISUAL_STARTER_PACK_ID}"
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["id"] == DEFAULT_PERSONA_VISUAL_STARTER_PACK_ID
+    assert payload["manifest"]["renderer_type"] == "sprite_frames"
+    assert payload["assets"][0]["mime_type"] == "image/png"
+
+
 def _upload_png(client: TestClient, persona_id: str, pack_id: str) -> dict:
     response = client.post(
         f"/api/v1/persona/profiles/{persona_id}/visual-packs/{pack_id}/assets",
@@ -332,6 +348,79 @@ def test_duplicate_visual_pack_rejects_other_user_target(persona_db: CharactersR
     assert response.json()["detail"]["code"] == "target_persona_not_found"
 
 
+def test_list_persona_visual_starter_packs(persona_db: CharactersRAGDB) -> None:
+    with _client_for_user(1, persona_db) as client:
+        response = client.get("/api/v1/persona/visual-starter-packs")
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert [item["id"] for item in payload["starter_packs"]] == [
+        DEFAULT_PERSONA_VISUAL_STARTER_PACK_ID
+    ]
+    starter = payload["starter_packs"][0]
+    assert starter["title"] == "Research Buddy Starter"
+    assert starter["renderer_type"] == "sprite_frames"
+    assert starter["asset_count"] == 1
+    assert {"idle", "listening", "thinking", "speaking", "error"}.issubset(
+        set(starter["states_offered"])
+    )
+
+
+def test_copy_visual_starter_pack_creates_draft_without_activation(
+    persona_db: CharactersRAGDB,
+) -> None:
+    with _client_for_user(1, persona_db) as client:
+        persona_id = _create_persona(client, name="Starter Target")
+        active_pack = _create_visual_pack(client, persona_id, title="Existing active visual")
+        active_asset = _upload_png(client, persona_id, active_pack["id"])
+        manifest_response = client.patch(
+            f"/api/v1/persona/profiles/{persona_id}/visual-packs/{active_pack['id']}/manifest",
+            json={"manifest": _valid_manifest(active_asset["id"]), "expected_version": active_pack["version"]},
+        )
+        assert manifest_response.status_code == 200, manifest_response.text
+        active_pack = manifest_response.json()
+        activated = client.post(
+            f"/api/v1/persona/profiles/{persona_id}/visual-packs/{active_pack['id']}/activate"
+        )
+        assert activated.status_code == 200, activated.text
+
+        response = client.post(
+            f"/api/v1/persona/visual-starter-packs/{DEFAULT_PERSONA_VISUAL_STARTER_PACK_ID}/copy",
+            json={"target_persona_id": persona_id},
+        )
+
+        assert response.status_code == 201, response.text
+        payload = response.json()
+        assert payload["title"] == "Research Buddy Starter"
+        assert payload["persona_id"] == persona_id
+        assert payload["status"] == "draft"
+        assert payload["provenance"] == "imported"
+        assert payload["parent_pack_id"] is None
+        assert payload["active_at"] is None
+        assert len(payload["assets"]) == 1
+        assert payload["assets"][0]["provenance"] == "imported"
+        assert "starter_idle" not in str(payload["manifest"])
+        assert persona_db.get_active_persona_visual_pack(
+            persona_id=persona_id,
+            user_id="1",
+        )["id"] == active_pack["id"]
+
+
+def test_copy_visual_starter_pack_rejects_unknown_starter(
+    persona_db: CharactersRAGDB,
+) -> None:
+    with _client_for_user(1, persona_db) as client:
+        persona_id = _create_persona(client, name="Starter Target")
+
+        response = client.post(
+            "/api/v1/persona/visual-starter-packs/missing-starter/copy",
+            json={"target_persona_id": persona_id},
+        )
+
+    assert response.status_code == 404
+    assert response.json()["detail"]["code"] == "starter_pack_not_found"
+
+
 def test_visual_library_save_list_update_and_delete(persona_db: CharactersRAGDB) -> None:
     with _client_for_user(1, persona_db) as client:
         persona_id = _create_persona(client, name="Library Source Persona")
@@ -444,6 +533,22 @@ def test_visual_library_use_creates_target_draft_without_activation(persona_db: 
             persona_id=target_persona_id,
             user_id="1",
         )["id"] == target_pack["id"]
+
+
+def test_copy_persona_visual_starter_pack_rejects_other_user_target(
+    persona_db: CharactersRAGDB,
+) -> None:
+    with _client_for_user(2, persona_db) as other_client:
+        other_persona_id = _create_persona(other_client, name="Other Starter Target")
+
+    with _client_for_user(1, persona_db) as client:
+        response = client.post(
+            f"/api/v1/persona/visual-starter-packs/{DEFAULT_PERSONA_VISUAL_STARTER_PACK_ID}/copy",
+            json={"target_persona_id": other_persona_id},
+        )
+
+    assert response.status_code == 404
+    assert response.json()["detail"]["code"] == "target_persona_not_found"
 
 
 def test_visual_library_stale_source_returns_409_but_delete_succeeds(


### PR DESCRIPTION
## Summary

What changed:
- Adds a fixture-backed bundled Persona Visual starter catalog with list/detail/copy API routes.
- Copies starters into normal user-owned inactive draft packs through existing Persona Visual storage and manifest validation.
- Adds review-fix hardening for fixture enum validation, update-return cleanup guards, typed starter catalog fixtures, manifest preview isolation coverage, and duplicate fixture asset-key coverage.
- Documents copy semantics in the implementation docs and long-lived Persona Visual design spec.

Why:
- Gives the Buddy/persona setup flow a backend-owned default visual starter without introducing global mutable visual packs.
- Keeps copied packs user-owned, persona-attached, inactive by default, and compatible with existing activation/review behavior.
- Ensures malformed bundled fixture data fails through the stable Persona Visual error contract rather than response serialization failures.
- Preserves the useful non-overlapping documentation/test ideas from overlapping PR #1700 while keeping PR #1701's cleaner starter-catalog service boundary.

## Validation

- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && LOGURU_LEVEL=ERROR python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py tldw_Server_API/tests/Persona/test_persona_visuals_api.py -q --tb=short --disable-warnings` -> 59 passed
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m py_compile tldw_Server_API/app/core/Persona/visual_starter_catalog.py tldw_Server_API/app/core/Persona/visual_starter_fixtures.py tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/app/api/v1/schemas/persona.py tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py`
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m black --check tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py`
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Persona/visual_starter_catalog.py tldw_Server_API/app/core/Persona/visual_starter_fixtures.py tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/app/api/v1/schemas/persona.py -f json -o /tmp/bandit_persona_visual_starter_catalog_review.json` -> 0 findings
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py -s B101 -f json -o /tmp/bandit_persona_visual_starter_catalog_port_skip_b101.json` -> 0 findings after excluding pytest assert usage
- [x] `git diff --check`

## Risk & Rollback

Risk level: Medium.

Primary risks:
- Starter fixtures are server-bundled, so malformed fixture metadata could affect catalog endpoints.
- Copying uses existing Persona Visual asset storage and DB rows, so partial-copy cleanup must remain reliable.

Mitigations:
- Starter fixtures are validated before list/detail/copy response construction.
- Copy failures keep the target pack in the existing cleanup path, including manifest/status update return guards.
- Copied packs remain inactive drafts and never replace or activate the current visual pack automatically.
- Starter detail responses return copied manifest previews, and tests protect against accidental fixture mutation.

Rollback plan:
- Revert this PR to remove the starter catalog endpoints, fixture service, docs, and tests.
- Existing user-owned Persona Visual packs are unaffected because the feature only creates ordinary draft packs through existing storage paths when the new copy endpoint is called.

## Tracker

- Closes #1694
- Parent: #1510
- Backlog: TASK-345 for initial implementation, TASK-348 for PR review fixes, TASK-354 for PR #1700 follow-up ports

## Change Summary

Draft pending human-authored Change summary per the AI-generated PR merge policy.
