### PR TITLE
Polish Persona Visual import handoff

### DIFF
--- a/Docs/superpowers/plans/2026-05-15-persona-visual-import-handoff-plan.md
+++ b/Docs/superpowers/plans/2026-05-15-persona-visual-import-handoff-plan.md
@@ -1,0 +1,29 @@
+## Stage 1: Plan and Baseline
+**Goal**: Keep the Persona Visual import handoff slice isolated and scoped to #1696.
+**Success Criteria**: TASK-357 has the approved plan, the worktree is on `codex/persona-visual-import-handoff-1696`, and no main-checkout files are edited.
+**Tests**: `git status --short --branch`
+**Status**: Complete
+
+## Stage 2: Focused Failing Tests
+**Goal**: Capture the missing import upload and handoff behavior before implementation.
+**Success Criteria**: Tests fail for invalid archive copy/no POST, backend FormData key, import status copy, and selected imported draft handoff.
+**Tests**: `bunx vitest run ../packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx`
+**Status**: Complete
+
+## Stage 3: Minimal Implementation
+**Goal**: Polish the Persona Visual archive import path without changing activation or renderer scope.
+**Success Criteria**: Upload uses the backend `archive` field, unsupported filenames fail locally with clear copy, preview/commit statuses are readable, and completed commits select the returned draft.
+**Tests**: Focused VisualPackEditor Vitest.
+**Status**: Complete
+
+## Stage 4: Validation
+**Goal**: Verify the touched scope and repo hygiene.
+**Success Criteria**: Focused tests pass, `git diff --check` passes, and Bandit is run for Python changes or documented as not applicable.
+**Tests**: Focused Vitest, `git diff --check`, optional backend/API/Bandit if Python changes are introduced.
+**Status**: Complete
+
+## Stage 5: Closeout
+**Goal**: Leave a reviewable branch with task metadata, commit, and PR.
+**Success Criteria**: TASK-357 is updated, changes are committed, and the PR references #1696/#1510.
+**Tests**: Final status and verification notes.
+**Status**: Complete

--- a/apps/packages/ui/src/assets/locale/en/sidepanel.json
+++ b/apps/packages/ui/src/assets/locale/en/sidepanel.json
@@ -514,6 +514,25 @@
     "createNewCharacter": "Create a New Character+",
     "importCharacter": "Import Character"
   },
