### PR TITLE
Validate Persona Visual state catalogs

### DIFF
--- a/backlog/tasks/task-356 - Implement-Persona-Visual-state-catalog-backend-validation.md
+++ b/backlog/tasks/task-356 - Implement-Persona-Visual-state-catalog-backend-validation.md
@@ -1,0 +1,60 @@
+---
+id: TASK-356
+title: Implement Persona Visual state catalog backend validation
+status: Done
+assignee: []
+created_date: '2026-05-15 02:15'
+updated_date: '2026-05-15 02:29'
+labels:
+  - persona
+  - buddy
+  - visual-packs
+  - backend
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1713'
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-05-14-persona-buddy-default-catalog-state-catalog-extension-design.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the backend validation slice from TASK-347 Stage 2. Persona Visual sprite packs must remain manifest_version: 1, while optionally supporting a V1-compatible state_catalog extension for declared custom state IDs. Validation should accept declared custom states in states, fallbacks, and authored_triggers, reject unknown or unsafe custom-state references, preserve required built-in activation behavior, and avoid changing non-sprite Manifest V2 semantics.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Plain Manifest V1 sprite_frames manifests continue to validate without state_catalog.
+- [x] #2 Declared state_catalog custom states can be referenced from states, fallbacks, and authored_triggers while required built-in activation behavior remains unchanged.
+- [x] #3 Unknown custom states, reserved built-in redeclarations, unsafe custom IDs, missing/invalid kind, excessive custom state count, excessive trigger count, fallback depth over 8, and fallback cycles are rejected.
+- [x] #4 Focused Persona Visual backend tests cover the new validation behavior and existing renderer manifest-version semantics remain unchanged.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented optional state_catalog validation in Persona Visual sprite frame manifests with declared custom states, reserved built-in protection, safe identifier/kind/label/tag/description bounds, trigger count cap, tool_name trigger support, and fallback depth/cycle validation.
+
+Verification: pytest tldw_Server_API/tests/Persona/test_persona_visuals_core.py -q; pytest focused Persona visual import/manifest/service/starter suite -q; git diff --check; bandit -r tldw_Server_API/app/core/Persona/visuals.py -f json.
+
+Draft PR: https://github.com/rmusser01/tldw_server/pull/1713
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added backend validation for V1 sprite_frames state_catalog custom states while preserving required built-in activation behavior and renderer manifest-version semantics. Added focused Persona Visual tests for custom state references, invalid catalog entries, bounds, trigger caps, fallback depth, and fallback cycles.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-358 - Address-PR-1713-persona-visual-state-catalog-review-feedback.md
+++ b/backlog/tasks/task-358 - Address-PR-1713-persona-visual-state-catalog-review-feedback.md
@@ -1,0 +1,63 @@
+---
+id: TASK-358
+title: Address PR 1713 persona visual state catalog review feedback
+status: Done
+assignee:
+  - codex
+created_date: '2026-05-15 02:49'
+updated_date: '2026-05-15 02:52'
+labels:
+  - persona
+  - review-fix
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1713'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the actionable Gemini review comments on PR #1713 for Persona Visual state catalog validation without broadening the PR scope.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 State catalog labels, descriptions, and tags reject all ASCII control characters, including DEL, not just newline, carriage return, and tab.
+- [x] #2 Allowed visual state ID calculation keeps behavior unchanged while avoiding unnecessary set copies.
+- [x] #3 Focused Persona visual manifest tests cover the control-character rejection edge case.
+- [x] #4 Relevant local verification passes for the touched Persona visual code.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused regression case in `tldw_Server_API/tests/Persona/test_persona_visuals_core.py` proving an ASCII control character outside the currently checked CR/LF/TAB set is rejected in state catalog user-facing text.
+2. Verify the new test fails against the current branch.
+3. Update `tldw_Server_API/app/core/Persona/visuals.py` so `_contains_control_character` rejects ASCII control range 0-31 and DEL, and simplify `_allowed_visual_state_ids` to union built-in IDs with the state catalog keys directly.
+4. Re-run the focused Persona visual tests, run Bandit on the touched Persona core file, update TASK-358 with verification, and push the branch for PR #1713.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Review feedback verified against PR #1713 threads: broaden state catalog control-character detection and simplify allowed visual state union. Added failing regression for ASCII DEL in label/description/tags, then updated validator. Verification: `python -m pytest tldw_Server_API/tests/Persona/test_persona_visuals_core.py -q` passed 41 tests; `python -m bandit -r tldw_Server_API/app/core/Persona/visuals.py -f json -o /tmp/bandit_persona_visuals_1713.json` reported 0 findings.
+
+No known skips or blockers. CI was not rerun locally beyond the focused Persona visual core test file and Bandit because the review feedback only touched the Persona manifest validator path.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the PR #1713 review fixes for Persona Visual state catalog validation. The validator now rejects the full ASCII control range plus DEL in catalog label, description, and tag text, and allowed visual state IDs now union built-in states with catalog keys directly without extra set copies. Added a focused regression test that failed before the validator change and now passes. Verification: `python -m pytest tldw_Server_API/tests/Persona/test_persona_visuals_core.py -q` passed 41 tests; Bandit on `tldw_Server_API/app/core/Persona/visuals.py` reported 0 findings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-359 - Address-PR-1713-Qodo-follow-up-review-comments.md
+++ b/backlog/tasks/task-359 - Address-PR-1713-Qodo-follow-up-review-comments.md
@@ -1,0 +1,59 @@
+---
+id: TASK-359
+title: Address PR 1713 Qodo follow-up review comments
+status: Done
+assignee: []
+created_date: '2026-05-15 03:02'
+updated_date: '2026-05-15 03:05'
+labels:
+  - persona
+  - review-fix
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1713'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the actionable Qodo follow-up comments on PR #1713 without broadening the Persona Visual state catalog validation scope.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Long assertion and parametrized decorator in test_persona_visuals_core.py are wrapped to PEP 8-friendly formatting.
+- [x] #2 New state-catalog helper functions have succinct docstrings describing purpose and validation behavior.
+- [x] #3 Unsafe custom state id failures return accurate diagnostics for pattern, prefix, and marker causes.
+- [x] #4 Focused Persona visual tests and security/style checks pass after the review fixes.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused failing tests for unsafe-prefix and unsafe-marker custom state id diagnostics.\n2. Apply minimal formatting/docstring/diagnostic fixes.\n3. Run focused tests, Bandit, diff check, and refresh PR threads.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Addressed Qodo follow-up comments on PR #1713: wrapped long test assertion/decorator plus the remaining long newly added tuple; added state-catalog helper docstrings; replaced the boolean custom-state ID helper with specific diagnostics for type, pattern, unsafe prefix, and unsafe marker failures.
+
+Verification: red test confirmed unsafe-prefix/unsafe-marker diagnostics failed before validator change; then 77 focused Persona visual tests passed; git diff --check passed; full PR diff added-line length scan found no lines over threshold; Bandit on tldw_Server_API/app/core/Persona/visuals.py reported 0 findings.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Resolved PR #1713 Qodo follow-up comments by tightening test formatting, documenting new helper behavior, and making custom state ID validation errors specific to the actual failure cause. Added regression coverage for unsafe prefix and unsafe marker diagnostics.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/Persona/visuals.py
+++ b/tldw_Server_API/app/core/Persona/visuals.py
@@ -435,7 +435,7 @@ def _validate_state_catalog_tags(state_id: str, tags: Any) -> None:
 
 
 def _allowed_visual_state_ids(manifest: dict[str, Any]) -> set[str]:
