### PR TITLE
Migrate MCPHub blocked labels to design-system registry

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -2464,7 +2464,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/MCPHub/GovernancePacksTab.tsx:Alert#antd-alert-governancepackstab-type-error-line-631-1s1abkv",
+    "id": "antd-product-state-import:src/components/Option/MCPHub/GovernancePacksTab.tsx:Alert#antd-alert-governancepackstab-type-error-line-632-1sb9x9u",
     "path": "src/components/Option/MCPHub/GovernancePacksTab.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -2475,7 +2475,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/MCPHub/GovernancePacksTab.tsx:Alert#antd-alert-governancepackstab-type-success-line-632-6pmctl",
+    "id": "antd-product-state-import:src/components/Option/MCPHub/GovernancePacksTab.tsx:Alert#antd-alert-governancepackstab-type-success-line-633-6fmr4m",
     "path": "src/components/Option/MCPHub/GovernancePacksTab.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -5101,28 +5101,6 @@
     "owner": "design-system",
     "reason": "Existing AntD Alert product-state UI in src/components/WorkflowEditor/NodePalette.tsx before the guard.",
     "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "canonical-state-label:src/components/Option/MCPHub/GovernancePacksTab.tsx:Blocked#label-blocked-governancepackstab-line-919-jq7i8j",
