### PR TITLE
Migrate WritingPlayground ready label to design-system registry

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -4532,7 +4532,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/WritingPlayground/index.tsx:Alert#antd-alert-writingplayground-type-error-line-1851-1iwji54",
+    "id": "antd-product-state-import:src/components/Option/WritingPlayground/index.tsx:Alert#antd-alert-writingplayground-type-error-line-1852-1jqib81",
     "path": "src/components/Option/WritingPlayground/index.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -4543,7 +4543,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/WritingPlayground/index.tsx:Alert#antd-alert-writingplayground-type-error-line-2106-a4vw34",
+    "id": "antd-product-state-import:src/components/Option/WritingPlayground/index.tsx:Alert#antd-alert-writingplayground-type-error-line-2107-aevhs3",
     "path": "src/components/Option/WritingPlayground/index.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -4554,7 +4554,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/WritingPlayground/index.tsx:Alert#antd-alert-writingplayground-type-error-line-2268-1hbqxc9",
+    "id": "antd-product-state-import:src/components/Option/WritingPlayground/index.tsx:Alert#antd-alert-writingplayground-type-error-line-2269-1h1rbna",
     "path": "src/components/Option/WritingPlayground/index.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -4565,7 +4565,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/WritingPlayground/index.tsx:Alert#antd-alert-writingplayground-type-info-line-1629-vhe1wl",
+    "id": "antd-product-state-import:src/components/Option/WritingPlayground/index.tsx:Alert#antd-alert-writingplayground-type-info-line-1630-q7or83",
     "path": "src/components/Option/WritingPlayground/index.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -4576,7 +4576,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/WritingPlayground/index.tsx:Alert#antd-alert-writingplayground-type-info-line-1665-1w4a7gt",
+    "id": "antd-product-state-import:src/components/Option/WritingPlayground/index.tsx:Alert#antd-alert-writingplayground-type-info-line-1666-1vabedw",
     "path": "src/components/Option/WritingPlayground/index.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -4587,7 +4587,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/WritingPlayground/index.tsx:Alert#antd-alert-writingplayground-type-info-line-2227-127flro",
+    "id": "antd-product-state-import:src/components/Option/WritingPlayground/index.tsx:Alert#antd-alert-writingplayground-type-info-line-2228-zpj6ix",
     "path": "src/components/Option/WritingPlayground/index.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -4598,7 +4598,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/WritingPlayground/index.tsx:Alert#antd-alert-writingplayground-type-warning-line-2222-laoxyx",
+    "id": "antd-product-state-import:src/components/Option/WritingPlayground/index.tsx:Alert#antd-alert-writingplayground-type-warning-line-2223-l0pc9y",
     "path": "src/components/Option/WritingPlayground/index.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -5101,17 +5101,6 @@
     "owner": "design-system",
     "reason": "Existing AntD Alert product-state UI in src/components/WorkflowEditor/NodePalette.tsx before the guard.",
     "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "canonical-state-label:src/components/Option/WritingPlayground/index.tsx:Ready",
