### PR TITLE
Fix PR 1582 review follow-ups

### DIFF
--- a/apps/packages/ui/src/components/Common/PromptSelect.tsx
+++ b/apps/packages/ui/src/components/Common/PromptSelect.tsx
@@ -13,7 +13,10 @@ import {
   OPEN_PROMPT_SELECT_EVENT,
   type PromptSelectOpenDetail
 } from "@/utils/prompt-select-events"
-import { scheduleFocusFirstVisibleElement } from "@/utils/focus-return"
+import {
+  normalizeFocusSelector,
+  scheduleFocusFirstVisibleElement
+} from "@/utils/focus-return"
 import { IconButton } from "./IconButton"
 import {
   normalizeSystemPromptOverrideValue,
@@ -255,9 +258,9 @@ export const PromptSelect: React.FC<Props> = ({
 
     const handleOpenPromptSelect = (event: Event) => {
       const detail = (event as CustomEvent<PromptSelectOpenDetail>).detail
-      if (detail?.returnFocusSelector) {
-        returnFocusSelectorRef.current = detail.returnFocusSelector
-      }
+      returnFocusSelectorRef.current = normalizeFocusSelector(
+        detail?.returnFocusSelector
+      )
       setDropdownOpen(true)
     }
 

--- a/apps/packages/ui/src/components/Option/Playground/Playground.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/Playground.tsx
@@ -309,11 +309,14 @@ export const Playground = () => {
         );
         setSelectedSystemPromptStatus(prompt ? "loaded" : "unavailable");
       })
-      .catch(() => {
-        if (!cancelled) {
-          setSelectedSystemPromptRecord(null);
-          setSelectedSystemPromptStatus("unavailable");
-        }
+      .catch((error) => {
+        if (cancelled) return;
+        console.warn("[Playground] Failed to resolve selected system prompt", {
+          promptId,
+          error,
+        });
+        setSelectedSystemPromptRecord(null);
+        setSelectedSystemPromptStatus("unavailable");
       });
 
     return () => {

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx
@@ -90,7 +90,10 @@ import type { Character } from "@/types/character";
 import { DEFAULT_CHAT_SETTINGS } from "@/types/chat-settings";
 import { ConnectionPhase, deriveConnectionUxState } from "@/types/connection";
 import { PASTED_TEXT_CHAR_LIMIT } from "@/utils/constant";
-import { scheduleFocusFirstVisibleElement } from "@/utils/focus-return";
+import {
+  normalizeFocusSelector,
+  scheduleFocusFirstVisibleElement,
+} from "@/utils/focus-return";
 // resolveApiProviderForModel moved to usePlaygroundRawPreview and usePlaygroundImageGen
 import {
   DEFAULT_CHARACTER_STORAGE_KEY,
@@ -1142,8 +1145,9 @@ export const PlaygroundForm = ({
     if (typeof window === "undefined") return;
     const handler = (event: Event) => {
       const detail = (event as CustomEvent<ModelSettingsOpenDetail>).detail;
-      modelSettingsReturnFocusSelectorRef.current =
-        detail?.returnFocusSelector ?? null;
+      modelSettingsReturnFocusSelectorRef.current = normalizeFocusSelector(
+        detail?.returnFocusSelector,
+      );
       setOpenModelSettings(true);
     };
     window.addEventListener(OPEN_MODEL_SETTINGS_EVENT, handler);
@@ -1290,8 +1294,9 @@ export const PlaygroundForm = ({
     if (typeof window === "undefined") return;
     const handler = (event: Event) => {
       const detail = (event as CustomEvent<McpSettingsOpenDetail>).detail;
-      mcpSettingsReturnFocusSelectorRef.current =
-        detail?.returnFocusSelector ?? null;
+      mcpSettingsReturnFocusSelectorRef.current = normalizeFocusSelector(
+        detail?.returnFocusSelector,
+      );
       closeComposerPopoversExcept("mcp");
       setMcpPopoverOpen(false);
       setMcpSettingsOpen(true);

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-controls.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-controls.test.tsx
@@ -11,6 +11,7 @@ import {
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Playground } from "../Playground";
+import { getPromptById } from "@/db/dexie/helpers";
 import { useMcpToolsStore } from "@/store/mcp-tools";
 import {
   OPEN_ASSISTANT_SELECT_EVENT,
@@ -501,6 +502,39 @@ describe("Playground cockpit controls", () => {
       window.removeEventListener(OPEN_MCP_SETTINGS_EVENT, openMcpSettings);
       window.removeEventListener(TOGGLE_WEB_SEARCH_EVENT, toggleWebSearch);
       window.removeEventListener(SET_TEMPORARY_CHAT_EVENT, setTemporaryChat);
+    }
+  });
+
+  it("logs selected prompt lookup failures while keeping the prompt unavailable state visible", async () => {
+    const promptLookupWarning = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    vi.mocked(getPromptById).mockRejectedValueOnce(
+      new Error("prompt cache unavailable"),
+    );
+    messageOptionState.value.selectedSystemPrompt = "prompt-missing";
+
+    try {
+      render(<Playground />);
+
+      const contextRail = within(
+        await screen.findByTestId("playground-cockpit-left-rail"),
+      ).getByTestId("playground-context-rail");
+
+      await waitFor(() => {
+        expect(promptLookupWarning).toHaveBeenCalledWith(
+          "[Playground] Failed to resolve selected system prompt",
+          expect.objectContaining({
+            promptId: "prompt-missing",
+            error: expect.any(Error),
+          }),
+        );
+      });
+      expect(
+        within(contextRail).getAllByText("Prompt details unavailable").length,
+      ).toBeGreaterThan(0);
+    } finally {
+      promptLookupWarning.mockRestore();
     }
   });
 

--- a/apps/packages/ui/src/utils/__tests__/focus-return.test.ts
+++ b/apps/packages/ui/src/utils/__tests__/focus-return.test.ts
@@ -1,7 +1,10 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
 
-import { focusFirstVisibleElement } from "../focus-return";
+import {
+  focusFirstVisibleElement,
+  normalizeFocusSelector,
+} from "../focus-return";
 
 describe("focus-return", () => {
   it("prefers the first visible enabled selector match", () => {
@@ -24,5 +27,23 @@ describe("focus-return", () => {
     expect(focusFirstVisibleElement("[data-return-target]")).toBe(true);
 
     expect(document.activeElement?.textContent).toBe("Hidden target");
+  });
+
+  it("ignores malformed selectors instead of throwing", () => {
+    document.body.innerHTML = `
+      <button data-return-target>Visible target</button>
+    `;
+
+    expect(() => focusFirstVisibleElement("[")).not.toThrow();
+    expect(focusFirstVisibleElement("[")).toBe(false);
+    expect(document.activeElement).toBe(document.body);
+  });
+
+  it("normalizes event-provided focus selectors before use", () => {
+    expect(normalizeFocusSelector("  [data-return-target]  ")).toBe(
+      "[data-return-target]",
+    );
+    expect(normalizeFocusSelector("   ")).toBeNull();
+    expect(normalizeFocusSelector(null)).toBeNull();
   });
 });

--- a/apps/packages/ui/src/utils/focus-return.ts
+++ b/apps/packages/ui/src/utils/focus-return.ts
@@ -26,16 +26,32 @@ const isHiddenBySelfOrAncestor = (element: HTMLElement): boolean => {
   return false;
 };
 
+export const normalizeFocusSelector = (
+  selector: unknown,
+): string | null => {
+  if (typeof selector !== "string") return null;
+  const trimmedSelector = selector.trim();
+  return trimmedSelector.length > 0 ? trimmedSelector : null;
+};
+
 export const getFirstVisibleFocusableElement = (
   selector: string,
   root?: ParentNode,
 ): HTMLElement | null => {
   if (typeof document === "undefined" && !root) return null;
 
+  const normalizedSelector = normalizeFocusSelector(selector);
+  if (!normalizedSelector) return null;
+
   const searchRoot = root ?? document;
-  const candidates = Array.from(
-    searchRoot.querySelectorAll<HTMLElement>(selector),
-  );
+  let candidates: HTMLElement[] = [];
+  try {
+    candidates = Array.from(
+      searchRoot.querySelectorAll<HTMLElement>(normalizedSelector),
+    );
+  } catch {
+    return null;
+  }
   return (
     candidates.find(
       (candidate) =>

--- a/apps/tldw-frontend/e2e/workflows/chat-cockpit.real-server.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/chat-cockpit.real-server.spec.ts
@@ -9,6 +9,7 @@ import {
   expect,
   test,
   type APIRequestContext,
+  type APIResponse,
   type Locator,
   type Page,
   type Response,
@@ -35,6 +36,32 @@ const apiHeaders = () => ({
   'x-api-key': apiKey,
 });
 
+const truncateForDiagnostics = (value: string, maxLength = 800): string =>
+  value.length > maxLength ? `${value.slice(0, maxLength)}...` : value;
+
+const parseApiJsonResponse = async <T>(
+  response: APIResponse,
+  method: string,
+  path: string
+): Promise<T> => {
+  try {
+    return (await response.json()) as T;
+  } catch {
+    let responseText = '<response body unavailable>';
+    try {
+      const text = await response.text();
+      responseText = text.trim()
+        ? truncateForDiagnostics(text.trim())
+        : '<empty response body>';
+    } catch {
+      // Keep the fallback marker when the response body cannot be read.
+    }
+    throw new Error(
+      `${method} ${path} returned non-JSON response (${response.status()}): ${responseText}`
+    );
+  }
+};
+
 const apiGet = async <T>(
   request: APIRequestContext,
   path: string
@@ -60,7 +87,7 @@ const apiPost = async <T>(
     },
     timeout: 30_000,
   });
-  const payload = await response.json().catch(() => null);
+  const payload = await parseApiJsonResponse<T | null>(response, 'POST', path);
   return { status: response.status(), body: payload as T | null };
 };
 
@@ -314,6 +341,24 @@ const assertProviderQualifiedPayload = async (page: Page, response: Response) =>
 };
 
 test.describe('/chat cockpit real-server parity', () => {
+  test('reports non-JSON API POST responses with response context', async () => {
+    const fakeRequest = {
+      post: async () => ({
+        status: () => 502,
+        json: async () => {
+          throw new Error('invalid json');
+        },
+        text: async () => 'upstream gateway returned HTML',
+      }),
+    } as unknown as APIRequestContext;
+
+    await expect(
+      apiPost(fakeRequest, '/api/v1/example', { sample: true })
+    ).rejects.toThrow(
+      /POST \/api\/v1\/example returned non-JSON response \(502\): upstream gateway returned HTML/
+    );
+  });
+
   test('does not intercept backend routes in this real-server spec', async ({}, testInfo) => {
     const fs = await import('node:fs');
     const { readFileSync } = fs;

--- a/apps/tldw-frontend/e2e/workflows/chat-cockpit.real-server.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/chat-cockpit.real-server.spec.ts
@@ -44,14 +44,17 @@ const parseApiJsonResponse = async <T>(
   method: string,
   path: string
 ): Promise<T> => {
+  if (response.status() === 204) {
+    return null as T;
+  }
   try {
     return (await response.json()) as T;
   } catch {
     let responseText = '<response body unavailable>';
     try {
-      const text = await response.text();
-      responseText = text.trim()
-        ? truncateForDiagnostics(text.trim())
+      const text = (await response.text()).trim();
+      responseText = text
+        ? truncateForDiagnostics(text)
         : '<empty response body>';
     } catch {
       // Keep the fallback marker when the response body cannot be read.
@@ -357,6 +360,22 @@ test.describe('/chat cockpit real-server parity', () => {
     ).rejects.toThrow(
       /POST \/api\/v1\/example returned non-JSON response \(502\): upstream gateway returned HTML/
     );
+  });
+
+  test('keeps successful 204 API POST responses as null bodies', async () => {
+    const fakeRequest = {
+      post: async () => ({
+        status: () => 204,
+        json: async () => {
+          throw new Error('empty body');
+        },
+        text: async () => '',
+      }),
+    } as unknown as APIRequestContext;
+
+    await expect(
+      apiPost(fakeRequest, '/api/v1/example', { sample: true })
+    ).resolves.toEqual({ status: 204, body: null });
   });
 
   test('does not intercept backend routes in this real-server spec', async ({}, testInfo) => {

--- a/backlog/tasks/task-346 - Address-PR-1582-post-merge-review-follow-ups.md
+++ b/backlog/tasks/task-346 - Address-PR-1582-post-merge-review-follow-ups.md
@@ -4,7 +4,7 @@ title: Address PR 1582 post-merge review follow-ups
 status: Done
 assignee: []
 created_date: '2026-05-14 20:02'
-updated_date: '2026-05-15 01:03'
+updated_date: '2026-05-15 01:12'
 labels:
   - webui
   - chat
@@ -15,6 +15,7 @@ references:
   - 'https://github.com/rmusser01/tldw_server/pull/1582#discussion_r3243931793'
   - 'https://github.com/rmusser01/tldw_server/pull/1582#discussion_r3243931800'
   - 'https://github.com/rmusser01/tldw_server/pull/1702'
+  - 'https://github.com/rmusser01/tldw_server/pull/1702#discussion_r3245176513'
 priority: medium
 ---
 
@@ -31,6 +32,7 @@ Follow-up slice for the merged chat cockpit PR #1582. Address only the three sti
 - [x] #3 Focus-return helpers and CustomEvent returnFocusSelector ingestion tolerate malformed or empty selectors without throwing.
 - [x] #4 Focused regression tests cover the new reliability behavior.
 - [x] #5 A new PR is opened against dev from a clean follow-up branch.
+- [x] #6 apiPost preserves successful empty 204 response behavior while retaining non-JSON diagnostics.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -41,12 +43,18 @@ Implemented focused PR #1582 review follow-ups: prompt lookup failures now log p
 Verification: focused Vitest for focus-return, Playground cockpit controls, PromptSelect modal; Playwright helper regression with TLDW_WEB_AUTOSTART=false; PlaygroundForm signals guard; git diff --check; frontend lint command completed with existing warnings only.
 
 Opened follow-up PR #1702 against dev. Bandit not run: touched implementation/test files are TypeScript/TSX/Markdown only, with no Python touched scope.
+
+PR #1702 review follow-up: Gemini identified a valid regression risk where parseApiJsonResponse would throw for successful 204 No Content responses. Reopening TASK-346 for a narrow test-first fix.
+
+PR #1702 review follow-up implemented test-first: added a 204 No Content apiPost regression test, then returned null for status 204 before JSON parsing and consolidated response text trimming in diagnostics.
+
+Verification: TLDW_WEB_AUTOSTART=false TLDW_E2E_API_KEY=dummy TLDW_E2E_SERVER_URL=http://127.0.0.1:1 bun run e2e:pw e2e/workflows/chat-cockpit.real-server.spec.ts -g 'API POST responses' --reporter=line; git diff --check; bun run lint e2e/workflows/chat-cockpit.real-server.spec.ts exited 0 with existing warnings only.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Addressed the three unresolved post-merge review findings from PR #1582 in follow-up PR #1702. Prompt lookup failures now retain diagnostic context, real-server POST JSON parse failures include response diagnostics, and focus-return selector ingestion is normalized/guarded. Focused Vitest, Playwright helper regression, PlaygroundForm guard, diff check, and frontend lint were run; broader PlaygroundForm follow-up-research runtime test still has a pre-existing MCP mock fixture gap unrelated to this slice.
+Addressed all current PR #1702 review comments. The new Gemini 204 No Content finding was verified with a failing regression test, fixed by preserving null bodies for 204 responses before JSON parsing, and rechecked with the API POST helper tests. The earlier PR #1582 review follow-ups remain covered: prompt lookup diagnostics, non-JSON response diagnostics, and focus selector hardening.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-346 - Address-PR-1582-post-merge-review-follow-ups.md
+++ b/backlog/tasks/task-346 - Address-PR-1582-post-merge-review-follow-ups.md
@@ -1,0 +1,60 @@
+---
+id: TASK-346
+title: Address PR 1582 post-merge review follow-ups
+status: Done
+assignee: []
+created_date: '2026-05-14 20:02'
+updated_date: '2026-05-15 01:03'
+labels:
+  - webui
+  - chat
+  - review-fix
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1582#discussion_r3243931786'
+  - 'https://github.com/rmusser01/tldw_server/pull/1582#discussion_r3243931793'
+  - 'https://github.com/rmusser01/tldw_server/pull/1582#discussion_r3243931800'
+  - 'https://github.com/rmusser01/tldw_server/pull/1702'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Follow-up slice for the merged chat cockpit PR #1582. Address only the three still-unresolved post-merge Qodo review findings: preserve diagnostic context for system-prompt lookup failures, preserve diagnostic context for real-server E2E JSON parse failures, and harden focus-return selector handling/event ingestion against malformed selectors. Base the work on current dev and open a new PR with focused verification.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Prompt lookup failures set the UI unavailable state while retaining useful diagnostic logging/context.
+- [x] #2 The real-server E2E apiPost helper reports JSON parse failures with response context instead of silently returning null.
+- [x] #3 Focus-return helpers and CustomEvent returnFocusSelector ingestion tolerate malformed or empty selectors without throwing.
+- [x] #4 Focused regression tests cover the new reliability behavior.
+- [x] #5 A new PR is opened against dev from a clean follow-up branch.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented focused PR #1582 review follow-ups: prompt lookup failures now log prompt id/error before unavailable UI state, apiPost non-JSON responses throw with status/body context, and focus-return selectors are normalized/guarded at utility plus PromptSelect/PlaygroundForm event ingestion.
+
+Verification: focused Vitest for focus-return, Playground cockpit controls, PromptSelect modal; Playwright helper regression with TLDW_WEB_AUTOSTART=false; PlaygroundForm signals guard; git diff --check; frontend lint command completed with existing warnings only.
+
+Opened follow-up PR #1702 against dev. Bandit not run: touched implementation/test files are TypeScript/TSX/Markdown only, with no Python touched scope.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed the three unresolved post-merge review findings from PR #1582 in follow-up PR #1702. Prompt lookup failures now retain diagnostic context, real-server POST JSON parse failures include response diagnostics, and focus-return selector ingestion is normalized/guarded. Focused Vitest, Playwright helper regression, PlaygroundForm guard, diff check, and frontend lint were run; broader PlaygroundForm follow-up-research runtime test still has a pre-existing MCP mock fixture gap unrelated to this slice.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- log selected system prompt lookup failures with prompt id/error context while preserving the unavailable UI state
- make malformed or empty focus-return selectors safe at the shared helper and event ingestion points
- make the real-server chat cockpit POST helper throw with status/body context on non-JSON responses

## Review threads addressed
- https://github.com/rmusser01/tldw_server/pull/1582#discussion_r3243931786
- https://github.com/rmusser01/tldw_server/pull/1582#discussion_r3243931793
- https://github.com/rmusser01/tldw_server/pull/1582#discussion_r3243931800

## Verification
- bun run test src/utils/__tests__/focus-return.test.ts src/components/Option/Playground/__tests__/Playground.cockpit-controls.test.tsx src/components/Common/__tests__/PromptSelect.system-prompt-modal.test.tsx --reporter=verbose
- TLDW_WEB_AUTOSTART=false TLDW_E2E_API_KEY=dummy TLDW_E2E_SERVER_URL=http://127.0.0.1:1 bun run e2e:pw e2e/workflows/chat-cockpit.real-server.spec.ts -g "reports non-JSON API POST responses" --reporter=line
- bun run test src/components/Option/Playground/__tests__/PlaygroundForm.signals.guard.test.ts --reporter=verbose
- git diff --check
- bun run lint ../packages/ui/src/utils/focus-return.ts ../packages/ui/src/components/Common/PromptSelect.tsx ../packages/ui/src/components/Option/Playground/Playground.tsx ../packages/ui/src/components/Option/Playground/PlaygroundForm.tsx e2e/workflows/chat-cockpit.real-server.spec.ts (passes with existing warnings; package UI paths are outside the tldw-frontend ESLint base)

## Change summary
Pending human-authored change summary before merge, per project policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the chat cockpit and focus return by logging prompt lookup failures, normalizing/guarding selectors, and surfacing non-JSON POST errors with response context. Preserves 204 No Content POST behavior and adds focused tests.

- **Bug Fixes**
  - Playground logs selected system prompt lookup failures with `promptId` and error while keeping the “Prompt details unavailable” UI; adds a test for this.
  - Focus return is defensive: adds `normalizeFocusSelector`, ignores empty/malformed selectors, and guards DOM queries; applied to Prompt Select and Model/MCP Settings open events with unit tests.
  - Real-server `apiPost` throws on non-JSON responses with status and a truncated body preview; preserves 204 responses as `null` bodies; e2e tests cover both cases.

<sup>Written for commit 92e0fd8d18ebca154c93eadff81d1af22ad38629. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

