### PR TITLE
Add traceable workspace artifact UI

### DIFF
--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/StudioPane/TraceableArtifactDetail.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/StudioPane/TraceableArtifactDetail.tsx
@@ -1,4 +1,6 @@
 import React from "react"
+import { Link } from "react-router-dom"
+import { useTranslation } from "react-i18next"
 import {
   Archive,
   CheckCircle,
@@ -19,6 +21,8 @@ import type {
   GeneratedArtifact,
   TraceableArtifactExportRef
 } from "@/types/workspace"
+
+type Translate = ReturnType<typeof useTranslation>["t"]
 
 const REVIEW_STATE_ORDER: ArtifactReviewStatus[] = [
   "draft",
@@ -52,20 +56,86 @@ const REVIEW_STATE_ICONS: Partial<
   archived: Archive
 }
 
-export const formatArtifactReviewStateLabel = (
-  status: ArtifactReviewStatus | string | undefined
-): string => {
-  if (!status) return "Draft"
-  return status
-    .split("_")
-    .filter(Boolean)
-    .map((part) => part[0].toUpperCase() + part.slice(1))
-    .join(" ")
+const REVIEW_STATE_COPY: Record<
+  ArtifactReviewStatus,
+  { key: string; defaultValue: string }
+> = {
+  draft: {
+    key: "playground:studio.traceableArtifact.reviewStates.draft",
+    defaultValue: "Draft"
+  },
+  reviewing: {
+    key: "playground:studio.traceableArtifact.reviewStates.reviewing",
+    defaultValue: "Reviewing"
+  },
+  accepted: {
+    key: "playground:studio.traceableArtifact.reviewStates.accepted",
+    defaultValue: "Accepted"
+  },
+  needs_revision: {
+    key: "playground:studio.traceableArtifact.reviewStates.needsRevision",
+    defaultValue: "Needs Revision"
+  },
+  rejected: {
+    key: "playground:studio.traceableArtifact.reviewStates.rejected",
+    defaultValue: "Rejected"
+  },
+  exported: {
+    key: "playground:studio.traceableArtifact.reviewStates.exported",
+    defaultValue: "Exported"
+  },
+  assigned: {
+    key: "playground:studio.traceableArtifact.reviewStates.assigned",
+    defaultValue: "Assigned"
+  },
+  archived: {
+    key: "playground:studio.traceableArtifact.reviewStates.archived",
+    defaultValue: "Archived"
+  }
 }
 
-const formatExportFormatLabel = (format: string): string => {
-  if (format.toLowerCase() === "md") return "Markdown"
-  return formatArtifactReviewStateLabel(format)
+const EXPORT_FORMAT_COPY: Record<string, { key: string; defaultValue: string }> = {
+  md: {
+    key: "playground:studio.traceableArtifact.exportFormats.markdown",
+    defaultValue: "Markdown"
+  },
+  markdown: {
+    key: "playground:studio.traceableArtifact.exportFormats.markdown",
+    defaultValue: "Markdown"
+  },
+  docx: {
+    key: "playground:studio.traceableArtifact.exportFormats.docx",
+    defaultValue: "DOCX"
+  },
+  pdf: {
+    key: "playground:studio.traceableArtifact.exportFormats.pdf",
+    defaultValue: "PDF"
+  },
+  slides: {
+    key: "playground:studio.traceableArtifact.exportFormats.slides",
+    defaultValue: "Slides"
+  },
+  chatbook: {
+    key: "playground:studio.traceableArtifact.exportFormats.chatbook",
+    defaultValue: "Chatbook"
+  }
+}
+
+const getArtifactReviewStateLabel = (
+  t: Translate,
+  status: ArtifactReviewStatus | undefined
+): string => {
+  const copy = REVIEW_STATE_COPY[status || "draft"]
+  return t(copy.key, copy.defaultValue)
+}
+
+const getExportFormatLabel = (t: Translate, format: string): string => {
+  const copy = EXPORT_FORMAT_COPY[format.toLowerCase()]
+  if (copy) return t(copy.key, copy.defaultValue)
+  return t("playground:studio.traceableArtifact.exportFormats.unknown", {
+    defaultValue: "{{format}}",
+    format
+  })
 }
 
 const buildAcpSessionRoute = (sessionId: string, view?: string): string => {
@@ -124,21 +194,24 @@ export const hasTraceableArtifactMetadata = (
       artifact.rootArtifactId ||
       artifact.artifactVersionId ||
       artifact.previousVersionId ||
-      artifact.schemaVersion
+      artifact.schemaVersion !== undefined
   )
 
 export const TraceableArtifactSummary: React.FC<
   TraceableArtifactSummaryProps
 > = ({ artifact, className }) => {
+  const { t } = useTranslation(["playground", "common"])
   const reviewStatus = artifact.reviewStatus || "draft"
+  const redactionRestricted =
+    artifact.redaction?.supportSafe === false || artifact.redaction?.redacted === true
   const versionLabel =
     artifact.version !== undefined ? `v${artifact.version}` : artifact.artifactVersionId
   const redactionLabel =
     artifact.redaction?.supportSafe === false
-      ? "Restricted"
+      ? t("playground:studio.traceableArtifact.restricted", "Restricted")
       : artifact.redaction?.redacted
-        ? "Redacted"
-        : "Support safe"
+        ? t("playground:studio.traceableArtifact.redacted", "Redacted")
+        : t("playground:studio.traceableArtifact.supportSafe", "Support safe")
 
   return (
     <div
@@ -151,18 +224,20 @@ export const TraceableArtifactSummary: React.FC<
         dot
         data-testid="traceable-artifact-review-state"
       >
-        {formatArtifactReviewStateLabel(reviewStatus)}
+        {getArtifactReviewStateLabel(t, reviewStatus)}
       </Badge>
       {versionLabel && (
         <Badge size="sm" variant="secondary" outline>
           {versionLabel}
         </Badge>
       )}
-      {(artifact.producerMetadata?.producerType || artifact.producerMetadata?.runId) && (
-        <Badge size="sm" variant="info" outline>
-          {artifact.producerMetadata.producerType?.toUpperCase() || "Run"}
-        </Badge>
-      )}
+      {!redactionRestricted &&
+        (artifact.producerMetadata?.producerType || artifact.producerMetadata?.runId) && (
+          <Badge size="sm" variant="info" outline>
+            {artifact.producerMetadata.producerType?.toUpperCase() ||
+              t("playground:studio.traceableArtifact.run", "Run")}
+          </Badge>
+        )}
       {artifact.redaction && (
         <Badge
           size="sm"
@@ -185,9 +260,12 @@ type TraceableArtifactDetailProps = {
 export const TraceableArtifactDetail: React.FC<
   TraceableArtifactDetailProps
 > = ({ artifact, onReviewStateChange, reviewStateControlsDisabled = false }) => {
+  const { t } = useTranslation(["playground", "common"])
   const reviewStatus = artifact.reviewStatus || "draft"
   const producer = artifact.producerMetadata
   const redaction = artifact.redaction
+  const redactionRestricted =
+    redaction?.supportSafe === false || redaction?.redacted === true
   const sessionId = producer?.sessionId
   const versionLabel =
     artifact.version !== undefined ? `v${artifact.version}` : undefined
@@ -198,10 +276,16 @@ export const TraceableArtifactDetail: React.FC<
     <div className="space-y-3 text-sm text-text">
       <TraceableArtifactSummary artifact={artifact} />
 
-      <DetailSection title="Review state" icon={ListChecks}>
+      <DetailSection
+        title={t("playground:studio.traceableArtifact.reviewState", "Review state")}
+        icon={ListChecks}
+      >
         <div
           role="group"
-          aria-label="Review state controls"
+          aria-label={t(
+            "playground:studio.traceableArtifact.reviewStateControls",
+            "Review state controls"
+          )}
           className="flex flex-wrap gap-1.5"
         >
           {REVIEW_STATE_ORDER.map((state) => {
@@ -227,54 +311,97 @@ export const TraceableArtifactDetail: React.FC<
                 )}
               >
                 {Icon && <Icon className="h-3 w-3" aria-hidden="true" />}
-                {formatArtifactReviewStateLabel(state)}
+                {getArtifactReviewStateLabel(t, state)}
               </button>
             )
           })}
         </div>
       </DetailSection>
 
-      <DetailSection title="ACP provenance" icon={GitBranch}>
-        {producer ? (
+      <DetailSection
+        title={t("playground:studio.traceableArtifact.acpProvenance", "ACP provenance")}
+        icon={GitBranch}
+      >
+        {redactionRestricted ? (
+          <p className="text-xs text-text-muted">
+            {t(
+              "playground:studio.traceableArtifact.provenanceRedacted",
+              "Provenance hidden by redaction posture"
+            )}
+          </p>
+        ) : producer ? (
           <div className="space-y-2">
             <dl className="grid gap-2 sm:grid-cols-2">
-              <TraceValue label="Producer" value={producer.producerType} />
-              <TraceValue label="Task" value={producer.producerId || producer.taskId} />
-              <TraceValue label="Run" value={producer.runId} />
-              <TraceValue label="Session" value={producer.sessionId} />
-              <TraceValue label="Model" value={producer.model} />
-              <TraceValue label="Provider" value={producer.provider} />
+              <TraceValue
+                label={t("playground:studio.traceableArtifact.producer", "Producer")}
+                value={producer.producerType}
+              />
+              <TraceValue
+                label={t("playground:studio.traceableArtifact.task", "Task")}
+                value={producer.producerId || producer.taskId}
+              />
+              <TraceValue
+                label={t("playground:studio.traceableArtifact.run", "Run")}
+                value={producer.runId}
+              />
+              <TraceValue
+                label={t("playground:studio.traceableArtifact.session", "Session")}
+                value={producer.sessionId}
+              />
+              <TraceValue
+                label={t("playground:studio.traceableArtifact.model", "Model")}
+                value={producer.model}
+              />
+              <TraceValue
+                label={t("playground:studio.traceableArtifact.provider", "Provider")}
+                value={producer.provider}
+              />
             </dl>
             {sessionId && (
               <div className="flex flex-wrap gap-2 pt-1">
-                <a
-                  href={buildAcpSessionRoute(sessionId)}
+                <Link
+                  to={buildAcpSessionRoute(sessionId)}
                   className="inline-flex items-center gap-1 rounded border border-border px-2 py-1 text-xs text-primary hover:bg-primary/10"
                 >
-                  Open session
+                  {t("playground:studio.traceableArtifact.openSession", "Open session")}
                   <ExternalLink className="h-3 w-3" aria-hidden="true" />
-                </a>
-                <a
-                  href={buildAcpSessionRoute(sessionId, "diagnostics")}
+                </Link>
+                <Link
+                  to={buildAcpSessionRoute(sessionId, "diagnostics")}
                   className="inline-flex items-center gap-1 rounded border border-border px-2 py-1 text-xs text-primary hover:bg-primary/10"
                 >
-                  Diagnostics
+                  {t("playground:studio.traceableArtifact.diagnostics", "Diagnostics")}
                   <ExternalLink className="h-3 w-3" aria-hidden="true" />
-                </a>
+                </Link>
               </div>
             )}
           </div>
         ) : (
-          <p className="text-xs text-text-muted">No ACP provenance recorded</p>
+          <p className="text-xs text-text-muted">
+            {t(
+              "playground:studio.traceableArtifact.noAcpProvenance",
+              "No ACP provenance recorded"
+            )}
+          </p>
         )}
       </DetailSection>
 
-      <DetailSection title="Source lineage" icon={GitBranch}>
-        {sourceLineage.length > 0 ? (
+      <DetailSection
+        title={t("playground:studio.traceableArtifact.sourceLineage", "Source lineage")}
+        icon={GitBranch}
+      >
+        {redactionRestricted ? (
+          <p className="text-xs text-text-muted">
+            {t(
+              "playground:studio.traceableArtifact.lineageRedacted",
+              "Source lineage hidden by redaction posture"
+            )}
+          </p>
+        ) : sourceLineage.length > 0 ? (
           <ul className="space-y-2">
             {sourceLineage.map((source) => (
               <li
-                key={`${source.sourceId}:${source.mediaId || source.title || ""}`}
+                key={`${source.sourceId}:${source.mediaId ?? source.title ?? ""}`}
                 className="rounded border border-border/70 bg-surface/60 p-2"
               >
                 <div className="flex flex-wrap items-start justify-between gap-2">
@@ -288,41 +415,73 @@ export const TraceableArtifactDetail: React.FC<
                   </div>
                   {source.citationCount !== undefined && (
                     <Badge size="sm" variant="secondary" outline>
-                      {source.citationCount}{" "}
-                      {source.citationCount === 1 ? "citation" : "citations"}
+                      {t("playground:studio.traceableArtifact.citationCount", {
+                        count: source.citationCount,
+                        defaultValue: "{{count}} citation",
+                        defaultValue_plural: "{{count}} citations"
+                      })}
                     </Badge>
                   )}
                 </div>
                 {(source.sourceType || source.mediaId !== undefined) && (
                   <dl className="mt-2 grid gap-2 sm:grid-cols-2">
-                    <TraceValue label="Type" value={source.sourceType} />
-                    <TraceValue label="Media" value={source.mediaId} />
+                    <TraceValue
+                      label={t("playground:studio.traceableArtifact.type", "Type")}
+                      value={source.sourceType}
+                    />
+                    <TraceValue
+                      label={t("playground:studio.traceableArtifact.media", "Media")}
+                      value={source.mediaId}
+                    />
                   </dl>
                 )}
               </li>
             ))}
           </ul>
         ) : (
-          <p className="text-xs text-text-muted">No source lineage recorded</p>
+          <p className="text-xs text-text-muted">
+            {t(
+              "playground:studio.traceableArtifact.noSourceLineage",
+              "No source lineage recorded"
+            )}
+          </p>
         )}
       </DetailSection>
 
-      <DetailSection title="Version" icon={History}>
+      <DetailSection
+        title={t("playground:studio.traceableArtifact.version", "Version")}
+        icon={History}
+      >
         <dl className="grid gap-2 sm:grid-cols-2">
-          <TraceValue label="Version" value={versionLabel} />
-          <TraceValue label="Version ID" value={artifact.artifactVersionId} />
-          <TraceValue label="Root" value={artifact.rootArtifactId} />
-          <TraceValue label="Previous" value={artifact.previousVersionId} />
           <TraceValue
-            label="Reason"
+            label={t("playground:studio.traceableArtifact.version", "Version")}
+            value={versionLabel}
+          />
+          <TraceValue
+            label={t("playground:studio.traceableArtifact.versionId", "Version ID")}
+            value={artifact.artifactVersionId}
+          />
+          <TraceValue
+            label={t("playground:studio.traceableArtifact.root", "Root")}
+            value={artifact.rootArtifactId}
+          />
+          <TraceValue
+            label={t("playground:studio.traceableArtifact.previous", "Previous")}
+            value={artifact.previousVersionId}
+          />
+          <TraceValue
+            label={t("playground:studio.traceableArtifact.reason", "Reason")}
             value={artifact.versionMetadata?.revisionReason}
           />
-          <TraceValue label="Schema" value={artifact.schemaVersion} />
+          <TraceValue
+            label={t("playground:studio.traceableArtifact.schema", "Schema")}
+            value={artifact.schemaVersion}
+          />
         </dl>
       </DetailSection>
 
       <DetailSection
-        title="Redaction"
+        title={t("playground:studio.traceableArtifact.redaction", "Redaction")}
         icon={
           redaction?.supportSafe === false || redaction?.redacted
             ? ShieldAlert
@@ -336,14 +495,18 @@ export const TraceableArtifactDetail: React.FC<
               variant={redaction.supportSafe === false ? "warning" : "success"}
               outline
             >
-              {redaction.supportSafe === false ? "Restricted" : "Support safe"}
+              {redaction.supportSafe === false
+                ? t("playground:studio.traceableArtifact.restricted", "Restricted")
+                : t("playground:studio.traceableArtifact.supportSafe", "Support safe")}
             </Badge>
             <Badge
               size="sm"
               variant={redaction.redacted ? "warning" : "secondary"}
               outline
             >
-              {redaction.redacted ? "Redacted" : "Not redacted"}
+              {redaction.redacted
+                ? t("playground:studio.traceableArtifact.redacted", "Redacted")
+                : t("playground:studio.traceableArtifact.notRedacted", "Not redacted")}
             </Badge>
             {redaction.retentionClass && (
               <Badge size="sm" variant="secondary" outline>
@@ -352,52 +515,78 @@ export const TraceableArtifactDetail: React.FC<
             )}
           </div>
         ) : (
-          <p className="text-xs text-text-muted">No redaction posture recorded</p>
+          <p className="text-xs text-text-muted">
+            {t(
+              "playground:studio.traceableArtifact.noRedactionPosture",
+              "No redaction posture recorded"
+            )}
+          </p>
         )}
       </DetailSection>
 
-      <DetailSection title="Exports" icon={FileOutput}>
+      <DetailSection
+        title={t("playground:studio.traceableArtifact.exports", "Exports")}
+        icon={FileOutput}
+      >
         {exportRefs.length > 0 ? (
           <ul className="space-y-1.5">
-            {exportRefs.map((exportRef) => (
+            {exportRefs.map((exportRef, index) => (
               <li
-                key={getExportRefKey(exportRef)}
+                key={getExportRefKey(exportRef, index)}
                 className="flex flex-wrap items-center gap-2 rounded border border-border/70 bg-surface/60 px-2 py-1.5"
               >
                 <Badge size="sm" variant="secondary" outline>
-                  {formatExportFormatLabel(exportRef.format)}
+                  {getExportFormatLabel(t, exportRef.format)}
                 </Badge>
                 {exportRef.fileId !== undefined && (
                   <span className="text-xs text-text-muted">
-                    file #{String(exportRef.fileId)}
+                    {t("playground:studio.traceableArtifact.fileRef", {
+                      id: String(exportRef.fileId),
+                      defaultValue: "file #{{id}}"
+                    })}
                   </span>
                 )}
                 {exportRef.jobId !== undefined && (
                   <span className="text-xs text-text-muted">
-                    job #{String(exportRef.jobId)}
+                    {t("playground:studio.traceableArtifact.jobRef", {
+                      id: String(exportRef.jobId),
+                      defaultValue: "job #{{id}}"
+                    })}
                   </span>
                 )}
                 {exportRef.status && (
-                  <span className="text-xs text-text-muted">{exportRef.status}</span>
+                  <span className="text-xs text-text-muted">
+                    {t("playground:studio.traceableArtifact.exportStatus", {
+                      defaultValue: "{{status}}",
+                      status: exportRef.status
+                    })}
+                  </span>
                 )}
               </li>
             ))}
           </ul>
         ) : (
-          <p className="text-xs text-text-muted">No exports recorded</p>
+          <p className="text-xs text-text-muted">
+            {t("playground:studio.traceableArtifact.noExports", "No exports recorded")}
+          </p>
         )}
       </DetailSection>
     </div>
   )
 }
 
-const getExportRefKey = (exportRef: TraceableArtifactExportRef): string =>
+const getExportRefKey = (
+  exportRef: TraceableArtifactExportRef,
+  index: number
+): string =>
   [
+    exportRef.id,
     exportRef.format,
     exportRef.fileId,
     exportRef.jobId,
     exportRef.artifactVersionId,
-    exportRef.url
+    exportRef.url,
+    index
   ]
     .filter((value) => value !== undefined && value !== null && value !== "")
     .map(String)

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/StudioPane/TraceableArtifactDetail.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/StudioPane/TraceableArtifactDetail.tsx
@@ -1,0 +1,404 @@
+import React from "react"
+import {
+  Archive,
+  CheckCircle,
+  ExternalLink,
+  FileOutput,
+  GitBranch,
+  History,
+  ListChecks,
+  Send,
+  ShieldAlert,
+  ShieldCheck,
+  XCircle
+} from "lucide-react"
+import { Badge, type BadgeVariant } from "@/components/ui/primitives/Badge"
+import { cn } from "@/libs/utils"
+import type {
+  ArtifactReviewStatus,
+  GeneratedArtifact,
+  TraceableArtifactExportRef
+} from "@/types/workspace"
+
+const REVIEW_STATE_ORDER: ArtifactReviewStatus[] = [
+  "draft",
+  "reviewing",
+  "accepted",
+  "needs_revision",
+  "rejected",
+  "exported",
+  "assigned",
+  "archived"
+]
+
+const REVIEW_STATE_VARIANTS: Record<ArtifactReviewStatus, BadgeVariant> = {
+  draft: "secondary",
+  reviewing: "info",
+  accepted: "success",
+  needs_revision: "warning",
+  rejected: "danger",
+  exported: "primary",
+  assigned: "info",
+  archived: "secondary"
+}
+
+const REVIEW_STATE_ICONS: Partial<
+  Record<ArtifactReviewStatus, React.ElementType>
+> = {
+  accepted: CheckCircle,
+  needs_revision: ListChecks,
+  rejected: XCircle,
+  assigned: Send,
+  archived: Archive
+}
+
+export const formatArtifactReviewStateLabel = (
+  status: ArtifactReviewStatus | string | undefined
+): string => {
+  if (!status) return "Draft"
+  return status
+    .split("_")
+    .filter(Boolean)
+    .map((part) => part[0].toUpperCase() + part.slice(1))
+    .join(" ")
+}
+
+const formatExportFormatLabel = (format: string): string => {
+  if (format.toLowerCase() === "md") return "Markdown"
+  return formatArtifactReviewStateLabel(format)
+}
+
+const buildAcpSessionRoute = (sessionId: string, view?: string): string => {
+  const params = new URLSearchParams({ session: sessionId })
+  if (view) params.set("view", view)
+  return `/acp-playground?${params.toString()}`
+}
+
+const TraceValue: React.FC<{
+  label: string
+  value?: React.ReactNode
+}> = ({ label, value }) => {
+  if (value === null || value === undefined || value === "") return null
+  return (
+    <div className="min-w-0">
+      <dt className="text-[10px] font-semibold uppercase tracking-wide text-text-muted">
+        {label}
+      </dt>
+      <dd className="mt-0.5 min-w-0 break-words text-xs text-text">{value}</dd>
+    </div>
+  )
+}
+
+const DetailSection: React.FC<{
+  title: string
+  icon: React.ElementType
+  children: React.ReactNode
+}> = ({ title, icon: Icon, children }) => (
+  <section className="rounded border border-border bg-surface2/40 p-3">
+    <div className="mb-2 flex items-center gap-2">
+      <Icon className="h-4 w-4 text-text-muted" />
+      <h4 className="text-xs font-semibold uppercase tracking-wide text-text-muted">
+        {title}
+      </h4>
+    </div>
+    {children}
+  </section>
+)
+
+type TraceableArtifactSummaryProps = {
+  artifact: GeneratedArtifact
+  className?: string
+}
+
+export const hasTraceableArtifactMetadata = (
+  artifact: GeneratedArtifact
+): boolean =>
+  Boolean(
+    artifact.reviewStatus ||
+      artifact.producerMetadata ||
+      artifact.sourceLineage?.length ||
+      artifact.reviewMetadata ||
+      artifact.versionMetadata ||
+      artifact.exportRefs?.length ||
+      artifact.redaction ||
+      artifact.rootArtifactId ||
+      artifact.artifactVersionId ||
+      artifact.previousVersionId ||
+      artifact.schemaVersion
+  )
+
+export const TraceableArtifactSummary: React.FC<
+  TraceableArtifactSummaryProps
+> = ({ artifact, className }) => {
+  const reviewStatus = artifact.reviewStatus || "draft"
+  const versionLabel =
+    artifact.version !== undefined ? `v${artifact.version}` : artifact.artifactVersionId
+  const redactionLabel =
+    artifact.redaction?.supportSafe === false
+      ? "Restricted"
+      : artifact.redaction?.redacted
+        ? "Redacted"
+        : "Support safe"
+
+  return (
+    <div
+      data-testid="traceable-artifact-summary"
+      className={cn("flex flex-wrap items-center gap-1.5", className)}
+    >
+      <Badge
+        size="sm"
+        variant={REVIEW_STATE_VARIANTS[reviewStatus]}
+        dot
+        data-testid="traceable-artifact-review-state"
+      >
+        {formatArtifactReviewStateLabel(reviewStatus)}
+      </Badge>
+      {versionLabel && (
+        <Badge size="sm" variant="secondary" outline>
+          {versionLabel}
+        </Badge>
+      )}
+      {(artifact.producerMetadata?.producerType || artifact.producerMetadata?.runId) && (
+        <Badge size="sm" variant="info" outline>
+          {artifact.producerMetadata.producerType?.toUpperCase() || "Run"}
+        </Badge>
+      )}
+      {artifact.redaction && (
+        <Badge
+          size="sm"
+          variant={artifact.redaction.supportSafe === false ? "warning" : "secondary"}
+          outline
+        >
+          {redactionLabel}
+        </Badge>
+      )}
+    </div>
+  )
+}
+
+type TraceableArtifactDetailProps = {
+  artifact: GeneratedArtifact
+  onReviewStateChange?: (reviewStatus: ArtifactReviewStatus) => void
+  reviewStateControlsDisabled?: boolean
+}
+
+export const TraceableArtifactDetail: React.FC<
+  TraceableArtifactDetailProps
+> = ({ artifact, onReviewStateChange, reviewStateControlsDisabled = false }) => {
+  const reviewStatus = artifact.reviewStatus || "draft"
+  const producer = artifact.producerMetadata
+  const redaction = artifact.redaction
+  const sessionId = producer?.sessionId
+  const versionLabel =
+    artifact.version !== undefined ? `v${artifact.version}` : undefined
+  const sourceLineage = artifact.sourceLineage || []
+  const exportRefs = artifact.exportRefs || []
+
+  return (
+    <div className="space-y-3 text-sm text-text">
+      <TraceableArtifactSummary artifact={artifact} />
+
+      <DetailSection title="Review state" icon={ListChecks}>
+        <div
+          role="group"
+          aria-label="Review state controls"
+          className="flex flex-wrap gap-1.5"
+        >
+          {REVIEW_STATE_ORDER.map((state) => {
+            const active = state === reviewStatus
+            const Icon = REVIEW_STATE_ICONS[state]
+            const disabled =
+              reviewStateControlsDisabled || !onReviewStateChange || active
+            return (
+              <button
+                key={state}
+                type="button"
+                disabled={disabled}
+                aria-pressed={active}
+                onClick={() => onReviewStateChange?.(state)}
+                className={cn(
+                  "inline-flex items-center gap-1 rounded border px-2 py-1 text-[11px] font-medium transition",
+                  active
+                    ? "border-primary/40 bg-primary/10 text-primary"
+                    : "border-border bg-surface text-text-muted hover:border-primary/40 hover:text-text",
+                  disabled && !active
+                    ? "cursor-not-allowed opacity-60 hover:border-border hover:text-text-muted"
+                    : ""
+                )}
+              >
+                {Icon && <Icon className="h-3 w-3" aria-hidden="true" />}
+                {formatArtifactReviewStateLabel(state)}
+              </button>
+            )
+          })}
+        </div>
+      </DetailSection>
+
+      <DetailSection title="ACP provenance" icon={GitBranch}>
+        {producer ? (
+          <div className="space-y-2">
+            <dl className="grid gap-2 sm:grid-cols-2">
+              <TraceValue label="Producer" value={producer.producerType} />
+              <TraceValue label="Task" value={producer.producerId || producer.taskId} />
+              <TraceValue label="Run" value={producer.runId} />
+              <TraceValue label="Session" value={producer.sessionId} />
+              <TraceValue label="Model" value={producer.model} />
+              <TraceValue label="Provider" value={producer.provider} />
+            </dl>
+            {sessionId && (
+              <div className="flex flex-wrap gap-2 pt-1">
+                <a
+                  href={buildAcpSessionRoute(sessionId)}
+                  className="inline-flex items-center gap-1 rounded border border-border px-2 py-1 text-xs text-primary hover:bg-primary/10"
+                >
+                  Open session
+                  <ExternalLink className="h-3 w-3" aria-hidden="true" />
+                </a>
+                <a
+                  href={buildAcpSessionRoute(sessionId, "diagnostics")}
+                  className="inline-flex items-center gap-1 rounded border border-border px-2 py-1 text-xs text-primary hover:bg-primary/10"
+                >
+                  Diagnostics
+                  <ExternalLink className="h-3 w-3" aria-hidden="true" />
+                </a>
+              </div>
+            )}
+          </div>
+        ) : (
+          <p className="text-xs text-text-muted">No ACP provenance recorded</p>
+        )}
+      </DetailSection>
+
+      <DetailSection title="Source lineage" icon={GitBranch}>
+        {sourceLineage.length > 0 ? (
+          <ul className="space-y-2">
+            {sourceLineage.map((source) => (
+              <li
+                key={`${source.sourceId}:${source.mediaId || source.title || ""}`}
+                className="rounded border border-border/70 bg-surface/60 p-2"
+              >
+                <div className="flex flex-wrap items-start justify-between gap-2">
+                  <div className="min-w-0">
+                    <p className="break-words text-xs font-medium text-text">
+                      {source.title || source.label || source.sourceId}
+                    </p>
+                    <p className="mt-0.5 break-words text-[11px] text-text-muted">
+                      {source.sourceId}
+                    </p>
+                  </div>
+                  {source.citationCount !== undefined && (
+                    <Badge size="sm" variant="secondary" outline>
+                      {source.citationCount}{" "}
+                      {source.citationCount === 1 ? "citation" : "citations"}
+                    </Badge>
+                  )}
+                </div>
+                {(source.sourceType || source.mediaId !== undefined) && (
+                  <dl className="mt-2 grid gap-2 sm:grid-cols-2">
+                    <TraceValue label="Type" value={source.sourceType} />
+                    <TraceValue label="Media" value={source.mediaId} />
+                  </dl>
+                )}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-xs text-text-muted">No source lineage recorded</p>
+        )}
+      </DetailSection>
+
+      <DetailSection title="Version" icon={History}>
+        <dl className="grid gap-2 sm:grid-cols-2">
+          <TraceValue label="Version" value={versionLabel} />
+          <TraceValue label="Version ID" value={artifact.artifactVersionId} />
+          <TraceValue label="Root" value={artifact.rootArtifactId} />
+          <TraceValue label="Previous" value={artifact.previousVersionId} />
+          <TraceValue
+            label="Reason"
+            value={artifact.versionMetadata?.revisionReason}
+          />
+          <TraceValue label="Schema" value={artifact.schemaVersion} />
+        </dl>
+      </DetailSection>
+
+      <DetailSection
+        title="Redaction"
+        icon={
+          redaction?.supportSafe === false || redaction?.redacted
+            ? ShieldAlert
+            : ShieldCheck
+        }
+      >
+        {redaction ? (
+          <div className="flex flex-wrap gap-1.5">
+            <Badge
+              size="sm"
+              variant={redaction.supportSafe === false ? "warning" : "success"}
+              outline
+            >
+              {redaction.supportSafe === false ? "Restricted" : "Support safe"}
+            </Badge>
+            <Badge
+              size="sm"
+              variant={redaction.redacted ? "warning" : "secondary"}
+              outline
+            >
+              {redaction.redacted ? "Redacted" : "Not redacted"}
+            </Badge>
+            {redaction.retentionClass && (
+              <Badge size="sm" variant="secondary" outline>
+                {redaction.retentionClass}
+              </Badge>
+            )}
+          </div>
+        ) : (
+          <p className="text-xs text-text-muted">No redaction posture recorded</p>
+        )}
+      </DetailSection>
+
+      <DetailSection title="Exports" icon={FileOutput}>
+        {exportRefs.length > 0 ? (
+          <ul className="space-y-1.5">
+            {exportRefs.map((exportRef) => (
+              <li
+                key={getExportRefKey(exportRef)}
+                className="flex flex-wrap items-center gap-2 rounded border border-border/70 bg-surface/60 px-2 py-1.5"
+              >
+                <Badge size="sm" variant="secondary" outline>
+                  {formatExportFormatLabel(exportRef.format)}
+                </Badge>
+                {exportRef.fileId !== undefined && (
+                  <span className="text-xs text-text-muted">
+                    file #{String(exportRef.fileId)}
+                  </span>
+                )}
+                {exportRef.jobId !== undefined && (
+                  <span className="text-xs text-text-muted">
+                    job #{String(exportRef.jobId)}
+                  </span>
+                )}
+                {exportRef.status && (
+                  <span className="text-xs text-text-muted">{exportRef.status}</span>
+                )}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-xs text-text-muted">No exports recorded</p>
+        )}
+      </DetailSection>
+    </div>
+  )
+}
+
+const getExportRefKey = (exportRef: TraceableArtifactExportRef): string =>
+  [
+    exportRef.format,
+    exportRef.fileId,
+    exportRef.jobId,
+    exportRef.artifactVersionId,
+    exportRef.url
+  ]
+    .filter((value) => value !== undefined && value !== null && value !== "")
+    .map(String)
+    .join(":")

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/StudioPane/__tests__/TraceableArtifactDetail.test.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/StudioPane/__tests__/TraceableArtifactDetail.test.tsx
@@ -1,11 +1,42 @@
 import React from "react"
 import { fireEvent, render, screen, within } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
 import { describe, expect, it, vi } from "vitest"
 import type { ArtifactReviewStatus, GeneratedArtifact } from "@/types/workspace"
 import {
+  hasTraceableArtifactMetadata,
   TraceableArtifactDetail,
   TraceableArtifactSummary
 } from "../TraceableArtifactDetail"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      key: string,
+      optionsOrDefault?:
+        | string
+        | {
+            defaultValue?: string
+            defaultValue_plural?: string
+            count?: number
+            id?: string
+            format?: string
+            status?: string
+          }
+    ) => {
+      if (typeof optionsOrDefault === "string") return optionsOrDefault
+      const defaultValue =
+        optionsOrDefault?.count !== 1 && optionsOrDefault?.defaultValue_plural
+          ? optionsOrDefault.defaultValue_plural
+          : optionsOrDefault?.defaultValue ?? key
+      return defaultValue
+        .replace("{{count}}", String(optionsOrDefault?.count ?? ""))
+        .replace("{{id}}", String(optionsOrDefault?.id ?? ""))
+        .replace("{{format}}", String(optionsOrDefault?.format ?? ""))
+        .replace("{{status}}", String(optionsOrDefault?.status ?? ""))
+    }
+  })
+}))
 
 const baseArtifact = (
   overrides: Partial<GeneratedArtifact> = {}
@@ -60,9 +91,16 @@ const baseArtifact = (
   ...overrides
 })
 
+const renderDetail = (artifact: GeneratedArtifact) =>
+  render(
+    <MemoryRouter>
+      <TraceableArtifactDetail artifact={artifact} />
+    </MemoryRouter>
+  )
+
 describe("TraceableArtifactDetail", () => {
   it("renders review state, provenance, lineage, versioning, redaction, and export details", () => {
-    render(<TraceableArtifactDetail artifact={baseArtifact()} />)
+    renderDetail(baseArtifact())
 
     expect(screen.getByTestId("traceable-artifact-review-state")).toHaveTextContent(
       "Accepted"
@@ -118,33 +156,88 @@ describe("TraceableArtifactDetail", () => {
   })
 
   it("renders unavailable metadata states without leaking raw support payloads", () => {
-    render(
-      <TraceableArtifactDetail
-        artifact={baseArtifact({
-          producerMetadata: undefined,
-          sourceLineage: undefined,
-          exportRefs: undefined,
-          exportTargets: undefined,
-          redaction: { supportSafe: false, redacted: true }
-        })}
-      />
+    renderDetail(
+      baseArtifact({
+        producerMetadata: undefined,
+        sourceLineage: undefined,
+        exportRefs: undefined,
+        exportTargets: undefined,
+        redaction: { supportSafe: true, redacted: false }
+      })
     )
 
     expect(screen.getByText("No ACP provenance recorded")).toBeInTheDocument()
     expect(screen.getByText("No source lineage recorded")).toBeInTheDocument()
     expect(screen.getByText("No exports recorded")).toBeInTheDocument()
-    expect(screen.getAllByText("Restricted").length).toBeGreaterThan(0)
-    expect(screen.getByText("Redacted")).toBeInTheDocument()
+    expect(screen.getAllByText("Support safe").length).toBeGreaterThan(0)
+    expect(screen.getByText("Not redacted")).toBeInTheDocument()
     expect(screen.queryByText("{")).not.toBeInTheDocument()
+  })
+
+  it("suppresses provenance and lineage details when redaction posture is restricted", () => {
+    renderDetail(
+      baseArtifact({
+        redaction: { supportSafe: false, redacted: true, retentionClass: "restricted" }
+      })
+    )
+
+    expect(screen.getByText("Provenance hidden by redaction posture")).toBeInTheDocument()
+    expect(screen.getByText("Source lineage hidden by redaction posture")).toBeInTheDocument()
+    expect(screen.queryByText("task-42")).not.toBeInTheDocument()
+    expect(screen.queryByText("run-7")).not.toBeInTheDocument()
+    expect(screen.queryByText("session-abc")).not.toBeInTheDocument()
+    expect(screen.queryByText("Transcript")).not.toBeInTheDocument()
+    expect(screen.queryByRole("link", { name: "Open session" })).not.toBeInTheDocument()
+  })
+
+  it("treats schema version zero as traceable metadata", () => {
+    expect(
+      hasTraceableArtifactMetadata(
+        baseArtifact({
+          reviewStatus: undefined,
+          producerMetadata: undefined,
+          sourceLineage: undefined,
+          reviewMetadata: undefined,
+          versionMetadata: undefined,
+          exportRefs: undefined,
+          redaction: undefined,
+          rootArtifactId: undefined,
+          artifactVersionId: undefined,
+          previousVersionId: undefined,
+          schemaVersion: 0
+        })
+      )
+    ).toBe(true)
+  })
+
+  it("renders duplicate-format export refs without duplicate React keys", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+
+    try {
+      renderDetail(
+        baseArtifact({
+          exportRefs: [{ format: "markdown" }, { format: "markdown" }]
+        })
+      )
+
+      const duplicateKeyWarnings = consoleError.mock.calls.filter(([message]) =>
+        String(message).includes("Encountered two children with the same key")
+      )
+      expect(duplicateKeyWarnings).toHaveLength(0)
+    } finally {
+      consoleError.mockRestore()
+    }
   })
 
   it("exposes review-state controls when a transition handler is provided", () => {
     const onReviewStateChange = vi.fn()
     render(
-      <TraceableArtifactDetail
-        artifact={baseArtifact({ reviewStatus: "reviewing" })}
-        onReviewStateChange={onReviewStateChange}
-      />
+      <MemoryRouter>
+        <TraceableArtifactDetail
+          artifact={baseArtifact({ reviewStatus: "reviewing" })}
+          onReviewStateChange={onReviewStateChange}
+        />
+      </MemoryRouter>
     )
 
     const controls = screen.getByRole("group", {

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/StudioPane/__tests__/TraceableArtifactDetail.test.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/StudioPane/__tests__/TraceableArtifactDetail.test.tsx
@@ -1,0 +1,157 @@
+import React from "react"
+import { fireEvent, render, screen, within } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import type { ArtifactReviewStatus, GeneratedArtifact } from "@/types/workspace"
+import {
+  TraceableArtifactDetail,
+  TraceableArtifactSummary
+} from "../TraceableArtifactDetail"
+
+const baseArtifact = (
+  overrides: Partial<GeneratedArtifact> = {}
+): GeneratedArtifact => ({
+  id: "art-traceable",
+  type: "report",
+  title: "Reviewed ACP Brief",
+  status: "completed",
+  reviewStatus: "accepted",
+  content: "# Brief\n\nAccepted body",
+  contentType: "text/markdown",
+  previewText: "Accepted body",
+  summary: "A reviewed ACP brief",
+  totalTokens: 560,
+  totalCostUsd: 0.12,
+  version: 3,
+  rootArtifactId: "root-art-1",
+  artifactVersionId: "version-art-3",
+  previousVersionId: "version-art-2",
+  schemaVersion: 1,
+  producerMetadata: {
+    producerType: "acp",
+    producerId: "task-42",
+    runId: "run-7",
+    sessionId: "session-abc"
+  },
+  sourceLineage: [
+    {
+      sourceId: "src-1",
+      sourceType: "media",
+      title: "Transcript",
+      mediaId: 42,
+      citationCount: 1
+    }
+  ],
+  reviewMetadata: {
+    reviewerId: "reviewer-1",
+    decision: "accepted"
+  },
+  versionMetadata: {
+    revisionReason: "Reviewer accepted the brief"
+  },
+  exportTargets: ["markdown"],
+  exportRefs: [{ format: "markdown", fileId: 101, status: "ready" }],
+  redaction: {
+    supportSafe: true,
+    redacted: false,
+    retentionClass: "standard"
+  },
+  createdAt: new Date("2026-05-06T12:05:00Z"),
+  completedAt: new Date("2026-05-06T12:06:00Z"),
+  ...overrides
+})
+
+describe("TraceableArtifactDetail", () => {
+  it("renders review state, provenance, lineage, versioning, redaction, and export details", () => {
+    render(<TraceableArtifactDetail artifact={baseArtifact()} />)
+
+    expect(screen.getByTestId("traceable-artifact-review-state")).toHaveTextContent(
+      "Accepted"
+    )
+    expect(screen.getByText("ACP provenance")).toBeInTheDocument()
+    expect(screen.getByText("task-42")).toBeInTheDocument()
+    expect(screen.getByText("run-7")).toBeInTheDocument()
+    expect(screen.getByText("session-abc")).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: "Open session" })).toHaveAttribute(
+      "href",
+      "/acp-playground?session=session-abc"
+    )
+    expect(screen.getByRole("link", { name: "Diagnostics" })).toHaveAttribute(
+      "href",
+      "/acp-playground?session=session-abc&view=diagnostics"
+    )
+
+    expect(screen.getAllByText("Version").length).toBeGreaterThan(0)
+    expect(screen.getAllByText("v3").length).toBeGreaterThan(0)
+    expect(screen.getByText("version-art-2")).toBeInTheDocument()
+    expect(screen.getByText("Reviewer accepted the brief")).toBeInTheDocument()
+
+    expect(screen.getByText("Transcript")).toBeInTheDocument()
+    expect(screen.getByText("src-1")).toBeInTheDocument()
+    expect(screen.getByText("1 citation")).toBeInTheDocument()
+
+    expect(screen.getAllByText("Support safe").length).toBeGreaterThan(0)
+    expect(screen.getByText("Not redacted")).toBeInTheDocument()
+    expect(screen.getByText("standard")).toBeInTheDocument()
+
+    expect(screen.getByText("Markdown")).toBeInTheDocument()
+    expect(screen.getByText("file #101")).toBeInTheDocument()
+  })
+
+  it.each<ArtifactReviewStatus>([
+    "accepted",
+    "needs_revision",
+    "rejected",
+    "assigned",
+    "archived"
+  ])("differentiates %s review state in the summary", (reviewStatus) => {
+    render(<TraceableArtifactSummary artifact={baseArtifact({ reviewStatus })} />)
+
+    const summary = screen.getByTestId("traceable-artifact-summary")
+    expect(
+      within(summary).getByText(
+        reviewStatus
+          .split("_")
+          .map((part) => part[0].toUpperCase() + part.slice(1))
+          .join(" ")
+      )
+    ).toBeInTheDocument()
+  })
+
+  it("renders unavailable metadata states without leaking raw support payloads", () => {
+    render(
+      <TraceableArtifactDetail
+        artifact={baseArtifact({
+          producerMetadata: undefined,
+          sourceLineage: undefined,
+          exportRefs: undefined,
+          exportTargets: undefined,
+          redaction: { supportSafe: false, redacted: true }
+        })}
+      />
+    )
+
+    expect(screen.getByText("No ACP provenance recorded")).toBeInTheDocument()
+    expect(screen.getByText("No source lineage recorded")).toBeInTheDocument()
+    expect(screen.getByText("No exports recorded")).toBeInTheDocument()
+    expect(screen.getAllByText("Restricted").length).toBeGreaterThan(0)
+    expect(screen.getByText("Redacted")).toBeInTheDocument()
+    expect(screen.queryByText("{")).not.toBeInTheDocument()
+  })
+
+  it("exposes review-state controls when a transition handler is provided", () => {
+    const onReviewStateChange = vi.fn()
+    render(
+      <TraceableArtifactDetail
+        artifact={baseArtifact({ reviewStatus: "reviewing" })}
+        onReviewStateChange={onReviewStateChange}
+      />
+    )
+
+    const controls = screen.getByRole("group", {
+      name: "Review state controls"
+    })
+    fireEvent.click(within(controls).getByRole("button", { name: "Needs Revision" }))
+
+    expect(onReviewStateChange).toHaveBeenCalledWith("needs_revision")
+  })
+})

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/StudioPane/index.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/StudioPane/index.tsx
@@ -57,6 +57,11 @@ import { useStoreChatModelSettings } from "@/store/model"
 import { getWorkspaceStudioNoSourcesHint } from "../source-location-copy"
 import { WorkProductTemplateChooser } from "./WorkProductTemplateChooser"
 import {
+  hasTraceableArtifactMetadata,
+  TraceableArtifactDetail,
+  TraceableArtifactSummary
+} from "./TraceableArtifactDetail"
+import {
   useArtifactGeneration,
   useAudioTtsSettings,
   useQuizParsing,
@@ -1010,15 +1015,22 @@ export const StudioPane: React.FC<StudioPaneProps> = ({
       return
     }
 
-    if (artifact.content) {
+    if (artifact.content || hasTraceableArtifactMetadata(artifact)) {
       Modal.info({
         title: artifact.title,
         content: (
-          <div className="max-h-96 overflow-y-auto whitespace-pre-wrap">
-            {artifact.content}
+          <div className="max-h-[70vh] space-y-4 overflow-y-auto">
+            {hasTraceableArtifactMetadata(artifact) && (
+              <TraceableArtifactDetail artifact={artifact} />
+            )}
+            {artifact.content && (
+              <div className="whitespace-pre-wrap rounded border border-border bg-surface p-3 text-sm text-text">
+                {artifact.content}
+              </div>
+            )}
           </div>
         ),
-        ...responsiveModalProps(600)
+        ...responsiveModalProps(760)
       })
     }
   }
@@ -2083,6 +2095,12 @@ export const StudioPane: React.FC<StudioPaneProps> = ({
                             {artifact.errorMessage}
                           </p>
                         )}
+                        {hasTraceableArtifactMetadata(artifact) && (
+                          <TraceableArtifactSummary
+                            artifact={artifact}
+                            className="mt-2"
+                          />
+                        )}
                       </div>
                     </div>
                     {artifact.status === "completed" && (
@@ -2096,7 +2114,9 @@ export const StudioPane: React.FC<StudioPaneProps> = ({
                           )}
                           className="flex flex-wrap items-center gap-1 rounded border border-border/70 bg-surface/70 px-1.5 py-1"
                         >
-                          {(artifact.content || artifact.audioUrl) && (
+                          {(artifact.content ||
+                            artifact.audioUrl ||
+                            hasTraceableArtifactMetadata(artifact)) && (
                             <Tooltip title={t("common:view", "View")}>
                               <button
                                 type="button"

--- a/apps/packages/ui/src/services/tldw/domains/workspace-api.ts
+++ b/apps/packages/ui/src/services/tldw/domains/workspace-api.ts
@@ -20,6 +20,8 @@ type SkillsListPayload = SkillsListResponse & {
   pagination?: OffsetPaginationMeta
 }
 
+export type WorkspaceArtifactJsonRecord = Record<string, unknown>
+
 export interface WorkspaceApiResponse {
   id: string
   name: string | null
@@ -57,9 +59,28 @@ export interface WorkspaceArtifactApiResponse {
   artifact_type: string
   title: string
   status: string
+  review_state?: string | null
+  content_type?: string | null
   content: string | null
+  preview_text?: string | null
+  summary?: string | null
   total_tokens: number | null
   total_cost_usd: number | null
+  owner_scope?: string | null
+  owner_id?: string | null
+  project_id?: string | null
+  task_id?: string | null
+  source_collection_id?: string | null
+  root_artifact_id?: string | null
+  artifact_version_id?: string | null
+  previous_version_id?: string | null
+  producer_metadata?: WorkspaceArtifactJsonRecord | null
+  source_lineage?: WorkspaceArtifactJsonRecord | WorkspaceArtifactJsonRecord[] | null
+  review_metadata?: WorkspaceArtifactJsonRecord | null
+  version_metadata?: WorkspaceArtifactJsonRecord | null
+  export_refs?: WorkspaceArtifactJsonRecord[] | null
+  redaction?: WorkspaceArtifactJsonRecord | null
+  schema_version?: number | null
   created_at: string
   completed_at: string | null
   version: number

--- a/apps/packages/ui/src/store/__tests__/workspace-api-first.test.ts
+++ b/apps/packages/ui/src/store/__tests__/workspace-api-first.test.ts
@@ -95,8 +95,10 @@ describe("workspace store API-first mutations", () => {
     "reviewing",
     "accepted",
     "needs_revision",
+    "rejected",
     "exported",
-    "assigned"
+    "assigned",
+    "archived"
   ])(
     "preserves server review status %s while deriving completed generation state",
     async (reviewStatus) => {
@@ -134,6 +136,128 @@ describe("workspace store API-first mutations", () => {
       })
     }
   )
+
+  it("maps traceable artifact contract fields into generated artifacts", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      id: "ws-traceable",
+      name: "Traceable WS",
+      version: 4,
+      sources: [],
+      artifacts: [
+        {
+          id: "art-traceable",
+          workspace_id: "ws-traceable",
+          artifact_type: "report",
+          title: "Reviewed ACP Brief",
+          status: "completed",
+          review_state: "accepted",
+          content_type: "text/markdown",
+          content: "# Brief\n\nAccepted body",
+          preview_text: "Accepted body",
+          summary: "A reviewed ACP brief",
+          total_tokens: 560,
+          total_cost_usd: 0.12,
+          owner_scope: "workspace",
+          owner_id: "workspace-owner",
+          project_id: "project-9",
+          task_id: "task-workspace-4",
+          source_collection_id: "collection-3",
+          root_artifact_id: "root-art-1",
+          artifact_version_id: "version-art-3",
+          previous_version_id: "version-art-2",
+          schema_version: 1,
+          producer_metadata: {
+            producer_type: "acp",
+            producer_id: "task-42",
+            run_id: "run-7",
+            session_id: "session-abc",
+            links: {
+              diagnostics: "/api/v1/acp/sessions/session-abc/diagnostics"
+            }
+          },
+          source_lineage: {
+            sources: [
+              {
+                source_id: "src-1",
+                source_type: "media",
+                label: "Transcript",
+                media_id: 42,
+                citation_spans: [{ start: 12, end: 48 }]
+              }
+            ]
+          },
+          review_metadata: {
+            reviewer_id: "reviewer-1",
+            decision: "accepted"
+          },
+          version_metadata: {
+            revision_reason: "Reviewer accepted the brief"
+          },
+          export_refs: [{ format: "md", file_id: 101, status: "ready" }],
+          redaction: {
+            support_safe: true,
+            redacted: false,
+            retention_class: "standard"
+          },
+          created_at: "2026-05-06T12:05:00Z",
+          completed_at: "2026-05-06T12:06:00Z",
+          version: 3
+        }
+      ],
+      notes: []
+    })
+
+    const state = await hydrateWorkspaceFromServer("ws-traceable", {
+      fetch: mockFetch
+    })
+
+    expect(state.artifacts[0]).toMatchObject({
+      id: "art-traceable",
+      status: "completed",
+      reviewStatus: "accepted",
+      contentType: "text/markdown",
+      previewText: "Accepted body",
+      summary: "A reviewed ACP brief",
+      ownerScope: "workspace",
+      ownerId: "workspace-owner",
+      projectId: "project-9",
+      taskId: "task-workspace-4",
+      sourceCollectionId: "collection-3",
+      rootArtifactId: "root-art-1",
+      artifactVersionId: "version-art-3",
+      previousVersionId: "version-art-2",
+      schemaVersion: 1,
+      producerMetadata: {
+        producerType: "acp",
+        producerId: "task-42",
+        runId: "run-7",
+        sessionId: "session-abc"
+      },
+      sourceLineage: [
+        {
+          sourceId: "src-1",
+          sourceType: "media",
+          title: "Transcript",
+          mediaId: 42,
+          citationCount: 1
+        }
+      ],
+      reviewMetadata: {
+        reviewerId: "reviewer-1",
+        decision: "accepted"
+      },
+      versionMetadata: {
+        revisionReason: "Reviewer accepted the brief"
+      },
+      exportRefs: [{ format: "markdown", fileId: 101, status: "ready" }],
+      exportTargets: ["markdown"],
+      redaction: {
+        supportSafe: true,
+        redacted: false,
+        retentionClass: "standard"
+      }
+    })
+  })
 
   it("does not mark unknown backend artifact statuses as completed", async () => {
     const mockFetch = vi.fn().mockResolvedValue({

--- a/apps/packages/ui/src/store/workspace-api.ts
+++ b/apps/packages/ui/src/store/workspace-api.ts
@@ -354,6 +354,10 @@ const normalizeExportRefs = (
 
       return {
         ...record,
+        id: pickValue(record, "id", "export_id", "exportId") as
+          | number
+          | string
+          | undefined,
         format,
         fileId: pickValue(record, "fileId", "file_id") as number | string | undefined,
         jobId: pickValue(record, "jobId", "job_id") as number | string | undefined,

--- a/apps/packages/ui/src/store/workspace-api.ts
+++ b/apps/packages/ui/src/store/workspace-api.ts
@@ -9,10 +9,18 @@ import type {
   WorkspaceSourceApiResponse
 } from "../services/tldw/domains/workspace-api"
 import type {
+  ArtifactExportTarget,
   ArtifactReviewStatus,
+  ArtifactSourceLineage,
   ArtifactStatus,
   ArtifactType,
   GeneratedArtifact,
+  TraceableArtifactExportRef,
+  TraceableArtifactProducerLinks,
+  TraceableArtifactProducerMetadata,
+  TraceableArtifactRedaction,
+  TraceableArtifactReviewMetadata,
+  TraceableArtifactVersionMetadata,
   WorkspaceSource,
   WorkspaceSourceType
 } from "../types/workspace"
@@ -70,9 +78,77 @@ const reviewStatuses = new Set<ArtifactReviewStatus>([
   "reviewing",
   "accepted",
   "needs_revision",
+  "rejected",
   "exported",
-  "assigned"
+  "assigned",
+  "archived"
 ])
+
+const exportTargetAliases: Record<string, ArtifactExportTarget> = {
+  md: "markdown",
+  markdown: "markdown",
+  docx: "docx",
+  pdf: "pdf",
+  ppt: "slides",
+  pptx: "slides",
+  presentation: "slides",
+  slides: "slides",
+  chatbook: "chatbook"
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value)
+
+const asRecord = (value: unknown): Record<string, unknown> | undefined =>
+  isRecord(value) ? value : undefined
+
+const asString = (value: unknown): string | undefined =>
+  typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined
+
+const asNumber = (value: unknown): number | undefined =>
+  typeof value === "number" && Number.isFinite(value) ? value : undefined
+
+const asStringArray = (value: unknown): string[] | undefined => {
+  if (!Array.isArray(value)) return undefined
+  const strings = value
+    .map((item) => asString(item))
+    .filter((item): item is string => Boolean(item))
+  return strings.length > 0 ? strings : undefined
+}
+
+const pickString = (
+  record: Record<string, unknown>,
+  ...keys: string[]
+): string | undefined => {
+  for (const key of keys) {
+    const value = asString(record[key])
+    if (value) return value
+  }
+  return undefined
+}
+
+const pickNumber = (
+  record: Record<string, unknown>,
+  ...keys: string[]
+): number | undefined => {
+  for (const key of keys) {
+    const value = asNumber(record[key])
+    if (value !== undefined) return value
+  }
+  return undefined
+}
+
+const pickValue = (
+  record: Record<string, unknown>,
+  ...keys: string[]
+): unknown => {
+  for (const key of keys) {
+    if (record[key] !== undefined && record[key] !== null) {
+      return record[key]
+    }
+  }
+  return undefined
+}
 
 const normalizeWorkspaceSourceType = (
   sourceType: string
@@ -107,6 +183,208 @@ const mapServerReviewStatus = (
     ? (status as ArtifactReviewStatus)
     : undefined
 
+const normalizeProducerLinks = (
+  links: unknown
+): TraceableArtifactProducerLinks | undefined => {
+  const record = asRecord(links)
+  if (!record) return undefined
+
+  const normalized: TraceableArtifactProducerLinks = {}
+  for (const [key, value] of Object.entries(record)) {
+    const url = asString(value)
+    if (url) normalized[key] = url
+  }
+
+  return Object.keys(normalized).length > 0 ? normalized : undefined
+}
+
+const normalizeProducerMetadata = (
+  metadata: unknown
+): TraceableArtifactProducerMetadata | undefined => {
+  const record = asRecord(metadata)
+  if (!record) return undefined
+
+  return {
+    ...record,
+    producerType: pickString(record, "producerType", "producer_type"),
+    producerId: pickString(record, "producerId", "producer_id"),
+    runId: pickString(record, "runId", "run_id"),
+    sessionId: pickString(record, "sessionId", "session_id"),
+    reviewId: pickString(record, "reviewId", "review_id"),
+    taskId: pickString(record, "taskId", "task_id"),
+    promptId: pickString(record, "promptId", "prompt_id"),
+    templateId: pickString(record, "templateId", "template_id"),
+    model: pickString(record, "model", "model_id", "modelId"),
+    provider: pickString(record, "provider", "provider_id", "providerId"),
+    completionReason: pickString(
+      record,
+      "completionReason",
+      "completion_reason"
+    ),
+    links: normalizeProducerLinks(record.links)
+  }
+}
+
+const normalizeReviewMetadata = (
+  metadata: unknown
+): TraceableArtifactReviewMetadata | undefined => {
+  const record = asRecord(metadata)
+  if (!record) return undefined
+
+  return {
+    ...record,
+    reviewerId: pickString(record, "reviewerId", "reviewer_id"),
+    decision: pickString(record, "decision", "review_state"),
+    decidedAt: pickString(record, "decidedAt", "decided_at"),
+    reason: pickString(record, "reason", "revision_reason", "rejection_reason")
+  }
+}
+
+const normalizeVersionMetadata = (
+  metadata: unknown
+): TraceableArtifactVersionMetadata | undefined => {
+  const record = asRecord(metadata)
+  if (!record) return undefined
+
+  return {
+    ...record,
+    revisionReason: pickString(record, "revisionReason", "revision_reason"),
+    versionLabel: pickString(record, "versionLabel", "version_label"),
+    comparedToVersionId: pickString(
+      record,
+      "comparedToVersionId",
+      "compared_to_version_id"
+    )
+  }
+}
+
+const normalizeRedaction = (metadata: unknown): TraceableArtifactRedaction | undefined => {
+  const record = asRecord(metadata)
+  if (!record) return undefined
+
+  return {
+    ...record,
+    supportSafe:
+      typeof pickValue(record, "supportSafe", "support_safe") === "boolean"
+        ? (pickValue(record, "supportSafe", "support_safe") as boolean)
+        : undefined,
+    redacted:
+      typeof pickValue(record, "redacted") === "boolean"
+        ? (pickValue(record, "redacted") as boolean)
+        : undefined,
+    retentionClass: pickString(record, "retentionClass", "retention_class"),
+    redactedFields: asStringArray(record.redactedFields ?? record.redacted_fields),
+    visibility: pickString(record, "visibility")
+  }
+}
+
+const normalizeSourceLineage = (
+  lineage: unknown
+): ArtifactSourceLineage[] | undefined => {
+  const entries = Array.isArray(lineage)
+    ? lineage
+    : isRecord(lineage)
+      ? Array.isArray(lineage.sources)
+        ? lineage.sources
+        : Array.isArray(lineage.source_refs)
+          ? lineage.source_refs
+          : []
+      : []
+
+  const normalized = entries
+    .map((entry, index): ArtifactSourceLineage | null => {
+      const record = asRecord(entry)
+      if (!record) {
+        const sourceId = asString(entry)
+        return sourceId ? { sourceId } : null
+      }
+
+      const citationSpans = Array.isArray(
+        record.citationSpans ?? record.citation_spans
+      )
+        ? ((record.citationSpans ?? record.citation_spans) as unknown[])
+        : undefined
+      const sourceId =
+        pickString(record, "sourceId", "source_id", "id") ||
+        `source-${index + 1}`
+      const title = pickString(record, "title", "label", "name")
+
+      return {
+        ...record,
+        sourceId,
+        sourceType: pickString(record, "sourceType", "source_type", "type"),
+        mediaId: pickNumber(record, "mediaId", "media_id"),
+        title,
+        label: pickString(record, "label", "title", "name"),
+        citationCount:
+          pickNumber(record, "citationCount", "citation_count") ??
+          (citationSpans && citationSpans.length > 0
+            ? citationSpans.length
+            : undefined),
+        citationSpans,
+        evidenceIds: asStringArray(record.evidenceIds ?? record.evidence_ids),
+        coverageNotes: pickString(record, "coverageNotes", "coverage_notes")
+      }
+    })
+    .filter((entry): entry is ArtifactSourceLineage => entry !== null)
+
+  return normalized.length > 0 ? normalized : undefined
+}
+
+const normalizeExportFormat = (format: unknown): string | undefined => {
+  const value = asString(format)?.toLowerCase()
+  if (!value) return undefined
+  return exportTargetAliases[value] || value
+}
+
+const normalizeExportRefs = (
+  refs: unknown
+): TraceableArtifactExportRef[] | undefined => {
+  if (!Array.isArray(refs)) return undefined
+
+  const normalized = refs
+    .map((entry): TraceableArtifactExportRef | null => {
+      const record = asRecord(entry)
+      if (!record) return null
+
+      const format = normalizeExportFormat(
+        pickValue(record, "format", "target", "type")
+      )
+      if (!format) return null
+
+      return {
+        ...record,
+        format,
+        fileId: pickValue(record, "fileId", "file_id") as number | string | undefined,
+        jobId: pickValue(record, "jobId", "job_id") as number | string | undefined,
+        artifactVersionId: pickString(
+          record,
+          "artifactVersionId",
+          "artifact_version_id"
+        ),
+        generatedAt: pickString(record, "generatedAt", "generated_at"),
+        expiresAt: pickString(record, "expiresAt", "expires_at"),
+        status: pickString(record, "status"),
+        url: pickString(record, "url"),
+        error: pickString(record, "error")
+      }
+    })
+    .filter((entry): entry is TraceableArtifactExportRef => entry !== null)
+
+  return normalized.length > 0 ? normalized : undefined
+}
+
+const normalizeExportTargets = (
+  refs: TraceableArtifactExportRef[] | undefined
+): ArtifactExportTarget[] | undefined => {
+  const targets = new Set<ArtifactExportTarget>()
+  refs?.forEach((ref) => {
+    const target = exportTargetAliases[ref.format.toLowerCase()]
+    if (target) targets.add(target)
+  })
+  return targets.size > 0 ? Array.from(targets) : undefined
+}
+
 const mapServerSourceToLocal = (
   source: WorkspaceSourceApiResponse
 ): WorkspaceSource => ({
@@ -121,19 +399,45 @@ const mapServerSourceToLocal = (
 
 const mapServerArtifactToLocal = (
   artifact: WorkspaceArtifactApiResponse
-): GeneratedArtifact => ({
-  id: artifact.id,
-  type: normalizeArtifactType(artifact.artifact_type),
-  title: artifact.title,
-  status: mapServerGenerationStatus(artifact),
-  reviewStatus: mapServerReviewStatus(artifact.status),
-  serverId: artifact.id,
-  content: artifact.content || undefined,
-  totalTokens: artifact.total_tokens ?? undefined,
-  totalCostUsd: artifact.total_cost_usd ?? undefined,
-  createdAt: new Date(artifact.created_at),
-  completedAt: artifact.completed_at ? new Date(artifact.completed_at) : undefined
-})
+): GeneratedArtifact => {
+  const exportRefs = normalizeExportRefs(artifact.export_refs)
+
+  return {
+    id: artifact.id,
+    type: normalizeArtifactType(artifact.artifact_type),
+    title: artifact.title,
+    status: mapServerGenerationStatus(artifact),
+    reviewStatus: mapServerReviewStatus(artifact.review_state || artifact.status),
+    serverId: artifact.id,
+    content: artifact.content || undefined,
+    contentType: artifact.content_type || undefined,
+    previewText: artifact.preview_text || undefined,
+    summary: artifact.summary || undefined,
+    totalTokens: artifact.total_tokens ?? undefined,
+    totalCostUsd: artifact.total_cost_usd ?? undefined,
+    ownerScope: artifact.owner_scope || undefined,
+    ownerId: artifact.owner_id || undefined,
+    projectId: artifact.project_id || undefined,
+    taskId: artifact.task_id || undefined,
+    sourceCollectionId: artifact.source_collection_id || undefined,
+    rootArtifactId: artifact.root_artifact_id || undefined,
+    artifactVersionId: artifact.artifact_version_id || undefined,
+    previousVersionId: artifact.previous_version_id || undefined,
+    schemaVersion: artifact.schema_version ?? undefined,
+    version: artifact.version,
+    producerMetadata: normalizeProducerMetadata(artifact.producer_metadata),
+    sourceLineage: normalizeSourceLineage(artifact.source_lineage),
+    reviewMetadata: normalizeReviewMetadata(artifact.review_metadata),
+    versionMetadata: normalizeVersionMetadata(artifact.version_metadata),
+    exportRefs,
+    exportTargets: normalizeExportTargets(exportRefs),
+    redaction: normalizeRedaction(artifact.redaction),
+    createdAt: new Date(artifact.created_at),
+    completedAt: artifact.completed_at
+      ? new Date(artifact.completed_at)
+      : undefined
+  }
+}
 
 /**
  * Hydrate local workspace state from the server.

--- a/apps/packages/ui/src/types/workspace.ts
+++ b/apps/packages/ui/src/types/workspace.ts
@@ -122,20 +122,99 @@ export type ArtifactReviewStatus =
   | "reviewing"
   | "accepted"
   | "needs_revision"
+  | "rejected"
   | "exported"
   | "assigned"
+  | "archived"
+
+export type ArtifactExportTarget =
+  | "markdown"
+  | "docx"
+  | "pdf"
+  | "slides"
+  | "chatbook"
 
 export interface ArtifactSourceLineage {
   sourceId: string
+  sourceType?: string
   mediaId?: number
   title?: string
+  label?: string
   citationCount?: number
+  citationSpans?: unknown[]
+  evidenceIds?: string[]
+  coverageNotes?: string
+  [key: string]: unknown
 }
 
 export interface ArtifactReviewChecklistItem {
   id: string
   label: string
   checked: boolean
+}
+
+export interface TraceableArtifactProducerLinks {
+  session?: string
+  run?: string
+  review?: string
+  diagnostics?: string
+  artifacts?: string
+  audit?: string
+  [key: string]: string | undefined
+}
+
+export interface TraceableArtifactProducerMetadata {
+  producerType?: string
+  producerId?: string
+  runId?: string
+  sessionId?: string
+  reviewId?: string
+  taskId?: string
+  promptId?: string
+  templateId?: string
+  model?: string
+  provider?: string
+  completionReason?: string
+  links?: TraceableArtifactProducerLinks
+  [key: string]: unknown
+}
+
+export interface TraceableArtifactReviewMetadata {
+  reviewerId?: string
+  decision?: ArtifactReviewStatus | string
+  decidedAt?: string
+  reason?: string
+  checklist?: ArtifactReviewChecklistItem[]
+  [key: string]: unknown
+}
+
+export interface TraceableArtifactVersionMetadata {
+  revisionReason?: string
+  versionLabel?: string
+  comparedToVersionId?: string
+  [key: string]: unknown
+}
+
+export interface TraceableArtifactExportRef {
+  format: string
+  fileId?: number | string
+  jobId?: number | string
+  artifactVersionId?: string
+  generatedAt?: string
+  expiresAt?: string
+  status?: string
+  url?: string
+  error?: string
+  [key: string]: unknown
+}
+
+export interface TraceableArtifactRedaction {
+  supportSafe?: boolean
+  redacted?: boolean
+  retentionClass?: string
+  redactedFields?: string[]
+  visibility?: string
+  [key: string]: unknown
 }
 
 export type StudyMaterialsPolicy = "general" | "workspace"
@@ -175,8 +254,25 @@ export interface GeneratedArtifact {
   reviewStatus?: ArtifactReviewStatus
   sourceLineage?: ArtifactSourceLineage[]
   reviewChecklist?: ArtifactReviewChecklistItem[]
-  exportTargets?: Array<"markdown" | "docx" | "pdf" | "slides" | "chatbook">
+  exportTargets?: ArtifactExportTarget[]
+  version?: number
   previousVersionId?: string
+  rootArtifactId?: string
+  artifactVersionId?: string
+  ownerScope?: string
+  ownerId?: string
+  projectId?: string
+  taskId?: string
+  sourceCollectionId?: string
+  contentType?: string
+  previewText?: string
+  summary?: string
+  schemaVersion?: number
+  producerMetadata?: TraceableArtifactProducerMetadata
+  reviewMetadata?: TraceableArtifactReviewMetadata
+  versionMetadata?: TraceableArtifactVersionMetadata
+  exportRefs?: TraceableArtifactExportRef[]
+  redaction?: TraceableArtifactRedaction
   estimatedTokens?: number
   estimatedCostUsd?: number
   totalTokens?: number

--- a/apps/packages/ui/src/types/workspace.ts
+++ b/apps/packages/ui/src/types/workspace.ts
@@ -196,6 +196,7 @@ export interface TraceableArtifactVersionMetadata {
 }
 
 export interface TraceableArtifactExportRef {
+  id?: number | string
   format: string
   fileId?: number | string
   jobId?: number | string

--- a/backlog/tasks/task-357 - Implement-Workspace-UI-detail-surface-for-ACP-issue-1707.md
+++ b/backlog/tasks/task-357 - Implement-Workspace-UI-detail-surface-for-ACP-issue-1707.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-05-15 02:33'
-updated_date: '2026-05-15 20:04'
+updated_date: '2026-05-15 03:33'
 labels:
   - acp
   - artifacts
@@ -56,6 +56,8 @@ Implemented traceable artifact response typing and store hydration for review_st
 PR #1714 review follow-up reopened this task to address Qodo and Gemini feedback on redaction-aware rendering, stable list keys, schema-version metadata detection, router-aware ACP session links, i18n-ready labels, and missing contract ticket references.
 
 Review follow-up verification: `bunx vitest run src/components/Option/WorkspacePlayground/StudioPane/__tests__/TraceableArtifactDetail.test.tsx` passed with 11 tests; `bunx vitest run src/components/Option/WorkspacePlayground/StudioPane/__tests__/TraceableArtifactDetail.test.tsx src/store/__tests__/workspace-api-first.test.ts` passed with 27 tests; `bunx vitest run src/components/Option/WorkspacePlayground/__tests__/StudioPane.stage2.test.tsx` passed with 26 tests; `git diff --check` passed; `bun run verify:design-system-state` passed with existing allowed baseline exceptions. Bandit remains not applicable because this review follow-up only changed TypeScript/React and Backlog metadata.
+
+Fresh PR #1714 closeout rerun on 2026-05-15: focused traceable artifact/store tests passed again (27 tests), git diff hygiene passed, and design-system verifier passed with the existing 486 allowed product-state baseline exceptions. Full UI TypeScript remains blocked by unrelated repo-wide baseline errors; grep over redirected output found no touched traceable-artifact file errors. A fresh local rerun of StudioPane.stage2 timed out in broad pre-existing StudioPane workflows (22/26 failed by timeout), so current closeout relies on the focused review-fix regression tests plus GitHub CI for the wider StudioPane gate.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-357 - Implement-Workspace-UI-detail-surface-for-ACP-issue-1707.md
+++ b/backlog/tasks/task-357 - Implement-Workspace-UI-detail-surface-for-ACP-issue-1707.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-05-15 02:33'
-updated_date: '2026-05-15 02:46'
+updated_date: '2026-05-15 20:04'
 labels:
   - acp
   - artifacts
@@ -14,6 +14,9 @@ dependencies: []
 references:
   - 'https://github.com/rmusser01/tldw_server/issues/1707'
   - 'https://github.com/rmusser01/tldw_server/issues/1703'
+  - 'https://github.com/rmusser01/tldw_server/issues/1525'
+  - 'https://github.com/rmusser01/tldw_server/issues/1538'
+  - 'https://github.com/rmusser01/tldw_server/issues/1532'
 documentation:
   - Docs/Product/Traceable_Work_Product_Artifact_Contract.md
   - Docs/Product/ACP_Agent_Orchestration_PRD.md
@@ -42,18 +45,23 @@ Implement the Workspace UI detail surface for traceable work-product artifacts. 
 3. Implement a focused artifact detail panel/list surface using existing UI primitives and state styles. - Complete
 4. Add tests for golden-path rendering, state badges/controls, provenance/lineage, and unavailable/error states. - Complete
 5. Verify with focused frontend tests plus diff hygiene. - Complete
+6. Address PR #1714 review feedback: hide provenance/lineage when redaction posture is not support-safe, make traceable metadata detection and list keys robust, route ACP links through the app router, externalize traceable artifact labels through i18n fallbacks, and add required contract ticket links. - Complete
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
 Implemented traceable artifact response typing and store hydration for review_state, lineage, ACP producer metadata, version metadata, export refs, redaction posture, owner placement, and content envelope fields. Added a Workspace Studio artifact summary/detail surface with review-state display, ACP session/diagnostics drill-through links, source lineage, version details, redaction posture, and export refs. Focused tests cover API mapping, rendering, unavailable metadata states, and review-state controls. Verification: vitest workspace-api-first + TraceableArtifactDetail passed; StudioPane.stage2 passed; git diff --check passed; design-system verifier passed with existing allowed baseline exceptions. Full UI tsc was attempted and failed on pre-existing unrelated repo-wide type errors outside touched files. Bandit not applicable because no Python code was changed.
+
+PR #1714 review follow-up reopened this task to address Qodo and Gemini feedback on redaction-aware rendering, stable list keys, schema-version metadata detection, router-aware ACP session links, i18n-ready labels, and missing contract ticket references.
+
+Review follow-up verification: `bunx vitest run src/components/Option/WorkspacePlayground/StudioPane/__tests__/TraceableArtifactDetail.test.tsx` passed with 11 tests; `bunx vitest run src/components/Option/WorkspacePlayground/StudioPane/__tests__/TraceableArtifactDetail.test.tsx src/store/__tests__/workspace-api-first.test.ts` passed with 27 tests; `bunx vitest run src/components/Option/WorkspacePlayground/__tests__/StudioPane.stage2.test.tsx` passed with 26 tests; `git diff --check` passed; `bun run verify:design-system-state` passed with existing allowed baseline exceptions. Bandit remains not applicable because this review follow-up only changed TypeScript/React and Backlog metadata.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Workspace Studio now understands traceable work-product artifact metadata from the #1703 storage/API foundation and can display it in the generated-output cards and detail modal. The UI shows review state, ACP provenance, source lineage, version chain, redaction posture, export refs, and ACP session/diagnostics drill-through links, with focused coverage for contract mapping and detail rendering.
+Workspace Studio now understands traceable work-product artifact metadata from the #1703 storage/API foundation and can display it in the generated-output cards and detail modal. The UI shows review state, ACP provenance, source lineage, version chain, redaction posture, export refs, and ACP session/diagnostics drill-through links, with focused coverage for contract mapping and detail rendering. PR #1714 review follow-up hardened the detail surface by suppressing provenance/lineage under restricted redaction posture, preserving schema version zero metadata, stabilizing export keys, routing ACP links through React Router, adding i18n fallbacks for user-facing labels, and linking the required artifact contract issues.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-357 - Implement-Workspace-UI-detail-surface-for-ACP-issue-1707.md
+++ b/backlog/tasks/task-357 - Implement-Workspace-UI-detail-surface-for-ACP-issue-1707.md
@@ -1,0 +1,67 @@
+---
+id: TASK-357
+title: Implement Workspace UI detail surface for ACP issue 1707
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-05-15 02:33'
+updated_date: '2026-05-15 02:46'
+labels:
+  - acp
+  - artifacts
+  - webui
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1707'
+  - 'https://github.com/rmusser01/tldw_server/issues/1703'
+documentation:
+  - Docs/Product/Traceable_Work_Product_Artifact_Contract.md
+  - Docs/Product/ACP_Agent_Orchestration_PRD.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the Workspace UI detail surface for traceable work-product artifacts. Start from the merged storage/API foundation in #1703 and expose one golden-path generated workspace brief with review state, source lineage, ACP provenance, version metadata, redaction posture, export affordances, and drill-through links. Keep this slice UI-focused and do not implement ACP promotion or export adapter behavior from #1706/#1705.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Workspace UI can display one traceable generated artifact end to end.
+- [x] #2 UI differentiates accepted, needs_revision, rejected, assigned, and archived states.
+- [x] #3 Source lineage and ACP provenance are visible without exposing support-redacted data.
+- [x] #4 Focused UI tests cover rendering, error/unavailable states, and review-state controls.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Survey existing Workspace/Agent Tasks frontend patterns and the #1703 workspace artifact API contract. - Complete
+2. Add typed frontend client/model support for traceable workspace artifacts where the existing API helpers expect it. - Complete
+3. Implement a focused artifact detail panel/list surface using existing UI primitives and state styles. - Complete
+4. Add tests for golden-path rendering, state badges/controls, provenance/lineage, and unavailable/error states. - Complete
+5. Verify with focused frontend tests plus diff hygiene. - Complete
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented traceable artifact response typing and store hydration for review_state, lineage, ACP producer metadata, version metadata, export refs, redaction posture, owner placement, and content envelope fields. Added a Workspace Studio artifact summary/detail surface with review-state display, ACP session/diagnostics drill-through links, source lineage, version details, redaction posture, and export refs. Focused tests cover API mapping, rendering, unavailable metadata states, and review-state controls. Verification: vitest workspace-api-first + TraceableArtifactDetail passed; StudioPane.stage2 passed; git diff --check passed; design-system verifier passed with existing allowed baseline exceptions. Full UI tsc was attempted and failed on pre-existing unrelated repo-wide type errors outside touched files. Bandit not applicable because no Python code was changed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Workspace Studio now understands traceable work-product artifact metadata from the #1703 storage/API foundation and can display it in the generated-output cards and detail modal. The UI shows review state, ACP provenance, source lineage, version chain, redaction posture, export refs, and ACP session/diagnostics drill-through links, with focused coverage for contract mapping and detail rendering.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Extend Workspace artifact API/client types and hydration mapping for the traceable artifact contract fields added by #1703.
- Add a Workspace Studio artifact summary/detail surface with review state, ACP provenance, source lineage, version metadata, redaction posture, export refs, and ACP session/diagnostics drill-through links.
- Add focused tests for traceable artifact mapping, rendering, unavailable metadata states, and review-state controls.

## Verification
- `./node_modules/.bin/vitest run src/store/__tests__/workspace-api-first.test.ts src/components/Option/WorkspacePlayground/StudioPane/__tests__/TraceableArtifactDetail.test.tsx --maxWorkers=1 --no-file-parallelism`
- `./node_modules/.bin/vitest run src/components/Option/WorkspacePlayground/__tests__/StudioPane.stage2.test.tsx --maxWorkers=1 --no-file-parallelism`
- `git diff --check`
- `bun run verify:design-system-state`

## Notes
- Full `./node_modules/.bin/tsc -p tsconfig.json --noEmit` was attempted and still fails on existing unrelated repo-wide type errors outside this touched slice.
- Bandit is not applicable because this PR does not touch Python code.
- Per the AI-generated PR merge policy, the requester should add a human-written Change summary before merge.

Closes #1707

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a traceable artifact view to Workspace Studio and maps new backend fields from #1707. The UI shows review state, ACP provenance, lineage, versioning, redaction, and export refs in cards and the detail modal, with redaction-aware hiding and i18n labels.

- **New Features**
  - Added `TraceableArtifactDetail` and `TraceableArtifactSummary`; the modal renders when content or traceable metadata exists, and cards show a compact summary.
  - Redaction-aware UI hides ACP provenance and lineage when restricted; ACP session/diagnostics links use in-app routes; labels are i18n-backed.
  - Review-state controls are optional and now support `rejected` and `archived`.

- **Refactors**
  - Extended API and `GeneratedArtifact` with content envelope (`contentType`, `previewText`, `summary`), ownership/version chain, schema version, producer metadata, lineage, review/version metadata, `export_refs`, redaction, and derived `exportTargets`.
  - Improved hydration: snake_case→camelCase, export format aliasing (`md`, `pptx`→`slides`), lineage parsing (object/array), stable keys for duplicate export refs, and schema version zero treated as valid metadata.
  - Added focused tests for mapping, rendering, unavailable/redaction states, duplicate export refs, and review-state controls.

<sup>Written for commit 907faf8bdc0a884cef63d312c946b0d8f7e852c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