-    "path": "src/components/Option/WritingPlayground/index.tsx",
-    "rule": "canonical-state-label",
-    "subject": "Ready",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing hardcoded \"Ready\" state label in src/components/Option/WritingPlayground/index.tsx before the guard.",
-    "replacement": "getDesignSystemState(...)",
     "migrationQueue": "shared-product-state"
   },
   {

--- a/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlayground.topbar-design-system-state.test.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlayground.topbar-design-system-state.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render, screen } from "@testing-library/react"
+import { render, screen, within } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const mockState = vi.hoisted(() => ({
@@ -206,6 +206,7 @@ describe("WritingPlayground topbar design-system state labels", () => {
   it("renders the ready diagnostics label from the design-system registry", () => {
     render(<WritingPlayground />)
 
-    expect(screen.getByText(mockState.registryReadyLabel)).toBeInTheDocument()
+    const topbar = screen.getByTestId("writing-playground-topbar")
+    expect(within(topbar).getByText(mockState.registryReadyLabel)).toBeInTheDocument()
   })
 })

--- a/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlayground.topbar-design-system-state.test.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlayground.topbar-design-system-state.test.tsx
@@ -1,0 +1,211 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mockState = vi.hoisted(() => ({
+  storageValues: new Map<string, unknown>(),
+  queryData: new Map<string, unknown>(),
+  registryReadyLabel: "Registry Ready",
+  resolveApiProviderForModel: vi.fn(async () => null as string | null),
+  streamCalls: [] as Array<{ messages: unknown[]; options: Record<string, unknown> }>,
+  sendCalls: [] as Array<{ messages: unknown[]; options: Record<string, unknown> }>
+}))
+
+vi.mock("@tanstack/react-query", () => {
+  const resolveQueryData = (queryKey: unknown): unknown => {
+    const key = Array.isArray(queryKey) ? queryKey[0] : queryKey
+    if (key === "writing-session" && Array.isArray(queryKey)) {
+      return mockState.queryData.get(
+        `writing-session:${String(queryKey[1] || "")}`
+      )
+    }
+    return mockState.queryData.get(String(key))
+  }
+
+  return {
+    useQuery: ({ queryKey }: { queryKey: unknown }) => ({
+      data: resolveQueryData(queryKey),
+      isLoading: false,
+      isFetching: false,
+      error: null
+    }),
+    useMutation: () => ({
+      mutate: vi.fn(),
+      mutateAsync: vi.fn(),
+      isPending: false
+    }),
+    useQueryClient: () => ({
+      invalidateQueries: vi.fn(),
+      setQueryData: vi.fn()
+    })
+  }
+})
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      key: string,
+      fallbackOrOptions?: string | { defaultValue?: string }
+    ) => {
+      if (typeof fallbackOrOptions === "string") return fallbackOrOptions
+      if (fallbackOrOptions?.defaultValue) return fallbackOrOptions.defaultValue
+      return key
+    }
+  })
+}))
+
+vi.mock("@plasmohq/storage/hook", () => ({
+  useStorage: <T,>(key: string, initial?: T) =>
+    React.useState<T | undefined>(() =>
+      mockState.storageValues.has(key)
+        ? (mockState.storageValues.get(key) as T)
+        : initial
+    )
+}))
+
+vi.mock("@/hooks/useServerOnline", () => ({
+  useServerOnline: () => true
+}))
+
+vi.mock("@/hooks/useServerCapabilities", () => ({
+  useServerCapabilities: () => ({
+    capabilities: { hasChat: true },
+    loading: false,
+    refresh: async () => {}
+  })
+}))
+
+vi.mock("@/design-system", async (importActual) => {
+  const actual = await importActual<typeof import("@/design-system")>()
+  return {
+    ...actual,
+    READY_STATE_LABEL: mockState.registryReadyLabel
+  }
+})
+
+vi.mock("@/utils/resolve-api-provider", () => ({
+  AUTO_MODEL_ID: "auto",
+  resolveApiProviderForModel: mockState.resolveApiProviderForModel
+}))
+
+vi.mock("@/components/Common/MarkdownPreview", () => ({
+  MarkdownPreview: ({ content }: { content: string }) => <div>{content}</div>
+}))
+
+vi.mock("@/services/tldw/TldwChat", () => ({
+  TldwChatService: class TldwChatServiceMock {
+    cancelStream() {}
+    async *streamMessage(
+      messages: unknown[],
+      options: Record<string, unknown>
+    ) {
+      mockState.streamCalls.push({ messages, options })
+      yield "mocked stream token"
+    }
+    async sendMessage(messages: unknown[], options: Record<string, unknown>) {
+      mockState.sendCalls.push({ messages, options })
+      return "mocked completion"
+    }
+  }
+}))
+
+vi.mock("@/services/writing-playground", () => ({
+  cloneWritingSession: vi.fn(),
+  createWritingSession: vi.fn(),
+  createWritingTemplate: vi.fn(),
+  createWritingTheme: vi.fn(),
+  createWritingWordcloud: vi.fn(),
+  countWritingTokens: vi.fn(),
+  deleteWritingSession: vi.fn(),
+  deleteWritingTemplate: vi.fn(),
+  deleteWritingTheme: vi.fn(),
+  exportWritingSnapshot: vi.fn(),
+  getWritingCapabilities: vi.fn(),
+  getWritingDefaults: vi.fn(),
+  getWritingWordcloud: vi.fn(),
+  getWritingSession: vi.fn(),
+  importWritingSnapshot: vi.fn(),
+  listWritingSessions: vi.fn(),
+  listWritingTemplates: vi.fn(),
+  listWritingThemes: vi.fn(),
+  tokenizeWritingText: vi.fn(),
+  updateWritingSession: vi.fn(),
+  updateWritingTemplate: vi.fn(),
+  updateWritingTheme: vi.fn()
+}))
+
+import { WritingPlayground } from "../index"
+import { useWritingPlaygroundStore } from "@/store/writing-playground"
+
+const DEFAULT_WRITING_CAPABILITIES = {
+  server: {
+    sessions: true,
+    templates: true,
+    themes: true,
+    defaults_catalog: false,
+    snapshots: false,
+    tokenize: true,
+    token_count: true
+  },
+  requested: {
+    provider: "openai",
+    tokenizer_available: true,
+    tokenizer: "mock-tokenizer",
+    tokenizer_kind: "mock",
+    tokenizer_source: "mock",
+    detokenize_available: true,
+    features: {
+      logprobs: true
+    },
+    supported_fields: ["top_logprobs"],
+    extra_body_compat: {
+      effective: true,
+      source: "mock",
+      notes: "mock"
+    }
+  }
+}
+
+beforeEach(() => {
+  mockState.storageValues.clear()
+  mockState.queryData.clear()
+  mockState.resolveApiProviderForModel.mockReset()
+  mockState.resolveApiProviderForModel.mockResolvedValue(null)
+  mockState.streamCalls.length = 0
+  mockState.sendCalls.length = 0
+
+  mockState.queryData.set("writing-capabilities", DEFAULT_WRITING_CAPABILITIES)
+  mockState.queryData.set("writing-defaults", { templates: [], themes: [] })
+  mockState.queryData.set("writing-sessions", {
+    sessions: [],
+    total: 0,
+    limit: 200,
+    offset: 0
+  })
+  mockState.queryData.set("writing-templates", {
+    templates: [],
+    total: 0,
+    limit: 200,
+    offset: 0
+  })
+  mockState.queryData.set("writing-themes", {
+    themes: [],
+    total: 0,
+    limit: 200,
+    offset: 0
+  })
+  mockState.queryData.set("writing-session:", null)
+
+  useWritingPlaygroundStore.setState({
+    activeSessionId: null,
+    activeSessionName: null
+  })
+})
+
+describe("WritingPlayground topbar design-system state labels", () => {
+  it("renders the ready diagnostics label from the design-system registry", () => {
+    render(<WritingPlayground />)
+
+    expect(screen.getByText(mockState.registryReadyLabel)).toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/components/Option/WritingPlayground/index.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/index.tsx
@@ -45,6 +45,7 @@ import {
 } from "lucide-react"
 import { useServerCapabilities } from "@/hooks/useServerCapabilities"
 import { useServerOnline } from "@/hooks/useServerOnline"
+import { READY_STATE_LABEL } from "@/design-system"
 import { formatRelativeTime } from "@/utils/dateFormatters"
 import { MarkdownPreview } from "@/components/Common/MarkdownPreview"
 import { TldwChatService } from "@/services/tldw/TldwChat"
@@ -2255,7 +2256,7 @@ export const WritingPlayground = () => {
               </Button>
             </Tooltip>
             <Tag color={diagnosticsSummary.status === "warning" ? "gold" : diagnosticsSummary.status === "busy" ? "blue" : "green"} className="!m-0">
-              {diagnosticsSummary.status === "warning" ? t("option:writingPlayground.diagnosticsWarning", "Warning") : diagnosticsSummary.status === "busy" ? t("option:writingPlayground.diagnosticsBusy", "Busy") : t("option:writingPlayground.diagnosticsReady", "Ready")}
+              {diagnosticsSummary.status === "warning" ? t("option:writingPlayground.diagnosticsWarning", "Warning") : diagnosticsSummary.status === "busy" ? t("option:writingPlayground.diagnosticsBusy", "Busy") : t("option:writingPlayground.diagnosticsReady", READY_STATE_LABEL)}
             </Tag>
             <Button type="text" size="small" icon={<Settings className="h-4 w-4" />} onClick={() => setInspectorOpen((prev) => !prev)} aria-label={t("option:writingPlayground.toggleInspector", "Toggle settings")} className={inspectorOpen ? "text-primary" : ""} />
           </div>

--- a/backlog/tasks/task-45.44.12.1 - Migrate-WritingPlayground-topbar-Ready-label-to-design-system-state-registry.md
+++ b/backlog/tasks/task-45.44.12.1 - Migrate-WritingPlayground-topbar-Ready-label-to-design-system-state-registry.md
@@ -4,7 +4,7 @@ title: Migrate WritingPlayground topbar Ready label to design-system state regis
 status: Done
 assignee: []
 created_date: '2026-05-15 03:14'
-updated_date: '2026-05-15 03:42'
+updated_date: '2026-05-15 03:50'
 labels:
   - design-system
   - webui
@@ -50,6 +50,12 @@ Implemented the WritingPlayground topbar Ready-label migration in isolated workt
 Verification: bunx vitest run src/components/Option/WritingPlayground/__tests__/WritingPlayground.topbar-design-system-state.test.tsx src/components/Option/WritingPlayground/__tests__/WritingPlaygroundDiagnosticsPanel.design-system-state.test.tsx src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed with 3 files and 54 tests. bun run verify:design-system-state passed with 483 baseline exceptions, 479 AntD product-state imports and 4 canonical-state-label exceptions remaining. JSON parse and git diff --check passed. bunx tsc --noEmit --pretty false still exits 2 on existing repo-wide type debt; touched-path filter found no diagnostics for WritingPlayground.topbar-design-system-state, WritingPlayground/index.tsx, design-system-product-state-baseline, or the task file. Bandit skipped because touched runtime scope is UI TypeScript, JSON baseline, and Backlog metadata only.
 
 Draft PR opened: https://github.com/rmusser01/tldw_server/pull/1716
+
+PR review follow-up: CodeRabbit requested scoping the topbar ready-label assertion to the writing-playground-topbar container instead of searching the full page. This is valid test hardening for the intended contract.
+
+PR review fix implemented: scoped the topbar ready-label test assertion to screen.getByTestId('writing-playground-topbar') and within(topbar).getByText(...), matching CodeRabbit's review thread.
+
+Review-fix verification: bunx vitest run src/components/Option/WritingPlayground/__tests__/WritingPlayground.topbar-design-system-state.test.tsx --reporter=dot passed with 1 test. bunx vitest run src/components/Option/WritingPlayground/__tests__/WritingPlayground.topbar-design-system-state.test.tsx src/components/Option/WritingPlayground/__tests__/WritingPlaygroundDiagnosticsPanel.design-system-state.test.tsx src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed with 54 tests. bun run verify:design-system-state passed with 483 baseline exceptions. git diff --check passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-45.44.12.1 - Migrate-WritingPlayground-topbar-Ready-label-to-design-system-state-registry.md
+++ b/backlog/tasks/task-45.44.12.1 - Migrate-WritingPlayground-topbar-Ready-label-to-design-system-state-registry.md
@@ -1,0 +1,69 @@
+---
+id: TASK-45.44.12.1
+title: Migrate WritingPlayground topbar Ready label to design-system state registry
+status: Done
+assignee: []
+created_date: '2026-05-15 03:14'
+updated_date: '2026-05-15 03:42'
+labels:
+  - design-system
+  - webui
+  - extension
+  - product-state
+  - writing-playground
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1669'
+  - apps/packages/ui/src/components/Option/WritingPlayground/index.tsx
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+  - 'https://github.com/rmusser01/tldw_server/pull/1716'
+parent_task_id: TASK-45.44.12
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replace the remaining hardcoded WritingPlayground topbar diagnostics Ready product-state label with the canonical design-system state registry value. Scope is limited to the WritingPlayground topbar ready status label and the matching product-state baseline entry.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 WritingPlayground topbar ready diagnostics label resolves through the design-system ready state label instead of a hardcoded canonical literal.
+- [x] #2 The matching WritingPlayground canonical-state-label baseline exception is removed and the design-system product-state verifier passes.
+- [x] #3 Focused WritingPlayground and design-system guard tests cover the registry-backed ready label behavior.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused failing WritingPlayground regression test that mocks the design-system ready label and expects the topbar ready status to render that registry label.
+2. Replace the topbar ready fallback with the exported design-system ready label without changing warning or busy behavior.
+3. Remove the resolved WritingPlayground baseline exception and run the focused WritingPlayground tests plus the product-state guard verifier.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the WritingPlayground topbar Ready-label migration in isolated worktree .worktrees/design-system-next-slice-5. Red/green proof: the new focused topbar design-system test fails against the hardcoded Ready fallback and passes when the topbar uses READY_STATE_LABEL. Removed the matching canonical-state-label baseline entry and refreshed only the shifted WritingPlayground AntD Alert baseline IDs caused by the added import.
+
+Verification: bunx vitest run src/components/Option/WritingPlayground/__tests__/WritingPlayground.topbar-design-system-state.test.tsx src/components/Option/WritingPlayground/__tests__/WritingPlaygroundDiagnosticsPanel.design-system-state.test.tsx src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed with 3 files and 54 tests. bun run verify:design-system-state passed with 483 baseline exceptions, 479 AntD product-state imports and 4 canonical-state-label exceptions remaining. JSON parse and git diff --check passed. bunx tsc --noEmit --pretty false still exits 2 on existing repo-wide type debt; touched-path filter found no diagnostics for WritingPlayground.topbar-design-system-state, WritingPlayground/index.tsx, design-system-product-state-baseline, or the task file. Bandit skipped because touched runtime scope is UI TypeScript, JSON baseline, and Backlog metadata only.
+
+Draft PR opened: https://github.com/rmusser01/tldw_server/pull/1716
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated the remaining WritingPlayground topbar Ready diagnostics label to the design-system ready state label, added focused regression coverage for registry-backed rendering, removed the resolved canonical-state-label baseline exception, and refreshed only pre-existing AntD Alert baseline IDs shifted by the new import.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Routes the WritingPlayground topbar ready diagnostics fallback through the design-system `READY_STATE_LABEL`.
- Adds focused rendering coverage that mocks the registry ready label and verifies the topbar uses it.
- Removes the resolved WritingPlayground canonical-state-label baseline exception and refreshes only shifted pre-existing AntD Alert baseline IDs caused by the new import.

## Verification
- `bunx vitest run src/components/Option/WritingPlayground/__tests__/WritingPlayground.topbar-design-system-state.test.tsx src/components/Option/WritingPlayground/__tests__/WritingPlaygroundDiagnosticsPanel.design-system-state.test.tsx src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` (3 files / 54 tests passed)
- `bun run verify:design-system-state` (passed; 483 baseline exceptions: 479 AntD product-state imports, 4 canonical-state-label exceptions remaining)
- `node -e "JSON.parse(require('fs').readFileSync('apps/packages/ui/scripts/design-system-product-state-baseline.json', 'utf8')); console.log('baseline json ok')"`
- `git diff --cached --check`
- `bunx tsc --noEmit --pretty false` still exits 2 on existing repo-wide type debt; touched-path filter found no diagnostics for the files changed in this PR.

## Known status
- The full existing `WritingPlayground.phase1-baseline.test.tsx` file still times out in older auto-routing tests in this worktree. The new topbar test is isolated and passes, and those timeout cases are not part of this label migration.
- Bandit skipped: touched runtime scope is UI TypeScript, JSON baseline data, and Backlog metadata only.

## Change summary
Human author: replace this placeholder with your own concise explanation of what changed and why these implementation choices were made before marking the PR ready for merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the WritingPlayground topbar “Ready” diagnostics label to the design-system registry to use a single source of truth, replacing the hardcoded string. Cleans up the product-state guard by removing the legacy exception and updating shifted AntD Alert baseline IDs.

- **Refactors**
  - Use `READY_STATE_LABEL` from `@/design-system` for the topbar “Ready” state.
  - Added a focused test that mocks the registry label and verifies topbar rendering; scoped the assertion to the `writing-playground-topbar` container.
  - Removed the WritingPlayground canonical-state-label baseline exception and refreshed shifted AntD Alert baseline IDs.

<sup>Written for commit c554b7e8945224d5fd17fdfaa0c7aa36bfc414b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

