### PR TITLE
Migrate remaining Ready labels to design-system registry

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -5126,28 +5126,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "canonical-state-label:src/components/Option/PresentationStudio/ExtensionStartPanel.tsx:Ready#label-ready-extensionstartpanel-line-398-1k4mwwz",
-    "path": "src/components/Option/PresentationStudio/ExtensionStartPanel.tsx",
-    "rule": "canonical-state-label",
-    "subject": "Ready",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing hardcoded \"Ready\" state label in src/components/Option/PresentationStudio/ExtensionStartPanel.tsx before the stable duplicate-id guard.",
-    "replacement": "getDesignSystemState(...)",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "canonical-state-label:src/components/Option/PresentationStudio/ExtensionStartPanel.tsx:Ready#label-ready-extensionstartpanel-line-402-9ry2vd",
-    "path": "src/components/Option/PresentationStudio/ExtensionStartPanel.tsx",
-    "rule": "canonical-state-label",
-    "subject": "Ready",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing hardcoded \"Ready\" state label in src/components/Option/PresentationStudio/ExtensionStartPanel.tsx before the stable duplicate-id guard.",
-    "replacement": "getDesignSystemState(...)",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "canonical-state-label:src/components/Option/WritingPlayground/index.tsx:Ready",
     "path": "src/components/Option/WritingPlayground/index.tsx",
     "rule": "canonical-state-label",

--- a/apps/packages/ui/src/components/Option/Playground/Playground.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/Playground.tsx
@@ -57,7 +57,7 @@ import { otherUnsupportedTypes } from "../Knowledge/utils/unsupported-types";
 import { useTranslation } from "react-i18next";
 import { useStoreMessageOption } from "@/store/option";
 import { useArtifactsStore } from "@/store/artifacts";
-import { getDesignSystemState } from "@/design-system";
+import { DEGRADED_STATE_LABEL, READY_STATE_LABEL } from "@/design-system";
 import { useSetting } from "@/hooks/useSetting";
 import { useStorage } from "@plasmohq/storage/hook";
 import { DEFAULT_CHAT_SETTINGS } from "@/types/chat-settings";