-    return set(VISUAL_STATE_IDS) | set(manifest.get("state_catalog", {}))
+    return VISUAL_STATE_IDS | manifest.get("state_catalog", {}).keys()
 
 
 def _is_safe_custom_state_id(state_id: str) -> bool:
@@ -449,7 +449,7 @@ def _is_safe_custom_state_id(state_id: str) -> bool:
 
 
 def _contains_control_character(value: str) -> bool:
-    return any(character in value for character in ("\r", "\n", "\t"))
+    return any(ord(character) < 32 or ord(character) == 127 for character in value)
 
 
 def _validate_state_references(

--- a/tldw_Server_API/app/core/Persona/visuals.py
+++ b/tldw_Server_API/app/core/Persona/visuals.py
@@ -360,17 +360,16 @@ def _validate_frame_region(
 
 
 def _validate_state_catalog(state_catalog: dict[str, Any]) -> None:
+    """Validate optional custom visual states declared by a sprite manifest."""
     if len(state_catalog) > MAX_CUSTOM_VISUAL_STATES:
         raise PersonaVisualManifestError(
             f"state_catalog may define at most {MAX_CUSTOM_VISUAL_STATES} custom states"
         )
 
     for state_id, entry in state_catalog.items():
-        if not isinstance(state_id, str) or not _is_safe_custom_state_id(state_id):
-            raise PersonaVisualManifestError(
-                "state_catalog custom state ids must match "
-                f"{CUSTOM_VISUAL_STATE_ID_PATTERN.pattern}"
-            )
+        state_id_error = _custom_state_id_error(state_id)
+        if state_id_error:
+            raise PersonaVisualManifestError(state_id_error)
         if state_id in VISUAL_STATE_IDS:
             raise PersonaVisualManifestError(
                 f"state_catalog custom state {state_id} is reserved"
@@ -416,6 +415,7 @@ def _validate_state_catalog(state_catalog: dict[str, Any]) -> None:
 
 
 def _validate_state_catalog_tags(state_id: str, tags: Any) -> None:
+    """Validate bounded user-facing tags for a custom visual state."""
     if not isinstance(tags, list) or len(tags) > MAX_STATE_CATALOG_TAGS:
         raise PersonaVisualManifestError(
             f"state_catalog[{state_id}].tags must be a list of at most "
@@ -435,20 +435,30 @@ def _validate_state_catalog_tags(state_id: str, tags: Any) -> None:
 
 
 def _allowed_visual_state_ids(manifest: dict[str, Any]) -> set[str]:
+    """Return built-in states plus declared custom state_catalog keys."""
     return VISUAL_STATE_IDS | manifest.get("state_catalog", {}).keys()
 
 
-def _is_safe_custom_state_id(state_id: str) -> bool:
+def _custom_state_id_error(state_id: Any) -> str | None:
+    """Return a specific custom state ID validation error, or None if valid."""
+    if not isinstance(state_id, str):
+        return "state_catalog custom state ids must be strings"
     if not CUSTOM_VISUAL_STATE_ID_PATTERN.fullmatch(state_id):
-        return False
+        return (
+            "state_catalog custom state ids must match "
+            f"{CUSTOM_VISUAL_STATE_ID_PATTERN.pattern}"
+        )
     lowered = state_id.lower()
     if lowered.startswith(UNSAFE_CUSTOM_STATE_PREFIXES):
-        return False
+        return "state_catalog custom state ids must not use unsafe prefixes"
     compact = re.sub(r"[._:-]+", "_", lowered)
-    return not any(marker in compact for marker in UNSAFE_CUSTOM_STATE_MARKERS)
+    if any(marker in compact for marker in UNSAFE_CUSTOM_STATE_MARKERS):
+        return "state_catalog custom state ids must not contain unsafe markers"
+    return None
 
 
 def _contains_control_character(value: str) -> bool:
+    """Return whether user-facing manifest text contains ASCII control codes."""
     return any(ord(character) < 32 or ord(character) == 127 for character in value)
 
 

--- a/tldw_Server_API/app/core/Persona/visuals.py
+++ b/tldw_Server_API/app/core/Persona/visuals.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any
@@ -21,14 +22,54 @@ VISUAL_STATE_IDS = {
     "offline",
 }
 REQUIRED_VISUAL_STATES = {"idle", "listening", "thinking", "speaking", "error"}
-SUPPORTED_TRIGGER_SOURCES = {"live_state", "tool_category", "mcp_runtime"}
+SUPPORTED_TRIGGER_SOURCES = {"live_state", "tool_category", "mcp_runtime", "tool_name"}
+SUPPORTED_STATE_CATALOG_KINDS = {
+    "tool_variant",
+    "reaction",
+    "live_variant",
+    "mcp_runtime",
+    "mood",
+    "pack_private",
+}
 
 MAX_FRAMES_PER_ANIMATION = 240
+MAX_CUSTOM_VISUAL_STATES = 256
+MAX_AUTHORED_TRIGGERS = 512
+MAX_FALLBACK_DEPTH = 8
 MIN_FRAME_DURATION_MS = 16
 MAX_FRAME_DURATION_MS = 30_000
 MIN_TRIGGER_DURATION_MS = 100
 MAX_TRIGGER_DURATION_MS = 30_000
 MAX_RENDERER_TYPE_ERROR_LENGTH = 100
+MAX_STATE_CATALOG_LABEL_LENGTH = 80
+MAX_STATE_CATALOG_DESCRIPTION_LENGTH = 280
+MAX_STATE_CATALOG_TAGS = 16
+MAX_STATE_CATALOG_TAG_LENGTH = 32
+CUSTOM_VISUAL_STATE_ID_PATTERN = re.compile(r"^[a-z][a-z0-9_.:-]{0,95}$")
+UNSAFE_CUSTOM_STATE_MARKERS = (
+    "access_token",
+    "api_key",
+    "apikey",
+    "auth_token",
+    "authorization",
+    "bearer_token",
+    "client_secret",
+    "password",
+    "passwd",
+    "private_key",
+    "refresh_token",
+    "secret",
+    "secret_key",
+)
+UNSAFE_CUSTOM_STATE_PREFIXES = (
+    "env:",
+    "file:",
+    "ftp:",
+    "http:",
+    "https:",
+    "proc:",
+    "ssh:",
+)
 
 
 class PersonaVisualManifestError(ValueError):
@@ -62,9 +103,13 @@ def validate_visual_manifest(
             available_asset_dimensions=dimensions,
         )
 
-    _validate_state_references(normalized)
-    _validate_fallbacks(normalized.get("fallbacks", {}))
-    _validate_authored_triggers(normalized.get("authored_triggers", []))
+    allowed_states = _allowed_visual_state_ids(normalized)
+    _validate_state_references(normalized, allowed_states=allowed_states)
+    _validate_fallbacks(normalized.get("fallbacks", {}), allowed_states=allowed_states)
+    _validate_authored_triggers(
+        normalized.get("authored_triggers", []),
+        allowed_states=allowed_states,
+    )
 
     resolved_required = {
         state: _resolve_state(state, normalized)
@@ -119,6 +164,7 @@ def _normalize_manifest_shape(
     animations = normalized.setdefault("animations", {})
     fallbacks = normalized.setdefault("fallbacks", {})
     authored_triggers = normalized.setdefault("authored_triggers", [])
+    state_catalog = normalized.setdefault("state_catalog", {})
 
     if not isinstance(states, dict):
         raise PersonaVisualManifestError("states must be an object")
@@ -128,6 +174,8 @@ def _normalize_manifest_shape(
         raise PersonaVisualManifestError("fallbacks must be an object")
     if not isinstance(authored_triggers, list):
         raise PersonaVisualManifestError("authored_triggers must be a list")
+    if not isinstance(state_catalog, dict):
+        raise PersonaVisualManifestError("state_catalog must be an object")
 
     for animation_id, animation in animations.items():
         if not isinstance(animation_id, str) or not animation_id:
@@ -135,6 +183,8 @@ def _normalize_manifest_shape(
         if not isinstance(animation, dict):
             raise PersonaVisualManifestError(f"Animation {animation_id} must be an object")
         animation["frames"] = _normalize_animation_frames(animation_id, animation)
+
+    _validate_state_catalog(state_catalog)
 
     return normalized
 
@@ -309,10 +359,107 @@ def _validate_frame_region(
         )
 
 
-def _validate_state_references(manifest: dict[str, Any]) -> None:
+def _validate_state_catalog(state_catalog: dict[str, Any]) -> None:
+    if len(state_catalog) > MAX_CUSTOM_VISUAL_STATES:
+        raise PersonaVisualManifestError(
+            f"state_catalog may define at most {MAX_CUSTOM_VISUAL_STATES} custom states"
+        )
+
+    for state_id, entry in state_catalog.items():
+        if not isinstance(state_id, str) or not _is_safe_custom_state_id(state_id):
+            raise PersonaVisualManifestError(
+                "state_catalog custom state ids must match "
+                f"{CUSTOM_VISUAL_STATE_ID_PATTERN.pattern}"
+            )
+        if state_id in VISUAL_STATE_IDS:
+            raise PersonaVisualManifestError(
+                f"state_catalog custom state {state_id} is reserved"
+            )
+        if not isinstance(entry, dict):
+            raise PersonaVisualManifestError(
+                f"state_catalog[{state_id}] must be an object"
+            )
+
+        label = entry.get("label")
+        if (
+            not isinstance(label, str)
+            or not label.strip()
+            or len(label) > MAX_STATE_CATALOG_LABEL_LENGTH
+            or _contains_control_character(label)
+        ):
+            raise PersonaVisualManifestError(
+                f"state_catalog[{state_id}].label must be a non-empty string up to "
+                f"{MAX_STATE_CATALOG_LABEL_LENGTH} characters"
+            )
+
+        kind = entry.get("kind")
+        if kind not in SUPPORTED_STATE_CATALOG_KINDS:
+            raise PersonaVisualManifestError(
+                f"state_catalog[{state_id}].kind must be one of "
+                f"{sorted(SUPPORTED_STATE_CATALOG_KINDS)}"
+            )
+
+        description = entry.get("description")
+        if description is not None and (
+            not isinstance(description, str)
+            or len(description) > MAX_STATE_CATALOG_DESCRIPTION_LENGTH
+            or _contains_control_character(description)
+        ):
+            raise PersonaVisualManifestError(
+                f"state_catalog[{state_id}].description must be a string up to "
+                f"{MAX_STATE_CATALOG_DESCRIPTION_LENGTH} characters"
+            )
+
+        tags = entry.get("tags")
+        if tags is not None:
+            _validate_state_catalog_tags(state_id, tags)
+
+
+def _validate_state_catalog_tags(state_id: str, tags: Any) -> None:
+    if not isinstance(tags, list) or len(tags) > MAX_STATE_CATALOG_TAGS:
+        raise PersonaVisualManifestError(
+            f"state_catalog[{state_id}].tags must be a list of at most "
+            f"{MAX_STATE_CATALOG_TAGS} strings"
+        )
+    for index, tag in enumerate(tags):
+        if (
+            not isinstance(tag, str)
+            or not tag.strip()
+            or len(tag) > MAX_STATE_CATALOG_TAG_LENGTH
+            or _contains_control_character(tag)
+        ):
+            raise PersonaVisualManifestError(
+                f"state_catalog[{state_id}].tags[{index}] must be a non-empty string "
+                f"up to {MAX_STATE_CATALOG_TAG_LENGTH} characters"
+            )
+
+
+def _allowed_visual_state_ids(manifest: dict[str, Any]) -> set[str]:
+    return set(VISUAL_STATE_IDS) | set(manifest.get("state_catalog", {}))
+
+
+def _is_safe_custom_state_id(state_id: str) -> bool:
+    if not CUSTOM_VISUAL_STATE_ID_PATTERN.fullmatch(state_id):
+        return False
+    lowered = state_id.lower()
+    if lowered.startswith(UNSAFE_CUSTOM_STATE_PREFIXES):
+        return False
+    compact = re.sub(r"[._:-]+", "_", lowered)
+    return not any(marker in compact for marker in UNSAFE_CUSTOM_STATE_MARKERS)
+
+
+def _contains_control_character(value: str) -> bool:
+    return any(character in value for character in ("\r", "\n", "\t"))
+
+
+def _validate_state_references(
+    manifest: dict[str, Any],
+    *,
+    allowed_states: set[str],
+) -> None:
     animations = manifest["animations"]
     for state, mapping in manifest["states"].items():
-        if state not in VISUAL_STATE_IDS:
+        if state not in allowed_states:
             raise PersonaVisualManifestError(f"Unknown visual state {state}")
         if not isinstance(mapping, dict):
             raise PersonaVisualManifestError(f"State {state} mapping must be an object")
@@ -325,14 +472,18 @@ def _validate_state_references(manifest: dict[str, Any]) -> None:
             )
 
 
-def _validate_fallbacks(fallbacks: dict[str, Any]) -> None:
+def _validate_fallbacks(
+    fallbacks: dict[str, Any],
+    *,
+    allowed_states: set[str],
+) -> None:
     for state, fallback_chain in fallbacks.items():
-        if state not in VISUAL_STATE_IDS:
+        if state not in allowed_states:
             raise PersonaVisualManifestError(f"Unknown fallback state {state}")
         if not isinstance(fallback_chain, list):
             raise PersonaVisualManifestError(f"Fallback {state} must be a list")
         for fallback_state in fallback_chain:
-            if fallback_state not in VISUAL_STATE_IDS:
+            if fallback_state not in allowed_states:
                 raise PersonaVisualManifestError(
                     f"Fallback {state} references unknown state {fallback_state}"
                 )
@@ -341,6 +492,11 @@ def _validate_fallbacks(fallbacks: dict[str, Any]) -> None:
     visited: set[str] = set()
 
     def visit(state: str, path: tuple[str, ...]) -> None:
+        if len(path) >= MAX_FALLBACK_DEPTH:
+            raise PersonaVisualManifestError(
+                f"Fallback chain depth exceeds {MAX_FALLBACK_DEPTH}: "
+                + " -> ".join((*path, state))
+            )
         if state in visiting:
             raise PersonaVisualManifestError(
                 "Fallback cycle detected: " + " -> ".join((*path, state))
@@ -357,7 +513,15 @@ def _validate_fallbacks(fallbacks: dict[str, Any]) -> None:
         visit(state, ())
 
 
-def _validate_authored_triggers(triggers: list[Any]) -> None:
+def _validate_authored_triggers(
+    triggers: list[Any],
+    *,
+    allowed_states: set[str],
+) -> None:
+    if len(triggers) > MAX_AUTHORED_TRIGGERS:
+        raise PersonaVisualManifestError(
+            f"authored_triggers may define at most {MAX_AUTHORED_TRIGGERS} triggers"
+        )
     for index, trigger in enumerate(triggers):
         if not isinstance(trigger, dict):
             raise PersonaVisualManifestError(f"authored_triggers[{index}] must be an object")
@@ -374,7 +538,7 @@ def _validate_authored_triggers(triggers: list[Any]) -> None:
         if not isinstance(match, str) or not match:
             raise PersonaVisualManifestError(f"authored_triggers[{index}].match is required")
         state = trigger.get("state")
-        if state not in VISUAL_STATE_IDS:
+        if state not in allowed_states:
             raise PersonaVisualManifestError(
                 f"authored_triggers[{index}].state must be a known visual state"
             )

--- a/tldw_Server_API/tests/Persona/test_persona_visuals_core.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visuals_core.py
@@ -233,6 +233,49 @@ def test_manifest_rejects_invalid_state_catalog_entries(
         )
 
 
+@pytest.mark.parametrize(
+    ("catalog_entry", "message"),
+    [
+        ({"label": "Bad\x7fLabel", "kind": "tool_variant"}, "label"),
+        (
+            {
+                "label": "Valid label",
+                "kind": "tool_variant",
+                "description": "Bad\x7fDescription",
+            },
+            "description",
+        ),
+        (
+            {
+                "label": "Valid label",
+                "kind": "tool_variant",
+                "tags": ["Bad\x7fTag"],
+            },
+            "tags",
+        ),
+    ],
+)
+def test_manifest_rejects_state_catalog_text_with_ascii_control_characters(
+    catalog_entry: dict[str, object],
+    message: str,
+) -> None:
+    manifest = _activatable_manifest()
+    manifest["state_catalog"] = {"tool.notes_search": catalog_entry}
+
+    with pytest.raises(PersonaVisualManifestError, match=message):
+        validate_visual_manifest(
+            manifest,
+            available_asset_ids={
+                "asset-idle",
+                "asset-listen",
+                "asset-think",
+                "asset-speak",
+                "asset-error",
+            },
+            require_activatable=True,
+        )
+
+
 def test_manifest_rejects_excessive_state_catalog_size() -> None:
     manifest = _activatable_manifest()
     manifest["state_catalog"] = {

--- a/tldw_Server_API/tests/Persona/test_persona_visuals_core.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visuals_core.py
@@ -132,6 +132,209 @@ def test_valid_manifest_resolves_required_states_and_normalizes_frames() -> None
     ]
 
 
+def test_manifest_accepts_declared_custom_state_catalog_references() -> None:
+    manifest = _activatable_manifest()
+    manifest["state_catalog"] = {
+        "tool.notes_search": {
+            "label": "Searching notes",
+            "kind": "tool_variant",
+            "description": "Shown while the notes search tool runs.",
+            "tags": ["tool", "notes"],
+        }
+    }
+    manifest["states"]["tool.notes_search"] = {"animation_id": "tool-notes-search"}
+    manifest["animations"]["tool-notes-search"] = {
+        "asset_ids": ["asset-tool-notes-search"],
+        "frame_rate": 8,
+        "loop": True,
+    }
+    manifest["fallbacks"]["tool.notes_search"] = ["tool_running", "thinking", "idle"]
+    manifest["authored_triggers"] = [
+        {
+            "id": "notes-search-tool",
+            "source": "tool_name",
+            "match": "notes.search",
+            "state": "tool.notes_search",
+            "duration_ms": 2400,
+            "priority": 80,
+        }
+    ]
+
+    result = validate_visual_manifest(
+        manifest,
+        available_asset_ids={
+            "asset-idle",
+            "asset-listen",
+            "asset-think",
+            "asset-speak",
+            "asset-error",
+            "asset-tool-notes-search",
+        },
+        require_activatable=True,
+    )
+
+    assert set(result.resolved_required_states) == REQUIRED_VISUAL_STATES
+    assert result.manifest["states"]["tool.notes_search"]["animation_id"] == "tool-notes-search"
+    assert result.manifest["authored_triggers"][0]["source"] == "tool_name"
+
+
+def test_manifest_rejects_builtin_state_catalog_redeclarations() -> None:
+    manifest = _activatable_manifest()
+    manifest["state_catalog"] = {
+        "idle": {
+            "label": "Custom idle",
+            "kind": "reaction",
+        }
+    }
+
+    with pytest.raises(PersonaVisualManifestError, match="reserved"):
+        validate_visual_manifest(
+            manifest,
+            available_asset_ids={
+                "asset-idle",
+                "asset-listen",
+                "asset-think",
+                "asset-speak",
+                "asset-error",
+            },
+            require_activatable=True,
+        )
+
+
+@pytest.mark.parametrize(
+    ("state_id", "catalog_entry", "message"),
+    [
+        ("Tool.Search", {"label": "Bad case", "kind": "tool_variant"}, "state_catalog"),
+        ("tool/search", {"label": "Bad slash", "kind": "tool_variant"}, "state_catalog"),
+        ("tool.notes_search", {"label": "No kind"}, "kind"),
+        ("tool.notes_search", {"label": "Bad kind", "kind": "unknown"}, "kind"),
+        ("tool.notes_search", {"label": "", "kind": "tool_variant"}, "label"),
+    ],
+)
+def test_manifest_rejects_invalid_state_catalog_entries(
+    state_id: str,
+    catalog_entry: dict[str, object],
+    message: str,
+) -> None:
+    manifest = _activatable_manifest()
+    manifest["state_catalog"] = {state_id: catalog_entry}
+
+    with pytest.raises(PersonaVisualManifestError, match=message):
+        validate_visual_manifest(
+            manifest,
+            available_asset_ids={
+                "asset-idle",
+                "asset-listen",
+                "asset-think",
+                "asset-speak",
+                "asset-error",
+            },
+            require_activatable=True,
+        )
+
+
+def test_manifest_rejects_excessive_state_catalog_size() -> None:
+    manifest = _activatable_manifest()
+    manifest["state_catalog"] = {
+        f"tool.extra_{index}": {"label": f"Extra {index}", "kind": "tool_variant"}
+        for index in range(257)
+    }
+
+    with pytest.raises(PersonaVisualManifestError, match="state_catalog"):
+        validate_visual_manifest(
+            manifest,
+            available_asset_ids={
+                "asset-idle",
+                "asset-listen",
+                "asset-think",
+                "asset-speak",
+                "asset-error",
+            },
+            require_activatable=True,
+        )
+
+
+def test_manifest_rejects_excessive_authored_triggers() -> None:
+    manifest = _activatable_manifest()
+    manifest["authored_triggers"] = [
+        {
+            "id": f"trigger-{index}",
+            "source": "live_state",
+            "match": "thinking",
+            "state": "thinking",
+            "duration_ms": 1000,
+            "priority": 10,
+        }
+        for index in range(513)
+    ]
+
+    with pytest.raises(PersonaVisualManifestError, match="authored_triggers"):
+        validate_visual_manifest(
+            manifest,
+            available_asset_ids={
+                "asset-idle",
+                "asset-listen",
+                "asset-think",
+                "asset-speak",
+                "asset-error",
+            },
+            require_activatable=True,
+        )
+
+
+def test_manifest_rejects_fallback_depth_over_eight() -> None:
+    manifest = _activatable_manifest()
+    manifest["fallbacks"] = {
+        "idle": ["wake_armed"],
+        "wake_armed": ["listening"],
+        "listening": ["thinking"],
+        "thinking": ["speaking"],
+        "speaking": ["tool_running"],
+        "tool_running": ["approval_needed"],
+        "approval_needed": ["error"],
+        "error": ["offline"],
+        "offline": [],
+    }
+
+    with pytest.raises(PersonaVisualManifestError, match="depth"):
+        validate_visual_manifest(
+            manifest,
+            available_asset_ids={
+                "asset-idle",
+                "asset-listen",
+                "asset-think",
+                "asset-speak",
+                "asset-error",
+            },
+            require_activatable=True,
+        )
+
+
+def test_manifest_rejects_custom_fallback_cycles() -> None:
+    manifest = _activatable_manifest()
+    manifest["state_catalog"] = {
+        "reaction.one": {"label": "One", "kind": "reaction"},
+        "reaction.two": {"label": "Two", "kind": "reaction"},
+    }
+    manifest["fallbacks"] = {
+        "reaction.one": ["reaction.two"],
+        "reaction.two": ["reaction.one"],
+    }
+
+    with pytest.raises(PersonaVisualManifestError, match="cycle"):
+        validate_visual_manifest(
+            manifest,
+            available_asset_ids={
+                "asset-idle",
+                "asset-listen",
+                "asset-think",
+                "asset-speak",
+                "asset-error",
+            },
+            require_activatable=True,
+        )
+
+
 @pytest.mark.parametrize("renderer_type", ["live2d", "static_image", "sprite_sheet", "not_real"])
 def test_manifest_rejects_unsupported_renderer_types(renderer_type: str) -> None:
     manifest = _activatable_manifest()

--- a/tldw_Server_API/tests/Persona/test_persona_visuals_core.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visuals_core.py
@@ -174,7 +174,10 @@ def test_manifest_accepts_declared_custom_state_catalog_references() -> None:
     )
 
     assert set(result.resolved_required_states) == REQUIRED_VISUAL_STATES
-    assert result.manifest["states"]["tool.notes_search"]["animation_id"] == "tool-notes-search"
+    assert (
+        result.manifest["states"]["tool.notes_search"]["animation_id"]
+        == "tool-notes-search"
+    )
     assert result.manifest["authored_triggers"][0]["source"] == "tool_name"
 
 
@@ -205,7 +208,11 @@ def test_manifest_rejects_builtin_state_catalog_redeclarations() -> None:
     ("state_id", "catalog_entry", "message"),
     [
         ("Tool.Search", {"label": "Bad case", "kind": "tool_variant"}, "state_catalog"),
-        ("tool/search", {"label": "Bad slash", "kind": "tool_variant"}, "state_catalog"),
+        (
+            "tool/search",
+            {"label": "Bad slash", "kind": "tool_variant"},
+            "state_catalog",
+        ),
         ("tool.notes_search", {"label": "No kind"}, "kind"),
         ("tool.notes_search", {"label": "Bad kind", "kind": "unknown"}, "kind"),
         ("tool.notes_search", {"label": "", "kind": "tool_variant"}, "label"),
@@ -218,6 +225,36 @@ def test_manifest_rejects_invalid_state_catalog_entries(
 ) -> None:
     manifest = _activatable_manifest()
     manifest["state_catalog"] = {state_id: catalog_entry}
+
+    with pytest.raises(PersonaVisualManifestError, match=message):
+        validate_visual_manifest(
+            manifest,
+            available_asset_ids={
+                "asset-idle",
+                "asset-listen",
+                "asset-think",
+                "asset-speak",
+                "asset-error",
+            },
+            require_activatable=True,
+        )
+
+
+@pytest.mark.parametrize(
+    ("state_id", "message"),
+    [
+        ("http:avatar", "unsafe prefix"),
+        ("tool.api_key", "unsafe marker"),
+    ],
+)
+def test_manifest_rejects_unsafe_state_catalog_ids_with_specific_messages(
+    state_id: str,
+    message: str,
+) -> None:
+    manifest = _activatable_manifest()
+    manifest["state_catalog"] = {
+        state_id: {"label": "Unsafe identifier", "kind": "tool_variant"}
+    }
 
     with pytest.raises(PersonaVisualManifestError, match=message):
         validate_visual_manifest(
@@ -378,7 +415,10 @@ def test_manifest_rejects_custom_fallback_cycles() -> None:
         )
 
 
-@pytest.mark.parametrize("renderer_type", ["live2d", "static_image", "sprite_sheet", "not_real"])
+@pytest.mark.parametrize(
+    "renderer_type",
+    ["live2d", "static_image", "sprite_sheet", "not_real"],
+)
 def test_manifest_rejects_unsupported_renderer_types(renderer_type: str) -> None:
     manifest = _activatable_manifest()
     manifest["renderer_type"] = renderer_type


### PR DESCRIPTION
## Summary
- Add optional `state_catalog` validation for V1 `sprite_frames` manifests while keeping renderer manifest versions unchanged.
- Allow declared custom states in state mappings, fallbacks, and authored triggers, including `tool_name` triggers.
- Reject reserved built-ins, unsafe/invalid custom IDs, invalid catalog metadata, excessive catalog/trigger sizes, fallback depth over 8, and fallback cycles.
- Add Backlog TASK-356 and focused Persona Visual regression coverage.

## Verification
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_visuals_core.py tldw_Server_API/tests/Persona/test_persona_visual_import_preview_validators.py tldw_Server_API/tests/Persona/test_persona_visual_manifest_assets.py tldw_Server_API/tests/Persona/test_persona_visual_service.py tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py -q`
- `git diff --check`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Persona/visuals.py -f json -o /tmp/bandit_persona_state_catalog_validation.json`

## Change summary
Human-authored change summary required before merge per project policy.

Refs TASK-356.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add backend validation for custom Persona Visual state catalogs in V1 `sprite_frames` manifests. Supports safe custom states and `tool_name` triggers without changing renderer behavior. Implements TASK-356 and addresses TASK-358 and TASK-359 review feedback.

- **New Features**
  - Validate optional `state_catalog` with strict schema: allowed kinds (`tool_variant`, `reaction`, `live_variant`, `mcp_runtime`, `mood`, `pack_private`), safe ID regex, unsafe prefix/marker guards, and label/description/tag bounds with full ASCII control-character checks (incl DEL).
  - Allow declared custom states in states, fallbacks, and authored triggers; support `tool_name` trigger source; enforce limits (custom states ≤256, triggers ≤512, fallback depth ≤8) and detect fallback cycles.
  - Use catalog keys when checking allowed states; keep V1 behavior unchanged for manifests without `state_catalog`.
  - Add focused tests for custom state references, reserved redeclarations, invalid entries, control-char rejection, size/limit violations, depth/cycle detection; return specific diagnostics for unsafe custom state IDs.

<sup>Written for commit cdfd0ddb7c2e594ebed5024f039b2c57a2a3d4ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