-    "path": "src/components/Option/MCPHub/GovernancePacksTab.tsx",
-    "rule": "canonical-state-label",
-    "subject": "Blocked",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing hardcoded \"Blocked\" state label in src/components/Option/MCPHub/GovernancePacksTab.tsx before the stable duplicate-id guard.",
-    "replacement": "getDesignSystemState(...)",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "canonical-state-label:src/components/Option/MCPHub/GovernancePacksTab.tsx:Blocked#label-blocked-governancepackstab-line-962-p0o8il",
-    "path": "src/components/Option/MCPHub/GovernancePacksTab.tsx",
-    "rule": "canonical-state-label",
-    "subject": "Blocked",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing hardcoded \"Blocked\" state label in src/components/Option/MCPHub/GovernancePacksTab.tsx before the stable duplicate-id guard.",
-    "replacement": "getDesignSystemState(...)",
     "migrationQueue": "shared-product-state"
   },
   {

--- a/apps/packages/ui/src/components/Option/MCPHub/GovernancePacksTab.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/GovernancePacksTab.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react"
 import { Alert, Button, Card, Descriptions, Divider, Empty, Input, List, Modal, Radio, Space, Tag, Typography } from "antd"
+import { BLOCKED_STATE_LABEL } from "@/design-system"
 
 import {
   checkGovernancePackUpdates,
@@ -916,7 +917,7 @@ export const GovernancePacksTab = () => {
               <Descriptions.Item label="Pack">{report.manifest.title}</Descriptions.Item>
               <Descriptions.Item label="Verdict">
                 <Tag color={getVerdictColor(report.verdict)}>
-                  {report.verdict === "importable" ? "Importable" : "Blocked"}
+                  {report.verdict === "importable" ? "Importable" : BLOCKED_STATE_LABEL}
                 </Tag>
               </Descriptions.Item>
               <Descriptions.Item label="Resolved capabilities">
@@ -959,7 +960,7 @@ export const GovernancePacksTab = () => {
               </Descriptions.Item>
               <Descriptions.Item label="Upgradeable">
                 <Tag color={upgradePlan.upgradeable ? "green" : "red"}>
-                  {upgradePlan.upgradeable ? "Ready to execute" : "Blocked"}
+                  {upgradePlan.upgradeable ? "Ready to execute" : BLOCKED_STATE_LABEL}
                 </Tag>
               </Descriptions.Item>
               {upgradeCandidate ? (

--- a/apps/packages/ui/src/components/Option/MCPHub/__tests__/GovernancePacksTab.test.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/__tests__/GovernancePacksTab.test.tsx
@@ -20,6 +20,10 @@ const mocks = vi.hoisted(() => ({
   listGovernancePackUpgradeHistory: vi.fn()
 }))
 
+const designSystemLabels = vi.hoisted(() => ({
+  blocked: "Registry Blocked"
+}))
+
 vi.mock("@/services/tldw/mcp-hub", () => ({
   listGovernancePacks: (...args: unknown[]) => mocks.listGovernancePacks(...args),
   getGovernancePackDetail: (...args: unknown[]) => mocks.getGovernancePackDetail(...args),
@@ -42,6 +46,26 @@ vi.mock("@/services/tldw/mcp-hub", () => ({
   executeGovernancePackUpgrade: (...args: unknown[]) => mocks.executeGovernancePackUpgrade(...args),
   listGovernancePackUpgradeHistory: (...args: unknown[]) => mocks.listGovernancePackUpgradeHistory(...args)
 }))
+
+vi.mock("@/design-system", async (importActual) => {
+  const actual = await importActual<typeof import("@/design-system")>()
+
+  return {
+    ...actual,
+    BLOCKED_STATE_LABEL: designSystemLabels.blocked,
+    getDesignSystemState: vi.fn(
+      (key: Parameters<typeof actual.getDesignSystemState>[0]) => {
+        const state = actual.getDesignSystemState(key)
+
+        if (key === "blocked") {
+          return { ...state, label: designSystemLabels.blocked }
+        }
+
+        return state
+      }
+    )
+  }
+})
 
 import { GovernancePacksTab } from "../GovernancePacksTab"
 
@@ -453,6 +477,100 @@ describe("GovernancePacksTab", () => {
     expect(await screen.findByText("Resolved capabilities")).toBeTruthy()
     expect(screen.getByText("tool.invoke.research")).toBeTruthy()
     expect(screen.getByText("Importable")).toBeTruthy()
+  })
+
+  it("renders blocked dry-run and upgrade statuses through design-system state labels", async () => {
+    mocks.dryRunGovernancePack.mockResolvedValueOnce({
+      report: {
+        manifest: {
+          pack_id: "researcher-pack",
+          pack_version: "1.0.0",
+          title: "Researcher Pack",
+          description: "Portable research governance pack"
+        },
+        digest: "a".repeat(64),
+        resolved_capabilities: ["filesystem.read"],
+        unresolved_capabilities: ["tool.invoke.research"],
+        warnings: [],
+        blocked_objects: ["permission_profile:researcher.profile"],
+        verdict: "blocked"
+      }
+    })
+    mocks.dryRunGovernancePackUpgrade.mockResolvedValueOnce({
+      plan: {
+        source_governance_pack_id: 81,
+        source_manifest: {
+          pack_id: "researcher-pack",
+          pack_version: "1.0.0",
+          title: "Researcher Pack"
+        },
+        target_manifest: {
+          pack_id: "researcher-pack",
+          pack_version: "1.1.0",
+          title: "Researcher Pack"
+        },
+        object_diff: [],
+        dependency_impact: [],
+        structural_conflicts: [],
+        behavioral_conflicts: ["permission_profile:researcher.profile changed"],
+        warnings: [],
+        planner_inputs_fingerprint: "plan-fingerprint",
+        adapter_state_fingerprint: "adapter-fingerprint",
+        upgradeable: false
+      }
+    })
+    const user = userEvent.setup()
+    render(<GovernancePacksTab />)
+
+    expect((await screen.findAllByText("Researcher Pack")).length).toBeGreaterThan(0)
+    fireEvent.change(screen.getByLabelText(/governance pack json/i), {
+      target: {
+        value: JSON.stringify({
+          manifest: {
+            pack_id: "researcher-pack",
+            pack_version: "1.0.0",
+            pack_schema_version: 1,
+            capability_taxonomy_version: 1,
+            adapter_contract_version: 1,
+            title: "Researcher Pack"
+          },
+          profiles: [],
+          approvals: [],
+          personas: [],
+          assignments: []
+        })
+      }
+    })
+
+    await user.click(screen.getByRole("button", { name: /preview pack/i }))
+
+    expect(await screen.findByText(designSystemLabels.blocked)).toBeTruthy()
+    expect(screen.queryByText("Blocked")).toBeNull()
+
+    fireEvent.change(screen.getByLabelText(/governance pack json/i), {
+      target: {
+        value: JSON.stringify({
+          manifest: {
+            pack_id: "researcher-pack",
+            pack_version: "1.1.0",
+            pack_schema_version: 1,
+            capability_taxonomy_version: 1,
+            adapter_contract_version: 1,
+            title: "Researcher Pack"
+          },
+          profiles: [],
+          approvals: [],
+          personas: [],
+          assignments: []
+        })
+      }
+    })
+
+    await user.click(screen.getByRole("button", { name: /preview upgrade/i }))
+
+    expect(await screen.findByRole("dialog")).toBeTruthy()
+    expect(await screen.findAllByText(designSystemLabels.blocked)).toHaveLength(2)
+    expect(screen.queryByText("Blocked")).toBeNull()
   })
 
   it("surfaces detail load failures without clearing the inventory", async () => {

--- a/apps/packages/ui/src/design-system/__tests__/states.test.ts
+++ b/apps/packages/ui/src/design-system/__tests__/states.test.ts
@@ -1,5 +1,6 @@
 import {
   CANONICAL_STATE_KEYS,
+  BLOCKED_STATE_LABEL,
   DESIGN_SYSTEM_STATES,
   EMPTY_STATE_LABEL,
   READY_STATE_LABEL,
@@ -182,5 +183,6 @@ describe("design-system state registry", () => {
   it("exports canonical state labels through defensive fallbacks", () => {
     expect(READY_STATE_LABEL).toBe(DESIGN_SYSTEM_STATES.ready.label)
     expect(EMPTY_STATE_LABEL).toBe(DESIGN_SYSTEM_STATES.empty.label)
+    expect(BLOCKED_STATE_LABEL).toBe(DESIGN_SYSTEM_STATES.blocked.label)
   })
 })

--- a/apps/packages/ui/src/design-system/states.ts
+++ b/apps/packages/ui/src/design-system/states.ts
@@ -215,6 +215,7 @@ export const READY_STATE_LABEL = getDesignSystemStateLabel("ready", "Ready")
 export const EMPTY_STATE_LABEL = getDesignSystemStateLabel("empty", "Empty")
 export const DEGRADED_STATE_LABEL = getDesignSystemStateLabel("degraded", "Degraded")
 export const ERROR_STATE_LABEL = getDesignSystemStateLabel("error", "Error")
+export const BLOCKED_STATE_LABEL = getDesignSystemStateLabel("blocked", "Blocked")
 
 export function isDesignSystemStateKey(value: unknown): value is DesignSystemStateKey {
   return (

--- a/backlog/tasks/task-45.44.4.1 - Migrate-MCPHub-governance-pack-Blocked-labels-to-design-system-state-registry.md
+++ b/backlog/tasks/task-45.44.4.1 - Migrate-MCPHub-governance-pack-Blocked-labels-to-design-system-state-registry.md
@@ -1,0 +1,63 @@
+---
+id: TASK-45.44.4.1
+title: Migrate MCPHub governance pack Blocked labels to design-system state registry
+status: Done
+assignee: []
+created_date: '2026-05-15 02:03'
+updated_date: '2026-05-15 02:14'
+labels:
+  - design-system
+  - webui
+  - product-state
+dependencies: []
+references:
+  - apps/packages/ui/src/components/Option/MCPHub/GovernancePacksTab.tsx
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+parent_task_id: TASK-45.44.4
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Remove the remaining GovernancePacksTab hardcoded Blocked canonical-state-label exceptions by routing them through the design-system state registry.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 GovernancePacksTab Blocked verdict and upgrade labels use the canonical blocked state label.
+- [x] #2 The product-state baseline no longer contains GovernancePacksTab canonical-state-label Blocked entries.
+- [x] #3 Focused MCPHub tests and design-system product-state verification pass.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented on branch codex/design-system-next-slice-4 after rebasing onto origin/dev at e66f1e75e. GovernancePacksTab now uses BLOCKED_STATE_LABEL from the design-system registry for blocked dry-run verdicts and blocked upgrade plans.
+
+Baseline update: removed the two GovernancePacksTab canonical-state-label Blocked exceptions. The remaining baseline after verification is 484 allowed legacy exceptions: 479 antd-product-state-import and 5 canonical-state-label.
+
+Verification passing: bunx vitest run src/components/Option/MCPHub/__tests__/GovernancePacksTab.test.tsx src/design-system/__tests__/states.test.ts src/design-system/__tests__/product-state-guard.test.ts --reporter=dot; bun run verify:design-system-state; git diff --check.
+
+TypeScript note: bunx tsc --noEmit --pretty false still exits 2 on existing package-wide type debt, including unrelated tests and existing Playground type errors.
+
+Bandit not run: touched runtime scope is UI TypeScript plus JSON baseline and Backlog metadata, with no Python execution path.
+
+PR link: https://github.com/rmusser01/tldw_server/pull/1712
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated MCPHub GovernancePacksTab blocked verdict and upgrade labels to the design-system state registry, added regression coverage, and removed the two corresponding canonical-state-label baseline exceptions. Focused tests and the design-system verifier pass; package-wide tsc remains blocked by existing unrelated type debt.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- route GovernancePacksTab blocked dry-run verdict and blocked upgrade labels through the design-system blocked state label
- add a defensive BLOCKED_STATE_LABEL export from the design-system state registry
- remove the two corresponding GovernancePacksTab canonical-state-label baseline exceptions and refresh adjacent stable AntD Alert baseline IDs after the import line shift
- add MCPHub regression coverage using a mocked registry label

## Verification
- bunx vitest run src/components/Option/MCPHub/__tests__/GovernancePacksTab.test.tsx src/design-system/__tests__/states.test.ts src/design-system/__tests__/product-state-guard.test.ts --reporter=dot
- bun run verify:design-system-state
- git diff --check

## Known status
- bunx tsc --noEmit --pretty false still exits 2 on existing package-wide type debt unrelated to this slice.
- Bandit not run: touched runtime scope is UI TypeScript plus JSON baseline and Backlog metadata.

## Change summary
Human maintainer must replace this section before marking ready for merge, per the AI-generated PR change-summary policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates MCPHub GovernancePacksTab “Blocked” labels to the design-system state registry for consistent wording and easier theming. Removes the last legacy exceptions and adds regression tests.

- **Refactors**
  - Exported `BLOCKED_STATE_LABEL` from `@/design-system` and used it for dry-run verdicts and upgrade status in GovernancePacksTab.
  - Removed two `canonical-state-label` baseline exceptions and refreshed adjacent AntD Alert baseline IDs after an import shift.
  - Added tests: MCPHub test mocks the registry label to verify the UI uses it, and a design-system test asserts the `BLOCKED_STATE_LABEL` fallback export.

<sup>Written for commit 5fb78825b1789abddb59e72bb9f296dd00f68bce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