@@ -133,7 +133,6 @@ const renderArtifactsPanel = () => (
 
 const SERVER_READINESS_STATE_EVENT = "tldw:server-readiness-state";
 type ServerReadinessState = "ready" | "degraded" | "blocked" | null;
-const DEGRADED_STATE_LABEL = getDesignSystemState("degraded").label;
 const COCKPIT_ASSISTANT_SELECT_TRIGGER_SELECTOR =
   "[data-cockpit-assistant-select-trigger]";
 const COCKPIT_PROMPT_SELECT_TRIGGER_SELECTOR =
@@ -1773,7 +1772,9 @@ export const Playground = () => {
       readyDetail: toText(
         t("playground:cockpit.sessionReadyDetail", "Conversation ready"),
       ),
-      readyStatusLabel: toText(t("playground:cockpit.sessionReady", "Ready")),
+      readyStatusLabel: toText(
+        t("playground:cockpit.sessionReady", READY_STATE_LABEL),
+      ),
       serverChatLabel: toText(
         t("playground:cockpit.sessionServer", "Server chat"),
       ),

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundContextRail.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundContextRail.tsx
@@ -10,7 +10,7 @@ import {
   Trash2,
   UserRound,
 } from "lucide-react";
-import { getDesignSystemState } from "@/design-system";
+import { DEGRADED_STATE_LABEL, READY_STATE_LABEL } from "@/design-system";
 
 const railSectionClass = "rounded-md border border-border bg-surface px-3 py-2";
 const railHeadingClass = "text-[11px] font-semibold uppercase text-text-muted";
@@ -20,7 +20,6 @@ const railActionClass =
   "mt-3 inline-flex min-h-[30px] items-center rounded-md border border-border bg-surface2 px-2.5 py-1 text-xs font-medium text-text hover:bg-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-focus";
 const clearActionClass =
   "inline-flex shrink-0 items-center rounded border border-border bg-surface2 px-1.5 py-0.5 text-[10px] font-medium text-text hover:bg-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-focus";
-const DEGRADED_STATE_LABEL = getDesignSystemState("degraded").label;
 const PROMPT_SELECT_TRIGGER_SELECTOR = "[data-cockpit-prompt-select-trigger]";
 
 type ContextCountItem = {
@@ -173,7 +172,7 @@ export const PlaygroundContextRail = ({
       : sessionStatus === "loading"
         ? t("cockpit.sessionLoading", "Loading conversation")
         : sessionStatus === "loaded"
-          ? t("cockpit.sessionReady", "Ready")
+          ? t("cockpit.sessionReady", READY_STATE_LABEL)
           : t("cockpit.sessionIdle", "Idle"));
   const sourceCountLabel =
     activeSourceCount === 1

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundRuntimeInspector.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundRuntimeInspector.tsx
@@ -1,6 +1,10 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { getDesignSystemState } from "@/design-system";
+import {
+  DEGRADED_STATE_LABEL,
+  ERROR_STATE_LABEL,
+  READY_STATE_LABEL,
+} from "@/design-system";
 import {
   RotateCcw,
   Settings2,
@@ -71,10 +75,6 @@ export type PlaygroundRuntimeInspectorProps = {
   settingSummaries?: RuntimeSettingSummary[];
   toolSummary?: RuntimeToolSummary | null;
 };
-
-const DEGRADED_STATE_LABEL = getDesignSystemState("degraded").label;
-const ERROR_STATE_LABEL = getDesignSystemState("error").label;
-const READY_STATE_LABEL = getDesignSystemState("ready").label;
 
 const toolStateClass = (state: RuntimeToolSummary["state"]) => {
   if (state === "available") return "border-success/40 bg-success/10 text-success";

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundStatusStrip.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundStatusStrip.tsx
@@ -1,5 +1,9 @@
 import { useTranslation } from "react-i18next";
-import { getDesignSystemState } from "@/design-system";
+import {
+  DEGRADED_STATE_LABEL,
+  ERROR_STATE_LABEL,
+  READY_STATE_LABEL,
+} from "@/design-system";
 import type { PlaygroundCockpitMode } from "./PlaygroundCockpitShell";
 import {
   formatCockpitMessageCount,
@@ -29,10 +33,6 @@ const pillClass =
   "inline-flex min-h-[24px] max-w-full items-center rounded-md border border-border bg-surface px-2 text-xs font-medium text-text";
 const actionClass =
   "inline-flex min-h-[26px] items-center gap-1 rounded-md border border-border bg-surface2 px-2 text-xs font-medium text-text hover:bg-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-focus";
-
-const DEGRADED_STATE_LABEL = getDesignSystemState("degraded").label;
-const ERROR_STATE_LABEL = getDesignSystemState("error").label;
-const READY_STATE_LABEL = getDesignSystemState("ready").label;
 
 export const PlaygroundStatusStrip = ({
   mode,

--- a/apps/packages/ui/src/components/Option/Playground/playground-cockpit-summaries.ts
+++ b/apps/packages/ui/src/components/Option/Playground/playground-cockpit-summaries.ts
@@ -6,6 +6,7 @@ import type {
   RuntimeToolSummary,
 } from "./PlaygroundRuntimeInspector";
 import type { McpHealthState } from "@/store/mcp-tools";
+import { READY_STATE_LABEL } from "@/design-system";
 
 type LegacyCharacterSelection = {
   id?: string | number;
@@ -123,7 +124,7 @@ const defaultSessionCopy = {
   localHistoryStatusLabel: "Local history",
   noSavedHistoryDetail: "No saved history yet",
   readyDetail: "Conversation ready",
-  readyStatusLabel: "Ready",
+  readyStatusLabel: READY_STATE_LABEL,
   serverChatLabel: "Server chat",
   temporaryChatLabel: "Temporary chat",
   temporaryDetail: "Not saved",

--- a/apps/packages/ui/src/components/Option/PresentationStudio/ExtensionStartPanel.tsx
+++ b/apps/packages/ui/src/components/Option/PresentationStudio/ExtensionStartPanel.tsx
@@ -1,10 +1,12 @@
 import React from "react"
+import { useTranslation } from "react-i18next"
 
 import { useConnectionState } from "@/hooks/useConnectionState"
 import { useServerCapabilities } from "@/hooks/useServerCapabilities"
 import { useServerOnline } from "@/hooks/useServerOnline"
 import { getScreenshotFromCurrentTab } from "@/libs/get-screenshot"
 import { tldwClient } from "@/services/tldw/TldwApiClient"
+import { EMPTY_STATE_LABEL, READY_STATE_LABEL } from "@/design-system"
 
 type SeedImage = {
   dataB64: string
@@ -80,6 +82,7 @@ const getActiveTabTitle = async (): Promise<string | null> => {
 }
 
 export const ExtensionStartPanel: React.FC = () => {
+  const { t } = useTranslation("option")
   const isOnline = useServerOnline()
   const { capabilities, loading } = useServerCapabilities()
   const { serverUrl } = useConnectionState()
@@ -105,6 +108,8 @@ export const ExtensionStartPanel: React.FC = () => {
 
   const hasSeedContent = narrationSeed.trim().length > 0 || imageSeed !== null
   const serverOrigin = resolveServerOrigin(serverUrl)
+  const readyStateLabel = t("presentationStudio.start.status.ready", READY_STATE_LABEL)
+  const emptyStateLabel = t("presentationStudio.start.status.empty", EMPTY_STATE_LABEL)
 
   const handleImageFileChange = async (
     event: React.ChangeEvent<HTMLInputElement>
@@ -395,11 +400,15 @@ export const ExtensionStartPanel: React.FC = () => {
             </div>
             <div className="flex items-center justify-between gap-3">
               <dt className="text-slate-500">Narration seed</dt>
-              <dd className="text-slate-700">{narrationSeed.trim().length > 0 ? "Ready" : "Empty"}</dd>
+              <dd className="text-slate-700">
+                {narrationSeed.trim().length > 0 ? readyStateLabel : emptyStateLabel}
+              </dd>
             </div>
             <div className="flex items-center justify-between gap-3">
               <dt className="text-slate-500">Image seed</dt>
-              <dd className="text-slate-700">{imageSeed ? "Ready" : "Empty"}</dd>
+              <dd className="text-slate-700">
+                {imageSeed ? readyStateLabel : emptyStateLabel}
+              </dd>
             </div>
           </dl>
 

--- a/apps/packages/ui/src/components/Option/PresentationStudio/__tests__/ExtensionStartPanel.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Option/PresentationStudio/__tests__/ExtensionStartPanel.design-system.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { ExtensionStartPanel } from "../ExtensionStartPanel"
+
+const designSystemLabels = vi.hoisted(() => ({
+  empty: "Registry Empty",
+  ready: "Registry Ready"
+}))
+
+const translationMock = vi.hoisted(() => ({
+  t: vi.fn((key: string, fallback: string) => fallback)
+}))
+
+vi.mock("@/hooks/useServerOnline", () => ({
+  useServerOnline: () => true
+}))
+
+vi.mock("@/hooks/useServerCapabilities", () => ({
+  useServerCapabilities: () => ({
+    loading: false,
+    capabilities: {
+      hasPresentationStudio: true
+    }
+  })
+}))
+
+vi.mock("@/hooks/useConnectionState", () => ({
+  useConnectionState: () => ({
+    serverUrl: "http://127.0.0.1:8000"
+  })
+}))
+
+vi.mock("@/libs/get-screenshot", () => ({
+  getScreenshotFromCurrentTab: vi.fn()
+}))
+
+vi.mock("@/services/tldw/TldwApiClient", () => ({
+  tldwClient: {
+    createPresentation: vi.fn()
+  }
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: translationMock.t
+  })
+}))
+
+vi.mock("@/design-system", async (importActual) => {
+  const actual = await importActual<typeof import("@/design-system")>()
+
+  return {
+    ...actual,
+    EMPTY_STATE_LABEL: designSystemLabels.empty,
+    READY_STATE_LABEL: designSystemLabels.ready,
+    getDesignSystemState: vi.fn(
+      (key: Parameters<typeof actual.getDesignSystemState>[0]) => {
+        const state = actual.getDesignSystemState(key)
+
+        if (key === "empty") {
+          return { ...state, label: designSystemLabels.empty }
+        }
+
+        if (key === "ready") {
+          return { ...state, label: designSystemLabels.ready }
+        }
+
+        return state
+      }
+    )
+  }
+})
+
+describe("ExtensionStartPanel design-system labels", () => {
+  it("renders seed statuses through translated design-system state labels", async () => {
+    render(<ExtensionStartPanel />)
+
+    expect(screen.getAllByText(designSystemLabels.empty)).toHaveLength(2)
+
+    fireEvent.change(screen.getByLabelText("Narration seed"), {
+      target: { value: "Open with the product story." }
+    })
+
+    const imageFile = new File(["seed"], "seed.png", { type: "image/png" })
+    fireEvent.change(screen.getByLabelText("Upload image"), {
+      target: { files: [imageFile] }
+    })
+
+    await waitFor(() => {
+      expect(screen.getAllByText(designSystemLabels.ready)).toHaveLength(2)
+    })
+    expect(screen.queryAllByText("Ready")).toHaveLength(0)
+    expect(screen.queryAllByText("Empty")).toHaveLength(0)
+    expect(translationMock.t).toHaveBeenCalledWith(
+      "presentationStudio.start.status.ready",
+      designSystemLabels.ready
+    )
+    expect(translationMock.t).toHaveBeenCalledWith(
+      "presentationStudio.start.status.empty",
+      designSystemLabels.empty
+    )
+    expect(screen.getByText("Server")).toBeInTheDocument()
+    expect(screen.getAllByText("Narration seed").length).toBeGreaterThan(0)
+    expect(screen.getByText("Image seed")).toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/design-system/__tests__/states.test.ts
+++ b/apps/packages/ui/src/design-system/__tests__/states.test.ts
@@ -1,6 +1,8 @@
 import {
   CANONICAL_STATE_KEYS,
   DESIGN_SYSTEM_STATES,
+  EMPTY_STATE_LABEL,
+  READY_STATE_LABEL,
   getDesignSystemState,
   isDesignSystemStateKey
 } from "../states"
@@ -175,5 +177,10 @@ describe("design-system state registry", () => {
 
   it("keeps state definitions aligned to the canonical key order", () => {
     expect(Object.keys(DESIGN_SYSTEM_STATES)).toEqual(CANONICAL_STATE_KEYS)
+  })
+
+  it("exports canonical state labels through defensive fallbacks", () => {
+    expect(READY_STATE_LABEL).toBe(DESIGN_SYSTEM_STATES.ready.label)
+    expect(EMPTY_STATE_LABEL).toBe(DESIGN_SYSTEM_STATES.empty.label)
   })
 })

--- a/apps/packages/ui/src/design-system/states.ts
+++ b/apps/packages/ui/src/design-system/states.ts
@@ -204,6 +204,18 @@ export function getDesignSystemState(key: DesignSystemStateKey): DesignSystemSta
   return DESIGN_SYSTEM_STATES[key]
 }
 
+export function getDesignSystemStateLabel(
+  key: DesignSystemStateKey,
+  fallback: string
+): string {
+  return getDesignSystemState(key)?.label ?? fallback
+}
+
+export const READY_STATE_LABEL = getDesignSystemStateLabel("ready", "Ready")
+export const EMPTY_STATE_LABEL = getDesignSystemStateLabel("empty", "Empty")
+export const DEGRADED_STATE_LABEL = getDesignSystemStateLabel("degraded", "Degraded")
+export const ERROR_STATE_LABEL = getDesignSystemStateLabel("error", "Error")
+
 export function isDesignSystemStateKey(value: unknown): value is DesignSystemStateKey {
   return (
     typeof value === "string" &&

--- a/backlog/tasks/task-45.44.1.1 - Migrate-Playground-cockpit-Ready-labels-to-design-system-state-registry.md
+++ b/backlog/tasks/task-45.44.1.1 - Migrate-Playground-cockpit-Ready-labels-to-design-system-state-registry.md
@@ -1,0 +1,82 @@
+---
+id: TASK-45.44.1.1
+title: Migrate Playground cockpit Ready labels to design-system state registry
+status: Done
+assignee:
+  - Codex
+created_date: '2026-05-15 01:10'
+updated_date: '2026-05-15 01:15'
+labels:
+  - design-system
+  - webui
+  - extension
+  - product-state
+dependencies: []
+references:
+  - >-
+    apps/packages/ui/src/components/Option/Playground/playground-cockpit-summaries.ts
+  - apps/packages/ui/src/components/Option/Playground/Playground.tsx
+  - apps/packages/ui/src/components/Option/Playground/PlaygroundContextRail.tsx
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-05-14-design-system-remaining-work-tracker-design.md
+parent_task_id: TASK-45.44.1
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replace the newly unbaselined Playground cockpit Ready product-state labels with the canonical design-system state registry so the product-state verifier stays closed on current dev.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Playground cockpit session Ready fallbacks resolve through getDesignSystemState instead of hardcoded canonical literals.
+- [x] #2 The current three unbaselined Playground Ready findings are eliminated without adding baseline debt.
+- [x] #3 Design-system product-state verifier passes after the Playground and ExtensionStartPanel migrations.
+- [x] #4 Verification records focused Vitest, product-state guard/verifier status, diff check, and TypeScript/Bandit applicability.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Use the product-state verifier failure as the red check for the three current Playground Ready labels.
+2. Add READY_STATE_LABEL constants from getDesignSystemState('ready') in the affected Playground cockpit modules.
+3. Replace only the three Ready translation/default fallbacks called out by the verifier.
+4. Verify with focused existing Playground cockpit tests where available, product-state guard tests, bun run verify:design-system-state, and diff checks.
+5. Record verification and skip notes in Backlog.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implementation replaced the three current unbaselined Playground cockpit Ready fallbacks with getDesignSystemState('ready').label in playground-cockpit-summaries.ts, Playground.tsx, and PlaygroundContextRail.tsx.
+
+Verified red before implementation: bun run verify:design-system-state reported three blocked Playground Ready canonical-state-label findings on current origin/dev.
+
+Verification passing: bunx vitest run src/components/Option/PresentationStudio/__tests__/ExtensionStartPanel.design-system.test.tsx src/components/Option/Playground/__tests__/playground-cockpit-summaries.test.ts src/components/Option/Playground/__tests__/PlaygroundContextRail.first-slice.test.tsx --reporter=dot; bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot; bun run verify:design-system-state; git diff --check.
+
+TypeScript note: bunx tsc --noEmit --pretty false exits 2 on existing package-wide type debt, including unrelated current Playground errors outside the touched lines.
+
+Bandit not run: touched runtime scope is UI TypeScript plus JSON baseline and Backlog metadata, with no Python execution path.
+
+PR link: https://github.com/rmusser01/tldw_server/pull/1709
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated three Playground cockpit Ready fallbacks to the design-system state registry and eliminated the new unbaselined Playground canonical-state-label verifier findings without adding baseline debt.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.44.11.1 - Migrate-ExtensionStartPanel-Ready-labels-to-design-system-state-registry.md
+++ b/backlog/tasks/task-45.44.11.1 - Migrate-ExtensionStartPanel-Ready-labels-to-design-system-state-registry.md
@@ -1,0 +1,80 @@
+---
+id: TASK-45.44.11.1
+title: Migrate ExtensionStartPanel Ready labels to design-system state registry
+status: Done
+assignee:
+  - Codex
+created_date: '2026-05-15 01:07'
+updated_date: '2026-05-15 01:14'
+labels:
+  - design-system
+  - webui
+  - extension
+  - product-state
+dependencies: []
+references:
+  - >-
+    apps/packages/ui/src/components/Option/PresentationStudio/ExtensionStartPanel.tsx
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-05-14-design-system-remaining-work-tracker-design.md
+parent_task_id: TASK-45.44.11
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replace the remaining ExtensionStartPanel hardcoded Ready product-state labels with the canonical design-system state registry while preserving existing Empty copy and launch-option rendering.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 ExtensionStartPanel resolves seeded narration and image Ready labels through getDesignSystemState instead of hardcoded canonical literals.
+- [x] #2 Focused coverage proves mocked design-system Ready label renders for narration and image seed status rows.
+- [x] #3 The two ExtensionStartPanel canonical-state-label baseline entries are removed and the design-system product-state verifier passes.
+- [x] #4 Verification records focused Vitest, product-state guard/verifier status, diff check, and TypeScript/Bandit applicability.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused ExtensionStartPanel design-system coverage that mocks getDesignSystemState('ready') and asserts the mocked Ready label appears for narration and image seed status rows while Empty remains unchanged.
+2. Run the focused test red to confirm current hardcoded Ready labels fail the registry assertion.
+3. Import getDesignSystemState in ExtensionStartPanel and use a module-level READY_STATE_LABEL for the two Ready status fallbacks.
+4. Remove the two ExtensionStartPanel canonical-state-label baseline entries.
+5. Verify with focused Vitest, product-state guard tests, bun run verify:design-system-state, git diff --check, and document Bandit/TypeScript applicability.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implementation replaced ExtensionStartPanel seeded narration and image Ready labels with getDesignSystemState('ready').label while preserving Empty copy.
+
+Verified red before implementation: focused ExtensionStartPanel design-system test failed because seeded status rows rendered literal Ready instead of the mocked registry label.
+
+Verification passing: bunx vitest run src/components/Option/PresentationStudio/__tests__/ExtensionStartPanel.design-system.test.tsx src/components/Option/Playground/__tests__/playground-cockpit-summaries.test.ts src/components/Option/Playground/__tests__/PlaygroundContextRail.first-slice.test.tsx --reporter=dot; bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot; bun run verify:design-system-state; git diff --check.
+
+TypeScript note: bunx tsc --noEmit --pretty false exits 2 on existing package-wide type debt, including unrelated current Playground errors outside the touched lines.
+
+Bandit not run: touched runtime scope is UI TypeScript plus JSON baseline and Backlog metadata, with no Python execution path.
+
+PR link: https://github.com/rmusser01/tldw_server/pull/1709
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated ExtensionStartPanel Ready status labels to the design-system state registry, added focused registry-label coverage, and removed the two resolved ExtensionStartPanel canonical-state-label baseline entries.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.44.20 - Address-PR-1709-design-state-review-comments.md
+++ b/backlog/tasks/task-45.44.20 - Address-PR-1709-design-state-review-comments.md
@@ -1,0 +1,58 @@
+---
+id: TASK-45.44.20
+title: Address PR 1709 design-state review comments
+status: Done
+assignee: []
+created_date: '2026-05-15 01:20'
+updated_date: '2026-05-15 01:25'
+labels:
+  - design-system
+  - webui
+  - pr-review
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1709'
+parent_task_id: TASK-45.44
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve actionable review comments on PR 1709 without broadening the design-system migration scope.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Ready state labels are centralized and use defensive registry fallbacks.
+- [x] #2 ExtensionStartPanel status labels use translation-backed design-system Ready and Empty fallbacks.
+- [x] #3 Focused tests and design-system guard verification pass.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Resolved PR 1709 review threads by exporting defensive READY/EMPTY/DEGRADED/ERROR state-label constants from the design-system registry and reusing them across the Playground status surfaces. ExtensionStartPanel now translates Ready and Empty status labels with design-system fallbacks.
+
+Verification passing: bunx vitest run src/design-system/__tests__/states.test.ts src/components/Option/PresentationStudio/__tests__/ExtensionStartPanel.design-system.test.tsx src/components/Option/Playground/__tests__/playground-cockpit-summaries.test.ts src/components/Option/Playground/__tests__/PlaygroundContextRail.first-slice.test.tsx src/design-system/__tests__/product-state-guard.test.ts --reporter=dot; bunx vitest run src/design-system/__tests__/product-state-guard.chat-playground-migration.test.ts --reporter=dot; bun run verify:design-system-state; git diff --check.
+
+TypeScript note: bunx tsc --noEmit --pretty false still exits 2 on existing package-wide type debt, including current Playground errors outside the touched lines.
+
+Bandit not run: touched runtime scope is UI TypeScript plus JSON baseline and Backlog metadata, with no Python execution path.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed PR 1709 design-system review comments by centralizing canonical state-label constants with fallbacks, reusing them across Playground status labels, and translating ExtensionStartPanel Ready/Empty status labels with design-system defaults. Focused Vitest and product-state guard checks pass; package-wide tsc remains blocked by existing unrelated type debt.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Route ExtensionStartPanel seeded status Ready labels through getDesignSystemState.
- Route the newly unbaselined Playground cockpit session Ready fallbacks through getDesignSystemState.
- Remove the resolved ExtensionStartPanel canonical-label baseline entries without adding new Playground baseline debt.

## Verification
- bunx vitest run src/components/Option/PresentationStudio/__tests__/ExtensionStartPanel.design-system.test.tsx src/components/Option/Playground/__tests__/playground-cockpit-summaries.test.ts src/components/Option/Playground/__tests__/PlaygroundContextRail.first-slice.test.tsx --reporter=dot
- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot
- bun run verify:design-system-state
- git diff --check
- git diff --cached --check
- bunx tsc --noEmit --pretty false: exits 2 on existing package-wide TypeScript debt, including unrelated current Playground errors outside the touched lines.
- Bandit: skipped because touched runtime scope is UI TypeScript/JSON/Backlog only.

## Change summary
TODO: human-authored change summary required before merge per Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes Ready/Empty/Degraded/Error status labels in the design-system and routes remaining UI fallbacks through registry-backed constants. Applies them across the Playground and ExtensionStartPanel, removes resolved baseline debt, and adds focused tests to keep the product-state verifier green.

- **Migration**
  - Exported defensive labels from `@/design-system` (`READY_STATE_LABEL`, `EMPTY_STATE_LABEL`, `DEGRADED_STATE_LABEL`, `ERROR_STATE_LABEL`) and used them in `Playground.tsx`, `PlaygroundContextRail.tsx`, `playground-cockpit-summaries.ts`, `PlaygroundRuntimeInspector.tsx`, `PlaygroundStatusStrip.tsx`, and `ExtensionStartPanel.tsx` (with i18n fallbacks).
  - Deleted two `canonical-state-label` entries from `design-system-product-state-baseline.json`.
  - Added `ExtensionStartPanel.design-system.test.tsx` and updated `design-system/__tests__/states.test.ts` to assert exported labels.

<sup>Written for commit 410be01dbfa9b700314fdfead5c888a0e281466a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