+  "personaGarden": {
+    "visuals": {
+      "importPreviewUnsupportedExtension": "Choose a {{extension}} archive exported from Persona Visual Packs.",
+      "importPreviewUnsupportedMimeType": "Choose a Persona Visual pack archive with a supported zip media type.",
+      "importPreviewTerminalStatus": "Import preview {{status}} during {{stage}}.",
+      "importPreviewBlocked": "Import preview completed with blockers. Review diagnostics before committing.",
+      "importPreviewCompleted": "Import preview completed. Review the draft plan before committing.",
+      "importPreviewQueued": "Import preview queued. Refresh to check validation status.",
+      "importPreviewProcessing": "Import preview is processing{{stageSuffix}}",
+      "importPreviewStatus": "Import preview {{status}}: {{stage}}",
+      "importPreviewQueuedStatus": "Import preview queued.",
+      "importCommitTerminalStatus": "Import commit {{status}} during {{stage}}.",
+      "importCommitCompleted": "Import commit completed. Review and activate the new draft when ready.",
+      "importCommitQueued": "Import commit queued. Refresh to check draft creation status.",
+      "importCommitProcessing": "Import commit is processing{{stageSuffix}}",
+      "importCommitStatus": "Import commit {{status}}: {{stage}}",
+      "importCommitQueuedStatus": "Import commit queued. Imported packs remain drafts until activated."
+    }
+  },
   "persona": {
     "unsavedStateDiscardPrompt": "You have unsaved state-doc changes. Discard local drafts?",
     "unsavedStateDiscardPromptConnect": "You have unsaved state-doc changes. Connect and discard local drafts?",

--- a/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
@@ -101,9 +101,14 @@ type LibraryEditDraft = {
   tags: string
 }
 
+type VisualPackTranslate = (
+  key: string,
+  options?: { defaultValue?: string; [key: string]: unknown }
+) => string
+
 const getGenerationReadinessCopy = (
   view: PersonaVisualGenerationReadinessView,
-  t: (key: string, options?: { defaultValue?: string }) => string
+  t: VisualPackTranslate
 ): { title: string; message: string; toneClassName: string } => {
   switch (view.status) {
     case "ready":
@@ -246,6 +251,12 @@ const TRIGGER_SOURCES: PersonaVisualAuthoredTrigger["source"][] = [
 ]
 
 const PORTABLE_VISUAL_PACK_EXTENSION = ".tldw-persona-vpack"
+const PORTABLE_VISUAL_PACK_MIME_TYPES = new Set([
+  "application/octet-stream",
+  "application/vnd.tldw.persona.visual-pack+zip",
+  "application/x-zip-compressed",
+  "application/zip"
+])
 const IMPORT_COMMIT_TERMINAL_STATUSES = new Set([
   "completed",
   "failed",
@@ -261,12 +272,33 @@ const IMPORT_PREVIEW_TERMINAL_STATUSES = new Set([
   "quarantined"
 ])
 
-const isPortableVisualPackFile = (file: File | null): boolean =>
+const hasPortableVisualPackExtension = (file: File | null): boolean =>
   !file || file.name.toLowerCase().endsWith(PORTABLE_VISUAL_PACK_EXTENSION)
 
-const getImportPreviewFileError = (file: File | null): string | null => {
+const hasSupportedPortableVisualPackMediaType = (file: File | null): boolean => {
+  if (!file) return true
+  const mediaType = file.type.trim().toLowerCase()
+  return !mediaType || PORTABLE_VISUAL_PACK_MIME_TYPES.has(mediaType)
+}
+
+const isPortableVisualPackFile = (file: File | null): boolean =>
+  hasPortableVisualPackExtension(file) && hasSupportedPortableVisualPackMediaType(file)
+
+const getImportPreviewFileError = (
+  file: File | null,
+  t: VisualPackTranslate
+): string | null => {
   if (isPortableVisualPackFile(file)) return null
-  return `Choose a ${PORTABLE_VISUAL_PACK_EXTENSION} archive exported from Persona Visual Packs.`
+  if (!hasPortableVisualPackExtension(file)) {
+    return t("sidepanel:personaGarden.visuals.importPreviewUnsupportedExtension", {
+      extension: PORTABLE_VISUAL_PACK_EXTENSION,
+      defaultValue: `Choose a ${PORTABLE_VISUAL_PACK_EXTENSION} archive exported from Persona Visual Packs.`
+    })
+  }
+  return t("sidepanel:personaGarden.visuals.importPreviewUnsupportedMimeType", {
+    defaultValue:
+      "Choose a Persona Visual pack archive with a supported zip media type."
+  })
 }
 
 type ImportPreviewStatus =
@@ -274,7 +306,10 @@ type ImportPreviewStatus =
   | PersonaVisualImportPreviewResponse
   | null
 
-const getImportPreviewJobCopy = (preview: ImportPreviewStatus): string | null => {
+const getImportPreviewJobCopy = (
+  preview: ImportPreviewStatus,
+  t: VisualPackTranslate
+): string | null => {
   if (!preview) return null
   const statusValue = String(preview.status || "").trim()
   const stageValue = String(preview.stage || "").trim()
@@ -288,26 +323,48 @@ const getImportPreviewJobCopy = (preview: ImportPreviewStatus): string | null =>
   ) {
     return (
       errorMessage ||
-      `Import preview ${statusValue} during ${stageValue || "validation"}.`
+      t("sidepanel:personaGarden.visuals.importPreviewTerminalStatus", {
+        stage: stageValue || "validation",
+        status: statusValue,
+        defaultValue: `Import preview ${statusValue} during ${stageValue || "validation"}.`
+      })
     )
   }
   if (statusValue === "blocked") {
-    return "Import preview completed with blockers. Review diagnostics before committing."
+    return t("sidepanel:personaGarden.visuals.importPreviewBlocked", {
+      defaultValue:
+        "Import preview completed with blockers. Review diagnostics before committing."
+    })
   }
   if (statusValue === "completed") {
-    return "Import preview completed. Review the draft plan before committing."
+    return t("sidepanel:personaGarden.visuals.importPreviewCompleted", {
+      defaultValue: "Import preview completed. Review the draft plan before committing."
+    })
   }
   if (statusValue === "queued") {
-    return "Import preview queued. Refresh to check validation status."
+    return t("sidepanel:personaGarden.visuals.importPreviewQueued", {
+      defaultValue: "Import preview queued. Refresh to check validation status."
+    })
   }
   if (statusValue === "processing") {
-    return `Import preview is processing${stageValue ? `: ${stageValue}` : "."}`
+    return t("sidepanel:personaGarden.visuals.importPreviewProcessing", {
+      stage: stageValue,
+      stageSuffix: stageValue ? `: ${stageValue}` : ".",
+      defaultValue: `Import preview is processing${stageValue ? `: ${stageValue}` : "."}`
+    })
   }
-  return stageValue ? `Import preview ${statusValue}: ${stageValue}` : null
+  return stageValue
+    ? t("sidepanel:personaGarden.visuals.importPreviewStatus", {
+        stage: stageValue,
+        status: statusValue,
+        defaultValue: `Import preview ${statusValue}: ${stageValue}`
+      })
+    : null
 }
 
 const getImportCommitJobCopy = (
-  job: PersonaVisualImportCommitStartResponse | PersonaVisualPortabilityJobResponse | null
+  job: PersonaVisualImportCommitStartResponse | PersonaVisualPortabilityJobResponse | null,
+  t: VisualPackTranslate
 ): string | null => {
   if (!job) return null
   const statusValue = String(job.status || "").trim()
@@ -319,19 +376,37 @@ const getImportCommitJobCopy = (
   if (["failed", "cancelled", "quarantined"].includes(statusValue)) {
     return (
       errorMessage ||
-      `Import commit ${statusValue} during ${stageValue || "commit"}.`
+      t("sidepanel:personaGarden.visuals.importCommitTerminalStatus", {
+        stage: stageValue || "commit",
+        status: statusValue,
+        defaultValue: `Import commit ${statusValue} during ${stageValue || "commit"}.`
+      })
     )
   }
   if (statusValue === "completed") {
-    return "Import commit completed. Review and activate the new draft when ready."
+    return t("sidepanel:personaGarden.visuals.importCommitCompleted", {
+      defaultValue: "Import commit completed. Review and activate the new draft when ready."
+    })
   }
   if (statusValue === "queued") {
-    return "Import commit queued. Refresh to check draft creation status."
+    return t("sidepanel:personaGarden.visuals.importCommitQueued", {
+      defaultValue: "Import commit queued. Refresh to check draft creation status."
+    })
   }
   if (statusValue === "processing") {
-    return `Import commit is processing${stageValue ? `: ${stageValue}` : "."}`
+    return t("sidepanel:personaGarden.visuals.importCommitProcessing", {
+      stage: stageValue,
+      stageSuffix: stageValue ? `: ${stageValue}` : ".",
+      defaultValue: `Import commit is processing${stageValue ? `: ${stageValue}` : "."}`
+    })
   }
-  return stageValue ? `Import commit ${statusValue}: ${stageValue}` : null
+  return stageValue
+    ? t("sidepanel:personaGarden.visuals.importCommitStatus", {
+        stage: stageValue,
+        status: statusValue,
+        defaultValue: `Import commit ${statusValue}: ${stageValue}`
+      })
+    : null
 }
 
 const DEFAULT_MANIFEST: PersonaVisualManifest = {
@@ -684,6 +759,7 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
   const unknownLabel = t("common:unknown", { defaultValue: "unknown" })
   const [packs, setPacks] = React.useState<PersonaVisualPack[]>([])
   const [selectedPackId, setSelectedPackId] = React.useState("")
+  const selectedPackIdRef = React.useRef("")
   const [draftTitle, setDraftTitle] = React.useState("")
   const [draftManifest, setDraftManifest] =
     React.useState<PersonaVisualManifest>(DEFAULT_MANIFEST)
@@ -836,6 +912,10 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
     [generationReadinessView, t]
   )
 
+  React.useEffect(() => {
+    selectedPackIdRef.current = selectedPackId
+  }, [selectedPackId])
+
   const loadPacks = React.useCallback(async (
     preferredPackId?: string | null
   ): Promise<boolean> => {
@@ -858,7 +938,7 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
       const preferred =
         explicitPreferredPack ??
         response.active_pack ??
-        nextPacks.find((pack) => pack.id === selectedPackId) ??
+        nextPacks.find((pack) => pack.id === selectedPackIdRef.current) ??
         nextPacks[0] ??
         null
       setSelectedPackId(preferred?.id || "")
@@ -1396,7 +1476,7 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
 
   const handleStartImportPreview = async () => {
     if (!selectedPersonaId || !selectedImportPreviewFile) return
-    const fileError = getImportPreviewFileError(selectedImportPreviewFile)
+    const fileError = getImportPreviewFileError(selectedImportPreviewFile, t)
     if (fileError) {
       setError(fileError)
       return
@@ -1415,7 +1495,11 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
       setImportDraftTitle("")
       setSelectedImportPreviewFile(null)
       if (importPreviewInputRef.current) importPreviewInputRef.current.value = ""
-      setStatusMessage("Import preview queued.")
+      setStatusMessage(
+        t("sidepanel:personaGarden.visuals.importPreviewQueuedStatus", {
+          defaultValue: "Import preview queued."
+        })
+      )
     } catch (previewError) {
       setError(
         previewError instanceof Error
@@ -1473,7 +1557,10 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
       )
       setImportCommitJob(job)
       setStatusMessage(
-        "Import commit queued. Imported packs remain drafts until activated."
+        t("sidepanel:personaGarden.visuals.importCommitQueuedStatus", {
+          defaultValue:
+            "Import commit queued. Imported packs remain drafts until activated."
+        })
       )
     } catch (commitError) {
       setError(
@@ -1501,7 +1588,10 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
         const refreshed = await loadPacks(job.pack_id)
         if (refreshed) {
           setStatusMessage(
-            "Import commit completed. Review and activate the new draft when ready."
+            t("sidepanel:personaGarden.visuals.importCommitCompleted", {
+              defaultValue:
+                "Import commit completed. Review and activate the new draft when ready."
+            })
           )
         } else {
           setStatusMessage(null)
@@ -2033,9 +2123,9 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
       ? exportJob.warnings
       : []
   const fullImportPreview = isFullImportPreview(importPreview) ? importPreview : null
-  const importPreviewFileError = getImportPreviewFileError(selectedImportPreviewFile)
-  const importPreviewJobCopy = getImportPreviewJobCopy(importPreview)
-  const importCommitJobCopy = getImportCommitJobCopy(importCommitJob)
+  const importPreviewFileError = getImportPreviewFileError(selectedImportPreviewFile, t)
+  const importPreviewJobCopy = getImportPreviewJobCopy(importPreview, t)
+  const importCommitJobCopy = getImportCommitJobCopy(importCommitJob, t)
   const importPreviewWarnings = fullImportPreview
     ? [
         ...(fullImportPreview.validation_warnings || []),
@@ -2103,8 +2193,9 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
             </div>
           </div>
           <Button
+            data-testid="persona-visual-pack-refresh-button"
             size="small"
-            onClick={() => void loadPacks()}
+            onClick={() => void loadPacks(selectedPack?.id)}
             disabled={loading}
           >
             {loading ? loadingLabel : refreshLabel}
@@ -3226,7 +3317,11 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
               <div className="text-[11px] font-semibold uppercase tracking-wide text-text-subtle">
                 Generated Candidates
               </div>
-              <Button size="small" onClick={() => void loadCandidates()}>
+              <Button
+                data-testid="persona-visual-candidates-refresh-button"
+                size="small"
+                onClick={() => void loadCandidates()}
+              >
                 {candidatesLoading ? loadingLabel : refreshLabel}
               </Button>
             </div>

--- a/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
@@ -252,6 +252,87 @@ const IMPORT_COMMIT_TERMINAL_STATUSES = new Set([
   "cancelled",
   "quarantined"
 ])
+const IMPORT_PREVIEW_TERMINAL_STATUSES = new Set([
+  "completed",
+  "failed",
+  "cancelled",
+  "blocked",
+  "deleted",
+  "quarantined"
+])
+
+const isPortableVisualPackFile = (file: File | null): boolean =>
+  !file || file.name.toLowerCase().endsWith(PORTABLE_VISUAL_PACK_EXTENSION)
+
+const getImportPreviewFileError = (file: File | null): string | null => {
+  if (isPortableVisualPackFile(file)) return null
+  return `Choose a ${PORTABLE_VISUAL_PACK_EXTENSION} archive exported from Persona Visual Packs.`
+}
+
+type ImportPreviewStatus =
+  | PersonaVisualImportPreviewStartResponse
+  | PersonaVisualImportPreviewResponse
+  | null
+
+const getImportPreviewJobCopy = (preview: ImportPreviewStatus): string | null => {
+  if (!preview) return null
+  const statusValue = String(preview.status || "").trim()
+  const stageValue = String(preview.stage || "").trim()
+  const errorMessage =
+    "error_message" in preview && typeof preview.error_message === "string"
+      ? preview.error_message.trim()
+      : ""
+  if (
+    IMPORT_PREVIEW_TERMINAL_STATUSES.has(statusValue) &&
+    !["blocked", "completed"].includes(statusValue)
+  ) {
+    return (
+      errorMessage ||
+      `Import preview ${statusValue} during ${stageValue || "validation"}.`
+    )
+  }
+  if (statusValue === "blocked") {
+    return "Import preview completed with blockers. Review diagnostics before committing."
+  }
+  if (statusValue === "completed") {
+    return "Import preview completed. Review the draft plan before committing."
+  }
+  if (statusValue === "queued") {
+    return "Import preview queued. Refresh to check validation status."
+  }
+  if (statusValue === "processing") {
+    return `Import preview is processing${stageValue ? `: ${stageValue}` : "."}`
+  }
+  return stageValue ? `Import preview ${statusValue}: ${stageValue}` : null
+}
+
+const getImportCommitJobCopy = (
+  job: PersonaVisualImportCommitStartResponse | PersonaVisualPortabilityJobResponse | null
+): string | null => {
+  if (!job) return null
+  const statusValue = String(job.status || "").trim()
+  const stageValue = String(job.stage || "").trim()
+  const errorMessage =
+    "error_message" in job && typeof job.error_message === "string"
+      ? job.error_message.trim()
+      : ""
+  if (["failed", "cancelled", "quarantined"].includes(statusValue)) {
+    return (
+      errorMessage ||
+      `Import commit ${statusValue} during ${stageValue || "commit"}.`
+    )
+  }
+  if (statusValue === "completed") {
+    return "Import commit completed. Review and activate the new draft when ready."
+  }
+  if (statusValue === "queued") {
+    return "Import commit queued. Refresh to check draft creation status."
+  }
+  if (statusValue === "processing") {
+    return `Import commit is processing${stageValue ? `: ${stageValue}` : "."}`
+  }
+  return stageValue ? `Import commit ${statusValue}: ${stageValue}` : null
+}
 
 const DEFAULT_MANIFEST: PersonaVisualManifest = {
   manifest_version: 1,
@@ -755,7 +836,9 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
     [generationReadinessView, t]
   )
 
-  const loadPacks = React.useCallback(async (): Promise<boolean> => {
+  const loadPacks = React.useCallback(async (
+    preferredPackId?: string | null
+  ): Promise<boolean> => {
     if (!isActive || !selectedPersonaId) {
       setPacks([])
       setSelectedPackId("")
@@ -769,7 +852,11 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
       const response = await listPersonaVisualPacks(selectedPersonaId)
       const nextPacks = response.packs || []
       setPacks(nextPacks)
+      const explicitPreferredPack = preferredPackId
+        ? nextPacks.find((pack) => pack.id === preferredPackId) ?? null
+        : null
       const preferred =
+        explicitPreferredPack ??
         response.active_pack ??
         nextPacks.find((pack) => pack.id === selectedPackId) ??
         nextPacks[0] ??
@@ -1309,6 +1396,11 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
 
   const handleStartImportPreview = async () => {
     if (!selectedPersonaId || !selectedImportPreviewFile) return
+    const fileError = getImportPreviewFileError(selectedImportPreviewFile)
+    if (fileError) {
+      setError(fileError)
+      return
+    }
     setPreviewingImport(true)
     setError(null)
     try {
@@ -1406,7 +1498,7 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
       )
       setImportCommitJob(job)
       if (job.status === "completed" && job.pack_id) {
-        const refreshed = await loadPacks()
+        const refreshed = await loadPacks(job.pack_id)
         if (refreshed) {
           setStatusMessage(
             "Import commit completed. Review and activate the new draft when ready."
@@ -1941,6 +2033,9 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
       ? exportJob.warnings
       : []
   const fullImportPreview = isFullImportPreview(importPreview) ? importPreview : null
+  const importPreviewFileError = getImportPreviewFileError(selectedImportPreviewFile)
+  const importPreviewJobCopy = getImportPreviewJobCopy(importPreview)
+  const importCommitJobCopy = getImportCommitJobCopy(importCommitJob)
   const importPreviewWarnings = fullImportPreview
     ? [
         ...(fullImportPreview.validation_warnings || []),
@@ -2428,7 +2523,7 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
                     size="small"
                     icon={<FileSearch className="h-3.5 w-3.5" />}
                     loading={previewingImport}
-                    disabled={!selectedImportPreviewFile}
+                    disabled={!selectedImportPreviewFile || Boolean(importPreviewFileError)}
                     onClick={() => void handleStartImportPreview()}
                   >
                     Preview
@@ -2444,6 +2539,14 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
                     Refresh
                   </Button>
                 </div>
+                {importPreviewFileError ? (
+                  <div
+                    data-testid="persona-visual-import-preview-file-error"
+                    className="mt-2 text-xs text-state-error"
+                  >
+                    {importPreviewFileError}
+                  </div>
+                ) : null}
                 {importPreview ? (
                   <div className="mt-2 space-y-1 text-xs text-text-muted">
                     <div className="flex flex-wrap items-center gap-2">
@@ -2456,6 +2559,11 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
                     <div data-testid="persona-visual-import-preview-summary">
                       {formatImportPreviewSummary(importPreview)}
                     </div>
+                    {importPreviewJobCopy ? (
+                      <div data-testid="persona-visual-import-preview-job-copy">
+                        {importPreviewJobCopy}
+                      </div>
+                    ) : null}
                     {importPreviewWarnings.length ? (
                       <div data-testid="persona-visual-import-preview-warnings">
                         {formatPreviewList(importPreviewWarnings)}
@@ -2661,16 +2769,23 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
                           </Button>
                         </div>
                         {importCommitJob ? (
-                          <div className="mt-2 flex flex-wrap items-center gap-2 text-text-muted">
-                            <Tag data-testid="persona-visual-import-commit-status">
-                              {importCommitJob.status}
-                            </Tag>
-                            <span data-testid="persona-visual-import-commit-stage">
-                              {importCommitJob.stage}
-                            </span>
-                            <span data-testid="persona-visual-import-commit-job-id">
-                              {importCommitJob.job_id}
-                            </span>
+                          <div className="mt-2 space-y-1 text-text-muted">
+                            <div className="flex flex-wrap items-center gap-2">
+                              <Tag data-testid="persona-visual-import-commit-status">
+                                {importCommitJob.status}
+                              </Tag>
+                              <span data-testid="persona-visual-import-commit-stage">
+                                {importCommitJob.stage}
+                              </span>
+                              <span data-testid="persona-visual-import-commit-job-id">
+                                {importCommitJob.job_id}
+                              </span>
+                            </div>
+                            {importCommitJobCopy ? (
+                              <div data-testid="persona-visual-import-commit-job-copy">
+                                {importCommitJobCopy}
+                              </div>
+                            ) : null}
                           </div>
                         ) : (
                           <div className="mt-2 text-text-muted">

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
@@ -1960,7 +1960,8 @@ describe("VisualPackEditor", () => {
         method === "POST"
       ) {
         const form = init?.body as FormData
-        expect((form.get("file") as File).name).toBe("portable.tldw-persona-vpack")
+        expect(form.get("file")).toBeNull()
+        expect((form.get("archive") as File).name).toBe("portable.tldw-persona-vpack")
         return okResponse({
           preview_id: "preview-1",
           job_id: "preview-job-1",
@@ -2118,15 +2119,182 @@ describe("VisualPackEditor", () => {
         "completed"
       )
     )
-    expect(screen.getByTestId("persona-visual-import-commit-refresh-button")).toBeDisabled()
     await waitFor(() =>
-      expect(screen.getByTestId("persona-visual-pack-select")).toHaveTextContent(
-        "Imported Visuals"
+      expect(screen.getByTestId("persona-visual-pack-select")).toHaveValue(
+        "pack-imported"
       )
     )
+    expect(screen.getByTestId("persona-visual-pack-status")).toHaveTextContent("draft")
     expect(
       calls.some((call) => call.includes("/activate") || call.includes("/manifest"))
     ).toBe(false)
+  })
+
+  it("rejects unsupported visual import archive filenames before upload", async () => {
+    const calls: string[] = []
+    const pack = {
+      id: "pack-1",
+      persona_id: "persona-1",
+      title: "Animated pack",
+      renderer_type: "sprite_frames",
+      status: "draft",
+      manifest: structuredClone(baseManifest),
+      assets: visualAssets,
+      version: 3
+    }
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string }) => {
+      const method = init?.method || "GET"
+      calls.push(`${method} ${path}`)
+      if (path === "/api/v1/persona/profiles/persona-1/visual-packs" && method === "GET") {
+        return okResponse([pack])
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/pack-1/generated-candidates" &&
+        method === "GET"
+      ) {
+        return okResponse({ candidates: [] })
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        error: `Unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(
+      <VisualPackEditor
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Garden Helper"
+        isActive
+      />
+    )
+
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-pack-status")).toHaveTextContent(
+        "draft"
+      )
+    )
+    const archive = new File(["not a portable pack"], "visuals.zip", {
+      type: "application/zip"
+    })
+    fireEvent.change(screen.getByTestId("persona-visual-import-preview-input"), {
+      target: { files: [archive] }
+    })
+
+    expect(
+      await screen.findByTestId("persona-visual-import-preview-file-error")
+    ).toHaveTextContent(".tldw-persona-vpack")
+    expect(screen.getByTestId("persona-visual-import-preview-button")).toBeDisabled()
+
+    fireEvent.click(screen.getByTestId("persona-visual-import-preview-button"))
+
+    expect(
+      calls.some((call) => call.includes("/visual-packs/import-previews"))
+    ).toBe(false)
+  })
+
+  it("shows import preview failure copy from the job response", async () => {
+    const pack = {
+      id: "pack-1",
+      persona_id: "persona-1",
+      title: "Animated pack",
+      renderer_type: "sprite_frames",
+      status: "draft",
+      manifest: structuredClone(baseManifest),
+      assets: visualAssets,
+      version: 3
+    }
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string; body?: any }) => {
+      const method = init?.method || "GET"
+      if (path === "/api/v1/persona/profiles/persona-1/visual-packs" && method === "GET") {
+        return okResponse([pack])
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/pack-1/generated-candidates" &&
+        method === "GET"
+      ) {
+        return okResponse({ candidates: [] })
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/import-previews" &&
+        method === "POST"
+      ) {
+        return okResponse({
+          preview_id: "preview-1",
+          job_id: "preview-job-1",
+          portability_job_id: "portability-preview-1",
+          operation: "import_preview",
+          target_persona_id: "persona-1",
+          status: "queued",
+          stage: "queued"
+        })
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/import-previews/preview-1" &&
+        method === "GET"
+      ) {
+        return okResponse({
+          preview_id: "preview-1",
+          job_id: "preview-job-1",
+          portability_job_id: "portability-preview-1",
+          operation: "import_preview",
+          target_persona_id: "persona-1",
+          status: "failed",
+          visual_status: "failed",
+          stage: "validate_archive",
+          bundle_summary: {},
+          validation_warnings: [],
+          conflicts: [],
+          proposed_plan: {},
+          quota_estimate: {},
+          required_choices: [],
+          target_warnings: [],
+          error_code: "invalid_archive",
+          error_message: "The archive could not be opened as a Persona Visual pack."
+        })
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        error: `Unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(
+      <VisualPackEditor
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Garden Helper"
+        isActive
+      />
+    )
+
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-pack-status")).toHaveTextContent(
+        "draft"
+      )
+    )
+    const archive = new File(["portable archive"], "portable.tldw-persona-vpack", {
+      type: "application/octet-stream"
+    })
+    fireEvent.change(screen.getByTestId("persona-visual-import-preview-input"), {
+      target: { files: [archive] }
+    })
+    fireEvent.click(screen.getByTestId("persona-visual-import-preview-button"))
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-import-preview-status")).toHaveTextContent(
+        "queued"
+      )
+    )
+
+    fireEvent.click(screen.getByTestId("persona-visual-import-preview-refresh-button"))
+
+    expect(
+      await screen.findByTestId("persona-visual-import-preview-job-copy")
+    ).toHaveTextContent("The archive could not be opened as a Persona Visual pack.")
   })
 
   it("surfaces blocked renderer import diagnostics and disables commit", async () => {

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
@@ -209,8 +209,11 @@ describe("VisualPackEditor", () => {
     )
 
     expect(await screen.findByTestId("persona-visual-pack-status")).toHaveTextContent("draft")
+    const candidatesRefreshButton = await screen.findByTestId(
+      "persona-visual-candidates-refresh-button"
+    )
     await waitFor(() =>
-      expect(screen.getAllByRole("button", { name: "Localized loading" })).toHaveLength(1)
+      expect(candidatesRefreshButton).toHaveTextContent("Localized loading")
     )
 
     resolveCandidates({
@@ -219,8 +222,75 @@ describe("VisualPackEditor", () => {
     })
 
     await waitFor(() =>
-      expect(screen.getAllByRole("button", { name: "Localized refresh" })).toHaveLength(2)
+      expect(candidatesRefreshButton).toHaveTextContent("Localized refresh")
     )
+  })
+
+  it("preserves the current pack selection when refreshing packs", async () => {
+    const activePack = {
+      id: "pack-active",
+      persona_id: "persona-1",
+      title: "Active pack",
+      renderer_type: "sprite_frames",
+      status: "active",
+      manifest: structuredClone(baseManifest),
+      assets: visualAssets,
+      version: 3
+    }
+    const draftPack = {
+      id: "pack-draft",
+      persona_id: "persona-1",
+      title: "Draft pack",
+      renderer_type: "sprite_frames",
+      status: "draft",
+      manifest: structuredClone(baseManifest),
+      assets: visualAssets,
+      version: 4
+    }
+    let listRequests = 0
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string }) => {
+      const method = init?.method || "GET"
+      if (path === "/api/v1/persona/profiles/persona-1/visual-packs" && method === "GET") {
+        listRequests += 1
+        return okResponse({
+          packs: [activePack, draftPack],
+          active_pack: activePack
+        })
+      }
+      if (
+        path.startsWith("/api/v1/persona/profiles/persona-1/visual-packs/") &&
+        path.endsWith("/generated-candidates") &&
+        method === "GET"
+      ) {
+        return okResponse({ candidates: [] })
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        error: `Unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(
+      <VisualPackEditor
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Garden Helper"
+        isActive
+      />
+    )
+
+    const select = await screen.findByTestId("persona-visual-pack-select")
+    await waitFor(() => expect(select).toHaveValue("pack-active"))
+
+    fireEvent.change(select, { target: { value: "pack-draft" } })
+    expect(select).toHaveValue("pack-draft")
+
+    fireEvent.click(screen.getByTestId("persona-visual-pack-refresh-button"))
+
+    await waitFor(() => expect(listRequests).toBeGreaterThan(1))
+    expect(select).toHaveValue("pack-draft")
   })
 
   it("shows selected pack health diagnostics from the shared visual pack classifier", async () => {
@@ -2195,6 +2265,71 @@ describe("VisualPackEditor", () => {
     ).toBe(false)
   })
 
+  it("rejects unsupported visual import archive media types before upload", async () => {
+    const calls: string[] = []
+    const pack = {
+      id: "pack-1",
+      persona_id: "persona-1",
+      title: "Animated pack",
+      renderer_type: "sprite_frames",
+      status: "draft",
+      manifest: structuredClone(baseManifest),
+      assets: visualAssets,
+      version: 3
+    }
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string }) => {
+      const method = init?.method || "GET"
+      calls.push(`${method} ${path}`)
+      if (path === "/api/v1/persona/profiles/persona-1/visual-packs" && method === "GET") {
+        return okResponse([pack])
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/pack-1/generated-candidates" &&
+        method === "GET"
+      ) {
+        return okResponse({ candidates: [] })
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        error: `Unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(
+      <VisualPackEditor
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Garden Helper"
+        isActive
+      />
+    )
+
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-pack-status")).toHaveTextContent(
+        "draft"
+      )
+    )
+    const archive = new File(["not a portable archive"], "portable.tldw-persona-vpack", {
+      type: "text/plain"
+    })
+    fireEvent.change(screen.getByTestId("persona-visual-import-preview-input"), {
+      target: { files: [archive] }
+    })
+
+    expect(
+      await screen.findByTestId("persona-visual-import-preview-file-error")
+    ).toHaveTextContent("supported zip media type")
+    expect(screen.getByTestId("persona-visual-import-preview-button")).toBeDisabled()
+
+    fireEvent.click(screen.getByTestId("persona-visual-import-preview-button"))
+
+    expect(
+      calls.some((call) => call.includes("/visual-packs/import-previews"))
+    ).toBe(false)
+  })
+
   it("shows import preview failure copy from the job response", async () => {
     const pack = {
       id: "pack-1",
@@ -2625,7 +2760,9 @@ describe("VisualPackEditor", () => {
     await waitFor(() =>
       expect(screen.getByTestId("persona-visual-import-conflict-choice")).toBeInTheDocument()
     )
-    expect(screen.getByTestId("persona-visual-import-commit-button")).toBeDisabled()
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-import-commit-button")).toBeDisabled()
+    )
 
     fireEvent.change(screen.getByTestId("persona-visual-import-target-mode"), {
       target: { value: "replace_draft" }

--- a/apps/packages/ui/src/services/persona-visuals.ts
+++ b/apps/packages/ui/src/services/persona-visuals.ts
@@ -440,7 +440,7 @@ export async function createPersonaVisualImportPreview(
   file: File
 ): Promise<PersonaVisualImportPreviewStartResponse> {
   const formData = new FormData()
-  formData.append("file", file)
+  formData.append("archive", file)
   return fetchPersonaVisualJson<PersonaVisualImportPreviewStartResponse>(
     personaVisualPath(personaId, "/visual-packs/import-previews"),
     {

--- a/backlog/tasks/task-357 - Polish-Persona-Visual-archive-upload-and-import-handoff.md
+++ b/backlog/tasks/task-357 - Polish-Persona-Visual-archive-upload-and-import-handoff.md
@@ -1,0 +1,99 @@
+---
+id: TASK-357
+title: Polish Persona Visual archive upload and import handoff
+status: Done
+assignee:
+  - Codex
+created_date: '2026-05-15 02:29'
+updated_date: '2026-05-15 02:53'
+labels:
+  - persona
+  - webui
+  - visual-packs
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1696'
+  - 'https://github.com/rmusser01/tldw_server/issues/1510'
+documentation:
+  - Docs/Code_Documentation/Persona_Visual_Packs.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement GitHub issue #1696 as the next persona-side setup-ready slice under the Persona/Buddy epic. Tighten the end-user Persona Visual archive upload/import path with clearer validation/failure copy, visible worker/status feedback where the current flow supports it, and an explicit post-commit handoff that selects/shows the new draft while preserving separate explicit activation. Keep this scoped to Persona Visual import handoff behavior; do not add automatic activation, Live2D runtime support, external provider execution, VN/CYOA behavior, or a new default starter catalog path.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Unsupported extensions or malformed archives fail with clear user-facing copy.
+- [x] #2 Import worker readiness/status is visible enough for a user to understand pending or unavailable work.
+- [x] #3 Successful import commit selects or shows the resulting draft and does not activate it.
+- [x] #4 Focused tests cover extension or failure copy and post-commit draft selection behavior.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Stage 1: Plan and baseline
+- Keep work isolated in .worktrees/persona-visual-import-handoff-1696 on codex/persona-visual-import-handoff-1696.
+- Scope remains #1696 only: Persona Visual archive upload/import handoff polish; no automatic activation, Live2D runtime, external provider execution, VN/CYOA, or starter catalog expansion.
+
+Stage 2: Failing focused tests
+- Add VisualPackEditor tests that unsupported archive names show clear copy and do not POST.
+- Add/extend import commit tests so completed commit selects the returned draft pack_id and keeps activation separate.
+- Add status/failure copy coverage for import preview or commit job responses.
+
+Stage 3: Minimal implementation
+- Fix createPersonaVisualImportPreview FormData to send archive, matching FastAPI.
+- Add client-side .tldw-persona-vpack guard and clear UI copy near the import picker.
+- Add compact import preview/commit status messages from status/stage/error fields.
+- Update completed commit refresh to select the returned draft pack_id after loadPacks succeeds.
+
+Stage 4: Validation
+- Run focused Vitest for VisualPackEditor.
+- Run targeted backend Persona visual API tests if backend import contract or errors change.
+- Run git diff --check and Bandit for touched Python if any Python changes are made; otherwise record Bandit as not applicable for TypeScript/Markdown-only changes.
+
+Stage 5: Closeout
+- Update TASK-357 acceptance criteria, notes, verification, and final summary.
+- Commit the focused branch and open/update the PR for #1696.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+2026-05-15: Started planning in isolated worktree .worktrees/persona-visual-import-handoff-1696 after PR #1701 merged. MCP Backlog is rooted at the dirty main checkout, so this task is being maintained with the Backlog CLI in the branch worktree.
+
+Verification 2026-05-15:
+- RED: focused VisualPackEditor Vitest failed on the new import expectations before implementation.
+- GREEN: bunx vitest run ../packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx passed with 26 tests.
+- Hygiene: git diff --check passed.
+- Bandit: not applicable because this slice touches TypeScript and Markdown only; no Python code changed.
+
+Known skips/blockers 2026-05-15:
+- Backend/API import contract was not changed in this slice, so backend Persona visual API tests were not run.
+- Bandit was skipped as not applicable because no Python files changed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the Persona Visual archive import handoff polish for #1696. The WebUI now sends import preview uploads with the backend archive field, rejects non-.tldw-persona-vpack filenames before upload, surfaces preview/commit job copy from status/stage/error fields, and selects the imported draft returned by a completed commit without activating it.
+
+Verification:
+- bunx vitest run ../packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx (26 passed)
+- git diff --check (passed)
+- Bandit N/A: TypeScript/Markdown-only changes.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-357 - Polish-Persona-Visual-archive-upload-and-import-handoff.md
+++ b/backlog/tasks/task-357 - Polish-Persona-Visual-archive-upload-and-import-handoff.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - Codex
 created_date: '2026-05-15 02:29'
-updated_date: '2026-05-15 02:53'
+updated_date: '2026-05-15 05:16'
 labels:
   - persona
   - webui
@@ -75,17 +75,34 @@ Verification 2026-05-15:
 Known skips/blockers 2026-05-15:
 - Backend/API import contract was not changed in this slice, so backend Persona visual API tests were not run.
 - Bandit was skipped as not applicable because no Python files changed.
+
+Review sweep 2026-05-15:
+- Live PR #1715 review surface has actionable Gemini i18n threads for new import copy.
+- Qodo MIME guard requirement is valid with browser File.type caveat: reject explicit unsupported non-empty types while allowing empty/generic archive types.
+- Qodo stale selectedPackId fallback is valid; fix should keep loadPacks stable and avoid refetching on selection changes.
+
+Review fixes 2026-05-15:
+- Addressed Gemini i18n comments by routing new import preview/commit copy through t() and adding English sidepanel locale keys.
+- Addressed Qodo MIME gap by rejecting explicit unsupported non-empty File.type values while allowing empty/generic zip archive media types for the custom extension.
+- Addressed Qodo stale reload selection by tracking the current selected pack id via ref and passing the selected pack explicitly from the pack refresh action.
+
+Review-fix verification 2026-05-15:
+- bunx vitest run ../packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx passed with 28 tests.
+- node -e JSON.parse(...) for apps/packages/ui/src/assets/locale/en/sidepanel.json passed.
+- git diff --check passed.
+- Bandit remains N/A because this review pass touched TypeScript/JSON/Markdown only.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented the Persona Visual archive import handoff polish for #1696. The WebUI now sends import preview uploads with the backend archive field, rejects non-.tldw-persona-vpack filenames before upload, surfaces preview/commit job copy from status/stage/error fields, and selects the imported draft returned by a completed commit without activating it.
+Implemented the Persona Visual archive import handoff polish for #1696 and addressed PR #1715 review feedback. The WebUI now sends import preview uploads with the backend archive field, rejects unsupported extensions and explicit unsupported media types before upload, surfaces localized preview/commit job copy, preserves the selected pack across refreshes, and selects imported drafts after completed commits without activating them.
 
 Verification:
-- bunx vitest run ../packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx (26 passed)
-- git diff --check (passed)
-- Bandit N/A: TypeScript/Markdown-only changes.
+- bunx vitest run ../packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx (28 passed)
+- node -e JSON.parse(...) for apps/packages/ui/src/assets/locale/en/sidepanel.json
+- git diff --check
+- Bandit N/A: TypeScript/JSON/Markdown-only changes.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Change summary
- Fix Persona Visual import preview uploads to send the backend `archive` field.
- Add client-side `.tldw-persona-vpack` filename validation and clearer preview/commit job copy from status, stage, and error fields.
- Select the imported draft returned by a completed import commit without activating it.

## Why
This completes the user-facing archive upload/import handoff polish tracked in #1696 while keeping activation explicit and avoiding runtime/provider scope creep.

## Tests
- `bunx vitest run ../packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx`
- `git diff --check HEAD~1..HEAD`
- Bandit N/A: TypeScript/Markdown-only changes.

Refs #1696
Refs #1510

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the Persona Visual archive import handoff to meet #1696: preview uploads now use the backend `archive` field, imports validate `.tldw-persona-vpack` and zip media types before upload, job messages are localized and clearer, and the UI auto-selects the imported draft post-commit while keeping activation manual and preserving the current selection on refresh.

- **New Features**
  - Import preview uploads send the `archive` key (not `file`).
  - Client-side guard for `.tldw-persona-vpack` and supported zip MIME types; inline error and disabled Preview when invalid.
  - Localized preview/commit job copy; shows stage, queued/processing text, and `error_message` on failures.
  - On completed commit, reload with `pack_id` to select the new draft; activation remains manual.
  - Refresh keeps the currently selected pack.
  - Tests cover archive key, filename/MIME guards, failure copy, post-commit draft selection, and selection preservation.

<sup>Written for commit c6dbfdbc878347c488a000499d96ec0d3ba68b71. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

